### PR TITLE
chore: track babysit pr:ready-state gate as repo hook + fix pnpm-banner parse bug

### DIFF
--- a/.claude/babysit-pr.sh
+++ b/.claude/babysit-pr.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Repo babysit gate for mento-protocol/monitoring-monorepo.
+#
+# The babysit-pr skill auto-discovers this file at `$REPO_ROOT/.claude/babysit-pr.sh`
+# (see babysit-prs.sh hook resolution) and sources it for BOTH local and cloud
+# runs. It augments the generic ALL_CLEAR gate with the repo's own readiness
+# probe (`pnpm pr:ready-state`) so babysit won't declare a PR clear until the
+# repo's required CI + review gates are satisfied. Defining `babysit_repo_gate`
+# here makes this the single source of truth; any copy vendored into a local
+# skill `hooks/` dir is sourced first and harmlessly overridden by this one.
+#
+# Contract (from the babysit-pr skill):
+#   babysit_repo_init <owner> <repo> <repo_root>
+#   babysit_repo_gate <pr> <owner> <repo> <repo_root>  -> prints "PASS|PENDING|FAIL [msg]"
+
+babysit_repo_init() {
+  if [[ "${BABYSIT_REQUIRE_CODEX_EXPLICIT:-false}" != "true" ]]; then
+    # Read by the babysit-prs.sh harness after it sources this hook; shellcheck
+    # can't see across the source boundary, hence the disable.
+    # shellcheck disable=SC2034
+    BABYSIT_REQUIRE_CODEX=1
+  fi
+}
+
+babysit_repo_gate() {
+  local pr=$1
+  local repo_root=$4
+
+  if [[ ! -f "$repo_root/package.json" ]]; then
+    printf 'PASS monitoring checkout not available'
+    return 0
+  fi
+
+  if ! node -e 'const scripts=require("./package.json").scripts||{}; process.exit(scripts["pr:ready-state"] ? 0 : 1)' >/dev/null 2>&1; then
+    printf 'PASS pr:ready-state script unavailable in this checkout'
+    return 0
+  fi
+
+  # `pnpm <script>` prints a "> pkg@ <script> <path>" banner to STDOUT before
+  # the script's own output. Piping that into jq makes it choke on the
+  # non-JSON preamble ("Invalid numeric literal"), and the `|| ready="false"`
+  # fallbacks below then silently report PENDING forever even when the PR is
+  # green + approved. `--silent` suppresses the banner so `--json` is clean,
+  # parseable output; capturing stderr to /dev/null keeps any script warning
+  # from corrupting the JSON too.
+  local output
+  output=$(pnpm --silent pr:ready-state --pr "$pr" --json 2>/dev/null) || {
+    printf 'FAIL pr:ready-state errored (repro: pnpm pr:ready-state --pr %s --json)' "$pr"
+    return 0
+  }
+
+  local ready summary
+  ready=$(printf '%s' "$output" | jq -r '
+    .ready // .summary.ready // .allClear // .all_clear // (.status == "ALL_CLEAR") // false
+  ' 2>/dev/null) || ready="false"
+  # `.summary` is the script's human one-liner (string), e.g.
+  # "2 required blocker(s) remain." — surface it so a PENDING gate says WHY
+  # instead of the opaque "pr:ready-state not ready".
+  summary=$(printf '%s' "$output" | jq -r '
+    .summary // .summaryText // .message // .status // empty
+  ' 2>/dev/null) || summary=""
+
+  if [[ "$ready" == "true" ]]; then
+    if [[ -n "$summary" ]]; then
+      printf 'PASS %s' "$summary"
+    else
+      printf 'PASS pr:ready-state ready'
+    fi
+  else
+    if [[ -n "$summary" ]]; then
+      printf 'PENDING %s' "$summary"
+    else
+      printf 'PENDING pr:ready-state not ready'
+    fi
+  fi
+}

--- a/.claude/babysit-pr.sh
+++ b/.claude/babysit-pr.sh
@@ -31,7 +31,10 @@ babysit_repo_gate() {
     return 0
   fi
 
-  if ! node -e 'const scripts=require("./package.json").scripts||{}; process.exit(scripts["pr:ready-state"] ? 0 : 1)' >/dev/null 2>&1; then
+  # Resolve package.json / the pr:ready-state script from $repo_root, not the
+  # caller's CWD — the harness may invoke this gate from a subdirectory, and
+  # the file guard above already keys on the absolute "$repo_root/package.json".
+  if ! (cd "$repo_root" && node -e 'const scripts=require("./package.json").scripts||{}; process.exit(scripts["pr:ready-state"] ? 0 : 1)') >/dev/null 2>&1; then
     printf 'PASS pr:ready-state script unavailable in this checkout'
     return 0
   fi
@@ -44,20 +47,22 @@ babysit_repo_gate() {
   # parseable output; capturing stderr to /dev/null keeps any script warning
   # from corrupting the JSON too.
   local output
-  output=$(pnpm --silent pr:ready-state --pr "$pr" --json 2>/dev/null) || {
+  output=$(cd "$repo_root" && pnpm --silent pr:ready-state --pr "$pr" --json 2>/dev/null) || {
     printf 'FAIL pr:ready-state errored (repro: pnpm pr:ready-state --pr %s --json)' "$pr"
     return 0
   }
 
+  # Explicit boolean test — do NOT use `.ready // …` fallbacks: jq's `//`
+  # treats an explicit `false` as empty, so a genuine `ready:false` would fall
+  # through to the next term. `pr:ready-state` always emits a top-level
+  # boolean `.ready`, so test it directly.
   local ready summary
-  ready=$(printf '%s' "$output" | jq -r '
-    .ready // .summary.ready // .allClear // .all_clear // (.status == "ALL_CLEAR") // false
-  ' 2>/dev/null) || ready="false"
+  ready=$(printf '%s' "$output" | jq -r 'if .ready == true then "true" else "false" end' 2>/dev/null) || ready="false"
   # `.summary` is the script's human one-liner (string), e.g.
   # "2 required blocker(s) remain." — surface it so a PENDING gate says WHY
   # instead of the opaque "pr:ready-state not ready".
   summary=$(printf '%s' "$output" | jq -r '
-    .summary // .summaryText // .message // .status // empty
+    .summary // .summaryText // .message // empty
   ' 2>/dev/null) || summary=""
 
   if [[ "$ready" == "true" ]]; then


### PR DESCRIPTION
## The Problem

- The babysit-pr gate ran `pnpm pr:ready-state --json | jq`, but `pnpm run` prints a `> pkg@ <script>` banner to stdout before the JSON — so jq hit "Invalid numeric literal" and the gate fell back to reporting **PENDING forever**, even when the PR was green and approved (observed live on #815/#817: they were ready ~3 min after open but the gate never cleared).
- The gate also lived only as an untracked local skill file, so it was unversioned, unreviewable, and absent entirely in cloud/web runs (the repo shipped the babysit `SKILL.md` but no hook).

## The Solution

- Track the gate as `.claude/babysit-pr.sh`, which the babysit-pr skill auto-discovers for both local and cloud runs, and fix the parsing so it reads the real readiness verdict.

## Details

- **Discovery:** `babysit-prs.sh` resolves hooks from `$REPO_ROOT/.claude/babysit-pr.sh` (and `.github/babysit-pr.sh`), sourcing them after any skill-dir hook — so this file is the single source of truth and harmlessly overrides a local copy.
- **Parse fix:** `pnpm --silent pr:ready-state … 2>/dev/null` suppresses the lifecycle banner and keeps stderr out of the JSON, so `jq -r '.ready'` actually sees `true`.
- **Better messages:** the summary jq now reads `.summary` (the script's human one-liner, e.g. "2 required blocker(s) remain.") instead of the non-existent `.summary.message`, so a pending gate says *why* rather than the opaque "pr:ready-state not ready".
- `babysit_repo_init` keeps requiring Codex (unless explicitly overridden); the `SC2034` on the harness-read variable is suppressed with an explanatory directive.

## Validation

- `bash -n` clean; `shellcheck` clean; repo quality gate (`./tools/trunk check`) passes.
- Functional test — sourced the hook and ran `babysit_repo_gate 817 …`: returns `PASS Pull request is already merged.` (the old code returned `PENDING pr:ready-state not ready` on the same input, reproduced by `pnpm pr:ready-state --pr 817 --json | jq` → `jq: parse error: Invalid numeric literal at line 2`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev tooling only; no production runtime, auth, or data paths—fixes babysit gate behavior and messaging.
> 
> **Overview**
> Adds a **versioned repo hook** at `.claude/babysit-pr.sh` so the babysit-pr skill can auto-discover CI/review readiness for local and cloud runs, replacing an unversioned local-only gate.
> 
> The hook runs `pnpm pr:ready-state --pr … --json` and maps `.ready` to **PASS** / **PENDING** / **FAIL**. It fixes a bug where piping pnpm output into `jq` failed on the lifecycle banner (`Invalid numeric literal`), which left PRs stuck **PENDING** even when green. **`pnpm --silent`** plus stderr suppression yields parseable JSON; **`jq`** tests `.ready == true` explicitly (avoiding `//` treating `false` as empty) and surfaces `.summary` so pending states explain blockers instead of a generic “not ready” message.
> 
> `babysit_repo_init` still requires Codex unless overridden; missing checkout or `pr:ready-state` script **PASS**es gracefully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e776679e228f1beb3ba4aaf97b7b4b96e2c2da16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->