### PR TITLE
ci: allow infra environment self review

### DIFF
--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -52,6 +52,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/aegis-terraform.yml
   push:
     branches: [main]
@@ -60,6 +61,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/aegis-terraform.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -51,6 +51,7 @@ on:
       - aegis/terraform/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/aegis-terraform.yml
   push:
     branches: [main]
@@ -58,6 +59,7 @@ on:
       - aegis/terraform/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/aegis-terraform.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -67,6 +67,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/alerts-infra.yml
   push:
     branches: [main]
@@ -75,6 +76,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/alerts-infra.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -66,6 +66,7 @@ on:
       - alerts/infra/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/alerts-infra.yml
   push:
     branches: [main]
@@ -73,6 +74,7 @@ on:
       - alerts/infra/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/alerts-infra.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -60,6 +60,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/alerts-rules.yml
   push:
     branches: [main]
@@ -68,6 +69,7 @@ on:
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
       - scripts/verify-github-environment-protection.mjs
+      - scripts/verify-github-environment-protection.test.mjs
       - .github/workflows/alerts-rules.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -59,6 +59,7 @@ on:
       - alerts/rules/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/alerts-rules.yml
   push:
     branches: [main]
@@ -66,6 +67,7 @@ on:
       - alerts/rules/**
       - scripts/sanitize-terraform-output.sh
       - scripts/notify-terraform-apply.mjs
+      - scripts/verify-github-environment-protection.mjs
       - .github/workflows/alerts-rules.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,8 @@ pnpm alerts:oncall:typecheck / alerts:oncall:test / alerts:oncall:build
 pnpm alerts:rules:lint
 pnpm alerts:rules:init / alerts:rules:plan
 # Apply happens via CI on merge to main for alerts-rules, alerts-delivery, and Aegis.
-# The production-infra gate enforces non-bypassable required-reviewer approval.
+# The production-infra gate enforces required-reviewer approval and allows
+# self-review for the sole-maintainer workflow.
 ```
 
 Terraform stack ownership is registered in `terraform.stacks.json` and

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -93,8 +93,8 @@ Pre-merge requirement for the production-environment split in issue #762:
 repo admins must create both environments in Settings -> Environments before
 merging the workflow change that first references them. GitHub auto-creates a
 missing environment on first workflow use with no protection rules, so
-`production-infra` must already have required reviewers, prevent self-review,
-administrator bypass disabled, and the protected-`main` branch restriction
+`production-infra` must already have required reviewers, self-review allowed
+for the required reviewer, administrator bypass disabled, and the protected-`main` branch restriction
 before any Terraform-changing commit can land on `main`. The Terraform apply
 workflows also verify this configuration before cloud authentication so an
 accidentally auto-created or bypassable environment fails closed before
@@ -105,8 +105,9 @@ repo's Actions workflows:
 
 - `production-infra`: used by Terraform apply jobs in `alerts-infra.yml`,
   `alerts-rules.yml`, and `aegis-terraform.yml`. Copy the required reviewers
-  from the old `production` environment, enable prevent self-review, disable
-  administrator bypass, and limit deployment branches to protected `main`.
+  from the old `production` environment, allow self-review for the required
+  reviewer, disable administrator bypass, and limit deployment branches to
+  protected `main`.
 - `production-services`: used by routine service deploy jobs such as
   `metrics-bridge.yml` and `aegis-app-engine.yml`. Limit deployment branches to
   protected `main`, but leave required reviewers unset by default so green

--- a/scripts/verify-github-environment-protection.mjs
+++ b/scripts/verify-github-environment-protection.mjs
@@ -18,7 +18,7 @@ export function environmentProtectionFailures(environment) {
     failures.push("required reviewers are not configured");
   }
   if (reviewers && reviewers.prevent_self_review !== false) {
-    failures.push("self-review is not enabled for required reviewers");
+    failures.push("self-review is not allowed for required reviewers");
   }
   if (
     branchPolicy?.protected_branches !== true ||

--- a/scripts/verify-github-environment-protection.mjs
+++ b/scripts/verify-github-environment-protection.mjs
@@ -17,8 +17,8 @@ export function environmentProtectionFailures(environment) {
   if (!reviewers || (reviewers.reviewers ?? []).length === 0) {
     failures.push("required reviewers are not configured");
   }
-  if (reviewers?.prevent_self_review !== true) {
-    failures.push("prevent self-review is not enabled");
+  if (reviewers && reviewers.prevent_self_review !== false) {
+    failures.push("self-review is not enabled for required reviewers");
   }
   if (
     branchPolicy?.protected_branches !== true ||

--- a/scripts/verify-github-environment-protection.test.mjs
+++ b/scripts/verify-github-environment-protection.test.mjs
@@ -11,7 +11,7 @@ const protectedEnvironment = {
   protection_rules: [
     {
       type: "required_reviewers",
-      prevent_self_review: true,
+      prevent_self_review: false,
       reviewers: [{ type: "User", reviewer: { login: "approver" } }],
     },
   ],
@@ -32,10 +32,7 @@ assert.deepEqual(
       custom_branch_policies: false,
     },
   }),
-  [
-    "required reviewers are not configured",
-    "prevent self-review is not enabled",
-  ],
+  ["required reviewers are not configured"],
 );
 
 assert.deepEqual(
@@ -44,7 +41,7 @@ assert.deepEqual(
     protection_rules: [
       {
         type: "required_reviewers",
-        prevent_self_review: false,
+        prevent_self_review: true,
         reviewers: [{ type: "User", reviewer: { login: "approver" } }],
       },
     ],
@@ -55,7 +52,7 @@ assert.deepEqual(
   }),
   [
     "admin bypass is not disabled",
-    "prevent self-review is not enabled",
+    "self-review is not enabled for required reviewers",
     "deployment branches are not limited to protected branches",
   ],
 );

--- a/scripts/verify-github-environment-protection.test.mjs
+++ b/scripts/verify-github-environment-protection.test.mjs
@@ -52,9 +52,26 @@ assert.deepEqual(
   }),
   [
     "admin bypass is not disabled",
-    "self-review is not enabled for required reviewers",
+    "self-review is not allowed for required reviewers",
     "deployment branches are not limited to protected branches",
   ],
+);
+
+assert.deepEqual(
+  environmentProtectionFailures({
+    can_admins_bypass: false,
+    protection_rules: [
+      {
+        type: "required_reviewers",
+        reviewers: [{ type: "User", reviewer: { login: "approver" } }],
+      },
+    ],
+    deployment_branch_policy: {
+      protected_branches: true,
+      custom_branch_policies: false,
+    },
+  }),
+  ["self-review is not allowed for required reviewers"],
 );
 
 assert.deepEqual(


### PR DESCRIPTION
## The Problem

- The new `production-infra` environment blocks Terraform applies when the sole maintainer merged the triggering PR.
- The repo verifier currently requires `prevent_self_review`, so flipping GitHub settings alone would still fail the apply job.

## The Solution

- Allow self-review for the required `production-infra` reviewer while keeping required reviewers, disabled admin bypass, and protected-`main` deployment restrictions.
- Update the verifier tests and docs to match the sole-maintainer approval model.
- Include the verifier script in Terraform apply workflow path filters so future guard changes run the relevant plan workflows.

## Validation

- `node scripts/verify-github-environment-protection.test.mjs`
- `pnpm tf:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Post-Merge

- Update the live `production-infra` GitHub Environment to set `prevent_self_review: false` on the required reviewers rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This relaxes the Terraform apply gate’s separation-of-duties check while still requiring reviewers and other protections; live GitHub environment settings must be updated post-merge or applies will keep failing the verifier.
> 
> **Overview**
> Unblocks **Terraform apply** when a sole maintainer merges the change that triggered the run, by aligning CI with GitHub’s **self-review allowed** setting on `production-infra`.
> 
> **`environmentProtectionFailures`** in `verify-github-environment-protection.mjs` no longer requires `prevent_self_review: true`; it now **fails** when self-review is **not** allowed (`prevent_self_review !== false`). Required reviewers, disabled admin bypass, and protected-`main` deployment branches are unchanged.
> 
> Tests, **`AGENTS.md`**, and **`docs/terraform.md`** describe the sole-maintainer model. The three Terraform apply workflows (`aegis-terraform`, `alerts-infra`, `alerts-rules`) list the verifier script and its test file in **path filters** so edits to that guard still run those workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1920944f7af04d0dbfeeb0388ad64d1020647701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->