### PR TITLE
Add reserve yield totals row

### DIFF
--- a/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
+++ b/ui-dashboard/src/app/revenue/_components/__tests__/revenue-page-client.test.tsx
@@ -417,6 +417,13 @@ describe("RevenuePageClient degraded fee states", () => {
     expect(html).toContain("wallet / ops");
     expect(html).toContain("FPMM AUSD / USDm");
     expect(html).toContain('aria-label="Reserve yield components"');
+    expect(html).toContain('aria-label="Reserve yield total row"');
+    expect(html).toContain("Total");
+    expect(html).toContain("3.889%");
+    expect(html).toContain("Blended APY across forecastable reserve balances.");
+    expect(html).toContain(
+      "Forecast totals use non-compounding math across current reserve balances.",
+    );
     expect(html.indexOf('aria-label="Reserve yield components"')).toBeLessThan(
       html.indexOf("data-table-error"),
     );
@@ -487,6 +494,9 @@ describe("RevenuePageClient degraded fee states", () => {
     expect(html).toContain("Forecast rates are unavailable");
     expect(html).not.toContain("Some forecast rates are unavailable");
     expect(html).toContain("showing balances without forecast");
+    expect(html).toContain(
+      "Forecast unavailable until APY sources load for current reserve holdings.",
+    );
     expect(html).toContain("N/A");
   });
 

--- a/ui-dashboard/src/app/revenue/_components/reserve-yield-components.tsx
+++ b/ui-dashboard/src/app/revenue/_components/reserve-yield-components.tsx
@@ -76,6 +76,27 @@ function reserveForecastMetric(value: number | null): string {
   return value === null ? "N/A" : `≈ ${formatUSD(value)}`;
 }
 
+function reserveTotalApyPercent(data: ReserveYieldResponse): number | null {
+  if (
+    data.forecastPrincipalUsd === null ||
+    data.next365dUsd === null ||
+    data.forecastPrincipalUsd <= 0
+  ) {
+    return null;
+  }
+  return (data.next365dUsd / data.forecastPrincipalUsd) * 100;
+}
+
+function reserveTotalForecastTitle(data: ReserveYieldResponse): string {
+  if (data.next365dUsd === null) {
+    return "Forecast unavailable until APY sources load for current reserve holdings.";
+  }
+  if (data.forecastUnavailableSymbols.length > 0) {
+    return `Forecast totals include holdings with APY sources only; missing APY for ${data.forecastUnavailableSymbols.join(", ")}.`;
+  }
+  return "Forecast totals use non-compounding math across current reserve balances.";
+}
+
 function reserveTileForecastMetric(value: number | null): string {
   return formatNullableUSD(value);
 }
@@ -224,6 +245,65 @@ function ReserveYieldHoldingRow({ holding }: { holding: ReserveYieldHolding }) {
   );
 }
 
+function ReserveYieldTotalRow({ data }: { data: ReserveYieldResponse }) {
+  const totalApyPercent = reserveTotalApyPercent(data);
+  const forecastTitle = reserveTotalForecastTitle(data);
+  return (
+    <tr
+      aria-label="Reserve yield total row"
+      className="border-t border-slate-700 bg-slate-900/80"
+    >
+      <th
+        scope="row"
+        colSpan={3}
+        className="px-2 py-2.5 text-left text-xs font-semibold text-slate-100 sm:px-4 sm:text-sm"
+      >
+        Total
+      </th>
+      <Td mono align="right" className="font-semibold text-slate-100 sm:!px-2">
+        {formatNullableUSD(data.principalUsd)}
+      </Td>
+      <Td
+        mono
+        align="right"
+        {...(data.earnedYieldError !== null
+          ? { title: data.earnedYieldError }
+          : {})}
+        className="font-semibold text-slate-100 sm:!px-2"
+      >
+        {formatNullableUSD(data.earnedYieldUsd)}
+      </Td>
+      <Td
+        mono
+        align="right"
+        title={`Blended APY across forecastable reserve balances. ${forecastTitle}`}
+        className="font-semibold text-slate-100 sm:!px-2"
+      >
+        {data.forecastUnavailableSymbols.length > 0 && totalApyPercent !== null
+          ? "≈ "
+          : ""}
+        {formatAnnualInterestRatePercent(totalApyPercent)}
+      </Td>
+      <Td
+        mono
+        align="right"
+        title={forecastTitle}
+        className="font-semibold text-slate-100 sm:!px-2"
+      >
+        {reserveForecastMetric(data.next30dUsd)}
+      </Td>
+      <Td
+        mono
+        align="right"
+        title={forecastTitle}
+        className="font-semibold text-slate-100 sm:!px-2"
+      >
+        {reserveForecastMetric(data.next365dUsd)}
+      </Td>
+    </tr>
+  );
+}
+
 function ReserveYieldTableShell({ children }: { children: ReactNode }) {
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-400">
@@ -252,7 +332,7 @@ export function ReserveYieldByHoldingTable({
 }: ReserveYieldTileState) {
   const holdings = data?.holdings ?? [];
 
-  if (holdings.length === 0) {
+  if (data === null || holdings.length === 0) {
     return (
       <section>
         <h2 className="mb-3 text-lg font-semibold text-white">
@@ -314,6 +394,9 @@ export function ReserveYieldByHoldingTable({
             <ReserveYieldHoldingRow key={holding.id} holding={holding} />
           ))}
         </tbody>
+        <tfoot>
+          <ReserveYieldTotalRow data={data} />
+        </tfoot>
       </Table>
     </section>
   );

--- a/ui-dashboard/src/app/revenue/_components/reserve-yield-components.tsx
+++ b/ui-dashboard/src/app/revenue/_components/reserve-yield-components.tsx
@@ -279,10 +279,9 @@ function ReserveYieldTotalRow({ data }: { data: ReserveYieldResponse }) {
         title={`Blended APY across forecastable reserve balances. ${forecastTitle}`}
         className="font-semibold text-slate-100 sm:!px-2"
       >
-        {data.forecastUnavailableSymbols.length > 0 && totalApyPercent !== null
-          ? "≈ "
-          : ""}
-        {formatAnnualInterestRatePercent(totalApyPercent)}
+        {totalApyPercent !== null && data.forecastUnavailableSymbols.length > 0
+          ? `≈ ${formatAnnualInterestRatePercent(totalApyPercent)}`
+          : formatAnnualInterestRatePercent(totalApyPercent)}
       </Td>
       <Td
         mono


### PR DESCRIPTION
## The Problem

- The reserve yield components table requires mental summing to reconcile holding rows with the reserve yield tile forecast totals.

## The Solution

- Add a totals row for reserve balance, known earned yield, blended APY, 30d forecast, and 1y forecast.

## Details

- Table-only change; no reserve-yield math, data fetching, chart, or table state behavior changes.
- Total APY is derived from the API totals as annual forecast divided by forecastable balance.
- Forecast cells explain the non-compounding basis in their titles, and unavailable rates keep forecast cells as N/A while preserving balance/earned totals.
- Checklist review: stateful-data-ui, SWR/Hasura, keyboard a11y, and code-health do not require deeper action because this PR adds no data flow, query, polling, keyboard, dependency, or package-boundary changes.

## Validation

- pnpm --filter @mento-protocol/ui-dashboard test -- revenue-page-client
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm agent:quality-gate --run
- Pre-push mapped quality gate
- Browser: http://127.0.0.1:3210/revenue with local Auth.js session; confirmed the total row rendered live values: .17M balance, K earned, 3.198% blended APY, ≈ .1K 30d, ≈ .4K 1y. Console had only expected local /api/address-labels 500 from missing Upstash env; /api/reserve-yield and production GraphQL calls returned 200.

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the revenue dashboard; no API, fetching, or reserve-yield calculation logic changes.
> 
> **Overview**
> Adds a **footer totals row** to the Reserve Yield Components table so balance, earned yield, blended APY, and 30d/1y forecasts align with the reserve yield tile without manual summing.
> 
> The row uses existing `ReserveYieldResponse` aggregates; **blended APY** is computed in the UI as `next365dUsd / forecastPrincipalUsd` (shown with `≈` when some symbols lack APY). Forecast cells use **title tooltips** for non-compounding math, partial-APY exclusions, or “forecast unavailable until APY sources load.” The table now treats **`data === null`** like an empty state (no footer), and tests assert the new **aria-label**, **Total** label, blended rate copy, and unavailable-forecast messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fb198215afa14d11efd9ea4a267b75edd4ef0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->