### PR TITLE
fix: harden alert functions — durable replay nonce + drop native keccak (#872 PR B)

### DIFF
--- a/alerts/infra/onchain-event-handler/package.json
+++ b/alerts/infra/onchain-event-handler/package.json
@@ -37,12 +37,10 @@
     "@google-cloud/logging": "^11.2.1",
     "axios": "^1.13.2",
     "env-schema": "^7.0.0",
-    "keccak": "^3.0.4",
     "viem": "2.50.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@types/keccak": "^3.0.5",
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.39.1",

--- a/alerts/infra/onchain-event-handler/pnpm-lock.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       env-schema:
         specifier: ^7.0.0
         version: 7.0.0
-      keccak:
-        specifier: ^3.0.4
-        version: 3.0.4
       viem:
         specifier: 2.50.4
         version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
@@ -42,9 +39,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4
-      '@types/keccak':
-        specifier: ^3.0.5
-        version: 3.0.5
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.4
@@ -546,9 +540,6 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/keccak@3.0.5':
-    resolution: {integrity: sha512-Mvu4StIJ9KyfPXDVRv3h0fWNBAjHPBQZ8EPcxhqA8FG6pLzxtytVXU5owB6J2/8xZ+ZspWTXJEUjAHt0pk0I1Q==}
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -1416,10 +1407,6 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  keccak@3.0.4:
-    resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
-    engines: {node: '>=10.0.0'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1607,9 +1594,6 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-api@2.0.2:
-    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -1618,10 +1602,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
 
   nodemon@3.1.14:
     resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
@@ -2659,10 +2639,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/keccak@3.0.5':
-    dependencies:
-      '@types/node': 24.12.4
-
   '@types/long@4.0.2': {}
 
   '@types/mime@1.3.5': {}
@@ -3652,12 +3628,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  keccak@3.0.4:
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.8.4
-      readable-stream: 3.6.2
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3810,13 +3780,9 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-addon-api@2.0.2: {}
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-gyp-build@4.8.4: {}
 
   nodemon@3.1.14:
     dependencies:

--- a/alerts/infra/onchain-event-handler/scripts/build-event-hashes.mjs
+++ b/alerts/infra/onchain-event-handler/scripts/build-event-hashes.mjs
@@ -18,10 +18,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
-const keccak = require("keccak");
+import { keccak256, stringToBytes } from "viem";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const moduleDir = join(__dirname, "..");
@@ -52,7 +49,7 @@ const events = abi
       })
       .filter(Boolean);
     const signature = `${item.name}(${paramTypes.join(",")})`;
-    const hash = `0x${keccak("keccak256").update(signature).digest("hex")}`;
+    const hash = keccak256(stringToBytes(signature));
     return { name: item.name, signature, hash };
   })
   .sort((a, b) => a.name.localeCompare(b.name));

--- a/alerts/infra/onchain-event-handler/src/constants.ts
+++ b/alerts/infra/onchain-event-handler/src/constants.ts
@@ -4,7 +4,7 @@
  * Multisig addresses are loaded from environment variables
  */
 
-import keccak from "keccak";
+import { keccak256, stringToBytes } from "viem";
 import { celo, mainnet } from "viem/chains";
 import safeAbi from "./safe-abi.json";
 import config from "./config";
@@ -23,14 +23,6 @@ const SECURITY_EVENT_NAMES = new Set([
   "DisabledModule",
   "ChangedGuard",
 ]);
-
-/**
- * Compute keccak256 hash of a string (for event signatures)
- */
-function keccak256(input: string): string {
-  const hash = keccak("keccak256").update(input).digest("hex");
-  return `0x${hash}`;
-}
 
 /**
  * Extract event signatures from ABI and compute their hashes
@@ -57,7 +49,9 @@ function extractEventSignatures() {
       const signatureStr = `${eventName}(${paramTypes.join(",")})`;
 
       // Compute keccak256 hash
-      const signatureHash = keccak256(signatureStr) as EventSignature;
+      const signatureHash = keccak256(
+        stringToBytes(signatureStr),
+      ) as EventSignature;
 
       // Store mapping
       eventSignatures[signatureHash] = eventName;

--- a/governance-watchdog/infra/cloud_function.tf
+++ b/governance-watchdog/infra/cloud_function.tf
@@ -37,6 +37,7 @@ resource "google_cloudfunctions2_function" "watchdog_notifications" {
       QUICKNODE_SECURITY_TOKEN_SECRET_ID = google_secret_manager_secret.quicknode_security_token.secret_id
       QUICKNODE_API_KEY_SECRET_ID        = google_secret_manager_secret.quicknode_api_key.secret_id
       X_AUTH_TOKEN_SECRET_ID             = google_secret_manager_secret.x_auth_token.secret_id
+      QUICKNODE_REPLAY_BUCKET            = google_storage_bucket.quicknode_replay_nonces.name
 
       # Logs execution ID for easier debugging => https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs
       LOG_EXECUTION_ID = true

--- a/governance-watchdog/infra/cloud_function.tf
+++ b/governance-watchdog/infra/cloud_function.tf
@@ -43,6 +43,11 @@ resource "google_cloudfunctions2_function" "watchdog_notifications" {
       LOG_EXECUTION_ID = true
     }
   }
+
+  # Gate the function on the replay-nonce IAM binding so a first apply cannot
+  # update the live function ahead of the objectCreator grant — otherwise signed
+  # QuickNode webhooks would 500 from replay protection during that window.
+  depends_on = [google_storage_bucket_iam_member.runtime_replay_nonce_creator]
 }
 
 # Allows the Quicknode Webhook service (and everyone else...) to call the cloud function

--- a/governance-watchdog/infra/storage.tf
+++ b/governance-watchdog/infra/storage.tf
@@ -118,3 +118,44 @@ resource "google_storage_bucket" "logging" {
 
   force_destroy = true
 }
+
+# trunk-ignore(checkov/CKV_GCP_62): bucket stores hashed nonce markers only; Cloud Audit Logs cover object writes
+resource "google_storage_bucket" "quicknode_replay_nonces" {
+  project  = module.governance_watchdog.project_id
+  name     = "${module.governance_watchdog.project_id}-quicknode-replay-nonces"
+  location = var.region
+
+  uniform_bucket_level_access = true
+  force_destroy               = true
+  public_access_prevention    = "enforced"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      age        = 1
+      with_state = "LIVE"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age        = 1
+      with_state = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "runtime_replay_nonce_creator" {
+  bucket = google_storage_bucket.quicknode_replay_nonces.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${module.governance_watchdog.service_account_email}"
+}

--- a/governance-watchdog/src/__tests__/index.test.ts
+++ b/governance-watchdog/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetSecret,
   mockHasAuthToken,
   mockIsFromQuicknode,
+  mockReserveQuickNodeNonce,
 } = vi.hoisted(() => ({
   mockCheckWebhookStatus: vi.fn(),
   mockDiscordSend: vi.fn(),
@@ -17,6 +18,7 @@ const {
   mockGetSecret: vi.fn(),
   mockHasAuthToken: vi.fn(),
   mockIsFromQuicknode: vi.fn(),
+  mockReserveQuickNodeNonce: vi.fn(),
 }));
 
 vi.mock("../config.js", () => ({
@@ -42,6 +44,10 @@ vi.mock("../utils/validate-request-origin.js", () => ({
 
 vi.mock("../quicknode-health/index.js", () => ({
   checkWebhookStatus: mockCheckWebhookStatus,
+}));
+
+vi.mock("../utils/quicknode-replay-protection.js", () => ({
+  reserveQuickNodeNonce: mockReserveQuickNodeNonce,
 }));
 
 vi.mock("discord.js", async (importOriginal) => ({
@@ -104,6 +110,7 @@ describe("governanceWatchdog HTTP entrypoint", () => {
     mockGetSecret.mockResolvedValue("fake-secret");
     mockIsFromQuicknode.mockResolvedValue(true);
     mockHasAuthToken.mockResolvedValue(false);
+    mockReserveQuickNodeNonce.mockResolvedValue({ valid: true });
     mockDiscordSend.mockResolvedValue(undefined);
     mockFetch.mockResolvedValue({
       ok: true,
@@ -167,6 +174,25 @@ describe("governanceWatchdog HTTP entrypoint", () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(mockDiscordSend).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects replayed QuickNode webhooks via the durable nonce", async () => {
+    mockReserveQuickNodeNonce.mockResolvedValue({
+      valid: false,
+      status: 200,
+      message: "Duplicate webhook nonce already processed",
+      replayed: true,
+    });
+    const governanceWatchdog = await loadFunction();
+    const res = makeRes();
+
+    await governanceWatchdog(makeReq("/", proposalCreated), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      "Duplicate webhook nonce already processed",
+    );
+    expect(mockDiscordSend).not.toHaveBeenCalled();
   });
 
   it("processes requests authenticated via x-auth-token", async () => {

--- a/governance-watchdog/src/__tests__/index.test.ts
+++ b/governance-watchdog/src/__tests__/index.test.ts
@@ -195,6 +195,23 @@ describe("governanceWatchdog HTTP entrypoint", () => {
     expect(mockDiscordSend).not.toHaveBeenCalled();
   });
 
+  it("returns 500 and suppresses notifications when nonce reservation fails", async () => {
+    mockReserveQuickNodeNonce.mockResolvedValue({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+    const governanceWatchdog = await loadFunction();
+    const res = makeRes();
+
+    await governanceWatchdog(makeReq("/", proposalCreated), res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith("Server configuration error");
+    expect(mockDiscordSend).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("processes requests authenticated via x-auth-token", async () => {
     mockIsFromQuicknode.mockResolvedValue(false);
     mockHasAuthToken.mockResolvedValue(true);

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -10,6 +10,7 @@ import { checkWebhookStatus } from "./quicknode-health/index.js";
 import { getCacheSize, isDuplicate } from "./utils/event-deduplication.js";
 import logError from "./utils/log-error.js";
 import parseRequestBody from "./utils/parse-request-body.js";
+import { reserveQuickNodeNonce } from "./utils/quicknode-replay-protection.js";
 import {
   hasAuthToken,
   isFromQuicknode,
@@ -111,6 +112,16 @@ const handleQuicknodeWebhook = async (
     const isHealthCheck = isHealthCheckWebhook(req.body);
 
     if (await isFromQuicknode(req)) {
+      const replay = await reserveQuickNodeNonce(
+        req.headers["x-qn-nonce"] as string,
+        req.headers["x-qn-timestamp"] as string,
+      );
+      if (!replay.valid) {
+        console.warn("QuickNode replay validation failed:", replay);
+        res.status(replay.status).send(replay.message);
+        return;
+      }
+
       // Skip verbose logging for health check webhooks to reduce log noise
       if (!isHealthCheck) {
         console.info("Received QuickNode Webhook:", req.body);

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -108,19 +108,12 @@ const handleQuicknodeWebhook = async (
    *  1) Come from QuickNode
    *  2) OR have an auth token (which we use for testing in production)
    */
+  let isQuicknodeWebhook = false;
   if (isProduction) {
     const isHealthCheck = isHealthCheckWebhook(req.body);
 
     if (await isFromQuicknode(req)) {
-      const replay = await reserveQuickNodeNonce(
-        req.headers["x-qn-nonce"] as string,
-        req.headers["x-qn-timestamp"] as string,
-      );
-      if (!replay.valid) {
-        console.warn("QuickNode replay validation failed:", replay);
-        res.status(replay.status).send(replay.message);
-        return;
-      }
+      isQuicknodeWebhook = true;
 
       // Skip verbose logging for health check webhooks to reduce log noise
       if (!isHealthCheck) {
@@ -148,6 +141,25 @@ const handleQuicknodeWebhook = async (
     );
     res.status(500).send("Something went wrong 🤔");
     return;
+  }
+
+  // Reserve the durable replay nonce only after the payload is confirmed
+  // non-empty and well-formed (mirrors the onchain-event-handler sibling):
+  // reserving earlier would burn the nonce on health-check pings or malformed
+  // envelopes, making a legitimate QuickNode retry look like a duplicate and
+  // permanently suppressing the alert.
+  if (isQuicknodeWebhook) {
+    const replay = await reserveQuickNodeNonce(
+      req.headers["x-qn-nonce"] as string,
+      req.headers["x-qn-timestamp"] as string,
+    );
+    if (!replay.valid) {
+      if (!replay.replayed) {
+        console.error("QuickNode replay protection error:", replay);
+      }
+      res.status(replay.status).send(replay.message);
+      return;
+    }
   }
 
   let eventsProcessed = 0;

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -163,6 +163,14 @@ const handleQuicknodeWebhook = async (
       res.status(replay.status).send(replay.message);
       return;
     }
+    if (replay.skipped) {
+      // Bucket misconfigured (e.g. a gcloud-only deploy without the Terraform
+      // env var): the webhook was processed WITHOUT replay protection. Page so
+      // the gap gets fixed, but never drop the alert.
+      logError("QuickNode replay protection disabled:", {
+        reason: replay.skipped,
+      });
+    }
   }
 
   let eventsProcessed = 0;

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -155,7 +155,10 @@ const handleQuicknodeWebhook = async (
     );
     if (!replay.valid) {
       if (!replay.replayed) {
-        console.error("QuickNode replay protection error:", replay);
+        // Structured ERROR so a replay-protection outage (bad bucket/IAM/env,
+        // metadata token, or Storage API) trips the cloud-function-errors
+        // Slack alert; raw console.error lands below ERROR and is excluded.
+        logError("QuickNode replay protection error:", replay);
       }
       res.status(replay.status).send(replay.message);
       return;

--- a/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
+++ b/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
@@ -1,0 +1,263 @@
+import crypto from "crypto";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+
+let warnSpy: MockInstance;
+let errorSpy: MockInstance;
+
+const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
+const metadataTokenUrl =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+function metadataTokenResponse(
+  body: Record<string, unknown> = {
+    access_token: "metadata-token",
+    expires_in: 300,
+  },
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function response(status = 200, statusText = "OK"): Response {
+  return new Response("{}", { status, statusText });
+}
+
+async function loadReserveQuickNodeNonce() {
+  vi.resetModules();
+  return (await import("../quicknode-replay-protection.js"))
+    .reserveQuickNodeNonce;
+}
+
+function nonceHash(nonce: string, timestamp: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${timestamp}:${nonce}`)
+    .digest("hex");
+}
+
+describe("reserveQuickNodeNonce", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    process.env.QUICKNODE_REPLAY_BUCKET = "replay-bucket";
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    if (originalReplayBucket === undefined) {
+      delete process.env.QUICKNODE_REPLAY_BUCKET;
+    } else {
+      process.env.QUICKNODE_REPLAY_BUCKET = originalReplayBucket;
+    }
+    vi.resetModules();
+  });
+
+  it("returns a server error without calling metadata when the replay bucket is missing", async () => {
+    delete process.env.QUICKNODE_REPLAY_BUCKET;
+    const fetchMock = vi.fn<typeof fetch>();
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "QUICKNODE_REPLAY_BUCKET is not configured",
+    );
+  });
+
+  it("reserves a nonce by writing a conditional object to the replay bucket", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(response());
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({ valid: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]).toEqual([
+      metadataTokenUrl,
+      {
+        headers: {
+          "metadata-flavor": "Google",
+        },
+      },
+    ]);
+
+    const [uploadUrl, uploadInit] = fetchMock.mock.calls[1];
+    const expectedHash = nonceHash("nonce-1", "1700000000");
+    expect(String(uploadUrl as URL)).toBe(
+      `https://storage.googleapis.com/upload/storage/v1/b/replay-bucket/o?uploadType=media&name=quicknode-replay-nonces%2F1700000000%2F${expectedHash}.json&ifGenerationMatch=0`,
+    );
+    expect(uploadInit).toMatchObject({
+      method: "POST",
+      headers: {
+        authorization: "Bearer metadata-token",
+        "content-type": "application/json",
+      },
+    });
+    expect(JSON.parse(uploadInit?.body as string)).toMatchObject({
+      timestamp: "1700000000",
+      nonceHash: expectedHash,
+    });
+  });
+
+  it("acknowledges a duplicate nonce when the conditional upload already exists", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(response(412, "Precondition Failed"));
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 200,
+      message: "Duplicate webhook nonce already processed",
+      replayed: true,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Rejected replayed QuickNode webhook nonce",
+      {
+        timestamp: "1700000000",
+        nonceHash: nonceHash("nonce-1", "1700000000"),
+      },
+    );
+  });
+
+  it("returns a server error when the conditional upload fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(response(503, "Service Unavailable"));
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to reserve QuickNode webhook nonce",
+      {
+        status: 503,
+        statusText: "Service Unavailable",
+        timestamp: "1700000000",
+        nonceHash: nonceHash("nonce-1", "1700000000"),
+      },
+    );
+  });
+
+  it("returns a server error when metadata token retrieval fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(response(500, "Metadata Unavailable"));
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "QuickNode replay protection failed",
+      {
+        error: "metadata token request failed: 500 Metadata Unavailable",
+        timestamp: "1700000000",
+        nonceHash: nonceHash("nonce-1", "1700000000"),
+      },
+    );
+  });
+
+  it("returns a server error when the metadata response is missing an access token", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse({ expires_in: 300 }));
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "QuickNode replay protection failed",
+      {
+        error: "metadata token response did not include access_token",
+        timestamp: "1700000000",
+        nonceHash: nonceHash("nonce-1", "1700000000"),
+      },
+    );
+  });
+
+  it("reuses a fresh metadata token for multiple nonce reservations", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(response())
+      .mockResolvedValueOnce(response());
+    const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({ valid: true });
+    await expect(
+      reserveQuickNodeNonce("nonce-2", "1700000001", {
+        fetchImpl: fetchMock,
+      }),
+    ).resolves.toEqual({ valid: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe(metadataTokenUrl);
+    expect(String(fetchMock.mock.calls[1][0] as URL)).toContain("nonce");
+    expect(String(fetchMock.mock.calls[2][0] as URL)).toContain(
+      nonceHash("nonce-2", "1700000001"),
+    );
+  });
+});

--- a/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
+++ b/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
@@ -65,7 +65,7 @@ describe("reserveQuickNodeNonce", () => {
     vi.resetModules();
   });
 
-  it("returns a server error without calling metadata when the replay bucket is missing", async () => {
+  it("degrades open without calling metadata when the replay bucket is missing", async () => {
     delete process.env.QUICKNODE_REPLAY_BUCKET;
     const fetchMock = vi.fn<typeof fetch>();
     const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
@@ -75,15 +75,11 @@ describe("reserveQuickNodeNonce", () => {
         fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({
-      valid: false,
-      status: 500,
-      message: "Server configuration error",
+      valid: true,
+      skipped: "QUICKNODE_REPLAY_BUCKET not configured",
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "QUICKNODE_REPLAY_BUCKET is not configured",
-    );
   });
 
   it("reserves a nonce by writing a conditional object to the replay bucket", async () => {

--- a/governance-watchdog/src/utils/quicknode-replay-protection.ts
+++ b/governance-watchdog/src/utils/quicknode-replay-protection.ts
@@ -9,7 +9,7 @@ const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
 type Fetch = typeof fetch;
 
 type ReplayProtectionResult =
-  | { valid: true }
+  | { valid: true; skipped?: string }
   | { valid: false; status: number; message: string; replayed?: boolean };
 
 interface ReplayProtectionOptions {
@@ -26,16 +26,21 @@ export async function reserveQuickNodeNonce(
   timestamp: string,
   options: ReplayProtectionOptions = {},
 ): Promise<ReplayProtectionResult> {
-  const setup = replayProtectionSetup(nonce, timestamp, options);
-  if (!setup.valid) return setup;
+  const bucketName =
+    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
+  if (!bucketName) {
+    // Degrade open: without a configured bucket we cannot dedupe, but failing
+    // every signed webhook (500) would drop governance alerts. Process the
+    // webhook and surface the misconfiguration so the call site can page.
+    return { valid: true, skipped: "QUICKNODE_REPLAY_BUCKET not configured" };
+  }
 
   const {
     fetchImpl,
-    bucketName,
     objectName,
     timestamp: requestTimestamp,
     nonceHash,
-  } = setup;
+  } = replayProtectionSetup(nonce, timestamp, bucketName, options);
 
   try {
     const accessToken = await getMetadataAccessToken(fetchImpl);
@@ -96,33 +101,21 @@ export async function reserveQuickNodeNonce(
 function replayProtectionSetup(
   nonce: string,
   timestamp: string,
+  bucketName: string,
   options: ReplayProtectionOptions,
-):
-  | {
-      valid: true;
-      fetchImpl: Fetch;
-      bucketName: string;
-      objectName: string;
-      timestamp: string;
-      nonceHash: string;
-    }
-  | { valid: false; status: number; message: string } {
-  const bucketName =
-    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
-  if (!bucketName) {
-    console.error("QUICKNODE_REPLAY_BUCKET is not configured");
-    return serverConfigurationError();
-  }
-
+): {
+  fetchImpl: Fetch;
+  objectName: string;
+  timestamp: string;
+  nonceHash: string;
+} {
   const nonceHash = crypto
     .createHash("sha256")
     .update(`${timestamp}:${nonce}`)
     .digest("hex");
 
   return {
-    valid: true,
     fetchImpl: options.fetchImpl ?? fetch,
-    bucketName,
     objectName: `quicknode-replay-nonces/${timestamp}/${nonceHash}.json`,
     timestamp,
     nonceHash,

--- a/governance-watchdog/src/utils/quicknode-replay-protection.ts
+++ b/governance-watchdog/src/utils/quicknode-replay-protection.ts
@@ -1,0 +1,182 @@
+import crypto from "crypto";
+
+const METADATA_TOKEN_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const STORAGE_UPLOAD_BASE_URL =
+  "https://storage.googleapis.com/upload/storage/v1/b";
+const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
+
+type Fetch = typeof fetch;
+
+type ReplayProtectionResult =
+  | { valid: true }
+  | { valid: false; status: number; message: string; replayed?: boolean };
+
+interface ReplayProtectionOptions {
+  bucketName?: string;
+  fetchImpl?: Fetch;
+}
+
+let cachedMetadataToken:
+  | { accessToken: string; expiresAtMs: number }
+  | undefined;
+
+export async function reserveQuickNodeNonce(
+  nonce: string,
+  timestamp: string,
+  options: ReplayProtectionOptions = {},
+): Promise<ReplayProtectionResult> {
+  const setup = replayProtectionSetup(nonce, timestamp, options);
+  if (!setup.valid) return setup;
+
+  const {
+    fetchImpl,
+    bucketName,
+    objectName,
+    timestamp: requestTimestamp,
+    nonceHash,
+  } = setup;
+
+  try {
+    const accessToken = await getMetadataAccessToken(fetchImpl);
+    const uploadUrl = new URL(
+      `${STORAGE_UPLOAD_BASE_URL}/${encodeURIComponent(bucketName)}/o`,
+    );
+    uploadUrl.searchParams.set("uploadType", "media");
+    uploadUrl.searchParams.set("name", objectName);
+    uploadUrl.searchParams.set("ifGenerationMatch", "0");
+
+    const response = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        receivedAt: new Date().toISOString(),
+        timestamp: requestTimestamp,
+        nonceHash,
+      }),
+    });
+
+    if (response.status === 412) {
+      console.warn("Rejected replayed QuickNode webhook nonce", {
+        timestamp: requestTimestamp,
+        nonceHash,
+      });
+      return {
+        valid: false,
+        status: 200,
+        message: "Duplicate webhook nonce already processed",
+        replayed: true,
+      };
+    }
+
+    if (!response.ok) {
+      console.error("Failed to reserve QuickNode webhook nonce", {
+        status: response.status,
+        statusText: response.statusText,
+        timestamp: requestTimestamp,
+        nonceHash,
+      });
+      return serverConfigurationError();
+    }
+  } catch (error) {
+    console.error("QuickNode replay protection failed", {
+      error: error instanceof Error ? error.message : String(error),
+      timestamp: requestTimestamp,
+      nonceHash,
+    });
+    return serverConfigurationError();
+  }
+
+  return { valid: true };
+}
+
+function replayProtectionSetup(
+  nonce: string,
+  timestamp: string,
+  options: ReplayProtectionOptions,
+):
+  | {
+      valid: true;
+      fetchImpl: Fetch;
+      bucketName: string;
+      objectName: string;
+      timestamp: string;
+      nonceHash: string;
+    }
+  | { valid: false; status: number; message: string } {
+  const bucketName =
+    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
+  if (!bucketName) {
+    console.error("QUICKNODE_REPLAY_BUCKET is not configured");
+    return serverConfigurationError();
+  }
+
+  const nonceHash = crypto
+    .createHash("sha256")
+    .update(`${timestamp}:${nonce}`)
+    .digest("hex");
+
+  return {
+    valid: true,
+    fetchImpl: options.fetchImpl ?? fetch,
+    bucketName,
+    objectName: `quicknode-replay-nonces/${timestamp}/${nonceHash}.json`,
+    timestamp,
+    nonceHash,
+  };
+}
+
+async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
+  if (
+    cachedMetadataToken &&
+    cachedMetadataToken.expiresAtMs - METADATA_TOKEN_REFRESH_SKEW_MS >
+      Date.now()
+  ) {
+    return cachedMetadataToken.accessToken;
+  }
+
+  const response = await fetchImpl(METADATA_TOKEN_URL, {
+    headers: {
+      "metadata-flavor": "Google",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `metadata token request failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    access_token?: unknown;
+    expires_in?: unknown;
+  };
+  if (typeof body.access_token !== "string" || !body.access_token) {
+    throw new Error("metadata token response did not include access_token");
+  }
+  const expiresInSeconds =
+    typeof body.expires_in === "number" && Number.isFinite(body.expires_in)
+      ? body.expires_in
+      : 300;
+  cachedMetadataToken = {
+    accessToken: body.access_token,
+    expiresAtMs: Date.now() + expiresInSeconds * 1000,
+  };
+
+  return body.access_token;
+}
+
+function serverConfigurationError(): {
+  valid: false;
+  status: number;
+  message: string;
+} {
+  return {
+    valid: false,
+    status: 500,
+    message: "Server configuration error",
+  };
+}

--- a/governance-watchdog/src/utils/validate-request-origin.ts
+++ b/governance-watchdog/src/utils/validate-request-origin.ts
@@ -11,9 +11,11 @@ import { verifyQuickNodeHmac } from "./quicknode-hmac.js";
  * set by QuickNode — but without a freshness check, a captured request (e.g. from
  * an intermediate proxy or log) could be replayed indefinitely to produce duplicate
  * governance notifications. 5 minutes comfortably covers QuickNode delivery retries
- * and clock skew. We deliberately do NOT track x-qn-nonce values: a nonce cache
- * would live in per-instance memory only, adding little on top of this window and
- * the event-deduplication cache (see ./event-deduplication.ts).
+ * and clock skew. On top of this window, x-qn-nonce values are now durably
+ * reserved in GCS via ./quicknode-replay-protection.js, so a captured request
+ * cannot be replayed even within the freshness window (the per-instance
+ * event-deduplication cache, see ./event-deduplication.ts, only dedupes within
+ * a single warm instance and does not survive restarts).
  */
 const MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,9 +277,6 @@ importers:
       env-schema:
         specifier: ^7.0.0
         version: 7.0.0
-      keccak:
-        specifier: ^3.0.4
-        version: 3.0.4
       viem:
         specifier: 2.50.4
         version: 2.50.4(typescript@5.9.3)(zod@4.4.3)
@@ -287,9 +284,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
-      '@types/keccak':
-        specifier: ^3.0.5
-        version: 3.0.5
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -3900,9 +3894,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/keccak@3.0.5':
-    resolution: {integrity: sha512-Mvu4StIJ9KyfPXDVRv3h0fWNBAjHPBQZ8EPcxhqA8FG6pLzxtytVXU5owB6J2/8xZ+ZspWTXJEUjAHt0pk0I1Q==}
-
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
@@ -7322,10 +7313,6 @@ packages:
   kdbush@4.0.2:
     resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
-  keccak@3.0.4:
-    resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
-    engines: {node: '>=10.0.0'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -8058,9 +8045,6 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
-  node-addon-api@2.0.2:
-    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
-
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -8081,10 +8065,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -13552,10 +13532,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/keccak@3.0.5':
-    dependencies:
-      '@types/node': 24.10.1
-
   '@types/long@4.0.2': {}
 
   '@types/luxon@3.7.1': {}
@@ -14001,7 +13977,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/coverage-v8@4.1.7)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@22.19.13)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -17886,12 +17862,6 @@ snapshots:
 
   kdbush@4.0.2: {}
 
-  keccak@3.0.4:
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.8.4
-      readable-stream: 3.6.2
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -18842,8 +18812,6 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
-  node-addon-api@2.0.2: {}
-
   node-domexception@1.0.0: {}
 
   node-emoji@1.11.0:
@@ -18859,8 +18827,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-gyp-build@4.8.4: {}
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
## The Problem

- `governance-watchdog` accepts QuickNode webhook replays inside a 5-minute timestamp window with **no durable nonce tracking**, while the sibling `onchain-event-handler` already has GCS-backed replay protection.
- `onchain-event-handler` carries a redundant **native `keccak`** dependency (+ `@types/keccak`); viem — already a dependency — provides `keccak256`.

## The Solution

- Port the GCS-backed durable replay-nonce reservation from `onchain-event-handler` into `governance-watchdog`, wire it into the QuickNode webhook path, and add the replay-nonce bucket + IAM member + function env var (terraform).
- Replace the native `keccak` import with viem `keccak256(stringToBytes(...))` in `onchain-event-handler`; the regenerated `event-hashes.json` is **byte-identical**, proving hash equivalence.

This is **PR B** (items 2 + 4) — the final piece of the #872 hygiene batch (items 1 + 7 landed in #974; items 3 + 5 + 6 in #973).

## Details

- **Item 2 (replay nonce):** `quicknode-replay-protection.ts` + its unit test are ported from `onchain-event-handler` (logger → `console`; NodeNext `.js` import + `console` spies in the test). Wired into `index.ts` at the top of the `isFromQuicknode` branch per the issue; a duplicate returns HTTP 200 (`"Duplicate webhook nonce already processed"`) so QuickNode does not retry. Terraform adds the `quicknode-replay-nonces` bucket (+ `objectCreator` IAM for the runtime SA) to `storage.tf` and `QUICKNODE_REPLAY_BUCKET` to the function env.
- **Item 4 (keccak):** `constants.ts` + `build-event-hashes.mjs` switch to viem; `keccak`/`@types/keccak` removed from `package.json`; the lockfile diff is limited to the keccak ecosystem (`keccak`, `@types/keccak`, and its native-build deps `node-addon-api`/`node-gyp-build`).
- **Deviation 1 — dropped the issue's step-11 `local-dotenv-file.tf`.** That file does not exist in the gov-watchdog stack (its local `.env` is produced by `bin/generate-env.mjs`, and `src/config.ts` loads only `.env`). The issue's premise was inaccurate for this stack. Local dev is unaffected because replay protection only runs when `NODE_ENV !== "development"`; the **deployed** function still receives `QUICKNODE_REPLAY_BUCKET` via `cloud_function.tf`. No inert/un-gitignored `.env.replay` artifact is introduced.
- **Deviation 2 — minimal lint adaptations to the port.** gov-watchdog's eslint is stricter than onchain-event-handler's, so the verbatim copy was adapted without behavior change: `replayProtectionSetup` is synchronous (it never awaited), `${String(response.status)}` in one template, `String(x as URL)` in two test assertions, and non-empty `() => undefined` console spies.
- **Replay placement tradeoff:** following the issue's step 8, the reserve sits at the top of the QuickNode branch, so health-check pings also reserve a nonce (one GCS conditional write per ping; nonce objects auto-expire via an age-1 lifecycle rule). The sibling instead reserves *after* payload validation. Happy to move it post-review if preferred — flagging since it's a behavioral choice inherited from the issue.

## Validation

```
# Item 4
pnpm --filter @mento-protocol/alerts-onchain-event-handler typecheck   # clean
pnpm --filter @mento-protocol/alerts-onchain-event-handler test        # 113 passed
pnpm --filter @mento-protocol/alerts-onchain-event-handler build:event-hashes
git diff --exit-code alerts/infra/onchain-event-listeners/event-hashes.json  # exit 0 (byte-identical)

# Item 2
pnpm gov-watchdog:typecheck   # clean
pnpm gov-watchdog:lint        # clean
pnpm gov-watchdog:test        # 85 passed (incl. ported replay test + a new replay-rejection wiring test)
pnpm tf validate governance-watchdog   # Success! The configuration is valid.
pnpm tf plan governance-watchdog -target=google_storage_bucket.quicknode_replay_nonces \
  -target=google_storage_bucket_iam_member.runtime_replay_nonce_creator
  # Plan: 2 to add, 0 to change, 0 to destroy (the replay-nonce bucket + objectCreator IAM)
```

The gov-watchdog terraform is **manual-apply**: a maintainer runs `pnpm gov-watchdog:deploy` after merge (one apply ships code + bucket + env var together). No `terraform apply` was run here. The full `pnpm gov-watchdog:tf:plan` requires `var.github_token` (a CI secret for the drift-workflow secret mirroring, unrelated to this change), so it's run by the maintainer at apply time; `terraform validate` confirms the HCL — including the `cloud_function.tf` env-var addition — is consistent, and the scoped plan above confirms the two new resources create cleanly with zero changes/destroys.

## Checklist

- [ ] The Problem has no more than three bullets.
- [ ] The Solution is plain English and understandable before reading the diff.
- [ ] Deeper implementation details come after the opening two sections.
- [ ] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production QuickNode webhook security path and adds GCS/IAM dependencies; misconfiguration can briefly run without replay protection (logged) or return 500 and suppress alerts until fixed.
> 
> **Overview**
> **governance-watchdog** now reserves QuickNode `x-qn-nonce` values in GCS (conditional object create) before processing signed webhooks, matching the onchain-event-handler pattern. Duplicates get HTTP 200 so QuickNode stops retrying; storage/IAM failures return 500 and block notifications. Reservation runs **after** the body is non-empty and error-free so health checks and bad envelopes do not burn nonces. Terraform adds a `quicknode-replay-nonces` bucket (1-day lifecycle), `objectCreator` for the runtime SA, `QUICKNODE_REPLAY_BUCKET` on the function, and `depends_on` so IAM exists before deploy.
> 
> **onchain-event-handler** drops the native `keccak` packages and uses viem `keccak256(stringToBytes(...))` in runtime constants and `build-event-hashes.mjs` (hashes stay equivalent).
> 
> Docs in `validate-request-origin` note durable nonce dedupe on top of the 5-minute timestamp window. New unit and handler tests cover replay acceptance, rejection, and outage behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad248e2ac5ff9a61c6a7bd3a5186d6457751a82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->