### PR TITLE
fix: harden indexer handler edge cases

### DIFF
--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -105,6 +105,16 @@ interface OracleReportedPoolCtx {
   } | null;
 }
 
+class OracleReportedPreWriteFailure extends Error {
+  constructor(
+    readonly poolId: string,
+    readonly reason: unknown,
+  ) {
+    super(String(reason));
+    this.name = "OracleReportedPreWriteFailure";
+  }
+}
+
 /** Process one pool's OracleReported update: self-heal, advance the oracle
  * cursor (or hold it when decimals are untrusted), then run the
  * breach/health/snapshot pipeline. Extracted from the handler's fan-out so the
@@ -115,28 +125,38 @@ async function processOracleReportedPool(
   poolId: string,
   c: OracleReportedPoolCtx,
 ): Promise<void> {
-  const initial = await context.Pool.get(poolId);
-  if (!initial) return;
-  // Self-heal invertRateFeed before computePriceDifference reads it.
-  // Without this, a pool deployed during an RPC blip whose only event
-  // post-deploy is OracleReported would persist wrong-orientation
-  // priceDifference / health / breach state until an FPMM event runs
-  // upsertPool's heal.
-  const existing = await selfHealTokenDecimals(
-    context,
-    await selfHealInvertRateFeed(context, initial),
-  );
+  let existing: Pool;
+  let oracleExpiry: bigint;
 
-  // Resolve oracleExpiry from DB if already populated, otherwise fetch
-  // via RPC (one-time seed — subsequent events use the DB value).
-  const oracleExpiry =
-    existing.oracleExpiry > 0n
-      ? existing.oracleExpiry
-      : ((await context.effect(reportExpiryEffect, {
-          chainId: c.chainId,
-          rateFeedID: c.rateFeedID,
-          blockNumber: c.blockNumber,
-        })) ?? existing.oracleExpiry);
+  try {
+    const initial = await context.Pool.get(poolId);
+    if (!initial) return;
+    // Self-heal invertRateFeed before computePriceDifference reads it.
+    // Without this, a pool deployed during an RPC blip whose only event
+    // post-deploy is OracleReported would persist wrong-orientation
+    // priceDifference / health / breach state until an FPMM event runs
+    // upsertPool's heal.
+    existing = await selfHealTokenDecimals(
+      context,
+      await selfHealInvertRateFeed(context, initial),
+    );
+
+    // Resolve oracleExpiry from DB if already populated, otherwise fetch
+    // via RPC (one-time seed — subsequent events use the DB value).
+    oracleExpiry =
+      existing.oracleExpiry > 0n
+        ? existing.oracleExpiry
+        : ((await context.effect(reportExpiryEffect, {
+            chainId: c.chainId,
+            rateFeedID: c.rateFeedID,
+            blockNumber: c.blockNumber,
+          })) ?? existing.oracleExpiry);
+  } catch (error) {
+    // These reads/effects happen before this pool queues any writes, so one
+    // pool's malformed id or transient RPC self-heal failure can be skipped
+    // without committing partial state for that pool.
+    throw new OracleReportedPreWriteFailure(poolId, error);
+  }
 
   const oraclePrice = c.oraclePrice;
 
@@ -391,10 +411,22 @@ indexer.onEvent(
     // Each poolId is distinct (getPoolsByFeed returns unique rows) so pool
     // writes don't race. Fan out in parallel — on a rate feed shared by 5-10
     // pools this collapses N sequential awaits into 1 concurrent batch.
+    // Isolate only the pre-write phase: RPC/self-heal failures for one pool
+    // should not drop sibling pool updates, but any failure after entity writes
+    // can have been queued must still fail the event instead of committing
+    // partial state for that pool.
     await Promise.all(
-      poolIds.map((poolId) =>
-        processOracleReportedPool(context, poolId, poolCtx),
-      ),
+      poolIds.map(async (poolId) => {
+        try {
+          await processOracleReportedPool(context, poolId, poolCtx);
+        } catch (error) {
+          if (!(error instanceof OracleReportedPreWriteFailure)) throw error;
+          context.log.warn(
+            `[sortedOracles] OracleReported pool pre-write phase failed for pool=${error.poolId} ` +
+              `feed=${rateFeedID} chain=${event.chainId}: ${String(error.reason)}`,
+          );
+        }
+      }),
     );
     // Cold-start: if this OracleReported is the first event for a feed whose
     // BreakerBox configs predate start_block, the resolve above bootstrapped

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -154,7 +154,8 @@ async function processOracleReportedPool(
   } catch (error) {
     // These reads/effects happen before this pool queues any writes, so one
     // pool's malformed id or transient RPC self-heal failure can be skipped
-    // without committing partial state for that pool.
+    // without committing partial state for that pool. The self-heal helpers
+    // return modified Pool objects and do not call Pool.set.
     throw new OracleReportedPreWriteFailure(poolId, error);
   }
 

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -33,11 +33,17 @@ import {
   findPendingScratch,
   findAndDrainPendingScratch,
 } from "../../wormhole/pairing.js";
+import {
+  warnUnmatchedScratchDrain,
+  type ScratchDrainEvent,
+} from "../../wormhole/scratchWarnings.js";
 import type { WormholeHandlerContext } from "../../wormhole/handlerContext.js";
 
 const PROVIDER = "WORMHOLE" as const;
 
-type HandlerContext = WormholeHandlerContext;
+type HandlerContext = WormholeHandlerContext & {
+  log: { warn: (message: string) => void };
+};
 
 /** Generated entity row types carry `readonly` on every field; the delta
  * builders below start as partial and mutate, then spread into the final
@@ -216,6 +222,13 @@ indexer.onEvent(
         currentLogIndex: event.logIndex,
       },
     );
+    if (!pending) {
+      warnUnmatchedScratchDrain(
+        context as HandlerContext,
+        event,
+        "WormholeTransferPending",
+      );
+    }
 
     const mgr = await ensureNttManagerSeed(
       context as HandlerContext,
@@ -523,17 +536,13 @@ function applyDestPendingToDelta(
  * because its payload lacks that identifier. */
 async function drainDestPending(
   context: HandlerContext,
-  event: {
-    chainId: number;
-    transaction: { hash: string };
-    logIndex: number;
-  },
+  event: ScratchDrainEvent,
   transceiver?: string,
 ): Promise<
   Awaited<ReturnType<HandlerContext["WormholeDestPending"]["get"]>> | undefined
 > {
   const transceiverLower = transceiver?.toLowerCase();
-  return findAndDrainPendingScratch(
+  const row = await findAndDrainPendingScratch(
     context.WormholeDestPending,
     {
       chainId: event.chainId,
@@ -544,6 +553,10 @@ async function drainDestPending(
       ? (row) => row.destTransceiver.toLowerCase() === transceiverLower
       : undefined,
   );
+  if (!row) {
+    warnUnmatchedScratchDrain(context, event, "WormholeDestPending");
+  }
+  return row;
 }
 
 indexer.onEvent(

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -469,6 +469,7 @@ indexer.onEvent(
         context as HandlerContext,
         event,
         mgr?.transceiver,
+        { warnOnMiss: false },
       );
     }
     const detailDelta: WormholeDetailDelta = {};
@@ -533,11 +534,13 @@ function applyDestPendingToDelta(
 /** Drain the scratch written by the earlier-in-tx ReceivedMessage. Pass
  * `transceiver` when the caller can identify it (MessageAttestedTo) so a
  * multi-transceiver tx doesn't cross-pair; TransferRedeemed passes undefined
- * because its payload lacks that identifier. */
+ * because its payload lacks that identifier. `warnOnMiss` is disabled only
+ * for callers that already emitted a more specific fallback warning. */
 async function drainDestPending(
   context: HandlerContext,
   event: ScratchDrainEvent,
   transceiver?: string,
+  options: { warnOnMiss?: boolean } = {},
 ): Promise<
   Awaited<ReturnType<HandlerContext["WormholeDestPending"]["get"]>> | undefined
 > {
@@ -553,7 +556,7 @@ async function drainDestPending(
       ? (row) => row.destTransceiver.toLowerCase() === transceiverLower
       : undefined,
   );
-  if (!row) {
+  if (!row && options.warnOnMiss !== false) {
     warnUnmatchedScratchDrain(context, event, "WormholeDestPending");
   }
   return row;

--- a/indexer-envio/src/wormhole/scratchWarnings.ts
+++ b/indexer-envio/src/wormhole/scratchWarnings.ts
@@ -1,0 +1,33 @@
+export type ScratchDrainEvent = {
+  chainId: number;
+  transaction: { hash: string };
+  logIndex: number;
+};
+
+export type ScratchEntity = "WormholeTransferPending" | "WormholeDestPending";
+
+type ScratchLogger = {
+  log: {
+    warn: (message: string) => void;
+  };
+};
+
+export function formatUnmatchedScratchDrainWarning(
+  event: ScratchDrainEvent,
+  scratchEntity: ScratchEntity,
+): string {
+  return (
+    `[wormhole] unmatched scratch row drain for ${scratchEntity} ` +
+    `(chain=${event.chainId} txHash=${event.transaction.hash} ` +
+    `logIndex=${event.logIndex}); ` +
+    "WormholeTransferPending/WormholeDestPending should be 0 in steady state."
+  );
+}
+
+export function warnUnmatchedScratchDrain(
+  context: ScratchLogger,
+  event: ScratchDrainEvent,
+  scratchEntity: ScratchEntity,
+): void {
+  context.log.warn(formatUnmatchedScratchDrainWarning(event, scratchEntity));
+}

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -989,4 +989,59 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
       "dependent pool inherits the tripped dependency's halt via the OracleReported cold-start",
     );
   });
+
+  it("SortedOracles.OracleReported isolates one pool's failure from sibling updates", async () => {
+    let mockDb = MockDb.createMockDb();
+    const goodPoolId = makePoolId(
+      CHAIN_ID,
+      "0x00000000000000000000000000000000000000d3",
+    );
+    // Malformed id forces the per-pool self-heal path to throw when it tries to
+    // extract the raw pool address. The sibling pool must still update.
+    const failingPoolId = `${CHAIN_ID}-bad-pool-id`;
+    mockDb = mockDb.entities.Pool.set(
+      makePool({
+        id: goodPoolId,
+        referenceRateFeedID: FEED,
+        invertRateFeedKnown: true,
+        tokenDecimalsKnown: true,
+        oracleExpiry: 1_700_010_000n,
+      }),
+    );
+    mockDb = mockDb.entities.Pool.set(
+      makePool({
+        id: failingPoolId,
+        referenceRateFeedID: FEED,
+        invertRateFeedKnown: true,
+        tokenDecimalsKnown: false,
+        oracleExpiry: 1_700_010_000n,
+      }),
+    );
+
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: SortedOracles.OracleReported.createMockEvent({
+        token: FEED,
+        reporter: "0x00000000000000000000000000000000000000aa",
+        value: 1_180_000_000_000_000_000_000_000n,
+        timestamp: 1_700_001_900n,
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 8,
+          srcAddress: "0xefb84935239dacdecf7c5ba76d8de40b077b7b33",
+          block: { number: 302, timestamp: 1_700_002_000 },
+        },
+      }),
+      mockDb,
+    });
+
+    const goodPool = mockDb.entities.Pool.get(goodPoolId) as
+      | { oraclePrice: bigint; lastFreshReporterAt: bigint }
+      | undefined;
+    assert.equal(
+      goodPool?.oraclePrice,
+      1_180_000_000_000_000_000_000_000n,
+      "healthy sibling pool still receives the oracle update",
+    );
+    assert.equal(goodPool?.lastFreshReporterAt, 1_700_001_900n);
+  });
 });

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -1043,5 +1043,14 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
       "healthy sibling pool still receives the oracle update",
     );
     assert.equal(goodPool?.lastFreshReporterAt, 1_700_001_900n);
+
+    const failingPool = mockDb.entities.Pool.get(failingPoolId) as
+      | { lastFreshReporterAt: bigint }
+      | undefined;
+    assert.notEqual(
+      failingPool?.lastFreshReporterAt,
+      1_700_001_900n,
+      "failing pool must not be updated via holdCursor - pre-write failure path must be taken",
+    );
   });
 });

--- a/indexer-envio/test/bridgeHandlers.test.ts
+++ b/indexer-envio/test/bridgeHandlers.test.ts
@@ -222,6 +222,28 @@ async function processTransferRedeemed(args: {
 }
 
 describe("Bridge-flows handlers — replay idempotency", () => {
+  it("TransferSentDigest continues when no source scratch row can be paired", async () => {
+    const e = pickManifestEntry();
+    let mockDb = MockDb.createMockDb();
+
+    mockDb = await TestWormholeNttManager.TransferSentDigest.processEvent({
+      event: TestWormholeNttManager.TransferSentDigest.createMockEvent({
+        digest: DIGEST_1,
+        mockEventData: mockEventData({
+          chainId: e.chainId,
+          manager: e.nttManagerProxy,
+          logIndex: 5,
+        }),
+      }),
+      mockDb,
+    });
+
+    const transfer = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${DIGEST_1.toLowerCase()}`,
+    );
+    assert.equal(transfer?.sourceChainId, e.chainId);
+  });
+
   it("replaying the same TransferSent pair does not double-count SENT rollups", async () => {
     const e = pickManifestEntry();
     let mockDb = MockDb.createMockDb();
@@ -908,6 +930,34 @@ describe("Bridge-flows handlers — ReceivedMessage (transceiver) interaction", 
     );
     assert.equal(detail?.msgSequence, 42n);
     assert.equal(detail?.sourceWormholeChainId, 14);
+  });
+
+  it("MessageAttestedTo continues when no destination scratch row can be drained", async () => {
+    const monad = findByNttManager(
+      143,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    assert.ok(monad);
+    let mockDb = MockDb.createMockDb();
+
+    mockDb = await TestWormholeNttManager.MessageAttestedTo.processEvent({
+      event: TestWormholeNttManager.MessageAttestedTo.createMockEvent({
+        digest: MANAGER_DIGEST,
+        transceiver: monad!.transceiverProxy,
+        index: 0,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monad!.nttManagerProxy,
+          logIndex: 7,
+        }),
+      }),
+      mockDb,
+    });
+
+    const transfer = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(transfer?.destChainId, 143);
   });
 
   it("replay (no MessageAttestedTo) leaves the scratch but does not pollute BridgeTransfer", async () => {

--- a/indexer-envio/test/wormholeScratchWarnings.test.ts
+++ b/indexer-envio/test/wormholeScratchWarnings.test.ts
@@ -23,6 +23,10 @@ describe("wormhole scratch warnings", () => {
 
     assert.match(warning, /WormholeDestPending/);
     assert.match(warning, /chain=143/);
+    assert.match(
+      warning,
+      /txHash=0x3333333333333333333333333333333333333333333333333333333333333333/,
+    );
     assert.match(warning, /logIndex=7/);
     assert.match(warning, /should be 0 in steady state/);
   });

--- a/indexer-envio/test/wormholeScratchWarnings.test.ts
+++ b/indexer-envio/test/wormholeScratchWarnings.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+  formatUnmatchedScratchDrainWarning,
+  warnUnmatchedScratchDrain,
+} from "../src/wormhole/scratchWarnings.js";
+
+const event = {
+  chainId: 143,
+  transaction: {
+    hash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+  },
+  logIndex: 7,
+};
+
+describe("wormhole scratch warnings", () => {
+  it("formats unmatched scratch drains with the scratch entity and event key", () => {
+    const warning = formatUnmatchedScratchDrainWarning(
+      event,
+      "WormholeDestPending",
+    );
+
+    assert.match(warning, /WormholeDestPending/);
+    assert.match(warning, /chain=143/);
+    assert.match(warning, /logIndex=7/);
+    assert.match(warning, /should be 0 in steady state/);
+  });
+
+  it("emits the formatted warning through context.log.warn", () => {
+    const warnings: string[] = [];
+    warnUnmatchedScratchDrain(
+      {
+        log: {
+          warn: (message) => warnings.push(message),
+        },
+      },
+      event,
+      "WormholeTransferPending",
+    );
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /WormholeTransferPending/);
+  });
+});


### PR DESCRIPTION
## The Problem

- A single OracleReported pool pre-write failure could reject the whole per-feed fan-out and transiently drop sibling pool updates.
- Wormhole scratch pairing misses were not visible enough for operators even though those scratch entities should drain to zero.
- The issue's other hygiene checks were already present on current main but still needed one closing PR tying the remaining gaps together.

## The Solution

- Isolate OracleReported pre-write work so one failing pool logs a warning without blocking sibling updates, while post-write failures still fail the event.
- Add a shared wormhole scratch warning helper and call it from both source and destination unmatched-drain paths.
- Cover the remaining behavior with targeted handler and helper tests, while relying on existing main tests for the already-fixed preload/feed/stables items.

## Details

- `sortedOracles.ts` now logs rejected per-pool pre-write updates with pool id, feed id, chain id, and the rejection reason.
- `nttManager.ts` now emits unmatched scratch-drain warnings for `WormholeTransferPending` and `WormholeDestPending`.
- `scratchWarnings.ts` centralizes warning formatting so tests can assert the exact operator-visible message without depending on Envio's test logger plumbing.
- `breakerHandlers.test.ts` proves one malformed pool id no longer prevents a healthy sibling pool from receiving its oracle update.
- `bridgeHandlers.test.ts` drives the source and destination unmatched scratch paths; `wormholeScratchWarnings.test.ts` verifies warning formatting/emission.
- Closes #871.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/breakerHandlers.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/bridgeHandlers.test.ts test/wormholeScratchWarnings.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/dailySnapshot.test.ts --reporter verbose`
- `pnpm --filter @mento-protocol/indexer-envio test:coverage`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Deferrals

- None

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches high-frequency oracle fan-out and bridge indexing paths; isolation is scoped to pre-write only, but misclassified errors could mask real pool failures or add log noise on scratch mismatches.
> 
> **Overview**
> **OracleReported** no longer fails the whole per-feed fan-out when one pool’s pre-write work blows up (malformed id, transient RPC/self-heal). Those errors are wrapped as `OracleReportedPreWriteFailure`, logged with pool/feed/chain context, and sibling pools still get their updates; anything that fails **after** writes may have been queued still fails the event.
> 
> **Wormhole** handlers now surface unmatched scratch pairing via a shared `scratchWarnings` helper: `TransferSentDigest` warns when no `WormholeTransferPending` row is found, and `drainDestPending` warns on empty `WormholeDestPending` drains (suppressed on `TransferRedeemed` fallback when a more specific warning already fired). Handlers still continue and upsert transfers when scratch rows are missing.
> 
> Targeted tests cover sibling oracle isolation, bridge flows without scratch rows, and warning message formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75dc1d4e94242da9f4f3e7777ee4b9fad1d88985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->