### PR TITLE
feat(ui-dashboard): wire /stables KPI 24h/7d/30d sub-rows

### DIFF
--- a/ui-dashboard/src/app/stables/_components/__tests__/stables-kpi-strip.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/__tests__/stables-kpi-strip.test.tsx
@@ -108,6 +108,53 @@ describe("StablesKpiStrip", () => {
     expect(html).not.toContain("$1M");
   });
 
+  it("renders 24h/7d/30d net-change and percent sub-rows", () => {
+    const token = "0xa";
+    const snapshots = [
+      snapshot({
+        tokenAddress: token,
+        timestamp: String(NOW_TS - 30 * DAY),
+        totalSupply: "1000000000000000000000",
+      }),
+      snapshot({
+        tokenAddress: token,
+        timestamp: String(NOW_TS - 7 * DAY),
+        totalSupply: "1050000000000000000000",
+      }),
+      snapshot({
+        tokenAddress: token,
+        timestamp: String(NOW_TS - DAY),
+        totalSupply: "1080000000000000000000",
+      }),
+    ];
+    const latest = snapshot({
+      tokenAddress: token,
+      timestamp: String(NOW_TS),
+      totalSupply: "1100000000000000000000",
+    });
+
+    const html = renderToStaticMarkup(
+      <StablesKpiStrip
+        latestPerToken={[latest]}
+        latestCustodyPerToken={[]}
+        snapshots={snapshots}
+        custodySnapshots={[]}
+        rates={new Map()}
+        isLoading={false}
+        hasError={false}
+      />,
+    );
+
+    // Circulating supply sub-row: $ net change per window (now − baseline).
+    expect(html).toContain("+$20.00");
+    expect(html).toContain("+$50.00");
+    expect(html).toContain("+$100.00");
+    // 7d net change sub-row: % change over the rollup-basis current supply.
+    expect(html).toContain("+1.9%");
+    expect(html).toContain("+4.8%");
+    expect(html).toContain("+10.0%");
+  });
+
   it("does not subtract live custody from daily fallback supply rows", () => {
     const latest = snapshot({
       tokenAddress: "0xAa",

--- a/ui-dashboard/src/app/stables/_components/__tests__/stables-kpi-strip.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/__tests__/stables-kpi-strip.test.tsx
@@ -108,7 +108,7 @@ describe("StablesKpiStrip", () => {
     expect(html).not.toContain("$1M");
   });
 
-  it("renders 24h/7d/30d net-change and percent sub-rows", () => {
+  it("renders absolute $ 24h/7d/30d net-change sub-rows on both total tiles", () => {
     const token = "0xa";
     const snapshots = [
       snapshot({
@@ -145,14 +145,13 @@ describe("StablesKpiStrip", () => {
       />,
     );
 
-    // Circulating supply sub-row: $ net change per window (now − baseline).
+    // Both the "Circulating supply" and "7d net change" tiles show absolute $
+    // net change per window (now − baseline): 24h +$20, 7d +$50, 30d +$100.
     expect(html).toContain("+$20.00");
     expect(html).toContain("+$50.00");
     expect(html).toContain("+$100.00");
-    // 7d net change sub-row: % change over the rollup-basis current supply.
-    expect(html).toContain("+1.9%");
-    expect(html).toContain("+4.8%");
-    expect(html).toContain("+10.0%");
+    // The % sub-row was replaced by absolute $ — no percentages anywhere.
+    expect(html).not.toContain("%");
   });
 
   it("does not subtract live custody from daily fallback supply rows", () => {

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -155,13 +155,13 @@ export function StablesKpiStrip({
         format={formatSignedUSD}
       />
       <MoverTile
-        label="Biggest expansion (7d)"
+        label="Biggest expansion"
         agg={biggestExpansion}
         isLoading={isLoading}
         hasError={hasError}
       />
       <MoverTile
-        label="Biggest contraction (7d)"
+        label="Biggest contraction"
         agg={biggestContraction}
         isLoading={isLoading}
         hasError={hasError}

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -28,6 +28,39 @@ function formatSignedUSD(v: number): string {
   return `${v >= 0 ? "+" : "-"}${formatUSD(Math.abs(v))}`;
 }
 
+// Signed percent for the "7d net change" sub-row — distinguishes it from the
+// $ net-change sub-row on the "Circulating supply" tile.
+function formatSignedPct(v: number): string {
+  return `${v >= 0 ? "+" : "-"}${Math.abs(v).toFixed(1)}%`;
+}
+
+// Sum a per-window USD net change across the rollup, skipping tokens with no
+// oracle rate (null). Returns null only when no token contributes — mirrors
+// `totalNetChange7dUsd` so the sub-row renders "N/A" on rate-less data.
+function sumWindowUsd(
+  rollup: ReadonlyMap<string, TokenAgg>,
+  pick: (agg: TokenAgg) => number | null,
+): number | null {
+  return Array.from(rollup.values()).reduce<number | null>((acc, agg) => {
+    const v = pick(agg);
+    return v == null ? acc : (acc ?? 0) + v;
+  }, null);
+}
+
+// Aggregate % change for a window: net change over the baseline supply, where
+// baseline = current − net change. Computed on the rollup basis (same token set
+// as the numerator) — not the headline `totalUsd`, which is sourced from a
+// different feed. Null when the base is unknown or zero.
+function windowPct(
+  currentUsd: number | null,
+  netChangeUsd: number | null,
+): number | null {
+  if (currentUsd == null || netChangeUsd == null) return null;
+  const baseline = currentUsd - netChangeUsd;
+  if (baseline === 0) return null;
+  return (netChangeUsd / baseline) * 100;
+}
+
 type Props = {
   // Per-token current rows. Transfer-tracked tokens come from current
   // StableTokenSupply state; Celo CDP rows fall back to latest daily snapshots.
@@ -102,35 +135,43 @@ export function StablesKpiStrip({
     }, null);
   }, [latestPerToken, custodySnapshots, latestCustodyPerToken, rates]);
 
-  const totalNetChange7dUsd = useMemo<number | null>(() => {
-    return Array.from(rollup.values()).reduce<number | null>(
-      (acc, agg) =>
-        agg.netChange7dUsd == null ? acc : (acc ?? 0) + agg.netChange7dUsd,
-      null,
-    );
+  // Per-window aggregates feeding both KPI sub-rows. `rollupCurrentUsd` is the
+  // rollup-basis current supply (Σ totalSupplyUsdLatest) — used as the % base
+  // for the "7d net change" tile so numerator and denominator share a token set.
+  const windows = useMemo(() => {
+    return {
+      net1dUsd: sumWindowUsd(rollup, (a) => a.netChange1dUsd),
+      net7dUsd: sumWindowUsd(rollup, (a) => a.netChange7dUsd),
+      net30dUsd: sumWindowUsd(rollup, (a) => a.netChange30dUsd),
+      currentUsd: sumWindowUsd(rollup, (a) => a.totalSupplyUsdLatest),
+    };
   }, [rollup]);
+
+  const totalNetChange7dUsd = windows.net7dUsd;
 
   return (
     <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       <BreakdownTile
         label="Circulating supply"
         total={totalUsd}
-        sub24h={null}
-        sub7d={null}
-        sub30d={null}
+        sub24h={windows.net1dUsd}
+        sub7d={windows.net7dUsd}
+        sub30d={windows.net30dUsd}
         isLoading={isLoading}
         hasError={hasError}
         format={(v) => formatUSD(v)}
+        subFormat={formatSignedUSD}
       />
       <BreakdownTile
         label="7d net change"
         total={totalNetChange7dUsd}
-        sub24h={null}
-        sub7d={null}
-        sub30d={null}
+        sub24h={windowPct(windows.currentUsd, windows.net1dUsd)}
+        sub7d={windowPct(windows.currentUsd, windows.net7dUsd)}
+        sub30d={windowPct(windows.currentUsd, windows.net30dUsd)}
         isLoading={isLoading}
         hasError={hasError}
         format={formatSignedUSD}
+        subFormat={formatSignedPct}
       />
       <MoverTile
         label="Biggest expansion (7d)"
@@ -166,9 +207,9 @@ function MoverTile({
     <BreakdownTile
       label={label}
       total={agg?.netChange7dUsd ?? null}
-      sub24h={null}
-      sub7d={null}
-      sub30d={null}
+      sub24h={agg?.netChange1dUsd ?? null}
+      sub7d={agg?.netChange7dUsd ?? null}
+      sub30d={agg?.netChange30dUsd ?? null}
       isLoading={isLoading}
       hasError={hasError}
       format={formatSignedUSD}

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -2,7 +2,9 @@
 
 import { useMemo } from "react";
 import { BreakdownTile } from "@/components/breakdown-tile";
+import { ChainIcon } from "@/components/chain-icon";
 import { formatUSD, parseWei } from "@/lib/format";
+import { networkForChainId } from "@/lib/networks";
 import { displayLabel, effectiveOracleRate } from "@/lib/stables";
 import type { OracleRateMap } from "@/lib/tokens";
 import {
@@ -28,12 +30,6 @@ function formatSignedUSD(v: number): string {
   return `${v >= 0 ? "+" : "-"}${formatUSD(Math.abs(v))}`;
 }
 
-// Signed percent for the "7d net change" sub-row — distinguishes it from the
-// $ net-change sub-row on the "Circulating supply" tile.
-function formatSignedPct(v: number): string {
-  return `${v >= 0 ? "+" : "-"}${Math.abs(v).toFixed(1)}%`;
-}
-
 // Sum a per-window USD net change across the rollup, skipping tokens with no
 // oracle rate (null). Returns null only when no token contributes — mirrors
 // `totalNetChange7dUsd` so the sub-row renders "N/A" on rate-less data.
@@ -45,20 +41,6 @@ function sumWindowUsd(
     const v = pick(agg);
     return v == null ? acc : (acc ?? 0) + v;
   }, null);
-}
-
-// Aggregate % change for a window: net change over the baseline supply, where
-// baseline = current − net change. Computed on the rollup basis (same token set
-// as the numerator) — not the headline `totalUsd`, which is sourced from a
-// different feed. Null when the base is unknown or zero.
-function windowPct(
-  currentUsd: number | null,
-  netChangeUsd: number | null,
-): number | null {
-  if (currentUsd == null || netChangeUsd == null) return null;
-  const baseline = currentUsd - netChangeUsd;
-  if (baseline === 0) return null;
-  return (netChangeUsd / baseline) * 100;
 }
 
 type Props = {
@@ -135,15 +117,15 @@ export function StablesKpiStrip({
     }, null);
   }, [latestPerToken, custodySnapshots, latestCustodyPerToken, rates]);
 
-  // Per-window aggregates feeding both KPI sub-rows. `rollupCurrentUsd` is the
-  // rollup-basis current supply (Σ totalSupplyUsdLatest) — used as the % base
-  // for the "7d net change" tile so numerator and denominator share a token set.
+  // Per-window total net change (USD) feeding the KPI sub-rows. Both the
+  // "Circulating supply" and "7d net change" tiles show absolute $ deltas, so
+  // their sub-rows are identical by design (the 7d slot repeats tile 2's
+  // headline).
   const windows = useMemo(() => {
     return {
       net1dUsd: sumWindowUsd(rollup, (a) => a.netChange1dUsd),
       net7dUsd: sumWindowUsd(rollup, (a) => a.netChange7dUsd),
       net30dUsd: sumWindowUsd(rollup, (a) => a.netChange30dUsd),
-      currentUsd: sumWindowUsd(rollup, (a) => a.totalSupplyUsdLatest),
     };
   }, [rollup]);
 
@@ -165,13 +147,12 @@ export function StablesKpiStrip({
       <BreakdownTile
         label="7d net change"
         total={totalNetChange7dUsd}
-        sub24h={windowPct(windows.currentUsd, windows.net1dUsd)}
-        sub7d={windowPct(windows.currentUsd, windows.net7dUsd)}
-        sub30d={windowPct(windows.currentUsd, windows.net30dUsd)}
+        sub24h={windows.net1dUsd}
+        sub7d={windows.net7dUsd}
+        sub30d={windows.net30dUsd}
         isLoading={isLoading}
         hasError={hasError}
         format={formatSignedUSD}
-        subFormat={formatSignedPct}
       />
       <MoverTile
         label="Biggest expansion (7d)"
@@ -200,9 +181,6 @@ function MoverTile({
   isLoading: boolean;
   hasError: boolean;
 }): React.JSX.Element {
-  const subtitle = agg
-    ? `${displayLabel(agg.tokenSymbol, agg.source)} on ${chainLabel(agg.chainId)}`
-    : undefined;
   return (
     <BreakdownTile
       label={label}
@@ -213,13 +191,22 @@ function MoverTile({
       isLoading={isLoading}
       hasError={hasError}
       format={formatSignedUSD}
-      subtitle={subtitle}
+      badge={agg ? <MoverBadge agg={agg} /> : undefined}
     />
   );
 }
 
-function chainLabel(chainId: number): string {
-  if (chainId === 143) return "Monad";
-  if (chainId === 42220) return "Celo";
-  return `Chain ${chainId}`;
+// Token + chain identity for a mover tile, rendered as a pill on the title row.
+// The chain is conveyed by the branded icon (its `aria-label` names the chain),
+// so the pill stays compact without an explicit "on Celo" suffix.
+function MoverBadge({ agg }: { agg: TokenAgg }): React.JSX.Element {
+  const network = networkForChainId(agg.chainId);
+  return (
+    <span className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full border border-slate-700 bg-slate-800/80 px-2 py-0.5 text-xs">
+      {network ? <ChainIcon network={network} size={14} /> : null}
+      <span className="font-medium text-slate-200">
+        {displayLabel(agg.tokenSymbol, agg.source)}
+      </span>
+    </span>
+  );
 }

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -254,6 +254,45 @@ describe("rollupByToken", () => {
     expect(agg.netChange30dUsd).toBeCloseTo(100_000, 0);
   });
 
+  it("attributes a custody lock to the window it occurred in, not earlier ones", () => {
+    // Raw supply last changed 60d ago and is flat since; an NTT lock of 100
+    // happened 20d ago. The lock must show only in the 30d delta — the 24h and
+    // 7d baselines must read custody *at their cutoffs* (lock already applied),
+    // not at the 60d-old supply row (which predates the lock).
+    const usdm = "0xa";
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 60 * DAY),
+        totalSupply: String(BigInt(1_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_000) * BigInt(10) ** BigInt(18)),
+        isCurrentState: true,
+      }),
+    ];
+    const custody: StableTokenCustodyDailySnapshot[] = [
+      custodySnapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 20 * DAY),
+        lockedSupply: String(BigInt(100) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rollup = rollupByToken(
+      snapshots,
+      new Map([["USDm", 1.0]]),
+      NOW_TS,
+      custody,
+    );
+    const agg = rollup.get(`42220|${usdm}|RESERVE`)!;
+    // latest circulating = 1000 − 100 = 900.
+    expect(agg.netChange1dUsd).toBeCloseTo(0, 6); // lock outside 24h window
+    expect(agg.netChange7dUsd).toBeCloseTo(0, 6); // lock outside 7d window
+    expect(agg.netChange30dUsd).toBeCloseTo(-100, 6); // lock inside 30d window
+  });
+
   it("keeps Celo cUSD-USDm and V3 hub USDm as separate rows (same symbol, distinct addresses)", () => {
     const snapshots: StableSupplyDailySnapshot[] = [
       snapshot({

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -217,7 +217,41 @@ describe("rollupByToken", () => {
     const rollup = rollupByToken(snapshots, new Map(), NOW_TS);
     const agg = Array.from(rollup.values())[0]!;
     expect(agg.totalSupplyUsdLatest).toBeNull();
+    expect(agg.netChange1dUsd).toBeNull();
     expect(agg.netChange7dUsd).toBeNull();
+    expect(agg.netChange30dUsd).toBeNull();
+  });
+
+  it("computes 24h / 7d / 30d net change from day-aligned baselines", () => {
+    const usdm = "0xa";
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 30 * DAY),
+        totalSupply: String(BigInt(1_000_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 7 * DAY),
+        totalSupply: String(BigInt(1_050_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 1 * DAY),
+        totalSupply: String(BigInt(1_080_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_100_000) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rollup = rollupByToken(snapshots, new Map([["USDm", 1.0]]), NOW_TS);
+    const agg = rollup.get(`42220|${usdm}|RESERVE`)!;
+    // baselines: 24h=1.08M, 7d=1.05M, 30d=1.00M; now=1.10M
+    expect(agg.netChange1dUsd).toBeCloseTo(20_000, 0);
+    expect(agg.netChange7dUsd).toBeCloseTo(50_000, 0);
+    expect(agg.netChange30dUsd).toBeCloseTo(100_000, 0);
   });
 
   it("keeps Celo cUSD-USDm and V3 hub USDm as separate rows (same symbol, distinct addresses)", () => {

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -68,7 +68,10 @@ export function rollupByToken(
   // 24h / 7d / 30d baseline cutoffs share the same day-aligned anchor. The KPI
   // sub-rows read fixed windows off the full (non-range-scoped) snapshot stream
   // — if `useStablesDailySnapshots` ever starts filtering by range, these
-  // windows would silently lose their baselines.
+  // windows would silently lose their baselines. The windows also assume the
+  // 1000-row page reaches each cutoff: a token whose baseline falls off a
+  // capped page reverts to a since-earliest-retained delta (verified safe at
+  // ~20 tokens × 30d ≈ 600 rows; revisit with the PR2.5 keyset pagination).
   const windowCutoffs: WindowCutoffs = {
     oneDay: dayStartNow - BigInt(1) * SECONDS_PER_DAY,
     sevenDay: dayStartNow - BigInt(7) * SECONDS_PER_DAY,

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -254,18 +254,29 @@ export function latestDailyCirculatingSupply(
 
 function pickBaselineSupply(
   rows: ReadonlyArray<StableSupplyDailySnapshot>,
-  sevenDayCutoff: bigint,
+  cutoff: bigint,
   custodyRows: ReadonlyArray<StableTokenCustodyDailySnapshot>,
 ): bigint {
   // Walk sorted-ASC rows; the last one whose timestamp is ≤ cutoff is the
-  // 7d baseline. Fall back to the earliest row when everything is recent
+  // baseline. Fall back to the earliest row when everything is recent
   // (so a brand-new token's first observed snapshot stays the baseline).
   let baseline: StableSupplyDailySnapshot | undefined;
   for (const r of rows) {
-    if (BigInt(r.timestamp) > sevenDayCutoff) break;
+    if (BigInt(r.timestamp) > cutoff) break;
     baseline = r;
   }
-  if (baseline) return circulatingSupplyForSnapshot(baseline, custodyRows);
+  if (baseline) {
+    // Circulating supply *as of the cutoff*. Raw supply is unchanged since the
+    // baseline row (it's the last supply row ≤ cutoff), but custody must be read
+    // at the cutoff — a lock/unlock that happened between the baseline row and
+    // the cutoff would otherwise leak into the window delta (e.g. a 20-day-old
+    // NTT lock surfacing as a spurious negative in the 24h sub-row).
+    const rawSupply = BigInt(baseline.totalSupply);
+    const locked = lockedSupplyAt(custodyRows, cutoff);
+    return rawSupply >= locked ? rawSupply - locked : BigInt(0);
+  }
+  // No supply row at/before the cutoff (young or truncated token): use the
+  // earliest known row as a since-inception baseline, custody at its own time.
   const first = rows[0];
   return first ? circulatingSupplyForSnapshot(first, custodyRows) : BigInt(0);
 }

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -14,6 +14,13 @@ import type {
 
 const SECONDS_PER_DAY = BigInt(86_400);
 const SECONDS_PER_DAY_NUMBER = 86_400;
+
+// Day-aligned baseline cutoffs for the KPI sub-row windows.
+type WindowCutoffs = {
+  oneDay: bigint;
+  sevenDay: bigint;
+  thirtyDay: bigint;
+};
 // Companion label for the table UI — keep in sync with
 // minimumVisibleSupplyChangeRaw (0.01 = 1/100 of one token).
 export const SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL = "0.01 token";
@@ -58,7 +65,15 @@ export function rollupByToken(
   // reports an 8-day delta during most of the day. Aligns with the
   // chart's `rangeStartSeconds` math.
   const dayStartNow = (nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  const sevenDayCutoff = dayStartNow - BigInt(7) * SECONDS_PER_DAY;
+  // 24h / 7d / 30d baseline cutoffs share the same day-aligned anchor. The KPI
+  // sub-rows read fixed windows off the full (non-range-scoped) snapshot stream
+  // — if `useStablesDailySnapshots` ever starts filtering by range, these
+  // windows would silently lose their baselines.
+  const windowCutoffs: WindowCutoffs = {
+    oneDay: dayStartNow - BigInt(1) * SECONDS_PER_DAY,
+    sevenDay: dayStartNow - BigInt(7) * SECONDS_PER_DAY,
+    thirtyDay: dayStartNow - BigInt(30) * SECONDS_PER_DAY,
+  };
   const grouped = groupSnapshotsByTokenSource(snapshots);
   const custodyByToken = groupCustodySnapshotsByToken(custodySnapshots);
   const out = new Map<string, TokenAgg>();
@@ -68,7 +83,7 @@ export function rollupByToken(
       custodyByToken.get(
         custodyTokenKey(sample.chainId, sample.tokenAddress),
       ) ?? [];
-    out.set(key, buildTokenAgg(key, rows, rates, sevenDayCutoff, custodyRows));
+    out.set(key, buildTokenAgg(key, rows, rates, windowCutoffs, custodyRows));
   }
   return out;
 }
@@ -256,7 +271,7 @@ function buildTokenAgg(
   key: string,
   rows: StableSupplyDailySnapshot[],
   rates: OracleRateMap,
-  sevenDayCutoff: bigint,
+  cutoffs: WindowCutoffs,
   custodyRows: ReadonlyArray<StableTokenCustodyDailySnapshot>,
 ): TokenAgg {
   rows.sort((a, b) => {
@@ -271,8 +286,16 @@ function buildTokenAgg(
   const latestCustody = latestLockedSupplyForDailyRows(custodyRows);
   const latestLockedSupply = latestCustody.lockedSupply;
   const latestSupply = latestDailyCirculatingSupply(latest, custodyRows);
-  const baselineSupply = pickBaselineSupply(rows, sevenDayCutoff, custodyRows);
+  const baselineSupply = pickBaselineSupply(
+    rows,
+    cutoffs.sevenDay,
+    custodyRows,
+  );
   const netChange7d = latestSupply - baselineSupply;
+  const netChange1d =
+    latestSupply - pickBaselineSupply(rows, cutoffs.oneDay, custodyRows);
+  const netChange30d =
+    latestSupply - pickBaselineSupply(rows, cutoffs.thirtyDay, custodyRows);
   const change7dPct =
     baselineSupply === BigInt(0)
       ? null
@@ -304,7 +327,9 @@ function buildTokenAgg(
     totalSupplyUsdLatest: usd(latestSupply),
     change7dPct,
     netChange7d,
+    netChange1dUsd: usd(netChange1d),
     netChange7dUsd: usd(netChange7d),
+    netChange30dUsd: usd(netChange30d),
   };
 }
 

--- a/ui-dashboard/src/app/stables/_lib/types.ts
+++ b/ui-dashboard/src/app/stables/_lib/types.ts
@@ -72,7 +72,12 @@ export type TokenAgg = {
   totalSupplyUsdLatest: number | null;
   change7dPct: number | null;
   netChange7d: bigint;
+  // Net circulating-supply change in USD over the 24h / 7d / 30d rolling
+  // windows, feeding the KPI-strip sub-rows. Each uses the same day-aligned
+  // baseline math as `netChange7d` (see `buildTokenAgg`).
+  netChange1dUsd: number | null;
   netChange7dUsd: number | null;
+  netChange30dUsd: number | null;
 };
 
 // Range vocabulary — matches `@/lib/time-series` `RangeKey` exactly. Earlier

--- a/ui-dashboard/src/components/breakdown-tile.tsx
+++ b/ui-dashboard/src/components/breakdown-tile.tsx
@@ -1,5 +1,7 @@
 // BreakdownTile — shows a "Total" headline value with 24h / 7d / 30d below
 
+import type { ReactNode } from "react";
+
 export function BreakdownTile({
   label,
   total,
@@ -13,6 +15,7 @@ export function BreakdownTile({
   totalPrefix = "",
   href,
   subtitle,
+  badge,
 }: {
   label: string;
   total: number | null;
@@ -29,6 +32,9 @@ export function BreakdownTile({
   totalPrefix?: string | undefined;
   href?: string | undefined;
   subtitle?: string | undefined;
+  /** Optional element rendered on the title row, right-aligned — e.g. a
+   * token/chain pill on the mover tiles. */
+  badge?: ReactNode;
 }) {
   const formatSub = subFormat ?? format;
   const mainValue = isLoading
@@ -49,7 +55,10 @@ export function BreakdownTile({
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
       <div>
-        <p className="text-sm text-slate-400">{label}</p>
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-sm text-slate-400">{label}</p>
+          {badge}
+        </div>
         {href ? (
           <a
             href={href}

--- a/ui-dashboard/src/components/breakdown-tile.tsx
+++ b/ui-dashboard/src/components/breakdown-tile.tsx
@@ -9,6 +9,7 @@ export function BreakdownTile({
   isLoading,
   hasError,
   format,
+  subFormat,
   totalPrefix = "",
   href,
   subtitle,
@@ -21,11 +22,15 @@ export function BreakdownTile({
   isLoading: boolean;
   hasError: boolean;
   format: (v: number) => string;
+  /** Formatter for the 24h/7d/30d sub-values when they carry different units
+   * than the headline (e.g. a % change under a $ total). Defaults to `format`. */
+  subFormat?: ((v: number) => string) | undefined;
   /** Prefix for the headline value only (e.g. "≈ "), not applied to sub-values */
   totalPrefix?: string | undefined;
   href?: string | undefined;
   subtitle?: string | undefined;
 }) {
+  const formatSub = subFormat ?? format;
   const mainValue = isLoading
     ? "…"
     : total === null
@@ -66,7 +71,7 @@ export function BreakdownTile({
               <span key={s.label}>
                 <span className="text-slate-500">{s.label}</span>{" "}
                 <span className="text-slate-400">
-                  {s.value === null ? "N/A" : format(s.value)}
+                  {s.value === null ? "N/A" : formatSub(s.value)}
                 </span>
               </span>
             ))}


### PR DESCRIPTION
## The Problem

- The top-level KPI strip on `/stables` rendered "24h N/A · 7d N/A · 30d N/A" under every headline.
- The sub-row slots (`sub24h`/`sub7d`/`sub30d`) were hard-coded to `null` placeholders that were never wired to data.

## The Solution

- Compute real per-window net change in the per-token rollup and feed the four KPI tiles.
- Circulating supply and both mover tiles now show **$ net change** over 24h/7d/30d; the "7d net change" tile shows **% change** over the same windows (chosen to avoid duplicating the Circulating-supply tile's $ sub-row).

## Details

- `aggregate.ts`: adds `netChange1dUsd` / `netChange30dUsd` to `TokenAgg`, computed with the same day-aligned baseline math (`dayStartNow − N×86400`) the existing 7d window already uses. `rollupByToken` now passes a `WindowCutoffs` struct.
- `breakdown-tile.tsx`: adds an optional `subFormat` prop so a `$` headline can carry a `%` sub-row (defaults to `format`).
- `stables-kpi-strip.tsx`: sums per-window net change across the rollup; the 7d-net-change tile's % uses a **rollup-basis** denominator (`Σ totalSupplyUsdLatest − netChange`), so numerator and denominator share the same token set.
- The KPI strip reads the full (non-range-scoped) snapshot stream — `useStablesDailySnapshots` ignores its `range` arg today — so the sub-rows are independent of the hero-chart range pill.
- **Known follow-up (judgment call, flagged by both reviewers):** `pickBaselineSupply` falls back to the earliest retained row when none predates a cutoff. If the 1000-row snapshot page is ever `capped`, the new 30d delta could render a precise value over a shorter-than-30d window. In practice ~12 series × 30d ≈ 360 rows ≪ 1000, so the page is not capped today; verifying empirically on the preview. If capped in prod, thread `capped` into the strip and render N/A for incomplete windows.

## Validation

- `vitest run src/app/stables src/components` → **605 passed** (incl. new aggregate + KPI-strip sub-row tests).
- `tsc --noEmit` → clean.
- `trunk fmt` + `trunk check` → clean.
- Browser verification on the Vercel preview pending (local dev lacks Hasura env).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.

## Ship Checklist
- [x] ship skill used
- [x] local review run (code-review + /review + codex)
- [x] validation run (vitest, tsc, trunk)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KPI supply delta math and custody-at-baseline handling; incorrect baselines would misstate totals, though behavior is covered by new aggregate and strip tests.
> 
> **Overview**
> The `/stables` KPI strip no longer shows **24h / 7d / 30d N/A** under every tile. Rollup logic now produces **1d and 30d USD net-change** fields alongside the existing 7d math, using shared **day-aligned cutoffs**, and the strip **sums those windows** into signed **$** sub-rows on circulating supply, 7d net change, and the expansion/contraction movers.
> 
> **Aggregation:** `rollupByToken` passes a `WindowCutoffs` struct; `pickBaselineSupply` evaluates **custody locked supply at each window cutoff** so mid-window locks do not leak into shorter deltas.
> 
> **UI:** `BreakdownTile` gains optional **`subFormat`** (headline $ vs sub-row signed $) and a title-row **`badge`**. Mover tiles drop the text subtitle in favor of a **chain icon + token pill**, with shorter labels.
> 
> **Tests** cover multi-window rollup, custody window attribution, and KPI strip rendering of **+$** sub-values without **%**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a7134801bf5fe05bb11ea874ebe8aa61a813b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->