### PR TITLE
refactor: export snapshot page size

### DIFF
--- a/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
+++ b/ui-dashboard/src/hooks/use-cdp-borrowing-revenue.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/queries";
 import {
   REQUEST_TIMEOUT_MS,
+  SNAPSHOT_PAGE_SIZE,
   fetchPaginatedRows,
 } from "@/lib/fetch-all-networks";
 import {
@@ -96,7 +97,6 @@ const EMPTY_SUMMARY: CdpBorrowingRevenueSummary = {
   bracketsTruncated: false,
 };
 
-const CDP_PAGE_SIZE = 1000;
 const CDP_REVENUE_CHAIN_IDS = new Set([42220]);
 
 function mergeSummaries(
@@ -201,11 +201,11 @@ async function fetchAllBracketPages(
     query: CDP_BORROWING_REVENUE_BRACKETS,
     responseKey: "InterestRateBracket",
     network,
-    pageSize: CDP_PAGE_SIZE,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       collateralIds,
-      limit: CDP_PAGE_SIZE,
-      offset: page * CDP_PAGE_SIZE,
+      limit: SNAPSHOT_PAGE_SIZE,
+      offset: page * SNAPSHOT_PAGE_SIZE,
     }),
     dedupKey: (r) => r.id,
   });
@@ -223,11 +223,11 @@ async function fetchAllFeeEventPages(
     query: CDP_BORROWING_FEE_EVENTS,
     responseKey: "TroveOperationEvent",
     network,
-    pageSize: CDP_PAGE_SIZE,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
-      limit: CDP_PAGE_SIZE,
-      offset: page * CDP_PAGE_SIZE,
+      limit: SNAPSHOT_PAGE_SIZE,
+      offset: page * SNAPSHOT_PAGE_SIZE,
     }),
     dedupKey: (r) => r.id,
   });
@@ -262,11 +262,11 @@ async function paginateDailySnapshots<T extends { id: string }>(
     query,
     responseKey: "LiquityBorrowingRevenueDailySnapshot",
     network,
-    pageSize: CDP_PAGE_SIZE,
+    pageSize: SNAPSHOT_PAGE_SIZE,
     variablesFor: (page) => ({
       chainId,
-      limit: CDP_PAGE_SIZE,
-      offset: page * CDP_PAGE_SIZE,
+      limit: SNAPSHOT_PAGE_SIZE,
+      offset: page * SNAPSHOT_PAGE_SIZE,
     }),
     dedupKey: (r) => r.id,
   });

--- a/ui-dashboard/src/lib/__tests__/fetch-all-networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/fetch-all-networks.test.ts
@@ -10,6 +10,7 @@ import { NETWORKS } from "@/lib/networks";
 // silently drop or rename a named export — 7 importers depend on these.
 const EXPECTED_EXPORT_NAMES = [
   "REQUEST_TIMEOUT_MS",
+  "SNAPSHOT_PAGE_SIZE",
   "blankNetworkData",
   "fetchAllFeeSnapshotPages",
   "fetchAllNetworks",

--- a/ui-dashboard/src/lib/network-fetcher/constants.ts
+++ b/ui-dashboard/src/lib/network-fetcher/constants.ts
@@ -1,0 +1,1 @@
+export const SNAPSHOT_PAGE_SIZE = 1000;

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -47,6 +47,9 @@ import type {
   SerializableError,
   SnapshotPageResult,
 } from "./types";
+import { SNAPSHOT_PAGE_SIZE } from "./constants";
+
+export { SNAPSHOT_PAGE_SIZE } from "./constants";
 
 /**
  * True iff every error channel on `n` is null — top-level, rates,
@@ -158,7 +161,6 @@ const emptyNetworkData = (
  * possible but rare and self-heal on the next refresh. A proper fix is
  * keyset pagination — tracked as a follow-up.
  */
-const SNAPSHOT_PAGE_SIZE = 1000;
 const SNAPSHOT_MAX_PAGES = 100;
 
 // Per-request abort budget. Matches `homepage-og.ts` and `useBridgeGQL`. Without

--- a/ui-dashboard/src/lib/queries/lp.ts
+++ b/ui-dashboard/src/lib/queries/lp.ts
@@ -1,17 +1,17 @@
 // LP-position queries (LiquidityPosition entity). The barrel re-export lives
 // in `../queries.ts` so existing `from "@/lib/queries"` imports stay stable;
 // consumers can also import directly from this module.
+import { SNAPSHOT_PAGE_SIZE } from "@/lib/network-fetcher/constants";
 
 // Preferred LP ownership query. Environments without LiquidityPosition should
 // show a migration message rather than attempt a correctness-risky fallback.
-const POOL_LP_POSITIONS_LIMIT = 1000;
 
 export const POOL_LP_POSITIONS = `
   query PoolLpPositions($poolId: String!) {
     LiquidityPosition(
       where: { poolId: { _eq: $poolId } }
       order_by: { netLiquidity: desc }
-      limit: ${POOL_LP_POSITIONS_LIMIT}
+      limit: ${SNAPSHOT_PAGE_SIZE}
     ) {
       id address netLiquidity lastUpdatedBlock lastUpdatedTimestamp
     }
@@ -21,7 +21,7 @@ export const POOL_LP_POSITIONS = `
 /**
  * Distinct LP addresses across the given pools, used to size the homepage
  * "unique LPs" tile. Paginated via `fetchAllLpAddressPages` using the
- * canonical `fetchPaginatedRows` helper (page size 1 000).
+ * canonical `fetchPaginatedRows` helper.
  *
  * `order_by: {id: asc}` gives offset pagination a stable sort so consecutive
  * pages neither overlap nor skip rows under concurrent inserts.


### PR DESCRIPTION
## The Problem

- `fetchPaginatedRows` uses one page-size sentinel, but some callers carried their own `1000` literals.
- If the helper sentinel changed without those duplicated literals changing, the first page could look like a short page and truncate results.

## The Solution

- Export `SNAPSHOT_PAGE_SIZE` from the network fetcher and use that shared constant in the CDP borrowing revenue pagination callers.
- Move the constant into a tiny constants module so LP query strings can share it without creating a query/fetcher barrel cycle.

## Details

- Updates the `@/lib/fetch-all-networks` surface-contract test to include the new public export.
- Keeps unrelated page-size constants untouched; this PR only updates the callers tied to `fetchPaginatedRows`.

Closes #932

## Deferrals

None

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- fetch-all-networks.test.ts use-cdp-borrowing-revenue.test.ts queries.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm dashboard:react-doctor:diff`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Browser verification via Chrome DevTools MCP on `http://127.0.0.1:3210/` and `/revenue` against live Envio data: homepage rendered LP metrics/table, revenue rendered CDP borrowing revenue rows, and all Hasura GraphQL requests returned 200. The only console/network error was the pre-existing local `/api/address-labels` 500 from missing Upstash credentials while a dev auth cookie was present; it is unrelated to this pagination refactor.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant extraction with no logic changes; only reduces risk of future pagination limit/sentinel mismatch.
> 
> **Overview**
> Introduces a single **`SNAPSHOT_PAGE_SIZE` (1000)** in `network-fetcher/constants.ts` and wires all `fetchPaginatedRows` callers to use it instead of local `1000` literals.
> 
> **CDP borrowing revenue** drops `CDP_PAGE_SIZE` and passes the shared constant for `pageSize`, `limit`, and `offset` on bracket, fee-event, and daily-snapshot pagination. **LP GraphQL** (`POOL_LP_POSITIONS`) replaces `POOL_LP_POSITIONS_LIMIT` with the same constant, imported from `constants` so query modules do not depend on the fetch barrel (avoids a cycle). The network fetcher re-exports the constant from `fetch.ts`; the **`fetch-all-networks` surface-contract test** now expects `SNAPSHOT_PAGE_SIZE` in the public API.
> 
> Behavior is unchanged at 1000; the point is keeping GraphQL `limit` aligned with `fetchPaginatedRows`'s short-page sentinel so pagination cannot silently truncate if only one side of that contract drifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6695b3244c33b4995ae43dbb698e79a84274a47a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->