### PR TITLE
fix: strip patchedDependencies from aegis App Engine deploy bundle

### DIFF
--- a/aegis/bin/deploy.sh
+++ b/aegis/bin/deploy.sh
@@ -37,8 +37,13 @@ const aegisPackage = JSON.parse(fs.readFileSync(aegisPackagePath, 'utf8'));
 const deployPackage = {
   ...aegisPackage,
   packageManager: rootPackage.packageManager,
-  pnpm: rootPackage.pnpm,
+  pnpm: { ...rootPackage.pnpm },
 };
+
+// The App Engine source bundle does not include the patches/ directory, and
+// aegis does not depend on any patched package. Drop patchedDependencies so the
+// Cloud Build `pnpm install` doesn't fail trying to read a missing patch file.
+delete deployPackage.pnpm.patchedDependencies;
 
 if (deployPackage.scripts) {
   delete deployPackage.scripts.build;
@@ -81,8 +86,22 @@ for (let index = aegisIndex + 1; index < packagesIndex; index += 1) {
 const aegisImporter = lines.slice(aegisIndex, aegisEndIndex);
 aegisImporter[0] = '  .:';
 
+// Strip the top-level patchedDependencies block from the lockfile head. The
+// patches/ directory is not uploaded with the App Engine source and aegis does
+// not depend on any patched package, so referencing it would break the Cloud
+// Build `pnpm install` with a missing-file error.
+const head = lines.slice(0, importersIndex + 1);
+const patchedIndex = head.findIndex((line) => line === 'patchedDependencies:');
+if (patchedIndex !== -1) {
+  let patchedEnd = patchedIndex + 1;
+  while (patchedEnd < head.length && /^\s/.test(head[patchedEnd])) {
+    patchedEnd += 1;
+  }
+  head.splice(patchedIndex, patchedEnd - patchedIndex);
+}
+
 const deployLock = [
-  ...lines.slice(0, importersIndex + 1),
+  ...head,
   '',
   ...aegisImporter,
   '',


### PR DESCRIPTION
## The Problem

- The Aegis App Engine deploy ([run 27585125181](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/27585125181/job/81553677381)) fails during Cloud Build's `pnpm install` with `ENOENT: no such file or directory, open '/workspace/patches/@lhci__utils@0.15.1.patch'`.
- The deploy bundle declares a patched dependency it doesn't ship: `aegis/bin/deploy.sh` copies the root `package.json`'s full `pnpm` field (including `pnpm.patchedDependencies`) and the lockfile's top-level `patchedDependencies:` block, but never copies the `patches/` directory.
- Aegis (a NestJS app) doesn't even depend on `@lhci/utils` — that patch belongs to Lighthouse CI elsewhere in the monorepo.

## The Solution

- Strip `patchedDependencies` from the generated deploy `package.json` and from the trimmed `pnpm-lock.yaml` head, so the bundled install no longer references a patch file that isn't there and isn't needed.

## Details

- `pnpm.overrides` and everything aegis actually installs are preserved untouched.
- Copying the patch file would not work either: pnpm errors on a patched dependency that doesn't apply to any installed package, so removal is the correct fix.
- The `@lhci/utils@0.15.1(patch_hash=...)` entries remaining in the full package catalog are for packages outside the aegis import graph and are never installed — identical to every other unused catalog entry that has always shipped in this bundle.
- Scope is limited to `aegis/bin/deploy.sh`; the deploy workflow (`aegis-app-engine.yml`) only invokes `pnpm aegis:deploy`, so no companion change is needed.
- The deploy workflow runs only on push to `main`, so this PR's CI exercises the aegis quality job but not `deploy.sh` itself — the fix is exercised when this merges and the deploy re-runs.

## Validation

- Simulated the exact bundle generation locally: generated `package.json` has no `patchedDependencies` and retains all 50 `pnpm.overrides`; generated lockfile head has no top-level `patchedDependencies:` block, with `overrides:` and `importers:` intact and no patch references in the head.
- `pnpm agent:quality-gate --run`: all aegis checks pass (trunk, `bash -n`, typecheck, build, lint, knip, `test:cov`, `code-health:deps`). The only failing mapped command is `cd aegis && forge test`, which fails solely because `forge` isn't installed in the agent environment — there are no Solidity changes in this PR.
- Closeout review: `pnpm agent:autoreview` global helper was unavailable, so a current-session diff review was performed instead (single-file change, behavior and edge cases checked, no docs/workflow drift).

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

---
_Generated by [Claude Code](https://claude.ai/code/session_017TgpuLebn6VTy4JgBQ3sTg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-packaging-only change in `deploy.sh`; no runtime app logic, with behavior limited to omitting unused patch metadata from the bundle.
> 
> **Overview**
> Fixes **Aegis App Engine** deploy failures where Cloud Build `pnpm install` errors because the bundle references monorepo **patch files** that are not uploaded.
> 
> **`aegis/bin/deploy.sh`** now clones the root `pnpm` config with a shallow copy, then **removes `pnpm.patchedDependencies`** from the generated deploy `package.json`. It also **strips the top-level `patchedDependencies:` block** from the trimmed `pnpm-lock.yaml` head before splicing in only the aegis importer. **`pnpm.overrides`** and the rest of the lockfile catalog stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9febca57ebd336153b4ceaa7d23a71da329cbb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->