### PR TITLE
Clarify Codex usage-limit readiness handling

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -187,11 +187,11 @@ Field expectations:
   needs `kind`, `name`, `state`, and `required: false`.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
-- `codexReviewSignal`: current-head Codex review-request state. Values are
+- `codexReviewSignal`: current-head Codex review state. Values are
   `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
   means a current-head `@codex review` request exists but no bot reaction or
-  review has been observed yet. `in_flight` means the current-head request has
-  a Codex `eyes` reaction, a current-head Codex review, or a current-head Codex
+  review has been observed yet. `in_flight` means the current head has a Codex
+  `eyes` reaction, a current-head Codex review, or a current-head Codex
   top-level result. `approved` means the final PR-description `+1` gate is
   present. `stale` means only older-head Codex signals exist.
 - `requiredStatusContexts[]`: required check contexts from classic branch
@@ -246,7 +246,7 @@ reached, stop posting duplicate `@codex review` requests and let
 `requested` or `in_flight`, keep watching until Codex approves, posts new
 feedback, or the signal becomes stale. Treat the Codex PR-description approval
 as externally blocked only when approval is still missing and no current-head
-review request is in progress; it remains blocked until quota/settings are
+Codex signal is in progress; it remains blocked until quota/settings are
 restored or the gate is intentionally overridden.
 
 ## Babysitting Speed Discipline

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -241,8 +241,12 @@ existing current-head request is `requested`, `in_flight`, or `approved`. A
 manual `@codex review` is only a fallback when the current head has no Codex
 signal after the normal automatic-review window.
 If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
-reached, stop posting further `@codex review` requests. The Codex
-PR-description approval remains externally blocked until quota/settings are
+reached, stop posting duplicate `@codex review` requests and let
+`codexReviewSignal` decide the next action. If the current head is already
+`requested` or `in_flight`, keep watching until Codex approves, posts new
+feedback, or the signal becomes stale. Treat the Codex PR-description approval
+as externally blocked only when approval is still missing and no current-head
+review request is in progress; it remains blocked until quota/settings are
 restored or the gate is intentionally overridden.
 
 ## Babysitting Speed Discipline

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -241,13 +241,14 @@ existing current-head request is `requested`, `in_flight`, or `approved`. A
 manual `@codex review` is only a fallback when the current head has no Codex
 signal after the normal automatic-review window.
 If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
-reached, stop posting duplicate `@codex review` requests and let
-`codexReviewSignal` decide the next action. If the current head is already
-`requested` or `in_flight`, keep watching until Codex approves, posts new
-feedback, or the signal becomes stale. Treat the Codex PR-description approval
-as externally blocked only when approval is still missing and no current-head
-Codex signal is in progress; it remains blocked until quota/settings are
-restored or the gate is intentionally overridden.
+reached, stop posting duplicate `@codex review` requests and inspect whether
+the limit reply is the current-head Codex result. If it is current-head and
+approval is still missing, treat the Codex PR-description approval as
+externally blocked even if `codexReviewSignal` reports `in_flight`; quota or
+settings must change, or the gate must be intentionally overridden. If the
+limit reply is only historical and the current head is `requested` or
+`in_flight` for another Codex signal, keep watching until Codex approves, posts
+new feedback, or the signal becomes stale.
 
 ## Babysitting Speed Discipline
 


### PR DESCRIPTION
## The Problem

- The PR readiness docs treated Codex usage-limit replies as an immediate external blocker.
- In practice, a current-head Codex request can still be requested or in flight after such a reply.

## The Solution

- Clarify that agents should stop duplicate Codex review pings, but continue watching when the current-head Codex signal is requested or in flight.
- Treat the approval gate as externally blocked only when no current-head review request is progressing.

## Details

- Docs-only follow-up from the PR #984 babysit/reflection loop.
- Keeps `codexReviewSignal` as the source of truth for the next action.

## Validation

- `git diff --check`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent readiness guidance; no runtime or auth/data paths modified.
> 
> **Overview**
> Updates **`docs/notes/pr-ready-state.md`** so PR babysitters handle Codex **usage-limit** replies without treating every limit message as an immediate external blocker.
> 
> **`codexReviewSignal`** wording is tightened to describe current-head Codex review state (including when `in_flight` applies to eyes, reviews, or top-level results). When **`chatgpt-codex-connector[bot]`** reports code-review usage limits, agents should stop duplicate `@codex review` pings, then branch on whether that reply is **current-head**: if it is and PR-description approval is still missing, treat approval as externally blocked even when the signal is `in_flight`; if the limit is only historical but the head is still `requested` or `in_flight`, keep watching until approval, new feedback, or staleness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fc83d90cd8d6d9286db7605c14d2ab41ef2e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->