### PR TITLE
chore: speed up PR readiness probe

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -2,7 +2,7 @@
 title: PR Ready State
 status: active
 owner: eng
-last_verified: 2026-05-21
+last_verified: 2026-06-05
 ---
 
 # PR Ready State
@@ -24,6 +24,8 @@ them required for the current PR.
 
 Required blockers:
 
+- Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
+  expensive readiness sweep because there is nothing left to fix or wait on.
 - Required check runs or status contexts that are failing, pending, queued, or
   missing from the branch-protection rollup.
 - Branch-protection context lookup failures caused by unreadable or
@@ -80,13 +82,16 @@ Expected top-level fields:
     "number": 123,
     "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/123",
     "title": "Tighten PR readiness checks",
+    "state": "OPEN",
     "isDraft": false,
     "headRefName": "chore/pr-ready-state",
     "headRefOid": "abcdef1",
     "headUpdatedAt": "2026-05-21T13:22:23.000Z",
     "baseRefName": "main",
     "mergeable": "MERGEABLE",
-    "reviewDecision": "APPROVED"
+    "reviewDecision": "APPROVED",
+    "mergedAt": null,
+    "closedAt": null
   },
   "required": {
     "ready": false,
@@ -149,9 +154,16 @@ Expected top-level fields:
 Field expectations:
 
 - `ready`: `true` only when every required blocker is clear. Optional lag must
-  not flip this to `false`.
+  not flip this to `false`. A PR whose `pr.state` is `MERGED` is terminal-ready;
+  a PR whose `pr.state` is `CLOSED` without merge is terminal-blocked with a
+  `state` blocker.
 - `required.ready`: mirrors the required-only decision and should be the value
   agents use for all-clear.
+- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe uses
+  this before fetching comments, reactions, check sources, and branch
+  protection so post-merge babysitting exits quickly and does not mistake
+  GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
+- `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
 - `required.blockers[]`: only required blockers. Every item needs `kind`,
   `name`, `state`, `required: true`, and a URL when GitHub provides one.
 - `optional.items[]`: advisory signals worth reporting separately. Every item

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -26,6 +26,8 @@ Required blockers:
 
 - Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
   expensive readiness sweep because there is nothing left to fix or wait on.
+  Closed-unmerged PRs report only the terminal `state` blocker; review gates are
+  non-required because no Codex or reviewer action can unblock a closed PR.
 - Required check runs or status contexts that are failing, pending, queued, or
   missing from the branch-protection rollup.
 - Branch-protection context lookup failures caused by unreadable or
@@ -164,6 +166,9 @@ Field expectations:
   protection so post-merge babysitting exits quickly and does not mistake
   GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
 - `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
+- Terminal closed PR summaries may use gate state `not_applicable` for gates
+  that are normally required on open PRs. Agents should act on the terminal
+  `state` blocker instead of requesting more review.
 - `required.blockers[]`: only required blockers. Every item needs `kind`,
   `name`, `state`, `required: true`, and a URL when GitHub provides one.
 - `optional.items[]`: advisory signals worth reporting separately. Every item

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -339,6 +339,60 @@ function currentHeadUpdatedAt(pr) {
   return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
 }
 
+function summaryPr(pr, headUpdatedAt = currentHeadUpdatedAt(pr)) {
+  return {
+    number: pr.number,
+    url: pr.url,
+    title: pr.title,
+    state: pr.state ?? null,
+    isDraft: Boolean(pr.isDraft),
+    headRefName: pr.headRefName,
+    headRefOid: pr.headRefOid,
+    baseRefName: pr.baseRefName,
+    mergeable: pr.mergeable ?? null,
+    reviewDecision: pr.reviewDecision ?? null,
+    headUpdatedAt:
+      headUpdatedAt === null ? null : new Date(headUpdatedAt).toISOString(),
+    mergedAt: pr.mergedAt ?? null,
+    closedAt: pr.closedAt ?? null,
+  };
+}
+
+function emptyStatusChecks() {
+  return {
+    pass: [],
+    fail: [],
+    pending: [],
+    skipped: [],
+  };
+}
+
+function terminalGates({ merged }) {
+  return {
+    codexDescriptionApproval: {
+      ready: merged,
+      required: true,
+      state: merged ? "present" : "missing",
+    },
+    codexReviewSignal: {
+      ready: merged,
+      required: false,
+      state: merged ? "approved" : "missing",
+      fallbackAction: merged ? "wait" : "request_review_once_after_grace",
+    },
+    reviewCommentReplies: {
+      ready: true,
+      required: true,
+      unrepliedCount: 0,
+    },
+    reviewThreads: {
+      ready: true,
+      required: true,
+      unresolvedCount: 0,
+    },
+  };
+}
+
 function reviewCommitOid(review) {
   return (
     review.commit?.oid ??
@@ -423,6 +477,46 @@ export function classifyCodexReviewSignal({
   if (hasCurrentRequest) return "requested";
   if (hasHistoricalSignal) return "stale";
   return "missing";
+}
+
+export function summarizeTerminalReadyState(pr) {
+  const state = normalizeStatusValue(pr.state);
+  const merged = state === "MERGED";
+  const requiredBlockers = merged
+    ? []
+    : [
+        {
+          kind: "state",
+          name: "Pull request is closed",
+          state: pr.state ?? "CLOSED",
+          required: true,
+          url: pr.url,
+        },
+      ];
+
+  return {
+    ready: merged,
+    required: {
+      ready: merged,
+      blockers: requiredBlockers,
+    },
+    optional: {
+      ready: true,
+      items: [],
+    },
+    gates: terminalGates({ merged }),
+    summary: merged
+      ? "Pull request is already merged."
+      : "Pull request is closed without merging.",
+    pr: summaryPr(pr),
+    statusChecks: emptyStatusChecks(),
+    requiredStatusContexts: [],
+    unresolvedReviewThreads: [],
+    unrepliedRootReviewComments: [],
+    topLevelBotComments: [],
+    codexApprovalReaction: merged,
+    codexReviewSignal: merged ? "approved" : "missing",
+  };
 }
 
 export function summarizeReadyState({
@@ -604,19 +698,7 @@ export function summarizeReadyState({
     optional,
     gates,
     summary,
-    pr: {
-      number: pr.number,
-      url: pr.url,
-      title: pr.title,
-      isDraft: Boolean(pr.isDraft),
-      headRefName: pr.headRefName,
-      headRefOid: pr.headRefOid,
-      baseRefName: pr.baseRefName,
-      mergeable: pr.mergeable ?? null,
-      reviewDecision: pr.reviewDecision ?? null,
-      headUpdatedAt:
-        headUpdatedAt === null ? null : new Date(headUpdatedAt).toISOString(),
-    },
+    pr: summaryPr(pr, headUpdatedAt),
     statusChecks,
     requiredStatusContexts,
     unresolvedReviewThreads,

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -370,24 +370,24 @@ function emptyStatusChecks() {
 function terminalGates({ merged }) {
   return {
     codexDescriptionApproval: {
-      ready: merged,
-      required: true,
-      state: merged ? "present" : "missing",
+      ready: true,
+      required: merged,
+      state: merged ? "present" : "not_applicable",
     },
     codexReviewSignal: {
-      ready: merged,
+      ready: true,
       required: false,
-      state: merged ? "approved" : "missing",
-      fallbackAction: merged ? "wait" : "request_review_once_after_grace",
+      state: merged ? "approved" : "not_applicable",
+      fallbackAction: "wait",
     },
     reviewCommentReplies: {
       ready: true,
-      required: true,
+      required: merged,
       unrepliedCount: 0,
     },
     reviewThreads: {
       ready: true,
-      required: true,
+      required: merged,
       unresolvedCount: 0,
     },
   };

--- a/scripts/pr-ready-state-format.mjs
+++ b/scripts/pr-ready-state-format.mjs
@@ -19,6 +19,7 @@ export function formatHuman(summary) {
     `PR #${pr.number}: ${summary.ready ? "READY" : "NOT READY"} - ${pr.title}`,
   );
   lines.push(`URL: ${pr.url}`);
+  if (pr.state) lines.push(`State: ${pr.state}`);
   lines.push(`Head: ${pr.headRefName} @ ${pr.headRefOid}`);
   lines.push(`Base: ${pr.baseRefName}`);
   lines.push(
@@ -125,6 +126,7 @@ export function formatCompact(summary) {
   return [
     `PR #${summary.pr.number} ${summary.ready ? "READY" : "BLOCKED"}`,
     `head=${summary.pr.headRefOid}`,
+    `state=${summary.pr.state ?? "UNKNOWN"}`,
     `mergeable=${summary.pr.mergeable ?? "UNKNOWN"}`,
     `required_blockers=${summary.required.blockers.length}`,
     `pending_checks=${blockerNames(pendingRequiredChecks)}`,

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -6,37 +6,53 @@
  * can stay offline and fixture-driven.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import {
   checkDisplayName,
   isCodexReviewRequestBody,
   summarizeReadyState,
+  summarizeTerminalReadyState,
 } from "./pr-ready-state-core.mjs";
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 
 function runGh(args) {
-  const result = spawnSync("gh", args, {
-    encoding: "utf8",
-    maxBuffer: 20 * 1024 * 1024,
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      reject(new Error(`gh ${args.join(" ")} failed: ${err.message}`));
+    });
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(
+          new Error(
+            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      resolve(stdout);
+    });
   });
-
-  if (result.error) {
-    throw new Error(`gh ${args.join(" ")} failed: ${result.error.message}`);
-  }
-
-  if (result.status !== 0) {
-    throw new Error(
-      `gh ${args.join(" ")} failed with exit ${result.status}:\n${result.stderr}`,
-    );
-  }
-
-  return result.stdout;
 }
 
-function ghJson(args) {
-  const stdout = runGh(args);
+async function ghJson(args) {
+  const stdout = await runGh(args);
   return stdout.trim() ? JSON.parse(stdout) : null;
 }
 
@@ -49,33 +65,22 @@ function ghApiArgs(repo, args) {
   return ghArgs;
 }
 
-function ghApiJsonPages(repo, args) {
-  const parsed = ghJson([...ghApiArgs(repo, args), "--paginate", "--slurp"]);
+async function ghApiJsonPages(repo, args) {
+  const parsed = await ghJson([
+    ...ghApiArgs(repo, args),
+    "--paginate",
+    "--slurp",
+  ]);
   if (!Array.isArray(parsed)) return [];
   return parsed.flatMap((page) => (Array.isArray(page) ? page : [page]));
 }
 
-function ghApiJsonResult(repo, args) {
-  const result = spawnSync("gh", ghApiArgs(repo, args), {
-    encoding: "utf8",
-    maxBuffer: 20 * 1024 * 1024,
-  });
-
-  if (result.error) {
-    return { ok: false, error: result.error.message };
-  }
-
-  if (result.status !== 0) {
-    return {
-      ok: false,
-      error: result.stderr.trim() || `exit ${result.status}`,
-    };
-  }
-
+async function ghApiJsonResult(repo, args) {
   try {
+    const stdout = await runGh(ghApiArgs(repo, args));
     return {
       ok: true,
-      value: result.stdout.trim() ? JSON.parse(result.stdout) : null,
+      value: stdout.trim() ? JSON.parse(stdout) : null,
     };
   } catch (err) {
     return {
@@ -85,29 +90,14 @@ function ghApiJsonResult(repo, args) {
   }
 }
 
-function ghApiJsonPagesResult(repo, args) {
-  const result = spawnSync(
-    "gh",
-    [...ghApiArgs(repo, args), "--paginate", "--slurp"],
-    {
-      encoding: "utf8",
-      maxBuffer: 20 * 1024 * 1024,
-    },
-  );
-
-  if (result.error) {
-    return { ok: false, error: result.error.message };
-  }
-
-  if (result.status !== 0) {
-    return {
-      ok: false,
-      error: result.stderr.trim() || `exit ${result.status}`,
-    };
-  }
-
+async function ghApiJsonPagesResult(repo, args) {
   try {
-    const parsed = result.stdout.trim() ? JSON.parse(result.stdout) : [];
+    const stdout = await runGh([
+      ...ghApiArgs(repo, args),
+      "--paginate",
+      "--slurp",
+    ]);
+    const parsed = stdout.trim() ? JSON.parse(stdout) : [];
     return {
       ok: true,
       value: Array.isArray(parsed)
@@ -442,13 +432,11 @@ function minIsoTimestamp(current, candidate) {
   return Date.parse(candidate) < Date.parse(current) ? candidate : current;
 }
 
-function fetchStatusSourceMap({ repo, headSha }) {
+async function fetchStatusSourceMap({ repo, headSha }) {
   const path = repoPath(repo);
-  const checkRunsResult = ghApiJsonPagesResult(repo, [
-    `repos/${path}/commits/${headSha}/check-runs`,
-  ]);
-  const statusesResult = ghApiJsonPagesResult(repo, [
-    `repos/${path}/commits/${headSha}/statuses`,
+  const [checkRunsResult, statusesResult] = await Promise.all([
+    ghApiJsonPagesResult(repo, [`repos/${path}/commits/${headSha}/check-runs`]),
+    ghApiJsonPagesResult(repo, [`repos/${path}/commits/${headSha}/statuses`]),
   ]);
 
   const sourceMap = new Map();
@@ -487,8 +475,8 @@ function fetchStatusSourceMap({ repo, headSha }) {
   return { sourceMap, observedAt };
 }
 
-function fetchWorkflowNameByPath(repo, pathKey = repoPath(repo)) {
-  const result = ghApiJsonPagesResult(repo, [
+async function fetchWorkflowNameByPath(repo, pathKey = repoPath(repo)) {
+  const result = await ghApiJsonPagesResult(repo, [
     `repos/${repoPath(repo)}/actions/workflows?per_page=100`,
   ]);
   const byPath = new Map();
@@ -506,7 +494,7 @@ function fetchWorkflowNameByPath(repo, pathKey = repoPath(repo)) {
   return { byPath, error: null };
 }
 
-function fetchWorkflowNamesForRules(repo, rules) {
+async function fetchWorkflowNamesForRules(repo, rules) {
   const fallbackRepoPath = repoPath(repo);
   const byPath = new Map();
   const unresolvedSources = unresolvedWorkflowSourcesFromRules(
@@ -521,12 +509,16 @@ function fetchWorkflowNamesForRules(repo, rules) {
     };
   }
 
-  for (const sourcePath of workflowRepoPathsFromRules(
-    rules,
-    fallbackRepoPath,
-  )) {
-    const sourceRepo = repoFromPath(sourcePath, repo.host);
-    const result = fetchWorkflowNameByPath(sourceRepo, sourcePath);
+  const results = await Promise.all(
+    workflowRepoPathsFromRules(rules, fallbackRepoPath).map(
+      async (sourcePath) => {
+        const sourceRepo = repoFromPath(sourcePath, repo.host);
+        return fetchWorkflowNameByPath(sourceRepo, sourcePath);
+      },
+    ),
+  );
+
+  for (const result of results) {
     if (result.error) return { byPath: new Map(), error: result.error };
     for (const [key, value] of result.byPath.entries()) {
       byPath.set(key, value);
@@ -558,7 +550,7 @@ export function fetchHeadUpdatedAt({ observedAt }) {
   return observedAt ?? null;
 }
 
-function fetchReviewThreads({ repo, number }) {
+async function fetchReviewThreads({ repo, number }) {
   const query = `
     query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
@@ -610,7 +602,7 @@ function fetchReviewThreads({ repo, number }) {
       args.push("-f", `cursor=${cursor}`);
     }
 
-    const data = ghJson(args);
+    const data = await ghJson(args);
 
     const page = data?.data?.repository?.pullRequest?.reviewThreads;
     if (!page) return threads;
@@ -620,36 +612,38 @@ function fetchReviewThreads({ repo, number }) {
   }
 }
 
-function attachCodexRequestReactions({ repo, issueComments }) {
-  return issueComments.map((comment) => {
-    if (!isCodexReviewRequestBody(comment.body)) return comment;
-    const result = ghApiJsonPagesResult(repo, [
-      "-H",
-      "Accept: application/vnd.github+json",
-      `repos/${repoPath(repo)}/issues/comments/${comment.id}/reactions`,
-    ]);
-    if (!result.ok) return comment;
+async function attachCodexRequestReactions({ repo, issueComments }) {
+  return Promise.all(
+    issueComments.map(async (comment) => {
+      if (!isCodexReviewRequestBody(comment.body)) return comment;
+      const result = await ghApiJsonPagesResult(repo, [
+        "-H",
+        "Accept: application/vnd.github+json",
+        `repos/${repoPath(repo)}/issues/comments/${comment.id}/reactions`,
+      ]);
+      if (!result.ok) return comment;
 
-    return {
-      ...comment,
-      reactions: result.value,
-    };
-  });
+      return {
+        ...comment,
+        reactions: result.value,
+      };
+    }),
+  );
 }
 
-function fetchRequiredStatusContexts({
+async function fetchRequiredStatusContexts({
   repo,
   baseRef,
   statusCheckRollup = [],
 }) {
   const encodedBaseRef = encodeURIComponent(baseRef);
-  const result = ghApiJsonResult(repo, [
+  const result = await ghApiJsonResult(repo, [
     `repos/${repoPath(repo)}/branches/${encodedBaseRef}/protection/required_status_checks`,
   ]);
 
   if (!result.ok) {
     if (result.error.includes("Branch not protected (HTTP 404)")) {
-      const rulesResult = ghApiJsonPagesResult(repo, [
+      const rulesResult = await ghApiJsonPagesResult(repo, [
         `repos/${repoPath(repo)}/rules/branches/${encodedBaseRef}`,
       ]);
 
@@ -662,7 +656,7 @@ function fetchRequiredStatusContexts({
 
       const workflowNameByPath = workflowPathsFromRules(rulesResult.value ?? [])
         .length
-        ? fetchWorkflowNamesForRules(repo, rulesResult.value ?? [])
+        ? await fetchWorkflowNamesForRules(repo, rulesResult.value ?? [])
         : { byPath: new Map(), error: null };
 
       return requiredStatusContextsFromRulesResult(rulesResult.value ?? [], {
@@ -685,7 +679,7 @@ function fetchRequiredStatusContexts({
   };
 }
 
-function fetchReadyState({ prArg, repoArg }) {
+async function fetchReadyState({ prArg, repoArg }) {
   const prViewArgs = [
     "pr",
     "view",
@@ -698,12 +692,15 @@ function fetchReadyState({ prArg, repoArg }) {
       "headRefOid",
       "isDraft",
       "mergeable",
+      "mergedAt",
       "number",
       "reviewDecision",
       "reviews",
+      "state",
       "statusCheckRollup",
       "title",
       "url",
+      "closedAt",
     ].join(","),
   ];
 
@@ -711,7 +708,7 @@ function fetchReadyState({ prArg, repoArg }) {
     prViewArgs.push("--repo", repoArg);
   }
 
-  const pr = ghJson(prViewArgs);
+  const pr = await ghJson(prViewArgs);
 
   const number = pr?.number;
   if (!number) {
@@ -720,10 +717,50 @@ function fetchReadyState({ prArg, repoArg }) {
 
   const repo = repoFromPullRequestUrl(pr.url) ?? splitRepo(repoArg);
   const path = repoPath(repo);
-  const { sourceMap, observedAt } = fetchStatusSourceMap({
+  if (["MERGED", "CLOSED"].includes(String(pr.state ?? "").toUpperCase())) {
+    return summarizeTerminalReadyState(pr);
+  }
+
+  const statusSourcePromise = fetchStatusSourceMap({
     repo,
     headSha: pr.headRefOid,
   });
+  const issueCommentsPromise = ghApiJsonPages(repo, [
+    `repos/${path}/issues/${number}/comments`,
+  ]);
+  const issueCommentsWithReactionsPromise = issueCommentsPromise.then(
+    (issueComments) => attachCodexRequestReactions({ repo, issueComments }),
+  );
+  const reactionsPromise = ghApiJsonPages(repo, [
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${path}/issues/${number}/reactions`,
+  ]);
+  const reviewCommentsPromise = ghApiJsonPages(repo, [
+    `repos/${path}/pulls/${number}/comments`,
+  ]);
+  const reviewThreadsPromise = fetchReviewThreads({ repo, number });
+  const requiredStatusContextsPromise = fetchRequiredStatusContexts({
+    repo,
+    baseRef: pr.baseRefName,
+    statusCheckRollup: pr.statusCheckRollup ?? [],
+  });
+
+  const [
+    { sourceMap, observedAt },
+    issueComments,
+    reactions,
+    reviewComments,
+    reviewThreads,
+    requiredStatusContexts,
+  ] = await Promise.all([
+    statusSourcePromise,
+    issueCommentsWithReactionsPromise,
+    reactionsPromise,
+    reviewCommentsPromise,
+    reviewThreadsPromise,
+    requiredStatusContextsPromise,
+  ]);
   const headUpdatedAt = fetchHeadUpdatedAt({
     observedAt,
   });
@@ -735,27 +772,6 @@ function fetchReadyState({ prArg, repoArg }) {
       sourceMap,
     ),
   };
-
-  const issueComments = attachCodexRequestReactions({
-    repo,
-    issueComments: ghApiJsonPages(repo, [
-      `repos/${path}/issues/${number}/comments`,
-    ]),
-  });
-  const reactions = ghApiJsonPages(repo, [
-    "-H",
-    "Accept: application/vnd.github+json",
-    `repos/${path}/issues/${number}/reactions`,
-  ]);
-  const reviewComments = ghApiJsonPages(repo, [
-    `repos/${path}/pulls/${number}/comments`,
-  ]);
-  const reviewThreads = fetchReviewThreads({ repo, number });
-  const requiredStatusContexts = fetchRequiredStatusContexts({
-    repo,
-    baseRef: pr.baseRefName,
-    statusCheckRollup: annotatedPr.statusCheckRollup ?? [],
-  });
 
   return summarizeReadyState({
     pr: annotatedPr,
@@ -839,7 +855,7 @@ async function main() {
 
     for (;;) {
       try {
-        const summary = fetchReadyState({ prArg, repoArg });
+        const summary = await fetchReadyState({ prArg, repoArg });
         process.stdout.write(renderSummary(summary, { json, compact, watch }));
       } catch (err) {
         if (!watch) throw err;

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -17,6 +17,8 @@ import {
 } from "./pr-ready-state-core.mjs";
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 
+const GH_OUTPUT_MAX_BYTES = 20 * 1024 * 1024;
+
 function runGh(args) {
   return new Promise((resolve, reject) => {
     const child = spawn("gh", args, {
@@ -24,19 +26,44 @@ function runGh(args) {
     });
     let stdout = "";
     let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let failed = false;
+
+    function fail(message) {
+      if (failed) return;
+      failed = true;
+      child.kill();
+      reject(new Error(message));
+    }
 
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes > GH_OUTPUT_MAX_BYTES) {
+        fail(
+          `gh ${args.join(" ")} stdout exceeded ${GH_OUTPUT_MAX_BYTES} byte limit`,
+        );
+        return;
+      }
       stdout += chunk;
     });
     child.stderr.on("data", (chunk) => {
+      stderrBytes += Buffer.byteLength(chunk);
+      if (stderrBytes > GH_OUTPUT_MAX_BYTES) {
+        fail(
+          `gh ${args.join(" ")} stderr exceeded ${GH_OUTPUT_MAX_BYTES} byte limit`,
+        );
+        return;
+      }
       stderr += chunk;
     });
     child.on("error", (err) => {
-      reject(new Error(`gh ${args.join(" ")} failed: ${err.message}`));
+      fail(`gh ${args.join(" ")} failed: ${err.message}`);
     });
     child.on("close", (status) => {
+      if (failed) return;
       if (status !== 0) {
         reject(
           new Error(

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -1336,6 +1336,9 @@ test("summarizes merged pull requests as terminal ready", () => {
   assertEqual(summary.summary, "Pull request is already merged.");
   assertEqual(summary.pr.state, "MERGED");
   assertEqual(summary.pr.mergedAt, "2026-06-05T11:08:01Z");
+  assertEqual(summary.gates.codexDescriptionApproval.required, true);
+  assertEqual(summary.gates.codexDescriptionApproval.state, "present");
+  assertEqual(summary.gates.codexReviewSignal.fallbackAction, "wait");
 });
 
 test("summarizes closed unmerged pull requests as terminal blocked", () => {
@@ -1351,6 +1354,11 @@ test("summarizes closed unmerged pull requests as terminal blocked", () => {
   assertEqual(summary.required.blockers[0].state, "CLOSED");
   assertEqual(summary.summary, "Pull request is closed without merging.");
   assertEqual(summary.pr.closedAt, "2026-06-05T11:08:01Z");
+  assertEqual(summary.gates.codexDescriptionApproval.ready, true);
+  assertEqual(summary.gates.codexDescriptionApproval.required, false);
+  assertEqual(summary.gates.codexDescriptionApproval.state, "not_applicable");
+  assertEqual(summary.gates.codexReviewSignal.fallbackAction, "wait");
+  assertEqual(summary.gates.reviewCommentReplies.required, false);
 });
 
 test("human output names the readiness verdict and codex reaction gate", () => {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -14,6 +14,7 @@ import {
   classifyCodexReviewSignal,
   isCodexReviewRequestBody,
   summarizeReadyState,
+  summarizeTerminalReadyState,
   splitRequiredAndOptionalChecks,
 } from "./pr-ready-state-core.mjs";
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
@@ -1321,6 +1322,37 @@ test("summarizes ready state when all blocking surfaces are clean", () => {
   assertEqual(summary.statusChecks.skipped.length, 1);
 });
 
+test("summarizes merged pull requests as terminal ready", () => {
+  const summary = summarizeTerminalReadyState({
+    ...basePr,
+    state: "MERGED",
+    mergeable: "UNKNOWN",
+    mergedAt: "2026-06-05T11:08:01Z",
+  });
+
+  assertEqual(summary.ready, true);
+  assertEqual(summary.required.ready, true);
+  assertEqual(summary.required.blockers.length, 0);
+  assertEqual(summary.summary, "Pull request is already merged.");
+  assertEqual(summary.pr.state, "MERGED");
+  assertEqual(summary.pr.mergedAt, "2026-06-05T11:08:01Z");
+});
+
+test("summarizes closed unmerged pull requests as terminal blocked", () => {
+  const summary = summarizeTerminalReadyState({
+    ...basePr,
+    state: "CLOSED",
+    closedAt: "2026-06-05T11:08:01Z",
+  });
+
+  assertEqual(summary.ready, false);
+  assertEqual(summary.required.ready, false);
+  assertEqual(summary.required.blockers[0].kind, "state");
+  assertEqual(summary.required.blockers[0].state, "CLOSED");
+  assertEqual(summary.summary, "Pull request is closed without merging.");
+  assertEqual(summary.pr.closedAt, "2026-06-05T11:08:01Z");
+});
+
 test("human output names the readiness verdict and codex reaction gate", () => {
   const output = formatHuman(
     summarizeReadyState({
@@ -1348,6 +1380,7 @@ test("compact output includes only readiness counters and Codex signal state", (
   );
 
   assert(output.includes("PR #123 BLOCKED"), output);
+  assert(output.includes("state=UNKNOWN"), output);
   assert(output.includes("required_blockers=1"), output);
   assert(output.includes("codex_approval=missing"), output);
   assert(output.includes("codex_signal=missing"), output);


### PR DESCRIPTION
## The Problem

- `pnpm pr:ready-state` is on the hot path for every ship and babysit loop, but each probe waited on independent GitHub API calls sequentially.
- After a PR merged, the probe could still report it blocked because GitHub returns `mergeable: UNKNOWN` for merged PRs.

## The Solution

- Fetch independent GitHub readiness inputs in parallel while preserving the same required gates for open PRs.
- Short-circuit merged and closed PRs from the initial `gh pr view` response so terminal PRs do not run the expensive comment/check sweep.

## Details

- Keeps branch-protection/ruleset lookup, status source annotation, review-thread checks, unreplied-comment checks, and Codex approval gates for open PRs.
- Adds `pr.state`, `pr.mergedAt`, and `pr.closedAt` to the JSON contract and compact output.
- Documents terminal behavior: merged PRs are terminal-ready, closed-unmerged PRs are terminal-blocked.

## Measured Impact

Baseline was measured on `origin/main` before this patch. After was measured on this branch.

| Case | Before | After | Impact |
| --- | ---: | ---: | ---: |
| Merged PR #788 JSON probe | ~6.2s | ~2.1s | ~66% faster |
| Open PR #789 readiness probe | ~6.2s | ~3.0-3.2s | ~48-52% faster |

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm pr:ready-state:test`
- `pnpm lint:scripts`
- `git diff --check`
- `pnpm agent:autoreview --engine local`
- Live timing checks against PR #788 and PR #789

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared agent readiness contract and hot-path timing; behavior shifts for merged/closed PRs and concurrent `gh` calls, though open-PR gate logic is intended to stay the same.
> 
> **Overview**
> **Speeds up `pnpm pr:ready-state`** by running independent GitHub fetches in parallel (comments, reactions, review threads, status sources, branch protection) and by switching `gh` subprocess I/O to async `spawn` with output size limits.
> 
> **Fixes terminal PR handling:** after `gh pr view` includes `state`, merged PRs return **ready** without the full comment/check sweep (avoiding false blocks from post-merge `mergeable: UNKNOWN`); closed-unmerged PRs get a single required `state` blocker with review gates marked not applicable.
> 
> **Extends the JSON/human contract** with `pr.state`, `pr.mergedAt`, and `pr.closedAt`, plus compact `state=` output; docs and unit tests cover terminal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc9ea2aa139436380661f88ad309e1359707d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->