### PR TITLE
chore: split production deploy environments

### DIFF
--- a/.github/workflows/aegis-app-engine.yml
+++ b/.github/workflows/aegis-app-engine.yml
@@ -34,8 +34,12 @@ jobs:
   deploy:
     name: Deploy (aegis)
     if: github.ref == 'refs/heads/main'
+    # GitHub Environment: records production deploy history and scopes
+    # production secrets. The `production-services` environment should not
+    # require routine human approval; PR review + required CI before merge are
+    # the service-deploy approval path.
     environment:
-      name: production
+      name: production-services
       url: https://mento-monitoring.uc.r.appspot.com
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15

--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -26,7 +26,7 @@ name: Aegis Terraform
 #   - `apply` job only runs on push/dispatch to main, only when the plan
 #     reported actual changes, and only for stack-root changes or explicit
 #     workflow_dispatch. Workflow/notifier-only edits can still plan, but they
-#     do not open the `production` Environment gate for unrelated drift.
+#     do not open the `production-infra` Environment gate for unrelated drift.
 #
 # Note: we intentionally do NOT save the plan as a binary artifact for
 # cross-job apply. HashiCorp warns that `terraform plan -out=` "saves
@@ -235,7 +235,7 @@ jobs:
           SLACK_CHANNEL: "${{ vars.TERRAFORM_APPLY_SLACK_CHANNEL || '#ci-operations' }}"
           TERRAFORM_PLAN_FILE: /tmp/tf-plan.txt
           TERRAFORM_STACK_LABEL: aegis/terraform
-          TERRAFORM_TARGET_ENVIRONMENT: production
+          TERRAFORM_TARGET_ENVIRONMENT: production-infra
         run: node "$GITHUB_WORKSPACE/scripts/notify-terraform-apply.mjs"
 
       - name: Post plan as sticky PR comment
@@ -336,17 +336,17 @@ jobs:
     # Apply when (a) on main, (b) push or dispatch event, (c) plan said
     # there are real changes, AND (d) the stack root changed or a maintainer
     # explicitly dispatched the workflow. Workflow/notifier-only edits can
-    # surface drift in the plan without opening the production approval gate.
+    # surface drift in the plan without opening the production-infra approval gate.
     if: >-
       github.ref == 'refs/heads/main'
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       && needs.plan.outputs.has-changes == 'true'
       && (github.event_name == 'workflow_dispatch' || needs.plan.outputs.stack-changed == 'true')
-    # Reuses the existing `production` environment shared with metrics-bridge,
-    # alerts/rules, and alerts/infra. The required-reviewer rule on that
-    # environment gates each apply behind manual approval.
+    # Terraform applies use the dedicated `production-infra` environment so
+    # required reviewers gate only infrastructure mutations, not routine
+    # service deploys.
     environment:
-      name: production
+      name: production-infra
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
@@ -384,7 +384,7 @@ jobs:
 
       - name: Apply
         # Re-plans + applies in a single step. The reviewer at the
-        # production-environment gate should read this job's plan output
+        # production-infra environment gate should read this job's plan output
         # before approving — it's the ground truth for what lands.
         # `-lock-timeout=10m`: apply must wait for any in-progress state
         # lock rather than failing the deploy.

--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -354,6 +354,7 @@ jobs:
       contents: read
       id-token: write
       actions: read
+      deployments: read
     defaults:
       run:
         working-directory: aegis/terraform
@@ -364,6 +365,12 @@ jobs:
       TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify production-infra environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ENVIRONMENT_NAME: production-infra
+        run: node "$GITHUB_WORKSPACE/scripts/verify-github-environment-protection.mjs"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -36,7 +36,7 @@ name: Alerts Infra
 #   - `apply` job only runs on push/dispatch to main, only when the plan
 #     reported actual changes, and only for stack-root changes or explicit
 #     workflow_dispatch. Workflow/notifier-only edits can still plan, but they
-#     do not open the `production` Environment gate for unrelated drift.
+#     do not open the `production-infra` Environment gate for unrelated drift.
 #
 # Required repository secrets mirror the `alerts_infra_ci_secret_names` local in
 # alerts/infra/main.tf, including Splunk On-Call credentials for the on-call
@@ -360,7 +360,7 @@ jobs:
           SLACK_CHANNEL: "${{ vars.TERRAFORM_APPLY_SLACK_CHANNEL || '#ci-operations' }}"
           TERRAFORM_PLAN_FILE: /tmp/tf-plan.txt
           TERRAFORM_STACK_LABEL: alerts/infra
-          TERRAFORM_TARGET_ENVIRONMENT: production
+          TERRAFORM_TARGET_ENVIRONMENT: production-infra
         run: node "$GITHUB_WORKSPACE/scripts/notify-terraform-apply.mjs"
 
       - name: Post plan as sticky PR comment
@@ -461,17 +461,17 @@ jobs:
     # Apply when (a) on main, (b) push or dispatch event, (c) plan said
     # there are real changes, AND (d) the stack root changed or a maintainer
     # explicitly dispatched the workflow. Workflow/notifier-only edits can
-    # surface drift in the plan without opening the production approval gate.
+    # surface drift in the plan without opening the production-infra approval gate.
     if: >-
       github.ref == 'refs/heads/main'
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       && needs.plan.outputs.has-changes == 'true'
       && (github.event_name == 'workflow_dispatch' || needs.plan.outputs.stack-changed == 'true')
-    # Reuses the existing `production` environment shared with metrics-bridge,
-    # aegis, and alerts/rules. The required-reviewer rule on that environment
-    # gates each apply behind manual approval.
+    # Terraform applies use the dedicated `production-infra` environment so
+    # required reviewers gate only infrastructure mutations, not routine
+    # service deploys.
     environment:
-      name: production
+      name: production-infra
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
@@ -520,7 +520,7 @@ jobs:
       - name: Apply
         id: apply
         # Re-plans + applies in a single step. The reviewer at the
-        # production-environment gate should read this job's plan output
+        # production-infra environment gate should read this job's plan output
         # before approving — it's the ground truth for what lands.
         # `-lock-timeout=10m`: apply must wait for any in-progress state
         # lock rather than failing the deploy.

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -479,6 +479,7 @@ jobs:
       contents: read
       id-token: write
       actions: read
+      deployments: read
     defaults:
       run:
         working-directory: alerts/infra
@@ -499,6 +500,12 @@ jobs:
       TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify production-infra environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ENVIRONMENT_NAME: production-infra
+        run: node "$GITHUB_WORKSPACE/scripts/verify-github-environment-protection.mjs"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -27,7 +27,7 @@ name: Alerts Rules
 #   - `apply` job only runs on push/dispatch to main, only when the plan
 #     reported actual changes, and only for stack-root changes or explicit
 #     workflow_dispatch. No-change merges skip apply entirely, so the
-#     `production` Environment approval only fires on eligible real-change
+#     `production-infra` Environment approval only fires on eligible real-change
 #     merges. Workflow/notifier-only edits can still plan, but they do not open
 #     the gate for unrelated drift.
 #   - During the legacy Discord cleanup, the apply job first targets the
@@ -314,7 +314,7 @@ jobs:
           SLACK_CHANNEL: "${{ vars.TERRAFORM_APPLY_SLACK_CHANNEL || '#ci-operations' }}"
           TERRAFORM_PLAN_FILE: /tmp/tf-plan.txt
           TERRAFORM_STACK_LABEL: alerts/rules
-          TERRAFORM_TARGET_ENVIRONMENT: production
+          TERRAFORM_TARGET_ENVIRONMENT: production-infra
         run: node "$GITHUB_WORKSPACE/scripts/notify-terraform-apply.mjs"
 
       - name: Post plan as sticky PR comment
@@ -416,17 +416,17 @@ jobs:
     # Apply when (a) on main, (b) push or dispatch event, (c) plan said
     # there are real changes, AND (d) the stack root changed or a maintainer
     # explicitly dispatched the workflow. Workflow/notifier-only edits can
-    # surface drift in the plan without opening the production approval gate.
+    # surface drift in the plan without opening the production-infra approval gate.
     if: >-
       github.ref == 'refs/heads/main'
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       && needs.plan.outputs.has-changes == 'true'
       && (github.event_name == 'workflow_dispatch' || needs.plan.outputs.stack-changed == 'true')
-    # Reuses the existing `production` environment shared with metrics-bridge,
-    # aegis, and alerts/infra. The required-reviewer rule on that environment
-    # gates each apply behind manual approval.
+    # Terraform applies use the dedicated `production-infra` environment so
+    # required reviewers gate only infrastructure mutations, not routine
+    # service deploys.
     environment:
-      name: production
+      name: production-infra
       url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
@@ -467,7 +467,7 @@ jobs:
       - name: Apply
         id: apply
         # Re-plans + applies in a single step. The reviewer at the
-        # production-environment gate should read this job's plan output
+        # production-infra environment gate should read this job's plan output
         # before approving — it's the ground truth for what lands.
         # `-lock-timeout=10m`: apply must wait for any in-progress state
         # lock rather than failing the deploy.

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -434,6 +434,7 @@ jobs:
       contents: read
       id-token: write
       actions: read
+      deployments: read
     defaults:
       run:
         working-directory: alerts/rules
@@ -446,6 +447,12 @@ jobs:
       TF_VAR_splunk_on_call_alerts_webhook_url: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_ALERTS_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify production-infra environment protection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ENVIRONMENT_NAME: production-infra
+        run: node "$GITHUB_WORKSPACE/scripts/verify-github-environment-protection.mjs"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -850,6 +850,8 @@ jobs:
         run: node scripts/check-deploy-root-anchors.test.mjs
       - name: Terraform stack registry suite
         run: pnpm tf:test
+      - name: GitHub environment protection suite
+        run: node scripts/verify-github-environment-protection.test.mjs
       - name: ESLint baseline-diff semantic suite
         # Direct behavioral coverage of scripts/eslint-baseline-diff.mjs
         # (matching, growth detection, line-proximity absorption, merge-base

--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -40,11 +40,12 @@ jobs:
     # run from main so it inherits the trust-main quality gate enforced by
     # the `CI / ci` required check on PRs merging to main.
     if: github.ref == 'refs/heads/main'
-    # GitHub Environment gate: adds deployment history in the Environments
-    # tab, and lets us optionally add required-reviewer / wait-timer rules
-    # in the repo Environments settings without workflow changes.
+    # GitHub Environment: records production deploy history and scopes
+    # production secrets. The `production-services` environment should not
+    # require routine human approval; PR review + required CI before merge are
+    # the service-deploy approval path.
     environment:
-      name: production
+      name: production-services
       url: https://console.cloud.google.com/run?project=mento-monitoring
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -70,7 +70,7 @@ jobs:
               const stdin = require("fs").readFileSync(0, "utf8");
               const { stacks } = JSON.parse(stdin);
               const filtered = stacks
-                .filter(s => s.ci.apply === "push-main-production-environment" || s.ci.drift === "scheduled")
+                .filter(s => s.ci.apply === "push-main-production-infra-environment" || s.ci.drift === "scheduled")
                 // `planSa` routes each leg to the least-privileged SA that can
                 // still run a full-refresh drift plan. A stack whose only GCP
                 // touch is the GCS backend (no google* provider) refreshes fine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,7 +462,7 @@ pnpm alerts:oncall:typecheck / alerts:oncall:test / alerts:oncall:build
 # Grafana metric alert rules (v3 Slack rules):
 pnpm alerts:rules:init / alerts:rules:plan
 # Apply happens via CI on merge to main for alerts-rules, alerts-delivery, and Aegis.
-# The production-infra gate enforces required-reviewer approval.
+# The production-infra gate enforces non-bypassable required-reviewer approval.
 ```
 
 Terraform stack ownership is registered in `terraform.stacks.json` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,7 +448,7 @@ pnpm aegis:logs               # Tail Aegis App Engine logs from mento-monitoring
 pnpm aegis:agent:seed-secrets # Seed/rotate Alloy remote-write Secret Manager versions
 pnpm aegis:agent:deploy       # Deploy the Grafana Alloy App Engine collector
 pnpm aegis:tf:init / aegis:tf:plan
-# Apply runs in CI on merge to main (aegis-terraform.yml; production gate).
+# Apply runs in CI on merge to main (aegis-terraform.yml; production-infra gate).
 
 # Infrastructure (Terraform)
 pnpm tf list                  # Registered Terraform stacks from terraform.stacks.json
@@ -462,7 +462,7 @@ pnpm alerts:oncall:typecheck / alerts:oncall:test / alerts:oncall:build
 # Grafana metric alert rules (v3 Slack rules):
 pnpm alerts:rules:init / alerts:rules:plan
 # Apply happens via CI on merge to main for alerts-rules, alerts-delivery, and Aegis.
-# Production gate enforces required-reviewer approval.
+# The production-infra gate enforces required-reviewer approval.
 ```
 
 Terraform stack ownership is registered in `terraform.stacks.json` and
@@ -476,7 +476,7 @@ terraform init -reconfigure   # GCS backend needs reinit in a fresh worktree
 terraform plan  -var-file=<main-checkout>/terraform/terraform.tfvars
 ```
 
-Never `terraform apply` without explicit user approval — plan first, surface the diff, wait for go-ahead. For stacks whose registry entry has `ci.apply == "push-main-production-environment"`, local `pnpm tf apply <stack>` is guarded: it only runs from a clean `main` checkout at `origin/main` or with the deliberate `--force-local-apply` override. CI-driven applies for those stacks are gated by the `production` GitHub Environment manual approval, which counts as explicit human approval.
+Never `terraform apply` without explicit user approval — plan first, surface the diff, wait for go-ahead. For stacks whose registry entry has `ci.apply == "push-main-production-infra-environment"`, local `pnpm tf apply <stack>` is guarded: it only runs from a clean `main` checkout at `origin/main` or with the deliberate `--force-local-apply` override. CI-driven applies for those stacks are gated by the `production-infra` GitHub Environment manual approval, which counts as explicit human approval.
 
 ## Package routing index
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -95,7 +95,9 @@ merging the workflow change that first references them. GitHub auto-creates a
 missing environment on first workflow use with no protection rules, so
 `production-infra` must already have required reviewers, prevent self-review,
 and the protected-`main` branch restriction before any Terraform-changing
-commit can land on `main`.
+commit can land on `main`. The Terraform apply workflows also verify this
+configuration before cloud authentication so an accidentally auto-created
+environment fails closed before `terraform apply`.
 
 Repo admins should keep exactly two production GitHub Environments for this
 repo's Actions workflows:

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@ Use it instead of inferring ownership from directory names.
 | Stack                 | Path                         | State prefix          | Owns                                                                                                                                                                                                                     | Plan/apply policy                                                                                                                                          |
 | --------------------- | ---------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `platform`            | `terraform/`                 | `monitoring-monorepo` | Dashboard Vercel project, Upstash, GCP project/APIs, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, CI WIF/IAM                                                                                | Manual plan; human-approved local apply                                                                                                                    |
-| `alerts-rules`        | `alerts/rules/`              | `alerts-rules`        | Protocol Grafana alert rules + the Aegis service-health rule group, Grafana folders, global Grafana notification policy, contact points, message templates, mute timings                                                 | PR plan; `main` apply through the `production` GitHub Environment                                                                                          |
-| `alerts-delivery`     | `alerts/infra/`              | `alerts-infra`        | QuickNode webhooks, alert Cloud Functions, Sentry bridge, Slack channel lifecycle, Splunk On-Call rotation announcements, related GCP resources                                                                          | PR plan; `main` apply through the `production` GitHub Environment                                                                                          |
-| `aegis`               | `aegis/terraform/`           | `aegis`               | Aegis Grafana dashboard and Aegis folder                                                                                                                                                                                 | PR plan; `main` apply through the `production` GitHub Environment                                                                                          |
+| `alerts-rules`        | `alerts/rules/`              | `alerts-rules`        | Protocol Grafana alert rules + the Aegis service-health rule group, Grafana folders, global Grafana notification policy, contact points, message templates, mute timings                                                 | PR plan; `main` apply through the `production-infra` GitHub Environment                                                                                    |
+| `alerts-delivery`     | `alerts/infra/`              | `alerts-infra`        | QuickNode webhooks, alert Cloud Functions, Sentry bridge, Slack channel lifecycle, Splunk On-Call rotation announcements, related GCP resources                                                                          | PR plan; `main` apply through the `production-infra` GitHub Environment                                                                                    |
+| `aegis`               | `aegis/terraform/`           | `aegis`               | Aegis Grafana dashboard and Aegis folder                                                                                                                                                                                 | PR plan; `main` apply through the `production-infra` GitHub Environment                                                                                    |
 | `governance-watchdog` | `governance-watchdog/infra/` | `governance-watchdog` | Dedicated governance-watchdog GCP project (project factory), the watchdog Cloud Function + source archive, Secret Manager secrets, QuickNode webhooks/filters, Cloud Scheduler health check, log-based monitoring/alerts | Manual plan (`pnpm gov-watchdog:tf:plan`); human-approved local apply via `pnpm gov-watchdog:deploy`; daily read-only drift plan via `terraform-drift.yml` |
 
 ## Commands
@@ -43,11 +43,11 @@ pnpm gov-watchdog:tf:plan
 `terraform validate`.
 
 For stacks where `terraform.stacks.json` declares
-`ci.apply == "push-main-production-environment"`, local
+`ci.apply == "push-main-production-infra-environment"`, local
 `pnpm tf apply <stack-id>` is guarded. It runs only when the checkout is on
 `main`, the worktree is clean, and `HEAD == origin/main`, unless the operator
 passes the deliberate override `--force-local-apply`. The expected safe path is
-to merge to `main` and let GitHub Actions apply through the `production`
+to merge to `main` and let GitHub Actions apply through the `production-infra`
 Environment approval.
 
 ## CI Model
@@ -63,7 +63,7 @@ in `terraform.stacks.json` rather than duplicating stack ownership in workflow
 YAML.
 
 `alerts-rules`, `alerts-delivery`, and `aegis` have CI apply behavior on
-`main`, gated by the `production` GitHub Environment. Their plan jobs can run
+`main`, gated by the `production-infra` GitHub Environment. Their plan jobs can run
 for workflow/notifier edits too, but the apply jobs only become eligible when
 the stack root changed or a maintainer used `workflow_dispatch`. The platform
 and `governance-watchdog` stacks remain manual-plan/manual-apply only —
@@ -71,6 +71,11 @@ governance-watchdog lives in its own GCP project and applies stay operator-run
 (`pnpm gov-watchdog:deploy`, which guards against dirty trees). It opts into
 scheduled drift detection, where CI runs a read-only plan under `org-terraform`
 impersonation without applying changes.
+
+Routine service deploy workflows use the separate `production-services` GitHub
+Environment. That environment records deploy history and scopes production
+secrets, but should not require routine manual approval; PR review plus
+required CI before merge is the approval path for normal service rollouts.
 
 When one of those CI-applied stacks plans real changes on `main`, the plan job
 posts a Slack apply-pending summary before the environment-gated apply job waits
@@ -81,6 +86,26 @@ exact resource address. Attribute values are intentionally omitted from Slack;
 use the workflow run for the full sanitized plan. The default destination is
 `#ci-failures`; set the repository variable `TERRAFORM_APPLY_SLACK_CHANNEL` to
 route these summaries to another public channel.
+
+## GitHub Environment Setup
+
+Repo admins should keep exactly two production GitHub Environments for this
+repo's Actions workflows:
+
+- `production-infra`: used by Terraform apply jobs in `alerts-infra.yml`,
+  `alerts-rules.yml`, and `aegis-terraform.yml`. Copy the required reviewers
+  from the old `production` environment, enable prevent self-review, and limit
+  deployment branches to protected `main`.
+- `production-services`: used by routine service deploy jobs such as
+  `metrics-bridge.yml` and `aegis-app-engine.yml`. Limit deployment branches to
+  protected `main`, but leave required reviewers unset by default so green
+  `main` deploys do not require an extra human approval.
+
+Keep the old `production` environment only as a temporary migration shim while
+older workflow runs drain. Once no workflow references it, remove or deprecate
+it in the repository settings. Do not move or recreate secrets with CLI
+commands; any environment-scoped secret changes must go through the owning IaC
+or a documented repo-admin settings change.
 
 ## Grafana Alert Ownership Migration
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -89,6 +89,14 @@ route these summaries to another public channel.
 
 ## GitHub Environment Setup
 
+Pre-merge requirement for the production-environment split in issue #762:
+repo admins must create both environments in Settings -> Environments before
+merging the workflow change that first references them. GitHub auto-creates a
+missing environment on first workflow use with no protection rules, so
+`production-infra` must already have required reviewers, prevent self-review,
+and the protected-`main` branch restriction before any Terraform-changing
+commit can land on `main`.
+
 Repo admins should keep exactly two production GitHub Environments for this
 repo's Actions workflows:
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -94,18 +94,19 @@ repo admins must create both environments in Settings -> Environments before
 merging the workflow change that first references them. GitHub auto-creates a
 missing environment on first workflow use with no protection rules, so
 `production-infra` must already have required reviewers, prevent self-review,
-and the protected-`main` branch restriction before any Terraform-changing
-commit can land on `main`. The Terraform apply workflows also verify this
-configuration before cloud authentication so an accidentally auto-created
-environment fails closed before `terraform apply`.
+administrator bypass disabled, and the protected-`main` branch restriction
+before any Terraform-changing commit can land on `main`. The Terraform apply
+workflows also verify this configuration before cloud authentication so an
+accidentally auto-created or bypassable environment fails closed before
+`terraform apply`.
 
 Repo admins should keep exactly two production GitHub Environments for this
 repo's Actions workflows:
 
 - `production-infra`: used by Terraform apply jobs in `alerts-infra.yml`,
   `alerts-rules.yml`, and `aegis-terraform.yml`. Copy the required reviewers
-  from the old `production` environment, enable prevent self-review, and limit
-  deployment branches to protected `main`.
+  from the old `production` environment, enable prevent self-review, disable
+  administrator bypass, and limit deployment branches to protected `main`.
 - `production-services`: used by routine service deploy jobs such as
   `metrics-bridge.yml` and `aegis-app-engine.yml`. Limit deployment branches to
   protected `main`, but leave required reviewers unset by default so green

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1357,6 +1357,9 @@ while IFS= read -r path; do
         scripts/notify-terraform-apply.mjs|scripts/notify-terraform-apply.test.mjs)
           add_command "node scripts/notify-terraform-apply.test.mjs" "Terraform apply Slack notifier changed"
           ;;
+        scripts/verify-github-environment-protection.mjs|scripts/verify-github-environment-protection.test.mjs)
+          add_command "node scripts/verify-github-environment-protection.test.mjs" "GitHub environment protection checker changed"
+          ;;
         scripts/eslint-baseline-diff.mjs)
           # The lint wrapper. A regression here would mask all per-package
           # baseline drift. Re-run every package's lint to exercise the

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2204,6 +2204,12 @@ assert_contains "- node scripts/check-deviation-threshold-drift.test.mjs (deviat
 run_gate "scripts/check-deviation-threshold-drift.test.mjs"
 assert_contains "- node scripts/check-deviation-threshold-drift.test.mjs (deviation threshold drift checker test changed)"
 
+run_gate "scripts/verify-github-environment-protection.mjs"
+assert_contains "- node scripts/verify-github-environment-protection.test.mjs (GitHub environment protection checker changed)"
+
+run_gate "scripts/verify-github-environment-protection.test.mjs"
+assert_contains "- node scripts/verify-github-environment-protection.test.mjs (GitHub environment protection checker changed)"
+
 run_gate "scripts/agent-autoreview.sh"
 assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview adapter changed)"
 

--- a/scripts/notify-terraform-apply.mjs
+++ b/scripts/notify-terraform-apply.mjs
@@ -478,7 +478,8 @@ async function main(env = process.env) {
   const runUrl = `${serverUrl}/${repo}/actions/runs/${env.GITHUB_RUN_ID}`;
   const commitUrl = sha ? `${serverUrl}/${repo}/commit/${sha}` : "";
   const stackLabel = env.TERRAFORM_STACK_LABEL || "terraform";
-  const targetEnvironment = env.TERRAFORM_TARGET_ENVIRONMENT || "production";
+  const targetEnvironment =
+    env.TERRAFORM_TARGET_ENVIRONMENT || "production-infra";
   const slackChannel = env.SLACK_CHANNEL || DEFAULT_SLACK_CHANNEL;
 
   if (!env.SLACK_BOT_TOKEN) {

--- a/scripts/tf-stacks.mjs
+++ b/scripts/tf-stacks.mjs
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(
   "..",
 );
 const registryPath = path.join(repoRoot, "terraform.stacks.json");
-const AUTO_APPLY_CI_POLICY = "push-main-production-environment";
+const AUTO_APPLY_CI_POLICY = "push-main-production-infra-environment";
 const FORCE_LOCAL_APPLY_ARG = "--force-local-apply";
 const ORIGIN_MAIN_FETCH_REFSPEC = "refs/heads/main:refs/remotes/origin/main";
 

--- a/scripts/tf-stacks.test.mjs
+++ b/scripts/tf-stacks.test.mjs
@@ -389,7 +389,8 @@ function autoAppliedStackWorkflowPaths(stacks) {
     ...new Set(
       stacks
         .filter(
-          (stack) => stack.ci?.apply === "push-main-production-environment",
+          (stack) =>
+            stack.ci?.apply === "push-main-production-infra-environment",
         )
         .flatMap((stack) =>
           (stack.changedPathPatterns ?? []).filter((pattern) =>

--- a/scripts/verify-github-environment-protection.mjs
+++ b/scripts/verify-github-environment-protection.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const DEFAULT_ENVIRONMENT = "production-infra";
+const DEFAULT_API_URL = "https://api.github.com";
+
+export function environmentProtectionFailures(environment) {
+  const rules = Array.isArray(environment.protection_rules)
+    ? environment.protection_rules
+    : [];
+  const reviewers = rules.find((rule) => rule.type === "required_reviewers");
+  const branchPolicy = environment.deployment_branch_policy;
+  const failures = [];
+
+  if (!reviewers || (reviewers.reviewers ?? []).length === 0) {
+    failures.push("required reviewers are not configured");
+  }
+  if (reviewers?.prevent_self_review !== true) {
+    failures.push("prevent self-review is not enabled");
+  }
+  if (
+    branchPolicy?.protected_branches !== true ||
+    branchPolicy?.custom_branch_policies !== false
+  ) {
+    failures.push("deployment branches are not limited to protected branches");
+  }
+
+  return failures;
+}
+
+export function environmentUrl(apiUrl, repository, environmentName) {
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    throw new Error("GITHUB_REPOSITORY must be in owner/repo form");
+  }
+
+  const base = apiUrl.endsWith("/") ? apiUrl : `${apiUrl}/`;
+  return new URL(
+    `repos/${owner}/${repo}/environments/${encodeURIComponent(environmentName)}`,
+    base,
+  );
+}
+
+async function fetchEnvironment({
+  apiUrl,
+  repository,
+  environmentName,
+  token,
+}) {
+  const response = await fetch(
+    environmentUrl(apiUrl, repository, environmentName),
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub environment lookup failed with HTTP ${response.status}`,
+    );
+  }
+
+  return response.json();
+}
+
+async function main(env = process.env) {
+  const token = env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+
+  const repository = env.GITHUB_REPOSITORY;
+  if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+
+  const environmentName = env.GITHUB_ENVIRONMENT_NAME || DEFAULT_ENVIRONMENT;
+  const environment = await fetchEnvironment({
+    apiUrl: env.GITHUB_API_URL || DEFAULT_API_URL,
+    repository,
+    environmentName,
+    token,
+  });
+  const failures = environmentProtectionFailures(environment);
+
+  if (failures.length > 0) {
+    throw new Error(
+      `${environmentName} environment is not apply-safe: ${failures.join("; ")}`,
+    );
+  }
+
+  console.log(`${environmentName} environment protection verified`);
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/verify-github-environment-protection.mjs
+++ b/scripts/verify-github-environment-protection.mjs
@@ -11,6 +11,9 @@ export function environmentProtectionFailures(environment) {
   const branchPolicy = environment.deployment_branch_policy;
   const failures = [];
 
+  if (environment.can_admins_bypass !== false) {
+    failures.push("admin bypass is not disabled");
+  }
   if (!reviewers || (reviewers.reviewers ?? []).length === 0) {
     failures.push("required reviewers are not configured");
   }

--- a/scripts/verify-github-environment-protection.test.mjs
+++ b/scripts/verify-github-environment-protection.test.mjs
@@ -7,6 +7,7 @@ import {
 } from "./verify-github-environment-protection.mjs";
 
 const protectedEnvironment = {
+  can_admins_bypass: false,
   protection_rules: [
     {
       type: "required_reviewers",
@@ -24,6 +25,7 @@ assert.deepEqual(environmentProtectionFailures(protectedEnvironment), []);
 
 assert.deepEqual(
   environmentProtectionFailures({
+    can_admins_bypass: false,
     protection_rules: [],
     deployment_branch_policy: {
       protected_branches: true,
@@ -38,6 +40,7 @@ assert.deepEqual(
 
 assert.deepEqual(
   environmentProtectionFailures({
+    can_admins_bypass: true,
     protection_rules: [
       {
         type: "required_reviewers",
@@ -51,9 +54,18 @@ assert.deepEqual(
     },
   }),
   [
+    "admin bypass is not disabled",
     "prevent self-review is not enabled",
     "deployment branches are not limited to protected branches",
   ],
+);
+
+assert.deepEqual(
+  environmentProtectionFailures({
+    protection_rules: protectedEnvironment.protection_rules,
+    deployment_branch_policy: protectedEnvironment.deployment_branch_policy,
+  }),
+  ["admin bypass is not disabled"],
 );
 
 assert.equal(

--- a/scripts/verify-github-environment-protection.test.mjs
+++ b/scripts/verify-github-environment-protection.test.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  environmentProtectionFailures,
+  environmentUrl,
+} from "./verify-github-environment-protection.mjs";
+
+const protectedEnvironment = {
+  protection_rules: [
+    {
+      type: "required_reviewers",
+      prevent_self_review: true,
+      reviewers: [{ type: "User", reviewer: { login: "approver" } }],
+    },
+  ],
+  deployment_branch_policy: {
+    protected_branches: true,
+    custom_branch_policies: false,
+  },
+};
+
+assert.deepEqual(environmentProtectionFailures(protectedEnvironment), []);
+
+assert.deepEqual(
+  environmentProtectionFailures({
+    protection_rules: [],
+    deployment_branch_policy: {
+      protected_branches: true,
+      custom_branch_policies: false,
+    },
+  }),
+  [
+    "required reviewers are not configured",
+    "prevent self-review is not enabled",
+  ],
+);
+
+assert.deepEqual(
+  environmentProtectionFailures({
+    protection_rules: [
+      {
+        type: "required_reviewers",
+        prevent_self_review: false,
+        reviewers: [{ type: "User", reviewer: { login: "approver" } }],
+      },
+    ],
+    deployment_branch_policy: {
+      protected_branches: false,
+      custom_branch_policies: true,
+    },
+  }),
+  [
+    "prevent self-review is not enabled",
+    "deployment branches are not limited to protected branches",
+  ],
+);
+
+assert.equal(
+  environmentUrl(
+    "https://api.github.test",
+    "mento-protocol/monitoring-monorepo",
+    "production infra",
+  ).toString(),
+  "https://api.github.test/repos/mento-protocol/monitoring-monorepo/environments/production%20infra",
+);
+
+console.log("verify-github-environment-protection tests passed");

--- a/terraform.stacks.json
+++ b/terraform.stacks.json
@@ -42,9 +42,9 @@
       "ci": {
         "validate": "changed-paths",
         "plan": "pull-request",
-        "apply": "push-main-production-environment"
+        "apply": "push-main-production-infra-environment"
       },
-      "applyPolicy": "ci-production-environment-approved",
+      "applyPolicy": "ci-production-infra-environment-approved",
       "changedPathPatterns": [
         "alerts/rules/**",
         "terraform.stacks.json",
@@ -79,9 +79,9 @@
       "ci": {
         "validate": "changed-paths",
         "plan": "pull-request",
-        "apply": "push-main-production-environment"
+        "apply": "push-main-production-infra-environment"
       },
-      "applyPolicy": "ci-production-environment-approved",
+      "applyPolicy": "ci-production-infra-environment-approved",
       "changedPathPatterns": [
         "alerts/infra/**",
         "terraform.stacks.json",
@@ -106,9 +106,9 @@
       "ci": {
         "validate": "changed-paths",
         "plan": "pull-request",
-        "apply": "push-main-production-environment"
+        "apply": "push-main-production-infra-environment"
       },
-      "applyPolicy": "ci-production-environment-approved",
+      "applyPolicy": "ci-production-infra-environment-approved",
       "changedPathPatterns": [
         "aegis/terraform/**",
         "terraform.stacks.json",


### PR DESCRIPTION
## The Problem

- Terraform applies and routine service deploys shared one `production` GitHub Environment, making approval policy ambiguous.
- Adding required reviewers to that shared environment gates normal service deploys, while removing them weakens Terraform apply control.

## The Solution

- Split production workflows into `production-infra` for Terraform applies and `production-services` for routine service deploys.
- Keep Terraform applies behind a manual environment approval, while service deploys rely on PR review plus required CI before merge.

## Details

- Moves `alerts-infra.yml`, `alerts-rules.yml`, and `aegis-terraform.yml` apply jobs to `production-infra`.
- Moves `metrics-bridge.yml` and `aegis-app-engine.yml` deploy jobs to `production-services`.
- Renames the Terraform stack registry apply enum to `push-main-production-infra-environment` and updates the stack wrapper plus drift workflow filter.
- Documents repo-admin setup for both GitHub Environments in `docs/terraform.md`.
- Refs #762 because the repo settings still need an admin to create/configure the two environments exactly as documented.

## Validation

- `pnpm tf:test`
- `node scripts/notify-terraform-apply.test.mjs`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Deferrals

- Repo-admin environment setup remains tracked by #762: create `production-infra` with required reviewers/prevent self-review/protected-main restriction, create `production-services` with protected-main restriction and no required reviewers by default, then deprecate the old `production` shim after workflow references drain.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deployment and Terraform apply gates; misconfigured or missing GitHub Environments could block deploys or allow applies without intended reviewer protection until #762 setup is complete.
> 
> **Overview**
> **Production GitHub Environments are split** so Terraform applies and routine service deploys no longer share one approval policy.
> 
> Terraform apply jobs in `alerts-infra.yml`, `alerts-rules.yml`, and `aegis-terraform.yml` now target **`production-infra`**. Each apply job runs **`verify-github-environment-protection.mjs`** before cloud auth (required reviewers, prevent self-review, no admin bypass, protected `main` only) and grants **`deployments: read`**. The stack registry enum is **`push-main-production-infra-environment`**; drift filtering, `tf-stacks.mjs`, Slack notifier defaults, and agent quality-gate/CI tests follow that rename.
> 
> **`metrics-bridge.yml`** and **`aegis-app-engine.yml`** deploy jobs use **`production-services`**, documented as deploy history + secret scoping without routine manual approval (PR + CI remain the gate).
> 
> **`docs/terraform.md`** and **`AGENTS.md`** describe the two-environment model and admin setup (**#762**): create/configure both environments before merge so GitHub does not auto-create an unprotected `production-infra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84b6be098070f89003b6ff765fe766f36b0ce1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->