### PR TITLE
Fix sUSDS reserve yield heartbeat

### DIFF
--- a/indexer-envio/src/handlers/susds.ts
+++ b/indexer-envio/src/handlers/susds.ts
@@ -6,7 +6,7 @@ import type {
 import { ZERO_ADDRESS } from "../constants.js";
 import { SECONDS_PER_DAY, asAddress, dayBucket, eventId } from "../helpers.js";
 import { indexer } from "../indexer.js";
-import { susdsSharePriceEffect } from "../rpc/effects.js";
+import { blockTimestampEffect, susdsSharePriceEffect } from "../rpc/effects.js";
 
 export const ETHEREUM_CHAIN_ID = 1;
 export const SUSDS_ADDRESS = "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd";
@@ -430,6 +430,28 @@ async function readSharePrice(
   return sharePriceUsdWei;
 }
 
+export async function recordSusdsYieldHeartbeatSnapshot(
+  context: SusdsContext,
+  blockNumber: bigint,
+): Promise<boolean> {
+  const blockTimestamp = await context.effect(blockTimestampEffect, {
+    chainId: ETHEREUM_CHAIN_ID,
+    blockNumber,
+  });
+  if (blockTimestamp === null || blockTimestamp <= 0n) return false;
+
+  const meta: BlockMeta = {
+    chainId: ETHEREUM_CHAIN_ID,
+    blockNumber,
+    blockTimestamp,
+  };
+  if (meta.blockTimestamp < V3_REVENUE_LAUNCH_TIMESTAMP) return false;
+
+  const sharePriceUsdWei = await readSharePrice(context, meta);
+  await recordSusdsYieldDailySnapshot(context, meta, sharePriceUsdWei);
+  return true;
+}
+
 async function shouldProcess(
   context: SusdsContext,
   movementId: string,
@@ -755,11 +777,6 @@ indexer.onEvent(
   },
 );
 
-type BlockWithTimestamp = {
-  readonly number: number;
-  readonly timestamp?: number;
-};
-
 indexer.onBlock(
   {
     name: "SusdsYieldDailySnapshotHeartbeat",
@@ -777,16 +794,6 @@ indexer.onBlock(
   },
   async ({ block, context }) => {
     if (context.isPreload) return;
-    const blockWithTimestamp = block as BlockWithTimestamp;
-    const timestamp = blockWithTimestamp.timestamp;
-    if (timestamp === undefined || timestamp <= 0) return;
-    const meta: BlockMeta = {
-      chainId: ETHEREUM_CHAIN_ID,
-      blockNumber: BigInt(block.number),
-      blockTimestamp: BigInt(timestamp),
-    };
-    if (meta.blockTimestamp < V3_REVENUE_LAUNCH_TIMESTAMP) return;
-    const sharePriceUsdWei = await readSharePrice(context, meta);
-    await recordSusdsYieldDailySnapshot(context, meta, sharePriceUsdWei);
+    await recordSusdsYieldHeartbeatSnapshot(context, BigInt(block.number));
   },
 );

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -24,6 +24,7 @@ export {
   _testHooks,
 } from "./rpc/block-fallback.js";
 export type { BlockFallbackResult } from "./rpc/block-fallback.js";
+export { fetchBlockTimestamp } from "./rpc/block.js";
 
 // Re-export pool-state symbols so existing callers that import from "./rpc.js"
 // continue to work without import-path changes (feeToken.ts, EventHandlers.ts,

--- a/indexer-envio/src/rpc/block.ts
+++ b/indexer-envio/src/rpc/block.ts
@@ -1,0 +1,53 @@
+import { getFallbackRpcClient, getRpcClient, logRpcFailure } from "./client.js";
+import { consoleLogger, type RpcLogger } from "./log.js";
+
+type BlockWithTimestamp = {
+  readonly timestamp?: bigint | number;
+};
+
+function normalizeBlockTimestamp(block: unknown): bigint | null {
+  if (typeof block !== "object" || block === null) return null;
+  const timestamp = (block as BlockWithTimestamp).timestamp;
+  if (typeof timestamp === "bigint") return timestamp;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return BigInt(timestamp);
+  }
+  return null;
+}
+
+export async function fetchBlockTimestamp(
+  chainId: number,
+  blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
+): Promise<bigint | null> {
+  try {
+    const block = await getRpcClient(chainId).getBlock({ blockNumber });
+    return normalizeBlockTimestamp(block);
+  } catch (err) {
+    const fallback = getFallbackRpcClient(chainId);
+    if (fallback !== null) {
+      try {
+        const block = await fallback.getBlock({ blockNumber });
+        return normalizeBlockTimestamp(block);
+      } catch (fallbackErr) {
+        logRpcFailure(
+          chainId,
+          "getBlockTimestampFallback",
+          `block:${blockNumber}`,
+          fallbackErr,
+          blockNumber,
+          log,
+        );
+      }
+    }
+    logRpcFailure(
+      chainId,
+      "getBlockTimestamp",
+      `block:${blockNumber}`,
+      err,
+      blockNumber,
+      log,
+    );
+    return null;
+  }
+}

--- a/indexer-envio/src/rpc/block.ts
+++ b/indexer-envio/src/rpc/block.ts
@@ -9,7 +9,7 @@ function normalizeBlockTimestamp(block: unknown): bigint | null {
   if (typeof block !== "object" || block === null) return null;
   const timestamp = (block as BlockWithTimestamp).timestamp;
   if (typeof timestamp === "bigint") return timestamp;
-  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+  if (typeof timestamp === "number" && Number.isInteger(timestamp)) {
     return BigInt(timestamp);
   }
   return null;
@@ -24,6 +24,14 @@ export async function fetchBlockTimestamp(
     const block = await getRpcClient(chainId).getBlock({ blockNumber });
     return normalizeBlockTimestamp(block);
   } catch (err) {
+    logRpcFailure(
+      chainId,
+      "getBlockTimestamp",
+      `block:${blockNumber}`,
+      err,
+      blockNumber,
+      log,
+    );
     const fallback = getFallbackRpcClient(chainId);
     if (fallback !== null) {
       try {
@@ -40,14 +48,6 @@ export async function fetchBlockTimestamp(
         );
       }
     }
-    logRpcFailure(
-      chainId,
-      "getBlockTimestamp",
-      `block:${blockNumber}`,
-      err,
-      blockNumber,
-      log,
-    );
     return null;
   }
 }

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -151,7 +151,10 @@ export function _clearRpcClients(): void {
  * viem surface is unused by the functions tested via this hook. */
 export function _setRpcClientForTests(
   chainId: number,
-  client: { readContract: (args: unknown) => Promise<unknown> } | null,
+  client: {
+    readContract?: (args: unknown) => Promise<unknown>;
+    getBlock?: (args: unknown) => Promise<unknown>;
+  } | null,
 ): void {
   if (client === null) {
     rpcClients.delete(chainId);

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -37,6 +37,7 @@ import {
   fetchReportExpiry,
 } from "./oracle-state.js";
 import { fetchFees, fetchRebalanceIncentiveAtBlock } from "./pool-fees.js";
+import { fetchBlockTimestamp } from "./block.js";
 import {
   fetchPoolExchange,
   fetchVirtualPoolExchangeId,
@@ -448,6 +449,28 @@ export const susdsSharePriceEffect = createEffect(
       input.blockNumber,
       context.log,
     ),
+);
+
+export const blockTimestampEffect = createEffect(
+  {
+    name: "blockTimestamp",
+    input: { chainId: S.int32, blockNumber: S.bigint },
+    output: S.nullable(S.bigint),
+    rateLimit: { calls: 200, per: "second" },
+    cache: false,
+  },
+  async ({ input, context }) => {
+    const result = await fetchBlockTimestamp(
+      input.chainId,
+      input.blockNumber,
+      context.log,
+    );
+    if (result === null) {
+      context.cache = false;
+      return null;
+    }
+    return result;
+  },
 );
 
 /** Convert the `feesEffect` output (explicit `undefined` keys) into a

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -451,6 +451,8 @@ export const susdsSharePriceEffect = createEffect(
     ),
 );
 
+// sUSDS daily heartbeat metadata is block-scoped. Keep it uncached for the
+// same reorg-safety reason as Group C effects.
 export const blockTimestampEffect = createEffect(
   {
     name: "blockTimestamp",
@@ -466,7 +468,6 @@ export const blockTimestampEffect = createEffect(
       context.log,
     );
     if (result === null) {
-      context.cache = false;
       return null;
     }
     return result;

--- a/indexer-envio/test/rpc-fetchers.test.ts
+++ b/indexer-envio/test/rpc-fetchers.test.ts
@@ -19,6 +19,7 @@ import {
   _setMockStableTotalSupply,
   fetchStableTotalSupply,
 } from "../src/rpc/stable-fetchers.ts";
+import { fetchBlockTimestamp } from "../src/rpc.ts";
 
 const CHAIN_ID = 42220;
 const POOL = "0x00000000000000000000000000000000000000aa";
@@ -76,6 +77,19 @@ describe("RPC fetchers reject non-historical latest fallbacks", () => {
     assert.equal(result, null);
     assert.equal(calls.length, 5);
     assert.equal(calls.at(-1)?.blockNumber, undefined);
+  });
+
+  it("fetchBlockTimestamp reads historical block timestamps by number", async () => {
+    _setRpcClientForTests(CHAIN_ID, {
+      getBlock: async (args) => {
+        assert.deepEqual(args, { blockNumber: BLOCK });
+        return { timestamp: 1_780_444_800n };
+      },
+    });
+
+    const result = await fetchBlockTimestamp(CHAIN_ID, BLOCK, noopLogger);
+
+    assert.equal(result, 1_780_444_800n);
   });
 
   it("fetchRebalanceThresholds fails closed when either threshold uses latest fallback", async () => {

--- a/indexer-envio/test/susds.test.ts
+++ b/indexer-envio/test/susds.test.ts
@@ -16,9 +16,14 @@ import {
   SUSDS_ADDRESS,
   TRACKED_SUSDS_WALLETS,
   V3_REVENUE_LAUNCH_TIMESTAMP,
+  recordSusdsYieldHeartbeatSnapshot,
   recordSusdsYieldDailySnapshot,
 } from "../src/handlers/susds.ts";
 import { ZERO_ADDRESS } from "../src/constants.ts";
+import {
+  blockTimestampEffect,
+  susdsSharePriceEffect,
+} from "../src/rpc/effects.ts";
 
 type MockDb = MockDbWith<{
   SusdsCostBasisLot: EntityCollection;
@@ -158,6 +163,34 @@ function dailySnapshotContext(
       },
     },
   } as unknown as Parameters<typeof recordSusdsYieldDailySnapshot>[0];
+}
+
+function heartbeatContext(
+  mockDb: MockDb,
+  blockTimestamp: bigint | null,
+  sharePriceUsdWei: bigint,
+): Parameters<typeof recordSusdsYieldHeartbeatSnapshot>[0] {
+  return {
+    ...dailySnapshotContext(mockDb),
+    effect: async (effect, input) => {
+      if (effect === blockTimestampEffect) {
+        assert.deepEqual(input, {
+          chainId: ETHEREUM_CHAIN_ID,
+          blockNumber: 300n,
+        });
+        return blockTimestamp;
+      }
+      if (effect === susdsSharePriceEffect) {
+        assert.deepEqual(input, {
+          chainId: ETHEREUM_CHAIN_ID,
+          tokenAddress: SUSDS_ADDRESS,
+          blockNumber: 300n,
+        });
+        return sharePriceUsdWei;
+      }
+      throw new Error("unexpected effect");
+    },
+  } as unknown as Parameters<typeof recordSusdsYieldHeartbeatSnapshot>[0];
 }
 
 describe("sUSDS reserve yield accounting", () => {
@@ -443,6 +476,37 @@ describe("sUSDS reserve yield accounting", () => {
     assert.equal(rows[0]?.totalEarnedYieldUsdWei, dollars(100));
     assert.equal(rows[1]?.totalEarnedYieldUsdWei, dollars(300));
     assert.equal(rows[1]?.dailyEarnedYieldUsdWei, dollars(200));
+  });
+
+  it("writes sUSDS daily snapshots from a block-number-only heartbeat", async () => {
+    let mockDb = MockDb.createMockDb();
+    const day1 = V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n;
+    const day2 = day1 + 86_400n;
+
+    setSharePrice(100, WAD);
+    mockDb = await deposit(
+      mockDb,
+      100,
+      0,
+      dollars(1000),
+      dollars(1000),
+      Number(day1 + 3_600n),
+    );
+
+    const didWrite = await recordSusdsYieldHeartbeatSnapshot(
+      heartbeatContext(mockDb, day2 + 3_600n, dollars(120) / 100n),
+      300n,
+    );
+
+    const rows = dailySnapshots(mockDb).sort((a, b) =>
+      a.timestamp < b.timestamp ? -1 : 1,
+    );
+    assert.equal(didWrite, true);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1]?.timestamp, day2);
+    assert.equal(rows[1]?.totalEarnedYieldUsdWei, dollars(200));
+    assert.equal(rows[1]?.dailyEarnedYieldUsdWei, dollars(200));
+    assert.equal(rows[1]?.sampledAtBlock, 300n);
   });
 
   it("uses the first post-launch sUSDS daily snapshot as the delta baseline", async () => {

--- a/indexer-envio/test/susds.test.ts
+++ b/indexer-envio/test/susds.test.ts
@@ -509,6 +509,18 @@ describe("sUSDS reserve yield accounting", () => {
     assert.equal(rows[1]?.sampledAtBlock, 300n);
   });
 
+  it("skips the sUSDS heartbeat snapshot when block timestamp RPC returns null", async () => {
+    const mockDb = MockDb.createMockDb();
+
+    const didWrite = await recordSusdsYieldHeartbeatSnapshot(
+      heartbeatContext(mockDb, null, WAD),
+      300n,
+    );
+
+    assert.equal(didWrite, false);
+    assert.equal(dailySnapshots(mockDb).length, 0);
+  });
+
   it("uses the first post-launch sUSDS daily snapshot as the delta baseline", async () => {
     let mockDb = MockDb.createMockDb();
     const beforeLaunch = Number(V3_REVENUE_LAUNCH_TIMESTAMP - 3_600n);

--- a/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
+++ b/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
@@ -384,7 +384,7 @@ function RevenuePeriodCards({
   return (
     <section
       aria-label="Revenue actuals by period"
-      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
     >
       {PERIOD_CARD_ORDER.map((key) => {
         const period = periods[key];


### PR DESCRIPTION
## The Problem

- `/revenue` still showed reserve actuals as `N/A` because production `SusdsYieldDailySnapshot` rows stopped at the Jun 3, 2026 bucket even though the hosted indexer was caught up.
- The sUSDS daily heartbeat was relying on `block.timestamp` from Envio `onBlock`, but this Envio runtime only supplies the block number there, so the heartbeat silently skipped.
- The top revenue cards used a wider four-column breakpoint than the forecast cards, so the first two rows did not line up.

## The Solution

- Add a block-timestamp RPC effect and use it from the sUSDS heartbeat before writing daily reserve-yield snapshots.
- Keep the dashboard's `N/A` degraded mode for stale reserve actuals until reindexing supplies complete daily rows.
- Align the actual revenue cards to the same three-column large-screen grid as the forecast row.

## Details

- `SusdsYieldDailySnapshotHeartbeat` now resolves the block timestamp from the block number, then uses the existing share-price effect and snapshot writer.
- The dashboard still keeps AUSD forecast-only and sUSDS actuals history-only; no forecast data is injected into historical actuals.
- Live Hasura currently has only three sUSDS daily snapshot buckets, with the latest at Jun 3, 2026. After this indexer fix is deployed and reindexed, daily rows should fill in and the reserve actuals should stop rendering as stale `N/A`.

## Invariants

- Reserve actual revenue is ledger/history-only; missing or stale sUSDS daily snapshots must stay visibly partial instead of being filled with forecasts.
- The heartbeat can run from Envio's block-number-only `onBlock` payload.
- The top actual cards and forecast cards share the same responsive grid behavior.

## Degraded Behavior

- If the block timestamp RPC read fails, the heartbeat skips that sample and leaves the existing partial-data UI behavior intact.
- If reserve history remains stale, `/revenue` continues showing reserve actuals as `N/A` with the stale-snapshot explanation.

## Deferrals

None

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test -- susds.test.ts rpc-fetchers.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio lint`
- `pnpm --filter @mento-protocol/ui-dashboard test -- revenue-page-client.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Browser verified `http://127.0.0.1:3210/revenue` authenticated: actual and forecast cards share the same three-column geometry; reserve actuals show `N/A` because live production history is stale at Jun 3, 2026. The only console error was the known local `/api/address-labels` 500 from missing Upstash env.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Ethereum mainnet RPC reads on the reserve-yield heartbeat path; failures are fail-closed but production needs reindex/deploy before reserve actuals recover.
> 
> **Overview**
> Fixes **stale reserve actuals on `/revenue`** by making the sUSDS daily snapshot heartbeat work when Envio `onBlock` only provides a **block number** (no `timestamp`), which had caused the heartbeat to no-op and `SusdsYieldDailySnapshot` rows to stop updating.
> 
> The indexer adds **`fetchBlockTimestamp`** (primary RPC + fallback) and an uncached **`blockTimestampEffect`**, then **`recordSusdsYieldHeartbeatSnapshot`** loads the timestamp by block, applies the existing launch cutoff, share-price read, and daily snapshot writer. The `SusdsYieldDailySnapshotHeartbeat` handler now delegates to that helper; a **null** timestamp skips the sample without changing partial-data behavior.
> 
> The revenue page **actual period cards** use the same **`lg:grid-cols-3`** layout as the forecast row (drops the extra large breakpoint column).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b05c6ee0dcd7d818b8246108b9ffff31705ffb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->