### PR TITLE
Restrict volume actor filters to signed-in users

### DIFF
--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -19,19 +19,29 @@ vi.mock("@/lib/graphql", () => ({
 }));
 
 vi.mock("../_lib/url-state", () => ({
-  useVolumeUrlState: () => ({
-    range: "7d",
-    actorFilter: volumeState.includeProtocolActors ? "all" : "organic",
-    includeProtocolActors: volumeState.includeProtocolActors,
-    exclusions: { addresses: [], sources: [] },
-    venue: volumeState.venue,
-    cutoff: 1_700_000_000,
-    utcDayKey: 20_000,
-    updateRange: vi.fn(),
-    updateIncludeProtocolActors: vi.fn(),
-    updateExclusions: vi.fn(),
-    updateVenue: vi.fn(),
-  }),
+  useVolumeUrlState: ({
+    canUseVolumeFilters,
+  }: {
+    canUseVolumeFilters: boolean;
+  }) => {
+    const includeProtocolActors = canUseVolumeFilters
+      ? volumeState.includeProtocolActors
+      : true;
+    return {
+      canUseVolumeFilters,
+      range: "7d",
+      actorFilter: includeProtocolActors ? "all" : "organic",
+      includeProtocolActors,
+      exclusions: { addresses: [], sources: [] },
+      venue: volumeState.venue,
+      cutoff: 1_700_000_000,
+      utcDayKey: 20_000,
+      updateRange: vi.fn(),
+      updateIncludeProtocolActors: vi.fn(),
+      updateExclusions: vi.fn(),
+      updateVenue: vi.fn(),
+    };
+  },
 }));
 
 vi.mock("../_lib/use-pool-volume-snapshots", () => ({
@@ -88,16 +98,28 @@ vi.mock("../_components/v3-volume-section", () => ({
 
 import { VolumeClient } from "../page-client";
 
-function renderVolume(venue: "v3" | "v2", includeProtocolActors = false) {
+function renderVolume(
+  venue: "v3" | "v2",
+  includeProtocolActors = false,
+  canUseVolumeFilters = true,
+) {
   volumeState.venue = venue;
   volumeState.includeProtocolActors = includeProtocolActors;
-  return renderToStaticMarkup(<VolumeClient />);
+  return renderToStaticMarkup(
+    <VolumeClient canUseVolumeFilters={canUseVolumeFilters} />,
+  );
 }
 
 function optionsFor(query: string) {
   const call = mockUseGQL.mock.calls.find(([document]) => document === query);
   expect(call, `missing useGQL call for ${query}`).toBeDefined();
   return call ? call[call.length - 1] : undefined;
+}
+
+function variablesFor(query: string) {
+  const call = mockUseGQL.mock.calls.find(([document]) => document === query);
+  expect(call, `missing useGQL call for ${query}`).toBeDefined();
+  return call ? call[1] : undefined;
 }
 
 describe("VolumeClient useGQL wiring", () => {
@@ -137,6 +159,36 @@ describe("VolumeClient useGQL wiring", () => {
       optionsFor(BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS),
     ).toMatchObject({
       timeoutMs: 8_000,
+    });
+  });
+
+  it("forces external users onto all volume and hides private filters", () => {
+    const html = renderVolume("v2", false, false);
+
+    expect(html).toContain(
+      "Top legacy-v2 traders on Mento by total USD volume",
+    );
+    expect(html).not.toContain('aria-label="Protocol actors"');
+    expect(html).not.toContain("Exploratory exclusions");
+    expect(variablesFor(BROKER_TRADER_DAILY_TOP)).toMatchObject({
+      isProtocolActorIn: [false, true],
+    });
+    expect(
+      optionsFor(BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS),
+    ).toMatchObject({
+      timeoutMs: 8_000,
+    });
+  });
+
+  it("keeps the private volume filters available for logged-in users", () => {
+    const html = renderVolume("v3", false, true);
+
+    expect(html).toContain('aria-label="Protocol actors"');
+    expect(html).toContain("Organic");
+    expect(html).toContain("All");
+    expect(html).toContain("Exploratory exclusions");
+    expect(variablesFor(TRADER_DAILY_TOP)).toMatchObject({
+      isProtocolActorIn: [false],
     });
   });
 

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
@@ -185,6 +185,7 @@ function renderVolumeTable(
         pools={
           new Map([[POOL_ID.toLowerCase(), { token0: "USDC", token1: "USDm" }]])
         }
+        emptyMessage="No traders matched this window. Try widening the range or including protocol actors."
         isLoading={false}
         hasError={false}
         hasExploratoryExclusions={false}
@@ -203,6 +204,7 @@ function renderV2Table(
       <V2VolumeTraderTable
         cutoff={CUTOFF}
         traders={[]}
+        emptyMessage="No legacy-v2 traders in this window. Either v2 volume has stopped, or try widening the range / including protocol actors."
         isLoading={false}
         hasError={false}
         hasExploratoryExclusions={false}

--- a/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
@@ -30,6 +30,7 @@ import { TableSectionTitle } from "./table-section-title";
 export function V2VolumeSection({
   rangeLabel,
   cutoff,
+  canUseVolumeFilters,
   v2Aggregated,
   v2AggregatorAggregated,
   hasExploratoryExclusions,
@@ -45,6 +46,7 @@ export function V2VolumeSection({
   rangeLabel: string;
   /** Same UTC-day cutoff used by the trader query; bounds the Via marker query. */
   cutoff: number;
+  canUseVolumeFilters: boolean;
   v2Aggregated: readonly BrokerTraderWindowRow[];
   v2AggregatorAggregated: readonly BrokerAggregatorWindowRow[];
   hasExploratoryExclusions: boolean;
@@ -73,6 +75,7 @@ export function V2VolumeSection({
         <V2VolumeTraderTable
           cutoff={cutoff}
           traders={v2Aggregated}
+          emptyMessage={v2EmptyMessage(canUseVolumeFilters)}
           isLoading={tableIsLoading}
           hasError={tableHasError}
           hasExploratoryExclusions={hasExploratoryExclusions}
@@ -88,4 +91,11 @@ export function V2VolumeSection({
       />
     </>
   );
+}
+
+function v2EmptyMessage(canUseVolumeFilters: boolean): string {
+  if (!canUseVolumeFilters) {
+    return "No legacy-v2 traders in this window. Either v2 volume has stopped, or try widening the range.";
+  }
+  return "No legacy-v2 traders in this window. Either v2 volume has stopped, or try widening the range / including protocol actors.";
 }

--- a/ui-dashboard/src/app/volume/_components/v2-volume-tables.tsx
+++ b/ui-dashboard/src/app/volume/_components/v2-volume-tables.tsx
@@ -73,12 +73,14 @@ function useV2TraderVia({
 export function V2VolumeTraderTable({
   cutoff,
   traders,
+  emptyMessage,
   isLoading,
   hasError,
   hasExploratoryExclusions,
 }: {
   cutoff: number;
   traders: readonly BrokerTraderWindowRow[];
+  emptyMessage: string;
   isLoading: boolean;
   hasError: boolean;
   hasExploratoryExclusions: boolean;
@@ -127,7 +129,7 @@ export function V2VolumeTraderTable({
         message={
           hasExploratoryExclusions
             ? "No legacy-v2 traders left after exploratory exclusions. Clear exclusions or widen the range."
-            : "No legacy-v2 traders in this window. Either v2 volume has stopped, or try widening the range / including protocol actors."
+            : emptyMessage
         }
       />
     );

--- a/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
@@ -37,6 +37,7 @@ export function V3VolumeSection({
   traders,
   pools,
   protocolActorFilter,
+  canUseVolumeFilters,
   exclusions,
   tableState,
   aggregators,
@@ -50,6 +51,7 @@ export function V3VolumeSection({
   traders: readonly TraderWindowRow[];
   pools: PoolMeta;
   protocolActorFilter: ReadonlyArray<boolean>;
+  canUseVolumeFilters: boolean;
   exclusions: VolumeExclusionState;
   tableState: V3TableState;
   aggregators: readonly AggregatorWindowRow[];
@@ -76,7 +78,7 @@ export function V3VolumeSection({
       <section>
         <TableSectionTitle
           label="About top traders table"
-          info="Ranks signer wallets by v3 Mento pool and VirtualPool USD volume in this window. Protocol actors are excluded unless included."
+          info={v3TraderTableInfo(canUseVolumeFilters)}
         >
           Top traders ({rangeLabel})
         </TableSectionTitle>
@@ -84,6 +86,7 @@ export function V3VolumeSection({
           cutoff={cutoff}
           traders={traders}
           pools={pools}
+          emptyMessage={volumeEmptyMessage(canUseVolumeFilters)}
           isLoading={tableState.isLoading}
           hasError={tableState.hasError}
           hasExploratoryExclusions={tableState.hasExploratoryExclusions}
@@ -100,4 +103,18 @@ export function V3VolumeSection({
       />
     </>
   );
+}
+
+function v3TraderTableInfo(canUseVolumeFilters: boolean): string {
+  if (!canUseVolumeFilters) {
+    return "Ranks signer wallets and protocol actors by total v3 Mento pool and VirtualPool USD volume in this window.";
+  }
+  return "Ranks signer wallets by v3 Mento pool and VirtualPool USD volume in this window. Protocol actors are excluded unless included.";
+}
+
+function volumeEmptyMessage(canUseVolumeFilters: boolean): string {
+  if (!canUseVolumeFilters) {
+    return "No traders matched this window. Try widening the range.";
+  }
+  return "No traders matched this window. Try widening the range or including protocol actors.";
 }

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -19,9 +19,7 @@ export function VolumePageHeader({ urlState }: { urlState: VolumeUrlState }) {
           Volume
         </h1>
         <p className="mt-1 text-sm text-slate-400">
-          {urlState.venue === "v3"
-            ? "Top traders on Mento by USD volume. Protocol actors are excluded by default."
-            : "Top legacy-v2 traders on Mento by USD volume. Protocol actors are excluded by default."}
+          {volumeHeaderSubtitle(urlState)}
         </p>
       </div>
       <div className="flex flex-wrap items-center gap-3">
@@ -33,13 +31,26 @@ export function VolumePageHeader({ urlState }: { urlState: VolumeUrlState }) {
           range={urlState.range}
           updateRange={urlState.updateRange}
         />
-        <ActorToggleGroup
-          includeProtocolActors={urlState.includeProtocolActors}
-          updateIncludeProtocolActors={urlState.updateIncludeProtocolActors}
-        />
+        {urlState.canUseVolumeFilters && (
+          <ActorToggleGroup
+            includeProtocolActors={urlState.includeProtocolActors}
+            updateIncludeProtocolActors={urlState.updateIncludeProtocolActors}
+          />
+        )}
       </div>
     </header>
   );
+}
+
+function volumeHeaderSubtitle(urlState: VolumeUrlState): string {
+  if (!urlState.canUseVolumeFilters) {
+    return urlState.venue === "v3"
+      ? "Top traders on Mento by total USD volume."
+      : "Top legacy-v2 traders on Mento by total USD volume.";
+  }
+  return urlState.venue === "v3"
+    ? "Top traders on Mento by USD volume. Protocol actors are excluded by default."
+    : "Top legacy-v2 traders on Mento by USD volume. Protocol actors are excluded by default.";
 }
 
 function VenueToggleGroup({
@@ -321,6 +332,7 @@ export function VolumeVenueSection({
       <V2VolumeSection
         rangeLabel={rangeLabel(range)}
         cutoff={cutoff}
+        canUseVolumeFilters={urlState.canUseVolumeFilters}
         v2Aggregated={aggregates.v2Aggregated}
         v2AggregatorAggregated={aggregates.v2AggregatorAggregated}
         hasExploratoryExclusions={aggregates.hasExploratoryExclusions}
@@ -341,6 +353,7 @@ export function VolumeVenueSection({
       traders={aggregates.aggregated}
       pools={model.poolMeta}
       protocolActorFilter={model.isProtocolActorIn}
+      canUseVolumeFilters={urlState.canUseVolumeFilters}
       exclusions={exclusions}
       tableState={{
         isLoading: status.tableIsLoading,

--- a/ui-dashboard/src/app/volume/_components/volume-table.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-table.tsx
@@ -37,6 +37,7 @@ export function VolumeTable({
   cutoff,
   traders,
   pools,
+  emptyMessage,
   isLoading,
   hasError,
   hasExploratoryExclusions,
@@ -47,6 +48,7 @@ export function VolumeTable({
   cutoff: number;
   traders: readonly TraderWindowRow[];
   pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
+  emptyMessage: string;
   isLoading: boolean;
   hasError: boolean;
   hasExploratoryExclusions: boolean;
@@ -106,7 +108,7 @@ export function VolumeTable({
         message={
           hasExploratoryExclusions
             ? "No traders left after exploratory exclusions. Clear exclusions or widen the range."
-            : "No traders matched this window. Try widening the range or including protocol actors."
+            : emptyMessage
         }
       />
     );

--- a/ui-dashboard/src/app/volume/_lib/__tests__/url-state.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/url-state.test.tsx
@@ -22,8 +22,14 @@ import { useVolumeUrlState, type Venue } from "../url-state";
 type UrlStateResult = ReturnType<typeof useVolumeUrlState>;
 type ResultRef = { current: UrlStateResult | null };
 
-function HookWrapper({ resultRef }: { resultRef: ResultRef }) {
-  resultRef.current = useVolumeUrlState();
+function HookWrapper({
+  resultRef,
+  canUseVolumeFilters,
+}: {
+  resultRef: ResultRef;
+  canUseVolumeFilters: boolean;
+}) {
+  resultRef.current = useVolumeUrlState({ canUseVolumeFilters });
   return null;
 }
 
@@ -38,10 +44,12 @@ function setup(url = "/volume") {
   root = createRoot(container);
 }
 
-function renderHook(): ResultRef {
+function renderHook(canUseVolumeFilters = true): ResultRef {
   const ref: ResultRef = { current: null };
   act(() => {
-    root.render(<HookWrapper resultRef={ref} />);
+    root.render(
+      <HookWrapper resultRef={ref} canUseVolumeFilters={canUseVolumeFilters} />,
+    );
   });
   return ref;
 }
@@ -80,6 +88,35 @@ describe("useVolumeUrlState", () => {
     });
     expect(ref.current?.venue).toBe("v2");
     expect(ref.current?.cutoff).toBeGreaterThan(0);
+  });
+
+  it("locks external users to all volume and strips private filter params", () => {
+    setup(
+      "/volume?foo=1&range=30d&actors=organic&exclude=0x00000000000000000000000000000000000000aa&excludeSources=cluster-abc",
+    );
+    const ref = renderHook(false);
+
+    expect(ref.current?.canUseVolumeFilters).toBe(false);
+    expect(ref.current?.actorFilter).toBe("all");
+    expect(ref.current?.includeProtocolActors).toBe(true);
+    expect(ref.current?.exclusions).toEqual({ addresses: [], sources: [] });
+    expect(window.location.search).toBe("?foo=1&range=30d");
+
+    act(() => {
+      ref.current?.updateIncludeProtocolActors(false);
+    });
+    expect(ref.current?.actorFilter).toBe("all");
+    expect(ref.current?.includeProtocolActors).toBe(true);
+    expect(window.location.search).toBe("?foo=1&range=30d");
+
+    act(() => {
+      ref.current?.updateExclusions({
+        addresses: ["0x00000000000000000000000000000000000000bb"],
+        sources: ["cluster-def"],
+      });
+    });
+    expect(ref.current?.exclusions).toEqual({ addresses: [], sources: [] });
+    expect(window.location.search).toBe("?foo=1&range=30d");
   });
 
   it("falls back to default state for invalid params", () => {
@@ -167,6 +204,28 @@ describe("useVolumeUrlState", () => {
     expect(ref.current?.includeProtocolActors).toBe(false);
     expect(ref.current?.exclusions).toEqual({ addresses: [], sources: [] });
     expect(ref.current?.venue).toBe("v3");
+  });
+
+  it("keeps external users locked to all volume across popstate", () => {
+    setup("/volume?actors=all");
+    const ref = renderHook(false);
+
+    expect(window.location.search).toBe("");
+
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/volume?actors=organic&venue=v2&exclude=0x00000000000000000000000000000000000000aa&excludeSources=cluster-abc",
+    );
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(ref.current?.actorFilter).toBe("all");
+    expect(ref.current?.includeProtocolActors).toBe(true);
+    expect(ref.current?.exclusions).toEqual({ addresses: [], sources: [] });
+    expect(ref.current?.venue).toBe("v2");
+    expect(window.location.search).toBe("?venue=v2");
   });
 
   it("refreshes the UTC day key at midnight so cutoffs can recompute", () => {

--- a/ui-dashboard/src/app/volume/_lib/__tests__/url-state.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/url-state.test.tsx
@@ -117,6 +117,12 @@ describe("useVolumeUrlState", () => {
     });
     expect(ref.current?.exclusions).toEqual({ addresses: [], sources: [] });
     expect(window.location.search).toBe("?foo=1&range=30d");
+
+    act(() => {
+      ref.current?.updateVenue("v2");
+    });
+    expect(ref.current?.venue).toBe("v2");
+    expect(window.location.search).toBe("?foo=1&range=30d&venue=v2");
   });
 
   it("falls back to default state for invalid params", () => {

--- a/ui-dashboard/src/app/volume/_lib/url-state.ts
+++ b/ui-dashboard/src/app/volume/_lib/url-state.ts
@@ -228,6 +228,8 @@ export function useVolumeUrlState({
   });
   useLockedVolumeFilterCanonicalization({ canUseVolumeFilters });
   const utcDayKey = useUtcDayKey();
+  // Re-derive the public result as a final defense: state initialization and
+  // action guards already lock anonymous users to total volume.
   const effectiveActorFilter: ActorFilter = canUseVolumeFilters
     ? actorFilter
     : "all";
@@ -286,6 +288,8 @@ function useVolumeUrlActions({
   );
   const updateIncludeProtocolActors = useCallback(
     (next: boolean) => {
+      // Defense-in-depth: the actor toggle is only rendered when private
+      // volume filters are available, so normal UI calls do not hit this path.
       if (!canUseVolumeFilters) {
         setActorFilter("all");
         writeUrl({ range, actorFilter: "all", exclusions, venue });
@@ -299,6 +303,8 @@ function useVolumeUrlActions({
   );
   const updateExclusions = useCallback(
     (next: VolumeExclusionState) => {
+      // Defense-in-depth: the exclusions panel is only rendered when private
+      // volume filters are available, so normal UI calls do not hit this path.
       if (!canUseVolumeFilters) {
         const emptyExclusions = { addresses: [], sources: [] };
         setExclusions(emptyExclusions);

--- a/ui-dashboard/src/app/volume/_lib/url-state.ts
+++ b/ui-dashboard/src/app/volume/_lib/url-state.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/volume-exclusions";
 
 export type Venue = "v3" | "v2";
-export type ActorFilter = "organic" | "all";
+type ActorFilter = "organic" | "all";
 type VolumeUrlSnapshot = {
   range: VolumeRangeKey;
   actorFilter: ActorFilter;
@@ -30,6 +30,27 @@ type VolumeUrlSetters = {
   setActorFilter: Dispatch<SetStateAction<ActorFilter>>;
   setExclusions: Dispatch<SetStateAction<VolumeExclusionState>>;
   setVenue: Dispatch<SetStateAction<Venue>>;
+};
+type VolumeUrlActionInputs = VolumeUrlSetters &
+  VolumeUrlSnapshot & {
+    canUseVolumeFilters: boolean;
+  };
+type VolumeUrlStateOptions = {
+  canUseVolumeFilters: boolean;
+};
+type VolumeUrlStateResult = {
+  canUseVolumeFilters: boolean;
+  range: VolumeRangeKey;
+  actorFilter: ActorFilter;
+  includeProtocolActors: boolean;
+  exclusions: VolumeExclusionState;
+  venue: Venue;
+  cutoff: number;
+  utcDayKey: number;
+  updateRange: (next: VolumeRangeKey) => void;
+  updateIncludeProtocolActors: (next: boolean) => void;
+  updateExclusions: (next: VolumeExclusionState) => void;
+  updateVenue: (next: Venue) => void;
 };
 
 const VALID_RANGES = new Set<VolumeRangeKey>([
@@ -104,22 +125,34 @@ function writeParamList(
   if (values.length > 0) params.set(key, values.join(","));
 }
 
-function writeVolumeUrl({
-  range,
-  actorFilter,
-  exclusions,
-  venue,
-}: VolumeUrlSnapshot) {
+function writeVolumeUrl(
+  { range, actorFilter, exclusions, venue }: VolumeUrlSnapshot,
+  canUseVolumeFilters: boolean,
+) {
   if (typeof window === "undefined") return;
   const params = new URLSearchParams(window.location.search);
   if (range === DEFAULT_RANGE) params.delete("range");
   else params.set("range", range);
-  if (actorFilter === DEFAULT_ACTOR_FILTER) params.delete("actors");
-  else params.set("actors", actorFilter);
-  writeParamList(params, "exclude", exclusions.addresses);
-  writeParamList(params, "excludeSources", exclusions.sources);
+  if (!canUseVolumeFilters) {
+    params.delete("actors");
+  } else if (actorFilter === DEFAULT_ACTOR_FILTER) {
+    params.delete("actors");
+  } else {
+    params.set("actors", actorFilter);
+  }
+  if (canUseVolumeFilters) {
+    writeParamList(params, "exclude", exclusions.addresses);
+    writeParamList(params, "excludeSources", exclusions.sources);
+  } else {
+    params.delete("exclude");
+    params.delete("excludeSources");
+  }
   if (venue === "v3") params.delete("venue");
   else params.set("venue", venue);
+  replaceVolumeUrlSearch(params);
+}
+
+function replaceVolumeUrlSearch(params: URLSearchParams) {
   const qs = params.toString();
   const nextUrl =
     window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
@@ -140,19 +173,9 @@ function writeVolumeUrl({
  * `cutoff` at midnight (codex finding 3183954662) and the precomputed
  * `rangeCutoffSeconds` value.
  */
-export function useVolumeUrlState(): {
-  range: VolumeRangeKey;
-  actorFilter: ActorFilter;
-  includeProtocolActors: boolean;
-  exclusions: VolumeExclusionState;
-  venue: Venue;
-  cutoff: number;
-  utcDayKey: number;
-  updateRange: (next: VolumeRangeKey) => void;
-  updateIncludeProtocolActors: (next: boolean) => void;
-  updateExclusions: (next: VolumeExclusionState) => void;
-  updateVenue: (next: Venue) => void;
-} {
+export function useVolumeUrlState({
+  canUseVolumeFilters,
+}: VolumeUrlStateOptions): VolumeUrlStateResult {
   // `useSearchParams()` here is load-bearing for direct page loads —
   // `useState` lazy initializers serialize their result on SSR and don't
   // re-run on hydration, so reading `window.location.search` only would
@@ -173,56 +196,44 @@ export function useVolumeUrlState(): {
     readRangeFromParams(initialReadParams),
   );
   const [actorFilter, setActorFilter] = useState<ActorFilter>(() =>
-    readActorFilterFromParams(initialReadParams),
+    canUseVolumeFilters ? readActorFilterFromParams(initialReadParams) : "all",
   );
   const [exclusions, setExclusions] = useState<VolumeExclusionState>(() =>
-    readExclusionsFromParams(initialReadParams),
+    canUseVolumeFilters
+      ? readExclusionsFromParams(initialReadParams)
+      : { addresses: [], sources: [] },
   );
   const [venue, setVenue] = useState<Venue>(() =>
     readVenueFromParams(initialReadParams),
   );
 
-  const writeUrl = useCallback((next: VolumeUrlSnapshot) => {
-    writeVolumeUrl(next);
-  }, []);
-
-  const updateRange = useCallback(
-    (next: VolumeRangeKey) => {
-      setRange(next);
-      writeUrl({ range: next, actorFilter, exclusions, venue });
-    },
-    [actorFilter, exclusions, venue, writeUrl],
-  );
-  const updateIncludeProtocolActors = useCallback(
-    (next: boolean) => {
-      const nextActorFilter: ActorFilter = next ? "all" : "organic";
-      setActorFilter(nextActorFilter);
-      writeUrl({ range, actorFilter: nextActorFilter, exclusions, venue });
-    },
-    [exclusions, range, venue, writeUrl],
-  );
-  const updateExclusions = useCallback(
-    (next: VolumeExclusionState) => {
-      setExclusions(next);
-      writeUrl({ range, actorFilter, exclusions: next, venue });
-    },
-    [actorFilter, range, venue, writeUrl],
-  );
-  const updateVenue = useCallback(
-    (next: Venue) => {
-      setVenue(next);
-      writeUrl({ range, actorFilter, exclusions, venue: next });
-    },
-    [range, actorFilter, exclusions, writeUrl],
-  );
-
-  useVolumePopstateSync({
+  const actions = useVolumeUrlActions({
+    canUseVolumeFilters,
+    range,
+    actorFilter,
+    exclusions,
+    venue,
     setRange,
     setActorFilter,
     setExclusions,
     setVenue,
   });
+
+  useVolumePopstateSync({
+    canUseVolumeFilters,
+    setRange,
+    setActorFilter,
+    setExclusions,
+    setVenue,
+  });
+  useLockedVolumeFilterCanonicalization({ canUseVolumeFilters });
   const utcDayKey = useUtcDayKey();
+  const effectiveActorFilter: ActorFilter = canUseVolumeFilters
+    ? actorFilter
+    : "all";
+  const effectiveExclusions: VolumeExclusionState = canUseVolumeFilters
+    ? exclusions
+    : { addresses: [], sources: [] };
 
   // `utcDayKey` is a dep so the cutoff re-derives at midnight even though
   // it's not referenced inside — `rangeCutoffSeconds` calls `Date.now()`
@@ -230,13 +241,89 @@ export function useVolumeUrlState(): {
   const cutoff = useMemo(() => rangeCutoffSeconds(range), [range, utcDayKey]);
 
   return {
+    canUseVolumeFilters,
     range,
-    actorFilter,
-    includeProtocolActors: actorFilter === "all",
-    exclusions,
+    actorFilter: effectiveActorFilter,
+    includeProtocolActors: effectiveActorFilter === "all",
+    exclusions: effectiveExclusions,
     venue,
     cutoff,
     utcDayKey,
+    ...actions,
+  };
+}
+
+function useVolumeUrlActions({
+  canUseVolumeFilters,
+  range,
+  actorFilter,
+  exclusions,
+  venue,
+  setRange,
+  setActorFilter,
+  setExclusions,
+  setVenue,
+}: VolumeUrlActionInputs): Pick<
+  VolumeUrlStateResult,
+  | "updateRange"
+  | "updateIncludeProtocolActors"
+  | "updateExclusions"
+  | "updateVenue"
+> {
+  const writeUrl = useCallback(
+    (next: VolumeUrlSnapshot) => {
+      writeVolumeUrl(next, canUseVolumeFilters);
+    },
+    [canUseVolumeFilters],
+  );
+
+  const updateRange = useCallback(
+    (next: VolumeRangeKey) => {
+      setRange(next);
+      writeUrl({ range: next, actorFilter, exclusions, venue });
+    },
+    [actorFilter, exclusions, venue, writeUrl, setRange],
+  );
+  const updateIncludeProtocolActors = useCallback(
+    (next: boolean) => {
+      if (!canUseVolumeFilters) {
+        setActorFilter("all");
+        writeUrl({ range, actorFilter: "all", exclusions, venue });
+        return;
+      }
+      const nextActorFilter: ActorFilter = next ? "all" : "organic";
+      setActorFilter(nextActorFilter);
+      writeUrl({ range, actorFilter: nextActorFilter, exclusions, venue });
+    },
+    [canUseVolumeFilters, exclusions, range, venue, writeUrl, setActorFilter],
+  );
+  const updateExclusions = useCallback(
+    (next: VolumeExclusionState) => {
+      if (!canUseVolumeFilters) {
+        const emptyExclusions = { addresses: [], sources: [] };
+        setExclusions(emptyExclusions);
+        writeUrl({
+          range,
+          actorFilter: "all",
+          exclusions: emptyExclusions,
+          venue,
+        });
+        return;
+      }
+      setExclusions(next);
+      writeUrl({ range, actorFilter, exclusions: next, venue });
+    },
+    [actorFilter, canUseVolumeFilters, range, venue, writeUrl, setExclusions],
+  );
+  const updateVenue = useCallback(
+    (next: Venue) => {
+      setVenue(next);
+      writeUrl({ range, actorFilter, exclusions, venue: next });
+    },
+    [actorFilter, exclusions, range, writeUrl, setVenue],
+  );
+
+  return {
     updateRange,
     updateIncludeProtocolActors,
     updateExclusions,
@@ -245,11 +332,12 @@ export function useVolumeUrlState(): {
 }
 
 function useVolumePopstateSync({
+  canUseVolumeFilters,
   setRange,
   setActorFilter,
   setExclusions,
   setVenue,
-}: VolumeUrlSetters) {
+}: VolumeUrlSetters & { canUseVolumeFilters: boolean }) {
   // Browser back/forward fires `popstate`. `replaceState` itself doesn't,
   // and `useSearchParams` doesn't observe our writes — popstate is the only
   // signal that real navigation moved the URL out from under us.
@@ -266,21 +354,50 @@ function useVolumePopstateSync({
         return prev === next ? prev : next;
       });
       setActorFilter((prev) => {
-        const next = readActorFilterFromParams(params);
+        const next = canUseVolumeFilters
+          ? readActorFilterFromParams(params)
+          : "all";
         return prev === next ? prev : next;
       });
       setExclusions((prev) => {
-        const next = readExclusionsFromParams(params);
+        const next = canUseVolumeFilters
+          ? readExclusionsFromParams(params)
+          : { addresses: [], sources: [] };
         return exclusionsEqual(prev, next) ? prev : next;
       });
       setVenue((prev) => {
         const next = readVenueFromParams(params);
         return prev === next ? prev : next;
       });
+      if (!canUseVolumeFilters) stripVolumeFilterParamsFromCurrentUrl();
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, [setActorFilter, setExclusions, setRange, setVenue]);
+  }, [canUseVolumeFilters, setActorFilter, setExclusions, setRange, setVenue]);
+}
+
+function useLockedVolumeFilterCanonicalization({
+  canUseVolumeFilters,
+}: {
+  canUseVolumeFilters: boolean;
+}) {
+  useEffect(() => {
+    if (typeof window === "undefined" || canUseVolumeFilters) return;
+    stripVolumeFilterParamsFromCurrentUrl();
+  }, [canUseVolumeFilters]);
+}
+
+function stripVolumeFilterParamsFromCurrentUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const changed =
+    params.has("actors") ||
+    params.has("exclude") ||
+    params.has("excludeSources");
+  if (!changed) return;
+  params.delete("actors");
+  params.delete("exclude");
+  params.delete("excludeSources");
+  replaceVolumeUrlSearch(params);
 }
 
 function useUtcDayKey(): number {

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -61,8 +61,12 @@ type PoolRow = {
 // stacked bars of varying widths that look noisy).
 const RANGES_WITH_CHART = new Set<VolumeRangeKey>(["30d", "90d", "all"]);
 
-export function VolumeClient() {
-  const urlState = useVolumeUrlState();
+export function VolumeClient({
+  canUseVolumeFilters,
+}: {
+  canUseVolumeFilters: boolean;
+}) {
+  const urlState = useVolumeUrlState({ canUseVolumeFilters });
   const model = useVolumePageModel(urlState);
   return <VolumePageView urlState={urlState} model={model} />;
 }
@@ -443,12 +447,14 @@ function VolumePageView({
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 sm:py-8 space-y-6">
       <VolumePageHeader urlState={urlState} />
-      <VolumeExclusionFilter
-        exclusions={displayedExclusions}
-        allowSourceExclusions={urlState.venue === "v3"}
-        sourceOptions={aggregates.sourceOptions}
-        onChange={urlState.updateExclusions}
-      />
+      {urlState.canUseVolumeFilters && (
+        <VolumeExclusionFilter
+          exclusions={displayedExclusions}
+          allowSourceExclusions={urlState.venue === "v3"}
+          sourceOptions={aggregates.sourceOptions}
+          onChange={urlState.updateExclusions}
+        />
+      )}
       <HeroDataQualityBanners
         staleChains={hero.staleChains}
         degradedChains={hero.degradedChains}

--- a/ui-dashboard/src/app/volume/page.tsx
+++ b/ui-dashboard/src/app/volume/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { getAuthSession } from "@/auth";
 import { VolumeClient } from "./page-client";
 
 export const metadata = {
@@ -7,10 +8,12 @@ export const metadata = {
     "Top traders on Mento by USD volume — sorted by 24h, 7d, 30d, or all-time, with per-pool flow breakdown.",
 };
 
-export default function VolumePage() {
+export default async function VolumePage() {
+  const session = await getAuthSession();
+
   return (
     <Suspense>
-      <VolumeClient />
+      <VolumeClient canUseVolumeFilters={!!session} />
     </Suspense>
   );
 }

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import { cache } from "react";
 import type { JWT } from "next-auth/jwt";
 import * as Sentry from "@sentry/nextjs";
 
@@ -225,7 +226,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
 });
 
-export async function getAuthSession() {
+export const getAuthSession = cache(async function getAuthSession() {
   const session = await auth();
   // A failed Google refresh probe (offboarded / revoked account) invalidates
   // the session even though the JWT itself is still cryptographically valid.
@@ -233,7 +234,7 @@ export async function getAuthSession() {
   return session?.user?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN)
     ? session
     : null;
-}
+});
 
 // Module augmentation is co-located here (rather than in auth.d.ts) so it
 // reliably merges with next-auth's types: a sibling `auth.d.ts` is treated as


### PR DESCRIPTION
## The Problem

- The volume page exposed the organic/all actor filter to external users.
- External users could also carry private exclusion parameters in the URL.
- Public volume views should always represent total volume, not a private filtered view.

## The Solution

- Gate the organic/all actor filter and exploratory exclusions behind the existing dashboard login session.
- Force logged-out users onto total volume and canonicalize private filter params out of the URL.
- Keep the private controls and organic default available for signed-in operators.

## Details

- `/volume` now checks `getAuthSession()` server-side and passes the filter permission into the client page.
- `useVolumeUrlState` treats anonymous users as `actors=all`, strips `actors`, `exclude`, and `excludeSources`, and keeps popstate navigation locked to total volume.
- Anonymous v2/v3 copy now says total volume and avoids suggesting hidden protocol-actor controls.
- Logged-in users keep the existing organic default, the all/organic toggle, and exploratory exclusions.

## Invariants

- Logged-out users always query volume with `isProtocolActorIn: [false, true]`.
- Logged-out URLs never retain `actors`, `exclude`, or `excludeSources`.
- Logged-out UI never renders the protocol-actors toggle or exploratory exclusions panel.
- Logged-in users keep the private filter controls and can still choose organic volume.

## Degraded Behavior

- Existing GraphQL error and empty states are preserved.
- Public empty-state copy does not reference unavailable private filters.
- Private exploratory-exclusion empty states remain available only to logged-in users.

## Intentional Non-Goals

- No auth changes beyond reusing the current dashboard session.
- No query/schema/indexer changes.
- No change to the logged-in organic-vs-all semantics.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- src/app/volume/__tests__/page-client.test.tsx src/app/volume/_lib/__tests__/url-state.test.tsx src/app/volume/_components/__tests__/volume-table.test.tsx` passed (`204` files, `2956` tests).
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` passed.
- `pnpm agent:quality-gate --run` passed all mapped commands, including coverage, dashboard browser tests, React Doctor diff/score, build, and size-limit.
- Pre-push `pnpm agent:quality-gate --run` passed all mapped commands again.
- `pnpm agent:autoreview --engine local` reported no accepted/actionable findings.
- Chrome DevTools manual verification passed for anonymous v3 and v2 URLs with private filter params: URLs canonicalized, private controls were absent, request bodies used total-volume actor filters, and no console errors appeared.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-gated UI and URL state that drives GraphQL `isProtocolActorIn`; mis-gating could hide controls from operators or leak private filter semantics to anonymous users, but behavior is heavily tested and defense-in-depth in url-state.
> 
> **Overview**
> **Restricts protocol-actor and exploratory-exclusion controls on `/volume` to signed-in dashboard users** so anonymous visitors always see **total** volume.
> 
> The volume route resolves `getAuthSession()` on the server and passes `canUseVolumeFilters={!!session}` into `VolumeClient`. `useVolumeUrlState` now takes that flag: logged-out users are locked to `actors=all`, private query params (`actors`, `exclude`, `excludeSources`) are stripped from the URL on load, popstate, and guarded updates, and the hook exposes `canUseVolumeFilters` on its result.
> 
> **UI:** The protocol-actors toggle and `VolumeExclusionFilter` render only when `canUseVolumeFilters` is true. Headers, table info tooltips, and empty states use “total volume” copy for anonymous users and omit hints about hidden filters. `VolumeTable` / v2 tables take a parent-supplied `emptyMessage` for those variants.
> 
> **Auth:** `getAuthSession` is wrapped in React `cache()` for deduped session reads within a request.
> 
> Tests cover URL locking, popstate, and client GraphQL variables for anonymous vs signed-in users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b7cef1129f70c739b5958b3e5f074035fe6f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->