### PR TITLE
feat(scripts): extract shared deploy-guard.sh and enforce clean-tree in all deploy scripts

### DIFF
--- a/aegis/bin/deploy.sh
+++ b/aegis/bin/deploy.sh
@@ -6,6 +6,9 @@ set -u          # Treat unset variables as an error when substituting
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 app_root="$repo_root/aegis"
 
+# shellcheck source=scripts/lib/deploy-guard.sh
+source "$repo_root/scripts/lib/deploy-guard.sh"
+
 # Build the App Engine entrypoint before uploading this checkout.
 cd "$repo_root"
 pnpm --filter @mento-protocol/aegis build

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -40,6 +40,9 @@ if [ "$SKIP_CONFIRM" = true ]; then
   TF_APPROVE="-auto-approve"
 fi
 
+# shellcheck source=scripts/lib/deploy-guard.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
+
 echo "━━━ Metrics Bridge Deploy ━━━"
 echo "Project:  ${PROJECT}"
 echo "Image:    ${IMAGE}"

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 PROJECT="${GCP_PROJECT:-mento-monitoring}"
 REGION="${GCP_REGION:-europe-west1}"
 AR_REPO="${REGION}-docker.pkg.dev/${PROJECT}/metrics-bridge"
-TAG="$(git rev-parse --short HEAD)"
-IMAGE="${AR_REPO}/metrics-bridge:${TAG}"
 SKIP_CONFIRM=false
 
 while [[ $# -gt 0 ]]; do
@@ -42,6 +40,15 @@ fi
 
 # shellcheck source=scripts/lib/deploy-guard.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
+
+# Anchor all subsequent terraform/gcloud mutations to the guarded repo root so
+# the guard and the deploy operate on the same checkout regardless of caller CWD.
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Compute TAG after cd so git rev-parse targets the guarded checkout.
+TAG="$(git rev-parse --short HEAD)"
+IMAGE="${AR_REPO}/metrics-bridge:${TAG}"
 
 echo "━━━ Metrics Bridge Deploy ━━━"
 echo "Project:  ${PROJECT}"

--- a/scripts/deploy-dashboard.sh
+++ b/scripts/deploy-dashboard.sh
@@ -48,6 +48,9 @@ ok "Logged in as $(vercel whoami "${VERCEL_TOKEN_ARGS[@]}" 2>/dev/null)"
 # No --scope: vercel deploy reads project/team from .vercel/project.json,
 # which is written by Terraform's local_file resource.
 
+# shellcheck source=scripts/lib/deploy-guard.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
+
 log "Deploying to production…"
 (cd "$REPO_ROOT" && vercel deploy --prod "${VERCEL_TOKEN_ARGS[@]}")
 ok "Deploy complete!"

--- a/scripts/deploy-gov-watchdog.sh
+++ b/scripts/deploy-gov-watchdog.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Deploy scripts must refuse dirty working trees before mutating external
-# systems (scripts/AGENTS.md). `terraform apply` archives the local checkout
-# into the Cloud Function source, so uncommitted edits would ship unreviewed
-# and make rollback/audit unreliable.
-if [[ -n "$(git status --porcelain)" ]]; then
-  echo "❌ Working directory is not clean. Commit or stash your changes first."
-  git status --short
-  exit 1
-fi
+# shellcheck source=scripts/lib/deploy-guard.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
 
 COMMIT_SHA=$(git rev-parse --short HEAD)
 COMMIT_MSG=$(git log -1 --pretty=%s)

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -72,6 +72,11 @@ fi
 # shellcheck source=scripts/lib/deploy-guard.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
 
+# Anchor all subsequent git/push mutations to the guarded repo root so the
+# guard and the deploy operate on the same checkout regardless of caller CWD.
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
 # Check if deploy branch exists on remote. When it doesn't, the first-time
 # create push below IS the webhook trigger; the subsequent `HEAD:refs/heads/...`
 # push will be a no-op ("Everything up-to-date"), but that's the create-push

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -69,12 +69,8 @@ else
   echo "🚀 Deploying indexer (network: $NETWORK) → branch: $DEPLOY_BRANCH"
 fi
 
-# Check if we're on a clean working tree
-if [[ -n "$(git status --porcelain)" ]]; then
-  echo "❌ Working directory is not clean. Commit or stash your changes first."
-  git status --short
-  exit 1
-fi
+# shellcheck source=scripts/lib/deploy-guard.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
 
 # Check if deploy branch exists on remote. When it doesn't, the first-time
 # create push below IS the webhook trigger; the subsequent `HEAD:refs/heads/...`

--- a/scripts/lib/deploy-guard.sh
+++ b/scripts/lib/deploy-guard.sh
@@ -2,8 +2,31 @@
 # Shared guard sourced by deploy scripts. Deploy scripts must refuse dirty
 # working trees before mutating external systems (scripts/AGENTS.md):
 # uncommitted edits would ship unreviewed and make rollback/audit unreliable.
-if [[ -n "$(git status --porcelain)" ]]; then
+#
+# Use `return` (not `exit`) on failure: this file is sourced, and `exit` would
+# kill the caller's parent shell — including an interactive terminal if someone
+# sources it by hand to test. All callers run `set -e`/`set -euo pipefail`, so a
+# non-zero return aborts the deploy. The `|| exit 1` fallback keeps it safe if
+# the file is ever executed directly instead of sourced (return outside a
+# sourced context is an error).
+#
+# Anchor the status check to THIS file's repo (scripts/lib/ → two levels up),
+# not the caller's CWD. The deploy scripts always deploy their own computed
+# repo root, so checking the caller's working directory would let a dirty
+# monitoring-monorepo checkout slip through when a script is launched from
+# elsewhere. Fail closed if `git -C` errors (e.g. the path is not a worktree).
+__deploy_guard_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+__deploy_guard_status="$(git -C "$__deploy_guard_root" status --porcelain 2>/dev/null)" || {
+  echo "❌ Could not read git status for $__deploy_guard_root. Aborting deploy."
+  unset __deploy_guard_root __deploy_guard_status
+  # shellcheck disable=SC2317  # reachable only when executed (not sourced)
+  return 1 2>/dev/null || exit 1
+}
+if [[ -n "$__deploy_guard_status" ]]; then
   echo "❌ Working directory is not clean. Commit or stash your changes first."
-  git status --short
-  exit 1
+  git -C "$__deploy_guard_root" status --short
+  unset __deploy_guard_root __deploy_guard_status
+  # shellcheck disable=SC2317  # reachable only when executed (not sourced)
+  return 1 2>/dev/null || exit 1
 fi
+unset __deploy_guard_root __deploy_guard_status

--- a/scripts/lib/deploy-guard.sh
+++ b/scripts/lib/deploy-guard.sh
@@ -9,7 +9,15 @@ if [[ -z "$_repo_root" ]]; then
   echo "❌ deploy-guard: not inside a git repository; refusing to deploy."
   return 1
 fi
-if [[ -n "$(git -C "$_repo_root" status --porcelain)" ]]; then
+# Capture status in a branch that fails closed: a command substitution inside
+# `[[ ... ]]` swallows a non-zero git exit even under `set -e`, so a corrupt or
+# unreadable worktree would yield empty output and look "clean". Check the exit
+# code explicitly and refuse to deploy if git itself errors.
+if ! _status="$(git -C "$_repo_root" status --porcelain)"; then
+  echo "❌ deploy-guard: 'git status' failed for $_repo_root; refusing to deploy."
+  return 1
+fi
+if [[ -n "$_status" ]]; then
   echo "❌ Working directory is not clean. Commit or stash your changes first."
   git -C "$_repo_root" status --short
   return 1

--- a/scripts/lib/deploy-guard.sh
+++ b/scripts/lib/deploy-guard.sh
@@ -1,32 +1,16 @@
 #!/usr/bin/env bash
-# Shared guard sourced by deploy scripts. Deploy scripts must refuse dirty
-# working trees before mutating external systems (scripts/AGENTS.md):
-# uncommitted edits would ship unreviewed and make rollback/audit unreliable.
-#
-# Use `return` (not `exit`) on failure: this file is sourced, and `exit` would
-# kill the caller's parent shell — including an interactive terminal if someone
-# sources it by hand to test. All callers run `set -e`/`set -euo pipefail`, so a
-# non-zero return aborts the deploy. The `|| exit 1` fallback keeps it safe if
-# the file is ever executed directly instead of sourced (return outside a
-# sourced context is an error).
-#
-# Anchor the status check to THIS file's repo (scripts/lib/ → two levels up),
-# not the caller's CWD. The deploy scripts always deploy their own computed
-# repo root, so checking the caller's working directory would let a dirty
-# monitoring-monorepo checkout slip through when a script is launched from
-# elsewhere. Fail closed if `git -C` errors (e.g. the path is not a worktree).
-__deploy_guard_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-__deploy_guard_status="$(git -C "$__deploy_guard_root" status --porcelain 2>/dev/null)" || {
-  echo "❌ Could not read git status for $__deploy_guard_root. Aborting deploy."
-  unset __deploy_guard_root __deploy_guard_status
-  # shellcheck disable=SC2317  # reachable only when executed (not sourced)
-  return 1 2>/dev/null || exit 1
-}
-if [[ -n "$__deploy_guard_status" ]]; then
-  echo "❌ Working directory is not clean. Commit or stash your changes first."
-  git -C "$__deploy_guard_root" status --short
-  unset __deploy_guard_root __deploy_guard_status
-  # shellcheck disable=SC2317  # reachable only when executed (not sourced)
-  return 1 2>/dev/null || exit 1
+# Shared guard sourced by deploy scripts. Refuses dirty working trees before
+# mutating external systems (scripts/AGENTS.md). Anchored to the repo that
+# contains this guard file so it checks the deployed checkout, not the caller's
+# cwd. Uses `return` (not `exit`) since it is sourced and all callers set -e.
+_guard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo_root="$(git -C "$_guard_dir" rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$_repo_root" ]]; then
+  echo "❌ deploy-guard: not inside a git repository; refusing to deploy."
+  return 1
 fi
-unset __deploy_guard_root __deploy_guard_status
+if [[ -n "$(git -C "$_repo_root" status --porcelain)" ]]; then
+  echo "❌ Working directory is not clean. Commit or stash your changes first."
+  git -C "$_repo_root" status --short
+  return 1
+fi

--- a/scripts/lib/deploy-guard.sh
+++ b/scripts/lib/deploy-guard.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Shared guard sourced by deploy scripts. Deploy scripts must refuse dirty
+# working trees before mutating external systems (scripts/AGENTS.md):
+# uncommitted edits would ship unreviewed and make rollback/audit unreliable.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "❌ Working directory is not clean. Commit or stash your changes first."
+  git status --short
+  exit 1
+fi


### PR DESCRIPTION
## The Problem

- Three deploy scripts (`deploy-dashboard.sh`, `deploy-bridge.sh`, `aegis/bin/deploy.sh`) had no clean-working-tree guard and could mutate external systems (Vercel, GCP Cloud Run, App Engine) with uncommitted local edits — violating the `scripts/AGENTS.md` operating rule.
- The other two scripts (`deploy-gov-watchdog.sh`, `deploy-indexer.sh`) each carried an identical inline guard, duplicating the logic.

## The Solution

- Extract the canonical clean-working-tree guard into `scripts/lib/deploy-guard.sh` and `source` it from all five deploy scripts, so every deploy entrypoint now refuses dirty working trees before touching an external system.

## Details

- Replaced the two inline guards in `deploy-gov-watchdog.sh` and `deploy-indexer.sh` with the sourced helper.
- Added the sourced guard to the three previously unguarded scripts, placed after read-only preflight (auth / flag parsing) but before any external mutation:
  - `deploy-dashboard.sh` — after Vercel auth check, before `vercel deploy --prod`
  - `deploy-bridge.sh` — after flag-parsing/TF_APPROVE, before `terraform apply` + `gcloud builds submit`
  - `aegis/bin/deploy.sh` — after `repo_root`/`app_root` vars, before `pnpm build` + `gcloud app deploy`
- The guard file deliberately omits `set -euo pipefail` — each caller owns its own shell options. `shellcheck source=` directives are included so shellcheck follows the source chain.

## Validation

- `bash -n` and `shellcheck -x` green on all six changed files.
- Guard fire test: creating an uncommitted file → guard prints the dirty-tree error and exits 1; file removed → guard is silent.
- `pnpm agent:quality-gate --run` — all mapped commands passed (trunk, aegis typecheck/lint/knip/test, dep-cruiser, forge test, context-check).

## Deferrals

- Anchoring the deploy *commands* (not just the clean-tree guard) to the guarded repo root — raised by Codex on this PR, deferred as beyond #851's scope and a larger hardening. Tracked in https://github.com/mento-protocol/monitoring-monorepo/issues/908.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #851

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-script hardening only; no runtime app logic. Slightly stricter deploy preconditions and safer git anchoring for bridge/indexer.
> 
> **Overview**
> Introduces **`scripts/lib/deploy-guard.sh`** and wires it into every deploy entrypoint so **dirty working trees are rejected** before Vercel, GCP, App Engine, Terraform, or git push mutations.
> 
> The guard is **repo-anchored** (`git -C` from the guard’s checkout), uses **`return 1`** for sourced callers with `set -e`, and **fails closed** if `git status` errors instead of treating a failed check as “clean.” Inline duplicate checks in **`deploy-gov-watchdog.sh`** and **`deploy-indexer.sh`** are removed in favor of the shared helper; **`deploy-dashboard.sh`**, **`deploy-bridge.sh`**, and **`aegis/bin/deploy.sh`** gain the guard after read-only preflight.
> 
> **`deploy-bridge.sh`** and **`deploy-indexer.sh`** also **`cd` to the guarded repo root** before image tag / git operations so deploy actions align with the tree the guard validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4753b500180795dcd83c85d40877219624462944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

