### PR TITLE
Trim zero duration units in oracle alerts

### DIFF
--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -109,6 +109,64 @@ locals {
   # `mento_pool_oracle_live_timestamp`.
   oracle_live_timestamp_compat_promql = "(mento_pool_oracle_live_timestamp or max without (last_oracle_update_url) (mento_pool_oracle_timestamp))"
   oracle_expiry_compat_promql         = "max without (last_oracle_update_url) (mento_pool_oracle_expiry)"
+  oracle_live_age_promql              = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+  oracle_expiry_duration_part_promql = {
+    OracleExpiryDays    = format("floor((%s) / 86400)", local.oracle_expiry_compat_promql)
+    OracleExpiryHours   = format("floor(((%s) %% 86400) / 3600)", local.oracle_expiry_compat_promql)
+    OracleExpiryMinutes = format("floor(((%s) %% 3600) / 60)", local.oracle_expiry_compat_promql)
+    OracleExpirySeconds = format("floor((%s) %% 60)", local.oracle_expiry_compat_promql)
+  }
+  oracle_age_duration_part_promql = {
+    OracleAgeDays    = format("floor((%s) / 86400)", local.oracle_live_age_promql)
+    OracleAgeHours   = format("floor(((%s) %% 86400) / 3600)", local.oracle_live_age_promql)
+    OracleAgeMinutes = format("floor(((%s) %% 3600) / 60)", local.oracle_live_age_promql)
+    OracleAgeSeconds = format("floor((%s) %% 60)", local.oracle_live_age_promql)
+  }
+
+  # Grafana annotation templates can call `humanizeDuration`, but cannot
+  # post-process its output. These oracle annotations use PromQL-derived
+  # duration parts to omit trailing zero units in Slack copy: "6m 0s" -> "6m",
+  # "1h 0m 0s" -> "1h", while keeping sub-minute values on humanizeDuration.
+  oracle_update_window_duration_annotation = join("", [
+    "{{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}",
+    "{{ if and $values.OracleExpirySeconds (eq $values.OracleExpirySeconds.Value 0.0) }}",
+    "{{ if and $values.OracleExpiryDays (gt $values.OracleExpiryDays.Value 0.0) }}",
+    "{{ printf \"%.0fd\" $values.OracleExpiryDays.Value }}",
+    "{{ if and $values.OracleExpiryHours (gt $values.OracleExpiryHours.Value 0.0) }} {{ printf \"%.0fh\" $values.OracleExpiryHours.Value }}{{ end }}",
+    "{{ if and $values.OracleExpiryMinutes (gt $values.OracleExpiryMinutes.Value 0.0) }} {{ printf \"%.0fm\" $values.OracleExpiryMinutes.Value }}{{ end }}",
+    "{{ else if and $values.OracleExpiryHours (gt $values.OracleExpiryHours.Value 0.0) }}",
+    "{{ printf \"%.0fh\" $values.OracleExpiryHours.Value }}",
+    "{{ if and $values.OracleExpiryMinutes (gt $values.OracleExpiryMinutes.Value 0.0) }} {{ printf \"%.0fm\" $values.OracleExpiryMinutes.Value }}{{ end }}",
+    "{{ else if and $values.OracleExpiryMinutes (gt $values.OracleExpiryMinutes.Value 0.0) }}",
+    "{{ printf \"%.0fm\" $values.OracleExpiryMinutes.Value }}",
+    "{{ else }}",
+    "{{ humanizeDuration $values.OracleExpiry.Value }}",
+    "{{ end }}",
+    "{{ else }}",
+    "{{ humanizeDuration $values.OracleExpiry.Value }}",
+    "{{ end }}",
+    "{{ else }}",
+    "expected",
+    "{{ end }}",
+  ])
+  oracle_live_age_duration_annotation = join("", [
+    "{{ if and $values.OracleAge (gt $values.OracleAge.Value 0.0) $values.OracleAgeSeconds (eq $values.OracleAgeSeconds.Value 0.0) }}",
+    "{{ if and $values.OracleAgeDays (gt $values.OracleAgeDays.Value 0.0) }}",
+    "{{ printf \"%.0fd\" $values.OracleAgeDays.Value }}",
+    "{{ if and $values.OracleAgeHours (gt $values.OracleAgeHours.Value 0.0) }} {{ printf \"%.0fh\" $values.OracleAgeHours.Value }}{{ end }}",
+    "{{ if and $values.OracleAgeMinutes (gt $values.OracleAgeMinutes.Value 0.0) }} {{ printf \"%.0fm\" $values.OracleAgeMinutes.Value }}{{ end }}",
+    "{{ else if and $values.OracleAgeHours (gt $values.OracleAgeHours.Value 0.0) }}",
+    "{{ printf \"%.0fh\" $values.OracleAgeHours.Value }}",
+    "{{ if and $values.OracleAgeMinutes (gt $values.OracleAgeMinutes.Value 0.0) }} {{ printf \"%.0fm\" $values.OracleAgeMinutes.Value }}{{ end }}",
+    "{{ else if and $values.OracleAgeMinutes (gt $values.OracleAgeMinutes.Value 0.0) }}",
+    "{{ printf \"%.0fm\" $values.OracleAgeMinutes.Value }}",
+    "{{ else }}",
+    "{{ humanizeDuration $values.OracleAge.Value }}",
+    "{{ end }}",
+    "{{ else }}",
+    "{{ humanizeDuration $values.OracleAge.Value }}",
+    "{{ end }}",
+  ])
   fx_oracle_pause_promql = format(
     "(mento_pool_oracle_live_timestamp{pair!~\"%s\",pair=~\".+/.+\"} or max without (last_oracle_update_url) (mento_pool_oracle_timestamp{pair!~\"%s\",pair=~\".+/.+\"})) and on() %s",
     local.usd_pegged_pair_regex,

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -32,8 +32,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
 
     annotations = {
       title            = "Oracle Update Delayed"
-      summary          = "The pool oracle has not published a new price within its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      summary          = "The pool oracle has not published a new price within its ${local.oracle_update_window_duration_annotation} update window."
+      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}${local.oracle_live_age_duration_annotation} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Update Recovered"
       resolved_summary = "The pool oracle is publishing recent prices again."
     }
@@ -89,7 +89,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        expr    = local.oracle_live_age_promql
         instant = true
       })
     }
@@ -106,6 +106,25 @@ resource "grafana_rule_group" "fpmms_oracle" {
         expr    = local.oracle_expiry_compat_promql
         instant = true
       })
+    }
+
+    dynamic "data" {
+      for_each = merge(local.oracle_expiry_duration_part_promql, local.oracle_age_duration_part_promql)
+      iterator = duration_part
+
+      content {
+        ref_id         = duration_part.key
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = duration_part.key
+          expr    = duration_part.value
+          instant = true
+        })
+      }
     }
 
     data {
@@ -334,8 +353,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
     # derivation has drifted from the on-chain expiry check.
     annotations = {
       title            = "Oracle Down"
-      summary          = "The pool oracle is far past its {{ if and $values.OracleExpiry (gt $values.OracleExpiry.Value 0.0) }}{{ humanizeDuration $values.OracleExpiry.Value }}{{ else }}expected{{ end }} update window."
-      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}{{ humanizeDuration $values.OracleAge.Value }} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
+      summary          = "The pool oracle is far past its ${local.oracle_update_window_duration_annotation} update window."
+      last_update      = "{{ if and $values.OracleTs $values.OracleAge (gt $values.OracleTs.Value 0.0) }}${local.oracle_live_age_duration_annotation} ago{{ else if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }}age unavailable{{ else }}never reported{{ end }}"
       resolved_title   = "Oracle Back Up"
       resolved_summary = "The pool oracle is back inside its update window."
     }
@@ -385,7 +404,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = format("time() - %s", local.oracle_live_timestamp_compat_promql)
+        expr    = local.oracle_live_age_promql
         instant = true
       })
     }
@@ -402,6 +421,25 @@ resource "grafana_rule_group" "fpmms_oracle" {
         expr    = local.oracle_expiry_compat_promql
         instant = true
       })
+    }
+
+    dynamic "data" {
+      for_each = merge(local.oracle_expiry_duration_part_promql, local.oracle_age_duration_part_promql)
+      iterator = duration_part
+
+      content {
+        ref_id         = duration_part.key
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = duration_part.key
+          expr    = duration_part.value
+          instant = true
+        })
+      }
     }
 
     data {


### PR DESCRIPTION
## The Problem
- Oracle alert copy uses Grafana's `humanizeDuration`, so exact whole-minute windows can render as noisy values like `6m 0s`.
- The same formatting issue can make whole-minute last-update ages look less polished in Slack.

## The Solution
- Add PromQL helper refs for oracle expiry and live-age duration parts, then use shared annotation templates that omit trailing zero units.
- Wire both Oracle Update Delayed and Oracle Down to use the cleaner formatter for update windows and last-update ages.

## Validation
- [x] `pnpm agent:quality-gate --run`
- [x] `pnpm agent:autoreview` (local deterministic fallback; Codex review engine unavailable in this environment)
- [x] pre-push quality gate rerun

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only PromQL and template changes; no change to alert conditions or thresholds, with slightly more instant queries per eval on two rules.
> 
> **Overview**
> Improves **Slack copy** for FPMM oracle liveness alerts by replacing raw `humanizeDuration` output (e.g. `6m 0s`, `1h 0m 0s`) with **shared annotation templates** that drop trailing zero units while still using `humanizeDuration` for sub-minute values.
> 
> In `main.tf`, adds PromQL **duration part** queries (days/hours/minutes/seconds) for oracle **expiry** and **live age**, plus `oracle_update_window_duration_annotation` and `oracle_live_age_duration_annotation` locals built from Go templates.
> 
> **Oracle Update Delayed** (warning) and **Oracle Liveness Critical** wire `summary` / `last_update` to those locals and gain a `dynamic "data"` block that runs the eight part queries as annotation-only instant queries. **Alert thresholds and firing logic are unchanged**—only notification text and extra eval queries for formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a9d36c520696a8c55be84838ef7cc031d0991c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->