### PR TITLE
test(indexer): restore non-handler coverage floor after folding handlers into global (#931)

### DIFF
--- a/indexer-envio/vitest.config.ts
+++ b/indexer-envio/vitest.config.ts
@@ -43,6 +43,25 @@ export default defineConfig({
           functions: 29,
           lines: 22,
         },
+        // Re-pins the pre-#925 non-handler floor so a coverage regression in
+        // well-tested code (rpc.ts, pool.ts, helpers.ts, src/pool/**, src/rpc/**,
+        // src/wormhole/**) isn't masked by low-coverage handler lines diluting
+        // the global pool. Two globs are needed: picomatch's !(handlers) extglob
+        // requires a child segment, so "src/!(handlers)/**/*.ts" covers non-handler
+        // subdirs but silently misses direct children of src/. "src/*.ts" fills
+        // that gap. Floors = floor(measured) - 2.
+        "src/*.ts": {
+          statements: 74,
+          branches: 71,
+          functions: 76,
+          lines: 77,
+        },
+        "src/!(handlers)/**/*.ts": {
+          statements: 65,
+          branches: 52,
+          functions: 75,
+          lines: 66,
+        },
       },
     },
   },


### PR DESCRIPTION
## The Problem

PR #925 correctly stopped excluding `src/handlers/**` from indexer coverage and
gated it with its own bucket — but folding ~13k handler lines into the global
pool dropped the global floors from 70/62/76/72 to 47/42/56/48. The drop is
denominator-driven (correct), yet it leaves the **non-handler** code diluted: a
real coverage regression in well-tested code (`rpc.ts`, `pool.ts`, `helpers.ts`,
`src/pool/**`, `src/rpc/**`, `src/wormhole/**`) can now be masked by
low-coverage handler lines dominating the global denominator.

## The Solution

Add two dedicated `coverage.thresholds` buckets that re-pin the pre-#925
non-handler floor, leaving the global and `src/handlers/**` buckets untouched:

- `"src/*.ts"` → 74/71/76/77 (top-level files)
- `"src/!(handlers)/**/*.ts"` → 65/52/75/66 (non-handler subdirs)

Two globs are required because picomatch's `!(handlers)` extglob needs a child
segment, so `src/!(handlers)/**/*.ts` silently misses the direct children of
`src/` (exactly the high-coverage `rpc.ts`/`pool.ts`/`helpers.ts`); `src/*.ts`
fills that gap. Verified both the extglob and the simple glob actually select
files in vitest's threshold matching. Floors set to `floor(measured) - 2`,
measured 2026-06-15.

## Details

- Closes #931.
- Global + `src/handlers/**` thresholds unchanged — this only ADDS a
  complementary non-handler floor; it does not loosen anything.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test:coverage` — 943 passed, all
  thresholds met (All files 49.91/44.39/58.29/50.57).

## Deferrals

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage configuration; no runtime or production behavior changes.
> 
> **Overview**
> After handlers were folded into global coverage (#925), the global denominator dropped enough that regressions in well-tested non-handler code (`rpc.ts`, `pool.ts`, `helpers.ts`, `src/pool/**`, `src/rpc/**`, `src/wormhole/**`) could slip past the gate.
> 
> This PR **adds** two complementary `coverage.thresholds` buckets in `vitest.config.ts` that re-pin the old non-handler floors (`floor(measured) - 2`): **`src/*.ts`** for top-level sources and **`src/!(handlers)/**/*.ts`** for non-handler subdirectories. Global and **`src/handlers/**`** thresholds are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a345881c77d21d0f1799ab2e36af6bcb348afe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->