### PR TITLE
Keep VictorOps trading state visible

### DIFF
--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -96,9 +96,9 @@ resource "grafana_message_template" "victorops_trading_mode_alert_title" {
   template = <<-EOT
 {{ define "victorops.trading_mode_alert_title" -}}
 {{ if (len .Alerts.Firing) -}}
-{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading halted by breaker
 {{ else if (len .Alerts.Resolved) -}}
-{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading resumed
 {{ else -}}
 Trading mode alert
 {{ end -}}
@@ -136,8 +136,6 @@ ${local.monad_chainlink_slug_branches}
 {{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
 {{ if or $mixedState (gt $firingCount 1) -}}
 {{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker
-{{ else -}}
-Trading halted by breaker.
 {{ end -}}
 {{ if $chainlinkURL -}}
 Next action: verify the Chainlink data source, then ack/snooze if the move is real. Do not manually reset unless the feed is wrong or the breaker is stuck after recovery.

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -273,6 +273,8 @@ test("VictorOps trading-mode title carries visible state and body carries action
   assert(titleStart >= 0 && titleEnd > titleStart, "title template not found");
 
   const titleTemplate = source.slice(titleStart, titleEnd);
+  // These assertions match exact whitespace in the Terraform template.
+  // If you reformat the guarded template lines, update these strings.
   assert(
     titleTemplate.includes(
       '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading halted by breaker',

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -255,7 +255,7 @@ test("CLI passes against the real repository", () => {
   );
 });
 
-test("VictorOps trading-mode title is stable and body carries state", () => {
+test("VictorOps trading-mode title carries visible state and body carries action", () => {
   const source = readFileSync(
     path.resolve(
       __dirname,
@@ -274,27 +274,29 @@ test("VictorOps trading-mode title is stable and body carries state", () => {
 
   const titleTemplate = source.slice(titleStart, titleEnd);
   assert(
-    !titleTemplate.includes("Trading halted by breaker"),
-    "VictorOps title should be the stable entity label, not the firing state",
+    titleTemplate.includes(
+      '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading halted by breaker',
+    ),
+    "VictorOps firing title should render the affected market and visible state",
   );
-  assert(
-    !titleTemplate.includes("Trading resumed"),
-    "VictorOps title should be the stable entity label, not the recovery state",
-  );
-
-  // These checks intentionally match exact whitespace in the Terraform
-  // template. If you reformat the guarded template lines, update these strings.
   assert(
     titleTemplate.includes(
-      '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}',
+      '{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading resumed',
     ),
-    "VictorOps firing title should render the affected market only",
+    "VictorOps resolved title should render the affected market and visible state",
   );
+
   assert(
     source.includes(
-      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ else -}}\nTrading halted by breaker.\n{{ end -}}\n{{ if $chainlinkURL -}}",
+      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ end -}}\n{{ if $chainlinkURL -}}",
     ),
-    "single firing bodies should carry the state without repeating the market title in SMS",
+    "single firing bodies should start with the next action instead of repeating title state in SMS",
+  );
+  assert(
+    !source.includes(
+      "{{ else -}}\nTrading halted by breaker.\n{{ end -}}\n{{ if $chainlinkURL -}}",
+    ),
+    "single firing bodies should not repeat the state sentence after the title",
   );
   assert(
     source.includes(


### PR DESCRIPTION
## The Problem

- Splunk On-Call/VictorOps Slack cards mostly expose the incident title/entity line before the longer description.
- After making the trading-mode title a stable market label, collapsed Slack cards only showed `USDT/USD [Monad]` and hid the actual state/action context.
- SMS still needs to avoid repeating the market/state after VictorOps prepends the incident title.

## The Solution

- Put the trading state back into the VictorOps trading-mode title, so Slack collapsed cards show `USDT/USD [Monad]: Trading halted by breaker` or `Trading resumed`.
- Keep the single-alert VictorOps body focused on `Next action` and links, so SMS reads as `title - Next action...` instead of duplicating the title state.

## Details

- Grouped/mixed VictorOps bodies still include per-alert pair and chain labels before their state lines.
- Single-firing bodies now start directly with the Chainlink/breaker next action.
- The regression test now pins the Slack-visible title state and the non-duplicated single-alert body contract.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic engine; clean)
- Browser verification not applicable: this changes Grafana/VictorOps notification templates, not UI behavior.

## Ship Checklist

- [x] local review/gate run
- [x] PR readiness probe planned