### PR TITLE
test(aegis): add real config.yaml integration spec

### DIFF
--- a/aegis/src/config.real.spec.ts
+++ b/aegis/src/config.real.spec.ts
@@ -1,0 +1,17 @@
+import loadConfig from './config';
+
+describe('production config.yaml', () => {
+  it('loads the committed config.yaml without throwing', () => {
+    expect(() => loadConfig()).not.toThrow();
+  });
+
+  it('produces metrics, each with a contract and function name', () => {
+    const config = loadConfig();
+    expect(config.metrics.length).toBeGreaterThan(0);
+    for (const m of config.metrics) {
+      expect(m.id).toBeTruthy();
+      expect(m.source.contract).toBeTruthy();
+      expect(m.source.functionAbi.name).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## The Problem

- A malformed metric source in `aegis/config.yaml` (wrong function signature format, undeclared contract, or missing token metadata) silently passes lint/typecheck but causes the App Engine service to crash-loop at startup instead of failing in CI.
- The existing `config.spec.ts` uses `jest.doMock('fs', …)` per-test, meaning it only validates hand-crafted YAML strings and never touches the committed production config file.

## The Solution

Adds `aegis/src/config.real.spec.ts` — a separate spec file with no `jest.mock` calls — that runs the real config loader against the committed `aegis/config.yaml`. Any parse failure (malformed source string, undeclared contract, missing token metadata) will now fail CI at the test stage instead of at App Engine startup.

## Details

- Placed in a **separate file** from `config.spec.ts` to avoid fs-mock contamination (the existing per-test `jest.doMock('fs', …)` pattern would intercept the real `readFileSync` if merged into the same file).
- Metric `id` is a `randomUUID()` — asserting uniqueness would be redundant since the loader already guarantees it by construction; the spec just asserts truthiness.
- Accessor names (`config.metrics`, `m.source.contract`, `m.source.functionAbi.name`) verified against real types in `config/index.ts` and `config/MetricSource.ts`.
- Jest `rootDir: "src"` + `testRegex: ".*\\.spec\\.ts$"` auto-discovers the new file with no config changes.

## Validation

```
cd aegis && pnpm exec jest --testPathPatterns="config.real"
# PASS src/config.real.spec.ts
# Tests: 2 passed

pnpm --filter @mento-protocol/aegis test:cov
# Tests: 65 passed, coverage above all floors (statements 87.91, branches 80, functions 89.61, lines 87.97)

pnpm aegis:lint && pnpm aegis:typecheck  # both pass
pnpm agent:quality-gate --run            # All mapped commands passed
```

Closes #849

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or config edits; it only strengthens CI coverage for the existing config loader.
> 
> **Overview**
> Adds **`config.real.spec.ts`**, a Jest spec that runs the real `loadConfig()` against the committed **`aegis/config.yaml`** with **no `fs` mocks**, so malformed production YAML fails in CI instead of at App Engine startup.
> 
> The new tests assert the loader does not throw and that every loaded metric has a non-empty **`id`**, **`source.contract`**, and **`source.functionAbi.name`**. The file stays separate from **`config.spec.ts`** so per-test `jest.doMock('fs', …)` does not intercept the real config read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b363b45255379f87b8a63eb34bc36bbdebf7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->