### PR TITLE
chore: enforce pinned github actions

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+      - name: Check GitHub Actions pins
+        run: node scripts/check-github-action-pins.mjs
       - uses: ./.trunk/setup-ci
       - uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,7 @@ pnpm code-health:schema-diff       # GraphQL schema breaking-change diff vs orig
 pnpm code-health                   # Run knip + deps together (everything except history + duplication)
 pnpm agent:autoreview              # Structured closeout review; Codex sandbox defaults to --engine local, override with --engine claude/codex
 pnpm lockfile:lint                 # Lockfile integrity + registry check (blocking; no install needed)
+node scripts/check-github-action-pins.mjs  # Verify workflow/composite-action `uses:` refs are SHA-pinned
 pnpm indexer:testnet:codegen       # Generate types (multichain testnet: Celo Sepolia + Monad testnet)
 pnpm indexer:testnet:dev           # Start indexer (multichain testnet)
 

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -51,7 +51,7 @@ Canonical good example: `.github/workflows/metrics-bridge.yml:41`.
 A `uses: org/action@v4` line trusts whoever owns that tag to never re-point it at malicious code. Tags are mutable; commit SHAs are not.
 
 - [ ] All third-party actions in workflows and composite actions MUST be pinned to a full commit SHA with the tag in a comment: `uses: org/action@<40-char-sha> # v6.0.2`
-- [ ] Local relative actions such as `uses: ./.github/actions/pnpm-install` are allowed.
+- [ ] Local relative actions such as `uses: ./.github/actions/pnpm-install` are allowed; the scanner follows their `action.yml` / `action.yaml` targets and checks nested third-party `uses:` entries too.
 - [ ] Run `node scripts/check-github-action-pins.mjs` locally when editing `.github/workflows/**`, `.github/actions/**`, or `.trunk/setup-ci/**`; the required `Code Quality` workflow runs the same check on every PR.
 
 Canonical good example: `.github/workflows/metrics-bridge.yml:59,62,68,117` — every external action SHA-pinned.

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -50,9 +50,9 @@ Canonical good example: `.github/workflows/metrics-bridge.yml:41`.
 
 A `uses: org/action@v4` line trusts whoever owns that tag to never re-point it at malicious code. Tags are mutable; commit SHAs are not.
 
-- [ ] All third-party actions in **deploy / write workflows** MUST be pinned to a full commit SHA with the tag in a comment: `uses: org/action@<40-char-sha> # v6.0.2`
-- [ ] First-party actions (`actions/checkout`, etc.) in deploy paths SHOULD also be SHA-pinned for consistency
-- [ ] Read-only audit/lint workflows MAY use tag pins, but prefer SHA pins for consistency
+- [ ] All third-party actions in workflows and composite actions MUST be pinned to a full commit SHA with the tag in a comment: `uses: org/action@<40-char-sha> # v6.0.2`
+- [ ] Local relative actions such as `uses: ./.github/actions/pnpm-install` are allowed.
+- [ ] Run `node scripts/check-github-action-pins.mjs` locally when editing `.github/workflows/**`, `.github/actions/**`, or `.trunk/setup-ci/**`; the required `Code Quality` workflow runs the same check on every PR.
 
 Canonical good example: `.github/workflows/metrics-bridge.yml:59,62,68,117` — every external action SHA-pinned.
 

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -48,7 +48,7 @@ tldr: rename/remove resources REQUIRE a `moved` block (`deletion_protection = tr
 
 ### CI workflow gates — `docs/pr-checklists/ci-workflow-gates.md`
 
-tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) MUST NOT use `paths:`/`paths-ignore:` (skipped runs = pending forever); **advisory** workflows SHOULD use `paths:` to avoid booting a runner on irrelevant PRs (CI-cost control). Deploy jobs MUST gate on `if: github.ref == 'refs/heads/main'`. Third-party actions MUST be SHA-pinned. Concurrency group with `cancel-in-progress: false`. Cache keys MUST include every input that affects the cached output. Full rules in the linked checklist.
+tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) MUST NOT use `paths:`/`paths-ignore:` (skipped runs = pending forever); **advisory** workflows SHOULD use `paths:` to avoid booting a runner on irrelevant PRs (CI-cost control). Deploy jobs MUST gate on `if: github.ref == 'refs/heads/main'`. Third-party actions MUST be SHA-pinned; `node scripts/check-github-action-pins.mjs` enforces this in Code Quality. Concurrency group with `cancel-in-progress: false`. Cache keys MUST include every input that affects the cached output. Full rules in the linked checklist.
 
 ### File-size budget
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1096,6 +1096,7 @@ while IFS= read -r path; do
     .github/workflows/*|.github/actions/*)
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
+      add_command "node scripts/check-github-action-pins.mjs" "GitHub Actions workflow/action changed"
       case "$path" in
         .github/workflows/ci.yml)
           add_surface "workspace"
@@ -1133,6 +1134,7 @@ while IFS= read -r path; do
       ;;
     .trunk/*)
       add_surface "tooling"
+      add_command "node scripts/check-github-action-pins.mjs" "Trunk workflow/action setup changed"
       add_command "pnpm agent:quality-gate:test" "agent quality gate trunk hook changed"
       ;;
     turbo.json)
@@ -1305,6 +1307,13 @@ while IFS= read -r path; do
           ;;
         scripts/lockfile-lint.mjs|scripts/lockfile-lint.test.mjs)
           add_command "pnpm lockfile:lint:test" "lockfile lint helper changed"
+          ;;
+        scripts/check-github-action-pins.mjs)
+          add_command "node scripts/check-github-action-pins.mjs" "GitHub Actions pin checker changed"
+          add_command "node scripts/check-github-action-pins.test.mjs" "GitHub Actions pin checker changed"
+          ;;
+        scripts/check-github-action-pins.test.mjs)
+          add_command "node scripts/check-github-action-pins.test.mjs" "GitHub Actions pin checker test changed"
           ;;
         scripts/notify-terraform-apply.mjs|scripts/notify-terraform-apply.test.mjs)
           add_command "node scripts/notify-terraform-apply.test.mjs" "Terraform apply Slack notifier changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1319,6 +1319,7 @@ assert_order \
 
 run_gate ".github/workflows/infra.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- node scripts/check-github-action-pins.mjs (GitHub Actions workflow/action changed)"
 assert_contains "- pnpm tf:test (Terraform registry workflow changed)"
 assert_contains "- TF_DATA_DIR=terraform/.terraform-agent-gate terraform -chdir=terraform fmt -check -recursive (Terraform registry workflow changed)"
 assert_contains "- TF_DATA_DIR=alerts/rules/.terraform-agent-gate terraform -chdir=alerts/rules fmt -check -recursive (Terraform registry workflow changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1291,11 +1291,13 @@ assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chd
 
 run_gate ".github/workflows/metrics-bridge.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- node scripts/check-github-action-pins.mjs (GitHub Actions workflow/action changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
 assert_contains "- pnpm agent:context-check (Cloud Run revision suffix guard changed)"
 
 run_gate ".github/workflows/ci.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- node scripts/check-github-action-pins.mjs (GitHub Actions workflow/action changed)"
 assert_contains "- pnpm install --frozen-lockfile (central CI workflow changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (central CI workflow changed)"
 assert_contains "- pnpm tf:test (Terraform registry-backed CI workflow changed)"
@@ -1325,6 +1327,7 @@ assert_contains "- TF_DATA_DIR=aegis/terraform/.terraform-agent-gate terraform -
 
 run_gate ".github/actions/pnpm-install/action.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- node scripts/check-github-action-pins.mjs (GitHub Actions workflow/action changed)"
 assert_contains "- pnpm install --frozen-lockfile (pnpm install action changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (pnpm install action changed)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (pnpm install action changed)"
@@ -1402,6 +1405,7 @@ assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping chan
 
 run_gate ".trunk/trunk.yaml"
 assert_contains "- tooling"
+assert_contains "- node scripts/check-github-action-pins.mjs (Trunk workflow/action setup changed)"
 assert_contains "- pnpm agent:quality-gate:test (agent quality gate trunk hook changed)"
 assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck"
 
@@ -2090,6 +2094,13 @@ assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
 
 run_gate "scripts/lockfile-lint.test.mjs"
 assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
+
+run_gate "scripts/check-github-action-pins.mjs"
+assert_contains "- node scripts/check-github-action-pins.mjs (GitHub Actions pin checker changed)"
+assert_contains "- node scripts/check-github-action-pins.test.mjs (GitHub Actions pin checker changed)"
+
+run_gate "scripts/check-github-action-pins.test.mjs"
+assert_contains "- node scripts/check-github-action-pins.test.mjs (GitHub Actions pin checker test changed)"
 
 run_gate "scripts/agent-autoreview.sh"
 assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview adapter changed)"

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -73,6 +73,22 @@ function isPinnedExternalAction(value) {
   return PINNED_REF.test(ref);
 }
 
+/** @param {string} line */
+function extractUsesRawValue(line) {
+  const plain = line.match(
+    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.+?)\s*$/,
+  );
+  if (plain) return plain[1] ?? "";
+
+  const flow = line.match(
+    /^\s*-\s*\{.*(?:"uses"|'uses'|uses)\s*:\s*([^,}]+).*}\s*$/,
+  );
+  if (!flow) return null;
+  const { comment } = splitInlineComment(line);
+  const value = flow[1] ?? "";
+  return comment ? `${value} # ${comment}` : value;
+}
+
 /** @param {string} raw */
 function hasReleaseTagComment(raw) {
   const { comment } = splitInlineComment(raw);
@@ -105,11 +121,8 @@ for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
   const text = readFileSync(file, "utf8");
   const lines = text.split(/\r?\n/);
   lines.forEach((line, index) => {
-    const match = line.match(
-      /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.+?)\s*$/,
-    );
-    if (!match) return;
-    const rawValue = match[1] ?? "";
+    const rawValue = extractUsesRawValue(line);
+    if (rawValue == null) return;
     const value = normalizeUsesValue(rawValue);
     if (value === "") return;
     if (isLocalAction(value)) {

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -80,11 +80,11 @@ function extractUsesRawValue(line) {
   );
   if (plain) return plain[1] ?? "";
 
-  const flow = line.match(
+  const { value: lineWithoutComment, comment } = splitInlineComment(line);
+  const flow = lineWithoutComment.match(
     /^\s*-\s*\{.*(?:"uses"|'uses'|uses)\s*:\s*([^,}]+).*}\s*$/,
   );
   if (!flow) return null;
-  const { comment } = splitInlineComment(line);
   const value = flow[1] ?? "";
   return comment ? `${value} # ${comment}` : value;
 }

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -6,9 +6,9 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 
-const ROOT = process.env["GITHUB_ACTION_PINS_ROOT"] ?? process.cwd();
+const ROOT = resolve(process.env["GITHUB_ACTION_PINS_ROOT"] ?? process.cwd());
 const PINNED_REF = /^[0-9a-fA-F]{40}$/;
 const SCAN_DIRS = [".github/workflows", ".github/actions", ".trunk/setup-ci"];
 
@@ -31,7 +31,7 @@ function* walkYaml(dir) {
 }
 
 /** @param {string} raw */
-function stripInlineComment(raw) {
+function splitInlineComment(raw) {
   let quote = "";
   for (let i = 0; i < raw.length; i++) {
     const char = raw[i];
@@ -39,15 +39,18 @@ function stripInlineComment(raw) {
       quote = quote === char ? "" : quote === "" ? char : quote;
     }
     if (char === "#" && quote === "") {
-      return raw.slice(0, i).trim();
+      return {
+        value: raw.slice(0, i).trim(),
+        comment: raw.slice(i + 1).trim(),
+      };
     }
   }
-  return raw.trim();
+  return { value: raw.trim(), comment: "" };
 }
 
 /** @param {string} raw */
 function normalizeUsesValue(raw) {
-  const value = stripInlineComment(raw);
+  const { value } = splitInlineComment(raw);
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
     (value.startsWith("'") && value.endsWith("'"))
@@ -70,17 +73,55 @@ function isPinnedExternalAction(value) {
   return PINNED_REF.test(ref);
 }
 
+/** @param {string} raw */
+function hasReleaseTagComment(raw) {
+  const { comment } = splitInlineComment(raw);
+  return /^v\d+(?:[.\w-].*)?$/.test(comment);
+}
+
+/** @param {string} root @param {string} path */
+function isInsideRoot(root, path) {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith("/"));
+}
+
+/** @param {string} fromFile @param {string} value */
+function localActionManifestPaths(fromFile, value) {
+  const base = value.startsWith("../")
+    ? resolve(dirname(fromFile), value)
+    : resolve(ROOT, value);
+  if (!isInsideRoot(ROOT, base)) return [];
+  return ["action.yml", "action.yaml"]
+    .map((name) => join(base, name))
+    .filter((path) => existsSync(path));
+}
+
 const failures = [];
 const files = SCAN_DIRS.flatMap((dir) => [...walkYaml(join(ROOT, dir))]).sort();
+const queuedFiles = new Set(files);
 
-for (const file of files) {
+for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+  const file = files[fileIndex];
   const text = readFileSync(file, "utf8");
   const lines = text.split(/\r?\n/);
   lines.forEach((line, index) => {
-    const match = line.match(/^\s*(?:-\s*)?uses:\s*(.+?)\s*$/);
+    const match = line.match(
+      /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.+?)\s*$/,
+    );
     if (!match) return;
-    const value = normalizeUsesValue(match[1] ?? "");
-    if (value === "" || isLocalAction(value) || isPinnedExternalAction(value)) {
+    const rawValue = match[1] ?? "";
+    const value = normalizeUsesValue(rawValue);
+    if (value === "") return;
+    if (isLocalAction(value)) {
+      for (const manifest of localActionManifestPaths(file, value)) {
+        if (!queuedFiles.has(manifest)) {
+          queuedFiles.add(manifest);
+          files.push(manifest);
+        }
+      }
+      return;
+    }
+    if (isPinnedExternalAction(value) && hasReleaseTagComment(rawValue)) {
       return;
     }
     failures.push({
@@ -92,7 +133,7 @@ for (const file of files) {
 }
 
 if (failures.length > 0) {
-  console.error("Unpinned GitHub Actions references found:");
+  console.error("Unpinned or undocumented GitHub Actions references found:");
   for (const failure of failures) {
     console.error(`- ${failure.file}:${failure.line} uses: ${failure.value}`);
   }

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Fail when workflow or composite-action `uses:` references point at mutable
+ * third-party refs. Local relative actions (`./...` / `../...`) are allowed;
+ * external actions must use a full 40-character commit SHA.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.env["GITHUB_ACTION_PINS_ROOT"] ?? process.cwd();
+const PINNED_REF = /^[0-9a-fA-F]{40}$/;
+const SCAN_DIRS = [".github/workflows", ".github/actions", ".trunk/setup-ci"];
+
+/** @param {string} path */
+function isYaml(path) {
+  return path.endsWith(".yml") || path.endsWith(".yaml");
+}
+
+/** @param {string} dir */
+function* walkYaml(dir) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkYaml(path);
+    } else if (entry.isFile() && isYaml(path)) {
+      yield path;
+    }
+  }
+}
+
+/** @param {string} raw */
+function stripInlineComment(raw) {
+  let quote = "";
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+    if ((char === '"' || char === "'") && (i === 0 || raw[i - 1] !== "\\")) {
+      quote = quote === char ? "" : quote === "" ? char : quote;
+    }
+    if (char === "#" && quote === "") {
+      return raw.slice(0, i).trim();
+    }
+  }
+  return raw.trim();
+}
+
+/** @param {string} raw */
+function normalizeUsesValue(raw) {
+  const value = stripInlineComment(raw);
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1).trim();
+  }
+  return value;
+}
+
+/** @param {string} value */
+function isLocalAction(value) {
+  return value.startsWith("./") || value.startsWith("../");
+}
+
+/** @param {string} value */
+function isPinnedExternalAction(value) {
+  const atIndex = value.lastIndexOf("@");
+  if (atIndex === -1) return false;
+  const ref = value.slice(atIndex + 1);
+  return PINNED_REF.test(ref);
+}
+
+const failures = [];
+const files = SCAN_DIRS.flatMap((dir) => [...walkYaml(join(ROOT, dir))]).sort();
+
+for (const file of files) {
+  const text = readFileSync(file, "utf8");
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    const match = line.match(/^\s*(?:-\s*)?uses:\s*(.+?)\s*$/);
+    if (!match) return;
+    const value = normalizeUsesValue(match[1] ?? "");
+    if (value === "" || isLocalAction(value) || isPinnedExternalAction(value)) {
+      return;
+    }
+    failures.push({
+      file: relative(ROOT, file),
+      line: index + 1,
+      value,
+    });
+  });
+}
+
+if (failures.length > 0) {
+  console.error("Unpinned GitHub Actions references found:");
+  for (const failure of failures) {
+    console.error(`- ${failure.file}:${failure.line} uses: ${failure.value}`);
+  }
+  console.error(
+    "Third-party actions must use a full 40-character commit SHA. " +
+      "Keep the release tag as an inline comment, e.g. `uses: org/action@<sha> # v1.2.3`.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `All ${files.length} workflow/composite-action YAML files use pinned external actions.`,
+);

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -103,6 +103,7 @@ jobs:
   test:
     steps:
       - uses: actions/checkout@v6
+      - uses: 'actions/setup-node@v4'
 `,
     );
 
@@ -111,6 +112,37 @@ jobs:
     contains(
       result.stderr,
       ".github/workflows/ci.yml:5 uses: actions/checkout@v6",
+      "failure location",
+    );
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:6 uses: actions/setup-node@v4",
+      "quoted failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails mutable tags in composite actions under .github/actions", () => {
+  const root = fixtureRoot("actions-fail");
+  try {
+    write(
+      root,
+      ".github/actions/pnpm-install/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/actions/pnpm-install/action.yml:5 uses: actions/setup-node@v4",
       "failure location",
     );
   } finally {

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -230,6 +230,7 @@ jobs:
   test:
     steps:
       - { uses: actions/checkout@v6 }
+      - { uses: actions/cache@v4 } # v4
 `,
     );
 
@@ -239,6 +240,11 @@ jobs:
       result.stderr,
       ".github/workflows/ci.yml:5 uses: actions/checkout@v6",
       "flow-style failure location",
+    );
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:6 uses: actions/cache@v4",
+      "commented flow-style failure location",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -103,7 +103,8 @@ jobs:
   test:
     steps:
       - uses: actions/checkout@v6
-      - uses: 'actions/setup-node@v4'
+      - "uses": actions/setup-node@v4
+      - uses: 'actions/cache@v4'
 `,
     );
 
@@ -117,7 +118,12 @@ jobs:
     contains(
       result.stderr,
       ".github/workflows/ci.yml:6 uses: actions/setup-node@v4",
-      "quoted failure location",
+      "quoted key failure location",
+    );
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:7 uses: actions/cache@v4",
+      "quoted value failure location",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -170,6 +176,68 @@ runs:
       result.stderr,
       ".trunk/setup-ci/action.yaml:5 uses: pnpm/action-setup@v4",
       "failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("discovers and fails mutable tags in local action targets", () => {
+  const root = fixtureRoot("local-target-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: ./tools/actions/custom
+`,
+    );
+    write(
+      root,
+      "tools/actions/custom/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "tools/actions/custom/action.yml:5 uses: actions/setup-node@v4",
+      "local target failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails pinned external actions without release-tag comments", () => {
+  const root = fixtureRoot("missing-comment");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA}
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      `.github/workflows/ci.yml:5 uses: actions/checkout@${PINNED_SHA}`,
+      "missing comment failure location",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Fixture tests for scripts/check-github-action-pins.mjs.
+ *
+ * Run: `node scripts/check-github-action-pins.test.mjs`
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const SCRIPT = resolve("scripts/check-github-action-pins.mjs");
+const PINNED_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+const tests = [];
+
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+/** @param {string} name */
+function fixtureRoot(name) {
+  return mkdtempSync(join(tmpdir(), `action-pin-${name}-`));
+}
+
+/** @param {string} root @param {string} path @param {string} content */
+function write(root, path, content) {
+  const fullPath = join(root, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, "utf8");
+}
+
+/** @param {string} root */
+function run(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: resolve("."),
+    env: { ...process.env, GITHUB_ACTION_PINS_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+/** @param {unknown} actual @param {unknown} expected @param {string} msg */
+function equal(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg}: expected ${expected}, got ${actual}`);
+  }
+}
+
+/** @param {string} haystack @param {string} needle @param {string} msg */
+function contains(haystack, needle, msg) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`${msg}: missing ${needle}\n${haystack}`);
+  }
+}
+
+test("passes pinned external actions and local relative actions", () => {
+  const root = fixtureRoot("pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v6.0.3
+      - uses: ./.github/actions/pnpm-install
+`,
+    );
+    write(
+      root,
+      ".github/actions/pnpm-install/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: 'actions/setup-node@${PINNED_SHA}' # v6.4.0
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 0, result.stderr);
+    contains(
+      result.stdout,
+      "All 2 workflow/composite-action YAML files",
+      "success output",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails mutable tags in workflow files", () => {
+  const root = fixtureRoot("workflow-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v6
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:5 uses: actions/checkout@v6",
+      "failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails mutable tags in composite actions under .trunk", () => {
+  const root = fixtureRoot("trunk-fail");
+  try {
+    write(
+      root,
+      ".trunk/setup-ci/action.yaml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".trunk/setup-ci/action.yaml:5 uses: pnpm/action-setup@v4",
+      "failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails missing refs and short SHAs", () => {
+  const root = fixtureRoot("bad-ref");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/cache
+      - uses: actions/setup-node@0123456789abcdef
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/cache", "missing ref");
+    contains(
+      result.stderr,
+      "uses: actions/setup-node@0123456789abcdef",
+      "short ref",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+let failures = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`not ok - ${name}`);
+    console.error(error instanceof Error ? error.stack : String(error));
+  }
+}
+
+if (failures > 0) {
+  process.exit(1);
+}
+
+console.log(`\n${tests.length} github action pin tests passed.`);

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -66,6 +66,7 @@ jobs:
   test:
     steps:
       - uses: actions/checkout@${PINNED_SHA} # v6.0.3
+      - { uses: actions/cache@${PINNED_SHA} } # v5.0.5
       - uses: ./.github/actions/pnpm-install
 `,
     );
@@ -212,6 +213,32 @@ runs:
       result.stderr,
       "tools/actions/custom/action.yml:5 uses: actions/setup-node@v4",
       "local target failure location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails mutable tags in flow-style workflow steps", () => {
+  const root = fixtureRoot("flow-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - { uses: actions/checkout@v6 }
+`,
+    );
+
+    const result = run(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:5 uses: actions/checkout@v6",
+      "flow-style failure location",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## The Problem

- Workflow and composite-action `uses:` references were only protected by manual review, so mutable third-party tags could be reintroduced.
- Dependabot can update pinned actions, but it does not fail PRs that add new unpinned action references.

## The Solution

- Add a small repository scanner that rejects third-party GitHub Actions unless they are pinned to a full 40-character commit SHA, while allowing local relative actions.
- Run the scanner in the required Code Quality workflow and through the local agent quality gate whenever workflow/action/tooling files change.

## Details

- Scans `.github/workflows/**`, `.github/actions/**`, and `.trunk/setup-ci/**` YAML files for `uses:` and `- uses:` entries.
- Allows `./...` and `../...` local composite actions.
- Keeps release tags as inline comments, for example `uses: org/action@<sha> # v1.2.3`.
- Updates CI workflow guidance and recurring review notes so future workflow edits have the same source of truth.

## Validation

- `node scripts/check-github-action-pins.mjs`
- `node scripts/check-github-action-pins.test.mjs`
- `pnpm lint:scripts`
- `pnpm agent:quality-gate:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #896

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CI/tooling validation with no application runtime or deploy behavior changes; risk is limited to false positives blocking merges if the scanner rules are too strict.
> 
> **Overview**
> Adds automated enforcement so new or changed workflow and composite-action `uses:` lines cannot rely on mutable version tags.
> 
> A new Node scanner (`scripts/check-github-action-pins.mjs`) walks `.github/workflows/**`, `.github/actions/**`, and `.trunk/setup-ci/**`, allows local `./` / `../` actions, follows nested composite manifests, and requires third-party refs to be **40-character SHAs** with a **release tag in an inline comment** (e.g. `uses: org/action@<sha> # v1.2.3`). Fixture tests cover failure modes (tags, missing comments, short SHAs, flow-style steps).
> 
> The required **Code Quality** workflow (`trunk.yml`) runs the scanner on every PR before Trunk. The agent quality gate and docs (`ci-workflow-gates.md`, `AGENTS.md`, recurring-review tldr) are updated so workflow/action edits trigger the same check locally and the pinning policy applies repo-wide, not only deploy paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8eb7374f0c85383c1ea8e400eb8db369b01a338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->