### PR TITLE
Clarify Codex rereview babysit flow

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -65,9 +65,14 @@ item required.
   sweep across review comments, review bodies, top-level comments, threads,
   check annotations, and failing check logs before all-clear. Use the root
   `AGENTS.md` reply templates. Do not resolve a thread without a reply first.
-- Codex current-head approval missing or in flight: wait for the existing
-  signal. Do not post duplicate `@codex review` requests while the probe says a
-  current-head request is `requested`, `in_flight`, or `approved`.
+- Codex current-head approval missing, stale, or in flight: wait for the
+  automatic current-head review path before taking action. Codex re-reviews new
+  pushes automatically in this repo; do not post `@codex review` as a routine
+  post-push step, and do not treat a `stale` signal immediately after a push as
+  permission to comment again. Never post duplicate requests while the probe
+  says a current-head request is `requested`, `in_flight`, or `approved`. Use
+  one manual request only as a fallback when the current head still has no
+  Codex signal after the normal automatic-review window.
 
 Never force-push or amend while babysitting.
 

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -65,9 +65,14 @@ item required.
   sweep across review comments, review bodies, top-level comments, threads,
   check annotations, and failing check logs before all-clear. Use the root
   `AGENTS.md` reply templates. Do not resolve a thread without a reply first.
-- Codex current-head approval missing or in flight: wait for the existing
-  signal. Do not post duplicate `@codex review` requests while the probe says a
-  current-head request is `requested`, `in_flight`, or `approved`.
+- Codex current-head approval missing, stale, or in flight: wait for the
+  automatic current-head review path before taking action. Codex re-reviews new
+  pushes automatically in this repo; do not post `@codex review` as a routine
+  post-push step, and do not treat a `stale` signal immediately after a push as
+  permission to comment again. Never post duplicate requests while the probe
+  says a current-head request is `requested`, `in_flight`, or `approved`. Use
+  one manual request only as a fallback when the current head still has no
+  Codex signal after the normal automatic-review window.
 
 Never force-push or amend while babysitting.
 


### PR DESCRIPTION
## The Problem

- The babysit skill made a stale Codex signal after a push look like a reason to post another `@codex review` comment.
- That creates unnecessary review-request noise because Codex re-reviews new pushes automatically in this repo.

## The Solution

- Clarify both mirrored babysit skill docs to wait for the automatic current-head review path after pushes.
- Keep manual `@codex review` as a later fallback only when the current head still has no Codex signal after the normal automatic-review window.

## Details

- Updates `.agents/skills/babysit-pr/SKILL.md` and `.claude/skills/babysit-pr/SKILL.md` in sync.
- Leaves the canonical `AGENTS.md` and `docs/notes/pr-ready-state.md` unchanged because they already stated this rule.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill guidance; no runtime, CI, or application code affected.
> 
> **Overview**
> Aligns the mirrored **babysit-pr** skill docs (`.agents/` and `.claude/`) with how Codex behaves on new pushes in this repo.
> 
> The **Codex current-head** blocker bullet now tells agents to **wait for automatic re-review** after a push, not treat a **`stale`** probe right after push as a reason to post **`@codex review`**. Manual **`@codex review`** is limited to a **single fallback** when the current head still has no Codex signal after the normal automatic-review window; duplicate requests remain forbidden while the probe shows **`requested`**, **`in_flight`**, or **`approved`**.
> 
> `AGENTS.md` and `docs/notes/pr-ready-state.md` are unchanged—the skills were lagging the canonical wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da6e060fa02d82bd4216ade2ba7cae16edbe092d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->