### PR TITLE
ci: cache Playwright Chromium in CI ui-dashboard job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,31 @@ jobs:
           fi
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/ui-dashboard test:coverage
+      - name: Cache Playwright Chromium
+        # `playwright install chromium` re-downloads ~130 MB on every run
+        # otherwise (~84s of uncached CI time). The cache key hashes BOTH
+        # `ui-dashboard/package.json` (the version range, e.g. `^1.60.0`)
+        # AND `pnpm-lock.yaml` (the resolved version pnpm actually picks).
+        # Keying on package.json alone misses lockfile-only
+        # `@playwright/test` updates within the caret range — in that case
+        # the key would stay constant while the Chromium revision Playwright
+        # wants flips, so every run restores the stale cache, the install
+        # step re-downloads, but actions/cache won't re-save under the
+        # already-hit key, so the next run re-downloads again indefinitely.
+        # Hashing the lockfile makes the key flip on any real Playwright
+        # version bump. Mirrors the proven step in lighthouse.yml.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('ui-dashboard/package.json', 'pnpm-lock.yaml') }}
+          # `restore-keys` lets an unrelated lockfile or `package.json`
+          # edit still reuse the most recent chromium cache instead of
+          # triggering a ~130 MB fresh download. `playwright install` then
+          # fast-validates the existing binary against the version it wants
+          # (no-op on match, re-download only on a real Playwright version
+          # bump). `--with-deps` still installs OS libraries (fast).
+          restore-keys: |
+            playwright-chromium-
       - name: Install Playwright Chromium
         run: pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium
       - name: Browser interaction tests


### PR DESCRIPTION
## The Problem

The `Quality Checks (ui-dashboard)` job in `.github/workflows/ci.yml` runs `playwright install --with-deps chromium`, which re-downloads ~130 MB of the Chromium browser binary on **every** dashboard PR run — about 84 seconds of uncached CI time on Blacksmith runners (billed per minute). The browser binary only actually changes on a real Playwright version bump, so this is wasted download time on the vast majority of runs.

## The Solution

Add a `Cache Playwright Chromium` step immediately before the existing `Install Playwright Chromium` step, caching `~/.cache/ms-playwright`. This copies the proven, already-shipped pattern from `.github/workflows/lighthouse.yml` — same `actions/cache` SHA, path, key, and restore-keys. The `playwright install --with-deps chromium` line is unchanged: on a cache hit it fast-validates the existing binary (no-op) and `--with-deps` still installs OS libraries (fast); the ~130 MB download only happens on a real version bump.

## Details

- Cache key hashes **both** `ui-dashboard/package.json` (the caret version range) **and** `pnpm-lock.yaml` (the resolved version pnpm picks). Keying on `package.json` alone misses lockfile-only `@playwright/test` updates within the caret range, which would otherwise pin a stale cache and re-download indefinitely.
- `restore-keys: playwright-chromium-` lets unrelated lockfile/package edits reuse the most recent cache instead of forcing a fresh ~130 MB download.
- `actions/cache` pinned to `27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5), identical to lighthouse.yml.
- Scope: only the Playwright install area of the `ui-dashboard` job is touched. No `runs-on:` changes (handled by a separate runner-sizing PR), no other jobs or workflows modified.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses cleanly.
- `actionlint .github/workflows/ci.yml` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application code. Stale-cache risk is mitigated by lockfile-aware cache keys already used in lighthouse.yml.
> 
> **Overview**
> Adds a **Cache Playwright Chromium** step to the `Quality Checks (ui-dashboard)` job in `.github/workflows/ci.yml`, placed immediately before the existing `playwright install --with-deps chromium` step.
> 
> The step caches `~/.cache/ms-playwright` via `actions/cache` (same pin, path, key, and `restore-keys` as `lighthouse.yml`). The cache key hashes both `ui-dashboard/package.json` and `pnpm-lock.yaml` so lockfile-only `@playwright/test` bumps invalidate stale browser binaries; `restore-keys: playwright-chromium-` allows partial key matches on unrelated edits. **Install and browser test steps are unchanged**—on a cache hit, install should validate or skip the large download while still running `--with-deps` for OS libraries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3243291388342290dfd5aeea11c9dc7f4901c952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->