### PR TITLE
ci: make PR-description '## Deferrals' section optional

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,8 @@
 Everything knowingly deferred from this PR — reviewer findings you chose not
 to address here, or work you judged out of scope — MUST have a GitHub issue
 describing the problem (and solution ideas, if any). List the issue links
-below, or write "None" if nothing was deferred. CI enforces this section.
+below. This section is OPTIONAL: delete it entirely when nothing was deferred.
+When you keep it, CI requires each item to be "None" or link a GitHub issue.
 -->
 
 - None

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -97,15 +97,19 @@ jobs:
           #    template's instructional comment can't satisfy the check.
           #    The section is OPTIONAL: a body with no Deferrals heading at all
           #    passes (nothing was deferred). But a near-miss heading
-          #    (`### Deferrals`, `## Deferrals:`, `##Deferrals`) must NOT
-          #    silently pass — it falls to the strict per-item validation only
-          #    when the heading is EXACTLY `## Deferrals`; otherwise it's an
-          #    error so an unlinked deferred section can't slip through. The
-          #    near-miss matcher uses `[[:space:]]*` (not `+`) so a missing
-          #    space after the hashes (`##Deferrals`) is still caught.
+          #    (`### Deferrals`, `## Deferrals:`, `##Deferrals`,
+          #    `## Deferrals.`, `## Deferrals — later`) must NOT silently pass
+          #    — it falls to the strict per-item validation only when the
+          #    heading is EXACTLY `## Deferrals`; otherwise it's an error so an
+          #    unlinked deferred section can't slip through. The near-miss
+          #    matcher allows any `#`-run with optional space, then `Deferrals`
+          #    followed by ANY non-word character or EOL — so a missing space
+          #    (`##Deferrals`) and any trailing punctuation/words are all
+          #    caught, while a genuinely different word (`## DeferralsX`,
+          #    `## Deferred work`) is not flagged.
           if grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
             : # canonical heading — fall through to strict per-item validation below
-          elif grep -qE '^#{1,6}[[:space:]]*Deferrals([[:space:]]|:|$)' <<<"$fence_stripped"; then
+          elif grep -qE '^#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped"; then
             echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. The section heading must be exactly '## Deferrals' (H2, no trailing punctuation), or remove it entirely if nothing was knowingly deferred. See AGENTS.md 'Deferral rule'."
             exit 1
           else

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -97,13 +97,15 @@ jobs:
           #    template's instructional comment can't satisfy the check.
           #    The section is OPTIONAL: a body with no Deferrals heading at all
           #    passes (nothing was deferred). But a near-miss heading
-          #    (`### Deferrals`, `## Deferrals:`) must NOT silently pass — it
-          #    falls to the strict per-item validation only when the heading is
-          #    EXACTLY `## Deferrals`; otherwise it's an error so an unlinked
-          #    deferred section can't slip through.
+          #    (`### Deferrals`, `## Deferrals:`, `##Deferrals`) must NOT
+          #    silently pass — it falls to the strict per-item validation only
+          #    when the heading is EXACTLY `## Deferrals`; otherwise it's an
+          #    error so an unlinked deferred section can't slip through. The
+          #    near-miss matcher uses `[[:space:]]*` (not `+`) so a missing
+          #    space after the hashes (`##Deferrals`) is still caught.
           if grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
             : # canonical heading — fall through to strict per-item validation below
-          elif grep -qE '^#{1,6}[[:space:]]+Deferrals([[:space:]]|:|$)' <<<"$fence_stripped"; then
+          elif grep -qE '^#{1,6}[[:space:]]*Deferrals([[:space:]]|:|$)' <<<"$fence_stripped"; then
             echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. The section heading must be exactly '## Deferrals' (H2, no trailing punctuation), or remove it entirely if nothing was knowingly deferred. See AGENTS.md 'Deferral rule'."
             exit 1
           else

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -98,24 +98,29 @@ jobs:
           #    The section is OPTIONAL: a body with no Deferrals heading at all
           #    passes (nothing was deferred). But a near-miss heading
           #    (`### Deferrals`, `## Deferrals:`, `##Deferrals`,
-          #    `## Deferrals.`, `## Deferrals — later`) must NOT silently pass
-          #    — it falls to the strict per-item validation only when the
-          #    heading is EXACTLY `## Deferrals`; otherwise it's an error so an
-          #    unlinked deferred section can't slip through. The near-miss
-          #    matcher allows any `#`-run with optional space, then `Deferrals`
-          #    followed by ANY non-word character or EOL — so a missing space
-          #    (`##Deferrals`) and any trailing punctuation/words are all
-          #    caught, while a genuinely different word (`## DeferralsX`,
-          #    `## Deferred work`) is not flagged.
-          if grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
-            : # canonical heading — fall through to strict per-item validation below
-          elif grep -qE '^#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped"; then
-            echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. The section heading must be exactly '## Deferrals' (H2, no trailing punctuation), or remove it entirely if nothing was knowingly deferred. See AGENTS.md 'Deferral rule'."
+          #    `## Deferrals.`, `## Deferrals — later`) must NOT silently pass —
+          #    otherwise an unlinked deferred section under a malformed heading
+          #    slips through. The "Deferrals-style heading" matcher allows any
+          #    `#`-run with optional space, then `Deferrals` followed by ANY
+          #    non-word character or EOL — so a missing space (`##Deferrals`)
+          #    and any trailing punctuation/words are all caught, while a
+          #    genuinely different word (`## DeferralsX`, `## Deferred work`) is
+          #    not flagged. We reject EVERY non-canonical Deferrals heading
+          #    first, INDEPENDENTLY of whether a canonical `## Deferrals` also
+          #    exists — a body can carry both a valid `## Deferrals` section and
+          #    a separate malformed one, and validating only the canonical
+          #    section would let the malformed one bypass the guard.
+          deferrals_style=$(grep -E '^#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped" || true)
+          near_miss=$(grep -vE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$deferrals_style" || true)
+          if [ -n "$near_miss" ]; then
+            echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. Every Deferrals heading must be exactly '## Deferrals' (H2, no trailing punctuation or extra words), or be removed if nothing was knowingly deferred. Offending heading(s): $(head -3 <<<"$near_miss" | tr '\n' ' '). See AGENTS.md 'Deferral rule'."
             exit 1
-          else
+          fi
+          if ! grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
             echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders, no Deferrals section (nothing deferred)."
             exit 0
           fi
+          # canonical heading present — fall through to strict per-item validation below
           deferrals=$(awk '
             /^##[[:space:]]+Deferrals[[:space:]]*$/ { insec = 1; next }
             insec && /^##[[:space:]]/ { insec = 0 }

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -113,8 +113,12 @@ jobs:
           #    `[[:space:]]{0,3}` prefix matches CommonMark heading indentation
           #    (1–3 leading spaces still render as a heading; 4+ is a code block
           #    and correctly not treated as a Deferrals section), so an indented
-          #    ` ## Deferrals.` can't slip past the matcher either.
-          deferrals_style=$(grep -E '^[[:space:]]{0,3}#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped" || true)
+          #    ` ## Deferrals.` can't slip past the matcher either. The detector
+          #    is case-INSENSITIVE (`grep -i`) so a case variant (`## deferrals`,
+          #    `## DEFERRALS`) is caught as a near-miss; the canonical filter and
+          #    presence check below stay exact-case, so only title-case
+          #    `## Deferrals` is accepted as the canonical heading.
+          deferrals_style=$(grep -iE '^[[:space:]]{0,3}#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped" || true)
           near_miss=$(grep -vE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$deferrals_style" || true)
           if [ -n "$near_miss" ]; then
             echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. Every Deferrals heading must be exactly '## Deferrals' (H2, no trailing punctuation or extra words), or be removed if nothing was knowingly deferred. Offending heading(s): $(head -3 <<<"$near_miss" | tr '\n' ' '). See AGENTS.md 'Deferral rule'."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -109,8 +109,12 @@ jobs:
           #    first, INDEPENDENTLY of whether a canonical `## Deferrals` also
           #    exists — a body can carry both a valid `## Deferrals` section and
           #    a separate malformed one, and validating only the canonical
-          #    section would let the malformed one bypass the guard.
-          deferrals_style=$(grep -E '^#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped" || true)
+          #    section would let the malformed one bypass the guard. The
+          #    `[[:space:]]{0,3}` prefix matches CommonMark heading indentation
+          #    (1–3 leading spaces still render as a heading; 4+ is a code block
+          #    and correctly not treated as a Deferrals section), so an indented
+          #    ` ## Deferrals.` can't slip past the matcher either.
+          deferrals_style=$(grep -E '^[[:space:]]{0,3}#{1,6}[[:space:]]*Deferrals([^[:alnum:]_]|$)' <<<"$fence_stripped" || true)
           near_miss=$(grep -vE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$deferrals_style" || true)
           if [ -n "$near_miss" ]; then
             echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. Every Deferrals heading must be exactly '## Deferrals' (H2, no trailing punctuation or extra words), or be removed if nothing was knowingly deferred. Offending heading(s): $(head -3 <<<"$near_miss" | tr '\n' ' '). See AGENTS.md 'Deferral rule'."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -2,10 +2,10 @@ name: PR Description
 
 # Enforces the repo PR-description standard (AGENTS.md "PR description standard"
 # + .github/PULL_REQUEST_TEMPLATE.md): every PR body must lead with
-# `## The Problem` and `## The Solution`, must not still contain the
-# unfilled template placeholders, and must declare deferrals — a
-# `## Deferrals` section that either says "None" or links the GitHub
-# issue(s) created for everything knowingly deferred from the PR.
+# `## The Problem` and `## The Solution`, and must not still contain the
+# unfilled template placeholders. The `## Deferrals` section is OPTIONAL —
+# omit it when nothing is deferred; when present it must say "None" or link a
+# GitHub issue per item (for everything knowingly deferred from the PR).
 #
 # REQUIRED-STATUS SAFETY: no workflow-level `paths:` filter — this is meant to
 # run on every PR so it can be a required status (AGENTS.md: required-status
@@ -95,7 +95,18 @@ jobs:
           #    checks below operate on fence_stripped (comments + code fences
           #    removed) so an example heading or issue ref inside a fence or the
           #    template's instructional comment can't satisfy the check.
-          if ! grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
+          #    The section is OPTIONAL: a body with no Deferrals heading at all
+          #    passes (nothing was deferred). But a near-miss heading
+          #    (`### Deferrals`, `## Deferrals:`) must NOT silently pass — it
+          #    falls to the strict per-item validation only when the heading is
+          #    EXACTLY `## Deferrals`; otherwise it's an error so an unlinked
+          #    deferred section can't slip through.
+          if grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
+            : # canonical heading — fall through to strict per-item validation below
+          elif grep -qE '^#{1,6}[[:space:]]+Deferrals([[:space:]]|:|$)' <<<"$fence_stripped"; then
+            echo "::error::PR description has a Deferrals-style heading that isn't exactly '## Deferrals'. The section heading must be exactly '## Deferrals' (H2, no trailing punctuation), or remove it entirely if nothing was knowingly deferred. See AGENTS.md 'Deferral rule'."
+            exit 1
+          else
             echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders, no Deferrals section (nothing deferred)."
             exit 0
           fi

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -86,18 +86,18 @@ jobs:
             exit 1
           fi
 
-          # 4) Deferral declaration (AGENTS.md "Deferral rule"): a `## Deferrals`
-          #    section must exist and either say "None" or reference at least
-          #    one GitHub issue (#123 or a full issues URL). This is the forcing
-          #    function for "every knowing deferral gets an issue" — CI can't
-          #    judge honesty, but it can require the explicit declaration, and a
-          #    "None" that contradicts deferred-marked review replies is
-          #    auditable. Operates on fence_stripped (comments + code fences
+          # 4) Deferral declaration (AGENTS.md "Deferral rule"): the `## Deferrals`
+          #    section is OPTIONAL. When it is omitted, the PR is treated as
+          #    deferring nothing — there is no need to write the section just to
+          #    say "None". When the section IS present, it must either say "None"
+          #    or reference at least one GitHub issue (#123 or a full issues URL):
+          #    that keeps every knowing deferral carrying its own issue link. The
+          #    checks below operate on fence_stripped (comments + code fences
           #    removed) so an example heading or issue ref inside a fence or the
           #    template's instructional comment can't satisfy the check.
           if ! grep -qE '^##[[:space:]]+Deferrals[[:space:]]*$' <<<"$fence_stripped"; then
-            echo "::error::PR description is missing the '## Deferrals' section. Everything knowingly deferred from this PR (reviewer findings not addressed here, or out-of-scope work) needs a GitHub issue — list the links there, or write 'None'. See AGENTS.md 'Deferral rule'."
-            exit 1
+            echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders, no Deferrals section (nothing deferred)."
+            exit 0
           fi
           deferrals=$(awk '
             /^##[[:space:]]+Deferrals[[:space:]]*$/ { insec = 1; next }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,9 +295,11 @@ GitHub issue for it with a clear description of the problem to be solved, plus
 solution ideas if you have them (otherwise describe the problem as best you
 can). Label it `agent-ready` when an agent could pick it up unaided.
 
-The PR body's `## Deferrals` section is the enforcement point: it must either
-say `None` or link the issue(s), and the required `PR description format`
-check fails without it. Two corollaries:
+The PR body's `## Deferrals` section is the enforcement point. It is optional:
+omit it when nothing was knowingly deferred — there's no need to write the
+section just to say "None". When the section is present, the `PR description
+format` check requires every item to either say `None` or link a GitHub issue,
+so a real deferral can't hide behind an empty declaration. Two corollaries:
 
 - Create the issue **before** posting a "Deferred — tracking in …" review
   reply; a deferred reply without an issue link is incomplete.


### PR DESCRIPTION
## The Problem

- The required `PR description format` check hard-failed any PR whose body lacked a `## Deferrals` section, forcing authors to write the heading and `- None` even when nothing was knowingly deferred.
- This tripped legitimately-clean PRs (e.g. #897, #911) purely on a missing boilerplate section.

## The Solution

Make the `## Deferrals` section optional: an omitted section is treated as "nothing deferred" and passes. When the section *is* present it's still strictly validated (each item must be `None` or link a GitHub issue), so real deferrals can't hide behind an empty declaration.

## Details

- `pr-description.yml`: a missing `## Deferrals` heading now passes. A near-miss heading (`### Deferrals`, `## Deferrals:`) is **rejected** rather than silently passing — only an exact `## Deferrals` H2 routes into the per-item validation. (The near-miss guard was added during review to close a fail-open the first pass introduced.)
- `AGENTS.md` "Deferral rule" and `.github/PULL_REQUEST_TEMPLATE.md` updated to describe the section as optional (docs-drift rule).

## Validation

```
# 7-case shell smoke test of the gate logic
1. no section                -> PASS
2. exact ## Deferrals - None -> PASS
3. exact, linked issue       -> PASS
4. exact, empty              -> FAIL (write the heading, fill it)
5. exact, bare prose         -> FAIL (needs issue link)
6. near-miss ### Deferrals   -> FAIL (rejected)
7. near-miss ## Deferrals:   -> FAIL (rejected)

trunk fmt + trunk check (pre-commit hook): no issues
```

## Deferrals

- #918 — extract the inline validator into a tested script with fixtures (surfaced during review)

## Ship Checklist

- [x] ship skill used
- [x] local review + codex review run (1 fail-open found and fixed in-PR)
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only PR-description CI shell logic and contributor docs; no runtime or security paths.
> 
> **Overview**
> The **PR description format** check no longer requires a `## Deferrals` heading. Bodies that omit it pass as “nothing deferred,” so authors are not forced to add `- None` boilerplate on clean PRs.
> 
> When `## Deferrals` **is** present, the same per-item rules apply (`None` or a GitHub issue link per bullet). The workflow adds a **near-miss heading** guard so variants like `### Deferrals`, `## Deferrals:`, or `##Deferrals` fail instead of slipping past validation, including when a canonical section also exists.
> 
> `AGENTS.md` (Deferral rule) and `.github/PULL_REQUEST_TEMPLATE.md` now describe the section as optional—delete it when there are no deferrals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058ec6d0a442595898b1605a9cd76a2d0fc87d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->