### PR TITLE
test: cover reserve yield heartbeat path

### DIFF
--- a/indexer-envio/src/handlers/susds.ts
+++ b/indexer-envio/src/handlers/susds.ts
@@ -452,6 +452,17 @@ export async function recordSusdsYieldHeartbeatSnapshot(
   return true;
 }
 
+export async function handleSusdsYieldDailySnapshotHeartbeat({
+  block,
+  context,
+}: {
+  block: { number: number | bigint };
+  context: SusdsContext;
+}): Promise<boolean> {
+  if (context.isPreload) return false;
+  return recordSusdsYieldHeartbeatSnapshot(context, BigInt(block.number));
+}
+
 async function shouldProcess(
   context: SusdsContext,
   movementId: string,
@@ -793,7 +804,6 @@ indexer.onBlock(
         : false,
   },
   async ({ block, context }) => {
-    if (context.isPreload) return;
-    await recordSusdsYieldHeartbeatSnapshot(context, BigInt(block.number));
+    await handleSusdsYieldDailySnapshotHeartbeat({ block, context });
   },
 );

--- a/indexer-envio/test/susds.test.ts
+++ b/indexer-envio/test/susds.test.ts
@@ -514,6 +514,30 @@ describe("sUSDS reserve yield accounting", () => {
     assert.equal(rows[1]?.sampledAtBlock, 300n);
   });
 
+  it("skips the sUSDS heartbeat onBlock handler path while preloading", async () => {
+    const mockDb = MockDb.createMockDb();
+    const context = heartbeatContext(
+      mockDb,
+      V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n + 1n,
+      WAD,
+      300n,
+    );
+
+    const didWrite = await handleSusdsYieldDailySnapshotHeartbeat({
+      block: { number: 300 },
+      context: {
+        ...context,
+        isPreload: true,
+        effect: async () => {
+          throw new Error("preload heartbeat must not read effects");
+        },
+      },
+    });
+
+    assert.equal(didWrite, false);
+    assert.equal(dailySnapshots(mockDb).length, 0);
+  });
+
   it("runs the sUSDS heartbeat onBlock handler path", async () => {
     let mockDb = MockDb.createMockDb();
     const day1 = V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n;
@@ -523,7 +547,6 @@ describe("sUSDS reserve yield accounting", () => {
     const heartbeatBlockNumber = BigInt(heartbeatBlock);
     const heartbeatTimestamp = day2 + 3_600n;
     const heartbeatSharePrice = dollars(120) / 100n;
-    let requestedBlock: bigint | undefined;
 
     setSharePrice(depositBlock, WAD);
     mockDb = await deposit(
@@ -545,19 +568,12 @@ describe("sUSDS reserve yield accounting", () => {
       block: { number: heartbeatBlock },
       context: {
         ...context,
-        effect: async (effect, input) => {
-          if (effect === blockTimestampEffect) {
-            requestedBlock = (input as { blockNumber: bigint }).blockNumber;
-          }
-          return context.effect(effect, input);
-        },
       },
     });
 
     const rows = dailySnapshots(mockDb).sort((a, b) =>
       a.timestamp < b.timestamp ? -1 : 1,
     );
-    assert.equal(requestedBlock, heartbeatBlockNumber);
     assert.equal(didWrite, true);
     assert.equal(rows.length, 2);
     assert.equal(rows[1]?.timestamp, day2);

--- a/indexer-envio/test/susds.test.ts
+++ b/indexer-envio/test/susds.test.ts
@@ -16,6 +16,7 @@ import {
   SUSDS_ADDRESS,
   TRACKED_SUSDS_WALLETS,
   V3_REVENUE_LAUNCH_TIMESTAMP,
+  handleSusdsYieldDailySnapshotHeartbeat,
   recordSusdsYieldHeartbeatSnapshot,
   recordSusdsYieldDailySnapshot,
 } from "../src/handlers/susds.ts";
@@ -140,11 +141,13 @@ function dailySnapshots(mockDb: MockDb) {
   return mockDb.entities.SusdsYieldDailySnapshot.getAll() as Array<{
     id: string;
     timestamp: bigint;
+    sharePriceUsdWei: bigint;
     totalEarnedYieldUsdWei: bigint;
     dailyEarnedYieldUsdWei: bigint;
     dailyRealizedYieldUsdWei: bigint;
     dailyUnrealizedYieldUsdWei: bigint;
     sampledAtBlock: bigint;
+    sampledAtTimestamp: bigint;
   }>;
 }
 
@@ -169,14 +172,16 @@ function heartbeatContext(
   mockDb: MockDb,
   blockTimestamp: bigint | null,
   sharePriceUsdWei: bigint,
+  expectedBlockNumber = 300n,
 ): Parameters<typeof recordSusdsYieldHeartbeatSnapshot>[0] {
   return {
     ...dailySnapshotContext(mockDb),
+    isPreload: false,
     effect: async (effect, input) => {
       if (effect === blockTimestampEffect) {
         assert.deepEqual(input, {
           chainId: ETHEREUM_CHAIN_ID,
-          blockNumber: 300n,
+          blockNumber: expectedBlockNumber,
         });
         return blockTimestamp;
       }
@@ -184,7 +189,7 @@ function heartbeatContext(
         assert.deepEqual(input, {
           chainId: ETHEREUM_CHAIN_ID,
           tokenAddress: SUSDS_ADDRESS,
-          blockNumber: 300n,
+          blockNumber: expectedBlockNumber,
         });
         return sharePriceUsdWei;
       }
@@ -507,6 +512,60 @@ describe("sUSDS reserve yield accounting", () => {
     assert.equal(rows[1]?.totalEarnedYieldUsdWei, dollars(200));
     assert.equal(rows[1]?.dailyEarnedYieldUsdWei, dollars(200));
     assert.equal(rows[1]?.sampledAtBlock, 300n);
+  });
+
+  it("runs the sUSDS heartbeat onBlock handler path", async () => {
+    let mockDb = MockDb.createMockDb();
+    const day1 = V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n;
+    const day2 = day1 + 86_400n;
+    const depositBlock = 22_990_100;
+    const heartbeatBlock = 22_990_300;
+    const heartbeatBlockNumber = BigInt(heartbeatBlock);
+    const heartbeatTimestamp = day2 + 3_600n;
+    const heartbeatSharePrice = dollars(120) / 100n;
+    let requestedBlock: bigint | undefined;
+
+    setSharePrice(depositBlock, WAD);
+    mockDb = await deposit(
+      mockDb,
+      depositBlock,
+      0,
+      dollars(1000),
+      dollars(1000),
+      Number(day1 + 3_600n),
+    );
+
+    const context = heartbeatContext(
+      mockDb,
+      heartbeatTimestamp,
+      heartbeatSharePrice,
+      heartbeatBlockNumber,
+    );
+    const didWrite = await handleSusdsYieldDailySnapshotHeartbeat({
+      block: { number: heartbeatBlock },
+      context: {
+        ...context,
+        effect: async (effect, input) => {
+          if (effect === blockTimestampEffect) {
+            requestedBlock = (input as { blockNumber: bigint }).blockNumber;
+          }
+          return context.effect(effect, input);
+        },
+      },
+    });
+
+    const rows = dailySnapshots(mockDb).sort((a, b) =>
+      a.timestamp < b.timestamp ? -1 : 1,
+    );
+    assert.equal(requestedBlock, heartbeatBlockNumber);
+    assert.equal(didWrite, true);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1]?.timestamp, day2);
+    assert.equal(rows[1]?.sharePriceUsdWei, heartbeatSharePrice);
+    assert.equal(rows[1]?.totalEarnedYieldUsdWei, dollars(200));
+    assert.equal(rows[1]?.dailyEarnedYieldUsdWei, dollars(200));
+    assert.equal(rows[1]?.sampledAtBlock, heartbeatBlockNumber);
+    assert.equal(rows[1]?.sampledAtTimestamp, heartbeatTimestamp);
   });
 
   it("skips the sUSDS heartbeat snapshot when block timestamp RPC returns null", async () => {

--- a/ui-dashboard/src/hooks/use-reserve-yield-history.ts
+++ b/ui-dashboard/src/hooks/use-reserve-yield-history.ts
@@ -32,6 +32,8 @@ const HISTORY_PAGE_SIZE = 1000;
 const HISTORY_MAX_PAGES = 20;
 
 function reserveYieldHistoryHasuraUrl(): string {
+  // Production Celo and Monad entries share the same multichain Envio Hasura
+  // endpoint; the Monad fallback is an endpoint fallback, not a chain switch.
   const url =
     NETWORKS["celo-mainnet"].hasuraUrl || NETWORKS["monad-mainnet"].hasuraUrl;
   if (!url) {


### PR DESCRIPTION
## The Problem

- Reserve yield history falls back between production network entries that share one multichain Envio endpoint, but the code did not explain that this is not a chain switch.
- The sUSDS daily heartbeat had snapshot-writer tests, but no direct coverage of the on-block handler path.

## The Solution

- Document that the Monad Hasura URL fallback is an endpoint fallback for the shared production Envio endpoint.
- Route the sUSDS on-block callback through a small exported heartbeat handler and test that path with mocked block timestamp/share-price effects and sampled snapshot metadata assertions.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/susds.test.ts`
- `pnpm agent:quality-gate --run`
- `~/.agents/skills/autoreview/scripts/autoreview --mode local --engine local --prompt-file docs/pr-checklists/stateful-data-ui.md`
- Fresh-context Codex subagent autoreview: no findings

## Deferrals

None

Closes #891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to centralizing the existing preload skip; remaining work is tests and a clarifying comment with no production logic changes in the dashboard hook.
> 
> **Overview**
> The sUSDS **daily yield heartbeat** `onBlock` callback now goes through an exported **`handleSusdsYieldDailySnapshotHeartbeat`** helper that returns early when **`context.isPreload`** is true, then delegates to the existing heartbeat snapshot writer. That keeps preload from firing block-timestamp and share-price RPC effects while making the handler path unit-testable.
> 
> **Tests** add direct coverage for preload (no effects, no snapshots) and for the live path (mocked effects, assertions on **`sharePriceUsdWei`**, **`sampledAtBlock`**, and **`sampledAtTimestamp`**). Test helpers gain configurable expected block numbers and **`isPreload: false`** on heartbeat context.
> 
> In the dashboard, a short comment clarifies that reserve yield history’s Celo/Monad Hasura URL choice is an **endpoint fallback** for a shared multichain Envio URL, not a chain switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058e9211d2809ace8a0384010180883d3876fbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->