### PR TITLE
perf: bound volume window flush history

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -514,6 +514,21 @@ type BrokerTraderDailySnapshot
   lastSeenTimestamp: BigInt!
 }
 
+# Per-(chainId, caller) lifetime rollup feeding the "all" window in
+# volumeWindowFlush.ts without rescanning every BrokerTraderDailySnapshot row
+# (#860). maybeHeartbeatFlushV2 runs before this row is written for the
+# current swap, so a flushed closed day never includes today's swap.
+type BrokerTraderAllTimeAggregate {
+  id: ID! # "{chainId}-{caller}"
+  chainId: Int! @index # exposed to getWhere for the "all"-window flush
+  caller: String!
+  volumeUsdWei: BigInt! @config(precision: 78)
+  swapCount: Int!
+  # Sticky-true for life — mirrors aggregatePerWindow's per-window OR.
+  isProtocolActor: Boolean!
+  updatedAtTimestamp: BigInt!
+}
+
 type BrokerAggregatorDailySnapshot {
   id: ID! # "{chainId}-{aggregator}-{day}"
   chainId: Int!
@@ -1933,6 +1948,21 @@ type TraderDailySnapshot @index(fields: ["chainId", "trader", "timestamp"]) {
   # the volume table's "Last active" column at sub-day precision (the day bucket
   # alone would show every active trader as "today").
   lastSeenTimestamp: BigInt!
+}
+
+# Per-(chainId, trader) lifetime rollup feeding the "all" window in
+# volumeWindowFlush.ts without rescanning every TraderDailySnapshot row
+# (#860). Written in applyVolumeSnapshots AFTER the heartbeat flush so a
+# flushed closed day never includes the current (today's) swap.
+type TraderAllTimeAggregate {
+  id: ID! # "{chainId}-{trader}"
+  chainId: Int! @index # exposed to getWhere for the "all"-window flush
+  trader: String!
+  volumeUsdWei: BigInt! @config(precision: 78)
+  swapCount: Int!
+  # Sticky-true for life — mirrors aggregatePerWindow's per-window OR.
+  isProtocolActor: Boolean!
+  updatedAtTimestamp: BigInt!
 }
 
 type TraderPoolDailySnapshot {

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -403,6 +403,7 @@ async function writeBrokerProducerRollups(args: {
     isProtocolOwnedAddress(chainId, caller) ||
     isProtocolActorEntryPoint(chainId, txTo);
   const callerDayId = `${chainId}-${caller}-${dayTs}`;
+  const allTimeId = `${chainId}-${caller}`;
   const aggregator = classifyBrokerEntryPoint(chainId, txTo);
   const aggDayId = `${chainId}-${aggregator}-${dayTs}`;
   const aggCallerMarkerId = `${chainId}-${aggregator}-${caller}-${dayTs}`;
@@ -412,11 +413,13 @@ async function writeBrokerProducerRollups(args: {
     existingAggCallerMarker,
     existingAggDay,
     existingTraderRouterMarker,
+    existingAllTime,
   ] = await Promise.all([
     context.BrokerTraderDailySnapshot.get(callerDayId),
     context.BrokerAggregatorTraderDayMarker.get(aggCallerMarkerId),
     context.BrokerAggregatorDailySnapshot.get(aggDayId),
     context.BrokerTraderRouterDayMarker.get(traderRouterMarkerId),
+    context.BrokerTraderAllTimeAggregate.get(allTimeId),
   ]);
 
   const traderDayState = upsertBrokerTraderDailySnapshot(context, {
@@ -466,6 +469,24 @@ async function writeBrokerProducerRollups(args: {
     aggCallerMarkerId,
     existingAggCallerMarker,
     callerDayIsProtocolActor: traderDayState.callerDayIsProtocolActor,
+  });
+
+  // Lifetime rollup for the v2 "all" window (#860). Safe ordering is
+  // structural here: maybeHeartbeatFlushV2 already ran earlier in the
+  // Broker.Swap handler, so flushed closed days never see this swap.
+  const prevAllTime = existingAllTime ?? {
+    volumeUsdWei: 0n,
+    swapCount: 0,
+    isProtocolActor: false,
+  };
+  context.BrokerTraderAllTimeAggregate.set({
+    id: allTimeId,
+    chainId,
+    caller,
+    volumeUsdWei: prevAllTime.volumeUsdWei + volumeUsdWei,
+    swapCount: prevAllTime.swapCount + 1,
+    isProtocolActor: prevAllTime.isProtocolActor || callerIsProtocolActor,
+    updatedAtTimestamp: blockTimestamp,
   });
 }
 

--- a/indexer-envio/src/volumeSnapshots.ts
+++ b/indexer-envio/src/volumeSnapshots.ts
@@ -3,6 +3,7 @@ import type {
   AggregatorTraderDayMarker,
   Pool,
   PoolDailyVolumeSnapshot,
+  TraderAllTimeAggregate,
   TraderDailySnapshot,
   TraderPoolDailySnapshot,
   TraderPoolDayMarker,
@@ -26,6 +27,10 @@ export type VolumeContext = V3FlushContext & {
   TraderDailySnapshot: {
     get: (id: string) => Promise<TraderDailySnapshot | undefined>;
     set: (entity: TraderDailySnapshot) => void;
+  };
+  TraderAllTimeAggregate: {
+    get: (id: string) => Promise<TraderAllTimeAggregate | undefined>;
+    set: (entity: TraderAllTimeAggregate) => void;
   };
   TraderPoolDailySnapshot: {
     get: (id: string) => Promise<TraderPoolDailySnapshot | undefined>;
@@ -93,6 +98,7 @@ interface SnapContext {
   day: bigint;
   dayKey: string;
   traderDayId: string;
+  traderAllTimeId: string;
   traderPoolDayId: string;
   poolDayId: string;
   aggregator: string;
@@ -111,6 +117,7 @@ interface ExistingEntries {
   traderPoolMarker: TraderPoolDayMarker | undefined;
   aggTraderMarker: AggregatorTraderDayMarker | undefined;
   traderDay: TraderDailySnapshot | undefined;
+  traderAllTime: TraderAllTimeAggregate | undefined;
   traderPoolDay: TraderPoolDailySnapshot | undefined;
   poolDay: PoolDailyVolumeSnapshot | undefined;
   aggDay: AggregatorDailySnapshot | undefined;
@@ -197,13 +204,12 @@ export async function applyVolumeSnapshots(
     traderDayState.traderDayIsProtocolActor,
   );
 
-  // Heartbeat: flush VolumeWindowSnapshot rows for any closed UTC days
-  // since the last flush. Reads only TraderDailySnapshot (already-written
-  // including this swap's row), filters by [windowStartDay, snapshotDay]
-  // inclusive — today's row is excluded by the upper bound, so we never write
-  // a "today" snapshot. The dashboard adds today's partial from a small direct
-  // query.
+  // Heartbeat: flush VolumeWindowSnapshot rows for any closed UTC days since
+  // the last flush. Rolling windows read a bounded daily range; "all" reads
+  // TraderAllTimeAggregate. That lifetime row must be updated only after the
+  // flush so a closed-day snapshot never includes the current swap.
   await flushVolumeWindow();
+  upsertTraderAllTimeAggregate(context, snap, existing.traderAllTime);
 }
 
 function buildSnapContext(args: ApplyVolumeSnapshotsArgs): SnapContext {
@@ -245,6 +251,7 @@ function buildSnapContext(args: ApplyVolumeSnapshotsArgs): SnapContext {
     day,
     dayKey,
     traderDayId: `${chainId}-${caller}-${dayKey}`,
+    traderAllTimeId: `${chainId}-${caller}`,
     traderPoolDayId: `${chainId}-${caller}-${poolId}-${dayKey}`,
     poolDayId: `${chainId}-${poolId}-${dayKey}`,
     aggregator,
@@ -277,6 +284,7 @@ async function loadExistingEntries(
     traderPoolMarker,
     aggTraderMarker,
     traderDay,
+    traderAllTime,
     traderPoolDay,
     poolDay,
     aggDay,
@@ -284,6 +292,7 @@ async function loadExistingEntries(
     context.TraderPoolDayMarker.get(snap.traderPoolDayId),
     context.AggregatorTraderDayMarker.get(snap.aggTraderDayMarkerId),
     context.TraderDailySnapshot.get(snap.traderDayId),
+    context.TraderAllTimeAggregate.get(snap.traderAllTimeId),
     context.TraderPoolDailySnapshot.get(snap.traderPoolDayId),
     context.PoolDailyVolumeSnapshot.get(snap.poolDayId),
     context.AggregatorDailySnapshot.get(snap.aggDayId),
@@ -292,6 +301,7 @@ async function loadExistingEntries(
     traderPoolMarker,
     aggTraderMarker,
     traderDay,
+    traderAllTime,
     traderPoolDay,
     poolDay,
     aggDay,
@@ -305,6 +315,12 @@ const EMPTY_TRADER_DAY = {
   poolIds: [] as readonly string[],
   volumeUsdWei: 0n,
   feesPaidUsdWei: 0n,
+  isProtocolActor: false,
+};
+
+const EMPTY_TRADER_ALL_TIME = {
+  volumeUsdWei: 0n,
+  swapCount: 0,
   isProtocolActor: false,
 };
 
@@ -348,6 +364,23 @@ function upsertTraderDailySnapshot(
     aggregatorKeys,
     poolIds,
   };
+}
+
+function upsertTraderAllTimeAggregate(
+  context: VolumeContext,
+  snap: SnapContext,
+  existing: TraderAllTimeAggregate | undefined,
+) {
+  const prev = existing ?? EMPTY_TRADER_ALL_TIME;
+  context.TraderAllTimeAggregate.set({
+    id: snap.traderAllTimeId,
+    chainId: snap.chainId,
+    trader: snap.caller,
+    volumeUsdWei: prev.volumeUsdWei + snap.volumeUsdWei,
+    swapCount: prev.swapCount + 1,
+    isProtocolActor: prev.isProtocolActor || snap.callerIsProtocolActor,
+    updatedAtTimestamp: snap.blockTimestamp,
+  });
 }
 
 const EMPTY_TRADER_POOL_DAY = {

--- a/indexer-envio/src/volumeWindowFlush.ts
+++ b/indexer-envio/src/volumeWindowFlush.ts
@@ -9,6 +9,11 @@
 // getWhere per UTC-day rollover per chain (not per event), reused across all
 // window aggregations. The "all" window reads the lifetime rollup, so flush
 // memory no longer grows with days indexed.
+//
+// Multi-day catch-up invariant: if the loop below flushes more than one closed
+// day, there were no swaps on the later unflushed days. A swap on an
+// intermediate UTC day would have invoked this heartbeat then and advanced the
+// cursor. Therefore the current lifetime rollup is valid for every missed day.
 
 import type {
   BrokerVolumeWindowSnapshot,
@@ -66,6 +71,8 @@ export async function flushV3VolumeWindowSnapshots(args: {
   // reads the O(distinct-traders) lifetime rollup instead of rescanning every
   // daily row (#860).
   const [rows, allTimeRows] = await Promise.all([
+    // Envio getWhere accepts one predicate key here. Fetch by the bounded
+    // timestamp window and let aggregatePerWindow drop cross-chain rows.
     args.context.TraderDailySnapshot.getWhere({
       timestamp: { _gte: windowStartDay(args.snapshotDay, "90d") },
     }),
@@ -163,6 +170,8 @@ export async function flushV2VolumeWindowSnapshots(args: {
   updatedAtTimestamp: bigint;
 }): Promise<void> {
   const [rows, allTimeRows] = await Promise.all([
+    // Envio getWhere accepts one predicate key here. Fetch by the bounded
+    // timestamp window and let aggregatePerWindow drop cross-chain rows.
     args.context.BrokerTraderDailySnapshot.getWhere({
       timestamp: { _gte: windowStartDay(args.snapshotDay, "90d") },
     }),

--- a/indexer-envio/src/volumeWindowFlush.ts
+++ b/indexer-envio/src/volumeWindowFlush.ts
@@ -1,26 +1,28 @@
 // Heartbeat-driven flush of VolumeWindowSnapshot /
 // BrokerVolumeWindowSnapshot rows. The first swap of a new UTC day
-// flushes all closed days since the last finalized one for all four
+// flushes all closed days since the last finalized one for all five
 // windowKeys. Today's row is intentionally never written by the indexer —
 // the dashboard adds today's partial from a small TraderDailySnapshot
 // query (see ui-dashboard/src/lib/queries/volume.ts).
 //
-// Cost: one chainId getWhere per UTC-day rollover per chain (not per
-// event), reused across all 4 in-memory window aggregations. Roughly
-// O(active_traders × days_indexed) memory at flush time, ~21k rows /
-// 100ms wall on Celo's "all" window — within Envio's per-event handler
-// budget.
+// Cost: one <=89-day daily-row getWhere plus one O(distinct-traders) lifetime
+// getWhere per UTC-day rollover per chain (not per event), reused across all
+// window aggregations. The "all" window reads the lifetime rollup, so flush
+// memory no longer grows with days indexed.
 
 import type {
   BrokerVolumeWindowSnapshot,
   BrokerTraderDailySnapshot,
+  BrokerTraderAllTimeAggregate,
   VolumeChainState,
   VolumeWindowSnapshot,
   TraderDailySnapshot,
+  TraderAllTimeAggregate,
 } from "envio";
 import { SECONDS_PER_DAY, dayBucket } from "./helpers.js";
 import {
   WINDOW_KEYS,
+  allTimeToWindowAggregates,
   aggregatePerWindow,
   buildVolumeWindowSnapshot,
   windowStartDay,
@@ -33,8 +35,13 @@ import {
 export type V3FlushContext = {
   TraderDailySnapshot: {
     getWhere: (query: {
-      chainId: { _eq: number };
+      timestamp: { _gte: bigint };
     }) => Promise<TraderDailySnapshot[]>;
+  };
+  TraderAllTimeAggregate: {
+    getWhere: (query: {
+      chainId: { _eq: number };
+    }) => Promise<TraderAllTimeAggregate[]>;
   };
   VolumeChainState: {
     get: (id: string) => Promise<VolumeChainState | undefined>;
@@ -45,7 +52,7 @@ export type V3FlushContext = {
   };
 };
 
-/** Flush all 4 window snapshots for a single (chainId, snapshotDay).
+/** Flush all 5 window snapshots for a single (chainId, snapshotDay).
  *  Idempotent: re-running with the same args overwrites with identical rows. */
 export async function flushV3VolumeWindowSnapshots(args: {
   context: V3FlushContext;
@@ -54,17 +61,29 @@ export async function flushV3VolumeWindowSnapshots(args: {
   blockNumber: bigint;
   updatedAtTimestamp: bigint;
 }): Promise<void> {
-  const rows = await args.context.TraderDailySnapshot.getWhere({
-    chainId: { _eq: args.chainId },
-  });
+  // Rolling windows (7d/30d/90d; 24h is empty by construction) need at most
+  // the last 89 closed days — 90d has the widest lower bound. The "all" window
+  // reads the O(distinct-traders) lifetime rollup instead of rescanning every
+  // daily row (#860).
+  const [rows, allTimeRows] = await Promise.all([
+    args.context.TraderDailySnapshot.getWhere({
+      timestamp: { _gte: windowStartDay(args.snapshotDay, "90d") },
+    }),
+    args.context.TraderAllTimeAggregate.getWhere({
+      chainId: { _eq: args.chainId },
+    }),
+  ]);
   const grouped = aggregatePerWindow(rows, args.chainId, args.snapshotDay);
+  const allAggregates = allTimeToWindowAggregates(allTimeRows, args.chainId);
   for (const w of WINDOW_KEYS) {
+    // grouped.all is computed from bounded daily rows and is incomplete by
+    // design. The all window must always use lifetime aggregates.
     const snap = buildVolumeWindowSnapshot({
       chainId: args.chainId,
       windowKey: w,
       snapshotDay: args.snapshotDay,
       windowStartDay: windowStartDay(args.snapshotDay, w),
-      aggregates: grouped[w],
+      aggregates: w === "all" ? allAggregates : grouped[w],
       blockNumber: args.blockNumber,
       updatedAtTimestamp: args.updatedAtTimestamp,
     });
@@ -119,8 +138,13 @@ export async function maybeHeartbeatFlushV3(args: {
 export type V2FlushContext = {
   BrokerTraderDailySnapshot: {
     getWhere: (query: {
-      chainId: { _eq: number };
+      timestamp: { _gte: bigint };
     }) => Promise<BrokerTraderDailySnapshot[]>;
+  };
+  BrokerTraderAllTimeAggregate: {
+    getWhere: (query: {
+      chainId: { _eq: number };
+    }) => Promise<BrokerTraderAllTimeAggregate[]>;
   };
   VolumeChainState: {
     get: (id: string) => Promise<VolumeChainState | undefined>;
@@ -138,9 +162,14 @@ export async function flushV2VolumeWindowSnapshots(args: {
   blockNumber: bigint;
   updatedAtTimestamp: bigint;
 }): Promise<void> {
-  const rows = await args.context.BrokerTraderDailySnapshot.getWhere({
-    chainId: { _eq: args.chainId },
-  });
+  const [rows, allTimeRows] = await Promise.all([
+    args.context.BrokerTraderDailySnapshot.getWhere({
+      timestamp: { _gte: windowStartDay(args.snapshotDay, "90d") },
+    }),
+    args.context.BrokerTraderAllTimeAggregate.getWhere({
+      chainId: { _eq: args.chainId },
+    }),
+  ]);
   // BrokerTraderDailySnapshot keys by `caller` (tx.from / signer EOA), but
   // the shared `aggregatePerWindow` helper expects a `trader` field on each
   // row (named for v3's TraderDailySnapshot). Map `caller → trader` here so
@@ -158,7 +187,19 @@ export async function flushV2VolumeWindowSnapshots(args: {
     args.chainId,
     args.snapshotDay,
   );
+  const allAggregates = allTimeToWindowAggregates(
+    allTimeRows.map((r) => ({
+      chainId: r.chainId,
+      trader: r.caller,
+      volumeUsdWei: r.volumeUsdWei,
+      swapCount: r.swapCount,
+      isProtocolActor: r.isProtocolActor,
+    })),
+    args.chainId,
+  );
   for (const w of WINDOW_KEYS) {
+    // grouped.all is computed from bounded daily rows and is incomplete by
+    // design. The all window must always use lifetime aggregates.
     // BrokerVolumeWindowSnapshot is structurally identical to
     // VolumeWindowSnapshot — see schema.graphql.
     const snap: BrokerVolumeWindowSnapshot = buildVolumeWindowSnapshot({
@@ -166,7 +207,7 @@ export async function flushV2VolumeWindowSnapshots(args: {
       windowKey: w,
       snapshotDay: args.snapshotDay,
       windowStartDay: windowStartDay(args.snapshotDay, w),
-      aggregates: grouped[w],
+      aggregates: w === "all" ? allAggregates : grouped[w],
       blockNumber: args.blockNumber,
       updatedAtTimestamp: args.updatedAtTimestamp,
     });

--- a/indexer-envio/src/volumeWindowSnapshot.ts
+++ b/indexer-envio/src/volumeWindowSnapshot.ts
@@ -97,10 +97,9 @@ export interface TraderDailyRow {
 
 /** Group raw daily-snapshot rows by trader, summed across each window's
  *  [windowStartDay, snapshotDay] inclusive range. Out-of-range and
- *  cross-chain rows are dropped defensively in case `getWhere({chainId:
- *  {_eq:n}})` ever surfaces rows the caller doesn't want under Envio's
- *  index internals — same belt-and-suspenders pattern used in
- *  handlers/feeToken.ts.
+ *  cross-chain rows are dropped defensively in case the caller's broader
+ *  `getWhere` fetch surfaces rows outside the target chain under Envio's index
+ *  internals — same belt-and-suspenders pattern used in handlers/feeToken.ts.
  *
  *  Also tracks per-trader first-day slice (volume + swap count on
  *  `windowStartDay`) and an `activeOutsideFirstDay` flag so the snapshot
@@ -166,6 +165,37 @@ export function aggregatePerWindow(
     out[w] = Array.from(byTrader.values());
   }
   return out;
+}
+
+/** Minimal subset of TraderAllTimeAggregate / BrokerTraderAllTimeAggregate
+ *  fields the "all"-window builder needs (v2 rows map caller -> trader). */
+export interface TraderAllTimeRow {
+  chainId: number;
+  trader: string;
+  volumeUsdWei: bigint;
+  swapCount: number;
+  isProtocolActor: boolean;
+}
+
+/** Build the "all" window's per-trader aggregates from lifetime rollup rows.
+ *  firstDay* fields are forced neutral: "all" has no first-day boundary
+ *  (mirrors aggregatePerWindow). Cross-chain rows are dropped defensively, same
+ *  belt-and-suspenders as aggregatePerWindow. */
+export function allTimeToWindowAggregates(
+  rows: ReadonlyArray<TraderAllTimeRow>,
+  chainId: number,
+): TraderWindowAggregate[] {
+  return rows
+    .filter((r) => r.chainId === chainId)
+    .map((r) => ({
+      trader: r.trader,
+      volumeUsdWei: r.volumeUsdWei,
+      swapCount: r.swapCount,
+      isProtocolActor: r.isProtocolActor,
+      firstDayVolumeUsdWei: 0n,
+      firstDaySwapCount: 0,
+      activeOutsideFirstDay: true,
+    }));
 }
 
 export interface BuildSnapshotArgs {

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -17,6 +17,7 @@ type MockDb = MockDbWith<{
   BrokerDailySnapshot: EntityReader;
   BrokerExchangeDailySnapshot: EntityReader;
   BrokerTraderDailySnapshot: EntityReader;
+  BrokerTraderAllTimeAggregate: EntityReader;
   BrokerAggregatorDailySnapshot: EntityReader;
   BrokerAggregatorTraderDayMarker: EntityReader;
   BrokerTraderRouterDayMarker: EntityReader;
@@ -451,6 +452,26 @@ describe("Broker.Swap handler", () => {
     // lastSeenTimestamp tracks the most recent swap's block timestamp
     // (not the day bucket) for sub-day "Last active" precision.
     assert.equal(row!.lastSeenTimestamp, 1_700_000_500n);
+
+    const lifetime = mockDb.entities.BrokerTraderAllTimeAggregate.get(
+      `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}`,
+    ) as
+      | {
+          chainId: number;
+          caller: string;
+          swapCount: number;
+          volumeUsdWei: bigint;
+          isProtocolActor: boolean;
+          updatedAtTimestamp: bigint;
+        }
+      | undefined;
+    assert.isOk(lifetime, "BrokerTraderAllTimeAggregate missing");
+    assert.equal(lifetime!.chainId, CHAIN_CELO);
+    assert.equal(lifetime!.caller, SIGNER_EOA.toLowerCase());
+    assert.equal(lifetime!.swapCount, 2);
+    assert.equal(lifetime!.volumeUsdWei, 1_500n * 10n ** 18n);
+    assert.equal(lifetime!.isProtocolActor, false);
+    assert.equal(lifetime!.updatedAtTimestamp, 1_700_000_500n);
   });
 
   it("does NOT flag isProtocolActor on brokerCaller-side match (avoids hiding MentoRouter users as protocol actor volume)", async () => {

--- a/indexer-envio/test/volumeSnapshots.test.ts
+++ b/indexer-envio/test/volumeSnapshots.test.ts
@@ -6,6 +6,7 @@ import type {
   VolumeWindowSnapshot,
   Pool,
   PoolDailyVolumeSnapshot,
+  TraderAllTimeAggregate,
   TraderDailySnapshot,
   TraderPoolDailySnapshot,
   TraderPoolDayMarker,
@@ -38,6 +39,7 @@ function makeContext(): {
   context: VolumeContext;
   store: {
     TraderDailySnapshot: Map<string, TraderDailySnapshot>;
+    TraderAllTimeAggregate: Map<string, TraderAllTimeAggregate>;
     TraderPoolDailySnapshot: Map<string, TraderPoolDailySnapshot>;
     PoolDailyVolumeSnapshot: Map<string, PoolDailyVolumeSnapshot>;
     AggregatorDailySnapshot: Map<string, AggregatorDailySnapshot>;
@@ -49,6 +51,7 @@ function makeContext(): {
 } {
   const store = {
     TraderDailySnapshot: new Map<string, TraderDailySnapshot>(),
+    TraderAllTimeAggregate: new Map<string, TraderAllTimeAggregate>(),
     TraderPoolDailySnapshot: new Map<string, TraderPoolDailySnapshot>(),
     PoolDailyVolumeSnapshot: new Map<string, PoolDailyVolumeSnapshot>(),
     AggregatorDailySnapshot: new Map<string, AggregatorDailySnapshot>(),
@@ -67,9 +70,16 @@ function makeContext(): {
     context: {
       TraderDailySnapshot: {
         ...wrap(store.TraderDailySnapshot),
-        getWhere: async (query: { chainId?: { _eq?: number } }) =>
+        getWhere: async (query: { timestamp: { _gte: bigint } }) =>
           Array.from(store.TraderDailySnapshot.values()).filter(
-            (r) => r.chainId === query.chainId?._eq,
+            (r) => r.timestamp >= query.timestamp._gte,
+          ),
+      },
+      TraderAllTimeAggregate: {
+        ...wrap(store.TraderAllTimeAggregate),
+        getWhere: async (query: { chainId: { _eq: number } }) =>
+          Array.from(store.TraderAllTimeAggregate.values()).filter(
+            (r) => r.chainId === query.chainId._eq,
           ),
       },
       TraderPoolDailySnapshot: wrap(store.TraderPoolDailySnapshot),
@@ -192,6 +202,14 @@ describe("applyVolumeSnapshots", () => {
     assert.equal(td.feesPaidUsdWei, (1_000n * ONE_USD * 30n) / 10_000n); // 3.0 USD
     assert.equal(td.isProtocolActor, false);
     assert.equal(td.lastSeenTimestamp, DAY_2026_05_04 + 3600n);
+
+    // TraderAllTimeAggregate feeds the "all" volume window.
+    const lifetime = store.TraderAllTimeAggregate.get(`${CHAIN}-${TRADER_A}`);
+    assert.ok(lifetime, "TraderAllTimeAggregate row written");
+    assert.equal(lifetime.volumeUsdWei, 1_000n * ONE_USD);
+    assert.equal(lifetime.swapCount, 1);
+    assert.equal(lifetime.isProtocolActor, false);
+    assert.equal(lifetime.updatedAtTimestamp, DAY_2026_05_04 + 3600n);
 
     // TraderPoolDailySnapshot
     const tpd = store.TraderPoolDailySnapshot.get(

--- a/indexer-envio/test/volumeWindowSnapshot.property.test.ts
+++ b/indexer-envio/test/volumeWindowSnapshot.property.test.ts
@@ -22,21 +22,25 @@
  * 14. buildVolumeWindowSnapshot: id has deterministic format
  * 15. maybeHeartbeatFlushV3: never decreases lastFlushedDay
  * 16. maybeHeartbeatFlushV3: written snapshot count = closed days × WINDOW_KEYS length
+ * 17. lifetime rollup "all" snapshot equals from-scratch daily aggregation
  */
 
 import { describe, it } from "vitest";
 import { strict as assert } from "assert";
 import * as fc from "fast-check";
 import type {
+  TraderAllTimeAggregate,
   VolumeChainState,
   VolumeWindowSnapshot,
   TraderDailySnapshot,
 } from "envio";
 import {
   WINDOW_KEYS,
+  allTimeToWindowAggregates,
   aggregatePerWindow,
   buildVolumeWindowSnapshot,
   windowStartDay,
+  type TraderAllTimeRow,
   type TraderDailyRow,
   type TraderWindowAggregate,
 } from "../src/volumeWindowSnapshot.js";
@@ -557,11 +561,105 @@ describe("buildVolumeWindowSnapshot — deterministic ID", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 17. Lifetime rollup "all" snapshot equals from-scratch daily aggregation
+// ---------------------------------------------------------------------------
+
+describe("allTimeToWindowAggregates — equivalent all-window snapshot", () => {
+  it("matches aggregatePerWindow(...).all for arbitrary historical rows", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.array(
+          fc.record({
+            daysAgo: fc.integer({ min: 0, max: 120 }),
+            trader: arbAddress(),
+            volumeUsdWei: arbAmount,
+            swapCount: arbSwapCount,
+            isProtocolActor: fc.boolean(),
+          }),
+          { maxLength: 60 },
+        ),
+        (snapshotDay, entries) => {
+          const rows: TraderDailyRow[] = entries.map((entry) => ({
+            chainId: CHAIN,
+            trader: entry.trader,
+            timestamp: snapshotDay - BigInt(entry.daysAgo) * SECONDS_PER_DAY,
+            volumeUsdWei: entry.volumeUsdWei,
+            swapCount: entry.swapCount,
+            isProtocolActor: entry.isProtocolActor,
+          }));
+          const lifetimeRows = Array.from(
+            rows
+              .reduce((byTrader, row) => {
+                const existing = byTrader.get(row.trader);
+                byTrader.set(row.trader, {
+                  chainId: row.chainId,
+                  trader: row.trader,
+                  volumeUsdWei:
+                    (existing?.volumeUsdWei ?? 0n) + row.volumeUsdWei,
+                  swapCount: (existing?.swapCount ?? 0) + row.swapCount,
+                  isProtocolActor:
+                    (existing?.isProtocolActor ?? false) || row.isProtocolActor,
+                });
+                return byTrader;
+              }, new Map<string, TraderAllTimeRow>())
+              .values(),
+          );
+          const fromScratch = buildVolumeWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "all",
+            snapshotDay,
+            windowStartDay: windowStartDay(snapshotDay, "all"),
+            aggregates: aggregatePerWindow(rows, CHAIN, snapshotDay).all,
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          const fromLifetime = buildVolumeWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "all",
+            snapshotDay,
+            windowStartDay: windowStartDay(snapshotDay, "all"),
+            aggregates: allTimeToWindowAggregates(lifetimeRows, CHAIN),
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          assert.deepEqual(fromLifetime, fromScratch);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 15 & 16. maybeHeartbeatFlushV3: lastFlushedDay never decreases;
 //           written snapshot count = closedDays × WINDOW_KEYS.length
 // ---------------------------------------------------------------------------
 
-function makeV3Context(traderRows: TraderDailySnapshot[] = []): {
+function deriveAllTimeV3(
+  traderRows: ReadonlyArray<TraderDailySnapshot>,
+): TraderAllTimeAggregate[] {
+  const byTrader = new Map<string, TraderAllTimeAggregate>();
+  for (const row of traderRows) {
+    const id = `${row.chainId}-${row.trader}`;
+    const existing = byTrader.get(id);
+    byTrader.set(id, {
+      id,
+      chainId: row.chainId,
+      trader: row.trader,
+      volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + row.volumeUsdWei,
+      swapCount: (existing?.swapCount ?? 0) + row.swapCount,
+      isProtocolActor:
+        (existing?.isProtocolActor ?? false) || row.isProtocolActor,
+      updatedAtTimestamp: row.lastSeenTimestamp,
+    });
+  }
+  return Array.from(byTrader.values());
+}
+
+function makeV3Context(
+  traderRows: TraderDailySnapshot[] = [],
+  allTimeRows: TraderAllTimeAggregate[] = deriveAllTimeV3(traderRows),
+): {
   context: V3FlushContext;
   store: {
     VolumeWindowSnapshot: Map<string, VolumeWindowSnapshot>;
@@ -581,8 +679,12 @@ function makeV3Context(traderRows: TraderDailySnapshot[] = []): {
   return {
     context: {
       TraderDailySnapshot: {
-        getWhere: async (query: { chainId?: { _eq?: number } }) =>
-          traderRows.filter((r) => r.chainId === query.chainId?._eq),
+        getWhere: async (query: { timestamp: { _gte: bigint } }) =>
+          traderRows.filter((r) => r.timestamp >= query.timestamp._gte),
+      },
+      TraderAllTimeAggregate: {
+        getWhere: async (query: { chainId: { _eq: number } }) =>
+          allTimeRows.filter((r) => r.chainId === query.chainId._eq),
       },
       VolumeChainState: wrap(store.VolumeChainState),
       VolumeWindowSnapshot: wrap(store.VolumeWindowSnapshot),

--- a/indexer-envio/test/volumeWindowSnapshot.test.ts
+++ b/indexer-envio/test/volumeWindowSnapshot.test.ts
@@ -877,6 +877,35 @@ describe("maybeHeartbeatFlushV3", () => {
     assert.equal(state?.lastFlushedDay, DAY_2026_05_06);
   });
 
+  it("multi-day all snapshots use the same lifetime total because skipped days had no swaps", async () => {
+    const DAY_2026_05_04 = DAY_2026_05_07 - 3n * SECONDS_PER_DAY;
+    const { context, store } = makeV3Context([
+      fakeTraderDay(TRADER_A, DAY_2026_05_05, 100n),
+    ]);
+    store.VolumeChainState.set(`${CHAIN}`, {
+      id: `${CHAIN}`,
+      chainId: CHAIN,
+      lastFlushedDay: DAY_2026_05_04,
+      lastFlushedDayBroker: 0n,
+      updatedAtTimestamp: 0n,
+    });
+
+    await maybeHeartbeatFlushV3({
+      context,
+      chainId: CHAIN,
+      blockTimestamp: DAY_2026_05_07 + 60n * 60n * 12n,
+      blockNumber: 100n,
+    });
+
+    for (const snapshotDay of [DAY_2026_05_05, DAY_2026_05_06]) {
+      const snapAll = store.VolumeWindowSnapshot.get(
+        `${CHAIN}-all-${snapshotDay}`,
+      );
+      assert.equal(snapAll?.totalVolumeUsdWei, 100n * ONE_USD);
+      assert.equal(snapAll?.totalSwapCount, 1);
+    }
+  });
+
   it("preserves lastFlushedDayBroker when advancing v3 cursor", async () => {
     const { context, store } = makeV3Context();
     store.VolumeChainState.set(`${CHAIN}`, {
@@ -1098,6 +1127,63 @@ describe("flushV2VolumeWindowSnapshots", () => {
       assert.equal(snap.totalVolumeUsdWei, 150n * ONE_USD);
       assert.equal(snap.uniqueTraders, 2);
     }
+  });
+
+  it("all window comes from lifetime rollups, not bounded daily rows", async () => {
+    const { context, store } = makeV2Context(
+      [fakeBrokerTraderDay(TRADER_A, DAY_2026_05_06, 100n)],
+      [
+        {
+          id: `${CHAIN}-${TRADER_A}`,
+          chainId: CHAIN,
+          caller: TRADER_A,
+          volumeUsdWei: 5_000n * ONE_USD,
+          swapCount: 7,
+          isProtocolActor: false,
+          updatedAtTimestamp: DAY_2026_05_06,
+        },
+      ],
+    );
+    await flushV2VolumeWindowSnapshots({
+      context,
+      chainId: CHAIN,
+      snapshotDay: DAY_2026_05_06,
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+
+    const snapAll = store.BrokerVolumeWindowSnapshot.get(
+      `${CHAIN}-all-${DAY_2026_05_06}`,
+    );
+    const snap7d = store.BrokerVolumeWindowSnapshot.get(
+      `${CHAIN}-7d-${DAY_2026_05_06}`,
+    );
+    assert.equal(snapAll?.totalVolumeUsdWei, 5_000n * ONE_USD);
+    assert.equal(snapAll?.totalSwapCount, 7);
+    assert.equal(snap7d?.totalVolumeUsdWei, 100n * ONE_USD);
+    assert.equal(snap7d?.totalSwapCount, 1);
+  });
+
+  it("bounds daily fetches to the 90d window", async () => {
+    let recordedQuery: { timestamp: { _gte: bigint } } | undefined;
+    const { context } = makeV2Context();
+    context.BrokerTraderDailySnapshot.getWhere = async (query) => {
+      recordedQuery = query;
+      return [];
+    };
+
+    await flushV2VolumeWindowSnapshots({
+      context,
+      chainId: CHAIN,
+      snapshotDay: DAY_2026_05_06,
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+
+    assert.equal(
+      recordedQuery?.timestamp._gte,
+      windowStartDay(DAY_2026_05_06, "90d"),
+    );
   });
 });
 

--- a/indexer-envio/test/volumeWindowSnapshot.test.ts
+++ b/indexer-envio/test/volumeWindowSnapshot.test.ts
@@ -1,7 +1,9 @@
 import { strict as assert } from "assert";
 import type {
+  BrokerTraderAllTimeAggregate,
   BrokerVolumeWindowSnapshot,
   BrokerTraderDailySnapshot,
+  TraderAllTimeAggregate,
   VolumeChainState,
   VolumeWindowSnapshot,
   TraderDailySnapshot,
@@ -672,7 +674,31 @@ describe("aggregatePerWindow — firstDay slice", () => {
 // Heartbeat smoke tests against a Map-backed mock context.
 // ---------------------------------------------------------------------------
 
-function makeV3Context(traderRows: TraderDailySnapshot[] = []): {
+function deriveAllTimeV3(
+  traderRows: ReadonlyArray<TraderDailySnapshot>,
+): TraderAllTimeAggregate[] {
+  const byTrader = new Map<string, TraderAllTimeAggregate>();
+  for (const row of traderRows) {
+    const id = `${row.chainId}-${row.trader}`;
+    const existing = byTrader.get(id);
+    byTrader.set(id, {
+      id,
+      chainId: row.chainId,
+      trader: row.trader,
+      volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + row.volumeUsdWei,
+      swapCount: (existing?.swapCount ?? 0) + row.swapCount,
+      isProtocolActor:
+        (existing?.isProtocolActor ?? false) || row.isProtocolActor,
+      updatedAtTimestamp: row.lastSeenTimestamp,
+    });
+  }
+  return Array.from(byTrader.values());
+}
+
+function makeV3Context(
+  traderRows: TraderDailySnapshot[] = [],
+  allTimeRows: TraderAllTimeAggregate[] = deriveAllTimeV3(traderRows),
+): {
   context: V3FlushContext;
   store: {
     VolumeWindowSnapshot: Map<string, VolumeWindowSnapshot>;
@@ -692,8 +718,12 @@ function makeV3Context(traderRows: TraderDailySnapshot[] = []): {
   return {
     context: {
       TraderDailySnapshot: {
-        getWhere: async (query: { chainId?: { _eq?: number } }) =>
-          traderRows.filter((r) => r.chainId === query.chainId?._eq),
+        getWhere: async (query: { timestamp: { _gte: bigint } }) =>
+          traderRows.filter((r) => r.timestamp >= query.timestamp._gte),
+      },
+      TraderAllTimeAggregate: {
+        getWhere: async (query: { chainId: { _eq: number } }) =>
+          allTimeRows.filter((r) => r.chainId === query.chainId._eq),
       },
       VolumeChainState: wrap(store.VolumeChainState),
       VolumeWindowSnapshot: wrap(store.VolumeWindowSnapshot),
@@ -725,7 +755,7 @@ function fakeTraderDay(
 }
 
 describe("flushV3VolumeWindowSnapshots", () => {
-  it("writes 4 rows (one per windowKey) for the same snapshotDay", async () => {
+  it("writes 5 rows (one per windowKey) for the same snapshotDay", async () => {
     const { context, store } = makeV3Context([
       fakeTraderDay(TRADER_A, DAY_2026_05_06, 100n),
       fakeTraderDay(TRADER_B, DAY_2026_05_06, 50n),
@@ -839,7 +869,7 @@ describe("maybeHeartbeatFlushV3", () => {
       blockTimestamp: DAY_2026_05_07 + 60n * 60n * 12n,
       blockNumber: 100n,
     });
-    // 2 days × 4 windowKeys = 8 rows
+    // 2 days × 5 windowKeys = 10 rows
     assert.equal(store.VolumeWindowSnapshot.size, 10);
     assert(store.VolumeWindowSnapshot.has(`${CHAIN}-7d-${DAY_2026_05_05}`));
     assert(store.VolumeWindowSnapshot.has(`${CHAIN}-7d-${DAY_2026_05_06}`));
@@ -872,12 +902,16 @@ describe("maybeHeartbeatFlushV3", () => {
   });
 
   it("excludes today's rows from window aggregates (upper bound = snapshotDay)", async () => {
-    const { context, store } = makeV3Context([
-      // Yesterday — should appear in 7d/30d/all snapshots
-      fakeTraderDay(TRADER_A, DAY_2026_05_06, 100n),
-      // Today — should NOT appear (timestamp > snapshotDay = yesterday)
-      fakeTraderDay(TRADER_C, DAY_2026_05_07, 999n),
-    ]);
+    const yesterday = fakeTraderDay(TRADER_A, DAY_2026_05_06, 100n);
+    const { context, store } = makeV3Context(
+      [
+        // Yesterday — should appear in rolling snapshots
+        yesterday,
+        // Today — should NOT appear (timestamp > snapshotDay = yesterday)
+        fakeTraderDay(TRADER_C, DAY_2026_05_07, 999n),
+      ],
+      deriveAllTimeV3([yesterday]),
+    );
     await maybeHeartbeatFlushV3({
       context,
       chainId: CHAIN,
@@ -896,6 +930,65 @@ describe("maybeHeartbeatFlushV3", () => {
     );
     assert.equal(snap24h?.totalVolumeUsdWei, 0n);
     assert.equal(snap24h?.uniqueTraders, 0);
+    const snapAll = store.VolumeWindowSnapshot.get(
+      `${CHAIN}-all-${DAY_2026_05_06}`,
+    );
+    assert.equal(snapAll?.totalVolumeUsdWei, 100n * ONE_USD);
+    assert.equal(snapAll?.uniqueTraders, 1);
+  });
+
+  it("all window comes from lifetime rollups, not bounded daily rows", async () => {
+    const { context, store } = makeV3Context(
+      [fakeTraderDay(TRADER_A, DAY_2026_05_06, 100n)],
+      [
+        {
+          id: `${CHAIN}-${TRADER_A}`,
+          chainId: CHAIN,
+          trader: TRADER_A,
+          volumeUsdWei: 5_000n * ONE_USD,
+          swapCount: 7,
+          isProtocolActor: false,
+          updatedAtTimestamp: DAY_2026_05_06,
+        },
+      ],
+    );
+    await flushV3VolumeWindowSnapshots({
+      context,
+      chainId: CHAIN,
+      snapshotDay: DAY_2026_05_06,
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+    const snapAll = store.VolumeWindowSnapshot.get(
+      `${CHAIN}-all-${DAY_2026_05_06}`,
+    );
+    const snap7d = store.VolumeWindowSnapshot.get(
+      `${CHAIN}-7d-${DAY_2026_05_06}`,
+    );
+    assert.equal(snapAll?.totalVolumeUsdWei, 5_000n * ONE_USD);
+    assert.equal(snapAll?.totalSwapCount, 7);
+    assert.equal(snap7d?.totalVolumeUsdWei, 100n * ONE_USD);
+    assert.equal(snap7d?.totalSwapCount, 1);
+  });
+
+  it("bounds daily fetches to the 90d window", async () => {
+    let recordedQuery: { timestamp: { _gte: bigint } } | undefined;
+    const { context } = makeV3Context();
+    context.TraderDailySnapshot.getWhere = async (query) => {
+      recordedQuery = query;
+      return [];
+    };
+    await flushV3VolumeWindowSnapshots({
+      context,
+      chainId: CHAIN,
+      snapshotDay: DAY_2026_05_06,
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+    assert.equal(
+      recordedQuery?.timestamp._gte,
+      windowStartDay(DAY_2026_05_06, "90d"),
+    );
   });
 });
 
@@ -906,7 +999,31 @@ describe("maybeHeartbeatFlushV3", () => {
 // v2 side end-to-end.
 // ---------------------------------------------------------------------------
 
-function makeV2Context(traderRows: BrokerTraderDailySnapshot[] = []): {
+function deriveAllTimeV2(
+  traderRows: ReadonlyArray<BrokerTraderDailySnapshot>,
+): BrokerTraderAllTimeAggregate[] {
+  const byCaller = new Map<string, BrokerTraderAllTimeAggregate>();
+  for (const row of traderRows) {
+    const id = `${row.chainId}-${row.caller}`;
+    const existing = byCaller.get(id);
+    byCaller.set(id, {
+      id,
+      chainId: row.chainId,
+      caller: row.caller,
+      volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + row.volumeUsdWei,
+      swapCount: (existing?.swapCount ?? 0) + row.swapCount,
+      isProtocolActor:
+        (existing?.isProtocolActor ?? false) || row.isProtocolActor,
+      updatedAtTimestamp: row.lastSeenTimestamp,
+    });
+  }
+  return Array.from(byCaller.values());
+}
+
+function makeV2Context(
+  traderRows: BrokerTraderDailySnapshot[] = [],
+  allTimeRows: BrokerTraderAllTimeAggregate[] = deriveAllTimeV2(traderRows),
+): {
   context: V2FlushContext;
   store: {
     BrokerVolumeWindowSnapshot: Map<string, BrokerVolumeWindowSnapshot>;
@@ -926,8 +1043,12 @@ function makeV2Context(traderRows: BrokerTraderDailySnapshot[] = []): {
   return {
     context: {
       BrokerTraderDailySnapshot: {
-        getWhere: async (query: { chainId?: { _eq?: number } }) =>
-          traderRows.filter((r) => r.chainId === query.chainId?._eq),
+        getWhere: async (query: { timestamp: { _gte: bigint } }) =>
+          traderRows.filter((r) => r.timestamp >= query.timestamp._gte),
+      },
+      BrokerTraderAllTimeAggregate: {
+        getWhere: async (query: { chainId: { _eq: number } }) =>
+          allTimeRows.filter((r) => r.chainId === query.chainId._eq),
       },
       VolumeChainState: wrap(store.VolumeChainState),
       BrokerVolumeWindowSnapshot: wrap(store.BrokerVolumeWindowSnapshot),
@@ -948,6 +1069,7 @@ function fakeBrokerTraderDay(
     caller,
     timestamp,
     swapCount: 1,
+    aggregatorKeys: ["broker"],
     volumeUsdWei: volumeUsd * ONE_USD,
     isProtocolActor,
     lastSeenTimestamp: timestamp,
@@ -955,7 +1077,7 @@ function fakeBrokerTraderDay(
 }
 
 describe("flushV2VolumeWindowSnapshots", () => {
-  it("writes 4 rows (one per windowKey) for the same snapshotDay", async () => {
+  it("writes 5 rows (one per windowKey) for the same snapshotDay", async () => {
     const { context, store } = makeV2Context([
       fakeBrokerTraderDay(TRADER_A, DAY_2026_05_06, 100n),
       fakeBrokerTraderDay(TRADER_B, DAY_2026_05_06, 50n),
@@ -1039,7 +1161,7 @@ describe("maybeHeartbeatFlushV2", () => {
       blockTimestamp: DAY_2026_05_07 + 60n * 60n * 12n,
       blockNumber: 100n,
     });
-    // 2 days × 4 windowKeys = 8 rows
+    // 2 days × 5 windowKeys = 10 rows
     assert.equal(store.BrokerVolumeWindowSnapshot.size, 10);
     assert(
       store.BrokerVolumeWindowSnapshot.has(`${CHAIN}-7d-${DAY_2026_05_05}`),


### PR DESCRIPTION
## The Problem

- Volume heartbeat flushes recomputed the `all` window by scanning every daily trader row for the chain.
- That made historical backfills grow with days indexed instead of with distinct traders.
- The hosted resync/promotion measurement still needs to happen after review.

## The Solution

- Persist per-trader lifetime rollups for v3 swaps and per-caller lifetime rollups for v2 Broker swaps.
- Keep 24h/7d/30d/90d flushes bounded to the most recent 90 closed UTC days.
- Build the `all` window from lifetime rows so the expensive path scales with distinct actors, not indexed history length.

## Invariants

- Heartbeat flushes still run before the current event writes its lifetime rollup, so closed-day snapshots never include today's partial swap.
- Lifetime `isProtocolActor` is sticky-true, matching the previous per-window OR semantics.
- The `all` window has neutral first-day catch-up fields because it has no boundary day.

## Degraded Behavior

- Cross-chain rows returned by broad indexed reads are still filtered defensively before aggregation.
- Old deployments without lifetime rows need a hosted reindex before the `all` window has complete data.

## Intentional Non-Goals

- This PR does not deploy, resync, or promote the hosted indexer.
- This PR does not close #860 until the post-merge hosted resync and snapshot wall-clock comparison are done.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test -- test/broker.test.ts test/volumeSnapshots.test.ts` (expanded to 62 files / 953 tests)
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview -- --prompt-file docs/pr-checklists/stateful-data-ui.md`

## Deferrals

None

Refs #860

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core volume snapshot materialization and ordering invariants; incorrect rollup or flush timing would skew dashboard totals until a reindex, though behavior is heavily tested and scoped to indexer aggregation.
> 
> **Overview**
> **Volume heartbeat flushes no longer scan every daily trader row for the chain.** Rolling windows (`7d` / `30d` / `90d`) load only daily snapshots back to the `90d` window start; the **`all`** window is built from new per-trader lifetime entities instead of unbounded history.
> 
> The indexer adds **`TraderAllTimeAggregate`** (v3) and **`BrokerTraderAllTimeAggregate`** (v2 Broker), updated on each swap with sticky **`isProtocolActor`**. **Flush runs before the lifetime row is written** so closed-day snapshots never include today’s partial swap; v3 does this in `applyVolumeSnapshots`, v2 relies on `maybeHeartbeatFlushV2` running earlier in the Broker handler.
> 
> `allTimeToWindowAggregates` feeds the **`all`** snapshot path for both venues; tests cover equivalence to full daily aggregation, 90d-bounded queries, and multi-day catch-up behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139a7f481e39b39e5759ad4a1a1f90247c328c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->