### PR TITLE
fix: pin undici to 7.24.2 to restore governance-watchdog Discord delivery

### DIFF
--- a/governance-watchdog/pnpm-lock.yaml
+++ b/governance-watchdog/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  flatted: '>=3.4.2'
+  flatted: 3.4.2
   undici: 7.24.2
 
 importers:

--- a/governance-watchdog/pnpm-lock.yaml
+++ b/governance-watchdog/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   flatted: '>=3.4.2'
-  undici: '>=6.24.0'
+  undici: 7.24.2
 
 importers:
 
@@ -2229,9 +2229,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.4.0:
-    resolution: {integrity: sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng==}
-    engines: {node: '>=22.19.0'}
+  undici@7.24.2:
+    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2495,7 +2495,7 @@ snapshots:
       discord-api-types: 0.38.48
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 8.4.0
+      undici: 7.24.2
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -3393,7 +3393,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 8.4.0
+      undici: 7.24.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4640,7 +4640,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.4.0: {}
+  undici@7.24.2: {}
 
   unpipe@1.0.0: {}
 

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -15,4 +15,4 @@ overrides:
   # notification delivery in production. 7.24.2 is what the last working
   # standalone deploy ran (npm package-lock) and satisfies the original
   # >=6.24.0 security floor.
-  undici: "7.24.2"
+  undici: 7.24.2

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -9,4 +9,10 @@ minimumReleaseAgeExclude:
 
 overrides:
   flatted: ">=3.4.2"
-  undici: ">=6.24.0"
+  # Exact pin, not a range: ">=6.24.0" resolved to undici 8.x on a fresh
+  # install, and @discordjs/rest 2.6.1 crashes against undici 8's stricter
+  # Headers webidl (Symbol(sensitiveHeaders) → TypeError), breaking Discord
+  # notification delivery in production. 7.24.2 is what the last working
+  # standalone deploy ran (npm package-lock) and satisfies the original
+  # >=6.24.0 security floor.
+  undici: "7.24.2"

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -8,11 +8,15 @@ minimumReleaseAgeExclude:
   - "@envio-dev/envio-cloud-*"
 
 overrides:
-  flatted: ">=3.4.2"
+  # Exact pin for the same reason as undici below: ranges resolve forward on
+  # fresh installs. 3.4.2 is what both the standalone npm lockfile and this
+  # lockfile resolve today.
+  flatted: 3.4.2
   # Exact pin, not a range: ">=6.24.0" resolved to undici 8.x on a fresh
   # install, and @discordjs/rest 2.6.1 crashes against undici 8's stricter
-  # Headers webidl (Symbol(sensitiveHeaders) → TypeError), breaking Discord
-  # notification delivery in production. 7.24.2 is what the last working
-  # standalone deploy ran (npm package-lock) and satisfies the original
-  # >=6.24.0 security floor.
+  # Headers webidl (Symbol(sensitiveHeaders) → TypeError) while wrapping the
+  # response — sends deliver but report as failures and rate-limit headers
+  # are never read. 7.24.2 is what the last working standalone deploy ran
+  # (npm package-lock) and satisfies the original >=6.24.0 security floor.
+  # Upgrade path (bump discord.js, then drop this): issue #833.
   undici: 7.24.2


### PR DESCRIPTION
## The Problem

- After the post-merge governance-watchdog deploy (#819, applied 2026-06-10 ~12:03 UTC), every prod **Discord** send throws `TypeError: Headers constructor: Key Symbol(sensitiveHeaders) … cannot be converted to a ByteString` and is logged as `❌ Failed to send Discord notification`.
- The message **does deliver**: `@discordjs/rest 2.6.1`'s `makeRequest` completes the network call first, then crashes wrapping the response (`headers: new Headers(res.headers)`) because **undici 8.4.0**'s stricter `Headers` constructor rejects the `Symbol(sensitiveHeaders)` key that `undici.request` now includes. Net effect: false-failure logs on every send (masking real failures) and `@discordjs/rest` never sees response headers — which is what it uses for Discord rate-limit handling.
- Root cause: the package-local `undici: ">=6.24.0"` override resolved to 8.4.0 on the fresh pnpm install, while the last working standalone npm deploy had 7.24.2 frozen in its lockfile — an unintended runtime-dep major bump hiding inside the range. Telegram is unaffected.

## The Solution

- Pin the override to the prod-proven exact version: `undici: 7.24.2` (satisfies the original `>=6.24.0` security floor) and regenerate the package-local `pnpm-lock.yaml`.
- Roll forward + redeploy (`pnpm gov-watchdog:deploy`) rather than roll back — the lockfile/workspace files are in the Terraform source hash, so the apply picks this up as a new source archive.

## Details

- Caught by the documented post-deploy verification step: `test:prod:ProposalCreated` fixture → logs showed `✅ Telegram` / `❌ Discord` with the undici webidl stack trace; the Discord message itself was then confirmed delivered in the channel, narrowing the failure to response wrapping.
- Evidence the pin matches last-known-good: standalone repo `package-lock.json` resolves `node_modules/undici` to **7.24.2**, same `discord.js 14.25.1` / `@discordjs/rest 2.6.1` as this tree.

## Validation

- `pnpm run typecheck`, `pnpm run test:unit` (12/12), `pnpm run build` — all green against the regenerated lockfile.
- Post-merge: redeploy + re-run `test:prod:ProposalCreated`, confirm `✅ Discord` in function logs (not just channel delivery).

## Deferrals

- #833 — upgrade `discord.js`/`@discordjs/rest` to an undici-8-compatible release, then drop the exact `undici` pin (the override comment cross-references the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency lockfile-only change with no application logic edits; main risk is redeploy picking up the pinned runtime until post-deploy Discord verification passes.
> 
> **Overview**
> **Pins `undici` and `flatted` to exact versions** in `governance-watchdog/pnpm-workspace.yaml` (replacing `>=6.24.0` / `>=3.4.2` ranges) and regenerates `pnpm-lock.yaml` so installs resolve **`undici@7.24.2`** instead of **8.4.0**.
> 
> The range had pulled in undici 8, which breaks **`@discordjs/rest@2.6.1`** when wrapping HTTP responses (`Headers` / `Symbol(sensitiveHeaders)`), causing prod Discord sends to log failures and skip rate-limit headers even when messages actually deliver. **7.24.2** matches the last working standalone deploy and still meets the original security floor; comments note a future path via discord.js bump (#833).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096b3c23d6ff102537c50bff269fe60bc71f59dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->