### PR TITLE
Clarify Aegis view-call failure pages

### DIFF
--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -235,9 +235,9 @@ resource "grafana_message_template" "slack_aegis_service_alert_title" {
 {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
 {{ .CommonLabels.alertname -}}
 {{ else if (len .Alerts.Firing) -}}
-{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}🚨 {{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}🚨 Aegis has stopped reporting data{{ else -}}🚨 {{ .Labels.alertname }}{{ end -}}{{ end -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq $alert.Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := $alert.Labels.chain | title -}}🚨 {{ $chain }}: Aegis view calls failing for {{ $alert.Labels.contract }}.{{ $alert.Labels.functionName }}{{ else if eq $alert.Labels.alertname "Aegis does not report new data" -}}🚨 Aegis has stopped reporting data{{ else -}}🚨 {{ $alert.Labels.alertname }}{{ end -}}{{ end -}}
 {{- else if (len .Alerts.Resolved) -}}
-{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}✅ {{ $chain }}: Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}✅ Aegis data reporting recovered{{ else -}}✅ {{ .Labels.alertname }} resolved{{ end -}}{{ end -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq $alert.Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := $alert.Labels.chain | title -}}✅ {{ $chain }}: Aegis view calls recovered for {{ $alert.Labels.contract }}.{{ $alert.Labels.functionName }}{{ else if eq $alert.Labels.alertname "Aegis does not report new data" -}}✅ Aegis data reporting recovered{{ else -}}✅ {{ $alert.Labels.alertname }} resolved{{ end -}}{{ end -}}
 {{- end -}}
 {{ end -}}
 EOT
@@ -257,7 +257,7 @@ Why this matters: Aegis cannot reliably read `{{ .Labels.contract }}.{{ .Labels.
 Next action: open Aegis logs, filter for `chain={{ .Labels.chain }}` and `call={{ .Labels.contract }}.{{ .Labels.functionName }}`, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
 - If RPC-only: check the configured primary/fallback endpoint health and provider status.
 - If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
-- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ . }}{{ else }}unknown{{ end }}
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ printf "%.0f" . }}{{ else }}unknown{{ end }}
 - <{{ .GeneratorURL }}&tab=instances|Alert details>
 - Logs: `pnpm aegis:logs`
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}

--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -232,10 +232,14 @@ resource "grafana_message_template" "slack_aegis_service_alert_title" {
   name     = "Slack - Aegis Service Alert Title"
   template = <<-EOT
 {{ define "slack.aegis_service_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] {{ .CommonLabels.alertname }}
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.alertname }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.alertname }}{{ end }}{{ end }}
-{{ end }}
+{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+{{ .CommonLabels.alertname -}}
+{{ else if (len .Alerts.Firing) -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}🚨 {{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}🚨 Aegis has stopped reporting data{{ else -}}🚨 {{ .Labels.alertname }}{{ end -}}{{ end -}}
+{{- else if (len .Alerts.Resolved) -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}✅ {{ $chain }}: Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}✅ Aegis data reporting recovered{{ else -}}✅ {{ .Labels.alertname }} resolved{{ end -}}{{ end -}}
+{{- end -}}
+{{ end -}}
 EOT
 }
 
@@ -243,34 +247,44 @@ resource "grafana_message_template" "slack_aegis_service_alert_message" {
   name     = "Slack - Aegis Service Alert Message"
   template = <<-EOT
 {{ define "slack.aegis_service_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
-{{ range .Alerts.Firing }}
-{{ if eq .Labels.alertname "Number of failed rpc calls" }}
-*🚨 FIRING: High number of failed RPC calls detected*
-- More than 10 errors were detected in a 5-minute timespan
-- Check the Aegis service logs for potential issues via `pnpm aegis:logs`
-- Verify RPC endpoint connectivity and stability
+{{ $mixedState := and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+{{ range .Alerts.Firing -}}
+{{ if eq .Labels.alertname "Aegis view-call failures [production]" }}
+{{ $chain := .Labels.chain | title -}}
+{{ if $mixedState }}*🚨 {{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}*
+{{ end -}}
+Why this matters: Aegis cannot reliably read `{{ .Labels.contract }}.{{ .Labels.functionName }}` on {{ $chain }}. These reads feed protocol monitoring metrics; if failures continue, downstream oracle, breaker, reserve, or trading-limit alerts can be delayed or suppressed.
+Next action: open Aegis logs, filter for `chain={{ .Labels.chain }}` and `call={{ .Labels.contract }}.{{ .Labels.functionName }}`, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
+- If RPC-only: check the configured primary/fallback endpoint health and provider status.
+- If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ . }}{{ else }}unknown{{ end }}
+- <{{ .GeneratorURL }}&tab=instances|Alert details>
+- Logs: `pnpm aegis:logs`
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}
-*🚨 FIRING: Aegis service is not reporting new data*
-- Aegis has not pushed any new data for more than 5 minutes
-- The service may be down or experiencing issues
-- Check Aegis service status and logs immediately
+{{ if $mixedState }}*🚨 Aegis has stopped reporting data*
+{{ end -}}
+Why this matters: Aegis has not pushed any new metrics for more than 5 minutes, so protocol alert inputs may be stale.
+Next action: check App Engine service health and Aegis logs immediately.
+- <{{ .GeneratorURL }}&tab=instances|Alert details>
+- Logs: `pnpm aegis:logs`
 {{ else }}
 *🚨 FIRING: {{ .Labels.alertname }}*
 {{ .Annotations.summary }}
 {{ end }}
 {{ end }}
-{{ range .Alerts.Resolved }}
-{{ if eq .Labels.alertname "Number of failed rpc calls" }}
-*✅ RESOLVED: RPC call failures have decreased*
-- The number of failed RPC calls is now within acceptable limits
+{{ range .Alerts.Resolved -}}
+{{ if eq .Labels.alertname "Aegis view-call failures [production]" }}
+{{ $chain := .Labels.chain | title -}}
+*{{ if $mixedState }}✅ {{ end }}Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }} on {{ $chain }}*
+- The per-call error rate is back below 10 failed samples per 5 minutes.
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}
-*✅ RESOLVED: Aegis service is reporting data again*
-- Aegis has resumed normal data reporting
+*{{ if $mixedState }}✅ {{ end }}Aegis data reporting recovered*
+- Aegis has resumed normal data reporting.
 {{ else }}
 *✅ RESOLVED: {{ .Labels.alertname }}*
 {{ end }}
 {{ end }}
+{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}
 {{ end }}
 EOT
 }

--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -257,7 +257,7 @@ Why this matters: Aegis cannot reliably read `{{ .Labels.contract }}.{{ .Labels.
 Next action: open Aegis logs, filter for `chain={{ .Labels.chain }}` and `call={{ .Labels.contract }}.{{ .Labels.functionName }}`, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
 - If RPC-only: check the configured primary/fallback endpoint health and provider status.
 - If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
-- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ printf "%.0f" . }}{{ else }}unknown{{ end }}
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ reReplaceAll "\\.[0-9]+$" "" (printf "%v" .) }}{{ else }}unknown{{ end }}
 - <{{ .GeneratorURL }}&tab=instances|Alert details>
 - Logs: `pnpm aegis:logs`
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -200,9 +200,9 @@ resource "grafana_message_template" "victorops_aegis_service_alert_title" {
 {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
 {{ .CommonLabels.alertname -}}
 {{ else if (len .Alerts.Firing) -}}
-{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}{{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}Aegis has stopped reporting data{{ else -}}{{ .Labels.alertname }}{{ end -}}{{ end -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq $alert.Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := $alert.Labels.chain | title -}}{{ $chain }}: Aegis view calls failing for {{ $alert.Labels.contract }}.{{ $alert.Labels.functionName }}{{ else if eq $alert.Labels.alertname "Aegis does not report new data" -}}Aegis has stopped reporting data{{ else -}}{{ $alert.Labels.alertname }}{{ end -}}{{ end -}}
 {{ else if (len .Alerts.Resolved) -}}
-{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}{{ $chain }}: Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}Aegis data reporting recovered{{ else -}}{{ .Labels.alertname }} resolved{{ end -}}{{ end -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq $alert.Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := $alert.Labels.chain | title -}}{{ $chain }}: Aegis view calls recovered for {{ $alert.Labels.contract }}.{{ $alert.Labels.functionName }}{{ else if eq $alert.Labels.alertname "Aegis does not report new data" -}}Aegis data reporting recovered{{ else -}}{{ $alert.Labels.alertname }} resolved{{ end -}}{{ end -}}
 {{ end -}}
 {{ end -}}
 EOT
@@ -223,7 +223,7 @@ Why this matters: Aegis cannot reliably read {{ .Labels.contract }}.{{ .Labels.f
 Next action: open Aegis logs, filter for chain={{ .Labels.chain }} and call={{ .Labels.contract }}.{{ .Labels.functionName }}, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
 - If RPC-only: check the configured primary/fallback endpoint health and provider status.
 - If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
-- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ . }}{{ else }}unknown{{ end }}
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ printf "%.0f" . }}{{ else }}unknown{{ end }}
 - Alert details: {{ .GeneratorURL }}&tab=instances
 - Logs: pnpm aegis:logs
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -196,11 +196,15 @@ EOT
 resource "grafana_message_template" "victorops_aegis_service_alert_title" {
   name     = "VictorOps - Aegis Service Alert Title"
   template = <<-EOT
-{{ define "victorops.aegis_service_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] {{ .CommonLabels.alertname }}
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.alertname }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.alertname }}{{ end }}{{ end }}
-{{ end }}
+{{ define "victorops.aegis_service_alert_title" -}}
+{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+{{ .CommonLabels.alertname -}}
+{{ else if (len .Alerts.Firing) -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}{{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}Aegis has stopped reporting data{{ else -}}{{ .Labels.alertname }}{{ end -}}{{ end -}}
+{{ else if (len .Alerts.Resolved) -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ if eq .Labels.alertname "Aegis view-call failures [production]" -}}{{ $chain := .Labels.chain | title -}}{{ $chain }}: Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }}{{ else if eq .Labels.alertname "Aegis does not report new data" -}}Aegis data reporting recovered{{ else -}}{{ .Labels.alertname }} resolved{{ end -}}{{ end -}}
+{{ end -}}
+{{ end -}}
 EOT
 }
 
@@ -208,34 +212,45 @@ resource "grafana_message_template" "victorops_aegis_service_alert_message" {
   name     = "VictorOps - Aegis Service Alert Message"
   template = <<-EOT
 {{ define "victorops.aegis_service_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
-{{ range .Alerts.Firing }}
-{{ if eq .Labels.alertname "Number of failed rpc calls" }}
-FIRING: High number of failed RPC calls detected
-- More than 10 errors were detected in a 5-minute timespan
-- Check the Aegis service logs for potential issues via `pnpm aegis:logs`
-- Verify RPC endpoint connectivity and stability
+{{ $firingCount := len .Alerts.Firing -}}
+{{ $mixedState := and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+{{ range .Alerts.Firing -}}
+{{ if eq .Labels.alertname "Aegis view-call failures [production]" }}
+{{ $chain := .Labels.chain | title -}}
+{{ if $mixedState }}{{ $chain }}: Aegis view calls failing for {{ .Labels.contract }}.{{ .Labels.functionName }}
+{{ end -}}
+Why this matters: Aegis cannot reliably read {{ .Labels.contract }}.{{ .Labels.functionName }} on {{ $chain }}. These reads feed protocol monitoring metrics; if failures continue, downstream oracle, breaker, reserve, or trading-limit alerts can be delayed or suppressed.
+Next action: open Aegis logs, filter for chain={{ .Labels.chain }} and call={{ .Labels.contract }}.{{ .Labels.functionName }}, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
+- If RPC-only: check the configured primary/fallback endpoint health and provider status.
+- If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ . }}{{ else }}unknown{{ end }}
+- Alert details: {{ .GeneratorURL }}&tab=instances
+- Logs: pnpm aegis:logs
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}
-FIRING: Aegis service is not reporting new data
-- Aegis has not pushed any new data for more than 5 minutes
-- The service may be down or experiencing issues
-- Check Aegis service status and logs immediately
+{{ if $mixedState }}Aegis has stopped reporting data
+{{ end -}}
+Why this matters: Aegis has not pushed any new metrics for more than 5 minutes, so protocol alert inputs may be stale.
+Next action: check App Engine service health and Aegis logs immediately.
+- Alert details: {{ .GeneratorURL }}&tab=instances
+- Logs: pnpm aegis:logs
 {{ else }}
 FIRING: {{ .Labels.alertname }}
 {{ .Annotations.summary }}
 {{ end }}
 {{ end }}
-{{ range .Alerts.Resolved }}
-{{ if eq .Labels.alertname "Number of failed rpc calls" }}
-RESOLVED: RPC call failures have decreased
-- The number of failed RPC calls is now within acceptable limits
+{{ range .Alerts.Resolved -}}
+{{ if eq .Labels.alertname "Aegis view-call failures [production]" }}
+{{ $chain := .Labels.chain | title -}}
+Aegis view calls recovered for {{ .Labels.contract }}.{{ .Labels.functionName }} on {{ $chain }}.
+- The per-call error rate is back below 10 failed samples per 5 minutes.
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}
-RESOLVED: Aegis service is reporting data again
-- Aegis has resumed normal data reporting
+Aegis data reporting recovered.
+- Aegis has resumed normal data reporting.
 {{ else }}
 RESOLVED: {{ .Labels.alertname }}
 {{ end }}
 {{ end }}
+{{ if eq $firingCount 0 }}No alerts are currently firing.{{ end }}
 {{ end }}
 EOT
 }

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -223,7 +223,7 @@ Why this matters: Aegis cannot reliably read {{ .Labels.contract }}.{{ .Labels.f
 Next action: open Aegis logs, filter for chain={{ .Labels.chain }} and call={{ .Labels.contract }}.{{ .Labels.functionName }}, and decide whether this is an RPC endpoint outage or a deterministic contract/config failure.
 - If RPC-only: check the configured primary/fallback endpoint health and provider status.
 - If deterministic: fix or revert the metric config; retrying a fallback endpoint will not help.
-- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ printf "%.0f" . }}{{ else }}unknown{{ end }}
+- Failed samples in the current 5m window: {{ with index .Values "errorCount" }}{{ reReplaceAll "\\.[0-9]+$" "" (printf "%v" .) }}{{ else }}unknown{{ end }}
 - Alert details: {{ .GeneratorURL }}&tab=instances
 - Logs: pnpm aegis:logs
 {{ else if eq .Labels.alertname "Aegis does not report new data" }}

--- a/alerts/rules/protocol-routing-locals.tf
+++ b/alerts/rules/protocol-routing-locals.tf
@@ -374,7 +374,7 @@ locals {
     },
     aegis_service_issues = {
       names = [
-        "Number of failed rpc calls",
+        "Aegis view-call failures [production]",
         "Aegis does not report new data"
       ],
       slack_title_template       = "slack.aegis_service_alert_title",

--- a/alerts/rules/rules-aegis-service.tf
+++ b/alerts/rules/rules-aegis-service.tf
@@ -146,8 +146,8 @@ resource "grafana_rule_group" "aegis_service_alerts" {
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
-      description = "Triggers if the time between the last aegis update and now is bigger than 5 mins."
-      summary     = "Tracks the time passed since the last update from aegis. \n\nThis alert triggering means aegis did not push any new data for > 5mins.\n\nIt is highly possible that the aegis is down."
+      description = "Aegis has not pushed any new metrics for more than 5 minutes. Protocol alert inputs may be stale."
+      summary     = "Aegis data reporting is stale. Check App Engine service health and Aegis logs immediately."
     }
     labels = {
       service  = "aegis"

--- a/alerts/rules/rules-aegis-service.tf
+++ b/alerts/rules/rules-aegis-service.tf
@@ -22,7 +22,7 @@ resource "grafana_rule_group" "aegis_service_alerts" {
   interval_seconds = 60
 
   rule {
-    name      = "Number of failed rpc calls"
+    name      = "Aegis view-call failures [production]"
     condition = "B"
 
     data {
@@ -35,9 +35,12 @@ resource "grafana_rule_group" "aegis_service_alerts" {
 
       datasource_uid = var.prometheus_datasource_uid
       model = jsonencode({
-        disableTextWrap     = false
-        editorMode          = "code"
-        expr                = "sum(increase(view_call_query_duration_count{status=\"error\"}[5m]))"
+        disableTextWrap = false
+        editorMode      = "code"
+        # Testnet poll errors have warning-only rules in rules-aegis-testnet.tf.
+        # Keep this page scoped to production and preserve the failing call
+        # labels so the on-call can see what broke without digging first.
+        expr                = "sum by (chain, contract, functionName) (increase(view_call_query_duration_count{chain=~\"^(celo|monad)$\",status=\"error\"}[5m]))"
         fullMetaSearch      = false
         includeNullMetadata = true
         instant             = true
@@ -79,8 +82,8 @@ resource "grafana_rule_group" "aegis_service_alerts" {
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
-      description = "Tracks the number of error responses from our monitoring service."
-      summary     = "More than 10 errors were detected in a 5-minute timespan."
+      description = "Aegis failed to read {{ $labels.contract }}.{{ $labels.functionName }} on {{ $labels.chain }}. These view calls feed protocol monitoring metrics; sustained failures can delay or suppress downstream alerts."
+      summary     = "Aegis recorded more than 10 failed production view-call samples for {{ $labels.contract }}.{{ $labels.functionName }} on {{ $labels.chain }} in 5 minutes."
     }
     labels = {
       service  = "aegis"


### PR DESCRIPTION
## The Problem

- The Aegis page for failed RPC calls did not say which chain or view call was failing.
- The alert text did not explain why sustained Aegis read failures matter for protocol monitoring.
- Testnet poll failures could contribute to a production page even though testnet already has warning-only Aegis health alerts.

## The Solution

- Rename the page to a production Aegis view-call failure alert, preserve the failing `chain`, `contract`, and `functionName` labels, and update Slack/Splunk messages so the on-call immediately sees the failing surface, impact, and next action.

## Details

- Scope the page query to production Aegis chains with `chain=~"^(celo|monad)$"`.
- Keep the existing `>10 failed samples in 5m for 5m` threshold, but apply it per production view call instead of one global all-chain sum.
- Keep testnet failures on the existing `service=aegis-testnet` warning-only rules.
- Include the current 5-minute failed-sample count and an explicit RPC-vs-deterministic failure triage path in both Slack and Splunk On-Call templates.
- No Terraform apply was run; apply remains on the normal merge/CI path.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Live Grafana/Prometheus spot checks showed recent noise was testnet-dominated and the new production-scoped query was currently zero.
- `pnpm agent:autoreview` used the local deterministic engine because nested Codex execution is unavailable inside the active Codex sandbox.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
