### PR TITLE
Rescale revenue chart when streams are hidden

### DIFF
--- a/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
@@ -87,4 +87,23 @@ describe("buildRevenueChartFigure", () => {
     });
     expect("range" in figure.layout.yaxis).toBe(false);
   });
+
+  it("keeps negative revenue days on Plotly autorange instead of restoring a fixed range", () => {
+    const figure = buildRevenueChartFigure([
+      {
+        timestamp: START,
+        reserveYieldUsd: -50,
+        swapFeesUsd: 0,
+        cdpBorrowingUsd: 0,
+        totalRevenueUsd: -50,
+        availableRevenueUsd: -50,
+      },
+    ]);
+
+    expect(figure.layout.yaxis).toMatchObject({
+      autorange: true,
+      rangemode: "tozero",
+    });
+    expect("range" in figure.layout.yaxis).toBe(false);
+  });
 });

--- a/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  revenueChartYAxisRange,
+  buildRevenueChartFigure,
   revenueChartEmptyMessage,
   revenueWeekOverWeekChangePct,
 } from "@/components/fee-over-time-chart";
@@ -59,20 +59,32 @@ describe("revenueChartEmptyMessage", () => {
   });
 });
 
-describe("revenueChartYAxisRange", () => {
-  it("keeps negative revenue days inside the visible y-axis range", () => {
-    const range = revenueChartYAxisRange([
+describe("buildRevenueChartFigure", () => {
+  it("lets Plotly rescale the stacked y-axis after legend toggles", () => {
+    const figure = buildRevenueChartFigure([
       {
         timestamp: START,
-        reserveYieldUsd: -50,
-        swapFeesUsd: 0,
+        reserveYieldUsd: 10_000,
+        swapFeesUsd: 10,
+        cdpBorrowingUsd: 5,
+        totalRevenueUsd: 10_015,
+        availableRevenueUsd: 10_015,
+      },
+      {
+        timestamp: START + DAY,
+        reserveYieldUsd: null,
+        swapFeesUsd: 12,
         cdpBorrowingUsd: 0,
-        totalRevenueUsd: -50,
-        availableRevenueUsd: -50,
+        totalRevenueUsd: null,
+        availableRevenueUsd: 12,
       },
     ]);
 
-    expect(range[0]).toBeLessThan(-50);
-    expect(range[1]).toBeGreaterThan(0);
+    expect(figure.layout.yaxis).toMatchObject({
+      autorange: true,
+      rangemode: "tozero",
+      fixedrange: true,
+    });
+    expect("range" in figure.layout.yaxis).toBe(false);
   });
 });

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -110,31 +110,7 @@ function buildTrace(args: {
   };
 }
 
-export function revenueChartYAxisRange(
-  series: ReadonlyArray<CanonicalRevenueDailyPoint>,
-): [number, number] {
-  const yValues: number[] = [];
-  for (const point of series) {
-    const values = [
-      point.swapFeesUsd,
-      point.cdpBorrowingUsd,
-      point.reserveYieldUsd,
-      point.availableRevenueUsd,
-      point.totalRevenueUsd,
-    ];
-    for (const value of values) {
-      if (value !== null) yValues.push(value);
-    }
-  }
-  const ymax = Math.max(0, ...yValues);
-  const ymin = Math.min(0, ...yValues);
-  if (ymax === 0 && ymin === 0) return [0, 1];
-  const span = Math.max(ymax - ymin, Math.abs(ymax || ymin) * 0.04, 1);
-  const padding = Math.max(span * 0.08, 1);
-  return [ymin < 0 ? ymin - padding : 0, ymax > 0 ? ymax + padding : padding];
-}
-
-function buildRevenueChartFigure(
+export function buildRevenueChartFigure(
   series: ReadonlyArray<CanonicalRevenueDailyPoint>,
 ) {
   const xs = series.map((p) => new Date(p.timestamp * 1000).toISOString());
@@ -190,7 +166,8 @@ function buildRevenueChartFigure(
         showticklabels: false,
         showline: false,
         zeroline: false,
-        range: revenueChartYAxisRange(series),
+        autorange: true as const,
+        rangemode: "tozero" as const,
         fixedrange: true,
       },
       showlegend: true,


### PR DESCRIPTION
## The Problem
- The Total Revenue chart kept a fixed y-axis range from all revenue streams even after a user hid Reserve from the legend.
- With Reserve hidden, the remaining Swap/CDP lines stayed compressed against the bottom and were effectively unreadable.

## The Solution
- Let Plotly autorange the stacked revenue chart from the currently visible legend traces instead of passing a fixed y-axis range.
- Pin the chart config with a unit test so the revenue chart keeps visible-trace y-axis rescaling behavior.

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- fee-over-time-chart.test.ts
- Browser-verified http://127.0.0.1:3210/revenue against live Envio data: hiding Reserve changed Plotly y-axis max from about 20034 to about 373, with Reserve set to legendonly.
- pnpm agent:quality-gate --run
- pnpm agent:autoreview

## Deferrals
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only chart layout change with unit tests; no API, auth, or data pipeline impact.
> 
> **Overview**
> The **Total Revenue** stacked chart no longer computes a fixed Plotly `yaxis.range` from all streams. **`buildRevenueChartFigure`** is exported and sets **`autorange: true`** with **`rangemode: "tozero"`** and no **`range`**, so Plotly can rescale the y-axis when users hide traces (e.g. Reserve) via the legend.
> 
> The custom **`revenueChartYAxisRange`** helper is removed. Tests now assert the figure layout instead of numeric range bounds, including negative-revenue days.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab52bdc937b3a4e3ec118cf68049999b346cc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->