### PR TITLE
fix: emit structured ERROR severity on governance-watchdog paging paths

### DIFF
--- a/governance-watchdog/infra/monitoring.tf
+++ b/governance-watchdog/infra/monitoring.tf
@@ -81,6 +81,13 @@ resource "google_monitoring_alert_policy" "health_check_policy" {
 # =============================================================================
 
 # Creates a metric that counts ERROR-level logs in the watchdog cloud function.
+# Request logs are excluded: every paging-worthy error path emits one structured
+# ERROR line (src/utils/log-error.ts) AND returns a 5xx whose request log is
+# ALSO severity ERROR — counting both would let a single transient failure
+# (e.g. one QuickNode 522) hit the 2-in-5min burst threshold and re-introduce
+# the false pages that threshold was built to suppress. App-emitted ERROR lines
+# are the sole signal; they also carry context (which webhooks are unhealthy)
+# that bare 500 request entries lack.
 resource "google_logging_metric" "error_logs_metric" {
   project     = module.governance_watchdog.project_id
   name        = "error_logs_count"
@@ -89,6 +96,7 @@ resource "google_logging_metric" "error_logs_metric" {
     severity>=ERROR
     resource.type="cloud_run_revision"
     resource.labels.service_name="${google_cloudfunctions2_function.watchdog_notifications.name}"
+    -logName="projects/${module.governance_watchdog.project_id}/logs/run.googleapis.com%2Frequests"
   EOF
 }
 

--- a/governance-watchdog/infra/scheduler.tf
+++ b/governance-watchdog/infra/scheduler.tf
@@ -31,9 +31,10 @@ resource "google_cloud_scheduler_job" "quicknode_health_check" {
   schedule    = "0 * * * *" # Every hour at minute 0
   time_zone   = "UTC"
 
-  # Note: If the health check fails, retries may generate multiple error logs which could
-  # trigger multiple Slack alerts. However, the error_logs_policy has a 60s aggregation
-  # window which should deduplicate alerts within that period.
+  # Note: If the health check fails persistently, the original attempt plus this
+  # retry produce two ERROR logs ~70s apart — which is exactly what lets the
+  # error_logs_policy's 2-in-5min burst threshold (300s aggregation window) fire
+  # for the hourly cadence, while a single transient failure stays below it.
   retry_config {
     retry_count          = 1 # Reduced from 3 to avoid alert spam if QuickNode API is down
     min_backoff_duration = "30s"

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -67,7 +67,11 @@ const handleQuicknodeHealthCheck = async (
     } else {
       // Structured ERROR severity so these feed the cloud-function-errors
       // Slack alert via error_logs_policy (plain console.error lands as
-      // severity DEFAULT and is invisible to the metric)
+      // severity DEFAULT and is invisible to the metric).
+      // Two separate logError calls are intentional: together they satisfy the
+      // policy's 2-in-5min burst threshold within a single invocation, so
+      // unhealthy webhooks page on the first failing check instead of waiting
+      // for the Scheduler retry. Do not collapse into one call.
       logError(
         `[QuickNodeHealth] ❌ Unhealthy webhooks detected: ${result.unhealthyWebhooks.join(", ")}`,
       );

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -8,6 +8,7 @@ import { initializeEventRegistry } from "./events/registry.js";
 import { EventType } from "./events/types.js";
 import { checkWebhookStatus } from "./quicknode-health/index.js";
 import { getCacheSize, isDuplicate } from "./utils/event-deduplication.js";
+import logError from "./utils/log-error.js";
 import parseRequestBody from "./utils/parse-request-body.js";
 import {
   hasAuthToken,
@@ -64,11 +65,13 @@ const handleQuicknodeHealthCheck = async (
       );
       res.status(200).send("All QuickNode webhooks are healthy");
     } else {
-      // Log as ERROR to trigger Slack alert via error_logs_policy
-      console.error(
+      // Structured ERROR severity so these feed the cloud-function-errors
+      // Slack alert via error_logs_policy (plain console.error lands as
+      // severity DEFAULT and is invisible to the metric)
+      logError(
         `[QuickNodeHealth] ❌ Unhealthy webhooks detected: ${result.unhealthyWebhooks.join(", ")}`,
       );
-      console.error(
+      logError(
         `[QuickNodeHealth] Webhook statuses: ${JSON.stringify(result.webhooks)}`,
       );
       res
@@ -78,7 +81,7 @@ const handleQuicknodeHealthCheck = async (
   } catch (error) {
     const requestDuration = Date.now() - requestStartTime;
     // Include timing in error log to help diagnose timeouts
-    console.error(
+    logError(
       `[QuickNodeHealth] ❌ Failed to check webhook status after ${String(requestDuration)}ms:`,
       error,
     );
@@ -124,7 +127,7 @@ const handleQuicknodeWebhook = async (
   }
 
   if (req.body && typeof req.body === "object" && "error" in req.body) {
-    console.error(
+    logError(
       "❌ Request body contains an error:",
       (req.body as { error: unknown }).error,
     );
@@ -182,7 +185,7 @@ export const governanceWatchdog: HttpFunction = async (
     // Default: handle QuickNode webhook events
     await handleQuicknodeWebhook(req, res);
   } catch (error) {
-    console.error("Error processing request:", error);
+    logError("Error processing request:", error);
     res.status(500).send("Something went wrong 🤔");
   }
 };

--- a/governance-watchdog/src/utils/__tests__/log-error.test.ts
+++ b/governance-watchdog/src/utils/__tests__/log-error.test.ts
@@ -32,7 +32,10 @@ describe("logError", () => {
 
     logError("request failed:", error);
 
-    const parsed = JSON.parse(loggedLine()) as { message: string };
+    const line = loggedLine();
+    // Stacks contain newlines; the JSON encoding must keep the entry single-line
+    expect(line).not.toContain("\n");
+    const parsed = JSON.parse(line) as { message: string };
     expect(parsed.message).toContain("request failed:");
     expect(parsed.message).toContain("Error: boom");
   });

--- a/governance-watchdog/src/utils/__tests__/log-error.test.ts
+++ b/governance-watchdog/src/utils/__tests__/log-error.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import logError from "../log-error.js";
+
+function loggedLine(): string {
+  const spy = vi.mocked(console.error);
+  expect(spy).toHaveBeenCalledTimes(1);
+  return spy.mock.calls[0][0] as string;
+}
+
+describe("logError", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a single-line JSON entry with severity ERROR", () => {
+    logError("something broke");
+
+    const line = loggedLine();
+    expect(line).not.toContain("\n");
+    expect(JSON.parse(line)).toEqual({
+      severity: "ERROR",
+      message: "something broke",
+    });
+  });
+
+  it("appends the stack for Error values", () => {
+    const error = new Error("boom");
+
+    logError("request failed:", error);
+
+    const parsed = JSON.parse(loggedLine()) as { message: string };
+    expect(parsed.message).toContain("request failed:");
+    expect(parsed.message).toContain("Error: boom");
+  });
+
+  it("serializes non-Error values", () => {
+    logError("payload error:", { code: 522 });
+
+    const parsed = JSON.parse(loggedLine()) as { message: string };
+    expect(parsed.message).toBe('payload error: {"code":522}');
+  });
+});

--- a/governance-watchdog/src/utils/log-error.ts
+++ b/governance-watchdog/src/utils/log-error.ts
@@ -1,0 +1,28 @@
+/**
+ * Emits a single-line JSON log entry that Cloud Run's logging agent parses
+ * into a LogEntry with severity ERROR. Raw console.error text lands as
+ * severity DEFAULT (verified live 2026-06-10) and is therefore invisible to
+ * the error_logs_count metric that feeds the cloud-function-errors Slack
+ * alert (infra/monitoring.tf).
+ *
+ * Contract: https://cloud.google.com/run/docs/logging#using-json — the
+ * `severity` and `message` fields of a one-line JSON object are promoted
+ * onto the LogEntry.
+ *
+ * Use this ONLY for error paths that should page Slack. Probe-facing rejects
+ * (e.g. the 401 path) must stay on plain console.error — unauthenticated
+ * internet noise must not feed the alert metric.
+ */
+export default function logError(message: string, error?: unknown): void {
+  const detail =
+    error === undefined ? message : `${message} ${formatError(error)}`;
+
+  console.error(JSON.stringify({ severity: "ERROR", message: detail }));
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return JSON.stringify(error);
+}


### PR DESCRIPTION
## The Problem

- `console.error` text lands in Cloud Run logs with severity DEFAULT (verified live), so no app-level error line has ever fed the `error_logs_count` metric behind the cloud-function-errors Slack alert — despite code comments claiming otherwise.
- The alert only fires today via a side-channel: severity-ERROR *request logs* for 5xx responses. Those entries carry zero app context (responders see bare 500s, not which webhooks are unhealthy), and any path that stopped returning 5xx would silently lose paging entirely.

## The Solution

- A tiny `logError` helper emits single-line JSON (`{severity:"ERROR", message}`) that Cloud Run promotes to a real ERROR LogEntry; the five paging-worthy error paths in `src/index.ts` now use it.
- The `error_logs_count` metric excludes request logs, making the context-rich app lines the sole alert signal.

## Details

- The request-log exclusion is load-bearing, not polish: every converted path also returns a 5xx whose request log is ALSO severity ERROR. Counting both would let a single transient failure (e.g. one QuickNode 522 with a successful Scheduler retry) hit the 2-in-5min burst threshold — exactly the false-page class that threshold was built to suppress (it fired on 2026-06-09 purely from paired request-log 500s, 72s apart from Scheduler's retry).
- Alert behavior after: persistent health-check failure still pages (2 app ERRORs ~70s apart via the Scheduler retry); the unhealthy-webhook path pages slightly *faster* (2 ERROR lines in one invocation → first failing check); single transient failures still don't page; the alert's `severity>=ERROR` console link now shows which webhooks are unhealthy.
- Deliberately NOT converted: the 401 `Unauthorized` reject (internet scanners hit it — two probes 310ms apart on 2026-06-10; ERROR severity there would page on noise) and `validate-request-origin.ts` (the signature-failure metric filters on its raw textPayload). `health_check_metric` (SEARCH on `[HealthCheck]`, different module) is unaffected.
- Also fixes the stale `scheduler.tf` comment claiming a "60s aggregation window" (actual: 300s).
- Merging does NOT deploy; an operator must run `pnpm gov-watchdog:deploy` from clean main, then verify per Validation.

## Validation

- `pnpm typecheck && pnpm lint && pnpm test:unit` → 6 files, 37 tests green (3 new pinning the JSON contract: single-line, severity ERROR, Error-stack and non-Error serialization); `pnpm knip` and `pnpm build` green; `terraform fmt -check` + trunk clean.
- Ground truth behind the design (read-only GCP + Slack evidence): all 60 severity≥ERROR entries in the last 30d are request/scheduler logs (zero app lines); 4xx request logs are WARNING, 5xx are ERROR; the 2026-06-09 Slack page traced to two health-check 500 request logs.
- Post-deploy verification plan: POST `{"error":"issue-841 verification"}` twice within 5 min via the x-auth path → expect two structured ERROR entries in `run.googleapis.com/stderr` (visible via `gcloud logging read 'severity>=ERROR'`), a deliberate cloud-function-errors page (note it in the channel; auto-closes in 24h), and `gcloud logging metrics describe error_logs_count` showing the `-logName` exclusion.

Closes #841

## Deferrals

- #879 — failed Discord/Telegram notification sends are swallowed with a 200 and never page (adjacent gap surfaced by this investigation; entangled with the documented notification-ack tradeoff, so decided separately).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-call alerting behavior (metric filter, log severity, burst thresholds); misconfiguration could miss pages or reintroduce false positives, though paths are narrowly scoped and documented.
> 
> **Overview**
> Adds a **`logError`** helper that writes single-line JSON (`severity: ERROR`) so Cloud Run promotes app errors into the **`error_logs_count`** metric behind the **cloud-function-errors** Slack alert. Paging paths in **`index.ts`** (QuickNode health failures, webhook body errors, top-level handler errors) now use it instead of plain **`console.error`**, which only lands as DEFAULT severity.
> 
> The **`error_logs_metric`** filter **excludes** `run.googleapis.com/requests` so 5xx request logs are not double-counted with app ERROR lines—avoiding false pages from one transient failure hitting the **2-in-5min** burst threshold. Unhealthy webhook checks intentionally emit **two** `logError` calls in one invocation so the first failing hourly check can page without waiting on Scheduler retry; **`scheduler.tf`** comments are updated to match the **300s** aggregation window behavior.
> 
> Unit tests pin the JSON contract. **401** and signature-failure paths stay on plain **`console.error`** by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cb546ebada0ba7ed7a655ae8a6a1d4cce5de78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->