### PR TITLE
Show partial integration probe status

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ pnpm infra:apply    # apply platform changes after review
 
 Aggregator integration snapshots are produced by the scheduled
 `Integration Probes` GitHub Actions workflow and rendered at
-`/integrations`. Run the same quote-only check manually with:
+`/integrations`. Chain statuses are `pass` only for full active USDm hub-pair
+coverage and `partial` when some pair directions pass but others still lack
+Mento v3 address evidence. Run the same quote-only check manually with:
 
 ```bash
 pnpm integrations:probe

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,7 +136,9 @@ from Upstash key `integration-probes:latest`. The scheduled
 `.github/workflows/integration-probes.yml` workflow refreshes it daily and can
 also be run manually with `workflow_dispatch`. `integration-probes:latest`
 expires after 3 days so missed scheduled probes surface as stale/missing
-dashboard data; dated history keys expire after 90 days.
+dashboard data; dated history keys expire after 90 days. Chain statuses are
+`pass` only when every active USDm hub-pair direction passes and `partial` when
+at least one direction passes but full coverage is still missing.
 
 ```bash
 pnpm integrations:probe

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -28,6 +28,8 @@ pnpm --filter @mento-protocol/integration-probes knip
 
 - Never mark a route `pass` from a source label alone. A pass requires
   Routerv300 or registered v3 pool/VirtualPool address evidence.
+- Chain-level coverage is `partial` when at least one pair direction passes
+  but the chain does not have full active USDm hub-pair coverage.
 - Missing adapter credentials must return `needs_key`, not `fail`.
 - Unsupported chain coverage must return `unsupported`, not `fail`.
 - Quote probes are read-only. Do not add funded canary swaps without a new
@@ -58,6 +60,9 @@ pnpm --filter @mento-protocol/integration-probes knip
   Uniswap V3 Celo pool sell-side balance, when RPC is available, to size a
   small discovery ladder after the default quote. This is only for amount
   selection; a pass still requires Mento v3 router or registered pool evidence.
+- Adapter order is dashboard display order. Keep LI.FI, Squid, and OpenOcean
+  first by operator priority, then sort remaining adapters by current public
+  30d aggregator/bridge volume where available.
 - `integration-probes:latest` expires after 3 days so failed scheduled probes
   degrade the dashboard instead of showing stale health forever. Dated history
   keys expire after 90 days.

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1226,6 +1226,9 @@ describe("aggregatePairStatus", () => {
       ]),
     ).toBe("needs_key");
     expect(
+      aggregatePairStatus([{ status: "needs_key" }, { status: "fail" }]),
+    ).toBe("fail");
+    expect(
       aggregatePairStatus([{ status: "error" }, { status: "error" }]),
     ).toBe("error");
     expect(aggregatePairStatus([])).toBe("error");

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1212,8 +1212,18 @@ describe("aggregatePairStatus", () => {
     expect(aggregatePairStatus([{ status: "pass" }, { status: "fail" }])).toBe(
       "partial",
     );
+    expect(aggregatePairStatus([{ status: "pass" }, { status: "error" }])).toBe(
+      "partial",
+    );
     expect(
       aggregatePairStatus([{ status: "pass" }, { status: "needs_key" }]),
+    ).toBe("needs_key");
+    expect(
+      aggregatePairStatus([
+        { status: "pass" },
+        { status: "needs_key" },
+        { status: "error" },
+      ]),
     ).toBe("needs_key");
     expect(
       aggregatePairStatus([{ status: "error" }, { status: "error" }]),

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1210,7 +1210,7 @@ describe("aggregatePairStatus", () => {
     );
     expect(aggregatePairStatus([{ status: "needs_key" }])).toBe("needs_key");
     expect(aggregatePairStatus([{ status: "pass" }, { status: "fail" }])).toBe(
-      "fail",
+      "partial",
     );
     expect(
       aggregatePairStatus([{ status: "pass" }, { status: "needs_key" }]),
@@ -1223,6 +1223,26 @@ describe("aggregatePairStatus", () => {
 });
 
 describe("aggregator quote builders", () => {
+  it("keeps the dashboard adapter order aligned with operator priority and public volume", () => {
+    expect(AGGREGATOR_ADAPTERS.map((adapter) => adapter.id)).toEqual([
+      "lifi",
+      "squid",
+      "openocean",
+      "kyberswap",
+      "okx",
+      "1inch",
+      "0x",
+      "cow-swap",
+      "paraswap",
+      "relay",
+      "odos",
+      "socket",
+      "rango",
+      "rubic",
+      "debridge",
+    ]);
+  });
+
   it("builds configured quote requests for v1 live adapters", () => {
     const env = {
       LIFI_API_KEY: "lifi-key",

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -144,6 +144,36 @@ describe("runIntegrationProbes", () => {
     expect(snapshot.aggregators[0]?.chains[0]?.pairs[0]?.poolId).toBe(POOL);
   });
 
+  it("marks a chain partial when only some pair directions pass", async () => {
+    const snapshot = await runIntegrationProbes({
+      chainIds: [42220],
+      adapters: [mixedCoverageAdapter()],
+      hasuraUrl: "https://hasura.test",
+      env: {},
+      fetcher: async (input) => {
+        if (String(input) === "https://hasura.test") {
+          return new Response(
+            JSON.stringify({ data: { Pool: [poolRow(POOL, "EURm")] } }),
+          );
+        }
+        return new Response(
+          String(input).includes("base-to-usdm")
+            ? JSON.stringify({ transactionRequest: { to: ROUTER_V300 } })
+            : JSON.stringify({ route: [{ protocol: "Other" }] }),
+        );
+      },
+    });
+
+    const chain = snapshot.aggregators[0]?.chains[0];
+    expect(chain?.status).toBe("partial");
+    expect(chain?.pairCoverage).toEqual({ passed: 1, total: 2 });
+    expect(chain?.blockingReason).toBe(
+      "Some USDm hub routes passed, but full pair coverage is not healthy.",
+    );
+    expect(snapshot.summary.partialChainChecks).toBe(1);
+    expect(snapshot.summary.failingChainChecks).toBe(0);
+  });
+
   it("bounds pair probe concurrency", async () => {
     const rowA = poolRow(POOL, "EURm");
     const rowB = poolRow(
@@ -348,6 +378,15 @@ function passingAdapter(): AggregatorAdapter {
     support: { 42220: "supported", 143: "supported" },
     researchNote: "fixture",
     quote: () => ({ url: "https://quote.test" }),
+  };
+}
+
+function mixedCoverageAdapter(): AggregatorAdapter {
+  return {
+    ...passingAdapter(),
+    id: "mixed",
+    label: "Mixed",
+    quote: (input) => ({ url: `https://mixed.test/${input.direction}` }),
   };
 }
 

--- a/integration-probes/src/__tests__/upstash.test.ts
+++ b/integration-probes/src/__tests__/upstash.test.ts
@@ -140,6 +140,7 @@ function fixtureSnapshot(
       aggregators: 0,
       chainChecks: 0,
       passingChainChecks: 0,
+      partialChainChecks: 0,
       failingChainChecks: 0,
       needsKeyChainChecks: 0,
       unsupportedChainChecks: 0,

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -73,16 +73,12 @@ export const PROBE_TAKER_ADDRESS = DEFAULT_TAKER;
 
 export const AGGREGATOR_ADAPTERS: AggregatorAdapter[] = [
   lifiAdapter(),
-  openOceanAdapter(),
-  zeroXAdapter(),
   squidAdapter(),
-  socketAdapter(),
-  rubicAdapter(),
-  relayAdapter(),
-  oneInchAdapter(),
+  openOceanAdapter(),
   kyberAdapter(),
   okxAdapter(),
-  rangoAdapter(),
+  oneInchAdapter(),
+  zeroXAdapter(),
   excludedAdapter(
     "cow-swap",
     "CoW Swap",
@@ -93,11 +89,15 @@ export const AGGREGATOR_ADAPTERS: AggregatorAdapter[] = [
     "ParaSwap / Velora",
     "Current supported-chain docs do not list Celo or Monad.",
   ),
+  relayAdapter(),
   excludedAdapter(
     "odos",
     "Odos",
     "Public chain metadata currently lists neither Celo nor Monad.",
   ),
+  socketAdapter(),
+  rangoAdapter(),
+  rubicAdapter(),
   excludedAdapter(
     "debridge",
     "deBridge",
@@ -139,35 +139,28 @@ export function aggregatePairStatus(
   results: readonly Pick<PairProbeResult, "status">[],
 ): ProbeStatus {
   if (results.length === 0) return "error";
-  if (results.every((result) => result.status === "pass")) return "pass";
-  if (results.every((result) => result.status === "unsupported")) {
-    return "unsupported";
-  }
-  if (results.every((result) => result.status === "needs_key")) {
+  const statuses = new Set(results.map((result) => result.status));
+  if (statuses.size === 1) return results[0]!.status;
+  if (statuses.has("needs_key") && onlyStatuses(statuses, "pass", "needs_key"))
     return "needs_key";
-  }
-  if (
-    results.some((result) => result.status === "needs_key") &&
-    results.every((result) => ["pass", "needs_key"].includes(result.status))
-  ) {
-    return "needs_key";
-  }
-  if (results.some((result) => result.status === "rate_limited")) {
-    return "rate_limited";
-  }
-  if (results.every((result) => result.status === "no_liquidity")) {
-    return "no_liquidity";
-  }
-  if (results.every((result) => result.status === "error")) {
-    return "error";
-  }
+  if (statuses.has("rate_limited")) return "rate_limited";
+  if (statuses.has("pass")) return "partial";
   return "fail";
+}
+
+function onlyStatuses(
+  statuses: ReadonlySet<ProbeStatus>,
+  ...allowed: ProbeStatus[]
+): boolean {
+  return [...statuses].every((status) => allowed.includes(status));
 }
 
 export function blockingReason(status: ProbeStatus): string | null {
   switch (status) {
     case "pass":
       return null;
+    case "partial":
+      return "Some USDm hub routes passed, but full pair coverage is not healthy.";
     case "unsupported":
       return "Aggregator does not currently advertise support for this chain.";
     case "needs_key":
@@ -418,6 +411,7 @@ function fallbackPriority(status: ProbeStatus): number {
       return 2;
     case "needs_key":
       return 1;
+    case "partial":
     case "pass":
       return 0;
   }

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -141,18 +141,10 @@ export function aggregatePairStatus(
   if (results.length === 0) return "error";
   const statuses = new Set(results.map((result) => result.status));
   if (statuses.size === 1) return results[0]!.status;
-  if (statuses.has("needs_key") && onlyStatuses(statuses, "pass", "needs_key"))
-    return "needs_key";
   if (statuses.has("rate_limited")) return "rate_limited";
+  if (statuses.has("needs_key")) return "needs_key";
   if (statuses.has("pass")) return "partial";
   return "fail";
-}
-
-function onlyStatuses(
-  statuses: ReadonlySet<ProbeStatus>,
-  ...allowed: ProbeStatus[]
-): boolean {
-  return [...statuses].every((status) => allowed.includes(status));
 }
 
 export function blockingReason(status: ProbeStatus): string | null {
@@ -411,7 +403,7 @@ function fallbackPriority(status: ProbeStatus): number {
       return 2;
     case "needs_key":
       return 1;
-    case "partial":
+    case "partial": // Chain-level aggregate only; pair probes never emit this.
     case "pass":
       return 0;
   }

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -142,7 +142,7 @@ export function aggregatePairStatus(
   const statuses = new Set(results.map((result) => result.status));
   if (statuses.size === 1) return results[0]!.status;
   if (statuses.has("rate_limited")) return "rate_limited";
-  if (statuses.has("needs_key")) return "needs_key";
+  if (statuses.has("needs_key") && statuses.has("pass")) return "needs_key";
   if (statuses.has("pass")) return "partial";
   return "fail";
 }

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -352,6 +352,8 @@ function nextStepFor(
     return firstError ?? "Configure adapter credentials.";
   if (status === "unsupported")
     return firstError ?? "Confirm chain support with the aggregator.";
+  if (status === "partial")
+    return "Inspect failing route evidence for pairs that still lack Mento v3 address evidence.";
   if (status === "fail")
     return "Inspect route evidence and ask aggregator to route through Mento v3.";
   return firstError ?? "Inspect raw probe response.";
@@ -365,6 +367,8 @@ function summarizeSnapshot(
     aggregators: aggregators.length,
     chainChecks: chains.length,
     passingChainChecks: chains.filter((chain) => chain.status === "pass")
+      .length,
+    partialChainChecks: chains.filter((chain) => chain.status === "partial")
       .length,
     failingChainChecks: chains.filter((chain) => chain.status === "fail")
       .length,

--- a/integration-probes/src/types.ts
+++ b/integration-probes/src/types.ts
@@ -9,6 +9,7 @@ export type ProbeChainId = (typeof PROBE_CHAIN_IDS)[number];
 export type AggregatorKind = "dex" | "cross_chain" | "meta" | "excluded";
 export type ProbeStatus =
   | "pass"
+  | "partial"
   | "fail"
   | "unsupported"
   | "needs_key"
@@ -127,6 +128,7 @@ export type IntegrationProbeSnapshot = {
     aggregators: number;
     chainChecks: number;
     passingChainChecks: number;
+    partialChainChecks: number;
     failingChainChecks: number;
     needsKeyChainChecks: number;
     unsupportedChainChecks: number;

--- a/ui-dashboard/src/app/integrations/__tests__/integration-probes-table.test.tsx
+++ b/ui-dashboard/src/app/integrations/__tests__/integration-probes-table.test.tsx
@@ -11,6 +11,7 @@ describe("IntegrationProbesTable", () => {
 
     expect(html).toContain("OpenOcean");
     expect(html).toContain("Pass");
+    expect(html).toContain("Partial");
     expect(html).toContain("Needs key");
     expect(html).toContain("Unsupported");
     expect(html).toContain("router-address");
@@ -161,7 +162,7 @@ function fixtureSnapshot(): IntegrationProbeSnapshot {
         credentialEnv: [],
         researchNote: "fixture",
         chains: [
-          chainFixture(42220, "Celo", "pass"),
+          partialChainFixture(42220, "Celo"),
           chainFixture(143, "Monad", "needs_key"),
         ],
       },
@@ -181,7 +182,8 @@ function fixtureSnapshot(): IntegrationProbeSnapshot {
     summary: {
       aggregators: 2,
       chainChecks: 4,
-      passingChainChecks: 1,
+      passingChainChecks: 0,
+      partialChainChecks: 1,
       failingChainChecks: 0,
       needsKeyChainChecks: 1,
       unsupportedChainChecks: 2,
@@ -210,6 +212,37 @@ function chainFixture(
         status,
         sellSymbol: "EURm",
         error: passing ? null : "fixture",
+      }),
+    ],
+  };
+}
+
+function partialChainFixture(
+  chainId: number,
+  chainLabel: string,
+): IntegrationProbeSnapshot["aggregators"][number]["chains"][number] {
+  return {
+    chainId,
+    chainSlug: chainLabel.toLowerCase().replace(" ", "-"),
+    chainLabel,
+    status: "partial",
+    pairCoverage: { passed: 1, total: 2 },
+    blockingReason: "fixture partial",
+    nextStep: "inspect failing route",
+    pairs: [
+      pairFixture({
+        chainId,
+        poolId: `${chainId}-0xpartialpass`,
+        status: "pass",
+        sellSymbol: "CHFm",
+        error: null,
+      }),
+      pairFixture({
+        chainId,
+        poolId: `${chainId}-0xpartialfail`,
+        status: "fail",
+        sellSymbol: "GBPm",
+        error: "missing evidence",
       }),
     ],
   };

--- a/ui-dashboard/src/app/integrations/_components/integration-status-badge.tsx
+++ b/ui-dashboard/src/app/integrations/_components/integration-status-badge.tsx
@@ -8,6 +8,10 @@ const STATUS_STYLES: Record<
     label: "Pass",
     className: "bg-emerald-500/20 text-emerald-300",
   },
+  partial: {
+    label: "Partial",
+    className: "bg-yellow-500/20 text-yellow-200",
+  },
   fail: {
     label: "Fail",
     className: "bg-red-500/20 text-red-300",

--- a/ui-dashboard/src/app/integrations/page.tsx
+++ b/ui-dashboard/src/app/integrations/page.tsx
@@ -68,6 +68,11 @@ function IntegrationsContent({
           subtitle="chain checks"
         />
         <Tile
+          label="Partial"
+          value={String(snapshot.summary.partialChainChecks)}
+          subtitle="some routes pass"
+        />
+        <Tile
           label="Needs Key"
           value={String(snapshot.summary.needsKeyChainChecks)}
         />

--- a/ui-dashboard/src/lib/__tests__/integration-probes.test.ts
+++ b/ui-dashboard/src/lib/__tests__/integration-probes.test.ts
@@ -19,6 +19,7 @@ describe("IntegrationProbeSnapshotSchema", () => {
         aggregators: 0,
         chainChecks: 0,
         passingChainChecks: 0,
+        partialChainChecks: 0,
         failingChainChecks: 0,
         needsKeyChainChecks: 0,
         unsupportedChainChecks: 0,
@@ -88,6 +89,7 @@ describe("IntegrationProbeSnapshotSchema", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.data?.summary.partialChainChecks).toBe(0);
     expect(
       result.data?.aggregators[0]?.chains[0]?.pairs[0]?.httpStatus,
     ).toBeNull();

--- a/ui-dashboard/src/lib/integration-probes.ts
+++ b/ui-dashboard/src/lib/integration-probes.ts
@@ -5,6 +5,7 @@ const INTEGRATION_PROBES_LATEST_KEY = "integration-probes:latest";
 
 const StatusSchema = z.enum([
   "pass",
+  "partial",
   "fail",
   "unsupported",
   "needs_key",
@@ -115,6 +116,7 @@ export const IntegrationProbeSnapshotSchema = z.object({
     aggregators: z.number(),
     chainChecks: z.number(),
     passingChainChecks: z.number(),
+    partialChainChecks: z.number().optional().default(0),
     failingChainChecks: z.number(),
     needsKeyChainChecks: z.number(),
     unsupportedChainChecks: z.number(),


### PR DESCRIPTION
## The Problem

- Squid and other adapters can have some working Mento v3 routes while still missing full USDm hub-pair coverage, but the dashboard only showed a binary fail/pass story.
- The adapter display order did not match the current operator priority or public size signals.

## The Solution

- Add a chain-level `partial` status for adapters with at least one passing pair direction but incomplete full coverage, and surface that state in the `/integrations` dashboard.
- Reorder the adapter list to put LI.FI, Squid, and OpenOcean first, then rank the remaining adapters by public 30d aggregator/bridge volume where available.

## Details

- `partial` is now a first-class `ProbeStatus` across probe aggregation, snapshot summaries, Upstash/dashboard parsing, status badges, summary tiles, and next-step copy.
- Historical snapshots stay compatible because the dashboard schema defaults missing `partialChainChecks` to `0`.
- The adapter-order regression test locks in the requested display order:
  - LI.FI
  - Squid
  - OpenOcean
  - KyberSwap, OKX, 1inch, 0x, CoW Swap, ParaSwap/Velora, Relay, Odos, Socket/Bungee, Rango, Rubic, deBridge
- Volume basis used for the non-fixed tail:
  - DeFiLlama DEX aggregator 30d volumes for KyberSwap, OKX, 1inch, 0x, CoW, Velora, Odos, Rubic, Rango, Bungee, LI.FI/OpenOcean reference checks.
  - DeFiLlama bridge/bridge-aggregator 30d volumes for Relay, Socket/Bungee, Rango, Rubic, and deBridge where DEX-aggregator data is not the right category.
- LI.FI rate-limit investigation note: the current `LIFI_API_KEY` is being sent and one-off keyed LI.FI quotes work. The rate-limited Monad failures are downstream Fly follow-up evidence calls (`api.fly.trade`) that are not authenticated by the LI.FI key. A future fix should add the Fly/Magpie API key path and pace/retry those downstream evidence calls separately.

## Invariants

- A chain is `pass` only when every active USDm hub-pair direction on that chain passes with address-level Mento v3 evidence.
- A chain is `partial` when at least one pair direction passes but the chain does not have full active USDm hub-pair coverage.
- `pass + needs_key` remains `needs_key`, so missing credentials are not hidden by partial coverage.
- Source-label-only evidence still does not pass.

## Degraded Behavior

- Old snapshots without `partialChainChecks` render with a partial count of `0`.
- Partial chains show a yellow status and a blocking reason that directs operators to inspect the failing pair evidence.
- Unsupported, needs-key, rate-limited, no-liquidity, and error states keep their existing meanings.

## Intentional Non-Goals

- This does not add Fly/Magpie credential support yet.
- This does not change funded-swap behavior; probes remain quote-only.
- This does not alter the Mento address-evidence bar for `pass`.

## Validation

- `pnpm agent:quality-gate --run` passed all mapped commands:
  - targeted Trunk check
  - integration-probes + ui-dashboard lint/typecheck/knip
  - integration-probes and dashboard coverage
  - dependency-cruiser boundary checks
  - dashboard Playwright browser tests
  - React Doctor diff + score
  - dashboard size-limit
- `pnpm agent:autoreview` ran; the Codex semantic review engine was unavailable in this environment, so the helper fell back to deterministic local review and reported no actionable findings.
- Chrome DevTools MCP browser verification could not run because the session profile was already locked by another Chrome DevTools MCP process. cmux browser fallback was also unavailable because its socket refused the connection. The dashboard Playwright browser suite did run and pass through the quality gate.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Quote-only probe classification and dashboard display changes; full pass still requires complete hub-pair Mento v3 address evidence, with backward-compatible snapshot parsing.
> 
> **Overview**
> Introduces a chain-level **`partial`** status when at least one active USDm hub-pair direction passes with Mento v3 address evidence but full coverage is still missing, instead of lumping that case into **`fail`**.
> 
> **Probe pipeline:** `ProbeStatus` and `aggregatePairStatus` treat mixed pass/non-pass pair results as `partial` (while `pass` + `needs_key` stays `needs_key`). Snapshots add `summary.partialChainChecks`, blocking reason, and next-step copy for partial chains.
> 
> **Dashboard:** `/integrations` parses and displays partial status (badge, summary tile, table fixtures). Older Upstash snapshots default missing `partialChainChecks` to `0`.
> 
> **Operator UX:** `AGGREGATOR_ADAPTERS` display order puts LI.FI, Squid, and OpenOcean first, then remaining adapters by public 30d volume; a regression test locks the order. README, deployment docs, and `integration-probes/AGENTS.md` document pass vs partial semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d237194a62547c0d9faa546f71d281da252b395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->