### PR TITLE
chore: pin pnpm/action-setup to SHA in trunk composite action

### DIFF
--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
     - name: Install npm dependencies
       shell: bash
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## The Problem

- `.trunk/setup-ci/action.yaml` referenced `pnpm/action-setup@v4` (a mutable tag), leaving it vulnerable to tag-mutation supply-chain attacks.
- Every other third-party `uses:` in this repo was already pinned to a 40-char SHA; this was the only remaining gap.

## The Solution

- Replace `pnpm/action-setup@v4` with `pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4` — a single-line change that hardens the composite action against tag-mutation attacks.

## Details

- SHA verified via `git ls-remote https://github.com/pnpm/action-setup 'refs/tags/v4^{}'` → `b906affcce14559ad1aafd4ab0e942779e9f58b1`. Matches the SHA already in use in `.github/actions/pnpm-install/action.yml`.
- Post-change scan: `grep -rn "uses:" .github/ .trunk/ | grep -v "@[0-9a-f]\{40\}" | grep -v "uses: \."` returns zero lines.
- Dependabot already bumps SHA-pinned actions, so future version updates will be handled automatically.

## Validation

```
grep -rn "uses:" .github/ .trunk/ | grep -v "@[0-9a-f]\{40\}" | grep -v "uses: \."
# → zero lines (no unpinned third-party actions remain)

pnpm agent:quality-gate --run
# → All mapped commands passed.
```

## Deferrals

- #896 — Add a CI lint step asserting every `uses:` in workflows and composite actions is SHA-pinned (non-trivial: needs checkov/custom script verification; deferred to follow-up).

Closes #844

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run (`pnpm agent:quality-gate --run` — all passed)
- [x] PR readiness probe planned
