### PR TITLE
feat(alerts): fan out oracle-relayer page alerts to #alerts-oracles

### DIFF
--- a/alerts/rules/notification-policies.tf
+++ b/alerts/rules/notification-policies.tf
@@ -112,6 +112,8 @@ resource "grafana_notification_policy" "all" {
     # this previously hardcoded `chain = "celo"` which silently dropped
     # Monad (env=prod) page alerts from #alerts-critical (sec-review
     # 2026-05-22 f-010).
+    # `continue = true` so pages also reach the #alerts-oracles copies below —
+    # the oracle-domain channel carries the full oracle picture, pages included.
     policy {
       contact_point = grafana_contact_point.slack_alerts_critical.name
 
@@ -133,12 +135,66 @@ resource "grafana_notification_policy" "all" {
         value = local.weekend_disabled_feeds_pattern
       }
 
+      continue = true
     }
 
     # Oracle Relayer page alerts → #alerts-critical (weekend FX, muted)
     # Same severity=page gating as the non-weekend policy above.
     policy {
       contact_point = grafana_contact_point.slack_alerts_critical.name
+      mute_timings  = [grafana_mute_timing.weekend_mute.name]
+
+      matcher {
+        label = "severity"
+        match = "="
+        value = "page"
+      }
+
+      matcher {
+        label = "service"
+        match = "="
+        value = "oracle-relayers"
+      }
+
+      matcher {
+        label = "rateFeed"
+        match = "=~"
+        value = local.weekend_disabled_feeds_pattern
+      }
+
+      continue = true
+    }
+
+    # Oracle Relayer page alerts → #alerts-oracles (non-weekend FX).
+    # Terminal copy of the #alerts-critical pair above (which `continue`s),
+    # in addition to Splunk On-Call — so page-grade oracle incidents are
+    # visible in the oracle-domain channel alongside the warning-grade ones.
+    policy {
+      contact_point = grafana_contact_point.slack_alerts_oracles.name
+
+      matcher {
+        label = "severity"
+        match = "="
+        value = "page"
+      }
+
+      matcher {
+        label = "service"
+        match = "="
+        value = "oracle-relayers"
+      }
+
+      matcher {
+        label = "rateFeed"
+        match = "!~"
+        value = local.weekend_disabled_feeds_pattern
+      }
+
+    }
+
+    # Oracle Relayer page alerts → #alerts-oracles (weekend FX, muted)
+    policy {
+      contact_point = grafana_contact_point.slack_alerts_oracles.name
       mute_timings  = [grafana_mute_timing.weekend_mute.name]
 
       matcher {


### PR DESCRIPTION
## The Problem

- Page-grade oracle-relayer alerts (`Oldest Report Expired` on celo/monad) route to Splunk On-Call + `#alerts-critical` only — `#alerts-oracles` never sees them.
- The oracle-domain channel therefore carries warnings (`Low Balance`, staleness warnings) but is blind to the most severe oracle incidents.

## The Solution

- Flip the two `#alerts-critical` oracle-relayer page policies to `continue = true` and add a terminal `#alerts-oracles` copy of the pair, so pages deliver to Splunk On-Call → `#alerts-critical` → `#alerts-oracles` (all three).

## Details

- Mirrors the fan-out idiom the tree already uses for the Splunk routes (`continue = true` upstream, terminal copy downstream).
- Two new policies = non-weekend FX + weekend-muted FX, preserving the `weekend_mute` timing split; matchers unchanged.
- No chain matcher needed: `severity = page` already implies prod chains (`rules-oracle-relayers.tf:22` only stamps `page` when `env == "prod"` — see the f-010 comment in the file).
- Context: oracle-relayer just completed Discord→Slack (mento-protocol/oracle-relayer#57, #59); app-emitted alerts now post to `#alerts-oracles`/`#alerts-testnet` via the shared `mento_alerts` bot. This completes the oracle-channel picture.

## Validation

- `pnpm tf validate alerts-rules` → Success.
- `pnpm alerts:rules:plan` → `grafana_notification_policy.all` updated in-place; the positional list churn nets out to exactly 2 × `continue = false → true` + 2 new `#alerts-oracles` page policies.
- Stash-tested clean main: live Grafana matches main's policy tree exactly (zero policy drift), and the `grafana_contact_point.splunk_on_call` update in the plan is a pre-existing perpetual provider rewrite of the sensitive write-only victorops block — present on clean main too, unrelated to this change.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)