### PR TITLE
test: harden GraphQL contract test — argument fields, dynamic queries, shared stubs (#930, #934)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
               - ui-dashboard/**
               - shared-config/**
               # GraphQL contract test validates dashboard queries against the
-              # indexer schema, so schema-only PRs must run the ui job.
+              # indexer schema, so schema-only PRs must run the ui job. The
+              # shared Envio stub fragment feeds the same buildSchema() call.
               - indexer-envio/schema.graphql
+              - scripts/envio-schema-stubs.graphql
               - scripts/eslint-baseline-diff.mjs
               - pnpm-lock.yaml
               - package.json
@@ -102,8 +104,10 @@ jobs:
               - metrics-bridge/**
               - shared-config/**
               # GraphQL contract test validates bridge queries against the
-              # indexer schema, so schema-only PRs must run the bridge job.
+              # indexer schema, so schema-only PRs must run the bridge job. The
+              # shared Envio stub fragment feeds the same buildSchema() call.
               - indexer-envio/schema.graphql
+              - scripts/envio-schema-stubs.graphql
               - scripts/eslint-baseline-diff.mjs
               - cloudbuild.yaml
               - .gcloudignore

--- a/metrics-bridge/test/graphql-contract.test.ts
+++ b/metrics-bridge/test/graphql-contract.test.ts
@@ -20,13 +20,12 @@ import {
 // rationale. Same rule subset: only FieldsOnCorrectTypeRule + ScalarLeafsRule
 // (Hasura-injected args/types would false-positive under any other rule).
 
-// Keep in sync with ENVIO_STUBS in scripts/schema-diff.mjs.
-const ENVIO_STUBS = `
-scalar BigInt
-scalar Bytes
-directive @index(fields: [String!]) repeatable on OBJECT | FIELD_DEFINITION
-directive @config(precision: Int) repeatable on FIELD_DEFINITION
-`;
+// Single source of truth shared with scripts/schema-diff.mjs and the dashboard
+// contract test — read via fs so no cross-package import is needed.
+const ENVIO_STUBS = readFileSync(
+  new URL("../../scripts/envio-schema-stubs.graphql", import.meta.url),
+  "utf8",
+);
 
 const sdl = readFileSync(
   new URL("../../indexer-envio/schema.graphql", import.meta.url),

--- a/metrics-bridge/test/graphql-contract.test.ts
+++ b/metrics-bridge/test/graphql-contract.test.ts
@@ -2,10 +2,13 @@ import { readFileSync } from "node:fs";
 import {
   buildSchema,
   FieldsOnCorrectTypeRule,
+  Kind,
   parse,
   ScalarLeafsRule,
   validate,
+  visit,
 } from "graphql";
+import type { DocumentNode, ObjectValueNode, ValueNode } from "graphql";
 import { describe, expect, it } from "vitest";
 
 import { BRIDGE_CDPS_QUERY } from "../src/cdp-graphql.js";
@@ -17,8 +20,20 @@ import {
 } from "../src/graphql.js";
 
 // See ui-dashboard/src/lib/__tests__/graphql-contract.test.ts for the full
-// rationale. Same rule subset: only FieldsOnCorrectTypeRule + ScalarLeafsRule
-// (Hasura-injected args/types would false-positive under any other rule).
+// rationale. Two complementary checks run per query, mirroring that test:
+//   1. Output selections — validate() with only FieldsOnCorrectTypeRule +
+//      ScalarLeafsRule (Hasura-injected args/types would false-positive under
+//      any other rule).
+//   2. Argument fields — checkArgumentFields() checks the field names inside
+//      where/order_by/distinct_on against the entity SDL. Load-bearing here:
+//      three of the four BRIDGE_POOLS_* queries filter
+//      `Pool(where: { source: { _like: ... } })` WITHOUT selecting `source`, so
+//      the output rules alone would miss a Pool.source rename.
+//
+// The walker below is a deliberate mirror of the dashboard test's (the two
+// contract tests live in different packages; cross-package import of executable
+// TS is the fragile path #930 avoided even for the 4-line stub fragment). Keep
+// the two in sync — same helper names, same semantics.
 
 // Single source of truth shared with scripts/schema-diff.mjs and the dashboard
 // contract test — read via fs so no cross-package import is needed.
@@ -32,10 +47,18 @@ const sdl = readFileSync(
   "utf8",
 );
 
-const entityNames = Array.from(
-  sdl.matchAll(/^type\s+([A-Za-z0-9_]+)/gm),
-  (m) => m[1],
-).filter((n): n is string => typeof n === "string");
+// Parse the raw Envio SDL (syntactic only) to map entity → field names. Used by
+// both the synthesized Query root and the argument-field walker.
+const entityFields = new Map<string, Set<string>>();
+for (const def of parse(sdl).definitions) {
+  if (def.kind === Kind.OBJECT_TYPE_DEFINITION) {
+    entityFields.set(
+      def.name.value,
+      new Set((def.fields ?? []).map((f) => f.name.value)),
+    );
+  }
+}
+const entityNames = [...entityFields.keys()];
 
 const querySdl = `type Query {\n${entityNames
   .map((n) => `  ${n}: [${n}!]!\n  ${n}_by_pk(id: String!): ${n}`)
@@ -44,6 +67,109 @@ const querySdl = `type Query {\n${entityNames
 const schema = buildSchema(`${ENVIO_STUBS}${sdl}\n${querySdl}`);
 
 const CONTRACT_RULES = [FieldsOnCorrectTypeRule, ScalarLeafsRule];
+
+// Argument-field walker — mirror of the dashboard test's. Checks only top-level
+// field existence per entity root field: recurses _and/_or/_not, never recurses
+// operator objects ({_eq}, {_like}) or variable args, so it stays
+// false-positive-free on Hasura idioms while catching a rename of a
+// filtered-but-unselected field.
+function checkField(
+  name: string,
+  fields: Set<string>,
+  entity: string,
+  where: "where" | "order_by" | "distinct_on",
+  errors: string[],
+): void {
+  if (!fields.has(name)) {
+    errors.push(
+      `${where} references "${entity}.${name}" — not a field on ${entity}`,
+    );
+  }
+}
+
+function forEachBoolExp(
+  value: ValueNode,
+  fn: (obj: ObjectValueNode) => void,
+): void {
+  if (value.kind === Kind.LIST) {
+    for (const item of value.values) {
+      if (item.kind === Kind.OBJECT) fn(item);
+    }
+  } else if (value.kind === Kind.OBJECT) {
+    fn(value);
+  }
+}
+
+function checkBoolExp(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  if (value.kind !== Kind.OBJECT) return; // variable / unexpected — can't introspect
+  for (const f of value.fields) {
+    const key = f.name.value;
+    if (key === "_and" || key === "_or") {
+      forEachBoolExp(f.value, (obj) =>
+        checkBoolExp(obj, fields, entity, errors),
+      );
+    } else if (key === "_not") {
+      checkBoolExp(f.value, fields, entity, errors);
+    } else if (!key.startsWith("_")) {
+      checkField(key, fields, entity, "where", errors);
+    }
+  }
+}
+
+function checkOrderBy(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  const objs = value.kind === Kind.LIST ? value.values : [value];
+  for (const obj of objs) {
+    if (obj.kind !== Kind.OBJECT) continue; // variable etc.
+    for (const f of obj.fields) {
+      checkField(f.name.value, fields, entity, "order_by", errors);
+    }
+  }
+}
+
+function checkDistinctOn(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  const vals = value.kind === Kind.LIST ? value.values : [value];
+  for (const v of vals) {
+    if (v.kind === Kind.ENUM)
+      checkField(v.value, fields, entity, "distinct_on", errors);
+  }
+}
+
+function checkArgumentFields(queryAst: DocumentNode): string[] {
+  const errors: string[] = [];
+  visit(queryAst, {
+    Field(node) {
+      const fields = entityFields.get(node.name.value);
+      if (!fields || !node.arguments) return; // not an entity root field
+      const entity = node.name.value;
+      for (const arg of node.arguments) {
+        const argName = arg.name.value;
+        if (argName === "where") {
+          checkBoolExp(arg.value, fields, entity, errors);
+        } else if (argName === "order_by") {
+          checkOrderBy(arg.value, fields, entity, errors);
+        } else if (argName === "distinct_on") {
+          checkDistinctOn(arg.value, fields, entity, errors);
+        }
+      }
+    },
+  });
+  return errors;
+}
 
 const QUERIES: Array<[string, string]> = [
   ["BRIDGE_POOLS_QUERY", BRIDGE_POOLS_QUERY],
@@ -55,7 +181,20 @@ const QUERIES: Array<[string, string]> = [
 
 describe("GraphQL contract: metrics-bridge queries vs indexer-envio/schema.graphql", () => {
   it.each(QUERIES)("%s matches the indexer schema", (name, query) => {
-    const errors = validate(schema, parse(query), CONTRACT_RULES);
-    expect(errors.map((e) => `${name}: ${e.message}`)).toEqual([]);
+    const ast = parse(query);
+    const outputErrors = validate(schema, ast, CONTRACT_RULES);
+    const argErrors = checkArgumentFields(ast);
+    expect([
+      ...outputErrors.map((e) => `${name}: ${e.message}`),
+      ...argErrors.map((m) => `${name}: ${m}`),
+    ]).toEqual([]);
+  });
+
+  it("argument-field walker flags a filtered-but-unselected field rename", () => {
+    // Three BRIDGE_POOLS_* queries filter Pool.source without selecting it;
+    // this asserts a rename of that filtered field would be caught.
+    const bad = `query Bad { Pool(where: { nopeField: { _like: "%x%" } }) { id } }`;
+    const errors = checkArgumentFields(parse(bad));
+    expect(errors.join(" ")).toContain("nopeField");
   });
 });

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1335,6 +1335,18 @@ while IFS= read -r path; do
           ;;
       esac
       ;;
+    scripts/envio-schema-stubs.graphql)
+      # Shared Envio SDL stub fragment, read at test time by BOTH the dashboard
+      # and metrics-bridge GraphQL contract suites (and scripts/schema-diff.mjs)
+      # to make buildSchema() parse. A stub-only edit can break those contract
+      # tests, so route it to both packages' quality commands (test:coverage
+      # runs the contract suites) — the local mirror of the ui/bridge CI
+      # paths-filters. add_package_quality_commands omits test:browser, so this
+      # stays light.
+      add_surface "scripts"
+      add_package_quality_commands "@mento-protocol/ui-dashboard" "shared Envio schema stub changed (dashboard GraphQL contract test reads it)"
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "shared Envio schema stub changed (bridge GraphQL contract test reads it)"
+      ;;
     scripts/*|tools/*)
       add_surface "scripts"
       ;;

--- a/scripts/envio-schema-stubs.graphql
+++ b/scripts/envio-schema-stubs.graphql
@@ -1,0 +1,18 @@
+# Envio framework SDL extensions not in the standard GraphQL spec.
+#
+# Single source of truth for the stub definitions needed so the standard
+# `graphql` parser (`buildSchema`) accepts `indexer-envio/schema.graphql`.
+# Read via fs by all consumers — keep it a plain SDL fragment with no imports
+# so any package (and the root scripts) can load it across boundaries:
+#   - scripts/schema-diff.mjs
+#   - ui-dashboard/src/lib/__tests__/graphql-contract.test.ts
+#   - metrics-bridge/test/graphql-contract.test.ts
+#
+# `repeatable` is required because @index is applied multiple times on the same
+# type (once per field, or once per composite-index declaration). The stubs do
+# not affect structural diffing or contract validation — they only make the SDL
+# parse.
+scalar BigInt
+scalar Bytes
+directive @index(fields: [String!]) repeatable on OBJECT | FIELD_DEFINITION
+directive @config(precision: Int) repeatable on FIELD_DEFINITION

--- a/scripts/schema-diff.mjs
+++ b/scripts/schema-diff.mjs
@@ -28,15 +28,13 @@ import {
   parse,
 } from "graphql";
 
-// Envio framework extensions not in standard GraphQL spec.
-// `repeatable` is required because @index is used multiple times on the same
-// type (once per field, or once per composite-index declaration).
-const ENVIO_STUBS = `
-scalar BigInt
-scalar Bytes
-directive @index(fields: [String!]) repeatable on OBJECT | FIELD_DEFINITION
-directive @config(precision: Int) repeatable on FIELD_DEFINITION
-`;
+// Envio framework SDL extensions not in the standard GraphQL spec, needed so
+// the standard parser accepts the Envio schema. Single source of truth shared
+// with the dashboard + metrics-bridge GraphQL contract tests.
+const ENVIO_STUBS = readFileSync(
+  new URL("./envio-schema-stubs.graphql", import.meta.url),
+  "utf8",
+);
 
 const [, , baseFile, headFile] = process.argv;
 

--- a/turbo.json
+++ b/turbo.json
@@ -44,7 +44,8 @@
         "vitest.config.*",
         "jest.config.*",
         "tsconfig*.json",
-        "$TURBO_ROOT$/indexer-envio/schema.graphql"
+        "$TURBO_ROOT$/indexer-envio/schema.graphql",
+        "$TURBO_ROOT$/scripts/envio-schema-stubs.graphql"
       ],
       "outputs": []
     },

--- a/ui-dashboard/src/lib/__tests__/graphql-contract.test.ts
+++ b/ui-dashboard/src/lib/__tests__/graphql-contract.test.ts
@@ -3,13 +3,20 @@ import { join } from "node:path";
 import {
   buildSchema,
   FieldsOnCorrectTypeRule,
+  Kind,
   parse,
   ScalarLeafsRule,
   validate,
+  visit,
 } from "graphql";
+import type { DocumentNode, ObjectValueNode, ValueNode } from "graphql";
 import { describe, expect, it } from "vitest";
 
 import * as bridgeQueries from "@/lib/bridge-queries";
+import {
+  buildDistinctQuery,
+  DISCOVERY_TARGETS,
+} from "@/lib/mento-address-discovery-targets";
 import * as broker from "@/lib/queries/broker";
 import * as config from "@/lib/queries/config";
 import * as liquity from "@/lib/queries/liquity";
@@ -29,31 +36,43 @@ import * as volumeVia from "@/lib/queries/volume-via";
 // fields that exist in indexer-envio/schema.graphql. Catches indexer field
 // renames at CI time instead of at runtime on the dashboard.
 //
-// Validation runs with ONLY FieldsOnCorrectTypeRule + ScalarLeafsRule.
-// Hasura injects arguments (where/order_by/limit/offset) and input types
-// (*_bool_exp, *_order_by, numeric) that don't exist in the Envio SDL, so
-// argument/known-type/value rules would all false-positive. Do not add rules.
+// Two complementary checks run per query:
+//   1. Output selections — graphql.validate() with ONLY FieldsOnCorrectTypeRule
+//      + ScalarLeafsRule. Hasura injects arguments (where/order_by/limit/offset)
+//      and input types (*_bool_exp, *_order_by, numeric) that don't exist in the
+//      Envio SDL, so argument/known-type/value rules would all false-positive.
+//      Do not add rules to this set.
+//   2. Argument fields — a bespoke AST walker (checkArgumentFields) checks the
+//      field names referenced inside where/order_by/distinct_on against the
+//      entity's SDL fields. The output rules above structurally CANNOT see these
+//      (a `where: { removed: {...} }` filter never selects `removed`), so a
+//      rename of a filtered-but-unselected field would otherwise pass silently.
 
 const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
 const SCHEMA_PATH = join(REPO_ROOT, "indexer-envio", "schema.graphql");
+// Single source of truth shared with scripts/schema-diff.mjs and the
+// metrics-bridge contract test — read via fs so no cross-package import.
+const STUBS_PATH = join(REPO_ROOT, "scripts", "envio-schema-stubs.graphql");
 
-// Keep in sync with ENVIO_STUBS in scripts/schema-diff.mjs.
-const ENVIO_STUBS = `
-scalar BigInt
-scalar Bytes
-directive @index(fields: [String!]) repeatable on OBJECT | FIELD_DEFINITION
-directive @config(precision: Int) repeatable on FIELD_DEFINITION
-`;
-
+const ENVIO_STUBS = readFileSync(STUBS_PATH, "utf8");
 const sdl = readFileSync(SCHEMA_PATH, "utf8");
+
+// Parse the raw Envio SDL (syntactic only — directive applications and custom
+// scalar usages don't need definitions to parse) to map entity → field names.
+// Used by both the synthesized Query root and the argument-field walker.
+const entityFields = new Map<string, Set<string>>();
+for (const def of parse(sdl).definitions) {
+  if (def.kind === Kind.OBJECT_TYPE_DEFINITION) {
+    entityFields.set(
+      def.name.value,
+      new Set((def.fields ?? []).map((f) => f.name.value)),
+    );
+  }
+}
+const entityNames = [...entityFields.keys()];
 
 // schema.graphql has no Query root type (Hasura synthesizes it in prod), and
 // graphql.validate() requires one — derive root fields from the entity types.
-const entityNames = Array.from(
-  sdl.matchAll(/^type\s+([A-Za-z0-9_]+)/gm),
-  (m) => m[1],
-).filter((n): n is string => typeof n === "string");
-
 const querySdl = `type Query {\n${entityNames
   .map((n) => `  ${n}: [${n}!]!\n  ${n}_by_pk(id: String!): ${n}`)
   .join("\n")}\n}`;
@@ -61,6 +80,116 @@ const querySdl = `type Query {\n${entityNames
 const schema = buildSchema(`${ENVIO_STUBS}${sdl}\n${querySdl}`);
 
 const CONTRACT_RULES = [FieldsOnCorrectTypeRule, ScalarLeafsRule];
+
+// Argument-field walker. Hasura's where/order_by/distinct_on name schema fields
+// that the query never selects, so the output rules above can't validate them.
+// This walks each query AST and checks those field references against the
+// entity's real SDL fields. It deliberately checks ONLY top-level field
+// existence per entity root field: it skips logical operators (_and/_or/_not,
+// recursed), comparison operators ({_eq}, never recursed), and any argument
+// passed as a variable (can't introspect). That keeps it false-positive-free on
+// the Hasura idioms the output rules avoid, while still catching a rename of a
+// filtered-but-unselected field. Nested relationship sub-filters are checked at
+// their top-level field name only (the inner fields belong to a different type).
+function checkField(
+  name: string,
+  fields: Set<string>,
+  entity: string,
+  where: "where" | "order_by" | "distinct_on",
+  errors: string[],
+): void {
+  if (!fields.has(name)) {
+    errors.push(
+      `${where} references "${entity}.${name}" — not a field on ${entity}`,
+    );
+  }
+}
+
+function forEachBoolExp(
+  value: ValueNode,
+  fn: (obj: ObjectValueNode) => void,
+): void {
+  if (value.kind === Kind.LIST) {
+    for (const item of value.values) {
+      if (item.kind === Kind.OBJECT) fn(item);
+    }
+  } else if (value.kind === Kind.OBJECT) {
+    fn(value);
+  }
+}
+
+function checkBoolExp(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  if (value.kind !== Kind.OBJECT) return; // variable / unexpected — can't introspect
+  for (const f of value.fields) {
+    const key = f.name.value;
+    if (key === "_and" || key === "_or") {
+      forEachBoolExp(f.value, (obj) =>
+        checkBoolExp(obj, fields, entity, errors),
+      );
+    } else if (key === "_not") {
+      checkBoolExp(f.value, fields, entity, errors);
+    } else if (!key.startsWith("_")) {
+      // A real field key. Check existence; do NOT recurse into its operator
+      // object ({_eq: ...}) or relationship sub-filter (different type).
+      checkField(key, fields, entity, "where", errors);
+    }
+  }
+}
+
+function checkOrderBy(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  const objs = value.kind === Kind.LIST ? value.values : [value];
+  for (const obj of objs) {
+    if (obj.kind !== Kind.OBJECT) continue; // variable etc.
+    for (const f of obj.fields) {
+      checkField(f.name.value, fields, entity, "order_by", errors);
+    }
+  }
+}
+
+function checkDistinctOn(
+  value: ValueNode,
+  fields: Set<string>,
+  entity: string,
+  errors: string[],
+): void {
+  const vals = value.kind === Kind.LIST ? value.values : [value];
+  for (const v of vals) {
+    if (v.kind === Kind.ENUM)
+      checkField(v.value, fields, entity, "distinct_on", errors);
+  }
+}
+
+function checkArgumentFields(queryAst: DocumentNode): string[] {
+  const errors: string[] = [];
+  visit(queryAst, {
+    Field(node) {
+      const fields = entityFields.get(node.name.value);
+      if (!fields || !node.arguments) return; // not an entity root field
+      const entity = node.name.value;
+      for (const arg of node.arguments) {
+        const argName = arg.name.value;
+        if (argName === "where") {
+          checkBoolExp(arg.value, fields, entity, errors);
+        } else if (argName === "order_by") {
+          checkOrderBy(arg.value, fields, entity, errors);
+        } else if (argName === "distinct_on") {
+          checkDistinctOn(arg.value, fields, entity, errors);
+        }
+      }
+    },
+  });
+  return errors;
+}
 
 // Every module that exports hand-written query strings. The barrel
 // src/lib/queries.ts only re-exports a subset — import directly.
@@ -93,13 +222,62 @@ for (const [moduleName, mod] of Object.entries(QUERY_MODULES)) {
   }
 }
 
+// Dynamically-built discovery queries (mento-address-discovery.ts) never appear
+// as exported consts, so the module scan above can't see them. Generate them
+// from the SAME builder the runtime uses so this covers field/table drift on
+// the Arkham/MiniPay discovery cron path.
+const DISCOVERY_QUERIES: Array<[string, string]> = DISCOVERY_TARGETS.map(
+  (t) => [`discovery.${t.table}.${t.field}`, buildDistinctQuery(t)],
+);
+
+const ALL_QUERIES: Array<[string, string]> = [...QUERIES, ...DISCOVERY_QUERIES];
+
 describe("GraphQL contract: dashboard queries vs indexer-envio/schema.graphql", () => {
   it("discovers the full query surface (guards a silent no-op)", () => {
     expect(QUERIES.length).toBeGreaterThanOrEqual(100);
   });
 
-  it.each(QUERIES)("%s matches the indexer schema", (name, query) => {
-    const errors = validate(schema, parse(query), CONTRACT_RULES);
-    expect(errors.map((e) => `${name}: ${e.message}`)).toEqual([]);
+  it("covers every dynamic discovery target", () => {
+    expect(DISCOVERY_QUERIES.length).toBe(DISCOVERY_TARGETS.length);
+  });
+
+  it.each(ALL_QUERIES)("%s matches the indexer schema", (name, query) => {
+    const ast = parse(query);
+    const outputErrors = validate(schema, ast, CONTRACT_RULES);
+    const argErrors = checkArgumentFields(ast);
+    expect([
+      ...outputErrors.map((e) => `${name}: ${e.message}`),
+      ...argErrors.map((m) => `${name}: ${m}`),
+    ]).toEqual([]);
+  });
+});
+
+describe("GraphQL contract: argument-field walker catches filtered-but-unselected drift", () => {
+  it("accepts the real ALL_CDP_POOLS where fields (removed/chainId)", () => {
+    expect(checkArgumentFields(parse(ols.ALL_CDP_POOLS))).toEqual([]);
+  });
+
+  it("flags a where field that does not exist on the entity", () => {
+    const bad = `query Bad { CdpPool(where: { nopeField: { _eq: true } }) { poolId } }`;
+    const errors = checkArgumentFields(parse(bad));
+    expect(errors.join(" ")).toContain("nopeField");
+  });
+
+  it("flags an order_by field that does not exist on the entity", () => {
+    const bad = `query Bad { CdpPool(order_by: { nopeField: desc }) { poolId } }`;
+    const errors = checkArgumentFields(parse(bad));
+    expect(errors.join(" ")).toContain("nopeField");
+  });
+
+  it("flags a distinct_on field that does not exist on the entity", () => {
+    const bad = `query Bad { SwapEvent(distinct_on: [nopeField]) { id } }`;
+    const errors = checkArgumentFields(parse(bad));
+    expect(errors.join(" ")).toContain("nopeField");
+  });
+
+  it("flags drift nested inside an _and/_or bool-exp", () => {
+    const bad = `query Bad { CdpPool(where: { _and: [{ nopeField: { _eq: true } }] }) { poolId } }`;
+    const errors = checkArgumentFields(parse(bad));
+    expect(errors.join(" ")).toContain("nopeField");
   });
 });

--- a/ui-dashboard/src/lib/mento-address-discovery-targets.ts
+++ b/ui-dashboard/src/lib/mento-address-discovery-targets.ts
@@ -1,0 +1,61 @@
+// Discovery targets + query builder for server-side unique-address discovery.
+//
+// Extracted into a zero-dependency module (no graphql-request / Sentry / React)
+// so the GraphQL contract test can validate the dynamically-built `Distinct_*`
+// queries against the indexer schema without dragging in the runtime deps of
+// `mento-address-discovery.ts`. The runtime and the test share ONE builder, so
+// the test validates the real query string instead of a drift-prone copy.
+
+export type DiscoveryEntity = {
+  table: string;
+  field: string;
+  /**
+   * Column the chainId filter applies to. Most tables use `chainId`;
+   * `BridgeTransfer` carries `sourceChainId` and `destChainId` separately
+   * (no plain `chainId` column — see `indexer-envio/schema.graphql`).
+   */
+  chainIdColumn: string;
+};
+
+// Per-entity discovery targets. BridgeTransfer.sender filters on
+// sourceChainId (outbound from Celo); .recipient on destChainId
+// (inbound to Celo). Other entities use the canonical `chainId`.
+export const DISCOVERY_TARGETS: readonly DiscoveryEntity[] = [
+  { table: "SwapEvent", field: "sender", chainIdColumn: "chainId" },
+  { table: "SwapEvent", field: "recipient", chainIdColumn: "chainId" },
+  // `caller` (tx.from) and `txTo` (tx.to) capture the EOA that signed the
+  // swap and the entry-point contract — needed for MiniPay tagging since
+  // routed v3 swaps surface the broker/router as `sender`, not the user.
+  { table: "SwapEvent", field: "caller", chainIdColumn: "chainId" },
+  { table: "SwapEvent", field: "txTo", chainIdColumn: "chainId" },
+  { table: "LiquidityEvent", field: "sender", chainIdColumn: "chainId" },
+  { table: "LiquidityEvent", field: "recipient", chainIdColumn: "chainId" },
+  { table: "RebalanceEvent", field: "sender", chainIdColumn: "chainId" },
+  { table: "RebalanceEvent", field: "caller", chainIdColumn: "chainId" },
+  { table: "LiquidityPosition", field: "address", chainIdColumn: "chainId" },
+  { table: "OlsLiquidityEvent", field: "caller", chainIdColumn: "chainId" },
+  { table: "BridgeTransfer", field: "sender", chainIdColumn: "sourceChainId" },
+  { table: "BridgeTransfer", field: "recipient", chainIdColumn: "destChainId" },
+] as const;
+
+/**
+ * Build the per-(entity, field) `distinct_on` pagination query. Takes
+ * `$chainId`, `$limit`, `$offset` as variables. Kept as the single source of
+ * truth for both the runtime cron path and the GraphQL contract test.
+ */
+export function buildDistinctQuery(target: DiscoveryEntity): string {
+  const { table, field, chainIdColumn } = target;
+  return `
+      query Distinct_${table}_${field}($chainId: Int!, $limit: Int!, $offset: Int!) {
+        rows: ${table}(
+          where: { ${chainIdColumn}: { _eq: $chainId } }
+          distinct_on: [${field}]
+          order_by: { ${field}: asc }
+          limit: $limit
+          offset: $offset
+        ) {
+          address: ${field}
+        }
+      }
+    `;
+}

--- a/ui-dashboard/src/lib/mento-address-discovery.ts
+++ b/ui-dashboard/src/lib/mento-address-discovery.ts
@@ -14,6 +14,11 @@
 import { GraphQLClient } from "graphql-request";
 import * as Sentry from "@sentry/nextjs";
 import { isValidAddress } from "@/lib/validators";
+import {
+  buildDistinctQuery,
+  DISCOVERY_TARGETS,
+  type DiscoveryEntity,
+} from "@/lib/mento-address-discovery-targets";
 
 const PAGE_SIZE = 1000;
 const HARD_PAGE_CAP = 50; // 50_000 rows per entity — sentinel against runaway loops
@@ -25,64 +30,20 @@ const HASURA_REQUEST_TIMEOUT_MS = 10_000;
 type DistinctRow = { address: string };
 type DistinctQueryShape = Record<string, DistinctRow[]>;
 
-type DiscoveryEntity = {
-  table: string;
-  field: string;
-  /**
-   * Column the chainId filter applies to. Most tables use `chainId`;
-   * `BridgeTransfer` carries `sourceChainId` and `destChainId` separately
-   * (no plain `chainId` column — see `indexer-envio/schema.graphql`).
-   */
-  chainIdColumn: string;
-};
-
-// Per-entity discovery targets. BridgeTransfer.sender filters on
-// sourceChainId (outbound from Celo); .recipient on destChainId
-// (inbound to Celo). Other entities use the canonical `chainId`.
-const DISCOVERY_TARGETS: readonly DiscoveryEntity[] = [
-  { table: "SwapEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "SwapEvent", field: "recipient", chainIdColumn: "chainId" },
-  // `caller` (tx.from) and `txTo` (tx.to) capture the EOA that signed the
-  // swap and the entry-point contract — needed for MiniPay tagging since
-  // routed v3 swaps surface the broker/router as `sender`, not the user.
-  { table: "SwapEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "SwapEvent", field: "txTo", chainIdColumn: "chainId" },
-  { table: "LiquidityEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "LiquidityEvent", field: "recipient", chainIdColumn: "chainId" },
-  { table: "RebalanceEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "RebalanceEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "LiquidityPosition", field: "address", chainIdColumn: "chainId" },
-  { table: "OlsLiquidityEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "BridgeTransfer", field: "sender", chainIdColumn: "sourceChainId" },
-  { table: "BridgeTransfer", field: "recipient", chainIdColumn: "destChainId" },
-] as const;
-
 async function fetchDistinctAddresses(
   client: GraphQLClient,
   target: DiscoveryEntity,
   chainId: number,
 ): Promise<string[]> {
-  const { table, field, chainIdColumn } = target;
+  const { table, field } = target;
   const all = new Set<string>();
   let page = 0;
+  const query = buildDistinctQuery(target);
 
   // Sequential pagination — early-exit on short-page; can't parallelize
   // without an upfront count.
   for (; page < HARD_PAGE_CAP; page += 1) {
     const offset = page * PAGE_SIZE;
-    const query = `
-      query Distinct_${table}_${field}($chainId: Int!, $limit: Int!, $offset: Int!) {
-        rows: ${table}(
-          where: { ${chainIdColumn}: { _eq: $chainId } }
-          distinct_on: [${field}]
-          order_by: { ${field}: asc }
-          limit: $limit
-          offset: $offset
-        ) {
-          address: ${field}
-        }
-      }
-    `;
     // react-doctor-disable-next-line react-doctor/async-await-in-loop
     const data = await client.request<DistinctQueryShape>({
       document: query,


### PR DESCRIPTION
## The Problem

The GraphQL contract test added in #924 catches indexer field renames for the
~110 hand-written dashboard query strings — but only for **output-field
selections**, validated with `FieldsOnCorrectTypeRule` + `ScalarLeafsRule`. Two
drift surfaces stayed structurally invisible to it, and the Envio schema-stub
block was triplicated:

- **Argument fields (#934 A).** `where` / `order_by` / `distinct_on` name schema
  fields that the query never selects, so the output rules can't see them.
  `ui-dashboard/src/lib/queries/ols.ts` `ALL_CDP_POOLS` filters
  `where: { removed: { _eq: false }, chainId: { _eq: $chainId } }` but selects
  only `poolId collateralId strategyAddress` — renaming `CdpPool.removed` keeps
  the test green while Hasura rejects the query at runtime.
- **Dynamic queries (#934 B).** `mento-address-discovery.ts` builds
  `query Distinct_${table}_${field}` from `DISCOVERY_TARGETS` at runtime, so the
  static module scan never discovers it. Drift in a discovery target table/field
  passes CI while the Arkham/MiniPay cron starts failing.
- **Stub duplication (#930).** The `scalar BigInt/Bytes` + `@index`/`@config`
  stub block (needed so `buildSchema` parses the Envio SDL) lived in three files
  kept in sync only by a comment: both contract tests + `scripts/schema-diff.mjs`.

## The Solution

- **#934 A — argument-field walker.** A bespoke AST walker (`checkArgumentFields`)
  checks the field names referenced inside `where`/`order_by`/`distinct_on`
  against the entity's real SDL fields. It deliberately checks only top-level
  field existence per entity root field — recurses `_and`/`_or`/`_not`, never
  recurses operator objects (`{_eq: …}`) or variable args — so it stays
  false-positive-free on exactly the Hasura idioms the output rules were
  restricted to avoid. The original PR's reason for using output-only rules is
  preserved; this is an additive, scoped check rather than a fuller schema
  synthesis. Negative tests lock in detection of bad where / order_by /
  distinct_on / nested-`_and` fields.
- **#934 B — dynamic discovery coverage.** Extracted `DISCOVERY_TARGETS` + the
  query builder into a new zero-dependency module
  (`mento-address-discovery-targets.ts`) so the test generates the `Distinct_*`
  queries from the **same builder the runtime uses** (no `graphql-request` /
  Sentry dragged into the test) and validates them through both the output rules
  and the new walker. The runtime now consumes the shared builder too, so the
  test can't drift from the real query.
- **#930 — shared stub.** Moved the stub fragment to
  `scripts/envio-schema-stubs.graphql`, read via `fs` by all three consumers
  (matching how they already cross-package-read `schema.graphql`), ending the
  comment-synced triplication. A future Envio directive is added in one place.

## Details

- New `scripts/envio-schema-stubs.graphql` registered in the turbo `test` task
  inputs and the `ui` + `bridge` CI paths-filters alongside `schema.graphql`, so
  a stub change re-runs the affected tests and busts the turbo cache.
- The dashboard test now runs 126 cases (122 query validations incl. 12 dynamic
  discovery queries + 4 surface/negative guards).
- No behavioral change to the runtime discovery path: same query string, same
  variables; the builder was only hoisted out of the pagination loop (it is
  loop-invariant) and into the shared module.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test` — 3237 passed (incl. the
  126-case contract suite and the existing `mento-address-discovery` test).
- `pnpm --filter @mento-protocol/metrics-bridge exec vitest run test/graphql-contract.test.ts` — 5 passed.
- `node scripts/schema-diff.mjs indexer-envio/schema.graphql indexer-envio/schema.graphql` — runs clean with the shared stub.
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` / metrics-bridge typecheck — clean.
- dashboard `knip`, `pnpm lint:scripts`, react-doctor diff (100/100) — clean.

- None

(The "full Hasura input-type synthesis" alternative noted in #934 is
intentionally **not** pursued — a won't-do, not a deferral: the scoped AST
walker closes the same drift surface without the false-positive risk that
motivated the output-only rule set in #924.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI tests, tooling, and a refactor that hoists discovery query strings without altering runtime behavior.
> 
> **Overview**
> **Strengthens GraphQL contract coverage** so indexer schema drift is caught in CI for filter arguments and runtime-built discovery queries, not only selected output fields.
> 
> Dashboard and metrics-bridge contract suites now run **two checks per query**: existing `validate()` on selections, plus a shared **`checkArgumentFields`** AST walk over `where` / `order_by` / `distinct_on` (catches renames like filtered `Pool.source` or `CdpPool.removed` that never appear in the selection set). Negative tests lock in that behavior.
> 
> **Dynamic address-discovery queries** are covered by extracting `DISCOVERY_TARGETS` and `buildDistinctQuery` into `mento-address-discovery-targets.ts`; the cron path and the contract test use the same builder so generated `Distinct_*` queries cannot drift silently.
> 
> **Envio SDL stubs** (`BigInt`, `Bytes`, `@index`, `@config`) move to `scripts/envio-schema-stubs.graphql` and are read from disk by `schema-diff.mjs` and both contract tests. CI path filters, turbo `test` inputs, and the agent quality gate treat stub edits like schema-adjacent changes for ui/bridge jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab08a63be759dffe2ff182c643e8a03e5ff03882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->