### PR TITLE
Prune orphan Celo trading mode alerts

### DIFF
--- a/aegis/README.md
+++ b/aegis/README.md
@@ -120,7 +120,7 @@ Testnet polling stops or records repeated view-call errors. See
 1. Update the [config.yaml](./config.yaml):
    - Add the new rate feed IDs and relayer signer wallets to `global.vars`
    - Add the new rate feeds as variants to the `SortedOracles.isOldestReportExpired()` metric
-   - Add the new rate feeds as variants to the `BreakerBox.getRateFeedTradingMode()` metric
+   - Add the new rate feeds as variants to the `BreakerBox.getRateFeedTradingMode()` metric only for chains where the feed backs a live tradable pool or exchange. A feed can exist in SortedOracles or BreakerBox without being a production trading-halt alert target.
    - Add the new relayer signer as variants to the `CELOToken.balanceOf()` metric
 1. [optional] If it's an FX rate feed with disabled trading on weekends because we don't get new price data on weekends:
    - Add the rate feed name to the `weekend_disabled_feeds` array in [alerts/rules/protocol-routing-locals.tf](../alerts/rules/protocol-routing-locals.tf)

--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -299,7 +299,8 @@ metrics:
       - [XOFUSD]
       - [ZARUSD]
   # Checks Celo Sepolia-only gas-payment rate feed trading modes. These feeds do
-  # not back current production Celo trading-mode alerts.
+  # not back current production Celo trading-mode alerts. EURXOF is omitted here
+  # too because it is not a CELO-quoted gas-payment feed and has no live pool.
   - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
     schedule: 0/10 * * * * *
     type: gauge

--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -270,7 +270,9 @@ chains:
       CELOZAR: '0xbCd7aA5683Ac7Fa0Cf2F5F4733aB47a8E7957b99' # keccak(CELOZAR)
 
 metrics:
-  # Checks rate feed trading modes
+  # Checks production Celo and Celo Sepolia trading modes for feeds that back live
+  # pools/exchanges on the target chain. Do not add feeds here just because they
+  # are registered in BreakerBox; orphan feed trading halts should not page.
   - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
     schedule: 0/10 * * * * *
     type: gauge
@@ -288,7 +290,6 @@ metrics:
       - [CHFUSD]
       - [COPUSD]
       - [EURUSD]
-      - [EURXOF]
       - [GBPUSD]
       - [GHSUSD]
       - [JPYUSD]
@@ -297,29 +298,27 @@ metrics:
       - [PHPUSD]
       - [XOFUSD]
       - [ZARUSD]
-      # celo/stable feeds registered in both Celo mainnet and Celo Sepolia BreakerBox
-      - [CELOBRL]
-      - [CELOEUR]
-      - [CELOXOF]
-  # Checks Celo Sepolia-only gas-payment rate feed trading modes.
-  # These feeds are reported by Celo mainnet SortedOracles but are not registered
-  # in the Celo mainnet BreakerBox.
+  # Checks Celo Sepolia-only gas-payment rate feed trading modes. These feeds do
+  # not back current production Celo trading-mode alerts.
   - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
     schedule: 0/10 * * * * *
     type: gauge
     chains: [celoSepolia]
     variants:
       - [CELOAUD]
+      - [CELOBRL]
       - [CELOCAD]
       - [CELOCHF]
       - [CELOCOP]
       - [CELOETH]
+      - [CELOEUR]
       - [CELOGBP]
       - [CELOGHS]
       - [CELOJPY]
       - [CELOKES]
       - [CELONGN]
       - [CELOPHP]
+      - [CELOXOF]
       - [CELOZAR]
 
   # Trading limits state - tracks all three netflow limits


### PR DESCRIPTION
## The Problem

- Celo trading-mode paging was still watching CELOBRL, CELOEUR, CELOXOF, and EURXOF even though those feeds do not back current production tradable pools or exchanges.
- CELOBRL and CELOEUR can enter BreakerBox mode 3 and page operators even though the live Celo pools use BRLUSD and EURUSD instead.

## The Solution

- Limit the shared Celo trading-mode metric to feeds that back live production pools or exchanges, while preserving the CELO-quoted gas-feed checks only on Celo Sepolia.

## Details

- Removed CELOBRL, CELOEUR, CELOXOF, and EURXOF from the production Celo BreakerBox.getRateFeedTradingMode variant set.
- Kept CELOBRL, CELOEUR, and CELOXOF in the Celo Sepolia-only gas-payment trading-mode metric.
- Left SortedOracles freshness and relayer-balance monitoring unchanged because feed liveness is separate from production trading-halt paging.
- Updated the Aegis rate-feed runbook so new BreakerBox trading-mode variants are added only when the feed backs a live tradable pool or exchange on that chain.
- Autoreview ran with the local deterministic engine inside the Codex sandbox and reported no actionable findings.

## Validation

- pnpm agent:quality-gate --run
- pnpm agent:autoreview
- Parsed aegis/config.yaml locally to confirm the shared Celo trading-mode metric no longer includes CELOBRL, CELOEUR, CELOXOF, or EURXOF.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Alert/monitoring scope change only; reduces false pages without touching on-chain logic, auth, or relayer freshness checks.
> 
> **Overview**
> **Production trading-halt paging** for `BreakerBox.getRateFeedTradingMode` is narrowed so only feeds that back **live tradable pools/exchanges** on Celo and Celo Sepolia are polled on the shared metric. **CELOBRL**, **CELOEUR**, **CELOXOF**, and **EURXOF** are removed from that set so orphan BreakerBox halts (e.g. CELO-quoted feeds while live pools use **BRLUSD** / **EURUSD**) no longer drive operator pages.
> 
> **CELOBRL**, **CELOEUR**, and **CELOXOF** stay monitored on a **Celo Sepolia–only** gas-payment trading-mode metric; **EURXOF** is dropped there as well (not a CELO gas feed, no live pool). Inline comments in `config.yaml` document the split between production alerts and Sepolia gas feeds.
> 
> The Aegis rate-feed runbook now says to add BreakerBox trading-mode variants only when a feed backs a live pool/exchange on that chain—not merely because it exists in BreakerBox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34b936fb0ecc8811e2b88d1dd81d7c545ea8e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->