### PR TITLE
chore: label repo-local skills

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-pr
-description: Monitor monitoring-monorepo PR readiness using the repo's shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.
+description: '[repo-skill] Monitor monitoring-monorepo PR readiness using the repo''s shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.'
 title: Babysit PR Skill
 status: active
 owner: eng

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forensic-report
-description: Use this skill when investigating a specific on-chain address (operator EOA, contract, attacker, MEV bot, suspicious counterparty, etc.) and producing a forensic report for the Mento address book. Triggers on requests like "investigate 0x...", "produce a forensic report on this address", "who is 0x...", "/forensic-report", "/onchain-sleuth", "/detective", or any time you're asked to identify an unknown address that interacts with Mento and the answer needs to land in the address-book report editor. Apply whenever the goal is a long-form attribution + activity write-up that gets stored in the `reports` Upstash hash.
+description: '[repo-skill] Use this skill when investigating a specific on-chain address (operator EOA, contract, attacker, MEV bot, suspicious counterparty, etc.) and producing a forensic report for the Mento address book. Triggers on requests like "investigate 0x...", "produce a forensic report on this address", "who is 0x...", "/forensic-report", "/onchain-sleuth", "/detective", or any time you''re asked to identify an unknown address that interacts with Mento and the answer needs to land in the address-book report editor. Apply whenever the goal is a long-form attribution + activity write-up that gets stored in the `reports` Upstash hash.'
 title: Forensic Report Skill
 status: active
 owner: eng

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: 'Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
+description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
 title: Ship Skill
 status: active
 owner: eng

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-pr
-description: Monitor monitoring-monorepo PR readiness using the repo's shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.
+description: '[repo-skill] Monitor monitoring-monorepo PR readiness using the repo''s shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.'
 title: Babysit PR Skill
 status: active
 owner: eng

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forensic-report
-description: Use this skill when investigating a specific on-chain address (operator EOA, contract, attacker, MEV bot, suspicious counterparty, etc.) and producing a forensic report for the Mento address book. Triggers on requests like "investigate 0x...", "produce a forensic report on this address", "who is 0x...", "/forensic-report", "/onchain-sleuth", "/detective", or any time you're asked to identify an unknown address that interacts with Mento and the answer needs to land in the address-book report editor. Apply whenever the goal is a long-form attribution + activity write-up that gets stored in the `reports` Upstash hash.
+description: '[repo-skill] Use this skill when investigating a specific on-chain address (operator EOA, contract, attacker, MEV bot, suspicious counterparty, etc.) and producing a forensic report for the Mento address book. Triggers on requests like "investigate 0x...", "produce a forensic report on this address", "who is 0x...", "/forensic-report", "/onchain-sleuth", "/detective", or any time you''re asked to identify an unknown address that interacts with Mento and the answer needs to land in the address-book report editor. Apply whenever the goal is a long-form attribution + activity write-up that gets stored in the `reports` Upstash hash.'
 title: Forensic Report Skill
 status: active
 owner: eng

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: 'Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
+description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
 title: Ship Skill
 status: active
 owner: eng


### PR DESCRIPTION
## The Problem

- Repo-local skills with global equivalents appear twice in Codex autocomplete with the same skill name.
- The local entries were hard to distinguish from global skills when invoking commands like `$ship` or `$babysit-pr`.

## The Solution

- Prefix the repo-local duplicate skill descriptions with `[repo-skill]` so autocomplete clearly identifies the local variant.
- Keep the `.claude/skills` mirrors in sync with the canonical `.agents/skills` copies.

## Details

- Updated `ship`, `babysit-pr`, and `forensic-report`, the repo-local skills that currently have same-name global equivalents.
- No workflow behavior changed; this is metadata-only for skill discovery/display.

## Validation

- pnpm agent:quality-gate --run
- pnpm agent:autoreview

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only; no runtime, CI, or skill execution behavior changes.
> 
> **Overview**
> Prefixes **`[repo-skill]`** on the YAML `description` in six skill manifests so Codex autocomplete can tell repo-local copies apart from same-name global skills (`ship`, `babysit-pr`, `forensic-report`).
> 
> Updates apply to **`.agents/skills`** (canonical) and matching **`.claude/skills`** mirrors. Skill names, triggers, and workflow bodies are unchanged—metadata only for discovery/display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ad6bf2b9a19559012732709e62d28ec811f4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->