### PR TITLE
Shorten CDP tile context row to '$X Gross · $Y Stability Pool Share'

### DIFF
--- a/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
+++ b/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
@@ -220,10 +220,14 @@ describe("RevenuePageClient degraded fee states", () => {
     expect(html).toContain("earned");
     expect(html).toContain("Gross");
     expect(html).toContain("$242.50");
-    expect(html).toContain("of which $181.87 goes to stability");
-    // Collected/receivable stay indexed but are no longer rendered.
+    expect(html).toContain("$181.87");
+    expect(html).toContain("Stability Pool Share");
+    // Collected/receivable stay indexed but are no longer rendered — the
+    // fixture's collectedUSD (30) / receivableUSD (30.63) must not appear.
     expect(html).not.toContain("Accruing");
     expect(html).not.toContain('role="progressbar"');
+    expect(html).not.toContain("$30.00");
+    expect(html).not.toContain("$30.63");
     expect(html).toContain("Protocol share of borrowing fees");
     expect(html).toContain("Protocol share of swap fees");
     expect(html).toContain("Borrowing Fees by CDP");

--- a/ui-dashboard/src/app/revenue/_components/cdp-borrowing-fees-tile.tsx
+++ b/ui-dashboard/src/app/revenue/_components/cdp-borrowing-fees-tile.tsx
@@ -47,14 +47,15 @@ export function CdpBorrowingFeesTile({
         </p>
         {showData && (
           <p className="mt-1.5 text-sm font-mono">
-            <span className="text-slate-500">Gross</span>{" "}
             <span className="text-slate-400">
               {formatUSD(summary.totalRevenueUSD)}
             </span>{" "}
-            <span className="text-slate-500">
-              · of which {formatUSD(summary.spYieldShareUSD)} goes to stability
-              pool
-            </span>
+            <span className="text-slate-500">Gross</span>{" "}
+            <span className="text-slate-500">·</span>{" "}
+            <span className="text-slate-400">
+              {formatUSD(summary.spYieldShareUSD)}
+            </span>{" "}
+            <span className="text-slate-500">Stability Pool Share</span>
           </p>
         )}
       </div>


### PR DESCRIPTION
## The Problem

- The CDP Borrowing Fees tile's context row ("Gross $4.5K · of which $3.4K goes to stability pool") reads as a sentence and runs long for a tile row.

## The Solution

Shorten it to the requested label-style form: `$4.5K Gross · $3.4K Stability Pool Share` (numbers first, compact labels).

## Details

- `cdp-borrowing-fees-tile.tsx`: reordered the row to value-then-label, label copy "Stability Pool Share".
- Test assertions updated to the new copy.

## Validation

- Targeted vitest (9 page tests), `pnpm typecheck`, `pnpm lint`, `trunk fmt` — all green.

## Deferrals

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only copy and layout on the revenue CDP tile with matching test updates; no fee calculation or data logic changes.
> 
> **Overview**
> The **CDP Borrowing Fees** tile context row is shortened from sentence-style copy to a compact **value-first** layout: gross total and stability-pool slice now read as `$X Gross · $Y Stability Pool Share` instead of leading with “Gross” and “of which … goes to stability pool.”
> 
> Revenue page tests were updated for the new labels and to assert collected/receivable amounts from the fixture still do not appear in the markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6c15af09af6e96085b5c613d749c75fc263c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->