### PR TITLE
ci: ARM runner compat test (throwaway — do not merge)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-2vcpu-ubuntu-2404-arm

--- a/.github/workflows/aegis-app-engine.yml
+++ b/.github/workflows/aegis-app-engine.yml
@@ -37,7 +37,7 @@ jobs:
     environment:
       name: production
       url: https://mento-monitoring.uc.r.appspot.com
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -98,7 +98,7 @@ jobs:
         && github.event.pull_request.user.login != 'dependabot[bot]')
       || (github.ref == 'refs/heads/main'
         && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       contents: read
@@ -348,7 +348,7 @@ jobs:
     environment:
       name: production
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -114,7 +114,7 @@ jobs:
         && github.event.pull_request.user.login != 'dependabot[bot]')
       || (github.ref == 'refs/heads/main'
         && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       contents: read
@@ -472,7 +472,7 @@ jobs:
     environment:
       name: production
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -108,7 +108,7 @@ jobs:
         && github.event.pull_request.user.login != 'dependabot[bot]')
       || (github.ref == 'refs/heads/main'
         && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       contents: read
@@ -424,7 +424,7 @@ jobs:
     environment:
       name: production
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions: read-all
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 2
     permissions:
       contents: read
@@ -195,7 +195,7 @@ jobs:
     name: Quality Checks (shared-config)
     needs: changes
     if: needs.changes.outputs.shared == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     permissions:
       checks: write
@@ -244,7 +244,7 @@ jobs:
     name: Quality Checks (ui-dashboard)
     needs: changes
     if: needs.changes.outputs.ui == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 25
     permissions:
       checks: write
@@ -315,10 +315,16 @@ jobs:
         # already-hit key, so the next run re-downloads again indefinitely.
         # Hashing the lockfile makes the key flip on any real Playwright
         # version bump. Mirrors the proven step in lighthouse.yml.
+        #
+        # `runner.arch` is in the key because this job runs on ARM while
+        # lighthouse.yml (same cache namespace) stays on x64 — Chromium
+        # binaries are arch-specific, and `playwright install` validates
+        # version, not architecture, so a cross-arch restore would pass
+        # validation and then die with an exec-format error.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('ui-dashboard/package.json', 'pnpm-lock.yaml') }}
+          key: playwright-chromium-${{ runner.arch }}-${{ hashFiles('ui-dashboard/package.json', 'pnpm-lock.yaml') }}
           # `restore-keys` lets an unrelated lockfile or `package.json`
           # edit still reuse the most recent chromium cache instead of
           # triggering a ~130 MB fresh download. `playwright install` then
@@ -326,7 +332,7 @@ jobs:
           # (no-op on match, re-download only on a real Playwright version
           # bump). `--with-deps` still installs OS libraries (fast).
           restore-keys: |
-            playwright-chromium-
+            playwright-chromium-${{ runner.arch }}-
       - name: Install Playwright Chromium
         run: pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium
       - name: Browser interaction tests
@@ -351,7 +357,7 @@ jobs:
     name: Quality Checks (indexer-envio)
     needs: changes
     if: needs.changes.outputs.indexer == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     permissions:
       checks: write
@@ -381,7 +387,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: indexer-envio/.envio
-          key: envio-generated-v3-${{ runner.os }}-${{ hashFiles('indexer-envio/config*.yaml', 'indexer-envio/schema.graphql', 'indexer-envio/package.json', 'indexer-envio/abis/**', 'indexer-envio/scripts/**') }}
+          key: envio-generated-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('indexer-envio/config*.yaml', 'indexer-envio/schema.graphql', 'indexer-envio/package.json', 'indexer-envio/abis/**', 'indexer-envio/scripts/**') }}
       - name: Validate YAML address drift
         # Every hex address in config*.yaml must resolve to either
         # @mento-protocol/contracts, indexer-envio/config/nttAddresses.json,
@@ -432,7 +438,7 @@ jobs:
     name: Quality Checks (metrics-bridge)
     needs: changes
     if: needs.changes.outputs.bridge == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       checks: write
@@ -474,7 +480,7 @@ jobs:
     name: Quality Checks (integration-probes)
     needs: changes
     if: needs.changes.outputs.integrationProbes == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       checks: write
@@ -515,7 +521,7 @@ jobs:
     name: Quality Checks (alerts Cloud Functions)
     needs: changes
     if: needs.changes.outputs.alerts == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       checks: write
@@ -604,7 +610,7 @@ jobs:
     name: Terraform Validate (registry)
     needs: changes
     if: needs.changes.outputs.terraform == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       contents: read
@@ -650,7 +656,7 @@ jobs:
     name: Quality Checks (aegis)
     needs: changes
     if: needs.changes.outputs.aegis == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       checks: write
@@ -706,7 +712,7 @@ jobs:
     name: Lint + test root scripts
     needs: changes
     if: needs.changes.outputs.rootScripts == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     permissions:
       checks: write
@@ -743,7 +749,7 @@ jobs:
     # (dep-cruiser config + knip configs) so a PR that only edits the
     # rule file is validated against the codebase before merge.
     if: needs.changes.outputs.shared == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.indexer == 'true' || needs.changes.outputs.bridge == 'true' || needs.changes.outputs.integrationProbes == 'true' || needs.changes.outputs.aegis == 'true' || needs.changes.outputs.codeHealth == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     permissions:
       checks: write

--- a/.github/workflows/code-health-duplication.yml
+++ b/.github/workflows/code-health-duplication.yml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
   duplication:
     name: jscpd
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     # Strictly advisory — never fails the PR. Surfaces duplication signal
     # via an uploaded artifact and (optionally) a PR summary comment.

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -37,7 +37,7 @@ permissions: read-all
 jobs:
   discover:
     name: Discover Terraform stacks
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     permissions:
       contents: read
@@ -99,7 +99,7 @@ jobs:
     name: Terraform Validate (${{ matrix.id }})
     needs: discover
     if: needs.discover.outputs.has-stacks == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/integration-probes.yml
+++ b/.github/workflows/integration-probes.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   probe:
     name: Run aggregator integration probes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
     env:
       NEXT_PUBLIC_HASURA_URL: ${{ vars.NEXT_PUBLIC_HASURA_URL }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -62,6 +62,12 @@ jobs:
     # When Lighthouse does run, a performance/accessibility assertion failure
     # warns/errors per the budgets in .lighthouserc.cjs.
     name: Core Web Vitals + accessibility (ui-dashboard)
+    # Deliberately NOT migrated to the cheaper ARM runners (every other
+    # Blacksmith job in this repo is on -arm): lhci launches Chrome via
+    # chrome-launcher, and Google does not publish Chrome (or Chrome for
+    # Testing) for linux-arm64, so the ARM runner image has no Chrome to
+    # launch. Migrating would require pointing CHROME_PATH at Playwright's
+    # arm64 Chromium — a behavior change to the audit browser, out of scope.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
@@ -290,11 +296,16 @@ jobs:
         # actions/cache won't re-save under the already-hit key, so the
         # next run re-downloads again indefinitely. Hashing the lockfile
         # makes the key flip on any real Playwright version bump.
+        #
+        # `runner.arch` is in the key because ci.yml's ui job (same cache
+        # namespace) runs on ARM while this job stays on x64 — Chromium
+        # binaries are arch-specific and a cross-arch restore would fail at
+        # exec time, not install time.
         if: steps.decide.outputs.run == 'true' && always()
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('ui-dashboard/package.json', 'pnpm-lock.yaml') }}
+          key: playwright-chromium-${{ runner.arch }}-${{ hashFiles('ui-dashboard/package.json', 'pnpm-lock.yaml') }}
           # `restore-keys` lets an unrelated lockfile or `package.json`
           # edit still reuse the most recent chromium cache instead of
           # triggering a ~130 MB fresh download. `playwright install` then fast-
@@ -302,7 +313,7 @@ jobs:
           # (no-op on match, re-download only on a real Playwright
           # version bump).
           restore-keys: |
-            playwright-chromium-
+            playwright-chromium-${{ runner.arch }}-
 
       - name: Install Playwright Chromium (for INP measurement)
         # The INP step uses `@playwright/test`'s chromium (the dashboard's

--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -46,7 +46,7 @@ jobs:
     environment:
       name: production
       url: https://console.cloud.google.com/run?project=mento-monitoring
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -29,7 +29,7 @@ jobs:
     # sets `break: 86`, so when the mutation step runs a score below 86% fails
     # the job.
     name: Dashboard logic baseline
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.
     permissions:
@@ -111,7 +111,7 @@ jobs:
     # sets `break: 92`, so when the mutation step runs a score below 92% fails
     # the job.
     name: Indexer logic baseline
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.
     permissions:
@@ -193,7 +193,7 @@ jobs:
     # sets `break: 84`, so when the mutation step runs a score below 84% fails
     # the job.
     name: Bridge rebalance probe baseline
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.
     permissions:

--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -63,7 +63,7 @@ jobs:
                 github.event.workflow_run.conclusion) &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.event == 'push')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     steps:
       - name: Post to #ci-failures

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -30,7 +30,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - name: Validate PR description
         # Body is passed via env (never interpolated into the script) to avoid

--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -38,7 +38,7 @@ jobs:
     #
     # Advisory only — exit code is always 0.
     name: GraphQL schema diff
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     # `pull-requests: write` is required to post the sticky PR comment.
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -43,7 +43,7 @@ jobs:
     #   - PR + filter failed (any cause)           → run (fail-closed)
     # When `size-limit` does run, a bundle over budget fails the job.
     name: Dashboard bundle size
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     # `pull-requests: read` is required by `dorny/paths-filter` in PR mode.
     permissions:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -67,7 +67,7 @@ permissions: read-all
 jobs:
   audit:
     name: npm advisory audit
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,7 +97,7 @@ jobs:
 
   lockfile-lint:
     name: lockfile integrity + registry check
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   discover:
     name: Discover auto-applied stacks
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
     name: Drift Plan (${{ matrix.id }})
     needs: discover
     if: needs.discover.outputs.has-stacks == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -19,7 +19,7 @@ permissions: read-all
 jobs:
   trunk:
     name: Code Quality
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
       checks: write

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -34,5 +34,15 @@ jobs:
       - uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1
         with:
           arguments: --all
+          # The action's internal ~/.cache/trunk key is
+          # `trunk-<cache-key>-<runner.os>-<hash of .trunk/trunk.yaml>` — no
+          # architecture component. This job runs on ARM now; without an arch
+          # discriminator it restores the x64-built tool cache saved before
+          # the migration (same key, immutable entry), trunk re-downloads the
+          # arm64 tools over the restored binaries every run, and the
+          # download-then-exec overlap surfaces as `execve failed: Text file
+          # busy` (seen on the ARM compat PR). Keying on runner.arch gives
+          # each architecture its own cache lineage.
+          cache-key: ${{ runner.arch }}
       - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
         if: always()

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   update-snapshots:
     name: Regenerate visual snapshot baselines (Linux)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 20
     permissions:
       contents: write

--- a/.trunk/configs/actionlint.yaml
+++ b/.trunk/configs/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-2vcpu-ubuntu-2404-arm

--- a/ui-dashboard/src/lib/address-book.ts
+++ b/ui-dashboard/src/lib/address-book.ts
@@ -149,3 +149,6 @@ export function countImportLabels(parsed: unknown): number {
 
   return 0;
 }
+
+// ARM-compat-test trigger: comment-only change so the size-limit, ui, and
+// lighthouse workflows run on this PR. Reverted before any merge.


### PR DESCRIPTION
## The Problem

- We hypothesize ~37.5% cheaper CI minutes by moving Blacksmith jobs from x64 ($0.004/min base) to ARM (`blacksmith-{2,4}vcpu-ubuntu-2404-arm`, $0.0025/min base), but per-job ARM compatibility has never been tested empirically in this repo.
- Two risks can only be settled by running the jobs: (1) the ui job's Playwright visual-snapshot baselines were rendered on x64 Chromium and carry no arch suffix; (2) the required `Code Quality` check downloads the trunk CLI + its hermetic tools per-platform.

## The Solution

- **Throwaway draft PR — never merges.** It flips every Blacksmith job (except `lighthouse.yml`, see below) to the same-vCPU ARM label so all PR-triggered workflows execute once on ARM, plus a trivial `ui-dashboard/src` comment so `size-limit`, `ui`, and the Vercel preview (needed by Lighthouse) also trigger.
- Non-PR read-only workflows (`mutation-testing`, `terraform-drift`, `integration-probes`, `infra`) are exercised via `workflow_dispatch` from this branch.
- The real migration PR follows after these results + a review pass; jobs that fail here stay on x64 there.

## Details

- `lighthouse.yml` intentionally stays on x64: lhci launches Chrome via chrome-launcher and Google ships no Chrome for linux-arm64.
- Playwright Chromium cache keys gain `${{ runner.arch }}` in both `ci.yml` and `lighthouse.yml` — they share a key namespace but now run on different architectures; a cross-arch restore would pass version validation and die with an exec-format error.
- Envio codegen cache key gains `${{ runner.arch }}` as well.
- Both actionlint `self-hosted-runner` allow-lists learn the `-arm` labels.
- Toolchain arm64 availability pre-verified: trunk CLI 1.25.0 tarball, `envio-linux-arm64`, foundry `linux_arm64`, Playwright Chromium arm64, esbuild/sharp/lightningcss arm64 variants in the lockfile, codecov CLI linux-arm64, and linux_arm64 builds for all 14 Terraform providers across the 4 stacks (lock files carry `zh:` hashes, so cross-platform `terraform init` needs no lockfile edits).

## Validation

- This PR **is** the validation run — results feed the migration decision matrix per job.
- `trunk fmt` + `trunk check` clean on all changed files locally.
