### PR TITLE
Fix alerts delivery drift env coverage

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -121,8 +121,13 @@ jobs:
       TF_VAR_splunk_on_call_alerts_webhook_url: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_ALERTS_WEBHOOK_URL }}
       TF_VAR_sentry_auth_token: ${{ secrets.TF_VAR_SENTRY_AUTH_TOKEN }}
       TF_VAR_billing_account: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
+      TF_VAR_terraform_service_account: org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com
       TF_VAR_quicknode_api_key: ${{ secrets.TF_VAR_QUICKNODE_API_KEY }}
       TF_VAR_quicknode_signing_secret: ${{ secrets.TF_VAR_QUICKNODE_SIGNING_SECRET }}
+      TF_VAR_splunk_on_call_api_id: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_ID }}
+      TF_VAR_splunk_on_call_api_key: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
+      TF_VAR_oncall_slack_channel_id: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
+      TF_VAR_oncall_support_usergroup_id: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
       TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     defaults:
       run:

--- a/scripts/tf-stacks.test.mjs
+++ b/scripts/tf-stacks.test.mjs
@@ -372,6 +372,43 @@ function assert(condition, message) {
   }
 }
 
+function terraformEnvNames(workflowPath) {
+  const contents = readFileSync(path.join(repoRoot, workflowPath), "utf8");
+  const names = new Set();
+  const terraformEnvLine = /^\s+(TF_VAR_[A-Za-z0-9_]+):\s+.+$/gmu;
+
+  for (const match of contents.matchAll(terraformEnvLine)) {
+    names.add(match[1]);
+  }
+
+  return names;
+}
+
+function assertDriftWorkflowEnvCoversAutoAppliedStackVars() {
+  const stackWorkflowPaths = [
+    ".github/workflows/alerts-rules.yml",
+    ".github/workflows/alerts-infra.yml",
+    ".github/workflows/aegis-terraform.yml",
+  ];
+  const requiredNames = new Set();
+
+  for (const workflowPath of stackWorkflowPaths) {
+    for (const name of terraformEnvNames(workflowPath)) {
+      requiredNames.add(name);
+    }
+  }
+
+  const driftNames = terraformEnvNames(".github/workflows/terraform-drift.yml");
+  const missingNames = [...requiredNames]
+    .filter((name) => !driftNames.has(name))
+    .sort();
+
+  assert(
+    missingNames.length === 0,
+    `terraform-drift.yml is missing TF_VAR_* values used by auto-applied stack workflows: ${missingNames.join(", ")}`,
+  );
+}
+
 const registry = JSON.parse(run(["list", "--json"]));
 const stackIds = registry.stacks.map((stack) => stack.id);
 const requiredStackIds = [
@@ -400,6 +437,8 @@ for (const stack of registry.stacks) {
     `${stack.id} must react to wrapper edits`,
   );
 }
+
+assertDriftWorkflowEnvCoversAutoAppliedStackVars();
 
 const tempDir = mkdtempSync(path.join(tmpdir(), "tf-stacks-test-"));
 try {

--- a/scripts/tf-stacks.test.mjs
+++ b/scripts/tf-stacks.test.mjs
@@ -384,12 +384,24 @@ function terraformEnvNames(workflowPath) {
   return names;
 }
 
-function assertDriftWorkflowEnvCoversAutoAppliedStackVars() {
-  const stackWorkflowPaths = [
-    ".github/workflows/alerts-rules.yml",
-    ".github/workflows/alerts-infra.yml",
-    ".github/workflows/aegis-terraform.yml",
-  ];
+function autoAppliedStackWorkflowPaths(stacks) {
+  return [
+    ...new Set(
+      stacks
+        .filter(
+          (stack) => stack.ci?.apply === "push-main-production-environment",
+        )
+        .flatMap((stack) =>
+          (stack.changedPathPatterns ?? []).filter((pattern) =>
+            pattern.startsWith(".github/workflows/"),
+          ),
+        ),
+    ),
+  ].sort();
+}
+
+function assertDriftWorkflowEnvCoversAutoAppliedStackVars(stacks) {
+  const stackWorkflowPaths = autoAppliedStackWorkflowPaths(stacks);
   const requiredNames = new Set();
 
   for (const workflowPath of stackWorkflowPaths) {
@@ -438,7 +450,7 @@ for (const stack of registry.stacks) {
   );
 }
 
-assertDriftWorkflowEnvCoversAutoAppliedStackVars();
+assertDriftWorkflowEnvCoversAutoAppliedStackVars(registry.stacks);
 
 const tempDir = mkdtempSync(path.join(tmpdir(), "tf-stacks-test-"));
 try {


### PR DESCRIPTION
## The Problem

- The scheduled Terraform drift workflow reported `alerts-delivery` would destroy the on-call announcer resources.
- That drift report was a false positive because the drift job did not pass the same Terraform variables as the alerts-infra plan/apply workflow.

## The Solution

- Mirror the missing alerts-infra `TF_VAR_*` values in the scheduled drift workflow so it evaluates production with the on-call announcer enabled.
- Add a regression test that fails when the drift workflow stops carrying any Terraform variables used by the auto-applied stack workflows.

## Details

- Adds the on-call Splunk, Slack channel, support usergroup, and Terraform service account variables to `.github/workflows/terraform-drift.yml`.
- Extends `scripts/tf-stacks.test.mjs` to compare `TF_VAR_*` coverage between `terraform-drift.yml` and the auto-applied stack workflows.
- Closes #784.

## Validation

- `pnpm tf:test` passed.
- `pnpm agent:autoreview` passed via deterministic fallback; Codex review engine was unavailable in this environment.
- `pnpm agent:quality-gate --run` passed.
- Live production `alerts-delivery` plan passed with exit code 0: `No changes. Your infrastructure matches the configuration.`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow env and test changes; no runtime app or Terraform module logic changes.
> 
> **Overview**
> Fixes **false-positive drift** on `alerts-delivery` by aligning the scheduled drift job with the same Terraform inputs as auto-apply.
> 
> **`terraform-drift.yml`** now passes the on-call Splunk API credentials, Slack channel/support usergroup IDs, and `TF_VAR_terraform_service_account` (write deployer SA) so drift plans evaluate production with the on-call announcer enabled instead of planning destroys.
> 
> **`scripts/tf-stacks.test.mjs`** adds a regression check: it unions every `TF_VAR_*` from workflows tied to stacks with `push-main-production-environment` apply and fails if `terraform-drift.yml` is missing any of them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d387659f3286aeeee99aa0b89a6259f892f770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->