### PR TITLE
fix: anchor deploy commands to guarded repo root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,6 +802,10 @@ jobs:
         # Without this in CI, a routing regression only fails locally (pre-push)
         # and could merge if a contributor bypasses the local gate.
         run: pnpm agent:quality-gate:test
+      - name: Deploy root-anchor regression suite
+        # Verifies deploy wrappers run deploy-sensitive commands from the same
+        # repo root that scripts/lib/deploy-guard.sh checked for cleanliness.
+        run: node scripts/check-deploy-root-anchors.test.mjs
       - name: Terraform stack registry suite
         run: pnpm tf:test
       - name: ESLint baseline-diff semantic suite

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -24,3 +24,4 @@ last_verified: 2026-05-20
 ## Verification
 
 Run `pnpm lint:scripts`, `bash -n scripts/<changed-script>.sh`, and `pnpm agent:quality-gate:test` when quality-gate routing changes.
+For deploy-wrapper changes, also run `node scripts/check-deploy-root-anchors.test.mjs`.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1257,6 +1257,11 @@ while IFS= read -r path; do
     scripts/*.sh)
       add_surface "scripts"
       case "$path" in
+        scripts/deploy-indexer.sh|scripts/deploy-bridge.sh|scripts/deploy-gov-watchdog.sh)
+          add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy root-anchor guard changed"
+          ;;
+      esac
+      case "$path" in
         scripts/check-agent-quality-gate-package-scripts.sh)
           add_command "bash scripts/check-agent-quality-gate-package-scripts.sh" "agent quality gate package script validator changed"
           add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
@@ -1285,6 +1290,9 @@ while IFS= read -r path; do
       case "$path" in
         scripts/check-agent-context.mjs)
           add_command "pnpm agent:context-check" "agent context checker changed"
+          ;;
+        scripts/check-deploy-root-anchors.test.mjs)
+          add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy root-anchor test changed"
           ;;
         scripts/agent-prewarm.mjs|scripts/agent-prewarm.test.mjs)
           add_command "pnpm agent:prewarm:test" "agent prewarm helper changed"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1257,8 +1257,8 @@ while IFS= read -r path; do
     scripts/*.sh)
       add_surface "scripts"
       case "$path" in
-        scripts/deploy-indexer.sh|scripts/deploy-bridge.sh|scripts/deploy-gov-watchdog.sh)
-          add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy root-anchor guard changed"
+        scripts/deploy-*.sh)
+          add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy wrapper changed"
           ;;
       esac
       case "$path" in

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1379,9 +1379,22 @@ assert_not_contains_mapped "- pnpm --filter @mento-protocol/ui-dashboard test:br
 run_gate "bootstrap-worktree.sh"
 assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
 
+run_gate "scripts/deploy-indexer.sh"
+assert_contains "- bash -n scripts/deploy-indexer.sh (shell script changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+
 run_gate "scripts/deploy-bridge.sh"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
 assert_occurrences 1 "- bash -n scripts/deploy-bridge.sh (shell script changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+
+run_gate "scripts/deploy-gov-watchdog.sh"
+assert_contains "- bash -n scripts/deploy-gov-watchdog.sh (shell script changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+
+run_gate "scripts/check-deploy-root-anchors.test.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor test changed)"
 
 run_gate "scripts/agent-session-end-hook.sh"
 assert_contains "- bash -n scripts/agent-session-end-hook.sh (shell script changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1381,16 +1381,20 @@ assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
 
 run_gate "scripts/deploy-indexer.sh"
 assert_contains "- bash -n scripts/deploy-indexer.sh (shell script changed)"
-assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+
+run_gate "scripts/deploy-indexer-status.sh"
+assert_contains "- bash -n scripts/deploy-indexer-status.sh (shell script changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
 
 run_gate "scripts/deploy-bridge.sh"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
 assert_occurrences 1 "- bash -n scripts/deploy-bridge.sh (shell script changed)"
-assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
 
 run_gate "scripts/deploy-gov-watchdog.sh"
 assert_contains "- bash -n scripts/deploy-gov-watchdog.sh (shell script changed)"
-assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor guard changed)"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
 
 run_gate "scripts/check-deploy-root-anchors.test.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"

--- a/scripts/check-deploy-root-anchors.test.mjs
+++ b/scripts/check-deploy-root-anchors.test.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Static regression checks for deploy scripts that source deploy-guard.sh.
+ *
+ * The guard validates the repository that contains the guard file. These
+ * scripts must then run git/build/deploy commands from that same repo root so
+ * an absolute-path invocation from another checkout cannot deploy foreign CWD
+ * artifacts after the monitoring-monorepo guard has passed.
+ */
+
+import { readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const scripts = [
+  {
+    path: "scripts/deploy-indexer.sh",
+    firstRepoCommand: "git ls-remote --heads origin",
+  },
+  {
+    path: "scripts/deploy-bridge.sh",
+    firstRepoCommand: 'TAG="$(git rev-parse --short HEAD)"',
+  },
+  {
+    path: "scripts/deploy-gov-watchdog.sh",
+    firstRepoCommand: "COMMIT_SHA=$(git rev-parse --short HEAD)",
+  },
+];
+
+let failures = 0;
+
+function assertOrdered(path, text, needles) {
+  let cursor = -1;
+  for (const needle of needles) {
+    const index = text.indexOf(needle, cursor + 1);
+    if (index === -1) {
+      console.error(
+        `${path}: missing ordered anchor ${JSON.stringify(needle)}`,
+      );
+      failures++;
+      return;
+    }
+    cursor = index;
+  }
+}
+
+for (const script of scripts) {
+  const absolutePath = resolve(ROOT, script.path);
+  const text = readFileSync(absolutePath, "utf8");
+  const displayPath = relative(ROOT, absolutePath);
+
+  assertOrdered(displayPath, text, [
+    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
+    'REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"',
+    'cd "$REPO_ROOT"',
+    script.firstRepoCommand,
+  ]);
+}
+
+if (failures > 0) {
+  process.exitCode = 1;
+} else {
+  console.log(
+    `All ${scripts.length} deploy scripts anchor repo commands after deploy-guard.`,
+  );
+}

--- a/scripts/check-deploy-root-anchors.test.mjs
+++ b/scripts/check-deploy-root-anchors.test.mjs
@@ -8,26 +8,50 @@
  * artifacts after the monitoring-monorepo guard has passed.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
-const scripts = [
-  {
-    path: "scripts/deploy-indexer.sh",
-    firstRepoCommand: "git ls-remote --heads origin",
-  },
-  {
-    path: "scripts/deploy-bridge.sh",
-    firstRepoCommand: 'TAG="$(git rev-parse --short HEAD)"',
-  },
-  {
-    path: "scripts/deploy-gov-watchdog.sh",
-    firstRepoCommand: "COMMIT_SHA=$(git rev-parse --short HEAD)",
-  },
-];
+const orderedAnchors = {
+  "scripts/deploy-dashboard.sh": [
+    'REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
+    '(cd "$REPO_ROOT" && vercel deploy --prod',
+  ],
+  "scripts/deploy-indexer.sh": [
+    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
+    'REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"',
+    'cd "$REPO_ROOT"',
+    "git ls-remote --heads origin",
+  ],
+  "scripts/deploy-bridge.sh": [
+    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
+    'REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"',
+    'cd "$REPO_ROOT"',
+    'TAG="$(git rev-parse --short HEAD)"',
+  ],
+  "scripts/deploy-gov-watchdog.sh": [
+    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
+    'REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"',
+    'cd "$REPO_ROOT"',
+    "COMMIT_SHA=$(git rev-parse --short HEAD)",
+  ],
+};
+
+const scripts = readdirSync(resolve(ROOT, "scripts"))
+  .filter(
+    (fileName) => fileName.startsWith("deploy-") && fileName.endsWith(".sh"),
+  )
+  .map((fileName) => `scripts/${fileName}`)
+  .filter((path) =>
+    readFileSync(resolve(ROOT, path), "utf8").includes("lib/deploy-guard.sh"),
+  )
+  .map((path) => ({
+    path,
+    orderedAnchors: orderedAnchors[path],
+  }));
 
 let failures = 0;
 
@@ -51,12 +75,13 @@ for (const script of scripts) {
   const text = readFileSync(absolutePath, "utf8");
   const displayPath = relative(ROOT, absolutePath);
 
-  assertOrdered(displayPath, text, [
-    'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"',
-    'REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"',
-    'cd "$REPO_ROOT"',
-    script.firstRepoCommand,
-  ]);
+  if (!script.orderedAnchors) {
+    console.error(`${displayPath}: missing orderedAnchors mapping`);
+    failures++;
+    continue;
+  }
+
+  assertOrdered(displayPath, text, script.orderedAnchors);
 }
 
 if (failures > 0) {

--- a/scripts/deploy-gov-watchdog.sh
+++ b/scripts/deploy-gov-watchdog.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # shellcheck source=scripts/lib/deploy-guard.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/deploy-guard.sh"
 
+# Anchor subsequent git and pnpm commands to the guarded repo root so the guard
+# and deploy operate on the same checkout even when invoked by absolute path.
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
 COMMIT_SHA=$(git rev-parse --short HEAD)
 COMMIT_MSG=$(git log -1 --pretty=%s)
 


### PR DESCRIPTION
## The Problem

- Some deploy wrappers validate the monitoring-monorepo checkout with `deploy-guard.sh`, but still run deploy-sensitive commands from the caller's current directory.
- Absolute-path invocations from another checkout could pass the clean-tree guard and then read commit metadata or deploy artifacts from the wrong repo.

## The Solution

- Anchor the governance-watchdog deploy wrapper to the guarded repo root before computing commit metadata or invoking its deploy command.
- Add a root-script regression check that all guarded deploy wrappers enter the guarded repo before their first deploy-sensitive command.

## Details

- `scripts/deploy-indexer.sh` and `scripts/deploy-bridge.sh` were already anchored on current `main`; this closes the remaining `scripts/deploy-gov-watchdog.sh` gap.
- `scripts/check-deploy-root-anchors.test.mjs` statically verifies the guarded deploy wrappers source `deploy-guard.sh`, resolve `REPO_ROOT`, `cd "$REPO_ROOT"`, and only then run their first repo-sensitive command.
- The root scripts CI job and local agent quality gate now run that regression when deploy wrappers or the regression itself change.

## Validation

- `node scripts/check-deploy-root-anchors.test.mjs`
- `pnpm lint:scripts`
- `bash -n scripts/deploy-gov-watchdog.sh scripts/agent-quality-gate.sh scripts/agent-quality-gate.test.sh`
- `pnpm agent:quality-gate:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Pre-push `pnpm agent:quality-gate --run`

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #908

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy entrypoints where a CWD/repo mismatch could ship the wrong commit; mitigated by a small script fix and static ordered-anchor tests wired into CI and the agent quality gate.
> 
> **Overview**
> **Deploy safety:** `scripts/deploy-gov-watchdog.sh` now resolves `REPO_ROOT` and `cd`s there immediately after sourcing `deploy-guard.sh`, so commit metadata and `pnpm deploy` run against the same checkout the guard validated—not the caller’s CWD when the script is invoked by absolute path.
> 
> **Regression coverage:** New `scripts/check-deploy-root-anchors.test.mjs` statically discovers `scripts/deploy-*.sh` files that source `lib/deploy-guard.sh` and asserts each has a per-script ordered anchor sequence (guard → `REPO_ROOT` → `cd` → first repo-sensitive command). CI’s root-scripts job and `agent-quality-gate` routing run this suite when deploy wrappers or the test itself change; `scripts/AGENTS.md` documents the extra local check for deploy-wrapper edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a583ecf3e3c24caa75a3875e11a327479a244130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->