### PR TITLE
feat(forensic-report): Mento indexer step, multi-chain doctrine, tooling matrix

### DIFF
--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -251,7 +251,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 {
   Trove(where: { owner: { _eq: "0xtarget" } }) {
     id
-    collateral
+    coll
     debt
     status
   }
@@ -280,7 +280,7 @@ Run a small battery keyed on the target address (all fields verified against `in
     }
     limit: 1000
   ) {
-    txHash
+    sentTxHash
     sender
     recipient
     amount

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -431,7 +431,7 @@ Before concluding "no interesting getters", do three things:
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --block $HEAD_BLOCK --rpc-url $RPC  # EIP-1822
    # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
    BEACON=0x…   # last 20 bytes of the beacon slot value above
-   cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
+   cast call "$BEACON" "implementation()(address)" --block "$HEAD_BLOCK" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
@@ -456,7 +456,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --rpc-url "$RPC"` (two complete commands; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --block "$HEAD_BLOCK" --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --block "$HEAD_BLOCK" --rpc-url "$RPC"` (two complete commands, block-pinned for reproducibility; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -526,19 +526,20 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
 
 ```bash
-# GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
-# Verify/extend against https://api.geckoterminal.com/api/v2/networks (a chain may have no GT coverage).
+# GeckoTerminal + DexScreener each use their OWN network slugs (NOT chain ids) — select both per $CHAIN
+# in one switch, like $BS in Step 4. Verify against api.geckoterminal.com/api/v2/networks and
+# DexScreener's docs (a chain may be on one but not the other — GeckoTerminal has no Monad, DexScreener does).
 case "$CHAIN" in
-  celo)     GT_NS=celo ;;
-  polygon)  GT_NS=polygon_pos ;;
-  ethereum) GT_NS=eth ;;
-  *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
+  celo)     GT_NS=celo;        DS_NS=celo ;;
+  monad)    GT_NS="";          DS_NS=monad ;;     # GeckoTerminal: no Monad; DexScreener: yes (verify slug)
+  polygon)  GT_NS=polygon_pos; DS_NS=polygon ;;
+  ethereum) GT_NS=eth;         DS_NS=ethereum ;;
+  *)        GT_NS=""; DS_NS=""; echo "No GeckoTerminal/DexScreener slug mapped for $CHAIN — verify their network lists, then set GT_NS/DS_NS or skip." >&2 ;;
 esac
-[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
-curl -s "https://api.dexscreener.com/token-pairs/v1/<ds-slug>/{tokenAddr}"         # chain-scoped: pairs for this token on $CHAIN only
-# <ds-slug> = DexScreener chain slug for $CHAIN (celo / ethereum / polygon / base / …). The chain-scoped
-# token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the token's pairs on ALL
-# chains and risked naming a different chain's venue/TVL for an unrelated same-address token.
+[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug
+[ -n "$DS_NS" ] && curl -s "https://api.dexscreener.com/token-pairs/v1/$DS_NS/{tokenAddr}"           # chain-scoped: pairs for this token on $CHAIN only; skipped when no DS slug
+# The chain-scoped token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the
+# token's pairs on ALL chains and risked naming a different chain's venue/TVL for a same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
@@ -569,8 +570,8 @@ A forensic product should screen every target. Primary, zero new dependency — 
 # guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
 # chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
 if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
-  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --rpc-url "$RPC"
-  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --rpc-url "$RPC"; done
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --block "$HEAD_BLOCK" --rpc-url "$RPC"
+  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --block "$HEAD_BLOCK" --rpc-url "$RPC"; done
 fi
 ```
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -175,7 +175,9 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 #     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
 #     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} }\"}" | jq .
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# (Ethereum is sUSDS-only in this indexer — that's why SusdsPosition is in the probe; without it an
+#  ethereum target would always look NOT-COVERED despite the indexer serving its sUSDS ledger.)
 # Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
 # empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
 # `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
@@ -280,6 +282,17 @@ Run a small battery keyed on the target address (all fields verified against `in
     coll
     debt
     status
+  }
+}
+{
+  # CDP operation HISTORY (open/adjust/close/liquidation), not just currently-owned troves — a target that
+  # opened then closed/was-liquidated owns no Trove now but is all over TroveOperationEvent.
+  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+    id
+    troveId
+    operation
+    collChange
+    debtChange
   }
 }
 {
@@ -544,7 +557,7 @@ esac
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `$DUNE_NS.dex.trades` (the target chain's table — `celo.dex.trades` / `monad.dex.trades` / …; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune's unified `dex.trades` spellbook filtered `WHERE blockchain = '$DUNE_NS'` (it's ONE cross-chain table with a `blockchain` column — there is no per-chain `celo.dex.trades`; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 
 ### Step 7 — Coverage and dead ends
 
@@ -575,7 +588,7 @@ if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deplo
 fi
 ```
 
-Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
+Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against an actual static OFAC list file, e.g. `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses/main/data/sanctioned_addresses_ETH.txt` (one 0x address per line; covers EVM addresses regardless of target chain). For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
 
 ### Step 8 — Bottom line
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -264,7 +264,7 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  Trove(where: { owner: { _eq: "0xtarget" } }) {
+  Trove(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
     coll
     debt
@@ -272,19 +272,19 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  LiquidityPosition(where: { address: { _eq: "0xtarget" } }) {
+  LiquidityPosition(where: { address: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     poolId
   }
 }
 {
-  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
     txHash
     kind
     amount
   }
 }
 {
-  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
+  BridgeBridger(where: { sender: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
   }
 }
@@ -346,7 +346,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
    - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
 5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
-6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **correct Celo coinType `0x8000A4EC`** (= `0x80000000 | 42220`; reverse namespace `a4ec.reverse`). Watch out: a common doc example mis-states this — `0x8000A4DC` decodes to chain 42204, the wrong chain. Mostly negatives for bot EOAs; one hit is gold.
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record (coinType `0`), which many owners set regardless of chain. Mostly negatives for bot EOAs; one hit is gold.
 
 For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
 
@@ -404,7 +404,7 @@ Before concluding "no interesting getters", do three things:
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
    ```
 
-2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify covers Celo, free, no key: `GET https://sourcify.dev/server/v2/contract/42220/{addr}?fields=all` (cross-check Celoscan).
+2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
 3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
 
 **For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
@@ -431,15 +431,20 @@ If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real h
 
 Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` both return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree on Celo. The free, no-key Celo Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow:
+**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` (and most public full nodes) whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree. The free, no-key Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow — point `BS` at the target chain's Blockscout instance:
 
 ```bash
-BS=https://celo.blockscout.com/api/v2
+# Pick the Blockscout v2 base for $CHAIN. Not every chain has one (e.g. Monad — see fallback below).
+case "$CHAIN" in
+  celo)    BS=https://celo.blockscout.com/api/v2 ;;
+  polygon) BS=https://polygon.blockscout.com/api/v2 ;;
+  *)       BS=<target chain's Blockscout v2 base, or use the RPC-native fallback> ;;
+esac
 curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
 curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
 ```
 
-Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (`chain_id: 42220`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector.
+Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
 
 > **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
 
@@ -488,11 +493,12 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
 ```bash
-curl -s "https://api.geckoterminal.com/api/v2/networks/celo/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"             # → every pair, dexId, liquidity.usd, volume.h24
+GT_NS=celo   # GeckoTerminal network slug for $CHAIN: celo / polygon_pos / eth / … (NOT the chain id; verify at /api/v2/networks)
+curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
 ```
 
-(Use `networks/celo/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. For chains other than Celo swap the `networks/<slug>` segment.)
+(Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
 **MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -66,12 +66,13 @@ mkdir -p .investigations
 #   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
 #   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
 #   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+#   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
-  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
-  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
-  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
-  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS." >&2; exit 1 ;;
+  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node; DefiLlama may not cover monad yet (Step 5.5 caveat)
+  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
+  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
 esac
 ```
 
@@ -333,7 +334,9 @@ A non-empty result here, scoped to the actual target chain, is far stronger than
 
 Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
-1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure. **For a CONTRACT target, don't trust an Arkham hit on the target address**: the same 20-byte address on Ethereum/L2 is usually an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically). For contracts, derive the deployer/operator EOA first (step 5) and run the cross-chain identity leg on THAT — only treat a same-address cross-chain hit as the target if bytecode/CREATE2 evidence proves the address is intentionally shared.
+1. Branch on target type before any cross-chain enrichment:
+   - **EOA target** → run `address_enriched/all` on it. Zero hits for a Celo-native EOA is a signal, not a failure.
+   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (step 5), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -454,8 +457,10 @@ case "$CHAIN" in
   polygon) BS=https://polygon.blockscout.com/api/v2 ;;
   *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
-curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
-curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+if [ -n "$BS" ]; then   # skip when no Blockscout for $CHAIN — use the RPC-native fallback below instead
+  curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
+  curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+fi
 ```
 
 Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
@@ -481,7 +486,7 @@ Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM`
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `$DL_NS:<lowercaseTokenAddress>`, where `DL_NS` is the DefiLlama slug for `$CHAIN` — set it alongside the other chain knobs (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`, base→`base`, arbitrum→`arbitrum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` is the DefiLlama slug set by Step 1's case switch (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
@@ -515,7 +520,7 @@ case "$CHAIN" in
   ethereum) GT_NS=eth ;;
   *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
-curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
 curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
 # MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
 # unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -47,7 +47,7 @@ Two artefacts:
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
+The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_, why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
 
 ## Procedure (how to fill the template)
 
@@ -734,7 +734,7 @@ mcp__upstash__redis_database_run_redis_commands({
 });
 ```
 
-Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the eight named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
+Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the nine named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
 
 ## Rules
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -33,7 +33,7 @@ Two facts shape every tool choice in this skill:
 
 So split the work into two legs and pick tools per leg:
 
-- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal, `cast` vs forno). These are the only ones that actually see the target chain.
+- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal (Celo; no Monad) / DexScreener, `cast` vs the chain's RPC). These are the only ones that actually see the target chain.
 - **Cross-chain identity leg** (who is _behind_ the address): pivot the operator EOA onto the chains the heavyweight attributors cover and let them work there.
 
 **Corollary — never drop a source just because it lacks Celo.** A Celo-blind tool (Nansen, EigenPhi, GoPlus, Across, …) is still the right tool for the identity leg, for Monad, and for Polygon/Ethereum once we deploy there. The **Tooling matrix** near the end of this file records what each source covers and which leg it serves — consult it instead of assuming "no Celo = useless".
@@ -85,7 +85,7 @@ cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
 ```
 
-For the attribution-anchoring storage reads in Step 3, pin them with `cast call <addr> <sig> --block $HEAD_BLOCK --rpc-url $RPC` so a future reader gets the same bytes.
+For the attribution-anchoring storage reads in Step 3, pin them with `cast call "$ADDR" "<sig>" --block "$HEAD_BLOCK" --rpc-url "$RPC"` (quote the `<sig>` placeholder so bash doesn't read it as a redirection) so a future reader gets the same bytes.
 
 Check whether a report already exists (we may be UPDATING, not creating):
 
@@ -153,7 +153,7 @@ mcp__upstash__redis_database_run_redis_commands({
 
 Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
-**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address.
+**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address — **but only consume a hit keyed on the target's own address as identity for an EOA target.** For a CONTRACT target, the same 20-byte address on the chains these caches cover is usually an unrelated account, so a target-address cache hit would mis-attribute the report; run the identity leg on the deployer/operator EOA instead (Step 2), unless shared-deployment is proven.
 
 **Don't treat the payloads as opaque blobs** — the typed accessors in `ui-dashboard/src/lib/` give exact field paths:
 
@@ -168,12 +168,15 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
 # Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
 # deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
-# Scope the probe to the TARGET chain. A generic SwapEvent(limit:1) passes on Celo data even when the
-# target chain is missing/unsynced — which would later make an empty battery look EMPTY (covered, found
-# nothing) when it's really NOT-COVERED (chain absent). If this returns 0 rows, mark the indexer
-# NOT-COVERED for $CHAIN, not EMPTY.
+# (a) Liveness: confirm the endpoint serves at all.
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}}, limit:1){ id } }\"}" | jq .
+  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+# (b) Chain coverage: probe several core entity types for $CHAIN_ID — a quiet/new chain may have
+#     bridge/CDP/supply activity but zero swaps, so DON'T equate 0 SwapEvent rows with NOT-COVERED.
+curl -s "$HASURA" -H 'content-type: application/json' \
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# Mark the indexer NOT-COVERED for $CHAIN only if the FULL Step 1.6 battery (all entity types) is empty
+# AND $CHAIN isn't in the indexer's configured chain list; otherwise an empty result is EMPTY (real signal).
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -415,11 +418,16 @@ Before concluding "no interesting getters", do three things:
 1. **Proxy check** (zero new dependency). Read the standard slots — a non-zero value means you've been reading an empty shell and must analyse the _implementation_ instead:
 
    ```bash
-   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). Non-zero → last 20 bytes = the address to analyse.
+   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). For impl/admin/EIP-1822, non-zero → last 20
+   # bytes IS the address to analyse. The BEACON slot is different: its last 20 bytes are the BEACON
+   # contract, not the impl — call beacon.implementation() and analyse THAT (see below).
    cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
    cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
    cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
+   BEACON=0x…   # last 20 bytes of the beacon slot value above
+   cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
@@ -443,7 +451,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` + `'getThreshold()(uint256)'` (use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -510,7 +518,7 @@ Caveats — surface them in the report when they bite:
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
 
 ```bash
 # GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
@@ -731,18 +739,18 @@ Pick the tool that covers the chain you're on and the leg you're working. **A bl
 
 **On-chain behaviour leg — Celo/Monad-native (free, the workhorses):**
 
-| Source                       | Celo              | Monad | Access            | Answers                                                     |
-| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
-| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
-| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)        |
-| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
-| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
-| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
-| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
-| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                   |
-| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
-| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
-| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
+| Source                       | Celo              | Monad | Access            | Answers                                                                        |
+| ---------------------------- | ----------------- | ----- | ----------------- | ------------------------------------------------------------------------------ |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6)                    |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)                           |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`                     |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                                    |
+| GeckoTerminal                | ✅                | ❌    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6); no Monad — use DexScreener there |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                                           |
+| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                                      |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                                       |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**                          |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                                        |
 
 **Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -43,7 +43,7 @@ So split the work into two legs and pick tools per leg:
 Two artefacts:
 
 1. **Local draft** at `.investigations/<address>-<slug>.md` (slug = first-3 words of derived display name, lowercase, kebab-cased). The `.investigations/` folder is gitignored — never commit drafts.
-2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script — same one `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` runs — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution. Atomicity matters: the editor route uses the same script, and a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
+2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script mirrors the atomic upsert pattern `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` uses — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution — but is a **simplified, non-CAS variant**: the live route additionally takes an `expectedVersion` base-version precondition and returns an `{ok, report}` envelope, whereas this skill does a fire-and-forget always-wins write and returns the bare encoded payload (exact script in the Lua section below). Atomicity still matters: a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
 
 ## Output template
 
@@ -530,7 +530,7 @@ _Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <versi
 
 ### Step 10 — Push to production (only on user confirmation)
 
-By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the SAME atomic Lua upsert the API route uses — never split-read-modify-write, which races the editor and any other skill invocation.
+By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the same atomic Lua upsert pattern the API route uses (the simplified non-CAS variant — see the Output section) — never split-read-modify-write, which races the editor and any other skill invocation.
 
 Keep `mcp__upstash__redis_database_run_redis_commands` out of repo-shared auto-allow lists. The MCP approval prompt is the production write guard for this path.
 
@@ -575,7 +575,7 @@ const partial = {
 };
 ```
 
-**Write it via Lua EVAL** (atomic — same script as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`):
+**Write it via Lua EVAL** (atomic — the same upsert pattern as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`, minus the optimistic-concurrency `expectedVersion` check; this skill always wins and returns the bare encoded payload):
 
 ```js
 const UPSERT_SCRIPT = `

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -285,9 +285,11 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  # CDP operation HISTORY (open/adjust/close/liquidation), not just currently-owned troves — a target that
-  # opened then closed/was-liquidated owns no Trove now but is all over TroveOperationEvent.
-  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+  # CDP operation HISTORY (open/adjust/close), not just currently-owned troves — a target that opened then
+  # closed owns no Trove now but is all over TroveOperationEvent. NOTE: the indexer records LIQUIDATE in a
+  # separate LiquidationEvent (keyed by trove/instance, not owner address), so liquidations are NOT in this
+  # entity — check LiquidationEvent by troveId if the target's trove may have been liquidated.
+  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, order_by: [{ timestamp: desc }, { id: desc }], limit: 1000) {
     id
     troveId
     operation
@@ -298,6 +300,13 @@ Run a small battery keyed on the target address (all fields verified against `in
 {
   LiquidityPosition(where: { address: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     poolId
+  }
+}
+{
+  # sUSDS yield ledger (Ethereum-only in this indexer) — keyed by `wallet`. Mirrors the coverage probe so
+  # an Ethereum target's position is actually queried, not just probed.
+  SusdsPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+    id
   }
 }
 {

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -66,7 +66,16 @@ mkdir -p .investigations
 **Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
 
 ```bash
-RPC=https://forno.celo.org
+# RPC MUST match $CHAIN — every cast call below (head block, storage reads, codehash,
+# sanctions oracle) executes against whatever this points at. Default Celo; override per
+# the target chain (Monad/Polygon/Ethereum full-node RPC) so a non-Celo investigation
+# isn't silently scoped to Celo. See the chain doctrine.
+case "$CHAIN" in
+  celo)    RPC=https://forno.celo.org ;;
+  monad)   RPC=https://rpc.monad.xyz ;;          # or the current Monad mainnet full node
+  polygon) RPC=https://polygon-rpc.com ;;
+  *)       RPC=<full-node RPC for $CHAIN> ;;
+esac
 HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
 cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
@@ -161,11 +170,15 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
 
+**Scope every query to the target chain.** Add `chainId: { _eq: <CHAIN_ID> }` to the `where` of each entity that carries it (every swap/rollup/rebalance/LP entity below does; `BridgeTransfer` does not). Without it, a multi-chain address silently merges its Celo and Monad footprints and misreports volume/activity. Drop the filter only when you deliberately want the all-chain Mento footprint.
+
+**Pick the filter field for the target type.** `caller` is `tx.from` — correct for an **EOA target**. For a **contract target** (router / aggregator / rebalancer / the bot contract itself), `tx.from` is the _operator EOA_, not the contract, so a `caller`-only filter returns a false-EMPTY even though the contract is all over the data. Filter on `sender` / `txTo` / `recipient` / `brokerCaller` instead, or `_in` across roles when the address could appear as either. The examples below show `caller`; swap the field to match the target.
+
 ```graphql
 # Lifetime rollups (fast path — swap volume, cadence, routers, protocol-actor flag)
 {
   TraderDailySnapshot(
-    where: { trader: { _eq: "0xtarget" } }
+    where: { trader: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
     order_by: { timestamp: desc }
     limit: 1000
   ) {
@@ -181,7 +194,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 }
 {
   BrokerTraderDailySnapshot(
-    where: { caller: { _eq: "0xtarget" } }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
     order_by: { timestamp: desc }
     limit: 1000
   ) {
@@ -196,8 +209,8 @@ Run a small battery keyed on the target address (all fields verified against `in
 # Raw per-swap detail (v3 pools + v2 broker)
 {
   SwapEvent(
-    where: { caller: { _eq: "0xtarget" } }
-    order_by: { blockTimestamp: desc }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
+    order_by: [{ blockTimestamp: desc }, { id: desc }] # id tiebreaker → deterministic offset pagination
     limit: 1000
   ) {
     txHash
@@ -217,8 +230,8 @@ Run a small battery keyed on the target address (all fields verified against `in
 }
 {
   BrokerSwapEvent(
-    where: { caller: { _eq: "0xtarget" }, routedViaV3Router: { _eq: false } }
-    order_by: { blockTimestamp: desc }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> }, routedViaV3Router: { _eq: false } }
+    order_by: [{ blockTimestamp: desc }, { id: desc }] # id tiebreaker → deterministic offset pagination
     limit: 1000
   ) {
     txHash
@@ -238,7 +251,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 
 # Role-specific: MEV keeper? CDP actor? LP? mint/burn? bridger?
 {
-  RebalanceEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+  RebalanceEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, order_by: [{ blockTimestamp: desc }, { id: desc }], limit: 1000) {
     txHash
     poolId
     sender
@@ -290,7 +303,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 
 Hard constraints (from `docs/pr-checklists/swr-polling-hasura.md`):
 
-- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**.
+- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**. When paging, `order_by` must end in a unique tiebreaker (`{ id: desc }`) — ordering by `blockTimestamp`/`timestamp` alone is non-deterministic when rows share a block, so plain offset pagination would skip and duplicate rows.
 - `volumeUsdWei` is 0 when neither leg is USD-pegged (non-stable FX pairs) — don't read that as "no volume".
 - `BrokerSwapEvent` with `routedViaV3Router:true` are v3 siblings already counted in `SwapEvent` — filter them out (`_eq:false`) to avoid double-counting.
 - `RebalanceEvent.notionalUsd`/`rewardUsd` use an empty-string sentinel when pre-reserve RPC failed — handle "" distinctly from "0".
@@ -352,7 +365,7 @@ FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY
 
 ```bash
 # (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
-CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   # runtime codehash
+CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash ($RPC from Step 1, scoped to $CHAIN)
 # Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
 ```
 
@@ -368,7 +381,7 @@ CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   #
 **For a contract target** — read public storage directly. Most arb / MEV contracts leave trivial getters in (router addresses, allowlists, fee tiers, hardcoded principals). Use the chain's full-node RPC (NOT HyperRPC — `eth_call` requires a full node):
 
 ```bash
-RPC=https://forno.celo.org   # or whatever full-node RPC for the target chain
+# Reuse $RPC from Step 1 (already scoped to $CHAIN — full node, NOT HyperRPC, since eth_call needs one).
 cast call $ADDR "router()(address)" --rpc-url $RPC
 cast call $ADDR "routerSushi()(address)" --rpc-url $RPC
 cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
@@ -399,8 +412,9 @@ Before concluding "no interesting getters", do three things:
 -- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
 SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
--- NONCE/ORIGIN: min_nonce=0 & max==count → Celo-native key. max_nonce >> count → key reused on OTHER chains
--- (its first Celo tx is NOT its birth — pivot to Arkham/Sim on those chains; this is the cross-chain identity lever).
+-- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
+--   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
+--   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
 SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
@@ -525,7 +539,7 @@ Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 
 End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
 
 ```
-_Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
 ```
 
 ### Step 10 — Push to production (only on user confirmation)
@@ -592,12 +606,22 @@ end
 
 payload.createdAt = (prior and prior.createdAt) or now
 payload.updatedAt = now
--- Coerce non-numeric prior versions to 0 before incrementing.
--- cjson.decode maps JSON null to cjson.null (truthy in Lua), so a
--- stored {"version": null} from a legacy/partial record would
--- propagate cjson.null into the arithmetic and crash the EVAL.
-local priorVersion = prior and prior.version
-if type(priorVersion) ~= 'number' then priorVersion = 0 end
+-- Mirror upsertReport()'s read-side version normalization. A true first write
+-- (no prior record) is version 1. cjson.decode maps JSON null to cjson.null
+-- (truthy in Lua), so a legacy/partial {"version": null} must be normalized,
+-- not propagated into arithmetic (which would crash the EVAL). Such records
+-- read as version 1 in JS, so normalize missing/invalid/<=0 to 1 here too —
+-- coercing to 0 would write version 1 over an existing record and regress the
+-- version the editor's optimistic-concurrency (CAS) path expects.
+local priorVersion = 0
+if prior then
+  priorVersion = prior.version
+  if type(priorVersion) ~= 'number' or priorVersion <= 0 then
+    priorVersion = 1
+  else
+    priorVersion = math.floor(priorVersion)
+  end
+end
 payload.version = priorVersion + 1
 
 local encoded = cjson.encode(payload)
@@ -625,7 +649,7 @@ The script returns the persisted record (already JSON-encoded). It handles every
 
 - `createdAt` preserved when updating; stamped fresh on first write
 - `updatedAt` always = now
-- `version` = `(prior.version or 0) + 1` — works even when the prior record is a legacy/partial entry without a numeric `version` field (Lua coerces `nil` → `0`, so first write is `1`, never `NaN`)
+- `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
 - Atomic against concurrent writers — the editor route + this skill + any future caller can interleave without losing updates
 
 **Verify:**

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -288,7 +288,9 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+  # Filter on caller (signer) OR counterparty (mint recipient / burn holder) — the target may be the
+  # recipient/holder rather than the tx signer, which a caller-only filter would miss.
+  StableSupplyChangeEvent(where: { _and: [{ _or: [{ caller: { _eq: "0xtarget" } }, { counterparty: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }, limit: 1000) {
     txHash
     kind
     amount
@@ -368,7 +370,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
    - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
 5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
-6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record (coinType `0`), which many owners set regardless of chain. Mostly negatives for bot EOAs; one hit is gold.
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record — viem's `getEnsName` defaults to the **Ethereum coinType `60`** (`evmChainIdToCoinType` → `60` for mainnet), which many owners set regardless of chain; call it once with the default and once with the chain-specific coinType above. Mostly negatives for bot EOAs; one hit is gold.
 
 For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
 
@@ -423,17 +425,17 @@ Before concluding "no interesting getters", do three things:
    # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). For impl/admin/EIP-1822, non-zero → last 20
    # bytes IS the address to analyse. The BEACON slot is different: its last 20 bytes are the BEACON
    # contract, not the impl — call beacon.implementation() and analyse THAT (see below).
-   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
-   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
-   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
-   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --block $HEAD_BLOCK --rpc-url $RPC  # impl
+   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --block $HEAD_BLOCK --rpc-url $RPC  # admin
+   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --block $HEAD_BLOCK --rpc-url $RPC  # beacon
+   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --block $HEAD_BLOCK --rpc-url $RPC  # EIP-1822
    # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
    BEACON=0x…   # last 20 bytes of the beacon slot value above
    cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
-3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
+3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a provider on `$RPC` — the target chain's, not forno, or it reads bytecode/proxy slots on the wrong chain — and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
 
 **For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
 
@@ -533,14 +535,15 @@ case "$CHAIN" in
   *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
 [ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
-# MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
-# unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'
+curl -s "https://api.dexscreener.com/token-pairs/v1/<ds-slug>/{tokenAddr}"         # chain-scoped: pairs for this token on $CHAIN only
+# <ds-slug> = DexScreener chain slug for $CHAIN (celo / ethereum / polygon / base / …). The chain-scoped
+# token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the token's pairs on ALL
+# chains and risked naming a different chain's venue/TVL for an unrelated same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `$DUNE_NS.dex.trades` (the target chain's table — `celo.dex.trades` / `monad.dex.trades` / …; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 
 ### Step 7 — Coverage and dead ends
 
@@ -722,7 +725,7 @@ The address-book index endpoint reads from the same hash on every request, so th
 Replace the old binary "skip if weak" with a per-claim grade on **load-bearing attribution claims only** (Cast of characters rows, fleet links, Bottom line) — not every sentence. This lets the report keep a useful "likely but unproven" lead instead of discarding it, as long as it's labelled honestly:
 
 - **CONFIRMED** — a deterministic on-chain fact (creation-tx `from`, a storage read, a codehash match, a decoded selector) or external ground truth (an ENS reverse record). No hedging words.
-- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
+- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + approval-graph).
 - **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
 
 Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A claim that can't reach POSSIBLE doesn't belong in the report at all.

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -71,7 +71,7 @@ case "$CHAIN" in
   monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
   polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
   ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
-  *)        CHAIN_ID=<id>;  RPC=<full-node RPC for $CHAIN>; DUNE_NS=<chain> ;;
+  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS." >&2; exit 1 ;;
 esac
 ```
 
@@ -166,8 +166,12 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
 # Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
 # deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
+# Scope the probe to the TARGET chain. A generic SwapEvent(limit:1) passes on Celo data even when the
+# target chain is missing/unsynced — which would later make an empty battery look EMPTY (covered, found
+# nothing) when it's really NOT-COVERED (chain absent). If this returns 0 rows, mark the indexer
+# NOT-COVERED for $CHAIN, not EMPTY.
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}}, limit:1){ id } }\"}" | jq .
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -291,9 +295,14 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
+  # BridgeTransfer carries sourceChainId/destChainId (not chainId). Scope to the target chain via either
+  # endpoint AND keep the sender/recipient role predicate; drop the chain clause only for the all-chain view.
   BridgeTransfer(
     where: {
-      _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }]
+      _and: [
+        { _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }] }
+        { _or: [{ sourceChainId: { _eq: <CHAIN_ID> } }, { destChainId: { _eq: <CHAIN_ID> } }] }
+      ]
     }
     limit: 1000
   ) {
@@ -324,7 +333,7 @@ A non-empty result here, scoped to the actual target chain, is far stronger than
 
 Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
-1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure.
+1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure. **For a CONTRACT target, don't trust an Arkham hit on the target address**: the same 20-byte address on Ethereum/L2 is usually an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically). For contracts, derive the deployer/operator EOA first (step 5) and run the cross-chain identity leg on THAT — only treat a same-address cross-chain hit as the target if bytecode/CREATE2 evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -334,12 +343,14 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    ```sql
    SELECT block_time, "from", value, hash
    FROM <chain>.transactions
-   WHERE "to" = LOWER('<addr>')
+   WHERE "to" = LOWER('<addr>') AND value > 0   -- value>0 skips zero-value relayer/user calls that aren't funding
    ORDER BY block_time ASC
    LIMIT 5;
    ```
 
-   That funder is usually the operator EOA.
+   That funder is usually the operator EOA. **If funding arrived as an ERC20** (e.g. a stablecoin), this
+   native-`value` query misses it — run the same oldest-first scan over token transfers (the chain's
+   ERC20 `Transfer` logs in Dune, or Sim token transfers) before concluding who the funder is.
 
 3. Run `address_enriched/all` on the operator EOA **across all chains** — this is the cross-chain identity leg, where personas (ENS / OpenSea / prior bots / CEX deposits) surface. The same key is usually active on Ethereum/L2s even when the target contract is Celo-native; that footprint is often the whole attribution.
 4. Trace one more hop back: who funded the operator? **Mento's own bridge is Wormhole NTT**, not the generic Ethereum bridges:
@@ -386,10 +397,11 @@ CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash 
 
 ```bash
 # Reuse $RPC from Step 1 (already scoped to $CHAIN — full node, NOT HyperRPC, since eth_call needs one).
-cast call $ADDR "router()(address)" --rpc-url $RPC
-cast call $ADDR "routerSushi()(address)" --rpc-url $RPC
-cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
-# … etc, try every name a typical arb contract uses
+cast call $ADDR "router()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+cast call $ADDR "routerSushi()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+cast call $ADDR "lastAddress()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+# … etc, try every name a typical arb contract uses. Pin --block $HEAD_BLOCK (from Step 1) so these
+# reads stay reproducible and match the provenance footer — without it you capture current state.
 ```
 
 If the contract is verified (sourcify or Celoscan): pull source, name the patterns. If unverified: look at the top selectors by frequency on Celoscan / explorer; OpenChain-decode any matching ones (`https://openchain.xyz/signatures?function=0x…`).
@@ -440,7 +452,7 @@ Pick a representative tx — preferably a recent successful one with the typical
 case "$CHAIN" in
   celo)    BS=https://celo.blockscout.com/api/v2 ;;
   polygon) BS=https://polygon.blockscout.com/api/v2 ;;
-  *)       BS=<target chain's Blockscout v2 base, or use the RPC-native fallback> ;;
+  *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
 curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
 curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
@@ -469,19 +481,19 @@ Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM`
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `<defillamaChainSlug>:<lowercaseTokenAddress>`. Celo's slug is `celo`; common others: `ethereum`, `base`, `arbitrum`, `optimism`, `polygon`. Native CELO uses its ERC20 wrapper `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `DL_NS` is the DefiLlama slug for `$CHAIN` — set it alongside the other chain knobs (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`, base→`base`, arbitrum→`arbitrum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
 ```bash
 TS=1742000000   # block timestamp, unix seconds
-curl -s "https://coins.llama.fi/prices/historical/$TS/celo:<tokenLower>" | jq '.coins'
+curl -s "https://coins.llama.fi/prices/historical/$TS/$DL_NS:<tokenLower>" | jq '.coins'
 # -> { "celo:0x…": { "decimals": 18, "symbol": "…", "price": 0.0629, "confidence": 0.99, "timestamp": … } }
 ```
 
-USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/celo:0xAAA,celo:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
+USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/$DL_NS:0xAAA,$DL_NS:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
 
-**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/celo:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
 
 Caveats — surface them in the report when they bite:
 
@@ -501,10 +513,12 @@ case "$CHAIN" in
   celo)     GT_NS=celo ;;
   polygon)  GT_NS=polygon_pos ;;
   ethereum) GT_NS=eth ;;
-  *)        GT_NS=<GeckoTerminal slug for $CHAIN, or skip if unlisted> ;;
+  *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
 curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
+# MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
+# unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
@@ -531,8 +545,12 @@ The distinction between `EMPTY` (source covers this chain, found nothing) and `N
 A forensic product should screen every target. Primary, zero new dependency — the Chainalysis OFAC oracle is live on Celo and reuses the `cast`/forno tooling already in Steps 3/4:
 
 ```bash
-# Run on the target AND each Step-2 funder/counterparty.
-cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+# The Chainalysis oracle lives at this address on Celo (and several other EVM chains) but is NOT
+# guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
+# chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
+if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+fi
 ```
 
 Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
@@ -668,7 +686,7 @@ The script returns the persisted record (already JSON-encoded). It handles every
 - `createdAt` preserved when updating; stamped fresh on first write
 - `updatedAt` always = now
 - `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
-- Atomic against concurrent writers — the editor route + this skill + any future caller can interleave without losing updates
+- Atomic per write and version stays monotonic — **but it is last-writer-wins on the body** (this variant has no `expectedVersion` precondition), so an editor save made between this skill's Step-1 read and the EVAL is silently overwritten. The editor's own CAS path will reject ITS now-stale save, but this skill never loses the race. If a hand-edited report might be in flight, re-read immediately before upload, or upload via the editor route instead.
 
 **Verify:**
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -65,11 +65,12 @@ mkdir -p .investigations
 # a non-Celo investigation must not silently read Celo data. Thread these everywhere:
 #   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
 #   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
-#   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+#   DUNE_NS  → value to hand-substitute for the `<chain>.` table prefix in the DuneSQL examples
+#              (the dune CLI doesn't shell-interpolate inside a SQL string, so swap it in manually)
 #   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
   celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node; DefiLlama may not cover monad yet (Step 5.5 caveat)
+  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;    DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node (repo-canonical rpc2.monad.xyz); DefiLlama may not cover monad yet (Step 5.5 caveat)
   polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
   ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
   *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
@@ -336,7 +337,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
 
 1. Branch on target type before any cross-chain enrichment:
    - **EOA target** → run `address_enriched/all` on it. Zero hits for a Celo-native EOA is a signal, not a failure.
-   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (step 5), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
+   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (item 5 below), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -383,7 +384,7 @@ FROM <chain>.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER
 
 ```bash
 # (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
-CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash ($RPC from Step 1, scoped to $CHAIN)
+CODE=$(cast code "$ADDR" --rpc-url "$RPC"); cast keccak "$CODE"   # runtime codehash ($ADDR/$RPC from Step 1, scoped to $CHAIN)
 # Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
 ```
 
@@ -442,7 +443,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service for Celo: `https://api.safe.global/tx-service/celo/` (keyless reads). This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -554,7 +555,8 @@ A forensic product should screen every target. Primary, zero new dependency — 
 # guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
 # chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
 if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
-  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --rpc-url "$RPC"
+  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --rpc-url "$RPC"; done
 fi
 ```
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -5,7 +5,7 @@ title: Forensic Report Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-06-15
 ---
 
 # Forensic Report
@@ -22,7 +22,21 @@ If the answer fits in `notes` (≤500 chars, single fact like "Binance hot 14"),
 
 - **address** (required): `0x…` (40 hex chars). Skill normalises to lowercase.
 - **context** (optional, one line): why you started looking — "showed up in the breaker-trip post-mortem", "biggest counterparty on the Mento broker last month", etc. Used in the TL;DR.
-- **chain hint** (optional): default Celo since that's where Mento lives. Used for the storage probe + tx-anatomy section.
+- **chain hint** (optional): default Celo since that's where Mento lives. Used for the storage probe + tx-anatomy section. See the chain doctrine below — the _target_ chain is one thing, the operator's _cross-chain footprint_ is another.
+
+## Chains & cross-chain doctrine
+
+Two facts shape every tool choice in this skill:
+
+1. **Mento is multi-chain and growing.** Celo (`42220`) is primary and where most targets live. **Monad (`143`) is live** (secondary). **Polygon and Ethereum are on the roadmap.** Never hardcode `42220`; thread the target chain id through every chain-scoped call.
+2. **One key, many chains.** If someone controls a private key on Celo, the same EOA almost always has a history on other EVM chains (Ethereum, Base, Arbitrum, …). That cross-chain footprint is usually where the _identity_ lives — ENS, OpenSea, CEX deposits, prior bots — because the richest attribution tools (Arkham, Nansen, EigenPhi, MetaSleuth) index Ethereum/L2s but **not** Celo.
+
+So split the work into two legs and pick tools per leg:
+
+- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal, `cast` vs forno). These are the only ones that actually see the target chain.
+- **Cross-chain identity leg** (who is _behind_ the address): pivot the operator EOA onto the chains the heavyweight attributors cover and let them work there.
+
+**Corollary — never drop a source just because it lacks Celo.** A Celo-blind tool (Nansen, EigenPhi, GoPlus, Across, …) is still the right tool for the identity leg, for Monad, and for Polygon/Ethereum once we deploy there. The **Tooling matrix** near the end of this file records what each source covers and which leg it serves — consult it instead of assuming "no Celo = useless".
 
 ## Output
 
@@ -33,7 +47,7 @@ Two artefacts:
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same eight named H2 sections in the same order (TL;DR, Cast of characters, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Arkham coverage, Bottom line), same code-fenced storage / tx blocks, same "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder.
+The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
 
 ## Procedure (how to fill the template)
 
@@ -44,9 +58,21 @@ Run these in order. Each step maps onto a section of the template — fill that 
 ```bash
 ADDR=$(echo "0x…" | tr 'A-Z' 'a-z')   # always lowercase the storage key
 CHAIN=celo                            # default; override if user said otherwise
+CHAIN_ID=42220                        # Celo. Monad=143, Polygon=137, Ethereum=1. Thread this everywhere.
 DATE=$(date -u +%F)
 mkdir -p .investigations
 ```
+
+**Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
+
+```bash
+RPC=https://forno.celo.org
+HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
+cast --version                                   # tool version, for the footer
+# Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
+```
+
+For the attribution-anchoring storage reads in Step 3, pin them with `cast call <addr> <sig> --block $HEAD_BLOCK --rpc-url $RPC` so a future reader gets the same bytes.
 
 Check whether a report already exists (we may be UPDATING, not creating):
 
@@ -114,9 +140,172 @@ mcp__upstash__redis_database_run_redis_commands({
 
 Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
-### Step 2 — Cast of characters (Arkham + funder graph)
+**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address.
 
-Use the `arkham` skill (project-scoped). If Step 1.5 returned cache hits, use that data directly — skip the live `address_enriched/all` call for those addresses. Arkham doesn't cover Celo or Monad, so the play is:
+**Don't treat the payloads as opaque blobs** — the typed accessors in `ui-dashboard/src/lib/` give exact field paths:
+
+- `intel_deep` (`intel-deep.ts`): `enriched[chain].arkhamEntity.id` is the **entity slug** — the join key into `intel_entities` / `intel_entity_cps` (those hashes are slug-keyed, not address-keyed). `candidate.sources` tells you _why_ it was cached (`cluster-…-caller` / `top-trader` / `top-bridger` / `tier1-attested`) — a free prior classification. `counterparties[chain]` has the top USD counterparties per chain.
+- Use `intel-legacy-fallback.ts` `hgetWithLegacy` semantics — older entries may sit under `arkham_*` legacy keys.
+
+### Step 1.6 — Mento indexer fingerprint (our own Celo/Monad-native source)
+
+**This is the primary on-chain-behaviour source for the target chain** — and it's the one the skill historically ignored. The repo runs its own Envio HyperIndex indexer of Mento protocol events with a **public, unauthenticated** Hasura GraphQL endpoint covering Celo (`42220`) and Monad (`143`). Because Arkham/Nansen are blind on both chains, this is where "what did this address do with Mento" actually gets answered. Query it _before_ the funder graph so you walk into Step 2 already knowing the target's Mento footprint.
+
+```bash
+HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
+# Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
+# deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
+curl -s "$HASURA" -H 'content-type: application/json' \
+  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+```
+
+Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
+
+```graphql
+# Lifetime rollups (fast path — swap volume, cadence, routers, protocol-actor flag)
+{
+  TraderDailySnapshot(
+    where: { trader: { _eq: "0xtarget" } }
+    order_by: { timestamp: desc }
+    limit: 1000
+  ) {
+    chainId
+    timestamp
+    swapCount
+    uniquePools
+    volumeUsdWei
+    feesPaidUsdWei
+    aggregatorKeys
+    isProtocolActor
+  }
+}
+{
+  BrokerTraderDailySnapshot(
+    where: { caller: { _eq: "0xtarget" } }
+    order_by: { timestamp: desc }
+    limit: 1000
+  ) {
+    chainId
+    timestamp
+    swapCount
+    volumeUsdWei
+    aggregatorKeys
+    isProtocolActor
+  }
+} # v2 path, Celo only
+# Raw per-swap detail (v3 pools + v2 broker)
+{
+  SwapEvent(
+    where: { caller: { _eq: "0xtarget" } }
+    order_by: { blockTimestamp: desc }
+    limit: 1000
+  ) {
+    txHash
+    blockTimestamp
+    chainId
+    poolId
+    caller
+    sender
+    recipient
+    txTo
+    amount0In
+    amount1In
+    amount0Out
+    amount1Out
+    volumeUsdWei
+  }
+}
+{
+  BrokerSwapEvent(
+    where: { caller: { _eq: "0xtarget" }, routedViaV3Router: { _eq: false } }
+    order_by: { blockTimestamp: desc }
+    limit: 1000
+  ) {
+    txHash
+    blockTimestamp
+    chainId
+    caller
+    brokerCaller
+    txTo
+    tokenIn
+    tokenOut
+    amountIn
+    amountOut
+    volumeUsdWei
+    exchangeId
+  }
+}
+
+# Role-specific: MEV keeper? CDP actor? LP? mint/burn? bridger?
+{
+  RebalanceEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+    txHash
+    poolId
+    sender
+    caller
+    notionalUsd
+    rewardUsd
+    effectivenessRatio
+  }
+}
+{
+  Trove(where: { owner: { _eq: "0xtarget" } }) {
+    id
+    collateral
+    debt
+    status
+  }
+}
+{
+  LiquidityPosition(where: { address: { _eq: "0xtarget" } }) {
+    poolId
+  }
+}
+{
+  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+    txHash
+    kind
+    amount
+  }
+}
+{
+  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
+    id
+  }
+}
+{
+  BridgeTransfer(
+    where: {
+      _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }]
+    }
+    limit: 1000
+  ) {
+    txHash
+    sender
+    recipient
+    amount
+  }
+}
+```
+
+Hard constraints (from `docs/pr-checklists/swr-polling-hasura.md`):
+
+- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**.
+- `volumeUsdWei` is 0 when neither leg is USD-pegged (non-stable FX pairs) — don't read that as "no volume".
+- `BrokerSwapEvent` with `routedViaV3Router:true` are v3 siblings already counted in `SwapEvent` — filter them out (`_eq:false`) to avoid double-counting.
+- `RebalanceEvent.notionalUsd`/`rewardUsd` use an empty-string sentinel when pre-reserve RPC failed — handle "" distinctly from "0".
+
+A non-empty result here, scoped to the actual target chain, is far stronger than anything the Celo-blind attributors can give — and a verified-live **empty** result is a real signal ("never interacted with Mento v2/v3 on Celo or Monad"), not a tooling gap.
+
+### Step 2 — Cast of characters (multi-chain attribution + funder graph)
+
+**Known-infra check first.** Before walking the funder graph or decompiling anything, match the target and its counterparties against the repo's canonical registries so you never mislabel protocol infrastructure as a suspicious actor (prefer on-chain facts over behavioural guesses):
+
+- `indexer-envio/config/aggregators.json` + shared-config `getAggregatorName(chainId, addr)` → instant match to `mento-router-v2` / `squid` / `lifi` / `0x` / `openocean`, **and** to any named MEV fleet cluster already documented there (those carry a pre-written narrative you can reuse verbatim in Steps 3/6/8).
+- shared-config `chainAddressLabels(chainId)` / `tokenSymbol()` (from `@mento-protocol/contracts`) → labels broker / reserve / pools / stables / fee recipients, and gives correct explorer links via `explorerAddressUrl`.
+- `indexer-envio/config/oracle-reporters.json` + `protocolActors.json` → flags Chainlink feeds / reporters / listed rebalancers as infra. If the target is a `Pool.rebalancerAddress`, it's an authorised protocol strategy contract, not an independent bot.
+
+Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
 1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
@@ -135,11 +324,44 @@ Use the `arkham` skill (project-scoped). If Step 1.5 returned cache hits, use th
 
    That funder is usually the operator EOA.
 
-3. Run `address_enriched/all` on the operator EOA across all chains — this is where personas like ENS / opensea / multichain footprint usually surface.
-4. Trace one more hop back: who funded the operator? If it's a bridge (Stargate, LayerZero, Hop, Across), name the bridge in the table.
-5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table.
+3. Run `address_enriched/all` on the operator EOA **across all chains** — this is the cross-chain identity leg, where personas (ENS / OpenSea / prior bots / CEX deposits) surface. The same key is usually active on Ethereum/L2s even when the target contract is Celo-native; that footprint is often the whole attribution.
+4. Trace one more hop back: who funded the operator? **Mento's own bridge is Wormhole NTT**, not the generic Ethereum bridges:
+   - Check the indexer `BridgeTransfer` / `BridgeBridger` from Step 1.6 first.
+   - Confirm/extend via **Wormholescan** (free, no key): `GET https://api.wormholescan.io/api/v1/operations?address=0x…&appId=NATIVE_TOKEN_TRANSFER` — note Wormhole uses its own chain ids (Celo=14, Monad=48), NOT EVM chain ids.
+   - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
+   - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
+5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **correct Celo coinType `0x8000A4EC`** (= `0x80000000 | 42220`; reverse namespace `a4ec.reverse`). Watch out: a common doc example mis-states this — `0x8000A4DC` decodes to chain 42204, the wrong chain. Mostly negatives for bot EOAs; one hit is gold.
 
-For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), and a one-line "what it does" note.
+For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
+
+### Step 2.5 — Operator-fleet clustering (find the OTHER bots)
+
+The skill historically walked exactly one hop to the funder and stopped. The highest-confidence attribution signal is **linkage**: what else did this operator deploy, fund, or run identical bytecode for. All three heuristics run on Dune `celo.*` (the existing `dune` skill — no new credential; identical on `monad.*` for Monad) plus `cast`. Feed the results into the "Related addresses / fleet" table.
+
+```sql
+-- (1) DEPLOYER FAN-OUT: every contract a deployer created.
+--     For CREATE2 the trace "from" is the FACTORY — recurse to the factory's own deployer.
+SELECT address, block_time, length(code) AS code_len, tx_hash
+FROM celo.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
+
+-- (2) COMMON-FUNDER CLUSTERING: every sibling EOA the operator's gas-refill EOA funded.
+SELECT "to" AS funded, count(*) n, min(block_time) first_fund
+FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
+```
+
+```bash
+# (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
+CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   # runtime codehash
+# Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
+```
+
+**Mandatory false-positive gates** — write these into the method, an unverified link is worse than none:
+
+- `value > 0` on funder edges; **never** treat a CEX hot wallet or a public CREATE2 factory as a "funder" — they fan out to thousands and create a garbage super-cluster.
+- EIP-1167 minimal-proxy clones share a codehash that differs only by the embedded impl address — cluster on the **impl**, not the clone shell.
+- Require a **second independent signal** (codehash + funder, or + activity-clock from Step 3) before asserting a link. Tag each link with a confidence tier.
+- **Never auto-merge.** Propose links a human ratifies; the report states the evidence, not a verdict.
 
 ### Step 3 — What it does
 
@@ -155,13 +377,57 @@ cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
 
 If the contract is verified (sourcify or Celoscan): pull source, name the patterns. If unverified: look at the top selectors by frequency on Celoscan / explorer; OpenChain-decode any matching ones (`https://openchain.xyz/signatures?function=0x…`).
 
-**For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant.
+Before concluding "no interesting getters", do three things:
+
+1. **Proxy check** (zero new dependency). Read the standard slots — a non-zero value means you've been reading an empty shell and must analyse the _implementation_ instead:
+
+   ```bash
+   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). Non-zero → last 20 bytes = the address to analyse.
+   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
+   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
+   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
+   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   ```
+
+2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify covers Celo, free, no key: `GET https://sourcify.dev/server/v2/contract/42220/{addr}?fields=all` (cross-check Celoscan).
+3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
+
+**For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
+
+```sql
+-- ACTIVITY CLOCK: flat 24h = automated bot; a dead-hours gap = operator's local night.
+-- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
+SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
+
+-- NONCE/ORIGIN: min_nonce=0 & max==count → Celo-native key. max_nonce >> count → key reused on OTHER chains
+-- (its first Celo tx is NOT its birth — pivot to Arkham/Sim on those chains; this is the cross-chain identity lever).
+SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
+
+-- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
+SELECT * FROM celo.logs
+WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925   -- Approval
+  AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
+```
+
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service for Celo: `https://api.safe.global/tx-service/celo/` (keyless reads). This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
-Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the selector via OpenChain.
+Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-Note the revert rate. For arb / MEV: ~30–50% reverts is normal (failed sniping). If it's lower, the bot is well-tuned; higher, it's overshooting.
+**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` both return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree on Celo. The free, no-key Celo Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow:
+
+```bash
+BS=https://celo.blockscout.com/api/v2
+curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
+curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+```
+
+Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (`chain_id: 42220`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector.
+
+> **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
+
+**Revert rate — measure, don't assume.** The old "~30–50% reverts is normal for sniping" is Ethereum-PGA reasoning that does **not** transfer to Celo. Since 2025-03 Celo is an OP-Stack L2 with a single sequencer: no public mempool, no Flashbots/PBS bundle market, ordering is sequencer-internal priority-fee. So the revert mechanism is different (priority-fee "first-spammed-first-served" backrunning, not competitive sandwich PGA wars). Compute the actual revert rate for _this_ target from its tx history and interpret it against that model. Monad's ordering differs again (own consensus / FastLane) — don't copy Celo's framing onto Monad.
 
 ### Step 5 — Capital and scale
 
@@ -173,23 +439,94 @@ dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_da
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
 ```
 
-Sum the USD value, drop scam airdrops (zero-value tokens with names like `CLAIM`, `voucher`). For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM` / `voucher`, use DefiLlama as a deterministic noise filter: a token DefiLlama won't price (no entry in the `current` response) or prices with low `confidence` (< ~0.9) has no real DEX liquidity — treat it as noise. Still list it per the template ("confirmed noise"), but keep only DefiLlama-priced, real-confidence holdings in the headline operating-capital number. See Step 5.5. For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+
+### Step 5.5 — Historical USD valuation (DefiLlama coins API — free, no Pro key)
+
+Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
+
+Key format is `<defillamaChainSlug>:<lowercaseTokenAddress>`. Celo's slug is `celo`; common others: `ethereum`, `base`, `arbitrum`, `optimism`, `polygon`. Native CELO uses its ERC20 wrapper `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+
+**Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
+
+```bash
+TS=1742000000   # block timestamp, unix seconds
+curl -s "https://coins.llama.fi/prices/historical/$TS/celo:<tokenLower>" | jq '.coins'
+# -> { "celo:0x…": { "decimals": 18, "symbol": "…", "price": 0.0629, "confidence": 0.99, "timestamp": … } }
+```
+
+USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/celo:0xAAA,celo:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
+
+**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/celo:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+
+Caveats — surface them in the report when they bite:
+
+- **Newer chains may be absent.** DefiLlama indexes Celo well; Monad and other recent chains may have no coin data. If a key returns nothing, fall back to Sim's spot `value_usd` and say so in the report rather than silently reporting a zero.
+- `coins.llama.fi` is not on the default sandbox network allowlist. It's a read-only public GET — allowlist the host or run the single command unsandboxed.
 
 ### Step 6 — Why \_\_\_, why these venues
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-### Step 7 — Arkham coverage
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
-Be candid about what Arkham did and didn't tell you. If the chain isn't supported, say it. If Arkham returned zero, say it. The "negative result" section is part of the audit trail — future you needs to know which leads were dead ends.
+```bash
+curl -s "https://api.geckoterminal.com/api/v2/networks/celo/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"             # → every pair, dexId, liquidity.usd, volume.h24
+```
+
+(Use `networks/celo/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. For chains other than Celo swap the `networks/<slug>` segment.)
+
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+
+### Step 7 — Coverage and dead ends
+
+Generalise the old "Arkham coverage" candour into a per-source audit trail — a future reader needs to know not just what you found but what you _looked at_ and why a lead was dead. Render it as a table, one row per source attempted, marked `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why:
+
+| Source               | Result      | Note                                                        |
+| -------------------- | ----------- | ----------------------------------------------------------- |
+| Arkham (cache/live)  | NOT-COVERED | Celo not indexed; operator EOA also clean on covered chains |
+| Mento Envio indexer  | HIT         | 4.2k SwapEvents, isProtocolActor=false                      |
+| Sim / Dune           | HIT         | …                                                           |
+| Sourcify / Celoscan  | EMPTY       | unverified — decompiled instead                             |
+| Sanctions (Step 7.5) | EMPTY       | not OFAC-listed on Celo oracle or static list               |
+| …                    | …           | …                                                           |
+
+The distinction between `EMPTY` (source covers this chain, found nothing) and `NOT-COVERED` (source can't see this chain) is the whole point — don't collapse them into "nothing found".
+
+### Step 7.5 — Sanctions & risk screening
+
+A forensic product should screen every target. Primary, zero new dependency — the Chainalysis OFAC oracle is live on Celo and reuses the `cast`/forno tooling already in Steps 3/4:
+
+```bash
+# Run on the target AND each Step-2 funder/counterparty.
+cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+```
+
+Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
 
 ### Step 8 — Bottom line
 
 Five bullets, one sentence each: Who / What / Where / How much / Goal. This is the section a Slack reader will copy-paste, so it has to stand alone without the rest of the report.
 
+### Step 8.5 — Adversarial verification gate (before save/upload)
+
+Invert your own confirmation bias right where this skill's own docs flag the most common error. Lightweight but mandatory — leave a one-line trace in the report ("Top alternative considered: …, rejected because …"):
+
+- **State the top alternative hypothesis** and hunt disconfirming evidence (arb bot vs MM rebalancer vs exchange sweep vs protocol keeper). Does your evidence _entail_ the headline, or merely fail to contradict it?
+- **Re-confirm the original funder** is genuinely the oldest inbound (Sim returns newest-first — the classic mis-attribution), and that `--chain-ids` was scoped to the target chain on every funder query.
+- **Re-confirm each fleet link** in Step 2.5 has its required second signal.
+- Downgrade any claim that can't survive this to a lower confidence tier, or cut it.
+
 ### Step 9 — Save the draft
 
 Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 3 words of the H1 display name, lowercased, kebab-cased. Example: H1 `Arbitrage Executor (idontloseiwin.eth)` → slug `arbitrage-executor`.
+
+End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
+
+```
+_Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+```
 
 ### Step 10 — Push to production (only on user confirmation)
 
@@ -302,6 +639,16 @@ mcp__upstash__redis_database_run_redis_commands({
 
 The address-book index endpoint reads from the same hash on every request, so the 📄 indicator + the report editor will pick up the new content on the next page load — no SWR mutate hook needed from this side.
 
+## Confidence tiers
+
+Replace the old binary "skip if weak" with a per-claim grade on **load-bearing attribution claims only** (Cast of characters rows, fleet links, Bottom line) — not every sentence. This lets the report keep a useful "likely but unproven" lead instead of discarding it, as long as it's labelled honestly:
+
+- **CONFIRMED** — a deterministic on-chain fact (creation-tx `from`, a storage read, a codehash match, a decoded selector) or external ground truth (an ENS reverse record). No hedging words.
+- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
+- **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
+
+Tag inline, e.g. `Operator EOA `0x…` **[PROBABLE: codehash + funder]**`. A claim that can't reach POSSIBLE doesn't belong in the report at all.
+
 ## Schema invariants (mirror these — the API enforces the same rules)
 
 - `body`: required, non-empty, ≤ 50,000 characters (50KB)
@@ -310,6 +657,57 @@ The address-book index endpoint reads from the same hash on every request, so th
 - `version`: starts at 1, increments on each write; preserve `createdAt` from the prior write if updating
 
 These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/address-reports-shared.ts`. If those constants change, mirror the changes here — the skill must not write a payload the API would reject on a manual edit.
+
+## Tooling matrix (by chain + leg)
+
+Pick the tool that covers the chain you're on and the leg you're working. **A blank in the Celo column does not mean "useless"** — it means use that source on the cross-chain identity leg (operator EOA on Ethereum/L2s), on Monad, or on Polygon/Ethereum once Mento deploys there. Coverage notes below were web-verified 2026-06-15; re-check before relying on a negative.
+
+**On-chain behaviour leg — Celo/Monad-native (free, the workhorses):**
+
+| Source                       | Celo              | Monad | Access            | Answers                                                     |
+| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)        |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
+| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
+| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                   |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
+
+**Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
+
+| Source              | Celo | Where it works        | Access                     | Use                                               |
+| ------------------- | ---- | --------------------- | -------------------------- | ------------------------------------------------- |
+| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live (key expired) | entity/persona of operator EOA                    |
+| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)             | labels/Smart-Money on the identity leg + Monad    |
+| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                  | MEV classification of operator's ETH strategy     |
+| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)             | labels incl. Celo — only if free paths fall short |
+| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier           | non-Mento DEX history (Envio covers Mento first)  |
+
+**Bridge leg:**
+
+| Source            | Celo | Monad | Access       | Use                                      |
+| ----------------- | ---- | ----- | ------------ | ---------------------------------------- |
+| Mento NTT cfg     | ✅   | ✅    | repo file    | classify NTT infra (`nttAddresses.json`) |
+| Wormholescan      | ✅   | ✅    | free, no key | Mento's own bridge (NTT) by address      |
+| LayerZeroScan     | ✅   | —     | free, no key | LZ/OFT funding paths by address          |
+| Across / deBridge | ❌   | ✅    | free API     | bridge funder on the **Monad** leg only  |
+
+**Risk / sanctions leg:**
+
+| Source             | Celo | Access            | Use                                           |
+| ------------------ | ---- | ----------------- | --------------------------------------------- |
+| Chainalysis oracle | ✅   | free `cast call`  | OFAC screen (per-chain SDN set; Step 7.5)     |
+| TRM screening      | any  | free, keyless     | chain-agnostic sanctions verdict              |
+| OFAC static list   | any  | free GitHub fetch | offline 0x-membership backstop                |
+| GoPlus             | ❌   | free (Monad 143)  | token/address risk on Monad+                  |
+| Scam Sniffer list  | ❌†  | free GitHub fetch | EVM-wide drainer flag (a hit ≠ Celo activity) |
+
+\* MetaSleuth/Tenderly/Phalcon/GoldRush etc. genuinely cover Celo but add a new paid/keyed dependency that overlaps the free workhorses — deferred, revisit per-target only if a free path proves inadequate.
+† Scam Sniffer's data is ~85% Ethereum; a hit is a global drainer flag, not proof of Celo activity. Frame honestly.
 
 ## Reference: production database
 
@@ -344,5 +742,6 @@ Match its tone (specific, evidence-anchored, code-fenced for storage / tx data),
 - **Never write a label or the `labels` hash from this skill.** Labels are a separate concern; the `arkham` skill or the address-book modal handles those.
 - **Never push to prod without explicit user confirmation.** Local draft is the default; upload only on `--upload` or after the user says "ship it" / "upload it" / equivalent.
 - **Mirror the schema invariants.** Don't write a payload the API would reject — that includes the body length cap, title length cap, version monotonicity, and `createdAt` preservation on update.
-- **Cite evidence.** Every claim about an address gets a tx hash, an Arkham response, a Sim balance snapshot, or a storage read backing it. "Probably MEV" is not enough; "selector `0x49aa2402` calls into a contract whose public `routerUniswap()` returns Uniswap V3 SwapRouter02 (factory `0xafe208a3…` matches official UniV3 on Celo)" is.
-- **Skip the report if attribution is weak.** Better to write a label + notes blurb than to ship a forensic report full of "may be" / "appears to be" / "possibly". Reports are durable; uncertainty in them poisons the audit trail.
+- **Cite evidence.** Every claim about an address gets a tx hash, an Arkham response, a Sim balance snapshot, an indexer row, or a storage read backing it. "Probably MEV" is not enough; "selector `0x49aa2402` calls into a contract whose public `routerUniswap()` returns Uniswap V3 SwapRouter02 (factory `0xafe208a3…` matches official UniV3 on Celo)" is.
+- **Grade, don't hedge.** Tag load-bearing attribution claims with a confidence tier (CONFIRMED / PROBABLE / POSSIBLE) instead of weasel words. A claim that can't reach POSSIBLE doesn't ship; if the whole attribution is sub-POSSIBLE, write a label + notes blurb instead of a durable report. Run the Step 8.5 adversarial gate before saving.
+- **Think multi-chain; never disable a source just because it lacks Celo.** The target chain (Celo today; Monad live; Polygon/Ethereum soon) drives the behaviour leg; the operator's cross-chain footprint drives the identity leg. A Celo-blind tool is the right tool for the identity leg / Monad / future chains — consult the Tooling matrix instead of dropping it. Thread the target chain id through every chain-scoped call; never hardcode `42220`.

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -450,7 +450,8 @@ Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*
 Pass the chain hint through to Sim — Mento is on Celo (`42220`) but the skill also runs against Monad (`143`) and any future chain. Hardcoding `--chain-ids 42220` would return empty / unrelated holdings for a Monad principal:
 
 ```bash
-CHAIN_ID=42220   # Celo mainnet. Monad mainnet is 143 (testnet is 10143 — use mainnet for prod investigations). Map other chains by their canonical mainnet chain id.
+# $CHAIN_ID is from Step 1's case switch (Celo 42220 / Monad 143 / …) — do NOT re-hardcode it.
+# Hardcoding 42220 would return empty / unrelated holdings for a Monad (or other-chain) principal.
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data | length'
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
 ```

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -58,25 +58,27 @@ Run these in order. Each step maps onto a section of the template — fill that 
 ```bash
 ADDR=$(echo "0x…" | tr 'A-Z' 'a-z')   # always lowercase the storage key
 CHAIN=celo                            # default; override if user said otherwise
-CHAIN_ID=42220                        # Celo. Monad=143, Polygon=137, Ethereum=1. Thread this everywhere.
 DATE=$(date -u +%F)
 mkdir -p .investigations
+
+# Derive EVERY chain-scoped knob from $CHAIN in ONE place so they never drift apart —
+# a non-Celo investigation must not silently read Celo data. Thread these everywhere:
+#   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
+#   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
+#   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+case "$CHAIN" in
+  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
+  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
+  *)        CHAIN_ID=<id>;  RPC=<full-node RPC for $CHAIN>; DUNE_NS=<chain> ;;
+esac
 ```
 
 **Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
 
 ```bash
-# RPC MUST match $CHAIN — every cast call below (head block, storage reads, codehash,
-# sanctions oracle) executes against whatever this points at. Default Celo; override per
-# the target chain (Monad/Polygon/Ethereum full-node RPC) so a non-Celo investigation
-# isn't silently scoped to Celo. See the chain doctrine.
-case "$CHAIN" in
-  celo)    RPC=https://forno.celo.org ;;
-  monad)   RPC=https://rpc.monad.xyz ;;          # or the current Monad mainnet full node
-  polygon) RPC=https://polygon-rpc.com ;;
-  *)       RPC=<full-node RPC for $CHAIN> ;;
-esac
-HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
+HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # $RPC from Step 1's case switch; the block reads are "as of"
 cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
 ```
@@ -329,7 +331,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
 
    ```sql
    SELECT block_time, "from", value, hash
-   FROM celo.transactions
+   FROM <chain>.transactions
    WHERE "to" = LOWER('<addr>')
    ORDER BY block_time ASC
    LIMIT 5;
@@ -356,11 +358,11 @@ The skill historically walked exactly one hop to the funder and stopped. The hig
 -- (1) DEPLOYER FAN-OUT: every contract a deployer created.
 --     For CREATE2 the trace "from" is the FACTORY — recurse to the factory's own deployer.
 SELECT address, block_time, length(code) AS code_len, tx_hash
-FROM celo.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
+FROM <chain>.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
 
 -- (2) COMMON-FUNDER CLUSTERING: every sibling EOA the operator's gas-refill EOA funded.
 SELECT "to" AS funded, count(*) n, min(block_time) first_fund
-FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
+FROM <chain>.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
 ```
 
 ```bash
@@ -409,16 +411,16 @@ Before concluding "no interesting getters", do three things:
 
 ```sql
 -- ACTIVITY CLOCK: flat 24h = automated bot; a dead-hours gap = operator's local night.
--- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
-SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
+-- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use <chain>.traces).
+SELECT hour(block_time) utc_hour, count(*) FROM <chain>.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
 -- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
 --   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
 --   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
-SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
+SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM <chain>.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
-SELECT * FROM celo.logs
+SELECT * FROM <chain>.logs
 WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925   -- Approval
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -284,7 +284,9 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  BridgeBridger(where: { sender: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+  # BridgeBridger is a cross-chain identity aggregate keyed by sender (sourceChainsUsed is a
+  # JSON array) — it has NO chainId field, so do not add a chainId filter here.
+  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
     id
   }
 }
@@ -493,7 +495,14 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
 ```bash
-GT_NS=celo   # GeckoTerminal network slug for $CHAIN: celo / polygon_pos / eth / … (NOT the chain id; verify at /api/v2/networks)
+# GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
+# Verify/extend against https://api.geckoterminal.com/api/v2/networks (a chain may have no GT coverage).
+case "$CHAIN" in
+  celo)     GT_NS=celo ;;
+  polygon)  GT_NS=polygon_pos ;;
+  ethereum) GT_NS=eth ;;
+  *)        GT_NS=<GeckoTerminal slug for $CHAIN, or skip if unlisted> ;;
+esac
 curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
 curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
 ```

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -442,10 +442,11 @@ Before concluding "no interesting getters", do three things:
 -- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use <chain>.traces).
 SELECT hour(block_time) utc_hour, count(*) FROM <chain>.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
--- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
---   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
---   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
-SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM <chain>.transactions WHERE "from" = <eoa>;
+-- AGE / FIRST-SEEN: first + last activity on THIS chain. NOTE: do NOT infer cross-chain reuse from nonce —
+--   EVM nonces are chain-LOCAL, so a key with Ethereum/Base history still starts at nonce 0 on its first
+--   Celo tx (max_nonce ≈ count-1 given complete data; a gap just means missing/filtered rows, not other-chain
+--   activity). To find the operator's other-chain footprint use the Arkham/Sim identity leg (Step 2), not nonce.
+SELECT min(block_time) AS first_seen, max(block_time) AS last_seen, count(*) AS tx_count FROM <chain>.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
 SELECT * FROM <chain>.logs

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -647,7 +647,7 @@ Replace the old binary "skip if weak" with a per-claim grade on **load-bearing a
 - **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
 - **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
 
-Tag inline, e.g. `Operator EOA `0x…` **[PROBABLE: codehash + funder]**`. A claim that can't reach POSSIBLE doesn't belong in the report at all.
+Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A claim that can't reach POSSIBLE doesn't belong in the report at all.
 
 ## Schema invariants (mirror these — the API enforces the same rules)
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -171,12 +171,14 @@ HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POS
 # (a) Liveness: confirm the endpoint serves at all.
 curl -s "$HASURA" -H 'content-type: application/json' \
   --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
-# (b) Chain coverage: probe several core entity types for $CHAIN_ID — a quiet/new chain may have
-#     bridge/CDP/supply activity but zero swaps, so DON'T equate 0 SwapEvent rows with NOT-COVERED.
+# (b) Chain coverage: probe a SPREAD of activity areas for $CHAIN_ID — swaps, LP, supply, rebalances, and
+#     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
+#     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
-# Mark the indexer NOT-COVERED for $CHAIN only if the FULL Step 1.6 battery (all entity types) is empty
-# AND $CHAIN isn't in the indexer's configured chain list; otherwise an empty result is EMPTY (real signal).
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} }\"}" | jq .
+# Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
+# empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
+# `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -451,7 +453,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` + `'getThreshold()(uint256)'` (use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --rpc-url "$RPC"` (two complete commands; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 

--- a/.agents/skills/forensic-report/template.md
+++ b/.agents/skills/forensic-report/template.md
@@ -6,16 +6,24 @@ One paragraph, plain language. Lead with what they are (`A proprietary multi-DEX
 
 ## Cast of characters
 
-| Role                       | Address     | Notes                                                              |
-| -------------------------- | ----------- | ------------------------------------------------------------------ |
-| **Original identity**      | `0x…`       | Persona / ENS / opensea handle, age, multichain footprint          |
-| **Bridge funder**          | `0x…`       | Stargate / LayerZero / Hop / Across — name the bridge              |
-| **Operator EOA**           | `0x…`       | Deployer of the target contract; age, multichain footprint         |
-| **Hot relayer EOA**        | `0x…`       | Single-purpose caller, age, what selector it hits                  |
-| **Principal/treasury EOA** | `0x…`       | Where the working capital sits                                     |
-| **The target**             | `0xADDRESS` | The investigation target — bytecode size + solc version (if known) |
+| Role                       | Address     | Confidence | Notes                                                              |
+| -------------------------- | ----------- | ---------- | ------------------------------------------------------------------ |
+| **Original identity**      | `0x…`       | PROBABLE   | Persona / ENS / opensea handle, age, multichain footprint          |
+| **Bridge funder**          | `0x…`       | CONFIRMED  | Wormhole NTT (Mento's bridge) / LayerZero / etc. — name it         |
+| **Operator EOA**           | `0x…`       | CONFIRMED  | Deployer of the target contract; age, multichain footprint         |
+| **Hot relayer EOA**        | `0x…`       | CONFIRMED  | Single-purpose caller, age, what selector it hits                  |
+| **Principal/treasury EOA** | `0x…`       | CONFIRMED  | Where the working capital sits                                     |
+| **The target**             | `0xADDRESS` | —          | The investigation target — bytecode size + solc version (if known) |
 
-Roles are descriptive, not fixed. Add or drop rows to match the topology. For an EOA target, "The target" IS the address being investigated; for a contract target add the deployer + relayer + principal rows above. Always include age (days since first activity), multichain footprint, and a one-line "what it does" note for each.
+Roles are descriptive, not fixed. Add or drop rows to match the topology. For an EOA target, "The target" IS the address being investigated; for a contract target add the deployer + relayer + principal rows above. Always include age (days since first activity), multichain footprint, a confidence tier (CONFIRMED / PROBABLE / POSSIBLE — see skill "Confidence tiers"), and a one-line "what it does" note for each.
+
+## Related addresses / fleet
+
+The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5). Each link carries the evidence and a confidence tier — never a bare assertion. Omit this section only if clustering found nothing, and say so in one line rather than dropping the heading.
+
+| Address | Link type                         | Evidence                                            | Confidence |
+| ------- | --------------------------------- | --------------------------------------------------- | ---------- |
+| `0x…`   | same deployer / codehash / funder | e.g. `keccak(runtime)=0x…` matches; funded by `0x…` | PROBABLE   |
 
 ## What it does
 
@@ -58,9 +66,9 @@ Principal wallet `0x…` holdings on chain `<CHAIN_ID>` (the chain you investiga
 - **`<amount>` `<TOKEN>`** (~$`<usd>` notional) — note any token with dual-native semantics (e.g. CELO is both native gas + ERC20)
 - $`<usd>` stablecoin (split by stablecoin if it matters: USDC / USDT / DAI / chain-native cUSD-cEUR-etc.)
 - `<list any meaningful additional holdings>`
-- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is)
+- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is — filter via DefiLlama price-presence / `confidence`, see skill Step 5.5, not by token name)
 
-Estimated **operating capital ≈ $`<usd>`**. Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
+Estimated **operating capital ≈ $`<usd>`** (value time-sensitive flows at block time via DefiLlama historical prices — skill Step 5.5 — not current spot). Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
 
 ## Why \_\_\_, why these venues
 
@@ -72,9 +80,20 @@ One paragraph. Don't just say "arbitrage" — name the structural mispricing for
 
 Connect the behaviour to the on-chain economics — don't just describe, explain.
 
-## Arkham coverage
+## Coverage and dead ends
 
-What did Arkham return / not return? Run `address_enriched/all` for cross-chain. If Arkham has zero data on the target — common when the chain isn't in Arkham's index (e.g. Celo, Monad) — say so explicitly. Then walk the funder graph through chains Arkham DOES cover. Name how attribution was actually arrived at:
+One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why. The `EMPTY` (covers this chain, found nothing) vs `NOT-COVERED` (can't see this chain) distinction is the whole point — don't collapse them.
+
+| Source                | Result      | Note                                                          |
+| --------------------- | ----------- | ------------------------------------------------------------- |
+| Arkham (cache / live) | NOT-COVERED | Celo/Monad not indexed; operator EOA on covered chains: `<…>` |
+| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`                           |
+| Sim / Dune            | HIT         | `<…>`                                                         |
+| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead                               |
+| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list)                   |
+| `<…>`                 | `<…>`       | `<…>`                                                         |
+
+**Top alternative hypothesis considered** (skill Step 8.5): `<e.g. MM rebalancer rather than arb bot>` — rejected because `<disconfirming evidence>`.
 
 > "Arkham has `<some / no>` data on the target across the chains it covers. Attribution came from `<the curated entity / a high-confidence prediction / the funder graph on chains Arkham does index>`: `<the chain on which the surfacing happened>` showed `<persona / entity>` funded `<operator EOA>`, and `<bridge / direct funder>` funded them on `<upstream chain>`."
 
@@ -82,12 +101,14 @@ What did Arkham return / not return? Run `address_enriched/all` for cross-chain.
 
 Five bullets, one sentence each. The LITERAL placeholder text is below — replace every value with what you actually found. Do NOT ship the placeholders. The skill's worked-example section (`SKILL.md` → "Worked example") points at the seed report's real bottom line for tone calibration; this template stays placeholder-only so a fresh investigation that copy-pastes blindly doesn't accidentally persist seed facts about a different address.
 
-- **Who**: `<persona / entity, one sentence — who's behind this address>`
+- **Who**: `<persona / entity, one sentence — who's behind this address>` `[CONFIRMED / PROBABLE / POSSIBLE]`
 - **What**: `<contract type / behavioural class, one sentence — what does it do>`
-- **Where**: `<chain + venues, one sentence — which chain, which contracts/pools/protocols it interacts with>`
+- **Where**: `<chain + venues, one sentence — target chain AND any other EVM chains the operator's key is active on>`
 - **How much**: `<capital + op rate, one sentence — working-capital USD, tx volume, time period>`
 - **Goal**: `<economic objective, one sentence — what's the strategy capturing>`
 
 ---
+
+_Provenance: `<chain>` head block `<N>` (hash `0x…`), RPC `<endpoint>`, cast `<version>`. Sim/DefiLlama queried `<UTC ts>`._
 
 _Investigation date: YYYY-MM-DD._

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -251,7 +251,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 {
   Trove(where: { owner: { _eq: "0xtarget" } }) {
     id
-    collateral
+    coll
     debt
     status
   }
@@ -280,7 +280,7 @@ Run a small battery keyed on the target address (all fields verified against `in
     }
     limit: 1000
   ) {
-    txHash
+    sentTxHash
     sender
     recipient
     amount

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -431,7 +431,7 @@ Before concluding "no interesting getters", do three things:
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --block $HEAD_BLOCK --rpc-url $RPC  # EIP-1822
    # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
    BEACON=0x…   # last 20 bytes of the beacon slot value above
-   cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
+   cast call "$BEACON" "implementation()(address)" --block "$HEAD_BLOCK" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
@@ -456,7 +456,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --rpc-url "$RPC"` (two complete commands; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --block "$HEAD_BLOCK" --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --block "$HEAD_BLOCK" --rpc-url "$RPC"` (two complete commands, block-pinned for reproducibility; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -526,19 +526,20 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
 
 ```bash
-# GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
-# Verify/extend against https://api.geckoterminal.com/api/v2/networks (a chain may have no GT coverage).
+# GeckoTerminal + DexScreener each use their OWN network slugs (NOT chain ids) — select both per $CHAIN
+# in one switch, like $BS in Step 4. Verify against api.geckoterminal.com/api/v2/networks and
+# DexScreener's docs (a chain may be on one but not the other — GeckoTerminal has no Monad, DexScreener does).
 case "$CHAIN" in
-  celo)     GT_NS=celo ;;
-  polygon)  GT_NS=polygon_pos ;;
-  ethereum) GT_NS=eth ;;
-  *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
+  celo)     GT_NS=celo;        DS_NS=celo ;;
+  monad)    GT_NS="";          DS_NS=monad ;;     # GeckoTerminal: no Monad; DexScreener: yes (verify slug)
+  polygon)  GT_NS=polygon_pos; DS_NS=polygon ;;
+  ethereum) GT_NS=eth;         DS_NS=ethereum ;;
+  *)        GT_NS=""; DS_NS=""; echo "No GeckoTerminal/DexScreener slug mapped for $CHAIN — verify their network lists, then set GT_NS/DS_NS or skip." >&2 ;;
 esac
-[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
-curl -s "https://api.dexscreener.com/token-pairs/v1/<ds-slug>/{tokenAddr}"         # chain-scoped: pairs for this token on $CHAIN only
-# <ds-slug> = DexScreener chain slug for $CHAIN (celo / ethereum / polygon / base / …). The chain-scoped
-# token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the token's pairs on ALL
-# chains and risked naming a different chain's venue/TVL for an unrelated same-address token.
+[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug
+[ -n "$DS_NS" ] && curl -s "https://api.dexscreener.com/token-pairs/v1/$DS_NS/{tokenAddr}"           # chain-scoped: pairs for this token on $CHAIN only; skipped when no DS slug
+# The chain-scoped token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the
+# token's pairs on ALL chains and risked naming a different chain's venue/TVL for a same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
@@ -569,8 +570,8 @@ A forensic product should screen every target. Primary, zero new dependency — 
 # guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
 # chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
 if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
-  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --rpc-url "$RPC"
-  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --rpc-url "$RPC"; done
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --block "$HEAD_BLOCK" --rpc-url "$RPC"
+  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --block "$HEAD_BLOCK" --rpc-url "$RPC"; done
 fi
 ```
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -175,7 +175,9 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 #     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
 #     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} }\"}" | jq .
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# (Ethereum is sUSDS-only in this indexer — that's why SusdsPosition is in the probe; without it an
+#  ethereum target would always look NOT-COVERED despite the indexer serving its sUSDS ledger.)
 # Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
 # empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
 # `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
@@ -280,6 +282,17 @@ Run a small battery keyed on the target address (all fields verified against `in
     coll
     debt
     status
+  }
+}
+{
+  # CDP operation HISTORY (open/adjust/close/liquidation), not just currently-owned troves — a target that
+  # opened then closed/was-liquidated owns no Trove now but is all over TroveOperationEvent.
+  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+    id
+    troveId
+    operation
+    collChange
+    debtChange
   }
 }
 {
@@ -544,7 +557,7 @@ esac
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `$DUNE_NS.dex.trades` (the target chain's table — `celo.dex.trades` / `monad.dex.trades` / …; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune's unified `dex.trades` spellbook filtered `WHERE blockchain = '$DUNE_NS'` (it's ONE cross-chain table with a `blockchain` column — there is no per-chain `celo.dex.trades`; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 
 ### Step 7 — Coverage and dead ends
 
@@ -575,7 +588,7 @@ if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deplo
 fi
 ```
 
-Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
+Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against an actual static OFAC list file, e.g. `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses/main/data/sanctioned_addresses_ETH.txt` (one 0x address per line; covers EVM addresses regardless of target chain). For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
 
 ### Step 8 — Bottom line
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -264,7 +264,7 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  Trove(where: { owner: { _eq: "0xtarget" } }) {
+  Trove(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
     coll
     debt
@@ -272,19 +272,19 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  LiquidityPosition(where: { address: { _eq: "0xtarget" } }) {
+  LiquidityPosition(where: { address: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     poolId
   }
 }
 {
-  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
     txHash
     kind
     amount
   }
 }
 {
-  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
+  BridgeBridger(where: { sender: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
   }
 }
@@ -346,7 +346,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
    - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
 5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
-6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **correct Celo coinType `0x8000A4EC`** (= `0x80000000 | 42220`; reverse namespace `a4ec.reverse`). Watch out: a common doc example mis-states this — `0x8000A4DC` decodes to chain 42204, the wrong chain. Mostly negatives for bot EOAs; one hit is gold.
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record (coinType `0`), which many owners set regardless of chain. Mostly negatives for bot EOAs; one hit is gold.
 
 For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
 
@@ -404,7 +404,7 @@ Before concluding "no interesting getters", do three things:
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
    ```
 
-2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify covers Celo, free, no key: `GET https://sourcify.dev/server/v2/contract/42220/{addr}?fields=all` (cross-check Celoscan).
+2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
 3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
 
 **For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
@@ -431,15 +431,20 @@ If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real h
 
 Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` both return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree on Celo. The free, no-key Celo Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow:
+**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` (and most public full nodes) whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree. The free, no-key Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow — point `BS` at the target chain's Blockscout instance:
 
 ```bash
-BS=https://celo.blockscout.com/api/v2
+# Pick the Blockscout v2 base for $CHAIN. Not every chain has one (e.g. Monad — see fallback below).
+case "$CHAIN" in
+  celo)    BS=https://celo.blockscout.com/api/v2 ;;
+  polygon) BS=https://polygon.blockscout.com/api/v2 ;;
+  *)       BS=<target chain's Blockscout v2 base, or use the RPC-native fallback> ;;
+esac
 curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
 curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
 ```
 
-Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (`chain_id: 42220`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector.
+Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
 
 > **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
 
@@ -488,11 +493,12 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
 ```bash
-curl -s "https://api.geckoterminal.com/api/v2/networks/celo/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"             # → every pair, dexId, liquidity.usd, volume.h24
+GT_NS=celo   # GeckoTerminal network slug for $CHAIN: celo / polygon_pos / eth / … (NOT the chain id; verify at /api/v2/networks)
+curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
 ```
 
-(Use `networks/celo/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. For chains other than Celo swap the `networks/<slug>` segment.)
+(Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
 **MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -66,12 +66,13 @@ mkdir -p .investigations
 #   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
 #   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
 #   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+#   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
-  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
-  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
-  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
-  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS." >&2; exit 1 ;;
+  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node; DefiLlama may not cover monad yet (Step 5.5 caveat)
+  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
+  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
 esac
 ```
 
@@ -333,7 +334,9 @@ A non-empty result here, scoped to the actual target chain, is far stronger than
 
 Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
-1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure. **For a CONTRACT target, don't trust an Arkham hit on the target address**: the same 20-byte address on Ethereum/L2 is usually an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically). For contracts, derive the deployer/operator EOA first (step 5) and run the cross-chain identity leg on THAT — only treat a same-address cross-chain hit as the target if bytecode/CREATE2 evidence proves the address is intentionally shared.
+1. Branch on target type before any cross-chain enrichment:
+   - **EOA target** → run `address_enriched/all` on it. Zero hits for a Celo-native EOA is a signal, not a failure.
+   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (step 5), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -454,8 +457,10 @@ case "$CHAIN" in
   polygon) BS=https://polygon.blockscout.com/api/v2 ;;
   *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
-curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
-curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+if [ -n "$BS" ]; then   # skip when no Blockscout for $CHAIN — use the RPC-native fallback below instead
+  curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
+  curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+fi
 ```
 
 Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
@@ -481,7 +486,7 @@ Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM`
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `$DL_NS:<lowercaseTokenAddress>`, where `DL_NS` is the DefiLlama slug for `$CHAIN` — set it alongside the other chain knobs (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`, base→`base`, arbitrum→`arbitrum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` is the DefiLlama slug set by Step 1's case switch (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
@@ -515,7 +520,7 @@ case "$CHAIN" in
   ethereum) GT_NS=eth ;;
   *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
-curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
 curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
 # MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
 # unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -47,7 +47,7 @@ Two artefacts:
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
+The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_, why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
 
 ## Procedure (how to fill the template)
 
@@ -734,7 +734,7 @@ mcp__upstash__redis_database_run_redis_commands({
 });
 ```
 
-Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the eight named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
+Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the nine named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
 
 ## Rules
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -33,7 +33,7 @@ Two facts shape every tool choice in this skill:
 
 So split the work into two legs and pick tools per leg:
 
-- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal, `cast` vs forno). These are the only ones that actually see the target chain.
+- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal (Celo; no Monad) / DexScreener, `cast` vs the chain's RPC). These are the only ones that actually see the target chain.
 - **Cross-chain identity leg** (who is _behind_ the address): pivot the operator EOA onto the chains the heavyweight attributors cover and let them work there.
 
 **Corollary — never drop a source just because it lacks Celo.** A Celo-blind tool (Nansen, EigenPhi, GoPlus, Across, …) is still the right tool for the identity leg, for Monad, and for Polygon/Ethereum once we deploy there. The **Tooling matrix** near the end of this file records what each source covers and which leg it serves — consult it instead of assuming "no Celo = useless".
@@ -85,7 +85,7 @@ cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
 ```
 
-For the attribution-anchoring storage reads in Step 3, pin them with `cast call <addr> <sig> --block $HEAD_BLOCK --rpc-url $RPC` so a future reader gets the same bytes.
+For the attribution-anchoring storage reads in Step 3, pin them with `cast call "$ADDR" "<sig>" --block "$HEAD_BLOCK" --rpc-url "$RPC"` (quote the `<sig>` placeholder so bash doesn't read it as a redirection) so a future reader gets the same bytes.
 
 Check whether a report already exists (we may be UPDATING, not creating):
 
@@ -153,7 +153,7 @@ mcp__upstash__redis_database_run_redis_commands({
 
 Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
-**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address.
+**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address — **but only consume a hit keyed on the target's own address as identity for an EOA target.** For a CONTRACT target, the same 20-byte address on the chains these caches cover is usually an unrelated account, so a target-address cache hit would mis-attribute the report; run the identity leg on the deployer/operator EOA instead (Step 2), unless shared-deployment is proven.
 
 **Don't treat the payloads as opaque blobs** — the typed accessors in `ui-dashboard/src/lib/` give exact field paths:
 
@@ -168,12 +168,15 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
 # Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
 # deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
-# Scope the probe to the TARGET chain. A generic SwapEvent(limit:1) passes on Celo data even when the
-# target chain is missing/unsynced — which would later make an empty battery look EMPTY (covered, found
-# nothing) when it's really NOT-COVERED (chain absent). If this returns 0 rows, mark the indexer
-# NOT-COVERED for $CHAIN, not EMPTY.
+# (a) Liveness: confirm the endpoint serves at all.
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}}, limit:1){ id } }\"}" | jq .
+  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+# (b) Chain coverage: probe several core entity types for $CHAIN_ID — a quiet/new chain may have
+#     bridge/CDP/supply activity but zero swaps, so DON'T equate 0 SwapEvent rows with NOT-COVERED.
+curl -s "$HASURA" -H 'content-type: application/json' \
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# Mark the indexer NOT-COVERED for $CHAIN only if the FULL Step 1.6 battery (all entity types) is empty
+# AND $CHAIN isn't in the indexer's configured chain list; otherwise an empty result is EMPTY (real signal).
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -415,11 +418,16 @@ Before concluding "no interesting getters", do three things:
 1. **Proxy check** (zero new dependency). Read the standard slots — a non-zero value means you've been reading an empty shell and must analyse the _implementation_ instead:
 
    ```bash
-   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). Non-zero → last 20 bytes = the address to analyse.
+   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). For impl/admin/EIP-1822, non-zero → last 20
+   # bytes IS the address to analyse. The BEACON slot is different: its last 20 bytes are the BEACON
+   # contract, not the impl — call beacon.implementation() and analyse THAT (see below).
    cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
    cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
    cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
    cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
+   BEACON=0x…   # last 20 bytes of the beacon slot value above
+   cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
@@ -443,7 +451,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` + `'getThreshold()(uint256)'` (use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -510,7 +518,7 @@ Caveats — surface them in the report when they bite:
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
 
 ```bash
 # GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
@@ -731,18 +739,18 @@ Pick the tool that covers the chain you're on and the leg you're working. **A bl
 
 **On-chain behaviour leg — Celo/Monad-native (free, the workhorses):**
 
-| Source                       | Celo              | Monad | Access            | Answers                                                     |
-| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
-| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
-| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)        |
-| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
-| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
-| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
-| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
-| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                   |
-| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
-| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
-| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
+| Source                       | Celo              | Monad | Access            | Answers                                                                        |
+| ---------------------------- | ----------------- | ----- | ----------------- | ------------------------------------------------------------------------------ |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6)                    |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)                           |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`                     |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                                    |
+| GeckoTerminal                | ✅                | ❌    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6); no Monad — use DexScreener there |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                                           |
+| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                                      |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                                       |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**                          |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                                        |
 
 **Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -43,7 +43,7 @@ So split the work into two legs and pick tools per leg:
 Two artefacts:
 
 1. **Local draft** at `.investigations/<address>-<slug>.md` (slug = first-3 words of derived display name, lowercase, kebab-cased). The `.investigations/` folder is gitignored — never commit drafts.
-2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script — same one `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` runs — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution. Atomicity matters: the editor route uses the same script, and a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
+2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script mirrors the atomic upsert pattern `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` uses — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution — but is a **simplified, non-CAS variant**: the live route additionally takes an `expectedVersion` base-version precondition and returns an `{ok, report}` envelope, whereas this skill does a fire-and-forget always-wins write and returns the bare encoded payload (exact script in the Lua section below). Atomicity still matters: a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
 
 ## Output template
 
@@ -530,7 +530,7 @@ _Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <versi
 
 ### Step 10 — Push to production (only on user confirmation)
 
-By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the SAME atomic Lua upsert the API route uses — never split-read-modify-write, which races the editor and any other skill invocation.
+By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the same atomic Lua upsert pattern the API route uses (the simplified non-CAS variant — see the Output section) — never split-read-modify-write, which races the editor and any other skill invocation.
 
 Keep `mcp__upstash__redis_database_run_redis_commands` out of repo-shared auto-allow lists. The MCP approval prompt is the production write guard for this path.
 
@@ -575,7 +575,7 @@ const partial = {
 };
 ```
 
-**Write it via Lua EVAL** (atomic — same script as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`):
+**Write it via Lua EVAL** (atomic — the same upsert pattern as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`, minus the optimistic-concurrency `expectedVersion` check; this skill always wins and returns the bare encoded payload):
 
 ```js
 const UPSERT_SCRIPT = `

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -285,9 +285,11 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  # CDP operation HISTORY (open/adjust/close/liquidation), not just currently-owned troves — a target that
-  # opened then closed/was-liquidated owns no Trove now but is all over TroveOperationEvent.
-  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+  # CDP operation HISTORY (open/adjust/close), not just currently-owned troves — a target that opened then
+  # closed owns no Trove now but is all over TroveOperationEvent. NOTE: the indexer records LIQUIDATE in a
+  # separate LiquidationEvent (keyed by trove/instance, not owner address), so liquidations are NOT in this
+  # entity — check LiquidationEvent by troveId if the target's trove may have been liquidated.
+  TroveOperationEvent(where: { owner: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, order_by: [{ timestamp: desc }, { id: desc }], limit: 1000) {
     id
     troveId
     operation
@@ -298,6 +300,13 @@ Run a small battery keyed on the target address (all fields verified against `in
 {
   LiquidityPosition(where: { address: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     poolId
+  }
+}
+{
+  # sUSDS yield ledger (Ethereum-only in this indexer) — keyed by `wallet`. Mirrors the coverage probe so
+  # an Ethereum target's position is actually queried, not just probed.
+  SusdsPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+    id
   }
 }
 {

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -66,7 +66,16 @@ mkdir -p .investigations
 **Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
 
 ```bash
-RPC=https://forno.celo.org
+# RPC MUST match $CHAIN — every cast call below (head block, storage reads, codehash,
+# sanctions oracle) executes against whatever this points at. Default Celo; override per
+# the target chain (Monad/Polygon/Ethereum full-node RPC) so a non-Celo investigation
+# isn't silently scoped to Celo. See the chain doctrine.
+case "$CHAIN" in
+  celo)    RPC=https://forno.celo.org ;;
+  monad)   RPC=https://rpc.monad.xyz ;;          # or the current Monad mainnet full node
+  polygon) RPC=https://polygon-rpc.com ;;
+  *)       RPC=<full-node RPC for $CHAIN> ;;
+esac
 HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
 cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
@@ -161,11 +170,15 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
 
+**Scope every query to the target chain.** Add `chainId: { _eq: <CHAIN_ID> }` to the `where` of each entity that carries it (every swap/rollup/rebalance/LP entity below does; `BridgeTransfer` does not). Without it, a multi-chain address silently merges its Celo and Monad footprints and misreports volume/activity. Drop the filter only when you deliberately want the all-chain Mento footprint.
+
+**Pick the filter field for the target type.** `caller` is `tx.from` — correct for an **EOA target**. For a **contract target** (router / aggregator / rebalancer / the bot contract itself), `tx.from` is the _operator EOA_, not the contract, so a `caller`-only filter returns a false-EMPTY even though the contract is all over the data. Filter on `sender` / `txTo` / `recipient` / `brokerCaller` instead, or `_in` across roles when the address could appear as either. The examples below show `caller`; swap the field to match the target.
+
 ```graphql
 # Lifetime rollups (fast path — swap volume, cadence, routers, protocol-actor flag)
 {
   TraderDailySnapshot(
-    where: { trader: { _eq: "0xtarget" } }
+    where: { trader: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
     order_by: { timestamp: desc }
     limit: 1000
   ) {
@@ -181,7 +194,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 }
 {
   BrokerTraderDailySnapshot(
-    where: { caller: { _eq: "0xtarget" } }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
     order_by: { timestamp: desc }
     limit: 1000
   ) {
@@ -196,8 +209,8 @@ Run a small battery keyed on the target address (all fields verified against `in
 # Raw per-swap detail (v3 pools + v2 broker)
 {
   SwapEvent(
-    where: { caller: { _eq: "0xtarget" } }
-    order_by: { blockTimestamp: desc }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }
+    order_by: [{ blockTimestamp: desc }, { id: desc }] # id tiebreaker → deterministic offset pagination
     limit: 1000
   ) {
     txHash
@@ -217,8 +230,8 @@ Run a small battery keyed on the target address (all fields verified against `in
 }
 {
   BrokerSwapEvent(
-    where: { caller: { _eq: "0xtarget" }, routedViaV3Router: { _eq: false } }
-    order_by: { blockTimestamp: desc }
+    where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> }, routedViaV3Router: { _eq: false } }
+    order_by: [{ blockTimestamp: desc }, { id: desc }] # id tiebreaker → deterministic offset pagination
     limit: 1000
   ) {
     txHash
@@ -238,7 +251,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 
 # Role-specific: MEV keeper? CDP actor? LP? mint/burn? bridger?
 {
-  RebalanceEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+  RebalanceEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, order_by: [{ blockTimestamp: desc }, { id: desc }], limit: 1000) {
     txHash
     poolId
     sender
@@ -290,7 +303,7 @@ Run a small battery keyed on the target address (all fields verified against `in
 
 Hard constraints (from `docs/pr-checklists/swr-polling-hasura.md`):
 
-- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**.
+- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**. When paging, `order_by` must end in a unique tiebreaker (`{ id: desc }`) — ordering by `blockTimestamp`/`timestamp` alone is non-deterministic when rows share a block, so plain offset pagination would skip and duplicate rows.
 - `volumeUsdWei` is 0 when neither leg is USD-pegged (non-stable FX pairs) — don't read that as "no volume".
 - `BrokerSwapEvent` with `routedViaV3Router:true` are v3 siblings already counted in `SwapEvent` — filter them out (`_eq:false`) to avoid double-counting.
 - `RebalanceEvent.notionalUsd`/`rewardUsd` use an empty-string sentinel when pre-reserve RPC failed — handle "" distinctly from "0".
@@ -352,7 +365,7 @@ FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY
 
 ```bash
 # (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
-CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   # runtime codehash
+CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash ($RPC from Step 1, scoped to $CHAIN)
 # Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
 ```
 
@@ -368,7 +381,7 @@ CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   #
 **For a contract target** — read public storage directly. Most arb / MEV contracts leave trivial getters in (router addresses, allowlists, fee tiers, hardcoded principals). Use the chain's full-node RPC (NOT HyperRPC — `eth_call` requires a full node):
 
 ```bash
-RPC=https://forno.celo.org   # or whatever full-node RPC for the target chain
+# Reuse $RPC from Step 1 (already scoped to $CHAIN — full node, NOT HyperRPC, since eth_call needs one).
 cast call $ADDR "router()(address)" --rpc-url $RPC
 cast call $ADDR "routerSushi()(address)" --rpc-url $RPC
 cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
@@ -399,8 +412,9 @@ Before concluding "no interesting getters", do three things:
 -- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
 SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
--- NONCE/ORIGIN: min_nonce=0 & max==count → Celo-native key. max_nonce >> count → key reused on OTHER chains
--- (its first Celo tx is NOT its birth — pivot to Arkham/Sim on those chains; this is the cross-chain identity lever).
+-- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
+--   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
+--   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
 SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
@@ -525,7 +539,7 @@ Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 
 End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
 
 ```
-_Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
 ```
 
 ### Step 10 — Push to production (only on user confirmation)
@@ -592,12 +606,22 @@ end
 
 payload.createdAt = (prior and prior.createdAt) or now
 payload.updatedAt = now
--- Coerce non-numeric prior versions to 0 before incrementing.
--- cjson.decode maps JSON null to cjson.null (truthy in Lua), so a
--- stored {"version": null} from a legacy/partial record would
--- propagate cjson.null into the arithmetic and crash the EVAL.
-local priorVersion = prior and prior.version
-if type(priorVersion) ~= 'number' then priorVersion = 0 end
+-- Mirror upsertReport()'s read-side version normalization. A true first write
+-- (no prior record) is version 1. cjson.decode maps JSON null to cjson.null
+-- (truthy in Lua), so a legacy/partial {"version": null} must be normalized,
+-- not propagated into arithmetic (which would crash the EVAL). Such records
+-- read as version 1 in JS, so normalize missing/invalid/<=0 to 1 here too —
+-- coercing to 0 would write version 1 over an existing record and regress the
+-- version the editor's optimistic-concurrency (CAS) path expects.
+local priorVersion = 0
+if prior then
+  priorVersion = prior.version
+  if type(priorVersion) ~= 'number' or priorVersion <= 0 then
+    priorVersion = 1
+  else
+    priorVersion = math.floor(priorVersion)
+  end
+end
 payload.version = priorVersion + 1
 
 local encoded = cjson.encode(payload)
@@ -625,7 +649,7 @@ The script returns the persisted record (already JSON-encoded). It handles every
 
 - `createdAt` preserved when updating; stamped fresh on first write
 - `updatedAt` always = now
-- `version` = `(prior.version or 0) + 1` — works even when the prior record is a legacy/partial entry without a numeric `version` field (Lua coerces `nil` → `0`, so first write is `1`, never `NaN`)
+- `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
 - Atomic against concurrent writers — the editor route + this skill + any future caller can interleave without losing updates
 
 **Verify:**

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -288,7 +288,9 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }, limit: 1000) {
+  # Filter on caller (signer) OR counterparty (mint recipient / burn holder) — the target may be the
+  # recipient/holder rather than the tx signer, which a caller-only filter would miss.
+  StableSupplyChangeEvent(where: { _and: [{ _or: [{ caller: { _eq: "0xtarget" } }, { counterparty: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }, limit: 1000) {
     txHash
     kind
     amount
@@ -368,7 +370,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
    - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
 5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
-6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record (coinType `0`), which many owners set regardless of chain. Mostly negatives for bot EOAs; one hit is gold.
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **chain-correct ENSIP-11 coinType** `0x80000000 | $CHAIN_ID` (Celo `42220` → `0x8000A4EC`, namespace `a4ec.reverse`; Monad `143` → `0x8000008F`; etc.). Watch out: a common doc example mis-states Celo as `0x8000A4DC`, which decodes to chain 42204 — wrong. Also try the default L1 reverse record — viem's `getEnsName` defaults to the **Ethereum coinType `60`** (`evmChainIdToCoinType` → `60` for mainnet), which many owners set regardless of chain; call it once with the default and once with the chain-specific coinType above. Mostly negatives for bot EOAs; one hit is gold.
 
 For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
 
@@ -423,17 +425,17 @@ Before concluding "no interesting getters", do three things:
    # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). For impl/admin/EIP-1822, non-zero → last 20
    # bytes IS the address to analyse. The BEACON slot is different: its last 20 bytes are the BEACON
    # contract, not the impl — call beacon.implementation() and analyse THAT (see below).
-   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
-   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
-   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
-   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --block $HEAD_BLOCK --rpc-url $RPC  # impl
+   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --block $HEAD_BLOCK --rpc-url $RPC  # admin
+   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --block $HEAD_BLOCK --rpc-url $RPC  # beacon
+   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --block $HEAD_BLOCK --rpc-url $RPC  # EIP-1822
    # If the beacon slot was non-zero, resolve the real implementation from the beacon contract:
    BEACON=0x…   # last 20 bytes of the beacon slot value above
    cast call "$BEACON" "implementation()(address)" --rpc-url "$RPC"
    ```
 
 2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify is multichain, free, no key: `GET https://sourcify.dev/server/v2/contract/$CHAIN_ID/{addr}?fields=all` (use `$CHAIN_ID` from Step 1 — `42220` for Celo, `143` Monad, etc.; cross-check the chain's explorer: Celoscan / Monadscan / Polygonscan / Etherscan).
-3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
+3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a provider on `$RPC` — the target chain's, not forno, or it reads bytecode/proxy slots on the wrong chain — and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
 
 **For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
 
@@ -533,14 +535,15 @@ case "$CHAIN" in
   *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
 [ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug for $CHAIN
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
-# MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
-# unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'
+curl -s "https://api.dexscreener.com/token-pairs/v1/<ds-slug>/{tokenAddr}"         # chain-scoped: pairs for this token on $CHAIN only
+# <ds-slug> = DexScreener chain slug for $CHAIN (celo / ethereum / polygon / base / …). The chain-scoped
+# token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the token's pairs on ALL
+# chains and risked naming a different chain's venue/TVL for an unrelated same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `$DUNE_NS.dex.trades` (the target chain's table — `celo.dex.trades` / `monad.dex.trades` / …; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
 
 ### Step 7 — Coverage and dead ends
 
@@ -722,7 +725,7 @@ The address-book index endpoint reads from the same hash on every request, so th
 Replace the old binary "skip if weak" with a per-claim grade on **load-bearing attribution claims only** (Cast of characters rows, fleet links, Bottom line) — not every sentence. This lets the report keep a useful "likely but unproven" lead instead of discarding it, as long as it's labelled honestly:
 
 - **CONFIRMED** — a deterministic on-chain fact (creation-tx `from`, a storage read, a codehash match, a decoded selector) or external ground truth (an ENS reverse record). No hedging words.
-- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
+- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + approval-graph).
 - **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
 
 Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A claim that can't reach POSSIBLE doesn't belong in the report at all.

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -71,7 +71,7 @@ case "$CHAIN" in
   monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
   polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
   ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
-  *)        CHAIN_ID=<id>;  RPC=<full-node RPC for $CHAIN>; DUNE_NS=<chain> ;;
+  *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS." >&2; exit 1 ;;
 esac
 ```
 
@@ -166,8 +166,12 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
 # Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
 # deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
+# Scope the probe to the TARGET chain. A generic SwapEvent(limit:1) passes on Celo data even when the
+# target chain is missing/unsynced — which would later make an empty battery look EMPTY (covered, found
+# nothing) when it's really NOT-COVERED (chain absent). If this returns 0 rows, mark the indexer
+# NOT-COVERED for $CHAIN, not EMPTY.
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}}, limit:1){ id } }\"}" | jq .
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -291,9 +295,14 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
+  # BridgeTransfer carries sourceChainId/destChainId (not chainId). Scope to the target chain via either
+  # endpoint AND keep the sender/recipient role predicate; drop the chain clause only for the all-chain view.
   BridgeTransfer(
     where: {
-      _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }]
+      _and: [
+        { _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }] }
+        { _or: [{ sourceChainId: { _eq: <CHAIN_ID> } }, { destChainId: { _eq: <CHAIN_ID> } }] }
+      ]
     }
     limit: 1000
   ) {
@@ -324,7 +333,7 @@ A non-empty result here, scoped to the actual target chain, is far stronger than
 
 Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
-1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure.
+1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure. **For a CONTRACT target, don't trust an Arkham hit on the target address**: the same 20-byte address on Ethereum/L2 is usually an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically). For contracts, derive the deployer/operator EOA first (step 5) and run the cross-chain identity leg on THAT — only treat a same-address cross-chain hit as the target if bytecode/CREATE2 evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -334,12 +343,14 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    ```sql
    SELECT block_time, "from", value, hash
    FROM <chain>.transactions
-   WHERE "to" = LOWER('<addr>')
+   WHERE "to" = LOWER('<addr>') AND value > 0   -- value>0 skips zero-value relayer/user calls that aren't funding
    ORDER BY block_time ASC
    LIMIT 5;
    ```
 
-   That funder is usually the operator EOA.
+   That funder is usually the operator EOA. **If funding arrived as an ERC20** (e.g. a stablecoin), this
+   native-`value` query misses it — run the same oldest-first scan over token transfers (the chain's
+   ERC20 `Transfer` logs in Dune, or Sim token transfers) before concluding who the funder is.
 
 3. Run `address_enriched/all` on the operator EOA **across all chains** — this is the cross-chain identity leg, where personas (ENS / OpenSea / prior bots / CEX deposits) surface. The same key is usually active on Ethereum/L2s even when the target contract is Celo-native; that footprint is often the whole attribution.
 4. Trace one more hop back: who funded the operator? **Mento's own bridge is Wormhole NTT**, not the generic Ethereum bridges:
@@ -386,10 +397,11 @@ CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash 
 
 ```bash
 # Reuse $RPC from Step 1 (already scoped to $CHAIN — full node, NOT HyperRPC, since eth_call needs one).
-cast call $ADDR "router()(address)" --rpc-url $RPC
-cast call $ADDR "routerSushi()(address)" --rpc-url $RPC
-cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
-# … etc, try every name a typical arb contract uses
+cast call $ADDR "router()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+cast call $ADDR "routerSushi()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+cast call $ADDR "lastAddress()(address)" --block $HEAD_BLOCK --rpc-url $RPC
+# … etc, try every name a typical arb contract uses. Pin --block $HEAD_BLOCK (from Step 1) so these
+# reads stay reproducible and match the provenance footer — without it you capture current state.
 ```
 
 If the contract is verified (sourcify or Celoscan): pull source, name the patterns. If unverified: look at the top selectors by frequency on Celoscan / explorer; OpenChain-decode any matching ones (`https://openchain.xyz/signatures?function=0x…`).
@@ -440,7 +452,7 @@ Pick a representative tx — preferably a recent successful one with the typical
 case "$CHAIN" in
   celo)    BS=https://celo.blockscout.com/api/v2 ;;
   polygon) BS=https://polygon.blockscout.com/api/v2 ;;
-  *)       BS=<target chain's Blockscout v2 base, or use the RPC-native fallback> ;;
+  *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
 curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
 curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
@@ -469,19 +481,19 @@ Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM`
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `<defillamaChainSlug>:<lowercaseTokenAddress>`. Celo's slug is `celo`; common others: `ethereum`, `base`, `arbitrum`, `optimism`, `polygon`. Native CELO uses its ERC20 wrapper `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `DL_NS` is the DefiLlama slug for `$CHAIN` — set it alongside the other chain knobs (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`, base→`base`, arbitrum→`arbitrum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
 ```bash
 TS=1742000000   # block timestamp, unix seconds
-curl -s "https://coins.llama.fi/prices/historical/$TS/celo:<tokenLower>" | jq '.coins'
+curl -s "https://coins.llama.fi/prices/historical/$TS/$DL_NS:<tokenLower>" | jq '.coins'
 # -> { "celo:0x…": { "decimals": 18, "symbol": "…", "price": 0.0629, "confidence": 0.99, "timestamp": … } }
 ```
 
-USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/celo:0xAAA,celo:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
+USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/$DL_NS:0xAAA,$DL_NS:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
 
-**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/celo:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
 
 Caveats — surface them in the report when they bite:
 
@@ -501,10 +513,12 @@ case "$CHAIN" in
   celo)     GT_NS=celo ;;
   polygon)  GT_NS=polygon_pos ;;
   ethereum) GT_NS=eth ;;
-  *)        GT_NS=<GeckoTerminal slug for $CHAIN, or skip if unlisted> ;;
+  *)        GT_NS=""; echo "No GeckoTerminal slug mapped for $CHAIN — verify at /api/v2/networks, then set GT_NS or skip." >&2 ;;
 esac
 curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
-curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # returns the token's pairs on ALL chains
+# MUST filter to the target chain before using, or you may name a different chain's venue/TVL for an
+# unrelated same-address token: ... | jq '[.pairs[] | select(.chainId == "<DexScreener slug for $CHAIN: celo/ethereum/polygon/base/…>")]'
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
@@ -531,8 +545,12 @@ The distinction between `EMPTY` (source covers this chain, found nothing) and `N
 A forensic product should screen every target. Primary, zero new dependency — the Chainalysis OFAC oracle is live on Celo and reuses the `cast`/forno tooling already in Steps 3/4:
 
 ```bash
-# Run on the target AND each Step-2 funder/counterparty.
-cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+# The Chainalysis oracle lives at this address on Celo (and several other EVM chains) but is NOT
+# guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
+# chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
+if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+fi
 ```
 
 Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
@@ -668,7 +686,7 @@ The script returns the persisted record (already JSON-encoded). It handles every
 - `createdAt` preserved when updating; stamped fresh on first write
 - `updatedAt` always = now
 - `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
-- Atomic against concurrent writers — the editor route + this skill + any future caller can interleave without losing updates
+- Atomic per write and version stays monotonic — **but it is last-writer-wins on the body** (this variant has no `expectedVersion` precondition), so an editor save made between this skill's Step-1 read and the EVAL is silently overwritten. The editor's own CAS path will reject ITS now-stale save, but this skill never loses the race. If a hand-edited report might be in flight, re-read immediately before upload, or upload via the editor route instead.
 
 **Verify:**
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -65,11 +65,12 @@ mkdir -p .investigations
 # a non-Celo investigation must not silently read Celo data. Thread these everywhere:
 #   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
 #   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
-#   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+#   DUNE_NS  → value to hand-substitute for the `<chain>.` table prefix in the DuneSQL examples
+#              (the dune CLI doesn't shell-interpolate inside a SQL string, so swap it in manually)
 #   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
   celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node; DefiLlama may not cover monad yet (Step 5.5 caveat)
+  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;    DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node (repo-canonical rpc2.monad.xyz); DefiLlama may not cover monad yet (Step 5.5 caveat)
   polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
   ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
   *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
@@ -336,7 +337,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
 
 1. Branch on target type before any cross-chain enrichment:
    - **EOA target** → run `address_enriched/all` on it. Zero hits for a Celo-native EOA is a signal, not a failure.
-   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (step 5), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
+   - **CONTRACT target** → do **NOT** run `address_enriched/all` on the contract address as an identity source yet. The same 20-byte address on Ethereum/L2 is almost always an unrelated EOA/contract (addresses aren't shared across chains unless deployed deterministically), so an Arkham hit there would record a false identity. Identify the deployer/operator EOA first (item 5 below), then run the identity leg on THAT EOA. Only treat a same-address cross-chain hit as the target if CREATE2/bytecode evidence proves the address is intentionally shared.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
    - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
    - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
@@ -383,7 +384,7 @@ FROM <chain>.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER
 
 ```bash
 # (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
-CODE=$(cast code <addr> --rpc-url $RPC); cast keccak $CODE   # runtime codehash ($RPC from Step 1, scoped to $CHAIN)
+CODE=$(cast code "$ADDR" --rpc-url "$RPC"); cast keccak "$CODE"   # runtime codehash ($ADDR/$RPC from Step 1, scoped to $CHAIN)
 # Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
 ```
 
@@ -442,7 +443,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service for Celo: `https://api.safe.global/tx-service/celo/` (keyless reads). This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
@@ -554,7 +555,8 @@ A forensic product should screen every target. Primary, zero new dependency — 
 # guaranteed everywhere (e.g. Monad). Only call it where it's deployed on $CHAIN; elsewhere rely on the
 # chain-agnostic TRM + static-OFAC paths below. Run on the target AND each Step-2 funder/counterparty.
 if [ "$CHAIN" = celo ]; then   # extend once you've verified the oracle is deployed on another target chain
-  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+  cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' "$ADDR" --rpc-url "$RPC"
+  # repeat for each Step-2 funder/counterparty, e.g.: for a in "$ADDR" "${FUNDERS[@]}"; do cast call 0x40C5…c8fb 'isSanctioned(address)(bool)' "$a" --rpc-url "$RPC"; done
 fi
 ```
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -5,7 +5,7 @@ title: Forensic Report Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-06-15
 ---
 
 # Forensic Report
@@ -22,7 +22,21 @@ If the answer fits in `notes` (≤500 chars, single fact like "Binance hot 14"),
 
 - **address** (required): `0x…` (40 hex chars). Skill normalises to lowercase.
 - **context** (optional, one line): why you started looking — "showed up in the breaker-trip post-mortem", "biggest counterparty on the Mento broker last month", etc. Used in the TL;DR.
-- **chain hint** (optional): default Celo since that's where Mento lives. Used for the storage probe + tx-anatomy section.
+- **chain hint** (optional): default Celo since that's where Mento lives. Used for the storage probe + tx-anatomy section. See the chain doctrine below — the _target_ chain is one thing, the operator's _cross-chain footprint_ is another.
+
+## Chains & cross-chain doctrine
+
+Two facts shape every tool choice in this skill:
+
+1. **Mento is multi-chain and growing.** Celo (`42220`) is primary and where most targets live. **Monad (`143`) is live** (secondary). **Polygon and Ethereum are on the roadmap.** Never hardcode `42220`; thread the target chain id through every chain-scoped call.
+2. **One key, many chains.** If someone controls a private key on Celo, the same EOA almost always has a history on other EVM chains (Ethereum, Base, Arbitrum, …). That cross-chain footprint is usually where the _identity_ lives — ENS, OpenSea, CEX deposits, prior bots — because the richest attribution tools (Arkham, Nansen, EigenPhi, MetaSleuth) index Ethereum/L2s but **not** Celo.
+
+So split the work into two legs and pick tools per leg:
+
+- **On-chain behaviour leg** (what the address _does_ — swaps, storage, capital, venues): use Celo/Monad-native sources (the Mento Envio indexer, Blockscout, Dune `celo.*`/`monad.*`, GeckoTerminal, `cast` vs forno). These are the only ones that actually see the target chain.
+- **Cross-chain identity leg** (who is _behind_ the address): pivot the operator EOA onto the chains the heavyweight attributors cover and let them work there.
+
+**Corollary — never drop a source just because it lacks Celo.** A Celo-blind tool (Nansen, EigenPhi, GoPlus, Across, …) is still the right tool for the identity leg, for Monad, and for Polygon/Ethereum once we deploy there. The **Tooling matrix** near the end of this file records what each source covers and which leg it serves — consult it instead of assuming "no Celo = useless".
 
 ## Output
 
@@ -33,7 +47,7 @@ Two artefacts:
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same eight named H2 sections in the same order (TL;DR, Cast of characters, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Arkham coverage, Bottom line), same code-fenced storage / tx blocks, same "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder.
+The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
 
 ## Procedure (how to fill the template)
 
@@ -44,9 +58,21 @@ Run these in order. Each step maps onto a section of the template — fill that 
 ```bash
 ADDR=$(echo "0x…" | tr 'A-Z' 'a-z')   # always lowercase the storage key
 CHAIN=celo                            # default; override if user said otherwise
+CHAIN_ID=42220                        # Celo. Monad=143, Polygon=137, Ethereum=1. Thread this everywhere.
 DATE=$(date -u +%F)
 mkdir -p .investigations
 ```
+
+**Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
+
+```bash
+RPC=https://forno.celo.org
+HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
+cast --version                                   # tool version, for the footer
+# Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
+```
+
+For the attribution-anchoring storage reads in Step 3, pin them with `cast call <addr> <sig> --block $HEAD_BLOCK --rpc-url $RPC` so a future reader gets the same bytes.
 
 Check whether a report already exists (we may be UPDATING, not creating):
 
@@ -114,9 +140,172 @@ mcp__upstash__redis_database_run_redis_commands({
 
 Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
-### Step 2 — Cast of characters (Arkham + funder graph)
+**These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address.
 
-Use the `arkham` skill (project-scoped). If Step 1.5 returned cache hits, use that data directly — skip the live `address_enriched/all` call for those addresses. Arkham doesn't cover Celo or Monad, so the play is:
+**Don't treat the payloads as opaque blobs** — the typed accessors in `ui-dashboard/src/lib/` give exact field paths:
+
+- `intel_deep` (`intel-deep.ts`): `enriched[chain].arkhamEntity.id` is the **entity slug** — the join key into `intel_entities` / `intel_entity_cps` (those hashes are slug-keyed, not address-keyed). `candidate.sources` tells you _why_ it was cached (`cluster-…-caller` / `top-trader` / `top-bridger` / `tier1-attested`) — a free prior classification. `counterparties[chain]` has the top USD counterparties per chain.
+- Use `intel-legacy-fallback.ts` `hgetWithLegacy` semantics — older entries may sit under `arkham_*` legacy keys.
+
+### Step 1.6 — Mento indexer fingerprint (our own Celo/Monad-native source)
+
+**This is the primary on-chain-behaviour source for the target chain** — and it's the one the skill historically ignored. The repo runs its own Envio HyperIndex indexer of Mento protocol events with a **public, unauthenticated** Hasura GraphQL endpoint covering Celo (`42220`) and Monad (`143`). Because Arkham/Nansen are blind on both chains, this is where "what did this address do with Mento" actually gets answered. Query it _before_ the funder graph so you walk into Step 2 already knowing the target's Mento footprint.
+
+```bash
+HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
+# Sanity-check the deployment is serving before trusting any EMPTY result — parallel Envio
+# deploys can prune an entry mid-serve, so a 404/empty endpoint is NOT a "no activity" finding:
+curl -s "$HASURA" -H 'content-type: application/json' \
+  --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
+```
+
+Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
+
+```graphql
+# Lifetime rollups (fast path — swap volume, cadence, routers, protocol-actor flag)
+{
+  TraderDailySnapshot(
+    where: { trader: { _eq: "0xtarget" } }
+    order_by: { timestamp: desc }
+    limit: 1000
+  ) {
+    chainId
+    timestamp
+    swapCount
+    uniquePools
+    volumeUsdWei
+    feesPaidUsdWei
+    aggregatorKeys
+    isProtocolActor
+  }
+}
+{
+  BrokerTraderDailySnapshot(
+    where: { caller: { _eq: "0xtarget" } }
+    order_by: { timestamp: desc }
+    limit: 1000
+  ) {
+    chainId
+    timestamp
+    swapCount
+    volumeUsdWei
+    aggregatorKeys
+    isProtocolActor
+  }
+} # v2 path, Celo only
+# Raw per-swap detail (v3 pools + v2 broker)
+{
+  SwapEvent(
+    where: { caller: { _eq: "0xtarget" } }
+    order_by: { blockTimestamp: desc }
+    limit: 1000
+  ) {
+    txHash
+    blockTimestamp
+    chainId
+    poolId
+    caller
+    sender
+    recipient
+    txTo
+    amount0In
+    amount1In
+    amount0Out
+    amount1Out
+    volumeUsdWei
+  }
+}
+{
+  BrokerSwapEvent(
+    where: { caller: { _eq: "0xtarget" }, routedViaV3Router: { _eq: false } }
+    order_by: { blockTimestamp: desc }
+    limit: 1000
+  ) {
+    txHash
+    blockTimestamp
+    chainId
+    caller
+    brokerCaller
+    txTo
+    tokenIn
+    tokenOut
+    amountIn
+    amountOut
+    volumeUsdWei
+    exchangeId
+  }
+}
+
+# Role-specific: MEV keeper? CDP actor? LP? mint/burn? bridger?
+{
+  RebalanceEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+    txHash
+    poolId
+    sender
+    caller
+    notionalUsd
+    rewardUsd
+    effectivenessRatio
+  }
+}
+{
+  Trove(where: { owner: { _eq: "0xtarget" } }) {
+    id
+    collateral
+    debt
+    status
+  }
+}
+{
+  LiquidityPosition(where: { address: { _eq: "0xtarget" } }) {
+    poolId
+  }
+}
+{
+  StableSupplyChangeEvent(where: { caller: { _eq: "0xtarget" } }, limit: 1000) {
+    txHash
+    kind
+    amount
+  }
+}
+{
+  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
+    id
+  }
+}
+{
+  BridgeTransfer(
+    where: {
+      _or: [{ sender: { _eq: "0xtarget" } }, { recipient: { _eq: "0xtarget" } }]
+    }
+    limit: 1000
+  ) {
+    txHash
+    sender
+    recipient
+    amount
+  }
+}
+```
+
+Hard constraints (from `docs/pr-checklists/swr-polling-hasura.md`):
+
+- **1000-row cap** per response; **no `_aggregate`** on hosted Hasura. For lifetime totals, page with `offset`/`limit` or narrow with `where`, then **sum client-side**.
+- `volumeUsdWei` is 0 when neither leg is USD-pegged (non-stable FX pairs) — don't read that as "no volume".
+- `BrokerSwapEvent` with `routedViaV3Router:true` are v3 siblings already counted in `SwapEvent` — filter them out (`_eq:false`) to avoid double-counting.
+- `RebalanceEvent.notionalUsd`/`rewardUsd` use an empty-string sentinel when pre-reserve RPC failed — handle "" distinctly from "0".
+
+A non-empty result here, scoped to the actual target chain, is far stronger than anything the Celo-blind attributors can give — and a verified-live **empty** result is a real signal ("never interacted with Mento v2/v3 on Celo or Monad"), not a tooling gap.
+
+### Step 2 — Cast of characters (multi-chain attribution + funder graph)
+
+**Known-infra check first.** Before walking the funder graph or decompiling anything, match the target and its counterparties against the repo's canonical registries so you never mislabel protocol infrastructure as a suspicious actor (prefer on-chain facts over behavioural guesses):
+
+- `indexer-envio/config/aggregators.json` + shared-config `getAggregatorName(chainId, addr)` → instant match to `mento-router-v2` / `squid` / `lifi` / `0x` / `openocean`, **and** to any named MEV fleet cluster already documented there (those carry a pre-written narrative you can reuse verbatim in Steps 3/6/8).
+- shared-config `chainAddressLabels(chainId)` / `tokenSymbol()` (from `@mento-protocol/contracts`) → labels broker / reserve / pools / stables / fee recipients, and gives correct explorer links via `explorerAddressUrl`.
+- `indexer-envio/config/oracle-reporters.json` + `protocolActors.json` → flags Chainlink feeds / reporters / listed rebalancers as infra. If the target is a `Pool.rebalancerAddress`, it's an authorised protocol strategy contract, not an independent bot.
+
+Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain identity leg** — Step 1.5 caches first; live calls only if the key is valid. Remember the doctrine: Arkham/Nansen don't cover Celo or Monad, so the play is:
 
 1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure.
 2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
@@ -135,11 +324,44 @@ Use the `arkham` skill (project-scoped). If Step 1.5 returned cache hits, use th
 
    That funder is usually the operator EOA.
 
-3. Run `address_enriched/all` on the operator EOA across all chains — this is where personas like ENS / opensea / multichain footprint usually surface.
-4. Trace one more hop back: who funded the operator? If it's a bridge (Stargate, LayerZero, Hop, Across), name the bridge in the table.
-5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table.
+3. Run `address_enriched/all` on the operator EOA **across all chains** — this is the cross-chain identity leg, where personas (ENS / OpenSea / prior bots / CEX deposits) surface. The same key is usually active on Ethereum/L2s even when the target contract is Celo-native; that footprint is often the whole attribution.
+4. Trace one more hop back: who funded the operator? **Mento's own bridge is Wormhole NTT**, not the generic Ethereum bridges:
+   - Check the indexer `BridgeTransfer` / `BridgeBridger` from Step 1.6 first.
+   - Confirm/extend via **Wormholescan** (free, no key): `GET https://api.wormholescan.io/api/v1/operations?address=0x…&appId=NATIVE_TOKEN_TRANSFER` — note Wormhole uses its own chain ids (Celo=14, Monad=48), NOT EVM chain ids.
+   - Match any counterparty against `indexer-envio/config/nttAddresses.json` (`nttManagerProxy` / `transceiverProxy` / `helper` / `tokenAddress`) so a transfer to/from NTT infra is labelled a bridge flow, not a real funder.
+   - For NON-Mento inbound bridges, reach for the right tracer per the Tooling matrix: **LayerZeroScan** covers Celo (`GET https://scan.layerzero-api.com/v1/messages/wallet/{eoa}`, Celo EID=30125); Across/deBridge cover **Monad only** (not Celo) so use them on the Monad leg.
+5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table. (The deployer is the seed for the fleet clustering in Step 2.5.)
+6. **ENS de-anon pivot** (the seed's `idontloseiwin.eth` is exactly this). A Celo address's ENS primary name lives in the **Ethereum L1** reverse registry, not on Celo — forno can't answer it. Resolve via `viem` `getEnsName({ address, coinType })` against an L1 RPC with the **correct Celo coinType `0x8000A4EC`** (= `0x80000000 | 42220`; reverse namespace `a4ec.reverse`). Watch out: a common doc example mis-states this — `0x8000A4DC` decodes to chain 42204, the wrong chain. Mostly negatives for bot EOAs; one hit is gold.
 
-For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), and a one-line "what it does" note.
+For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), a one-line "what it does" note, and a **confidence tier** on the attribution claim (see "Confidence tiers" below).
+
+### Step 2.5 — Operator-fleet clustering (find the OTHER bots)
+
+The skill historically walked exactly one hop to the funder and stopped. The highest-confidence attribution signal is **linkage**: what else did this operator deploy, fund, or run identical bytecode for. All three heuristics run on Dune `celo.*` (the existing `dune` skill — no new credential; identical on `monad.*` for Monad) plus `cast`. Feed the results into the "Related addresses / fleet" table.
+
+```sql
+-- (1) DEPLOYER FAN-OUT: every contract a deployer created.
+--     For CREATE2 the trace "from" is the FACTORY — recurse to the factory's own deployer.
+SELECT address, block_time, length(code) AS code_len, tx_hash
+FROM celo.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
+
+-- (2) COMMON-FUNDER CLUSTERING: every sibling EOA the operator's gas-refill EOA funded.
+SELECT "to" AS funded, count(*) n, min(block_time) first_fund
+FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
+```
+
+```bash
+# (3) CODEHASH CLUSTERING: byte-identical bots, even across different deployers/factories.
+CODE=$(cast code <addr> --rpc-url https://forno.celo.org); cast keccak $CODE   # runtime codehash
+# Pre-filter candidates from creation_traces by length(code), then confirm by keccak match.
+```
+
+**Mandatory false-positive gates** — write these into the method, an unverified link is worse than none:
+
+- `value > 0` on funder edges; **never** treat a CEX hot wallet or a public CREATE2 factory as a "funder" — they fan out to thousands and create a garbage super-cluster.
+- EIP-1167 minimal-proxy clones share a codehash that differs only by the embedded impl address — cluster on the **impl**, not the clone shell.
+- Require a **second independent signal** (codehash + funder, or + activity-clock from Step 3) before asserting a link. Tag each link with a confidence tier.
+- **Never auto-merge.** Propose links a human ratifies; the report states the evidence, not a verdict.
 
 ### Step 3 — What it does
 
@@ -155,13 +377,57 @@ cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
 
 If the contract is verified (sourcify or Celoscan): pull source, name the patterns. If unverified: look at the top selectors by frequency on Celoscan / explorer; OpenChain-decode any matching ones (`https://openchain.xyz/signatures?function=0x…`).
 
-**For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant.
+Before concluding "no interesting getters", do three things:
+
+1. **Proxy check** (zero new dependency). Read the standard slots — a non-zero value means you've been reading an empty shell and must analyse the _implementation_ instead:
+
+   ```bash
+   # EIP-1967 impl / admin / beacon, then EIP-1822 (UUPS). Non-zero → last 20 bytes = the address to analyse.
+   cast storage $ADDR 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
+   cast storage $ADDR 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
+   cast storage $ADDR 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50 --rpc-url $RPC  # beacon
+   cast storage $ADDR 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7 --rpc-url $RPC  # EIP-1822
+   ```
+
+2. **Verified-source check before decompiling** — exact source beats pseudo-source. Sourcify covers Celo, free, no key: `GET https://sourcify.dev/server/v2/contract/42220/{addr}?fields=all` (cross-check Celoscan).
+3. **Decompile if unverified** — these are chain-agnostic (they operate on raw bytecode, so Celo non-indexing is irrelevant): Dedaub API (`https://api.dedaub.com`, free tier, async POST→poll) for readable pseudo-Solidity, or local **heimdall-rs** (`heimdall decompile/cfg`, MIT, nothing leaves the machine — use for sensitive targets). Enumerate the full selector surface first with WhatsABI (`@shazow/whatsabi`, autoloads over a forno provider and follows EIP-1967 proxies), then resolve names via the OpenChain DB. This is the only way to describe what a closed-source proprietary bot actually does.
+
+**For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant. Add these cheap, Celo-native behavioural fingerprints (all free via the `dune` skill on `celo.*` or `cast`):
+
+```sql
+-- ACTIVITY CLOCK: flat 24h = automated bot; a dead-hours gap = operator's local night.
+-- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
+SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
+
+-- NONCE/ORIGIN: min_nonce=0 & max==count → Celo-native key. max_nonce >> count → key reused on OTHER chains
+-- (its first Celo tx is NOT its birth — pivot to Arkham/Sim on those chains; this is the cross-chain identity lever).
+SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
+
+-- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
+SELECT * FROM celo.logs
+WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925   -- Approval
+  AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
+```
+
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call <safe> 'getOwners()(address[])'` + `'getThreshold()(uint256)'` — and link Safes by intersecting owner sets. Free hosted Safe tx-service for Celo: `https://api.safe.global/tx-service/celo/` (keyless reads). This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 
-Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the selector via OpenChain.
+Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-Note the revert rate. For arb / MEV: ~30–50% reverts is normal (failed sniping). If it's lower, the bot is well-tuned; higher, it's overshooting.
+**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` both return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree on Celo. The free, no-key Celo Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow:
+
+```bash
+BS=https://celo.blockscout.com/api/v2
+curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
+curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+```
+
+Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (`chain_id: 42220`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector.
+
+> **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
+
+**Revert rate — measure, don't assume.** The old "~30–50% reverts is normal for sniping" is Ethereum-PGA reasoning that does **not** transfer to Celo. Since 2025-03 Celo is an OP-Stack L2 with a single sequencer: no public mempool, no Flashbots/PBS bundle market, ordering is sequencer-internal priority-fee. So the revert mechanism is different (priority-fee "first-spammed-first-served" backrunning, not competitive sandwich PGA wars). Compute the actual revert rate for _this_ target from its tx history and interpret it against that model. Monad's ordering differs again (own consensus / FastLane) — don't copy Celo's framing onto Monad.
 
 ### Step 5 — Capital and scale
 
@@ -173,23 +439,94 @@ dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_da
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
 ```
 
-Sum the USD value, drop scam airdrops (zero-value tokens with names like `CLAIM`, `voucher`). For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM` / `voucher`, use DefiLlama as a deterministic noise filter: a token DefiLlama won't price (no entry in the `current` response) or prices with low `confidence` (< ~0.9) has no real DEX liquidity — treat it as noise. Still list it per the template ("confirmed noise"), but keep only DefiLlama-priced, real-confidence holdings in the headline operating-capital number. See Step 5.5. For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+
+### Step 5.5 — Historical USD valuation (DefiLlama coins API — free, no Pro key)
+
+Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
+
+Key format is `<defillamaChainSlug>:<lowercaseTokenAddress>`. Celo's slug is `celo`; common others: `ethereum`, `base`, `arbitrum`, `optimism`, `polygon`. Native CELO uses its ERC20 wrapper `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+
+**Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
+
+```bash
+TS=1742000000   # block timestamp, unix seconds
+curl -s "https://coins.llama.fi/prices/historical/$TS/celo:<tokenLower>" | jq '.coins'
+# -> { "celo:0x…": { "decimals": 18, "symbol": "…", "price": 0.0629, "confidence": 0.99, "timestamp": … } }
+```
+
+USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/celo:0xAAA,celo:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
+
+**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/celo:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+
+Caveats — surface them in the report when they bite:
+
+- **Newer chains may be absent.** DefiLlama indexes Celo well; Monad and other recent chains may have no coin data. If a key returns nothing, fall back to Sim's spot `value_usd` and say so in the report rather than silently reporting a zero.
+- `coins.llama.fi` is not on the default sandbox network allowlist. It's a read-only public GET — allowlist the host or run the single command unsandboxed.
 
 ### Step 6 — Why \_\_\_, why these venues
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-### Step 7 — Arkham coverage
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
-Be candid about what Arkham did and didn't tell you. If the chain isn't supported, say it. If Arkham returned zero, say it. The "negative result" section is part of the audit trail — future you needs to know which leads were dead ends.
+```bash
+curl -s "https://api.geckoterminal.com/api/v2/networks/celo/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
+curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"             # → every pair, dexId, liquidity.usd, volume.h24
+```
+
+(Use `networks/celo/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. For chains other than Celo swap the `networks/<slug>` segment.)
+
+**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune `dex.trades` on Celo (group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+
+### Step 7 — Coverage and dead ends
+
+Generalise the old "Arkham coverage" candour into a per-source audit trail — a future reader needs to know not just what you found but what you _looked at_ and why a lead was dead. Render it as a table, one row per source attempted, marked `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why:
+
+| Source               | Result      | Note                                                        |
+| -------------------- | ----------- | ----------------------------------------------------------- |
+| Arkham (cache/live)  | NOT-COVERED | Celo not indexed; operator EOA also clean on covered chains |
+| Mento Envio indexer  | HIT         | 4.2k SwapEvents, isProtocolActor=false                      |
+| Sim / Dune           | HIT         | …                                                           |
+| Sourcify / Celoscan  | EMPTY       | unverified — decompiled instead                             |
+| Sanctions (Step 7.5) | EMPTY       | not OFAC-listed on Celo oracle or static list               |
+| …                    | …           | …                                                           |
+
+The distinction between `EMPTY` (source covers this chain, found nothing) and `NOT-COVERED` (source can't see this chain) is the whole point — don't collapse them into "nothing found".
+
+### Step 7.5 — Sanctions & risk screening
+
+A forensic product should screen every target. Primary, zero new dependency — the Chainalysis OFAC oracle is live on Celo and reuses the `cast`/forno tooling already in Steps 3/4:
+
+```bash
+# Run on the target AND each Step-2 funder/counterparty.
+cast call 0x40C57923924B5c5c5455c48D93317139ADDaC8fb 'isSanctioned(address)(bool)' <target> --rpc-url $RPC
+```
+
+Caveat to write into the report: the **per-chain Celo oracle's SDN set is not identical to Ethereum's** — a `false` on Celo is not an authoritative global negative. For a definitive verdict also hit the chain-agnostic free path (works for any `0x` address regardless of chain): TRM's keyless `POST https://api.trmlabs.com/public/v1/sanctions/screening` `[{"address":"0x…"}]`, or set-membership against the static OFAC list at `raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses`. For scam/phishing (not sanctions), cross-check counterparties against the Scam Sniffer blacklist and — on chains it covers (Monad `143`, not Celo) — GoPlus; see the Tooling matrix for coverage. Most Mento targets return clean; the value is the rare hit and a citable verified negative for the audit trail.
 
 ### Step 8 — Bottom line
 
 Five bullets, one sentence each: Who / What / Where / How much / Goal. This is the section a Slack reader will copy-paste, so it has to stand alone without the rest of the report.
 
+### Step 8.5 — Adversarial verification gate (before save/upload)
+
+Invert your own confirmation bias right where this skill's own docs flag the most common error. Lightweight but mandatory — leave a one-line trace in the report ("Top alternative considered: …, rejected because …"):
+
+- **State the top alternative hypothesis** and hunt disconfirming evidence (arb bot vs MM rebalancer vs exchange sweep vs protocol keeper). Does your evidence _entail_ the headline, or merely fail to contradict it?
+- **Re-confirm the original funder** is genuinely the oldest inbound (Sim returns newest-first — the classic mis-attribution), and that `--chain-ids` was scoped to the target chain on every funder query.
+- **Re-confirm each fleet link** in Step 2.5 has its required second signal.
+- Downgrade any claim that can't survive this to a lower confidence tier, or cut it.
+
 ### Step 9 — Save the draft
 
 Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 3 words of the H1 display name, lowercased, kebab-cased. Example: H1 `Arbitrage Executor (idontloseiwin.eth)` → slug `arbitrage-executor`.
+
+End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
+
+```
+_Provenance: Celo head block <N> (hash <0x…>), RPC forno.celo.org, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+```
 
 ### Step 10 — Push to production (only on user confirmation)
 
@@ -302,6 +639,16 @@ mcp__upstash__redis_database_run_redis_commands({
 
 The address-book index endpoint reads from the same hash on every request, so the 📄 indicator + the report editor will pick up the new content on the next page load — no SWR mutate hook needed from this side.
 
+## Confidence tiers
+
+Replace the old binary "skip if weak" with a per-claim grade on **load-bearing attribution claims only** (Cast of characters rows, fleet links, Bottom line) — not every sentence. This lets the report keep a useful "likely but unproven" lead instead of discarding it, as long as it's labelled honestly:
+
+- **CONFIRMED** — a deterministic on-chain fact (creation-tx `from`, a storage read, a codehash match, a decoded selector) or external ground truth (an ENS reverse record). No hedging words.
+- **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
+- **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
+
+Tag inline, e.g. `Operator EOA `0x…` **[PROBABLE: codehash + funder]**`. A claim that can't reach POSSIBLE doesn't belong in the report at all.
+
 ## Schema invariants (mirror these — the API enforces the same rules)
 
 - `body`: required, non-empty, ≤ 50,000 characters (50KB)
@@ -310,6 +657,57 @@ The address-book index endpoint reads from the same hash on every request, so th
 - `version`: starts at 1, increments on each write; preserve `createdAt` from the prior write if updating
 
 These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/address-reports-shared.ts`. If those constants change, mirror the changes here — the skill must not write a payload the API would reject on a manual edit.
+
+## Tooling matrix (by chain + leg)
+
+Pick the tool that covers the chain you're on and the leg you're working. **A blank in the Celo column does not mean "useless"** — it means use that source on the cross-chain identity leg (operator EOA on Ethereum/L2s), on Monad, or on Polygon/Ethereum once Mento deploys there. Coverage notes below were web-verified 2026-06-15; re-check before relying on a negative.
+
+**On-chain behaviour leg — Celo/Monad-native (free, the workhorses):**
+
+| Source                       | Celo              | Monad | Access            | Answers                                                     |
+| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)        |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
+| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
+| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                   |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
+
+**Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
+
+| Source              | Celo | Where it works        | Access                     | Use                                               |
+| ------------------- | ---- | --------------------- | -------------------------- | ------------------------------------------------- |
+| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live (key expired) | entity/persona of operator EOA                    |
+| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)             | labels/Smart-Money on the identity leg + Monad    |
+| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                  | MEV classification of operator's ETH strategy     |
+| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)             | labels incl. Celo — only if free paths fall short |
+| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier           | non-Mento DEX history (Envio covers Mento first)  |
+
+**Bridge leg:**
+
+| Source            | Celo | Monad | Access       | Use                                      |
+| ----------------- | ---- | ----- | ------------ | ---------------------------------------- |
+| Mento NTT cfg     | ✅   | ✅    | repo file    | classify NTT infra (`nttAddresses.json`) |
+| Wormholescan      | ✅   | ✅    | free, no key | Mento's own bridge (NTT) by address      |
+| LayerZeroScan     | ✅   | —     | free, no key | LZ/OFT funding paths by address          |
+| Across / deBridge | ❌   | ✅    | free API     | bridge funder on the **Monad** leg only  |
+
+**Risk / sanctions leg:**
+
+| Source             | Celo | Access            | Use                                           |
+| ------------------ | ---- | ----------------- | --------------------------------------------- |
+| Chainalysis oracle | ✅   | free `cast call`  | OFAC screen (per-chain SDN set; Step 7.5)     |
+| TRM screening      | any  | free, keyless     | chain-agnostic sanctions verdict              |
+| OFAC static list   | any  | free GitHub fetch | offline 0x-membership backstop                |
+| GoPlus             | ❌   | free (Monad 143)  | token/address risk on Monad+                  |
+| Scam Sniffer list  | ❌†  | free GitHub fetch | EVM-wide drainer flag (a hit ≠ Celo activity) |
+
+\* MetaSleuth/Tenderly/Phalcon/GoldRush etc. genuinely cover Celo but add a new paid/keyed dependency that overlaps the free workhorses — deferred, revisit per-target only if a free path proves inadequate.
+† Scam Sniffer's data is ~85% Ethereum; a hit is a global drainer flag, not proof of Celo activity. Frame honestly.
 
 ## Reference: production database
 
@@ -344,5 +742,6 @@ Match its tone (specific, evidence-anchored, code-fenced for storage / tx data),
 - **Never write a label or the `labels` hash from this skill.** Labels are a separate concern; the `arkham` skill or the address-book modal handles those.
 - **Never push to prod without explicit user confirmation.** Local draft is the default; upload only on `--upload` or after the user says "ship it" / "upload it" / equivalent.
 - **Mirror the schema invariants.** Don't write a payload the API would reject — that includes the body length cap, title length cap, version monotonicity, and `createdAt` preservation on update.
-- **Cite evidence.** Every claim about an address gets a tx hash, an Arkham response, a Sim balance snapshot, or a storage read backing it. "Probably MEV" is not enough; "selector `0x49aa2402` calls into a contract whose public `routerUniswap()` returns Uniswap V3 SwapRouter02 (factory `0xafe208a3…` matches official UniV3 on Celo)" is.
-- **Skip the report if attribution is weak.** Better to write a label + notes blurb than to ship a forensic report full of "may be" / "appears to be" / "possibly". Reports are durable; uncertainty in them poisons the audit trail.
+- **Cite evidence.** Every claim about an address gets a tx hash, an Arkham response, a Sim balance snapshot, an indexer row, or a storage read backing it. "Probably MEV" is not enough; "selector `0x49aa2402` calls into a contract whose public `routerUniswap()` returns Uniswap V3 SwapRouter02 (factory `0xafe208a3…` matches official UniV3 on Celo)" is.
+- **Grade, don't hedge.** Tag load-bearing attribution claims with a confidence tier (CONFIRMED / PROBABLE / POSSIBLE) instead of weasel words. A claim that can't reach POSSIBLE doesn't ship; if the whole attribution is sub-POSSIBLE, write a label + notes blurb instead of a durable report. Run the Step 8.5 adversarial gate before saving.
+- **Think multi-chain; never disable a source just because it lacks Celo.** The target chain (Celo today; Monad live; Polygon/Ethereum soon) drives the behaviour leg; the operator's cross-chain footprint drives the identity leg. A Celo-blind tool is the right tool for the identity leg / Monad / future chains — consult the Tooling matrix instead of dropping it. Thread the target chain id through every chain-scoped call; never hardcode `42220`.

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -450,7 +450,8 @@ Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*
 Pass the chain hint through to Sim — Mento is on Celo (`42220`) but the skill also runs against Monad (`143`) and any future chain. Hardcoding `--chain-ids 42220` would return empty / unrelated holdings for a Monad principal:
 
 ```bash
-CHAIN_ID=42220   # Celo mainnet. Monad mainnet is 143 (testnet is 10143 — use mainnet for prod investigations). Map other chains by their canonical mainnet chain id.
+# $CHAIN_ID is from Step 1's case switch (Celo 42220 / Monad 143 / …) — do NOT re-hardcode it.
+# Hardcoding 42220 would return empty / unrelated holdings for a Monad (or other-chain) principal.
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data | length'
 dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
 ```

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -58,25 +58,27 @@ Run these in order. Each step maps onto a section of the template — fill that 
 ```bash
 ADDR=$(echo "0x…" | tr 'A-Z' 'a-z')   # always lowercase the storage key
 CHAIN=celo                            # default; override if user said otherwise
-CHAIN_ID=42220                        # Celo. Monad=143, Polygon=137, Ethereum=1. Thread this everywhere.
 DATE=$(date -u +%F)
 mkdir -p .investigations
+
+# Derive EVERY chain-scoped knob from $CHAIN in ONE place so they never drift apart —
+# a non-Celo investigation must not silently read Celo data. Thread these everywhere:
+#   CHAIN_ID → Hasura `chainId` filters + Sim `--chain-ids`
+#   RPC      → every `cast` call (head block, storage, codehash, sanctions oracle)
+#   DUNE_NS  → Dune table prefix (the `<chain>.` in `<chain>.transactions`, etc.)
+case "$CHAIN" in
+  celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc.monad.xyz;     DUNE_NS=monad ;;    # current Monad mainnet full node
+  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum ;;
+  *)        CHAIN_ID=<id>;  RPC=<full-node RPC for $CHAIN>; DUNE_NS=<chain> ;;
+esac
 ```
 
 **Capture provenance up front** — mutable-state reads (storage, balances, prices) are only reproducible if pinned to a block. Record these and put them in the report's provenance footer:
 
 ```bash
-# RPC MUST match $CHAIN — every cast call below (head block, storage reads, codehash,
-# sanctions oracle) executes against whatever this points at. Default Celo; override per
-# the target chain (Monad/Polygon/Ethereum full-node RPC) so a non-Celo investigation
-# isn't silently scoped to Celo. See the chain doctrine.
-case "$CHAIN" in
-  celo)    RPC=https://forno.celo.org ;;
-  monad)   RPC=https://rpc.monad.xyz ;;          # or the current Monad mainnet full node
-  polygon) RPC=https://polygon-rpc.com ;;
-  *)       RPC=<full-node RPC for $CHAIN> ;;
-esac
-HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # the block your storage/balance reads are "as of"
+HEAD_BLOCK=$(cast block-number --rpc-url $RPC)   # $RPC from Step 1's case switch; the block reads are "as of"
 cast --version                                   # tool version, for the footer
 # Note the RPC endpoint, $HEAD_BLOCK, and the UTC timestamp of each Sim/DefiLlama query.
 ```
@@ -329,7 +331,7 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
 
    ```sql
    SELECT block_time, "from", value, hash
-   FROM celo.transactions
+   FROM <chain>.transactions
    WHERE "to" = LOWER('<addr>')
    ORDER BY block_time ASC
    LIMIT 5;
@@ -356,11 +358,11 @@ The skill historically walked exactly one hop to the funder and stopped. The hig
 -- (1) DEPLOYER FAN-OUT: every contract a deployer created.
 --     For CREATE2 the trace "from" is the FACTORY — recurse to the factory's own deployer.
 SELECT address, block_time, length(code) AS code_len, tx_hash
-FROM celo.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
+FROM <chain>.creation_traces WHERE "from" = <deployer> ORDER BY block_time ASC;
 
 -- (2) COMMON-FUNDER CLUSTERING: every sibling EOA the operator's gas-refill EOA funded.
 SELECT "to" AS funded, count(*) n, min(block_time) first_fund
-FROM celo.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
+FROM <chain>.transactions WHERE "from" = <funder> AND value > 0 GROUP BY 1 ORDER BY n DESC;
 ```
 
 ```bash
@@ -409,16 +411,16 @@ Before concluding "no interesting getters", do three things:
 
 ```sql
 -- ACTIVITY CLOCK: flat 24h = automated bot; a dead-hours gap = operator's local night.
--- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use celo.traces).
-SELECT hour(block_time) utc_hour, count(*) FROM celo.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
+-- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use <chain>.traces).
+SELECT hour(block_time) utc_hour, count(*) FROM <chain>.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
 -- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
 --   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
 --   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
-SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM celo.transactions WHERE "from" = <eoa>;
+SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM <chain>.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
-SELECT * FROM celo.logs
+SELECT * FROM <chain>.logs
 WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925   -- Approval
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -284,7 +284,9 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  BridgeBridger(where: { sender: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+  # BridgeBridger is a cross-chain identity aggregate keyed by sender (sourceChainsUsed is a
+  # JSON array) — it has NO chainId field, so do not add a chainId filter here.
+  BridgeBridger(where: { sender: { _eq: "0xtarget" } }) {
     id
   }
 }
@@ -493,7 +495,14 @@ Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing
 **Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key, Celo+Monad-covering APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL":
 
 ```bash
-GT_NS=celo   # GeckoTerminal network slug for $CHAIN: celo / polygon_pos / eth / … (NOT the chain id; verify at /api/v2/networks)
+# GeckoTerminal uses its own network slugs (NOT chain ids) — select per $CHAIN, like $BS in Step 4.
+# Verify/extend against https://api.geckoterminal.com/api/v2/networks (a chain may have no GT coverage).
+case "$CHAIN" in
+  celo)     GT_NS=celo ;;
+  polygon)  GT_NS=polygon_pos ;;
+  ethereum) GT_NS=eth ;;
+  *)        GT_NS=<GeckoTerminal slug for $CHAIN, or skip if unlisted> ;;
+esac
 curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min)
 curl -s "https://api.dexscreener.com/latest/dex/tokens/{tokenAddr}"               # → every pair, dexId, liquidity.usd, volume.h24 (chain-agnostic by token addr)
 ```

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -442,10 +442,11 @@ Before concluding "no interesting getters", do three things:
 -- Report as a UTC band, never a country. MUST be an EOA ("from"); a contract returns 0 rows (use <chain>.traces).
 SELECT hour(block_time) utc_hour, count(*) FROM <chain>.transactions WHERE "from" = <eoa> GROUP BY 1 ORDER BY 1;
 
--- NONCE/ORIGIN: sequential nonces start at 0, so a chain-native key has max_nonce = count-1.
---   min_nonce=0 AND max_nonce = count-1 → Celo-native key (no gaps).  max_nonce >> count-1 → key reused on
---   OTHER chains (its first Celo tx is NOT its birth — pivot to Arkham/Sim there; the cross-chain identity lever).
-SELECT min(nonce), max(nonce), count(*), min(block_time), max(block_time) FROM <chain>.transactions WHERE "from" = <eoa>;
+-- AGE / FIRST-SEEN: first + last activity on THIS chain. NOTE: do NOT infer cross-chain reuse from nonce —
+--   EVM nonces are chain-LOCAL, so a key with Ethereum/Base history still starts at nonce 0 on its first
+--   Celo tx (max_nonce ≈ count-1 given complete data; a gap just means missing/filtered rows, not other-chain
+--   activity). To find the operator's other-chain footprint use the Arkham/Sim identity leg (Step 2), not nonce.
+SELECT min(block_time) AS first_seen, max(block_time) AS last_seen, count(*) AS tx_count FROM <chain>.transactions WHERE "from" = <eoa>;
 
 -- APPROVAL GRAPH: topic1=owner (delegation OUT → routers it trusts), topic2=spender (delegation IN → who can move its funds).
 SELECT * FROM <chain>.logs

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -647,7 +647,7 @@ Replace the old binary "skip if weak" with a per-claim grade on **load-bearing a
 - **PROBABLE** — a funder-graph or behavioural inference corroborated by **≥2 independent signals** (e.g. codehash + common-funder, or activity-clock + nonce-origin).
 - **POSSIBLE** — a single uncorroborated heuristic. Allowed in the report, but must carry the tag so a reader never mistakes it for fact.
 
-Tag inline, e.g. `Operator EOA `0x…` **[PROBABLE: codehash + funder]**`. A claim that can't reach POSSIBLE doesn't belong in the report at all.
+Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A claim that can't reach POSSIBLE doesn't belong in the report at all.
 
 ## Schema invariants (mirror these — the API enforces the same rules)
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -171,12 +171,14 @@ HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POS
 # (a) Liveness: confirm the endpoint serves at all.
 curl -s "$HASURA" -H 'content-type: application/json' \
   --data '{"query":"{ SwapEvent(limit:1){ id } }"}' | jq .
-# (b) Chain coverage: probe several core entity types for $CHAIN_ID — a quiet/new chain may have
-#     bridge/CDP/supply activity but zero swaps, so DON'T equate 0 SwapEvent rows with NOT-COVERED.
+# (b) Chain coverage: probe a SPREAD of activity areas for $CHAIN_ID — swaps, LP, supply, rebalances, and
+#     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
+#     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
-# Mark the indexer NOT-COVERED for $CHAIN only if the FULL Step 1.6 battery (all entity types) is empty
-# AND $CHAIN isn't in the indexer's configured chain list; otherwise an empty result is EMPTY (real signal).
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} }\"}" | jq .
+# Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
+# empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
+# `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
 ```
 
 Run a small battery keyed on the target address (all fields verified against `indexer-envio/schema.graphql`). `caller` = `tx.from` (the signing EOA — the volume-attribution primary key); `sender`/`brokerCaller` = `msg.sender` to the pool/broker (often a router); `txTo` = entry-point contract (identifies the aggregator router). All three are in each row, so you disambiguate EOA-vs-router on the spot.
@@ -451,7 +453,7 @@ WHERE topic0 = 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92
   AND topic1 = <32-byte left-padded owner> LIMIT 100;   -- events are grant HISTORY; for live use eth_call allowance()
 ```
 
-If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` + `'getThreshold()(uint256)'` (use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
+If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real human signers and policy — `cast call "$ADDR" 'getOwners()(address[])' --rpc-url "$RPC"` and `cast call "$ADDR" 'getThreshold()(uint256)' --rpc-url "$RPC"` (two complete commands; use the in-scope `$ADDR`/`$RPC`, not a bare `<safe>` token) — and link Safes by intersecting owner sets. Free hosted Safe tx-service (keyless reads) is per-chain — `https://api.safe.global/tx-service/<safe-slug>/api/v1/safes/<safe>/`, where `<safe-slug>` is the chain's Safe short-name (celo→`celo`, polygon→`pol`, ethereum→`eth`); not every chain has one (Monad doesn't), so don't copy the `celo` slug for a non-Celo target. This exposes the people behind a treasury/managed-bot the proxy address would otherwise hide.
 
 ### Step 4 — Transaction anatomy
 

--- a/.claude/skills/forensic-report/template.md
+++ b/.claude/skills/forensic-report/template.md
@@ -6,16 +6,24 @@ One paragraph, plain language. Lead with what they are (`A proprietary multi-DEX
 
 ## Cast of characters
 
-| Role                       | Address     | Notes                                                              |
-| -------------------------- | ----------- | ------------------------------------------------------------------ |
-| **Original identity**      | `0x…`       | Persona / ENS / opensea handle, age, multichain footprint          |
-| **Bridge funder**          | `0x…`       | Stargate / LayerZero / Hop / Across — name the bridge              |
-| **Operator EOA**           | `0x…`       | Deployer of the target contract; age, multichain footprint         |
-| **Hot relayer EOA**        | `0x…`       | Single-purpose caller, age, what selector it hits                  |
-| **Principal/treasury EOA** | `0x…`       | Where the working capital sits                                     |
-| **The target**             | `0xADDRESS` | The investigation target — bytecode size + solc version (if known) |
+| Role                       | Address     | Confidence | Notes                                                              |
+| -------------------------- | ----------- | ---------- | ------------------------------------------------------------------ |
+| **Original identity**      | `0x…`       | PROBABLE   | Persona / ENS / opensea handle, age, multichain footprint          |
+| **Bridge funder**          | `0x…`       | CONFIRMED  | Wormhole NTT (Mento's bridge) / LayerZero / etc. — name it         |
+| **Operator EOA**           | `0x…`       | CONFIRMED  | Deployer of the target contract; age, multichain footprint         |
+| **Hot relayer EOA**        | `0x…`       | CONFIRMED  | Single-purpose caller, age, what selector it hits                  |
+| **Principal/treasury EOA** | `0x…`       | CONFIRMED  | Where the working capital sits                                     |
+| **The target**             | `0xADDRESS` | —          | The investigation target — bytecode size + solc version (if known) |
 
-Roles are descriptive, not fixed. Add or drop rows to match the topology. For an EOA target, "The target" IS the address being investigated; for a contract target add the deployer + relayer + principal rows above. Always include age (days since first activity), multichain footprint, and a one-line "what it does" note for each.
+Roles are descriptive, not fixed. Add or drop rows to match the topology. For an EOA target, "The target" IS the address being investigated; for a contract target add the deployer + relayer + principal rows above. Always include age (days since first activity), multichain footprint, a confidence tier (CONFIRMED / PROBABLE / POSSIBLE — see skill "Confidence tiers"), and a one-line "what it does" note for each.
+
+## Related addresses / fleet
+
+The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5). Each link carries the evidence and a confidence tier — never a bare assertion. Omit this section only if clustering found nothing, and say so in one line rather than dropping the heading.
+
+| Address | Link type                         | Evidence                                            | Confidence |
+| ------- | --------------------------------- | --------------------------------------------------- | ---------- |
+| `0x…`   | same deployer / codehash / funder | e.g. `keccak(runtime)=0x…` matches; funded by `0x…` | PROBABLE   |
 
 ## What it does
 
@@ -58,9 +66,9 @@ Principal wallet `0x…` holdings on chain `<CHAIN_ID>` (the chain you investiga
 - **`<amount>` `<TOKEN>`** (~$`<usd>` notional) — note any token with dual-native semantics (e.g. CELO is both native gas + ERC20)
 - $`<usd>` stablecoin (split by stablecoin if it matters: USDC / USDT / DAI / chain-native cUSD-cEUR-etc.)
 - `<list any meaningful additional holdings>`
-- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is)
+- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is — filter via DefiLlama price-presence / `confidence`, see skill Step 5.5, not by token name)
 
-Estimated **operating capital ≈ $`<usd>`**. Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
+Estimated **operating capital ≈ $`<usd>`** (value time-sensitive flows at block time via DefiLlama historical prices — skill Step 5.5 — not current spot). Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
 
 ## Why \_\_\_, why these venues
 
@@ -72,9 +80,20 @@ One paragraph. Don't just say "arbitrage" — name the structural mispricing for
 
 Connect the behaviour to the on-chain economics — don't just describe, explain.
 
-## Arkham coverage
+## Coverage and dead ends
 
-What did Arkham return / not return? Run `address_enriched/all` for cross-chain. If Arkham has zero data on the target — common when the chain isn't in Arkham's index (e.g. Celo, Monad) — say so explicitly. Then walk the funder graph through chains Arkham DOES cover. Name how attribution was actually arrived at:
+One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why. The `EMPTY` (covers this chain, found nothing) vs `NOT-COVERED` (can't see this chain) distinction is the whole point — don't collapse them.
+
+| Source                | Result      | Note                                                          |
+| --------------------- | ----------- | ------------------------------------------------------------- |
+| Arkham (cache / live) | NOT-COVERED | Celo/Monad not indexed; operator EOA on covered chains: `<…>` |
+| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`                           |
+| Sim / Dune            | HIT         | `<…>`                                                         |
+| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead                               |
+| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list)                   |
+| `<…>`                 | `<…>`       | `<…>`                                                         |
+
+**Top alternative hypothesis considered** (skill Step 8.5): `<e.g. MM rebalancer rather than arb bot>` — rejected because `<disconfirming evidence>`.
 
 > "Arkham has `<some / no>` data on the target across the chains it covers. Attribution came from `<the curated entity / a high-confidence prediction / the funder graph on chains Arkham does index>`: `<the chain on which the surfacing happened>` showed `<persona / entity>` funded `<operator EOA>`, and `<bridge / direct funder>` funded them on `<upstream chain>`."
 
@@ -82,12 +101,14 @@ What did Arkham return / not return? Run `address_enriched/all` for cross-chain.
 
 Five bullets, one sentence each. The LITERAL placeholder text is below — replace every value with what you actually found. Do NOT ship the placeholders. The skill's worked-example section (`SKILL.md` → "Worked example") points at the seed report's real bottom line for tone calibration; this template stays placeholder-only so a fresh investigation that copy-pastes blindly doesn't accidentally persist seed facts about a different address.
 
-- **Who**: `<persona / entity, one sentence — who's behind this address>`
+- **Who**: `<persona / entity, one sentence — who's behind this address>` `[CONFIRMED / PROBABLE / POSSIBLE]`
 - **What**: `<contract type / behavioural class, one sentence — what does it do>`
-- **Where**: `<chain + venues, one sentence — which chain, which contracts/pools/protocols it interacts with>`
+- **Where**: `<chain + venues, one sentence — target chain AND any other EVM chains the operator's key is active on>`
 - **How much**: `<capital + op rate, one sentence — working-capital USD, tx volume, time period>`
 - **Goal**: `<economic objective, one sentence — what's the strategy capturing>`
 
 ---
+
+_Provenance: `<chain>` head block `<N>` (hash `0x…`), RPC `<endpoint>`, cast `<version>`. Sim/DefiLlama queried `<UTC ts>`._
 
 _Investigation date: YYYY-MM-DD._


### PR DESCRIPTION
## The Problem

- The `forensic-report` skill led every investigation with Arkham, which is **blind to Celo and Monad** — the only chains Mento runs on — so the strongest source for "what did this address do with Mento" went unused.
- The repo's own Envio indexer (per-address Mento swaps/rebalances/LP/CDP/bridge over a public Hasura endpoint) was not wired into the skill at all.
- Several steps carried Ethereum-era assumptions that are wrong for Celo (e.g. "30–50% reverts is normal", `cast` traces, generic bridge guesses).

## The Solution

- Reframe the skill as **multi-chain**: a behaviour leg (Celo/Monad-native sources) and a cross-chain identity leg (the Arkham/Nansen-class tools used on the operator's Ethereum/L2 footprint — never dropped just because they lack Celo, since one key usually spans EVM chains and Mento is adding Polygon/Ethereum).
- Add the **Envio indexer fingerprint** (new Step 1.6) as the primary on-chain source, plus operator-**fleet clustering** (Step 2.5), proxy/decompile + behavioral fingerprints (Step 3), Blockscout call-tree/state-changes (Step 4), venue naming + Celo-L2 MEV correction (Step 6), Wormhole-NTT bridge leg (Step 2), sanctions screening (Step 7.5), confidence tiers, an adversarial-verification gate (Step 8.5), and a provenance footer.
- Catalog every researched tool in a **Tooling matrix (by chain × leg × access)** so Celo-blind tools are placed where they're useful rather than discarded.

## Details

- Findings come from a deep research pass that web-verified each tool's Celo/Monad coverage and pricing; refuted claims were corrected, not propagated (e.g. `cast run` fails on Celo's CIP-64 `0x7b` tx type; Across/Nansen/GoPlus are Celo-blind; the correct ENS Celo coinType is `0x8000A4EC`).
- All GraphQL entities/fields verified against `indexer-envio/schema.graphql`; storage slots, the Chainalysis Celo oracle, and the DefiLlama/Blockscout/GeckoTerminal/Wormholescan/Sourcify endpoints were live-checked (HTTP 200 / correct shapes).
- The skill's Lua upsert is documented as a **simplified non-CAS variant** of `upsertReport()` (the live route added an `expectedVersion` precondition + `{ok, report}` envelope) so the doc doesn't overstate fidelity.
- Scope is docs-only: the canonical `.agents/skills/forensic-report/*` and its byte-identical `.claude/skills/` mirror (enforced by `scripts/check-agent-context.mjs`). No code, no behavior change outside the skill instructions.

## Validation

- `node scripts/check-agent-context.mjs` → passes (18 managed files); `.agents` ↔ `.claude` mirror byte-identical.
- `trunk fmt` + `trunk check` (markdownlint/prettier) → clean (fixed one MD038 nested-code-span).
- Local `/code-review` cleanup pass fixed two GraphQL field bugs (`Trove.collateral`→`coll`, `BridgeTransfer.txHash`→`sentTxHash`) that would have errored.
- Local `/review` (full specialist pass) → PASS; fixed a stale section count + section-name mismatch; deep-verified technical claims live.
- `codex-review` did not complete — it timed out at the script's 720s cap on the 221 KB diff (inconclusive, no findings); the local review covered the diff with live endpoint/schema verification.

## Deferrals

- None

## Ship Checklist

- [x] ship skill used
- [x] local review run (`/code-review` + `/review`; codex timed out)
- [x] validation run (guardrail check + trunk fmt/check)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skills and templates; no production code paths. The skill still documents optional Upstash writes with explicit user confirmation and CAS limitations.
> 
> **Overview**
> This PR **rewrites the forensic-report agent skill and report template** (mirrored under `.agents/` and `.claude/`). It does not change application runtime code.
> 
> The skill now splits investigations into an **on-chain behaviour leg** (Celo/Monad-native tools) and a **cross-chain identity leg** (Arkham-class tools on the operator EOA). Step 1 derives `CHAIN_ID`, RPC, and Dune/DefiLlama namespaces from a single `$CHAIN` switch instead of hardcoding Celo.
> 
> **New or expanded procedure:** Step **1.6** (Mento Envio Hasura fingerprint with chain-scoped GraphQL), **2.5** (operator fleet clustering), **5.5** (DefiLlama historical USD), **7.5** (sanctions/risk), **8.5** (adversarial verification). Existing steps gain infra registry checks, contract-vs-EOA attribution rules, Wormhole NTT bridge tracing, proxy/decompile paths, Blockscout tx anatomy (and Celo `cast run` / revert-rate corrections), venue APIs, and a **tooling matrix** by chain × leg.
> 
> **Report shape:** `template.md` adds **Related addresses / fleet**, **Confidence** columns, **Coverage and dead ends** (replacing Arkham-only coverage), provenance footer, and graded bottom-line claims.
> 
> **Upload docs:** Lua upsert is documented as a **non-CAS, last-writer-wins** variant of `upsertReport()` with aligned legacy `version` normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90db32e0b70e8b9b2f61287ac1bcc1ab00450fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->