### PR TITLE
fix: floor oncall supply-chain deps

### DIFF
--- a/alerts/infra/oncall-announcer/package.json
+++ b/alerts/infra/oncall-announcer/package.json
@@ -43,7 +43,9 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
+    "@grpc/grpc-js": "1.14.4",
     "body-parser@<1.20.5": "1.20.5",
+    "esbuild": "0.28.1",
     "express": "4.22.2",
     "form-data@<2.5.6": "2.5.6",
     "form-data@>=4.0.0 <4.0.6": "4.0.6",

--- a/alerts/infra/oncall-announcer/pnpm-lock.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@grpc/grpc-js': 1.14.4
   body-parser@<1.20.5: 1.20.5
+  esbuild: 0.28.1
   express: 4.22.2
   form-data@<2.5.6: 2.5.6
   form-data@>=4.0.0 <4.0.6: 4.0.6
@@ -1961,7 +1963,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: 0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0

--- a/alerts/infra/oncall-announcer/pnpm-workspace.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-workspace.yaml
@@ -8,13 +8,17 @@ minimumReleaseAgeExclude:
   - "@envio-dev/envio-cloud-*"
   # Security override floors for the 2026-06-15 advisory batch may be younger
   # than the 3-day release-age gate.
+  - "@esbuild/*"
   - form-data
+  - esbuild
   - js-yaml
   - protobufjs
   - vite
 
 overrides:
+  "@grpc/grpc-js": 1.14.4
   body-parser@<1.20.5: 1.20.5
+  esbuild: 0.28.1
   express: 4.22.2
   form-data@<2.5.6: 2.5.6
   "form-data@>=4.0.0 <4.0.6": 4.0.6


### PR DESCRIPTION
## The Problem

- The standalone oncall-announcer package still resolved advisory-hit transitive versions.
- Its standalone lockfile needs the same explicit supply-chain floors as the root workspace.
- The advisory batch needs a small package-local fix that does not disturb unrelated alert infra.

## The Solution

- Floor `@grpc/grpc-js` to `1.14.4` and `esbuild` to `0.28.1` in the oncall-announcer standalone overrides.
- Regenerate the standalone lockfile so the resolved peer graph uses the floored versions.
- Allow the fresh esbuild floor through the package-local minimum-release-age gate for this advisory batch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm install --frozen-lockfile` from `alerts/infra/oncall-announcer`
- `pnpm lockfile:lint`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer typecheck`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer lint`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer test:coverage`
- `pnpm agent:quality-gate --run --allow-package-script-changes`
- `pnpm agent:autoreview`

## Notes

- `pnpm audit --audit-level high` was not run locally because the escalated command was rejected: it sends private dependency metadata to npm.

## Deferrals

None

Closes #903

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and override-only changes with no application logic; minor risk from pinning transitive build/grpc tooling versions.
> 
> **Overview**
> Aligns the **standalone** `alerts/infra/oncall-announcer` install graph with the repo’s advisory supply-chain floors so transitive deps no longer resolve below patched versions.
> 
> Adds pnpm **overrides** for `@grpc/grpc-js` **1.14.4** and **esbuild** **0.28.1** in `package.json` and `pnpm-workspace.yaml`, updates `pnpm-lock.yaml` (including Vite’s pinned `esbuild` peer), and exempts `esbuild` / `@esbuild/*` from **minimumReleaseAge** so the new floor can install under the 3-day gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c765082b6e2e5633999363271897909fe04d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->