### PR TITLE
docs: rot-proof indexer status reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,20 +329,20 @@ Sourced from the published [`@mento-protocol/contracts`](https://www.npmjs.com/p
 
 ## Key Files
 
-| What                      | Where                                                                            |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| Indexer schema            | `indexer-envio/schema.graphql`                                                   |
-| Event handlers            | `indexer-envio/src/EventHandlers.ts`                                             |
-| Pool ID helpers           | `indexer-envio/src/helpers.ts`                                                   |
-| Multichain config         | `indexer-envio/config.multichain.mainnet.yaml`                                   |
-| Indexer status + endpoint | `indexer-envio/STATUS.md`                                                        |
-| Dashboard app             | `ui-dashboard/src/app/`                                                          |
-| Network defs              | `ui-dashboard/src/lib/networks.ts`                                               |
-| GraphQL queries           | `ui-dashboard/src/lib/queries.ts` (barrel) + `ui-dashboard/src/lib/queries/*.ts` |
-| Terraform infrastructure  | `terraform/`                                                                     |
+| What                         | Where                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| Indexer schema               | `indexer-envio/schema.graphql`                                                   |
+| Event handlers               | `indexer-envio/src/EventHandlers.ts`                                             |
+| Pool ID helpers              | `indexer-envio/src/helpers.ts`                                                   |
+| Multichain config            | `indexer-envio/config.multichain.mainnet.yaml`                                   |
+| Indexer deployment reference | `indexer-envio/STATUS.md`                                                        |
+| Dashboard app                | `ui-dashboard/src/app/`                                                          |
+| Network defs                 | `ui-dashboard/src/lib/networks.ts`                                               |
+| GraphQL queries              | `ui-dashboard/src/lib/queries.ts` (barrel) + `ui-dashboard/src/lib/queries/*.ts` |
+| Terraform infrastructure     | `terraform/`                                                                     |
 
 ## Documentation
 
 - [`indexer-envio/README.md`](./indexer-envio/README.md) — Indexer reference
-- [`indexer-envio/STATUS.md`](./indexer-envio/STATUS.md) — Current sync state + endpoint
+- [`indexer-envio/STATUS.md`](./indexer-envio/STATUS.md) — Static endpoint + deployment reference
 - [`docs/deployment.md`](./docs/deployment.md) — Full deployment guide

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -216,7 +216,7 @@ treating it as live. The static production endpoint never changes on redeploy:
 https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 ```
 
-See [`STATUS.md`](./STATUS.md) for current sync state and endpoint details.
+See [`STATUS.md`](./STATUS.md) for the static endpoint and deployment reference.
 
 ## Key Files
 

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -7,10 +7,10 @@ Ethereum Mainnet `1` sUSDS reserve-yield events) on the Envio Cloud `mento`
 project (org `mento-protocol`), Production Medium tier.
 
 This file documents only facts that stay true across redeployments. For live
-sync state and the currently promoted deployment, run:
+sync state and the latest deployment currently visible to Envio, run:
 
 ```bash
-pnpm deploy:indexer:status          # latest deployment status
+pnpm deploy:indexer:status          # latest visible deployment status
 pnpm deploy:indexer:status --json   # machine-readable
 ```
 

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -1,23 +1,18 @@
-# Indexer Status
+# Indexer Deployment Reference
 
-Last updated: 2026-05-13
+## Deployment Model
 
-## Current State
+Single multichain mainnet indexer (Celo Mainnet `42220` + Monad `143` +
+Ethereum Mainnet `1` sUSDS reserve-yield events) on the Envio Cloud `mento`
+project (org `mento-protocol`), Production Medium tier.
 
-Single multichain mainnet indexer (Celo + Monad) live on Envio Cloud.
+This file documents only facts that stay true across redeployments. For live
+sync state and the currently promoted deployment, run:
 
-| Network      | Envio Project | Tier              | Status | Sync state                          |
-| ------------ | ------------- | ----------------- | ------ | ----------------------------------- |
-| Celo Mainnet | `mento`       | Production Medium | Live   | Caught up at `2026-05-13T11:54:24Z` |
-| Monad        | `mento`       | Production Medium | Live   | Caught up at `2026-05-13T11:54:24Z` |
-
-Current production deployment:
-
-| Field       | Value                                        |
-| ----------- | -------------------------------------------- |
-| Commit      | `cea00ee`                                    |
-| Commit name | `Optimize Envio v3 indexer sync path (#405)` |
-| Created     | `2026-05-13T10:42:34Z`                       |
+```bash
+pnpm deploy:indexer:status          # latest deployment status
+pnpm deploy:indexer:status --json   # machine-readable
+```
 
 ## GraphQL Endpoint
 


### PR DESCRIPTION
## The Problem

- `indexer-envio/STATUS.md` mixed stable endpoint documentation with stale deployment-specific facts.
- README links described it as a current sync-state page even though live sync state belongs in the deploy status command.

## The Solution

- Rework `STATUS.md` into a static indexer deployment reference and point operators to `pnpm deploy:indexer:status` for live state.
- Update the inbound README references so they no longer promise current sync status in a static file.

## Details

- Removes dated sync timestamps, stale deployment commit metadata, and the old `Last updated` header.
- Keeps the stable endpoint, pool ID format, config, legacy projects, schema, and local dev sections in place.
- Uses the current mainnet config/live status chain set: Celo `42220`, Monad `143`, and Ethereum Mainnet `1` sUSDS reserve-yield events.
- No `ui-dashboard/`, TypeScript, Terraform, schema, or deploy-flow changes.

## Validation

- `env -u NEXT_PUBLIC_HASURA_URL pnpm dashboard:dev`
  - observed: `[dashboard:dev] NEXT_PUBLIC_HASURA_URL not set; using live Envio endpoint https://indexer.hyperindex.xyz/2f3dd15/v1/graphql`
  - local sandbox then failed to bind `0.0.0.0:3000` with `EPERM`, after the required wrapper verification line appeared.
- `grep -nE "Last updated|cea00ee|Caught up at|2026-05-13" indexer-envio/STATUS.md` returned no matches.
- `grep -rn "current sync state" README.md indexer-envio/README.md` returned no matches.
- `volta run --node 22 pnpm deploy:indexer:status` printed latest deployment `1c3f77f`, 100.00% caught up on chains `1`, `143`, and `42220`.
- `pnpm exec trunk fmt`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #867

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime, schema, or deploy script changes.
> 
> **Overview**
> **`indexer-envio/STATUS.md`** is reframed from a live “status” page into a **static deployment reference**: dated sync tables, commit metadata, and “last updated” are removed, and operators are directed to **`pnpm deploy:indexer:status`** (and `--json`) for current sync and the latest visible deployment. The deployment model section now explicitly includes **Ethereum Mainnet `1` sUSDS reserve-yield** alongside Celo and Monad.
> 
> **Root and indexer READMEs** stop implying that **`STATUS.md`** holds current sync state—table labels and doc bullets now describe it as static endpoint + deployment reference only (minor Key Files table alignment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3d996401a939b5eead0e756a98e9f5346b2b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->