### PR TITLE
Fix Oracle Down recovery Slack copy

### DIFF
--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -220,7 +220,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
       resolved_title   = "Oracle back up"
-      resolved_summary = "Oracle Down condition cleared — swaps should no longer revert outside scheduled FX pauses."
+      resolved_summary = "Swaps should no longer revert."
     }
 
     labels = {

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -220,7 +220,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
       resolved_title   = "Oracle back up"
-      resolved_summary = "Oracle usable again — swaps will no longer revert. Oracle is reporting for this pool."
+      resolved_summary = "Oracle Down condition cleared — swaps should no longer revert outside scheduled FX pauses."
     }
 
     labels = {

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -218,7 +218,9 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      resolved_title   = "Oracle back up"
+      resolved_summary = "Oracle usable again — swaps will no longer revert. Oracle is reporting for this pool."
     }
 
     labels = {


### PR DESCRIPTION
## The Problem

- Resolved Oracle Down Slack posts still used outage wording, so recovery messages said swaps would revert.
- Operators need the recovery message to clearly say the oracle is usable again.

## The Solution

- Keep the firing message unchanged and add resolved-only title/summary annotations for the Oracle Down rule.

## Details

- Uses the existing shared Slack template support for resolved_title and resolved_summary.
- Scope is limited to the FPMM Oracle Down rule.

## Validation

- pnpm agent:quality-gate --run
- pnpm agent:autoreview (deterministic fallback; no actionable findings)
- pre-push agent quality gate reused the fresh successful run

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform annotation-only change for one alert rule; no query, threshold, or routing changes.
> 
> **Overview**
> Fixes **Oracle Down** Slack messages when the alert clears: resolved posts no longer reuse the firing **summary** (“swaps will revert”).
> 
> The **Oracle Down** Grafana rule now sets **`resolved_title`** (“Oracle back up”) and **`resolved_summary`** (“Swaps should no longer revert.”), wired through the existing Slack body template that prefers those annotations on **resolved** status. Firing **`summary`** text is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c23c4e7c309fe0e3f312d1220325a4f7816f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->