### PR TITLE
fix: harden scripts and bridge transition state

### DIFF
--- a/metrics-bridge/eslint-baseline.json
+++ b/metrics-bridge/eslint-baseline.json
@@ -3,21 +3,14 @@
     "file": "src/deviation-alert-state.ts",
     "ruleId": "complexity",
     "message": "Function 'classifyDeviationAlertState' has a complexity of 16. Maximum allowed is 10.",
-    "line": 138,
+    "line": 114,
     "linePreview": " | export function classifyDeviationAlertState( | pool: PoolRow,"
   },
   {
     "file": "src/deviation-alert-state.ts",
     "ruleId": "complexity",
-    "message": "Function 'shouldRecordTransition' has a complexity of 11. Maximum allowed is 10.",
-    "line": 306,
-    "linePreview": " | function shouldRecordTransition( | previous: StateSnapshot,"
-  },
-  {
-    "file": "src/deviation-alert-state.ts",
-    "ruleId": "complexity",
     "message": "Function 'transitionReason' has a complexity of 17. Maximum allowed is 10.",
-    "line": 187,
+    "line": 163,
     "linePreview": " | function transitionReason( | from: DeviationAlertState,"
   },
   {

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -53,6 +53,7 @@ type StateSnapshot = {
   enteredAt: number;
   criticalSignal: CriticalSignalState | null;
   criticalSignalEnteredAt: number | null;
+  restoredWarningDwell: boolean;
 };
 
 type CriticalSignalState = "critical" | "deviation_ratio_unavailable_critical";
@@ -262,6 +263,21 @@ function initialEnteredAt(
   return nowSeconds;
 }
 
+function isRestartRestoredCriticalWarning(
+  previous: StateSnapshot | undefined,
+  currentState: ClassifiedDeviationAlertState,
+  nowSeconds: number,
+): boolean {
+  return (
+    !previous &&
+    currentState.state === "warning" &&
+    currentState.breachStartedAt !== null &&
+    nowSeconds - currentState.breachStartedAt >=
+      DEVIATION_WARNING_PENDING_SECONDS &&
+    currentState.criticalSignal !== null
+  );
+}
+
 function buildCurrentSnapshot(
   previous: StateSnapshot | undefined,
   currentState: ClassifiedDeviationAlertState,
@@ -294,7 +310,22 @@ function buildCurrentSnapshot(
     state,
     enteredAt,
     criticalSignalEnteredAt: signalEnteredAt,
+    restoredWarningDwell: previous
+      ? previous.state === state && previous.restoredWarningDwell
+      : isRestartRestoredCriticalWarning(previous, currentState, nowSeconds),
   };
+}
+
+function canRecordEscalationTransition(
+  previous: StateSnapshot,
+  current: StateSnapshot,
+  nowSeconds: number,
+): boolean {
+  return (
+    !previous.restoredWarningDwell &&
+    alertCouldHaveFired(previous, nowSeconds) &&
+    alertCouldHaveFired(current, nowSeconds)
+  );
 }
 
 function shouldRecordTransition(
@@ -309,10 +340,7 @@ function shouldRecordTransition(
     case "state_changed":
       return false;
     case "escalated_to_critical":
-      return (
-        alertCouldHaveFired(previous, nowSeconds) &&
-        alertCouldHaveFired(current, nowSeconds)
-      );
+      return canRecordEscalationTransition(previous, current, nowSeconds);
     case "recovered":
     case "deescalated_to_warning":
     case "deviation_ratio_unavailable":

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -253,12 +253,32 @@ function criticalStateCanFire(
   return nowSeconds - conditionEnteredAt > DEVIATION_CRITICAL_PENDING_SECONDS;
 }
 
+function lastFxReopenAtOrBefore(nowSeconds: number): number {
+  const date = new Date(nowSeconds * 1000);
+  const secondsSinceWeekStart =
+    date.getUTCDay() * 86_400 +
+    date.getUTCHours() * 3_600 +
+    date.getUTCMinutes() * 60 +
+    date.getUTCSeconds();
+  const sundayReopen = 23 * 3_600;
+  const delta =
+    secondsSinceWeekStart >= sundayReopen
+      ? secondsSinceWeekStart - sundayReopen
+      : secondsSinceWeekStart + 7 * 86_400 - sundayReopen;
+  return nowSeconds - delta;
+}
+
 function initialEnteredAt(
   currentState: ClassifiedDeviationAlertState,
+  pair: string,
   nowSeconds: number,
 ): number {
   if (currentState.state === "warning" && currentState.breachStartedAt) {
-    return Math.min(currentState.breachStartedAt, nowSeconds);
+    const persistedStart = Math.min(currentState.breachStartedAt, nowSeconds);
+    if (isFxPair(pair)) {
+      return Math.max(persistedStart, lastFxReopenAtOrBefore(nowSeconds));
+    }
+    return persistedStart;
   }
   return nowSeconds;
 }
@@ -281,6 +301,7 @@ function isRestartRestoredCriticalWarning(
 function buildCurrentSnapshot(
   previous: StateSnapshot | undefined,
   currentState: ClassifiedDeviationAlertState,
+  pair: string,
   nowSeconds: number,
 ): StateSnapshot {
   const signalEnteredAt = criticalSignalEnteredAt(
@@ -302,17 +323,21 @@ function buildCurrentSnapshot(
       // so alertCouldHaveFired() does not reset to process start and suppress
       // the next recovery's Slack context. Data-gap states intentionally start
       // now: a stale breach start is not evidence that ratio data has been
-      // missing long enough for the data-gap alert to fire.
-      initialEnteredAt(currentState, nowSeconds);
+      // missing long enough for the data-gap alert to fire. FX pairs clamp to
+      // the latest Sunday 23:00 UTC reopen, because weekend-suppressed breach
+      // age cannot count toward warning dwell after markets reopen.
+      initialEnteredAt(currentState, pair, nowSeconds);
 
   return {
     ...currentState,
     state,
     enteredAt,
     criticalSignalEnteredAt: signalEnteredAt,
-    restoredWarningDwell: previous
-      ? previous.state === state && previous.restoredWarningDwell
-      : isRestartRestoredCriticalWarning(previous, currentState, nowSeconds),
+    restoredWarningDwell:
+      currentState.criticalSignal !== null &&
+      (previous
+        ? previous.state === state && previous.restoredWarningDwell
+        : isRestartRestoredCriticalWarning(previous, currentState, nowSeconds)),
   };
 }
 
@@ -392,7 +417,12 @@ export function observeDeviationAlertState(
 
   const currentState = classifyDeviationAlertState(pool, pair, nowSeconds);
   const previous = previousStates.get(pool.id);
-  const current = buildCurrentSnapshot(previous, currentState, nowSeconds);
+  const current = buildCurrentSnapshot(
+    previous,
+    currentState,
+    pair,
+    nowSeconds,
+  );
 
   const newTransitions: DeviationAlertTransition[] = [];
   if (

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -53,7 +53,6 @@ type StateSnapshot = {
   enteredAt: number;
   criticalSignal: CriticalSignalState | null;
   criticalSignalEnteredAt: number | null;
-  restoredWarningDwell: boolean;
 };
 
 type CriticalSignalState = "critical" | "deviation_ratio_unavailable_critical";
@@ -226,6 +225,7 @@ function isCriticalAlertState(
 function criticalSignalEnteredAt(
   previous: StateSnapshot | undefined,
   currentState: ClassifiedDeviationAlertState,
+  enteredAt: number,
   nowSeconds: number,
 ): number | null {
   if (!currentState.criticalSignal) return null;
@@ -234,6 +234,9 @@ function criticalSignalEnteredAt(
   }
   if (previous && isCriticalAlertState(previous.state)) {
     return previous.criticalSignalEnteredAt ?? previous.enteredAt;
+  }
+  if (!previous && currentState.state === "warning") {
+    return enteredAt;
   }
   return nowSeconds;
 }
@@ -283,39 +286,16 @@ function initialEnteredAt(
   return nowSeconds;
 }
 
-function isRestartRestoredCriticalWarning(
-  previous: StateSnapshot | undefined,
-  currentState: ClassifiedDeviationAlertState,
-  nowSeconds: number,
-): boolean {
-  return (
-    !previous &&
-    currentState.state === "warning" &&
-    currentState.breachStartedAt !== null &&
-    nowSeconds - currentState.breachStartedAt >=
-      DEVIATION_CRITICAL_FIRING_SECONDS &&
-    currentState.criticalSignal !== null
-  );
-}
-
 function buildCurrentSnapshot(
   previous: StateSnapshot | undefined,
   currentState: ClassifiedDeviationAlertState,
   pair: string,
   nowSeconds: number,
 ): StateSnapshot {
-  const signalEnteredAt = criticalSignalEnteredAt(
-    previous,
-    currentState,
-    nowSeconds,
-  );
-  const state: DeviationAlertState =
-    criticalStateCanFire(currentState, signalEnteredAt, nowSeconds) &&
-    currentState.criticalSignal
-      ? currentState.criticalSignal
-      : currentState.state;
   const enteredAt = previous
-    ? previous.state === state
+    ? previous.state === currentState.state ||
+      (isCriticalAlertState(previous.state) &&
+        previous.state === currentState.criticalSignal)
       ? previous.enteredAt
       : nowSeconds
     : // Process restart (liveness probe): no in-memory snapshot exists, but
@@ -327,17 +307,23 @@ function buildCurrentSnapshot(
       // the latest Sunday 23:00 UTC reopen, because weekend-suppressed breach
       // age cannot count toward warning dwell after markets reopen.
       initialEnteredAt(currentState, pair, nowSeconds);
+  const signalEnteredAt = criticalSignalEnteredAt(
+    previous,
+    currentState,
+    enteredAt,
+    nowSeconds,
+  );
+  const state: DeviationAlertState =
+    criticalStateCanFire(currentState, signalEnteredAt, nowSeconds) &&
+    currentState.criticalSignal
+      ? currentState.criticalSignal
+      : currentState.state;
 
   return {
     ...currentState,
     state,
     enteredAt,
     criticalSignalEnteredAt: signalEnteredAt,
-    restoredWarningDwell:
-      currentState.criticalSignal !== null &&
-      (previous
-        ? previous.state === state && previous.restoredWarningDwell
-        : isRestartRestoredCriticalWarning(previous, currentState, nowSeconds)),
   };
 }
 
@@ -347,7 +333,6 @@ function canRecordEscalationTransition(
   nowSeconds: number,
 ): boolean {
   return (
-    !previous.restoredWarningDwell &&
     alertCouldHaveFired(previous, nowSeconds) &&
     alertCouldHaveFired(current, nowSeconds)
   );

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -273,7 +273,7 @@ function isRestartRestoredCriticalWarning(
     currentState.state === "warning" &&
     currentState.breachStartedAt !== null &&
     nowSeconds - currentState.breachStartedAt >=
-      DEVIATION_WARNING_PENDING_SECONDS &&
+      DEVIATION_CRITICAL_FIRING_SECONDS &&
     currentState.criticalSignal !== null
   );
 }

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -267,8 +267,15 @@ function buildCurrentSnapshot(
     currentState.criticalSignal
       ? currentState.criticalSignal
       : currentState.state;
-  const enteredAt =
-    previous && previous.state === state ? previous.enteredAt : nowSeconds;
+  const enteredAt = previous
+    ? previous.state === state
+      ? previous.enteredAt
+      : nowSeconds
+    : // Process restart (liveness probe): no in-memory snapshot exists, but
+      // the indexer-persisted breach start survives. Seed enteredAt from it
+      // so alertCouldHaveFired() does not reset to process start and suppress
+      // the next transition's Slack context.
+      Math.min(currentState.breachStartedAt ?? nowSeconds, nowSeconds);
 
   return {
     ...currentState,

--- a/metrics-bridge/src/deviation-alert-state.ts
+++ b/metrics-bridge/src/deviation-alert-state.ts
@@ -252,6 +252,16 @@ function criticalStateCanFire(
   return nowSeconds - conditionEnteredAt > DEVIATION_CRITICAL_PENDING_SECONDS;
 }
 
+function initialEnteredAt(
+  currentState: ClassifiedDeviationAlertState,
+  nowSeconds: number,
+): number {
+  if (currentState.state === "warning" && currentState.breachStartedAt) {
+    return Math.min(currentState.breachStartedAt, nowSeconds);
+  }
+  return nowSeconds;
+}
+
 function buildCurrentSnapshot(
   previous: StateSnapshot | undefined,
   currentState: ClassifiedDeviationAlertState,
@@ -274,8 +284,10 @@ function buildCurrentSnapshot(
     : // Process restart (liveness probe): no in-memory snapshot exists, but
       // the indexer-persisted breach start survives. Seed enteredAt from it
       // so alertCouldHaveFired() does not reset to process start and suppress
-      // the next transition's Slack context.
-      Math.min(currentState.breachStartedAt ?? nowSeconds, nowSeconds);
+      // the next recovery's Slack context. Data-gap states intentionally start
+      // now: a stale breach start is not evidence that ratio data has been
+      // missing long enough for the data-gap alert to fire.
+      initialEnteredAt(currentState, nowSeconds);
 
   return {
     ...currentState,

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -105,8 +105,8 @@ describe("deviation alert transition rehydration", () => {
     expect(restored.newTransitions).toHaveLength(0);
   });
 
-  it("does not emit duplicate critical escalation after restart-restored warning", () => {
-    const restoredWarning = observeDeviationAlertState(
+  it("restores already-fired critical breaches without duplicate escalation", () => {
+    const restoredCritical = observeDeviationAlertState(
       makePool({
         deviationBreachStartedAt: "1713200000",
         lastDeviationRatio: "1.08",
@@ -115,8 +115,8 @@ describe("deviation alert transition rehydration", () => {
       1713204000,
     );
 
-    expect(restoredWarning.state).toBe("warning");
-    expect(restoredWarning.newTransitions).toHaveLength(0);
+    expect(restoredCritical.state).toBe("critical");
+    expect(restoredCritical.newTransitions).toHaveLength(0);
 
     const stillCritical = observeDeviationAlertState(
       makePool({
@@ -187,8 +187,8 @@ describe("deviation alert transition rehydration", () => {
     expect(recovered.newTransitions).toHaveLength(0);
   });
 
-  it("clears restored critical dwell when the critical signal clears", () => {
-    const restoredWarning = observeDeviationAlertState(
+  it("preserves critical recovery context after an already-fired critical restart", () => {
+    const restoredCritical = observeDeviationAlertState(
       makePool({
         deviationBreachStartedAt: "1713200000",
         lastDeviationRatio: "1.08",
@@ -197,20 +197,40 @@ describe("deviation alert transition rehydration", () => {
       1713204000,
     );
 
-    expect(restoredWarning.state).toBe("warning");
-    expect(restoredWarning.newTransitions).toHaveLength(0);
+    expect(restoredCritical.state).toBe("critical");
+    expect(restoredCritical.newTransitions).toHaveLength(0);
 
-    const belowCritical = observeDeviationAlertState(
+    const recovered = observeDeviationAlertState(
       makePool({
-        deviationBreachStartedAt: "1713200000",
-        lastDeviationRatio: "1.02",
+        deviationBreachStartedAt: "0",
+        lastDeviationRatio: "1.00",
       }),
       "GBPm/USDm",
       1713204050,
     );
 
-    expect(belowCritical.state).toBe("warning");
-    expect(belowCritical.newTransitions).toHaveLength(0);
+    expect(recovered.state).toBe("ok");
+    expect(recovered.newTransitions).toHaveLength(1);
+    expect(recovered.newTransitions[0]).toMatchObject({
+      from: "critical",
+      to: "ok",
+      reason: "recovered",
+      breachStartedAt: 1713200000,
+    });
+  });
+
+  it("keeps escalation context when a restored critical signal clears and returns", () => {
+    const earlyRestart = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.02",
+      }),
+      "GBPm/USDm",
+      1713204000,
+    );
+
+    expect(earlyRestart.state).toBe("warning");
+    expect(earlyRestart.newTransitions).toHaveLength(0);
 
     const criticalSignalReturned = observeDeviationAlertState(
       makePool({
@@ -218,7 +238,7 @@ describe("deviation alert transition rehydration", () => {
         lastDeviationRatio: "1.08",
       }),
       "GBPm/USDm",
-      1713204080,
+      1713204050,
     );
 
     expect(criticalSignalReturned.state).toBe("warning");
@@ -230,7 +250,7 @@ describe("deviation alert transition rehydration", () => {
         lastDeviationRatio: "1.08",
       }),
       "GBPm/USDm",
-      1713204142,
+      1713204112,
     );
 
     expect(critical.state).toBe("critical");

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -104,4 +104,30 @@ describe("deviation alert transition rehydration", () => {
     expect(restored.state).toBe("warning");
     expect(restored.newTransitions).toHaveLength(0);
   });
+
+  it("does not emit duplicate critical escalation after restart-restored warning", () => {
+    const restoredWarning = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713204000,
+    );
+
+    expect(restoredWarning.state).toBe("warning");
+    expect(restoredWarning.newTransitions).toHaveLength(0);
+
+    const stillCritical = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713204070,
+    );
+
+    expect(stillCritical.state).toBe("critical");
+    expect(stillCritical.newTransitions).toHaveLength(0);
+  });
 });

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -64,6 +64,7 @@ describe("deviation alert transition rehydration", () => {
     );
 
     expect(warning.state).toBe("warning");
+    expect(warning.newTransitions).toHaveLength(0);
 
     const recovered = observeDeviationAlertState(
       makePool(),
@@ -76,5 +77,31 @@ describe("deviation alert transition rehydration", () => {
       reason: "recovered",
       breachStartedAt: 1713200000,
     });
+  });
+
+  it("does not backdate data-gap dwell from breach age after restart", () => {
+    const unavailable = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "-1",
+      }),
+      "GBPm/USDm",
+      1713202000,
+    );
+
+    expect(unavailable.state).toBe("deviation_ratio_unavailable_warning");
+    expect(unavailable.newTransitions).toHaveLength(0);
+
+    const restored = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.02",
+      }),
+      "GBPm/USDm",
+      1713202030,
+    );
+
+    expect(restored.state).toBe("warning");
+    expect(restored.newTransitions).toHaveLength(0);
   });
 });

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
-import { USD_PEGGED_SYMBOLS } from "../src/deviation-alert-state.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  observeDeviationAlertState,
+  resetDeviationAlertStateForTests,
+  USD_PEGGED_SYMBOLS,
+} from "../src/deviation-alert-state.js";
+import { makePool } from "./fixtures.js";
 
 function repoFile(path: string): string {
   return readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
@@ -40,5 +45,36 @@ describe("USD_PEGGED_SYMBOLS drift protection", () => {
 
     expect(sortSymbols(USD_PEGGED_SYMBOLS)).toEqual(dashboardSymbols);
     expect(terraformSymbols).toEqual(dashboardSymbols);
+  });
+});
+
+describe("deviation alert transition rehydration", () => {
+  afterEach(() => {
+    resetDeviationAlertStateForTests();
+  });
+
+  it("uses persisted breach start after restart so recovery context is not suppressed", () => {
+    const warning = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.02",
+      }),
+      "GBPm/USDm",
+      1713202000,
+    );
+
+    expect(warning.state).toBe("warning");
+
+    const recovered = observeDeviationAlertState(
+      makePool(),
+      "GBPm/USDm",
+      1713202030,
+    );
+
+    expect(recovered.newTransitions).toHaveLength(1);
+    expect(recovered.newTransitions[0]).toMatchObject({
+      reason: "recovered",
+      breachStartedAt: 1713200000,
+    });
   });
 });

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -130,4 +130,34 @@ describe("deviation alert transition rehydration", () => {
     expect(stillCritical.state).toBe("critical");
     expect(stillCritical.newTransitions).toHaveLength(0);
   });
+
+  it("keeps the first critical escalation after an early critical-magnitude restart", () => {
+    const earlyRestart = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713201800,
+    );
+
+    expect(earlyRestart.state).toBe("warning");
+    expect(earlyRestart.newTransitions).toHaveLength(0);
+
+    const critical = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713203662,
+    );
+
+    expect(critical.state).toBe("critical");
+    expect(critical.newTransitions).toHaveLength(1);
+    expect(critical.newTransitions[0]).toMatchObject({
+      reason: "escalated_to_critical",
+      breachStartedAt: 1713200000,
+    });
+  });
 });

--- a/metrics-bridge/test/deviation-alert-state.test.ts
+++ b/metrics-bridge/test/deviation-alert-state.test.ts
@@ -160,4 +160,84 @@ describe("deviation alert transition rehydration", () => {
       breachStartedAt: 1713200000,
     });
   });
+
+  it("does not inherit weekend-suppressed FX breach age after restart", () => {
+    const reopened = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713564000",
+        lastDeviationRatio: "1.02",
+      }),
+      "GBPm/USDm",
+      1713740400,
+    );
+
+    expect(reopened.state).toBe("warning");
+    expect(reopened.newTransitions).toHaveLength(0);
+
+    const recovered = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "0",
+        lastDeviationRatio: "1.00",
+      }),
+      "GBPm/USDm",
+      1713740700,
+    );
+
+    expect(recovered.state).toBe("ok");
+    expect(recovered.newTransitions).toHaveLength(0);
+  });
+
+  it("clears restored critical dwell when the critical signal clears", () => {
+    const restoredWarning = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713204000,
+    );
+
+    expect(restoredWarning.state).toBe("warning");
+    expect(restoredWarning.newTransitions).toHaveLength(0);
+
+    const belowCritical = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.02",
+      }),
+      "GBPm/USDm",
+      1713204050,
+    );
+
+    expect(belowCritical.state).toBe("warning");
+    expect(belowCritical.newTransitions).toHaveLength(0);
+
+    const criticalSignalReturned = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713204080,
+    );
+
+    expect(criticalSignalReturned.state).toBe("warning");
+    expect(criticalSignalReturned.newTransitions).toHaveLength(0);
+
+    const critical = observeDeviationAlertState(
+      makePool({
+        deviationBreachStartedAt: "1713200000",
+        lastDeviationRatio: "1.08",
+      }),
+      "GBPm/USDm",
+      1713204142,
+    );
+
+    expect(critical.state).toBe("critical");
+    expect(critical.newTransitions).toHaveLength(1);
+    expect(critical.newTransitions[0]).toMatchObject({
+      reason: "escalated_to_critical",
+      breachStartedAt: 1713200000,
+    });
+  });
 });

--- a/scripts/sanitize-terraform-output.sh
+++ b/scripts/sanitize-terraform-output.sh
@@ -14,8 +14,9 @@ sed -E \
 	-e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
 	-e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
 	-e 's#(\\?"api_key\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-	-e 's#(api_key[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-	-e 's#(key[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
+	-e 's#(api_key[[:space:]]*[:=][[:space:]]*)[^"[:space:]\\]+#\1[REDACTED]#g' \
+	-e 's#(\\?"[A-Za-z0-9_-]*api[-_]key\\?"[[:space:]]*=[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+	-e 's#(_key[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
 	-e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
 	-e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
 	-e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \

--- a/scripts/sanitize-terraform-output.sh
+++ b/scripts/sanitize-terraform-output.sh
@@ -13,7 +13,7 @@ sed -E \
 	-e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
 	-e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
 	-e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-	-e 's#(\\?"api_key\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+	-e 's#(\\?"[A-Za-z0-9_-]*api[-_]key\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
 	-e 's#(api_key[[:space:]]*[:=][[:space:]]*)[^"[:space:]\\]+#\1[REDACTED]#g' \
 	-e 's#(\\?"[A-Za-z0-9_-]*api[-_]key\\?"[[:space:]]*=[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
 	-e 's#(_key[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \

--- a/scripts/sanitize-terraform-output.sh
+++ b/scripts/sanitize-terraform-output.sh
@@ -13,6 +13,9 @@ sed -E \
 	-e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
 	-e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
 	-e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+	-e 's#(\\?"api_key\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+	-e 's#(api_key[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
+	-e 's#(key[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
 	-e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
 	-e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
 	-e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,8 @@
 #
 # What it does:
 #   1. Install all pnpm workspace dependencies
-#   2. Run Envio codegen (required for indexer-envio TypeScript to compile)
+#   2. Install Playwright Chromium for ui-dashboard browser tests
+#   3. Run Envio codegen (required for indexer-envio TypeScript to compile)
 #
 # Why codegen is needed:
 #   The indexer-envio package imports from a `generated/` directory that Envio
@@ -22,6 +23,9 @@ echo "  core.hooksPath → .trunk/hooks"
 
 echo "▶ Installing dependencies..."
 pnpm install --frozen-lockfile
+
+echo "▶ Installing Playwright Chromium (ui-dashboard browser tests)..."
+pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium
 
 echo "▶ Verifying ui-dashboard dependency resolution..."
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,10 +24,10 @@ echo "  core.hooksPath → .trunk/hooks"
 echo "▶ Installing dependencies..."
 pnpm install --frozen-lockfile
 
-echo "▶ Installing Playwright Chromium (ui-dashboard browser tests)..."
-if ! pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium; then
+echo "▶ Installing Playwright Chromium and host dependencies (ui-dashboard browser tests)..."
+if ! pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium; then
 	echo "  ⚠ Playwright Chromium install failed; continuing setup." >&2
-	echo "    Run 'pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium' before browser tests." >&2
+	echo "    Run 'pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium' before browser tests." >&2
 fi
 
 echo "▶ Verifying ui-dashboard dependency resolution..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,7 +25,10 @@ echo "▶ Installing dependencies..."
 pnpm install --frozen-lockfile
 
 echo "▶ Installing Playwright Chromium (ui-dashboard browser tests)..."
-pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium
+if ! pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium; then
+	echo "  ⚠ Playwright Chromium install failed; continuing setup." >&2
+	echo "    Run 'pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium' before browser tests." >&2
+fi
 
 echo "▶ Verifying ui-dashboard dependency resolution..."
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"


### PR DESCRIPTION
## The Problem

- Terraform/log sanitization did not redact several `api_key` and generic key assignment forms.
- Fresh setup did not install the Playwright browser that dashboard browser tests need.
- Metrics-bridge lost persisted breach timing across process restarts, so the next recovery transition could miss Slack context.

## The Solution

- Add the missing sanitizer patterns, install Playwright Chromium in `scripts/setup.sh`, and seed metrics-bridge alert-state timing from the persisted breach start when in-memory state is empty.
- Cover the bridge restart case with a focused regression test.

## Details

- Adds redaction for `api_key = "..."`, JSON-style `"api_key": "..."`, unquoted `api_key=...`, and quoted `*_key = "..."` forms.
- Adds the same Playwright Chromium install command used by the agent quality gate to the setup script.
- Rehydrates `enteredAt` from `deviationBreachStartedAt` after a restart so `alertCouldHaveFired()` does not suppress the recovery transition.
- Refs #872. This is one slice of the hygiene batch; the dashboard and governance-watchdog/keccak slices are separate.

## Validation

- `bash -n scripts/sanitize-terraform-output.sh`
- `bash -n scripts/setup.sh`
- `pnpm lint:scripts`
- `pnpm --filter @mento-protocol/metrics-bridge test -- deviation-alert-state.test.ts`
- `pnpm --filter @mento-protocol/metrics-bridge typecheck`
- `pnpm --filter @mento-protocol/metrics-bridge lint`
- `./tools/trunk fmt scripts/sanitize-terraform-output.sh scripts/setup.sh metrics-bridge/src/deviation-alert-state.ts metrics-bridge/test/deviation-alert-state.test.ts`
- `./tools/trunk check scripts/sanitize-terraform-output.sh scripts/setup.sh metrics-bridge/src/deviation-alert-state.ts metrics-bridge/test/deviation-alert-state.test.ts`
- sanitizer fixture check for all four new key forms
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- `git diff --check`

## Deferrals

- Remaining #872 slices stay in #872: dashboard cron/limit-status hardening, governance-watchdog replay nonce, and onchain-event-handler keccak cleanup.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alert transition and Slack context behavior changes on bridge restart are subtle and operationally visible; script changes are low risk aside from setup time/network for Playwright.
> 
> **Overview**
> Extends **Terraform/log sanitization** with patterns that redact `api_key` in JSON, HCL-style assignments, unquoted forms, and quoted `*_key` values.
> 
> **`scripts/setup.sh`** now installs Playwright Chromium (with deps) for ui-dashboard browser tests, with a non-fatal fallback if install fails.
> 
> **Metrics-bridge deviation alert state** rehydrates in-memory timing after a process restart when there is no prior snapshot: `enteredAt` is seeded from indexer-persisted `deviationBreachStartedAt` for active **warning** breaches so `alertCouldHaveFired()` does not treat dwell as reset and suppress recovery Slack transitions. **Data-gap** (`deviation_ratio_unavailable_*`) states still start dwell at **now**; **FX** pairs clamp rehydrated warning age to the latest **Sunday 23:00 UTC** reopen so weekend-suppressed breach age does not count after markets reopen. Critical signal timing and escalation recording are adjusted accordingly, with a focused **rehydration** test suite and `resetDeviationAlertStateForTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37c88d08417182df5b503ae708e45c8deb6f5ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->