### PR TITLE
Fix duplicate VictorOps trading alert text

### DIFF
--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -96,9 +96,9 @@ resource "grafana_message_template" "victorops_trading_mode_alert_title" {
   template = <<-EOT
 {{ define "victorops.trading_mode_alert_title" -}}
 {{ if (len .Alerts.Firing) -}}
-{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker{{ end -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
 {{ else if (len .Alerts.Resolved) -}}
-{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed{{ end -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
 {{ else -}}
 Trading mode alert
 {{ end -}}
@@ -136,6 +136,8 @@ ${local.monad_chainlink_slug_branches}
 {{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
 {{ if or $mixedState (gt $firingCount 1) -}}
 {{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker
+{{ else -}}
+Trading halted by breaker for {{ $rateFeedWithSlash }} [{{ $chain }}].
 {{ end -}}
 {{ if $chainlinkURL -}}
 Next action: verify the Chainlink data source, then ack/snooze if the move is real. Do not manually reset unless the feed is wrong or the breaker is stuck after recovery.

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -231,7 +231,7 @@ test("CLI passes against the real repository", () => {
   );
 });
 
-test("VictorOps trading-mode body stays distinct from the incident title", () => {
+test("VictorOps trading-mode title is stable and body carries state", () => {
   const source = readFileSync(
     path.resolve(
       __dirname,
@@ -240,14 +240,37 @@ test("VictorOps trading-mode body stays distinct from the incident title", () =>
     ),
     "utf8",
   );
+  const titleStart = source.indexOf(
+    'resource "grafana_message_template" "victorops_trading_mode_alert_title"',
+  );
+  const titleEnd = source.indexOf(
+    'resource "grafana_message_template" "victorops_trading_mode_alert_message"',
+  );
+  assert(titleStart >= 0 && titleEnd > titleStart, "title template not found");
+
+  const titleTemplate = source.slice(titleStart, titleEnd);
+  assert(
+    !titleTemplate.includes("Trading halted by breaker"),
+    "VictorOps title should be the stable entity label, not the firing state",
+  );
+  assert(
+    !titleTemplate.includes("Trading resumed"),
+    "VictorOps title should be the stable entity label, not the recovery state",
+  );
 
   // These checks intentionally match exact whitespace in the Terraform
   // template. If you reformat the guarded template lines, update these strings.
   assert(
     source.includes(
-      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ end -}}\n{{ if $chainlinkURL -}}",
+      '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}',
     ),
-    "single firing alerts should start the body at the next action, not repeat the title",
+    "VictorOps firing title should render the affected market only",
+  );
+  assert(
+    source.includes(
+      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ else -}}\nTrading halted by breaker for {{ $rateFeedWithSlash }} [{{ $chain }}].\n{{ end -}}\n{{ if $chainlinkURL -}}",
+    ),
+    "single firing bodies should carry the state without repeating the entity title",
   );
   assert(
     source.includes(

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -261,7 +261,7 @@ test("VictorOps trading-mode title is stable and body carries state", () => {
   // These checks intentionally match exact whitespace in the Terraform
   // template. If you reformat the guarded template lines, update these strings.
   assert(
-    source.includes(
+    titleTemplate.includes(
       '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}',
     ),
     "VictorOps firing title should render the affected market only",


### PR DESCRIPTION
## The Problem

- Splunk On-Call trading-mode alerts repeat the same state sentence in the incident heading and the VictorOps entity display field.
- The duplicate copy makes recovery messages harder to scan because the stable incident title can keep the original firing wording.

## The Solution

- Make the VictorOps trading-mode title a stable affected-market label and keep the firing/resolved state wording in the message body.

## Details

- Trading-mode VictorOps titles now render values such as `USDT/USD [Celo]` instead of appending `Trading halted by breaker` or `Trading resumed`.
- Single firing bodies now explicitly say `Trading halted by breaker for ...`, so the incident still carries state without duplicating the title.
- Existing Splunk On-Call incidents can retain old headings; this changes future Grafana-delivered payloads after the alerts-rules stack is applied.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic engine; clean)
- Browser verification not applicable: this only changes Grafana alert templates and a root lint regression.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned