### PR TITLE
fix: surface watchdog send failures

### DIFF
--- a/governance-watchdog/src/events/__tests__/event-handler-factory.test.ts
+++ b/governance-watchdog/src/events/__tests__/event-handler-factory.test.ts
@@ -83,7 +83,8 @@ describe("createEventHandler notification failures", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.clearAllMocks();
+    mockSendDiscordNotification.mockClear();
+    mockSendTelegramNotification.mockClear();
   });
 
   it("logs Discord send failures as structured ERROR entries and still sends Telegram", async () => {
@@ -96,8 +97,9 @@ describe("createEventHandler notification failures", () => {
 
     expect(mockSendDiscordNotification).toHaveBeenCalledOnce();
     expect(mockSendTelegramNotification).toHaveBeenCalledOnce();
-    expect(loggedErrors()).toHaveLength(1);
-    const [entry] = loggedErrors();
+    const errors = loggedErrors();
+    expect(errors).toHaveLength(1);
+    const [entry] = errors;
     expect(entry.severity).toBe("ERROR");
     expect(entry.message).toContain(
       "Failed to send Discord notification for ProposalCreated event:",
@@ -115,8 +117,9 @@ describe("createEventHandler notification failures", () => {
 
     expect(mockSendDiscordNotification).toHaveBeenCalledOnce();
     expect(mockSendTelegramNotification).toHaveBeenCalledOnce();
-    expect(loggedErrors()).toHaveLength(1);
-    const [entry] = loggedErrors();
+    const errors = loggedErrors();
+    expect(errors).toHaveLength(1);
+    const [entry] = errors;
     expect(entry.severity).toBe("ERROR");
     expect(entry.message).toContain(
       "Failed to send Telegram notification for ProposalCreated event:",

--- a/governance-watchdog/src/events/__tests__/event-handler-factory.test.ts
+++ b/governance-watchdog/src/events/__tests__/event-handler-factory.test.ts
@@ -1,0 +1,126 @@
+import { EmbedBuilder } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEventHandler,
+  type EventHandlerConfig,
+} from "../event-handler-factory.js";
+import {
+  EventType,
+  type ProposalCreatedEvent,
+  type QuicknodeEvent,
+} from "../types.js";
+
+const { mockSendDiscordNotification, mockSendTelegramNotification } =
+  vi.hoisted(() => ({
+    mockSendDiscordNotification: vi.fn(),
+    mockSendTelegramNotification: vi.fn(),
+  }));
+
+vi.mock("../../event-notifications/send-discord-notification.js", () => ({
+  default: mockSendDiscordNotification,
+}));
+
+vi.mock("../../event-notifications/send-telegram-notification.js", () => ({
+  default: mockSendTelegramNotification,
+}));
+
+const event: QuicknodeEvent & ProposalCreatedEvent = {
+  address: "0x47036d78bb3169b4f5560dd77bf93f4412a59852",
+  blockHash: "0xdeadbeef",
+  blockNumber: "1",
+  logIndex: "0",
+  name: EventType.ProposalCreated,
+  transactionHash: "0xabc",
+  proposalId: BigInt(1),
+  proposer: "0x1234567890123456789012345678901234567890",
+  calldatas: "0x",
+  description: "{}",
+  endBlock: BigInt(100),
+  signatures: "",
+  startBlock: BigInt(1),
+  targets: "0x1234567890123456789012345678901234567890",
+  values: BigInt(0),
+  version: 1,
+};
+
+const config: EventHandlerConfig<typeof event> = {
+  eventType: EventType.ProposalCreated,
+  validateEvent: (value: unknown): value is typeof event =>
+    (value as QuicknodeEvent).name === EventType.ProposalCreated,
+  getDiscordMessage: () => ({
+    content: "Proposal created",
+    embed: new EmbedBuilder().setTitle("Proposal created"),
+  }),
+  getTelegramMessage: () => ({
+    toHTML: (title: string) => `<b>${title}</b>`,
+  }),
+  emoji: "GOV",
+};
+
+interface StructuredErrorLog {
+  severity: string;
+  message: string;
+}
+
+function loggedErrors(): StructuredErrorLog[] {
+  const calls = vi.mocked(console.error).mock.calls as unknown[][];
+  return calls.map((call) => {
+    const line = call[0];
+    if (typeof line !== "string") {
+      throw new TypeError("Expected console.error to receive a string log");
+    }
+    return JSON.parse(line) as StructuredErrorLog;
+  });
+}
+
+describe("createEventHandler notification failures", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    mockSendDiscordNotification.mockResolvedValue(undefined);
+    mockSendTelegramNotification.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("logs Discord send failures as structured ERROR entries and still sends Telegram", async () => {
+    mockSendDiscordNotification.mockRejectedValueOnce(
+      new Error("discord unavailable"),
+    );
+    const handler = createEventHandler(config);
+
+    await handler(event);
+
+    expect(mockSendDiscordNotification).toHaveBeenCalledOnce();
+    expect(mockSendTelegramNotification).toHaveBeenCalledOnce();
+    expect(loggedErrors()).toHaveLength(1);
+    const [entry] = loggedErrors();
+    expect(entry.severity).toBe("ERROR");
+    expect(entry.message).toContain(
+      "Failed to send Discord notification for ProposalCreated event:",
+    );
+    expect(entry.message).toContain("Error: discord unavailable");
+  });
+
+  it("logs Telegram send failures as structured ERROR entries", async () => {
+    mockSendTelegramNotification.mockRejectedValueOnce(
+      new Error("telegram unavailable"),
+    );
+    const handler = createEventHandler(config);
+
+    await handler(event);
+
+    expect(mockSendDiscordNotification).toHaveBeenCalledOnce();
+    expect(mockSendTelegramNotification).toHaveBeenCalledOnce();
+    expect(loggedErrors()).toHaveLength(1);
+    const [entry] = loggedErrors();
+    expect(entry.severity).toBe("ERROR");
+    expect(entry.message).toContain(
+      "Failed to send Telegram notification for ProposalCreated event:",
+    );
+    expect(entry.message).toContain("Error: telegram unavailable");
+  });
+});

--- a/governance-watchdog/src/events/event-handler-factory.ts
+++ b/governance-watchdog/src/events/event-handler-factory.ts
@@ -2,6 +2,7 @@ import assert from "assert/strict";
 import { EmbedBuilder } from "discord.js";
 import sendDiscordNotification from "../event-notifications/send-discord-notification.js";
 import sendTelegramNotification from "../event-notifications/send-telegram-notification.js";
+import logError from "../utils/log-error.js";
 import { EventType, QuicknodeEvent } from "./types.js";
 import { createEventTitle } from "./utils/create-event-title.js";
 
@@ -52,7 +53,7 @@ export function createEventHandler<T extends QuicknodeEvent>(
         `✅ Successfully sent Discord notification for ${config.eventType} event`,
       );
     } catch (error) {
-      console.error(
+      logError(
         `❌ Failed to send Discord notification for ${config.eventType} event:`,
         error,
       );
@@ -71,7 +72,7 @@ export function createEventHandler<T extends QuicknodeEvent>(
         `✅ Successfully sent Telegram notification for ${config.eventType} event`,
       );
     } catch (error) {
-      console.error(
+      logError(
         `❌ Failed to send Telegram notification for ${config.eventType} event:`,
         error,
       );


### PR DESCRIPTION
## The Problem

- Governance notification send failures were logged with raw `console.error`.
- Cloud Run treats those text logs as default severity, so Discord/Telegram delivery failures did not feed the existing ERROR log alert path.

## The Solution

- Route Discord and Telegram notification send failures through the existing `logError` helper.
- Add focused event-handler factory tests proving each send-failure path emits structured `severity: ERROR` logs while preserving the current 200/continue processing behavior.

## Details

- This intentionally does not change QuickNode acknowledgement semantics; failed notification sends are still swallowed after logging so this PR stays scoped to observability.
- Probe-facing auth rejects remain on plain `console.error` and are not changed.

Closes #879

## Deferrals

None

## Validation

- `pnpm --filter @mento-protocol/governance-watchdog exec vitest run src/events/__tests__/event-handler-factory.test.ts src/utils/__tests__/log-error.test.ts`
- `pnpm --filter @mento-protocol/governance-watchdog test:unit`
- `pnpm --filter @mento-protocol/governance-watchdog typecheck`
- `pnpm --filter @mento-protocol/governance-watchdog lint`
- `pnpm --filter @mento-protocol/governance-watchdog build`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in notification error paths; no auth, data, or QuickNode acknowledgement semantics changes.
> 
> **Overview**
> Discord and Telegram delivery failures in the governance event handler now go through **`logError`** instead of plain **`console.error`**, so Cloud Run promotes them to **`severity: ERROR`** and existing error-log alerting can fire.
> 
> **Behavior is unchanged** for request handling: failures are still caught after each send attempt, and the handler continues (e.g. Telegram still runs when Discord fails).
> 
> New **Vitest** coverage in **`event-handler-factory.test.ts`** asserts structured ERROR log shape and that both notification paths are still invoked on partial failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa90d51fae91cb2f8104cee6b6f9755794dc58e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->