### PR TITLE
fix: drop the root undici override so consumers keep their own pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "pnpm": {
     "overrides": {
       "envio>react": "19.2.6",
-      "undici": ">=6.24.0",
       "flatted": ">=3.4.2",
       "serialize-javascript": ">=7.0.5",
       "diff@>=6": ">=8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   envio>react: 19.2.6
-  undici: '>=6.24.0'
   flatted: '>=3.4.2'
   serialize-javascript: '>=7.0.5'
   diff@>=6: '>=8.0.3'
@@ -9777,8 +9776,16 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.24.2:
-    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
+
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -10778,7 +10785,7 @@ snapshots:
       discord-api-types: 0.38.48
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.24.2
+      undici: 6.24.1
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -13978,7 +13985,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 7.24.2
+      undici: 6.26.0
 
   '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
@@ -15265,7 +15272,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.24.2
+      undici: 6.24.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17765,7 +17772,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.2
+      undici: 7.27.2
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -21037,7 +21044,11 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.24.2: {}
+  undici@6.24.1: {}
+
+  undici@6.26.0: {}
+
+  undici@7.27.2: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,15 @@ packages:
   - alerts/infra/oncall-announcer
   - governance-watchdog
 
+# No undici override on purpose (overrides live in package.json#pnpm.overrides,
+# which can't carry comments): discord.js/@discordjs/rest pin undici exactly
+# (6.24.1), and the other root-graph consumers' own ranges (@vercel/blob ^6.23.0,
+# jsdom ^7.24.5) resolve at or above the 6.24.0/7.24.0 advisory floor from the
+# 2026-03 GHSA batch. A range override forward-resolves the whole graph to
+# undici 8.x on fresh installs, which broke Discord delivery (#831/#833/#837).
+# If a future undici advisory lands, bump the consumers instead of re-adding a
+# blanket override.
+
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - "@mento-protocol/*"


### PR DESCRIPTION
## The Problem

- The root `pnpm.overrides` carries `"undici": ">=6.24.0"` — an unbounded range that forward-resolves the entire root graph to undici 8.x on any fresh install, the exact configuration that broke governance-watchdog Discord delivery (#831/#833).
- The override also forces jsdom to undici 7.24.2, **below** jsdom's own declared `^7.24.5` minimum, and keeps the root graph diverged from the deployed governance-watchdog artifact (nested lockfile, undici 6.24.1).

## The Solution

- Drop the override entirely. Every root-graph consumer resolves advisory-clean on its own range, so the floor protects nothing while the range creates the 8.x cliff.

## Details

- Root-graph undici consumers are exactly four (verified with `pnpm why -r undici` + registry metadata): discord.js@14.26.4 and @discordjs/rest@2.6.1 (pin undici **exactly 6.24.1**), @vercel/blob@2.4.0 (`^6.23.0` → 6.26.0), jsdom@29.0.1 (`^7.24.5` → 7.27.2). All at or above the 2026-03 GHSA-batch fix versions (6.24.0/7.24.0).
- The "cap to `<8`" option from the issue was simulated and rejected: pnpm range overrides resolve to the **highest version in range**, so a fresh resolve under the cap floats every consumer to an untested 7.27.2 — still clobbering discord.js's exact pin and keeping root ≠ nested ≠ deployed. Dropping is stable on both incremental and from-scratch resolution (verified by simulation in a scratch copy): undici 8.x is unreachable from any consumer's own range.
- After the drop, discord.js resolves undici 6.24.1 in the root graph == nested governance-watchdog graph == deployed artifact.
- `pnpm-workspace.yaml` gains a no-override-on-purpose comment (package.json can't carry comments), mirroring the nested governance-watchdog precedent; future undici advisories are handled by bumping consumers, with the daily `supply-chain.yml` audit cron as the safety net.

## Validation

- `pnpm why -r undici` → 6.24.1 (discord.js/@discordjs/rest), 6.26.0 (@vercel/blob), 7.27.2 (jsdom); no 8.x reachable.
- `pnpm audit --audit-level=high` → exit 0 (the 6 pre-existing moderates — ws/uuid/qs/brace-expansion — are byte-identical to main).
- `node scripts/lockfile-lint.mjs` → passed; root `pnpm install --frozen-lockfile --ignore-scripts --lockfile-dir .` → green.
- `pnpm --filter ui-dashboard test` → 205 files, 3034 tests passed on the new jsdom 7.27.2/undici resolution.
- `governance-watchdog/` untouched (separate nested workspace/lockfile, still single undici@6.24.1).

Closes #837

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only supply-chain change with no application logic; main risk is a future undici advisory without consumer bumps, mitigated by documented policy and supply-chain audit.
> 
> **Overview**
> Removes the root **`pnpm.overrides`** entry **`"undici": ">=6.24.0"`**, which was hoisting the whole dependency graph to **undici 8.x** on clean installs and clobbering **discord.js**’s exact **6.24.1** pin (Discord delivery regressions in #831/#833/#837).
> 
> The lockfile now lets each consumer keep its own resolution: **6.24.1** for Discord, **6.26.0** for **@vercel/blob**, **7.27.2** for **jsdom** (no single forced **7.24.2**). **`pnpm-workspace.yaml`** documents why there is intentionally no blanket **undici** override and to bump consumers on future advisories instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549e97c6e20fbcc958d5b1699bc3363cfb738486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->