### PR TITLE
fix: include pnpm patches in bridge deploy image

### DIFF
--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -19,6 +19,7 @@ on:
       - pnpm-workspace.yaml
       - pnpm-lock.yaml
       - package.json
+      - patches/**
       - .github/workflows/metrics-bridge.yml
 
 # Serialize all deploys: a workflow-name-only group (no SHA, no ref) means

--- a/metrics-bridge/Dockerfile
+++ b/metrics-bridge/Dockerfile
@@ -2,6 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches/ patches/
 COPY metrics-bridge/package.json metrics-bridge/
 # shared-config is a workspace dep of metrics-bridge. The ROOT `postinstall`
 # builds shared-config/dist via tsc, so the whole package (incl. src/ +
@@ -23,6 +24,7 @@ WORKDIR /app
 RUN addgroup -S bridge && adduser -S bridge -G bridge
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches/ patches/
 COPY metrics-bridge/package.json metrics-bridge/
 # Copy shared-config's package.json + runtime JSON exports (the `exports` map
 # points at `./*.json` directly). Covers both the install step below AND the


### PR DESCRIPTION
## The Problem

- The post-merge metrics-bridge production deploy failed in Cloud Build during `pnpm install`.
- The root lockfile now references a pnpm patch file, but the bridge Docker build context did not copy root `patches/`.
- Future patch-file-only dependency changes also would not trigger the bridge deploy workflow.

## The Solution

- Copy root `patches/` into both metrics-bridge Docker install stages before running pnpm.
- Include `patches/**` in the metrics-bridge deploy workflow path filter so dependency patch inputs redeploy the image.

## Validation

- `pnpm --filter @mento-protocol/metrics-bridge lint`
- `pnpm --filter @mento-protocol/metrics-bridge typecheck`
- `pnpm --filter @mento-protocol/metrics-bridge test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Remote Cloud Build: `717044d8-f3f7-4ece-8cbb-5cabf6df55b8` succeeded with tag `metrics-bridge:codex-docker-patches-3c6b37c3`

## Deferrals

None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy packaging and CI path-filter only; no application runtime logic changes.
> 
> **Overview**
> Fixes **metrics-bridge production deploy failures** when the root lockfile references pnpm patch files that were missing from the Docker build context.
> 
> The **metrics-bridge Dockerfile** now **`COPY patches/`** into both the builder and runtime install stages **before** `pnpm install --frozen-lockfile`, so patch resolution matches the monorepo.
> 
> The **metrics-bridge deploy workflow** path filter now includes **`patches/**`**, so patch-only dependency changes trigger a new image build and deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b795692192cacd2e7bb2772a4e0b9df7eb5c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->