### PR TITLE
fix: harden dashboard cron and limit state

### DIFF
--- a/ui-dashboard/src/lib/__tests__/cron-auth.test.ts
+++ b/ui-dashboard/src/lib/__tests__/cron-auth.test.ts
@@ -58,6 +58,9 @@ describe("requireCronAuth", () => {
     await expect(
       requireCronAuth(makeReq("Bearer  secret"), "test"),
     ).resolves.toMatchObject({ status: 401 });
+    await expect(
+      requireCronAuth(makeReq("Bearer secret-extra"), "test"),
+    ).resolves.toMatchObject({ status: 401 });
   });
 
   it("401s when no Authorization header is present", async () => {

--- a/ui-dashboard/src/lib/__tests__/cron-auth.test.ts
+++ b/ui-dashboard/src/lib/__tests__/cron-auth.test.ts
@@ -48,6 +48,18 @@ describe("requireCronAuth", () => {
     expect(res?.status).toBe(401);
   });
 
+  it("401s when the secret is present outside the exact bearer token", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CRON_SECRET", "secret");
+
+    await expect(
+      requireCronAuth(makeReq("Basic secret"), "test"),
+    ).resolves.toMatchObject({ status: 401 });
+    await expect(
+      requireCronAuth(makeReq("Bearer  secret"), "test"),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
   it("401s when no Authorization header is present", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("CRON_SECRET", "secret");

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -1042,6 +1042,25 @@ describe("computeEffectiveStatus", () => {
     ).toBe("WARN");
   });
 
+  it("rejects inherited object keys from indexed limitStatus", () => {
+    expect(
+      resolveLimitStatus({
+        source: "fpmm_factory",
+        limitStatus: "constructor",
+        limitPressure0: "1.05",
+        limitPressure1: "0",
+      }),
+    ).toBe("CRITICAL");
+    expect(
+      resolveLimitStatus({
+        source: "fpmm_factory",
+        limitStatus: "toString",
+        limitPressure0: "0",
+        limitPressure1: "0.85",
+      }),
+    ).toBe("WARN");
+  });
+
   it("passes degenerate reserve state through the effective status type", () => {
     expect(
       computeEffectiveStatus({

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -9,6 +9,7 @@ import {
   liveHealthCounters,
   computeRebalancerLiveness,
   worstStatus,
+  resolveLimitStatus,
 } from "../health";
 
 // Mock weekend.ts so health tests are deterministic regardless of real-world day.
@@ -1001,6 +1002,42 @@ describe("computeEffectiveStatus", () => {
         limitStatus: "WARN",
         limitPressure0: "0",
         limitPressure1: "0",
+      }),
+    ).toBe("WARN");
+  });
+
+  it("falls back to live pressure when indexed limitStatus is malformed", () => {
+    expect(
+      resolveLimitStatus({
+        source: "fpmm_factory",
+        limitStatus: "ok",
+        limitPressure0: "1.05",
+        limitPressure1: "0",
+      }),
+    ).toBe("CRITICAL");
+  });
+
+  it("does not let malformed limitStatus poison effective status", () => {
+    expect(
+      computeEffectiveStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: FRESH_TS,
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+        limitStatus: "BROKEN",
+        limitPressure0: "0",
+        limitPressure1: "0",
+      }),
+    ).toBe("OK");
+  });
+
+  it("rejects non-limit health statuses from indexed limitStatus", () => {
+    expect(
+      resolveLimitStatus({
+        source: "fpmm_factory",
+        limitStatus: "HALTED",
+        limitPressure0: "0",
+        limitPressure1: "0.85",
       }),
     ).toBe("WARN");
   });

--- a/ui-dashboard/src/lib/cron-auth.ts
+++ b/ui-dashboard/src/lib/cron-auth.ts
@@ -1,4 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "crypto";
+
+function timingSafeStringEquals(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  return aBytes.length === bBytes.length && timingSafeEqual(aBytes, bBytes);
+}
 
 /**
  * Bearer-only auth gate for cron-triggered GET routes.
@@ -34,7 +42,12 @@ export async function requireCronAuth(
     );
   }
 
-  if (req.headers.get("authorization") === `Bearer ${cronSecret}`) {
+  if (
+    timingSafeStringEquals(
+      req.headers.get("authorization") ?? "",
+      `Bearer ${cronSecret}`,
+    )
+  ) {
     return null;
   }
 

--- a/ui-dashboard/src/lib/cron-auth.ts
+++ b/ui-dashboard/src/lib/cron-auth.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
 
 function timingSafeStringEquals(a: string, b: string): boolean {
-  const encoder = new TextEncoder();
-  const aBytes = encoder.encode(a);
-  const bBytes = encoder.encode(b);
-  return aBytes.length === bBytes.length && timingSafeEqual(aBytes, bBytes);
+  const key = Buffer.from(b);
+  const aDigest = createHmac("sha256", key).update(a).digest();
+  const bDigest = createHmac("sha256", key).update(b).digest();
+  return timingSafeEqual(aDigest, bDigest);
 }
 
 /**

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -548,17 +548,20 @@ type IndexedLimitStatus = Extract<
   "N/A" | "OK" | "WARN" | "CRITICAL"
 >;
 
-const INDEXED_LIMIT_STATUSES: Record<IndexedLimitStatus, true> = {
-  "N/A": true,
-  OK: true,
-  WARN: true,
-  CRITICAL: true,
-};
+const INDEXED_LIMIT_STATUSES = new Set<IndexedLimitStatus>([
+  "N/A",
+  "OK",
+  "WARN",
+  "CRITICAL",
+]);
 
 function isIndexedLimitStatus(
   value: string | undefined,
 ): value is IndexedLimitStatus {
-  return value !== undefined && value in INDEXED_LIMIT_STATUSES;
+  return (
+    value !== undefined &&
+    INDEXED_LIMIT_STATUSES.has(value as IndexedLimitStatus)
+  );
 }
 
 /** Resolve a pool's effective limit status. Reads the indexer-stored

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -543,19 +543,37 @@ export function worstStatus(a: HealthStatus, b: HealthStatus): HealthStatus {
   return STATUS_RANK[a] >= STATUS_RANK[b] ? a : b;
 }
 
+type IndexedLimitStatus = Extract<
+  HealthStatus,
+  "N/A" | "OK" | "WARN" | "CRITICAL"
+>;
+
+const INDEXED_LIMIT_STATUSES: Record<IndexedLimitStatus, true> = {
+  "N/A": true,
+  OK: true,
+  WARN: true,
+  CRITICAL: true,
+};
+
+function isIndexedLimitStatus(
+  value: string | undefined,
+): value is IndexedLimitStatus {
+  return value !== undefined && value in INDEXED_LIMIT_STATUSES;
+}
+
 /** Resolve a pool's effective limit status. Reads the indexer-stored
- * `limitStatus` string when present (cast to `HealthStatus` — the indexer
- * only ever writes one of the four values), falling back to the live
- * `computeLimitStatus` for older pools that pre-date the indexed field. */
+ * `limitStatus` string when present and valid, falling back to the live
+ * `computeLimitStatus` for older pools that pre-date the indexed field or
+ * malformed GraphQL payloads. */
 export function resolveLimitStatus(pool: {
   source?: string | undefined;
+  wrappedExchangeId?: string | null | undefined;
   limitStatus?: string | undefined;
   limitPressure0?: string | undefined;
   limitPressure1?: string | undefined;
 }): HealthStatus {
-  return (
-    (pool.limitStatus as HealthStatus | undefined) ?? computeLimitStatus(pool)
-  );
+  if (isIndexedLimitStatus(pool.limitStatus)) return pool.limitStatus;
+  return computeLimitStatus(pool);
 }
 
 /**
@@ -575,6 +593,7 @@ export function resolveLimitStatus(pool: {
 export function computeEffectiveStatus(
   pool: {
     source?: string | undefined;
+    wrappedExchangeId?: string | null | undefined;
     oracleOk?: boolean | undefined;
     oracleTimestamp?: string | undefined;
     oracleExpiry?: string | undefined;


### PR DESCRIPTION
## The Problem

- Dashboard cron auth compared bearer tokens with a plain string equality path.
- Limit-status recovery should reject stale or malformed indexed values before they affect health badges.
- The #872 hygiene batch is split into focused PRs so review stays tractable.

## The Solution

- Use byte-length prechecks plus `timingSafeEqual` for cron bearer comparisons.
- Tighten indexed limit-status validation and add regression coverage for malformed status values.
- Keep this PR scoped to the dashboard hardening slice of #872.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/cron-auth.test.ts src/lib/__tests__/health.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Local dashboard server on `http://127.0.0.1:3210`; homepage rendered HTTP 200 with live Envio default data. Chrome DevTools MCP could not attach because the shared profile was already locked by another browser instance.

## Deferrals

None

Refs #872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth on cron routes that trigger Redis/blob side effects and changes how health badges are derived from untrusted indexed fields; scope is limited to dashboard lib code with targeted tests.
> 
> **Overview**
> Hardens **cron GET route auth** and **pool health badge** logic in the dashboard.
> 
> **Cron auth:** Production `requireCronAuth` no longer uses `===` on the full `Authorization` header. It compares the header to `Bearer ${CRON_SECRET}` via **HMAC-SHA256 digests and `timingSafeEqual`**, so only an exact bearer match passes. New tests reject `Basic secret`, double spaces, and `Bearer secret-extra`.
> 
> **Limit status:** `resolveLimitStatus` used to cast indexed `limitStatus` straight to `HealthStatus`. It now accepts only **`N/A` | `OK` | `WARN` | `CRITICAL`**; anything else (wrong casing, `HALTED`, prototype keys like `constructor`) falls back to live **`computeLimitStatus`** from pressures. That keeps malformed GraphQL/indexer strings from poisoning **`computeEffectiveStatus`** on the homepage and OG paths. Pool types gain optional **`wrappedExchangeId`** on limit-resolution inputs for VP alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ed4805d177395d9edf2fd15661bb8d4de16ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->