### PR TITLE
Quiet oracle down flakes

### DIFF
--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -110,6 +110,9 @@ locals {
   oracle_timestamp_compat_promql      = "max without (last_oracle_update_url) (mento_pool_oracle_timestamp)"
   oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or ${local.oracle_timestamp_compat_promql})"
   oracle_expiry_compat_promql         = "max without (last_oracle_update_url) (mento_pool_oracle_expiry)"
+  # Age helpers intentionally repeat the timestamp expression in the guard and
+  # fallback so annotation queries keep a label-matched `-1` sentinel for
+  # never-reported pools without depending on a recording rule.
   oracle_timestamp_age_promql = format(
     "((time() - %s) and on(chain_id, pool_id, pair) (%s > 0)) or on(chain_id, pool_id, pair) (0 * %s - 1)",
     local.oracle_timestamp_compat_promql,

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -111,12 +111,14 @@ locals {
   oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or ${local.oracle_timestamp_compat_promql})"
   oracle_expiry_compat_promql         = "max without (last_oracle_update_url) (mento_pool_oracle_expiry)"
   oracle_timestamp_age_promql = format(
-    "(time() - %s) and on(chain_id, pool_id, pair) (%s > 0)",
+    "((time() - %s) and on(chain_id, pool_id, pair) (%s > 0)) or on(chain_id, pool_id, pair) (0 * %s - 1)",
+    local.oracle_timestamp_compat_promql,
     local.oracle_timestamp_compat_promql,
     local.oracle_timestamp_compat_promql,
   )
   oracle_live_age_compat_promql = format(
-    "(time() - %s) and on(chain_id, pool_id, pair) (%s > 0)",
+    "((time() - %s) and on(chain_id, pool_id, pair) (%s > 0)) or on(chain_id, pool_id, pair) (0 * %s - 1)",
+    local.oracle_live_timestamp_compat_promql,
     local.oracle_live_timestamp_compat_promql,
     local.oracle_live_timestamp_compat_promql,
   )

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -107,8 +107,19 @@ locals {
   # The timestamp expression keeps a rollout fallback to the old raw timestamp
   # series so Grafana can apply before the bridge revision that publishes
   # `mento_pool_oracle_live_timestamp`.
-  oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or max without (last_oracle_update_url) (mento_pool_oracle_timestamp))"
+  oracle_timestamp_compat_promql      = "max without (last_oracle_update_url) (mento_pool_oracle_timestamp)"
+  oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or ${local.oracle_timestamp_compat_promql})"
   oracle_expiry_compat_promql         = "max without (last_oracle_update_url) (mento_pool_oracle_expiry)"
+  oracle_timestamp_age_promql = format(
+    "(time() - %s) and on(chain_id, pool_id, pair) (%s > 0)",
+    local.oracle_timestamp_compat_promql,
+    local.oracle_timestamp_compat_promql,
+  )
+  oracle_live_age_compat_promql = format(
+    "(time() - %s) and on(chain_id, pool_id, pair) (%s > 0)",
+    local.oracle_live_timestamp_compat_promql,
+    local.oracle_live_timestamp_compat_promql,
+  )
   fx_oracle_pause_promql = format(
     "(mento_pool_oracle_live_timestamp{pair!~\"%s\",pair=~\".+/.+\"} or max without (last_oracle_update_url) (mento_pool_oracle_timestamp{pair!~\"%s\",pair=~\".+/.+\"})) and on() %s",
     local.usd_pegged_pair_regex,

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -33,7 +33,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       title            = "Oracle Update Delayed"
       summary          = "The pool oracle has not published a new price within its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      last_update      = "{{ if $values.OracleAge }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Update Recovered"
       resolved_summary = "The pool oracle is publishing recent prices again."
     }
@@ -63,8 +63,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     # Annotation helper queries:
     #   - OracleTs: live freshness timestamp. == 0 means the indexer has never
     #     seen a live median update for this pool.
-    #   - OracleAge: seconds since live update; only meaningful when
-    #     OracleTs > 0.
+    #   - OracleAge: seconds since live update; absent when OracleTs <= 0.
     #   - OracleExpiry: the configured update window, displayed in the summary.
     data {
       ref_id         = "OracleTs"
@@ -89,7 +88,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        expr    = local.oracle_live_age_compat_promql
         instant = true
       })
     }
@@ -150,7 +149,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle contract flag is false — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Oracle contract flag is false — swaps will revert.{{ if $values.OracleAge }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -181,7 +180,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleTs"
-        expr    = "max without (last_oracle_update_url) (mento_pool_oracle_timestamp)"
+        expr    = local.oracle_timestamp_compat_promql
         instant = true
       })
     }
@@ -195,7 +194,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = "time() - max without (last_oracle_update_url) (mento_pool_oracle_timestamp)"
+        expr    = local.oracle_timestamp_age_promql
         instant = true
       })
     }
@@ -232,13 +231,13 @@ resource "grafana_rule_group" "fpmms_oracle" {
   rule {
     name           = "Oracle Down"
     condition      = "threshold"
-    for            = "1m"
+    for            = "5m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
       title            = "Oracle Not Usable"
-      summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last live update age unavailable.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary          = "Oracle not usable — swaps will revert.{{ if $values.OracleAge }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
       resolved_title   = "Oracle back up"
       resolved_summary = "Swaps should no longer revert."
     }
@@ -288,7 +287,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        expr    = local.oracle_live_age_compat_promql
         instant = true
       })
     }
@@ -335,7 +334,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       title            = "Oracle Down"
       summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      last_update      = "{{ if $values.OracleAge }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Back Up"
       resolved_summary = "The pool oracle is back inside its update window."
     }
@@ -361,7 +360,9 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # See Oracle Liveness for the annotation helper query rationale.
+    # See Oracle Liveness for the annotation helper query rationale; OracleAge
+    # is absent for true never-reported pools instead of relying on an age
+    # cutoff.
     data {
       ref_id         = "OracleTs"
       datasource_uid = var.prometheus_datasource_uid
@@ -385,7 +386,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        expr    = local.oracle_live_age_compat_promql
         instant = true
       })
     }

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -33,7 +33,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       title            = "Oracle Update Delayed"
       summary          = "The pool oracle has not published a new price within its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if $values.OracleAge }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
+      last_update      = "{{ if and $values.OracleAge (gt $values.OracleAge.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Update Recovered"
       resolved_summary = "The pool oracle is publishing recent prices again."
     }
@@ -63,7 +63,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
     # Annotation helper queries:
     #   - OracleTs: live freshness timestamp. == 0 means the indexer has never
     #     seen a live median update for this pool.
-    #   - OracleAge: seconds since live update; absent when OracleTs <= 0.
+    #   - OracleAge: seconds since live update; -1 when OracleTs <= 0 so the
+    #     annotation helper keeps a label-matched fallback series.
     #   - OracleExpiry: the configured update window, displayed in the summary.
     data {
       ref_id         = "OracleTs"
@@ -149,7 +150,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle contract flag is false — swaps will revert.{{ if $values.OracleAge }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Oracle contract flag is false — swaps will revert.{{ if and $values.OracleAge (gt $values.OracleAge.Value 0.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -237,7 +238,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
 
     annotations = {
       title            = "Oracle Not Usable"
-      summary          = "Oracle not usable — swaps will revert.{{ if $values.OracleAge }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary          = "Oracle not usable — swaps will revert.{{ if and $values.OracleAge (gt $values.OracleAge.Value 0.0) }} Last live update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
       resolved_title   = "Oracle back up"
       resolved_summary = "Swaps should no longer revert."
     }
@@ -334,7 +335,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     annotations = {
       title            = "Oracle Down"
       summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if $values.OracleAge }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
+      last_update      = "{{ if and $values.OracleAge (gt $values.OracleAge.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Back Up"
       resolved_summary = "The pool oracle is back inside its update window."
     }
@@ -361,8 +362,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
     }
 
     # See Oracle Liveness for the annotation helper query rationale; OracleAge
-    # is absent for true never-reported pools instead of relying on an age
-    # cutoff.
+    # is -1 for true never-reported pools instead of relying on a missing
+    # annotation series.
     data {
       ref_id         = "OracleTs"
       datasource_uid = var.prometheus_datasource_uid

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -264,7 +264,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
 
     # See Oracle Liveness for the OracleTs / OracleAge rationale. Oracle Down
     # fires on the same live freshness anchor, so its Slack age text cannot
-    # drift from the timestamp used by the live-down gate.
+    # drift from the timestamp used by the live-down gate. OracleTs is kept as
+    # a Grafana UI diagnostic; Slack copy branches on OracleAge.
     data {
       ref_id         = "OracleTs"
       datasource_uid = var.prometheus_datasource_uid

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,7 +119,7 @@ Metrics pipeline and first-cut alert rules are shipped end-to-end:
 | Service          | Rule                                    | Severity | Threshold                                                                        |
 | ---------------- | --------------------------------------- | -------- | -------------------------------------------------------------------------------- |
 | `fpmms`          | Oracle Liveness                         | warning  | liveness ratio `> 1.2` for 2m (FX-weekend gated)                                 |
-| `fpmms`          | Oracle Down                             | critical | `oracle_ok < 0.5` for 1m                                                         |
+| `fpmms`          | Oracle Down                             | critical | `oracle_ok < 0.5` for 5m                                                         |
 | `fpmms`          | Oracle Liveness Critical                | critical | liveness ratio `> 3` for 1m (FX-weekend gated)                                   |
 | `fpmms`          | Deviation Breach                        | warning  | `deviation_ratio > 1.01` for 15m (above 1% tolerance)                            |
 | `fpmms`          | Deviation Breach (anchored)             | warning  | anchored breach + deviation-ratio data unavailable for 15m                       |


### PR DESCRIPTION
## The Problem

- `Oracle Down` pages can fire on short oracle-expiry windows while the relayer stale-feed path already waits 5m.
- Slack alert copy can say an oracle has never reported when Grafana has an age value but the template branch cannot rely on `OracleTs`.

## The Solution

- Make the live `Oracle Down` rule wait 5m before paging, matching the stale-feed debounce.
- Make oracle-age helper queries keep a label-matched `-1` fallback for true zero timestamps, then branch alert copy on `OracleAge > 0`.

## Details

- Adds shared PromQL helpers for raw/live oracle timestamps and label-preserving age expressions.
- Preserves the newer oracle-liveness Slack title/resolution fields from `main` while fixing last-update fallback behavior.
- Records the Grafana annotation-query fallback invariant in `alerts/AGENTS.md`.
- Updates `docs/ROADMAP.md` so the documented `Oracle Down` threshold matches the Terraform rule.
- Terraform plan also shows existing `grafana_contact_point.splunk_on_call` sensitive-block churn unrelated to this PR; no apply was run.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback; Codex review engine unavailable)
- `pnpm tf plan alerts-rules -var-file=/Users/chapati/code/mento/monitoring-monorepo/alerts/rules/terraform.tfvars -compact-warnings`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
