### PR TITLE
chore: speed up agent session gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ targeted Trunk checks for faster local iteration. Deleted paths,
 Trunk/tooling changes, and package-manager or package-manifest changes still run
 full-repo Trunk locally. CI also runs a required full-repo Trunk check on every
 PR. Normal `--run` mode executes independent quality-phase commands with
-bounded parallelism (`--parallel <n>`, default `2`, or
+bounded parallelism (`--parallel <n>`, default `auto` capped at 4 workers, or
 `AGENT_QUALITY_PARALLELISM`). Preflight, codegen, post-codegen install,
 Terraform init/validate chains, Playwright browser install, and shared-config
 build setup remain ordered. Dashboard `test:browser` and build-backed
@@ -230,11 +230,13 @@ The Trunk pre-push hook delegates to this same path-aware gate with
 `--fail-fast --skip-if-fresh`, so the hook stops on the first failed mapped
 command instead of burning through the rest of the suite, and it reuses a
 recent successful manual gate run when the fetched base commit, mapped command
-plan, gate implementation, changed paths, and validated file content are
-unchanged. For a push that intentionally changes package scripts or
-package-manager config, review the script/lifecycle diff first, then
-temporarily set `agent.qualityGate.allowPackageScriptChanges=true` in local git
-config for that push.
+plan, gate implementation, changed paths, validated file content, package-risk
+state, and package-script acknowledgement are unchanged. For a push that
+intentionally changes package scripts or package-manager config, review the
+script/lifecycle diff first, then temporarily set
+`agent.qualityGate.allowPackageScriptChanges=true` in local git config for that
+push; a just-passed acknowledged manual gate can then satisfy the pre-push
+`--skip-if-fresh` check.
 
 Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
 local dashboard browser tests, and dashboard React Doctor checks run through
@@ -305,8 +307,13 @@ pnpm --silent pr:feedback-state --pr <number> --json
 For an interactive low-noise watch, use:
 
 ```bash
-pnpm pr:ready-state --pr <number> --watch --compact
+pnpm pr:ready-state --pr <number> --watch --compact --until-ready
 ```
+
+`--until-ready` preserves the same polling output but exits 0 once the PR is
+ready or merged, exits nonzero if the PR closes unmerged, and otherwise keeps
+polling. Omit it only when you intentionally want the watch to run until manual
+interruption.
 
 Use the command's required-only result as the readiness source of truth. The raw
 GitHub status rollup and required review gates decide readiness; advisory bot

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -72,7 +72,7 @@ read-only `gh api` scraping during review sweeps.
 Suggested invocation:
 
 ```bash
-pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--compact] [--watch]
+pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]
 pnpm --silent pr:feedback-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--watch]
 ```
 
@@ -81,7 +81,11 @@ pnpm --silent pr:feedback-state [<number-or-url>] [--pr <number-or-url>] [--repo
 consumers that can parse newline-delimited JSON. Use `pnpm --silent` for
 feedback-state machine consumers so pnpm does not prepend its run-script
 banner. The `pr:feedback-state` Node entry point always prints JSON; in watch
-mode it emits one compact JSON object per poll.
+mode it emits one compact JSON object per poll. Add `--until-ready` to
+`pr:ready-state --watch` when the foreground loop should exit automatically:
+it exits 0 once the summary is ready or the PR is merged, exits nonzero for a
+closed-unmerged PR, and otherwise keeps polling. Without `--until-ready`, watch
+mode keeps the existing behavior and runs until interrupted.
 
 Expected top-level fields:
 
@@ -212,7 +216,7 @@ Field expectations:
 5. Run `pnpm --silent pr:feedback-state --pr <number> --json` for a feedback-only sweep,
    or `pnpm pr:ready-state --pr <number> --json` for the final readiness
    source of truth. For a foreground wait loop, use
-   `pnpm pr:ready-state --pr <number> --watch --compact`.
+   `pnpm pr:ready-state --pr <number> --watch --compact --until-ready`.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
    `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -26,9 +26,9 @@ Options:
                  implementation, and validated file content. Intended for the
                  pre-push hook only.
   --parallel <n> With --run, execute independent quality commands with up to
-                 n concurrent jobs. Default: 2. Fail-fast mode stays
-                 sequential so it still stops before starting the next mapped
-                 command.
+                 n concurrent jobs. Default: auto, capped at 4. Fail-fast mode
+                 stays sequential so it still stops before starting the next
+                 mapped command.
   -h, --help     Show this help.
 
 Environment:
@@ -40,7 +40,7 @@ Environment:
   AGENT_QUALITY_FAIL_FAST
                       Same behavior as --fail-fast when set to 1 or true.
   AGENT_QUALITY_PARALLELISM
-                      Same behavior as --parallel.
+                      Same behavior as --parallel. Use auto for the default.
 USAGE
 }
 
@@ -51,7 +51,7 @@ changed_paths_input_file=""
 allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
 fail_fast="${AGENT_QUALITY_FAIL_FAST:-false}"
 skip_if_fresh="${AGENT_QUALITY_SKIP_IF_FRESH:-false}"
-quality_parallelism="${AGENT_QUALITY_PARALLELISM:-2}"
+quality_parallelism="${AGENT_QUALITY_PARALLELISM:-auto}"
 if [[ -z "$allow_package_script_changes" ]]; then
   allow_package_script_changes="$(git config --bool --get agent.qualityGate.allowPackageScriptChanges 2>/dev/null || true)"
 fi
@@ -125,6 +125,26 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+auto_quality_parallelism() {
+  local cpu_count
+  cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  if [[ ! "$cpu_count" =~ ^[0-9]+$ || "$cpu_count" -lt 1 ]]; then
+    cpu_count="$(sysctl -n hw.ncpu 2>/dev/null || true)"
+  fi
+  if [[ ! "$cpu_count" =~ ^[0-9]+$ || "$cpu_count" -lt 1 ]]; then
+    cpu_count=2
+  fi
+  if [[ "$cpu_count" -gt 4 ]]; then
+    echo 4
+  else
+    echo "$cpu_count"
+  fi
+}
+
+if [[ "$quality_parallelism" == "auto" ]]; then
+  quality_parallelism="$(auto_quality_parallelism)"
+fi
 
 if [[ ! "$quality_parallelism" =~ ^[0-9]+$ || "$quality_parallelism" -lt 1 ]]; then
   echo "error: --parallel requires a positive integer" >&2
@@ -220,10 +240,26 @@ has_command() {
   local command="$1"
   shift
   local entry
+  local command_key
+  local entry_key
+  command_key="$(command_dedupe_key "$command")"
   for entry in "$@"; do
-    [[ "${entry%%|*}" == "$command" ]] && return 0
+    entry_key="$(command_dedupe_key "${entry%%|*}")"
+    [[ "$entry_key" == "$command_key" ]] && return 0
   done
   return 1
+}
+
+command_dedupe_key() {
+  local command="$1"
+  case "$command" in
+    "pnpm agent:quality-gate:test"|"bash scripts/agent-quality-gate.test.sh")
+      echo "agent-quality-gate.test"
+      ;;
+    *)
+      echo "$command"
+      ;;
+  esac
 }
 
 has_preflight_command() {
@@ -1459,7 +1495,7 @@ if [[ "$mode" == "dry-run" ]]; then
 fi
 
 if [[ "$skip_if_fresh" == "1" || "$skip_if_fresh" == "true" ]]; then
-  if [[ "$package_script_risk_changed" != true ]] && is_fresh_success_stamp; then
+  if is_fresh_success_stamp; then
     echo "Previous successful agent quality gate run is still fresh; skipping mapped commands."
     exit 0
   fi

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -250,6 +250,8 @@ has_command() {
   return 1
 }
 
+# The package.json script and direct shell entrypoint are the same regression
+# suite; keep them as one mapped command when both are touched.
 command_dedupe_key() {
   local command="$1"
   case "$command" in

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -6,6 +6,8 @@ cd "$repo_root"
 
 paths_file="$(mktemp)"
 output_file="$(mktemp)"
+gate_cache_dir="$(mktemp -d)"
+turbo_facts_file="$(mktemp)"
 codex_hooks_backup="$(mktemp)"
 claude_settings_backup="$(mktemp)"
 untracked_skill_artifact=".claude/skills/.agent-quality-gate-test.tmp"
@@ -17,7 +19,7 @@ restore_hook_configs() {
   cp "$claude_settings_backup" .claude/settings.json
 }
 
-trap 'restore_hook_configs; rm -f "$paths_file" "$output_file" "$output_file.pnpm-args" "$untracked_skill_artifact" "$codex_hooks_backup" "$claude_settings_backup"' EXIT
+trap 'restore_hook_configs; rm -rf "$gate_cache_dir"; rm -f "$paths_file" "$output_file" "$turbo_facts_file" "$output_file.pnpm-args" "$untracked_skill_artifact" "$codex_hooks_backup" "$claude_settings_backup"' EXIT
 
 fail() {
   echo "agent-quality-gate test failed: $*" >&2
@@ -34,11 +36,36 @@ run_gate() {
     printf '%s\n' "$path" >> "$paths_file"
   done
 
+  local cache_key
+  local cache_output_file
+  local cache_paths_file
+  cache_key="$(run_gate_cache_key "$@")"
+  cache_output_file="$gate_cache_dir/$cache_key.output"
+  cache_paths_file="$gate_cache_dir/$cache_key.paths"
+  if [[ -f "$cache_output_file" && -f "$cache_paths_file" ]] &&
+    cmp -s "$paths_file" "$cache_paths_file"; then
+    cp "$cache_output_file" "$output_file"
+    return
+  fi
+
   AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
     scripts/agent-quality-gate.sh \
     --changed-paths-file "$paths_file" \
     --base origin/test \
     > "$output_file"
+
+  cp "$paths_file" "$cache_paths_file"
+  cp "$output_file" "$cache_output_file"
+}
+
+run_gate_cache_key() {
+  local path
+  {
+    printf 'base=%s\n' "origin/test"
+    for path in "$@"; do
+      printf 'path=%s\n' "$path"
+    done
+  } | cksum | awk '{ print $1 "-" $2 }'
 }
 
 run_gate_expect_failure() {
@@ -202,16 +229,7 @@ assert_turbo_task_has_input() {
   local task_name="$1"
   local expected_input="$2"
 
-  node - "$task_name" "$expected_input" <<'NODE' ||
-const fs = require("node:fs");
-const [taskName, expectedInput] = process.argv.slice(2);
-const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-const inputs = config.tasks?.[taskName]?.inputs ?? [];
-if (!inputs.includes(expectedInput)) {
-  console.error(`missing input ${expectedInput} for turbo task ${taskName}`);
-  process.exit(1);
-}
-NODE
+  grep -Fxq -- "input	${task_name}	${expected_input}" "$turbo_facts_file" ||
     fail "expected turbo task $task_name to include input: $expected_input"
 }
 
@@ -219,16 +237,7 @@ assert_turbo_task_lacks_input() {
   local task_name="$1"
   local unexpected_input="$2"
 
-  node - "$task_name" "$unexpected_input" <<'NODE' ||
-const fs = require("node:fs");
-const [taskName, unexpectedInput] = process.argv.slice(2);
-const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-const inputs = config.tasks?.[taskName]?.inputs ?? [];
-if (inputs.includes(unexpectedInput)) {
-  console.error(`unexpected input ${unexpectedInput} for turbo task ${taskName}`);
-  process.exit(1);
-}
-NODE
+  ! grep -Fxq -- "input	${task_name}	${unexpected_input}" "$turbo_facts_file" ||
     fail "expected turbo task $task_name not to include input: $unexpected_input"
 }
 
@@ -236,16 +245,7 @@ assert_turbo_task_has_env() {
   local task_name="$1"
   local expected_env="$2"
 
-  node - "$task_name" "$expected_env" <<'NODE' ||
-const fs = require("node:fs");
-const [taskName, expectedEnv] = process.argv.slice(2);
-const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-const env = config.tasks?.[taskName]?.env ?? [];
-if (!env.includes(expectedEnv)) {
-  console.error(`missing env ${expectedEnv} for turbo task ${taskName}`);
-  process.exit(1);
-}
-NODE
+  grep -Fxq -- "env	${task_name}	${expected_env}" "$turbo_facts_file" ||
     fail "expected turbo task $task_name to include env: $expected_env"
 }
 
@@ -253,32 +253,45 @@ assert_turbo_task_has_output() {
   local task_name="$1"
   local expected_output="$2"
 
-  node - "$task_name" "$expected_output" <<'NODE' ||
-const fs = require("node:fs");
-const [taskName, expectedOutput] = process.argv.slice(2);
-const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-const outputs = config.tasks?.[taskName]?.outputs ?? [];
-if (!outputs.includes(expectedOutput)) {
-  console.error(`missing output ${expectedOutput} for turbo task ${taskName}`);
-  process.exit(1);
-}
-NODE
+  grep -Fxq -- "output	${task_name}	${expected_output}" "$turbo_facts_file" ||
     fail "expected turbo task $task_name to include output: $expected_output"
+}
+
+assert_turbo_task_depends_on() {
+  local task_name="$1"
+  local expected_dependency="$2"
+
+  grep -Fxq -- "dependsOn	${task_name}	${expected_dependency}" "$turbo_facts_file" ||
+    fail "expected turbo task $task_name to depend on: $expected_dependency"
 }
 
 assert_turbo_task_absent() {
   local task_name="$1"
 
-  node - "$task_name" <<'NODE' ||
+  ! grep -Fxq -- "task	${task_name}" "$turbo_facts_file" ||
+    fail "expected turbo task to be absent: $task_name"
+}
+
+write_turbo_facts() {
+  node - <<'NODE' > "$turbo_facts_file"
 const fs = require("node:fs");
-const [taskName] = process.argv.slice(2);
 const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-if (Object.prototype.hasOwnProperty.call(config.tasks ?? {}, taskName)) {
-  console.error(`unexpected turbo task ${taskName}`);
-  process.exit(1);
+for (const [taskName, taskConfig] of Object.entries(config.tasks ?? {})) {
+  console.log(`task\t${taskName}`);
+  for (const input of taskConfig.inputs ?? []) {
+    console.log(`input\t${taskName}\t${input}`);
+  }
+  for (const env of taskConfig.env ?? []) {
+    console.log(`env\t${taskName}\t${env}`);
+  }
+  for (const output of taskConfig.outputs ?? []) {
+    console.log(`output\t${taskName}\t${output}`);
+  }
+  for (const dependency of taskConfig.dependsOn ?? []) {
+    console.log(`dependsOn\t${taskName}\t${dependency}`);
+  }
 }
 NODE
-    fail "expected turbo task to be absent: $task_name"
 }
 
 assert_order() {
@@ -315,6 +328,8 @@ assert_script_occurrences 1 "command -v shasum"
 assert_script_occurrences 0 "shasum -a 256 | awk"
 assert_script_occurrences 0 'shasum -a 256 "$1"'
 
+write_turbo_facts
+
 assert_turbo_task_has_input "build" '$TURBO_ROOT$/shared-config/src/**'
 assert_turbo_task_has_input "build" '$TURBO_ROOT$/shared-config/*.json'
 assert_turbo_task_has_input "build" "postcss.config.*"
@@ -333,16 +348,7 @@ assert_turbo_task_has_output "build" "!.next/dev/**"
 assert_turbo_task_has_input "size-limit" ".next/**"
 assert_turbo_task_has_input "size-limit" "!.next/cache/**"
 assert_turbo_task_has_input "size-limit" "!.next/dev/**"
-node - <<'NODE' ||
-const fs = require("node:fs");
-const config = JSON.parse(fs.readFileSync("turbo.json", "utf8"));
-const dependsOn = config.tasks?.["size-limit"]?.dependsOn ?? [];
-if (!dependsOn.includes("build")) {
-  console.error("size-limit must depend on build because it reads .next output");
-  process.exit(1);
-}
-NODE
-  fail "expected turbo size-limit task to depend on build"
+assert_turbo_task_depends_on "size-limit" "build"
 node - <<'NODE' ||
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
@@ -705,6 +711,48 @@ assert_not_contains "- pnpm agent:quality-gate:test"
 assert_not_contains "- pnpm install --frozen-lockfile"
 assert_not_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen"
 assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard lint"
+
+dedupe_quality_gate_alias_repo="$(mktemp -d)"
+(
+  cd "$dedupe_quality_gate_alias_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p scripts
+  cat > package.json <<'JSON'
+{
+  "name": "fixture",
+  "scripts": {
+    "agent:quality-gate": "./scripts/agent-quality-gate.sh",
+    "agent:quality-gate:test": "bash scripts/agent-quality-gate.test.sh",
+    "agent:context-check": "node scripts/check-agent-context.mjs",
+    "agent:autoreview": "./scripts/agent-autoreview.sh",
+    "agent:prewarm": "node scripts/agent-prewarm.mjs",
+    "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "pr:feedback-state": "node scripts/pr-feedback-state.mjs",
+    "pr:feedback-state:test": "node scripts/pr-feedback-state.test.mjs",
+    "pr:ready-state": "node scripts/pr-ready-state.mjs",
+    "pr:ready-state:test": "node scripts/pr-ready-state.test.mjs",
+    "lockfile:lint": "node scripts/lockfile-lint.mjs",
+    "lockfile:lint:test": "node scripts/lockfile-lint.test.mjs"
+  }
+}
+JSON
+  printf '#!/usr/bin/env bash\n' > scripts/agent-quality-gate.sh
+  git add .
+  git commit -qm init
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.scripts["agent:quality-gate:test"] = "bash scripts/agent-quality-gate.test.sh --fixture";
+fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+  printf 'echo updated\n' >> scripts/agent-quality-gate.sh
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$dedupe_quality_gate_alias_repo"
+assert_occurrences 1 "- bash scripts/agent-quality-gate.test.sh"
+assert_not_contains "- pnpm agent:quality-gate:test"
 
 lockfile_script_repo="$(mktemp -d)"
 (
@@ -1457,6 +1505,45 @@ assert_contains "+ pnpm agent:prewarm:test"
 assert_contains "All mapped commands passed."
 assert_not_contains "parallel marker was not created"
 
+auto_parallel_quality_repo="$(mktemp -d)"
+(
+  cd "$auto_parallel_quality_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin scripts tools
+  printf 'console.log("fixture");\n' > scripts/agent-prewarm.mjs
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/getconf <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "_NPROCESSORS_ONLN" ]]; then
+  echo 8
+  exit 0
+fi
+exit 1
+STUB
+  chmod +x bin/getconf bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'scripts/agent-prewarm.mjs\n' > changed-paths.txt
+  PATH="$auto_parallel_quality_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      > "$output_file" 2>&1
+)
+rm -rf "$auto_parallel_quality_repo"
+assert_contains "Running quality commands with parallelism 4."
+assert_contains "All mapped commands passed."
+
 quality_setup_repo="$(mktemp -d)"
 (
   cd "$quality_setup_repo"
@@ -1583,6 +1670,55 @@ STUB
     fail "fresh gate stamp did not skip duplicate run"
 )
 rm -rf "$fresh_stamp_repo"
+assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
+
+package_risk_fresh_stamp_repo="$(mktemp -d)"
+(
+  cd "$package_risk_fresh_stamp_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin tools
+  printf 'fixture\n' > README.md
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+counter_file="${COUNTER_FILE:?}"
+count=0
+if [[ -f "$counter_file" ]]; then
+  count="$(cat "$counter_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$counter_file"
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'packages/fixture/package.json\n' > changed-paths.txt
+  COUNTER_FILE="$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    PATH="$package_risk_fresh_stamp_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --allow-package-script-changes \
+      > "$output_file" 2>&1
+  COUNTER_FILE="$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    PATH="$package_risk_fresh_stamp_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --skip-if-fresh \
+      --allow-package-script-changes \
+      >> "$output_file" 2>&1
+  [[ "$(cat "$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
+    fail "fresh gate stamp did not skip duplicate package-risk run"
+)
+rm -rf "$package_risk_fresh_stamp_repo"
 assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
 stale_stamp_repo="$(mktemp -d)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -62,9 +62,24 @@ run_gate_cache_key() {
   local path
   {
     printf 'base=%s\n' "origin/test"
+    printf 'repoState=%s\n' "$(run_gate_repo_state_key)"
     for path in "$@"; do
       printf 'path=%s\n' "$path"
     done
+  } | cksum | awk '{ print $1 "-" $2 }'
+}
+
+run_gate_repo_state_key() {
+  {
+    git diff --no-ext-diff --binary
+    git diff --cached --no-ext-diff --binary
+    git ls-files --others --exclude-standard |
+      while IFS= read -r path; do
+        printf 'untracked=%s\n' "$path"
+        if [[ -f "$path" ]]; then
+          cksum "./$path"
+        fi
+      done
   } | cksum | awk '{ print $1 "-" $2 }'
 }
 

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -863,7 +863,7 @@ export async function fetchReadyState({ prArg, repoArg }) {
 }
 
 function usage() {
-  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n\nNote: --watch --json emits newline-delimited JSON, one summary per poll.\n`;
+  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n\nNote: --watch --json emits newline-delimited JSON, one summary per poll. --until-ready only affects watch mode.\n`;
 }
 
 function readFlagValue(rest, flag) {
@@ -887,6 +887,7 @@ export function parseArgs(argv) {
       json: false,
       compact: false,
       watch: false,
+      untilReady: false,
       prArg: null,
       repoArg: null,
     };
@@ -895,8 +896,9 @@ export function parseArgs(argv) {
   const json = argv.includes("--json");
   const compact = argv.includes("--compact");
   const watch = argv.includes("--watch");
+  const untilReady = argv.includes("--until-ready");
   const rest = argv.filter(
-    (arg) => !["--json", "--compact", "--watch"].includes(arg),
+    (arg) => !["--json", "--compact", "--watch", "--until-ready"].includes(arg),
   );
   const repoArg = readFlagValue(rest, "--repo");
   let prArg = readFlagValue(rest, "--pr");
@@ -907,7 +909,7 @@ export function parseArgs(argv) {
   if (!prArg || rest.length > 0) {
     throw new Error(usage());
   }
-  return { json, compact, watch, prArg, repoArg };
+  return { json, compact, watch, untilReady, prArg, repoArg };
 }
 
 export function renderSummary(summary, { json, compact, watch = false }) {
@@ -916,15 +918,23 @@ export function renderSummary(summary, { json, compact, watch = false }) {
   return formatHuman(summary);
 }
 
+export function watchLoopExitCode(summary, { untilReady = false } = {}) {
+  if (!untilReady) return null;
+
+  const state = String(summary?.pr?.state ?? "").toUpperCase();
+  if (summary?.ready === true || state === "MERGED") return 0;
+  if (state === "CLOSED") return 1;
+  return null;
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function main() {
   try {
-    const { help, json, compact, watch, prArg, repoArg } = parseArgs(
-      process.argv.slice(2),
-    );
+    const { help, json, compact, watch, untilReady, prArg, repoArg } =
+      parseArgs(process.argv.slice(2));
     if (help) {
       process.stdout.write(usage());
       return;
@@ -934,6 +944,11 @@ async function main() {
       try {
         const summary = await fetchReadyState({ prArg, repoArg });
         process.stdout.write(renderSummary(summary, { json, compact, watch }));
+        const exitCode = watchLoopExitCode(summary, { untilReady });
+        if (watch && exitCode !== null) {
+          process.exitCode = exitCode;
+          return;
+        }
       } catch (err) {
         if (!watch) throw err;
         const message = err instanceof Error ? err.message : String(err);

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -909,6 +909,9 @@ export function parseArgs(argv) {
   if (!prArg || rest.length > 0) {
     throw new Error(usage());
   }
+  if (untilReady && !watch) {
+    throw new Error("--until-ready requires --watch");
+  }
   return { json, compact, watch, untilReady, prArg, repoArg };
 }
 

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -29,6 +29,7 @@ import {
   requiredStatusContextsFromRules,
   requiredStatusContextsFromRulesResult,
   splitRepo,
+  watchLoopExitCode,
   workflowPathsFromRules,
 } from "./pr-ready-state.mjs";
 
@@ -146,8 +147,20 @@ test("parses explicit help without requiring a PR argument", () => {
     json: false,
     compact: false,
     watch: false,
+    untilReady: false,
     prArg: null,
     repoArg: null,
+  });
+});
+
+test("parses watch until-ready mode without changing other flags", () => {
+  assertDeepEqual(parseArgs(["123", "--watch", "--compact", "--until-ready"]), {
+    json: false,
+    compact: true,
+    watch: true,
+    untilReady: true,
+    prArg: "123",
+    repoArg: undefined,
   });
 });
 
@@ -1081,6 +1094,62 @@ test("watch JSON output is one compact JSON object per line", () => {
 
   assertEqual(output.split("\n").length, 2);
   assertDeepEqual(JSON.parse(output), summary);
+});
+
+test("until-ready watch decision preserves default watch polling", () => {
+  assertEqual(
+    watchLoopExitCode(
+      {
+        ready: true,
+        pr: { state: "OPEN" },
+      },
+      { untilReady: false },
+    ),
+    null,
+  );
+});
+
+test("until-ready watch decision exits on ready, merged, or closed-unmerged states", () => {
+  assertEqual(
+    watchLoopExitCode(
+      {
+        ready: false,
+        pr: { state: "OPEN" },
+      },
+      { untilReady: true },
+    ),
+    null,
+  );
+  assertEqual(
+    watchLoopExitCode(
+      {
+        ready: true,
+        pr: { state: "OPEN" },
+      },
+      { untilReady: true },
+    ),
+    0,
+  );
+  assertEqual(
+    watchLoopExitCode(
+      {
+        ready: false,
+        pr: { state: "MERGED" },
+      },
+      { untilReady: true },
+    ),
+    0,
+  );
+  assertEqual(
+    watchLoopExitCode(
+      {
+        ready: false,
+        pr: { state: "CLOSED" },
+      },
+      { untilReady: true },
+    ),
+    1,
+  );
 });
 
 test("uses first timestamped timeline item after current head commit for freshness", () => {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -164,6 +164,13 @@ test("parses watch until-ready mode without changing other flags", () => {
   });
 });
 
+test("rejects until-ready outside watch mode", () => {
+  assertThrows(
+    () => parseArgs(["123", "--until-ready"]),
+    "--until-ready requires --watch",
+  );
+});
+
 test("rejects missing flag values at the CLI boundary", () => {
   assertThrows(
     () => parseArgs(["--repo", "--pr", "123"]),


### PR DESCRIPTION
## The Problem

- Agent session gates still repeated work that had just passed locally.
- Readiness watches could reach all-clear but keep running until manually stopped.
- The gate regression suite carried fixed overhead from repeated helper lookups.

## The Solution

- Reuse a matching successful manual gate run during pre-push, avoid duplicate gate-regression commands, and let readiness watches exit automatically when they reach a useful terminal state.

## Details

- De-dupes `pnpm agent:quality-gate:test` and `bash scripts/agent-quality-gate.test.sh` when both map to the same regression suite.
- Lets `--skip-if-fresh` reuse package-risk runs when the package-risk state and package-script acknowledgement are unchanged in the success stamp.
- Changes default quality-gate parallelism to auto-detect CPU count with a conservative cap of 4 workers while preserving fail-fast sequencing, setup ordering, and dashboard `.next` serialization.
- Adds `pnpm pr:ready-state --watch --compact --until-ready` so foreground babysits exit 0 on ready/merged and nonzero on closed-unmerged.
- Speeds fixed test-harness checks by caching Turbo task facts and exact repeated dry-run fixture outputs.

## Validation

- `node scripts/pr-ready-state.test.mjs` passed, 62 tests.
- `command time -p bash scripts/agent-quality-gate.test.sh` passed, `real 49.93`.
- `command time -p pnpm agent:quality-gate --run` passed, `real 50.54`.
- `command time -p pnpm agent:quality-gate --run --skip-if-fresh` skipped in `real 0.97`.
- `pnpm agent:autoreview --engine local` reported no accepted/actionable deterministic findings.
- `git diff --check` passed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-push skip-if-fresh semantics and default gate parallelism; behavior is covered by expanded regression tests but affects every agent push workflow.
> 
> **Overview**
> Speeds up agent session gates and PR babysitting by cutting duplicate work and making watch loops exit on their own.
> 
> **Agent quality gate** defaults `--parallel` to **auto** (CPU count, max 4) instead of a fixed 2. **`--skip-if-fresh`** no longer always skips when package manifests changed; the success stamp already records package-risk and script acknowledgement, so a recent acknowledged run can satisfy pre-push **`--skip-if-fresh`**. Mapped commands **dedupe** `pnpm agent:quality-gate:test` and `bash scripts/agent-quality-gate.test.sh` so the same regression suite is not scheduled twice.
> 
> **`pnpm pr:ready-state`** adds **`--until-ready`** with **`--watch`**: exit **0** when required readiness is true or the PR is merged, **1** when closed unmerged, otherwise keep polling.
> 
> **`agent-quality-gate.test.sh`** caches repeated dry-run fixture output and precomputes Turbo task facts once to shrink fixed harness overhead. **AGENTS.md** and **`docs/notes/pr-ready-state.md`** document the new defaults and flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66a63c14868d420cb030ca4815f120eefbd5f5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->