### PR TITLE
test(indexer): gate src/handlers/** coverage instead of excluding it

### DIFF
--- a/indexer-envio/vitest.config.ts
+++ b/indexer-envio/vitest.config.ts
@@ -18,16 +18,31 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/*.d.ts", "src/handlers/**/*.ts"],
-      // Floors: measured 2026-06-03 with Envio event-handler registration files
-      // excluded. Handlers are exercised by integration tests, but their module
-      // scope and framework callbacks are not meaningful global unit-coverage
-      // inputs. Threshold = floor(current) - 2.
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
+      // Floors = floor(measured) - 2, measured 2026-06-15.
+      //
+      // The ~12.4k lines under src/handlers/** were previously excluded from
+      // coverage entirely — exercised end-to-end by the integration harness
+      // (test/helpers/indexerTestHarness.ts) but invisible to every gate. They
+      // are now included and gated two ways: the "src/handlers/**/*.ts" glob
+      // bucket gives them a dedicated floor, and (since vitest also folds glob
+      // files into the global pool) the global floors were re-measured over all
+      // of src. Net effect: handlers go from ungated to ratcheted, and the
+      // global gate now spans every source file rather than a hand-picked
+      // subset. The handler floors are low because the harness drives common
+      // paths, not rare-event branches — the bucket's job is visibility plus a
+      // regression ratchet, not a high bar. Raising it is follow-up work.
       thresholds: {
-        statements: 70,
-        branches: 62,
-        functions: 76,
-        lines: 72,
+        statements: 47,
+        branches: 42,
+        functions: 56,
+        lines: 48,
+        "src/handlers/**/*.ts": {
+          statements: 22,
+          branches: 14,
+          functions: 29,
+          lines: 22,
+        },
       },
     },
   },


### PR DESCRIPTION
## The Problem

- The ~12.4k lines under `indexer-envio/src/handlers/**` — the most correctness-critical code in the repo, feeding the dashboard and every alert — were in the coverage config's `exclude`.
- They are exercised end-to-end by the integration harness, but no gate measured them, so a new handler branch could merge with zero tests and trip nothing.

## The Solution

Stop excluding `src/handlers/**` from coverage and gate it with a dedicated threshold bucket, so handler coverage is visible and ratcheted against regression.

## Details

`indexer-envio/vitest.config.ts`:
- Removed `src/handlers/**/*.ts` from `coverage.exclude` so handlers are measured.
- Added a `"src/handlers/**/*.ts"` threshold bucket at `floor(measured) - 2` = 22/14/29/22. The floor is intentionally low: the harness drives common event paths, not the long tail of rare-event branches (handler coverage is ~24% today). The bucket's job is visibility + a regression ratchet, not a high bar.
- The global floors (70/62/76/72 → 47/42/56/48) are re-measured because vitest folds glob-bucket files into the global pool, so the aggregate % necessarily drops once 12.4k previously-unmeasured lines are included — the denominator grew. No file's coverage decreased; net coverage enforcement increases (handlers go from ungated to ratcheted), and the global gate now spans every source file instead of a hand-picked subset.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test:coverage` → 940 tests pass, both the global and `src/handlers/**` buckets green (exit 0).
- `typecheck` + `lint` clean. CI green except this guard.

## Deferrals

- The issue's mutation-testing half is deferred to #850 (kept open). At ~24% handler coverage, Stryker mutants on those files would overwhelmingly survive and score below the `low: 80` floor, so they'd all be trialed-and-deferred per `docs/mutation-testing.md` — a slow run for no net gate. Mutation gating becomes meaningful only after handler unit coverage rises.
- The non-handler coverage floor is diluted by folding handlers into the global pool — tracked in #931. The clean fix (a dedicated non-handler bucket) needs a deliberate negation-glob-vs-enumeration call, so it is a follow-up rather than part of this PR.

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

