### PR TITLE
Clarify failed integration route evidence

### DIFF
--- a/integration-probes/src/__tests__/evidence.test.ts
+++ b/integration-probes/src/__tests__/evidence.test.ts
@@ -97,4 +97,22 @@ describe("detectEvidence", () => {
     expect(result.sourceLabels).toEqual(["Mento"]);
     expect(result.evidence).toEqual([]);
   });
+
+  it("uses route venue fields instead of token names for downstream provider", () => {
+    const result = detectEvidence(
+      {
+        route: {
+          estimate: {
+            toToken: { name: "Mento Swiss Franc" },
+            actions: [{ data: { dex: "Uniswap V3" } }],
+          },
+        },
+      },
+      { routerAddresses: [ROUTER], poolAddresses: [POOL] },
+    );
+
+    expect(result.passes).toBe(false);
+    expect(result.sourceLabels).toEqual(["Mento Swiss Franc"]);
+    expect(result.downstreamProvider).toBe("Uniswap V3");
+  });
 });

--- a/integration-probes/src/evidence.ts
+++ b/integration-probes/src/evidence.ts
@@ -6,8 +6,8 @@ const ADDRESS_EXACT_RE = /^0x[a-fA-F0-9]{40}$/;
 const HEX_PAYLOAD_RE = /^0x(?:[a-fA-F0-9]{2})+$/;
 const ABI_ADDRESS_PADDING = "0".repeat(24);
 const MENTO_LABEL_RE = /\bmento\b/i;
-const LABEL_KEYS = new Set([
-  "name",
+const ROUTE_VENUE_KEYS = [
+  "dex",
   "tool",
   "toolName",
   "provider",
@@ -15,7 +15,9 @@ const LABEL_KEYS = new Set([
   "source",
   "label",
   "providerType",
-]);
+] as const;
+const TOKEN_METADATA_PATH_RE =
+  /\.(?:fromToken|toToken|token|token0|token1|coin|coins)\b/;
 const TARGET_KEYS = new Set(["to", "target", "txTarget", "allowanceTarget"]);
 
 export type EvidenceAddressBook = {
@@ -78,9 +80,15 @@ function sourceLabelEvidence(strings: readonly StringAtPath[]): string[] {
 function firstInterestingLabel(
   strings: readonly StringAtPath[],
 ): string | null {
-  for (const item of strings) {
-    if (!LABEL_KEYS.has(item.key)) continue;
-    if (item.value.length > 0 && item.value.length <= 80) return item.value;
+  for (const key of ROUTE_VENUE_KEYS) {
+    const label = strings.find(
+      (item) =>
+        item.key === key &&
+        !TOKEN_METADATA_PATH_RE.test(item.path) &&
+        item.value.length > 0 &&
+        item.value.length <= 80,
+    );
+    if (label) return label.value;
   }
   return null;
 }

--- a/ui-dashboard/src/app/integrations/__tests__/integration-probes-table.test.tsx
+++ b/ui-dashboard/src/app/integrations/__tests__/integration-probes-table.test.tsx
@@ -49,8 +49,94 @@ describe("IntegrationProbesTable", () => {
     );
 
     expect(html).toContain("FAILINGm -&gt; USDm");
-    expect(html).toContain("missing router evidence");
+    expect(html).toContain("no Mento v3 router/pool address evidence");
     expect(html).toContain("1 more route checks in the snapshot.");
+  });
+
+  it("explains strict address-evidence failures with the selected venue", () => {
+    const snapshot = fixtureSnapshot();
+    const chain = snapshot.aggregators[0]?.chains[0];
+    if (!chain) throw new Error("missing chain fixture");
+    chain.status = "fail";
+    chain.pairCoverage = { passed: 0, total: 1 };
+    chain.pairs = [
+      pairFixture({
+        chainId: chain.chainId,
+        poolId: `${chain.chainId}-0xfail`,
+        status: "fail",
+        sellSymbol: "CHFm",
+        error: null,
+        sourceLabels: ["Mento Dollar", "Mento Swiss Franc"],
+        downstreamProvider: "Mento Swiss Franc",
+        txTarget: "0x5615cdab10dc425a742d643d949a7f474c01abc4",
+        responsePreview:
+          '{"route":{"estimate":{"actions":[{"data":{"dex":"Uniswap V3","target":"0x5615CDAb10dc425a742d643d949a7F474C01abc4"}}]}}}',
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <IntegrationProbesTable snapshot={snapshot} />,
+    );
+
+    expect(html).toContain("CHFm -&gt; USDm");
+    expect(html).toContain("no Mento v3 router/pool address evidence");
+    expect(html).toContain("selected venue: Uniswap V3");
+    expect(html).toContain("venue Uniswap V3");
+    expect(html).toContain(
+      "tx target: 0x5615cdab10dc425a742d643d949a7f474c01abc4",
+    );
+    expect(html).not.toContain("provider Mento Swiss Franc");
+  });
+
+  it("prioritizes preview venue keys and ignores source-only labels", () => {
+    const snapshot = fixtureSnapshot();
+    const chain = snapshot.aggregators[0]?.chains[0];
+    if (!chain) throw new Error("missing chain fixture");
+    chain.status = "fail";
+    chain.pairCoverage = { passed: 0, total: 3 };
+    chain.pairs = [
+      pairFixture({
+        chainId: chain.chainId,
+        poolId: `${chain.chainId}-0xpriority`,
+        status: "fail",
+        sellSymbol: "CHFm",
+        error: null,
+        sourceLabels: ["Mento Swiss Franc"],
+        downstreamProvider: "Mento Swiss Franc",
+        responsePreview:
+          '{"provider":"Mento Swiss Franc","protocol":"Other","dex":"Uniswap V3"}',
+      }),
+      pairFixture({
+        chainId: chain.chainId,
+        poolId: `${chain.chainId}-0xlabel`,
+        status: "fail",
+        sellSymbol: "EURm",
+        error: null,
+        sourceLabels: ["Mento Euro"],
+        downstreamProvider: "Mento Euro",
+        responsePreview: '{"protocol":"Mento Euro"}',
+      }),
+      pairFixture({
+        chainId: chain.chainId,
+        poolId: `${chain.chainId}-0xprovider`,
+        status: "fail",
+        sellSymbol: "GBPm",
+        error: null,
+        downstreamProvider: "Uniswap V3",
+        responsePreview: '{"dex":"Other DEX"}',
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <IntegrationProbesTable snapshot={snapshot} />,
+    );
+
+    expect(html).toContain("selected venue: Uniswap V3");
+    expect(html).toContain("venue Uniswap V3");
+    expect(html).not.toContain("selected venue: Mento Euro");
+    expect(html).not.toContain("venue Mento Euro");
+    expect(html).not.toContain("selected venue: Other DEX");
+    expect(html).not.toContain("venue Other DEX");
   });
 });
 
@@ -135,12 +221,20 @@ function pairFixture({
   status,
   sellSymbol,
   error,
+  sourceLabels = [],
+  downstreamProvider = null,
+  txTarget = null,
+  responsePreview = null,
 }: {
   chainId: number;
   poolId: string;
   status: IntegrationProbeSnapshot["aggregators"][number]["chains"][number]["pairs"][number]["status"];
   sellSymbol: string;
   error: string | null;
+  sourceLabels?: string[];
+  downstreamProvider?: string | null;
+  txTarget?: string | null;
+  responsePreview?: string | null;
 }): IntegrationProbeSnapshot["aggregators"][number]["chains"][number]["pairs"][number] {
   const passing = status === "pass";
   return {
@@ -159,16 +253,16 @@ function pairFixture({
           },
         ]
       : [],
-    sourceLabels: [],
-    txTarget: null,
-    downstreamProvider: null,
+    sourceLabels,
+    txTarget,
+    downstreamProvider,
     routeVariant: passing ? "default" : null,
     routeAmountUsd: passing ? "1" : null,
     attemptCount: passing ? 3 : null,
     requestUrl: null,
     httpStatus: passing ? 200 : null,
     latencyMs: passing ? 42 : null,
-    responsePreview: null,
+    responsePreview,
     error,
   };
 }

--- a/ui-dashboard/src/app/integrations/_components/integration-probes-table.tsx
+++ b/ui-dashboard/src/app/integrations/_components/integration-probes-table.tsx
@@ -7,6 +7,15 @@ import type {
 import { IntegrationStatusBadge } from "./integration-status-badge";
 
 const CHAIN_ORDER = [42220, 143];
+const PREVIEW_VENUE_KEYS = [
+  "dex",
+  "tool",
+  "toolName",
+  "provider",
+  "protocol",
+  "source",
+  "providerType",
+] as const;
 
 export function IntegrationProbesTable({
   snapshot,
@@ -154,17 +163,31 @@ function evidenceText(pair: IntegrationProbeChain["pairs"][number]): string {
       .map((item) => `${item.type}: ${item.value}`)
       .join(" | ");
   }
+  if (pair.status === "fail") {
+    const venue = selectedVenue(pair);
+    const parts = [
+      "no Mento v3 router/pool address evidence",
+      venue ? `selected venue: ${venue}` : null,
+      pair.txTarget ? `tx target: ${pair.txTarget}` : null,
+      pair.sourceLabels.length > 0
+        ? `labels: ${pair.sourceLabels.join(", ")}`
+        : null,
+    ].filter((part): part is string => part !== null);
+    return parts.join("; ");
+  }
+  if (pair.error) return pair.error;
   if (pair.sourceLabels.length > 0) {
     return `label only: ${pair.sourceLabels.join(", ")}`;
   }
-  return pair.error ?? pair.downstreamProvider ?? "no address evidence";
+  return selectedVenue(pair) ?? "no address evidence";
 }
 
 function metaText(pair: IntegrationProbeChain["pairs"][number]): string {
+  const venue = selectedVenue(pair);
   const parts = [
     pair.httpStatus === null ? null : `HTTP ${pair.httpStatus}`,
     pair.latencyMs === null ? null : `${pair.latencyMs}ms`,
-    pair.downstreamProvider ? `provider ${pair.downstreamProvider}` : null,
+    venue ? `venue ${venue}` : null,
     pair.routeVariant ? `variant ${pair.routeVariant}` : null,
     pair.routeAmountUsd ? `amount ${pair.routeAmountUsd}` : null,
     pair.attemptCount && pair.attemptCount > 1
@@ -172,6 +195,43 @@ function metaText(pair: IntegrationProbeChain["pairs"][number]): string {
       : null,
   ].filter((part): part is string => part !== null);
   return parts.length > 0 ? parts.join(" | ") : "quote not requested";
+}
+
+function selectedVenue(
+  pair: IntegrationProbeChain["pairs"][number],
+): string | null {
+  if (
+    pair.downstreamProvider &&
+    !isSourceOnlyVenue(pair, pair.downstreamProvider)
+  ) {
+    return pair.downstreamProvider;
+  }
+  return venueFromPreview(pair);
+}
+
+function venueFromPreview(
+  pair: IntegrationProbeChain["pairs"][number],
+): string | null {
+  const preview = pair.responsePreview;
+  if (!preview) return null;
+  for (const key of PREVIEW_VENUE_KEYS) {
+    const venue = previewVenueValue(preview, key);
+    if (!venue || isSourceOnlyVenue(pair, venue)) continue;
+    return venue;
+  }
+  return null;
+}
+
+function previewVenueValue(preview: string, key: string): string | null {
+  const match = preview.match(new RegExp(`"${key}"\\s*:\\s*"([^"]+)"`));
+  return match?.[1] ?? null;
+}
+
+function isSourceOnlyVenue(
+  pair: IntegrationProbeChain["pairs"][number],
+  venue: string,
+): boolean {
+  return pair.status === "fail" && pair.sourceLabels.includes(venue);
 }
 
 function kindLabel(kind: IntegrationProbeAggregator["kind"]): string {


### PR DESCRIPTION
## The Problem

- Failed integration rows could show only Mento token labels, making it unclear why a quote failed strict Mento v3 validation.
- Squid responses with `dex: "Uniswap V3"` were displayed as `provider Mento Swiss Franc` because token names were treated like route providers.

## The Solution

- Prefer route venue fields such as `dex`, `tool`, `provider`, and `protocol` when extracting the downstream provider from probe responses.
- Show strict failures as missing Mento v3 router/pool address evidence, including the selected venue, tx target, and labels when available.
- Parse the stored response preview as a dashboard fallback so existing snapshots can explain selected venues before the next probe run.

## Invariants

- A route still passes only with Routerv300 or registered v3 pool/VirtualPool address evidence.
- Token names may appear as labels, but they must not be displayed as the selected route venue.
- Stored v1 snapshots remain compatible; no schema bump is required.

## Validation

- `pnpm --filter @mento-protocol/integration-probes test -- --runInBand`
- `pnpm --filter @mento-protocol/integration-probes typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/app/integrations/__tests__/integration-probes-table.test.tsx src/lib/__tests__/integration-probes.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm --filter @mento-protocol/integration-probes lint`
- `pnpm agent:quality-gate --run`
- Browser verified local preview route with Chrome DevTools: the expanded Squid row shows `selected venue: Uniswap V3`, `no Mento v3 router/pool address evidence`, and no console errors.

## Degraded Behavior

- If no venue can be extracted, failed rows still explain that Mento v3 address evidence is missing.
- If only source labels exist, they are rendered as labels rather than provider proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and evidence-labeling logic only; pass/fail still depends on Mento v3 router/pool address evidence with no schema change.
> 
> **Overview**
> Failed integration probe rows now explain **strict Mento v3 validation** more clearly: when a quote fails for missing router/pool address evidence, the UI shows that message plus **selected venue**, **tx target**, and **labels** instead of a generic error or misleading provider text.
> 
> **Probe evidence extraction** (`detectEvidence`) no longer treats arbitrary string keys (including token `name`) as the downstream provider. It walks a fixed priority list of route venue keys (`dex`, `tool`, `provider`, `protocol`, etc.) and skips values under token metadata paths so token names like "Mento Swiss Franc" stay as source labels while `dex: "Uniswap V3"` becomes the downstream provider.
> 
> The **dashboard table** adds `selectedVenue` logic: it prefers stored `downstreamProvider` when it is not a source-only label, otherwise parses `responsePreview` with the same venue key order so older snapshots still show the right venue. Meta lines use **venue** instead of **provider**, and source-only labels are filtered out as venues on failed rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c21514333065752bc0fcc457838ef0a717ce00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->