### PR TITLE
feat(integrations): authenticate Fly.trade probe requests with FLYTRADE_API_KEY

### DIFF
--- a/.github/workflows/integration-probes.yml
+++ b/.github/workflows/integration-probes.yml
@@ -23,6 +23,7 @@ jobs:
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
       UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       LIFI_API_KEY: ${{ secrets.LIFI_API_KEY }}
+      FLYTRADE_API_KEY: ${{ secrets.FLYTRADE_API_KEY }}
       OPENOCEAN_API_KEY: ${{ secrets.OPENOCEAN_API_KEY }}
       ZEROX_API_KEY: ${{ secrets.ZEROX_API_KEY }}
       ONEINCH_API_KEY: ${{ secrets.ONEINCH_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | ------------------------------- | ------------------------------------------------------------------------------------------- |
 | `INTEGRATION_PROBES_HASURA_URL` | Optional override for the pool-discovery GraphQL endpoint                                   |
 | `LIFI_API_KEY`                  | LI.FI/Jumper quote API key; probes return `needs_key` without it                            |
+| `FLYTRADE_API_KEY`              | Optional Fly.trade (Magpie) API key for authenticated Fly follow-up requests                |
 | `OPENOCEAN_API_KEY`             | Optional OpenOcean Pro quote API key                                                        |
 | `ZEROX_API_KEY`                 | Optional 0x quote API key                                                                   |
 | `ONEINCH_API_KEY`               | Optional 1inch quote API key                                                                |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,12 +152,16 @@ pnpm integrations:probe --adapter openocean,relay --chain 42220 --pair-limit 1 -
 `INTEGRATION_PROBES_HASURA_URL` can override `NEXT_PUBLIC_HASURA_URL` for pool
 discovery. `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with the
 `x-lifi-api-key` header so scheduled runs avoid public quote limits,
+`FLYTRADE_API_KEY` authenticates the Fly.trade follow-up requests behind Monad
+LI.FI routes with the `apikey` header against `api.magpiefi.xyz` (falling back
+to the public `api.fly.trade` origin when unset),
 `OPENOCEAN_API_KEY` enables the OpenOcean Pro endpoint for OpenOcean checks,
 and `SQUID_INTEGRATOR_ID` identifies Mento's Squid quote probes through the
 `x-integrator-id` header. Squid Celo probes also read Uniswap V3 pool balances
 through `SQUID_CELO_RPC_URL` when set, defaulting to Forno, to size discovery
 amounts after the default quote. These are managed by the platform Terraform stack
-from `lifi_api_key`, `openocean_api_key`, and `squid_integrator_id`. The same
+from `lifi_api_key`, `flytrade_api_key`, `openocean_api_key`, and
+`squid_integrator_id`. The same
 platform stack mirrors
 `INTEGRATION_PROBES_HASURA_URL`, `UPSTASH_REDIS_REST_URL`, and
 `UPSTASH_REDIS_REST_TOKEN` into repo-level GitHub Actions secrets so scheduled

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -89,6 +89,12 @@ pnpm --filter @mento-protocol/integration-probes knip
   `OKX_DEX_PASSPHRASE`.
 - `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with
   `x-lifi-api-key`; keep it server-side and Terraform-managed.
+- `FLYTRADE_API_KEY` authenticates the Fly.trade follow-up requests behind
+  Monad LI.FI routes with the `apikey` header against the authenticated
+  `api.magpiefi.xyz` origin; without it the probe falls back to the public
+  `api.fly.trade` origin. It is optional (not part of `credentialEnv`), so a
+  missing key never renders LI.FI as `needs_key`. Keep it server-side and
+  Terraform-managed.
 - `SQUID_INTEGRATOR_ID` authenticates Squid quote probes with
   `x-integrator-id`; keep it server-side and Terraform-managed.
 - `SQUID_CELO_RPC_URL` optionally overrides the default Forno Celo RPC used for

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { flyApiHeaders, flyQuoteUrl } from "../adapterRequests.js";
 import {
   AGGREGATOR_ADAPTERS,
   aggregatePairStatus,
@@ -479,6 +480,14 @@ describe("probeAdapterPair", () => {
     for (const headers of flyHeaders) {
       expect(headers).toEqual({ apikey: "fly-key" });
     }
+  });
+
+  it("treats an empty FLYTRADE_API_KEY as unset and stays on the public Fly origin", () => {
+    const env = { FLYTRADE_API_KEY: "" };
+    expect(flyApiHeaders(env)).toBeUndefined();
+    expect(flyQuoteUrl(monadInput, "monad", env)).toContain(
+      "https://api.fly.trade/aggregator/quote",
+    );
   });
 
   it("uses the winning LI.FI discovery amount for Fly follow-up quotes", async () => {

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { flyApiHeaders, flyQuoteUrl } from "../adapterRequests.js";
+import {
+  flyApiHeaders,
+  flyDistributionsUrl,
+  flyQuoteUrl,
+} from "../adapterRequests.js";
 import {
   AGGREGATOR_ADAPTERS,
   aggregatePairStatus,
@@ -487,6 +491,9 @@ describe("probeAdapterPair", () => {
     expect(flyApiHeaders(env)).toBeUndefined();
     expect(flyQuoteUrl(monadInput, "monad", env)).toContain(
       "https://api.fly.trade/aggregator/quote",
+    );
+    expect(flyDistributionsUrl("some-quote-id", env)).toContain(
+      "https://api.fly.trade/aggregator/distributions",
     );
   });
 

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -425,6 +425,62 @@ describe("probeAdapterPair", () => {
     expect(calls).toHaveLength(3);
   });
 
+  it("sends Fly follow-ups to the authenticated origin with the apikey header when FLYTRADE_API_KEY is set", async () => {
+    const lifi = AGGREGATOR_ADAPTERS.find((item) => item.id === "lifi");
+    expect(lifi).toBeDefined();
+    const flyHeaders: unknown[] = [];
+
+    const result = await probeAdapterPair({
+      adapter: lifi!,
+      chain: monadChain,
+      input: monadInput,
+      fetcher: async (url, init) => {
+        const href = String(url);
+        if (href.startsWith("https://li.quest/v1/quote")) {
+          expect(JSON.stringify(init?.headers)).not.toContain("fly-key");
+          return new Response(
+            JSON.stringify({
+              tool: "fly",
+              transactionRequest: { to: PRIMARY_TARGET },
+            }),
+          );
+        }
+        if (href.startsWith("https://api.magpiefi.xyz/aggregator/quote?")) {
+          flyHeaders.push(init?.headers);
+          return new Response(
+            JSON.stringify({
+              id: "391cd96d-c4bb-453a-8ab8-2459b5a2f57c",
+            }),
+          );
+        }
+        if (
+          href ===
+          "https://api.magpiefi.xyz/aggregator/distributions?quoteId=391cd96d-c4bb-453a-8ab8-2459b5a2f57c"
+        ) {
+          flyHeaders.push(init?.headers);
+          return new Response(
+            JSON.stringify({
+              distributions: [
+                { route: [{ protocol: "mento-v3", pool: { address: POOL } }] },
+              ],
+            }),
+          );
+        }
+        throw new Error(`unexpected URL ${href}`);
+      },
+      env: { LIFI_API_KEY: "lifi-key", FLYTRADE_API_KEY: "fly-key" },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.requestUrl).toContain(
+      "https://api.magpiefi.xyz/aggregator/distributions",
+    );
+    expect(flyHeaders).toHaveLength(2);
+    for (const headers of flyHeaders) {
+      expect(headers).toEqual({ apikey: "fly-key" });
+    }
+  });
+
   it("uses the winning LI.FI discovery amount for Fly follow-up quotes", async () => {
     const lifi = AGGREGATOR_ADAPTERS.find((item) => item.id === "lifi");
     expect(lifi).toBeDefined();

--- a/integration-probes/src/adapterRequests.ts
+++ b/integration-probes/src/adapterRequests.ts
@@ -12,6 +12,11 @@ const LIFI_FLY_EXCHANGE = "fly";
 export const SQUID_MAX_QUOTE_REQUESTS_PER_RUN = 160;
 export const SQUID_QUOTE_REQUEST_DELAY_MS = 2_500;
 
+// Fly.trade serves keyed requests from the magpiefi origin; the fly.trade
+// origin is the public, unauthenticated tier.
+const FLY_AUTHENTICATED_API_ORIGIN = "https://api.magpiefi.xyz";
+const FLY_PUBLIC_API_ORIGIN = "https://api.fly.trade";
+
 const LIFI_FLY_CHAIN_ID = 143;
 const LIFI_FLY_NETWORKS: Partial<Record<number, string>> = {
   [LIFI_FLY_CHAIN_ID]: "monad",
@@ -125,8 +130,24 @@ export function lifiFlyNetwork(chainId: number): string | null {
   return LIFI_FLY_NETWORKS[chainId] ?? null;
 }
 
-export function flyQuoteUrl(input: QuoteProbeInput, network: string): string {
-  const url = new URL("https://api.fly.trade/aggregator/quote");
+export function flyApiHeaders(
+  env: NodeJS.ProcessEnv,
+): RequestHeaders | undefined {
+  return env.FLYTRADE_API_KEY ? { apikey: env.FLYTRADE_API_KEY } : undefined;
+}
+
+function flyApiOrigin(env: NodeJS.ProcessEnv): string {
+  return env.FLYTRADE_API_KEY
+    ? FLY_AUTHENTICATED_API_ORIGIN
+    : FLY_PUBLIC_API_ORIGIN;
+}
+
+export function flyQuoteUrl(
+  input: QuoteProbeInput,
+  network: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const url = new URL(`${flyApiOrigin(env)}/aggregator/quote`);
   setParams(url, {
     network,
     fromTokenAddress: input.sellToken.address,
@@ -140,8 +161,11 @@ export function flyQuoteUrl(input: QuoteProbeInput, network: string): string {
   return url.toString();
 }
 
-export function flyDistributionsUrl(quoteId: string): string {
-  const url = new URL("https://api.fly.trade/aggregator/distributions");
+export function flyDistributionsUrl(
+  quoteId: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const url = new URL(`${flyApiOrigin(env)}/aggregator/distributions`);
   setParams(url, { quoteId });
   return url.toString();
 }

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -1,5 +1,6 @@
 import { detectEvidence } from "./evidence.js";
 import {
+  flyApiHeaders,
   flyDistributionsUrl,
   flyQuoteId,
   flyQuoteUrl,
@@ -26,6 +27,7 @@ import type {
   QuoteRequest,
   QuoteResponseEvidenceArgs,
   QuoteResponseEvidenceHook,
+  RequestHeaders,
   TimedPayload,
 } from "./adapterTypes.js";
 import type {
@@ -635,7 +637,7 @@ function lifiAdapter(): AggregatorAdapter {
     researchNote:
       "LI.FI chain metadata lists both Celo and Monad; scheduled probes use an API key and route-discovery attempts to avoid confusing cheaper non-Mento default routes with missing Mento support.",
     quote: (input, env) =>
-      lifiQuoteRequests(input, env, lifiAfterResponseHook(input)),
+      lifiQuoteRequests(input, env, lifiAfterResponseHook(input, env)),
   };
 }
 
@@ -823,12 +825,16 @@ function excludedAdapter(
 
 function lifiAfterResponseHook(
   input: QuoteProbeInput,
+  env: NodeJS.ProcessEnv,
 ): QuoteResponseEvidenceHook | undefined {
-  return lifiFlyNetwork(input.chainId) ? lifiFlyEvidence : undefined;
+  return lifiFlyNetwork(input.chainId)
+    ? (args) => lifiFlyEvidence(args, env)
+    : undefined;
 }
 
 async function lifiFlyEvidence(
   args: QuoteResponseEvidenceArgs,
+  env: NodeJS.ProcessEnv,
 ): Promise<PairProbeResult | null> {
   if (!lifiPayloadUsesFly(args.payload)) return null;
   const network = lifiFlyNetwork(args.input.chainId);
@@ -836,7 +842,8 @@ async function lifiFlyEvidence(
 
   const quoteRequest = downstreamRequest(
     args.request,
-    flyQuoteUrl(lifiFollowUpInput(args.input, args.request), network),
+    flyQuoteUrl(lifiFollowUpInput(args.input, args.request), network, env),
+    flyApiHeaders(env),
   );
   const quotePayload = await fetchDownstreamPayload({
     ...args,
@@ -869,7 +876,8 @@ async function lifiFlyEvidence(
 
   const distributionRequest = downstreamRequest(
     args.request,
-    flyDistributionsUrl(quoteId),
+    flyDistributionsUrl(quoteId, env),
+    flyApiHeaders(env),
   );
   const distributionPayload = await fetchDownstreamPayload({
     ...args,
@@ -936,9 +944,14 @@ function mergedStrings(
   return [...new Set([...left, ...right])].sort();
 }
 
-function downstreamRequest(parent: QuoteRequest, url: string): QuoteRequest {
+function downstreamRequest(
+  parent: QuoteRequest,
+  url: string,
+  headers?: RequestHeaders,
+): QuoteRequest {
   return {
     url,
+    ...(headers ? { init: { headers } } : {}),
     ...(parent.amountDecimal ? { amountDecimal: parent.amountDecimal } : {}),
     ...(parent.amountRaw ? { amountRaw: parent.amountRaw } : {}),
     ...(parent.variant ? { variant: parent.variant } : {}),

--- a/terraform/github-secrets.tf
+++ b/terraform/github-secrets.tf
@@ -97,6 +97,16 @@ resource "github_actions_secret" "integration_probe_lifi_api_key" {
   value       = var.lifi_api_key
 }
 
+resource "github_actions_secret" "integration_probe_flytrade_api_key" {
+  # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
+  # `vercel_automation_bypass`; see the comment above for the threat model.
+  count = var.flytrade_api_key == "" ? 0 : 1
+
+  repository  = "monitoring-monorepo"
+  secret_name = "FLYTRADE_API_KEY"
+  value       = var.flytrade_api_key
+}
+
 resource "github_actions_secret" "integration_probe_openocean_api_key" {
   # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
   # `vercel_automation_bypass`; see the comment above for the threat model.

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -44,6 +44,11 @@ upstash_api_key = "..."
 # `count`-gated so `terraform apply` succeeds without it.
 # lifi_api_key = "..."
 
+# Fly.trade (Magpie) API key for the scheduled integration-probes workflow.
+# Leave empty until provisioned; the GitHub Actions secret resource is
+# `count`-gated so `terraform apply` succeeds without it.
+# flytrade_api_key = "..."
+
 # OpenOcean Pro API key for the scheduled integration-probes workflow.
 # Leave empty until provisioned; the GitHub Actions secret resource is
 # `count`-gated so `terraform apply` succeeds without it.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,6 +87,16 @@ variable "lifi_api_key" {
   default     = ""
 }
 
+variable "flytrade_api_key" {
+  description = <<-EOT
+    Fly.trade (Magpie) API key for the scheduled integration-probes workflow.
+    Mirrors into the repo-level Actions secret `FLYTRADE_API_KEY`.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "openocean_api_key" {
   description = <<-EOT
     OpenOcean Pro API key for the scheduled integration-probes workflow.


### PR DESCRIPTION
<!-- Required format. Keep The Problem to at most three bullets. -->

## The Problem

- The daily LI.FI integration probe follows Monad routes into Fly.trade's public API tier, which rate-limits the probe: this morning's run reported Monad LI.FI as `rate_limited` (0/14 pair-directions) with HTTP 429s on every Fly follow-up.
- Fly.trade has now issued us an API key, but the probe had no way to use it.

## The Solution

Mento received a Fly.trade API key. When the new optional `FLYTRADE_API_KEY` env var is set, the probe sends its Fly.trade follow-up requests (quote + distributions, behind Monad LI.FI routes) to Fly's authenticated `api.magpiefi.xyz` origin with the `apikey` header instead of the public `api.fly.trade` tier. Without the key, behavior is unchanged.

## Details

- `integration-probes/src/adapterRequests.ts`: `flyApiHeaders()` + origin selection — both keyed off the same `env.FLYTRADE_API_KEY`, so origin and header cannot desync; empty string counts as unset.
- `integration-probes/src/adapters.ts`: threads `env` into the LI.FI→Fly evidence hook and attaches the headers via `downstreamRequest`. The LI.FI `x-lifi-api-key` is still never forwarded to Fly.
- `FLYTRADE_API_KEY` is deliberately **not** in LI.FI's `credentialEnv`: a missing key must not render LI.FI as `needs_key` because the public-tier fallback still works.
- Secret delivery follows the existing pattern: `flytrade_api_key` Terraform variable + count-gated `github_actions_secret` mirror in the platform stack, plus the workflow env mapping in `integration-probes.yml`. The secret has already been applied (targeted `terraform apply`) and verified on the repo.
- Docs: `integration-probes/AGENTS.md`, `docs/deployment.md`, README env table, `terraform.tfvars.example`.

## Validation

- `pnpm test` in `integration-probes/`: 77/77 green, including a new test asserting the authenticated origin + `apikey` header (and that the key never leaks to `li.quest`), plus an empty-string fallback test.
- `pnpm typecheck`, `pnpm lint`, `trunk fmt`, `trunk check`: clean.
- Live keyed run (`--adapter lifi`, both chains): Monad went from `rate_limited` 0/14 (HTTP 429 on `api.fly.trade`) to `partial` 8/14 with HTTP 200 from `api.magpiefi.xyz` and registered Mento v3 pool-address evidence via Fly (EURm/GBPm/JPYm both directions, USDm→USDC, USDT0→USDm). Celo unchanged: LI.FI returns no quotes there (Fly is not exposed by LI.FI on Celo).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional probe credential and outbound API routing only; no dashboard auth or on-chain paths change, and behavior without the key stays on the public Fly tier.
> 
> **Overview**
> Adds optional **`FLYTRADE_API_KEY`** so Monad **LI.FI → Fly** follow-up calls (quote + distributions) can use Fly’s authenticated **`api.magpiefi.xyz`** tier with an **`apikey`** header instead of the rate-limited public **`api.fly.trade`** origin. Origin and headers stay tied to the same env check; an empty string is treated as unset.
> 
> Probe code threads **`env`** through the LI.FI Fly evidence hook and **`downstreamRequest`** so Fly requests carry the key without forwarding **`LIFI_API_KEY`**. The key is **not** on LI.FI’s **`credentialEnv`**, so missing Fly credentials still fall back to the public API and never mark LI.FI as **`needs_key`**.
> 
> **Terraform** adds **`flytrade_api_key`** and a count-gated **`FLYTRADE_API_KEY`** GitHub Actions secret; the integration-probes workflow maps it. README, deployment docs, and **`integration-probes/AGENTS.md`** document the variable. New tests cover authenticated origin/headers and empty-key fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b0d0b440206452c4594dd7c2b6f8c8fa33241be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->