### PR TITLE
refactor(cdp-revenue): replace hand-rolled paginators with fetchPaginatedRows (fixes shared AbortSignal bug)

### DIFF
--- a/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Targeted tests for the paginator helpers inside `use-cdp-borrowing-revenue`.
+ *
+ * Strategy: spy on `fetchPaginatedRows` (the canonical helper the three thin
+ * wrappers now delegate to) to verify:
+ *   (a) a fresh AbortSignal.timeout is created per page, not shared across
+ *       the whole pagination loop (the bug fixed by this PR), and
+ *   (b) boundary-duplicate rows are deduped so windowed totals can't
+ *       double-count when an insert lands between page requests.
+ *
+ * We do NOT render the hook or exercise SWR — that's covered by the existing
+ * cdp-borrowing-revenue.test.ts (pure math) and revenue-page-client.test.tsx
+ * (mocked hook). These tests are unit-level: they drive the GraphQL client
+ * mock directly through `fetchAllNetworks.fetchPaginatedRows`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// graphql-request mock
+// ---------------------------------------------------------------------------
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+import { GraphQLClient } from "graphql-request";
+
+// ---------------------------------------------------------------------------
+// Import the module-private helpers via the public fetchPaginatedRows export.
+// We test fetchPaginatedRows directly since that's the canonical function the
+// three wrappers delegate to, and it's now exported from fetch-all-networks.
+// ---------------------------------------------------------------------------
+
+import {
+  fetchPaginatedRows,
+  warnedCapKeys,
+  partialPageLastCapturedAt,
+} from "@/lib/fetch-all-networks";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeClient(): InstanceType<typeof GraphQLClient> {
+  return new GraphQLClient("https://example.com/graphql");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    warnedCapKeys.clear();
+    partialPageLastCapturedAt.clear();
+  });
+
+  it("calls AbortSignal.timeout once per page, not once for the whole loop", async () => {
+    const client = makeClient();
+    const PAGE_SIZE = 1000;
+
+    // Simulate 2 full pages then a partial page (3 pages total → 3 signals).
+    const fullPage = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `row-${i}`,
+    }));
+    const partialPage = [{ id: "row-last" }];
+
+    const requestMock = vi
+      .mocked(client.request)
+      .mockResolvedValueOnce({ TestKey: fullPage })
+      .mockResolvedValueOnce({ TestKey: fullPage })
+      .mockResolvedValueOnce({ TestKey: partialPage });
+
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+
+    await fetchPaginatedRows({
+      client,
+      query: "query { TestKey { id } }",
+      responseKey: "TestKey",
+      network: "celo-mainnet",
+      variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+      dedupKey: (r: { id: string }) => r.id,
+    });
+
+    // 3 pages → 3 separate AbortSignal.timeout() calls (one per request).
+    expect(timeoutSpy).toHaveBeenCalledTimes(3);
+    expect(requestMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("creates distinct signal objects for each page (not the same reference)", async () => {
+    const client = makeClient();
+    const PAGE_SIZE = 1000;
+
+    const page1 = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `p1-${i}`,
+    }));
+    const page2 = [{ id: "p2-0" }];
+
+    // Capture the signal passed into each client.request() call.
+    const capturedSignals: AbortSignal[] = [];
+    vi.mocked(client.request).mockImplementation(
+      async (opts: { signal?: AbortSignal; [k: string]: unknown }) => {
+        if (opts.signal) capturedSignals.push(opts.signal);
+        const callIndex = capturedSignals.length - 1;
+        return callIndex === 0 ? { TestKey: page1 } : { TestKey: page2 };
+      },
+    );
+
+    await fetchPaginatedRows({
+      client,
+      query: "query { TestKey { id } }",
+      responseKey: "TestKey",
+      network: "celo-mainnet",
+      variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+      dedupKey: (r: { id: string }) => r.id,
+    });
+
+    // Each page must get its own signal object — not the same reference.
+    expect(capturedSignals).toHaveLength(2);
+    expect(capturedSignals[0]).not.toBe(capturedSignals[1]);
+  });
+});
+
+describe("fetchPaginatedRows — boundary-duplicate dedup", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    warnedCapKeys.clear();
+    partialPageLastCapturedAt.clear();
+  });
+
+  it("deduplicates a row that appears at the tail of one page and head of the next", async () => {
+    const client = makeClient();
+    const PAGE_SIZE = 1000;
+
+    // Page 0: 1000 rows, last row has id "boundary-row".
+    const page0 = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: i === PAGE_SIZE - 1 ? "boundary-row" : `r0-${i}`,
+    }));
+    // Page 1: first row is the same "boundary-row" (re-emitted by Hasura
+    // under concurrent insert), then a short tail.
+    const page1 = [
+      { id: "boundary-row" }, // duplicate
+      { id: "r1-0" },
+      { id: "r1-1" },
+    ];
+
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ TestKey: page0 })
+      .mockResolvedValueOnce({ TestKey: page1 });
+
+    const result = await fetchPaginatedRows({
+      client,
+      query: "query { TestKey { id } }",
+      responseKey: "TestKey",
+      network: "celo-mainnet",
+      variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+      dedupKey: (r: { id: string }) => r.id,
+    });
+
+    // Total unique rows: 1000 (page0) + 2 new from page1 (r1-0, r1-1).
+    // "boundary-row" must appear exactly once.
+    expect(result.rows).toHaveLength(PAGE_SIZE + 2);
+    const ids = result.rows.map((r) => r.id);
+    const boundaryCount = ids.filter((id) => id === "boundary-row").length;
+    expect(boundaryCount).toBe(1);
+    expect(result.truncated).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns all rows without duplicates across three pages", async () => {
+    const client = makeClient();
+    const PAGE_SIZE = 1000;
+
+    const page0 = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `r-${i}`,
+    }));
+    const page1 = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `r-${PAGE_SIZE + i}`,
+    }));
+    const page2 = [{ id: "r-last" }];
+
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ TestKey: page0 })
+      .mockResolvedValueOnce({ TestKey: page1 })
+      .mockResolvedValueOnce({ TestKey: page2 });
+
+    const result = await fetchPaginatedRows({
+      client,
+      query: "query { TestKey { id } }",
+      responseKey: "TestKey",
+      network: "celo-mainnet",
+      variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+      dedupKey: (r: { id: string }) => r.id,
+    });
+
+    const uniqueIds = new Set(result.rows.map((r) => r.id));
+    expect(result.rows).toHaveLength(uniqueIds.size);
+    expect(result.rows).toHaveLength(PAGE_SIZE * 2 + 1);
+  });
+});

--- a/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
@@ -107,13 +107,16 @@ describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
 
     // Capture the signal passed into each client.request() call.
     const capturedSignals: AbortSignal[] = [];
-    vi.mocked(client.request).mockImplementation(
-      async (opts: { signal?: AbortSignal; [k: string]: unknown }) => {
-        if (opts.signal) capturedSignals.push(opts.signal);
-        const callIndex = capturedSignals.length - 1;
-        return callIndex === 0 ? { TestKey: page1 } : { TestKey: page2 };
-      },
-    );
+    type RequestArg = Parameters<typeof client.request>[0];
+    vi.mocked(client.request).mockImplementation(async (opts: RequestArg) => {
+      const sig =
+        opts != null && typeof opts === "object" && "signal" in opts
+          ? (opts as { signal?: AbortSignal | null }).signal
+          : undefined;
+      if (sig) capturedSignals.push(sig);
+      const callIndex = capturedSignals.length - 1;
+      return callIndex === 0 ? { TestKey: page1 } : { TestKey: page2 };
+    });
 
     await fetchPaginatedRows({
       client,

--- a/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
+++ b/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
@@ -18,7 +18,10 @@ import {
   CDP_BORROWING_REVENUE_MARKETS_LEGACY,
   ORACLE_RATES,
 } from "@/lib/queries";
-import { REQUEST_TIMEOUT_MS } from "@/lib/fetch-all-networks";
+import {
+  REQUEST_TIMEOUT_MS,
+  fetchPaginatedRows,
+} from "@/lib/fetch-all-networks";
 import {
   aggregateCdpBorrowingRevenue,
   aggregateCdpBorrowingRevenueMarkets,
@@ -89,14 +92,6 @@ async function fetchMarketsWithCompat(
   }
 }
 
-type BracketsResponse = {
-  InterestRateBracket: CdpBorrowingRevenueBracket[];
-};
-
-type FeeEventsResponse = {
-  TroveOperationEvent: CdpBorrowingFeeEvent[];
-};
-
 type BracketPageResult = {
   rows: CdpBorrowingRevenueBracket[];
   truncated: boolean;
@@ -152,12 +147,7 @@ const EMPTY_SUMMARY: CdpBorrowingRevenueSummary = {
   bracketsTruncated: false,
 };
 
-const BRACKET_PAGE_SIZE = 1000;
-const BRACKET_MAX_PAGES = 20;
-const FEE_EVENT_PAGE_SIZE = 1000;
-const FEE_EVENT_MAX_PAGES = 20;
-const DAILY_SNAPSHOT_PAGE_SIZE = 1000;
-const DAILY_SNAPSHOT_MAX_PAGES = 20;
+const CDP_PAGE_SIZE = 1000;
 const CDP_REVENUE_CHAIN_IDS = new Set([42220]);
 
 function mergeSummaries(
@@ -255,57 +245,43 @@ async function requestWithTimeout<T>(
 async function fetchAllBracketPages(
   client: GraphQLClient,
   collateralIds: string[],
+  network: string,
 ): Promise<BracketPageResult> {
-  const rows: CdpBorrowingRevenueBracket[] = [];
-  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  for (let page = 0; page < BRACKET_MAX_PAGES; page++) {
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Bracket pagination is intentionally sequential so we can stop after the first short page.
-    const response = await requestWithTimeout<BracketsResponse>(
-      client,
-      CDP_BORROWING_REVENUE_BRACKETS,
-      {
-        collateralIds,
-        limit: BRACKET_PAGE_SIZE,
-        offset: page * BRACKET_PAGE_SIZE,
-      },
-      signal,
-    );
-    const pageRows = response.InterestRateBracket ?? [];
-    rows.push(...pageRows);
-    if (pageRows.length < BRACKET_PAGE_SIZE) {
-      return { rows, truncated: false };
-    }
-  }
-
-  return { rows, truncated: true };
+  const result = await fetchPaginatedRows<CdpBorrowingRevenueBracket, unknown>({
+    client,
+    query: CDP_BORROWING_REVENUE_BRACKETS,
+    responseKey: "InterestRateBracket",
+    network,
+    variablesFor: (page) => ({
+      collateralIds,
+      limit: CDP_PAGE_SIZE,
+      offset: page * CDP_PAGE_SIZE,
+    }),
+    dedupKey: (r) => r.id,
+  });
+  if (result.error) throw result.error;
+  return { rows: result.rows, truncated: result.truncated };
 }
 
 async function fetchAllFeeEventPages(
   client: GraphQLClient,
   chainId: number,
+  network: string,
 ): Promise<FeeEventPageResult> {
-  const rows: CdpBorrowingFeeEvent[] = [];
-  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  for (let page = 0; page < FEE_EVENT_MAX_PAGES; page++) {
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Event pagination is intentionally sequential so we can stop after the first short page.
-    const response = await requestWithTimeout<FeeEventsResponse>(
-      client,
-      CDP_BORROWING_FEE_EVENTS,
-      {
-        chainId,
-        limit: FEE_EVENT_PAGE_SIZE,
-        offset: page * FEE_EVENT_PAGE_SIZE,
-      },
-      signal,
-    );
-    const pageRows = response.TroveOperationEvent ?? [];
-    rows.push(...pageRows);
-    if (pageRows.length < FEE_EVENT_PAGE_SIZE) {
-      return { rows, truncated: false };
-    }
-  }
-
-  return { rows, truncated: true };
+  const result = await fetchPaginatedRows<CdpBorrowingFeeEvent, unknown>({
+    client,
+    query: CDP_BORROWING_FEE_EVENTS,
+    responseKey: "TroveOperationEvent",
+    network,
+    variablesFor: (page) => ({
+      chainId,
+      limit: CDP_PAGE_SIZE,
+      offset: page * CDP_PAGE_SIZE,
+    }),
+    dedupKey: (r) => r.id,
+  });
+  if (result.error && result.rows.length === 0) throw result.error;
+  return { rows: result.rows, truncated: result.truncated };
 }
 
 function isMissingDailySnapshotEntityError(err: unknown): boolean {
@@ -330,55 +306,41 @@ async function paginateDailySnapshots<T extends { id: string }>(
   client: GraphQLClient,
   chainId: number,
   query: string,
+  network: string,
 ): Promise<{ rows: T[]; truncated: boolean }> {
-  const rows: T[] = [];
   // Offset pagination over the append-only snapshot table is unstable under
   // concurrent inserts: a new row landing between page requests shifts the
   // `timestamp desc, id desc` window and can re-emit a boundary row on the next
-  // page. Dedup by stable row id (matches `fetchPaginatedRows` in
-  // `lib/network-fetcher/fetch.ts`) so windowed totals can't double-count.
-  const seen = new Set<string>();
-  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  for (let page = 0; page < DAILY_SNAPSHOT_MAX_PAGES; page++) {
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Snapshot pagination is intentionally sequential so we can stop after the first short page.
-    const response = await requestWithTimeout<
-      Record<"LiquityBorrowingRevenueDailySnapshot", T[]>
-    >(
-      client,
-      query,
-      {
-        chainId,
-        limit: DAILY_SNAPSHOT_PAGE_SIZE,
-        offset: page * DAILY_SNAPSHOT_PAGE_SIZE,
-      },
-      signal,
-    );
-    const pageRows = response.LiquityBorrowingRevenueDailySnapshot ?? [];
-    for (const row of pageRows) {
-      if (seen.has(row.id)) continue;
-      seen.add(row.id);
-      rows.push(row);
-    }
-    // Stop on the raw page length, not the deduped count — a full page that
-    // happens to contain a boundary duplicate must not look "short" and
-    // truncate pagination a page early.
-    if (pageRows.length < DAILY_SNAPSHOT_PAGE_SIZE) {
-      return { rows, truncated: false };
-    }
-  }
-
-  return { rows, truncated: true };
+  // page. fetchPaginatedRows deduplicates by dedupKey (row id) so windowed
+  // totals can't double-count. It also creates a fresh AbortSignal.timeout per
+  // page (fixing the shared-signal bug in the old hand-rolled loop).
+  const result = await fetchPaginatedRows<T, unknown>({
+    client,
+    query,
+    responseKey: "LiquityBorrowingRevenueDailySnapshot",
+    network,
+    variablesFor: (page) => ({
+      chainId,
+      limit: CDP_PAGE_SIZE,
+      offset: page * CDP_PAGE_SIZE,
+    }),
+    dedupKey: (r) => r.id,
+  });
+  if (result.error && result.rows.length === 0) throw result.error;
+  return { rows: result.rows, truncated: result.truncated };
 }
 
 async function fetchAllDailySnapshotPages(
   client: GraphQLClient,
   chainId: number,
+  network: string,
 ): Promise<DailySnapshotPageResult> {
   try {
     const page = await paginateDailySnapshots<CdpBorrowingRevenueDailySnapshot>(
       client,
       chainId,
       CDP_BORROWING_REVENUE_DAILY_SNAPSHOTS,
+      network,
     );
     return { ...page, unavailable: false, collectedUnavailable: false };
   } catch (err) {
@@ -386,7 +348,7 @@ async function fetchAllDailySnapshotPages(
     if (isMissingSnapshotCollectedFieldError(err)) {
       const legacy = await paginateDailySnapshots<
         Omit<CdpBorrowingRevenueDailySnapshot, "collected">
-      >(client, chainId, CDP_BORROWING_REVENUE_DAILY_SNAPSHOTS_LEGACY);
+      >(client, chainId, CDP_BORROWING_REVENUE_DAILY_SNAPSHOTS_LEGACY, network);
       return {
         rows: legacy.rows.map((row) => ({ ...row, collected: "0" })),
         truncated: legacy.truncated,
@@ -417,6 +379,7 @@ async function fetchAllDailySnapshotPages(
 async function resolveDailyBorrowingFeeSeries(
   client: GraphQLClient,
   chainId: number,
+  network: string,
   aggregateArgs: {
     collaterals: ReadonlyArray<CdpBorrowingRevenueCollateral>;
     instances: ReadonlyArray<CdpBorrowingRevenueInstance>;
@@ -434,9 +397,10 @@ async function resolveDailyBorrowingFeeSeries(
     const dailySnapshotPages = await fetchAllDailySnapshotPages(
       client,
       chainId,
+      network,
     );
     const fallbackFeeEventPages = dailySnapshotPages.unavailable
-      ? await fetchAllFeeEventPages(client, chainId)
+      ? await fetchAllFeeEventPages(client, chainId, network)
       : undefined;
     return {
       points:
@@ -508,6 +472,7 @@ async function fetchRevenueForNetwork(
       fetchAllBracketPages(
         client,
         collaterals.map((c) => c.id),
+        network.id,
       ),
     ]);
     const rates: OracleRateMap = buildOracleRateMap(
@@ -525,6 +490,7 @@ async function fetchRevenueForNetwork(
     const daily = await resolveDailyBorrowingFeeSeries(
       client,
       network.chainId,
+      network.id,
       aggregateArgs,
     );
 

--- a/ui-dashboard/src/lib/__tests__/fetch-all-networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/fetch-all-networks.test.ts
@@ -14,6 +14,7 @@ const EXPECTED_EXPORT_NAMES = [
   "fetchAllFeeSnapshotPages",
   "fetchAllNetworks",
   "fetchNetworkData",
+  "fetchPaginatedRows",
   "isNetworkDataFullyHealthy",
   "partialPageLastCapturedAt",
   "warnedCapKeys",

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -191,7 +191,7 @@ export const partialPageLastCapturedAt = new Map<string, number>();
  * under concurrent inserts, so dedup is required to keep windowed totals
  * accurate even when a refresh hits mid-write.
  */
-async function fetchPaginatedRows<TRow, TVars>(args: {
+export async function fetchPaginatedRows<TRow, TVars>(args: {
   client: GraphQLClient;
   query: string;
   responseKey: string;


### PR DESCRIPTION
## The Problem

The three CDP revenue paginators in `use-cdp-borrowing-revenue.ts` created a single `AbortSignal.timeout` before the pagination loop and reused it for every page request. If the first page consumed most of the 5-second budget, subsequent pages were aborted immediately — silently dropping data and appearing as an unexplained truncation rather than a real timeout.

## The Solution

Refactor the three hand-rolled paginators (`fetchAllBracketPages`, `fetchAllFeeEventPages`, `paginateDailySnapshots`) to delegate to the canonical `fetchPaginatedRows` helper, which already creates a fresh `AbortSignal.timeout` per page. This also removes ~100 lines of duplicated pagination code and brings CDP paginators in line with all other FPMM paginators in the codebase.

## Details

- **Export `fetchPaginatedRows`** from `fetch.ts` (was module-private) and add it to `EXPECTED_EXPORT_NAMES` in the surface-contract test
- **Thread `network: string`** from `fetchRevenueForNetwork` down through the call chain — needed for Sentry `(network, responseKey)` keying inside `fetchPaginatedRows`
- **Fail-hard semantics preserved**: brackets throw on any error; fee-events/snapshots throw only when `error && rows.length === 0` (preserving the existing truncated→failed flow)
- **Safe behavioral deltas**: max pages 20→100; dedup added to fee-events (IDs unique → no math change); additive Sentry signals for bracket/fee paginations
- **Removed**: 6 CDP-specific page-size/max-pages constants, 2 now-unused response type aliases
- **New tests** (`src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts`): per-page fresh-signal spy, distinct signal object assertion, boundary-duplicate dedup, three-page no-duplicate correctness
- Revenue math is byte-identical; existing `cdp-borrowing-revenue.test.ts` and `revenue-page-client.test.tsx` pass untouched

## Validation

- `pnpm test`: 3101/3101 passed (4 new tests)
- `pnpm lint`: green
- `pnpm build`: green
- `pnpm react-doctor`: 100/100, no issues
- `test:browser`: 16/16 passed (known ~1/15 flake, confirmed green on re-run)
- chrome-devtools MCP not available in this agent session

## Deferrals

None

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
