### PR TITLE
docs: align PR workflow guidance

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -56,9 +56,15 @@ item required.
 - Merge conflict: fetch the base branch, merge or rebase once according to the
   repo's current workflow, resolve, run focused validation, commit, and push.
 - Unreplied review comment or unresolved thread: fetch every feedback surface,
-  triage each finding, implement valid fixes, and reply to every comment. Use
-  the root `AGENTS.md` reply templates. Do not resolve a thread without a
-  reply first.
+  triage each finding, implement valid fixes, and reply to every comment. In
+  Codex, inspect `pnpm pr:ready-state --pr <number> --json` first as a triage
+  shortcut for the currently reported blockers: its `unresolvedReviewThreads[]`
+  and `unrepliedRootReviewComments[]` entries often include the full comment
+  body, URL, path, line, and id needed to understand the finding before making
+  raw `gh api` calls. This does **not** replace the required full feedback
+  sweep across review comments, review bodies, top-level comments, threads,
+  check annotations, and failing check logs before all-clear. Use the root
+  `AGENTS.md` reply templates. Do not resolve a thread without a reply first.
 - Codex current-head approval missing or in flight: wait for the existing
   signal. Do not post duplicate `@codex review` requests while the probe says a
   current-head request is `requested`, `in_flight`, or `approved`.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -56,9 +56,15 @@ item required.
 - Merge conflict: fetch the base branch, merge or rebase once according to the
   repo's current workflow, resolve, run focused validation, commit, and push.
 - Unreplied review comment or unresolved thread: fetch every feedback surface,
-  triage each finding, implement valid fixes, and reply to every comment. Use
-  the root `AGENTS.md` reply templates. Do not resolve a thread without a
-  reply first.
+  triage each finding, implement valid fixes, and reply to every comment. In
+  Codex, inspect `pnpm pr:ready-state --pr <number> --json` first as a triage
+  shortcut for the currently reported blockers: its `unresolvedReviewThreads[]`
+  and `unrepliedRootReviewComments[]` entries often include the full comment
+  body, URL, path, line, and id needed to understand the finding before making
+  raw `gh api` calls. This does **not** replace the required full feedback
+  sweep across review comments, review bodies, top-level comments, threads,
+  check annotations, and failing check logs before all-clear. Use the root
+  `AGENTS.md` reply templates. Do not resolve a thread without a reply first.
 - Codex current-head approval missing or in flight: wait for the existing
   signal. Do not post duplicate `@codex review` requests while the probe says a
   current-head request is `requested`, `in_flight`, or `approved`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,15 +243,19 @@ baselines, and Terraform.
 
 ## PR description standard
 
-Every PR description must start with these sections, in this order:
+Every PR description must start with these exact heading lines, in this order:
 
-### The Problem
+```markdown
+## The Problem
+```
 
 - Maximum three bullets.
 - State the user/operator/reviewer problem in plain English.
 - Avoid implementation details unless they are needed to understand the impact.
 
-### The Solution
+```markdown
+## The Solution
+```
 
 - Explain in simple terms how the PR solves that problem.
 - Keep this understandable before reading the diff.

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -167,14 +167,19 @@ If the risky behavior is interactive, a static markup assertion is not enough.
 
 ## 6. PR description requirements
 
-Before opening the PR, start with the repo-wide description standard:
+Before opening the PR, start with the repo-wide description standard's exact
+heading lines:
 
-### The Problem
+```markdown
+## The Problem
+```
 
 - Maximum three bullets.
 - Explain the user/operator/reviewer problem in plain English.
 
-### The Solution
+```markdown
+## The Solution
+```
 
 - Explain in simple terms how the PR solves that problem.
 


### PR DESCRIPTION
## The Problem

- Repo guidance showed `### The Problem` / `### The Solution`, but the PR-description workflow enforces exact `##` headings.
- Babysitting Codex feedback could start with raw GitHub API calls even when `pr:ready-state --json` already includes enough blocker context for first triage.

## The Solution

- Align AGENTS and the stateful-data checklist with the enforced `## The Problem` / `## The Solution` heading level.
- Update the repo babysit-pr skill and Claude mirror to use `pr:ready-state --json` as a first triage aid for reported review blockers.
- Preserve the full GitHub feedback sweep requirement before all-clear.

## Details

- This is a docs/workflow-only follow-up from the PR #778 babysitting loop.
- No runtime dashboard, indexer, or infrastructure behavior changes.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (initial finding fixed)
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (clean)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Refs #778

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only workflow and skill text updates; no application, indexer, or infrastructure behavior changes.
> 
> **Overview**
> **Docs-only** alignment so agent-facing guidance matches what the PR workflow actually enforces, plus a faster first step when babysitting review blockers in Codex.
> 
> **PR description standard:** `AGENTS.md` and `docs/pr-checklists/stateful-data-ui.md` now require the opening sections to use exact `## The Problem` and `## The Solution` lines (shown in fenced examples), replacing references to `###` headings that disagreed with enforcement.
> 
> **Babysit PR:** The repo-local `babysit-pr` skill (`.agents/skills/` and `.claude/skills/` mirror) tells Codex to start triage from `pnpm pr:ready-state --pr <number> --json`, using `unresolvedReviewThreads[]` and `unrepliedRootReviewComments[]` for comment bodies and metadata before falling back to raw `gh api`. The mandatory full GitHub feedback sweep before all-clear is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0b62d9fd57d8441aef6faf8190b85113adb06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->