### PR TITLE
Pause Arkham enrichment cron

### DIFF
--- a/terraform/dashboard.tf
+++ b/terraform/dashboard.tf
@@ -166,10 +166,10 @@ resource "vercel_project_environment_variable" "cron_secret" {
   sensitive = true
 }
 
-# Arkham Intelligence API key for the nightly enrichment cron. Production-only
-# so a compromised preview build can't burn the rate-limit budget. `count`
-# guard skips creation when the key isn't yet provisioned — the dashboard
-# still deploys cleanly without it (the cron route returns 500 on missing key).
+# Arkham Intelligence API key for manual enrichment runs. Production-only so a
+# compromised preview build can't burn the rate-limit budget. `count` guard
+# skips creation when the key isn't provisioned; the Vercel schedule is disabled
+# while access is unavailable.
 resource "vercel_project_environment_variable" "arkham_api_key" {
   count      = var.arkham_api_key == "" ? 0 : 1
   project_id = vercel_project.dashboard.id

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -55,8 +55,9 @@ upstash_api_key = "..."
 # squid_integrator_id = "..."
 
 # ── Arkham Intelligence ───────────────────────────────────────────────────────
-# API key for the nightly /api/arkham/enrich cron that tags Mento counterparties.
+# API key for manual /api/arkham/enrich counterparty tagging.
 # Apply for access at https://intel.arkm.com/api — gated, no self-serve signup.
+# The Vercel schedule is disabled while access is unavailable.
 # Leave empty until provisioned; the env var resource is `count`-gated so
 # `terraform apply` succeeds without it.
 # arkham_api_key = "..."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -137,10 +137,12 @@ variable "cron_secret" {
 
 variable "arkham_api_key" {
   description = <<-EOT
-    Arkham Intelligence API key, used by the nightly /api/arkham/enrich
-    cron to attach curated labels/entity attribution to Mento counterparty
-    addresses. Apply for access at https://intel.arkm.com/api (gated).
-    Server-side only — never exposed to the browser.
+    Arkham Intelligence API key, used by the manual /api/arkham/enrich
+    endpoint to attach curated labels/entity attribution to Mento counterparty
+    addresses when API access is available. The Vercel schedule is disabled
+    while access is unavailable. Apply for access at
+    https://intel.arkm.com/api (gated). Server-side only — never exposed to
+    the browser.
   EOT
   type        = string
   sensitive   = true

--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -18,7 +18,8 @@ NEXT_PUBLIC_HASURA_URL=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 NEXT_PUBLIC_SENTRY_DSN=
 
 # ── Arkham Intelligence ───────────────────────────────────────────────────
-# API key for nightly counterparty enrichment (/api/arkham/enrich cron).
+# API key for manual counterparty enrichment (/api/arkham/enrich).
 # Apply for access at https://intel.arkm.com/api — gated, no self-serve.
+# The Vercel schedule is disabled while access is unavailable.
 # Server-only — never expose to the browser.
 ARKHAM_API_KEY=

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -212,8 +212,9 @@ async function writeEnrichmentLabels(
  * - `mode=dryRun` — fetch from Arkham but skip the Redis write.
  * - `limit=N` — hard cap on addresses processed (default 10000).
  */
-// The handler accepts no body — `mode` and `limit` are query params — so GET is
-// enough for an explicit operator-triggered run.
+// Keep GET for this side-effecting endpoint because the historical Vercel cron
+// integration invoked this path with GET, and operator-triggered runs use query
+// params rather than a request body.
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const authBail = await requireCronAuth(req, "arkham/enrich");
   if (authBail) return authBail;

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -18,7 +18,6 @@ import {
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { NETWORKS } from "@/lib/networks";
-import { withFlushedMonitor } from "@/lib/sentry-cron";
 
 // Vercel hobby/pro hard caps the per-invocation duration on `serverless` —
 // a 5k-address run at 60ms spacing is ~5 minutes which fits in the 800s
@@ -196,7 +195,11 @@ async function writeEnrichmentLabels(
 }
 
 /**
- * Cron-triggered enrichment of Mento counterparty addresses with Arkham data.
+ * Manual enrichment of Mento counterparty addresses with Arkham data.
+ *
+ * The Vercel schedule is intentionally disabled while the team does not have
+ * Arkham API access. Keep this endpoint for a deliberate CRON_SECRET-gated
+ * backfill/refresh if access is restored.
  *
  * Auth: Bearer `CRON_SECRET`. This is a GET route with expensive side
  * effects, so session-only auth is intentionally rejected by `requireCronAuth`
@@ -205,13 +208,12 @@ async function writeEnrichmentLabels(
  * Query params:
  * - `mode=new` (default) — only enrich addresses not yet labelled.
  * - `mode=refresh` — re-enrich addresses already tagged `arkham`. Use this
- *   monthly to pick up newly-attributed entities.
+ *   manually to pick up newly-attributed entities after access is restored.
  * - `mode=dryRun` — fetch from Arkham but skip the Redis write.
  * - `limit=N` — hard cap on addresses processed (default 10000).
  */
-// Vercel cron jobs invoke the configured path with a GET request, not POST.
-// Exporting POST instead would 405 every scheduled run. The handler accepts
-// no body — `mode` and `limit` are query params — so GET is the right verb.
+// The handler accepts no body — `mode` and `limit` are query params — so GET is
+// enough for an explicit operator-triggered run.
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const authBail = await requireCronAuth(req, "arkham/enrich");
   if (authBail) return authBail;
@@ -236,85 +238,73 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
 
   try {
-    return await withFlushedMonitor(
-      "arkham-enrich",
-      async () => {
-        // Pre-flight: health check, address discovery, and existing-label
-        // read have no data dependency on each other — run concurrently so
-        // we don't pay 3× the round-trip latency before Arkham work begins.
-        const [healthy, discovery, existing] = await Promise.all([
-          fetchHealth(apiKey),
-          discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
-          getLabels(),
-        ]);
+    // Pre-flight: health check, address discovery, and existing-label read
+    // have no data dependency on each other — run concurrently so we don't
+    // pay 3× the round-trip latency before Arkham work begins.
+    const [healthy, discovery, existing] = await Promise.all([
+      fetchHealth(apiKey),
+      discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
+      getLabels(),
+    ]);
 
-        if (!healthy) {
-          throw new Error("arkham_health_check_failed");
-        }
+    if (!healthy) {
+      throw new Error("arkham_health_check_failed");
+    }
 
-        const { addresses, perEntity } = discovery;
-        const filterMode = mode === "dryRun" ? "new" : mode;
-        let candidates = filterCandidates(addresses, existing, filterMode);
+    const { addresses, perEntity } = discovery;
+    const filterMode = mode === "dryRun" ? "new" : mode;
+    let candidates = filterCandidates(addresses, existing, filterMode);
 
-        // Refresh-mode rotation: if the arkham-tagged set ever exceeds
-        // `maxAddresses`, a deterministic alphabetical slice would re-process
-        // the same prefix every month and never revisit the tail. Sort by
-        // `updatedAt` ascending so the staler entries refresh first; the
-        // post-write `updatedAt` rolls them to the end of the queue, giving
-        // round-robin coverage across runs.
-        if (mode === "refresh") {
-          candidates = candidates.sort((a, b) => {
-            const ua = existing[a]?.updatedAt ?? "";
-            const ub = existing[b]?.updatedAt ?? "";
-            return ua.localeCompare(ub);
-          });
-        }
-        candidates = candidates.slice(0, maxAddresses);
+    // Refresh-mode rotation: if the arkham-tagged set ever exceeds
+    // `maxAddresses`, a deterministic alphabetical slice would re-process
+    // the same prefix every month and never revisit the tail. Sort by
+    // `updatedAt` ascending so the staler entries refresh first; the
+    // post-write `updatedAt` rolls them to the end of the queue, giving
+    // round-robin coverage across runs.
+    if (mode === "refresh") {
+      candidates = candidates.sort((a, b) => {
+        const ua = existing[a]?.updatedAt ?? "";
+        const ub = existing[b]?.updatedAt ?? "";
+        return ua.localeCompare(ub);
+      });
+    }
+    candidates = candidates.slice(0, maxAddresses);
 
-        const results = await enrichBatch(candidates, { apiKey });
-        const writes = await buildLabelWrites(results, mode);
-        const { errors } = writes;
-        const enrichedCount = await writeEnrichmentLabels(mode, writes);
-        // In write modes this is based on actual atomic writes, so concurrent
-        // inserts/edits that beat our compare-and-set are counted as skipped.
-        const skippedCount = results.length - enrichedCount - errors.length;
+    const results = await enrichBatch(candidates, { apiKey });
+    const writes = await buildLabelWrites(results, mode);
+    const { errors } = writes;
+    const enrichedCount = await writeEnrichmentLabels(mode, writes);
+    // In write modes this is based on actual atomic writes, so concurrent
+    // inserts/edits that beat our compare-and-set are counted as skipped.
+    const skippedCount = results.length - enrichedCount - errors.length;
 
-        if (errors.length > 0) {
-          // Tag in Sentry but don't fail the run — partial success is normal
-          // (e.g. one 5xx during a 5k-address batch).
-          Sentry.captureMessage(
-            `[arkham/enrich] ${errors.length} errors during batch`,
-            {
-              tags: { route: "arkham/enrich", mode },
-              extra: { errors: errors.slice(0, 50) },
-              level: "warning",
-            },
-          );
-        }
+    if (errors.length > 0) {
+      // Tag in Sentry but don't fail the run — partial success is normal
+      // (e.g. one 5xx during a 5k-address batch).
+      Sentry.captureMessage(
+        `[arkham/enrich] ${errors.length} errors during batch`,
+        {
+          tags: { route: "arkham/enrich", mode },
+          extra: { errors: errors.slice(0, 50) },
+          level: "warning",
+        },
+      );
+    }
 
-        const body: EnrichResponse = {
-          ok: true,
-          discoveryChainId: CELO_CHAIN_ID,
-          discovered: addresses.length,
-          candidates: candidates.length,
-          enriched: enrichedCount,
-          skipped: skippedCount,
-          errors: errors.length,
-          durationMs: Date.now() - startedAt,
-          perEntity,
-          sampleErrors: errors.slice(0, 5),
-          mode,
-        };
-        return NextResponse.json(body);
-      },
-      {
-        // Cron schedule mirrors vercel.json — keep them in sync.
-        schedule: { type: "crontab", value: "0 4 * * *" },
-        checkinMargin: 5,
-        maxRuntime: 15,
-        timezone: "Etc/UTC",
-      },
-    );
+    const body: EnrichResponse = {
+      ok: true,
+      discoveryChainId: CELO_CHAIN_ID,
+      discovered: addresses.length,
+      candidates: candidates.length,
+      enriched: enrichedCount,
+      skipped: skippedCount,
+      errors: errors.length,
+      durationMs: Date.now() - startedAt,
+      perEntity,
+      sampleErrors: errors.slice(0, 5),
+      mode,
+    };
+    return NextResponse.json(body);
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "arkham/enrich", mode } });
     console.error("[arkham/enrich]", err);

--- a/ui-dashboard/vercel.json
+++ b/ui-dashboard/vercel.json
@@ -13,14 +13,6 @@
       "schedule": "30 3 * * *"
     },
     {
-      "path": "/api/arkham/enrich",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/arkham/enrich?mode=refresh",
-      "schedule": "30 4 1 * *"
-    },
-    {
       "path": "/api/minipay/tag",
       "schedule": "0 5 * * *"
     }


### PR DESCRIPTION
## The Problem

- The Arkham enrichment cron still runs in production even though we no longer have Arkham API access.
- Each scheduled run fails and keeps the Sentry Cron Monitor noisy.
- Operators need the endpoint kept available for an intentional manual backfill if access returns.

## The Solution

- Remove the scheduled Vercel cron entries and stop registering the route as an active Sentry Cron Monitor.
- Keep the API route behind CRON_SECRET so it can be run manually if Arkham access is restored.

## Details

- Removed `/api/arkham/enrich` and `/api/arkham/enrich?mode=refresh` from `ui-dashboard/vercel.json`.
- Removed the `withFlushedMonitor("arkham-enrich", ...)` wrapper while preserving normal Sentry exception capture.
- Updated Terraform and env examples to describe Arkham enrichment as manual while access is unavailable.
- The existing Sentry Cron Monitor was disabled in Sentry before opening this PR.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback; clean)
- Browser-backed dashboard tests passed via the mapped quality gate; no rendered UI surface changed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduling and observability-only changes; no auth, Redis write logic, or user-facing UI changes.
> 
> **Overview**
> Stops **scheduled** Arkham counterparty enrichment now that production no longer has API access, while keeping a **manual** backfill path if access returns.
> 
> **Vercel:** Removes both `/api/arkham/enrich` crons from `vercel.json` (daily new enrich and monthly `mode=refresh`), so prod no longer invokes the route on a schedule.
> 
> **`/api/arkham/enrich`:** Drops the `withFlushedMonitor("arkham-enrich", …)` Sentry Cron Monitor wrapper (avoids noisy failed check-ins); enrichment logic, `CRON_SECRET` auth, and normal `Sentry.captureException` / batch warnings are unchanged. Docs now describe the route as operator-triggered, not cron-driven.
> 
> **Terraform / env examples:** Comments and variable descriptions updated to match—Arkham key is for manual runs; schedule disabled while access is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a867ff02196fa2d2bfd9a135922b963d032a363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->