### PR TITLE
docs(ui-dashboard): document fetchPaginatedRows page-size invariant; harden test

### DIFF
--- a/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts
@@ -105,8 +105,12 @@ describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
     }));
     const page2 = [{ id: "p2-0" }];
 
-    // Capture the signal passed into each client.request() call.
+    // Capture the signal passed into each client.request() call. Use a
+    // dedicated call counter rather than deriving the page index from
+    // capturedSignals.length so the fixture selection can't desync if a
+    // future code path ever omits the signal field.
     const capturedSignals: AbortSignal[] = [];
+    let callCount = 0;
     type RequestArg = Parameters<typeof client.request>[0];
     vi.mocked(client.request).mockImplementation(async (opts: RequestArg) => {
       const sig =
@@ -114,8 +118,7 @@ describe("fetchPaginatedRows — AbortSignal.timeout per page", () => {
           ? (opts as { signal?: AbortSignal | null }).signal
           : undefined;
       if (sig) capturedSignals.push(sig);
-      const callIndex = capturedSignals.length - 1;
-      return callIndex === 0 ? { TestKey: page1 } : { TestKey: page2 };
+      return callCount++ === 0 ? { TestKey: page1 } : { TestKey: page2 };
     });
 
     await fetchPaginatedRows({

--- a/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
+++ b/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
@@ -326,6 +326,12 @@ async function paginateDailySnapshots<T extends { id: string }>(
     }),
     dedupKey: (r) => r.id,
   });
+  // Mid-loop errors with partial rows are intentionally absorbed here: the
+  // chart renders the partial history (flagged via `truncated`) rather than
+  // failing closed, and `fetchPaginatedRows` has already captured the error to
+  // Sentry (throttled per network:responseKey). We only rethrow when NOTHING
+  // was fetched (page-0 failure), so the caller's daily-series fallback chain
+  // still degrades to fee-event reconstruction / `failed` state on total loss.
   if (result.error && result.rows.length === 0) throw result.error;
   return { rows: result.rows, truncated: result.truncated };
 }

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -191,6 +191,12 @@ export const partialPageLastCapturedAt = new Map<string, number>();
  * key extractor — offset pagination over an append-only table is unstable
  * under concurrent inserts, so dedup is required to keep windowed totals
  * accurate even when a refresh hits mid-write.
+ *
+ * IMPORTANT: the `limit` a caller passes via `variablesFor` MUST equal
+ * `SNAPSHOT_PAGE_SIZE` (1000). That constant is the early-exit sentinel — the
+ * loop stops when a page returns fewer than `SNAPSHOT_PAGE_SIZE` rows. A caller
+ * passing a smaller `limit` (e.g. 500) would terminate after the first page
+ * because `500 < 1000` always holds, silently truncating the result set.
  */
 export async function fetchPaginatedRows<TRow, TVars>(args: {
   client: GraphQLClient;


### PR DESCRIPTION
## The Problem

- Two load-bearing facts about `fetchPaginatedRows` were left undocumented after #906 merged: the page-size invariant that makes pagination terminate correctly, and the deliberate fail-open behavior on mid-loop errors. A future caller can silently truncate results or misread the error handling without them.
- The signal-capture test derived its page index from `capturedSignals.length`, so it would desync if a code path ever stopped passing the abort signal.

## The Solution

- Document the invariant directly on `fetchPaginatedRows`: a caller's `limit` (via `variablesFor`) MUST equal `SNAPSHOT_PAGE_SIZE` (1000), because that constant is the loop's early-exit sentinel — a smaller limit terminates after page 0 and silently truncates.
- Document the fail-open contract on the CDP hook: partial rows render as `truncated`; only a page-0 total failure rethrows.
- Harden the test to count calls with a dedicated counter rather than inferring the page index from the captured-signal array.

## Details

- Comment-only changes plus one test refactor; no behavior change.
- Verified the invariant against `fetch.ts`: `SNAPSHOT_PAGE_SIZE = 1000` (line 161) is exactly the early-exit comparison (`batch.length < SNAPSHOT_PAGE_SIZE`).
- These are the polish edits that were authored on the #906 branch but never committed before that PR merged.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- `vitest run src/hooks/__tests__/use-cdp-borrowing-revenue.test.ts` — 4 passed

## Deferrals

- #932 — export `SNAPSHOT_PAGE_SIZE` so `fetchPaginatedRows` callers stop duplicating the `1000` page-size literal (pre-existing; surfaced by the review on this PR).

Refs #854
