### PR TITLE
refactor(metrics-bridge): extract canonical isFpmmPool predicate

### DIFF
--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -347,19 +347,11 @@ export function updateMetrics(
 ): void {
   resetPollGauges();
 
-  // Exclude VirtualPools healed from FPMMs. The base query already filters
-  // `source: { _like: "%fpmm%" }`, which excludes pools with source
-  // "virtual_pool_factory". However, a healed VP retains its original
-  // "fpmm_factory" source until the next re-sync, so the source filter alone
-  // is not sufficient. The canonical VP predicate (mirroring
-  // `isVirtualPool` in `indexer-envio/src/helpers.ts` and
-  // `ui-dashboard/src/lib/types.ts`) also gates on `wrappedExchangeId`:
-  // "" = native FPMM; non-empty = VP. Skip VPs here so their stale FPMM
-  // gauges don't fire phantom alerts.
-  const fpmmPools = pools.filter((p) => !p.wrappedExchangeId);
-
+  // `pools` is already filtered to FPMM-only rows by `isFpmmPool` at the poller
+  // boundary (see `pollPools`), so healed VirtualPools never reach gauge
+  // publication here.
   const activePoolIds = new Set<string>();
-  for (const pool of fpmmPools) {
+  for (const pool of pools) {
     activePoolIds.add(pool.id);
     updatePoolMetrics(pool, nowSeconds);
   }

--- a/metrics-bridge/src/poller.ts
+++ b/metrics-bridge/src/poller.ts
@@ -10,7 +10,7 @@ import {
 import { runRebalanceProbes } from "./rebalance-probe.js";
 import { markHealthy } from "./server.js";
 import { POLL_INTERVAL_MS, REBALANCE_PROBE_EVERY_N_POLLS } from "./config.js";
-import type { PoolRow } from "./types.js";
+import { isFpmmPool, type PoolRow } from "./types.js";
 
 // Cycle counter — 0-indexed, advanced AFTER each probe check on successful
 // Hasura polls. The rebalance probe runs when
@@ -94,7 +94,10 @@ async function pollPools(): Promise<void> {
   let pools: PoolRow[];
   try {
     const data = await fetchPools();
-    pools = data.Pool;
+    // Exclude healed VirtualPools at the boundary so BOTH gauge publication and
+    // the rebalance probe see FPMM-only rows. See `isFpmmPool` for why the
+    // `source: { _like: "%fpmm%" }` query filter alone is insufficient.
+    pools = data.Pool.filter(isFpmmPool);
   } catch (error) {
     recordPollError(
       "hasura_query",

--- a/metrics-bridge/src/rebalance-probe.ts
+++ b/metrics-bridge/src/rebalance-probe.ts
@@ -32,7 +32,7 @@ import {
   type RebalanceProbeResult,
 } from "./rebalance-check.js";
 import { getRpcClient } from "./rpc.js";
-import type { PoolRow } from "./types.js";
+import { isFpmmPool, type PoolRow } from "./types.js";
 
 // Module-scope re-entrancy guard. The production poller awaits each
 // `runRebalanceProbes()` call before scheduling the next loop, so cycles can't
@@ -67,34 +67,32 @@ export function _resetProbeInProgressForTests(): void {
  *   - `rebalancerAddress` non-empty (pool has a probe-able liquidity strategy)
  */
 export function eligibleForProbe(pools: PoolRow[]): PoolRow[] {
-  // Mirror the VP exclusion from `updateMetrics`: a healed VP retains its
-  // FPMM source until re-sync, so `wrappedExchangeId` is the canonical gate.
-  // "" = FPMM (probe); non-empty = VP (skip — the pool no longer fires the
-  // Deviation Breach Critical alert so annotating it would emit a phantom
-  // `mento_pool_rebalance_blocked` gauge).
-  return pools
-    .filter((p) => !p.wrappedExchangeId)
-    .filter((pool) => {
-      if (Number(pool.deviationBreachStartedAt) <= 0) return false;
-      const ratio = parseFloat(pool.lastDeviationRatio);
-      if (!Number.isFinite(ratio)) return false;
-      if (ratio <= REBALANCE_PROBE_TOLERANCE_THRESHOLD) return false;
-      const openBreachPeak = parseFloat(pool.currentOpenBreachPeak);
-      const entryThreshold =
-        pool.currentOpenBreachEntryThreshold > 0
-          ? pool.currentOpenBreachEntryThreshold
-          : LEGACY_OPEN_BREACH_ENTRY_THRESHOLD;
-      const openBreachPeakRatio =
-        Number.isFinite(openBreachPeak) && openBreachPeak > 0
-          ? openBreachPeak / entryThreshold
-          : 0;
-      const crossedCritical =
-        ratio > REBALANCE_PROBE_DEVIATION_THRESHOLD ||
-        openBreachPeakRatio > REBALANCE_PROBE_DEVIATION_THRESHOLD;
-      if (!crossedCritical) return false;
-      if (!pool.rebalancerAddress) return false;
-      return true;
-    });
+  // Defense-in-depth VP exclusion via the canonical `isFpmmPool` predicate.
+  // The poller already filters to FPMM-only rows at the boundary, but a healed
+  // VP that slipped through (or a direct caller passing unfiltered pools) no
+  // longer fires the Deviation Breach Critical alert, so annotating it would
+  // emit a phantom `mento_pool_rebalance_blocked` gauge.
+  return pools.filter(isFpmmPool).filter((pool) => {
+    if (Number(pool.deviationBreachStartedAt) <= 0) return false;
+    const ratio = parseFloat(pool.lastDeviationRatio);
+    if (!Number.isFinite(ratio)) return false;
+    if (ratio <= REBALANCE_PROBE_TOLERANCE_THRESHOLD) return false;
+    const openBreachPeak = parseFloat(pool.currentOpenBreachPeak);
+    const entryThreshold =
+      pool.currentOpenBreachEntryThreshold > 0
+        ? pool.currentOpenBreachEntryThreshold
+        : LEGACY_OPEN_BREACH_ENTRY_THRESHOLD;
+    const openBreachPeakRatio =
+      Number.isFinite(openBreachPeak) && openBreachPeak > 0
+        ? openBreachPeak / entryThreshold
+        : 0;
+    const crossedCritical =
+      ratio > REBALANCE_PROBE_DEVIATION_THRESHOLD ||
+      openBreachPeakRatio > REBALANCE_PROBE_DEVIATION_THRESHOLD;
+    if (!crossedCritical) return false;
+    if (!pool.rebalancerAddress) return false;
+    return true;
+  });
 }
 
 /**

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -38,9 +38,24 @@ export interface PoolRow {
   // in the GraphQL response.
   rebalancerAddress: string;
   // "" = FPMM (native pool), non-empty hex = VP (VirtualPool healed from an
-  // FPMM). Keep rows where !wrappedExchangeId; skip VPs in updateMetrics().
+  // FPMM). Filtered out by `isFpmmPool` before any gauge/probe work.
   // Schema: `Pool.wrappedExchangeId: String! @index` (schema.graphql:181).
   wrappedExchangeId: string;
+}
+
+// Canonical FPMM predicate, mirroring `isVirtualPool` in
+// `indexer-envio/src/helpers.ts` and `ui-dashboard/src/lib/types.ts`. A healed
+// VirtualPool retains its original "fpmm_factory" source until the next re-sync,
+// so the bridge's `source: { _like: "%fpmm%" }` query filter alone is not
+// sufficient — `wrappedExchangeId` is the load-bearing discriminator:
+// "" = native FPMM; non-empty = healed VP. Applied once at the poller boundary
+// so BOTH gauge publication (`updateMetrics`) and the rebalance probe
+// (`runRebalanceProbes`) operate on FPMM-only rows from a single source of
+// truth instead of each re-deriving the guard. `eligibleForProbe` also applies
+// it defensively, since a leaked VP with a non-empty `rebalancerAddress` would
+// otherwise publish a phantom `mento_pool_rebalance_blocked` gauge.
+export function isFpmmPool(pool: PoolRow): boolean {
+  return !pool.wrappedExchangeId;
 }
 
 export interface BridgePoolsResponse {

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -43,11 +43,15 @@ export interface PoolRow {
   wrappedExchangeId: string;
 }
 
-// Canonical FPMM predicate, mirroring `isVirtualPool` in
-// `indexer-envio/src/helpers.ts` and `ui-dashboard/src/lib/types.ts`. A healed
-// VirtualPool retains its original "fpmm_factory" source until the next re-sync,
-// so the bridge's `source: { _like: "%fpmm%" }` query filter alone is not
-// sufficient — `wrappedExchangeId` is the load-bearing discriminator:
+// Canonical FPMM predicate. Analogous to `isVirtualPool` in
+// `indexer-envio/src/helpers.ts` and `ui-dashboard/src/lib/types.ts`, but
+// simplified: those check two conditions (`source.includes("virtual") ||
+// wrappedExchangeId`), whereas here the GQL query's `source: { _like: "%fpmm%" }`
+// filter has already excluded native VPs (`source: "virtual_pool_factory"`) at
+// the query boundary, leaving `wrappedExchangeId` as the only remaining
+// discriminator. A healed VirtualPool retains its original "fpmm_factory" source
+// until the next re-sync, so the source filter alone is not sufficient —
+// `wrappedExchangeId` is the load-bearing discriminator:
 // "" = native FPMM; non-empty = healed VP. Applied once at the poller boundary
 // so BOTH gauge publication (`updateMetrics`) and the rebalance probe
 // (`runRebalanceProbes`) operate on FPMM-only rows from a single source of

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -1715,7 +1715,11 @@ describe("label-shape contract: alert template ↔ metric labels", () => {
   });
 });
 
-describe("updateMetrics — VirtualPool exclusion", () => {
+describe("updateMetrics — VirtualPool transition", () => {
+  // VP exclusion itself is enforced at the poll boundary by `isFpmmPool`
+  // (covered in poller.test.ts). The behavior that lives in `updateMetrics` is
+  // deviation-alert-state pruning: once a healed VP is filtered out upstream, a
+  // subsequent poll that no longer carries its id must evict the stale state.
   const DEFAULT_NOW_SECONDS = 1713200100;
 
   beforeEach(() => {
@@ -1729,39 +1733,29 @@ describe("updateMetrics — VirtualPool exclusion", () => {
     vi.useRealTimers();
   });
 
-  it("publishes gauges for a native FPMM pool (empty wrappedExchangeId)", async () => {
-    const pool = makePool({ wrappedExchangeId: "" });
-    updateMetrics([pool], DEFAULT_NOW_SECONDS);
-    const values = await getMetricValues(register, "mento_pool_health_status");
-    expect(values.some((v) => v.labels.pool_id === pool.id)).toBe(true);
-  });
-
-  it("publishes no gauges for a healed VirtualPool (non-empty wrappedExchangeId, source fpmm_factory)", async () => {
-    // A VP healed from an FPMM retains source="fpmm_factory" until resync, so
-    // the base query's source filter is insufficient. The bridge must also check
-    // wrappedExchangeId to block phantom gauge publication.
-    const vp = makePool({
-      id: "42220-0x000000000000000000000000000000000000dead",
-      wrappedExchangeId:
-        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-      source: "fpmm_factory",
+  it("prunes deviation alert state when an FPMM heals to a VP and drops out", async () => {
+    // Poll 1: an FPMM in an active critical breach registers deviation state.
+    const fpmm = makePool({
+      wrappedExchangeId: "",
+      deviationBreachStartedAt: String(DEFAULT_NOW_SECONDS - 60),
+      lastDeviationRatio: "1.10",
+      currentOpenBreachPeak: "1.10",
     });
-    updateMetrics([vp], DEFAULT_NOW_SECONDS);
-    const values = await getMetricValues(register, "mento_pool_health_status");
-    expect(values.some((v) => v.labels.pool_id === vp.id)).toBe(false);
-  });
+    updateMetrics([fpmm], DEFAULT_NOW_SECONDS);
+    expect(
+      (
+        await getMetricValues(register, "mento_pool_deviation_alert_state")
+      ).some((v) => v.labels.pool_id === fpmm.id),
+    ).toBe(true);
 
-  it("publishes gauges only for FPMMs when the list is mixed", async () => {
-    const fpmm = makePool({ wrappedExchangeId: "" });
-    const vp = makePool({
-      id: "42220-0x000000000000000000000000000000000000dead",
-      wrappedExchangeId:
-        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-      source: "fpmm_factory",
-    });
-    updateMetrics([fpmm, vp], DEFAULT_NOW_SECONDS);
-    const values = await getMetricValues(register, "mento_pool_health_status");
-    expect(values.some((v) => v.labels.pool_id === fpmm.id)).toBe(true);
-    expect(values.some((v) => v.labels.pool_id === vp.id)).toBe(false);
+    // Poll 2: the pool has healed to a VP, so `isFpmmPool` filters it out at the
+    // poll boundary and `updateMetrics` receives an empty list — its id is
+    // absent from activePoolIds and the stale deviation state is pruned.
+    updateMetrics([], DEFAULT_NOW_SECONDS);
+    expect(
+      (
+        await getMetricValues(register, "mento_pool_deviation_alert_state")
+      ).some((v) => v.labels.pool_id === fpmm.id),
+    ).toBe(false);
   });
 });

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { register } from "../src/metrics.js";
 import * as metricsModule from "../src/metrics.js";
 import {
+  makePool,
   makePoolResponse,
   getGaugeValue,
   getMetricValues,
@@ -242,6 +243,29 @@ describe("poll", () => {
     );
     expect(await pollErrorValue("rebalance_probe")).toBe(1);
     errorSpy.mockRestore();
+  });
+
+  it("excludes healed VirtualPools from BOTH gauge publication and the rebalance probe", async () => {
+    // Regression: the VP filter must live at the poll boundary, not only in
+    // updateMetrics. A VP with a non-empty rebalancerAddress would otherwise
+    // still be probed and publish a phantom mento_pool_rebalance_blocked gauge.
+    const fpmm = makePool({ id: "42220-0xfpmm", wrappedExchangeId: "" });
+    const vp = makePool({
+      id: "42220-0xdead",
+      source: "fpmm_factory",
+      wrappedExchangeId:
+        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    });
+    mockFetchPools.mockResolvedValueOnce(makePoolResponse([fpmm, vp]));
+    const updateSpy = vi.spyOn(metricsModule, "updateMetrics");
+
+    await poll();
+
+    const updateArg = updateSpy.mock.calls[0]?.[0];
+    expect(updateArg?.map((p) => p.id)).toEqual([fpmm.id]);
+    const probeArg = mockRunRebalanceProbes.mock.calls[0]?.[0];
+    expect(probeArg?.map((p) => p.id)).toEqual([fpmm.id]);
+    updateSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## The Problem

- PR #904 excluded healed VirtualPools from FPMM gauges by hand-rolling the same `\!wrappedExchangeId` guard in two places (`updateMetrics` and the rebalance probe), so the discriminator lives in two spots that can drift.
- That PR also merged a `graphql.ts` comment referencing an `isFpmmPool` helper that was never committed — the function only existed in an uncommitted working tree, so the comment pointed at a symbol that doesn't exist on `main`.

## The Solution

- Extract a single canonical `isFpmmPool(pool)` predicate in `metrics-bridge/src/types.ts` (mirroring `isVirtualPool` in the indexer and dashboard) and apply it once at the poller boundary, so both gauge publication and the rebalance probe consume FPMM-only rows from one source of truth.
- `eligibleForProbe` now uses the same helper as a defense-in-depth guard rather than its own inline copy, and the stale `graphql.ts` reference is now truthful.

## Details

- `poller.ts`: `data.Pool.filter(isFpmmPool)` at fetch time feeds both `updateMetrics` and `runRebalanceProbes`.
- `metrics.ts`: drops the now-redundant inline `.filter(...)` from `updateMetrics`.
- `rebalance-probe.ts`: `eligibleForProbe` keeps the VP guard defensively via `isFpmmPool` (the probe can be called directly with unfiltered pools).
- Pure refactor — no behavior change. A healed VP is still excluded from every gauge it touched before.

## Validation

- `pnpm --filter @mento-protocol/metrics-bridge typecheck` — clean
- `pnpm --filter @mento-protocol/metrics-bridge lint` — clean (eslint baseline-diff)
- `pnpm --filter @mento-protocol/metrics-bridge test` — 232 passed (includes a new poller test asserting healed VPs are excluded from BOTH gauge publication and the rebalance probe)

## Deferrals

None.

Refs #853

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that preserves the existing `!wrappedExchangeId` rule; main impact is monitoring alert correctness if the predicate drifts, with new poller tests locking the boundary behavior.
> 
> **Overview**
> Introduces a shared **`isFpmmPool`** helper in `types.ts` (empty `wrappedExchangeId` = native FPMM) and applies it **once** in `pollPools` via `data.Pool.filter(isFpmmPool)`, so gauge updates and rebalance probes both see the same FPMM-only list instead of duplicating the healed VirtualPool guard.
> 
> **`updateMetrics`** no longer filters inline; **`eligibleForProbe`** calls **`isFpmmPool`** for defense in depth. Tests move VP exclusion coverage to the poller and add a case for pruning deviation alert state when a pool drops out after healing to a VP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154bd57301bee3d700245daab466ff7a40ebae64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->