### PR TITLE
fix(alerts): suppress FX stale relayer pages during market close

### DIFF
--- a/alerts/rules/mute-timings.tf
+++ b/alerts/rules/mute-timings.tf
@@ -1,11 +1,13 @@
-# Create a mute timing for weekend market closing hours (Friday 22:00 UTC to Sunday 22:00 UTC)
-# This is to prevent alerts from being fired during the weekend when FX markets are closed.
+# Create a mute timing for weekend market closing hours
+# (Friday 21:00 UTC to Sunday 23:00 UTC, plus the Sunday 23:00 reopen-grace hour).
+# This prevents oracle-relayer stale-price alerts for FX feeds from paging while
+# market data is expected to be paused.
 resource "grafana_mute_timing" "weekend_mute" {
   name = "Weekend Market Closing Hours"
 
   intervals {
     times {
-      start = "22:00"
+      start = "21:00"
       end   = "24:00"
     }
     weekdays = ["friday"]
@@ -20,7 +22,7 @@ resource "grafana_mute_timing" "weekend_mute" {
   intervals {
     times {
       start = "00:00"
-      end   = "22:00"
+      end   = "24:00"
     }
     weekdays = ["sunday"]
     location = "UTC"

--- a/alerts/rules/protocol-routing-locals.tf
+++ b/alerts/rules/protocol-routing-locals.tf
@@ -103,8 +103,20 @@ locals {
     "ZARUSD"
   ]
 
-  # Create a regex pattern for the weekend-disabled feeds
-  weekend_disabled_feeds_pattern = join("|", local.weekend_disabled_feeds)
+  # Aegis historically published `rateFeed` as compact IDs (`CHFUSD`) but the
+  # relayer log labels and alert copy use slash-form pairs (`CHF/USD`). Match
+  # both label shapes so FX weekend mute policies keep working if the exporter
+  # or Grafana alert instance carries either representation.
+  weekend_disabled_feed_label_variants = distinct(flatten([
+    for feed in local.weekend_disabled_feeds : [
+      feed,
+      replace(feed, "/^([A-Z]{3,}?)([A-Z]{3})$/", "$1/$2"),
+    ]
+  ]))
+
+  # Regex pattern for weekend-disabled feeds. Anchored so similarly named
+  # future feeds cannot accidentally inherit FX market-close suppression.
+  weekend_disabled_feeds_pattern = "^(${join("|", local.weekend_disabled_feed_label_variants)})$"
 
   # Per-feed Celo relayer signer wallets. Used by the Slack stale-price alert
   # template to link "<pair> relayer on Celo" to the signer's celoscan page.

--- a/alerts/rules/protocol-routing-locals.tf
+++ b/alerts/rules/protocol-routing-locals.tf
@@ -107,6 +107,9 @@ locals {
   # relayer log labels and alert copy use slash-form pairs (`CHF/USD`). Match
   # both label shapes so FX weekend mute policies keep working if the exporter
   # or Grafana alert instance carries either representation.
+  # The split assumes the quote leg is a 3-letter FX/feed suffix. For 6-char
+  # feeds (`CHFUSD`) that yields `CHF/USD`; for 7-char CELO feeds the first
+  # capture backtracks to 4 chars (`CELO/PHP`) before the end anchor can match.
   weekend_disabled_feed_label_variants = distinct(flatten([
     for feed in local.weekend_disabled_feeds : [
       feed,


### PR DESCRIPTION
## The Problem

FX oracle relayers intentionally stop publishing while traditional FX markets are closed. The current oracle-relayer notification policy tries to mute weekend-disabled FX feeds, but the shared mute timing starts at Fri 22:00 UTC even though the repo's live oracle rules use Fri 21:00 UTC as FX close. That leaves the first closed-market hour exposed to page-severity stale-price alerts, which matches the forwarded Monad alerts.

The feed matcher also only listed compact rate-feed IDs such as `CHFUSD`. Alert/logging surfaces can carry slash-form feed labels such as `CHF/USD`, so the notification policy should match both shapes instead of depending on one exporter representation.

## The Solution

- Move the Grafana `weekend_mute` timing to Fri 21:00 UTC through all of Sunday, covering the documented FX market close and the existing Sunday 23:00 reopen-grace hour.
- Build `weekend_disabled_feeds_pattern` from both compact and slash-form feed label variants, then anchor the regex so only explicitly listed FX feeds inherit market-close suppression.

## Verification

- `tofu -chdir=alerts/rules fmt -check -recursive -diff`
- `TF_DATA_DIR=alerts/rules/.tofu-agent-gate tofu -chdir=alerts/rules init -backend=false -input=false`
- `TF_DATA_DIR=alerts/rules/.tofu-agent-gate tofu -chdir=alerts/rules validate -no-color`
- regex smoke check: `CHFUSD` normalizes to `CHF/USD`, and the anchored regex matches both `CHFUSD` and `CHF/USD`
- `pnpm agent:quality-gate --run` via an OpenTofu-backed `terraform` shim: all mapped commands passed
- `git diff --check`

Note: native `terraform` is not installed in this environment, so Terraform-compatible validation used OpenTofu v1.11.5. I reverted OpenTofu's generated provider lockfile changes before committing; the PR intentionally changes only alert-rule source files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and which oracle-relayer page alerts are muted; incorrect timing or regex could miss real incidents or over-suppress pages during market hours.
> 
> **Overview**
> Aligns **Grafana weekend mute timing** with documented FX market close: **Friday mute starts at 21:00 UTC** (was 22:00), and **Sunday runs through 24:00** (was until 22:00) so stale oracle-relayer pages stay suppressed through the Sunday reopen-grace window.
> 
> **`weekend_disabled_feeds_pattern`** now matches both **compact** (`CHFUSD`) and **slash-form** (`CHF/USD`) `rateFeed` labels via `weekend_disabled_feed_label_variants`, with **anchored regex** so only listed FX feeds get weekend suppression in notification policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0b7daca4f1a855e9d4c4c1d1fd1bef47acd99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->