### PR TITLE
fix: de-duplicate on-call trading halt alert bodies

### DIFF
--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -110,6 +110,9 @@ resource "grafana_message_template" "victorops_trading_mode_alert_message" {
   name     = "VictorOps - Trading Mode Alert Message"
   template = <<-EOT
 {{ define "victorops.trading_mode_alert_message" }}
+{{ $firingCount := len .Alerts.Firing -}}
+{{ $resolvedCount := len .Alerts.Resolved -}}
+{{ $mixedState := and $firingCount $resolvedCount -}}
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
@@ -131,7 +134,9 @@ ${local.monad_chainlink_slug_branches}
 {{ if and $chainId $pool -}}{{ $poolURL = printf "https://monitoring.mento.org/pool/%s-%s?tab=oracle" $chainId $pool }}{{ end -}}
 {{ $chainlinkURL := "" -}}
 {{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
+{{ if or $mixedState (gt $firingCount 1) -}}
 {{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker
+{{ end -}}
 {{ if $chainlinkURL -}}
 Next action: verify the Chainlink data source, then ack/snooze if the move is real. Do not manually reset unless the feed is wrong or the breaker is stuck after recovery.
 - Chainlink data source: {{ $chainlinkURL }}
@@ -145,10 +150,10 @@ Alert time: {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed
+Trading resumed for {{ $rateFeedWithSlash }} [{{ $chain }}].
 {{ end -}}
 
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
+{{ if eq $firingCount 0 }}No alerts are currently firing.{{ end }}
 {{ end -}}
 EOT
 }

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -241,6 +241,8 @@ test("VictorOps trading-mode body stays distinct from the incident title", () =>
     "utf8",
   );
 
+  // These checks intentionally match exact whitespace in the Terraform
+  // template. If you reformat the guarded template lines, update these strings.
   assert(
     source.includes(
       "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ end -}}\n{{ if $chainlinkURL -}}",

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -228,6 +228,36 @@ test("CLI passes against the real repository", () => {
   assert(
     /PromQL expressions parsed/.test(result.stdout),
     `expected summary output, got: ${result.stdout}`,
+  );
+});
+
+test("VictorOps trading-mode body stays distinct from the incident title", () => {
+  const source = readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "alerts/rules/message-templates-victorops.tf",
+    ),
+    "utf8",
+  );
+
+  assert(
+    source.includes(
+      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ end -}}\n{{ if $chainlinkURL -}}",
+    ),
+    "single firing alerts should start the body at the next action, not repeat the title",
+  );
+  assert(
+    source.includes(
+      "Trading resumed for {{ $rateFeedWithSlash }} [{{ $chain }}].",
+    ),
+    "resolved trading-mode bodies should use resumed wording",
+  );
+  assert(
+    source.includes(
+      "{{ if eq $firingCount 0 }}No alerts are currently firing.",
+    ),
+    "the resolved footer should use the computed firing count",
   );
 });
 


### PR DESCRIPTION
## The Problem

- Splunk On-Call trading-mode incidents repeated the same halt sentence in both the incident title and the description.
- Resolved trading-mode notifications were harder to scan because the recovery text was too close to the firing wording.

## The Solution

- Keep the incident title as the compact state label, but make the VictorOps description start with the operator action for single firing alerts and use explicit resumed wording for resolved alerts.

## Details

- Single firing trading-mode pages no longer repeat `USDT/USD [Celo]: Trading halted by breaker` at the top of the body.
- Grouped or mixed-state notifications still include per-feed headings in the body so multiple alerts remain distinguishable.
- Resolved bodies now say `Trading resumed for <pair> [<chain>].` and still include the no-firing footer.
- The Grafana resolved title template already renders `Trading resumed`; Splunk On-Call may still preserve the original entity title on an already-created incident, so the recovery body is now explicit and non-duplicative.

## Validation

- `pnpm alerts:rules:lint:test`
- `pnpm alerts:rules:lint`
- `pnpm tf validate alerts-rules`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Grafana VictorOps notification text and a unit test; no alert evaluation or routing logic is modified.
> 
> **Overview**
> Splunk On-Call **trading-mode** incident descriptions no longer repeat the same halt line that already appears in the incident title.
> 
> The VictorOps message template now tracks firing/resolved counts and only prints per-feed `Trading halted by breaker` headings when there are **multiple firing alerts** or **mixed firing and resolved** state; a **single** firing page jumps straight to the operator next-action block (Chainlink / breaker links). **Resolved** sections use explicit `Trading resumed for <pair> [<chain>].` wording, and the no-firing footer keys off the computed `$firingCount`.
> 
> A regression test in `scripts/alert-rules-lint.test.mjs` asserts those template strings so future formatting edits do not reintroduce title/body duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb6a37e67516bf49506f895d2785f0c0e3d8f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->