### PR TITLE
docs: retire production environment shim

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -113,11 +113,10 @@ repo's Actions workflows:
   protected `main`, but leave required reviewers unset by default so green
   `main` deploys do not require an extra human approval.
 
-Keep the old `production` environment only as a temporary migration shim while
-older workflow runs drain. Once no workflow references it, remove or deprecate
-it in the repository settings. Do not move or recreate secrets with CLI
-commands; any environment-scoped secret changes must go through the owning IaC
-or a documented repo-admin settings change.
+The old `Production` migration-shim environment was removed on 2026-06-17 after
+workflow references drained. Do not recreate it. Do not move or recreate secrets
+with CLI commands; any environment-scoped secret changes must go through the
+owning IaC or a documented repo-admin settings change.
 
 ## Grafana Alert Ownership Migration
 


### PR DESCRIPTION
## The Problem

- The Terraform runbook still described the old `Production` GitHub Environment as a temporary migration shim.
- That environment has now been removed, so future operators should not recreate it by following stale docs.

## The Solution

- Update the GitHub Environment setup docs to record that the old `Production` shim was removed on 2026-06-17 and should stay removed.

## Details

- Keeps the current expected production environments as `production-infra` and `production-services`.
- Preserves the existing IaC-first warning for environment-scoped secrets.
- Docs-only change.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- `git diff --check`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to the Terraform runbook with no workflow or infrastructure changes.
> 
> **Overview**
> Updates **`docs/terraform.md`** so the GitHub Environment section matches reality after the migration: the former temporary **`Production`** shim is **gone as of 2026-06-17**, and operators must **not** recreate it.
> 
> The runbook still documents the two supported environments—**`production-infra`** and **`production-services`**—and keeps the IaC-first note for environment-scoped secrets; only the shim lifecycle wording changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9400882a18304e50434a237317138326d928bf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->