### PR TITLE
Sortable CDP trove table + fix horizontal overflow

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -326,6 +326,30 @@ function clickButton(handle: Handle, label: string) {
   });
 }
 
+function clickSortHeader(handle: Handle, label: string) {
+  const button = Array.from(
+    handle.container.querySelectorAll("thead button"),
+  ).find((candidate) => (candidate.textContent ?? "").startsWith(label));
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Sort header not found: ${label}`);
+  }
+  act(() => {
+    button.click();
+  });
+}
+
+function clickAriaLabel(handle: Handle, label: string) {
+  const button = handle.container.querySelector(
+    `button[aria-label="${label}"]`,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  act(() => {
+    button.click();
+  });
+}
+
 function searchTroves(handle: Handle, value: string) {
   const input = handle.container.querySelector("#cdp-trove-search");
   if (!(input instanceof HTMLInputElement)) {
@@ -825,6 +849,76 @@ describe("CdpDetailClient", () => {
     expect(rows[1]).toContain("Batch");
     expect(rows[2]).toContain("0xhigher");
     expect(rows[2]).toContain("#2");
+  });
+
+  it("sorts open troves on header click, persists the column to the URL, and resets to page 1", () => {
+    window.history.replaceState(null, "", "/cdps/gbpm");
+    // 30 troves, equal interest rate so default order is troveId-ascending;
+    // debt is the INVERSE of troveId so a debt sort is visibly distinct from
+    // the default order. Owners are zero-padded to avoid substring collisions.
+    const troves = Array.from({ length: 30 }, (_, i) =>
+      trove({
+        id: `srt-${i + 1}`,
+        troveId: String(i + 1),
+        owner: `0xowner${String(i + 1).padStart(2, "0")}`,
+        debt: wei(30 - i),
+        interestRate: rateBps(100),
+      }),
+    );
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === CDP_MARKETS) {
+        return { data: marketsData(), error: null, isLoading: false };
+      }
+      if (query === CDP_TROVE_SCHEMA_FIELDS) {
+        return { data: troveSchemaData(), error: null, isLoading: false };
+      }
+      if (
+        query === CDP_MARKET_DETAIL ||
+        query === CDP_MARKET_DETAIL_WITH_TROVE_TX
+      ) {
+        return {
+          data: detailData({
+            openTroves: troves,
+            depositors: [],
+            cdpPools: [],
+          }),
+          error: null,
+          isLoading: false,
+        };
+      }
+      if (query === CDP_INSTANCE_DAILY_SNAPSHOTS) {
+        return {
+          data: { LiquityInstanceDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    render(handle!);
+
+    // Default: rank order (equal rate → troveId asc) → owner01 first, no params.
+    expect(troveRowText(handle!)[0]).toContain("0xowner01");
+    expect(window.location.search).toBe("");
+
+    // Page to the second page (rows 26-30 in default order).
+    clickAriaLabel(handle!, "Next page");
+    expect(troveRowText(handle!)[0]).toContain("0xowner26");
+
+    // Click Debt → resets to page 1, ascending (owner30 has the lowest debt),
+    // and the active column is reflected in the URL.
+    clickSortHeader(handle!, "Debt");
+    expect(handle!.container.textContent).toContain("page 1 of 2");
+    expect(troveRowText(handle!)[0]).toContain("0xowner30");
+    expect(window.location.search).toBe("?trovesSort=debt&trovesDir=asc");
+
+    // Toggle to descending — owner01 has the highest debt.
+    clickSortHeader(handle!, "Debt");
+    expect(troveRowText(handle!)[0]).toContain("0xowner01");
+    expect(window.location.search).toBe("?trovesSort=debt&trovesDir=desc");
+
+    window.history.replaceState(null, "", "/");
   });
 
   it("does not rank missing batch troves by their stale direct rate", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -586,8 +586,11 @@ describe("CdpDetailClient", () => {
       `a[href="https://app.mento.org/borrow/manage/${troveId}?token=GBPm"]`,
     );
     expect(link).not.toBeNull();
-    expect(link?.textContent).toBe(troveId);
-    expect(link?.textContent).not.toContain("#");
+    // Display text is middle-ellipsized to avoid blowing out the column width;
+    // the full id stays in the href + title (and never carries a `#` prefix).
+    expect(link?.textContent).toBe("0x5f23…3ac4");
+    expect(link?.getAttribute("title")).toBe(troveId);
+    expect(link?.getAttribute("href")).not.toContain("#");
     expect(link?.target).toBe("_blank");
     expect(link?.rel).toBe("noopener noreferrer");
   });
@@ -985,7 +988,11 @@ describe("CdpDetailClient", () => {
 
     const headers = Array.from(
       handle!.container.querySelectorAll('table[aria-label="GBPm troves"] th'),
-    ).map((header) => header.textContent);
+    ).map((header) =>
+      // Strip the sortable-header indicator glyphs (↕/↑/↓) and info ⓘ so the
+      // assertion tracks the column label, not the sort affordance.
+      header.textContent?.replace(/[↕↑↓ⓘ]/g, "").trim(),
+    );
     expect(headers).toEqual([
       "Last owner / Trove",
       "Status",

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/trove-sort.test.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/trove-sort.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { CdpTrove } from "../../../_lib/types";
+import { sortDisplayRows, type TroveDisplayRow } from "../trove-sort";
+
+function makeTrove(overrides: Partial<CdpTrove>): CdpTrove {
+  return {
+    id: "1",
+    troveId: "1",
+    owner: "0xowner",
+    previousOwner: "0x0000000000000000000000000000000000000000",
+    status: "active",
+    debt: "0",
+    coll: "0",
+    icrBps: 0,
+    interestRate: "0",
+    interestBatchId: null,
+    openedAt: "0",
+    openedTxHash: "0xopen",
+    closedAt: null,
+    closedTxHash: null,
+    lastUpdatedAt: "0",
+    lastUpdatedTxHash: null,
+    liquidatedDebt: null,
+    liquidatedColl: null,
+    collSurplus: null,
+    priceAtLiquidation: null,
+    redemptionCount: 0,
+    redeemedDebt: "0",
+    redeemedColl: "0",
+    redemptionFeePaidCum: "0",
+    ...overrides,
+  };
+}
+
+function row(
+  overrides: Partial<CdpTrove>,
+  effectiveRate: bigint | null = BigInt(0),
+): TroveDisplayRow {
+  return {
+    trove: makeTrove(overrides),
+    effectiveRate,
+    rank: null,
+    tied: false,
+    rateSource: "direct",
+  };
+}
+
+const ids = (rows: TroveDisplayRow[]) => rows.map((r) => r.trove.id);
+
+describe("sortDisplayRows (open tab)", () => {
+  const rows = [
+    row({ id: "a", debt: "300", coll: "100", icrBps: 150 }, BigInt(5)),
+    row({ id: "b", debt: "100", coll: "300", icrBps: 200 }, BigInt(3)),
+    row({ id: "c", debt: "200", coll: "200", icrBps: 175 }, BigInt(7)),
+  ];
+
+  it("sorts by debt ascending and descending", () => {
+    expect(ids(sortDisplayRows(rows, "open", "debt", "asc"))).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+    expect(ids(sortDisplayRows(rows, "open", "debt", "desc"))).toEqual([
+      "a",
+      "c",
+      "b",
+    ]);
+  });
+
+  it("sorts by collateral", () => {
+    expect(ids(sortDisplayRows(rows, "open", "collateral", "asc"))).toEqual([
+      "a",
+      "c",
+      "b",
+    ]);
+  });
+
+  it("rank/interest order by effective interest rate ascending", () => {
+    expect(ids(sortDisplayRows(rows, "open", "rank", "asc"))).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(ids(sortDisplayRows(rows, "open", "interest", "asc"))).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+
+  it("keeps ICR-unavailable rows (sentinel < 0) last in both directions", () => {
+    const withSentinel = [
+      row({ id: "a", icrBps: 150 }),
+      row({ id: "x", icrBps: -1 }),
+      row({ id: "b", icrBps: 200 }),
+    ];
+    expect(
+      ids(sortDisplayRows(withSentinel, "open", "icr", "asc")).at(-1),
+    ).toBe("x");
+    expect(
+      ids(sortDisplayRows(withSentinel, "open", "icr", "desc")).at(-1),
+    ).toBe("x");
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...rows];
+    sortDisplayRows(input, "open", "debt", "asc");
+    expect(ids(input)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("sortDisplayRows (history tab)", () => {
+  it("sorts by ended time using closedAt, falling back to lastUpdatedAt", () => {
+    const rows = [
+      row({ id: "a", closedAt: "300" }),
+      row({ id: "b", closedAt: null, lastUpdatedAt: "500" }),
+      row({ id: "c", closedAt: "100" }),
+    ];
+    expect(ids(sortDisplayRows(rows, "history", "ended", "desc"))).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+
+  it("keeps never-liquidated troves last regardless of direction", () => {
+    const rows = [
+      row({ id: "a", liquidatedDebt: "100" }),
+      row({ id: "b", liquidatedDebt: null }),
+      row({ id: "c", liquidatedDebt: "300" }),
+    ];
+    expect(
+      ids(sortDisplayRows(rows, "history", "liquidated", "asc")).at(-1),
+    ).toBe("b");
+    expect(
+      ids(sortDisplayRows(rows, "history", "liquidated", "desc")).at(-1),
+    ).toBe("b");
+  });
+});

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -363,7 +363,8 @@ function TroveTableResults({
       {capped && (
         <p className="px-1 pt-1 text-xs text-amber-400">
           Showing {CDP_TROVES_DETAIL_LIMIT.toLocaleString()} fetched troves for
-          this view — search covers fetched rows only.
+          this view — search and sorting cover these fetched rows only, not the
+          full set.
           {activeTab === "open" && rankSuppressed
             ? " Redemption ranks are hidden because the full open-trove set is not loaded."
             : ""}

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -4,12 +4,14 @@ import { useMemo, useState, type ReactNode } from "react";
 import { AddressLink } from "@/components/address-link";
 import { EmptyBox } from "@/components/feedback";
 import { Pagination } from "@/components/pagination";
-import { Table, Row, Th, Td } from "@/components/table";
+import { Table, Row, Td } from "@/components/table";
 import { Tooltip } from "@/components/tooltip";
 import { formatTimestamp, relativeTime } from "@/lib/format";
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
+import type { SortDir } from "@/lib/table-sort";
 import { explorerTxUrl } from "@/lib/tokens";
 import { useRovingTabIndex } from "@/lib/use-roving-tab-index";
+import { useTableSort } from "@/lib/use-table-sort";
 import {
   CDP_TROVE_OPEN_STATUSES,
   CDP_TROVES_DETAIL_LIMIT,
@@ -18,32 +20,31 @@ import {
   type CdpTrove,
 } from "../../_lib/types";
 import { formatTokenAmount } from "../../_lib/format";
+import { HistoryTroveHeader, OpenTroveHeader } from "./trove-table-headers";
+import {
+  compareRedemptionPriorityRows,
+  HISTORY_SORT_DEFAULT_DIR,
+  HISTORY_SORT_DEFAULT_KEY,
+  HISTORY_SORT_KEYS,
+  OPEN_SORT_DEFAULT_DIR,
+  OPEN_SORT_DEFAULT_KEY,
+  OPEN_SORT_KEYS,
+  parseBigInt,
+  sortDisplayRows,
+  type HistorySortKey,
+  type OpenSortKey,
+  type TroveDisplayRow,
+  type TroveSortKey,
+} from "./trove-sort";
 
 const TROVE_TABS = ["open", "history"] as const;
 
 type TroveTab = (typeof TROVE_TABS)[number];
 
-type TroveDisplayRow = {
-  trove: CdpTrove;
-  effectiveRate: bigint | null;
-  rank: number | null;
-  tied: boolean;
-  rateSource: "direct" | "batch" | null;
-};
-
 const TROVE_PAGE_SIZE = 25;
 const D18 = BigInt(10) ** BigInt(18);
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const MENTO_APP_BORROW_MANAGE_BASE_URL = "https://app.mento.org/borrow/manage";
-const ICR_INDEXED_EXPLAINER = (
-  <>
-    Individual Collateral Ratio (
-    <code className="rounded bg-slate-900 px-1 font-mono text-[11px] text-slate-100">
-      coll. / debt
-    </code>
-    ) snapshot from the latest indexed trove event, not a live oracle/RPC read.
-  </>
-);
 
 const troveTabId = (tab: TroveTab) => `cdp-trove-tab-${tab}`;
 const trovePanelId = (tab: TroveTab) => `cdp-trove-panel-${tab}`;
@@ -62,10 +63,25 @@ export function CdpTroveTable({
   const [activeTab, setActiveTab] = useState<TroveTab>("open");
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
+  const openSort = useTableSort<OpenSortKey>({
+    defaultKey: OPEN_SORT_DEFAULT_KEY,
+    defaultDir: OPEN_SORT_DEFAULT_DIR,
+    validKeys: OPEN_SORT_KEYS,
+    paramPrefix: "troves",
+  });
+  const historySort = useTableSort<HistorySortKey>({
+    defaultKey: HISTORY_SORT_DEFAULT_KEY,
+    defaultDir: HISTORY_SORT_DEFAULT_DIR,
+    validKeys: HISTORY_SORT_KEYS,
+    paramPrefix: "trovesHist",
+  });
+  const activeSort = activeTab === "open" ? openSort : historySort;
   const tableRows = useTroveTableRows({
     activeTab,
     search,
     page,
+    sortKey: activeSort.sortKey,
+    sortDir: activeSort.sortDir,
     openTroves,
     allTroves,
     interestBatches,
@@ -78,6 +94,14 @@ export function CdpTroveTable({
   const updateSearch = (next: string) => {
     setSearch(next);
     setPage(1);
+  };
+  const handleSort = (key: TroveSortKey) => {
+    setPage(1);
+    if (activeTab === "open") {
+      openSort.handleSort(key as OpenSortKey);
+    } else {
+      historySort.handleSort(key as HistorySortKey);
+    }
   };
 
   return (
@@ -105,6 +129,9 @@ export function CdpTroveTable({
             total={tableRows.filteredRows.length}
             capped={tableRows.activeCapped}
             rankSuppressed={tableRows.rankSuppressed}
+            sortKey={activeSort.sortKey}
+            sortDir={activeSort.sortDir}
+            onSort={handleSort}
             onPageChange={setPage}
           />
         )}
@@ -117,6 +144,8 @@ function useTroveTableRows({
   activeTab,
   search,
   page,
+  sortKey,
+  sortDir,
   openTroves,
   allTroves,
   interestBatches,
@@ -124,6 +153,8 @@ function useTroveTableRows({
   activeTab: TroveTab;
   search: string;
   page: number;
+  sortKey: TroveSortKey;
+  sortDir: SortDir;
   openTroves: CdpTrove[];
   allTroves: CdpTrove[];
   interestBatches: CdpInterestBatch[];
@@ -155,9 +186,13 @@ function useTroveTableRows({
       troveMatchesSearch(trove, normalizedSearch),
     );
   }, [normalizedSearch, sourceRows]);
+  const sortedRows = useMemo(
+    () => sortDisplayRows(filteredRows, activeTab, sortKey, sortDir),
+    [filteredRows, activeTab, sortKey, sortDir],
+  );
   const totalPages = Math.max(
     1,
-    Math.ceil(filteredRows.length / TROVE_PAGE_SIZE),
+    Math.ceil(sortedRows.length / TROVE_PAGE_SIZE),
   );
   const clampedPage = Math.max(1, Math.min(page, totalPages));
   const start = (clampedPage - 1) * TROVE_PAGE_SIZE;
@@ -173,7 +208,7 @@ function useTroveTableRows({
   return {
     sourceRows,
     filteredRows,
-    visibleRows: filteredRows.slice(start, start + TROVE_PAGE_SIZE),
+    visibleRows: sortedRows.slice(start, start + TROVE_PAGE_SIZE),
     clampedPage,
     activeCapped,
     rankSuppressed: activeTab === "open" && openCapped,
@@ -257,6 +292,9 @@ function TroveTableResults({
   total,
   capped,
   rankSuppressed,
+  sortKey,
+  sortDir,
+  onSort,
   onPageChange,
 }: {
   activeTab: TroveTab;
@@ -267,14 +305,32 @@ function TroveTableResults({
   total: number;
   capped: boolean;
   rankSuppressed: boolean;
+  sortKey: TroveSortKey;
+  sortDir: SortDir;
+  onSort: (key: TroveSortKey) => void;
   onPageChange: (page: number) => void;
 }) {
   const historyView = activeTab === "history";
   return (
     <>
-      <Table aria-label={`${collateral.symbol} troves`}>
+      <Table
+        aria-label={`${collateral.symbol} troves`}
+        scrollClassName="xl:overflow-x-clip"
+      >
         <thead>
-          {historyView ? <HistoryTroveHeader /> : <OpenTroveHeader />}
+          {historyView ? (
+            <HistoryTroveHeader
+              sortKey={sortKey as HistorySortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            />
+          ) : (
+            <OpenTroveHeader
+              sortKey={sortKey as OpenSortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            />
+          )}
         </thead>
         <tbody>
           {visibleRows.length === 0 ? (
@@ -354,51 +410,6 @@ function TroveTabButton({
     >
       {children}
     </button>
-  );
-}
-
-function OpenTroveHeader() {
-  return (
-    <Row>
-      <Th align="right">Rank</Th>
-      <Th>Owner / Trove</Th>
-      <Th>Status</Th>
-      <Th align="right">Debt</Th>
-      <Th align="right">Collateral</Th>
-      <Th align="right">
-        <span className="inline-flex items-center justify-end gap-1">
-          <Tooltip
-            label="About indexed ICR"
-            content={ICR_INDEXED_EXPLAINER}
-            align="right"
-          >
-            <span className="inline-flex items-center gap-1">
-              ICR (indexed)
-              <span className="text-slate-500" aria-hidden="true">
-                ⓘ
-              </span>
-            </span>
-          </Tooltip>
-        </span>
-      </Th>
-      <Th align="right">Interest</Th>
-      <Th align="right">Updated</Th>
-    </Row>
-  );
-}
-
-function HistoryTroveHeader() {
-  return (
-    <Row>
-      <Th>Last owner / Trove</Th>
-      <Th>Status</Th>
-      <Th align="right">Opened</Th>
-      <Th align="right">Ended / Updated</Th>
-      <Th align="right">Remaining collateral</Th>
-      <Th align="right">Redeemed</Th>
-      <Th align="right">Redemption fee</Th>
-      <Th align="right">Liquidated</Th>
-    </Row>
   );
 }
 
@@ -521,13 +532,25 @@ function OwnerTroveCell({
         href={troveManageUrl(trove.troveId, collateral.symbol)}
         target="_blank"
         rel="noopener noreferrer"
+        title={trove.troveId}
         aria-label={`Manage trove ${trove.troveId} in the Mento app`}
         className="font-mono text-[10px] text-slate-500 hover:text-slate-300 hover:underline focus:outline-none focus:ring-1 focus:ring-indigo-500"
       >
-        {trove.troveId}
+        {shortenTroveId(trove.troveId)}
       </a>
     </div>
   );
+}
+
+/**
+ * Trove IDs are uint256 token ids (often a 66-char `0x…` hash). Rendering them
+ * in full blew the first column out past the viewport (horizontal scroll);
+ * middle-ellipsize for display while keeping the full id in the link + title.
+ */
+function shortenTroveId(troveId: string): string {
+  return troveId.length <= 13
+    ? troveId
+    : `${troveId.slice(0, 6)}…${troveId.slice(-4)}`;
 }
 
 function RankValue({ row }: { row: TroveDisplayRow }) {
@@ -798,45 +821,6 @@ function displayRowForTrove(
     tied: false,
     rateSource: directRate != null ? "direct" : null,
   };
-}
-
-function compareRedemptionPriorityRows(
-  a: TroveDisplayRow,
-  b: TroveDisplayRow,
-): number {
-  const rate = compareNullableBigInt(a.effectiveRate, b.effectiveRate);
-  if (rate !== 0) return rate;
-  const troveId = compareNumericStrings(a.trove.troveId, b.trove.troveId);
-  if (troveId !== 0) return troveId;
-  return a.trove.id.localeCompare(b.trove.id);
-}
-
-function compareNullableBigInt(a: bigint | null, b: bigint | null): number {
-  if (a == null && b == null) return 0;
-  if (a == null) return 1;
-  if (b == null) return -1;
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
-}
-
-function compareNumericStrings(a: string, b: string): number {
-  const parsedA = parseBigInt(a);
-  const parsedB = parseBigInt(b);
-  if (parsedA != null && parsedB != null) {
-    if (parsedA < parsedB) return -1;
-    if (parsedA > parsedB) return 1;
-    return 0;
-  }
-  return a.localeCompare(b);
-}
-
-function parseBigInt(value: string): bigint | null {
-  try {
-    return BigInt(value);
-  } catch {
-    return null;
-  }
 }
 
 function troveManageUrl(troveId: string, tokenSymbol: string): string {

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/trove-sort.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/trove-sort.ts
@@ -92,6 +92,9 @@ function tiebreakRows(a: TroveDisplayRow, b: TroveDisplayRow): number {
 function openSortValue(key: OpenSortKey, row: TroveDisplayRow): bigint | null {
   const t = row.trove;
   switch (key) {
+    // "rank" and "interest" intentionally share the same key: redemption rank
+    // IS ascending-interest-rate order, so both columns sort identically. Kept
+    // as two sortable headers because each is a natural click target.
     case "rank":
     case "interest":
       return row.effectiveRate;

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/trove-sort.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/trove-sort.ts
@@ -1,0 +1,167 @@
+import type { SortDir } from "@/lib/table-sort";
+import type { CdpTrove } from "../../_lib/types";
+
+export type TroveDisplayRow = {
+  trove: CdpTrove;
+  effectiveRate: bigint | null;
+  rank: number | null;
+  tied: boolean;
+  rateSource: "direct" | "batch" | null;
+};
+
+export type TroveSortTab = "open" | "history";
+export type OpenSortKey =
+  | "rank"
+  | "debt"
+  | "collateral"
+  | "icr"
+  | "interest"
+  | "updated";
+export type HistorySortKey =
+  | "opened"
+  | "ended"
+  | "remainingColl"
+  | "redeemed"
+  | "redemptionFee"
+  | "liquidated";
+export type TroveSortKey = OpenSortKey | HistorySortKey;
+
+export const OPEN_SORT_KEYS: ReadonlySet<OpenSortKey> = new Set<OpenSortKey>([
+  "rank",
+  "debt",
+  "collateral",
+  "icr",
+  "interest",
+  "updated",
+]);
+export const HISTORY_SORT_KEYS: ReadonlySet<HistorySortKey> =
+  new Set<HistorySortKey>([
+    "opened",
+    "ended",
+    "remainingColl",
+    "redeemed",
+    "redemptionFee",
+    "liquidated",
+  ]);
+
+export const OPEN_SORT_DEFAULT_KEY: OpenSortKey = "rank";
+export const HISTORY_SORT_DEFAULT_KEY: HistorySortKey = "ended";
+export const OPEN_SORT_DEFAULT_DIR: SortDir = "asc";
+export const HISTORY_SORT_DEFAULT_DIR: SortDir = "desc";
+
+/**
+ * Sort display rows by the chosen column. Rows whose sort value is unavailable
+ * (null effectiveRate, ICR sentinel `< 0`, never-liquidated) always sort last,
+ * regardless of direction — so toggling asc/desc never floats "unknown" to the
+ * top where it would read as a real extreme.
+ */
+export function sortDisplayRows(
+  rows: readonly TroveDisplayRow[],
+  tab: TroveSortTab,
+  key: TroveSortKey,
+  dir: SortDir,
+): TroveDisplayRow[] {
+  const sign = dir === "asc" ? 1 : -1;
+  const valueOf = (row: TroveDisplayRow): bigint | null =>
+    tab === "open"
+      ? openSortValue(key as OpenSortKey, row)
+      : historySortValue(key as HistorySortKey, row);
+  return [...rows].sort((a, b) => {
+    const av = valueOf(a);
+    const bv = valueOf(b);
+    if (av === null || bv === null) {
+      if (av === bv) return tiebreakRows(a, b);
+      return av === null ? 1 : -1;
+    }
+    if (av !== bv) return (av < bv ? -1 : 1) * sign;
+    return tiebreakRows(a, b);
+  });
+}
+
+/**
+ * Direction-independent tiebreak shared by every sort key: order by numeric
+ * trove id, then the composite entity id. Mirrors the tail of
+ * {@link compareRedemptionPriorityRows} so the default rank sort is stable and
+ * matches the indexer's redemption ordering exactly.
+ */
+function tiebreakRows(a: TroveDisplayRow, b: TroveDisplayRow): number {
+  const byTroveId = compareNumericStrings(a.trove.troveId, b.trove.troveId);
+  return byTroveId !== 0 ? byTroveId : a.trove.id.localeCompare(b.trove.id);
+}
+
+function openSortValue(key: OpenSortKey, row: TroveDisplayRow): bigint | null {
+  const t = row.trove;
+  switch (key) {
+    case "rank":
+    case "interest":
+      return row.effectiveRate;
+    case "debt":
+      return parseBigInt(t.debt);
+    case "collateral":
+      return parseBigInt(t.coll);
+    case "icr":
+      return t.icrBps < 0 ? null : BigInt(t.icrBps);
+    case "updated":
+      return parseBigInt(t.lastUpdatedAt);
+  }
+}
+
+function historySortValue(
+  key: HistorySortKey,
+  row: TroveDisplayRow,
+): bigint | null {
+  const t = row.trove;
+  switch (key) {
+    case "opened":
+      return parseBigInt(t.openedAt);
+    case "ended":
+      return parseBigInt(t.closedAt ?? t.lastUpdatedAt);
+    case "remainingColl":
+      return parseBigInt(t.coll);
+    case "redeemed":
+      return parseBigInt(t.redeemedDebt);
+    case "redemptionFee":
+      return parseBigInt(t.redemptionFeePaidCum);
+    case "liquidated":
+      return t.liquidatedDebt == null ? null : parseBigInt(t.liquidatedDebt);
+  }
+}
+
+export function compareRedemptionPriorityRows(
+  a: TroveDisplayRow,
+  b: TroveDisplayRow,
+): number {
+  const rate = compareNullableBigInt(a.effectiveRate, b.effectiveRate);
+  if (rate !== 0) return rate;
+  const troveId = compareNumericStrings(a.trove.troveId, b.trove.troveId);
+  if (troveId !== 0) return troveId;
+  return a.trove.id.localeCompare(b.trove.id);
+}
+
+function compareNullableBigInt(a: bigint | null, b: bigint | null): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function compareNumericStrings(a: string, b: string): number {
+  const parsedA = parseBigInt(a);
+  const parsedB = parseBigInt(b);
+  if (parsedA != null && parsedB != null) {
+    if (parsedA < parsedB) return -1;
+    if (parsedA > parsedB) return 1;
+    return 0;
+  }
+  return a.localeCompare(b);
+}
+
+export function parseBigInt(value: string): bigint | null {
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/trove-table-headers.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/trove-table-headers.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { SortableTh } from "@/components/sortable-th";
 import { Row, Th } from "@/components/table";
 import { Tooltip } from "@/components/tooltip";
@@ -28,17 +27,26 @@ export function OpenTroveHeader({
 }) {
   return (
     <Row>
-      <SortableInfoTh
+      <SortableTh
         sortKey="rank"
         activeSortKey={sortKey}
         sortDir={sortDir}
         onSort={onSort}
-        info={RANK_EXPLAINER}
-        infoLabel="About redemption rank"
-        infoAlign="left"
+        align="right"
+        trailing={
+          <Tooltip
+            label="About redemption rank"
+            content={RANK_EXPLAINER}
+            align="left"
+          >
+            <span className="text-slate-500" aria-hidden="true">
+              ⓘ
+            </span>
+          </Tooltip>
+        }
       >
         Rank
-      </SortableInfoTh>
+      </SortableTh>
       <Th>Owner / Trove</Th>
       <Th>Status</Th>
       <SortableTh
@@ -59,17 +67,26 @@ export function OpenTroveHeader({
       >
         Collateral
       </SortableTh>
-      <SortableInfoTh
+      <SortableTh
         sortKey="icr"
         activeSortKey={sortKey}
         sortDir={sortDir}
         onSort={onSort}
-        info={ICR_INDEXED_EXPLAINER}
-        infoLabel="About indexed ICR"
-        infoAlign="right"
+        align="right"
+        trailing={
+          <Tooltip
+            label="About indexed ICR"
+            content={ICR_INDEXED_EXPLAINER}
+            align="right"
+          >
+            <span className="text-slate-500" aria-hidden="true">
+              ⓘ
+            </span>
+          </Tooltip>
+        }
       >
         ICR (indexed)
-      </SortableInfoTh>
+      </SortableTh>
       <SortableTh
         sortKey="interest"
         activeSortKey={sortKey}
@@ -160,69 +177,5 @@ export function HistoryTroveHeader({
         Liquidated
       </SortableTh>
     </Row>
-  );
-}
-
-/**
- * Right-aligned sortable header with an adjacent info tooltip. The tooltip
- * trigger is a sibling of the sort button — never nested inside it — because
- * the tooltip renders its own `<button>` and nesting interactive controls is
- * invalid markup the a11y suite would flag.
- */
-function SortableInfoTh<K extends string>({
-  sortKey,
-  activeSortKey,
-  sortDir,
-  onSort,
-  info,
-  infoLabel,
-  infoAlign,
-  children,
-}: {
-  sortKey: K;
-  activeSortKey: K;
-  sortDir: SortDir;
-  onSort: (key: K) => void;
-  info: ReactNode;
-  infoLabel: string;
-  infoAlign: "left" | "right";
-  children: ReactNode;
-}) {
-  const isActive = sortKey === activeSortKey;
-  return (
-    <th
-      scope="col"
-      aria-sort={
-        isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
-      }
-      className="whitespace-nowrap px-2 py-2 text-right text-xs font-medium text-slate-400 sm:px-4 sm:py-3 sm:text-sm"
-    >
-      <span className="inline-flex items-center justify-end gap-1">
-        <button
-          type="button"
-          onClick={() => onSort(sortKey)}
-          className="flex cursor-pointer select-none items-center gap-1 border-0 bg-transparent p-0 text-xs font-medium text-slate-400 hover:text-slate-200 sm:text-sm"
-        >
-          {children}
-          {isActive ? (
-            <span className="text-indigo-400">
-              {sortDir === "asc" ? "↑" : "↓"}
-            </span>
-          ) : (
-            <span
-              className="text-[1.1em] leading-none text-slate-600"
-              style={{ fontVariantEmoji: "text" }}
-            >
-              ↕
-            </span>
-          )}
-        </button>
-        <Tooltip label={infoLabel} content={info} align={infoAlign}>
-          <span className="text-slate-500" aria-hidden="true">
-            ⓘ
-          </span>
-        </Tooltip>
-      </span>
-    </th>
   );
 }

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/trove-table-headers.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/trove-table-headers.tsx
@@ -1,0 +1,228 @@
+import type { ReactNode } from "react";
+import { SortableTh } from "@/components/sortable-th";
+import { Row, Th } from "@/components/table";
+import { Tooltip } from "@/components/tooltip";
+import type { SortDir } from "@/lib/table-sort";
+import type { HistorySortKey, OpenSortKey, TroveSortKey } from "./trove-sort";
+
+const ICR_INDEXED_EXPLAINER = (
+  <>
+    Individual Collateral Ratio (
+    <code className="rounded bg-slate-900 px-1 font-mono text-[11px] text-slate-100">
+      coll. / debt
+    </code>
+    ) snapshot from the latest indexed trove event, not a live oracle/RPC read.
+  </>
+);
+const RANK_EXPLAINER =
+  "Redemption priority. Troves are redeemed against in ascending interest-rate order — rank #1 is the lowest-rate trove and is redeemed first. Troves sharing a rate share a rank (shown as a tie).";
+
+export function OpenTroveHeader({
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  sortKey: OpenSortKey;
+  sortDir: SortDir;
+  onSort: (key: TroveSortKey) => void;
+}) {
+  return (
+    <Row>
+      <SortableInfoTh
+        sortKey="rank"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        info={RANK_EXPLAINER}
+        infoLabel="About redemption rank"
+        infoAlign="left"
+      >
+        Rank
+      </SortableInfoTh>
+      <Th>Owner / Trove</Th>
+      <Th>Status</Th>
+      <SortableTh
+        sortKey="debt"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Debt
+      </SortableTh>
+      <SortableTh
+        sortKey="collateral"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Collateral
+      </SortableTh>
+      <SortableInfoTh
+        sortKey="icr"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        info={ICR_INDEXED_EXPLAINER}
+        infoLabel="About indexed ICR"
+        infoAlign="right"
+      >
+        ICR (indexed)
+      </SortableInfoTh>
+      <SortableTh
+        sortKey="interest"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Interest
+      </SortableTh>
+      <SortableTh
+        sortKey="updated"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Updated
+      </SortableTh>
+    </Row>
+  );
+}
+
+export function HistoryTroveHeader({
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  sortKey: HistorySortKey;
+  sortDir: SortDir;
+  onSort: (key: TroveSortKey) => void;
+}) {
+  return (
+    <Row>
+      <Th>Last owner / Trove</Th>
+      <Th>Status</Th>
+      <SortableTh
+        sortKey="opened"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Opened
+      </SortableTh>
+      <SortableTh
+        sortKey="ended"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Ended / Updated
+      </SortableTh>
+      <SortableTh
+        sortKey="remainingColl"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Remaining collateral
+      </SortableTh>
+      <SortableTh
+        sortKey="redeemed"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Redeemed
+      </SortableTh>
+      <SortableTh
+        sortKey="redemptionFee"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Redemption fee
+      </SortableTh>
+      <SortableTh
+        sortKey="liquidated"
+        activeSortKey={sortKey}
+        sortDir={sortDir}
+        onSort={onSort}
+        align="right"
+      >
+        Liquidated
+      </SortableTh>
+    </Row>
+  );
+}
+
+/**
+ * Right-aligned sortable header with an adjacent info tooltip. The tooltip
+ * trigger is a sibling of the sort button — never nested inside it — because
+ * the tooltip renders its own `<button>` and nesting interactive controls is
+ * invalid markup the a11y suite would flag.
+ */
+function SortableInfoTh<K extends string>({
+  sortKey,
+  activeSortKey,
+  sortDir,
+  onSort,
+  info,
+  infoLabel,
+  infoAlign,
+  children,
+}: {
+  sortKey: K;
+  activeSortKey: K;
+  sortDir: SortDir;
+  onSort: (key: K) => void;
+  info: ReactNode;
+  infoLabel: string;
+  infoAlign: "left" | "right";
+  children: ReactNode;
+}) {
+  const isActive = sortKey === activeSortKey;
+  return (
+    <th
+      scope="col"
+      aria-sort={
+        isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+      }
+      className="whitespace-nowrap px-2 py-2 text-right text-xs font-medium text-slate-400 sm:px-4 sm:py-3 sm:text-sm"
+    >
+      <span className="inline-flex items-center justify-end gap-1">
+        <button
+          type="button"
+          onClick={() => onSort(sortKey)}
+          className="flex cursor-pointer select-none items-center gap-1 border-0 bg-transparent p-0 text-xs font-medium text-slate-400 hover:text-slate-200 sm:text-sm"
+        >
+          {children}
+          {isActive ? (
+            <span className="text-indigo-400">
+              {sortDir === "asc" ? "↑" : "↓"}
+            </span>
+          ) : (
+            <span
+              className="text-[1.1em] leading-none text-slate-600"
+              style={{ fontVariantEmoji: "text" }}
+            >
+              ↕
+            </span>
+          )}
+        </button>
+        <Tooltip label={infoLabel} content={info} align={infoAlign}>
+          <span className="text-slate-500" aria-hidden="true">
+            ⓘ
+          </span>
+        </Tooltip>
+      </span>
+    </th>
+  );
+}

--- a/ui-dashboard/src/components/sortable-th.tsx
+++ b/ui-dashboard/src/components/sortable-th.tsx
@@ -8,6 +8,12 @@ interface SortableThProps<K extends string> {
   onSort: (key: K) => void;
   align?: "left" | "right" | undefined;
   className?: string | undefined;
+  /**
+   * Optional element rendered as a *sibling* of the sort button (e.g. an info
+   * tooltip). Kept outside the button so its own interactive trigger isn't
+   * nested inside the button — invalid markup the a11y suite flags.
+   */
+  trailing?: ReactNode | undefined;
   children: ReactNode;
 }
 
@@ -18,11 +24,32 @@ export function SortableTh<K extends string>({
   onSort,
   align = "left",
   className = "",
+  trailing,
   children,
 }: SortableThProps<K>) {
   const isActive = sortKey === activeSortKey;
   const alignClass = align === "right" ? "text-right" : "text-left";
-  const buttonAlign = align === "right" ? "justify-end ml-auto" : "";
+  const buttonAlign =
+    align === "right" && !trailing ? "justify-end ml-auto" : "";
+  const sortButton = (
+    <button
+      type="button"
+      className={`flex items-center gap-1 cursor-pointer select-none bg-transparent border-0 p-0 font-medium text-xs sm:text-sm text-slate-400 hover:text-slate-200 ${buttonAlign}`}
+      onClick={() => onSort(sortKey)}
+    >
+      {children}
+      {isActive ? (
+        <span className="text-indigo-400">{sortDir === "asc" ? "↑" : "↓"}</span>
+      ) : (
+        <span
+          className="text-slate-600 text-[1.1em] leading-none"
+          style={{ fontVariantEmoji: "text" }}
+        >
+          ↕
+        </span>
+      )}
+    </button>
+  );
   return (
     <th
       scope="col"
@@ -31,25 +58,18 @@ export function SortableTh<K extends string>({
       }
       className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 ${alignClass} whitespace-nowrap ${className}`}
     >
-      <button
-        type="button"
-        className={`flex items-center gap-1 cursor-pointer select-none bg-transparent border-0 p-0 font-medium text-xs sm:text-sm text-slate-400 hover:text-slate-200 ${buttonAlign}`}
-        onClick={() => onSort(sortKey)}
-      >
-        {children}
-        {isActive ? (
-          <span className="text-indigo-400">
-            {sortDir === "asc" ? "↑" : "↓"}
-          </span>
-        ) : (
-          <span
-            className="text-slate-600 text-[1.1em] leading-none"
-            style={{ fontVariantEmoji: "text" }}
-          >
-            ↕
-          </span>
-        )}
-      </button>
+      {trailing ? (
+        <span
+          className={`inline-flex items-center gap-1 ${
+            align === "right" ? "justify-end" : ""
+          }`}
+        >
+          {sortButton}
+          {trailing}
+        </span>
+      ) : (
+        sortButton
+      )}
     </th>
   );
 }

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -3,12 +3,28 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 export function Table({
   children,
   "aria-label": ariaLabel,
+  scrollClassName,
 }: {
   children: ReactNode;
   "aria-label"?: string;
+  /**
+   * Extra classes for the scroll wrapper. Use to opt a specific table into
+   * `overflow-x` overrides — e.g. `xl:overflow-x-clip` to suppress the phantom
+   * horizontal scrollbar that hover-tooltip popovers add at widths where the
+   * table already fits, while keeping `overflow-x-auto` scrolling on narrow
+   * viewports where the table genuinely overflows.
+   */
+  scrollClassName?: string;
 }) {
   return (
-    <div className="overflow-x-auto rounded-lg border border-slate-800">
+    <div
+      className={[
+        "overflow-x-auto rounded-lg border border-slate-800",
+        scrollClassName,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
       <table className="w-full text-sm" aria-label={ariaLabel}>
         {children}
       </table>

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -13,6 +13,11 @@ export function Table({
    * horizontal scrollbar that hover-tooltip popovers add at widths where the
    * table already fits, while keeping `overflow-x-auto` scrolling on narrow
    * viewports where the table genuinely overflows.
+   *
+   * Note: this is appended, not merged (no `tailwind-merge` here). It reliably
+   * overrides the base `overflow-x-auto` only via a responsive prefix
+   * (`xl:overflow-x-clip` wins at its breakpoint by media-query order). A
+   * non-responsive `overflow-x-*` here would leave the winner to cascade order.
    */
   scrollClassName?: string;
 }) {


### PR DESCRIPTION
## The Problem

Follow-up to #810. Reviewing the live CDP trove table surfaced three issues:

- **Horizontal scroll on desktop.** The trove-ID line rendered the full 66-char uint256 id, forcing the first column to ~430px and pushing the table past the viewport — owner names were clipped and the table scrolled sideways.
- **No sorting.** Open troves were locked in redemption-rank order; there was no way to sort by debt, collateral, ICR, interest, or last-updated.
- **Opaque "Rank" column.** Nothing explained what the rank means.

## The Solution

- Middle-ellipsize the trove-ID display (`0x5f23…3ac4`); the full id stays in the link `href`, `title`, and `aria-label`.
- Make **both** trove tabs sortable via the shared `SortableTh` + `useTableSort` (URL-persisted through `history.replaceState`). Open keeps its default of **rank / lowest-interest-first**; History defaults to **most-recently-ended first**. Unavailable values (null interest rate, ICR `-1` sentinel, never-liquidated) always sort last in both directions.
- Add a **Rank tooltip**: "Redemption priority. Troves are redeemed against in ascending interest-rate order — rank #1 is the lowest-rate trove and is redeemed first. Troves sharing a rate share a rank."

## Details

- Extracted the sort comparators + `TroveDisplayRow` type into `trove-sort.ts`, and the table headers into `trove-table-headers.tsx`, to keep `cdp-trove-table.tsx` under the `max-lines` cap.
- Added an opt-in `scrollClassName` to the shared `Table`; the troves table passes `xl:overflow-x-clip` so the hover-tooltip popovers can no longer add a phantom horizontal scrollbar at widths where the table already fits, while narrow viewports keep `overflow-x-auto` scrolling. Default behavior for all other tables is unchanged.

## Validation

- `pnpm agent:quality-gate --run`: trunk, lint, typecheck, coverage tests (3008), knip, react-doctor diff + score (100), size-limit all green. The one failing mapped command — the `pool tab overflow on mobile` browser test — fails **identically on the base commit** (pre-existing sandbox-only rendering difference; green in CI).
- New `trove-sort` unit tests; updated `cdp-detail-client` assertions for the truncated id + sortable headers.
- Browser-verified on `/cdps/gbpm`: no desktop horizontal scroll (≥1280), narrow-viewport scroll preserved, sort + URL state works, tooltips render un-clipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UI and client-side sorting over already-fetched trove rows; no auth or backend changes.
> 
> **Overview**
> Adds **sortable columns** to the CDP trove table on both **Open** and **History** tabs via `SortableTh` and `useTableSort`, with sort state in the URL (`troves*` / `trovesHist*`) and page reset on sort. Sort logic lives in new `trove-sort.ts`; headers move to `trove-table-headers.tsx` with a **redemption rank** tooltip. **Trove IDs** are middle-ellipsized in the UI while full ids remain in `href`, `title`, and `aria-label`.
> 
> `SortableTh` gains an optional **`trailing`** slot so info tooltips sit beside (not inside) the sort button. The shared **`Table`** accepts **`scrollClassName`**; the troves table uses `xl:overflow-x-clip` to avoid phantom horizontal scroll when tooltips render. The fetch-cap disclaimer now notes that search/sort apply only to loaded rows.
> 
> New **`trove-sort`** unit tests and expanded **`cdp-detail-client`** coverage for truncation, headers, and sort/URL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3db1d33aaafbaf97f0176cba807c8ebe2b623a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->