### PR TITLE
Enforce deferral declarations via the required PR-description check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,20 @@
 
 - [Commands and results.]
 
+## Deferrals
+
+<!--
+Everything knowingly deferred from this PR — reviewer findings you chose not
+to address here, or work you judged out of scope — MUST have a GitHub issue
+describing the problem (and solution ideas, if any). List the issue links
+below, or write "None" if nothing was deferred. CI enforces this section.
+-->
+
+- None
+
 ## Checklist
 
 - [ ] The Problem has no more than three bullets.
 - [ ] The Solution is plain English and understandable before reading the diff.
 - [ ] Deeper implementation details come after the opening two sections.
+- [ ] Every knowing deferral is listed under Deferrals with a GitHub issue link.

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -2,8 +2,10 @@ name: PR Description
 
 # Enforces the repo PR-description standard (AGENTS.md "PR description standard"
 # + .github/PULL_REQUEST_TEMPLATE.md): every PR body must lead with
-# `## The Problem` and `## The Solution`, and must not still contain the
-# unfilled template placeholders.
+# `## The Problem` and `## The Solution`, must not still contain the
+# unfilled template placeholders, and must declare deferrals — a
+# `## Deferrals` section that either says "None" or links the GitHub
+# issue(s) created for everything knowingly deferred from the PR.
 #
 # REQUIRED-STATUS SAFETY: no workflow-level `paths:` filter — this is meant to
 # run on every PR so it can be a required status (AGENTS.md: required-status
@@ -84,4 +86,28 @@ jobs:
             exit 1
           fi
 
-          echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders."
+          # 4) Deferral declaration (AGENTS.md "Deferral rule"): a `## Deferrals`
+          #    section must exist and either say "None" or reference at least
+          #    one GitHub issue (#123 or a full issues URL). This is the forcing
+          #    function for "every knowing deferral gets an issue" — CI can't
+          #    judge honesty, but it can require the explicit declaration, and a
+          #    "None" that contradicts deferred-marked review replies is
+          #    auditable. Operates on fence_stripped (comments + code fences
+          #    removed) so an example heading or issue ref inside a fence or the
+          #    template's instructional comment can't satisfy the check.
+          if ! grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
+            echo "::error::PR description is missing the '## Deferrals' section. Everything knowingly deferred from this PR (reviewer findings not addressed here, or out-of-scope work) needs a GitHub issue — list the links there, or write 'None'. See AGENTS.md 'Deferral rule'."
+            exit 1
+          fi
+          deferrals=$(awk '
+            /^##[[:space:]]+Deferrals[[:space:]]*$/ { insec = 1; next }
+            insec && /^##[[:space:]]/ { insec = 0 }
+            insec { print }
+          ' <<<"$fence_stripped")
+          if ! grep -qiE '(^|[^[:alnum:]])none([^[:alnum:]]|$)' <<<"$deferrals" \
+             && ! grep -qE '#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+' <<<"$deferrals"; then
+            echo "::error::The '## Deferrals' section must either say 'None' or reference at least one GitHub issue (#123 or an issues URL) per knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
+            exit 1
+          fi
+
+          echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders, deferrals declared."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -104,9 +104,13 @@ jobs:
             insec && /^##[[:space:]]/ { insec = 0 }
             insec { print }
           ' <<<"$fence_stripped")
-          if ! grep -qiE '(^|[^[:alnum:]])none([^[:alnum:]]|$)' <<<"$deferrals" \
+          # "None" must be the section's explicit value — a line that is
+          # exactly `None` (optionally as a `-`/`*` list item, optional
+          # trailing period). Prose that merely contains the word ("None of
+          # the follow-ups are tracked yet") does NOT satisfy the check.
+          if ! grep -qiE '^[[:space:]]*([-*][[:space:]]+)?none[[:space:]]*\.?[[:space:]]*$' <<<"$deferrals" \
              && ! grep -qE '#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+' <<<"$deferrals"; then
-            echo "::error::The '## Deferrals' section must either say 'None' or reference at least one GitHub issue (#123 or an issues URL) per knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
+            echo "::error::The '## Deferrals' section must either be exactly 'None' (own line / list item) or reference at least one GitHub issue (#123 or an issues URL) per knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
             exit 1
           fi
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -104,22 +104,30 @@ jobs:
             insec && /^##[[:space:]]/ { insec = 0 }
             insec { print }
           ' <<<"$fence_stripped")
-          # "None" satisfies the gate only when it is the section's SOLE
-          # non-blank content — every non-blank line must be exactly `None`
-          # (optionally a `-`/`*` list item, optional trailing period).
-          # Prose containing the word ("None of the follow-ups are tracked
-          # yet"), or a leftover `- None` next to an added untracked
-          # deferral line, does NOT pass; any other content requires an
-          # issue reference.
-          deferrals_nonblank=$(grep -vE '^[[:space:]]*$' <<<"$deferrals" || true)
-          none_only=false
-          if [ -n "$deferrals_nonblank" ] \
-             && ! grep -qviE '^[[:space:]]*([-*][[:space:]]+)?none[[:space:]]*\.?[[:space:]]*$' <<<"$deferrals_nonblank"; then
-            none_only=true
+          # The gate validates ITEMS: list bullets (`- …` / `* …`) plus
+          # standalone `None` lines. Everything else in the section —
+          # wrapped continuation lines, generated trailers like the
+          # `🤖 Generated with …` footer or a bot summary — is ignored, so
+          # metadata appended after a final `## Deferrals` section can't
+          # block a valid body. Rules:
+          #   - at least one item must exist;
+          #   - every item must either be exactly `None` (optional trailing
+          #     period) or reference a GitHub issue (#123 / issues URL).
+          # That makes each knowing deferral carry its own issue link — one
+          # linked item can't cover an untracked sibling — while a leftover
+          # `- None` next to real linked items stays harmless, and prose
+          # merely containing the word "none" never passes.
+          none_re='^[[:space:]]*([-*][[:space:]]+)?[Nn][Oo][Nn][Ee][[:space:]]*\.?[[:space:]]*$'
+          issue_re='#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+'
+          items=$(grep -E '^[[:space:]]*[-*][[:space:]]+[^[:space:]]' <<<"$deferrals" || true)
+          standalone_none=$(grep -E "$none_re" <<<"$deferrals" || true)
+          if [ -z "$items" ] && [ -z "$standalone_none" ]; then
+            echo "::error::The '## Deferrals' section must list its content as items: '- None' when nothing was knowingly deferred, or one '- #123 …' / issues-URL item per deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
+            exit 1
           fi
-          if [ "$none_only" != true ] \
-             && ! grep -qE '#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+' <<<"$deferrals_nonblank"; then
-            echo "::error::The '## Deferrals' section must either be exactly 'None' (as its only content) or reference a GitHub issue (#123 or an issues URL) for each knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
+          bad_items=$(grep -vE "$none_re" <<<"$items" | grep -vE "$issue_re" || true)
+          if [ -n "$bad_items" ]; then
+            echo "::error::Every item in '## Deferrals' must either be 'None' or reference a GitHub issue (#123 or an issues URL) — one linked item does not cover an untracked sibling. Missing issue reference on: $(head -3 <<<"$bad_items" | tr '\n' ' ')"
             exit 1
           fi
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -104,13 +104,22 @@ jobs:
             insec && /^##[[:space:]]/ { insec = 0 }
             insec { print }
           ' <<<"$fence_stripped")
-          # "None" must be the section's explicit value — a line that is
-          # exactly `None` (optionally as a `-`/`*` list item, optional
-          # trailing period). Prose that merely contains the word ("None of
-          # the follow-ups are tracked yet") does NOT satisfy the check.
-          if ! grep -qiE '^[[:space:]]*([-*][[:space:]]+)?none[[:space:]]*\.?[[:space:]]*$' <<<"$deferrals" \
-             && ! grep -qE '#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+' <<<"$deferrals"; then
-            echo "::error::The '## Deferrals' section must either be exactly 'None' (own line / list item) or reference at least one GitHub issue (#123 or an issues URL) per knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
+          # "None" satisfies the gate only when it is the section's SOLE
+          # non-blank content — every non-blank line must be exactly `None`
+          # (optionally a `-`/`*` list item, optional trailing period).
+          # Prose containing the word ("None of the follow-ups are tracked
+          # yet"), or a leftover `- None` next to an added untracked
+          # deferral line, does NOT pass; any other content requires an
+          # issue reference.
+          deferrals_nonblank=$(grep -vE '^[[:space:]]*$' <<<"$deferrals" || true)
+          none_only=false
+          if [ -n "$deferrals_nonblank" ] \
+             && ! grep -qviE '^[[:space:]]*([-*][[:space:]]+)?none[[:space:]]*\.?[[:space:]]*$' <<<"$deferrals_nonblank"; then
+            none_only=true
+          fi
+          if [ "$none_only" != true ] \
+             && ! grep -qE '#[0-9]+|github\.com/[^[:space:]]+/issues/[0-9]+' <<<"$deferrals_nonblank"; then
+            echo "::error::The '## Deferrals' section must either be exactly 'None' (as its only content) or reference a GitHub issue (#123 or an issues URL) for each knowing deferral. Create the issue first (problem description + solution ideas if you have them), then link it here."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,23 @@ Every PR description must start with these exact heading lines, in this order:
 The first two sections are not a change log. They are the reviewer-facing story
 for why the PR exists and why this approach resolves it.
 
+## Deferral rule
+
+Every time something is knowingly deferred from a PR — a reviewer finding you
+chose not to address in that PR, or work you judged out of scope — create a
+GitHub issue for it with a clear description of the problem to be solved, plus
+solution ideas if you have them (otherwise describe the problem as best you
+can). Label it `agent-ready` when an agent could pick it up unaided.
+
+The PR body's `## Deferrals` section is the enforcement point: it must either
+say `None` or link the issue(s), and the required `PR description format`
+check fails without it. Two corollaries:
+
+- Create the issue **before** posting a "Deferred — tracking in …" review
+  reply; a deferred reply without an issue link is incomplete.
+- A won't-fix with evidence is **not** a deferral (no issue needed); a "good
+  idea, later" is.
+
 ## PR feedback sweep rule
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.


### PR DESCRIPTION
## The Problem

- Knowing deferrals (reviewer findings parked as "later", out-of-scope follow-ups) only live in PR comments and ship summaries, so they evaporate instead of becoming backlog.
- The new project rule — every knowing deferral gets a GitHub issue with a problem description + solution ideas — was advisory only; nothing enforced it.

## The Solution

Make the rule structurally enforced: every PR body must carry a `## Deferrals` section that either says `None` or links the issue(s), and the already-required `PR description format` CI check fails without it. CI can't judge honesty, but it forces an explicit per-PR declaration — and a "None" that contradicts "Deferred — tracking in…" review replies is immediately auditable.

## Details

- `.github/PULL_REQUEST_TEMPLATE.md`: new `## Deferrals` section (instructional comment + `- None` default) and a checklist item.
- `.github/workflows/pr-description.yml`: check 4 — `## Deferrals` heading must exist; its content must say `None` or reference an issue (`#123` / issues URL). Runs on the comment- and fence-stripped body, so the template's instructional comment and fenced examples can neither satisfy nor fake the check; `none` is matched as a whole word ("nonessential" doesn't pass). Same env-var-only handling of `PR_BODY` (no new interpolation).
- `AGENTS.md`: new "Deferral rule" section after the PR description standard — create the issue *before* posting a deferred review reply; `agent-ready` label when an agent could pick it up; won't-fix-with-evidence is not a deferral.
- Heads-up: open PR #819 predates the section and will fail the check on its next `synchronize`/`edited` event until its body gains a `## Deferrals` line.

## Validation

- Gate logic replicated locally and run against 10 body variants: `None` bullet, `#824` link, issues-URL → pass; missing section, empty section, prose without issue link, `None` only inside an HTML comment, fenced fake `## Deferrals` heading, `nonessential` substring → fail with the intended error. Template default body passes.
- `trunk check` clean on all three files (actionlint/checkov/prettier/markdownlint).

## Deferrals

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process and CI-only changes to PR templates and workflow validation; no runtime or application code paths.
> 
> **Overview**
> Turns the **deferral rule** into a required PR gate: every body must include **`## Deferrals`** with either `- None` or one bullet per deferred item linking a GitHub issue (`#123` or issues URL).
> 
> **`.github/PULL_REQUEST_TEMPLATE.md`** adds the section (with guidance comment), default `- None`, and a checklist line. **`pr-description.yml`** adds check 4 on the comment/fence-stripped body so fenced or commented examples cannot satisfy the rule; list items must each be `None` or carry an issue ref. **`AGENTS.md`** documents when to open issues (before “deferred” review replies), `agent-ready` labeling, and that evidence-backed won’t-fix is not a deferral.
> 
> **Note:** older open PRs without the section will fail the required check until their descriptions are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19db7a4e10e8df5be03a7710c120e1d1a727cf03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->