### PR TITLE
ci: right-size light CI jobs to 2-vCPU Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions: read-all
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 2
     permissions:
       contents: read
@@ -195,7 +195,7 @@ jobs:
     name: Quality Checks (shared-config)
     needs: changes
     if: needs.changes.outputs.shared == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
       checks: write
@@ -407,7 +407,7 @@ jobs:
     name: Quality Checks (metrics-bridge)
     needs: changes
     if: needs.changes.outputs.bridge == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       checks: write
@@ -449,7 +449,7 @@ jobs:
     name: Quality Checks (integration-probes)
     needs: changes
     if: needs.changes.outputs.integrationProbes == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       checks: write
@@ -490,7 +490,7 @@ jobs:
     name: Quality Checks (alerts Cloud Functions)
     needs: changes
     if: needs.changes.outputs.alerts == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       checks: write
@@ -579,7 +579,7 @@ jobs:
     name: Terraform Validate (registry)
     needs: changes
     if: needs.changes.outputs.terraform == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       contents: read
@@ -625,7 +625,7 @@ jobs:
     name: Quality Checks (aegis)
     needs: changes
     if: needs.changes.outputs.aegis == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       checks: write
@@ -681,7 +681,7 @@ jobs:
     name: Lint + test root scripts
     needs: changes
     if: needs.changes.outputs.rootScripts == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
       checks: write
@@ -718,7 +718,7 @@ jobs:
     # (dep-cruiser config + knip configs) so a PR that only edits the
     # rule file is validated against the codebase before merge.
     if: needs.changes.outputs.shared == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.indexer == 'true' || needs.changes.outputs.bridge == 'true' || needs.changes.outputs.integrationProbes == 'true' || needs.changes.outputs.aegis == 'true' || needs.changes.outputs.codeHealth == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
       checks: write

--- a/.github/workflows/code-health-duplication.yml
+++ b/.github/workflows/code-health-duplication.yml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
   duplication:
     name: jscpd
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     # Strictly advisory — never fails the PR. Surfaces duplication signal
     # via an uploaded artifact and (optionally) a PR summary comment.

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -37,7 +37,7 @@ permissions: read-all
 jobs:
   discover:
     name: Discover Terraform stacks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
       contents: read
@@ -99,7 +99,7 @@ jobs:
     name: Terraform Validate (${{ matrix.id }})
     needs: discover
     if: needs.discover.outputs.has-stacks == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -63,7 +63,7 @@ jobs:
                 github.event.workflow_run.conclusion) &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.event == 'push')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - name: Post to #ci-failures

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -30,7 +30,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Validate PR description
         # Body is passed via env (never interpolated into the script) to avoid

--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -38,7 +38,7 @@ jobs:
     #
     # Advisory only — exit code is always 0.
     name: GraphQL schema diff
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     # `pull-requests: write` is required to post the sticky PR comment.
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -67,7 +67,7 @@ permissions: read-all
 jobs:
   audit:
     name: npm advisory audit
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,7 +97,7 @@ jobs:
 
   lockfile-lint:
     name: lockfile integrity + registry check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   discover:
     name: Discover auto-applied stacks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.trunk/configs/actionlint.yaml
+++ b/.trunk/configs/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-2vcpu-ubuntu-2404


### PR DESCRIPTION
## The Problem

Every CI job runs on `blacksmith-4vcpu-ubuntu-2404`. Blacksmith bills per vCPU, so a 4-vCPU runner costs **$0.008/min** while a 2-vCPU runner (`blacksmith-2vcpu-ubuntu-2404`) costs **$0.004/min — half the price**. Most of our jobs are short and startup-dominated (checkout + `pnpm install` + a quick lint/validate/diff) and use nowhere near 4 cores. Paying for 4 vCPU on those jobs is wasted spend; the extra cores sit idle.

## The Solution

Move only the **light, startup-dominated, non-CPU-bound** jobs to `blacksmith-2vcpu-ubuntu-2404`, halving their cost with negligible wall-clock impact. Keep every CPU-bound job (heavy test suites, Next.js builds, browser/Playwright/Lighthouse, mutation testing, Terraform plan/apply) on 4-vCPU — halving their cores would roughly double their wall-clock and eat the saving.

The decision was **data-driven**: every `runs-on: blacksmith` job was measured from recent GitHub Actions run durations before classifying it. When genuinely unsure, the job stayed on 4-vCPU (conservative — never risk slowing a job to save half a cent). No ARM migration; only the vCPU count `4vcpu` → `2vcpu` changed. Only `runs-on:` label values were edited — no steps, triggers, or other logic touched.

## Details

Changes are limited to `runs-on:` label values plus a one-line addition to each actionlint config. **The two actionlint files (`.github/actionlint.yaml`, `.trunk/configs/actionlint.yaml`) gain the new `blacksmith-2vcpu-ubuntu-2404` entry in their `self-hosted-runner` allow-list — required for the lint gate to pass, since the allow-list is explicit and would otherwise reject the new label.** This is intentional, not scope creep.

### Moved to 2-vCPU (18 jobs)

| Workflow | Job | Median | Why light |
|---|---|---|---|
| ci.yml | Detect changes | 9s | path-filter only; runs every PR + push |
| ci.yml | Quality Checks (shared-config) | 29s | lint/typecheck of a tiny package |
| ci.yml | Quality Checks (metrics-bridge) | 33s | lint/test, startup-dominated |
| ci.yml | Quality Checks (integration-probes) | 33s | lint/test, startup-dominated |
| ci.yml | Quality Checks (alerts Cloud Functions) | 45s | lint/test (borderline: 191s max) |
| ci.yml | Quality Checks (aegis) | 60s | lint/test (borderline upper edge) |
| ci.yml | Terraform Validate (registry) | 32s | `terraform validate` only, no plan |
| ci.yml | Lint + test root scripts | 38s | small script test suite |
| ci.yml | Code Health (cross-package) | 28s | static checks |
| code-health-duplication.yml | jscpd | 29s | duplication scan, IO-bound |
| schema-diff.yml | GraphQL schema diff | 9s | diff only, advisory |
| pr-description.yml | PR description format | 4s | regex check on PR body |
| supply-chain.yml | npm advisory audit | 13s | `npm audit` over lockfile |
| supply-chain.yml | lockfile integrity + registry check | 8s | lockfile lint |
| infra.yml | Discover Terraform stacks | 9s | enumerates stacks |
| infra.yml | Terraform Validate (matrix) | 19s | `terraform validate` only, no plan |
| terraform-drift.yml | Discover auto-applied stacks | 5s | enumerates stacks |
| notify-slack-on-main-failure.yml | notify | trivial | single Slack curl |

### Kept on 4-vCPU (CPU-bound or required, not changed)

| Workflow | Job | Median | Why kept |
|---|---|---|---|
| ci.yml | Quality Checks (ui-dashboard) | 155s | Playwright install + browser tests + coverage |
| ci.yml | Quality Checks (indexer-envio) | 108s | heavy test suite (can spike to 600s+) |
| size-limit.yml | Dashboard bundle size | 49s | runs `pnpm dashboard:build` (Next.js build) |
| integration-probes.yml | Run aggregator integration probes | 95s | network-heavy, spikes to 430s |
| lighthouse.yml | Core Web Vitals + accessibility | 245s | headless-browser audit |
| metrics-bridge.yml | Build & Deploy | 178s | build + deploy |
| aegis-app-engine.yml | Deploy (aegis) | 151s | build + deploy |
| trunk.yml | Code Quality | 59s | required gating check; parallelizes linters |
| update-snapshots.yml | Regenerate visual snapshot baselines | n/a | Playwright (browser) |
| mutation-testing.yml | Dashboard/Indexer/Bridge baselines (×3) | n/a | Stryker mutation testing, CPU-bound |
| aegis-terraform.yml | Terraform Plan / Apply | 30s / — | Terraform plan/apply (keep per rule) |
| alerts-infra.yml | Terraform Plan / Apply | 41s / 157s | Terraform plan/apply |
| alerts-rules.yml | Terraform Plan / Apply | 33s / 29s | Terraform plan/apply |
| terraform-drift.yml | Drift Plan (matrix) | 23–46s | Terraform plan |

### Rough monthly saving

The dollars concentrate in the high-frequency per-PR jobs (Detect changes runs on every PR and push; the per-package Quality Checks fire on path matches). At the current merge cadence (~250–300 PRs/month) the moved jobs total on the order of a few thousand vCPU-minutes/month that now bill at half rate, for a **rough saving of ~$5–15/month**. Small in absolute terms, but free: zero expected wall-clock regression on any moved job.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on all 8 changed workflow files — all parse OK.
- `actionlint` on all changed workflows — clean for runner labels after extending both `actionlint.yaml` allow-lists. The only remaining output is two pre-existing `SC2016` *info* notes in `infra.yml` / `terraform-drift.yml` `run:` blocks, present on `main` before this change and unrelated to it.
- `git diff` confirms only `runs-on:` lines (+18/−18) plus the two one-line actionlint allow-list additions changed — no steps, triggers, or other logic touched.
- Repo pre-commit quality gate run (no `--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner label-only changes with no application or deploy logic; worst case is slightly slower or queued light jobs, not altered test/deploy behavior.
> 
> **Overview**
> Cuts Blacksmith CI spend by moving **light, startup-dominated jobs** from `blacksmith-4vcpu-ubuntu-2404` to **`blacksmith-2vcpu-ubuntu-2404`** (half the per-minute vCPU cost). Only **`runs-on:`** labels change—no steps, triggers, or job logic.
> 
> **`ci.yml`** retargets nine jobs: change detection, several package quality gates (shared-config, metrics-bridge, integration-probes, alerts, aegis), registry Terraform validate, root scripts lint/test, and cross-package code health. **`ui`** and **`indexer`** stay on 4-vCPU.
> 
> Other workflows get the same treatment for cheap jobs: **jscpd**, **schema diff**, **PR description** check, **supply-chain** audit and lockfile-lint, **infra** discover/validate, **terraform-drift** discover only, and **Slack main-failure** notify. **Terraform plan/apply**, builds, Playwright, Lighthouse, and **drift-check** matrix plans remain on 4-vCPU.
> 
> **`.github/actionlint.yaml`** and **`.trunk/configs/actionlint.yaml`** add the new runner label to the self-hosted allow-list so actionlint accepts it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d925819f59cc5ee469c13d162229e125381425af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->