### PR TITLE
Link CDP Updated time directly to its transaction

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -652,7 +652,7 @@ describe("CdpDetailClient", () => {
     );
   });
 
-  it("links updated timestamps to their updating transaction", () => {
+  it("links updated timestamps directly to their updating transaction", () => {
     render(handle!);
 
     const link = handle!.container.querySelector<HTMLAnchorElement>(
@@ -663,16 +663,15 @@ describe("CdpDetailClient", () => {
     expect(link?.textContent).toBe("0s ago");
     expect(link?.target).toBe("_blank");
     expect(link?.rel).toBe("noopener noreferrer");
-    expect(link?.getAttribute("title")).toBeNull();
-
-    const tooltipId = link?.getAttribute("aria-describedby");
-    expect(tooltipId).toBeTruthy();
-    expect(
-      handle!.container.ownerDocument.getElementById(tooltipId!)?.textContent,
-    ).toContain("Opens transaction 0xupdated");
+    // No custom tooltip popover — the relative time opens the tx on click and
+    // the exact timestamp stays available via the native title.
+    expect(link?.getAttribute("aria-describedby")).toBeNull();
+    expect(link?.getAttribute("title")).toBe(
+      `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    );
   });
 
-  it("keeps exact updated timestamp tooltips when the update tx hash is unavailable", () => {
+  it("shows the exact updated timestamp as a native title when the tx hash is unavailable", () => {
     mockUseGQL.mockImplementation((query: string | null) => {
       if (query === CDP_MARKETS) {
         return { data: marketsData(), error: null, isLoading: false };
@@ -703,15 +702,19 @@ describe("CdpDetailClient", () => {
 
     render(handle!);
 
-    const trigger = handle!.container.querySelector<HTMLElement>(
-      'table[aria-label="GBPm troves"] tbody tr td:nth-child(8) [aria-describedby]',
+    const cell = handle!.container.querySelector<HTMLElement>(
+      'table[aria-label="GBPm troves"] tbody tr td:nth-child(8)',
     );
-    expect(trigger).not.toBeNull();
-    expect(trigger?.textContent).toBe("0s ago");
-    const tooltipId = trigger?.getAttribute("aria-describedby");
-    expect(
-      handle!.container.ownerDocument.getElementById(tooltipId!)?.textContent,
-    ).toBe(`Updated at ${new Date(NOW * 1000).toLocaleString()}.`);
+    expect(cell).not.toBeNull();
+    // No link (no tx hash) and no custom tooltip — just the relative time with
+    // the exact timestamp on the native title.
+    expect(cell?.querySelector("a")).toBeNull();
+    expect(cell?.querySelector("[aria-describedby]")).toBeNull();
+    const value = cell?.querySelector<HTMLElement>("span[title]");
+    expect(value?.textContent).toBe("0s ago");
+    expect(value?.getAttribute("title")).toBe(
+      `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    );
   });
 
   it("renders empty detail tables without replacing market-level KPIs", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -668,10 +668,10 @@ describe("CdpDetailClient", () => {
     expect(link?.getAttribute("title")).toBe(
       `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
-    // Exact timestamp + destination exposed to assistive tech via real sr-only
-    // text (native title is hover-only).
+    // Exact timestamp + destination (incl. the shortened tx hash so rows are
+    // distinguishable) exposed to assistive tech via real sr-only text.
     expect(link?.querySelector(".sr-only")?.textContent).toBe(
-      `, updated at ${new Date(NOW * 1000).toLocaleString()}, opens transaction`,
+      `, updated at ${new Date(NOW * 1000).toLocaleString()}, opens transaction 0xupdated`,
     );
   });
 

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -669,6 +669,10 @@ describe("CdpDetailClient", () => {
     expect(link?.getAttribute("title")).toBe(
       `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
+    // Exact timestamp is exposed to assistive tech (title is hover-only).
+    expect(link?.getAttribute("aria-label")).toBe(
+      `0s ago, updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    );
   });
 
   it("shows the exact updated timestamp as a native title when the tx hash is unavailable", () => {
@@ -714,6 +718,9 @@ describe("CdpDetailClient", () => {
     expect(value?.textContent).toBe("0s ago");
     expect(value?.getAttribute("title")).toBe(
       `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    );
+    expect(value?.getAttribute("aria-label")).toBe(
+      `0s ago, updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
   });
 

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/__tests__/cdp-detail-client.test.tsx
@@ -660,18 +660,18 @@ describe("CdpDetailClient", () => {
     );
     expect(link).not.toBeNull();
     expect(link?.href).toBe("https://celoscan.io/tx/0xupdated");
-    expect(link?.textContent).toBe("0s ago");
     expect(link?.target).toBe("_blank");
     expect(link?.rel).toBe("noopener noreferrer");
-    // No custom tooltip popover — the relative time opens the tx on click and
-    // the exact timestamp stays available via the native title.
+    // Visible text is the relative time; no custom tooltip popover.
+    expect(link?.firstChild?.textContent).toBe("0s ago");
     expect(link?.getAttribute("aria-describedby")).toBeNull();
     expect(link?.getAttribute("title")).toBe(
       `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
-    // Exact timestamp is exposed to assistive tech (title is hover-only).
-    expect(link?.getAttribute("aria-label")).toBe(
-      `0s ago, updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    // Exact timestamp + destination exposed to assistive tech via real sr-only
+    // text (native title is hover-only).
+    expect(link?.querySelector(".sr-only")?.textContent).toBe(
+      `, updated at ${new Date(NOW * 1000).toLocaleString()}, opens transaction`,
     );
   });
 
@@ -710,17 +710,17 @@ describe("CdpDetailClient", () => {
       'table[aria-label="GBPm troves"] tbody tr td:nth-child(8)',
     );
     expect(cell).not.toBeNull();
-    // No link (no tx hash) and no custom tooltip — just the relative time with
-    // the exact timestamp on the native title.
+    // No link (no tx hash) and no custom tooltip — the relative time with the
+    // exact timestamp on the native title plus real sr-only text for AT.
     expect(cell?.querySelector("a")).toBeNull();
     expect(cell?.querySelector("[aria-describedby]")).toBeNull();
     const value = cell?.querySelector<HTMLElement>("span[title]");
-    expect(value?.textContent).toBe("0s ago");
+    expect(value?.firstChild?.textContent).toBe("0s ago");
     expect(value?.getAttribute("title")).toBe(
       `Updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
-    expect(value?.getAttribute("aria-label")).toBe(
-      `0s ago, updated at ${new Date(NOW * 1000).toLocaleString()}`,
+    expect(value?.querySelector(".sr-only")?.textContent).toBe(
+      `, updated at ${new Date(NOW * 1000).toLocaleString()}`,
     );
   });
 

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -702,9 +702,9 @@ function UpdatedValue({
   const network = networkId ? NETWORKS[networkId] : null;
   // Deliberately a plain link, not a Tooltip (unlike EventTimeValue on the
   // History tab): the relative time is already clickable, so the popover was
-  // just noise. The exact timestamp is exposed to assistive tech via aria-label
-  // (the native title alone is hover-only) and to sighted users via the title.
-  const accessibleLabel = `${label}, updated at ${timestamp}`;
+  // just noise. The exact timestamp + destination are exposed to assistive tech
+  // via real sr-only text (a native title or aria-label on a non-interactive
+  // span isn't reliably announced) and to sighted users via the title.
   if (trove.lastUpdatedTxHash && network != null) {
     return (
       <a
@@ -712,10 +712,12 @@ function UpdatedValue({
         target="_blank"
         rel="noopener noreferrer"
         title={`Updated at ${timestamp}`}
-        aria-label={accessibleLabel}
         className="font-mono text-slate-300 transition-colors hover:text-indigo-300"
       >
         {label}
+        <span className="sr-only">
+          , updated at {timestamp}, opens transaction
+        </span>
       </a>
     );
   }
@@ -727,12 +729,9 @@ function UpdatedValue({
     ? `Updated at ${timestamp} · tx ${trove.lastUpdatedTxHash}`
     : `Updated at ${timestamp}`;
   return (
-    <span
-      className="text-slate-300"
-      title={fallbackTitle}
-      aria-label={accessibleLabel}
-    >
+    <span className="text-slate-300" title={fallbackTitle}>
       {label}
+      <span className="sr-only">, updated at {timestamp}</span>
     </span>
   );
 }

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -700,9 +700,9 @@ function UpdatedValue({
   const timestamp = formatTimestamp(trove.lastUpdatedAt);
   const networkId = networkIdForChainId(chainId);
   const network = networkId ? NETWORKS[networkId] : null;
-  // When the tx hash + explorer are known, the relative time links straight to
-  // the transaction (no popover). The exact timestamp stays available via the
-  // native title on hover.
+  // Deliberately a plain link, not a Tooltip (unlike EventTimeValue on the
+  // History tab): the relative time is already clickable, so the popover was
+  // just noise. The exact timestamp rides along on the native title instead.
   if (trove.lastUpdatedTxHash && network != null) {
     return (
       <a
@@ -717,8 +717,14 @@ function UpdatedValue({
     );
   }
 
+  // No linkable explorer for this chain: still disclose the tx hash in the
+  // title when one exists (mirrors EventTimeValue's no-explorer fallback) so it
+  // isn't silently dropped.
+  const fallbackTitle = trove.lastUpdatedTxHash
+    ? `Updated at ${timestamp} · tx ${trove.lastUpdatedTxHash}`
+    : `Updated at ${timestamp}`;
   return (
-    <span className="text-slate-300" title={`Updated at ${timestamp}`}>
+    <span className="text-slate-300" title={fallbackTitle}>
       {label}
     </span>
   );

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -702,7 +702,9 @@ function UpdatedValue({
   const network = networkId ? NETWORKS[networkId] : null;
   // Deliberately a plain link, not a Tooltip (unlike EventTimeValue on the
   // History tab): the relative time is already clickable, so the popover was
-  // just noise. The exact timestamp rides along on the native title instead.
+  // just noise. The exact timestamp is exposed to assistive tech via aria-label
+  // (the native title alone is hover-only) and to sighted users via the title.
+  const accessibleLabel = `${label}, updated at ${timestamp}`;
   if (trove.lastUpdatedTxHash && network != null) {
     return (
       <a
@@ -710,6 +712,7 @@ function UpdatedValue({
         target="_blank"
         rel="noopener noreferrer"
         title={`Updated at ${timestamp}`}
+        aria-label={accessibleLabel}
         className="font-mono text-slate-300 transition-colors hover:text-indigo-300"
       >
         {label}
@@ -724,7 +727,11 @@ function UpdatedValue({
     ? `Updated at ${timestamp} · tx ${trove.lastUpdatedTxHash}`
     : `Updated at ${timestamp}`;
   return (
-    <span className="text-slate-300" title={fallbackTitle}>
+    <span
+      className="text-slate-300"
+      title={fallbackTitle}
+      aria-label={accessibleLabel}
+    >
       {label}
     </span>
   );

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -698,42 +698,29 @@ function UpdatedValue({
 }) {
   const label = relativeTime(trove.lastUpdatedAt);
   const timestamp = formatTimestamp(trove.lastUpdatedAt);
-  if (!trove.lastUpdatedTxHash) {
-    return (
-      <Tooltip content={`Updated at ${timestamp}.`} align="right">
-        <span className="text-slate-300">{label}</span>
-      </Tooltip>
-    );
-  }
-
   const networkId = networkIdForChainId(chainId);
   const network = networkId ? NETWORKS[networkId] : null;
-  if (network == null) {
+  // When the tx hash + explorer are known, the relative time links straight to
+  // the transaction (no popover). The exact timestamp stays available via the
+  // native title on hover.
+  if (trove.lastUpdatedTxHash && network != null) {
     return (
-      <Tooltip
-        content={`Updated at ${timestamp}. Transaction: ${trove.lastUpdatedTxHash}.`}
-        align="right"
-      >
-        <span className="text-slate-300">{label}</span>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip
-      content={`Updated at ${timestamp}. Opens transaction ${trove.lastUpdatedTxHash}.`}
-      align="right"
-      asChild
-    >
       <a
         href={explorerTxUrl(network, trove.lastUpdatedTxHash)}
         target="_blank"
         rel="noopener noreferrer"
+        title={`Updated at ${timestamp}`}
         className="font-mono text-slate-300 transition-colors hover:text-indigo-300"
       >
         {label}
       </a>
-    </Tooltip>
+    );
+  }
+
+  return (
+    <span className="text-slate-300" title={`Updated at ${timestamp}`}>
+      {label}
+    </span>
   );
 }
 

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -537,21 +537,20 @@ function OwnerTroveCell({
         aria-label={`Manage trove ${trove.troveId} in the Mento app`}
         className="font-mono text-[10px] text-slate-500 hover:text-slate-300 hover:underline focus:outline-none focus:ring-1 focus:ring-indigo-500"
       >
-        {shortenTroveId(trove.troveId)}
+        {shortenHex(trove.troveId)}
       </a>
     </div>
   );
 }
 
 /**
- * Trove IDs are uint256 token ids (often a 66-char `0x…` hash). Rendering them
- * in full blew the first column out past the viewport (horizontal scroll);
- * middle-ellipsize for display while keeping the full id in the link + title.
+ * Middle-ellipsize a long hex string (trove uint256 id, tx hash) for display.
+ * Trove IDs rendered in full blew the first column past the viewport; tx hashes
+ * read in full are noise in screen-reader link names. Short, distinguishable
+ * form; the full value stays in the link href / title.
  */
-function shortenTroveId(troveId: string): string {
-  return troveId.length <= 13
-    ? troveId
-    : `${troveId.slice(0, 6)}…${troveId.slice(-4)}`;
+function shortenHex(value: string): string {
+  return value.length <= 13 ? value : `${value.slice(0, 6)}…${value.slice(-4)}`;
 }
 
 function RankValue({ row }: { row: TroveDisplayRow }) {
@@ -716,7 +715,8 @@ function UpdatedValue({
       >
         {label}
         <span className="sr-only">
-          , updated at {timestamp}, opens transaction
+          , updated at {timestamp}, opens transaction{" "}
+          {shortenHex(trove.lastUpdatedTxHash)}
         </span>
       </a>
     );

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-trove-table.tsx
@@ -731,7 +731,12 @@ function UpdatedValue({
   return (
     <span className="text-slate-300" title={fallbackTitle}>
       {label}
-      <span className="sr-only">, updated at {timestamp}</span>
+      <span className="sr-only">
+        , updated at {timestamp}
+        {trove.lastUpdatedTxHash
+          ? `, tx ${shortenHex(trove.lastUpdatedTxHash)}`
+          : ""}
+      </span>
     </span>
   );
 }

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -217,8 +217,13 @@ test.describe("dashboard browser flows", () => {
       "href",
       "https://celoscan.io/tx/0x2222222222222222222222222222222222222222222222222222222222222222",
     );
-    await expect(firstUpdatedLink).toHaveAttribute("aria-describedby", /.+/);
-    await expect(firstUpdatedLink).not.toHaveAttribute("title", /.+/);
+    // The Updated time links straight to the tx — no custom tooltip popover;
+    // the exact timestamp lives on the native title.
+    await expect(firstUpdatedLink).not.toHaveAttribute(
+      "aria-describedby",
+      /.+/,
+    );
+    await expect(firstUpdatedLink).toHaveAttribute("title", /^Updated at /);
 
     await page.getByRole("tab", { name: "History" }).click();
     await expect(table).toContainText("redeemed");


### PR DESCRIPTION
## The Problem

On the CDP detail open-troves table, the "Updated" column showed the relative time wrapped in a hover popover ("Updated at … Opens transaction 0x…"). The transaction was only reachable by reading the tooltip, and the popover was visual noise on a value that's really just a link.

## The Solution

Make the relative time link straight to the updating transaction — clicking opens the explorer in a new tab. The exact timestamp stays available via the lightweight native `title` on hover; the custom tooltip popover is removed from this cell entirely. When no tx hash is available the relative time renders as plain text with the same native title (no link).

## Details

- `UpdatedValue` (open tab) no longer wraps its content in `Tooltip`; it returns a direct `<a>` (tx hash + known explorer) or a plain `<span>` otherwise, both carrying `title="Updated at <timestamp>"`.
- Scope: only the open-tab "Updated" column. The History tab's Opened / Ended-Updated cells still use the shared `EventTimeValue` tooltip — left as-is for now.

## Validation

- Updated the two jsdom tests (`cdp-detail-client.test.tsx`) and the CDP browser test (`dashboard-flows.test.ts`) to assert the direct link + native title and the absence of the custom tooltip.
- `tsc`, eslint baseline, `test:browser` (full suite), and the CDP vitest suite (109) all green.
- Browser-verified locally on `/cdps/gbpm`: the "Updated" time is a direct `celoscan.io/tx/…` link, `title` carries the exact timestamp, and no popover renders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the open-troves Updated column and tests; no API, auth, or data-layer impact.
> 
> **Overview**
> On the CDP open-troves table, the **Updated** column no longer uses a custom `Tooltip` around the relative time. When an updating tx hash and explorer are available, the relative time is a **direct explorer link**; the exact time is on the native `title`, and **sr-only** text announces the timestamp and a shortened tx hash for assistive tech.
> 
> When there is no link (missing hash or unknown explorer), the cell is plain text with the same `title` / sr-only pattern, including the full tx in the title when a hash exists but the chain has no explorer.
> 
> `shortenTroveId` is generalized to **`shortenHex`** for trove IDs and tx hashes in display/sr-only copy. **History** tab `EventTimeValue` tooltips are unchanged. Unit and browser tests were updated for the new link, title, and absence of tooltip popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53680e714207f443577634ce68ff0b2b6b80af71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->