### PR TITLE
docs: capture CI verification lessons

### DIFF
--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -31,6 +31,14 @@ gh api repos/mento-protocol/monitoring-monorepo/rulesets \
   -q '.rules[] | select(.type=="required_status_checks").parameters.required_status_checks[].context'
 ```
 
+After changing a required-status workflow or replacing the tool that reports its
+checks, verify the live PR status rollup with
+`pnpm pr:ready-state --pr <number> --json`. Confirm the intended required
+context is the only tool-owned check GitHub surfaces. PR #1008/#1010 exposed the
+failure mode: an action-created `Trunk Check` Checks API run appeared alongside
+the intended `Code Quality` job, and GitHub grouped the extra failure under the
+advisory schema-diff workflow in the PR UI.
+
 - [ ] **Ruleset-required** workflows MUST NOT use `paths:` / `paths-ignore:` filters — they must run on every PR. If you want path-conditional work, run every PR but skip the expensive job inside via `if:` checks (or `paths-filter`-style gating that reports a green check on no-op).
 - [ ] **Advisory** workflows (everything _not_ in the ruleset list above) SHOULD use a workflow-level `paths:` filter so they don't boot a runner on irrelevant PRs. A skipped advisory check is simply absent — it cannot leave a _required_ check pending. This is a deliberate CI-cost control; see `lighthouse.yml`, `size-limit.yml`, and `supply-chain.yml` for the pattern (the workflow-level `paths:` mirrors the in-job `filter` step, which is kept as a fail-closed backstop). **Exception:** a workflow that posts a sticky PR comment AND clears it on revert (e.g. `schema-diff.yml`) must stay unfiltered — a `paths:` skip on a revert PR strands the stale comment because the cleanup step never runs. Keep run/skip in-job there.
 - [ ] If you make an advisory workflow required, add it to the ruleset **and** remove its `paths:` filter in the same change.

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -73,6 +73,13 @@ AUTH_GOOGLE_SECRET=local-dev-google-secret \
 pnpm dev --hostname 127.0.0.1 --port 3210
 ```
 
+Vercel preview URLs can redirect agent Chrome sessions to Vercel login/SSO. If
+the PR is not about preview protection, do not treat that redirect as a browser
+verification blocker by itself: use the localhost path above for the manual
+browser smoke, and cite the CI Vercel/Lighthouse checks as the preview-level
+proof. If the PR does touch preview protection or deployment access, verify the
+preview route itself with the configured bypass path from the workflow.
+
 The required local data env is:
 
 - `NEXT_PUBLIC_HASURA_URL` for hosted multichain Hasura data. `pnpm dev`


### PR DESCRIPTION
## The Problem

- The Trunk/action check confusion from PR #1008/#1010 is easy to regress without an explicit required-status verification step.
- Agent-side browser verification can hit Vercel preview SSO, but the dashboard docs did not state when localhost verification is the right fallback.

## The Solution

- Add a CI workflow checklist note to verify the live PR status rollup after replacing required-status reporting tools, including accidental extra Checks API contexts.
- Add dashboard local-dev guidance for Vercel preview SSO redirects and when to use localhost smoke verification plus CI Vercel/Lighthouse evidence.

## Validation

- `pnpm agent:quality-gate --run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, CI, or application behavior changes.
> 
> **Overview**
> Documents two operational lessons from recent PR work so agents and maintainers do not repeat the same mistakes.
> 
> **CI workflow gates** (`docs/pr-checklists/ci-workflow-gates.md`): After swapping required-status tooling, verify the live PR rollup with `pnpm pr:ready-state --pr <number> --json` and confirm only the intended tool-owned context appears—PR #1008/#1010 showed an extra `Trunk Check` Checks API run beside `Code Quality`, with GitHub mis-grouping the failure under an advisory workflow.
> 
> **Dashboard agent dev** (`ui-dashboard/AGENTS.md`): Vercel preview URLs may redirect to Vercel login/SSO during agent browser checks. For PRs that are not about preview protection, use localhost smoke on port 3210 and treat CI Vercel/Lighthouse as preview proof; only exercise the preview URL (with workflow bypass) when the change touches preview protection or deployment access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e86a16405568aa59979fab528be929a9faec60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->