### PR TITLE
feat: surface probe budget exhaustion

### DIFF
--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1289,6 +1289,9 @@ describe("aggregatePairStatus", () => {
     );
     expect(
       aggregatePairStatus([{ status: "pass" }, { status: "budget_exhausted" }]),
+    ).toBe("partial");
+    expect(
+      aggregatePairStatus([{ status: "fail" }, { status: "budget_exhausted" }]),
     ).toBe("budget_exhausted");
     expect(
       aggregatePairStatus([{ status: "pass" }, { status: "needs_key" }]),

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1288,6 +1288,9 @@ describe("aggregatePairStatus", () => {
       "partial",
     );
     expect(
+      aggregatePairStatus([{ status: "pass" }, { status: "budget_exhausted" }]),
+    ).toBe("budget_exhausted");
+    expect(
       aggregatePairStatus([{ status: "pass" }, { status: "needs_key" }]),
     ).toBe("needs_key");
     expect(

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -328,7 +328,7 @@ describe("probeAdapterPair", () => {
       quoteBudget: { remaining: 0 },
     });
 
-    expect(result.status).toBe("rate_limited");
+    expect(result.status).toBe("budget_exhausted");
     expect(result.attemptCount).toBe(0);
     expect(builtRequests).toBe(false);
   });
@@ -929,7 +929,7 @@ describe("probeAdapterPair", () => {
     expect(calls).toBe(2);
   });
 
-  it("marks route discovery as rate-limited when the quote-attempt budget is exhausted", async () => {
+  it("marks route discovery as budget_exhausted when the quote-attempt budget is exhausted", async () => {
     const adapter: AggregatorAdapter = {
       id: "multi-attempt",
       label: "Multi Attempt",
@@ -964,15 +964,15 @@ describe("probeAdapterPair", () => {
       quoteBudget: { remaining: 1 },
     });
 
-    expect(result.status).toBe("rate_limited");
+    expect(result.status).toBe("budget_exhausted");
     expect(result.requestUrl).toBeNull();
     expect(result.error).toBe("Adapter quote-attempt budget exhausted.");
     expect(result.attemptCount).toBe(1);
-    expect(blockingReason(result.status)).toContain("request budget");
+    expect(blockingReason(result.status)).toContain("quote-request budget");
     expect(calls).toBe(1);
   });
 
-  it("marks budget exhaustion before the first quote as rate-limited", async () => {
+  it("marks budget exhaustion before the first quote as budget_exhausted", async () => {
     const adapter: AggregatorAdapter = {
       id: "multi-attempt",
       label: "Multi Attempt",
@@ -1005,7 +1005,7 @@ describe("probeAdapterPair", () => {
       quoteBudget: { remaining: 0 },
     });
 
-    expect(result.status).toBe("rate_limited");
+    expect(result.status).toBe("budget_exhausted");
     expect(result.requestUrl).toBeNull();
     expect(result.routeVariant).toBeNull();
     expect(result.sourceLabels).toEqual([]);

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -230,6 +230,31 @@ describe("runIntegrationProbes", () => {
     const pairs = snapshot.aggregators[0]?.chains[0]?.pairs ?? [];
     expect(quoteFetches).toBe(3);
     expect(pairs.map((pair) => pair.attemptCount)).toEqual([2, 1]);
+    expect(pairs.map((pair) => pair.status)).toContain("budget_exhausted");
+  });
+
+  it("logs a per-adapter quote-budget summary line", async () => {
+    const lines: string[] = [];
+    await runIntegrationProbes({
+      chainIds: [42220],
+      adapters: [budgetedAdapter()],
+      pairConcurrency: 1,
+      hasuraUrl: "https://hasura.test",
+      env: {},
+      log: (line) => lines.push(line),
+      fetcher: async (input) => {
+        if (String(input) === "https://hasura.test") {
+          return new Response(
+            JSON.stringify({ data: { Pool: [poolRow(POOL, "EURm")] } }),
+          );
+        }
+        return new Response(JSON.stringify({ route: [{ protocol: "Other" }] }));
+      },
+    });
+
+    expect(lines).toContain(
+      "[integration-probes] adapter=budgeted quoteAttempts=3/3 remainingBudget=0",
+    );
   });
 
   it("serializes budgeted adapter pair probes", async () => {

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -275,6 +275,54 @@ describe("runIntegrationProbes", () => {
     expect(chain?.nextStep).toContain("maxQuoteRequestsPerRun");
   });
 
+  it("keeps the generic partial next step when budget exhaustion follows failed routes", async () => {
+    let quoteFetches = 0;
+    const rows = [
+      poolRow(POOL, "EURm"),
+      poolRow("42220-0x4444444444444444444444444444444444444444", "GBPm"),
+    ];
+    const snapshot = await runIntegrationProbes({
+      chainIds: [42220],
+      adapters: [
+        {
+          ...passingAdapter(),
+          id: "partial-failed-budgeted",
+          label: "Partial Failed Budgeted",
+          maxQuoteRequestsPerRun: 2,
+          quote: (input) => ({
+            url: `https://partial-failed-budgeted.test/${input.pairId}/${input.direction}`,
+          }),
+        },
+      ],
+      pairConcurrency: 1,
+      hasuraUrl: "https://hasura.test",
+      env: {},
+      fetcher: async (input) => {
+        if (String(input) === "https://hasura.test") {
+          return new Response(JSON.stringify({ data: { Pool: rows } }));
+        }
+        quoteFetches += 1;
+        return new Response(
+          quoteFetches === 1
+            ? JSON.stringify({ transactionRequest: { to: ROUTER_V300 } })
+            : JSON.stringify({ route: [{ protocol: "Other" }] }),
+        );
+      },
+    });
+
+    const chain = snapshot.aggregators[0]?.chains[0];
+    expect(quoteFetches).toBe(2);
+    expect(chain?.status).toBe("partial");
+    expect(chain?.pairs.map((pair) => pair.status)).toEqual([
+      "pass",
+      "fail",
+      "budget_exhausted",
+      "budget_exhausted",
+    ]);
+    expect(chain?.nextStep).toContain("route evidence");
+    expect(chain?.nextStep).not.toContain("maxQuoteRequestsPerRun");
+  });
+
   it("logs a per-adapter quote-budget summary line", async () => {
     const lines: string[] = [];
     await runIntegrationProbes({

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -231,6 +231,7 @@ describe("runIntegrationProbes", () => {
     expect(quoteFetches).toBe(3);
     expect(pairs.map((pair) => pair.attemptCount)).toEqual([2, 1]);
     expect(pairs.map((pair) => pair.status)).toContain("budget_exhausted");
+    expect(snapshot.summary.failingChainChecks).toBe(1);
   });
 
   it("logs a per-adapter quote-budget summary line", async () => {

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -234,6 +234,47 @@ describe("runIntegrationProbes", () => {
     expect(snapshot.summary.failingChainChecks).toBe(1);
   });
 
+  it("uses the budget next step for partial chains with exhausted budget", async () => {
+    let quoteFetches = 0;
+    const snapshot = await runIntegrationProbes({
+      chainIds: [42220],
+      adapters: [
+        {
+          ...passingAdapter(),
+          id: "partial-budgeted",
+          label: "Partial Budgeted",
+          maxQuoteRequestsPerRun: 1,
+          quote: (input) => ({
+            url: `https://partial-budgeted.test/${input.direction}`,
+          }),
+        },
+      ],
+      pairConcurrency: 1,
+      hasuraUrl: "https://hasura.test",
+      env: {},
+      fetcher: async (input) => {
+        if (String(input) === "https://hasura.test") {
+          return new Response(
+            JSON.stringify({ data: { Pool: [poolRow(POOL, "EURm")] } }),
+          );
+        }
+        quoteFetches += 1;
+        return new Response(
+          JSON.stringify({ transactionRequest: { to: ROUTER_V300 } }),
+        );
+      },
+    });
+
+    const chain = snapshot.aggregators[0]?.chains[0];
+    expect(quoteFetches).toBe(1);
+    expect(chain?.status).toBe("partial");
+    expect(chain?.pairs.map((pair) => pair.status)).toEqual([
+      "pass",
+      "budget_exhausted",
+    ]);
+    expect(chain?.nextStep).toContain("maxQuoteRequestsPerRun");
+  });
+
   it("logs a per-adapter quote-budget summary line", async () => {
     const lines: string[] = [];
     await runIntegrationProbes({

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -144,6 +144,7 @@ export function aggregatePairStatus(
   const statuses = new Set(results.map((result) => result.status));
   if (statuses.size === 1) return results[0]!.status;
   if (statuses.has("rate_limited")) return "rate_limited";
+  if (statuses.has("budget_exhausted")) return "budget_exhausted";
   if (statuses.has("needs_key") && statuses.has("pass")) return "needs_key";
   if (statuses.has("pass")) return "partial";
   return "fail";
@@ -160,7 +161,9 @@ export function blockingReason(status: ProbeStatus): string | null {
     case "needs_key":
       return "Probe credentials are missing.";
     case "rate_limited":
-      return "Aggregator API rate-limited the probe or the probe hit its configured request budget.";
+      return "Aggregator API rate-limited the probe.";
+    case "budget_exhausted":
+      return "Probe exhausted its configured per-run quote-request budget before completing.";
     case "no_liquidity":
       return "Aggregator returned no route or no liquidity.";
     case "error":
@@ -247,7 +250,7 @@ function quoteBudgetExhaustedResult(
   return {
     ...skippedResult(
       input,
-      "rate_limited",
+      "budget_exhausted",
       "Adapter quote-attempt budget exhausted.",
     ),
     attemptCount,
@@ -401,6 +404,7 @@ function fallbackPriority(status: ProbeStatus): number {
       return 4;
     case "error":
       return 3;
+    case "budget_exhausted":
     case "rate_limited":
       return 2;
     case "needs_key":
@@ -412,7 +416,11 @@ function fallbackPriority(status: ProbeStatus): number {
 }
 
 function terminalStatus(status: ProbeStatus): boolean {
-  return status === "needs_key" || status === "rate_limited";
+  return (
+    status === "needs_key" ||
+    status === "rate_limited" ||
+    status === "budget_exhausted"
+  );
 }
 
 function requestErrored(result: PairProbeResult): boolean {

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -144,9 +144,9 @@ export function aggregatePairStatus(
   const statuses = new Set(results.map((result) => result.status));
   if (statuses.size === 1) return results[0]!.status;
   if (statuses.has("rate_limited")) return "rate_limited";
-  if (statuses.has("budget_exhausted")) return "budget_exhausted";
   if (statuses.has("needs_key") && statuses.has("pass")) return "needs_key";
   if (statuses.has("pass")) return "partial";
+  if (statuses.has("budget_exhausted")) return "budget_exhausted";
   return "fail";
 }
 

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -385,6 +385,12 @@ function nextStepFor(
   pairs: readonly PairProbeResult[],
 ): string | null {
   if (status === "pass") return null;
+  if (
+    status === "partial" &&
+    pairs.some((pair) => pair.status === "budget_exhausted")
+  ) {
+    return FALLBACK_NEXT_STEPS.budget_exhausted;
+  }
   const firstError = pairs.find((pair) => pair.error)?.error;
   if (!ERROR_FIRST_NEXT_STEP_STATUSES.has(status)) {
     return FALLBACK_NEXT_STEPS[status];

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -403,8 +403,9 @@ function summarizeSnapshot(
       .length,
     partialChainChecks: chains.filter((chain) => chain.status === "partial")
       .length,
-    failingChainChecks: chains.filter((chain) => chain.status === "fail")
-      .length,
+    failingChainChecks: chains.filter(
+      (chain) => chain.status === "fail" || chain.status === "budget_exhausted",
+    ).length,
     needsKeyChainChecks: chains.filter((chain) => chain.status === "needs_key")
       .length,
     unsupportedChainChecks: chains.filter(

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -385,9 +385,11 @@ function nextStepFor(
   pairs: readonly PairProbeResult[],
 ): string | null {
   if (status === "pass") return null;
+  const nonPassingPairs = pairs.filter((pair) => pair.status !== "pass");
   if (
     status === "partial" &&
-    pairs.some((pair) => pair.status === "budget_exhausted")
+    nonPassingPairs.length > 0 &&
+    nonPassingPairs.every((pair) => pair.status === "budget_exhausted")
   ) {
     return FALLBACK_NEXT_STEPS.budget_exhausted;
   }

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -18,11 +18,33 @@ import {
   type IntegrationProbeSnapshot,
   type PairProbeResult,
   type ProbeChainId,
+  type ProbeStatus,
 } from "./types.js";
 import { volumeSignalsForAdapters } from "./volumeSignals.js";
 
 const DEFAULT_ADAPTER_CONCURRENCY = 3;
 const DEFAULT_PAIR_CONCURRENCY = 4;
+
+const ERROR_FIRST_NEXT_STEP_STATUSES = new Set<ProbeStatus>([
+  "needs_key",
+  "unsupported",
+  "rate_limited",
+  "no_liquidity",
+  "error",
+]);
+
+const FALLBACK_NEXT_STEPS: Record<Exclude<ProbeStatus, "pass">, string> = {
+  partial:
+    "Inspect failing route evidence for pairs that still lack Mento v3 address evidence.",
+  fail: "Inspect route evidence and ask aggregator to route through Mento v3.",
+  needs_key: "Configure adapter credentials.",
+  unsupported: "Confirm chain support with the aggregator.",
+  rate_limited: "Inspect raw probe response.",
+  no_liquidity: "Inspect raw probe response.",
+  error: "Inspect raw probe response.",
+  budget_exhausted:
+    "Raise the adapter's maxQuoteRequestsPerRun or reduce probed pairs; the aggregator did not rate-limit us.",
+};
 
 type BeforeQuoteRequest = () => Promise<void>;
 
@@ -39,6 +61,7 @@ export type RunProbeOptions = {
   pairLimit?: number | undefined;
   adapterConcurrency?: number | undefined;
   pairConcurrency?: number | undefined;
+  log?: ((line: string) => void) | undefined;
 };
 
 export async function runIntegrationProbes(
@@ -48,6 +71,8 @@ export async function runIntegrationProbes(
   const amountUsd = options.amountUsd ?? "1";
   const env = options.env ?? process.env;
   const now = options.now ?? new Date();
+  const log =
+    options.log ?? ((line: string) => process.stderr.write(`${line}\n`));
   const chainConfigs = await buildChainProbeConfigs({
     hasuraUrl: firstNonEmpty(
       options.hasuraUrl,
@@ -78,6 +103,7 @@ export async function runIntegrationProbes(
       options.pairConcurrency,
       DEFAULT_PAIR_CONCURRENCY,
     ),
+    log,
   });
 
   return {
@@ -161,6 +187,7 @@ async function probeAdapters(args: {
   volumeSignals: ReadonlyMap<string, AggregatorProbeResult["volumeSignal"]>;
   adapterConcurrency: number;
   pairConcurrency: number;
+  log: (line: string) => void;
 }): Promise<AggregatorProbeResult[]> {
   return mapConcurrent(
     args.adapters,
@@ -174,6 +201,12 @@ async function probeAdapters(args: {
         quoteBudget,
         beforeQuoteRequest,
       });
+      if (quoteBudget && adapter.maxQuoteRequestsPerRun !== undefined) {
+        const used = adapter.maxQuoteRequestsPerRun - quoteBudget.remaining;
+        args.log(
+          `[integration-probes] adapter=${adapter.id} quoteAttempts=${used}/${adapter.maxQuoteRequestsPerRun} remainingBudget=${quoteBudget.remaining}`,
+        );
+      }
       return {
         id: adapter.id,
         label: adapter.label,
@@ -353,15 +386,10 @@ function nextStepFor(
 ): string | null {
   if (status === "pass") return null;
   const firstError = pairs.find((pair) => pair.error)?.error;
-  if (status === "needs_key")
-    return firstError ?? "Configure adapter credentials.";
-  if (status === "unsupported")
-    return firstError ?? "Confirm chain support with the aggregator.";
-  if (status === "partial")
-    return "Inspect failing route evidence for pairs that still lack Mento v3 address evidence.";
-  if (status === "fail")
-    return "Inspect route evidence and ask aggregator to route through Mento v3.";
-  return firstError ?? "Inspect raw probe response.";
+  if (!ERROR_FIRST_NEXT_STEP_STATUSES.has(status)) {
+    return FALLBACK_NEXT_STEPS[status];
+  }
+  return firstError ?? FALLBACK_NEXT_STEPS[status];
 }
 
 function summarizeSnapshot(

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -201,10 +201,10 @@ async function probeAdapters(args: {
         quoteBudget,
         beforeQuoteRequest,
       });
-      if (quoteBudget && adapter.maxQuoteRequestsPerRun !== undefined) {
-        const used = adapter.maxQuoteRequestsPerRun - quoteBudget.remaining;
+      if (adapter.maxQuoteRequestsPerRun !== undefined) {
+        const used = adapter.maxQuoteRequestsPerRun - quoteBudget!.remaining;
         args.log(
-          `[integration-probes] adapter=${adapter.id} quoteAttempts=${used}/${adapter.maxQuoteRequestsPerRun} remainingBudget=${quoteBudget.remaining}`,
+          `[integration-probes] adapter=${adapter.id} quoteAttempts=${used}/${adapter.maxQuoteRequestsPerRun} remainingBudget=${quoteBudget!.remaining}`,
         );
       }
       return {

--- a/integration-probes/src/types.ts
+++ b/integration-probes/src/types.ts
@@ -20,6 +20,7 @@ export type ProbeStatus =
   | "needs_key"
   | "no_liquidity"
   | "rate_limited"
+  | "budget_exhausted"
   | "error";
 
 type EvidenceType = "router-address" | "pool-address" | "source-label";

--- a/ui-dashboard/src/app/integrations/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/integrations/__tests__/page.server.test.tsx
@@ -78,4 +78,53 @@ describe("IntegrationsPage", () => {
     expect(html).toContain("Redis offline");
     expect(html).not.toContain("No integration probe snapshot");
   });
+
+  it("renders a stale snapshot banner when the latest snapshot is older than 48 hours", async () => {
+    mockGetIntegrationProbeSnapshot.mockResolvedValue({
+      snapshot: snapshotFixture(
+        new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      ),
+      error: null,
+    });
+
+    const html = renderToStaticMarkup(await IntegrationsPage());
+
+    expect(html).toContain("Snapshot is stale");
+  });
+
+  it("hides the stale snapshot banner for a fresh snapshot", async () => {
+    mockGetIntegrationProbeSnapshot.mockResolvedValue({
+      snapshot: snapshotFixture(new Date().toISOString()),
+      error: null,
+    });
+
+    const html = renderToStaticMarkup(await IntegrationsPage());
+
+    expect(html).not.toContain("Snapshot is stale");
+  });
 });
+
+function snapshotFixture(generatedAt: string) {
+  return {
+    schemaVersion: 1 as const,
+    generatedAt,
+    amountUsd: "1",
+    takerAddress: "0x000000000000000000000000000000000000dEaD",
+    pairSource: {
+      kind: "hasura" as const,
+      hasuraUrlConfigured: true,
+      note: "fixture",
+    },
+    chains: [],
+    aggregators: [],
+    summary: {
+      aggregators: 0,
+      chainChecks: 0,
+      passingChainChecks: 0,
+      partialChainChecks: 0,
+      failingChainChecks: 0,
+      needsKeyChainChecks: 0,
+      unsupportedChainChecks: 0,
+    },
+  };
+}

--- a/ui-dashboard/src/app/integrations/_components/integration-status-badge.tsx
+++ b/ui-dashboard/src/app/integrations/_components/integration-status-badge.tsx
@@ -32,6 +32,10 @@ const STATUS_STYLES: Record<
     label: "Rate-limited",
     className: "bg-cyan-500/20 text-cyan-300",
   },
+  budget_exhausted: {
+    label: "Budget hit",
+    className: "bg-purple-500/20 text-purple-300",
+  },
   error: {
     label: "Error",
     className: "bg-red-500/20 text-red-300",

--- a/ui-dashboard/src/app/integrations/page.tsx
+++ b/ui-dashboard/src/app/integrations/page.tsx
@@ -26,6 +26,7 @@ export default async function IntegrationsPage() {
   if (!session?.user?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN)) notFound();
 
   const { snapshot, error } = await getIntegrationProbeSnapshot();
+  const nowMs = Date.now();
   return (
     <div className="space-y-8">
       <header className="space-y-2">
@@ -42,7 +43,7 @@ export default async function IntegrationsPage() {
       )}
 
       {snapshot ? (
-        <IntegrationsContent snapshot={snapshot} />
+        <IntegrationsContent snapshot={snapshot} nowMs={nowMs} />
       ) : error ? null : (
         <EmptyBox message="No integration probe snapshot has been published yet." />
       )}
@@ -51,12 +52,25 @@ export default async function IntegrationsPage() {
 }
 
 function IntegrationsContent({
+  nowMs,
   snapshot,
 }: {
+  nowMs: number;
   snapshot: IntegrationProbeSnapshot;
 }) {
   return (
     <>
+      {snapshotIsStale(snapshot.generatedAt, nowMs) && (
+        <div
+          role="status"
+          className="rounded-lg border border-amber-900/50 bg-amber-950/30 px-4 py-3 text-sm text-amber-300"
+        >
+          Snapshot is stale: last successful probe run was{" "}
+          {formatSnapshotTime(snapshot.generatedAt)}. Probes run daily at 06:17
+          UTC; check the Integration Probes workflow and aggregator API keys.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
         <Tile
           label="Aggregators"
@@ -105,6 +119,15 @@ function IntegrationsContent({
       </section>
     </>
   );
+}
+
+// Probes run daily at 06:17 UTC in integration-probes.yml; this is 2x cadence.
+const SNAPSHOT_STALE_AFTER_MS = 48 * 60 * 60 * 1000;
+
+function snapshotIsStale(generatedAt: string, nowMs: number): boolean {
+  const generated = new Date(generatedAt).getTime();
+  if (Number.isNaN(generated)) return true;
+  return nowMs - generated > SNAPSHOT_STALE_AFTER_MS;
 }
 
 function formatSnapshotTime(value: string): string {

--- a/ui-dashboard/src/app/integrations/page.tsx
+++ b/ui-dashboard/src/app/integrations/page.tsx
@@ -62,7 +62,7 @@ function IntegrationsContent({
     <>
       {snapshotIsStale(snapshot.generatedAt, nowMs) && (
         <div
-          role="status"
+          role="alert"
           className="rounded-lg border border-amber-900/50 bg-amber-950/30 px-4 py-3 text-sm text-amber-300"
         >
           Snapshot is stale: last successful probe run was{" "}

--- a/ui-dashboard/src/lib/__tests__/integration-probes.test.ts
+++ b/ui-dashboard/src/lib/__tests__/integration-probes.test.ts
@@ -198,4 +198,66 @@ describe("IntegrationProbeSnapshotSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("accepts the budget_exhausted status", () => {
+    const result = IntegrationProbeSnapshotSchema.safeParse({
+      schemaVersion: 1,
+      generatedAt: "2026-06-01T00:00:00.000Z",
+      amountUsd: "1",
+      takerAddress: "0x000000000000000000000000000000000000dEaD",
+      pairSource: {
+        kind: "hasura",
+        hasuraUrlConfigured: true,
+        note: "fixture",
+      },
+      chains: [],
+      aggregators: [
+        {
+          id: "budgeted",
+          label: "Budgeted",
+          kind: "dex",
+          tier: 1,
+          credentialEnv: [],
+          researchNote: "fixture",
+          chains: [
+            {
+              chainId: 42220,
+              chainSlug: "celo",
+              chainLabel: "Celo",
+              status: "budget_exhausted",
+              pairCoverage: { passed: 0, total: 1 },
+              blockingReason: "fixture",
+              nextStep: "fixture",
+              pairs: [
+                {
+                  pairId: "42220:EURm-USDm:42220-0xpool",
+                  poolId: "42220-0xpool",
+                  direction: "base-to-usdm",
+                  sellSymbol: "EURm",
+                  buySymbol: "USDm",
+                  status: "budget_exhausted",
+                  evidence: [],
+                  sourceLabels: [],
+                  txTarget: null,
+                  downstreamProvider: null,
+                  requestUrl: null,
+                  error: "Adapter quote-attempt budget exhausted.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      summary: {
+        aggregators: 1,
+        chainChecks: 1,
+        passingChainChecks: 0,
+        failingChainChecks: 0,
+        needsKeyChainChecks: 0,
+        unsupportedChainChecks: 0,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/ui-dashboard/src/lib/integration-probes.ts
+++ b/ui-dashboard/src/lib/integration-probes.ts
@@ -11,6 +11,7 @@ const StatusSchema = z.enum([
   "needs_key",
   "no_liquidity",
   "rate_limited",
+  "budget_exhausted",
   "error",
 ]);
 


### PR DESCRIPTION
## The Problem

- Probe self-budget exhaustion looked identical to real upstream rate limiting, making operator triage misleading.
- Budgeted adapter runs did not log how much of the quote-request budget was consumed.
- `/integrations` could show a nearly expired snapshot without warning operators that the scheduled probe was stale.

## The Solution

- Add a distinct `budget_exhausted` status end to end: probe result, snapshot schema, dashboard badge, blocking reason, and next-step copy.
- Log one per-adapter quote-budget summary line after each budgeted adapter run.
- Show an amber stale-snapshot banner on `/integrations` when the latest snapshot is older than 48 hours.

## Details

- Upstream HTTP 429 and Cloudflare paths remain `rate_limited`; only local quote-attempt budget exhaustion becomes `budget_exhausted`.
- The dashboard schema still accepts v1 snapshots and adds the new enum value without a schema-version bump.
- The stale banner uses the dynamic server render timestamp and has `role="status"` for assistive tech.
- Closes #866.

## Deferrals

None

## Validation

- `pnpm --filter @mento-protocol/integration-probes test -- src/__tests__/adapters.test.ts src/__tests__/runner.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/integration-probes.test.ts src/app/integrations/__tests__/page.server.test.tsx`
- `pnpm --filter @mento-protocol/integration-probes typecheck`
- `pnpm --filter @mento-protocol/integration-probes lint`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- Browser verification at `http://127.0.0.1:3210/integrations` with a local Redis fixture: authenticated page rendered the stale banner and `Budget hit` badge; console errors were clean after fixture labels support; mobile-width status banner had no horizontal overflow.
- `pnpm agent:quality-gate --run --skip-if-fresh`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and UI-only status/schema additions; no auth or payment paths, with backward-compatible snapshot parsing.
> 
> **Overview**
> Introduces a dedicated **`budget_exhausted`** probe status so per-run quote-request caps are no longer reported as upstream **`rate_limited`**. Pair and chain aggregation, blocking reasons, operator next steps, snapshot schema, and the integrations **Budget hit** badge all understand the new status; **`rate_limited`** messaging is narrowed to real API throttling.
> 
> The probe runner logs **`quoteAttempts=used/limit`** per budgeted adapter, counts fully budget-exhausted chains in **`failingChainChecks`**, and suggests raising **`maxQuoteRequestsPerRun`** when a partial chain failed only due to budget.
> 
> On **`/integrations`**, snapshots older than **48 hours** show an amber stale banner (with tests); fresh snapshots do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f973280636df55fa921025a5470e73449cc067e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->