### PR TITLE
fix(ui-dashboard): give /volume INP gate headroom for cold-start

### DIFF
--- a/ui-dashboard/scripts/measure-inp-lib.mjs
+++ b/ui-dashboard/scripts/measure-inp-lib.mjs
@@ -1,0 +1,55 @@
+// Pure, browser-free helpers for measure-inp.mjs, extracted so the readiness
+// timeout selection and terminal-state classification can be unit-tested
+// without launching Chromium (#775). measure-inp.mjs is a blocking CI gate, so
+// drift in this logic can send maintainers toward the wrong fix; the tests in
+// measure-inp-lib.test.mjs pin the behaviour.
+
+// How long to wait for a surface's readiness anchor before failing. Most
+// surfaces settle in well under this. `/volume` overrides it: it fires the
+// heaviest query waterfall on the page (top-traders + aggregator + broker +
+// pools snapshots, then client-side re-aggregation), and on a cold preview
+// deployment hit by a contended CI runner the sorted "Volume" header can take
+// longer than the default to render. A warm-backend readiness ceiling measured
+// at 20× CPU + Slow 4G is ~12s, so the override leaves headroom for preview
+// cold-start latency without masking a genuine hang (a true stall still trips
+// the override and fails closed).
+export const DEFAULT_READY_TIMEOUT_MS = 20_000;
+export const VOLUME_READY_TIMEOUT_MS = 45_000;
+
+// A surface uses its explicit readyTimeout when set, else the default.
+export function resolveReadyTimeout(surface) {
+  return surface.readyTimeout ?? DEFAULT_READY_TIMEOUT_MS;
+}
+
+// Source for the EmptyBox copy the `/volume` tables render when a window
+// legitimately has no rows (top-traders `VolumeTable` and the v2/v3
+// `AggregatorBreakdownSection`). Kept as a string so measure-inp.mjs can inject
+// it into `page.evaluate` (which can't close over a module import) while this
+// module stays the single source of truth the tests assert against.
+export const EMPTY_VOLUME_MARKER_PATTERN =
+  "no traders (matched|left)|no v[23] aggregator (activity|volume)";
+
+// True when page body text contains one of the `/volume` empty-state messages.
+export function matchesEmptyVolumeMarker(bodyText) {
+  return new RegExp(EMPTY_VOLUME_MARKER_PATTERN, "i").test(bodyText);
+}
+
+// Turn the DOM markers captured after a readiness timeout into a human cause.
+// The bare "Timeout exceeded" can't tell slow-render from empty/error data, and
+// each needs a different fix. `error` takes priority (a backend failure is the
+// most actionable), then `loading`, then `empty`.
+export function classifyTerminalState({ loading, error, empty }) {
+  if (error) return "data backend erroring (ErrorBox / role=alert present)";
+  if (loading)
+    return "still loading after timeout (slow data fetch/render — likely preview cold-start)";
+  if (empty) return "no data (EmptyBox present — window legitimately empty)";
+  return "unknown (no loading/error/empty marker found)";
+}
+
+// Cause string for when the page itself died before it could be classified
+// (Target closed, crash, GC during the wait). The caller always rethrows the
+// primary timeout error; this only annotates why classification was
+// unavailable, so the more useful signal is never erased.
+export function unavailableTerminalState(diagMessage) {
+  return `unavailable (page closed/crashed before it could be classified: ${diagMessage})`;
+}

--- a/ui-dashboard/scripts/measure-inp-lib.test.mjs
+++ b/ui-dashboard/scripts/measure-inp-lib.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTerminalState,
+  DEFAULT_READY_TIMEOUT_MS,
+  matchesEmptyVolumeMarker,
+  resolveReadyTimeout,
+  unavailableTerminalState,
+  VOLUME_READY_TIMEOUT_MS,
+} from "./measure-inp-lib.mjs";
+
+describe("resolveReadyTimeout", () => {
+  it("uses the default when a surface sets no readyTimeout", () => {
+    expect(resolveReadyTimeout({ name: "pools-filter" })).toBe(
+      DEFAULT_READY_TIMEOUT_MS,
+    );
+  });
+
+  it("uses the surface's explicit readyTimeout (the /volume override)", () => {
+    expect(
+      resolveReadyTimeout({
+        name: "volume-sort",
+        readyTimeout: VOLUME_READY_TIMEOUT_MS,
+      }),
+    ).toBe(VOLUME_READY_TIMEOUT_MS);
+  });
+
+  it("keeps the two timeouts distinct and ordered", () => {
+    expect(VOLUME_READY_TIMEOUT_MS).toBeGreaterThan(DEFAULT_READY_TIMEOUT_MS);
+  });
+});
+
+describe("classifyTerminalState", () => {
+  it("reports a backend error first — role=alert wins over other markers", () => {
+    expect(
+      classifyTerminalState({ loading: true, error: true, empty: true }),
+    ).toMatch(/backend erroring/);
+  });
+
+  it("reports still-loading when only the skeleton is up", () => {
+    expect(
+      classifyTerminalState({ loading: true, error: false, empty: false }),
+    ).toMatch(/still loading/);
+  });
+
+  it("reports empty when the window legitimately has no rows", () => {
+    expect(
+      classifyTerminalState({ loading: false, error: false, empty: true }),
+    ).toMatch(/no data/);
+  });
+
+  it("reports unknown when no marker is present", () => {
+    expect(
+      classifyTerminalState({ loading: false, error: false, empty: false }),
+    ).toMatch(/unknown/);
+  });
+});
+
+describe("matchesEmptyVolumeMarker", () => {
+  it.each([
+    "No traders matched this window. Try widening the range or including protocol actors.",
+    "No traders left after exploratory exclusions. Clear exclusions or widen the range.",
+    "No v3 aggregator activity in this window.",
+    "No v2 aggregator volume in this window.",
+  ])("matches the /volume empty-state copy: %s", (text) => {
+    expect(matchesEmptyVolumeMarker(text)).toBe(true);
+  });
+
+  it("does not match a populated table", () => {
+    expect(
+      matchesEmptyVolumeMarker("Top traders (7d)  Volume  Swaps  Pools"),
+    ).toBe(false);
+  });
+});
+
+describe("unavailableTerminalState", () => {
+  it("preserves the underlying page.evaluate failure reason", () => {
+    const cause = unavailableTerminalState(
+      "Target page, context or browser has been closed",
+    );
+    expect(cause).toMatch(/page closed\/crashed/);
+    expect(cause).toContain("Target page, context or browser has been closed");
+  });
+});

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -297,23 +297,36 @@ async function measureSurface(browser, surface) {
       // (#775). Loading skeleton still up → slow data fetch/render; ErrorBox
       // → the indexer's GraphQL endpoint is erroring; EmptyBox → the window
       // legitimately has no rows. Still fails closed regardless.
-      const diag = await page.evaluate(() => ({
-        loading: !!document.querySelector(
-          '[role="status"][aria-label="Loading"]',
-        ),
-        error: !!document.querySelector('[role="alert"]'),
-        empty:
-          /no traders (matched|left)|no v[23] aggregator (activity|volume)/i.test(
-            document.body.innerText,
+      //
+      // This classification is best-effort: if the page itself died during the
+      // wait (`Target closed`, crash, GC), `page.evaluate` throws too. Guard it
+      // so the secondary failure can't erase the primary timeout — that error
+      // is the more useful signal, so we always rethrow it, annotated either
+      // with the terminal state or with why the classification was unavailable.
+      let cause;
+      try {
+        const diag = await page.evaluate(() => ({
+          loading: !!document.querySelector(
+            '[role="status"][aria-label="Loading"]',
           ),
-      }));
-      const cause = diag.error
-        ? "data backend erroring (ErrorBox / role=alert present)"
-        : diag.loading
-          ? "still loading after timeout (slow data fetch/render — likely preview cold-start)"
-          : diag.empty
-            ? "no data (EmptyBox present — window legitimately empty)"
-            : "unknown (no loading/error/empty marker found)";
+          error: !!document.querySelector('[role="alert"]'),
+          empty:
+            /no traders (matched|left)|no v[23] aggregator (activity|volume)/i.test(
+              document.body.innerText,
+            ),
+        }));
+        cause = diag.error
+          ? "data backend erroring (ErrorBox / role=alert present)"
+          : diag.loading
+            ? "still loading after timeout (slow data fetch/render — likely preview cold-start)"
+            : diag.empty
+              ? "no data (EmptyBox present — window legitimately empty)"
+              : "unknown (no loading/error/empty marker found)";
+      } catch (diagErr) {
+        const diagMsg =
+          diagErr instanceof Error ? diagErr.message : String(diagErr);
+        cause = `unavailable (page closed/crashed before it could be classified: ${diagMsg})`;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`${msg} — terminal state: ${cause}`);
     }

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -40,6 +40,13 @@
 import { chromium } from "@playwright/test";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import {
+  classifyTerminalState,
+  EMPTY_VOLUME_MARKER_PATTERN,
+  resolveReadyTimeout,
+  unavailableTerminalState,
+  VOLUME_READY_TIMEOUT_MS,
+} from "./measure-inp-lib.mjs";
 
 const PREVIEW_URL = process.env.PREVIEW_URL;
 const BYPASS_HEADERS_JSON = process.env.BYPASS_HEADERS_JSON;
@@ -78,18 +85,6 @@ const webVitalsIife = resolve(
   "dist",
   "web-vitals.iife.js",
 );
-
-// How long to wait for a surface's readiness anchor before failing. Most
-// surfaces settle in well under this. `/volume` overrides it (see below):
-// it fires the heaviest query waterfall on the page (top-traders +
-// aggregator + broker + pools snapshots, then client-side re-aggregation),
-// and on a cold preview deployment hit by a contended CI runner the sorted
-// "Volume" header can take longer than the default to render. A warm-backend
-// readiness ceiling measured at 20× CPU + Slow 4G is ~12s, so the override
-// leaves headroom for preview cold-start latency without masking a genuine
-// hang (a true stall still trips the override and fails closed). Issue #775.
-const DEFAULT_READY_TIMEOUT_MS = 20_000;
-const VOLUME_READY_TIMEOUT_MS = 45_000;
 
 // One surface = one navigation + interaction sequence + INP read. Each
 // runs in a fresh chromium context so prior interactions can't pollute
@@ -284,10 +279,9 @@ async function measureSurface(browser, surface) {
       );
     });
 
-    const readyTimeout = surface.readyTimeout ?? DEFAULT_READY_TIMEOUT_MS;
     try {
       await page.waitForSelector(surface.readySelector, {
-        timeout: readyTimeout,
+        timeout: resolveReadyTimeout(surface),
       });
     } catch (err) {
       // The bare "Timeout 20000ms exceeded" can't tell slow-render from
@@ -305,27 +299,24 @@ async function measureSurface(browser, surface) {
       // with the terminal state or with why the classification was unavailable.
       let cause;
       try {
-        const diag = await page.evaluate(() => ({
-          loading: !!document.querySelector(
-            '[role="status"][aria-label="Loading"]',
-          ),
-          error: !!document.querySelector('[role="alert"]'),
-          empty:
-            /no traders (matched|left)|no v[23] aggregator (activity|volume)/i.test(
-              document.body.innerText,
+        // The empty-marker regex is injected from the lib (page.evaluate can't
+        // close over a module import) so the pattern stays single-sourced and
+        // unit-tested.
+        const diag = await page.evaluate(
+          (emptyPattern) => ({
+            loading: !!document.querySelector(
+              '[role="status"][aria-label="Loading"]',
             ),
-        }));
-        cause = diag.error
-          ? "data backend erroring (ErrorBox / role=alert present)"
-          : diag.loading
-            ? "still loading after timeout (slow data fetch/render — likely preview cold-start)"
-            : diag.empty
-              ? "no data (EmptyBox present — window legitimately empty)"
-              : "unknown (no loading/error/empty marker found)";
+            error: !!document.querySelector('[role="alert"]'),
+            empty: new RegExp(emptyPattern, "i").test(document.body.innerText),
+          }),
+          EMPTY_VOLUME_MARKER_PATTERN,
+        );
+        cause = classifyTerminalState(diag);
       } catch (diagErr) {
         const diagMsg =
           diagErr instanceof Error ? diagErr.message : String(diagErr);
-        cause = `unavailable (page closed/crashed before it could be classified: ${diagMsg})`;
+        cause = unavailableTerminalState(diagMsg);
       }
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`${msg} — terminal state: ${cause}`);

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -79,6 +79,18 @@ const webVitalsIife = resolve(
   "web-vitals.iife.js",
 );
 
+// How long to wait for a surface's readiness anchor before failing. Most
+// surfaces settle in well under this. `/volume` overrides it (see below):
+// it fires the heaviest query waterfall on the page (top-traders +
+// aggregator + broker + pools snapshots, then client-side re-aggregation),
+// and on a cold preview deployment hit by a contended CI runner the sorted
+// "Volume" header can take longer than the default to render. A warm-backend
+// readiness ceiling measured at 20× CPU + Slow 4G is ~12s, so the override
+// leaves headroom for preview cold-start latency without masking a genuine
+// hang (a true stall still trips the override and fails closed). Issue #775.
+const DEFAULT_READY_TIMEOUT_MS = 20_000;
+const VOLUME_READY_TIMEOUT_MS = 45_000;
+
 // One surface = one navigation + interaction sequence + INP read. Each
 // runs in a fresh chromium context so prior interactions can't pollute
 // the next surface's `onINP` observer.
@@ -115,6 +127,7 @@ const SURFACES = [
     // Volume `SortableTh` only mounts once the table has columns, so it's
     // a reliable "rows have loaded" anchor.
     readySelector: 'th[aria-sort] button:has-text("Volume")',
+    readyTimeout: VOLUME_READY_TIMEOUT_MS,
     async interact(page) {
       // The volume page ships with one window active by default; clicking
       // a sibling triggers a `window.history.replaceState`-backed re-render
@@ -159,6 +172,7 @@ const SURFACES = [
     // gate purposes, and Playwright's strict-mode locator would
     // otherwise throw on the multi-match.
     readySelector: 'th[aria-sort] button:has-text("Volume")',
+    readyTimeout: VOLUME_READY_TIMEOUT_MS,
     async interact(page) {
       // Click the Volume column header to toggle sort. The
       // `useTableSort` hook re-derives the sorted list on each click, so
@@ -270,7 +284,39 @@ async function measureSurface(browser, surface) {
       );
     });
 
-    await page.waitForSelector(surface.readySelector, { timeout: 20_000 });
+    const readyTimeout = surface.readyTimeout ?? DEFAULT_READY_TIMEOUT_MS;
+    try {
+      await page.waitForSelector(surface.readySelector, {
+        timeout: readyTimeout,
+      });
+    } catch (err) {
+      // The bare "Timeout 20000ms exceeded" can't tell slow-render from
+      // empty/error data — both look identical and each needs a different
+      // fix. Classify the terminal state the page actually settled into so
+      // the next failure self-diagnoses instead of forcing a re-investigation
+      // (#775). Loading skeleton still up → slow data fetch/render; ErrorBox
+      // → the indexer's GraphQL endpoint is erroring; EmptyBox → the window
+      // legitimately has no rows. Still fails closed regardless.
+      const diag = await page.evaluate(() => ({
+        loading: !!document.querySelector(
+          '[role="status"][aria-label="Loading"]',
+        ),
+        error: !!document.querySelector('[role="alert"]'),
+        empty:
+          /no traders (matched|left)|no v[23] aggregator (activity|volume)/i.test(
+            document.body.innerText,
+          ),
+      }));
+      const cause = diag.error
+        ? "data backend erroring (ErrorBox / role=alert present)"
+        : diag.loading
+          ? "still loading after timeout (slow data fetch/render — likely preview cold-start)"
+          : diag.empty
+            ? "no data (EmptyBox present — window legitimately empty)"
+            : "unknown (no loading/error/empty marker found)";
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`${msg} — terminal state: ${cause}`);
+    }
     await surface.interact(page);
 
     // Settle window: let the browser paint and deliver every

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -304,8 +304,12 @@ async function measureSurface(browser, surface) {
         // unit-tested.
         const diag = await page.evaluate(
           (emptyPattern) => ({
+            // Prefix-match so the shared skeletons that label themselves
+            // "Loading table" / "Loading metrics" / "Loading chart" (via the
+            // status-role helper in components/skeletons.tsx) are recognized as
+            // loading too, not just the bare "Loading" feedback Skeleton.
             loading: !!document.querySelector(
-              '[role="status"][aria-label="Loading"]',
+              '[role="status"][aria-label^="Loading"]',
             ),
             error: !!document.querySelector('[role="alert"]'),
             empty: new RegExp(emptyPattern, "i").test(document.body.innerText),


### PR DESCRIPTION
## The Problem

The `Core Web Vitals + accessibility (ui-dashboard)` gate (`ui-dashboard/scripts/measure-inp.mjs`) intermittently failed on the two `/volume` scenarios with `page.waitForSelector: Timeout 20000ms exceeded` (waiting for `th[aria-sort] button:has-text("Volume")`), adding a red, non-required check to every dashboard PR that touches anything under `ui-dashboard/`. Tracked in #775.

`/volume` is the heaviest page on the dashboard: it fires the top-traders, aggregator, broker, and pools snapshot queries, then re-aggregates them client-side. Both `/volume` tables (`VolumeTable`, `AggregatorBreakdownSection`) render the sortable **Volume** header only in the data-present branch (loading → `Skeleton`, empty → `EmptyBox`, error → `ErrorBox` — none contain `th[aria-sort]`), so the readiness anchor sits behind that entire waterfall.

**Root cause — timeout headroom, not empty data:**

- **Empty is effectively unreachable for the default view.** The default is `venue=v3, range=7d`, and the top-traders table is venue-agnostic (`TraderDailySnapshot` has no venue field). The live endpoint returns ~121 trader-day + ~29 v3-aggregator-day rows over 7d, so the header renders on any normal Celo week. (The issue's "weekend/empty" hypothesis would only bite a 24h window.)
- **It's `/volume`-specific latency.** In the failing CI runs, `pools-filter` (1st surface) passed at ~24ms while the `/volume` surfaces (3rd/4th) timed out — the opposite of a generic preview cold-start, which would penalize the first surface.
- **Measured ceiling.** At 20× CPU throttle + Slow 4G against the warm prod backend, `/volume` readiness is ~12s — already over half the 20s budget on a warm backend. The CI failures add cold preview-deployment data-fetch latency on a contended runner, pushing past 20s.

## The Solution

Surgical, one file (`ui-dashboard/scripts/measure-inp.mjs`):

1. **Per-surface `readyTimeout`** — raise only `/volume` to 45s (≈33s of headroom over the measured ~12s warm ceiling); every other surface keeps the 20s default. A genuine hang still trips the longer timeout and fails closed.
2. **On-timeout terminal-state diagnostic** — when readiness times out, classify what the page actually settled into (still-loading skeleton → slow data fetch/render; `role=alert` → indexer erroring; `EmptyBox` text → legitimately empty) and append it to the error, so the next failure self-diagnoses instead of forcing a re-investigation. Still fails closed in every case.

No change to the 200ms INP budget, the fail-closed-on-null behavior, or any interaction logic.

**Verification:**

- `node --check` clean.
- Local run against prod (`PREVIEW_URL=https://monitoring.mento.org`) passes all four surfaces (`/volume` at 32ms).
- Catch-path exercised with a never-matching selector against warm prod → correctly classifies `unknown (no loading/error/empty marker found)`; `page.evaluate` + regex run without error.
- This PR self-triggers the gate against its own preview; true acceptance is watching ~5 subsequent dashboard-PR runs (ideally spanning a weekend), per the issue.

Closes #775.

## Ship Checklist
- [x] ship workflow used
- [x] local review run (advisor x2)
- [x] validation run (node --check, prod happy-path, catch-path probe)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the ui-dashboard INP measurement script and new test-only helpers; INP budget and interaction logic are unchanged.
> 
> **Overview**
> Reduces flaky **Core Web Vitals INP** CI failures on `/volume` by giving only the two volume surfaces a **45s** readiness wait (others stay at **20s**) and by enriching timeout errors with a **terminal-state** hint (loading vs backend error vs empty vs page crash).
> 
> Readiness logic moves into **`measure-inp-lib.mjs`** (timeout resolution, empty-volume copy regex, classification helpers) with **Vitest** coverage so the blocking gate’s behaviour does not drift unnoticed. On readiness timeout, the script still **fails closed** but appends a classified cause after a best-effort DOM probe (`role=status` loading, `role=alert`, empty copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88af936a8151bcda2ae2bc9b938ff4c7421c5f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->