### PR TITLE
chore: parallelize agent gate commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,12 @@ tests instead of the package-script refusal path. Existing changed paths run
 targeted Trunk checks for faster local iteration. Deleted paths,
 Trunk/tooling changes, and package-manager or package-manifest changes still run
 full-repo Trunk locally. CI also runs a required full-repo Trunk check on every
-PR.
+PR. Normal `--run` mode executes independent quality-phase commands with
+bounded parallelism (`--parallel <n>`, default `2`, or
+`AGENT_QUALITY_PARALLELISM`). Preflight, codegen, post-codegen install,
+Terraform init/validate chains, Playwright browser install, and shared-config
+build setup remain ordered. `--fail-fast` stays sequential so it still stops
+before starting the next mapped command.
 
 For non-trivial behavioral, workflow, security, data-flow, or UI batches, run
 the structured closeout review after the mapped gate and before pushing:
@@ -211,7 +216,10 @@ pnpm agent:prewarm --base origin/main
 It is a no-op when the gate maps no relevant Turbo commands. Like the run mode
 gate, prewarm refuses to execute Turbo-backed package scripts when package
 manifests, lockfiles, `.npmrc`, or pnpmfile changed unless you first review the
-script/lifecycle diff and pass `--allow-package-script-changes`.
+script/lifecycle diff and pass `--allow-package-script-changes`. Prewarm runs
+Turbo commands with bounded parallelism too (`--parallel <n>`, default `2`, or
+`AGENT_PREWARM_PARALLELISM`) and captures each command's output separately so
+concurrent logs do not interleave.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
 `--fail-fast --skip-if-fresh`, so the hook stops on the first failed mapped

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,10 @@ PR. Normal `--run` mode executes independent quality-phase commands with
 bounded parallelism (`--parallel <n>`, default `2`, or
 `AGENT_QUALITY_PARALLELISM`). Preflight, codegen, post-codegen install,
 Terraform init/validate chains, Playwright browser install, and shared-config
-build setup remain ordered. `--fail-fast` stays sequential so it still stops
-before starting the next mapped command.
+build setup remain ordered. Dashboard `test:browser` and build-backed
+`size-limit` also stay serialized because both touch `ui-dashboard/.next`.
+`--fail-fast` stays sequential so it still stops before starting the next mapped
+command.
 
 For non-trivial behavioral, workflow, security, data-flow, or UI batches, run
 the structured closeout review after the mapped gate and before pushing:
@@ -219,7 +221,8 @@ manifests, lockfiles, `.npmrc`, or pnpmfile changed unless you first review the
 script/lifecycle diff and pass `--allow-package-script-changes`. Prewarm runs
 Turbo commands with bounded parallelism too (`--parallel <n>`, default `2`, or
 `AGENT_PREWARM_PARALLELISM`) and captures each command's output separately so
-concurrent logs do not interleave.
+concurrent logs do not interleave. The same dashboard `.next` serialization rule
+applies to prewarm.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
 `--fail-fast --skip-if-fresh`, so the hook stops on the first failed mapped

--- a/scripts/agent-prewarm.mjs
+++ b/scripts/agent-prewarm.mjs
@@ -246,7 +246,7 @@ export function runCommandsParallel(commands, parallelism) {
   let nextIndex = 0;
   let active = 0;
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     if (commands.length === 0) {
       resolve([]);
       return;
@@ -259,15 +259,17 @@ export function runCommandsParallel(commands, parallelism) {
         nextIndex += 1;
         active += 1;
 
-        runCommand(command).then((result) => {
-          results[commandIndex] = result;
-          active -= 1;
-          if (nextIndex >= commands.length && active === 0) {
-            resolve(results);
-            return;
-          }
-          launch();
-        });
+        runCommand(command)
+          .then((result) => {
+            results[commandIndex] = result;
+            active -= 1;
+            if (nextIndex >= commands.length && active === 0) {
+              resolve(results);
+              return;
+            }
+            launch();
+          })
+          .catch(reject);
       }
     };
 
@@ -369,6 +371,8 @@ async function main() {
       continue;
     }
 
+    // Successful Turbo output is intentionally suppressed here. Parallel runs
+    // otherwise interleave progress logs; failures replay captured output.
     console.log(`✓ ${result.command} (${formatDuration(result.elapsedMs)})`);
   }
 

--- a/scripts/agent-prewarm.mjs
+++ b/scripts/agent-prewarm.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const usage = `Usage: scripts/agent-prewarm.mjs [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--dry-run] [--allow-package-script-changes]
+const maxCapturedBytes = 20 * 1024 * 1024;
+const defaultParallelism = 2;
+
+const usage = `Usage: scripts/agent-prewarm.mjs [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--dry-run] [--allow-package-script-changes] [--parallel <n>]
 
 Prewarm Turbo's local cache for the Turbo-backed commands already mapped by
 the agent quality gate. The helper only runs commands shaped as:
@@ -21,6 +24,8 @@ Options:
   --allow-package-script-changes
                  With run mode, acknowledge package manifest/script changes
                  before executing Turbo-backed package scripts.
+  --parallel <n> Execute up to n Turbo commands concurrently. Default: 2.
+                 Can also be set with AGENT_PREWARM_PARALLELISM.
   -h, --help     Show this help.
 `;
 
@@ -81,10 +86,21 @@ export function hasPackageScriptRisk(gateOutput) {
   return false;
 }
 
+export function parseParallelism(value, label = "--parallel") {
+  if (!/^[0-9]+$/.test(value) || Number(value) < 1) {
+    throw new Error(`${label} requires a positive integer`);
+  }
+  return Number(value);
+}
+
 function parseArgs(argv) {
   const forwardedArgs = [];
   let mode = "run";
   let allowPackageScriptChanges = false;
+  let parallelism = parseParallelism(
+    process.env.AGENT_PREWARM_PARALLELISM ?? String(defaultParallelism),
+    "AGENT_PREWARM_PARALLELISM",
+  );
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -106,15 +122,37 @@ function parseArgs(argv) {
       case "--allow-package-script-changes":
         allowPackageScriptChanges = true;
         break;
+      case "--parallel":
+      case "--jobs": {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error(`${arg} requires a value`);
+        }
+        parallelism = parseParallelism(value, arg);
+        index += 1;
+        break;
+      }
       case "-h":
       case "--help":
-        return { help: true, mode, forwardedArgs, allowPackageScriptChanges };
+        return {
+          help: true,
+          mode,
+          forwardedArgs,
+          allowPackageScriptChanges,
+          parallelism,
+        };
       default:
         throw new Error(`unknown argument: ${arg}`);
     }
   }
 
-  return { help: false, mode, forwardedArgs, allowPackageScriptChanges };
+  return {
+    help: false,
+    mode,
+    forwardedArgs,
+    allowPackageScriptChanges,
+    parallelism,
+  };
 }
 
 function runGate(forwardedArgs) {
@@ -129,7 +167,115 @@ function runGate(forwardedArgs) {
   );
 }
 
-function main() {
+function createCollector() {
+  let bytes = 0;
+  let truncated = false;
+  const chunks = [];
+
+  return {
+    append(chunk) {
+      if (bytes >= maxCapturedBytes) {
+        truncated = true;
+        return;
+      }
+
+      const remaining = maxCapturedBytes - bytes;
+      if (chunk.length > remaining) {
+        chunks.push(chunk.subarray(0, remaining));
+        bytes += remaining;
+        truncated = true;
+        return;
+      }
+
+      chunks.push(chunk);
+      bytes += chunk.length;
+    },
+    text() {
+      const suffix = truncated ? "\n[output truncated after 20 MiB]\n" : "";
+      return `${Buffer.concat(chunks).toString("utf8")}${suffix}`;
+    },
+  };
+}
+
+function formatDuration(milliseconds) {
+  const seconds = Math.max(0, Math.round(milliseconds / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m${seconds % 60}s`;
+}
+
+function runCommand(command) {
+  const stdout = createCollector();
+  const stderr = createCollector();
+  const startedAt = Date.now();
+
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (chunk) => stdout.append(chunk));
+    child.stderr.on("data", (chunk) => stderr.append(chunk));
+
+    child.on("error", (error) => {
+      resolve({
+        command,
+        error,
+        status: 1,
+        elapsedMs: Date.now() - startedAt,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+      });
+    });
+
+    child.on("close", (status, signal) => {
+      resolve({
+        command,
+        signal,
+        status: status ?? 1,
+        elapsedMs: Date.now() - startedAt,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+      });
+    });
+  });
+}
+
+export function runCommandsParallel(commands, parallelism) {
+  const results = new Array(commands.length);
+  let nextIndex = 0;
+  let active = 0;
+
+  return new Promise((resolve) => {
+    if (commands.length === 0) {
+      resolve([]);
+      return;
+    }
+
+    const launch = () => {
+      while (active < parallelism && nextIndex < commands.length) {
+        const commandIndex = nextIndex;
+        const command = commands[commandIndex];
+        nextIndex += 1;
+        active += 1;
+
+        runCommand(command).then((result) => {
+          results[commandIndex] = result;
+          active -= 1;
+          if (nextIndex >= commands.length && active === 0) {
+            resolve(results);
+            return;
+          }
+          launch();
+        });
+      }
+    };
+
+    launch();
+  });
+}
+
+async function main() {
   let parsed;
   try {
     parsed = parseArgs(process.argv.slice(2));
@@ -194,15 +340,15 @@ function main() {
     return 2;
   }
 
-  let failures = 0;
+  console.log();
+  console.log(`Running Turbo commands with parallelism ${parsed.parallelism}.`);
   for (const command of commands) {
-    console.log();
     console.log(`+ ${command}`);
-    const result = spawnSync(command, {
-      shell: true,
-      stdio: "inherit",
-    });
+  }
 
+  let failures = 0;
+  const results = await runCommandsParallel(commands, parsed.parallelism);
+  for (const result of results) {
     if (result.error) {
       console.error(`Failed to run command: ${result.error.message}`);
       failures += 1;
@@ -210,8 +356,20 @@ function main() {
     }
 
     if (result.status !== 0) {
+      console.error();
+      console.error(
+        `Command failed after ${formatDuration(result.elapsedMs)}: ${result.command}`,
+      );
+      if (result.stdout) process.stderr.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      if (result.signal) {
+        console.error(`Command terminated by signal: ${result.signal}`);
+      }
       failures += 1;
+      continue;
     }
+
+    console.log(`✓ ${result.command} (${formatDuration(result.elapsedMs)})`);
   }
 
   if (failures > 0) {
@@ -226,5 +384,12 @@ function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  process.exit(main());
+  main()
+    .then((exitCode) => {
+      process.exit(exitCode);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
 }

--- a/scripts/agent-prewarm.mjs
+++ b/scripts/agent-prewarm.mjs
@@ -53,6 +53,30 @@ export function extractTurboPrewarmCommands(gateOutput) {
   return commands;
 }
 
+export function isDashboardNextWorkspaceCommand(command) {
+  return (
+    command ===
+      "pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw" ||
+    command ===
+      "pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw"
+  );
+}
+
+export function splitPrewarmCommands(commands) {
+  const serialCommands = [];
+  const parallelCommands = [];
+
+  for (const command of commands) {
+    if (isDashboardNextWorkspaceCommand(command)) {
+      serialCommands.push(command);
+    } else {
+      parallelCommands.push(command);
+    }
+  }
+
+  return { serialCommands, parallelCommands };
+}
+
 export function hasPackageScriptRisk(gateOutput) {
   let inChangedPaths = false;
 
@@ -348,8 +372,16 @@ async function main() {
     console.log(`+ ${command}`);
   }
 
+  // Keep dashboard .next writers/readers out of the prewarm parallel pool:
+  // test:browser starts a dev server, while size-limit runs build first.
+  const { serialCommands, parallelCommands } = splitPrewarmCommands(commands);
   let failures = 0;
-  const results = await runCommandsParallel(commands, parsed.parallelism);
+  const serialResults = await runCommandsParallel(serialCommands, 1);
+  const parallelResults = await runCommandsParallel(
+    parallelCommands,
+    parsed.parallelism,
+  );
+  const results = [...serialResults, ...parallelResults];
   for (const result of results) {
     if (result.error) {
       console.error(`Failed to run command: ${result.error.message}`);

--- a/scripts/agent-prewarm.test.mjs
+++ b/scripts/agent-prewarm.test.mjs
@@ -4,6 +4,7 @@ import {
   hasPackageScriptRisk,
   parseParallelism,
   runCommandsParallel,
+  splitPrewarmCommands,
 } from "./agent-prewarm.mjs";
 
 const gateOutput = `Agent quality gate
@@ -17,17 +18,33 @@ Mapped safe local commands:
 - pnpm exec turbo run test --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard changed)
 - pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw (duplicate)
 - REACT_DOCTOR_BASE_REF=origin/main REACT_DOCTOR_BASE_CACHE_KEY=abc123 pnpm exec turbo run react-doctor:diff --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard client code should keep React Doctor clean)
+- pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard changed)
 - pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw (ui-dashboard bundle inputs changed)
 
 Dry run only. Re-run with --run to execute the mapped commands.
 `;
 
-assert.deepEqual(extractTurboPrewarmCommands(gateOutput), [
+const extractedTurboCommands = extractTurboPrewarmCommands(gateOutput);
+
+assert.deepEqual(extractedTurboCommands, [
   "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw",
   "pnpm exec turbo run test --filter=@mento-protocol/ui-dashboard --cache=local:rw",
   "REACT_DOCTOR_BASE_REF=origin/main REACT_DOCTOR_BASE_CACHE_KEY=abc123 pnpm exec turbo run react-doctor:diff --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  "pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw",
   "pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw",
 ]);
+
+assert.deepEqual(splitPrewarmCommands(extractedTurboCommands), {
+  serialCommands: [
+    "pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+    "pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  ],
+  parallelCommands: [
+    "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --filter=@mento-protocol/metrics-bridge --cache=local:rw",
+    "pnpm exec turbo run test --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+    "REACT_DOCTOR_BASE_REF=origin/main REACT_DOCTOR_BASE_CACHE_KEY=abc123 pnpm exec turbo run react-doctor:diff --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  ],
+});
 
 assert.deepEqual(
   extractTurboPrewarmCommands(`Agent quality gate

--- a/scripts/agent-prewarm.test.mjs
+++ b/scripts/agent-prewarm.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import {
   extractTurboPrewarmCommands,
   hasPackageScriptRisk,
+  parseParallelism,
+  runCommandsParallel,
 } from "./agent-prewarm.mjs";
 
 const gateOutput = `Agent quality gate
@@ -62,6 +64,31 @@ Mapped safe local commands:
 - pnpm pr:ready-state:test (PR ready-state helper changed)
 `),
   false,
+);
+
+assert.equal(parseParallelism("1"), 1);
+assert.equal(parseParallelism("4"), 4);
+assert.throws(() => parseParallelism("0"), /positive integer/);
+assert.throws(() => parseParallelism("auto"), /positive integer/);
+
+const parallelResults = await runCommandsParallel(
+  [
+    'node -e "setTimeout(() => process.exit(0), 50)"',
+    'node -e "setTimeout(() => process.exit(0), 10)"',
+  ],
+  2,
+);
+assert.deepEqual(
+  parallelResults.map((result) => result.status),
+  [0, 0],
+);
+assert.equal(
+  parallelResults[0].command,
+  'node -e "setTimeout(() => process.exit(0), 50)"',
+);
+assert.equal(
+  parallelResults[1].command,
+  'node -e "setTimeout(() => process.exit(0), 10)"',
 );
 
 console.log("agent prewarm tests passed");

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh] [--parallel <n>]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -25,6 +25,10 @@ Options:
                  used the same base, changed paths, command plan, gate
                  implementation, and validated file content. Intended for the
                  pre-push hook only.
+  --parallel <n> With --run, execute independent quality commands with up to
+                 n concurrent jobs. Default: 2. Fail-fast mode stays
+                 sequential so it still stops before starting the next mapped
+                 command.
   -h, --help     Show this help.
 
 Environment:
@@ -35,6 +39,8 @@ Environment:
                       when set to 1 or true.
   AGENT_QUALITY_FAIL_FAST
                       Same behavior as --fail-fast when set to 1 or true.
+  AGENT_QUALITY_PARALLELISM
+                      Same behavior as --parallel.
 USAGE
 }
 
@@ -45,6 +51,7 @@ changed_paths_input_file=""
 allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
 fail_fast="${AGENT_QUALITY_FAIL_FAST:-false}"
 skip_if_fresh="${AGENT_QUALITY_SKIP_IF_FRESH:-false}"
+quality_parallelism="${AGENT_QUALITY_PARALLELISM:-2}"
 if [[ -z "$allow_package_script_changes" ]]; then
   allow_package_script_changes="$(git config --bool --get agent.qualityGate.allowPackageScriptChanges 2>/dev/null || true)"
 fi
@@ -99,6 +106,14 @@ while [[ $# -gt 0 ]]; do
       skip_if_fresh="true"
       shift
       ;;
+    --parallel|--jobs)
+      quality_parallelism="${2:-}"
+      if [[ -z "$quality_parallelism" ]]; then
+        echo "error: $1 requires a positive integer" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -110,6 +125,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ ! "$quality_parallelism" =~ ^[0-9]+$ || "$quality_parallelism" -lt 1 ]]; then
+  echo "error: --parallel requires a positive integer" >&2
+  exit 2
+fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -1559,21 +1579,213 @@ run_mapped_command() {
   return "$exit_code"
 }
 
-for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}" \
-  "${codegen_commands[@]+"${codegen_commands[@]}"}" \
-  "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}" \
-  "${quality_commands[@]+"${quality_commands[@]}"}"; do
-  command="${entry%%|*}"
-  if ! run_mapped_command "$command"; then
-    failures=$((failures + 1))
-    if [[ "$fail_fast" == "1" || "$fail_fast" == "true" ]]; then
-      echo
-      echo "Stopping after first failed mapped command (--fail-fast)." >&2
-      print_command_summary
-      exit 1
+run_mapped_command_to_files() {
+  local command="$1"
+  local output_file="$2"
+  local status_file="$3"
+  local elapsed_file="$4"
+  local start_ts
+  local end_ts
+  local elapsed
+  local exit_code
+
+  start_ts="$(date +%s)"
+  set +e
+  bash -c "$command" > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  end_ts="$(date +%s)"
+  elapsed=$((end_ts - start_ts))
+
+  printf '%s\n' "$exit_code" > "$status_file"
+  printf '%s\n' "$elapsed" > "$elapsed_file"
+}
+
+is_quality_setup_command() {
+  local command="$1"
+  case "$command" in
+    "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium")
+      return 0
+      ;;
+    "pnpm --filter @mento-protocol/monitoring-config build")
+      return 0
+      ;;
+    TF_DATA_DIR=*terraform\ -chdir=*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+run_mapped_entries_sequential() {
+  local entry
+  local command
+  shift
+
+  for entry in "$@"; do
+    command="${entry%%|*}"
+    if ! run_mapped_command "$command"; then
+      failures=$((failures + 1))
+      if [[ "$fail_fast" == "1" || "$fail_fast" == "true" ]]; then
+        echo
+        echo "Stopping after first failed mapped command (--fail-fast)." >&2
+        print_command_summary
+        exit 1
+      fi
     fi
+  done
+}
+
+run_mapped_entries_parallel() {
+  local phase="$1"
+  local max_parallel="$2"
+  shift 2
+  local entries=("$@")
+  local total="${#entries[@]}"
+  local next_index=0
+  local completed=0
+  local active_pids=()
+  local active_commands=()
+  local active_output_files=()
+  local active_status_files=()
+  local active_elapsed_files=()
+  local next_active_pids=()
+  local next_active_commands=()
+  local next_active_output_files=()
+  local next_active_status_files=()
+  local next_active_elapsed_files=()
+  local running_pids=()
+  local entry
+  local command
+  local output_file
+  local status_file
+  local elapsed_file
+  local pid
+  local i
+  local status
+  local elapsed
+
+  if [[ "$total" -eq 0 ]]; then
+    return
   fi
-done
+
+  if [[ "$max_parallel" -le 1 || "$total" -le 1 ]]; then
+    run_mapped_entries_sequential "$phase" "${entries[@]}"
+    return
+  fi
+
+  echo
+  echo "Running ${phase} commands with parallelism ${max_parallel}."
+
+  while [[ "$completed" -lt "$total" ]]; do
+    while [[ "$next_index" -lt "$total" && "${#active_pids[@]}" -lt "$max_parallel" ]]; do
+      entry="${entries[$next_index]}"
+      command="${entry%%|*}"
+      output_file="$(make_tmpfile)"
+      status_file="$(make_tmpfile)"
+      elapsed_file="$(make_tmpfile)"
+
+      echo
+      echo "+ ${command}"
+      run_mapped_command_to_files "$command" "$output_file" "$status_file" "$elapsed_file" &
+      pid="$!"
+
+      active_pids+=("$pid")
+      active_commands+=("$command")
+      active_output_files+=("$output_file")
+      active_status_files+=("$status_file")
+      active_elapsed_files+=("$elapsed_file")
+
+      next_index=$((next_index + 1))
+    done
+
+    running_pids=()
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] && running_pids+=("$pid")
+    done < <(jobs -pr || true)
+    next_active_pids=()
+    next_active_commands=()
+    next_active_output_files=()
+    next_active_status_files=()
+    next_active_elapsed_files=()
+
+    for i in "${!active_pids[@]}"; do
+      pid="${active_pids[$i]}"
+      if list_contains_word "$pid" "${running_pids[@]+"${running_pids[@]}"}"; then
+        next_active_pids+=("$pid")
+        next_active_commands+=("${active_commands[$i]}")
+        next_active_output_files+=("${active_output_files[$i]}")
+        next_active_status_files+=("${active_status_files[$i]}")
+        next_active_elapsed_files+=("${active_elapsed_files[$i]}")
+        continue
+      fi
+
+      if ! wait "$pid"; then
+        :
+      fi
+
+      command="${active_commands[$i]}"
+      output_file="${active_output_files[$i]}"
+      status_file="${active_status_files[$i]}"
+      elapsed_file="${active_elapsed_files[$i]}"
+      status="$(cat "$status_file" 2>/dev/null || echo 127)"
+      elapsed="$(cat "$elapsed_file" 2>/dev/null || echo 0)"
+
+      if [[ "$status" -eq 0 ]]; then
+        record_command_summary "ok" "$elapsed" "$command"
+        echo "✓ ${command} ($(format_duration "$elapsed"))"
+      else
+        failures=$((failures + 1))
+        record_command_summary "fail" "$elapsed" "$command"
+        echo "Command failed after $(format_duration "$elapsed"): ${command}" >&2
+        filter_expected_output < "$output_file" >&2
+      fi
+
+      rm -f "$output_file" "$status_file" "$elapsed_file"
+      completed=$((completed + 1))
+    done
+
+    active_pids=("${next_active_pids[@]+"${next_active_pids[@]}"}")
+    active_commands=("${next_active_commands[@]+"${next_active_commands[@]}"}")
+    active_output_files=("${next_active_output_files[@]+"${next_active_output_files[@]}"}")
+    active_status_files=("${next_active_status_files[@]+"${next_active_status_files[@]}"}")
+    active_elapsed_files=("${next_active_elapsed_files[@]+"${next_active_elapsed_files[@]}"}")
+
+    if [[ ${#active_pids[@]} -gt 0 ]]; then
+      sleep 0.1
+    fi
+  done
+}
+
+run_quality_phase() {
+  local setup_entries=()
+  local parallel_entries=()
+  local entry
+  local command
+
+  if [[ "$fail_fast" == "1" || "$fail_fast" == "true" || "$quality_parallelism" -le 1 ]]; then
+    run_mapped_entries_sequential "quality" "${quality_commands[@]+"${quality_commands[@]}"}"
+    return
+  fi
+
+  for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
+    command="${entry%%|*}"
+    if is_quality_setup_command "$command"; then
+      setup_entries+=("$entry")
+    else
+      parallel_entries+=("$entry")
+    fi
+  done
+
+  run_mapped_entries_sequential "quality setup" "${setup_entries[@]+"${setup_entries[@]}"}"
+  run_mapped_entries_parallel "quality" "$quality_parallelism" "${parallel_entries[@]+"${parallel_entries[@]}"}"
+}
+
+run_mapped_entries_sequential "preflight" "${preflight_commands[@]+"${preflight_commands[@]}"}"
+run_mapped_entries_sequential "codegen" "${codegen_commands[@]+"${codegen_commands[@]}"}"
+run_mapped_entries_sequential "post-codegen" "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"
+run_quality_phase
 
 print_command_summary
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1469,6 +1469,10 @@ fi
 
 failures=0
 command_summaries=()
+supports_wait_n=false
+if help wait 2>/dev/null | grep -q -- "-n"; then
+  supports_wait_n=true
+fi
 
 format_duration() {
   local seconds="$1"
@@ -1603,6 +1607,9 @@ run_mapped_command_to_files() {
 
 is_quality_setup_command() {
   local command="$1"
+  # These commands have side effects that later quality checks depend on, so
+  # they must finish before the independent quality pool starts. Keep this list
+  # in sync with new setup-style commands added by the path mapper above.
   case "$command" in
     "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium")
       return 0
@@ -1621,6 +1628,8 @@ is_quality_setup_command() {
 run_mapped_entries_sequential() {
   local entry
   local command
+  # $1 is the phase label, accepted for call-site symmetry with the parallel
+  # runner. Sequential execution does not need to print the phase.
   shift
 
   for entry in "$@"; do
@@ -1752,7 +1761,9 @@ run_mapped_entries_parallel() {
     active_status_files=("${next_active_status_files[@]+"${next_active_status_files[@]}"}")
     active_elapsed_files=("${next_active_elapsed_files[@]+"${next_active_elapsed_files[@]}"}")
 
-    if [[ ${#active_pids[@]} -gt 0 ]]; then
+    if [[ ${#active_pids[@]} -gt 0 && "$supports_wait_n" == true ]]; then
+      wait -n 2>/dev/null || true
+    elif [[ ${#active_pids[@]} -gt 0 ]]; then
       sleep 0.1
     fi
   done

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1625,6 +1625,23 @@ is_quality_setup_command() {
   return 1
 }
 
+is_quality_serial_command() {
+  local command="$1"
+  # Dashboard browser tests start a Next dev server while size-limit runs a
+  # build-backed Turbo task. Both touch ui-dashboard/.next, so keep them
+  # mutually exclusive instead of letting the parallel pool overlap them.
+  case "$command" in
+    "pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw")
+      return 0
+      ;;
+    "pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw")
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 run_mapped_entries_sequential() {
   local entry
   local command
@@ -1771,6 +1788,7 @@ run_mapped_entries_parallel() {
 
 run_quality_phase() {
   local setup_entries=()
+  local serial_entries=()
   local parallel_entries=()
   local entry
   local command
@@ -1784,12 +1802,15 @@ run_quality_phase() {
     command="${entry%%|*}"
     if is_quality_setup_command "$command"; then
       setup_entries+=("$entry")
+    elif is_quality_serial_command "$command"; then
+      serial_entries+=("$entry")
     else
       parallel_entries+=("$entry")
     fi
   done
 
   run_mapped_entries_sequential "quality setup" "${setup_entries[@]+"${setup_entries[@]}"}"
+  run_mapped_entries_sequential "quality serialized" "${serial_entries[@]+"${serial_entries[@]}"}"
   run_mapped_entries_parallel "quality" "$quality_parallelism" "${parallel_entries[@]+"${parallel_entries[@]}"}"
 }
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1491,6 +1491,51 @@ grep -Fq -- "+ pnpm --filter @mento-protocol/ui-dashboard typecheck" "$output_fi
 assert_contains "All mapped commands passed."
 assert_not_contains "consumer typecheck started before shared-config build"
 
+dashboard_serial_repo="$(mktemp -d)"
+(
+  cd "$dashboard_serial_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin tools ui-dashboard/src/app
+  printf 'export default function Page() { return null; }\n' > ui-dashboard/src/app/page.tsx
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  exec\ turbo\ run\ test:browser*|exec\ turbo\ run\ size-limit*)
+    if ! mkdir "${DASHBOARD_NEXT_LOCK:?}"; then
+      echo "dashboard .next command overlapped"
+      exit 1
+    fi
+    sleep 0.2
+    rmdir "$DASHBOARD_NEXT_LOCK"
+    ;;
+esac
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'ui-dashboard/src/app/page.tsx\n' > changed-paths.txt
+  DASHBOARD_NEXT_LOCK="$dashboard_serial_repo/next-lock" \
+    PATH="$dashboard_serial_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 8 \
+      > "$output_file" 2>&1
+)
+rm -rf "$dashboard_serial_repo"
+assert_contains "+ pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw"
+assert_contains "+ pnpm exec turbo run size-limit --filter=@mento-protocol/ui-dashboard --cache=local:rw"
+assert_contains "All mapped commands passed."
+assert_not_contains "dashboard .next command overlapped"
+
 fresh_stamp_repo="$(mktemp -d)"
 (
   cd "$fresh_stamp_repo"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1397,6 +1397,100 @@ assert_contains "- ok "
 assert_not_contains "expected fixture failure that should stay quiet"
 assert_not_contains "successful command noise that should stay quiet"
 
+parallel_quality_repo="$(mktemp -d)"
+(
+  cd "$parallel_quality_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin scripts tools
+  printf 'console.log("fixture");\n' > scripts/agent-prewarm.mjs
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+marker="${PARALLEL_MARKER:?}"
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  if [[ -f "$marker" ]]; then
+    exit 0
+  fi
+  sleep 0.05
+done
+echo "parallel marker was not created while trunk was running"
+exit 1
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+: > "${PARALLEL_MARKER:?}"
+sleep 0.1
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'scripts/agent-prewarm.mjs\n' > changed-paths.txt
+  PARALLEL_MARKER="$parallel_quality_repo/parallel-marker" \
+    PATH="$parallel_quality_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 4 \
+      > "$output_file" 2>&1
+)
+rm -rf "$parallel_quality_repo"
+assert_contains "Running quality commands with parallelism 4."
+assert_contains "+ ./tools/trunk check scripts/agent-prewarm.mjs"
+assert_contains "+ pnpm lint:scripts"
+assert_contains "+ pnpm agent:prewarm:test"
+assert_contains "All mapped commands passed."
+assert_not_contains "parallel marker was not created"
+
+quality_setup_repo="$(mktemp -d)"
+(
+  cd "$quality_setup_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin shared-config/src tools
+  printf 'export const fixture = true;\n' > shared-config/src/config.ts
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  "--filter @mento-protocol/monitoring-config build")
+    sleep 0.2
+    : > "${BUILD_MARKER:?}"
+    ;;
+  "--filter @mento-protocol/ui-dashboard typecheck")
+    if [[ ! -f "${BUILD_MARKER:?}" ]]; then
+      echo "consumer typecheck started before shared-config build"
+      exit 1
+    fi
+    ;;
+esac
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'shared-config/src/config.ts\n' > changed-paths.txt
+  BUILD_MARKER="$quality_setup_repo/build-marker" \
+    PATH="$quality_setup_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 8 \
+      > "$output_file" 2>&1
+)
+rm -rf "$quality_setup_repo"
+assert_contains "+ pnpm --filter @mento-protocol/monitoring-config build"
+grep -Fq -- "+ pnpm --filter @mento-protocol/ui-dashboard typecheck" "$output_file" ||
+  fail "expected direct shared-config consumer typecheck to run"
+assert_contains "All mapped commands passed."
+assert_not_contains "consumer typecheck started before shared-config build"
+
 fresh_stamp_repo="$(mktemp -d)"
 (
   cd "$fresh_stamp_repo"


### PR DESCRIPTION
## The Problem

- `pnpm agent:quality-gate --run` still executed independent quality checks one after another, so agent closeout time included avoidable serial wait.
- `pnpm agent:prewarm` had the same sequential shape for Turbo cache warmups.
- A naive parallel runner would risk starting dependent setup work out of order.

## The Solution

- Add bounded parallel execution for independent quality-phase commands, defaulting to two concurrent jobs.
- Keep correctness-sensitive work ordered: preflight, codegen, post-codegen install, Terraform init/validate chains, Playwright browser install, shared-config build setup, and strict `--fail-fast`.
- Parallelize Turbo prewarm commands with separate output capture so concurrent logs do not interleave.

## Notes

- `pnpm agent:quality-gate --run --parallel <n>` and `AGENT_QUALITY_PARALLELISM` control gate fanout.
- `pnpm agent:prewarm --parallel <n>` and `AGENT_PREWARM_PARALLELISM` control prewarm fanout.
- Default fanout is `2`, chosen after measuring this branch because `4` created more contention on the long regression suite.

## Performance

- Controlled benchmark with four independent one-second mapped commands:
  - Sequential emulation, `--parallel 1`: `4.54s`
  - New default, `--parallel 2`: `2.42s`
  - Impact: about `47%` faster wall time for independent mapped work.
- Real current branch gate:
  - Sequential emulation, `--parallel 1`: about `43s` observed wall time.
  - New default, `--parallel 2`: about `38s` on the comparable run, with later reruns varying because `pnpm agent:quality-gate:test` ranged from `36s` to `44s`.

## Validation

- `bash -n scripts/agent-quality-gate.sh`
- `node --check scripts/agent-prewarm.mjs`
- `pnpm agent:prewarm:test`
- `pnpm agent:quality-gate:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:prewarm --dry-run`
- `git diff --check`
- `pnpm agent:autoreview` clean; Codex review engine unavailable locally, deterministic fallback reported no actionable findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrency changes local CI orchestration; mitigations serialize .next and setup dependencies, but parallel runs could still expose latent resource contention or ordering bugs in mapped commands.
> 
> **Overview**
> **Speeds up local agent closeout** by running independent mapped quality checks and Turbo prewarm tasks concurrently instead of strictly one-by-one.
> 
> `pnpm agent:quality-gate --run` gains **`--parallel <n>`** (default **2**, or **`AGENT_QUALITY_PARALLELISM`**). Preflight, codegen, post-codegen install, Terraform validate chains, Playwright install, and **`shared-config` build** still run in order; dashboard **`test:browser`** and **`size-limit`** stay serial because both use **`ui-dashboard/.next`**. **`--fail-fast`** remains fully sequential.
> 
> **`pnpm agent:prewarm`** mirrors the same fanout (**`--parallel`**, **`AGENT_PREWARM_PARALLELISM`**) with per-command output capture so parallel Turbo logs do not interleave; failures replay captured stdout/stderr.
> 
> **`AGENTS.md`** documents the knobs and ordering rules. Regression tests cover parallel quality execution, setup-before-consumer ordering, and dashboard **`.next`** mutual exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df203966784fd83a95ad7b71e7c9a5a877e5236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->