### PR TITLE
Document Grafana annotation query invariant

### DIFF
--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -24,6 +24,11 @@ Separate GCS state (`prefix=alerts-rules` for rules, `prefix=alerts-infra` for i
 - **QuickNode state-management hack** in `alerts/infra/onchain-event-listeners/main.tf` is scoped to the current chain via `var.chain_key`. Renaming the `module "onchain_event_listeners"` block in `alerts/infra/main.tf` would silently break the state-rm grep.
 - **Cloud Function lockfiles**: Cloud Build deploys `alerts/infra/onchain-event-handler/` and `alerts/infra/oncall-announcer/` as standalone source roots, so keep each package-local `pnpm-lock.yaml` in sync when its deps change. Regenerate with `cd <function-dir> && pnpm install --lockfile-only --lockfile-dir .`. Each package-local `pnpm-workspace.yaml` mirrors the root release-age guard and carries standalone Cloud Build overrides; keep it in the function source hash. CI installs from package-local locks before function checks, and supply-chain CI audits/lints root plus both function lockfiles.
 - **Slack delivery is the active path.** `alerts/rules/` owns Grafana Slack contact points plus Splunk routing for page-severity protocol and Aegis service-health alerts. `alerts/infra/`: Sentry alerts go to Slack via `sentry-bridge`; on-chain multisig events route to Slack via `slack-channels` + the Cloud Function; Splunk On-Call rotations route to Slack via `oncall-announcer` and reconcile @support-engineer.
+- **Annotation queries must stay evaluable.** In Grafana alert rules,
+  annotation/helper queries can propagate `NoData` through the whole rule even
+  when the base alert query is firing. Do not let annotation-only series
+  disappear while the base alert can still fire; prefer a label-matched
+  fallback or sentinel series, then branch Slack templates on the sentinel.
 
 ## Verification
 


### PR DESCRIPTION
## The Problem

- Grafana alert annotation/helper queries can make an otherwise firing alert evaluate as NoData when their series disappear.
- That rule is easy to miss when editing `alerts/rules/`, which can reintroduce flaky or silent alert behavior.

## The Solution

- Document the invariant in `alerts/AGENTS.md`: annotation-only series must stay evaluable while the base alert can fire, usually with a label-matched fallback or sentinel.

## Details

- Captures the lesson from the oracle flake fix follow-up review.
- Keeps the guidance scoped to the alerts package where future Grafana alert-rule edits will read it.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback; Codex review engine unavailable)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/operator guidance with no impact on deployed alerts or infrastructure.
> 
> **Overview**
> Adds an **Operating Rules** bullet in `alerts/AGENTS.md` so anyone editing Grafana rules in `alerts/rules/` knows annotation/helper queries must not go empty while the base alert can still fire—otherwise Grafana can flip the whole rule to **NoData** even when the threshold is breaching.
> 
> The guidance matches patterns already used in rule locals (label-matched fallbacks, `-1` sentinels, Slack template branching). This is documentation only; no Terraform or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c405dcbb128a36494d252605664ada5351019cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->