### PR TITLE
Link CDP tile headline to DeBank + dynamic SP-split tooltip

### DIFF
--- a/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
+++ b/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
@@ -58,6 +58,7 @@ function cdpMarket(
     chainId: 42220,
     collIndex: 0,
     symbol,
+    spYieldSplitBps: 7500,
     activeDebtUSD,
     averageAnnualInterestRatePercent,
     annualInterestRunRateUSD,
@@ -222,6 +223,14 @@ describe("RevenuePageClient degraded fee states", () => {
     expect(html).toContain("$242.50");
     expect(html).toContain("$181.87");
     expect(html).toContain("Stability Pool Share");
+    // Headline deep-links to the feeRecipient's DeBank profile, like the
+    // Swap Fees tile.
+    expect(html).toContain('aria-label="CDP Borrowing Fees: $60.63"');
+    expect(html.match(/debank\.com\/profile\/0x0dd57f6f/gi)?.length).toBe(2);
+    // All-time tooltip states the live on-chain split (7500 bps fixture).
+    expect(html).toContain(
+      "Split: 25% protocol treasury, 75% Stability Pool depositor yield.",
+    );
     // Collected/receivable stay indexed but are no longer rendered — the
     // fixture's collectedUSD (30) / receivableUSD (30.63) must not appear.
     expect(html).not.toContain("Accruing");
@@ -377,5 +386,43 @@ describe("RevenuePageClient degraded fee states", () => {
     // the (successful) market/bracket/rate queries.
     expect(html).not.toContain("Unable to load CDP borrowing fees");
     expect(html).toContain("$20.00");
+  });
+});
+
+describe("cdpBorrowingTotalTooltip fallback via RevenuePageClient", () => {
+  beforeEach(() => {
+    mockUseProtocolFees.mockReset();
+    mockUseCdpBorrowingRevenue.mockReset();
+  });
+
+  it("falls back to generic split wording when market splits disagree", () => {
+    const gbp = cdpMarket("GBPm", 187.5, 125, 62.5);
+    const chf = { ...cdpMarket("CHFm", 55, 55, 0), spYieldSplitBps: 5000 };
+    const html = renderRevenue([], false, {
+      summary: EMPTY_CDP_REVENUE,
+      markets: [gbp, chf],
+      isLoading: false,
+      hasError: false,
+    });
+
+    expect(html).toContain(
+      "The protocol keeps the share shown in the summary tile",
+    );
+    expect(html).not.toContain("% protocol treasury");
+  });
+
+  it("falls back to generic split wording on the unloaded -1 sentinel", () => {
+    const gbp = { ...cdpMarket("GBPm", 187.5, 125, 62.5), spYieldSplitBps: -1 };
+    const html = renderRevenue([], false, {
+      summary: EMPTY_CDP_REVENUE,
+      markets: [gbp],
+      isLoading: false,
+      hasError: false,
+    });
+
+    expect(html).toContain(
+      "The protocol keeps the share shown in the summary tile",
+    );
+    expect(html).not.toContain("% protocol treasury");
   });
 });

--- a/ui-dashboard/src/app/revenue/_components/cdp-borrowing-fees-tile.tsx
+++ b/ui-dashboard/src/app/revenue/_components/cdp-borrowing-fees-tile.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "@mento-protocol/monitoring-config/protocol-fee";
 import { formatUSD } from "@/lib/format";
 import type { CdpBorrowingRevenueSummary } from "@/lib/cdp-borrowing-revenue";
 
@@ -37,14 +38,22 @@ export function CdpBorrowingFeesTile({
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
       <div>
         <p className="text-sm text-slate-400">CDP Borrowing Fees</p>
-        <p className="mt-1 text-2xl font-semibold text-white font-mono">
+        {/* Same DeBank deep-link as the Swap Fees tile (BreakdownTile href) —
+            both fee streams land in the same feeRecipient Safe. */}
+        <a
+          href={`https://debank.com/profile/${PROTOCOL_FEE_RECIPIENT_ADDRESS}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`CDP Borrowing Fees: ${mainValue}`}
+          className="mt-1 block text-2xl font-semibold text-white font-mono hover:text-indigo-400 transition-colors"
+        >
           {mainValue}
           {showData && (
             <span className="ml-1.5 text-sm font-normal text-slate-500">
               earned
             </span>
           )}
-        </p>
+        </a>
         {showData && (
           <p className="mt-1.5 text-sm font-mono">
             <span className="text-slate-400">

--- a/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
+++ b/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
@@ -29,9 +29,36 @@ const CDP_BORROWING_HEADER_INFO = {
     "Cumulative one-time borrowing fees paid when troves are opened or debt is increased (gross, before the SP yield split).",
   interest:
     "Accrued interest so far, including live accrual since the last indexer update (gross, before the SP yield split).",
-  total:
-    "Upfront fees plus accrued interest — gross fees paid by borrowers. The protocol keeps the share shown in the summary tile; the rest is StabilityPool depositor yield.",
 } as const;
+
+const bpsToPercentLabel = (bps: number): string => {
+  const pct = bps / 100;
+  return Number.isInteger(pct)
+    ? String(pct)
+    : String(Math.round(pct * 100) / 100);
+};
+
+// The split is governance-set on-chain per market (SystemParams.SP_YIELD_SPLIT,
+// indexed as LiquityCollateral.spYieldSplitBps and surfaced per market row),
+// so the tooltip states the live values instead of hardcoding 25/75. Falls
+// back to generic wording when markets disagree or the indexer hasn't loaded
+// the param yet (-1 sentinel).
+function cdpBorrowingTotalTooltip(
+  markets: ReadonlyArray<CdpBorrowingRevenueMarket>,
+): string {
+  const splits = [...new Set(markets.map((m) => m.spYieldSplitBps))];
+  const bps =
+    splits.length === 1 &&
+    splits[0] !== undefined &&
+    splits[0] >= 0 &&
+    splits[0] <= 10_000
+      ? splits[0]
+      : null;
+  if (bps === null) {
+    return "Gross borrowing fees (upfront + accrued interest), paid by borrowers. The protocol keeps the share shown in the summary tile; the rest is Stability Pool depositor yield.";
+  }
+  return `Gross borrowing fees (upfront + accrued interest), paid by borrowers. Split: ${bpsToPercentLabel(10_000 - bps)}% protocol treasury, ${bpsToPercentLabel(bps)}% Stability Pool depositor yield.`;
+}
 
 const CDP_AVERAGE_APR_INFO = (
   <span className="block space-y-1.5">
@@ -472,7 +499,7 @@ function CdpBorrowingFeesByMarketTable({
             <Th align="right" className="sm:!px-2">
               <CdpBorrowingHeaderInfo
                 label="All-time"
-                content={CDP_BORROWING_HEADER_INFO.total}
+                content={cdpBorrowingTotalTooltip(markets)}
                 tooltipAlign="right"
               />
             </Th>

--- a/ui-dashboard/src/lib/cdp-borrowing-revenue.ts
+++ b/ui-dashboard/src/lib/cdp-borrowing-revenue.ts
@@ -107,6 +107,9 @@ export type CdpBorrowingRevenueMarket = {
   chainId: number;
   collIndex: number;
   symbol: string;
+  // On-chain SP_YIELD_SPLIT for this market (bps; -1 = not loaded yet).
+  // Surfaced so the UI can state the live split instead of hardcoding 25/75.
+  spYieldSplitBps: number;
   activeDebtUSD: number;
   averageAnnualInterestRatePercent: number | null;
   annualInterestRunRateUSD: number;
@@ -490,6 +493,7 @@ export function aggregateCdpBorrowingRevenueMarkets({
         chainId: collateral.chainId,
         collIndex: collateral.collIndex,
         symbol: collateral.symbol,
+        spYieldSplitBps: collateral.spYieldSplitBps,
         activeDebtUSD: addPricedWei(
           collateral.symbol,
           activeDebtWei(collateralInstances),


### PR DESCRIPTION
## The Problem

- The CDP Borrowing Fees tile headline wasn't clickable, while the Swap Fees tile already deep-links to the feeRecipient's DeBank profile — inconsistent, and both fee streams land in the same Safe.
- The "All-time" column tooltip on Borrowing Fees by CDP described the yield split vaguely ("the share shown in the summary tile") instead of stating the actual numbers.

## The Solution

Link the CDP headline to the same DeBank profile, and have the tooltip state the live split ("Split: 25% protocol treasury, 75% Stability Pool depositor yield") — computed from the indexed on-chain `SP_YIELD_SPLIT`, not hardcoded.

## Details

- `cdp-borrowing-fees-tile.tsx`: headline wrapped in the same anchor pattern as `BreakdownTile` (`target="_blank"`, `rel="noopener noreferrer"`, aria-label, hover style), href from `PROTOCOL_FEE_RECIPIENT_ADDRESS`.
- `CdpBorrowingRevenueMarket` gains `spYieldSplitBps` (already indexed on `LiquityCollateral` and present in the markets query); `cdpBorrowingTotalTooltip(markets)` renders the precise percentages when all markets agree on a valid split, and falls back to the previous generic wording on disagreement or the `-1` unloaded sentinel.
- Tests: DeBank link asserted on the page (two `debank.com/profile/0x0dd57f…` anchors), exact tooltip copy at 7500 bps, plus fallback cases for mixed splits and the sentinel.

## Validation

- Targeted vitest (11 page tests), `pnpm typecheck`, `pnpm lint`, `trunk fmt` — all green.

## Deferrals

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Revenue dashboard presentation and copy only; no changes to fee math, auth, or on-chain behavior.
> 
> **Overview**
> Aligns the **CDP Borrowing Fees** summary tile with **Swap Fees** by turning the protocol-share headline into a DeBank profile link for `PROTOCOL_FEE_RECIPIENT_ADDRESS` (same external-link and aria-label pattern as `BreakdownTile`).
> 
> The **Borrowing Fees by CDP** “All-time” header tooltip no longer uses vague split wording when data allows: `cdpBorrowingTotalTooltip(markets)` derives protocol vs Stability Pool percentages from each market’s indexed `spYieldSplitBps` (surfaced on `CdpBorrowingRevenueMarket` from collateral aggregation). It shows explicit “Split: X% protocol treasury, Y% …” when all markets share one valid split, and reverts to the previous generic copy when splits disagree or the `-1` not-loaded sentinel applies.
> 
> Tests cover the DeBank anchors, the 7500 bps tooltip text, and both fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54aa49df64eb0ad6a1e899cb73782790779d1cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->