### PR TITLE
fix(ci): gitignore gha-creds file so Aegis deploy-guard passes

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -28,5 +28,6 @@ terraform.tfvars
 # Credentials file written into the workspace root by
 # google-github-actions/auth during CI. This file has its own ignore rules
 # (it does not fall back to .gitignore), so the pattern must be repeated here
-# to keep the CI credential file out of the `gcloud builds submit` source archive.
+# to keep the CI credential file out of the `gcloud builds submit` source
+# archive. Left unanchored on purpose, matching .gitignore.
 gha-creds-*.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -24,3 +24,9 @@ terraform/
 *.env
 *.env.*
 terraform.tfvars
+
+# Credentials file written into the workspace root by
+# google-github-actions/auth during CI. This file has its own ignore rules
+# (it does not fall back to .gitignore), so the pattern must be repeated here
+# to keep the CI credential file out of the `gcloud builds submit` source archive.
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ test-results/
 # Credentials file written into the workspace root by
 # google-github-actions/auth during CI. Ignored so the deploy-guard
 # clean-tree check (scripts/lib/deploy-guard.sh) doesn't flag it as a
-# dirty working tree before `gcloud app deploy`.
+# dirty working tree before `gcloud app deploy`. Left unanchored on
+# purpose: a credentials file is never safe to commit at any depth.
 gha-creds-*.json
 .env.sepolia
 .env.production.local

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ playwright-report/
 test-results/
 .env
 .env.local
+# Credentials file written into the workspace root by
+# google-github-actions/auth during CI. Ignored so the deploy-guard
+# clean-tree check (scripts/lib/deploy-guard.sh) doesn't flag it as a
+# dirty working tree before `gcloud app deploy`.
+gha-creds-*.json
 .env.sepolia
 .env.production.local
 .next/


### PR DESCRIPTION
## The Problem

- The `Aegis App Engine` deploy job fails at the clean-tree guard: `❌ Working directory is not clean.`
- `google-github-actions/auth` writes `gha-creds-*.json` into the workspace root, which the deploy-guard added in #899 (`scripts/lib/deploy-guard.sh`) flags as a dirty tree before `gcloud app deploy`.

## The Solution

- Add `gha-creds-*.json` to `.gitignore` so `git status --porcelain` (the guard's check) no longer sees the CI auth artifact, while still catching real source/lockfile changes.
- Add the same pattern to the root `.gcloudignore` so the credentials file is also kept out of `metrics-bridge`'s `gcloud builds submit .` source archive.

## Details

- The guard runs `git status` at the repo root (`--show-toplevel`), exactly where the auth action writes the file — a root-relative `.gitignore` pattern matches it. Confirmed with `git check-ignore -v`.
- `.gcloudignore` does **not** fall back to `.gitignore`, so the pattern must be repeated there; the only CI workflow that runs `gcloud builds submit .` after auth is `metrics-bridge.yml`. Confirmed the file is excluded via `gcloud meta list-files-for-upload`.
- Patterns are intentionally left unanchored (repo-wide): a credentials file is never safe to commit at any depth in a public repo. Comments in both files say so.
- Aegis is the only guarded deploy script that runs in a CI workflow alongside GCP auth; the other four (`deploy-indexer/dashboard/gov-watchdog/bridge.sh`) are agent/local-driven, so no sibling sites are affected.

## Validation

- `git check-ignore -v gha-creds-<hex>.json` → matched by the new line.
- `git status --porcelain` clean after dropping a dummy `gha-creds-*.json` at root.
- Pre-push quality gate green (trunk check, metrics-bridge lint/typecheck/test/knip, code-health:deps).
- Local + Codex review: 1 verified HIGH (the `.gcloudignore` gap) fixed; no remaining blockers.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only ignore rules for ephemeral CI credentials; no runtime, auth logic, or application code changes.
> 
> **Overview**
> **Unblocks Aegis App Engine deploys** that were failing the deploy-guard clean-tree check when `google-github-actions/auth` drops `gha-creds-*.json` in the repo root.
> 
> Adds a repo-wide `gha-creds-*.json` pattern to **`.gitignore`** so `git status --porcelain` no longer treats that CI credential file as a dirty working tree before `gcloud app deploy`.
> 
> Repeats the same pattern in **`.gcloudignore`** because Cloud Build upload rules do not inherit `.gitignore`, keeping the credentials file out of `metrics-bridge`'s `gcloud builds submit` archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30cd69fa760a62bd57f22ddd0ce77bce2d3f001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->