### PR TITLE
docs: require master context routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,17 +28,21 @@ use.
 
 ## Cross-Protocol Context
 
-For broader Mento protocol context beyond this monitoring repo, start with the
-private `mento-master-context` checkout when available:
+For any protocol-level question that crosses beyond this monitoring repo, first
+read the private `mento-master-context` router when the checkout is available:
 
 ```text
 ../mento-master-context/.agents/mento-context/README.md
 ```
 
-Use it to find source-of-truth contracts, deployments, live-state recipes, data
-semantics, Aegis/Grafana context, docs, and whitepaper sources. It is a router,
-not live truth; verify current values through the source-specific repo, API,
-RPC, or dashboard path it points to.
+This applies before broad repo searches for questions about contracts,
+deployments, addresses, ABIs, live on-chain state, stable supply, reserve data,
+monitoring data semantics, Aegis/Grafana metrics, docs, the whitepaper, business
+model, or legal/risk framing. Load only the relevant master-context card(s), then
+return to this repo for implementation details. It is a router, not live truth;
+verify current values through the source-specific repo, API, RPC, or dashboard
+path it points to. When answering, mention which master-context card you used or
+state that the checkout was unavailable.
 
 ## Secrets Rule (IaC Before CLI)
 


### PR DESCRIPTION
## The Problem

- Agents can answer protocol-level questions from local repo internals without first using the shared Mento master context.
- That makes cross-repo source-of-truth routing inconsistent for protocol state, deployment, monitoring, business, and risk questions.

## The Solution

- Require agents to read the sibling `mento-master-context` router first for protocol-level questions before broad local searches.
- Keep the master context framed as a router, with current values still verified through the source-specific repo, API, RPC, or dashboard path.

## Details

- Updates only the root `AGENTS.md` Cross-Protocol Context section.
- Explicitly covers contracts, deployments, addresses, ABIs, live on-chain state, stable supply, reserve data, monitoring semantics, Aegis/Grafana, docs, whitepaper, business model, and legal/risk framing.
- Requires answers to mention the master-context card used or state that the checkout was unavailable.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview --engine local`
- `git diff --check`
- Fresh canary agents: monitoring passed before and after the wording change; deployments failure was fixed by the same stronger wording in its sibling PR.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no runtime, auth, or data-path behavior is modified.
> 
> **Overview**
> **Tightens agent routing** for questions that go beyond this monitoring repo by requiring a **first** read of the sibling `mento-master-context` router (`../mento-master-context/.agents/mento-context/README.md`) when that checkout exists, **before** broad local repo searches.
> 
> The **Cross-Protocol Context** section now spells out covered topics (contracts, deployments, addresses, ABIs, on-chain state, reserves, monitoring semantics, Aegis/Grafana, docs, whitepaper, business/legal framing), instructs agents to load only the relevant context card(s) then return here for implementation, and requires answers to **cite the card used** or note that the checkout was unavailable—while still treating master context as a router, not live truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de8331d205cf67c900962a39b407cb746f34749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->