### PR TITLE
Document dashboard auth-state verification

### DIFF
--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -2,7 +2,9 @@
 
 Verify the current UI state in the browser using chrome-devtools MCP.
 
-Default to the dev server at <http://localhost:3000> (or 3001 if 3000 is in use). When the user asks to verify against production, use <https://monitoring.mento.org>.
+Default to the local dev server. Prefer <http://127.0.0.1:3210> when you started
+it yourself, otherwise use <http://localhost:3000> (or 3001 if 3000 is in use).
+When the user asks to verify against production, use <https://monitoring.mento.org>.
 
 ## Pages to cover by default
 
@@ -13,7 +15,7 @@ When the user asks for a broad verify (no specific page), hit these in order and
 3. **Pool detail** `/pool/{id}` — pick any active pool from `/pools`. Verify TVL/volume charts, oracle freshness, rebalance history, swap table
 4. **Revenue** `/revenue` — KPI tiles + historical chart
 5. **Bridge Flows** `/bridge-flows` — Wormhole NTT transfers (see below)
-6. **Address book** `/address-book` — auth-gated; skip when not signed in, otherwise verify the labels list renders
+6. **Address book** `/address-book` — auth-gated; verify logged-in when possible, otherwise verify the logged-out redirect/sign-in state
 
 For a narrow verify (specific page or feature), skip the list and go directly to the requested URL.
 
@@ -23,20 +25,38 @@ For a narrow verify (specific page or feature), skip the list and go directly to
 
 2. **Navigate** to the relevant page. If the user specified a URL or route, use that. Otherwise follow the "Pages to cover" list above.
 
-3. **Verify content** using `evaluate_script` for targeted checks (~50 tokens each):
+3. **Choose auth state deliberately.** Do not rely on whatever cookies happen
+   to be in the browser. For public/logged-out checks, use an isolated browser
+   context or clear `authjs.session-token` and `__Secure-authjs.session-token`.
+   For logged-in localhost checks, follow `ui-dashboard/AGENTS.md` to mint a
+   local `authjs.session-token` for `dev@mentolabs.xyz` using the same
+   `AUTH_SECRET` as the dev server. Session-dependent surfaces should be checked
+   in both states.
+
+4. **Verify content** using `evaluate_script` for targeted checks (~50 tokens each):
    - Page heading and key text rendered correctly
    - Data values are non-empty and plausible (not "$0.00" or "..." everywhere)
    - No "No pools found" or similar empty-state messages when data is expected
 
-4. **Check for errors** with `list_console_messages(types: ["error"])`. Report any 500s, unhandled exceptions, or React errors.
+5. **Check for errors** with `list_console_messages(types: ["error"])`. Report any 500s, unhandled exceptions, or React errors.
 
-5. **Take a snapshot** only if something looks wrong or you need to investigate further. Prefer `take_snapshot(filePath)` to save tokens, then grep the file for what you need.
+6. **Take a snapshot** only if something looks wrong or you need to investigate further. Prefer `take_snapshot(filePath)` to save tokens, then grep the file for what you need.
 
-6. **If testing interactions** (sort, click, tab switch), use `click(uid, includeSnapshot=true)` for action + verification in a single call.
+7. **If testing interactions** (sort, click, tab switch), use `click(uid, includeSnapshot=true)` for action + verification in a single call.
 
-7. **If testing responsive layout**, use `resize_page` + `evaluate_script` to check column visibility at each breakpoint (desktop 1440, tablet 768, mobile 375).
+8. **If testing responsive layout**, use `resize_page` + `evaluate_script` to check column visibility at each breakpoint (desktop 1440, tablet 768, mobile 375).
 
-8. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
+9. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
+
+## Auth-state checks
+
+- Logged out: nav shows `Sign in`; authenticated-only nav links are hidden;
+  protected routes redirect to `/sign-in?callbackUrl=...`.
+- Logged in: nav shows `dev@mentolabs.xyz` and `Sign out`; `/address-book`,
+  `/entities`, and `/integrations` render; edit affordances and authenticated
+  controls are visible.
+- `/volume`: logged-out users see total volume only; logged-in users can see
+  the Organic/All control. Verify whichever of those states the change affects.
 
 ## Page-specific checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ pnpm indexer:testnet:codegen       # Generate types (multichain testnet: Celo Se
 pnpm indexer:testnet:dev           # Start indexer (multichain testnet)
 
 # Dashboard
-pnpm dashboard:dev            # Dev server
+pnpm dashboard:dev            # Dev server; see ui-dashboard/AGENTS.md for logged-in/out localhost verification
 pnpm dashboard:build          # Production build
 pnpm dashboard:size-limit     # Check bundle size against budgets (run after build)
 pnpm --filter @mento-protocol/ui-dashboard test:browser                   # Fixture-driven browser interaction + visual snapshot tests
@@ -444,7 +444,7 @@ Each package has its own `AGENTS.md` (Claude Code reads them as `CLAUDE.md` via 
 ## Environment
 
 - Indexer needs Docker for local dev (Postgres + Hasura containers)
-- Dashboard needs `NEXT_PUBLIC_HASURA_URL` env var for local dev; run `vercel env pull ui-dashboard/.env.local` to pull from the linked project
+- Dashboard localhost UI review needs `NEXT_PUBLIC_HASURA_URL`; real address-label/authenticated surfaces also need `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, and local Auth.js placeholders (`AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`). See `ui-dashboard/AGENTS.md` for the logged-in/logged-out verification workflow and local session-cookie recipe.
 - Production env vars are managed by Terraform except Vercel Blob OIDC variables, which are managed by the Vercel store integration — see `terraform/terraform.tfvars.example`
 - See root README.md for full env var documentation
 
@@ -454,7 +454,7 @@ Repo-tracked under `.claude/commands/`. Each `.md` file is the body Claude Code 
 
 | Command                              | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/verify-ui`                         | Drive chrome-devtools MCP through the dashboard's pages with token-budget guidance and per-page acceptance checks (KPI presence, chart wiring, interaction smoke tests, responsive layouts). Defaults to `localhost:3000`; pass `prod` to verify against `monitoring.mento.org`.                                                                                                                                                                                                                                                                          |
+| `/verify-ui`                         | Drive chrome-devtools MCP through the dashboard's pages with token-budget guidance and per-page acceptance checks (KPI presence, chart wiring, interaction smoke tests, responsive layouts). Defaults to a localhost dev server; pass `prod` to verify against `monitoring.mento.org`. For session-dependent surfaces, verify both logged-out and locally simulated logged-in states per `ui-dashboard/AGENTS.md`.                                                                                                                                        |
 | `/autoreview [args]`                 | Run the shared structured closeout review helper (`pnpm agent:autoreview`) from Claude Code. Defaults to Codex as the review engine; pass `--engine claude` only when Claude review is explicitly wanted.                                                                                                                                                                                                                                                                                                                                                 |
 | `/babysit-indexer-deploy [<commit>]` | Arm a `Monitor` that polls Envio's deployment registry every 45s internally but only emits on state change (`REGISTERED` / `READY_TO_PROMOTE` / `BUILD_FAILED` / `SYNC_DEADLINE` / `ERROR`). Prompts for `pnpm deploy:indexer:promote <commit>` once every chain is caught up — never auto-promotes. Bails after 30min of 404s (build likely failed) or 90min of stagnation. Defaults to `git rev-parse --short origin/envio` when no commit is passed. Replaces the prior `/loop 5m` cron version, which produced ~12 idle macOS notifications per sync. |
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ pnpm indexer:testnet:codegen && pnpm indexer:testnet:dev
 pnpm dashboard:dev
 ```
 
+For deterministic browser review, run the dashboard package directly on a fixed
+port and verify both auth states when the UI differs for signed-in users:
+
+```bash
+cd ui-dashboard
+AUTH_SECRET=local-dev-dashboard-auth-secret-do-not-use-in-prod \
+AUTH_GOOGLE_ID=local-dev-google-id \
+AUTH_GOOGLE_SECRET=local-dev-google-secret \
+pnpm dev --hostname 127.0.0.1 --port 3210
+```
+
+Open <http://127.0.0.1:3210>. Use no Auth.js session cookie for logged-out
+checks. To simulate a signed-in `@mentolabs.xyz` user locally, mint an
+`authjs.session-token` with `next-auth/jwt` using the same `AUTH_SECRET`; the
+exact agent workflow lives in [`ui-dashboard/AGENTS.md`](./ui-dashboard/AGENTS.md).
+
 ### Run Aegis
 
 ```bash
@@ -189,6 +205,9 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | `HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL` | Optional upstream URL override for local mainnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
 | `UPSTASH_REDIS_REST_URL`                 | Address labels storage (Upstash Redis)                                                                     |
 | `UPSTASH_REDIS_REST_TOKEN`               | Address labels Redis auth token                                                                            |
+| `AUTH_SECRET`                            | Auth.js JWT secret; required for local simulated login and real OAuth sessions                             |
+| `AUTH_GOOGLE_ID`                         | Google OAuth client id; non-empty placeholder is enough for local simulated login                          |
+| `AUTH_GOOGLE_SECRET`                     | Google OAuth client secret; non-empty placeholder is enough for local simulated login                      |
 | `BLOB_STORE_ID`                          | Vercel Blob OIDC store id for daily label backups (set by the Vercel store integration)                    |
 | `BLOB_WEBHOOK_PUBLIC_KEY`                | Vercel Blob OIDC public key (set by the Vercel store integration)                                          |
 

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -55,6 +55,73 @@ REACT_DOCTOR_BASE_REF=origin/main pnpm react-doctor:diff  # Diff gate used by th
 pnpm dashboard:react-doctor:diff  # CI-equivalent diff scan from repo root
 ```
 
+## Local Dev Server And Auth States
+
+For UI work, verify both public and authenticated states when the changed
+surface behaves differently by session. Examples: nav links, address-label edit
+affordances, `/address-book`, `/entities`, `/integrations`, and `/volume`
+Organic/All controls.
+
+Use a fixed localhost port so the user can inspect the exact URL you verified:
+
+```bash
+cd ui-dashboard
+AUTH_SECRET=local-dev-dashboard-auth-secret-do-not-use-in-prod \
+AUTH_GOOGLE_ID=local-dev-google-id \
+AUTH_GOOGLE_SECRET=local-dev-google-secret \
+pnpm dev --hostname 127.0.0.1 --port 3210
+```
+
+The required local data env is:
+
+- `NEXT_PUBLIC_HASURA_URL` for hosted multichain Hasura data.
+- `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` when address labels,
+  reports, entities, or authenticated editing surfaces need real data.
+- `AUTH_SECRET`, `AUTH_GOOGLE_ID`, and `AUTH_GOOGLE_SECRET` for local Auth.js
+  session handling. Placeholder Google values are fine for agent-side simulated
+  sessions; they only need to be non-empty so protected middleware is active.
+
+Other Vercel vars, Blob vars, cron secrets, and automation-bypass secrets are
+not needed for ordinary localhost UI review unless the task directly touches
+that route.
+
+Logged-out verification:
+
+- Use an isolated browser context, or clear both `authjs.session-token` and
+  `__Secure-authjs.session-token` cookies for `127.0.0.1`.
+- Expect public pages to show `Sign in`.
+- Expect protected pages (`/address-book`, `/entities`, `/integrations`) to
+  redirect to `/sign-in?callbackUrl=...` when auth env is configured.
+
+Logged-in verification:
+
+1. Start the dev server with the same `AUTH_SECRET` value used below.
+2. Mint a local Auth.js JWT with `next-auth/jwt` from `ui-dashboard/`:
+
+```bash
+AUTH_SECRET=local-dev-dashboard-auth-secret-do-not-use-in-prod node --input-type=module -e 'import { encode } from "next-auth/jwt"; const secret = process.env.AUTH_SECRET; if (!secret) throw new Error("AUTH_SECRET is required"); const token = await encode({ secret, salt: "authjs.session-token", token: { email: "dev@mentolabs.xyz", refresh_token: "local-dev", expires_at: Math.floor(Date.now() / 1000) + 3600 }, maxAge: 30 * 24 * 60 * 60 }); console.log(token);'
+```
+
+3. In Chrome DevTools MCP, set the cookie on the localhost page, replacing
+   `<TOKEN>` with the command output:
+
+```js
+document.cookie =
+  "authjs.session-token=<TOKEN>; Path=/; SameSite=Lax; Max-Age=2592000";
+location.reload();
+```
+
+4. Expect the nav to show `dev@mentolabs.xyz` and `Sign out`. Authenticated-only
+   routes should render instead of redirecting, and authenticated-only controls
+   should be visible.
+
+Never use production OAuth secrets just to simulate local login. If a task needs
+the real OAuth callback flow, say that explicitly and verify it separately.
+
+Interactive `next dev` can rewrite `ui-dashboard/next-env.d.ts` to import
+`./.next/dev/types/routes.d.ts`. Before committing, restore it to
+`./.next/types/routes.d.ts` if the dev server dirtied the worktree.
+
 ## Browser Interaction Tests
 
 `pnpm test:browser` starts the real Next.js app plus


### PR DESCRIPTION
## The Problem

- Agents had to infer how to run the dashboard locally with real data.
- Logged-in and logged-out dashboard states were not documented as separate design targets.
- Local auth simulation, minimal env vars, and Next dev cleanup were scattered across prior runs instead of durable docs.

## The Solution

- Document the fixed-port dashboard dev-server workflow and the minimal env needed for local UI review.
- Add explicit logged-out and locally simulated logged-in verification steps.
- Update `/verify-ui` so future browser checks deliberately cover the relevant auth states.

## Details

- `ui-dashboard/AGENTS.md` now owns the canonical local Auth.js session-cookie recipe for `dev@mentolabs.xyz`.
- Root `README.md` and `AGENTS.md` point back to the dashboard package instructions instead of duplicating the full procedure.
- The docs call out that ordinary localhost UI review does not need production OAuth, Blob, cron, or automation-bypass secrets.
- The dashboard package instructions also remind agents to restore `next-env.d.ts` if interactive `next dev` rewrites it.

## Validation

- `./tools/trunk check AGENTS.md README.md ui-dashboard/AGENTS.md .claude/commands/verify-ui.md`
- `AUTH_SECRET=local-dev-dashboard-auth-secret-do-not-use-in-prod node --input-type=module -e 'import { encode } from "next-auth/jwt"; const secret = process.env.AUTH_SECRET; if (!secret) throw new Error("AUTH_SECRET is required"); const token = await encode({ secret, salt: "authjs.session-token", token: { email: "dev@mentolabs.xyz", refresh_token: "local-dev", expires_at: Math.floor(Date.now() / 1000) + 3600 }, maxAge: 30 * 24 * 60 * 60 }); console.log(token.length > 100 ? "token minted" : "token too short");'`
- `pnpm agent:quality-gate --run` passed after stopping the prior inspection dev server that occupied the browser-test port.
- `pnpm agent:autoreview` ran; Codex review engine was unavailable, so deterministic fallback reported no actionable findings.
- Pre-push `pnpm agent:quality-gate --run --fail-fast --skip-if-fresh` passed all mapped commands.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or deployment behavior modified.
> 
> **Overview**
> Documents how agents and reviewers should run the dashboard locally and **deliberately verify logged-out vs locally simulated logged-in** behavior, instead of relying on ad hoc tribal knowledge.
> 
> **`ui-dashboard/AGENTS.md`** becomes the canonical guide: fixed `127.0.0.1:3210` dev server, minimal env (`NEXT_PUBLIC_HASURA_URL`, Upstash for label/auth surfaces, placeholder `AUTH_*`), cookie clearing for logged-out checks, and a `next-auth/jwt` recipe to mint `authjs.session-token` for `dev@mentolabs.xyz`. It also notes restoring `next-env.d.ts` after interactive `next dev`.
> 
> Root **`README.md`** and **`AGENTS.md`** link to that workflow and list Auth env vars; **`/verify-ui`** now prefers `127.0.0.1:3210`, requires explicit auth-state setup, adds an **Auth-state checks** section, and tightens `/address-book` expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508c5dbfb3cbf3f31ab7a23f47c3dac0bf49774e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->