### PR TITLE
fix: thread explicit pagination page size

### DIFF
--- a/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
@@ -87,6 +87,7 @@ describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
       query: "query { TestKey { id } }",
       responseKey: "TestKey",
       network: "celo-mainnet",
+      pageSize: PAGE_SIZE,
       variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
       dedupKey: (r: { id: string }) => r.id,
     });
@@ -123,6 +124,7 @@ describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
       query: "query { TestKey { id } }",
       responseKey: "TestKey",
       network: "celo-mainnet",
+      pageSize: PAGE_SIZE,
       variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
       dedupKey: (r: { id: string }) => r.id,
     });
@@ -165,6 +167,7 @@ describe("fetchPaginatedRows — boundary-duplicate dedup", () => {
       query: "query { TestKey { id } }",
       responseKey: "TestKey",
       network: "celo-mainnet",
+      pageSize: PAGE_SIZE,
       variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
       dedupKey: (r: { id: string }) => r.id,
     });
@@ -201,6 +204,7 @@ describe("fetchPaginatedRows — boundary-duplicate dedup", () => {
       query: "query { TestKey { id } }",
       responseKey: "TestKey",
       network: "celo-mainnet",
+      pageSize: PAGE_SIZE,
       variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
       dedupKey: (r: { id: string }) => r.id,
     });
@@ -208,5 +212,36 @@ describe("fetchPaginatedRows — boundary-duplicate dedup", () => {
     const uniqueIds = new Set(result.rows.map((r) => r.id));
     expect(result.rows).toHaveLength(uniqueIds.size);
     expect(result.rows).toHaveLength(PAGE_SIZE * 2 + 1);
+  });
+
+  it("uses the caller pageSize as the short-page sentinel", async () => {
+    const client = makeClient();
+    const PAGE_SIZE = 2;
+
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ TestKey: [{ id: "r0" }, { id: "r1" }] })
+      .mockResolvedValueOnce({ TestKey: [{ id: "r2" }, { id: "r3" }] })
+      .mockResolvedValueOnce({ TestKey: [{ id: "r4" }] });
+
+    const result = await fetchPaginatedRows({
+      client,
+      query: "query { TestKey { id } }",
+      responseKey: "TestKey",
+      network: "celo-mainnet",
+      pageSize: PAGE_SIZE,
+      variablesFor: (page) => ({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+      dedupKey: (r: { id: string }) => r.id,
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(3);
+    expect(result.rows.map((row) => row.id)).toEqual([
+      "r0",
+      "r1",
+      "r2",
+      "r3",
+      "r4",
+    ]);
+    expect(result.truncated).toBe(false);
+    expect(result.error).toBeNull();
   });
 });

--- a/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
+++ b/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
@@ -252,6 +252,7 @@ async function fetchAllBracketPages(
     query: CDP_BORROWING_REVENUE_BRACKETS,
     responseKey: "InterestRateBracket",
     network,
+    pageSize: CDP_PAGE_SIZE,
     variablesFor: (page) => ({
       collateralIds,
       limit: CDP_PAGE_SIZE,
@@ -273,6 +274,7 @@ async function fetchAllFeeEventPages(
     query: CDP_BORROWING_FEE_EVENTS,
     responseKey: "TroveOperationEvent",
     network,
+    pageSize: CDP_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
       limit: CDP_PAGE_SIZE,
@@ -319,6 +321,7 @@ async function paginateDailySnapshots<T extends { id: string }>(
     query,
     responseKey: "LiquityBorrowingRevenueDailySnapshot",
     network,
+    pageSize: CDP_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
       limit: CDP_PAGE_SIZE,

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -183,9 +183,10 @@ const PARTIAL_PAGE_THROTTLE_MS = 60_000;
 export const partialPageLastCapturedAt = new Map<string, number>();
 
 /**
- * Generic paginated fetcher with the Hasura fail-open contract documented on
- * `SNAPSHOT_PAGE_SIZE`: hard-fail on page 0, preserve and flag truncated on
- * mid-loop failure, log cap exhaustion once per (network, responseKey).
+ * Generic paginated fetcher with the Hasura fail-open contract documented
+ * above: hard-fail on page 0, preserve and flag truncated on mid-loop failure,
+ * log cap exhaustion once per (network, responseKey). `pageSize` must match the
+ * GraphQL `limit` passed by `variablesFor`; it is the short-page sentinel.
  *
  * Callers parameterize: variables shape per page, response key, and a dedup
  * key extractor — offset pagination over an append-only table is unstable
@@ -197,13 +198,22 @@ export async function fetchPaginatedRows<TRow, TVars>(args: {
   query: string;
   responseKey: string;
   network: string;
+  pageSize: number;
   variablesFor: (page: number) => TVars;
   dedupKey: (row: TRow) => string;
   /** Extra payload merged into the Sentry capture for this responseKey. */
   extra?: Record<string, unknown>;
 }): Promise<PaginatedPageResult<TRow>> {
-  const { client, query, responseKey, network, variablesFor, dedupKey, extra } =
-    args;
+  const {
+    client,
+    query,
+    responseKey,
+    network,
+    pageSize,
+    variablesFor,
+    dedupKey,
+    extra,
+  } = args;
   const seen = new Set<string>();
   const rows: TRow[] = [];
   // Sequential pagination — each iteration breaks early when the page
@@ -249,7 +259,7 @@ export async function fetchPaginatedRows<TRow, TVars>(args: {
       seen.add(key);
       rows.push(row);
     }
-    if (batch.length < SNAPSHOT_PAGE_SIZE) {
+    if (batch.length < pageSize) {
       return { rows, truncated: false, error: null };
     }
   }
@@ -264,7 +274,7 @@ export async function fetchPaginatedRows<TRow, TVars>(args: {
       extra: {
         rowsFetched: rows.length,
         maxPages: SNAPSHOT_MAX_PAGES,
-        pageSize: SNAPSHOT_PAGE_SIZE,
+        pageSize,
         ...extra,
       },
     });
@@ -286,6 +296,7 @@ async function fetchAllDailySnapshotPages(
     query: POOL_DAILY_SNAPSHOTS_ALL,
     responseKey: "PoolDailySnapshot",
     network,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       poolIds,
       limit: SNAPSHOT_PAGE_SIZE,
@@ -312,6 +323,7 @@ async function fetchAllBrokerDailySnapshotPages(
     query: BROKER_DAILY_SNAPSHOTS_ALL,
     responseKey: "BrokerDailySnapshot",
     network,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
       limit: SNAPSHOT_PAGE_SIZE,
@@ -341,6 +353,7 @@ async function fetchAllLpAddressPages(
     query: UNIQUE_LP_ADDRESSES,
     responseKey: "LiquidityPosition",
     network,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       poolIds,
       limit: SNAPSHOT_PAGE_SIZE,
@@ -370,6 +383,7 @@ export async function fetchAllFeeSnapshotPages(
     query: POOL_DAILY_FEE_SNAPSHOTS_PAGE,
     responseKey: "PoolDailyFeeSnapshot",
     network,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
       limit: SNAPSHOT_PAGE_SIZE,


### PR DESCRIPTION
## The Problem

- `fetchPaginatedRows` used the dashboard snapshot page size as its short-page sentinel even though callers own their GraphQL `limit`.
- That was safe for current 1000-row callers, but a future smaller-limit caller could stop after only one page.

## The Solution

- Thread an explicit `pageSize` through `fetchPaginatedRows` and require each caller to pass the same value it sends as the GraphQL `limit`.
- Add a regression test that uses a smaller page size and proves pagination continues until the true short page.

## Details

- Closes #913.
- Invariant: `pageSize` must match the `limit` returned by `variablesFor`; it is the only short-page sentinel.
- Existing dashboard snapshot callers continue to pass `SNAPSHOT_PAGE_SIZE`.
- CDP borrowing revenue callers now pass `CDP_PAGE_SIZE`.
- Degraded behavior is unchanged: first-page failures still throw, mid-loop failures still return partial rows with `truncated: true`, and cap exhaustion still emits the warning metadata with the caller page size.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard test -- use-cdp-borrowing-revenue.test.ts fetch-all-networks.test.ts`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Browser check: opened `http://127.0.0.1:3210` with Chrome DevTools MCP, confirmed the dashboard rendered live data, and `list_console_messages(types: ["error"])` returned no errors.

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API change with no behavior change for existing 1000-row limits; fixes a latent early-stop bug only when a caller used a smaller limit without updating the helper.
> 
> **Overview**
> **`fetchPaginatedRows` no longer assumes `SNAPSHOT_PAGE_SIZE` when deciding the last page.** Callers must pass `pageSize`, aligned with the GraphQL `limit` from `variablesFor`; pagination stops when `batch.length < pageSize`.
> 
> Network snapshot helpers pass `SNAPSHOT_PAGE_SIZE`; CDP borrowing revenue paths pass `CDP_PAGE_SIZE`. Cap-exhaustion Sentry metadata uses the caller’s `pageSize`. Fail-open behavior (first-page throw, partial rows on mid-loop errors) is unchanged.
> 
> A regression test uses `pageSize: 2` to ensure full pages keep fetching until a true short page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f9ec441886416f507d5b431f113e81636b2321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->