### PR TITLE
fix: skip Vercel builds without local git

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,11 +129,15 @@ The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](
 
 Terraform stack ownership is registered in [`terraform.stacks.json`](../terraform.stacks.json) and summarized in [`docs/terraform.md`](./terraform.md). The dashboard/platform stack lives in [`terraform/`](../terraform/). The team-level Vercel Blob store is managed through Vercel Storage and linked to the project outside Terraform. The platform stack covers:
 
-- Vercel project creation and configuration (`root_directory`, `ignore_command`, Git integration)
+- Vercel project creation and configuration (`root_directory`, Git integration)
 - All Terraform-managed environment variables (Hasura URLs, Upstash Redis credentials)
 - Custom domain (`monitoring.mento.org`)
 - Upstash Redis database (address labels storage)
 - Monitoring GCP project/APIs, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, and CI WIF/IAM
+
+The path-aware Vercel ignore command lives in
+[`ui-dashboard/vercel.json`](../ui-dashboard/vercel.json), not Terraform, so the
+script can be reviewed and tested with dashboard changes.
 
 **State is stored remotely** in GCS at `gs://mento-terraform-tfstate-6ed6/monitoring-monorepo/`. No local backup is needed — GCS is the source of truth and has object versioning enabled.
 
@@ -344,22 +348,26 @@ envio
 The dashboard project intentionally skips builds when no dashboard-affecting
 files changed. The skip script is `ui-dashboard/scripts/vercel-ignore-build.sh`;
 it watches `ui-dashboard/`, `shared-config/`, and workspace dependency metadata.
-The script tries three anchors in order:
+The script uses local Git metadata when available, then falls back to GitHub's
+API when Vercel has stripped `.git` from the uploaded source. It tries three
+anchors in order:
 
 1. **PR preview deployments** — Vercel provides `VERCEL_GIT_PULL_REQUEST_ID`,
-   and the script diffs from the merge base with `origin/main`.
+   and the script diffs from the merge base with `origin/main` or, without local
+   Git metadata, from GitHub's paginated PR file list.
 2. **First-push branch fallback** — when Vercel ships neither
    `VERCEL_GIT_PULL_REQUEST_ID` nor `VERCEL_GIT_PREVIOUS_SHA` (which happens
-   when `git push` outruns `gh pr create`), the script falls back to the
-   merge base with `origin/main` as long as `VERCEL_GIT_COMMIT_REF` points
-   at a non-`main` branch.
+   when `git push` outruns `gh pr create`), the script falls back to the merge
+   base with `origin/main` when local Git exists. Without local Git, it uses the
+   GitHub compare API only for single-commit branch pushes; multi-commit branch
+   fallbacks build to avoid false skips.
 3. **Subsequent branch / production deployments** — `VERCEL_GIT_PREVIOUS_SHA`
-   is set, so the script diffs from that SHA to keep the resource-saving
-   behavior.
+   is set, so the script diffs from that SHA locally or through GitHub compare
+   to keep the resource-saving behavior.
 
-If a dashboard-affecting change was skipped, check that the relevant base
-commit is present in the shallow clone. For env-only changes that require a
-fresh production runtime, run the manual deploy from the monorepo root:
+If the script cannot prove a deployment is dashboard-clean, it builds. For
+env-only changes that require a fresh production runtime, run the manual deploy
+from the monorepo root:
 
 ```bash
 vercel deploy --prod --force --with-cache --archive=tgz --yes

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -50,6 +50,11 @@ tldr: rename/remove resources REQUIRE a `moved` block (`deletion_protection = tr
 
 tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) MUST NOT use `paths:`/`paths-ignore:` (skipped runs = pending forever); **advisory** workflows SHOULD use `paths:` to avoid booting a runner on irrelevant PRs (CI-cost control). Deploy jobs MUST gate on `if: github.ref == 'refs/heads/main'`. Third-party actions MUST be SHA-pinned; `node scripts/check-github-action-pins.mjs` enforces this in Code Quality. Concurrency group with `cancel-in-progress: false`. Cache keys MUST include every input that affects the cached output. Full rules in the linked checklist.
 
+### Marker-based setup/cache scripts
+
+- If a setup/cache script uses marker files or input hashes to skip work, the skip condition MUST verify the actual output that downstream commands need, not just the marker. Examples: dependency skips should verify a representative package resolves, Playwright skips should verify the browser executable exists, and codegen skips should verify the generated facade file exists.
+- Write marker files only after every validation step represented by that marker has passed. A failed post-install validation must not leave a fresh marker that makes the next run skip the install or rebuild path.
+
 ### File-size budget
 
 - Source files MUST stay under **600 lines** (soft cap, advisory). If your change would push a file over 600 lines, split it in the same PR — extract sub-components, helpers, or per-domain modules. Don't append "just one more thing" to a file that's already drifting up.

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -23,6 +23,137 @@ dashboard_paths=(
 
 pull_request_id="${VERCEL_GIT_PULL_REQUEST_ID:-}"
 commit_ref="${VERCEL_GIT_COMMIT_REF:-}"
+commit_sha="${VERCEL_GIT_COMMIT_SHA:-}"
+repo_owner="${VERCEL_GIT_REPO_OWNER:-mento-protocol}"
+repo_slug="${VERCEL_GIT_REPO_SLUG:-monitoring-monorepo}"
+github_api_base="${GITHUB_API_BASE_URL:-https://api.github.com}"
+
+has_git_repo() {
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+skip_or_build_from_files() {
+  local changed_files="$1"
+  local skip_message="$2"
+  local build_message="$3"
+
+  local changed_file dashboard_path
+  while IFS= read -r changed_file; do
+    [[ -n "$changed_file" ]] || continue
+    for dashboard_path in "${dashboard_paths[@]}"; do
+      case "$changed_file" in
+        "$dashboard_path" | "$dashboard_path"/*)
+          echo "$build_message"
+          exit 1
+          ;;
+      esac
+    done
+  done <<<"$changed_files"
+
+  echo "$skip_message"
+  exit 0
+}
+
+github_changed_files() {
+  local mode="$1"
+  local base_ref="$2"
+  local head_ref="$3"
+
+  GITHUB_DIFF_MODE="$mode" \
+    GITHUB_DIFF_BASE="$base_ref" \
+    GITHUB_DIFF_HEAD="$head_ref" \
+    GITHUB_API_BASE_URL="$github_api_base" \
+    GITHUB_REPO_OWNER="$repo_owner" \
+    GITHUB_REPO_SLUG="$repo_slug" \
+    node <<'NODE'
+const mode = process.env.GITHUB_DIFF_MODE;
+const baseRef = process.env.GITHUB_DIFF_BASE;
+const headRef = process.env.GITHUB_DIFF_HEAD;
+const apiBase = process.env.GITHUB_API_BASE_URL;
+const owner = process.env.GITHUB_REPO_OWNER;
+const repo = process.env.GITHUB_REPO_SLUG;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "monitoring-monorepo-vercel-ignore-build",
+};
+if (token) {
+  headers.Authorization = `Bearer ${token}`;
+}
+
+function apiUrl(path) {
+  return new URL(path, `${apiBase.replace(/\/+$/, "")}/`);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText} from ${url}`);
+  }
+  return response.json();
+}
+
+async function listPrFiles(prNumber) {
+  const files = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const url = apiUrl(
+      `/repos/${owner}/${repo}/pulls/${encodeURIComponent(
+        prNumber,
+      )}/files?per_page=100&page=${page}`,
+    );
+    const pageFiles = await fetchJson(url);
+    if (!Array.isArray(pageFiles)) {
+      throw new Error("GitHub PR files response was not an array");
+    }
+    files.push(...pageFiles.map((file) => file.filename).filter(Boolean));
+    if (pageFiles.length < 100) {
+      return files;
+    }
+  }
+  throw new Error("GitHub PR file list exceeded pagination safety limit");
+}
+
+async function compareFiles(base, head, singleCommitOnly) {
+  const url = apiUrl(
+    `/repos/${owner}/${repo}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
+  );
+  const comparison = await fetchJson(url);
+  if (singleCommitOnly && comparison.ahead_by > 1) {
+    throw new Error(
+      `branch fallback has ${comparison.ahead_by} commits; build instead of risking a false skip`,
+    );
+  }
+  if (!Array.isArray(comparison.files)) {
+    throw new Error("GitHub compare response did not include files");
+  }
+  if (comparison.files.length >= 300) {
+    throw new Error("GitHub compare response may be truncated at 300 files");
+  }
+  return comparison.files.map((file) => file.filename).filter(Boolean);
+}
+
+try {
+  let files;
+  if (mode === "pr") {
+    files = await listPrFiles(headRef);
+  } else if (mode === "branch-first") {
+    files = await compareFiles(baseRef, headRef, true);
+  } else if (mode === "compare") {
+    files = await compareFiles(baseRef, headRef, false);
+  } else {
+    throw new Error(`unknown diff mode: ${mode}`);
+  }
+  console.log(files.join("\n"));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+NODE
+}
 
 skip_or_build_from_base() {
   local base_sha="$1"
@@ -41,6 +172,8 @@ skip_or_build_from_base() {
 resolve_main_merge_base() {
   local production_ref="origin/main"
 
+  has_git_repo || return 1
+
   if ! git cat-file -e "${production_ref}^{commit}" 2>/dev/null; then
     git fetch --quiet origin "main:refs/remotes/${production_ref}" 2>/dev/null
   fi
@@ -52,6 +185,13 @@ if [[ -n "$pull_request_id" ]]; then
   if pr_base_sha="$(resolve_main_merge_base)"; then
     skip_or_build_from_base \
       "$pr_base_sha" \
+      "No dashboard-affecting changes in PR #${pull_request_id}; skipping build." \
+      "Dashboard-affecting changes detected in PR #${pull_request_id}; building dashboard."
+  fi
+
+  if changed_files="$(github_changed_files pr "" "$pull_request_id")"; then
+    skip_or_build_from_files \
+      "$changed_files" \
       "No dashboard-affecting changes in PR #${pull_request_id}; skipping build." \
       "Dashboard-affecting changes detected in PR #${pull_request_id}; building dashboard."
   fi
@@ -74,6 +214,14 @@ if [[ -z "$base_sha" ]]; then
         "Dashboard-affecting changes detected on branch ${commit_ref} vs main; building dashboard."
     fi
 
+    if [[ -n "$commit_sha" ]] &&
+      changed_files="$(github_changed_files branch-first main "$commit_sha")"; then
+      skip_or_build_from_files \
+        "$changed_files" \
+        "No dashboard-affecting changes on branch ${commit_ref} vs main; skipping build." \
+        "Dashboard-affecting changes detected on branch ${commit_ref} vs main; building dashboard."
+    fi
+
     echo "Could not resolve origin/main for branch ${commit_ref}; building dashboard."
     exit 1
   fi
@@ -83,6 +231,14 @@ if [[ -z "$base_sha" ]]; then
 fi
 
 if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+  if [[ -n "$commit_sha" ]] &&
+    changed_files="$(github_changed_files compare "$base_sha" "$commit_sha")"; then
+    skip_or_build_from_files \
+      "$changed_files" \
+      "No dashboard-affecting changes since previous successful Vercel deployment; skipping build." \
+      "Dashboard-affecting changes detected since previous successful Vercel deployment; building dashboard."
+  fi
+
   echo "Previous Vercel SHA ${base_sha} is unavailable in this clone; building dashboard."
   exit 1
 fi

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 fixture_repo="$(mktemp -d)"
 output_file="$(mktemp)"
-trap 'rm -rf "$fixture_repo"; rm -f "$output_file"' EXIT
+mock_server_pid=""
+mock_api_base=""
+trap '[[ -z "$mock_server_pid" ]] || kill "$mock_server_pid" 2>/dev/null || true; rm -rf "$fixture_repo"; rm -f "$output_file"' EXIT
 
 fail() {
   echo "vercel-ignore-build test failed: $*" >&2
   echo >&2
   echo "Last output:" >&2
   sed 's/^/  /' "$output_file" >&2
+  if [[ -f "$fixture_repo/mock-github-api.log" ]]; then
+    echo >&2
+    echo "Mock GitHub API log:" >&2
+    sed 's/^/  /' "$fixture_repo/mock-github-api.log" >&2
+  fi
   exit 1
 }
 
@@ -40,6 +47,89 @@ assert_output_contains() {
   local expected="$1"
   grep -Fq "$expected" "$output_file" ||
     fail "expected output to contain: ${expected}"
+}
+
+start_mock_github_api() {
+  local port_file="$fixture_repo/mock-github-api-port"
+
+  cat >"$fixture_repo/mock-github-api.mjs" <<'NODE'
+import http from "node:http";
+import { writeFileSync } from "node:fs";
+
+const portFile = process.argv[2];
+
+const responses = new Map([
+  [
+    "/repos/mento-protocol/monitoring-monorepo/pulls/982/files",
+    [{ filename: "docs/pr-checklists/recurring-review-patterns.md" }],
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/pulls/983/files",
+    [{ filename: "ui-dashboard/src/app/page.tsx" }],
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/main...sha-docs",
+    {
+      ahead_by: 1,
+      files: [{ filename: "docs/pr-checklists/recurring-review-patterns.md" }],
+    },
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/main...sha-dashboard",
+    { ahead_by: 1, files: [{ filename: "ui-dashboard/src/app/page.tsx" }] },
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/main...sha-multi-docs",
+    {
+      ahead_by: 2,
+      files: [{ filename: "docs/pr-checklists/recurring-review-patterns.md" }],
+    },
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/previous-sha...sha-docs",
+    {
+      ahead_by: 1,
+      files: [{ filename: "docs/pr-checklists/recurring-review-patterns.md" }],
+    },
+  ],
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/previous-sha...sha-dashboard",
+    { ahead_by: 1, files: [{ filename: "ui-dashboard/src/app/page.tsx" }] },
+  ],
+]);
+
+const server = http.createServer((request, response) => {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  console.error(url.pathname);
+  const body = responses.get(url.pathname);
+
+  if (!body) {
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ message: `no fixture for ${url.pathname}` }));
+    return;
+  }
+
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock server did not bind to a TCP port");
+  }
+  writeFileSync(portFile, String(address.port));
+});
+NODE
+
+  node "$fixture_repo/mock-github-api.mjs" "$port_file" >"$fixture_repo/mock-github-api.log" 2>&1 &
+  mock_server_pid=$!
+  for _ in {1..50}; do
+    [[ -s "$port_file" ]] && break
+    sleep 0.1
+  done
+  [[ -s "$port_file" ]] || fail "mock GitHub API did not start"
+  mock_api_base="http://127.0.0.1:$(cat "$port_file")"
 }
 
 mkdir -p "$fixture_repo/ui-dashboard/scripts" "$fixture_repo/shared-config"
@@ -100,12 +190,77 @@ expect_build "branch fallback only triggers on non-main commit ref" \
   VERCEL_GIT_COMMIT_REF=main
 assert_output_contains "No VERCEL_GIT_PREVIOUS_SHA; building dashboard."
 
+start_mock_github_api
+nogit_repo="$fixture_repo/no-git"
+mkdir -p "$nogit_repo/ui-dashboard/scripts"
+cp "$repo_root/ui-dashboard/scripts/vercel-ignore-build.sh" "$nogit_repo/ui-dashboard/scripts/vercel-ignore-build.sh"
+
+cd "$nogit_repo"
+
+expect_skip "PR docs-only changes skip without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PULL_REQUEST_ID=982
+assert_output_contains "No dashboard-affecting changes in PR #982"
+
+expect_build "PR dashboard changes build without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PULL_REQUEST_ID=983
+assert_output_contains "Dashboard-affecting changes detected in PR #983"
+
+expect_skip "branch first push docs-only change skips without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_COMMIT_REF=docs-only \
+  VERCEL_GIT_COMMIT_SHA=sha-docs
+assert_output_contains "No dashboard-affecting changes on branch docs-only vs main"
+
+expect_build "branch first push dashboard change builds without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_COMMIT_REF=dashboard-pr \
+  VERCEL_GIT_COMMIT_SHA=sha-dashboard
+assert_output_contains "Dashboard-affecting changes detected on branch dashboard-pr vs main"
+
+expect_build "branch first push multi-commit fallback builds without local git" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_COMMIT_REF=docs-only \
+  VERCEL_GIT_COMMIT_SHA=sha-multi-docs
+assert_output_contains "Could not resolve origin/main for branch docs-only"
+
+expect_skip "previous SHA docs-only change skips without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PREVIOUS_SHA=previous-sha \
+  VERCEL_GIT_COMMIT_SHA=sha-docs
+assert_output_contains "No dashboard-affecting changes since previous successful Vercel deployment"
+
+expect_build "previous SHA dashboard change builds without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PREVIOUS_SHA=previous-sha \
+  VERCEL_GIT_COMMIT_SHA=sha-dashboard
+assert_output_contains "Dashboard-affecting changes detected since previous successful Vercel deployment"
+
+cd "$fixture_repo"
+
 git update-ref -d refs/remotes/origin/main
 expect_build "PR falls back to build when origin/main is unavailable" \
+  GITHUB_API_BASE_URL=http://127.0.0.1:9 \
   VERCEL_GIT_PULL_REQUEST_ID=409
 assert_output_contains "Could not resolve origin/main for PR #409; building dashboard."
 
 expect_build "branch fallback falls back to build when origin/main is unavailable" \
+  GITHUB_API_BASE_URL=http://127.0.0.1:9 \
   VERCEL_GIT_COMMIT_REF=docs-only
 assert_output_contains "Could not resolve origin/main for branch docs-only; building dashboard."
 


### PR DESCRIPTION
## The Problem

- Vercel preview builds were running for docs-only PRs even though the dashboard ignore script is supposed to skip non-dashboard changes.
- The ignore script depended on local Git metadata, but Vercel strips `.git` before running `ignoreCommand`.

## The Solution

- Keep the local Git path for normal/test checkouts, and add a GitHub API fallback for Vercel's stripped source tree.
- Preserve fail-open behavior: when the script cannot prove a deployment is dashboard-clean, it builds.

## Details

- PR previews use GitHub's paginated PR file list when local Git is unavailable.
- Previous-SHA deployments use GitHub compare when the previous commit is not present locally.
- First-push branch deployments use GitHub compare only for single-commit branch pushes; multi-commit branch fallbacks build to avoid false skips.
- Adds the marker-based setup/cache review rule that started this mini PR.
- Updates deployment docs to describe the real ignore-command ownership and fallback behavior.

## Validation

- `bash -n ui-dashboard/scripts/vercel-ignore-build.sh ui-dashboard/scripts/vercel-ignore-build.test.sh`
- `bash ui-dashboard/scripts/vercel-ignore-build.test.sh`
- `./tools/trunk fmt ui-dashboard/scripts/vercel-ignore-build.sh ui-dashboard/scripts/vercel-ignore-build.test.sh docs/deployment.md`
- `./tools/trunk check ui-dashboard/scripts/vercel-ignore-build.sh ui-dashboard/scripts/vercel-ignore-build.test.sh docs/deployment.md`
- `pnpm lint:scripts`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vercel production/preview build gating; conservative fallbacks reduce false skips but misclassified paths or API edge cases could still skip or over-build.
> 
> **Overview**
> **Vercel’s dashboard skip script** now works when Vercel uploads source **without** a `.git` directory: it still prefers local `git diff` / merge-base logic, but falls back to GitHub (paginated PR file lists and compare API) using `VERCEL_GIT_*` metadata and optional `GITHUB_TOKEN`. Ambiguous cases **default to building**—e.g. multi-commit branch fallbacks without local git, API errors, or compare responses with ≥300 files.
> 
> The script gains shared path-matching via `skip_or_build_from_files`, a small embedded **Node** helper for API calls, and **shell tests** with a mock GitHub HTTP server covering no-git PR, branch-first, and previous-SHA scenarios.
> 
> **Docs:** `deployment.md` notes the ignore command lives in `ui-dashboard/vercel.json` (not Terraform) and documents the git-then-API anchor order. **Recurring review patterns** add rules for marker-based setup/cache scripts: verify real outputs before skipping, and write markers only after validations pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a47093aaaf7f2a7c034a7d320c4c843821d7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->