### PR TITLE
Hide revenue nav for logged-out users

### DIFF
--- a/ui-dashboard/src/components/__tests__/nav-links.test.tsx
+++ b/ui-dashboard/src/components/__tests__/nav-links.test.tsx
@@ -19,7 +19,7 @@ vi.mock("next-auth/react", () => ({
 }));
 
 describe("NavLinks", () => {
-  it("shows Addresses and Integrations links when user is authenticated", () => {
+  it("shows protected links when user is authenticated", () => {
     mockUseSession.mockReturnValue({
       data: { user: { email: "alice@mentolabs.xyz" } },
     });
@@ -28,24 +28,26 @@ describe("NavLinks", () => {
     expect(html).toContain("/address-book");
     expect(html).toContain("Integrations");
     expect(html).toContain("/integrations");
+    expect(html).toContain("Revenue");
+    expect(html).toContain("/revenue");
   });
 
-  it("hides Addresses and Integrations links when user is not authenticated", () => {
+  it("hides protected links when user is not authenticated", () => {
     mockUseSession.mockReturnValue({ data: null });
     const html = renderToStaticMarkup(<NavLinks />);
     expect(html).not.toContain("Addresses");
     expect(html).not.toContain("/address-book");
     expect(html).not.toContain("Integrations");
     expect(html).not.toContain("/integrations");
+    expect(html).not.toContain("Revenue");
+    expect(html).not.toContain("/revenue");
   });
 
-  it("always shows Pools, Revenue, and home links regardless of auth", () => {
+  it("always shows Pools and home links regardless of auth", () => {
     mockUseSession.mockReturnValue({ data: null });
     const html = renderToStaticMarkup(<NavLinks />);
     expect(html).toContain("Pools");
     expect(html).toContain("/pools");
-    expect(html).toContain("Revenue");
-    expect(html).toContain("/revenue");
     expect(html).toContain("Mento Analytics");
   });
 

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -52,12 +52,14 @@ export function NavLinks() {
       >
         CDPs
       </Link>
-      <Link
-        href="/revenue"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Revenue
-      </Link>
+      {session && (
+        <Link
+          href="/revenue"
+          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+        >
+          Revenue
+        </Link>
+      )}
       {session && (
         <Link
           href="/address-book"


### PR DESCRIPTION
## The Problem

- The Revenue page is SSO-gated, but the global nav still advertised it to logged-out visitors.
- That exposed a restricted surface as a visible menu option even though unauthenticated users can only reach the sign-in redirect.

## The Solution

- Hide the Revenue nav link unless the user has an authenticated session, matching the existing Integrations and Addresses behavior.

## Details

- Keeps the `/revenue` route protection unchanged.
- Updates the nav unit tests so protected links are asserted together for authenticated and logged-out states.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Pre-push `pnpm agent:quality-gate --run`
- Browser verification: logged-out clean context had no Revenue link; simulated logged-in nav showed Revenue.

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
