### PR TITLE
chore: speed up agent quality gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,12 +223,14 @@ package-manager config, review the script/lifecycle diff first, then
 temporarily set `agent.qualityGate.allowPackageScriptChanges=true` in local git
 config for that push.
 
-Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard build,
-dashboard size-limit, local dashboard browser tests, and dashboard React Doctor
-checks run through Turbo's local filesystem cache
-(`pnpm exec turbo run ... --cache=local:rw`). Remote caching is disabled in
-`turbo.json`. The Turbo config is only for the gate's explicit per-package
-`--filter` invocations; do not use it as a general workspace task orchestrator.
+Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
+local dashboard browser tests, and dashboard React Doctor checks run through
+Turbo's local filesystem cache (`pnpm exec turbo run ... --cache=local:rw`).
+The gate coalesces same-task Turbo checks into one invocation with multiple
+explicit `--filter` arguments when several packages map the same task. Remote
+caching is disabled in `turbo.json`. The Turbo config is only for the gate's
+explicit package-filtered invocations; do not use it as a general workspace
+task orchestrator.
 Per-package coverage floors run as direct package commands such as
 `pnpm --filter <pkg> test:coverage` (or Aegis `test:cov`) so they always
 exercise the current local coverage threshold rather than a stale cached test
@@ -237,9 +239,10 @@ Dashboard build/browser/React Doctor cache keys explicitly include
 `shared-config`, package-manager, workflow, wrapper-script, and relevant env
 inputs; CI still runs browser tests normally and remains the Linux snapshot
 authority. The only task dependency is `size-limit -> build`, because
-size-limit reads `.next/` output. High-risk or cross-layer commands stay outside
-Turbo, including codegen, install, dep-cruiser, coverage floors, mutation
-baselines, and Terraform.
+size-limit reads `.next/` output; the local gate relies on that dependency
+instead of mapping a separate dashboard build command for size-limit checks.
+High-risk or cross-layer commands stay outside Turbo, including codegen,
+install, dep-cruiser, coverage floors, mutation baselines, and Terraform.
 
 ## PR description standard
 

--- a/docs/notes/agent-gate-dashboard-cache-safety.md
+++ b/docs/notes/agent-gate-dashboard-cache-safety.md
@@ -3,18 +3,20 @@
 Status: implemented by `chore/agent-gate-dashboard-turbo`.
 
 This note defines the conservative input surface and regression tests required
-for caching dashboard build or browser-test commands in the agent quality gate.
+for caching dashboard size-limit or browser-test commands in the agent quality
+gate.
 The Turbo worker PR established the repo's canonical local cache runner and
-command mapping shape; dashboard build, size-limit, and browser-test local
-agent-gate commands now use that runner with the input surface below.
+command mapping shape; dashboard size-limit and browser-test local agent-gate
+commands now use that runner with the input surface below. Dashboard build runs
+as the Turbo dependency of size-limit instead of as a separate local gate
+command.
 
 ## Scope
 
 Candidate commands:
 
-- `pnpm dashboard:build`
-- `pnpm dashboard:size-limit` when it consumes the build output
-- `pnpm --filter @mento-protocol/ui-dashboard test:browser`
+- `pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw`
+- `pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw`
 
 `size-limit` depends on `build` in `turbo.json` because it reads `.next/`
 output. Its config measures concrete static assets referenced by Next's build
@@ -107,28 +109,22 @@ silently reuse an incompatible cached result.
 Add these tests next to the Turbo worker's command-mapping tests, not by
 rewriting the quality-gate dispatcher.
 
-1. `shared-config/src/chains.ts` invalidates both dashboard build and browser
-   tests.
+1. `shared-config/src/chains.ts` invalidates dashboard size-limit, its build
+   dependency, and browser tests.
 
    This is the mandatory guard for the previously unsafe naive Turbo prototype:
    changing `shared-config/src/chains.ts` did not invalidate
    `ui-dashboard` tests. The test should fail if the cache key only includes
    direct `ui-dashboard/**` inputs or only package dependency declarations.
 
-2. `shared-config/fx-calendar.json` invalidates dashboard build and browser
-   tests.
+2. `shared-config/fx-calendar.json` invalidates dashboard size-limit, its build
+   dependency, and browser tests.
 
    This covers JSON exports consumed by `ui-dashboard/src/lib/weekend.ts` and
    the existing Playwright deterministic-weekend fixtures.
 
 3. `ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs` invalidates
-   browser tests but does not force a dashboard build-only cache miss.
-
-   Current gate note: this path does map to `pnpm dashboard:build` today because
-   the shell `case` pattern `ui-dashboard/*.mjs` also matches nested `.mjs`
-   paths. If PR 3 changes that routing, do it as an explicit narrow fix with a
-   regression test; otherwise keep routing as-is and still keep the build cache
-   key separate from browser fixture inputs.
+   browser tests but does not force a dashboard size-limit/build cache miss.
 
 4. `ui-dashboard/playwright.config.ts` invalidates browser tests but does not
    force a dashboard build-only cache miss.
@@ -149,12 +145,13 @@ Current agent-gate behavior:
 
 - Direct `ui-dashboard/*` changes map to dashboard package checks,
   Playwright Chromium install, browser tests, and React Doctor checks. The
-  build/size-limit routing is bundle-affecting paths only. Browser fixtures and
-  Playwright config invalidate browser-test cache entries without forcing an
-  unrelated dashboard build cache miss.
+  size-limit routing is bundle-affecting paths only, with Turbo running
+  dashboard build through the `size-limit -> build` task dependency. Browser
+  fixtures and Playwright config invalidate browser-test cache entries without
+  forcing an unrelated dashboard build cache miss.
 - `shared-config/*` changes map to shared-config package checks, shared-config
-  build, dashboard and metrics-bridge typechecks, plus dashboard build and
-  size-limit.
+  build, dashboard and metrics-bridge typechecks, plus dashboard size-limit
+  with its build dependency.
 - `shared-config/*` changes do not currently map to local browser tests. The
   browser-test cache key still must include shared-config inputs so a manual or
   future mapped `test:browser` invocation cannot hit stale dashboard metadata.

--- a/scripts/agent-prewarm.mjs
+++ b/scripts/agent-prewarm.mjs
@@ -7,7 +7,7 @@ const usage = `Usage: scripts/agent-prewarm.mjs [--base <ref>] [--head <ref>] [-
 Prewarm Turbo's local cache for the Turbo-backed commands already mapped by
 the agent quality gate. The helper only runs commands shaped as:
 
-  pnpm exec turbo run <task> --filter=<package> --cache=local:rw
+  pnpm exec turbo run <task> --filter=<package> [--filter=<package> ...] --cache=local:rw
 
 It deliberately ignores deploy, Terraform, mutation, codegen, install, and
 other non-Turbo commands.
@@ -38,7 +38,7 @@ export function extractTurboPrewarmCommands(gateOutput) {
     if (line.trim() === "") break;
 
     const match = line.match(
-      /^- ((?:[A-Z0-9_]+=[^\s()]+ )*pnpm exec turbo run [^()]+ --filter=@mento-protocol\/[^\s()]+ --cache=local:rw)(?: \(.+\))?$/,
+      /^- ((?:[A-Z0-9_]+=[^\s()]+ )*pnpm exec turbo run [^()]+(?: --filter=@mento-protocol\/[^\s()]+)+ --cache=local:rw)(?: \(.+\))?$/,
     );
     if (match && !commands.includes(match[1])) {
       commands.push(match[1]);

--- a/scripts/agent-prewarm.test.mjs
+++ b/scripts/agent-prewarm.test.mjs
@@ -9,22 +9,22 @@ const gateOutput = `Agent quality gate
 Mapped safe local commands:
 - ./tools/trunk check ui-dashboard/src/app/page.tsx (changed existing paths should pass targeted Trunk checks)
 - pnpm indexer:codegen (indexer-envio changed)
-- pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard changed)
+- pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw (ui-dashboard changed; metrics-bridge changed)
 - TF_DATA_DIR=terraform/.terraform-agent-gate terraform -chdir=terraform validate -no-color (Terraform changed)
 - pnpm dashboard:mutation (dashboard mutation baseline changed)
 - pnpm exec turbo run test --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard changed)
-- pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --cache=local:rw (duplicate)
+- pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw (duplicate)
 - REACT_DOCTOR_BASE_REF=origin/main REACT_DOCTOR_BASE_CACHE_KEY=abc123 pnpm exec turbo run react-doctor:diff --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard client code should keep React Doctor clean)
-- pnpm exec turbo run build --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard bundle inputs changed)
+- pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard bundle inputs changed)
 
 Dry run only. Re-run with --run to execute the mapped commands.
 `;
 
 assert.deepEqual(extractTurboPrewarmCommands(gateOutput), [
-  "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw",
   "pnpm exec turbo run test --filter=@mento-protocol/ui-dashboard --cache=local:rw",
   "REACT_DOCTOR_BASE_REF=origin/main REACT_DOCTOR_BASE_CACHE_KEY=abc123 pnpm exec turbo run react-doctor:diff --filter=@mento-protocol/ui-dashboard --cache=local:rw",
-  "pnpm exec turbo run build --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  "pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw",
 ]);
 
 assert.deepEqual(

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -489,7 +489,8 @@ add_ui_mutation_baseline() {
 
 add_ui_size_limit() {
   local reason="$1"
-  add_turbo_dashboard_task "build" "$reason"
+  # `size-limit` depends on `build` in turbo.json, so one Turbo invocation
+  # preserves the build guarantee without paying for a separate scheduler run.
   add_turbo_dashboard_task "size-limit" "$reason"
 }
 
@@ -679,6 +680,102 @@ sort_codegen_commands() {
   codegen_commands=()
   for entry in "${sorted[@]+"${sorted[@]}"}"; do
     codegen_commands+=("$entry")
+  done
+}
+
+find_turbo_task_index() {
+  local task="$1"
+  local index
+  for index in "${!turbo_group_tasks[@]}"; do
+    if [[ "${turbo_group_tasks[$index]}" == "$task" ]]; then
+      echo "$index"
+      return 0
+    fi
+  done
+  return 1
+}
+
+list_contains_word() {
+  local needle="$1"
+  local word
+  shift
+  for word in "$@"; do
+    [[ "$word" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+reason_list_contains() {
+  local reasons="$1"
+  local reason="$2"
+  [[ "; ${reasons}; " == *"; ${reason}; "* ]]
+}
+
+compact_turbo_quality_commands() {
+  local compacted_kinds=()
+  local compacted_values=()
+  local turbo_group_tasks=()
+  local turbo_group_packages=()
+  local turbo_group_reasons=()
+  local entry
+  local command
+  local reason
+  local task
+  local package_name
+  local group_index
+  local existing_packages
+  local existing_reasons
+  local kind
+  local value
+  local package_filters
+  local package
+
+  for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
+    command="${entry%%|*}"
+    reason="${entry#*|}"
+
+    if [[ "$command" =~ ^pnpm\ exec\ turbo\ run\ ([^[:space:]]+)\ --filter=(@mento-protocol/[^[:space:]]+)\ --cache=local:rw$ ]]; then
+      task="${BASH_REMATCH[1]}"
+      package_name="${BASH_REMATCH[2]}"
+
+      if group_index="$(find_turbo_task_index "$task")"; then
+        existing_packages="${turbo_group_packages[$group_index]}"
+        if ! list_contains_word "$package_name" $existing_packages; then
+          turbo_group_packages[$group_index]="${existing_packages} ${package_name}"
+        fi
+
+        existing_reasons="${turbo_group_reasons[$group_index]}"
+        if ! reason_list_contains "$existing_reasons" "$reason"; then
+          turbo_group_reasons[$group_index]="${existing_reasons}; ${reason}"
+        fi
+      else
+        turbo_group_tasks+=("$task")
+        turbo_group_packages+=("$package_name")
+        turbo_group_reasons+=("$reason")
+        compacted_kinds+=("turbo")
+        compacted_values+=("$task")
+      fi
+    else
+      compacted_kinds+=("plain")
+      compacted_values+=("$entry")
+    fi
+  done
+
+  quality_commands=()
+  for index in "${!compacted_kinds[@]}"; do
+    kind="${compacted_kinds[$index]}"
+    value="${compacted_values[$index]}"
+    if [[ "$kind" == "plain" ]]; then
+      quality_commands+=("$value")
+      continue
+    fi
+
+    group_index="$(find_turbo_task_index "$value")"
+    package_filters=""
+    for package in ${turbo_group_packages[$group_index]}; do
+      package_filters+=" --filter=${package}"
+    done
+    quality_commands+=("pnpm exec turbo run ${value}${package_filters} --cache=local:rw|${turbo_group_reasons[$group_index]}")
   done
 }
 
@@ -1178,6 +1275,7 @@ done < "$changed_paths_file"
 
 add_trunk_check_command
 sort_codegen_commands
+compact_turbo_quality_commands
 
 hash_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -725,6 +725,7 @@ compact_turbo_quality_commands() {
   local group_index
   local existing_packages
   local existing_reasons
+  local existing_package_array
   local kind
   local value
   local package_filters
@@ -740,7 +741,8 @@ compact_turbo_quality_commands() {
 
       if group_index="$(find_turbo_task_index "$task")"; then
         existing_packages="${turbo_group_packages[$group_index]}"
-        if ! list_contains_word "$package_name" $existing_packages; then
+        read -r -a existing_package_array <<< "$existing_packages"
+        if ! list_contains_word "$package_name" "${existing_package_array[@]}"; then
           turbo_group_packages[$group_index]="${existing_packages} ${package_name}"
         fi
 
@@ -772,7 +774,8 @@ compact_turbo_quality_commands() {
 
     group_index="$(find_turbo_task_index "$value")"
     package_filters=""
-    for package in ${turbo_group_packages[$group_index]}; do
+    read -r -a existing_package_array <<< "${turbo_group_packages[$group_index]}"
+    for package in "${existing_package_array[@]}"; do
       package_filters+=" --filter=${package}"
     done
     quality_commands+=("pnpm exec turbo run ${value}${package_filters} --cache=local:rw|${turbo_group_reasons[$group_index]}")

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -65,8 +65,13 @@ run_gate_expect_failure() {
 assert_contains() {
   local expected="$1"
   expected="$(normalize_expected_command "$expected")"
-  grep -Fq -- "$expected" "$output_file" ||
-    fail "expected output to contain: $expected"
+  if grep -Fq -- "$expected" "$output_file"; then
+    return
+  fi
+  if [[ -n "$(turbo_filter_line_number "$expected")" ]]; then
+    return
+  fi
+  fail "expected output to contain: $expected"
 }
 
 assert_occurrences() {
@@ -118,8 +123,43 @@ NODE
 
 line_number() {
   local needle="$1"
+  local turbo_line
   needle="$(normalize_expected_command "$needle")"
-  grep -nF -- "$needle" "$output_file" | head -n 1 | cut -d: -f1
+  if grep -Fq -- "$needle" "$output_file"; then
+    grep -nF -- "$needle" "$output_file" | head -n 1 | cut -d: -f1
+    return
+  fi
+  turbo_line="$(turbo_filter_line_number "$needle")"
+  if [[ -n "$turbo_line" ]]; then
+    echo "$turbo_line"
+  fi
+}
+
+turbo_filter_line_number() {
+  local normalized="$1"
+  local rest
+  local task_name
+  local package_name
+  local reason=""
+
+  case "$normalized" in
+    "- pnpm exec turbo run "*" --filter=@mento-protocol/"*" --cache=local:rw"*)
+      rest="${normalized#- pnpm exec turbo run }"
+      task_name="${rest%% *}"
+      rest="${normalized#* --filter=}"
+      package_name="${rest%% *}"
+      if [[ "$normalized" == *" ("*")" ]]; then
+        reason="${normalized#* (}"
+        reason="${reason%)}"
+      fi
+      awk \
+        -v task="$task_name" \
+        -v package_filter="--filter=${package_name}" \
+        -v reason="$reason" \
+        'index($0, "- pnpm exec turbo run " task " ") && index($0, package_filter) && index($0, " --cache=local:rw") && (reason == "" || index($0, reason)) { print NR; exit }' \
+        "$output_file"
+      ;;
+  esac
 }
 
 normalize_expected_command() {
@@ -580,6 +620,12 @@ run_gate ".npmrc"
 assert_contains "- pnpm install --frozen-lockfile (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (package manager config changed)"
+assert_contains "- pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/indexer-envio --filter=@mento-protocol/metrics-bridge --filter=@mento-protocol/integration-probes --filter=@mento-protocol/monitoring-config --filter=@mento-protocol/aegis --cache=local:rw (package manager config changed)"
+assert_contains "- pnpm exec turbo run typecheck --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/indexer-envio --filter=@mento-protocol/metrics-bridge --filter=@mento-protocol/integration-probes --filter=@mento-protocol/monitoring-config --filter=@mento-protocol/aegis --cache=local:rw (package manager config changed)"
+assert_contains "- pnpm exec turbo run knip --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/indexer-envio --filter=@mento-protocol/metrics-bridge --filter=@mento-protocol/integration-probes --filter=@mento-protocol/monitoring-config --filter=@mento-protocol/aegis --cache=local:rw (package manager config changed (knip: unused files/deps/exports))"
+assert_occurrences 1 "- pnpm exec turbo run lint --filter="
+assert_occurrences 1 "- pnpm exec turbo run typecheck --filter="
+assert_occurrences 1 "- pnpm exec turbo run knip --filter="
 # Workspace-wide triggers (npmrc, root pkg.json, ci.yml) intentionally do
 # NOT run the dashboard playwright suite — chromium --single-process mode
 # (required in sandbox) is flaky on keyboard/route-heavy tests, and CI's
@@ -1011,11 +1057,10 @@ assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React 
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage (ui-dashboard changed (coverage floor))"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
-assert_contains "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 assert_occurrences 1 "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
-assert_occurrences 1 "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_occurrences 1 "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
+assert_not_contains_mapped "- pnpm dashboard:build"
 
 run_gate "ui-dashboard/react-doctor.config.json"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
@@ -1033,19 +1078,15 @@ assert_not_contains_mapped "- pnpm dashboard:build"
 assert_not_contains_mapped "- pnpm dashboard:size-limit"
 
 run_gate "ui-dashboard/postcss.config.mjs"
-assert_contains "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 
 run_gate "ui-dashboard/next.config.ts"
-assert_contains "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 
 run_gate "ui-dashboard/sentry.shared.ts"
-assert_contains "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 
 run_gate "ui-dashboard/src/instrumentation-client.ts"
-assert_contains "- pnpm dashboard:build (ui-dashboard bundle inputs changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 
 run_gate "ui-dashboard/src/lib/weekend.ts"
@@ -1249,12 +1290,10 @@ assert_order \
 assert_order \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
   "- pnpm --filter @mento-protocol/indexer-envio typecheck (shared-config vendored indexer fixture changed)"
-assert_contains "- pnpm dashboard:build (shared-config exports feed the dashboard bundle)"
 assert_contains "- pnpm dashboard:size-limit (shared-config exports feed the dashboard bundle)"
 
 run_gate "shared-config/src/chains.ts"
 assert_contains "- pnpm --filter @mento-protocol/monitoring-config test:coverage (shared-config changed (coverage floor))"
-assert_contains "- pnpm dashboard:build (shared-config exports feed the dashboard bundle)"
 assert_contains "- pnpm dashboard:size-limit (shared-config exports feed the dashboard bundle)"
 # The cache key includes shared-config inputs for browser tests, but the local
 # gate still does not broaden shared-config-only edits into Playwright runs.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -156,7 +156,7 @@ turbo_filter_line_number() {
         -v task="$task_name" \
         -v package_filter="--filter=${package_name}" \
         -v reason="$reason" \
-        'index($0, "- pnpm exec turbo run " task " ") && index($0, package_filter) && index($0, " --cache=local:rw") && (reason == "" || index($0, reason)) { print NR; exit }' \
+        'index($0, "- pnpm exec turbo run " task " ") && index($0, package_filter " ") && index($0, " --cache=local:rw") && (reason == "" || index($0, reason)) { print NR; exit }' \
         "$output_file"
       ;;
   esac


### PR DESCRIPTION
## The Problem

- The pre-push agent quality gate paid repeated Turbo startup and scheduling overhead for workspace-wide changes.
- Dashboard size-limit checks also mapped a separate dashboard build even though Turbo already knows size-limit depends on build.
- That made broad workflow/package-manager pushes slower without adding extra correctness coverage.

## The Solution

- Group same-task Turbo checks into one package-filtered Turbo invocation, so Turbo schedules all affected packages together.
- Let the dashboard size-limit Turbo task pull in its required build dependency instead of mapping a second build command.
- Keep preflight, codegen, install, package-script refusal, coverage floors, mutation baselines, Terraform, and dep-cruiser outside the optimization.

## Details

- Updates the gate dispatcher to compact only simple Turbo-backed package tasks; non-Turbo commands and env-prefixed React Doctor diff commands keep their existing ordering.
- Updates prewarm parsing to accept grouped Turbo commands.
- Tightens regression tests to assert the exact workspace-wide grouped lint/typecheck/knip command shape and one occurrence per grouped task.
- Updates agent docs and the dashboard cache safety note to reflect that size-limit owns the build dependency.

## Measured Impact

- Dashboard bundle path: Turbo dry-run scheduler time 6.64s -> 5.78s, about 13% faster.
- Shared-config path: 4.45s -> 3.52s, about 21% faster.
- Workspace trigger (.npmrc): 17.22s -> 4.12s, about 76% faster.
- Central CI workflow trigger: 17.93s -> 4.07s, about 77% faster.

## Validation

- pnpm agent:quality-gate --run
- pnpm agent:quality-gate:test
- pnpm lint:scripts
- pnpm agent:prewarm:test
- bash -n scripts/agent-quality-gate.sh
- bash -n scripts/agent-quality-gate.test.sh
- git diff --check
- Turbo dry-runs for grouped multi-filter commands and size-limit -> build dependency scheduling
- External read-only reviewer found no actionable quality-gate regression; follow-up test specificity gap was fixed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local/pre-push quality-gate command planning and Turbo invocation shape; coverage is regression-tested but a grouping bug could skip or mis-order package checks.
> 
> **Overview**
> Speeds up the **agent quality gate** and **pre-push** path by cutting repeated Turbo scheduler work, without dropping the checks that were already mapped.
> 
> **Same-task Turbo coalescing:** After path mapping, simple `pnpm exec turbo run <task> --filter=<pkg> --cache=local:rw` entries for the same task are merged into one command with multiple `--filter` arguments (e.g. workspace-wide `.npmrc` changes produce a single grouped `lint` / `typecheck` / `knip` line instead of one Turbo invocation per package). Non-Turbo commands, env-prefixed React Doctor diff runs, and command order for plain entries are unchanged.
> 
> **Dashboard build via size-limit:** Bundle-affecting paths no longer map a separate dashboard `build` Turbo task; `add_ui_size_limit` only schedules `size-limit`, relying on `turbo.json`'s `size-limit -> build` dependency so build still runs without a second scheduler pass.
> 
> **Prewarm + tests + docs:** `agent-prewarm` parsing accepts multi-filter Turbo lines; gate regression tests assert grouped workspace commands and treat a package filter as present on a coalesced line; `AGENTS.md` and the dashboard cache-safety note describe coalescing and size-limit owning the build dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9760b5400fca86b9edce366a5446e4c9c867b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->