### PR TITLE
fix: governance-watchdog post-import hardening + discord.js/undici resolution fix

### DIFF
--- a/governance-watchdog/.env.example
+++ b/governance-watchdog/.env.example
@@ -10,6 +10,7 @@ GCP_PROJECT_ID=
 # You can check it manually via `gcloud secrets list`
 DISCORD_WEBHOOK_URL_SECRET_ID=discord-webhook-url
 TELEGRAM_BOT_TOKEN_SECRET_ID=telegram-bot-token
+QUICKNODE_API_KEY_SECRET_ID=quicknode-api-key
 QUICKNODE_SECURITY_TOKEN_SECRET_ID=quicknode-security-token
 X_AUTH_TOKEN_SECRET_ID=x-auth-token
 

--- a/governance-watchdog/ADDING_EVENTS.md
+++ b/governance-watchdog/ADDING_EVENTS.md
@@ -55,7 +55,7 @@ function main(data) {
 }
 ```
 
-**Deploy the updated filter to QuickNode** using the deploy script:
+**Deploy the updated filter to QuickNode** using the deploy script (commit your filter changes first — the script refuses dirty working trees):
 
 ```bash
 # Deploy a specific webhook
@@ -123,7 +123,7 @@ Once your filter function works correctly:
 
    Keep only the events your handler actually uses — this reduces Cloud Function invocation volume.
 
-3. **Deploy to the permanent webhook** via:
+3. **Deploy to the permanent webhook** (commit your filter changes first — the script refuses dirty working trees):
 
    ```bash
    ./bin/deploy-quicknode-filter.sh --webhook <healthcheck|governor>

--- a/governance-watchdog/README.md
+++ b/governance-watchdog/README.md
@@ -228,7 +228,9 @@ QuickNode webhooks use the `evmAbiFilter` template to match blockchain events by
    */
    ```
 
-2. **Deploy to QuickNode** using the deploy script:
+2. **Commit your changes** — the deploy script refuses dirty working trees so that only reviewed, committed filter code ships to the live webhooks.
+
+3. **Deploy to QuickNode** using the deploy script:
 
    ```sh
    ./bin/deploy-quicknode-filter.sh --webhook healthcheck   # SortedOracles
@@ -238,7 +240,7 @@ QuickNode webhooks use the `evmAbiFilter` template to match blockchain events by
 
    This reads the ABI and contract addresses from the comment header, builds the `templateArgs` payload, and calls `PATCH /webhooks/{id}/template/evmAbiFilterGo` to apply the update live (no downtime).
 
-3. **Verify** by checking the [QuickNode Webhooks Dashboard](https://dashboard.quicknode.com/webhooks) or inspecting the raw webhook via:
+4. **Verify** by checking the [QuickNode Webhooks Dashboard](https://dashboard.quicknode.com/webhooks) or inspecting the raw webhook via:
 
    ```bash
    curl -X GET "https://api.quicknode.com/webhooks/rest/v1/webhooks/$webhook_id" \

--- a/governance-watchdog/bin/deploy-quicknode-filter.sh
+++ b/governance-watchdog/bin/deploy-quicknode-filter.sh
@@ -32,9 +32,10 @@ FILTER_DIR="${REPO_ROOT}/infra/quicknode-filter-functions"
 # Deploy scripts must refuse dirty working trees before mutating external
 # systems (scripts/AGENTS.md). This script PATCHes the live QuickNode webhook
 # templates from local filter files, so uncommitted edits would ship unreviewed.
-if [[ -n "$(git status --porcelain)" ]]; then
+# -C pins the check to the repo the filter files are read from, not the cwd.
+if [[ -n "$(git -C "${REPO_ROOT}" status --porcelain)" ]]; then
 	echo "❌ Working directory is not clean. Commit or stash your changes first."
-	git status --short
+	git -C "${REPO_ROOT}" status --short
 	exit 1
 fi
 

--- a/governance-watchdog/bin/deploy-quicknode-filter.sh
+++ b/governance-watchdog/bin/deploy-quicknode-filter.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 #   - gcloud CLI authenticated with access to the governance-watchdog project
 #   - curl, python3 available
 #   - QuickNode API key stored in GCP Secret Manager as "quicknode-api-key"
+#     (override with QUICKNODE_API_KEY_SECRET_ID if the Terraform variable
+#     quicknode_api_key_secret_id is customized — see infra/variables.tf)
 # =============================================================================
 
 WEBHOOK_TARGET="${1:-all}"
@@ -84,7 +86,7 @@ fetch_api_key() {
 		exit 1
 	fi
 	QN_API_KEY=$(gcloud secrets versions access latest \
-		--secret=quicknode-api-key \
+		--secret="${QUICKNODE_API_KEY_SECRET_ID:-quicknode-api-key}" \
 		--project="${project_id}" 2>/dev/null)
 	if [[ -z ${QN_API_KEY} ]]; then
 		echo "❌ Could not fetch QuickNode API key from Secret Manager."

--- a/governance-watchdog/bin/deploy-quicknode-filter.sh
+++ b/governance-watchdog/bin/deploy-quicknode-filter.sh
@@ -27,6 +27,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FILTER_DIR="${REPO_ROOT}/infra/quicknode-filter-functions"
 
+# Deploy scripts must refuse dirty working trees before mutating external
+# systems (scripts/AGENTS.md). This script PATCHes the live QuickNode webhook
+# templates from local filter files, so uncommitted edits would ship unreviewed.
+if [[ -n "$(git status --porcelain)" ]]; then
+	echo "❌ Working directory is not clean. Commit or stash your changes first."
+	git status --short
+	exit 1
+fi
+
 # Webhook IDs (from QuickNode API)
 # Webhook IDs are server-assigned by QuickNode and will change if webhooks are deleted and recreated.
 # To find current IDs: curl -s -H "x-api-key: <key>" https://api.quicknode.com/webhooks/rest/v1/webhooks | jq '.data[] | {id, name}'

--- a/governance-watchdog/bin/deploy-via-gcloud.sh
+++ b/governance-watchdog/bin/deploy-via-gcloud.sh
@@ -21,7 +21,7 @@ deploy_via_gcloud() {
 		--impersonate-service-account "${terraform_service_account}" \
 		--project "${project_id}" \
 		--region "${region}" \
-		--runtime nodejs20 \
+		--runtime nodejs22 \
 		--service-account "${project_service_account}" \
 		--source . \
 		--trigger-http

--- a/governance-watchdog/bin/reprocess-event.ts
+++ b/governance-watchdog/bin/reprocess-event.ts
@@ -281,9 +281,13 @@ async function fetchEventsByBlockHash(
 
   console.log(`🔍 Fetching block ${blockHash}...`);
 
+  // includeTransactions: false returns transaction hashes only — that's all the
+  // loop needs, since fetchEventsByTxHash fetches each receipt itself. (With
+  // `true`, viem returns full transaction objects and the string-typed loop
+  // below would process zero transactions.)
   const block = await publicClient.getBlock({
     blockHash,
-    includeTransactions: true,
+    includeTransactions: false,
   });
 
   const txCount = block.transactions.length;
@@ -292,20 +296,14 @@ async function fetchEventsByBlockHash(
   const allEvents: QuicknodeEvent[] = [];
 
   for (const tx of block.transactions) {
-    if (typeof tx === "string") {
-      // Transaction hash only, fetch receipt
-      try {
-        const events = await fetchEventsByTxHash(tx as `0x${string}`);
-        allEvents.push(...events);
-      } catch (error: unknown) {
-        if (process.env.DEBUG) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          const txHashStr = String(tx);
-          console.log(
-            `⚠️  Error fetching events from tx ${txHashStr}: ${errorMessage}`,
-          );
-        }
+    try {
+      const events = await fetchEventsByTxHash(tx);
+      allEvents.push(...events);
+    } catch (error: unknown) {
+      if (process.env.DEBUG) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.log(`⚠️  Error fetching events from tx ${tx}: ${errorMessage}`);
       }
     }
   }

--- a/governance-watchdog/infra/local-dotenv-file.tf
+++ b/governance-watchdog/infra/local-dotenv-file.tf
@@ -7,6 +7,7 @@ resource "local_file" "env_file" {
     TELEGRAM_BOT_TOKEN_SECRET_ID=${var.telegram_bot_token_secret_id}
     TELEGRAM_CHAT_ID=${var.telegram_chat_id}
     TELEGRAM_TEST_CHAT_ID=${var.telegram_test_chat_id}
+    QUICKNODE_API_KEY_SECRET_ID=${var.quicknode_api_key_secret_id}
     QUICKNODE_SECURITY_TOKEN_SECRET_ID=${var.quicknode_security_token_secret_id}
     X_AUTH_TOKEN_SECRET_ID=${var.x_auth_token_secret_id}
   EOT

--- a/governance-watchdog/infra/main.tf
+++ b/governance-watchdog/infra/main.tf
@@ -1,5 +1,8 @@
 module "governance_watchdog" {
   activate_apis = [
+    # Gen2 function builds publish their images through Artifact Registry; without
+    # this a from-scratch apply on a fresh project fails before the function exists.
+    "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",
     "cloudfunctions.googleapis.com",
     "cloudresourcemanager.googleapis.com",

--- a/governance-watchdog/infra/monitoring.tf
+++ b/governance-watchdog/infra/monitoring.tf
@@ -65,9 +65,12 @@ resource "google_monitoring_alert_policy" "health_check_policy" {
   notification_channels = [google_monitoring_notification_channel.victorops_channel.id]
   severity              = "CRITICAL"
 
-  # Extends the incident auto-close window beyond GCP's 7-day default so a
-  # still-firing incident isn't closed under responders. The API stores values
-  # above 7 days verbatim (verified on the live policy).
+  # Extends the incident auto-close window beyond GCP's 7-day default. The API
+  # stores values above 7 days verbatim (verified on the live policy).
+  # ~21 days is the deliberate policy — ample time to act on a CRITICAL page —
+  # not the "effectively never auto-close" the previous comment claimed; an
+  # incident nobody acted on for three weeks is a process problem, not one
+  # more weeks of open-incident state would fix.
   alert_strategy {
     auto_close = "1800000s" # ~21 days
   }

--- a/governance-watchdog/infra/monitoring.tf
+++ b/governance-watchdog/infra/monitoring.tf
@@ -3,8 +3,12 @@ resource "google_logging_metric" "health_check_metric" {
   project     = module.governance_watchdog.project_id
   name        = "health_check_logs_count"
   description = "Number of log entries containing 'health check' in the watchdog cloud function"
-  filter      = <<EOF
-    severity=DEFAULT
+  # severity>=DEFAULT matches every severity: console.* writes to stdout land as
+  # DEFAULT today, but if the function ever adopts structured logging the same
+  # line would land as INFO — a severity=DEFAULT filter would then silently zero
+  # this metric and keep the CRITICAL no-health-check-logs alert firing forever.
+  filter = <<EOF
+    severity>=DEFAULT
     SEARCH("`[HealthCheck]`")
     resource.labels.service_name="${google_cloudfunctions2_function.watchdog_notifications.name}"
   EOF
@@ -61,9 +65,11 @@ resource "google_monitoring_alert_policy" "health_check_policy" {
   notification_channels = [google_monitoring_notification_channel.victorops_channel.id]
   severity              = "CRITICAL"
 
-  # This is a workaround to prevent the alert from being automatically closed after 7 days (even if still firing)
+  # Extends the incident auto-close window beyond GCP's 7-day default so a
+  # still-firing incident isn't closed under responders. The API stores values
+  # above 7 days verbatim (verified on the live policy).
   alert_strategy {
-    auto_close = "1800000s" # 20+ years, effectively never auto-close
+    auto_close = "1800000s" # ~21 days
   }
 }
 
@@ -190,7 +196,7 @@ resource "google_monitoring_alert_policy" "signature_failure_policy" {
       2. Check the security token for the failing webhook
       3. Ensure it matches the value in GCP Secret Manager:
          ```
-         gcloud secrets versions access latest --secret="quicknode_security_token" --project="${module.governance_watchdog.project_id}"
+         gcloud secrets versions access latest --secret="${google_secret_manager_secret.quicknode_security_token.secret_id}" --project="${module.governance_watchdog.project_id}"
          ```
       4. Update the webhook in QuickNode with the correct token
       5. If the token is correct, check the logs for the cloud function to see if there are any errors processing the webhook.

--- a/governance-watchdog/infra/secret-manager.tf
+++ b/governance-watchdog/infra/secret-manager.tf
@@ -66,7 +66,7 @@ resource "google_secret_manager_secret_version" "x_auth_token" {
 # Creates a new secret for the Quicknode Security Token which is used to verify that requests to the Cloud Function are coming from Quicknode.
 resource "google_secret_manager_secret" "quicknode_security_token" {
   project   = module.governance_watchdog.project_id
-  secret_id = "quicknode-security-token"
+  secret_id = var.quicknode_security_token_secret_id
 
   replication {
     auto {}
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret_version" "quicknode_security_token" {
 # for webhook health status monitoring.
 resource "google_secret_manager_secret" "quicknode_api_key" {
   project   = module.governance_watchdog.project_id
-  secret_id = "quicknode-api-key"
+  secret_id = var.quicknode_api_key_secret_id
 
   replication {
     auto {}

--- a/governance-watchdog/infra/variables.tf
+++ b/governance-watchdog/infra/variables.tf
@@ -87,6 +87,13 @@ variable "quicknode_api_key" {
 
 # You can look this up via:
 #  `gcloud secrets list`
+variable "quicknode_api_key_secret_id" {
+  type    = string
+  default = "quicknode-api-key"
+}
+
+# You can look this up via:
+#  `gcloud secrets list`
 variable "quicknode_security_token_secret_id" {
   type    = string
   default = "quicknode-security-token"

--- a/governance-watchdog/package.json
+++ b/governance-watchdog/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@google-cloud/functions-framework": "3.5.1",
     "@google-cloud/secret-manager": "5.6.0",
-    "discord.js": "14.25.1",
+    "discord.js": "14.26.4",
     "env-schema": "6.0.1",
     "viem": "2.33.3"
   },

--- a/governance-watchdog/pnpm-lock.yaml
+++ b/governance-watchdog/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   flatted: 3.4.2
-  undici: 7.24.2
 
 importers:
 
@@ -19,8 +18,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0
       discord.js:
-        specifier: 14.25.1
-        version: 14.25.1
+        specifier: 14.26.4
+        version: 14.26.4
       env-schema:
         specifier: 6.0.1
         version: 6.0.1
@@ -1096,8 +1095,8 @@ packages:
   discord-api-types@0.38.48:
     resolution: {integrity: sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==}
 
-  discord.js@14.25.1:
-    resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
+  discord.js@14.26.4:
+    resolution: {integrity: sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==}
     engines: {node: '>=18'}
 
   dotenv-expand@10.0.0:
@@ -2229,9 +2228,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.2:
-    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
-    engines: {node: '>=20.18.1'}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2495,7 +2494,7 @@ snapshots:
       discord-api-types: 0.38.48
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.24.2
+      undici: 6.24.1
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -3379,7 +3378,7 @@ snapshots:
 
   discord-api-types@0.38.48: {}
 
-  discord.js@14.25.1:
+  discord.js@14.26.4:
     dependencies:
       '@discordjs/builders': 1.14.1
       '@discordjs/collection': 1.5.3
@@ -3393,7 +3392,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.24.2
+      undici: 6.24.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4640,7 +4639,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.2: {}
+  undici@6.24.1: {}
 
   unpipe@1.0.0: {}
 

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -8,15 +8,13 @@ minimumReleaseAgeExclude:
   - "@envio-dev/envio-cloud-*"
 
 overrides:
-  # Exact pin for the same reason as undici below: ranges resolve forward on
-  # fresh installs. 3.4.2 is what both the standalone npm lockfile and this
-  # lockfile resolve today.
+  # Exact pin because ranges resolve forward on fresh installs. 3.4.2 is what
+  # both the standalone npm lockfile and this lockfile resolve today.
   flatted: 3.4.2
-  # Exact pin, not a range: ">=6.24.0" resolved to undici 8.x on a fresh
-  # install, and @discordjs/rest 2.6.1 crashes against undici 8's stricter
-  # Headers webidl (Symbol(sensitiveHeaders) → TypeError) while wrapping the
-  # response — sends deliver but report as failures and rate-limit headers
-  # are never read. 7.24.2 is what the last working standalone deploy ran
-  # (npm package-lock) and satisfies the original >=6.24.0 security floor.
-  # Upgrade path (bump discord.js, then drop this): issue #833.
-  undici: 7.24.2
+  # No undici override: discord.js and @discordjs/rest both pin undici EXACTLY
+  # (6.24.1 as of discord.js 14.26.4), which already satisfies the >=6.24.0
+  # security floor from the 2026 advisory batch. Overriding past their pin is
+  # what broke prod once (undici 8's stricter Headers webidl rejects
+  # Symbol(sensitiveHeaders) in @discordjs/rest's response wrapping — sends
+  # deliver but report as failures; see issue #833). If a future undici
+  # advisory lands, bump discord.js instead of re-adding an override.

--- a/governance-watchdog/src/config.ts
+++ b/governance-watchdog/src/config.ts
@@ -4,6 +4,7 @@ interface Env {
   GCP_PROJECT_ID: string;
   DISCORD_WEBHOOK_URL_SECRET_ID: string;
   DISCORD_TEST_WEBHOOK_URL_SECRET_ID: string;
+  QUICKNODE_API_KEY_SECRET_ID: string;
   QUICKNODE_SECURITY_TOKEN_SECRET_ID: string;
   X_AUTH_TOKEN_SECRET_ID: string;
   TELEGRAM_BOT_TOKEN_SECRET_ID: string;
@@ -16,6 +17,7 @@ const schema: JSONSchemaType<Env> = {
   required: [
     "GCP_PROJECT_ID",
     "DISCORD_WEBHOOK_URL_SECRET_ID",
+    "QUICKNODE_API_KEY_SECRET_ID",
     "QUICKNODE_SECURITY_TOKEN_SECRET_ID",
     "X_AUTH_TOKEN_SECRET_ID",
     "TELEGRAM_BOT_TOKEN_SECRET_ID",
@@ -25,6 +27,7 @@ const schema: JSONSchemaType<Env> = {
     GCP_PROJECT_ID: { type: "string" },
     DISCORD_WEBHOOK_URL_SECRET_ID: { type: "string" },
     DISCORD_TEST_WEBHOOK_URL_SECRET_ID: { type: "string" },
+    QUICKNODE_API_KEY_SECRET_ID: { type: "string" },
     QUICKNODE_SECURITY_TOKEN_SECRET_ID: { type: "string" },
     X_AUTH_TOKEN_SECRET_ID: { type: "string" },
     TELEGRAM_BOT_TOKEN_SECRET_ID: { type: "string" },

--- a/governance-watchdog/src/event-notifications/message-builder.discord.ts
+++ b/governance-watchdog/src/event-notifications/message-builder.discord.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder } from "discord.js";
-import { MessageBuilder } from "./message-builder.base";
+import { MessageBuilder } from "./message-builder.base.js";
 
 /**
  * Theme configuration for different event types

--- a/governance-watchdog/src/event-notifications/message-builder.telegram.ts
+++ b/governance-watchdog/src/event-notifications/message-builder.telegram.ts
@@ -1,4 +1,4 @@
-import { MessageBuilder } from "./message-builder.base";
+import { MessageBuilder } from "./message-builder.base.js";
 
 /**
  * Telegram message builder for proposal events

--- a/governance-watchdog/src/events/__tests__/process-event.test.ts
+++ b/governance-watchdog/src/events/__tests__/process-event.test.ts
@@ -12,7 +12,7 @@ import {
 const mockHandler = vi.fn().mockResolvedValue(undefined);
 const mockHealthCheckHandler = vi.fn();
 
-vi.mock("../registry", () => ({
+vi.mock("../registry.js", () => ({
   eventRegistry: {
     getHandler: vi.fn(() => mockHandler),
     getSpecialHandler: vi.fn(() => mockHealthCheckHandler),

--- a/governance-watchdog/src/events/process-event.ts
+++ b/governance-watchdog/src/events/process-event.ts
@@ -1,4 +1,4 @@
-import { eventRegistry } from "./registry";
+import { eventRegistry } from "./registry.js";
 import { EventType, QuicknodeEvent } from "./types.js";
 
 /**

--- a/governance-watchdog/src/events/types.ts
+++ b/governance-watchdog/src/events/types.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder } from "discord.js";
-import { TelegramMessageBuilder } from "../event-notifications/message-builder.telegram";
-import type { EventHandlerConfig } from "./event-handler-factory";
+import { TelegramMessageBuilder } from "../event-notifications/message-builder.telegram.js";
+import type { EventHandlerConfig } from "./event-handler-factory.js";
 
 /**
  * Event type enum - all supported governance events

--- a/governance-watchdog/src/health-check/__tests__/health-check.test.ts
+++ b/governance-watchdog/src/health-check/__tests__/health-check.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventType, type QuicknodeEvent } from "../../events/types.js";
+
+const SORTED_ORACLES_ADDRESS = "0xefb84935239dacdecf7c5ba76d8de40b077b7b33";
+const CELO_CUSD_RATE_FEED_ADDRESS =
+  "0x765DE816845861e75A25fCA122bb6898B8B1282a";
+
+/** Build a typed MedianUpdated event emitted by a given contract address */
+const makeMedianUpdated = (
+  address: string,
+  token: string = CELO_CUSD_RATE_FEED_ADDRESS,
+): QuicknodeEvent => ({
+  address,
+  blockHash: "0xdeadbeef",
+  blockNumber: "47256479",
+  logIndex: "0xf9",
+  name: EventType.MedianUpdated,
+  token: token as `0x${string}`,
+  transactionHash: "0xabc",
+  value: BigInt("251823330000000000000000"),
+});
+
+describe("handleHealthCheckEvent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs [HealthCheck] for a cUSD MedianUpdated event from SortedOracles", async () => {
+    const { default: handleHealthCheckEvent } = await import("../index.js");
+
+    handleHealthCheckEvent(makeMedianUpdated(SORTED_ORACLES_ADDRESS));
+
+    expect(console.info).toHaveBeenCalledWith(
+      "[HealthCheck]: Block",
+      "47256479",
+    );
+  });
+
+  it("ignores MedianUpdated events emitted by other contracts", async () => {
+    const { default: handleHealthCheckEvent } = await import("../index.js");
+
+    handleHealthCheckEvent(
+      makeMedianUpdated("0x1234567890123456789012345678901234567890"),
+    );
+
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it("ignores MedianUpdated events from SortedOracles for other rate feeds", async () => {
+    const { default: handleHealthCheckEvent } = await import("../index.js");
+
+    handleHealthCheckEvent(
+      makeMedianUpdated(
+        SORTED_ORACLES_ADDRESS,
+        "0x0000000000000000000000000000000000000001",
+      ),
+    );
+
+    expect(console.info).not.toHaveBeenCalled();
+  });
+});

--- a/governance-watchdog/src/health-check/index.ts
+++ b/governance-watchdog/src/health-check/index.ts
@@ -1,6 +1,20 @@
 import assert from "assert";
 import { QuicknodeEvent } from "../events/types.js";
-import isHealthCheckEvent from "./is-health-check-event";
+import isHealthCheckEvent from "./is-health-check-event.js";
+
+/**
+ * SortedOracles contract address on Celo mainnet — the only contract whose
+ * MedianUpdated events count as health checks. Any contract can emit the same
+ * event signature, and QuickNode's evmAbiFilter `contracts` field is silently
+ * ignored by the API (see events/process-event.ts), so without this guard a
+ * third-party contract could keep the health-check alert green even if the
+ * real SortedOracles webhook stopped delivering.
+ *
+ * ⚠️  If SortedOracles is ever redeployed, update this constant AND the
+ * contracts field in infra/quicknode-filter-functions/sorted-oracles.js.
+ */
+const SORTED_ORACLES_ADDRESS =
+  "0xefb84935239dacdecf7c5ba76d8de40b077b7b33".toLowerCase();
 
 // CELO/cUSD rate feed address - only log health checks for this feed
 const CELO_CUSD_RATE_FEED_ADDRESS =
@@ -8,6 +22,11 @@ const CELO_CUSD_RATE_FEED_ADDRESS =
 
 export default function handleHealthCheckEvent(event: QuicknodeEvent) {
   assert(isHealthCheckEvent(event), "Expected MedianUpdated event");
+
+  // Only trust MedianUpdated events emitted by the real SortedOracles contract
+  if (event.address.toLowerCase() !== SORTED_ORACLES_ADDRESS) {
+    return;
+  }
 
   // Only log health check for cUSD token
   if (event.token.toLowerCase() === CELO_CUSD_RATE_FEED_ADDRESS) {

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -136,7 +136,9 @@ const handleQuicknodeWebhook = async (
   let eventsDeduplicated = 0;
 
   for (const quicknodeEvent of parseRequestBody(req.body)) {
-    // Skip duplicated events to prevent sending multiple notifications
+    // Skip duplicated events to prevent sending multiple notifications.
+    // Note: isDuplicate registers the event as seen immediately, even if
+    // processing then fails — see the invariant note in utils/event-deduplication.ts.
     if (isDuplicate(quicknodeEvent)) {
       eventsDeduplicated++;
       continue;

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -169,6 +169,12 @@ export const governanceWatchdog: HttpFunction = async (
   try {
     // Route based on path
     if (req.path === "/quicknode-health") {
+      // Deliberately unauthenticated (documented tradeoff, like the function's
+      // public ingress — see infra/cloud_function.tf): the endpoint is read-only,
+      // leaks nothing sensitive (webhook names/statuses only), and Cloud
+      // Scheduler's hourly OIDC-signed call is not verified app-side to keep
+      // this path dependency-free. Cost of an unauthenticated hit is one
+      // Secret Manager read + one QuickNode API call, bounded by quota.
       await handleQuicknodeHealthCheck(req, res);
       return;
     }

--- a/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
+++ b/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
@@ -17,21 +17,23 @@ interface FakeWebhook {
   id: string;
   name: string;
   status: string;
+  network: string;
+}
+
+function fakePage(webhooks: FakeWebhook[]) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ data: webhooks }),
+  };
 }
 
 function mockWebhooksResponse(webhooks: FakeWebhook[]) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ data: webhooks }),
-    }),
-  );
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fakePage(webhooks)));
 }
 
 const ACTIVE_WEBHOOKS: FakeWebhook[] = [
-  { id: "1", name: "SortedOracles", status: "active" },
-  { id: "2", name: "MentoGovernor", status: "active" },
+  { id: "1", name: "SortedOracles", status: "active", network: "celo-mainnet" },
+  { id: "2", name: "MentoGovernor", status: "active", network: "celo-mainnet" },
 ];
 
 describe("checkWebhookStatus", () => {
@@ -75,10 +77,33 @@ describe("checkWebhookStatus", () => {
     expect(result.unhealthyWebhooks).toEqual(["MentoGovernor (missing)"]);
   });
 
+  it("treats a same-named webhook on another network as missing", async () => {
+    mockWebhooksResponse([
+      {
+        id: "1",
+        name: "SortedOracles",
+        status: "active",
+        network: "ethereum-mainnet",
+      },
+      ACTIVE_WEBHOOKS[1],
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual(["SortedOracles (missing)"]);
+  });
+
   it("stays healthy when an unexpected webhook is inactive", async () => {
     mockWebhooksResponse([
       ...ACTIVE_WEBHOOKS,
-      { id: "3", name: "StagingWebhook", status: "paused" },
+      {
+        id: "3",
+        name: "StagingWebhook",
+        status: "paused",
+        network: "celo-mainnet",
+      },
     ]);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
@@ -91,7 +116,12 @@ describe("checkWebhookStatus", () => {
   it("reports unhealthy when an expected webhook is present but not active", async () => {
     mockWebhooksResponse([
       ACTIVE_WEBHOOKS[0],
-      { id: "2", name: "MentoGovernor", status: "paused" },
+      {
+        id: "2",
+        name: "MentoGovernor",
+        status: "paused",
+        network: "celo-mainnet",
+      },
     ]);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
@@ -99,6 +129,31 @@ describe("checkWebhookStatus", () => {
 
     expect(result.healthy).toBe(false);
     expect(result.unhealthyWebhooks).toEqual(["MentoGovernor (paused)"]);
+  });
+
+  it("pages through all webhooks before deciding one is missing", async () => {
+    // First page is full (100 unrelated webhooks); the expected ones are on page 2
+    const filler: FakeWebhook[] = Array.from({ length: 100 }, (_, i) => ({
+      id: `filler-${String(i)}`,
+      name: `Other-${String(i)}`,
+      status: "active",
+      network: "celo-mainnet",
+    }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(fakePage(filler))
+      .mockResolvedValueOnce(fakePage(ACTIVE_WEBHOOKS));
+    vi.stubGlobal("fetch", fetchMock);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("limit=100&offset=0");
+    expect(String(fetchMock.mock.calls[1][0])).toContain(
+      "limit=100&offset=100",
+    );
   });
 
   it("reads the API key secret id from config", async () => {

--- a/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
+++ b/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
@@ -75,6 +75,19 @@ describe("checkWebhookStatus", () => {
     expect(result.unhealthyWebhooks).toEqual(["MentoGovernor (missing)"]);
   });
 
+  it("stays healthy when an unexpected webhook is inactive", async () => {
+    mockWebhooksResponse([
+      ...ACTIVE_WEBHOOKS,
+      { id: "3", name: "StagingWebhook", status: "paused" },
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(true);
+    expect(result.unhealthyWebhooks).toEqual([]);
+  });
+
   it("reports unhealthy when an expected webhook is present but not active", async () => {
     mockWebhooksResponse([
       ACTIVE_WEBHOOKS[0],

--- a/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
+++ b/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock getSecret so no Secret Manager calls happen
+const mockGetSecret = vi.fn();
+vi.mock("../../utils/get-secret.js", () => ({
+  default: mockGetSecret,
+}));
+
+// Mock config to avoid env-schema validation during tests
+vi.mock("../../config.js", () => ({
+  default: {
+    QUICKNODE_API_KEY_SECRET_ID: "quicknode-api-key",
+  },
+}));
+
+interface FakeWebhook {
+  id: string;
+  name: string;
+  status: string;
+}
+
+function mockWebhooksResponse(webhooks: FakeWebhook[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: webhooks }),
+    }),
+  );
+}
+
+const ACTIVE_WEBHOOKS: FakeWebhook[] = [
+  { id: "1", name: "SortedOracles", status: "active" },
+  { id: "2", name: "MentoGovernor", status: "active" },
+];
+
+describe("checkWebhookStatus", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    mockGetSecret.mockResolvedValue("test-api-key");
+  });
+
+  it("reports healthy when both expected webhooks are active", async () => {
+    mockWebhooksResponse(ACTIVE_WEBHOOKS);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(true);
+    expect(result.unhealthyWebhooks).toEqual([]);
+  });
+
+  it("reports unhealthy when the account has no webhooks at all", async () => {
+    mockWebhooksResponse([]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual([
+      "SortedOracles (missing)",
+      "MentoGovernor (missing)",
+    ]);
+  });
+
+  it("reports unhealthy when one expected webhook is missing", async () => {
+    mockWebhooksResponse([ACTIVE_WEBHOOKS[0]]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual(["MentoGovernor (missing)"]);
+  });
+
+  it("reports unhealthy when an expected webhook is present but not active", async () => {
+    mockWebhooksResponse([
+      ACTIVE_WEBHOOKS[0],
+      { id: "2", name: "MentoGovernor", status: "paused" },
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual(["MentoGovernor (paused)"]);
+  });
+
+  it("reads the API key secret id from config", async () => {
+    mockWebhooksResponse(ACTIVE_WEBHOOKS);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    await checkWebhookStatus();
+
+    expect(mockGetSecret).toHaveBeenCalledWith("quicknode-api-key");
+  });
+});

--- a/governance-watchdog/src/quicknode-health/check-webhook-status.ts
+++ b/governance-watchdog/src/quicknode-health/check-webhook-status.ts
@@ -1,3 +1,4 @@
+import config from "../config.js";
 import getSecret from "../utils/get-secret.js";
 
 interface QuicknodeWebhook {
@@ -28,6 +29,14 @@ interface WebhookHealthResult {
 const QUICKNODE_API_BASE_URL = "https://api.quicknode.com";
 const HEALTHY_STATUSES = ["active"];
 
+/**
+ * Webhooks Terraform provisions in infra/quicknode.tf — keep in sync if one is
+ * ever renamed or added there. Requiring these by name means an account with
+ * zero webhooks (deleted webhooks, or an API key scoped to the wrong account)
+ * reports unhealthy instead of "no inactive webhooks → healthy".
+ */
+const EXPECTED_WEBHOOK_NAMES = ["SortedOracles", "MentoGovernor"];
+
 /** Timeout for QuickNode API requests (30 seconds) */
 const QUICKNODE_API_TIMEOUT_MS = 30_000;
 
@@ -42,9 +51,7 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
   let apiKey: string;
   const secretStartTime = Date.now();
   try {
-    apiKey = await getSecret(
-      process.env.QUICKNODE_API_KEY_SECRET_ID ?? "quicknode-api-key",
-    );
+    apiKey = await getSecret(config.QUICKNODE_API_KEY_SECRET_ID);
   } catch (error) {
     const secretDuration = Date.now() - secretStartTime;
     throw new Error(
@@ -106,9 +113,17 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
     isHealthy: HEALTHY_STATUSES.includes(webhook.status.toLowerCase()),
   }));
 
-  const unhealthyWebhooks = webhookStatuses
-    .filter((w) => !w.isHealthy)
-    .map((w) => `${w.name} (${w.status})`);
+  const presentNames = new Set(webhooks.map((webhook) => webhook.name));
+  const missingWebhooks = EXPECTED_WEBHOOK_NAMES.filter(
+    (name) => !presentNames.has(name),
+  );
+
+  const unhealthyWebhooks = [
+    ...missingWebhooks.map((name) => `${name} (missing)`),
+    ...webhookStatuses
+      .filter((w) => !w.isHealthy)
+      .map((w) => `${w.name} (${w.status})`),
+  ];
 
   return {
     healthy: unhealthyWebhooks.length === 0,

--- a/governance-watchdog/src/quicknode-health/check-webhook-status.ts
+++ b/governance-watchdog/src/quicknode-health/check-webhook-status.ts
@@ -31,9 +31,12 @@ const HEALTHY_STATUSES = ["active"];
 
 /**
  * Webhooks Terraform provisions in infra/quicknode.tf — keep in sync if one is
- * ever renamed or added there. Requiring these by name means an account with
- * zero webhooks (deleted webhooks, or an API key scoped to the wrong account)
- * reports unhealthy instead of "no inactive webhooks → healthy".
+ * ever renamed or added there. Health is derived from exactly this set: each
+ * expected webhook must be present AND active, so an account with zero
+ * webhooks (deleted webhooks, or an API key scoped to the wrong account)
+ * reports unhealthy instead of "no inactive webhooks → healthy". Webhooks
+ * outside this set are reported in the status list but don't affect health —
+ * they belong to other services and would page the wrong on-call.
  */
 const EXPECTED_WEBHOOK_NAMES = ["SortedOracles", "MentoGovernor"];
 
@@ -121,7 +124,7 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
   const unhealthyWebhooks = [
     ...missingWebhooks.map((name) => `${name} (missing)`),
     ...webhookStatuses
-      .filter((w) => !w.isHealthy)
+      .filter((w) => EXPECTED_WEBHOOK_NAMES.includes(w.name) && !w.isHealthy)
       .map((w) => `${w.name} (${w.status})`),
   ];
 

--- a/governance-watchdog/src/quicknode-health/check-webhook-status.ts
+++ b/governance-watchdog/src/quicknode-health/check-webhook-status.ts
@@ -32,16 +32,35 @@ const HEALTHY_STATUSES = ["active"];
 /**
  * Webhooks Terraform provisions in infra/quicknode.tf — keep in sync if one is
  * ever renamed or added there. Health is derived from exactly this set: each
- * expected webhook must be present AND active, so an account with zero
- * webhooks (deleted webhooks, or an API key scoped to the wrong account)
- * reports unhealthy instead of "no inactive webhooks → healthy". Webhooks
- * outside this set are reported in the status list but don't affect health —
- * they belong to other services and would page the wrong on-call.
+ * expected webhook must be present (matched by name AND network, so a
+ * same-named webhook on another network can't mask a deleted production one)
+ * AND active. An account with zero webhooks (deleted webhooks, or an API key
+ * scoped to the wrong account) therefore reports unhealthy instead of
+ * "no inactive webhooks → healthy". Webhooks outside this set are reported in
+ * the status list but don't affect health — they belong to other services and
+ * would page the wrong on-call.
  */
-const EXPECTED_WEBHOOK_NAMES = ["SortedOracles", "MentoGovernor"];
+const EXPECTED_WEBHOOKS = [
+  { name: "SortedOracles", network: "celo-mainnet" },
+  { name: "MentoGovernor", network: "celo-mainnet" },
+];
+
+/**
+ * The webhooks endpoint is paginated (default limit 20), so we page through
+ * every result — an expected webhook beyond the first page must not be
+ * reported as missing.
+ */
+const WEBHOOKS_PAGE_LIMIT = 100;
 
 /** Timeout for QuickNode API requests (30 seconds) */
 const QUICKNODE_API_TIMEOUT_MS = 30_000;
+
+function isExpectedWebhook(webhook: QuicknodeWebhook): boolean {
+  return EXPECTED_WEBHOOKS.some(
+    (expected) =>
+      expected.name === webhook.name && expected.network === webhook.network,
+  );
+}
 
 /**
  * Checks the health status of all QuickNode webhooks.
@@ -63,52 +82,62 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
   }
   const secretDuration = Date.now() - secretStartTime;
 
-  // Call QuickNode API with timeout
+  // Call QuickNode API with timeout, paging through all results
   const fetchStartTime = Date.now();
-  let response: Response;
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-    }, QUICKNODE_API_TIMEOUT_MS);
+  const webhooks: QuicknodeWebhook[] = [];
+  let offset = 0;
 
-    response = await fetch(
-      `${QUICKNODE_API_BASE_URL}/webhooks/rest/v1/webhooks`,
-      {
-        method: "GET",
-        headers: {
-          "x-api-key": apiKey,
-          "Content-Type": "application/json",
+  for (;;) {
+    let response: Response;
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort();
+      }, QUICKNODE_API_TIMEOUT_MS);
+
+      response = await fetch(
+        `${QUICKNODE_API_BASE_URL}/webhooks/rest/v1/webhooks?limit=${String(WEBHOOKS_PAGE_LIMIT)}&offset=${String(offset)}`,
+        {
+          method: "GET",
+          headers: {
+            "x-api-key": apiKey,
+            "Content-Type": "application/json",
+          },
+          signal: controller.signal,
         },
-        signal: controller.signal,
-      },
-    );
+      );
 
-    clearTimeout(timeoutId);
-  } catch (error) {
-    const fetchDuration = Date.now() - fetchStartTime;
-    const isTimeout = error instanceof Error && error.name === "AbortError";
-    throw new Error(
-      `QuickNode API request failed after ${String(fetchDuration)}ms (secretFetch=${String(secretDuration)}ms): ${
-        isTimeout
-          ? `Request timed out after ${String(QUICKNODE_API_TIMEOUT_MS)}ms`
-          : error instanceof Error
-            ? error.message
-            : String(error)
-      }`,
-    );
+      clearTimeout(timeoutId);
+    } catch (error) {
+      const fetchDuration = Date.now() - fetchStartTime;
+      const isTimeout = error instanceof Error && error.name === "AbortError";
+      throw new Error(
+        `QuickNode API request failed after ${String(fetchDuration)}ms (secretFetch=${String(secretDuration)}ms): ${
+          isTimeout
+            ? `Request timed out after ${String(QUICKNODE_API_TIMEOUT_MS)}ms`
+            : error instanceof Error
+              ? error.message
+              : String(error)
+        }`,
+      );
+    }
+
+    if (!response.ok) {
+      const fetchDuration = Date.now() - fetchStartTime;
+      const totalDuration = Date.now() - startTime;
+      throw new Error(
+        `QuickNode API returned ${String(response.status)} ${response.statusText} after ${String(fetchDuration)}ms (total=${String(totalDuration)}ms, secretFetch=${String(secretDuration)}ms)`,
+      );
+    }
+
+    const page = (await response.json()) as QuicknodeWebhooksResponse;
+    webhooks.push(...page.data);
+
+    if (page.data.length < WEBHOOKS_PAGE_LIMIT) {
+      break;
+    }
+    offset += WEBHOOKS_PAGE_LIMIT;
   }
-  const fetchDuration = Date.now() - fetchStartTime;
-
-  if (!response.ok) {
-    const totalDuration = Date.now() - startTime;
-    throw new Error(
-      `QuickNode API returned ${String(response.status)} ${response.statusText} after ${String(fetchDuration)}ms (total=${String(totalDuration)}ms, secretFetch=${String(secretDuration)}ms)`,
-    );
-  }
-
-  const data = (await response.json()) as QuicknodeWebhooksResponse;
-  const webhooks = data.data;
 
   const webhookStatuses = webhooks.map((webhook) => ({
     name: webhook.name,
@@ -116,16 +145,24 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
     isHealthy: HEALTHY_STATUSES.includes(webhook.status.toLowerCase()),
   }));
 
-  const presentNames = new Set(webhooks.map((webhook) => webhook.name));
-  const missingWebhooks = EXPECTED_WEBHOOK_NAMES.filter(
-    (name) => !presentNames.has(name),
+  const missingWebhooks = EXPECTED_WEBHOOKS.filter(
+    (expected) =>
+      !webhooks.some(
+        (webhook) =>
+          webhook.name === expected.name &&
+          webhook.network === expected.network,
+      ),
   );
 
   const unhealthyWebhooks = [
-    ...missingWebhooks.map((name) => `${name} (missing)`),
-    ...webhookStatuses
-      .filter((w) => EXPECTED_WEBHOOK_NAMES.includes(w.name) && !w.isHealthy)
-      .map((w) => `${w.name} (${w.status})`),
+    ...missingWebhooks.map((expected) => `${expected.name} (missing)`),
+    ...webhooks
+      .filter(
+        (webhook) =>
+          isExpectedWebhook(webhook) &&
+          !HEALTHY_STATUSES.includes(webhook.status.toLowerCase()),
+      )
+      .map((webhook) => `${webhook.name} (${webhook.status})`),
   ];
 
   return {

--- a/governance-watchdog/src/utils/__tests__/validate-request-origin.test.ts
+++ b/governance-watchdog/src/utils/__tests__/validate-request-origin.test.ts
@@ -1,0 +1,189 @@
+import type { Request } from "@google-cloud/functions-framework";
+import crypto from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock getSecret so no Secret Manager calls happen and we can assert call counts
+const mockGetSecret = vi.fn();
+vi.mock("../get-secret.js", () => ({
+  default: mockGetSecret,
+}));
+
+// Mock config to avoid env-schema validation during tests
+vi.mock("../../config.js", () => ({
+  default: {
+    QUICKNODE_SECURITY_TOKEN_SECRET_ID: "quicknode-security-token",
+    X_AUTH_TOKEN_SECRET_ID: "x-auth-token",
+  },
+}));
+
+const SECURITY_TOKEN = "test-security-token";
+const PAYLOAD = JSON.stringify({ result: [] });
+
+/** Sign a payload the way QuickNode does: HMAC-SHA256 over nonce+timestamp+payload */
+function sign(nonce: string, timestamp: string, payload: string): string {
+  return crypto
+    .createHmac("sha256", SECURITY_TOKEN)
+    .update(nonce + timestamp + payload)
+    .digest("hex");
+}
+
+/** Build a Request-like object carrying QuickNode headers and a raw body */
+function makeQuicknodeRequest(headers: Record<string, string>): Request {
+  return {
+    headers,
+    rawBody: Buffer.from(PAYLOAD),
+  } as unknown as Request;
+}
+
+/** A fresh unix-seconds timestamp string */
+function freshTimestamp(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+describe("isFromQuicknode", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetSecret.mockResolvedValue(SECURITY_TOKEN);
+  });
+
+  it("accepts a correctly signed request with a fresh timestamp", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+    const nonce = "abc123";
+    const timestamp = freshTimestamp();
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": nonce,
+        "x-qn-timestamp": timestamp,
+        "x-qn-signature": sign(nonce, timestamp, PAYLOAD),
+      }),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("accepts a fresh timestamp in milliseconds (unit tolerance)", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+    const nonce = "abc123";
+    const timestamp = String(Date.now());
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": nonce,
+        "x-qn-timestamp": timestamp,
+        "x-qn-signature": sign(nonce, timestamp, PAYLOAD),
+      }),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("rejects when QuickNode headers are missing — without reading any secret", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+
+    const result = await isFromQuicknode(makeQuicknodeRequest({}));
+
+    expect(result).toBe(false);
+    expect(mockGetSecret).not.toHaveBeenCalled();
+  });
+
+  it("rejects a replayed (stale) timestamp even with a valid signature — without reading any secret", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+    const nonce = "abc123";
+    // 10 minutes old: outside the 5-minute replay window
+    const timestamp = String(Math.floor(Date.now() / 1000) - 10 * 60);
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": nonce,
+        "x-qn-timestamp": timestamp,
+        "x-qn-signature": sign(nonce, timestamp, PAYLOAD),
+      }),
+    );
+
+    expect(result).toBe(false);
+    expect(mockGetSecret).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-numeric timestamp", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+    const nonce = "abc123";
+    const timestamp = "not-a-number";
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": nonce,
+        "x-qn-timestamp": timestamp,
+        "x-qn-signature": sign(nonce, timestamp, PAYLOAD),
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("cleanly rejects a malformed signature of the wrong length (no TypeError)", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": "abc123",
+        "x-qn-timestamp": freshTimestamp(),
+        "x-qn-signature": "deadbeef", // 8 chars instead of 64
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("rejects a wrong signature of the correct length", async () => {
+    const { isFromQuicknode } = await import("../validate-request-origin.js");
+
+    const result = await isFromQuicknode(
+      makeQuicknodeRequest({
+        "x-qn-nonce": "abc123",
+        "x-qn-timestamp": freshTimestamp(),
+        "x-qn-signature": "0".repeat(64),
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("hasAuthToken", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetSecret.mockResolvedValue("expected-auth-token");
+  });
+
+  it("rejects when the x-auth-token header is absent — without reading any secret", async () => {
+    const { hasAuthToken } = await import("../validate-request-origin.js");
+
+    const result = await hasAuthToken({ headers: {} } as unknown as Request);
+
+    expect(result).toBe(false);
+    expect(mockGetSecret).not.toHaveBeenCalled();
+  });
+
+  it("accepts the correct auth token", async () => {
+    const { hasAuthToken } = await import("../validate-request-origin.js");
+
+    const result = await hasAuthToken({
+      headers: { "x-auth-token": "expected-auth-token" },
+    } as unknown as Request);
+
+    expect(result).toBe(true);
+  });
+
+  it("rejects a wrong auth token", async () => {
+    const { hasAuthToken } = await import("../validate-request-origin.js");
+
+    const result = await hasAuthToken({
+      headers: { "x-auth-token": "wrong-token" },
+    } as unknown as Request);
+
+    expect(result).toBe(false);
+  });
+});

--- a/governance-watchdog/src/utils/__tests__/validate-request-origin.test.ts
+++ b/governance-watchdog/src/utils/__tests__/validate-request-origin.test.ts
@@ -186,4 +186,14 @@ describe("hasAuthToken", () => {
 
     expect(result).toBe(false);
   });
+
+  it("rejects a wrong auth token of the same length", async () => {
+    const { hasAuthToken } = await import("../validate-request-origin.js");
+
+    const result = await hasAuthToken({
+      headers: { "x-auth-token": "expected-auth-tokeX" },
+    } as unknown as Request);
+
+    expect(result).toBe(false);
+  });
 });

--- a/governance-watchdog/src/utils/event-deduplication.ts
+++ b/governance-watchdog/src/utils/event-deduplication.ts
@@ -114,7 +114,13 @@ export function isDuplicate(event: QuicknodeEvent): boolean {
     }
   }
 
-  // Update the cache
+  // INVARIANT (deliberate tradeoff): the event is registered as seen BEFORE the
+  // caller runs processEvent. If downstream delivery (Discord/Telegram) then
+  // fails, a QuickNode retry within DEDUPLICATION_WINDOW_MS is dropped — we
+  // prefer a missed notification over duplicate notification spam. Retries
+  // after the window (or ones landing on another instance — this cache is
+  // per-instance memory) are processed normally. Do not move this set() to
+  // after processing without revisiting that tradeoff.
   processedEvents.set(eventId, now);
 
   if (process.env.DEBUG) {

--- a/governance-watchdog/src/utils/validate-request-origin.ts
+++ b/governance-watchdog/src/utils/validate-request-origin.ts
@@ -82,13 +82,22 @@ export async function hasAuthToken(req: Request): Promise<boolean> {
 
   // Don't burn a Secret Manager read when the header is absent (see the
   // pre-check note in isFromQuicknode).
-  if (!authToken) {
+  if (typeof authToken !== "string" || authToken === "") {
     return false;
   }
 
   const expectedAuthToken = await getSecret(config.X_AUTH_TOKEN_SECRET_ID);
 
-  return authToken === expectedAuthToken;
+  // Constant-time comparison, like the signature check above. The length
+  // pre-check is required (timingSafeEqual throws on mismatched lengths)
+  // and leaks only the token length.
+  const encoder = new TextEncoder();
+  const given = encoder.encode(authToken);
+  const expected = encoder.encode(expectedAuthToken);
+
+  return (
+    given.length === expected.length && crypto.timingSafeEqual(given, expected)
+  );
 }
 
 /**

--- a/governance-watchdog/src/utils/validate-request-origin.ts
+++ b/governance-watchdog/src/utils/validate-request-origin.ts
@@ -1,30 +1,58 @@
 import type { Request } from "@google-cloud/functions-framework";
 import crypto from "crypto";
-import config from "../config";
-import getSecret from "./get-secret";
+import config from "../config.js";
+import getSecret from "./get-secret.js";
+
+/**
+ * Maximum allowed age (and future clock skew) of the x-qn-timestamp header.
+ *
+ * The timestamp is part of the HMAC input, so a verified signature proves it was
+ * set by QuickNode — but without a freshness check, a captured request (e.g. from
+ * an intermediate proxy or log) could be replayed indefinitely to produce duplicate
+ * governance notifications. 5 minutes comfortably covers QuickNode delivery retries
+ * and clock skew. We deliberately do NOT track x-qn-nonce values: a nonce cache
+ * would live in per-instance memory only, adding little on top of this window and
+ * the event-deduplication cache (see ./event-deduplication.ts).
+ */
+const MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60;
 
 export async function isFromQuicknode(req: Request): Promise<boolean> {
-  const quicknodeSecurityToken = await getSecret(
-    config.QUICKNODE_SECURITY_TOKEN_SECRET_ID,
-  );
   const nonce = req.headers["x-qn-nonce"] as string;
   const timestamp = req.headers["x-qn-timestamp"] as string;
   const givenSignature = req.headers["x-qn-signature"] as string;
 
+  // Cheap pre-checks come before any getSecret() call: the function is publicly
+  // invokable and getSecret intentionally doesn't cache values, so every check we
+  // can do without a Secret Manager round trip saves quota and latency on
+  // unauthenticated scans and malformed traffic.
   if (!nonce || !timestamp || !givenSignature) {
     console.error("QuickNode Validation: Missing required QuickNode headers");
     return false;
   }
+
+  if (!isTimestampFresh(timestamp)) {
+    console.error(
+      `QuickNode Validation: x-qn-timestamp outside the ±${String(
+        MAX_TIMESTAMP_SKEW_SECONDS,
+      )}s replay window: ${timestamp}`,
+    );
+    return false;
+  }
+
+  // Use rawBody for signature verification - this is the original request body
+  // before any parsing. Re-serializing req.body with JSON.stringify() can produce
+  // different output than what was sent, causing signature verification to fail.
+  if (!req.rawBody) {
+    console.error(
+      "❌ QuickNode Validation: req.rawBody is not available. Cannot verify signature.",
+    );
+    return false;
+  }
+
   try {
-    // Use rawBody for signature verification - this is the original request body
-    // before any parsing. Re-serializing req.body with JSON.stringify() can produce
-    // different output than what was sent, causing signature verification to fail.
-    if (!req.rawBody) {
-      console.error(
-        "❌ QuickNode Validation: req.rawBody is not available. Cannot verify signature.",
-      );
-      return false;
-    }
+    const quicknodeSecurityToken = await getSecret(
+      config.QUICKNODE_SECURITY_TOKEN_SECRET_ID,
+    );
     const payloadString = req.rawBody.toString();
     const isValid = verifySignature(
       quicknodeSecurityToken,
@@ -51,9 +79,33 @@ export async function isFromQuicknode(req: Request): Promise<boolean> {
 
 export async function hasAuthToken(req: Request): Promise<boolean> {
   const authToken = req.headers["x-auth-token"];
+
+  // Don't burn a Secret Manager read when the header is absent (see the
+  // pre-check note in isFromQuicknode).
+  if (!authToken) {
+    return false;
+  }
+
   const expectedAuthToken = await getSecret(config.X_AUTH_TOKEN_SECRET_ID);
 
   return authToken === expectedAuthToken;
+}
+
+/**
+ * Checks that the x-qn-timestamp header is within the replay window.
+ * QuickNode sends unix epoch seconds; we tolerate milliseconds defensively
+ * because the unit is controlled by QuickNode and guessing wrong would reject
+ * every legitimate webhook (which QuickNode punishes by terminating it).
+ */
+function isTimestampFresh(timestamp: string): boolean {
+  const parsed = Number(timestamp);
+  if (!Number.isFinite(parsed)) {
+    return false;
+  }
+  const timestampMs = parsed > 1e12 ? parsed : parsed * 1000;
+  return (
+    Math.abs(Date.now() - timestampMs) <= MAX_TIMESTAMP_SKEW_SECONDS * 1000
+  );
 }
 
 // Taken from https://www.quicknode.com/guides/quicknode-products/streams/validating-incoming-streams-webhook-messages
@@ -82,6 +134,15 @@ function verifySignature(
     console.log("\nSignatures:");
     console.log("- Computed:", computedSignature);
     console.log("- Given:", givenSignature);
+  }
+
+  // Reject signatures of the wrong length before converting: timingSafeEqual
+  // throws on length-mismatched buffers and hexToBytes throws on odd-length hex,
+  // turning a malformed x-qn-signature into a noisy TypeError instead of a clean
+  // reject. The expected length is fixed (64 hex chars for HMAC-SHA256), so this
+  // comparison leaks nothing secret.
+  if (givenSignature.length !== computedSignature.length) {
+    return false;
   }
 
   // Convert to Uint8Array manually to satisfy timingSafeEqual's ArrayBufferView requirement

--- a/governance-watchdog/src/utils/validate-request-origin.ts
+++ b/governance-watchdog/src/utils/validate-request-origin.ts
@@ -22,7 +22,7 @@ export async function isFromQuicknode(req: Request): Promise<boolean> {
   const givenSignature = req.headers["x-qn-signature"] as string;
 
   // Cheap pre-checks come before any getSecret() call: the function is publicly
-  // invokable and getSecret intentionally doesn't cache values, so every check we
+  // callable and getSecret intentionally doesn't cache values, so every check we
   // can do without a Secret Manager round trip saves quota and latency on
   // unauthenticated scans and malformed traffic.
   if (!nonce || !timestamp || !givenSignature) {

--- a/governance-watchdog/src/utils/validate-request-origin.ts
+++ b/governance-watchdog/src/utils/validate-request-origin.ts
@@ -105,6 +105,11 @@ export async function hasAuthToken(req: Request): Promise<boolean> {
  * QuickNode sends unix epoch seconds; we tolerate milliseconds defensively
  * because the unit is controlled by QuickNode and guessing wrong would reject
  * every legitimate webhook (which QuickNode punishes by terminating it).
+ *
+ * Do NOT "clean this up" into a strict seconds-only check: the tolerance does
+ * not widen the window (each timestamp string normalizes to a single instant,
+ * and the timestamp is HMAC-bound so an attacker can't re-encode it), but
+ * removing it would reject every webhook if QuickNode ever switches units.
  */
 function isTimestampFresh(timestamp: string): boolean {
   const parsed = Number(timestamp);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0
       discord.js:
-        specifier: 14.25.1
-        version: 14.25.1
+        specifier: 14.26.4
+        version: 14.26.4
       env-schema:
         specifier: 6.0.1
         version: 6.0.1
@@ -5470,8 +5470,8 @@ packages:
   discord-api-types@0.38.48:
     resolution: {integrity: sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==}
 
-  discord.js@14.25.1:
-    resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
+  discord.js@14.26.4:
+    resolution: {integrity: sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==}
     engines: {node: '>=18'}
 
   doctypes@1.1.0:
@@ -15251,7 +15251,7 @@ snapshots:
 
   discord-api-types@0.38.48: {}
 
-  discord.js@14.25.1:
+  discord.js@14.26.4:
     dependencies:
       '@discordjs/builders': 1.14.1
       '@discordjs/collection': 1.5.3


### PR DESCRIPTION
## The Problem

- PR #819 imported governance-watchdog byte-identical to the standalone repo, deferring 16 pre-existing reviewer findings (auth ordering, replay protection, env-schema gaps, monitoring/Terraform drift, broken operator tooling) to #820.
- The package pinned `undici` 7.24.2 via a workspace override as a prod hotfix (#831); the override pattern itself is what broke Discord delivery, and #833 tracks the proper fix.

## The Solution

- Implement every deferred finding from #820 across `src/`, `infra/`, and `bin/`: cheap auth pre-checks before Secret Manager reads, a timestamp replay window, clean signature rejects, a required env-schema entry, missing-webhook health detection, a SortedOracles emitter guard, metric/runbook/API fixes, and operator-script fixes.
- Bump discord.js to 14.26.4 and drop the undici override entirely — discord.js and @discordjs/rest pin undici exactly (6.24.1, advisory-clean), which is the configuration upstream ships; no override means no forward-resolution risk.

## Details

- Three issue claims were corrected against ground truth: (1) no discord.js release "supports undici 8" (even v15-dev pins 7.x exact and still wraps `new Headers(res.headers)`) — the breakage only ever came from our override rewiring `@discordjs/rest`'s exact pin, so the fix is to stop overriding, not to wait for an upstream release; (2) GCP does NOT clamp `auto_close` to 7 days (the live policy stores 1800000s verbatim), so that finding became a comment-only fix; (3) `[HealthCheck]` logs land as severity DEFAULT today (verified live), so the metric is not currently misfiring — the `severity>=DEFAULT` filter widening is future-proofing against structured-logging adoption.
- Replay protection is a ±5-minute `x-qn-timestamp` window checked before any secret read; nonce tracking is deliberately skipped — a per-instance nonce cache adds almost nothing over the window plus the 60s event-dedup cache (documented in code).
- `QUICKNODE_API_KEY_SECRET_ID` is now required at cold start. Prod already sets it (`cloud_function.tf`); the generated local `.env` now includes it (`local-dotenv-file.tf`). Pre-existing local `.env` files fail fast with a self-naming error until `pnpm generate:env` is re-run.
- Terraform: hardcoded `secret_id`s now use their variables (defaults byte-match the old literals, so the plan is a no-op on those resources); the signature-failure runbook interpolates the real secret id instead of the wrong `quicknode_security_token` literal; the `artifactregistry.googleapis.com` hunk was merged with main's #835 line.
- `/quicknode-health` now requires both Terraform-provisioned webhooks ("SortedOracles", "MentoGovernor") to be present and active — an account with zero webhooks no longer reports healthy.
- `x-auth-token` comparison is now constant-time, matching the signature path.
- Dedup register-before-process and the unauthenticated `/quicknode-health` route remain deliberate tradeoffs, now documented in code at the exact decision points.
- Merging does NOT deploy: an operator must run `pnpm gov-watchdog:deploy` from a clean main checkout, then verify per Validation.

## Validation

- `cd governance-watchdog && pnpm typecheck && pnpm lint && pnpm knip && pnpm build && pnpm test:unit` → 5 files, 31 tests green (19 new: replay window, length guard, secret-read ordering, webhook-missing detection, SortedOracles guard, constant-time token compare).
- `terraform -chdir=governance-watchdog/infra fmt -check -recursive` + `terraform validate` → clean.
- Root and nested `pnpm install --frozen-lockfile` both green; `pnpm why undici` in the package shows a single `undici@6.24.1`.
- Incident repro: wrapping a live `undici.request()` response with `new Headers(res.headers)` — the exact `@discordjs/rest` line that threw under undici 8 — succeeds on the resolved 6.24.1.
- Live GCP checks (read-only SA): the deployed function already sets `QUICKNODE_API_KEY_SECRET_ID` and runs nodejs22; the live `no-health-check-logs` policy stores `auto_close=1800000s` verbatim; live `[HealthCheck]` entries carry severity DEFAULT.
- Post-deploy (manual): run `pnpm --filter @mento-protocol/governance-watchdog test:prod:ProposalCreated` and confirm the function logs show `✅ Successfully sent Discord notification` (per #833, channel delivery alone is not sufficient proof), plus `pnpm gov-watchdog:logs` for `[HealthCheck]` entries and the `health_check_logs_count` metric incrementing.

Closes #820
Closes #833

## Deferrals

- #837 — cap or scope the root `undici: >=6.24.0` override (pre-existing forward-resolution hazard; affects the root workspace graph only, the deployed artifact builds from the nested lockfile).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production webhook authentication, on-call health metrics, and notification delivery dependencies; changes are well-tested but need a clean deploy and post-deploy Discord/health verification.
> 
> **Overview**
> Hardens **governance-watchdog** after monorepo import: webhook auth, health signals, infra/ops, and Discord delivery dependencies.
> 
> **Security & ingress:** QuickNode verification now rejects missing headers, stale `x-qn-timestamp` (±5 min), and bad signature lengths **before** Secret Manager reads; `x-auth-token` uses constant-time compare. **Health checks** only count `MedianUpdated` from the real SortedOracles contract (not just cUSD token). **QuickNode REST health** requires Terraform’s `SortedOracles` and `MentoGovernor` on `celo-mainnet` to exist and be `active`, with API pagination so webhooks aren’t falsely “missing.”
> 
> **Deps & deploy:** Bumps **discord.js** to 14.26.4 and **drops the `undici` override** so `@discordjs/rest` keeps its pinned 6.24.1 (fixes false Discord send failures). gcloud deploy uses **nodejs22**; filter deploy script blocks dirty git trees and respects `QUICKNODE_API_KEY_SECRET_ID`.
> 
> **Terraform / monitoring:** Secret IDs wired through variables; local `.env` generation adds `QUICKNODE_API_KEY_SECRET_ID` (required in `config.ts`); enables **Artifact Registry** API for fresh applies; health metric filter `severity>=DEFAULT`; alert runbook uses the real QuickNode security secret id.
> 
> **Tests & tooling:** New unit tests for auth, webhook health, and SortedOracles guard; fixes `reprocess-event` block scanning (`includeTransactions: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5478a91e7a0754c3bee01f80fb45c55cb198c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->