### PR TITLE
Reduce trading alert Slack duplication

### DIFF
--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -148,7 +148,9 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
   # the per-feed allowlist comes from `reference-data-directory.vercel.app/feeds-<chain>-mainnet.json`.
   template = <<-EOT
 {{ define "slack.trading_mode_alert_message" }}
-{{ $mixedState := and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+{{ $firingCount := len .Alerts.Firing -}}
+{{ $resolvedCount := len .Alerts.Resolved -}}
+{{ $mixedState := and $firingCount $resolvedCount -}}
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
@@ -170,7 +172,9 @@ ${local.monad_chainlink_slug_branches}
 {{ if and $chainId $pool -}}{{ $poolURL = printf "https://monitoring.mento.org/pool/%s-%s?tab=oracle" $chainId $pool }}{{ end -}}
 {{ $chainlinkURL := "" -}}
 {{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
+{{ if or $mixedState (gt $firingCount 1) -}}
 *{{ if $mixedState }}🚨 {{ end }}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker*
+{{ end -}}
 {{ if $chainlinkURL -}}
 Next action: verify the Chainlink data source, then ack/snooze if the move is real. Do not manually reset unless the feed is wrong or the breaker is stuck after recovery.
 - <{{ $chainlinkURL }}|Chainlink {{ $rateFeedWithSlash }} data source> at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
@@ -185,10 +189,12 @@ Next action: open breaker status and confirm the underlying rate-feed or market 
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
+{{ if or $mixedState (gt $resolvedCount 1) -}}
 *{{ if $mixedState }}✅ {{ end }}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed*
 {{ end -}}
+{{ end -}}
 
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}
+{{ if eq $firingCount 0 }}No alerts are currently firing 🙂.{{ end }}
 {{ end -}}
 EOT
 }

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -96,9 +96,9 @@ resource "grafana_message_template" "victorops_trading_mode_alert_title" {
   template = <<-EOT
 {{ define "victorops.trading_mode_alert_title" -}}
 {{ if (len .Alerts.Firing) -}}
-{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading halted by breaker
+{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
 {{ else if (len .Alerts.Resolved) -}}
-{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading resumed
+{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}
 {{ else -}}
 Trading mode alert
 {{ end -}}
@@ -136,6 +136,8 @@ ${local.monad_chainlink_slug_branches}
 {{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
 {{ if or $mixedState (gt $firingCount 1) -}}
 {{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker
+{{ else -}}
+Trading halted by breaker.
 {{ end -}}
 {{ if $chainlinkURL -}}
 Next action: verify the Chainlink data source, then ack/snooze if the move is real. Do not manually reset unless the feed is wrong or the breaker is stuck after recovery.
@@ -150,7 +152,34 @@ Alert time: {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-Trading resumed for {{ $rateFeedWithSlash }} [{{ $chain }}].
+{{ $chainId := "" -}}
+${local.chain_id_branches}
+{{ $chainlinkFeedPath := "" -}}
+${local.chainlink_feed_path_branches}
+{{ $pool := "" -}}
+{{ $chainlinkSlug := "" -}}
+{{ if eq .Labels.chain "celo" -}}
+${local.celo_pool_branches}
+${local.celo_chainlink_slug_branches}
+{{ end -}}
+{{ if eq .Labels.chain "monad" -}}
+${local.monad_pool_branches}
+${local.monad_chainlink_slug_branches}
+{{ end -}}
+{{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
+{{ if and $chainId $pool -}}{{ $poolURL = printf "https://monitoring.mento.org/pool/%s-%s?tab=oracle" $chainId $pool }}{{ end -}}
+{{ $chainlinkURL := "" -}}
+{{ if and $chainlinkFeedPath $chainlinkSlug -}}{{ $chainlinkURL = printf "https://data.chain.link/feeds/%s/%s" $chainlinkFeedPath $chainlinkSlug }}{{ end -}}
+{{ if or $mixedState (gt $resolvedCount 1) -}}
+{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed
+{{ else -}}
+Trading resumed.
+{{ end -}}
+{{ if $chainlinkURL -}}
+- Chainlink data source: {{ $chainlinkURL }}
+{{ end -}}
+- Breaker status: {{ $poolURL }}
+Resolved at: {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
 {{ end -}}
 
 {{ if eq $firingCount 0 }}No alerts are currently firing.{{ end }}

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -296,21 +296,45 @@ test("trading-mode notification templates avoid single-alert duplicate headings"
     "VictorOps title should not repeat resolved state in entity_display_name",
   );
 
+  const messageStart = source.indexOf(
+    'resource "grafana_message_template" "victorops_trading_mode_alert_message"',
+  );
+  const messageEnd = source.indexOf(
+    'resource "grafana_message_template" "victorops_trading_limits_alert_title"',
+  );
   assert(
-    source.includes(
+    messageStart >= 0 && messageEnd > messageStart,
+    "message template not found",
+  );
+  const messageTemplate = source.slice(messageStart, messageEnd);
+  const resolvedStart = messageTemplate.indexOf(
+    "{{ range .Alerts.Resolved -}}",
+  );
+  const resolvedEnd = messageTemplate.indexOf(
+    "{{ if eq $firingCount 0 }}No alerts are currently firing.",
+    resolvedStart,
+  );
+  assert(
+    resolvedStart >= 0 && resolvedEnd > resolvedStart,
+    "resolved message block not found",
+  );
+  const resolvedTemplate = messageTemplate.slice(resolvedStart, resolvedEnd);
+
+  assert(
+    messageTemplate.includes(
       "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ else -}}\nTrading halted by breaker.\n{{ end -}}\n{{ if $chainlinkURL -}}",
     ),
-    "VictorOps state_message should carry firing state for single-alert Slack cards",
+    "VictorOps state_message should carry per-feed firing context when multi-alert or mixed",
   );
   assert(
-    source.includes(
+    messageTemplate.includes(
       "{{ if or $mixedState (gt $resolvedCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed\n{{ else -}}\nTrading resumed.\n{{ end -}}",
     ),
-    "VictorOps state_message should carry resolved state for single-alert Slack cards",
+    "VictorOps state_message should carry resolved state outside entity_display_name",
   );
   assert(
-    source.includes("- Chainlink data source: {{ $chainlinkURL }}"),
-    "VictorOps state_message should include Chainlink URLs when available",
+    resolvedTemplate.includes("- Chainlink data source: {{ $chainlinkURL }}"),
+    "VictorOps resolved state_message should include Chainlink URLs when available",
   );
   assert(
     source.includes(

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -255,7 +255,7 @@ test("CLI passes against the real repository", () => {
   );
 });
 
-test("VictorOps trading-mode title carries visible state and body carries action", () => {
+test("trading-mode notification templates avoid single-alert duplicate headings", () => {
   const source = readFileSync(
     path.resolve(
       __dirname,
@@ -277,40 +277,71 @@ test("VictorOps trading-mode title carries visible state and body carries action
   // If you reformat the guarded template lines, update these strings.
   assert(
     titleTemplate.includes(
-      '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading halted by breaker',
+      '{{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}',
     ),
-    "VictorOps firing title should render the affected market and visible state",
+    "VictorOps firing title should render the stable affected market",
   );
   assert(
     titleTemplate.includes(
-      '{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}: Trading resumed',
+      '{{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}{{ $chain := .Labels.chain | title -}}{{ $rateFeedWithSlash }} [{{ $chain }}]{{ end -}}',
     ),
-    "VictorOps resolved title should render the affected market and visible state",
+    "VictorOps resolved title should render the stable affected market",
+  );
+  assert(
+    !titleTemplate.includes(": Trading halted by breaker"),
+    "VictorOps title should not repeat state in entity_display_name",
+  );
+  assert(
+    !titleTemplate.includes(": Trading resumed"),
+    "VictorOps title should not repeat resolved state in entity_display_name",
   );
 
   assert(
     source.includes(
-      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ end -}}\n{{ if $chainlinkURL -}}",
+      "{{ if or $mixedState (gt $firingCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker\n{{ else -}}\nTrading halted by breaker.\n{{ end -}}\n{{ if $chainlinkURL -}}",
     ),
-    "single firing bodies should start with the next action instead of repeating title state in SMS",
-  );
-  assert(
-    !source.includes(
-      "{{ else -}}\nTrading halted by breaker.\n{{ end -}}\n{{ if $chainlinkURL -}}",
-    ),
-    "single firing bodies should not repeat the state sentence after the title",
+    "VictorOps state_message should carry firing state for single-alert Slack cards",
   );
   assert(
     source.includes(
-      "Trading resumed for {{ $rateFeedWithSlash }} [{{ $chain }}].",
+      "{{ if or $mixedState (gt $resolvedCount 1) -}}\n{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed\n{{ else -}}\nTrading resumed.\n{{ end -}}",
     ),
-    "resolved trading-mode bodies should use resumed wording",
+    "VictorOps state_message should carry resolved state for single-alert Slack cards",
+  );
+  assert(
+    source.includes("- Chainlink data source: {{ $chainlinkURL }}"),
+    "VictorOps state_message should include Chainlink URLs when available",
   );
   assert(
     source.includes(
       "{{ if eq $firingCount 0 }}No alerts are currently firing.",
     ),
     "the resolved footer should use the computed firing count",
+  );
+});
+
+test("Slack trading-mode bodies suppress duplicate single-alert headings", () => {
+  const source = readFileSync(
+    path.resolve(__dirname, "..", "alerts/rules/message-templates-slack.tf"),
+    "utf8",
+  );
+  assert(
+    source.includes(
+      "{{ if or $mixedState (gt $firingCount 1) -}}\n*{{ if $mixedState }}🚨 {{ end }}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading halted by breaker*\n{{ end -}}\n{{ if $chainlinkURL -}}",
+    ),
+    "single firing Slack bodies should start with next action instead of repeating the title",
+  );
+  assert(
+    source.includes(
+      "{{ if or $mixedState (gt $resolvedCount 1) -}}\n*{{ if $mixedState }}✅ {{ end }}{{ $rateFeedWithSlash }} [{{ $chain }}]: Trading resumed*\n{{ end -}}\n{{ end -}}\n\n{{ if eq $firingCount 0 }}No alerts are currently firing",
+    ),
+    "single resolved Slack bodies should not repeat the resolved title line",
+  );
+  assert(
+    source.includes(
+      "<{{ $chainlinkURL }}|Chainlink {{ $rateFeedWithSlash }} data source>",
+    ),
+    "native Slack trading-mode firing body should keep Chainlink links",
   );
 });
 


### PR DESCRIPTION
## The Problem

- Native Grafana `#alerts-critical` trading-mode messages repeat the same title as the first body line for single firing/resolved alerts.
- The VictorOps/Splunk On-Call Slack app also repeats `entity_display_name` in its fixed card layout, so putting state in the VictorOps title makes the card noisy.
- Resolved VictorOps cards did not expose Chainlink or breaker-status context in the visible state message.

## The Solution

- Suppress the repeated first body heading in native Slack trading-mode messages when there is only one firing or one resolved alert; grouped/mixed messages still keep per-alert headings.
- Use a stable market-only VictorOps title (`USDT/USD [Celo]`) and put state/action/details in the VictorOps description/state message.
- Add Chainlink and breaker-status lines to resolved VictorOps trading-mode state messages, matching firing messages where possible.

## Details

- Native Slack firing single-alert body now starts at `Next action`, preserving the clickable Chainlink and breaker-status links.
- Native Slack resolved single-alert body now avoids repeating the resolved title and keeps the `No alerts are currently firing` footer.
- VictorOps still cannot fully control the Splunk On-Call Slack app card layout from Grafana; this PR avoids feeding duplicate state into `entity_display_name` and keeps the actionable details in `state_message`.
- Added regression coverage for both VictorOps and native Slack single-alert duplicate-heading behavior.

## Validation

- `pnpm alerts:rules:lint:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic engine; clean)
- Browser verification not applicable: this changes Grafana/Splunk On-Call notification templates, not UI behavior.

## Ship Checklist

- [x] local review/gate run
- [x] PR readiness probe planned