### PR TITLE
chore: drop one-time import block for gcf-artifacts repo

### DIFF
--- a/governance-watchdog/infra/artifact-registry.tf
+++ b/governance-watchdog/infra/artifact-registry.tf
@@ -1,14 +1,9 @@
 # Cloud Functions auto-creates this Docker repo for function build images and
 # never cleans it up — it had accumulated 64 images (~1.9 GB) by 2026-06-10.
-# One-time adoption: this import block brings the existing repo into state so
-# the cleanup policies below can manage retention. DELETE this block after the
-# adopting apply lands — it is not valid for from-scratch bring-up (the repo
-# wouldn't exist yet; Terraform creates it from the resource instead).
-import {
-  to = google_artifact_registry_repository.gcf_artifacts
-  id = "projects/${module.governance_watchdog.project_id}/locations/${var.region}/repositories/gcf-artifacts"
-}
-
+# Adopted into state on 2026-06-10 via a one-time import block (PR #835,
+# removed after the adopting apply) so the cleanup policies below manage
+# retention. On from-scratch bring-up Terraform creates the repo before
+# Cloud Functions would.
 resource "google_artifact_registry_repository" "gcf_artifacts" {
   #checkov:skip=CKV_GCP_84:Repo is auto-created and managed by Cloud Functions with Google-managed encryption; imported as-is purely to attach cleanup policies. Switching to CMEK would force recreation and break the managed deploy flow.
   project       = module.governance_watchdog.project_id


### PR DESCRIPTION
## The Problem

- PR #835's `import` block was one-time scaffolding to adopt the existing `gcf-artifacts` repo into Terraform state. The adopting apply landed on 2026-06-10 (`1 imported, 1 added, 2 changed, 0 destroyed`), so the block is now spent — and it would break from-scratch bring-up, where the repo doesn't exist to import.

## The Solution

- Remove the import block and fold its history into the resource comment. Terraform now owns the repo via state; on a fresh project it creates the repo from the resource.

## Details

- Follow-through promised in the PR #835 review thread (Cursor's "import id hardcodes prod project" finding).

## Validation

- `pnpm tf validate governance-watchdog` green.
- Plan against prod state after removal: the `gcf_artifacts` repo plans **stable with no import and no destroy** (only the known checkout-local artifacts — gitignored `.env` creation and a content-equal source-zip re-upload — appear).

## Deferrals

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only scaffolding removal with no resource attribute changes; validated as a stable plan against prod state.
> 
> **Overview**
> Removes the spent one-time Terraform **`import`** block for `google_artifact_registry_repository.gcf_artifacts` in `artifact-registry.tf` after the adopting apply from PR #835 landed.
> 
> The **`gcf_artifacts`** resource and its cleanup policies are unchanged; comments now document that the repo was adopted into state on 2026-06-10 and that fresh bring-up relies on Terraform creating the repo instead of importing it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86615a43f186dcee5cd1b35d8f8c1f4d4abe0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->