### PR TITLE
Add liquidity-aware Squid probe ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,19 +194,20 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 
 ### Integration Probes
 
-| Variable                        | Description                                                      |
-| ------------------------------- | ---------------------------------------------------------------- |
-| `INTEGRATION_PROBES_HASURA_URL` | Optional override for the pool-discovery GraphQL endpoint        |
-| `LIFI_API_KEY`                  | LI.FI/Jumper quote API key; probes return `needs_key` without it |
-| `OPENOCEAN_API_KEY`             | Optional OpenOcean Pro quote API key                             |
-| `ZEROX_API_KEY`                 | Optional 0x quote API key                                        |
-| `ONEINCH_API_KEY`               | Optional 1inch quote API key                                     |
-| `SQUID_INTEGRATOR_ID`           | Squid integrator id; probes return `needs_key` without it        |
-| `SOCKET_API_KEY`                | Optional Socket quote API key                                    |
-| `RANGO_API_KEY`                 | Optional Rango quote API key                                     |
-| `OKX_DEX_API_KEY`               | Optional OKX DEX API key                                         |
-| `OKX_DEX_SECRET`                | Optional OKX DEX signing secret                                  |
-| `OKX_DEX_PASSPHRASE`            | Optional OKX DEX passphrase                                      |
+| Variable                        | Description                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------------- |
+| `INTEGRATION_PROBES_HASURA_URL` | Optional override for the pool-discovery GraphQL endpoint                                   |
+| `LIFI_API_KEY`                  | LI.FI/Jumper quote API key; probes return `needs_key` without it                            |
+| `OPENOCEAN_API_KEY`             | Optional OpenOcean Pro quote API key                                                        |
+| `ZEROX_API_KEY`                 | Optional 0x quote API key                                                                   |
+| `ONEINCH_API_KEY`               | Optional 1inch quote API key                                                                |
+| `SQUID_INTEGRATOR_ID`           | Squid integrator id; probes return `needs_key` without it                                   |
+| `SQUID_CELO_RPC_URL`            | Optional Celo RPC override for Squid Uniswap-liquidity discovery sizing (defaults to Forno) |
+| `SOCKET_API_KEY`                | Optional Socket quote API key                                                               |
+| `RANGO_API_KEY`                 | Optional Rango quote API key                                                                |
+| `OKX_DEX_API_KEY`               | Optional OKX DEX API key                                                                    |
+| `OKX_DEX_SECRET`                | Optional OKX DEX signing secret                                                             |
+| `OKX_DEX_PASSPHRASE`            | Optional OKX DEX passphrase                                                                 |
 
 Production env vars are managed by Terraform except the Blob OIDC variables, which are managed by the Vercel store integration. See [`terraform/`](./terraform/).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -149,7 +149,9 @@ discovery. `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with the
 `x-lifi-api-key` header so scheduled runs avoid public quote limits,
 `OPENOCEAN_API_KEY` enables the OpenOcean Pro endpoint for OpenOcean checks,
 and `SQUID_INTEGRATOR_ID` identifies Mento's Squid quote probes through the
-`x-integrator-id` header. These are managed by the platform Terraform stack
+`x-integrator-id` header. Squid Celo probes also read Uniswap V3 pool balances
+through `SQUID_CELO_RPC_URL` when set, defaulting to Forno, to size discovery
+amounts after the default quote. These are managed by the platform Terraform stack
 from `lifi_api_key`, `openocean_api_key`, and `squid_integrator_id`. The same
 platform stack mirrors
 `INTEGRATION_PROBES_HASURA_URL`, `UPSTASH_REDIS_REST_URL`, and

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -54,6 +54,10 @@ pnpm --filter @mento-protocol/integration-probes knip
 - Squid quote probes are capped and paced between requests because bursty
   route checks can trigger 429s. Do not remove or lower the request delay
   without live route evidence that the scheduled probe remains healthy.
+- Squid Celo probes use Mento reserve metadata plus the current official
+  Uniswap V3 Celo pool sell-side balance, when RPC is available, to size a
+  small discovery ladder after the default quote. This is only for amount
+  selection; a pass still requires Mento v3 router or registered pool evidence.
 - `integration-probes:latest` expires after 3 days so failed scheduled probes
   degrade the dashboard instead of showing stale health forever. Dated history
   keys expire after 90 days.
@@ -73,3 +77,5 @@ pnpm --filter @mento-protocol/integration-probes knip
   `x-lifi-api-key`; keep it server-side and Terraform-managed.
 - `SQUID_INTEGRATOR_ID` authenticates Squid quote probes with
   `x-integrator-id`; keep it server-side and Terraform-managed.
+- `SQUID_CELO_RPC_URL` optionally overrides the default Forno Celo RPC used for
+  Squid Uniswap-liquidity discovery sizing. It is not a credential.

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -297,6 +297,70 @@ describe("probeAdapterPair", () => {
     expect(result.routeAmountUsd).toBe("250");
   });
 
+  it("does not build async quote requests after a shared budget is exhausted", async () => {
+    let builtRequests = false;
+    const adapter: AggregatorAdapter = {
+      id: "async-budgeted",
+      label: "Async Budgeted",
+      kind: "dex",
+      tier: 1,
+      support: { 42220: "supported" },
+      researchNote: "test",
+      quote: async () => {
+        builtRequests = true;
+        return { url: "https://example.test/should-not-build" };
+      },
+    };
+
+    const result = await probeAdapterPair({
+      adapter,
+      chain,
+      input,
+      fetcher: async () => {
+        throw new Error("should not fetch");
+      },
+      env: {},
+      quoteBudget: { remaining: 0 },
+    });
+
+    expect(result.status).toBe("rate_limited");
+    expect(result.attemptCount).toBe(0);
+    expect(builtRequests).toBe(false);
+  });
+
+  it("does not run failure discovery after the final budgeted attempt", async () => {
+    let builtDiscovery = false;
+    const adapter: AggregatorAdapter = {
+      id: "lazy-budgeted",
+      label: "Lazy Budgeted",
+      kind: "dex",
+      tier: 1,
+      support: { 42220: "supported" },
+      researchNote: "test",
+      quote: () => ({
+        url: "https://example.test/default",
+        afterFailure: async () => {
+          builtDiscovery = true;
+          return [{ url: "https://example.test/discovery" }];
+        },
+      }),
+    };
+
+    const result = await probeAdapterPair({
+      adapter,
+      chain,
+      input,
+      fetcher: async () =>
+        new Response(JSON.stringify({ route: [{ protocol: "Other" }] })),
+      env: {},
+      quoteBudget: { remaining: 1 },
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.attemptCount).toBe(1);
+    expect(builtDiscovery).toBe(false);
+  });
+
   it("follows LI.FI Fly routes to Monad Fly distributions for pool evidence", async () => {
     const lifi = AGGREGATOR_ADAPTERS.find((item) => item.id === "lifi");
     expect(lifi).toBeDefined();

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -263,6 +263,40 @@ describe("probeAdapterPair", () => {
     expect(result.attemptCount).toBe(2);
   });
 
+  it("awaits async adapter quote builders", async () => {
+    const adapter: AggregatorAdapter = {
+      id: "async-attempt",
+      label: "Async Attempt",
+      kind: "dex",
+      tier: 1,
+      support: { 42220: "supported" },
+      researchNote: "test",
+      quote: async () => [
+        {
+          url: "https://example.test/async",
+          amountDecimal: "250",
+          variant: "async-discovery",
+        },
+      ],
+    };
+
+    const result = await probeAdapterPair({
+      adapter,
+      chain,
+      input,
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({ route: [{ pool: `swap through ${POOL}` }] }),
+        ),
+      env: {},
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.requestUrl).toBe("https://example.test/async");
+    expect(result.routeVariant).toBe("async-discovery");
+    expect(result.routeAmountUsd).toBe("250");
+  });
+
   it("follows LI.FI Fly routes to Monad Fly distributions for pool evidence", async () => {
     const lifi = AGGREGATOR_ADAPTERS.find((item) => item.id === "lifi");
     expect(lifi).toBeDefined();
@@ -1229,7 +1263,7 @@ describe("aggregator quote builders", () => {
     );
 
     const squid = AGGREGATOR_ADAPTERS.find((item) => item.id === "squid");
-    expect(squid?.maxQuoteRequestsPerRun).toBe(80);
+    expect(squid?.maxQuoteRequestsPerRun).toBe(160);
     expect(squid?.quoteRequestDelayMs).toBe(2500);
     const squidRequest = squid?.quote?.(input, env);
     const squidQuoteRequest = firstQuoteRequest(squidRequest);

--- a/integration-probes/src/__tests__/pairs.test.ts
+++ b/integration-probes/src/__tests__/pairs.test.ts
@@ -28,6 +28,8 @@ describe("hubPairsFromPoolRows", () => {
     expect(pairs[0]?.poolAddress).toBe(
       "0x3333333333333333333333333333333333333333",
     );
+    expect(pairs[0]?.baseReserveRaw).toBe("1");
+    expect(pairs[0]?.quoteReserveRaw).toBe("1");
   });
 
   it("omits drained and non-USDm pools", () => {
@@ -82,6 +84,10 @@ describe("buildQuoteInputs", () => {
       "usdm-to-base",
     ]);
     expect(inputs[0]?.amountRaw).toBe("1000000000000000000");
+    expect(inputs[0]?.sellReserveRaw).toBe("1");
+    expect(inputs[0]?.buyReserveRaw).toBe("1");
+    expect(inputs[1]?.sellReserveRaw).toBe("1");
+    expect(inputs[1]?.buyReserveRaw).toBe("1");
   });
 });
 

--- a/integration-probes/src/__tests__/squidLiquidity.test.ts
+++ b/integration-probes/src/__tests__/squidLiquidity.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { squidQuoteRequests } from "../adapterRequests.js";
-import type { ChainProbeConfig, FetchLike, QuoteProbeInput } from "../types.js";
+import type {
+  ChainProbeConfig,
+  FetchLike,
+  PairProbeResult,
+  QuoteProbeInput,
+} from "../types.js";
 
 const SELL = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const BUY = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -48,7 +53,7 @@ const chain: ChainProbeConfig = {
 
 describe("squidQuoteRequests", () => {
   it("builds a liquidity-aware Celo discovery ladder from Uniswap depth", async () => {
-    const requests = await squidQuoteRequests(
+    const requests = await squidRequestsAfterDefaultFailure(
       input,
       { SQUID_INTEGRATOR_ID: "squid-id" },
       chain,
@@ -78,7 +83,7 @@ describe("squidQuoteRequests", () => {
   });
 
   it("falls back to Mento reserve sizing when Uniswap depth is unavailable", async () => {
-    const requests = await squidQuoteRequests(
+    const requests = await squidRequestsAfterDefaultFailure(
       input,
       { SQUID_INTEGRATOR_ID: "squid-id" },
       chain,
@@ -102,7 +107,7 @@ describe("squidQuoteRequests", () => {
   });
 
   it("does not call Celo RPC for non-Celo ladders", async () => {
-    const requests = await squidQuoteRequests(
+    const requests = await squidRequestsAfterDefaultFailure(
       {
         ...input,
         chainId: 143,
@@ -129,7 +134,7 @@ describe("squidQuoteRequests", () => {
   });
 
   it("uses the first-hop sell depth from an active via-USDT path", async () => {
-    const requests = await squidQuoteRequests(
+    const requests = await squidRequestsAfterDefaultFailure(
       input,
       { SQUID_INTEGRATOR_ID: "squid-id" },
       chainWithUsdt(),
@@ -154,6 +159,49 @@ describe("squidQuoteRequests", () => {
     ).toBe(true);
   });
 });
+
+async function squidRequestsAfterDefaultFailure(
+  input: QuoteProbeInput,
+  env: NodeJS.ProcessEnv,
+  chain: ChainProbeConfig,
+  fetcher: FetchLike,
+): Promise<ReturnType<typeof squidQuoteRequests>> {
+  const defaultRequests = squidQuoteRequests(input, env);
+  const defaultRequest = defaultRequests[0]!;
+  expect(defaultRequests).toHaveLength(1);
+  expect(defaultRequest.afterFailure).toEqual(expect.any(Function));
+  const discoveredRequests = await defaultRequest.afterFailure!({
+    chain,
+    input,
+    fetcher,
+    request: defaultRequest,
+    primaryResult: failedPrimaryResult(input),
+  });
+  return [...defaultRequests, ...discoveredRequests];
+}
+
+function failedPrimaryResult(input: QuoteProbeInput): PairProbeResult {
+  return {
+    pairId: input.pairId,
+    poolId: "42220-0xpool",
+    direction: input.direction,
+    sellSymbol: input.sellToken.symbol,
+    buySymbol: input.buyToken.symbol,
+    status: "fail",
+    evidence: [],
+    sourceLabels: [],
+    txTarget: null,
+    downstreamProvider: null,
+    routeVariant: "default",
+    routeAmountUsd: input.amountDecimal,
+    attemptCount: 1,
+    requestUrl: "https://apiplus.squidrouter.com/v2/route",
+    httpStatus: 200,
+    latencyMs: 1,
+    responsePreview: "{}",
+    error: null,
+  };
+}
 
 function uniswapRpcFetcher(poolSellBalanceRaw: string): FetchLike {
   return async (_input, init) => {

--- a/integration-probes/src/__tests__/squidLiquidity.test.ts
+++ b/integration-probes/src/__tests__/squidLiquidity.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { squidQuoteRequests } from "../adapterRequests.js";
+import type { ChainProbeConfig, FetchLike, QuoteProbeInput } from "../types.js";
+
+const SELL = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const BUY = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const USDT = "0xdddddddddddddddddddddddddddddddddddddddd";
+const POOL = "0xcccccccccccccccccccccccccccccccccccccccc";
+const VIA_POOL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const RAW_1 = "1000000000000000000";
+const RAW_1K = "1000000000000000000000";
+const RAW_2K = "2000000000000000000000";
+const RAW_10K = "10000000000000000000000";
+
+const input: QuoteProbeInput = {
+  chainId: 42220,
+  pairId: "42220:EURm-USDm:42220-0xpool",
+  direction: "base-to-usdm",
+  sellToken: { symbol: "EURm", address: SELL, decimals: 18 },
+  buyToken: { symbol: "USDm", address: BUY, decimals: 18 },
+  amountDecimal: "1",
+  amountRaw: RAW_1,
+  sellReserveRaw: RAW_10K,
+  buyReserveRaw: RAW_10K,
+  takerAddress: "0x000000000000000000000000000000000000dEaD",
+};
+
+const chain: ChainProbeConfig = {
+  chainId: 42220,
+  chainLabel: "Celo",
+  chainSlug: "celo",
+  routerAddresses: [],
+  poolAddresses: [],
+  pairs: [
+    {
+      id: input.pairId,
+      chainId: input.chainId,
+      poolId: "42220-0xpool",
+      poolAddress: "0xpool",
+      poolSource: "fpmm_factory",
+      base: input.sellToken,
+      quote: input.buyToken,
+      baseReserveRaw: RAW_10K,
+      quoteReserveRaw: RAW_10K,
+    },
+  ],
+};
+
+describe("squidQuoteRequests", () => {
+  it("builds a liquidity-aware Celo discovery ladder from Uniswap depth", async () => {
+    const requests = await squidQuoteRequests(
+      input,
+      { SQUID_INTEGRATOR_ID: "squid-id" },
+      chain,
+      uniswapRpcFetcher(RAW_1K),
+    );
+
+    expect(requests).toHaveLength(9);
+    expect(requests[0]?.variant).toBe("default");
+    expect(requestBody(requests[0]!).fromAmount).toBe(RAW_1);
+    expect(requests.map((request) => request.amountDecimal)).toEqual([
+      "1",
+      "5",
+      "10",
+      "20",
+      "50",
+      "100",
+      "2000",
+      "5000",
+      "9000",
+    ]);
+    expect(
+      requests.some(
+        (request) => request.variant === "squid-uniswap-depth-0.5pct",
+      ),
+    ).toBe(true);
+    expect(requestBody(requests[1]!).fromAmount).toBe("5000000000000000000");
+  });
+
+  it("falls back to Mento reserve sizing when Uniswap depth is unavailable", async () => {
+    const requests = await squidQuoteRequests(
+      input,
+      { SQUID_INTEGRATOR_ID: "squid-id" },
+      chain,
+      async () => {
+        throw new Error("rpc unavailable");
+      },
+    );
+
+    expect(requests.map((request) => request.amountDecimal)).toEqual([
+      "1",
+      "10",
+      "100",
+      "500",
+      "2000",
+      "5000",
+      "9000",
+    ]);
+    expect(
+      requests.some((request) => request.variant?.startsWith("squid-mento")),
+    ).toBe(true);
+  });
+
+  it("does not call Celo RPC for non-Celo ladders", async () => {
+    const requests = await squidQuoteRequests(
+      {
+        ...input,
+        chainId: 143,
+        sellToken: { ...input.sellToken, decimals: 0 },
+        amountRaw: "1",
+        sellReserveRaw: "1000",
+      },
+      { SQUID_INTEGRATOR_ID: "squid-id" },
+      { ...chain, chainId: 143 },
+      async () => {
+        throw new Error("should not call RPC");
+      },
+    );
+
+    expect(requests.map((request) => request.amountDecimal)).toEqual([
+      "1",
+      "10",
+      "50",
+      "100",
+      "200",
+      "500",
+      "900",
+    ]);
+  });
+
+  it("uses the first-hop sell depth from an active via-USDT path", async () => {
+    const requests = await squidQuoteRequests(
+      input,
+      { SQUID_INTEGRATOR_ID: "squid-id" },
+      chainWithUsdt(),
+      viaUsdtRpcFetcher(),
+    );
+
+    expect(requests.map((request) => request.amountDecimal)).toEqual([
+      "1",
+      "10",
+      "40",
+      "100",
+      "200",
+      "500",
+      "2000",
+      "5000",
+      "9000",
+    ]);
+    expect(
+      requests.some(
+        (request) => request.variant === "squid-uniswap-depth-2pct",
+      ),
+    ).toBe(true);
+  });
+});
+
+function uniswapRpcFetcher(poolSellBalanceRaw: string): FetchLike {
+  return async (_input, init) => {
+    const body = JSON.parse(String(init?.body));
+    const data = String(body.params[0].data);
+    if (data.startsWith("0x1698ee82")) {
+      const fee = BigInt(`0x${data.slice(-64)}`);
+      return new Response(
+        JSON.stringify({
+          result: encodeAddressResult(fee === 100n ? POOL : ZERO_ADDRESS),
+        }),
+      );
+    }
+    if (data.startsWith("0x1a686502")) {
+      return new Response(JSON.stringify({ result: encodeUint(1n) }));
+    }
+    if (data.startsWith("0x70a08231")) {
+      return new Response(
+        JSON.stringify({ result: encodeUint(BigInt(poolSellBalanceRaw)) }),
+      );
+    }
+    throw new Error(`unexpected RPC data ${data}`);
+  };
+}
+
+function viaUsdtRpcFetcher(): FetchLike {
+  return async (_input, init) => {
+    const body = JSON.parse(String(init?.body));
+    const call = body.params[0] as { to: string; data: string };
+    if (call.data.startsWith("0x1698ee82")) {
+      const fee = BigInt(`0x${call.data.slice(-64)}`);
+      const pool =
+        fee === 100n && callIncludes(call.data, SELL, USDT)
+          ? POOL
+          : fee === 100n && callIncludes(call.data, USDT, BUY)
+            ? VIA_POOL
+            : ZERO_ADDRESS;
+      return new Response(
+        JSON.stringify({ result: encodeAddressResult(pool) }),
+      );
+    }
+    if (call.data.startsWith("0x1a686502")) {
+      return new Response(JSON.stringify({ result: encodeUint(1n) }));
+    }
+    if (call.data.startsWith("0x70a08231")) {
+      const balance = call.to.toLowerCase() === SELL ? RAW_2K : RAW_1K;
+      return new Response(
+        JSON.stringify({ result: encodeUint(BigInt(balance)) }),
+      );
+    }
+    throw new Error(`unexpected RPC data ${call.data}`);
+  };
+}
+
+function chainWithUsdt(): ChainProbeConfig {
+  return {
+    ...chain,
+    pairs: [
+      ...chain.pairs,
+      {
+        id: "42220:USDT-USDm:42220-0xusdt",
+        chainId: input.chainId,
+        poolId: "42220-0xusdt",
+        poolAddress: "0xusdt",
+        poolSource: "fpmm_factory",
+        base: { symbol: "USDT", address: USDT, decimals: 18 },
+        quote: input.buyToken,
+      },
+    ],
+  };
+}
+
+function callIncludes(data: string, a: string, b: string): boolean {
+  return (
+    data.includes(encodeAddressArg(a)) && data.includes(encodeAddressArg(b))
+  );
+}
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function requestBody(request: { init?: RequestInit }): Record<string, unknown> {
+  return JSON.parse(String(request.init?.body)) as Record<string, unknown>;
+}
+
+function encodeAddressResult(address: string): string {
+  return `0x${address.replace(/^0x/u, "").padStart(64, "0")}`;
+}
+
+function encodeAddressArg(address: string): string {
+  return address.replace(/^0x/u, "").padStart(64, "0");
+}
+
+function encodeUint(value: bigint): string {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}

--- a/integration-probes/src/adapterRequests.ts
+++ b/integration-probes/src/adapterRequests.ts
@@ -3,12 +3,13 @@ import type {
   QuoteResponseEvidenceHook,
   RequestHeaders,
 } from "./adapterTypes.js";
-import type { QuoteProbeInput } from "./types.js";
+import type { ChainProbeConfig, FetchLike, QuoteProbeInput } from "./types.js";
+import { squidLiquidityAmountCandidates } from "./squidLiquidity.js";
 
 const LIFI_INTEGRATOR = "mento-probes";
 export const LIFI_MAX_QUOTE_REQUESTS_PER_RUN = 180;
-export const LIFI_FLY_EXCHANGE = "fly";
-export const SQUID_MAX_QUOTE_REQUESTS_PER_RUN = 80;
+const LIFI_FLY_EXCHANGE = "fly";
+export const SQUID_MAX_QUOTE_REQUESTS_PER_RUN = 160;
 export const SQUID_QUOTE_REQUEST_DELAY_MS = 2_500;
 
 const LIFI_FLY_CHAIN_ID = 143;
@@ -38,9 +39,11 @@ export function postRequest(
   url: string,
   body: unknown,
   headers?: RequestHeaders,
+  metadata: Omit<QuoteRequest, "url" | "init"> = {},
 ): QuoteRequest {
   return {
     url,
+    ...metadata,
     init: {
       method: "POST",
       headers: { "content-type": "application/json", ...headers },
@@ -225,6 +228,48 @@ export function squidBody(input: QuoteProbeInput): unknown {
     slippage: 1,
     quoteOnly: true,
   };
+}
+
+export async function squidQuoteRequests(
+  input: QuoteProbeInput,
+  env: NodeJS.ProcessEnv,
+  chain: ChainProbeConfig,
+  fetcher: FetchLike,
+): Promise<readonly QuoteRequest[]> {
+  const headers = {
+    "x-integrator-id": env.SQUID_INTEGRATOR_ID!,
+  };
+  const defaultRequest = postRequest(
+    "https://apiplus.squidrouter.com/v2/route",
+    squidBody(input),
+    headers,
+    {
+      amountDecimal: input.amountDecimal,
+      amountRaw: input.amountRaw,
+      variant: "default",
+    },
+  );
+  const candidates = await squidLiquidityAmountCandidates({
+    input,
+    chain,
+    fetcher,
+    env,
+  });
+  return dedupeRequests([
+    defaultRequest,
+    ...candidates.map((candidate) =>
+      postRequest(
+        "https://apiplus.squidrouter.com/v2/route",
+        squidBody({
+          ...input,
+          amountDecimal: candidate.amountDecimal,
+          amountRaw: candidate.amountRaw,
+        }),
+        headers,
+        candidate,
+      ),
+    ),
+  ]);
 }
 
 export function relayBody(input: QuoteProbeInput): unknown {

--- a/integration-probes/src/adapterRequests.ts
+++ b/integration-probes/src/adapterRequests.ts
@@ -230,7 +230,35 @@ export function squidBody(input: QuoteProbeInput): unknown {
   };
 }
 
-export async function squidQuoteRequests(
+export function squidQuoteRequests(
+  input: QuoteProbeInput,
+  env: NodeJS.ProcessEnv,
+): readonly QuoteRequest[] {
+  const headers = {
+    "x-integrator-id": env.SQUID_INTEGRATOR_ID!,
+  };
+  return [
+    postRequest(
+      "https://apiplus.squidrouter.com/v2/route",
+      squidBody(input),
+      headers,
+      {
+        amountDecimal: input.amountDecimal,
+        amountRaw: input.amountRaw,
+        variant: "default",
+        afterFailure: (args) =>
+          squidDiscoveryQuoteRequests(
+            args.input,
+            env,
+            args.chain,
+            args.fetcher,
+          ),
+      },
+    ),
+  ];
+}
+
+async function squidDiscoveryQuoteRequests(
   input: QuoteProbeInput,
   env: NodeJS.ProcessEnv,
   chain: ChainProbeConfig,
@@ -239,25 +267,14 @@ export async function squidQuoteRequests(
   const headers = {
     "x-integrator-id": env.SQUID_INTEGRATOR_ID!,
   };
-  const defaultRequest = postRequest(
-    "https://apiplus.squidrouter.com/v2/route",
-    squidBody(input),
-    headers,
-    {
-      amountDecimal: input.amountDecimal,
-      amountRaw: input.amountRaw,
-      variant: "default",
-    },
-  );
   const candidates = await squidLiquidityAmountCandidates({
     input,
     chain,
     fetcher,
     env,
   });
-  return dedupeRequests([
-    defaultRequest,
-    ...candidates.map((candidate) =>
+  return dedupeRequests(
+    candidates.map((candidate) =>
       postRequest(
         "https://apiplus.squidrouter.com/v2/route",
         squidBody({
@@ -269,7 +286,7 @@ export async function squidQuoteRequests(
         candidate,
       ),
     ),
-  ]);
+  );
 }
 
 export function relayBody(input: QuoteProbeInput): unknown {

--- a/integration-probes/src/adapterTypes.ts
+++ b/integration-probes/src/adapterTypes.ts
@@ -12,6 +12,7 @@ export type QuoteRequest = {
   amountDecimal?: string;
   amountRaw?: string;
   afterResponse?: QuoteResponseEvidenceHook;
+  afterFailure?: QuoteFailureDiscoveryHook;
 };
 
 export type QuoteAttemptBudget = {
@@ -24,6 +25,10 @@ export type QuoteResponseEvidenceHook = (
   args: QuoteResponseEvidenceArgs,
 ) => Promise<PairProbeResult | null>;
 
+type QuoteFailureDiscoveryHook = (
+  args: QuoteFailureDiscoveryArgs,
+) => Promise<readonly QuoteRequest[]>;
+
 export type QuoteResponseEvidenceArgs = {
   chain: ChainProbeConfig;
   input: QuoteProbeInput;
@@ -32,6 +37,14 @@ export type QuoteResponseEvidenceArgs = {
   payload: unknown;
   primaryResult: PairProbeResult;
   quoteBudget?: QuoteAttemptBudget | undefined;
+};
+
+type QuoteFailureDiscoveryArgs = {
+  chain: ChainProbeConfig;
+  input: QuoteProbeInput;
+  fetcher: FetchLike;
+  request: QuoteRequest;
+  primaryResult: PairProbeResult;
 };
 
 export type TimedPayload = {

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -192,6 +192,9 @@ async function fetchAndEvaluate(args: {
   quoteBudget?: QuoteAttemptBudget | undefined;
   beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
+  if (!hasQuoteAttempt(args.quoteBudget)) {
+    return quoteBudgetExhaustedResult(args.input, 0);
+  }
   const requests = normalizeQuoteRequests(
     await args.adapter.quote!(args.input, args.env, {
       chain: args.chain,
@@ -201,7 +204,9 @@ async function fetchAndEvaluate(args: {
   let fallback: PairProbeResult | null = null;
   let attemptCount = 0;
   let requestErrorAttempts = 0;
-  for (const request of requests) {
+  const queue = [...requests];
+  for (let index = 0; index < queue.length; index += 1) {
+    const request = queue[index]!;
     if (!consumeQuoteAttempt(args.quoteBudget)) {
       return quoteBudgetExhaustedResult(args.input, attemptCount);
     }
@@ -221,10 +226,31 @@ async function fetchAndEvaluate(args: {
     if (requestErrorLimitReached(result, requestErrorAttempts)) {
       return result;
     }
+    await appendFailureDiscoveryRequests({ ...args, request, result, queue });
   }
   return fallback
     ? { ...fallback, attemptCount }
     : skippedResult(args.input, "error", "No quote requests built.");
+}
+
+async function appendFailureDiscoveryRequests(args: {
+  chain: ChainProbeConfig;
+  input: QuoteProbeInput;
+  fetcher: FetchLike;
+  request: QuoteRequest;
+  result: PairProbeResult;
+  queue: QuoteRequest[];
+  quoteBudget?: QuoteAttemptBudget | undefined;
+}): Promise<void> {
+  if (!args.request.afterFailure || !hasQuoteAttempt(args.quoteBudget)) return;
+  const discoveredRequests = await args.request.afterFailure({
+    chain: args.chain,
+    input: args.input,
+    fetcher: args.fetcher,
+    request: args.request,
+    primaryResult: args.result,
+  });
+  args.queue.push(...normalizeQuoteRequests(discoveredRequests));
 }
 
 function quoteBudgetExhaustedResult(
@@ -410,6 +436,10 @@ function consumeQuoteAttempt(budget: QuoteAttemptBudget | undefined): boolean {
   if (budget.remaining <= 0) return false;
   budget.remaining -= 1;
   return true;
+}
+
+function hasQuoteAttempt(budget: QuoteAttemptBudget | undefined): boolean {
+  return !budget || budget.remaining > 0;
 }
 
 async function responseJson(response: Response): Promise<unknown> {
@@ -672,7 +702,7 @@ function squidAdapter(): AggregatorAdapter {
       "Celo Squid routing is observed in the repo registry; Monad needs quote evidence. Probes are serialized and paced to avoid 429s from bursty route checks.",
     quote: (input, env, context) =>
       context
-        ? squidQuoteRequests(input, env, context.chain, context.fetcher)
+        ? squidQuoteRequests(input, env)
         : postRequest(
             "https://apiplus.squidrouter.com/v2/route",
             squidBody(input),

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -17,6 +17,7 @@ import {
   socketUrl,
   SQUID_MAX_QUOTE_REQUESTS_PER_RUN,
   squidBody,
+  squidQuoteRequests,
   SQUID_QUOTE_REQUEST_DELAY_MS,
   zeroXUrl,
 } from "./adapterRequests.js";
@@ -41,6 +42,14 @@ const REQUEST_ERROR_ATTEMPT_LIMIT = 2;
 
 type ChainSupport = "supported" | "unsupported" | "unknown";
 type BeforeQuoteRequest = () => Promise<void>;
+type QuoteBuildContext = {
+  chain: ChainProbeConfig;
+  fetcher: FetchLike;
+};
+type QuoteBuildResult =
+  | QuoteRequest
+  | readonly QuoteRequest[]
+  | Promise<QuoteRequest | readonly QuoteRequest[]>;
 
 export type AggregatorAdapter = {
   id: string;
@@ -53,7 +62,8 @@ export type AggregatorAdapter = {
   quote?: (
     input: QuoteProbeInput,
     env: NodeJS.ProcessEnv,
-  ) => QuoteRequest | readonly QuoteRequest[];
+    context?: QuoteBuildContext,
+  ) => QuoteBuildResult;
   maxQuoteRequestsPerRun?: number;
   quoteRequestDelayMs?: number;
   nextStep?: string;
@@ -183,7 +193,10 @@ async function fetchAndEvaluate(args: {
   beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
   const requests = normalizeQuoteRequests(
-    args.adapter.quote!(args.input, args.env),
+    await args.adapter.quote!(args.input, args.env, {
+      chain: args.chain,
+      fetcher: args.fetcher,
+    }),
   );
   let fallback: PairProbeResult | null = null;
   let attemptCount = 0;
@@ -657,14 +670,16 @@ function squidAdapter(): AggregatorAdapter {
     quoteRequestDelayMs: SQUID_QUOTE_REQUEST_DELAY_MS,
     researchNote:
       "Celo Squid routing is observed in the repo registry; Monad needs quote evidence. Probes are serialized and paced to avoid 429s from bursty route checks.",
-    quote: (input, env) =>
-      postRequest(
-        "https://apiplus.squidrouter.com/v2/route",
-        squidBody(input),
-        {
-          "x-integrator-id": env.SQUID_INTEGRATOR_ID!,
-        },
-      ),
+    quote: (input, env, context) =>
+      context
+        ? squidQuoteRequests(input, env, context.chain, context.fetcher)
+        : postRequest(
+            "https://apiplus.squidrouter.com/v2/route",
+            squidBody(input),
+            {
+              "x-integrator-id": env.SQUID_INTEGRATOR_ID!,
+            },
+          ),
   };
 }
 

--- a/integration-probes/src/pairs.ts
+++ b/integration-probes/src/pairs.ts
@@ -196,6 +196,8 @@ function pairFromPoolRow(chainId: number, row: PoolRow): HubPair | null {
       poolSource: row.source,
       base: token1,
       quote: token0,
+      baseReserveRaw: row.reserves1,
+      quoteReserveRaw: row.reserves0,
     });
   }
   if (token1.symbol === USDM && token0.symbol !== USDM) {
@@ -206,6 +208,8 @@ function pairFromPoolRow(chainId: number, row: PoolRow): HubPair | null {
       poolSource: row.source,
       base: token0,
       quote: token1,
+      baseReserveRaw: row.reserves0,
+      quoteReserveRaw: row.reserves1,
     });
   }
   return null;
@@ -218,6 +222,8 @@ function makePair(args: {
   poolSource: string;
   base: TokenProbe;
   quote: TokenProbe;
+  baseReserveRaw?: string | undefined;
+  quoteReserveRaw?: string | undefined;
 }): HubPair {
   return {
     id: `${args.chainId}:${args.base.symbol}-${USDM}:${args.poolId}`,
@@ -227,6 +233,8 @@ function makePair(args: {
     poolSource: args.poolSource,
     base: args.base,
     quote: args.quote,
+    baseReserveRaw: args.baseReserveRaw,
+    quoteReserveRaw: args.quoteReserveRaw,
   };
 }
 
@@ -271,6 +279,10 @@ function quoteInput(
 ): QuoteProbeInput {
   const sellToken = direction === "base-to-usdm" ? pair.base : pair.quote;
   const buyToken = direction === "base-to-usdm" ? pair.quote : pair.base;
+  const sellReserveRaw =
+    direction === "base-to-usdm" ? pair.baseReserveRaw : pair.quoteReserveRaw;
+  const buyReserveRaw =
+    direction === "base-to-usdm" ? pair.quoteReserveRaw : pair.baseReserveRaw;
   return {
     chainId: pair.chainId,
     pairId: pair.id,
@@ -279,6 +291,8 @@ function quoteInput(
     buyToken,
     amountDecimal: amountUsd,
     amountRaw: decimalAmountToRaw(amountUsd, sellToken.decimals),
+    sellReserveRaw,
+    buyReserveRaw,
     takerAddress,
   };
 }

--- a/integration-probes/src/squidLiquidity.ts
+++ b/integration-probes/src/squidLiquidity.ts
@@ -1,0 +1,359 @@
+import type {
+  ChainProbeConfig,
+  FetchLike,
+  QuoteProbeInput,
+  TokenProbe,
+} from "./types.js";
+
+const CELO_CHAIN_ID = 42220;
+const DEFAULT_CELO_RPC_URL = "https://forno.celo.org";
+const CELO_UNISWAP_V3_FACTORY =
+  "0xAfE208a311B21f13EF87E33A90049fC17A7acDEc".toLowerCase();
+const UNISWAP_FEE_TIERS = [100, 500, 3000, 10000] as const;
+const INTERMEDIATE_SYMBOLS = ["USDT", "USDC"] as const;
+const MAX_DISCOVERY_AMOUNTS = 8;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const SELECTOR_GET_POOL = "0x1698ee82";
+const SELECTOR_LIQUIDITY = "0x1a686502";
+const SELECTOR_BALANCE_OF = "0x70a08231";
+
+type AmountSeed = {
+  amountRaw: bigint;
+  variant: string;
+};
+
+export type SquidLiquidityAmountCandidate = {
+  amountDecimal: string;
+  amountRaw: string;
+  variant: string;
+};
+
+export async function squidLiquidityAmountCandidates(args: {
+  input: QuoteProbeInput;
+  chain: ChainProbeConfig;
+  fetcher: FetchLike;
+  env: NodeJS.ProcessEnv;
+}): Promise<SquidLiquidityAmountCandidate[]> {
+  const externalSellDepthRaw = await uniswapSellDepthRaw(args).catch(
+    () => null,
+  );
+  const seeds = amountSeeds({
+    input: args.input,
+    uniswapSellDepthRaw: externalSellDepthRaw,
+  });
+  return limitDiscoveryAmounts(dedupeAndSortSeeds(seeds)).map((seed) => ({
+    amountRaw: seed.amountRaw.toString(),
+    amountDecimal: rawAmountToDecimal(
+      seed.amountRaw,
+      args.input.sellToken.decimals,
+    ),
+    variant: seed.variant,
+  }));
+}
+
+function amountSeeds(args: {
+  input: QuoteProbeInput;
+  uniswapSellDepthRaw: string | null;
+}): AmountSeed[] {
+  const baseAmountRaw = BigInt(args.input.amountRaw);
+  const sellReserveRaw = optionalBigInt(args.input.sellReserveRaw);
+  const capRaw =
+    sellReserveRaw === null ? null : ratioAmount(sellReserveRaw, 95n, 100n);
+  return [
+    ...fixedMultiplierSeeds(baseAmountRaw),
+    ...uniswapDepthSeeds(args.uniswapSellDepthRaw),
+    ...mentoReserveSeeds(sellReserveRaw),
+  ].filter(
+    (seed) => seed.amountRaw > baseAmountRaw && amountWithinCap(seed, capRaw),
+  );
+}
+
+function fixedMultiplierSeeds(baseAmountRaw: bigint): AmountSeed[] {
+  return [
+    { amountRaw: baseAmountRaw * 10n, variant: "squid-fixed-10x" },
+    { amountRaw: baseAmountRaw * 100n, variant: "squid-fixed-100x" },
+  ];
+}
+
+function uniswapDepthSeeds(depthRaw: string | null): AmountSeed[] {
+  const depth = optionalBigInt(depthRaw);
+  if (depth === null) return [];
+  return [
+    {
+      amountRaw: ratioAmount(depth, 1n, 200n),
+      variant: "squid-uniswap-depth-0.5pct",
+    },
+    {
+      amountRaw: ratioAmount(depth, 1n, 50n),
+      variant: "squid-uniswap-depth-2pct",
+    },
+    {
+      amountRaw: ratioAmount(depth, 1n, 20n),
+      variant: "squid-uniswap-depth-5pct",
+    },
+    {
+      amountRaw: ratioAmount(depth, 1n, 10n),
+      variant: "squid-uniswap-depth-10pct",
+    },
+    {
+      amountRaw: ratioAmount(depth, 1n, 4n),
+      variant: "squid-uniswap-depth-25pct",
+    },
+    {
+      amountRaw: ratioAmount(depth, 1n, 2n),
+      variant: "squid-uniswap-depth-50pct",
+    },
+  ];
+}
+
+function mentoReserveSeeds(sellReserveRaw: bigint | null): AmountSeed[] {
+  if (sellReserveRaw === null) return [];
+  return [
+    {
+      amountRaw: ratioAmount(sellReserveRaw, 1n, 20n),
+      variant: "squid-mento-reserve-5pct",
+    },
+    {
+      amountRaw: ratioAmount(sellReserveRaw, 1n, 5n),
+      variant: "squid-mento-reserve-20pct",
+    },
+    {
+      amountRaw: ratioAmount(sellReserveRaw, 1n, 2n),
+      variant: "squid-mento-reserve-50pct",
+    },
+    {
+      amountRaw: ratioAmount(sellReserveRaw, 9n, 10n),
+      variant: "squid-mento-reserve-90pct",
+    },
+  ];
+}
+
+function amountWithinCap(seed: AmountSeed, capRaw: bigint | null): boolean {
+  return seed.amountRaw > 0n && (capRaw === null || seed.amountRaw <= capRaw);
+}
+
+function ratioAmount(
+  value: bigint,
+  numerator: bigint,
+  denominator: bigint,
+): bigint {
+  return (value * numerator) / denominator;
+}
+
+function optionalBigInt(value: string | null | undefined): bigint | null {
+  if (!value) return null;
+  const parsed = BigInt(value);
+  return parsed > 0n ? parsed : null;
+}
+
+function dedupeAndSortSeeds(seeds: readonly AmountSeed[]): AmountSeed[] {
+  const byAmount = new Map<string, AmountSeed>();
+  for (const seed of seeds) {
+    const key = seed.amountRaw.toString();
+    if (!byAmount.has(key)) byAmount.set(key, seed);
+  }
+  return [...byAmount.values()].sort((a, b) =>
+    a.amountRaw < b.amountRaw ? -1 : a.amountRaw > b.amountRaw ? 1 : 0,
+  );
+}
+
+function limitDiscoveryAmounts(seeds: readonly AmountSeed[]): AmountSeed[] {
+  if (seeds.length <= MAX_DISCOVERY_AMOUNTS) return [...seeds];
+  return dedupeAndSortSeeds([
+    ...seeds.slice(0, 5),
+    ...seeds.slice(-(MAX_DISCOVERY_AMOUNTS - 5)),
+  ]);
+}
+
+function rawAmountToDecimal(raw: bigint, decimals: number): string {
+  if (decimals === 0) return raw.toString();
+  const digits = raw.toString().padStart(decimals + 1, "0");
+  const whole = digits.slice(0, -decimals) || "0";
+  const fraction = digits.slice(-decimals).replace(/0+$/u, "");
+  return fraction ? `${whole}.${fraction}` : whole;
+}
+
+async function uniswapSellDepthRaw(args: {
+  input: QuoteProbeInput;
+  chain: ChainProbeConfig;
+  fetcher: FetchLike;
+  env: NodeJS.ProcessEnv;
+}): Promise<string | null> {
+  if (args.input.chainId !== CELO_CHAIN_ID) return null;
+  const rpcUrl = args.env.SQUID_CELO_RPC_URL ?? DEFAULT_CELO_RPC_URL;
+  const paths = liquidityProbePaths(args.input, args.chain);
+  let bestDepth = 0n;
+  for (const path of paths) {
+    const depth = await pathSellDepthRaw({
+      fetcher: args.fetcher,
+      rpcUrl,
+      path,
+      sellToken: args.input.sellToken,
+    });
+    if (depth > bestDepth) bestDepth = depth;
+  }
+  return bestDepth > 0n ? bestDepth.toString() : null;
+}
+
+function liquidityProbePaths(
+  input: QuoteProbeInput,
+  chain: ChainProbeConfig,
+): TokenProbe[][] {
+  const tokens = tokensBySymbol(chain);
+  const direct = [[input.sellToken, input.buyToken]];
+  const via = INTERMEDIATE_SYMBOLS.flatMap((symbol) => {
+    const intermediate = tokens.get(symbol);
+    if (!intermediate || tokenMatches(intermediate, input.sellToken)) return [];
+    if (tokenMatches(intermediate, input.buyToken)) return [];
+    return [[input.sellToken, intermediate, input.buyToken]];
+  });
+  return [...direct, ...via];
+}
+
+function tokensBySymbol(chain: ChainProbeConfig): Map<string, TokenProbe> {
+  const out = new Map<string, TokenProbe>();
+  for (const pair of chain.pairs) {
+    out.set(pair.base.symbol, pair.base);
+    out.set(pair.quote.symbol, pair.quote);
+  }
+  return out;
+}
+
+async function pathSellDepthRaw(args: {
+  fetcher: FetchLike;
+  rpcUrl: string;
+  path: readonly TokenProbe[];
+  sellToken: TokenProbe;
+}): Promise<bigint> {
+  if (args.path.length === 2) {
+    return bestPoolSellDepthRaw({
+      ...args,
+      tokenA: args.path[0]!,
+      tokenB: args.path[1]!,
+      sellToken: args.sellToken,
+    });
+  }
+  const intermediate = args.path[1]!;
+  const [firstHopDepth, secondHopDepth] = await Promise.all([
+    bestPoolSellDepthRaw({
+      ...args,
+      tokenA: args.path[0]!,
+      tokenB: intermediate,
+      sellToken: args.sellToken,
+    }),
+    bestPoolSellDepthRaw({
+      ...args,
+      tokenA: intermediate,
+      tokenB: args.path[2]!,
+      sellToken: intermediate,
+    }),
+  ]);
+  return secondHopDepth > 0n ? firstHopDepth : 0n;
+}
+
+async function bestPoolSellDepthRaw(args: {
+  fetcher: FetchLike;
+  rpcUrl: string;
+  tokenA: TokenProbe;
+  tokenB: TokenProbe;
+  sellToken: TokenProbe;
+}): Promise<bigint> {
+  let best = 0n;
+  for (const fee of UNISWAP_FEE_TIERS) {
+    const pool = await uniswapPoolAddress(args, fee);
+    if (pool === null) continue;
+    const [liquidity, sellBalance] = await Promise.all([
+      readUint256(args.fetcher, args.rpcUrl, pool, SELECTOR_LIQUIDITY),
+      readUint256(
+        args.fetcher,
+        args.rpcUrl,
+        args.sellToken.address,
+        balanceOfCall(pool),
+      ),
+    ]);
+    if (liquidity > 0n && sellBalance > best) best = sellBalance;
+  }
+  return best;
+}
+
+async function uniswapPoolAddress(
+  args: {
+    fetcher: FetchLike;
+    rpcUrl: string;
+    tokenA: TokenProbe;
+    tokenB: TokenProbe;
+  },
+  fee: number,
+): Promise<string | null> {
+  const result = await ethCall(
+    args.fetcher,
+    args.rpcUrl,
+    CELO_UNISWAP_V3_FACTORY,
+    `${SELECTOR_GET_POOL.slice(2)}${encodeAddress(args.tokenA.address)}${encodeAddress(args.tokenB.address)}${encodeUint(fee)}`,
+  );
+  const address = decodeAddress(result);
+  return address === ZERO_ADDRESS ? null : address;
+}
+
+async function readUint256(
+  fetcher: FetchLike,
+  rpcUrl: string,
+  to: string,
+  data: string,
+): Promise<bigint> {
+  const result = await ethCall(fetcher, rpcUrl, to, data);
+  return BigInt(result);
+}
+
+async function ethCall(
+  fetcher: FetchLike,
+  rpcUrl: string,
+  to: string,
+  data: string,
+): Promise<string> {
+  const response = await fetcher(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_call",
+      params: [
+        { to, data: data.startsWith("0x") ? data : `0x${data}` },
+        "latest",
+      ],
+    }),
+  });
+  if (!response.ok) throw new Error(`Celo RPC failed: ${response.status}`);
+  const payload = (await response.json()) as {
+    result?: string;
+    error?: { message?: string };
+  };
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "Celo RPC returned an error");
+  }
+  if (!payload.result) throw new Error("Celo RPC returned no result");
+  return payload.result;
+}
+
+function balanceOfCall(address: string): string {
+  return `${SELECTOR_BALANCE_OF}${encodeAddress(address)}`;
+}
+
+function encodeAddress(address: string): string {
+  return address.toLowerCase().replace(/^0x/u, "").padStart(64, "0");
+}
+
+function encodeUint(value: number): string {
+  return value.toString(16).padStart(64, "0");
+}
+
+function decodeAddress(value: string): string {
+  const hex = value.toLowerCase().replace(/^0x/u, "").padStart(64, "0");
+  return `0x${hex.slice(-40)}`;
+}
+
+function tokenMatches(a: TokenProbe, b: TokenProbe): boolean {
+  return a.address.toLowerCase() === b.address.toLowerCase();
+}

--- a/integration-probes/src/squidLiquidity.ts
+++ b/integration-probes/src/squidLiquidity.ts
@@ -130,7 +130,7 @@ function mentoReserveSeeds(sellReserveRaw: bigint | null): AmountSeed[] {
 }
 
 function amountWithinCap(seed: AmountSeed, capRaw: bigint | null): boolean {
-  return seed.amountRaw > 0n && (capRaw === null || seed.amountRaw <= capRaw);
+  return capRaw === null || seed.amountRaw <= capRaw;
 }
 
 function ratioAmount(
@@ -249,6 +249,7 @@ async function pathSellDepthRaw(args: {
       sellToken: intermediate,
     }),
   ]);
+  // The second-hop depth is only a liveness check; returned depth stays in SELL units.
   return secondHopDepth > 0n ? firstHopDepth : 0n;
 }
 
@@ -259,22 +260,23 @@ async function bestPoolSellDepthRaw(args: {
   tokenB: TokenProbe;
   sellToken: TokenProbe;
 }): Promise<bigint> {
-  let best = 0n;
-  for (const fee of UNISWAP_FEE_TIERS) {
-    const pool = await uniswapPoolAddress(args, fee);
-    if (pool === null) continue;
-    const [liquidity, sellBalance] = await Promise.all([
-      readUint256(args.fetcher, args.rpcUrl, pool, SELECTOR_LIQUIDITY),
-      readUint256(
-        args.fetcher,
-        args.rpcUrl,
-        args.sellToken.address,
-        balanceOfCall(pool),
-      ),
-    ]);
-    if (liquidity > 0n && sellBalance > best) best = sellBalance;
-  }
-  return best;
+  const depths = await Promise.all(
+    UNISWAP_FEE_TIERS.map(async (fee) => {
+      const pool = await uniswapPoolAddress(args, fee);
+      if (pool === null) return 0n;
+      const [liquidity, sellBalance] = await Promise.all([
+        readUint256(args.fetcher, args.rpcUrl, pool, SELECTOR_LIQUIDITY),
+        readUint256(
+          args.fetcher,
+          args.rpcUrl,
+          args.sellToken.address,
+          balanceOfCall(pool),
+        ),
+      ]);
+      return liquidity > 0n ? sellBalance : 0n;
+    }),
+  );
+  return depths.reduce((best, depth) => (depth > best ? depth : best), 0n);
 }
 
 async function uniswapPoolAddress(
@@ -303,7 +305,7 @@ async function readUint256(
   data: string,
 ): Promise<bigint> {
   const result = await ethCall(fetcher, rpcUrl, to, data);
-  return BigInt(result);
+  return BigInt(result === "0x" ? "0x0" : result);
 }
 
 async function ethCall(

--- a/integration-probes/src/types.ts
+++ b/integration-probes/src/types.ts
@@ -38,6 +38,8 @@ export type HubPair = {
   poolSource: string;
   base: TokenProbe;
   quote: TokenProbe;
+  baseReserveRaw?: string | undefined;
+  quoteReserveRaw?: string | undefined;
 };
 
 type PairDirection = "base-to-usdm" | "usdm-to-base";
@@ -50,6 +52,8 @@ export type QuoteProbeInput = {
   buyToken: TokenProbe;
   amountDecimal: string;
   amountRaw: string;
+  sellReserveRaw?: string | undefined;
+  buyReserveRaw?: string | undefined;
   takerAddress: string;
 };
 


### PR DESCRIPTION
## The Problem

- Squid can have Mento v3 integrated but still choose Uniswap V3 for tiny Celo stablecoin quotes.
- The current probe only tries the default amount, so it can mark available Mento v3 routes as failed.

## The Solution

- Add a Squid-specific discovery ladder that sizes later quote attempts from current Celo Uniswap sell-side depth and indexed Mento reserves.
- Keep the pass rule unchanged: Squid only passes when the quote response contains Mento v3 router or registered pool address evidence.

## Details

- Threads Hasura-derived pair reserve metadata into quote inputs so adapters can size route-specific discovery amounts.
- Allows adapter quote builders to be async, while preserving the existing direct-builder compatibility path used by tests.
- Uses Celo Uniswap V3 factory/pool RPC reads for Squid Celo discovery sizing, with a Mento-reserve fallback if RPC is unavailable.
- Keeps Squid requests serialized and paced, and raises the per-run Squid quote-attempt budget to cover the new bounded ladder.
- Documents optional `SQUID_CELO_RPC_URL`; it is only for sizing discovery attempts and is not pass evidence or a credential.

## Validation

- `pnpm --filter @mento-protocol/integration-probes test`
- `pnpm --filter @mento-protocol/integration-probes typecheck`
- `pnpm --filter @mento-protocol/integration-probes lint`
- `pnpm --filter @mento-protocol/integration-probes knip`
- `pnpm --filter @mento-protocol/integration-probes test:coverage`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback; no actionable findings)
- Live paced Squid smoke for Celo `USDm -> JPYm`: passed on attempt 4 at `squid-uniswap-depth-0.5pct`, with both Mento v3 pool and Routerv300 address evidence.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases scheduled Squid API and optional Celo RPC load and changes probe pass/fail semantics for small-quote false negatives; pass criteria and budget caps limit blast radius.
> 
> **Overview**
> Adds a **liquidity-aware Squid discovery ladder** so Celo probes can retry with larger quote amounts after the default swap fails, without relaxing the existing Mento v3 pass rule.
> 
> **Probe pipeline:** Hub pairs and quote inputs now carry **indexed Mento reserve metadata** (`baseReserveRaw` / `quoteReserveRaw` and per-direction sell/buy reserves). Adapter `quote` builders may be **async**, and quote requests gain an **`afterFailure` hook** that appends follow-up attempts to a bounded queue; discovery is skipped when the quote-attempt budget is already exhausted.
> 
> **Squid-specific:** After a failed default quote, Celo sizing uses **Uniswap V3 sell-side depth** (factory/pool RPC via optional `SQUID_CELO_RPC_URL`, default Forno) with **Mento-reserve fallbacks** when RPC is unavailable; non-Celo chains use fixed multipliers only. Squid **per-run quote budget rises from 80 to 160** to cover the capped ladder; pacing is unchanged.
> 
> **Docs:** README, deployment guide, and `integration-probes/AGENTS.md` document `SQUID_CELO_RPC_URL` as sizing-only (not pass evidence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fca1ee4c190426f623b33f4a4f5a794fb6f7789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->