### PR TITLE
Classify Mento rebalancer volume as protocol

### DIFF
--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -28,7 +28,7 @@ This is mandatory for cross-layer/stateful data work. Do not assume the UI/query
 - `src/EventHandlers.ts` — Event processing logic
 - `src/contractAddresses.ts` — Contract address resolution from `@mento-protocol/contracts`; also exports `CONTRACT_NAMESPACE_BY_CHAIN` (backed by `config/deployment-namespaces.json`)
 - `config/deployment-namespaces.json` — Vendored copy of the chain ID → active namespace map used by Envio hosted builds
-- `config/protocolActors.json` — Manual protocol-controlled swap entry-point overrides for the dashboard volume filter. Dynamic pool rebalancers are classified from `Pool.rebalancerAddress`; add entries here only for protocol actors that are not already discoverable from pool state.
+- `config/protocolActors.json` — Manual protocol-controlled caller/entry-point overrides for the dashboard volume filter. Dynamic pool liquidity-strategy contracts are classified from `Pool.rebalancerAddress`; add entries here only for protocol actors that are not already discoverable from pool state or normal contract metadata.
 - `scripts/run-envio-with-env.mjs` — Wrapper that loads .env before running envio CLI
 - `scripts/checkYamlAddresses.mjs` — Drift gate; asserts every hex address in `config*.yaml` resolves to `@mento-protocol/contracts`, `config/nttAddresses.json`, or the inline allowlist (testnet pool instances). Runs in CI before codegen; invoke locally with `pnpm check:yaml-addresses`. When bumping the contracts package, run this first — a renamed entry shows up here in <1s.
 - `abis/` — Vendored ABIs, refreshed from `@mento-protocol/contracts` via `pnpm generate:abis`. ERC20 stub + Wormhole NTT minimal subsets are hand-vendored (excluded from the script — see `scripts/generateAbis.mjs` header).

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -56,11 +56,11 @@ This prevents collisions when the same contract address is deployed on multiple 
 | `config.multichain.testnet.yaml`     | Celo Sepolia + Monad Testnet                      |
 | `config.multichain.bridge-only.yaml` | Local bridge-flow validation harness              |
 
-`config/protocolActors.json` contains manual protocol-controlled swap
-entry-point overrides for the dashboard volume filter. Pool rebalancers are
-classified automatically from `Pool.rebalancerAddress`; add manual entries only
-for protocol actors that cannot be derived from pool state or the normal
-contract/NTT address metadata.
+`config/protocolActors.json` contains manual protocol-controlled caller and
+entry-point overrides for the dashboard volume filter. Pool liquidity-strategy
+contracts are classified automatically from `Pool.rebalancerAddress`; add
+manual entries only for protocol actors that cannot be derived from pool state
+or the normal contract/NTT address metadata.
 
 Deploy branch: `envio` → triggers hosted reindex on push.
 

--- a/indexer-envio/config/protocolActors.json
+++ b/indexer-envio/config/protocolActors.json
@@ -1,6 +1,12 @@
 {
-  "$comment": "Manual protocol-actor address overrides for the volume page. Dynamic pool rebalancers are classified from Pool.rebalancerAddress automatically; add real-chain entries only for protocol-controlled contracts that are not in contracts.json/nttAddresses.json or when tx.to should hide the signer from user-volume views. Chain 99999 is a test fixture for the manual override lookup path.",
+  "$comment": "Manual protocol-actor address overrides for the volume page. Entries classify both signer/caller matches and tx.to entry-point matches as non-organic protocol volume. For EOA entries, tx.to classification is mostly defensive; it is operationally meaningful for contract entries. Dynamic pool liquidity-strategy contracts are classified from Pool.rebalancerAddress automatically; add real-chain entries only for protocol-controlled actors that are not in contracts.json/nttAddresses.json or cannot be derived from pool state. Chain 99999 is a test fixture for the manual override lookup path.",
   "entries": [
+    {
+      "chainId": 42220,
+      "address": "0xaa8299FC6A685B5f9Ce9bdA8d0B3ea3D54731976",
+      "label": "mento-rebalancer",
+      "category": "rebalancer"
+    },
     {
       "chainId": 99999,
       "address": "0x0000000000000000000000000000000000000a11",

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -501,6 +501,11 @@ type BrokerTraderDailySnapshot
   caller: String! @index
   timestamp: BigInt! @index # UTC day bucket
   swapCount: Int!
+  # V2 route names this caller touched on this UTC day. Used to keep
+  # BrokerAggregatorDailySnapshot's primary fields consistent with the
+  # day-sticky isProtocolActor flag if a caller flips into protocol-actor
+  # classification after earlier same-day organic Broker swaps.
+  aggregatorKeys: [String!]!
   volumeUsdWei: BigInt!
   isProtocolActor: Boolean! @index
   # Block timestamp of the caller's most recent v2-direct swap within this
@@ -521,17 +526,31 @@ type BrokerAggregatorDailySnapshot {
   aggregator: String!
   lastSeenAggregatorAddress: String!
   timestamp: BigInt! @index
+  # Primary fields exclude protocol-actor callers and drive the dashboard's
+  # default view. The *IncludingProtocolActors siblings back the page-level mode.
   swapCount: Int!
+  swapCountIncludingProtocolActors: Int!
   uniqueTraders: Int!
+  uniqueTradersIncludingProtocolActors: Int!
   volumeUsdWei: BigInt!
+  volumeUsdWeiIncludingProtocolActors: BigInt!
 }
 
-# Existence-only marker: dedupes first-touch increments of
-# BrokerAggregatorDailySnapshot.uniqueTraders. Mirrors AggregatorTraderDayMarker.
+# Per-(aggregator, caller, day) marker: dedupes first-touch increments of
+# BrokerAggregatorDailySnapshot.uniqueTraders and carries the caller's route
+# contribution so the primary fields can be corrected if that caller-day flips
+# into protocol-actor classification. Mirrors AggregatorTraderDayMarker.
 # Keyed by `caller` (tx.from / signer EOA) so uniqueTraders counts distinct
 # signer EOAs per day, not distinct msg.sender contracts.
 type BrokerAggregatorTraderDayMarker {
   id: ID! # "{chainId}-{aggregator}-{caller}-{day}"
+  chainId: Int!
+  aggregator: String!
+  caller: String!
+  timestamp: BigInt!
+  swapCount: Int!
+  volumeUsdWei: BigInt!
+  isProtocolActor: Boolean!
 }
 
 # Per-(trader, tx.to, day) marker for v2 volume Via attribution at raw

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -65,6 +65,19 @@ function classifyBrokerEntryPoint(chainId: number, txTo: string): string {
   return classifyAggregator(chainId, txTo);
 }
 
+function appendUnique(values: readonly string[], value: string): string[] {
+  return values.includes(value) ? [...values] : [...values, value];
+}
+
+function subtractCount(value: number, delta: number): number {
+  return Math.max(0, value - delta);
+}
+
+function subtractWei(value: bigint, delta: bigint): bigint {
+  const next = value - delta;
+  return next > 0n ? next : 0n;
+}
+
 async function maybeHealBrokerCallerPool(
   context: EvmOnEventContext,
   pool: Pool | undefined,
@@ -84,6 +97,288 @@ async function preloadBrokerSwapInputs(args: {
     args.context.BrokerExchangeDailySnapshot.get(args.exchangeSnapshotId),
     args.context.Pool.get(args.brokerCallerPoolId),
   ]);
+}
+
+const EMPTY_BROKER_TRADER_DAY = {
+  swapCount: 0,
+  aggregatorKeys: [] as readonly string[],
+  volumeUsdWei: 0n,
+  isProtocolActor: false,
+};
+
+const EMPTY_BROKER_AGG_DAY = {
+  swapCount: 0,
+  swapCountIncludingProtocolActors: 0,
+  uniqueTraders: 0,
+  uniqueTradersIncludingProtocolActors: 0,
+  volumeUsdWei: 0n,
+  volumeUsdWeiIncludingProtocolActors: 0n,
+};
+
+const EMPTY_BROKER_AGG_CORRECTION = {
+  swapCount: 0,
+  uniqueTraders: 0,
+  volumeUsdWei: 0n,
+};
+
+type BrokerTraderDayState = {
+  callerDayBecameProtocolActor: boolean;
+  callerDayIsProtocolActor: boolean;
+  aggregatorKeys: readonly string[];
+};
+
+export type BrokerAggregatorMarkerLike = {
+  swapCount?: number;
+  volumeUsdWei?: bigint;
+  isProtocolActor?: boolean;
+};
+
+export type BrokerAggregatorCorrection = {
+  swapCount: number;
+  uniqueTraders: number;
+  volumeUsdWei: bigint;
+};
+
+type BrokerTraderDayLike = {
+  swapCount: number;
+  aggregatorKeys?: readonly string[];
+  volumeUsdWei: bigint;
+  isProtocolActor: boolean;
+};
+
+type BrokerAggregatorDayLike = {
+  swapCount: number;
+  swapCountIncludingProtocolActors?: number;
+  uniqueTraders: number;
+  uniqueTradersIncludingProtocolActors?: number;
+  volumeUsdWei: bigint;
+  volumeUsdWeiIncludingProtocolActors?: bigint;
+};
+
+function correctionFromBrokerAggregatorMarker(
+  marker: BrokerAggregatorMarkerLike | undefined,
+): BrokerAggregatorCorrection | undefined {
+  if (!marker || marker.isProtocolActor !== false) return undefined;
+  if (
+    typeof marker.swapCount !== "number" ||
+    typeof marker.volumeUsdWei !== "bigint"
+  ) {
+    return undefined;
+  }
+  return {
+    swapCount: marker.swapCount,
+    uniqueTraders: 1,
+    volumeUsdWei: marker.volumeUsdWei,
+  };
+}
+
+export const _testHooks = {
+  correctionFromBrokerAggregatorMarker,
+};
+
+async function collectBrokerAggregatorPrimaryCorrections(
+  context: EvmOnEventContext,
+  args: {
+    chainId: number;
+    caller: string;
+    dayTs: bigint;
+    aggregator: string;
+    aggregatorKeys: readonly string[];
+    existingAggCallerMarker: BrokerAggregatorMarkerLike | undefined;
+  },
+): Promise<Map<string, BrokerAggregatorCorrection>> {
+  const corrections = new Map<string, BrokerAggregatorCorrection>();
+  const touchedMarkers = await Promise.all(
+    args.aggregatorKeys.map(async (touchedAggregator) => {
+      const marker =
+        touchedAggregator === args.aggregator
+          ? args.existingAggCallerMarker
+          : await context.BrokerAggregatorTraderDayMarker.get(
+              `${args.chainId}-${touchedAggregator}-${args.caller}-${args.dayTs}`,
+            );
+      return { touchedAggregator, marker };
+    }),
+  );
+
+  for (const { touchedAggregator, marker } of touchedMarkers) {
+    const correction = correctionFromBrokerAggregatorMarker(marker);
+    if (!correction) continue;
+    corrections.set(touchedAggregator, correction);
+  }
+
+  const touchedAggDays = await Promise.all(
+    Array.from(corrections, async ([touchedAggregator]) => {
+      if (touchedAggregator === args.aggregator) return { touchedAggregator };
+      const touchedAggDay = await context.BrokerAggregatorDailySnapshot.get(
+        `${args.chainId}-${touchedAggregator}-${args.dayTs}`,
+      );
+      return { touchedAggregator, touchedAggDay };
+    }),
+  );
+
+  for (const { touchedAggregator, touchedAggDay } of touchedAggDays) {
+    if (touchedAggregator === args.aggregator) continue;
+    if (!touchedAggDay) continue;
+    const correction = corrections.get(touchedAggregator);
+    if (!correction) continue;
+    context.BrokerAggregatorDailySnapshot.set({
+      ...touchedAggDay,
+      swapCount: subtractCount(touchedAggDay.swapCount, correction.swapCount),
+      uniqueTraders: subtractCount(
+        touchedAggDay.uniqueTraders,
+        correction.uniqueTraders,
+      ),
+      volumeUsdWei: subtractWei(
+        touchedAggDay.volumeUsdWei,
+        correction.volumeUsdWei,
+      ),
+    });
+  }
+
+  return corrections;
+}
+
+function upsertBrokerTraderDailySnapshot(
+  context: EvmOnEventContext,
+  args: {
+    chainId: number;
+    caller: string;
+    callerDayId: string;
+    dayTs: bigint;
+    blockTimestamp: bigint;
+    volumeUsdWei: bigint;
+    aggregator: string;
+    callerIsProtocolActor: boolean;
+    existingCallerDay: BrokerTraderDayLike | undefined;
+  },
+): BrokerTraderDayState {
+  const prevCallerDay = args.existingCallerDay ?? EMPTY_BROKER_TRADER_DAY;
+  const callerDayIsProtocolActor =
+    prevCallerDay.isProtocolActor || args.callerIsProtocolActor;
+  const callerDayBecameProtocolActor =
+    args.existingCallerDay !== undefined &&
+    !prevCallerDay.isProtocolActor &&
+    args.callerIsProtocolActor;
+  const aggregatorKeys = appendUnique(
+    prevCallerDay.aggregatorKeys ?? [],
+    args.aggregator,
+  );
+
+  context.BrokerTraderDailySnapshot.set({
+    id: args.callerDayId,
+    chainId: args.chainId,
+    caller: args.caller,
+    timestamp: args.dayTs,
+    swapCount: prevCallerDay.swapCount + 1,
+    aggregatorKeys,
+    volumeUsdWei: prevCallerDay.volumeUsdWei + args.volumeUsdWei,
+    isProtocolActor: callerDayIsProtocolActor,
+    lastSeenTimestamp: args.blockTimestamp,
+  });
+
+  return {
+    callerDayBecameProtocolActor,
+    callerDayIsProtocolActor,
+    aggregatorKeys,
+  };
+}
+
+async function upsertBrokerAggregatorDailySnapshot(
+  context: EvmOnEventContext,
+  args: {
+    chainId: number;
+    caller: string;
+    txTo: string;
+    dayTs: bigint;
+    volumeUsdWei: bigint;
+    aggregator: string;
+    aggDayId: string;
+    aggCallerFirstTouch: boolean;
+    existingAggDay: BrokerAggregatorDayLike | undefined;
+    existingAggCallerMarker: BrokerAggregatorMarkerLike | undefined;
+    traderDayState: BrokerTraderDayState;
+  },
+): Promise<void> {
+  const corrections = args.traderDayState.callerDayBecameProtocolActor
+    ? await collectBrokerAggregatorPrimaryCorrections(context, {
+        chainId: args.chainId,
+        caller: args.caller,
+        dayTs: args.dayTs,
+        aggregator: args.aggregator,
+        aggregatorKeys: args.traderDayState.aggregatorKeys,
+        existingAggCallerMarker: args.existingAggCallerMarker,
+      })
+    : new Map<string, BrokerAggregatorCorrection>();
+  const prevAggDay = args.existingAggDay ?? EMPTY_BROKER_AGG_DAY;
+  const correction =
+    corrections.get(args.aggregator) ?? EMPTY_BROKER_AGG_CORRECTION;
+  const primarySwapBase = subtractCount(
+    prevAggDay.swapCount,
+    correction.swapCount,
+  );
+  const primaryUniqueBase = subtractCount(
+    prevAggDay.uniqueTraders,
+    correction.uniqueTraders,
+  );
+  const primaryVolumeBase = subtractWei(
+    prevAggDay.volumeUsdWei,
+    correction.volumeUsdWei,
+  );
+  const prevSwapCountIncludingProtocolActors =
+    prevAggDay.swapCountIncludingProtocolActors ?? prevAggDay.swapCount;
+  const prevUniqueTradersIncludingProtocolActors =
+    prevAggDay.uniqueTradersIncludingProtocolActors ?? prevAggDay.uniqueTraders;
+  const prevVolumeUsdWeiIncludingProtocolActors =
+    prevAggDay.volumeUsdWeiIncludingProtocolActors ?? prevAggDay.volumeUsdWei;
+  const callerDayIsProtocolActor = args.traderDayState.callerDayIsProtocolActor;
+
+  context.BrokerAggregatorDailySnapshot.set({
+    id: args.aggDayId,
+    chainId: args.chainId,
+    aggregator: args.aggregator,
+    lastSeenAggregatorAddress: args.txTo,
+    timestamp: args.dayTs,
+    swapCount: primarySwapBase + (callerDayIsProtocolActor ? 0 : 1),
+    swapCountIncludingProtocolActors: prevSwapCountIncludingProtocolActors + 1,
+    uniqueTraders:
+      primaryUniqueBase +
+      (!callerDayIsProtocolActor && args.aggCallerFirstTouch ? 1 : 0),
+    uniqueTradersIncludingProtocolActors:
+      prevUniqueTradersIncludingProtocolActors +
+      (args.aggCallerFirstTouch ? 1 : 0),
+    volumeUsdWei:
+      primaryVolumeBase + (callerDayIsProtocolActor ? 0n : args.volumeUsdWei),
+    volumeUsdWeiIncludingProtocolActors:
+      prevVolumeUsdWeiIncludingProtocolActors + args.volumeUsdWei,
+  });
+}
+
+function upsertBrokerAggregatorTraderDayMarker(
+  context: EvmOnEventContext,
+  args: {
+    chainId: number;
+    caller: string;
+    dayTs: bigint;
+    volumeUsdWei: bigint;
+    aggregator: string;
+    aggCallerMarkerId: string;
+    existingAggCallerMarker: BrokerAggregatorMarkerLike | undefined;
+    callerDayIsProtocolActor: boolean;
+  },
+): void {
+  context.BrokerAggregatorTraderDayMarker.set({
+    id: args.aggCallerMarkerId,
+    chainId: args.chainId,
+    aggregator: args.aggregator,
+    caller: args.caller,
+    timestamp: args.dayTs,
+    swapCount: (args.existingAggCallerMarker?.swapCount ?? 0) + 1,
+    volumeUsdWei:
+      (args.existingAggCallerMarker?.volumeUsdWei ?? 0n) + args.volumeUsdWei,
+    isProtocolActor:
+      (args.existingAggCallerMarker?.isProtocolActor ?? false) ||
+      args.callerDayIsProtocolActor,
+  });
 }
 
 async function writeBrokerProducerRollups(args: {
@@ -123,23 +418,20 @@ async function writeBrokerProducerRollups(args: {
     context.BrokerAggregatorDailySnapshot.get(aggDayId),
     context.BrokerTraderRouterDayMarker.get(traderRouterMarkerId),
   ]);
-  context.BrokerTraderDailySnapshot.set({
-    id: callerDayId,
+
+  const traderDayState = upsertBrokerTraderDailySnapshot(context, {
     chainId,
     caller,
-    timestamp: dayTs,
-    swapCount: (existingCallerDay?.swapCount ?? 0) + 1,
-    volumeUsdWei: (existingCallerDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
-    isProtocolActor: existingCallerDay
-      ? existingCallerDay.isProtocolActor || callerIsProtocolActor
-      : callerIsProtocolActor,
-    lastSeenTimestamp: blockTimestamp,
+    callerDayId,
+    dayTs,
+    blockTimestamp,
+    volumeUsdWei,
+    aggregator,
+    callerIsProtocolActor,
+    existingCallerDay,
   });
 
   const aggCallerFirstTouch = existingAggCallerMarker === undefined;
-  if (aggCallerFirstTouch) {
-    context.BrokerAggregatorTraderDayMarker.set({ id: aggCallerMarkerId });
-  }
   if (existingTraderRouterMarker === undefined) {
     context.BrokerTraderRouterDayMarker.set({
       id: traderRouterMarkerId,
@@ -150,16 +442,30 @@ async function writeBrokerProducerRollups(args: {
       timestamp: dayTs,
     });
   }
-  context.BrokerAggregatorDailySnapshot.set({
-    id: aggDayId,
+
+  await upsertBrokerAggregatorDailySnapshot(context, {
     chainId,
+    caller,
+    txTo,
+    dayTs,
+    volumeUsdWei,
     aggregator,
-    lastSeenAggregatorAddress: txTo,
-    timestamp: dayTs,
-    swapCount: (existingAggDay?.swapCount ?? 0) + 1,
-    uniqueTraders:
-      (existingAggDay?.uniqueTraders ?? 0) + (aggCallerFirstTouch ? 1 : 0),
-    volumeUsdWei: (existingAggDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    aggDayId,
+    aggCallerFirstTouch,
+    existingAggDay,
+    existingAggCallerMarker,
+    traderDayState,
+  });
+
+  upsertBrokerAggregatorTraderDayMarker(context, {
+    chainId,
+    caller,
+    dayTs,
+    volumeUsdWei,
+    aggregator,
+    aggCallerMarkerId,
+    existingAggCallerMarker,
+    callerDayIsProtocolActor: traderDayState.callerDayIsProtocolActor,
   });
 }
 

--- a/indexer-envio/src/protocol-actors.ts
+++ b/indexer-envio/src/protocol-actors.ts
@@ -65,10 +65,13 @@ const ALL_INDEXED_CHAIN_IDS: number[] = Object.keys(
  *   may be implementation contracts in the registry) are filtered cheaply.
  * - Wormhole-NTT helper / nttManager / transceiver proxies from
  *   `config/nttAddresses.json` for cross-chain liquidity flows.
+ * - Manual protocol actors from `config/protocolActors.json` for signer EOAs
+ *   or entry-point contracts that are not discoverable from the normal
+ *   contract metadata.
  *
- * Per-pool rebalancer EOAs are NOT in this static set — they're stored on
- * `Pool.rebalancerAddress` and checked dynamically in `isProtocolOwnedAddress(...)`
- * via the optional `pool` argument.
+ * Per-pool liquidity-strategy contracts are stored on `Pool.rebalancerAddress`
+ * and checked dynamically in `isProtocolOwnedAddress(...)` via the optional
+ * `pool` argument.
  */
 // Per-chain NTT-bridge address index. Built first so it can be reused by
 // both `PROTOCOL_OWNED_ADDRESSES_BY_CHAIN` (union into the protocol-owned set) and
@@ -144,8 +147,8 @@ const MANUAL_PROTOCOL_ACTORS_BY_CHAIN: Map<number, Set<string>> = (() => {
  * table by default (with a UI toggle to show them separately).
  *
  * Pass `pool` when the address is being classified in a swap context: the
- * pool's `rebalancerAddress` is the dynamic per-pool EOA that wouldn't be
- * in the static contracts.json set.
+ * pool's `rebalancerAddress` is the dynamic per-pool liquidity-strategy
+ * contract that may not be in the static contracts.json set.
  */
 export function isProtocolOwnedAddress(
   chainId: number,
@@ -155,6 +158,7 @@ export function isProtocolOwnedAddress(
   if (!addr) return false;
   const lower = addr.toLowerCase();
   if (PROTOCOL_OWNED_ADDRESSES_BY_CHAIN.get(chainId)?.has(lower)) return true;
+  if (MANUAL_PROTOCOL_ACTORS_BY_CHAIN.get(chainId)?.has(lower)) return true;
   if (
     pool?.rebalancerAddress &&
     pool.rebalancerAddress.toLowerCase() === lower
@@ -169,9 +173,9 @@ export function isProtocolOwnedAddress(
  * initiated by protocol automation. This is intentionally narrower than
  * `isProtocolOwnedAddress`: the protocol-owned set includes user-facing Broker/Router
  * contracts, and OR-checking those direct entry points would hide normal users
- * routing through the Mento UI. Dynamic pool rebalancers, manual overrides,
- * and non-user-facing static contracts are safe tx.to filters because those
- * contracts are protocol-controlled actors.
+ * routing through the Mento UI. Dynamic pool liquidity strategies, manual
+ * overrides, and non-user-facing static contracts are safe tx.to filters
+ * because those contracts are protocol-controlled actors.
  */
 export function isProtocolActorEntryPoint(
   chainId: number,

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -8,6 +8,7 @@ import {
   _setMockFeeTokenMeta,
   _clearMockFeeTokenMeta,
 } from "../src/EventHandlers.ts";
+import { _testHooks as brokerTestHooks } from "../src/handlers/broker.ts";
 import { dayBucket, makePoolId } from "../src/helpers.ts";
 import { getContractAddress } from "../src/contractAddresses.ts";
 
@@ -48,6 +49,8 @@ const BROKER_PROXY = "0x777A8255cA72412f0d706dc03C9D1987306B4CaD";
 // brokerCaller (Router direct-to-Broker vs VirtualPool).
 const V3_ROUTER = "0x4861840C2EfB2b98312B0aE34d86fD73E8f9B6f6";
 const OPEN_LIQUIDITY_STRATEGY = "0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f";
+const SQUID_ROUTER = "0xce16f69375520ab01377ce7b88f5ba8c48f8d666";
+const MENTO_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 const VIRTUAL_POOL_ADDR =
   "0x00000000000000000000000000000000000000aa".toLowerCase();
 
@@ -504,6 +507,147 @@ describe("Broker.Swap handler", () => {
     assert.isOk(row, "BrokerTraderDailySnapshot row missing");
     assert.equal(row!.caller, NORMAL_EOA.toLowerCase());
     assert.equal(row!.isProtocolActor, true);
+  });
+
+  it("flags v2 signer rows as protocol actor when caller is the manual Mento rebalancer", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: SQUID_ROUTER,
+      brokerCaller: SQUID_ROUTER,
+      txFrom: MENTO_REBALANCER_EOA,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const id = `${CHAIN_CELO}-${MENTO_REBALANCER_EOA}-${dayTs}`;
+    const row = mockDb.entities.BrokerTraderDailySnapshot.get(id) as
+      | { caller: string; isProtocolActor: boolean; aggregatorKeys: string[] }
+      | undefined;
+    assert.isOk(row, "BrokerTraderDailySnapshot row missing");
+    assert.equal(row!.caller, MENTO_REBALANCER_EOA);
+    assert.equal(row!.isProtocolActor, true);
+    assert.deepEqual(row!.aggregatorKeys, ["squid"]);
+
+    const aggRow = mockDb.entities.BrokerAggregatorDailySnapshot.get(
+      `${CHAIN_CELO}-squid-${dayTs}`,
+    ) as
+      | {
+          swapCount: number;
+          swapCountIncludingProtocolActors: number;
+          uniqueTraders: number;
+          uniqueTradersIncludingProtocolActors: number;
+          volumeUsdWei: bigint;
+          volumeUsdWeiIncludingProtocolActors: bigint;
+        }
+      | undefined;
+    assert.isOk(aggRow, "BrokerAggregatorDailySnapshot row missing");
+    assert.equal(aggRow!.swapCount, 0);
+    assert.equal(aggRow!.swapCountIncludingProtocolActors, 1);
+    assert.equal(aggRow!.uniqueTraders, 0);
+    assert.equal(aggRow!.uniqueTradersIncludingProtocolActors, 1);
+    assert.equal(aggRow!.volumeUsdWei, 0n);
+    assert.equal(
+      aggRow!.volumeUsdWeiIncludingProtocolActors,
+      1_000n * 10n ** 18n,
+    );
+  });
+
+  it("subtracts prior v2 aggregator primary volume when a caller day flips protocol actor", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: SQUID_ROUTER,
+      brokerCaller: SQUID_ROUTER,
+    });
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 101,
+      blockTimestamp: 1_700_000_500,
+      logIndex: 0,
+      txTo: OPEN_LIQUIDITY_STRATEGY,
+      brokerCaller: OPEN_LIQUIDITY_STRATEGY,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
+      `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
+    ) as { isProtocolActor: boolean; aggregatorKeys: string[] } | undefined;
+    assert.isOk(traderRow, "BrokerTraderDailySnapshot row missing");
+    assert.equal(traderRow!.isProtocolActor, true);
+    assert.deepEqual(traderRow!.aggregatorKeys, ["squid", "protocol"]);
+
+    const squid = mockDb.entities.BrokerAggregatorDailySnapshot.get(
+      `${CHAIN_CELO}-squid-${dayTs}`,
+    ) as
+      | {
+          swapCount: number;
+          swapCountIncludingProtocolActors: number;
+          uniqueTraders: number;
+          uniqueTradersIncludingProtocolActors: number;
+          volumeUsdWei: bigint;
+          volumeUsdWeiIncludingProtocolActors: bigint;
+        }
+      | undefined;
+    assert.isOk(squid, "Squid BrokerAggregatorDailySnapshot row missing");
+    assert.equal(squid!.swapCount, 0);
+    assert.equal(squid!.swapCountIncludingProtocolActors, 1);
+    assert.equal(squid!.uniqueTraders, 0);
+    assert.equal(squid!.uniqueTradersIncludingProtocolActors, 1);
+    assert.equal(squid!.volumeUsdWei, 0n);
+    assert.equal(
+      squid!.volumeUsdWeiIncludingProtocolActors,
+      1_000n * 10n ** 18n,
+    );
+
+    const protocol = mockDb.entities.BrokerAggregatorDailySnapshot.get(
+      `${CHAIN_CELO}-protocol-${dayTs}`,
+    ) as
+      | {
+          swapCount: number;
+          swapCountIncludingProtocolActors: number;
+          uniqueTraders: number;
+          uniqueTradersIncludingProtocolActors: number;
+          volumeUsdWei: bigint;
+          volumeUsdWeiIncludingProtocolActors: bigint;
+        }
+      | undefined;
+    assert.isOk(protocol, "Protocol BrokerAggregatorDailySnapshot row missing");
+    assert.equal(protocol!.swapCount, 0);
+    assert.equal(protocol!.swapCountIncludingProtocolActors, 1);
+    assert.equal(protocol!.uniqueTraders, 0);
+    assert.equal(protocol!.uniqueTradersIncludingProtocolActors, 1);
+    assert.equal(protocol!.volumeUsdWei, 0n);
+    assert.equal(
+      protocol!.volumeUsdWeiIncludingProtocolActors,
+      1_000n * 10n ** 18n,
+    );
+  });
+
+  it("ignores old v2 aggregator markers that lack primary contribution fields", () => {
+    assert.isUndefined(
+      brokerTestHooks.correctionFromBrokerAggregatorMarker({}),
+    );
+    assert.isUndefined(
+      brokerTestHooks.correctionFromBrokerAggregatorMarker({
+        swapCount: 1,
+        isProtocolActor: false,
+      }),
+    );
+    assert.deepEqual(
+      brokerTestHooks.correctionFromBrokerAggregatorMarker({
+        swapCount: 2,
+        volumeUsdWei: 3_000n,
+        isProtocolActor: false,
+      }),
+      {
+        swapCount: 2,
+        uniqueTraders: 1,
+        volumeUsdWei: 3_000n,
+      },
+    );
   });
 
   it("does NOT write trader/aggregator rollups when routedViaV3Router=true (avoids double-count vs v3)", async () => {

--- a/indexer-envio/test/protocol-actors.test.ts
+++ b/indexer-envio/test/protocol-actors.test.ts
@@ -17,6 +17,7 @@ const CELO_OPEN_LIQUIDITY_STRATEGY =
   "0x54e2ae8c8448912e17ce0b2453bafb7b0d80e40f";
 const CELO_PROTOCOL_FEE_RECIPIENT =
   "0x0dd57f6f181d0469143fe9380762d8a112e96e4a";
+const CELO_MENTO_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 
 // Real Monad addresses + an NTT transceiver proxy from nttAddresses.json.
 const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";
@@ -37,6 +38,17 @@ describe("isProtocolOwnedAddress", () => {
     assert.equal(isProtocolOwnedAddress(CHAIN_CELO, CELO_RESERVE), true);
     assert.equal(
       isProtocolOwnedAddress(CHAIN_CELO, CELO_PROTOCOL_FEE_RECIPIENT),
+      true,
+    );
+  });
+
+  it("flags manual Celo protocol actor EOAs as protocol-owned callers", () => {
+    assert.equal(
+      isProtocolOwnedAddress(CHAIN_CELO, CELO_MENTO_REBALANCER_EOA),
+      true,
+    );
+    assert.equal(
+      isProtocolActorEntryPoint(CHAIN_CELO, CELO_MENTO_REBALANCER_EOA),
       true,
     );
   });
@@ -126,8 +138,16 @@ describe("isProtocolOwnedAddress", () => {
 
   it("flags manual protocol actor overrides by chain", () => {
     assert.equal(
+      isProtocolOwnedAddress(CHAIN_TEST_FIXTURE, TEST_MANUAL_PROTOCOL_ACTOR),
+      true,
+    );
+    assert.equal(
       isProtocolActorEntryPoint(CHAIN_TEST_FIXTURE, TEST_MANUAL_PROTOCOL_ACTOR),
       true,
+    );
+    assert.equal(
+      isProtocolOwnedAddress(CHAIN_CELO, TEST_MANUAL_PROTOCOL_ACTOR),
+      false,
     );
     assert.equal(
       isProtocolActorEntryPoint(CHAIN_CELO, TEST_MANUAL_PROTOCOL_ACTOR),

--- a/indexer-envio/test/volumeSnapshots.test.ts
+++ b/indexer-envio/test/volumeSnapshots.test.ts
@@ -22,6 +22,7 @@ const TRADER_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const SQUID = "0xce16f69375520ab01377ce7b88f5ba8c48f8d666";
 const LIFI = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
 const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+const MENTO_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 const POOL_ADDR_1 = "0x1111111111111111111111111111111111111111";
 const POOL_ADDR_2 = "0x2222222222222222222222222222222222222222";
 const POOL_ID_1 = `${CHAIN}-${POOL_ADDR_1}`;
@@ -476,6 +477,43 @@ describe("applyVolumeSnapshots", () => {
     assert.equal(ad.swapCountIncludingProtocolActors, 1);
     assert.equal(ad.volumeUsdWei, 0n);
     assert.equal(ad.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
+  });
+
+  it("manual Mento rebalancer signer is protocol volume even through an aggregator", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    await applyVolumeSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: MENTO_REBALANCER_EOA,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+      blockNumber: 0n,
+    });
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${MENTO_REBALANCER_EOA}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.isProtocolActor, true);
+    const ad = store.AggregatorDailySnapshot.get(
+      `${CHAIN}-squid-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(ad.swapCount, 0);
+    assert.equal(ad.swapCountIncludingProtocolActors, 1);
+    assert.equal(ad.volumeUsdWei, 0n);
+    assert.equal(ad.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
+    const pd = store.PoolDailyVolumeSnapshot.get(
+      `${CHAIN}-${POOL_ID_1}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(pd.swapCount, 0);
+    assert.equal(pd.swapCountIncludingProtocolActors, 1);
+    assert.equal(pd.volumeUsdWei, 0n);
+    assert.equal(pd.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
   });
 
   it("direct-entry Broker txTo does not hide the signer as protocol volume", async () => {

--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   BROKER_AGGREGATOR_DAILY_TOP,
+  BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
   BROKER_TRADER_DAILY_TOP,
   POOLS_FOR_VOLUME,
   TRADER_DAILY_TOP,
@@ -10,6 +11,7 @@ import {
 const mockUseGQL = vi.hoisted(() => vi.fn());
 const volumeState = vi.hoisted(() => ({
   venue: "v3" as "v3" | "v2",
+  includeProtocolActors: false,
 }));
 
 vi.mock("@/lib/graphql", () => ({
@@ -19,8 +21,8 @@ vi.mock("@/lib/graphql", () => ({
 vi.mock("../_lib/url-state", () => ({
   useVolumeUrlState: () => ({
     range: "7d",
-    actorFilter: "organic",
-    includeProtocolActors: false,
+    actorFilter: volumeState.includeProtocolActors ? "all" : "organic",
+    includeProtocolActors: volumeState.includeProtocolActors,
     exclusions: { addresses: [], sources: [] },
     venue: volumeState.venue,
     cutoff: 1_700_000_000,
@@ -86,8 +88,9 @@ vi.mock("../_components/v3-volume-section", () => ({
 
 import { VolumeClient } from "../page-client";
 
-function renderVolume(venue: "v3" | "v2") {
+function renderVolume(venue: "v3" | "v2", includeProtocolActors = false) {
   volumeState.venue = venue;
+  volumeState.includeProtocolActors = includeProtocolActors;
   return renderToStaticMarkup(<VolumeClient />);
 }
 
@@ -123,6 +126,16 @@ describe("VolumeClient useGQL wiring", () => {
       timeoutMs: 8_000,
     });
     expect(optionsFor(BROKER_AGGREGATOR_DAILY_TOP)).toMatchObject({
+      timeoutMs: 8_000,
+    });
+  });
+
+  it("switches the v2 aggregator query ordering with the actor filter", () => {
+    renderVolume("v2", true);
+
+    expect(
+      optionsFor(BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS),
+    ).toMatchObject({
       timeoutMs: 8_000,
     });
   });

--- a/ui-dashboard/src/app/volume/_lib/use-volume-aggregates.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-volume-aggregates.ts
@@ -152,9 +152,10 @@ function useVolumeExclusionModel({
   );
   const selectedV2AggregatorRows = useMemo(
     () =>
-      includeProtocolActors
-        ? v2AggregatorRows
-        : v2AggregatorRows.filter((r) => r.aggregator !== "protocol"),
+      selectAggregatorRowsForActorFilter(
+        v2AggregatorRows,
+        includeProtocolActors,
+      ),
     [v2AggregatorRows, includeProtocolActors],
   );
   const filteredV2AggregatorRows = useMemo(

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -5,11 +5,11 @@ import { useGQL } from "@/lib/graphql";
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { formatUSD } from "@/lib/format";
 import {
-  BROKER_AGGREGATOR_DAILY_TOP,
   BROKER_TRADER_DAILY_TOP,
   POOLS_FOR_VOLUME,
   TRADER_DAILY_TOP,
   aggregatorDailyTopQuery,
+  brokerAggregatorDailyTopQuery,
 } from "@/lib/queries/volume";
 import {
   AggregatorDailyTopSchema,
@@ -201,7 +201,9 @@ function useVolumeQueries({
   const v2AggregatorsResult = useGQL<{
     BrokerAggregatorDailySnapshot: BrokerAggregatorDailyRow[];
   }>(
-    venue === "v2" ? BROKER_AGGREGATOR_DAILY_TOP : null,
+    venue === "v2"
+      ? brokerAggregatorDailyTopQuery(includeProtocolActors)
+      : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
     { timeoutMs: 8_000, schema: BrokerAggregatorDailyTopSchema },
   );

--- a/ui-dashboard/src/lib/__tests__/volume-aggregators.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume-aggregators.test.ts
@@ -8,7 +8,10 @@ import {
 import {
   AGGREGATOR_DAILY_TOP,
   AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
+  BROKER_AGGREGATOR_DAILY_TOP,
+  BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
   aggregatorDailyTopQuery,
+  brokerAggregatorDailyTopQuery,
 } from "../queries/volume";
 
 const USD = (n: number) =>
@@ -120,6 +123,23 @@ describe("aggregatorDailyTopQuery", () => {
       AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
     );
     expect(aggregatorDailyTopQuery(true)).toContain(
+      "order_by: [{ volumeUsdWeiIncludingProtocolActors: desc }, { id: asc }]",
+    );
+  });
+});
+
+describe("brokerAggregatorDailyTopQuery", () => {
+  it("orders by the displayed broker aggregator volume for the active actor filter", () => {
+    expect(brokerAggregatorDailyTopQuery(false)).toBe(
+      BROKER_AGGREGATOR_DAILY_TOP,
+    );
+    expect(brokerAggregatorDailyTopQuery(false)).toContain(
+      "order_by: [{ volumeUsdWei: desc }, { id: asc }]",
+    );
+    expect(brokerAggregatorDailyTopQuery(true)).toBe(
+      BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
+    );
+    expect(brokerAggregatorDailyTopQuery(true)).toContain(
       "order_by: [{ volumeUsdWeiIncludingProtocolActors: desc }, { id: asc }]",
     );
   });

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -908,7 +908,10 @@ function brokerAggregator(
     id: `${partial.chainId}-${partial.aggregator}-${partial.timestamp}`,
     lastSeenAggregatorAddress: "0x0000000000000000000000000000000000000000",
     swapCount: 1,
+    swapCountIncludingProtocolActors: 1,
     uniqueTraders: 1,
+    uniqueTradersIncludingProtocolActors: 1,
+    volumeUsdWeiIncludingProtocolActors: partial.volumeUsdWei,
     ...partial,
   };
 }

--- a/ui-dashboard/src/lib/queries/__tests__/volume-schemas.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/volume-schemas.test.ts
@@ -388,8 +388,11 @@ describe("BrokerAggregatorDailyTopSchema smoke test", () => {
           lastSeenAggregatorAddress: "0xunknown",
           timestamp: "1700000000",
           swapCount: 3,
+          swapCountIncludingProtocolActors: 4,
           uniqueTraders: 2,
+          uniqueTradersIncludingProtocolActors: 3,
           volumeUsdWei: "500",
+          volumeUsdWeiIncludingProtocolActors: "600",
         },
       ],
     });

--- a/ui-dashboard/src/lib/queries/volume-schemas.ts
+++ b/ui-dashboard/src/lib/queries/volume-schemas.ts
@@ -232,8 +232,11 @@ const BrokerAggregatorDailyRowSchema = z.object({
   lastSeenAggregatorAddress: z.string(),
   timestamp: z.string(),
   swapCount: z.number(),
+  swapCountIncludingProtocolActors: z.number(),
   uniqueTraders: z.number(),
+  uniqueTradersIncludingProtocolActors: z.number(),
   volumeUsdWei: z.string(),
+  volumeUsdWeiIncludingProtocolActors: z.string(),
 });
 
 export const BrokerAggregatorDailyTopSchema = z.object({

--- a/ui-dashboard/src/lib/queries/volume.ts
+++ b/ui-dashboard/src/lib/queries/volume.ts
@@ -320,8 +320,8 @@ export const BROKER_TRADER_DAILY_TOP = /* GraphQL */ `
  * in `indexer-envio/config/aggregators.json` and ideally an integrator we
  * should reach out to about migrating to v3.
  *
- * No protocol-actor filter — `aggregator` is already a canonical name; the
- * `protocol` value covers Mento internals and is naturally tiny.
+ * Primary fields exclude protocol actors and drive the default organic view.
+ * The *IncludingProtocolActors siblings back the page-level actor toggle.
  */
 export const BROKER_AGGREGATOR_DAILY_TOP = /* GraphQL */ `
   query BrokerAggregatorDailyTop($afterTimestamp: numeric!, $limit: Int!) {
@@ -336,11 +336,47 @@ export const BROKER_AGGREGATOR_DAILY_TOP = /* GraphQL */ `
       lastSeenAggregatorAddress
       timestamp
       swapCount
+      swapCountIncludingProtocolActors
       uniqueTraders
+      uniqueTradersIncludingProtocolActors
       volumeUsdWei
+      volumeUsdWeiIncludingProtocolActors
     }
   }
 `;
+
+export const BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS = /* GraphQL */ `
+  query BrokerAggregatorDailyTopIncludingProtocolActors(
+    $afterTimestamp: numeric!
+    $limit: Int!
+  ) {
+    BrokerAggregatorDailySnapshot(
+      where: { timestamp: { _gte: $afterTimestamp } }
+      order_by: [{ volumeUsdWeiIncludingProtocolActors: desc }, { id: asc }]
+      limit: $limit
+    ) {
+      id
+      chainId
+      aggregator
+      lastSeenAggregatorAddress
+      timestamp
+      swapCount
+      swapCountIncludingProtocolActors
+      uniqueTraders
+      uniqueTradersIncludingProtocolActors
+      volumeUsdWei
+      volumeUsdWeiIncludingProtocolActors
+    }
+  }
+`;
+
+export function brokerAggregatorDailyTopQuery(
+  includeProtocolActors: boolean,
+): string {
+  return includeProtocolActors
+    ? BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS
+    : BROKER_AGGREGATOR_DAILY_TOP;
+}
 
 // ---------------------------------------------------------------------------
 // Pre-rolled hero metrics. `distinct_on: [chainId]` returns the LATEST

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -16,7 +16,7 @@ import { SECONDS_PER_DAY } from "@/lib/time-series";
 import { parseWei, weiToUsd as formatWeiToUsd } from "@/lib/format";
 import {
   aggregateAggregatorsByWindow,
-  type AggregatorDailyRowBase,
+  type AggregatorDailyRow,
   type AggregatorWindowRow,
 } from "@/lib/volume-aggregators";
 import {
@@ -412,9 +412,7 @@ export type BrokerTraderWindowRow = {
   lastSeenTimestamp: number;
 };
 
-export type BrokerAggregatorDailyRow = AggregatorDailyRowBase & {
-  id: string;
-};
+export type BrokerAggregatorDailyRow = AggregatorDailyRow;
 export type BrokerAggregatorWindowRow = AggregatorWindowRow;
 
 /** Per-(trader, tx.to, day) row returned by `BrokerTraderRouterDayMarker`. */

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -379,6 +379,29 @@ const stableChanges = [
   ),
 ];
 
+function volumeDay() {
+  return Math.floor(nowSeconds() / DAY_SECONDS) * DAY_SECONDS;
+}
+
+function brokerAggregatorDailySnapshots() {
+  const timestamp = String(volumeDay());
+  return [
+    {
+      id: `42220-squid-${timestamp}`,
+      chainId: 42220,
+      aggregator: "squid",
+      lastSeenAggregatorAddress: "0xce16f69375520ab01377ce7b88f5ba8c48f8d666",
+      timestamp,
+      swapCount: 0,
+      swapCountIncludingProtocolActors: 1,
+      uniqueTraders: 0,
+      uniqueTradersIncludingProtocolActors: 1,
+      volumeUsdWei: "0",
+      volumeUsdWeiIncludingProtocolActors: "1000000000000000000000",
+    },
+  ];
+}
+
 function unhandledOperation(op) {
   const message = `Unhandled fixture GraphQL operation: ${op}`;
   process.stderr.write(`${message}\n`);
@@ -399,6 +422,51 @@ function rowsByPoolIds(poolIds) {
 function handleGraphQL({ query, variables = {} }) {
   const op = operationName(query ?? "");
   switch (op) {
+    case "PoolsForVolume":
+      return {
+        Pool: pools.map(({ id, chainId, token0, token1 }) => ({
+          id,
+          chainId,
+          token0,
+          token1,
+        })),
+      };
+    case "TraderDailyTop":
+      return { TraderDailySnapshot: [] };
+    case "PoolDailyVolume":
+      return { PoolDailyVolumeSnapshot: [] };
+    case "AggregatorDailyTop":
+    case "AggregatorDailyTopIncludingProtocolActors":
+      return { AggregatorDailySnapshot: [] };
+    case "BrokerTraderDailyTop":
+      return { BrokerTraderDailySnapshot: [] };
+    case "BrokerAggregatorDailyTop":
+    case "BrokerAggregatorDailyTopIncludingProtocolActors":
+      return {
+        BrokerAggregatorDailySnapshot: brokerAggregatorDailySnapshots(),
+      };
+    case "VolumeWindowLatest":
+      return { volumeWindowSnapshots: [] };
+    case "BrokerVolumeWindowLatest":
+      return { brokerVolumeWindowSnapshots: [] };
+    case "VolumeWindowFirstDayLatest":
+      return { volumeWindowFirstDaySnapshots: [] };
+    case "BrokerVolumeWindowFirstDayLatest":
+      return { brokerVolumeWindowFirstDaySnapshots: [] };
+    case "VolumeWindowTradersLatest":
+      return { volumeWindowTraderSnapshots: [] };
+    case "VolumePartialOverlapTraders":
+      return { volumePartialOverlapTraders: [] };
+    case "BrokerVolumePartialOverlapTraders":
+      return { brokerVolumePartialOverlapTraders: [] };
+    case "VolumeTodayTraders":
+      return { volumeTodayTraders: [] };
+    case "BrokerVolumeTodayTraders":
+      return { brokerVolumeTodayTraders: [] };
+    case "VolumeYesterdayTraders":
+      return { volumeYesterdayTraders: [] };
+    case "BrokerVolumeYesterdayTraders":
+      return { brokerVolumeYesterdayTraders: [] };
     case "AllPoolsWithHealth":
       return { Pool: poolRowsForChain(variables.chainId) };
     case "OracleRates":

--- a/ui-dashboard/tests/browser/visual-snapshots.test.ts
+++ b/ui-dashboard/tests/browser/visual-snapshots.test.ts
@@ -264,6 +264,7 @@ test.describe("visual snapshots", () => {
       "AggregatorDailyTopIncludingProtocolActors",
       "BrokerTraderDailyTop",
       "BrokerAggregatorDailyTop",
+      "BrokerAggregatorDailyTopIncludingProtocolActors",
       "VolumeWindowLatest",
       "BrokerVolumeWindowLatest",
       "VolumeWindowFirstDayLatest",


### PR DESCRIPTION
## The Problem

- The `/volume` organic view can still count swaps signed by the Mento rebalancer when that wallet routes through normal swap paths.
- Those flows are protocol-internal activity, so they should not be mixed with external demand.
- The v2 aggregator breakdown also needs the same organic/all split, otherwise routes like Squid can still show protocol rebalancer volume as external flow.

## The Solution

- Classify the Mento rebalancer wallet as a manual protocol actor and give v2 broker aggregator rows the same primary versus including-protocol field split that v3 already uses.
- Update the volume page's v2 aggregator query and actor toggle to read those fields, so organic mode hides protocol signer volume and all mode can still show it.

## Details

- Extends `config/protocolActors.json` semantics so manual entries classify signer/caller matches and defensively classify `tx.to` entry-point matches as protocol volume.
- Adds the checksummed Celo Mento rebalancer EOA to the manual actor list.
- Preserves the existing direct Broker/Router guard so normal Mento UI or SDK users are not hidden as protocol actors.
- Adds `*IncludingProtocolActors` fields to `BrokerAggregatorDailySnapshot` and enriches `BrokerAggregatorTraderDayMarker` so same-day protocol flips subtract prior organic v2 route contributions.
- Reuses the dashboard's shared aggregator actor-filter selector for v2 rows.
- Updates fixture-backed browser data so the volume page exercises a v2 protocol-only Squid row.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm --filter @mento-protocol/indexer-envio test broker.test.ts protocol-actors.test.ts volumeSnapshots.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard test volume-aggregators.test.ts volume.test.ts volume-schemas.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard test:browser`
- `pnpm agent:autoreview` (local deterministic fallback; Codex review engine unavailable, no actionable findings)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] browser verification run with fixture-backed Playwright volume page coverage
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema and rollup logic changes affect published volume metrics and require a reindex; classification logic is scoped to manual actors and existing guards but wrong overrides would skew organic totals.
> 
> **Overview**
> **Protocol classification:** Adds the Celo Mento rebalancer EOA to `protocolActors.json` and applies manual entries in `isProtocolOwnedAddress` / `isProtocolActorEntryPoint` so signer and entry-point matches count as protocol volume (without hiding normal Broker/Router UI users).
> 
> **Indexer v2 rollups:** Extends `BrokerAggregatorDailySnapshot` with `*IncludingProtocolActors` fields, tracks `aggregatorKeys` on `BrokerTraderDailySnapshot`, and enriches `BrokerAggregatorTraderDayMarker` with per-route contribution. Refactors `writeBrokerProducerRollups` so organic primary totals exclude protocol callers and **subtract prior same-day organic contributions** when a caller-day flips to protocol-actor.
> 
> **Dashboard:** Adds `brokerAggregatorDailyTopQuery(includeProtocolActors)`, switches v2 aggregator fetches/order by with the actor toggle, and uses `selectAggregatorRowsForActorFilter` for v2 rows (replacing a hard `protocol` bucket filter). Tests and Hasura fixtures updated for the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4093eb6d84bd3db218745a88f92d71013ca55ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

