### PR TITLE
Move reserve yield table and add totals row

### DIFF
--- a/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
+++ b/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
@@ -417,6 +417,12 @@ describe("RevenuePageClient degraded fee states", () => {
     expect(html).toContain("wallet / ops");
     expect(html).toContain("FPMM AUSD / USDm");
     expect(html).toContain('aria-label="Reserve yield components"');
+    expect(html.indexOf('aria-label="Reserve yield components"')).toBeLessThan(
+      html.indexOf("data-table-error"),
+    );
+    expect(html.indexOf('aria-label="Reserve yield components"')).toBeLessThan(
+      html.indexOf("Borrowing Fees by CDP"),
+    );
   });
 
   it("labels the sUSDS APY fallback source when Block Analitica supplies the rate", () => {

--- a/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
+++ b/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
@@ -234,6 +234,14 @@ function RevenueContent() {
         isBorrowingFeesApproximate={borrowingFeesChartApprox}
       />
 
+      <div className="grid grid-cols-1 gap-6">
+        <ReserveYieldByHoldingTable
+          data={reserveYieldState.data}
+          isLoading={reserveYieldState.isLoading}
+          hasError={reserveYieldState.hasError}
+        />
+      </div>
+
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
         <RevenueByPoolTable
           networkData={networkData}
@@ -244,14 +252,6 @@ function RevenueContent() {
           markets={cdpBorrowingMarkets}
           isLoading={isCdpBorrowingRevenueLoading}
           hasError={hasCdpBorrowingRevenueError}
-        />
-      </div>
-
-      <div className="grid grid-cols-1 gap-6">
-        <ReserveYieldByHoldingTable
-          data={reserveYieldState.data}
-          isLoading={reserveYieldState.isLoading}
-          hasError={reserveYieldState.hasError}
         />
       </div>
     </div>


### PR DESCRIPTION
## The Problem

- The reserve yield breakdown currently sits below the swap-fee and borrowing-fee tables, making it harder to scan with the reserve yield tile.
- The reserve yield components table requires mental summing to reconcile the holding rows with the tile forecast totals.

## The Solution

- Move the Reserve Yield Components table above the Swap Fees by Pool and Borrowing Fees by CDP tables.
- Add a totals row for reserve balance, known earned yield, blended APY, 30d forecast, and 1y forecast.

## Details

- Layout/table-only change; no reserve-yield math, data fetching, chart, or table state behavior changes.
- Total APY is derived from the API totals as annual forecast divided by forecastable balance, and forecast cells explain the non-compounding basis in their titles.
- If forecast rates are unavailable, the total row keeps balances/earned values visible and shows unavailable forecast cells.
- Checklist review: stateful-data-ui, SWR/Hasura, keyboard a11y, and code-health do not require deeper action because this PR adds no data flow, query, polling, keyboard, dependency, or package-boundary changes.

## Validation

- pnpm --filter @mento-protocol/ui-dashboard test -- revenue-page-client
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm agent:quality-gate --run
- Browser: http://127.0.0.1:3210/revenue with local Auth.js session; confirmed Reserve Yield Components appears before Swap Fees by Pool and Borrowing Fees by CDP, and the total row rendered live values: .17M balance, K earned, 3.198% blended APY, ≈ .1K 30d, ≈ .4K 1y. Console had only expected local /api/address-labels 500 from missing Upstash env; /api/reserve-yield and production GraphQL calls returned 200.

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned