### PR TITLE
experiment: pilot react compiler annotation mode

### DIFF
--- a/docs/notes/react-compiler-annotation-pilot.md
+++ b/docs/notes/react-compiler-annotation-pilot.md
@@ -25,7 +25,7 @@ Result before enabling the compiler:
 - Next compile phase: 9.7s.
 - TypeScript phase: 8.3s.
 
-The same command failed inside the Codex sandbox before escalation because Turbopack attempted to bind a local port and macOS denied it with `Operation not permitted`.
+The same command can fail in restricted local sandboxes when Turbopack attempts to bind a local port and macOS denies it with `Operation not permitted`.
 
 ## Compiler-enabled evidence
 

--- a/docs/notes/react-compiler-annotation-pilot.md
+++ b/docs/notes/react-compiler-annotation-pilot.md
@@ -1,0 +1,57 @@
+# React Compiler annotation-mode pilot
+
+Issue: #709
+
+## Scope
+
+- Enable `babel-plugin-react-compiler` for `ui-dashboard`.
+- Keep global compilation off with `reactCompiler: { compilationMode: "annotation" }`.
+- Opt in only `ui-dashboard/src/app/pools/_components/pools-page-client.tsx` via `"use memo"` on `PoolsContent`.
+
+`/pools` was chosen as the first high-churn surface because it combines live pool data, URL-backed filter and limit controls, derived pool maps, sortable global pools, and recent-swap table rendering. Existing browser coverage already exercises navigation, layout, degraded query handling, and weekend-banner hydration on this route.
+
+## Baseline
+
+Local command:
+
+```bash
+command time -p pnpm dashboard:build
+```
+
+Result before enabling the compiler:
+
+- Build status: pass when run outside the Codex sandbox.
+- Wall time: 23.28s.
+- Next compile phase: 9.7s.
+- TypeScript phase: 8.3s.
+
+The same command failed inside the Codex sandbox before escalation because Turbopack attempted to bind a local port and macOS denied it with `Operation not permitted`.
+
+## Compiler-enabled evidence
+
+Local command:
+
+```bash
+command time -p pnpm dashboard:build
+```
+
+Result after enabling annotation mode and adding `"use memo"` to `PoolsContent`:
+
+- Build status: pass when run outside the Codex sandbox.
+- Wall time: 26.30s.
+- Next compile phase: 11.1s.
+- TypeScript phase: 9.8s.
+- Delta vs baseline: +3.02s wall time and +1.4s compile time.
+
+Browser interaction evidence:
+
+- Added a `/pools` browser regression for raw pool-address filtering while preserving `poolsSort` / `poolsDir` URL state.
+- Focused run: `pnpm --filter @mento-protocol/ui-dashboard test:browser --grep "filters pools swaps"` passed in 2.6s.
+- Traced focused run: `pnpm --filter @mento-protocol/ui-dashboard test:browser --grep "filters pools swaps" --trace on` passed in 2.4s and wrote `ui-dashboard/test-results/dashboard-flows-dashboard--8fb52-erving-table-sort-URL-state/trace.zip`.
+- Full fixture-backed browser run: `pnpm --filter @mento-protocol/ui-dashboard test:browser` passed 17/17 in 47.4s; the new `/pools` test passed in 828ms within that run.
+
+## Rollout decision
+
+Keep annotation mode for now. This pilot proves the annotated `/pools` surface still builds and passes interaction coverage, but it does not show a build-time win and the captured browser evidence is functional/trace evidence rather than a repeatable render-count improvement. Do not switch to `reactCompiler: true` until at least one measured interaction on `/pools` shows a repeatable render or responsiveness win and the dashboard gate stays green with more annotated surfaces.
+
+No `"use no memo"` exclusions are currently required.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,13 +597,13 @@ importers:
         version: link:../shared-config
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.106.2(esbuild@0.28.1))
+        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.106.2(esbuild@0.28.1))
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/blob':
         specifier: ^2.4.0
         version: 2.4.0
@@ -618,10 +618,10 @@ importers:
         version: 7.4.0(graphql@16.13.1)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 5.0.0-beta.30(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       plotly.js-basic-dist-min:
         specifier: ^3.4.0
         version: 3.4.0
@@ -695,6 +695,9 @@ importers:
       axe-core:
         specifier: ^4.11.4
         version: 4.11.4
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.7.0)
@@ -883,16 +886,8 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -1056,10 +1051,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -4699,6 +4690,9 @@ packages:
   babel-plugin-jest-hoist@30.2.0:
     resolution: {integrity: sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
@@ -10425,7 +10419,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -10441,7 +10435,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -10454,7 +10448,7 @@ snapshots:
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -10469,7 +10463,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -10497,14 +10491,14 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10512,14 +10506,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -10535,15 +10529,11 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -10552,11 +10542,11 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -10711,7 +10701,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -10720,15 +10710,10 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -13100,7 +13085,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.106.2(esbuild@0.28.1))':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.106.2(esbuild@0.28.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -13113,7 +13098,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.6)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(esbuild@0.28.1))
-      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -13460,23 +13445,23 @@ snapshots:
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/bn.js@5.2.0':
     dependencies:
@@ -13991,9 +13976,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/blob@2.4.0':
@@ -14016,7 +14001,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/coverage-v8@4.1.7)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@22.19.13)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -14456,6 +14441,10 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
+
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.6):
     dependencies:
       '@babel/core': 7.29.6
@@ -14483,7 +14472,7 @@ snapshots:
 
   babel-walk@3.0.0-canary-5:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   badgen@3.3.2: {}
 
@@ -14971,7 +14960,7 @@ snapshots:
   constantinople@4.0.1:
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   content-disposition@0.5.4:
     dependencies:
@@ -17685,7 +17674,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.6)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.6)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jest/expect-utils': 30.2.0
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.2.0
@@ -18227,7 +18216,7 @@ snapshots:
   magicast@0.5.2:
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@3.1.0:
@@ -18816,15 +18805,15 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  next-auth@5.0.0-beta.30(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  next-auth@5.0.0-beta.30(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -18845,6 +18834,7 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.60.0
+      babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -21571,7 +21561,7 @@ snapshots:
   with@7.0.2:
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       assert-never: 1.4.0
       babel-walk: 3.0.0-canary-5
 

--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -2,6 +2,9 @@ import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  reactCompiler: {
+    compilationMode: "annotation",
+  },
   // Drop the `x-powered-by: Next.js` fingerprint header.
   poweredByHeader: false,
   env: {

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -59,6 +59,7 @@
     "@types/react-plotly.js": "^2.6.4",
     "@vitest/coverage-v8": "^4.1.0",
     "axe-core": "^4.11.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.0.3",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-you-might-not-need-an-effect": "0.10.1",

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -57,6 +57,8 @@ function PoolsContent({
 }: {
   initialNetworkData?: NetworkData[] | undefined;
 }) {
+  "use memo";
+
   // `initialNetworkData` lets first paint render the full pools table from
   // SSR data instead of a 3-row `<Skeleton />` — fixes the 0.49 CLS that
   // lhci flagged on this route (BACKLOG "Lighthouse CI Follow-Ups"). The

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -356,6 +356,26 @@ test.describe("dashboard browser flows", () => {
     ).toBeVisible();
   });
 
+  test("filters pools swaps by raw address while preserving table sort URL state", async ({
+    page,
+  }) => {
+    await page.goto("/pools?poolsSort=tvl&poolsDir=asc");
+
+    await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
+    await page
+      .getByLabel("Filter swaps by pool ID or pool address")
+      .fill("0x462fe04b4fd719cbd04c0310365d421d02aaa19e");
+    await page.getByRole("button", { name: "Apply" }).click();
+
+    await expect(page).toHaveURL(/pool=42220-/);
+    await expect(page).toHaveURL(/poolsSort=tvl/);
+    await expect(page).toHaveURL(/poolsDir=asc/);
+    await expect(
+      page.getByRole("heading", { name: "Swaps for USDC/USDm" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Clear" })).toBeVisible();
+  });
+
   test("filters stable supply changes by committed USD threshold", async ({
     page,
   }) => {

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -359,9 +359,13 @@ test.describe("dashboard browser flows", () => {
   test("filters pools swaps by raw address while preserving table sort URL state", async ({
     page,
   }) => {
-    await page.goto("/pools?poolsSort=tvl&poolsDir=asc");
+    await page.goto("/pools");
 
     await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
+    await page.getByRole("button", { name: /TVL/ }).click();
+    await expect(page).toHaveURL(/poolsSort=tvl/);
+    await expect(page).toHaveURL(/poolsDir=asc/);
+
     await page
       .getByLabel("Filter swaps by pool ID or pool address")
       .fill("0x462fe04b4fd719cbd04c0310365d421d02aaa19e");


### PR DESCRIPTION
## The Problem

- The dashboard had no React Compiler pilot despite being on Next 16 and React 19.
- Enabling compiler globally would be too broad without build-time and interaction evidence.
- The rollout decision needed to be documented from measured data, not assumption.

## The Solution

- Add `babel-plugin-react-compiler` and enable `reactCompiler` in annotation mode only.
- Annotate the high-churn `/pools` client surface with `"use memo"`.
- Add a `/pools` browser regression covering raw-address filtering while preserving URL sort state, then document the build and trace results.

## Evidence

- Baseline `pnpm dashboard:build`: 23.28s wall, 9.7s compile, 8.3s TypeScript.
- Compiler annotation-mode `pnpm dashboard:build`: 26.30s wall, 11.1s compile, 9.8s TypeScript.
- Delta: +3.02s wall and +1.4s compile, so no build-time win.
- Focused `/pools` browser test passed in 2.6s.
- Traced focused `/pools` browser test passed in 2.4s and wrote `ui-dashboard/test-results/dashboard-flows-dashboard--8fb52-erving-table-sort-URL-state/trace.zip`.
- Full `pnpm --filter @mento-protocol/ui-dashboard test:browser` passed 17/17.

## Rollout Decision

Stay in annotation mode. This proves the annotated `/pools` surface builds and passes interaction coverage, but it does not justify switching to `reactCompiler: true` yet. No `"use no memo"` exclusions are currently required.

## Validation

- `pnpm agent:quality-gate --run --allow-package-script-changes`
- pre-push rerun of the same mapped gate
- `pnpm agent:autoreview -- --prompt-file docs/pr-checklists/stateful-data-ui.md --prompt-file docs/pr-checklists/keyboard-a11y-controlled-widgets.md`

Chrome DevTools MCP could not attach in this session because the shared profile was locked by another browser instance; fixture-backed Playwright browser tests and trace capture were used for browser verification.

## Deferrals

None

Closes #709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped opt-in on one client component plus build tooling; behavior is covered by existing and new browser tests, with no auth or data-path changes.
> 
> **Overview**
> Pilots **React Compiler** on the dashboard in **annotation mode** only: adds `babel-plugin-react-compiler`, sets `reactCompiler: { compilationMode: "annotation" }` in `next.config.ts`, and opts in `PoolsContent` on `/pools` with `"use memo"`.
> 
> Adds a Playwright regression that filters swaps by raw pool address while **`poolsSort` / `poolsDir` URL state** stays intact, and records build/browser evidence in `docs/notes/react-compiler-annotation-pilot.md`. The note keeps annotation mode for now (build ~3s slower; no measured render win yet) and defers global `reactCompiler: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1200c5f87abb1c528741f7ebde41864503bcd653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->