### PR TITLE
perf: skip redundant Vercel preview builds

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,7 +39,6 @@ on:
     paths:
       - ui-dashboard/**
       - shared-config/**
-      - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
       - patches/**
@@ -113,7 +112,6 @@ jobs:
             dashboard:
               - ui-dashboard/**
               - shared-config/**
-              - package.json
               - pnpm-lock.yaml
               - pnpm-workspace.yaml
               - patches/**

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,6 +39,7 @@ on:
     paths:
       - ui-dashboard/**
       - shared-config/**
+      - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
       - patches/**
@@ -112,6 +113,7 @@ jobs:
             dashboard:
               - ui-dashboard/**
               - shared-config/**
+              - package.json
               - pnpm-lock.yaml
               - pnpm-workspace.yaml
               - patches/**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -121,7 +121,7 @@ commit:
 
 ## Dashboard Deployment (Vercel)
 
-**Vercel's native Git integration watches `main`** — every push that changes dashboard-affecting files triggers an automatic production deploy. Pushes that only touch unrelated directories (e.g. `terraform/`, `indexer-envio/`) are skipped by `ui-dashboard/scripts/vercel-ignore-build.sh`. PR preview deployments compare the PR diff against `origin/main`, so docs-only PRs skip even when `main` has had dashboard changes since the last successful production deployment.
+**Vercel's native Git integration watches `main`** — every push that changes dashboard-affecting files triggers an automatic production deploy. Pushes that only touch unrelated directories (e.g. `terraform/`, `indexer-envio/`) are skipped by `ui-dashboard/scripts/vercel-ignore-build.sh`. PR preview deployments diff each push incrementally against that branch's previous preview deployment (falling back to the merge base with `origin/main` on a branch's first push). So a docs-only PR skips, and once a branch's dashboard change has been previewed, later non-dashboard commits on the same branch skip too instead of rebuilding the whole branch on every push.
 
 The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](https://monitoring.mento.org).
 
@@ -352,9 +352,13 @@ The script uses local Git metadata when available, then falls back to GitHub's
 API when Vercel has stripped `.git` from the uploaded source. It tries three
 anchors in order:
 
-1. **PR preview deployments** — Vercel provides `VERCEL_GIT_PULL_REQUEST_ID`,
-   and the script diffs from the merge base with `origin/main` or, without local
-   Git metadata, from GitHub's paginated PR file list.
+1. **PR preview deployments** — Vercel provides `VERCEL_GIT_PULL_REQUEST_ID`.
+   When the branch already has a previous deployment (`VERCEL_GIT_PREVIOUS_SHA`),
+   the script diffs incrementally from that SHA — locally or via GitHub compare —
+   so intermediate pushes that don't touch the dashboard skip instead of
+   rebuilding the whole branch. On the first push (no previous deployment) it
+   diffs from the merge base with `origin/main`, or, without local Git metadata,
+   from GitHub's paginated PR file list.
 2. **First-push branch fallback** — when Vercel ships neither
    `VERCEL_GIT_PULL_REQUEST_ID` nor `VERCEL_GIT_PREVIOUS_SHA` (which happens
    when `git push` outruns `gh pr create`), the script falls back to the merge

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -8,12 +8,15 @@ cd "$repo_root"
 dashboard_paths=(
   "ui-dashboard"
   "shared-config"
-  # Root package.json is intentionally NOT watched: it only carries workspace
-  # scripts and root devDeps, which never enter the dashboard build. A
-  # build-relevant root change (e.g. a `pnpm.overrides` edit that re-pins a
-  # dashboard dependency) always co-changes `pnpm-lock.yaml`, which IS watched —
-  # so we skip the frequent script/devDep-only root edits (agent tooling, alert
-  # linters) without losing real coverage.
+  # Root package.json IS watched: it pins `packageManager` (the pnpm version
+  # Vercel installs/builds the dashboard with) and carries `pnpm.overrides` /
+  # `pnpm.patchedDependencies`, all of which shape the dashboard build
+  # environment. A `packageManager`-only bump (and some override/patch edits)
+  # changes that toolchain WITHOUT touching `pnpm-lock.yaml`, so watching the
+  # lockfile alone would false-skip a real build-environment change. Matches as
+  # an exact filename via the `"$dashboard_path"` case below (no `/*` children,
+  # same as `pnpm-lock.yaml`).
+  "package.json"
   "pnpm-lock.yaml"
   "pnpm-workspace.yaml"
   "patches"

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -230,6 +230,17 @@ if [[ -n "$pull_request_id" ]]; then
         "No dashboard-affecting changes since previous deployment for PR #${pull_request_id}; skipping build." \
         "Dashboard-affecting changes detected since previous deployment for PR #${pull_request_id}; building dashboard."
     fi
+
+    # We have a previous deployment for this branch but could not compare it to
+    # HEAD: the previous SHA is absent from this (gitless/shallow) clone AND the
+    # GitHub compare was rejected — either because the histories diverged
+    # (compareFiles fails closed on a non-ancestor base after a force-push) or
+    # the compare API was unreachable. Do NOT fall through to the PR-vs-main
+    # diff: the preview alias still serves the previous build, which may carry
+    # dashboard changes HEAD no longer has, so a PR-vs-main skip would strand a
+    # stale dashboard preview. Fail closed and build.
+    echo "Previous deployment ${previous_sha} could not be compared to HEAD for PR #${pull_request_id}; building dashboard."
+    exit 1
   fi
 
   if pr_base_sha="$(resolve_main_merge_base)"; then

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -128,6 +128,23 @@ async function compareFiles(base, head, singleCommitOnly) {
     `/repos/${owner}/${repo}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
   );
   const comparison = await fetchJson(url);
+  // GitHub's /compare/base...head endpoint is THREE-DOT (merge-base) semantics:
+  // its file list only reflects head-side changes since the merge-base. After a
+  // PR branch rebase/force-push the previous-deployment `base` is no longer an
+  // ancestor of `head`, so a dashboard change present in the deployed preview
+  // but diverged from head can be OMITTED from this list — authorizing a FALSE
+  // SKIP that serves stale dashboard code. The file list is only a safe basis
+  // for a skip when `base` is proven an ancestor of `head`: status "ahead"/
+  // "identical" with behind_by === 0. If histories diverged ("diverged"/
+  // "behind", behind_by > 0), fail closed so the bash caller falls through to
+  // the full-PR-files diff / merge-base / build. Treat a missing/undefined
+  // behind_by conservatively as 0 (ancestor) so callers/fixtures that don't
+  // surface the field still skip on a clean ahead-only compare.
+  if (comparison.behind_by > 0) {
+    throw new Error(
+      `compare base is not an ancestor of head (behind_by=${comparison.behind_by}, status=${comparison.status}); build instead of risking a false skip`,
+    );
+  }
   if (singleCommitOnly && comparison.ahead_by > 1) {
     throw new Error(
       `branch fallback has ${comparison.ahead_by} commits; build instead of risking a false skip`,

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -140,14 +140,18 @@ async function compareFiles(base, head, singleCommitOnly) {
   // for a skip when `base` is proven an ancestor of `head`: status "ahead"/
   // "identical" with behind_by === 0. If histories diverged ("diverged"/
   // "behind", behind_by > 0), fail closed so the bash caller falls through to
-  // the full-PR-files diff / merge-base / build. Treat a missing/undefined
-  // behind_by conservatively as 0 (ancestor) so callers/fixtures that don't
-  // surface the field still skip on a clean ahead-only compare.
-  if (comparison.behind_by > 0) {
+  // the full-PR-files diff / merge-base / build. An absent `behind_by` is
+  // treated as 0 (assume ancestor); GitHub always includes the field on a real
+  // compare response, so this only matters for callers/fixtures that omit it.
+  if ((comparison.behind_by ?? 0) > 0) {
     throw new Error(
       `compare base is not an ancestor of head (behind_by=${comparison.behind_by}, status=${comparison.status}); build instead of risking a false skip`,
     );
   }
+  // singleCommitOnly is irrelevant once behind_by === 0 proves `base` is an
+  // ancestor of `head`: three-dot then collapses to two-dot, so the net diff
+  // over N commits is a safe basis for a skip. It only guards branch-first mode,
+  // where no ancestry is established.
   if (singleCommitOnly && comparison.ahead_by > 1) {
     throw new Error(
       `branch fallback has ${comparison.ahead_by} commits; build instead of risking a false skip`,

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -8,7 +8,12 @@ cd "$repo_root"
 dashboard_paths=(
   "ui-dashboard"
   "shared-config"
-  "package.json"
+  # Root package.json is intentionally NOT watched: it only carries workspace
+  # scripts and root devDeps, which never enter the dashboard build. A
+  # build-relevant root change (e.g. a `pnpm.overrides` edit that re-pins a
+  # dashboard dependency) always co-changes `pnpm-lock.yaml`, which IS watched —
+  # so we skip the frequent script/devDep-only root edits (agent tooling, alert
+  # linters) without losing real coverage.
   "pnpm-lock.yaml"
   "pnpm-workspace.yaml"
   "patches"
@@ -24,6 +29,7 @@ dashboard_paths=(
 pull_request_id="${VERCEL_GIT_PULL_REQUEST_ID:-}"
 commit_ref="${VERCEL_GIT_COMMIT_REF:-}"
 commit_sha="${VERCEL_GIT_COMMIT_SHA:-}"
+previous_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
 repo_owner="${VERCEL_GIT_REPO_OWNER:-mento-protocol}"
 repo_slug="${VERCEL_GIT_REPO_SLUG:-monitoring-monorepo}"
 github_api_base="${GITHUB_API_BASE_URL:-https://api.github.com}"
@@ -182,6 +188,30 @@ resolve_main_merge_base() {
 }
 
 if [[ -n "$pull_request_id" ]]; then
+  # Prefer an incremental diff against this branch's previous successful
+  # deployment so intermediate WIP pushes that don't touch the dashboard skip,
+  # instead of rebuilding the whole branch on every commit. The preview alias
+  # keeps the last built output, which already reflects HEAD's dashboard state,
+  # so skipping here never serves a stale dashboard. Falls through to the full
+  # branch diff below on the first push (no previous deployment) or when the
+  # previous SHA can't be resolved.
+  if [[ -n "$previous_sha" ]]; then
+    if git cat-file -e "${previous_sha}^{commit}" 2>/dev/null; then
+      skip_or_build_from_base \
+        "$previous_sha" \
+        "No dashboard-affecting changes since previous deployment for PR #${pull_request_id}; skipping build." \
+        "Dashboard-affecting changes detected since previous deployment for PR #${pull_request_id}; building dashboard."
+    fi
+
+    if [[ -n "$commit_sha" ]] &&
+      changed_files="$(github_changed_files compare "$previous_sha" "$commit_sha")"; then
+      skip_or_build_from_files \
+        "$changed_files" \
+        "No dashboard-affecting changes since previous deployment for PR #${pull_request_id}; skipping build." \
+        "Dashboard-affecting changes detected since previous deployment for PR #${pull_request_id}; building dashboard."
+    fi
+  fi
+
   if pr_base_sha="$(resolve_main_merge_base)"; then
     skip_or_build_from_base \
       "$pr_base_sha" \
@@ -200,7 +230,7 @@ if [[ -n "$pull_request_id" ]]; then
   exit 1
 fi
 
-base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
+base_sha="$previous_sha"
 
 if [[ -z "$base_sha" ]]; then
   # First push of a feature branch can outrun GitHub's PR registration, so Vercel

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -88,13 +88,34 @@ const responses = new Map([
   [
     "/repos/mento-protocol/monitoring-monorepo/compare/previous-sha...sha-docs",
     {
+      status: "ahead",
       ahead_by: 1,
+      behind_by: 0,
       files: [{ filename: "docs/pr-checklists/recurring-review-patterns.md" }],
     },
   ],
   [
     "/repos/mento-protocol/monitoring-monorepo/compare/previous-sha...sha-dashboard",
-    { ahead_by: 1, files: [{ filename: "ui-dashboard/src/app/page.tsx" }] },
+    {
+      status: "ahead",
+      ahead_by: 1,
+      behind_by: 0,
+      files: [{ filename: "ui-dashboard/src/app/page.tsx" }],
+    },
+  ],
+  // Diverged history (e.g. after a PR branch rebase/force-push): the previous
+  // deployment SHA is NOT an ancestor of head, so this THREE-DOT compare only
+  // reports the docs-only head-side change and OMITS any diverged dashboard
+  // change. The ancestry guard (behind_by > 0) must reject this file list and
+  // force a build rather than a false skip.
+  [
+    "/repos/mento-protocol/monitoring-monorepo/compare/diverged-prev...sha-diverged",
+    {
+      status: "diverged",
+      ahead_by: 1,
+      behind_by: 2,
+      files: [{ filename: "docs/x.md" }],
+    },
   ],
 ]);
 
@@ -308,6 +329,20 @@ expect_build "PR incremental dashboard change builds without local git via GitHu
   VERCEL_GIT_PREVIOUS_SHA=previous-sha \
   VERCEL_GIT_COMMIT_SHA=sha-dashboard
 assert_output_contains "Dashboard-affecting changes detected since previous deployment for PR #985"
+
+# Diverged history after a rebase/force-push: the previous deployment SHA is not
+# an ancestor of head, so the THREE-DOT gitless compare returns only the
+# docs-only head-side file and omits the diverged dashboard change. The ancestry
+# guard must reject that file list and fall through to a build, NOT false-skip on
+# the docs-only list.
+expect_build "PR incremental diverged compare builds (no false skip on non-ancestor base)" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PULL_REQUEST_ID=986 \
+  VERCEL_GIT_PREVIOUS_SHA=diverged-prev \
+  VERCEL_GIT_COMMIT_SHA=sha-diverged
+assert_output_contains "Could not resolve origin/main for PR #986; building dashboard."
 
 cd "$fixture_repo"
 

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -117,6 +117,14 @@ const responses = new Map([
       files: [{ filename: "docs/x.md" }],
     },
   ],
+  // PR-vs-main file list for the diverged PR. It reports ONLY the docs-only
+  // head, so the PR-files fallback WOULD authorize a skip — the script must
+  // fail closed on the unusable previous-deployment SHA before ever consulting
+  // this list, otherwise the diverged dashboard build on the alias goes stale.
+  [
+    "/repos/mento-protocol/monitoring-monorepo/pulls/986/files",
+    [{ filename: "docs/x.md" }],
+  ],
 ]);
 
 const server = http.createServer((request, response) => {
@@ -335,16 +343,18 @@ assert_output_contains "Dashboard-affecting changes detected since previous depl
 # Diverged history after a rebase/force-push: the previous deployment SHA is not
 # an ancestor of head, so the THREE-DOT gitless compare returns only the
 # docs-only head-side file and omits the diverged dashboard change. The ancestry
-# guard must reject that file list and fall through to a build, NOT false-skip on
-# the docs-only list.
-expect_build "PR incremental diverged compare builds (no false skip on non-ancestor base)" \
+# guard rejects that compare, and because a previous deployment exists but can't
+# be compared, the script MUST fail closed and build here — even though the
+# PR-vs-main file list (fixture #986) reports docs-only and would otherwise
+# authorize a skip that strands the diverged dashboard build on the alias.
+expect_build "PR incremental diverged compare fails closed to build (no PR-files false skip)" \
   GITHUB_API_BASE_URL="$mock_api_base" \
   GIT_CEILING_DIRECTORIES="$nogit_repo" \
   GIT_DIR="$nogit_repo/.git-missing" \
   VERCEL_GIT_PULL_REQUEST_ID=986 \
   VERCEL_GIT_PREVIOUS_SHA=diverged-prev \
   VERCEL_GIT_COMMIT_SHA=sha-diverged
-assert_output_contains "Could not resolve origin/main for PR #986; building dashboard."
+assert_output_contains "Previous deployment diverged-prev could not be compared to HEAD for PR #986; building dashboard."
 
 cd "$fixture_repo"
 

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -143,6 +143,7 @@ git config user.name "Vercel Ignore Test"
 printf 'dashboard v1\n' > ui-dashboard/app.txt
 printf 'shared v1\n' > shared-config/config.txt
 printf 'docs v1\n' > AGENTS.md
+printf '{ "name": "root", "scripts": { "a": "echo a" } }\n' > package.json
 git add .
 git commit -qm "initial dashboard"
 previous_sha="$(git rev-parse --verify HEAD)"
@@ -156,9 +157,9 @@ git switch -c docs-only >/dev/null 2>&1
 printf 'docs v2\n' > AGENTS.md
 git commit -am "docs-only PR change" -q
 
-expect_skip "PR docs-only changes skip from origin/main" \
-  VERCEL_GIT_PULL_REQUEST_ID=407 \
-  VERCEL_GIT_PREVIOUS_SHA="$previous_sha"
+expect_skip "PR first push with docs-only change skips against origin/main" \
+  VERCEL_GIT_PULL_REQUEST_ID=407
+assert_output_contains "No dashboard-affecting changes in PR #407"
 
 expect_build "non-PR deployments still compare from previous successful SHA" \
   VERCEL_GIT_PREVIOUS_SHA="$previous_sha"
@@ -170,9 +171,23 @@ git switch -c dashboard-pr "$main_sha" >/dev/null 2>&1
 printf 'dashboard v3\n' > ui-dashboard/app.txt
 git commit -am "dashboard PR change" -q
 
-expect_build "PR dashboard changes build from origin/main" \
-  VERCEL_GIT_PULL_REQUEST_ID=408 \
-  VERCEL_GIT_PREVIOUS_SHA="$main_sha"
+expect_build "PR first push with dashboard change builds against origin/main" \
+  VERCEL_GIT_PULL_REQUEST_ID=408
+assert_output_contains "Dashboard-affecting changes detected in PR #408"
+
+# Root package.json is not a watched path: a script/devDep-only root edit (no
+# dashboard code) must skip even though it changes the repo's top-level manifest.
+git switch -c root-pkg-only "$main_sha" >/dev/null 2>&1
+printf '{ "name": "root", "scripts": { "a": "echo a", "b": "echo b" } }\n' > package.json
+git commit -am "chore: add a root script" -q
+
+expect_skip "PR root package.json-only change skips" \
+  VERCEL_GIT_PULL_REQUEST_ID=413
+assert_output_contains "No dashboard-affecting changes in PR #413"
+
+# Restore HEAD for the branch-fallback tests below, which assume the dashboard
+# branch is checked out.
+git switch dashboard-pr >/dev/null 2>&1
 
 # First push of a branch can race ahead of GitHub's PR registration — Vercel
 # then ships neither VERCEL_GIT_PULL_REQUEST_ID nor VERCEL_GIT_PREVIOUS_SHA.
@@ -189,6 +204,31 @@ assert_output_contains "No dashboard-affecting changes on branch docs-only vs ma
 expect_build "branch fallback only triggers on non-main commit ref" \
   VERCEL_GIT_COMMIT_REF=main
 assert_output_contains "No VERCEL_GIT_PREVIOUS_SHA; building dashboard."
+
+# Incremental preview diff: a branch whose first commit changed the dashboard
+# (already deployed), then a docs-only follow-up push. The full branch-vs-main
+# diff still shows the dashboard change, so the merge-base path would rebuild,
+# but the diff against the previous branch deployment does not — so the
+# redundant follow-up push skips.
+git switch -c pr-incremental "$main_sha" >/dev/null 2>&1
+printf 'dashboard v3\n' > ui-dashboard/app.txt
+git commit -am "dashboard change in PR" -q
+pr_prev_sha="$(git rev-parse --verify HEAD)"
+printf 'docs v3\n' > AGENTS.md
+git commit -am "docs-only follow-up in PR" -q
+
+expect_skip "PR docs-only follow-up skips against previous branch deployment" \
+  VERCEL_GIT_PULL_REQUEST_ID=410 \
+  VERCEL_GIT_PREVIOUS_SHA="$pr_prev_sha"
+assert_output_contains "No dashboard-affecting changes since previous deployment for PR #410"
+
+printf 'dashboard v4\n' > ui-dashboard/app.txt
+git commit -am "more dashboard work in PR" -q
+
+expect_build "PR dashboard follow-up builds against previous branch deployment" \
+  VERCEL_GIT_PULL_REQUEST_ID=410 \
+  VERCEL_GIT_PREVIOUS_SHA="$pr_prev_sha"
+assert_output_contains "Dashboard-affecting changes detected since previous deployment for PR #410"
 
 start_mock_github_api
 nogit_repo="$fixture_repo/no-git"
@@ -250,6 +290,24 @@ expect_build "previous SHA dashboard change builds without local git via GitHub 
   VERCEL_GIT_PREVIOUS_SHA=previous-sha \
   VERCEL_GIT_COMMIT_SHA=sha-dashboard
 assert_output_contains "Dashboard-affecting changes detected since previous successful Vercel deployment"
+
+expect_skip "PR incremental docs-only change skips without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PULL_REQUEST_ID=984 \
+  VERCEL_GIT_PREVIOUS_SHA=previous-sha \
+  VERCEL_GIT_COMMIT_SHA=sha-docs
+assert_output_contains "No dashboard-affecting changes since previous deployment for PR #984"
+
+expect_build "PR incremental dashboard change builds without local git via GitHub API" \
+  GITHUB_API_BASE_URL="$mock_api_base" \
+  GIT_CEILING_DIRECTORIES="$nogit_repo" \
+  GIT_DIR="$nogit_repo/.git-missing" \
+  VERCEL_GIT_PULL_REQUEST_ID=985 \
+  VERCEL_GIT_PREVIOUS_SHA=previous-sha \
+  VERCEL_GIT_COMMIT_SHA=sha-dashboard
+assert_output_contains "Dashboard-affecting changes detected since previous deployment for PR #985"
 
 cd "$fixture_repo"
 

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -196,15 +196,17 @@ expect_build "PR first push with dashboard change builds against origin/main" \
   VERCEL_GIT_PULL_REQUEST_ID=408
 assert_output_contains "Dashboard-affecting changes detected in PR #408"
 
-# Root package.json is not a watched path: a script/devDep-only root edit (no
-# dashboard code) must skip even though it changes the repo's top-level manifest.
+# Root package.json IS a watched path: it pins `packageManager` and carries
+# pnpm overrides/patches that shape the dashboard build environment, so a
+# root-package.json-only change must BUILD even though it touches no dashboard
+# code (a `packageManager` bump changes the toolchain without a lockfile diff).
 git switch -c root-pkg-only "$main_sha" >/dev/null 2>&1
 printf '{ "name": "root", "scripts": { "a": "echo a", "b": "echo b" } }\n' > package.json
 git commit -am "chore: add a root script" -q
 
-expect_skip "PR root package.json-only change skips" \
+expect_build "PR root package.json-only change builds" \
   VERCEL_GIT_PULL_REQUEST_ID=413
-assert_output_contains "No dashboard-affecting changes in PR #413"
+assert_output_contains "Dashboard-affecting changes detected in PR #413"
 
 # Restore HEAD for the branch-fallback tests below, which assume the dashboard
 # branch is checked out.


### PR DESCRIPTION
## The Problem

- Vercel build-minute spend rose sharply: ~50 preview builds/day (bursts to 340), ~99% full Turbopack builds, preview:production ≈ 4:1, trending up week-over-week.
- The driver was redundant preview builds: the ignore script diffed each PR push against the `origin/main` merge-base, so every one of the 8–13 intermediate WIP commits per PR rebuilt the whole branch even when it didn't touch the dashboard.

## The Solution

- PR pushes now diff incrementally against the branch's previous deployment (`VERCEL_GIT_PREVIOUS_SHA`). Once a dashboard change has been previewed, later non-dashboard commits on the same branch skip instead of rebuilding the whole branch. The first push (no previous deployment) falls back to the `origin/main` merge-base, so no preview coverage is lost.

## Details

- Incremental path order: local git two-dot diff → GitHub `compare` → fall back to merge-base → PR-files API → build (fail-open).
- `compareFiles` now fails closed when the previous-deployment base is not an ancestor of HEAD (`behind_by > 0`, e.g. after a rebase/force-push). GitHub's `compare` is three-dot, so without this a diverged dashboard change could be omitted from the file list and authorize a false skip that serves a stale preview.
- Root `package.json` stays a watched path: it pins `packageManager` (the pnpm version Vercel builds with) and carries `pnpm.overrides` / `pnpm.patchedDependencies`, which can change the build environment without touching `pnpm-lock.yaml`. An intermediate commit dropped it to cut script/devDep-only rebuilds; reverted after review since the incremental diff already removes most of that cost.
- `.github/workflows/lighthouse.yml`'s two path-filter lists are kept in sync with `dashboard_paths`, so a non-dashboard PR never waits on a preview that won't build.
- Turbo remote cache was considered and measured-out: Vercel already restores the Next.js build cache between deployments, install is ~6s, and turbo isn't in the Vercel build path — a cache hit needs identical inputs, but every build we actually run has dashboard changes.

## Validation

- `bash ui-dashboard/scripts/vercel-ignore-build.test.sh` — passes. Added tests: incremental skip/build, first-push merge-base skip/build, no-git GitHub-compare incremental paths, diverged-history fail-closed, and a `package.json` build case.
- `shellcheck -x` clean; `trunk fmt` and `trunk check` clean on all changed files.

## Deferrals

- Test coverage asserting a build for non-`ui-dashboard/` watched paths (lockfile / patches / `.lighthouserc.cjs` / `packageManager`) on both code paths: #988
- Lighthouse preview-wait can time out when an incremental skip posts no Vercel preview for the new head SHA (does not affect this PR): #991
