### PR TITLE
feat: surface onchain handler alert drops

### DIFF
--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -150,6 +150,7 @@ jobs:
       TF_VAR_splunk_on_call_api_key: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
       TF_VAR_oncall_slack_channel_id: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
       TF_VAR_oncall_support_usergroup_id: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
+      TF_VAR_slack_notification_channel_id: ${{ secrets.TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID }}
       # Slack (for restapi.slack provider — creates/archives Sentry alert channels)
       TF_VAR_slack_bot_token: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
       # GitHub (for github_actions_secret resources that self-manage these secrets)
@@ -493,6 +494,7 @@ jobs:
       TF_VAR_splunk_on_call_api_key: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
       TF_VAR_oncall_slack_channel_id: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
       TF_VAR_oncall_support_usergroup_id: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
+      TF_VAR_slack_notification_channel_id: ${{ secrets.TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID }}
       TF_VAR_slack_bot_token: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
       TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -128,6 +128,7 @@ jobs:
       TF_VAR_splunk_on_call_api_key: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
       TF_VAR_oncall_slack_channel_id: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
       TF_VAR_oncall_support_usergroup_id: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
+      TF_VAR_slack_notification_channel_id: ${{ secrets.TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID }}
       TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     defaults:
       run:

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -9,6 +9,7 @@ Terraform-managed alert infrastructure for monitoring Mento's infrastructure acr
 ├── main.tf                 # Root configuration and module orchestration
 ├── variables.tf            # Shared variable definitions
 ├── outputs.tf              # Aggregated outputs
+├── monitoring.tf           # Log-based drop metrics + alert policies for onchain-event-handler
 │
 ├── channels/
 │   ├── sentry-bridge/      # Sentry JS error monitoring (Sentry → Slack bridge)

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -26,6 +26,7 @@ module "project_factory" {
     "cloudscheduler.googleapis.com",
     "storage.googleapis.com",
     "logging.googleapis.com",
+    "monitoring.googleapis.com",
     "run.googleapis.com",              # Required for Cloud Functions Gen2
     "artifactregistry.googleapis.com", # Required for Cloud Functions Gen2
     "secretmanager.googleapis.com",    # Required for Secret Manager
@@ -307,22 +308,27 @@ locals {
     "TF_VAR_SPLUNK_ON_CALL_API_ID",
     "TF_VAR_SPLUNK_ON_CALL_API_KEY",
   ]) : toset([])
+  alerts_infra_ci_monitoring_secret_names = var.slack_notification_channel_id != "" ? toset([
+    "TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID",
+  ]) : toset([])
   alerts_infra_ci_secret_names = setunion(
     local.alerts_infra_ci_base_secret_names,
     local.alerts_infra_ci_oncall_secret_names,
+    local.alerts_infra_ci_monitoring_secret_names,
   )
 
   alerts_infra_ci_secret_values = {
-    TF_VAR_SENTRY_AUTH_TOKEN           = var.sentry_auth_token
-    TF_VAR_BILLING_ACCOUNT             = var.billing_account
-    TF_VAR_QUICKNODE_API_KEY           = var.quicknode_api_key
-    TF_VAR_QUICKNODE_SIGNING_SECRET    = var.quicknode_signing_secret
-    TF_VAR_ONCALL_SLACK_CHANNEL_ID     = var.oncall_slack_channel_id
-    TF_VAR_ONCALL_SUPPORT_USERGROUP_ID = var.oncall_support_usergroup_id
-    TF_VAR_SPLUNK_ON_CALL_API_ID       = var.splunk_on_call_api_id
-    TF_VAR_SPLUNK_ON_CALL_API_KEY      = var.splunk_on_call_api_key
-    TF_VAR_SLACK_BOT_TOKEN             = var.slack_bot_token
-    TF_VAR_GITHUB_TOKEN                = var.github_token
+    TF_VAR_SENTRY_AUTH_TOKEN             = var.sentry_auth_token
+    TF_VAR_BILLING_ACCOUNT               = var.billing_account
+    TF_VAR_QUICKNODE_API_KEY             = var.quicknode_api_key
+    TF_VAR_QUICKNODE_SIGNING_SECRET      = var.quicknode_signing_secret
+    TF_VAR_ONCALL_SLACK_CHANNEL_ID       = var.oncall_slack_channel_id
+    TF_VAR_ONCALL_SUPPORT_USERGROUP_ID   = var.oncall_support_usergroup_id
+    TF_VAR_SPLUNK_ON_CALL_API_ID         = var.splunk_on_call_api_id
+    TF_VAR_SPLUNK_ON_CALL_API_KEY        = var.splunk_on_call_api_key
+    TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID = var.slack_notification_channel_id
+    TF_VAR_SLACK_BOT_TOKEN               = var.slack_bot_token
+    TF_VAR_GITHUB_TOKEN                  = var.github_token
   }
 }
 

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -4,22 +4,27 @@
 # does not replay the batch. These metrics and policies make those drops
 # human-visible. Pattern mirrors governance-watchdog/infra/monitoring.tf.
 
-# Counts ERROR-level logs from the handler. Pinned to the handler's service name
-# so oncall-announcer errors in the same project do not cross-page.
+# Counts drop-path ERROR-level logs from the handler. Pinned to the handler's
+# service name so oncall-announcer errors in the same project do not cross-page;
+# narrowed to per-event drop logs so public auth probes do not page.
 resource "google_logging_metric" "onchain_handler_errors" {
   project     = local.project_id
   name        = "onchain_event_handler_error_logs"
-  description = "ERROR-level log entries in the onchain-event-handler Cloud Function (dropped Safe alerts, chain-detection failures, replay-protection failures)"
+  description = "Drop-path ERROR-level log entries in the onchain-event-handler Cloud Function (dropped Safe alerts)"
   filter      = <<EOF
     severity>=ERROR
     resource.type="cloud_run_revision"
     resource.labels.service_name="${module.onchain_event_handler.function_name}"
+    (
+      jsonPayload.message.message="Error processing log" OR
+      jsonPayload.message.message="No notification channel found"
+    )
   EOF
 }
 
 # Counts events skipped because the processing budget elapsed. These are logged
-# at WARNING with a stable reason field, so the ERROR metric above does not see
-# them.
+# at WARNING with a stable reason field nested under LogSync's message payload,
+# so the ERROR metric above does not see them.
 resource "google_logging_metric" "onchain_handler_budget_skips" {
   project     = local.project_id
   name        = "onchain_event_handler_budget_skips"
@@ -28,7 +33,7 @@ resource "google_logging_metric" "onchain_handler_budget_skips" {
     severity="WARNING"
     resource.type="cloud_run_revision"
     resource.labels.service_name="${module.onchain_event_handler.function_name}"
-    jsonPayload.reason="skipped_due_to_timeout"
+    jsonPayload.message.reason="skipped_due_to_timeout"
   EOF
 }
 
@@ -49,7 +54,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_errors_policy" {
       Safe transactions manually.
 
       **View recent error logs:**
-      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
+      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22%20AND%20(jsonPayload.message.message%3D%22Error%20processing%20log%22%20OR%20jsonPayload.message.message%3D%22No%20notification%20channel%20found%22);duration=PT24H
     EOT
     mime_type = "text/markdown"
   }
@@ -104,7 +109,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_budget_skips_policy" 
       recent Safe multisig activity manually.
 
       **View recent budget-skip logs:**
-      https://console.cloud.google.com/logs/query;query=jsonPayload.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
+      https://console.cloud.google.com/logs/query;query=jsonPayload.message.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
     EOT
     mime_type = "text/markdown"
   }

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -1,0 +1,143 @@
+# Drop-path observability for the onchain-event-handler Cloud Function.
+# The handler is at-most-once by design: per-event failures and processing
+# budget skips are logged and intentionally answered with HTTP 200 so QuickNode
+# does not replay the batch. These metrics and policies make those drops
+# human-visible. Pattern mirrors governance-watchdog/infra/monitoring.tf.
+
+# Counts ERROR-level logs from the handler. Pinned to the handler's service name
+# so oncall-announcer errors in the same project do not cross-page.
+resource "google_logging_metric" "onchain_handler_errors" {
+  project     = local.project_id
+  name        = "onchain_event_handler_error_logs"
+  description = "ERROR-level log entries in the onchain-event-handler Cloud Function (dropped Safe alerts, chain-detection failures, replay-protection failures)"
+  filter      = <<EOF
+    severity>=ERROR
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${module.onchain_event_handler.function_name}"
+  EOF
+}
+
+# Counts events skipped because the processing budget elapsed. These are logged
+# at WARNING with a stable reason field, so the ERROR metric above does not see
+# them.
+resource "google_logging_metric" "onchain_handler_budget_skips" {
+  project     = local.project_id
+  name        = "onchain_event_handler_budget_skips"
+  description = "Log entries reporting events skipped by the onchain-event-handler processing budget"
+  filter      = <<EOF
+    severity>=WARNING
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${module.onchain_event_handler.function_name}"
+    jsonPayload.reason="skipped_due_to_timeout"
+  EOF
+}
+
+resource "google_monitoring_alert_policy" "onchain_handler_errors_policy" {
+  count = var.slack_notification_channel_id != "" ? 1 : 0
+
+  project      = local.project_id
+  display_name = "onchain-event-handler-errors"
+  combiner     = "OR"
+  enabled      = true
+
+  documentation {
+    content   = <<-EOT
+      ## Error in onchain-event-handler (likely a dropped Safe multisig alert)
+
+      The handler logs ERROR and answers HTTP 200 on per-event failures, so
+      QuickNode will NOT redeliver. Check the logs and re-verify the affected
+      Safe transactions manually.
+
+      **View recent error logs:**
+      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT3H
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "Any handler error in 5 minutes"
+
+    condition_threshold {
+      filter = <<EOF
+        resource.type = "cloud_run_revision" AND
+        metric.type   = "logging.googleapis.com/user/${google_logging_metric.onchain_handler_errors.name}"
+      EOF
+
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = ["projects/${local.project_id}/notificationChannels/${var.slack_notification_channel_id}"]
+  severity              = "ERROR"
+
+  alert_strategy {
+    auto_close = "86400s"
+  }
+}
+
+resource "google_monitoring_alert_policy" "onchain_handler_budget_skips_policy" {
+  count = var.slack_notification_channel_id != "" ? 1 : 0
+
+  project      = local.project_id
+  display_name = "onchain-event-handler-budget-skips"
+  combiner     = "OR"
+  enabled      = true
+
+  documentation {
+    content   = <<-EOT
+      ## Processing-budget skip in onchain-event-handler
+
+      The onchain-event-handler ran out of processing budget and skipped Safe
+      events without alerting on them. QuickNode will not redeliver — re-verify
+      recent Safe multisig activity manually.
+
+      **View recent budget-skip logs:**
+      https://console.cloud.google.com/logs/query;query=jsonPayload.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT3H
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "Any budget skip in 5 minutes"
+
+    condition_threshold {
+      filter = <<EOF
+        resource.type = "cloud_run_revision" AND
+        metric.type   = "logging.googleapis.com/user/${google_logging_metric.onchain_handler_budget_skips.name}"
+      EOF
+
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = ["projects/${local.project_id}/notificationChannels/${var.slack_notification_channel_id}"]
+  severity              = "ERROR"
+
+  alert_strategy {
+    auto_close = "86400s"
+  }
+}

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -17,14 +17,17 @@ resource "google_logging_metric" "onchain_handler_errors" {
     resource.labels.service_name="${module.onchain_event_handler.function_name}"
     (
       jsonPayload.message.message="Error processing log" OR
-      jsonPayload.message.message="No notification channel found"
+      jsonPayload.message="Error processing log" OR
+      jsonPayload.message.message="No notification channel found" OR
+      jsonPayload.message="No notification channel found"
     )
   EOF
 }
 
 # Counts events skipped because the processing budget elapsed. These are logged
-# at WARNING with a stable reason field nested under LogSync's message payload,
-# so the ERROR metric above does not see them.
+# at WARNING with a stable reason field, so the ERROR metric above does not see
+# them. Match both direct structured-logger fields and LogSync's nested message
+# payload shape.
 resource "google_logging_metric" "onchain_handler_budget_skips" {
   project     = local.project_id
   name        = "onchain_event_handler_budget_skips"
@@ -33,7 +36,10 @@ resource "google_logging_metric" "onchain_handler_budget_skips" {
     severity="WARNING"
     resource.type="cloud_run_revision"
     resource.labels.service_name="${module.onchain_event_handler.function_name}"
-    jsonPayload.message.reason="skipped_due_to_timeout"
+    (
+      jsonPayload.message.reason="skipped_due_to_timeout" OR
+      jsonPayload.reason="skipped_due_to_timeout"
+    )
   EOF
 }
 
@@ -54,7 +60,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_errors_policy" {
       Safe transactions manually.
 
       **View recent error logs:**
-      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22%20AND%20(jsonPayload.message.message%3D%22Error%20processing%20log%22%20OR%20jsonPayload.message.message%3D%22No%20notification%20channel%20found%22);duration=PT24H
+      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22%20AND%20(jsonPayload.message.message%3D%22Error%20processing%20log%22%20OR%20jsonPayload.message%3D%22Error%20processing%20log%22%20OR%20jsonPayload.message.message%3D%22No%20notification%20channel%20found%22%20OR%20jsonPayload.message%3D%22No%20notification%20channel%20found%22);duration=PT24H
     EOT
     mime_type = "text/markdown"
   }
@@ -109,7 +115,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_budget_skips_policy" 
       recent Safe multisig activity manually.
 
       **View recent budget-skip logs:**
-      https://console.cloud.google.com/logs/query;query=jsonPayload.message.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
+      https://console.cloud.google.com/logs/query;query=(jsonPayload.message.reason%3D%22skipped_due_to_timeout%22%20OR%20jsonPayload.reason%3D%22skipped_due_to_timeout%22)%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
     EOT
     mime_type = "text/markdown"
   }

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -25,7 +25,7 @@ resource "google_logging_metric" "onchain_handler_budget_skips" {
   name        = "onchain_event_handler_budget_skips"
   description = "Log entries reporting events skipped by the onchain-event-handler processing budget"
   filter      = <<EOF
-    severity>=WARNING
+    severity="WARNING"
     resource.type="cloud_run_revision"
     resource.labels.service_name="${module.onchain_event_handler.function_name}"
     jsonPayload.reason="skipped_due_to_timeout"
@@ -49,7 +49,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_errors_policy" {
       Safe transactions manually.
 
       **View recent error logs:**
-      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT3H
+      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
     EOT
     mime_type = "text/markdown"
   }
@@ -104,7 +104,7 @@ resource "google_monitoring_alert_policy" "onchain_handler_budget_skips_policy" 
       recent Safe multisig activity manually.
 
       **View recent budget-skip logs:**
-      https://console.cloud.google.com/logs/query;query=jsonPayload.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT3H
+      https://console.cloud.google.com/logs/query;query=jsonPayload.reason%3D%22skipped_due_to_timeout%22%20AND%20resource.labels.service_name%3D%22${module.onchain_event_handler.function_name}%22;duration=PT24H
     EOT
     mime_type = "text/markdown"
   }

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -117,6 +117,12 @@ github_token = "github_pat_..."
 # Optional Settings
 #####################
 
+# Slack notification channel ID for onchain-event-handler drop alerts.
+# Created manually via OAuth in GCP Console (Monitoring → Alerting → Edit
+# Notification Channels) after the project exists. Leave unset to skip creating
+# the alert policies.
+# slack_notification_channel_id = "1234567890123456789"
+
 # Enable debug mode for REST API provider (shows API requests/responses)
 # Useful for troubleshooting REST API provider issues
 # debug_mode = true

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -128,6 +128,17 @@ variable "oncall_support_usergroup_id" {
   }
 }
 
+variable "slack_notification_channel_id" {
+  description = "GCP Monitoring Slack notification channel ID for onchain-event-handler drop alerts (numeric suffix from projects/.../notificationChannels/<id>). Leave empty to skip creating the alert policies until the channel exists."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.slack_notification_channel_id == "" || can(regex("^[0-9]+$", var.slack_notification_channel_id))
+    error_message = "slack_notification_channel_id must be empty or a GCP Monitoring notification channel ID such as 7755148860700532944."
+  }
+}
+
 variable "splunk_on_call_api_base_url" {
   description = "Base URL for the Splunk On-Call public API. The historical VictorOps API host remains the canonical endpoint."
   type        = string

--- a/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
+++ b/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
@@ -34,6 +34,18 @@ function mockWebhooksResponse(webhooks: FakeWebhook[]) {
 const ACTIVE_WEBHOOKS: FakeWebhook[] = [
   { id: "1", name: "SortedOracles", status: "active", network: "celo-mainnet" },
   { id: "2", name: "MentoGovernor", status: "active", network: "celo-mainnet" },
+  {
+    id: "3",
+    name: "safe-multisig-monitor-celo-abc12345",
+    status: "active",
+    network: "celo-mainnet",
+  },
+  {
+    id: "4",
+    name: "safe-multisig-monitor-ethereum-abc12345",
+    status: "active",
+    network: "ethereum-mainnet",
+  },
 ];
 
 describe("checkWebhookStatus", () => {
@@ -44,7 +56,7 @@ describe("checkWebhookStatus", () => {
     mockGetSecret.mockResolvedValue("test-api-key");
   });
 
-  it("reports healthy when both expected webhooks are active", async () => {
+  it("reports healthy when all expected webhooks are active", async () => {
     mockWebhooksResponse(ACTIVE_WEBHOOKS);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
@@ -64,11 +76,17 @@ describe("checkWebhookStatus", () => {
     expect(result.unhealthyWebhooks).toEqual([
       "SortedOracles (missing)",
       "MentoGovernor (missing)",
+      "safe-multisig-monitor-celo-* (missing or inactive)",
+      "safe-multisig-monitor-ethereum-* (missing or inactive)",
     ]);
   });
 
   it("reports unhealthy when one expected webhook is missing", async () => {
-    mockWebhooksResponse([ACTIVE_WEBHOOKS[0]]);
+    mockWebhooksResponse([
+      ACTIVE_WEBHOOKS[0],
+      ACTIVE_WEBHOOKS[2],
+      ACTIVE_WEBHOOKS[3],
+    ]);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
     const result = await checkWebhookStatus();
@@ -86,6 +104,8 @@ describe("checkWebhookStatus", () => {
         network: "ethereum-mainnet",
       },
       ACTIVE_WEBHOOKS[1],
+      ACTIVE_WEBHOOKS[2],
+      ACTIVE_WEBHOOKS[3],
     ]);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
@@ -99,7 +119,7 @@ describe("checkWebhookStatus", () => {
     mockWebhooksResponse([
       ...ACTIVE_WEBHOOKS,
       {
-        id: "3",
+        id: "5",
         name: "StagingWebhook",
         status: "paused",
         network: "celo-mainnet",
@@ -122,6 +142,8 @@ describe("checkWebhookStatus", () => {
         status: "paused",
         network: "celo-mainnet",
       },
+      ACTIVE_WEBHOOKS[2],
+      ACTIVE_WEBHOOKS[3],
     ]);
     const { checkWebhookStatus } = await import("../check-webhook-status.js");
 
@@ -154,6 +176,64 @@ describe("checkWebhookStatus", () => {
     expect(String(fetchMock.mock.calls[1][0])).toContain(
       "limit=100&offset=100",
     );
+  });
+
+  it("reports unhealthy when a Safe webhook prefix has no active match", async () => {
+    mockWebhooksResponse([
+      ...ACTIVE_WEBHOOKS.slice(0, 3),
+      {
+        id: "4",
+        name: "safe-multisig-monitor-ethereum-abc12345",
+        status: "paused",
+        network: "ethereum-mainnet",
+      },
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual([
+      "safe-multisig-monitor-ethereum-* (missing or inactive)",
+    ]);
+  });
+
+  it("stays healthy when a paused old Safe webhook lingers next to an active replacement", async () => {
+    mockWebhooksResponse([
+      ...ACTIVE_WEBHOOKS,
+      {
+        id: "5",
+        name: "safe-multisig-monitor-celo-deadbeef",
+        status: "paused",
+        network: "celo-mainnet",
+      },
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(true);
+    expect(result.unhealthyWebhooks).toEqual([]);
+  });
+
+  it("treats a Safe webhook on the wrong network as missing", async () => {
+    mockWebhooksResponse([
+      ...ACTIVE_WEBHOOKS.slice(0, 3),
+      {
+        id: "4",
+        name: "safe-multisig-monitor-ethereum-abc12345",
+        status: "active",
+        network: "celo-mainnet",
+      },
+    ]);
+    const { checkWebhookStatus } = await import("../check-webhook-status.js");
+
+    const result = await checkWebhookStatus();
+
+    expect(result.healthy).toBe(false);
+    expect(result.unhealthyWebhooks).toEqual([
+      "safe-multisig-monitor-ethereum-* (missing or inactive)",
+    ]);
   });
 
   it("reads the API key secret id from config", async () => {

--- a/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
+++ b/governance-watchdog/src/quicknode-health/__tests__/check-webhook-status.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock getSecret so no Secret Manager calls happen
@@ -29,6 +31,44 @@ function fakePage(webhooks: FakeWebhook[]) {
 
 function mockWebhooksResponse(webhooks: FakeWebhook[]) {
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fakePage(webhooks)));
+}
+
+function repoRoot() {
+  return process.cwd().endsWith("governance-watchdog")
+    ? join(process.cwd(), "..")
+    : process.cwd();
+}
+
+function alertsInfraMultisigChains() {
+  const variables = readFileSync(
+    join(repoRoot(), "alerts", "infra", "variables.tf"),
+    "utf8",
+  );
+  const defaultBlockPattern = new RegExp(
+    [
+      'variable "multisigs"[\\s\\S]*?default = \\{',
+      "(?<body>[\\s\\S]*?)",
+      "\\n[ ]{2}\\}\\n\\n[ ]{2}validation",
+    ].join(""),
+  );
+  const defaultBlock = defaultBlockPattern.exec(variables)?.groups?.body;
+  if (!defaultBlock) {
+    throw new Error(
+      "Unable to locate alerts/infra var.multisigs default block",
+    );
+  }
+
+  const chains = new Set<string>();
+  const chainPattern = /chain\s+=\s+"([^"]+)"/g;
+  for (
+    let match = chainPattern.exec(defaultBlock);
+    match;
+    match = chainPattern.exec(defaultBlock)
+  ) {
+    chains.add(match[1]);
+  }
+
+  return [...chains].sort();
 }
 
 const ACTIVE_WEBHOOKS: FakeWebhook[] = [
@@ -234,6 +274,10 @@ describe("checkWebhookStatus", () => {
     expect(result.unhealthyWebhooks).toEqual([
       "safe-multisig-monitor-ethereum-* (missing or inactive)",
     ]);
+  });
+
+  it("documents Safe webhook prefixes for every alerts/infra multisig chain", () => {
+    expect(alertsInfraMultisigChains()).toEqual(["celo", "ethereum"]);
   });
 
   it("reads the API key secret id from config", async () => {

--- a/governance-watchdog/src/quicknode-health/check-webhook-status.ts
+++ b/governance-watchdog/src/quicknode-health/check-webhook-status.ts
@@ -46,6 +46,24 @@ const EXPECTED_WEBHOOKS = [
 ];
 
 /**
+ * Safe-multisig webhooks provisioned by alerts/infra (one per chain). Their
+ * names carry a config-hash suffix — `safe-multisig-monitor-<chain>-<hash8>`,
+ * see `webhook_name` in alerts/infra/main.tf and the name construction in
+ * alerts/infra/onchain-event-listeners/main.tf — so they are matched by prefix
+ * + network instead of exact name. Healthy = at least one ACTIVE webhook per
+ * prefix; a paused old webhook lingering next to its active replacement
+ * (QuickNode recreate flow) must not alarm. Keep in sync with the chains in
+ * alerts/infra `var.multisigs`.
+ */
+const EXPECTED_WEBHOOK_PREFIXES = [
+  { namePrefix: "safe-multisig-monitor-celo-", network: "celo-mainnet" },
+  {
+    namePrefix: "safe-multisig-monitor-ethereum-",
+    network: "ethereum-mainnet",
+  },
+];
+
+/**
  * The webhooks endpoint is paginated (default limit 20), so we page through
  * every result — an expected webhook beyond the first page must not be
  * reported as missing.
@@ -154,8 +172,21 @@ export const checkWebhookStatus = async (): Promise<WebhookHealthResult> => {
       ),
   );
 
+  const missingPrefixWebhooks = EXPECTED_WEBHOOK_PREFIXES.filter(
+    (expected) =>
+      !webhooks.some(
+        (webhook) =>
+          webhook.name.startsWith(expected.namePrefix) &&
+          webhook.network === expected.network &&
+          HEALTHY_STATUSES.includes(webhook.status.toLowerCase()),
+      ),
+  );
+
   const unhealthyWebhooks = [
     ...missingWebhooks.map((expected) => `${expected.name} (missing)`),
+    ...missingPrefixWebhooks.map(
+      (expected) => `${expected.namePrefix}* (missing or inactive)`,
+    ),
     ...webhooks
       .filter(
         (webhook) =>


### PR DESCRIPTION
## The Problem

- The Safe multisig alert handler intentionally returns HTTP 200 on per-event failures and budget skips, so QuickNode will not retry dropped alerts.
- Those drop paths were only visible in logs, with no Cloud Monitoring metric or policy to notify humans.
- Governance Watchdog's QuickNode health check did not verify the Safe multisig webhooks managed by alerts/infra.

## The Solution

- Add log-based metrics and optional Slack-routed alert policies for onchain-event-handler ERROR logs and processing-budget skips.
- Wire the new Monitoring notification channel variable through alerts-infra CI, drift checks, Terraform secret mirroring, and docs.
- Extend Governance Watchdog's QuickNode health check to require active Safe webhook prefixes for Celo and Ethereum, with tests for missing, wrong-network, and paused-replacement cases.

## Details

- Enables `monitoring.googleapis.com` for the alerts project before managing Monitoring alert policies.
- Keeps policies count-gated on `slack_notification_channel_id`, so the stack remains safe before the GCP Monitoring Slack channel is bootstrapped.
- Uses the numeric GCP Monitoring notification-channel ID, not a Slack conversation ID.
- Preserves exact-name matching for `SortedOracles` and `MentoGovernor`; Safe webhooks use prefix + network matching because Terraform appends a config-hash suffix.
- No Terraform apply was run locally.

## Validation

- `pnpm --filter @mento-protocol/governance-watchdog test:unit`
- `pnpm --filter @mento-protocol/governance-watchdog typecheck`
- `pnpm --filter @mento-protocol/governance-watchdog lint`
- `terraform -chdir=alerts/infra init -backend=false`
- `terraform -chdir=alerts/infra validate`
- `pnpm tf validate alerts-delivery`
- `pnpm agent:quality-gate --run`
- `~/.agents/skills/autoreview/scripts/autoreview --mode local --engine local`
- Fresh-context autoreview found three issues; all were fixed and the quality gate/autoreview were rerun clean.

## Deferrals

None

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Closes #842

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multisig alert visibility and on-call paging for dropped handler events and QuickNode webhook gaps; policies are opt-in via channel ID and the health check is additive but can page if Safe webhooks are missing or misconfigured.
> 
> **Overview**
> Adds **GCP Monitoring** for the onchain-event-handler’s intentional drop paths (per-event ERRORs and processing-budget skips), routing optional **Slack** alerts when `slack_notification_channel_id` is set. The stack enables `monitoring.googleapis.com`, introduces `monitoring.tf` with log-based metrics and count-gated alert policies, and threads the new Terraform variable through **alerts-infra** / **drift** workflows and GitHub Actions secret mirroring.
> 
> **Governance Watchdog**’s QuickNode health check now requires at least one **active** `safe-multisig-monitor-<chain>-*` webhook per Celo and Ethereum (prefix + network, to match Terraform’s hash suffix), with expanded unit tests and a guard that chains stay aligned with `alerts/infra` `var.multisigs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed78879f7dc403ca2f7b89f29722f4a6ebe8d6dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->