### PR TITLE
Clarify oracle liveness Slack alerts

### DIFF
--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -221,7 +221,7 @@ locals {
     *Previous Oracle Price:* {{ .Annotations.previous_oracle_price }}
     {{ end -}}
     {{ if .Annotations.last_update -}}
-    *Last update:* {{ .Annotations.last_update }}
+    *Last Update:* {{ .Annotations.last_update }}
     {{ end -}}
     {{ if .Annotations.breach_started -}}
     *Started:* {{ .Annotations.breach_started }}

--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -15,7 +15,7 @@ resource "grafana_contact_point" "slack_critical" {
     # keeps Slack's push/preview text small and unobtrusive; the prominent
     # human-readable title is rendered as the first line of the body, where
     # mrkdwn links are honoured (see local.slack_body_template).
-    title = "{{ if eq .Status \"firing\" }}🔴{{ else }}✅{{ end }}"
+    title = "{{ if eq .Status \"firing\" }}🚨{{ else }}✅{{ end }}"
     text  = local.slack_body_template
   }
 }
@@ -39,7 +39,7 @@ resource "grafana_contact_point" "slack_critical_transition" {
     token                   = var.slack_bot_token
     recipient               = var.slack_channel_critical
     disable_resolve_message = true
-    title                   = "{{ if eq .Status \"firing\" }}🔴{{ else }}✅{{ end }}"
+    title                   = "{{ if eq .Status \"firing\" }}🚨{{ else }}✅{{ end }}"
     text                    = local.slack_body_template
   }
 }
@@ -125,6 +125,8 @@ locals {
   #
   # Layout (pool-scoped, e.g. fpmms rules):
   #   1. Bold linked title: `*<pool details URL|alertname — pair · chain>*`.
+  #      Rules can override the display title with `title`; resolved messages
+  #      can override it with `resolved_title`.
   #      Acts as the prominent visual title because Grafana's attachment.title
   #      links to grafana.com and that link target is not configurable from
   #      the terraform provider.
@@ -155,6 +157,8 @@ locals {
   #      message, reserves, rebalance-blocked reason, then start time.
   #      Rebalancer alerts may add Last Rebalance / Root Cause rows when the
   #      rule exposes those annotations.
+  #      Rules may also add a `last_update` row when freshness is the primary
+  #      signal.
   #   5. Metadata row: start time plus resolved time when applicable. The
   #      per-row `View alert` link was removed — Grafana's attachment title
   #      still links to grafana.com via the (unconfigurable) `title_link`, so
@@ -168,7 +172,7 @@ locals {
   #   6. *Alert ID* — Grafana's `.Fingerprint`, a deterministic hash of the
   #      alert's label set. The same value is rendered on the firing and the
   #      resolved message, so an operator scrolling Slack can match a ✅
-  #      "resolved" post back to the 🔴 "fired" post that opened the breach.
+  #      "resolved" post back to the firing post that opened the breach.
   #      Especially useful for deviation breaches where the same pool can
   #      churn through multiple fire/resolve cycles in a day.
   #
@@ -180,6 +184,7 @@ locals {
     {{ range .Alerts -}}
     {{ $isResolved := eq .Status "resolved" -}}
     {{ $title := .Labels.alertname -}}
+    {{ if .Annotations.title -}}{{ $title = .Annotations.title }}{{ end -}}
     {{ if and $isResolved .Annotations.resolved_title -}}{{ $title = .Annotations.resolved_title }}{{ end -}}
     {{ if .Labels.pool_id -}}
     *<https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|{{ $title }}{{ if .Labels.pair }} — {{ .Labels.pair }}{{ end }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
@@ -214,6 +219,9 @@ locals {
     {{ end -}}
     {{ if .Annotations.previous_oracle_price -}}
     *Previous Oracle Price:* {{ .Annotations.previous_oracle_price }}
+    {{ end -}}
+    {{ if .Annotations.last_update -}}
+    *Last update:* {{ .Annotations.last_update }}
     {{ end -}}
     {{ if .Annotations.breach_started -}}
     *Started:* {{ .Annotations.breach_started }}

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -108,6 +108,7 @@ locals {
   # series so Grafana can apply before the bridge revision that publishes
   # `mento_pool_oracle_live_timestamp`.
   oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or max without (last_oracle_update_url) (mento_pool_oracle_timestamp))"
+  oracle_expiry_compat_promql         = "max without (last_oracle_update_url) (mento_pool_oracle_expiry)"
   fx_oracle_pause_promql = format(
     "(mento_pool_oracle_live_timestamp{pair!~\"%s\",pair=~\".+/.+\"} or max without (last_oracle_update_url) (mento_pool_oracle_timestamp{pair!~\"%s\",pair=~\".+/.+\"})) and on() %s",
     local.usd_pegged_pair_regex,
@@ -122,8 +123,9 @@ locals {
   # suppression match avoids re-evaluating the division twice per tick.
   # Referenced by the warning + critical rules in rules-fpmms.tf.
   fx_gated_liveness_ratio_promql = format(
-    "((time() - %s) / ignoring(last_oracle_update_url) (mento_pool_oracle_expiry > 0)) unless on(chain_id, pool_id, pair) (%s)",
+    "((time() - %s) / ignoring(last_oracle_update_url) (%s > 0)) unless on(chain_id, pool_id, pair) (%s)",
     local.oracle_live_timestamp_compat_promql,
+    local.oracle_expiry_compat_promql,
     local.fx_oracle_pause_promql,
   )
 

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -31,7 +31,10 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue (> 1.2× expiry).{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      title            = "Oracle Update Delayed"
+      summary          = "The pool oracle has not published a new price within its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
+      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      resolved_summary = "The pool oracle is publishing recent prices again."
     }
 
     labels = {
@@ -56,11 +59,12 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # Two queries, used together by the annotation template:
+    # Annotation helper queries:
     #   - OracleTs: live freshness timestamp. == 0 means the indexer has never
     #     seen a live median update for this pool.
     #   - OracleAge: seconds since live update; only meaningful when
     #     OracleTs > 0.
+    #   - OracleExpiry: the configured update window, displayed in the summary.
     data {
       ref_id         = "OracleTs"
       datasource_uid = var.prometheus_datasource_uid
@@ -85,6 +89,20 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "OracleAge"
         expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "OracleExpiry"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleExpiry"
+        expr    = local.oracle_expiry_compat_promql
         instant = true
       })
     }
@@ -310,8 +328,10 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} > 3 — report badly stale.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
-      description = "Liveness ratio exceeds 3× the contract expiry. If Oracle Down stays quiet while this fires, the indexer's oracleOk derivation has drifted from the on-chain expiry check."
+      title            = "Oracle Down"
+      summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
+      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      resolved_summary = "The pool oracle is back inside its update window."
     }
 
     labels = {
@@ -335,9 +355,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # See Oracle Liveness for the OracleTs / OracleAge rationale — same
-    # pair is used here so the annotation can detect the never-live-update
-    # sentinel instead of leaning on an age cutoff.
+    # See Oracle Liveness for the annotation helper query rationale.
     data {
       ref_id         = "OracleTs"
       datasource_uid = var.prometheus_datasource_uid
@@ -362,6 +380,20 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "OracleAge"
         expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "OracleExpiry"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleExpiry"
+        expr    = local.oracle_expiry_compat_promql
         instant = true
       })
     }

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -34,6 +34,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       title            = "Oracle Update Delayed"
       summary          = "The pool oracle has not published a new price within its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
       last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      resolved_title   = "Oracle Update Recovered"
       resolved_summary = "The pool oracle is publishing recent prices again."
     }
 
@@ -331,6 +332,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       title            = "Oracle Down"
       summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
       last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      resolved_title   = "Oracle Back Up"
       resolved_summary = "The pool oracle is back inside its update window."
     }
 

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -237,6 +237,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
+      title            = "Oracle Not Usable"
       summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
       resolved_title   = "Oracle back up"
       resolved_summary = "Swaps should no longer revert."
@@ -328,6 +329,9 @@ resource "grafana_rule_group" "fpmms_oracle" {
     exec_err_state = "Error"
     no_data_state  = "OK"
 
+    # Diagnostic retained out of Slack copy: if this fires while the live
+    # Oracle Down rule stays quiet, check whether the indexer's oracleOk
+    # derivation has drifted from the on-chain expiry check.
     annotations = {
       title            = "Oracle Down"
       summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."


### PR DESCRIPTION
## The Problem

- Oracle liveness Slack alerts led with implementation terms like "live-ratio", which made the alert harder to understand quickly.
- The last oracle update was buried in the sentence instead of being a scan-friendly metadata row.
- Critical oracle liveness alerts used the same red-circle severity marker as other critical alerts instead of the requested page-style marker.

## The Solution

- Show the operator-facing warning title as "Oracle Update Delayed" and the critical liveness title as "Oracle Down", while preserving pair and chain in the existing Slack title format.
- Replace the ratio-led summaries with plain language about the oracle missing its update window.
- Render "Last update" as a standard key/value row and use the siren emoji for critical Slack contact points.

## Details

- Keeps the underlying Grafana rule names stable, so the critical liveness rule does not collide with the existing `Oracle Down` rule.
- Adds an `OracleExpiry` helper query so the Slack summary can show the pool's actual update window.
- Adds resolved summaries for the liveness warning and critical rules so recovery messages do not repeat stale firing copy.

## Validation

- `terraform -chdir=alerts/rules fmt`
- `pnpm tf validate alerts-rules`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (deterministic fallback; no accepted/actionable findings)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only notification copy and annotation wiring; firing conditions and thresholds are unchanged aside from refactoring the liveness ratio PromQL to use a shared expiry expression.
> 
> **Overview**
> Improves **oracle liveness Slack messaging** so operators see plain-language titles and scan-friendly freshness, without changing Grafana rule names or alert thresholds.
> 
> The shared **`slack_body_template`** now honors **`title`** / **`resolved_title`** annotations for the bold linked headline, renders a **`last_update`** row when rules set it, and uses **🚨** (instead of 🔴) on critical Slack attachment titles. Oracle liveness rules swap ratio-heavy copy for operator-facing titles (**Oracle Update Delayed**, **Oracle Down** on critical liveness, **Oracle Not Usable** on live Oracle Down), summaries about missing the pool’s update window, dedicated **`last_update`** annotations, and **`resolved_*`** text for recovery. **`OracleExpiry`** helper queries and **`oracle_expiry_compat_promql`** feed humanized expiry into summaries and refactor the FX-gated liveness ratio denominator; critical liveness drops the Slack **`description`** (diagnostic note moved to a comment only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521b2dc9649d0bf0827c2a2ae2ae511208a8a740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->