### PR TITLE
test: pin deviation threshold parity between shared-config floats and indexer bigints

### DIFF
--- a/indexer-envio/test/deviationThresholdSharedConfigSync.test.ts
+++ b/indexer-envio/test/deviationThresholdSharedConfigSync.test.ts
@@ -19,8 +19,10 @@ import {
  * the source file and regex-extract the float literals, then assert that the
  * bigint fraction equals the float.
  *
- * Both 101/100 === 1.01 and 105/100 === 1.05 are exact in IEEE-754 (no
- * rounding error), so strict equality is safe here.
+ * Both `Number(101n) / Number(100n)` and the literal `1.01` parse to the same
+ * nearest IEEE-754 double (likewise for 105/100 and 1.05), so there's no
+ * rounding divergence between the two paths and strict equality is safe — but
+ * neither value is exact in binary (1.01 is a non-terminating fraction).
  *
  * If this test fails, update BOTH files together:
  *   - indexer-envio/src/pool/health.ts   (bigint NUM/DEN pairs)

--- a/indexer-envio/test/deviationThresholdSharedConfigSync.test.ts
+++ b/indexer-envio/test/deviationThresholdSharedConfigSync.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from "assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  DEVIATION_CRITICAL_DEN,
+  DEVIATION_CRITICAL_NUM,
+  DEVIATION_TOLERANCE_DEN,
+  DEVIATION_TOLERANCE_NUM,
+} from "../src/pool/health.js";
+
+/**
+ * Drift-protection test. `indexer-envio/src/pool/health.ts` stores the
+ * deviation-threshold boundaries as `num/den` bigint pairs for integer-safe
+ * arithmetic. `shared-config/src/thresholds.ts` stores the same boundaries
+ * as IEEE-754 float ratios (consumed by the dashboard and metrics-bridge).
+ *
+ * We can't import shared-config at runtime (Envio builds outside the pnpm
+ * workspace — see src/contractAddresses.ts:14-18), so instead we fs-read
+ * the source file and regex-extract the float literals, then assert that the
+ * bigint fraction equals the float.
+ *
+ * Both 101/100 === 1.01 and 105/100 === 1.05 are exact in IEEE-754 (no
+ * rounding error), so strict equality is safe here.
+ *
+ * If this test fails, update BOTH files together:
+ *   - indexer-envio/src/pool/health.ts   (bigint NUM/DEN pairs)
+ *   - shared-config/src/thresholds.ts    (float RATIO constants)
+ */
+describe("deviation thresholds — numeric parity with shared-config/src/thresholds.ts", () => {
+  const sharedConfigPath = join(
+    import.meta.dirname,
+    "..",
+    "..",
+    "shared-config",
+    "src",
+    "thresholds.ts",
+  );
+  const source = readFileSync(sharedConfigPath, "utf8");
+
+  function extractRatio(name: string): number {
+    const match = source.match(
+      new RegExp(`export\\s+const\\s+${name}\\s*=\\s*([\\d.]+)`),
+    );
+    assert.ok(
+      match,
+      `Could not find 'export const ${name}' in shared-config/src/thresholds.ts`,
+    );
+    return Number(match[1]);
+  }
+
+  it("DEVIATION_TOLERANCE_NUM/DEN equals DEVIATION_TOLERANCE_RATIO", () => {
+    const ratio = extractRatio("DEVIATION_TOLERANCE_RATIO");
+    assert.strictEqual(
+      Number(DEVIATION_TOLERANCE_NUM) / Number(DEVIATION_TOLERANCE_DEN),
+      ratio,
+      "DEVIATION_TOLERANCE_NUM/DEN in indexer-envio/src/pool/health.ts does not equal " +
+        `DEVIATION_TOLERANCE_RATIO (${ratio}) in shared-config/src/thresholds.ts. ` +
+        "Update both files together.",
+    );
+  });
+
+  it("DEVIATION_CRITICAL_NUM/DEN equals DEVIATION_CRITICAL_RATIO", () => {
+    const ratio = extractRatio("DEVIATION_CRITICAL_RATIO");
+    assert.strictEqual(
+      Number(DEVIATION_CRITICAL_NUM) / Number(DEVIATION_CRITICAL_DEN),
+      ratio,
+      "DEVIATION_CRITICAL_NUM/DEN in indexer-envio/src/pool/health.ts does not equal " +
+        `DEVIATION_CRITICAL_RATIO (${ratio}) in shared-config/src/thresholds.ts. ` +
+        "Update both files together.",
+    );
+  });
+});

--- a/shared-config/src/thresholds.ts
+++ b/shared-config/src/thresholds.ts
@@ -14,8 +14,9 @@
  * Strict `>` flips the pool to WARN (or above).
  *
  * Mirrors `DEVIATION_TOLERANCE_NUM / DEVIATION_TOLERANCE_DEN` in
- * `indexer-envio/src/pool.ts`; the indexer's `test/healthStatusParity.test.ts`
- * enforces parity with the dashboard's `computeHealthStatus`.
+ * `indexer-envio/src/pool/health.ts`; `test/deviationThresholdSharedConfigSync.test.ts`
+ * enforces numeric parity and `test/healthStatusParity.test.ts` enforces
+ * behavioral parity with the dashboard's `computeHealthStatus`.
  */
 export const DEVIATION_TOLERANCE_RATIO = 1.01;
 
@@ -26,7 +27,9 @@ export const DEVIATION_TOLERANCE_RATIO = 1.01;
  * magnitude, duration alone never escalates a breach to CRITICAL.
  *
  * Mirrors `DEVIATION_CRITICAL_NUM / DEVIATION_CRITICAL_DEN` in
- * `indexer-envio/src/pool.ts`. Also gates the metrics-bridge rebalance-reason
- * probe so the annotation only attaches to alerts that can actually fire.
+ * `indexer-envio/src/pool/health.ts`; `test/deviationThresholdSharedConfigSync.test.ts`
+ * enforces numeric parity and `test/healthStatusParity.test.ts` enforces
+ * behavioral parity. Also gates the metrics-bridge rebalance-reason probe so
+ * the annotation only attaches to alerts that can actually fire.
  */
 export const DEVIATION_CRITICAL_RATIO = 1.05;

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -1,6 +1,7 @@
 /**
  * Health status computation for pool oracle monitoring.
- * Mirrors the logic in the indexer's EventHandlers.ts.
+ * Mirrors the deviation-threshold logic in the indexer's pool/health.ts;
+ * behavioral parity enforced by indexer-envio/test/healthStatusParity.test.ts.
  */
 
 export type HealthStatus =


### PR DESCRIPTION
## The Problem

- `shared-config/src/thresholds.ts` holds deviation-threshold float ratios (`1.01`, `1.05`) and `indexer-envio/src/pool/health.ts` holds the same values as bigint fractions (`101n/100n`, `105n/100n`), but nothing prevents them from drifting apart silently.
- Both JSDoc blocks in `shared-config/src/thresholds.ts` pointed at `indexer-envio/src/pool.ts` — a stale path (logic moved to `pool/health.ts`).
- The header comment in `ui-dashboard/src/lib/health.ts` said it mirrors `EventHandlers.ts` — another stale pointer.

## The Solution

- Add `indexer-envio/test/deviationThresholdSharedConfigSync.test.ts`: fs-reads `shared-config/src/thresholds.ts`, regex-extracts the float ratios, imports the bigint constants from `src/pool/health.js`, and asserts `Number(NUM)/Number(DEN) === ratio` for both boundaries. Follows the same pattern as `aggregators-parity.test.ts`.
- Fix both stale pointer comments in `shared-config/src/thresholds.ts` to reference `pool/health.ts` and mention both sync tests.
- Fix the `ui-dashboard/src/lib/health.ts` header to reference `pool/health.ts` and name `healthStatusParity.test.ts`.

## Details

- `Number(101n)/Number(100n)` and the literal `1.01` parse to the same nearest IEEE-754 double (likewise 105/100 and 1.05), so `assert.strictEqual` is safe — though neither value is exact in binary.
- The indexer cannot import `shared-config` at runtime (Envio builds outside the pnpm workspace; see `src/contractAddresses.ts:14-18`), so fs-read + regex is the correct pattern — not a direct import.

## Deferrals

- Part B (grep-based CI check for HCL literals in `alerts/rules/rules-fpmms.tf`) is deferred to #901. The banner in that file already names `shared-config/src/thresholds.ts` as canonical; the PromQL string embedding makes regex matching brittle, so the check needs careful scoping to avoid false positives.

## Validation

```
cd indexer-envio && pnpm test
# Test Files  60 passed (60)
# Tests  940 passed (940)

pnpm exec trunk fmt <changed files>
# ✔ No issues

./tools/trunk check <changed files>
# ✔ No issues
```

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run (tests, trunk)
- [x] PR readiness probe planned

Closes #857

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no runtime logic or threshold values are modified.
> 
> **Overview**
> Adds **drift protection** so indexer bigint deviation boundaries (`101/100`, `105/100` in `pool/health.ts`) cannot silently diverge from `shared-config` float ratios (`1.01`, `1.05`).
> 
> New test **`deviationThresholdSharedConfigSync.test.ts`** reads `shared-config/src/thresholds.ts` from disk (no runtime import—Envio builds outside the pnpm workspace), regex-extracts the ratio constants, and asserts `Number(NUM)/Number(DEN)` matches each float with strict equality.
> 
> **Comment-only fixes** in `shared-config/src/thresholds.ts` and `ui-dashboard/src/lib/health.ts` replace stale pointers (`pool.ts`, `EventHandlers.ts`) with `pool/health.ts` and name both parity tests (`deviationThresholdSharedConfigSync` for numeric sync, `healthStatusParity` for behavioral).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3837f54725c17785d61ae3dd6cfc5ac3a8979d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->