### PR TITLE
Explain organic volume filter

### DIFF
--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -170,6 +170,7 @@ describe("VolumeClient useGQL wiring", () => {
     );
     expect(html).not.toContain('aria-label="Protocol actors"');
     expect(html).not.toContain("Organic shows external trader volume only");
+    expect(html).not.toContain("All shows all volume incl.");
     expect(html).not.toContain("Exploratory exclusions");
     expect(variablesFor(BROKER_TRADER_DAILY_TOP)).toMatchObject({
       isProtocolActorIn: [false, true],
@@ -187,9 +188,12 @@ describe("VolumeClient useGQL wiring", () => {
     expect(html).toContain('aria-label="Protocol actors"');
     expect(html).toContain("Organic");
     expect(html).toContain(
-      "Organic shows external trader volume only. All also includes Mento protocol/internal flows.",
+      "Organic shows external trader volume only. Excluding internal &amp; rebalancing flows.",
     );
     expect(html).toContain("All");
+    expect(html).toContain(
+      "All shows all volume incl. internal &amp; rebalancing flows.",
+    );
     expect(html).toContain("Exploratory exclusions");
     expect(variablesFor(TRADER_DAILY_TOP)).toMatchObject({
       isProtocolActorIn: [false],

--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -169,8 +169,8 @@ describe("VolumeClient useGQL wiring", () => {
       "Top legacy-v2 traders on Mento by total USD volume",
     );
     expect(html).not.toContain('aria-label="Protocol actors"');
-    expect(html).not.toContain("Organic shows external trader volume only");
-    expect(html).not.toContain("All shows all volume incl.");
+    expect(html).not.toContain("Filter out internal");
+    expect(html).not.toContain("Shows all volume incl.");
     expect(html).not.toContain("Exploratory exclusions");
     expect(variablesFor(BROKER_TRADER_DAILY_TOP)).toMatchObject({
       isProtocolActorIn: [false, true],
@@ -187,12 +187,10 @@ describe("VolumeClient useGQL wiring", () => {
 
     expect(html).toContain('aria-label="Protocol actors"');
     expect(html).toContain("Organic");
-    expect(html).toContain(
-      "Organic shows external trader volume only. Excluding internal &amp; rebalancing flows.",
-    );
+    expect(html).toContain("Filter out internal &amp; rebalancing flows.");
     expect(html).toContain("All");
     expect(html).toContain(
-      "All shows all volume incl. internal &amp; rebalancing flows.",
+      "Shows all volume incl. internal &amp; rebalancing flows.",
     );
     expect(html).toContain("Exploratory exclusions");
     expect(variablesFor(TRADER_DAILY_TOP)).toMatchObject({

--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -169,6 +169,7 @@ describe("VolumeClient useGQL wiring", () => {
       "Top legacy-v2 traders on Mento by total USD volume",
     );
     expect(html).not.toContain('aria-label="Protocol actors"');
+    expect(html).not.toContain("Organic shows external trader volume only");
     expect(html).not.toContain("Exploratory exclusions");
     expect(variablesFor(BROKER_TRADER_DAILY_TOP)).toMatchObject({
       isProtocolActorIn: [false, true],
@@ -185,6 +186,9 @@ describe("VolumeClient useGQL wiring", () => {
 
     expect(html).toContain('aria-label="Protocol actors"');
     expect(html).toContain("Organic");
+    expect(html).toContain(
+      "Organic shows external trader volume only. All also includes Mento protocol/internal flows.",
+    );
     expect(html).toContain("All");
     expect(html).toContain("Exploratory exclusions");
     expect(variablesFor(TRADER_DAILY_TOP)).toMatchObject({

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -121,12 +121,13 @@ function ActorToggleGroup({
       <SegmentButton
         active={!includeProtocolActors}
         label="Organic"
-        tooltip="Organic shows external trader volume only. All also includes Mento protocol/internal flows."
+        tooltip="Organic shows external trader volume only. Excluding internal & rebalancing flows."
         onClick={() => updateIncludeProtocolActors(false)}
       />
       <SegmentButton
         active={includeProtocolActors}
         label="All"
+        tooltip="All shows all volume incl. internal & rebalancing flows."
         onClick={() => updateIncludeProtocolActors(true)}
       />
     </div>

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -121,13 +121,13 @@ function ActorToggleGroup({
       <SegmentButton
         active={!includeProtocolActors}
         label="Organic"
-        tooltip="Organic shows external trader volume only. Excluding internal & rebalancing flows."
+        tooltip="Filter out internal & rebalancing flows."
         onClick={() => updateIncludeProtocolActors(false)}
       />
       <SegmentButton
         active={includeProtocolActors}
         label="All"
-        tooltip="All shows all volume incl. internal & rebalancing flows."
+        tooltip="Shows all volume incl. internal & rebalancing flows."
         onClick={() => updateIncludeProtocolActors(true)}
       />
     </div>

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -169,7 +169,7 @@ function SegmentButton({
         <span
           id={tooltipId}
           role="tooltip"
-          className="absolute right-0 top-full z-30 w-64 pt-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+          className="pointer-events-none absolute right-0 top-full z-30 w-64 pt-2 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
         >
           <span className="block rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-left text-xs font-normal leading-relaxed text-slate-200 shadow-lg">
             {tooltip}

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -169,9 +169,11 @@ function SegmentButton({
         <span
           id={tooltipId}
           role="tooltip"
-          className="pointer-events-none absolute left-0 top-full z-30 mt-2 w-64 rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-left text-xs font-normal leading-relaxed text-slate-200 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+          className="absolute right-0 top-full z-30 w-64 pt-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
         >
-          {tooltip}
+          <span className="block rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-left text-xs font-normal leading-relaxed text-slate-200 shadow-lg">
+            {tooltip}
+          </span>
         </span>
       )}
     </span>

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Tile } from "@/components/feedback";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { formatUSD } from "@/lib/format";
@@ -120,6 +121,7 @@ function ActorToggleGroup({
       <SegmentButton
         active={!includeProtocolActors}
         label="Organic"
+        tooltip="Organic shows external trader volume only. All also includes Mento protocol/internal flows."
         onClick={() => updateIncludeProtocolActors(false)}
       />
       <SegmentButton
@@ -134,30 +136,45 @@ function ActorToggleGroup({
 function SegmentButton({
   active,
   label,
+  tooltip,
   className = "",
   onClick,
 }: {
   active: boolean;
   label: string;
+  tooltip?: string;
   className?: string;
   onClick: () => void;
 }) {
+  const tooltipId = useId();
   const stateClass = active
     ? " bg-slate-700 text-white shadow-sm"
     : " text-slate-400 hover:text-slate-200";
   return (
-    <button
-      type="button"
-      aria-pressed={active}
-      onClick={onClick}
-      className={
-        "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
-        className +
-        stateClass
-      }
-    >
-      {label}
-    </button>
+    <span className="group relative inline-flex">
+      <button
+        type="button"
+        aria-pressed={active}
+        aria-describedby={tooltip ? tooltipId : undefined}
+        onClick={onClick}
+        className={
+          "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+          className +
+          stateClass
+        }
+      >
+        {label}
+      </button>
+      {tooltip && (
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className="pointer-events-none absolute left-0 top-full z-30 mt-2 w-64 rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-left text-xs font-normal leading-relaxed text-slate-200 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+        >
+          {tooltip}
+        </span>
+      )}
+    </span>
   );
 }
 


### PR DESCRIPTION
## The Problem

- Logged-in users can choose Organic or All volume, but the labels do not explain the difference at the point of use.
- Organic is a private operator-only filter, so its meaning should be clear without needing prior context.

## The Solution

- Add a concise hover/focus tooltip to the Organic segment explaining that Organic excludes Mento protocol/internal flows, while All includes them.
- Keep the tooltip behind the same logged-in-only control, so external users still only see total volume.

## Details

- Extends the existing segment button with an optional accessible tooltip.
- Wires the Organic segment to `aria-describedby` when the tooltip exists.
- Leaves the All segment and volume URL/query behavior unchanged.

## Validation

- `./tools/trunk fmt ui-dashboard/src/app/volume/_components/volume-page-sections.tsx ui-dashboard/src/app/volume/__tests__/page-client.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/app/volume/__tests__/page-client.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `./tools/trunk check ui-dashboard/src/app/volume/_components/volume-page-sections.tsx ui-dashboard/src/app/volume/__tests__/page-client.test.tsx`
- Chrome DevTools local browser verification on `/volume`: signed-in session, hovered Organic, tooltip visible, no console errors.
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (deterministic fallback clean; Codex review engine unavailable locally)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy and tooltip behavior on an existing logged-in filter; no query, URL, or auth logic changes.
> 
> **Overview**
> Adds **hover/focus tooltips** on the logged-in-only **Organic** and **All** volume segments so operators see what each mode means without leaving the control.
> 
> `SegmentButton` now accepts an optional `tooltip`, wires **`aria-describedby`** when present, and shows an accessible **`role="tooltip"`** panel on hover/focus-within. Venue and time-window segments are unchanged (no tooltips).
> 
> Tests assert external users still do not see tooltip copy, and signed-in users get the new explanatory strings in the static markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef59f5cf6dc2c0538888ec79001309c0a1be6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->