### PR TITLE
fix: ref-gate deployer WIF binding

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -144,9 +144,11 @@ jobs:
           # (`alerts/infra`) stay on the write-capable deployer because a
           # full-refresh drift plan reads GCP resources the read-only seed SA
           # has no project roles to see. `==` yields a real boolean, so the
-          # ternary can't misfire on a stringified matrix value. The
-          # repo-scoped WIF binding (terraform/ci-wif.tf) lets any workflow in
-          # this repo mint either token — no IAM change was needed to swap.
+          # ternary can't misfire on a stringified matrix value. The deployer
+          # WIF binding (terraform/ci-wif.tf) is ref-gated to refs/heads/main:
+          # schedule runs and main dispatches still authenticate, while a
+          # non-main dispatch intentionally fails the write leg at auth. The
+          # plan-SA binding stays repo-scoped for read-only PR/ref checks.
           service_account: ${{ matrix.planSa == 'readonly' && secrets.GCP_SERVICE_ACCOUNT_PLAN || secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -81,12 +81,18 @@ resource "google_service_account" "metrics_bridge_deployer" {
   depends_on = [google_project_service.iam]
 }
 
-# Any workflow in the repo can impersonate the deployer SA. Tighten later by
-# swapping principalSet → principal with a workflow-ref attribute mapping.
+# Ref-gated: only workflow runs whose OIDC `ref` claim is `refs/heads/main`
+# can impersonate the write-capable deployer SA: push-to-main deploys,
+# scheduled drift runs, and `workflow_dispatch` from main. The repo gate is
+# enforced upstream by the provider's `attribute_condition` above
+# (repository == mento-protocol/monitoring-monorepo); binding + condition
+# together enforce repo and ref. Dispatching a deployer-consuming workflow
+# from a non-main ref now fails at the auth step by design; PR jobs use the
+# read-only plan SA below.
 resource "google_service_account_iam_member" "deployer_wif_binding" {
   service_account_id = google_service_account.metrics_bridge_deployer.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/mento-protocol/monitoring-monorepo"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.ref/refs/heads/main"
 }
 
 # Project-level grants the CI SA needs for the full deploy flow:
@@ -215,10 +221,10 @@ resource "google_service_account" "metrics_bridge_plan_readonly" {
   depends_on = [google_project_service.iam]
 }
 
-# Same WIF binding shape as `deployer_wif_binding` above — the GitHub repo
-# is the upstream gate. Same "tighten later by swapping principalSet → principal
-# with a workflow-ref attribute mapping" note applies here; revisit alongside
-# the deployer-binding tightening.
+# Repo-scoped: deliberately not ref-gated like `deployer_wif_binding` above.
+# PR plan jobs run from PR merge refs (`refs/pull/<n>/merge`), so this binding
+# must stay on `attribute.repository`. The SA is read-only; worst case a rogue
+# repo workflow reads Terraform state, not write infra.
 resource "google_service_account_iam_member" "plan_readonly_wif_binding" {
   service_account_id = google_service_account.metrics_bridge_plan_readonly.name
   role               = "roles/iam.workloadIdentityUser"

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -89,6 +89,9 @@ resource "google_service_account" "metrics_bridge_deployer" {
 # together enforce repo and ref. Dispatching a deployer-consuming workflow
 # from a non-main ref now fails at the auth step by design; PR jobs use the
 # read-only plan SA below.
+# Invariant: repo scope relies on the provider's `attribute_condition` above.
+# If that condition ever allows another repo, that repo's refs/heads/main
+# workflows would also match this binding. Review both resources together.
 resource "google_service_account_iam_member" "deployer_wif_binding" {
   service_account_id = google_service_account.metrics_bridge_deployer.name
   role               = "roles/iam.workloadIdentityUser"


### PR DESCRIPTION
## The Problem

- The write-capable `metrics-bridge-deployer` service account could be impersonated by any workflow in this repository because its WIF member matched only the repository.
- That left branch or PR-introduced workflows with `id-token: write` too close to production deploy credentials.

## The Solution

- Ref-gate the deployer WIF binding to `refs/heads/main` while preserving the provider-level repository condition.
- Keep the read-only plan service account repo-scoped so PR plan jobs on `refs/pull/<n>/merge` continue to work.

## Details

- The deployer binding now matches `attribute.ref/refs/heads/main`; the provider still enforces `attribute.repository == "mento-protocol/monitoring-monorepo"`.
- The plan-readonly binding remains on `attribute.repository/mento-protocol/monitoring-monorepo` and its comment explains why PR refs need that shape.
- `terraform-drift.yml` now documents the intended behavior: schedule runs and main dispatches authenticate the write leg, while non-main dispatches fail the write leg at auth and can still exercise read-only legs.
- No WIF provider mapping, provider condition, workflow auth input, or GitHub secret changed.
- Refs #852.

## Deferrals

- Post-merge human-run `pnpm infra:plan`, approved `pnpm infra:apply`, and the positive/negative `terraform-drift.yml` dispatch checks remain tracked in #852.

## Validation

- `./tools/trunk fmt .github/workflows/terraform-drift.yml terraform/ci-wif.tf`
- `pnpm tf validate platform`
- `pnpm agent:quality-gate --run --skip-if-fresh`
- `pnpm agent:autoreview`
- Focused subagent review; wording finding fixed, no Terraform WIF binding-shape findings.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Workload Identity Federation bindings for the production deployer service account; incorrect rollout could block main deploys until Terraform apply completes, but the change reduces impersonation risk from non-main workflows.
> 
> **Overview**
> **Tightens who can mint the write-capable CI deployer identity** by changing `deployer_wif_binding` in `terraform/ci-wif.tf` from a repo-wide `attribute.repository` principal to `attribute.ref/refs/heads/main`, layered on the existing provider `attribute_condition` for `mento-protocol/monitoring-monorepo`.
> 
> **Read-only plan auth is unchanged in shape**: `plan_readonly_wif_binding` stays repo-scoped so PR jobs on `refs/pull/<n>/merge` can still authenticate; comments now spell out why that binding is not ref-gated and the security trade-off.
> 
> **`terraform-drift.yml` comments** are updated to match: scheduled drift and main dispatches can still use the deployer SA; non-main `workflow_dispatch` on legs that select the deployer secret should fail at Google auth by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef775c6b0793b8c6a33eaaf811280defd2be997f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->