### PR TITLE
Reduce trading-mode flapping pages

### DIFF
--- a/alerts/rules/notification-policies.tf
+++ b/alerts/rules/notification-policies.tf
@@ -366,7 +366,7 @@ resource "grafana_notification_policy" "all" {
         group_by        = ["alertname", "chain", "rateFeed"]
         group_wait      = "30s"
         group_interval  = "5m"
-        repeat_interval = "24h"
+        repeat_interval = "1d"
 
         matcher {
           label = "severity"

--- a/alerts/rules/rules-trading-modes.tf
+++ b/alerts/rules/rules-trading-modes.tf
@@ -7,11 +7,15 @@ resource "grafana_rule_group" "trading_modes" {
     for_each = local.chains
 
     content {
-      name           = "Trading Mode Alert [${rule.value.title}]"
-      condition      = "isTradingHalted"
-      for            = "5m"
-      exec_err_state = "Error"
-      no_data_state  = "NoData"
+      name      = "Trading Mode Alert [${rule.value.title}]"
+      condition = "isTradingHalted"
+      for       = "5m"
+      # USDT/USD can hover around the breaker threshold and briefly repeg before
+      # tripping again. Keep the incident open across short healthy dips so
+      # Splunk On-Call does not create a fresh SMS page for every flap.
+      keep_firing_for = "1h"
+      exec_err_state  = "Error"
+      no_data_state   = "NoData"
 
       annotations = {
         summary = "Trading is halted for the {{ $labels.rateFeed }} rate feed on {{ $labels.chain | title }}. Check if a breaker tripped."

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -416,6 +416,19 @@ test("trading-mode Splunk pages repeat slowly per rate feed", () => {
     /\bcontinue\s*=\s*true/.test(splunkPolicy),
     "trading-mode Splunk policy must continue so Slack alerts-critical also fires",
   );
+
+  const tradingModeRules = readFileSync(
+    path.resolve(__dirname, "..", "alerts/rules/rules-trading-modes.tf"),
+    "utf8",
+  );
+  assert(
+    /\bfor\s*=\s*"5m"/.test(tradingModeRules),
+    "trading-mode alerts should still page quickly after a sustained halt",
+  );
+  assert(
+    /\bkeep_firing_for\s*=\s*"1h"/.test(tradingModeRules),
+    "trading-mode alerts should keep incidents open across short breaker flaps",
+  );
 });
 
 test("CLI reports parse failures and unknown bridge metrics", () => {

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -409,7 +409,7 @@ test("trading-mode Splunk pages repeat slowly per rate feed", () => {
     "trading-mode pages should keep resolve and group updates prompt",
   );
   assert(
-    /\brepeat_interval\s*=\s*"24h"/.test(splunkPolicy),
+    /\brepeat_interval\s*=\s*"1d"/.test(splunkPolicy),
     "trading-mode pages should not repeat SMS/pager notifications more than daily",
   );
   assert(

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -416,17 +416,19 @@ test("trading-mode Splunk pages repeat slowly per rate feed", () => {
     /\bcontinue\s*=\s*true/.test(splunkPolicy),
     "trading-mode Splunk policy must continue so Slack alerts-critical also fires",
   );
+});
 
+test("trading-mode alerts keep incidents open across short flaps", () => {
   const tradingModeRules = readFileSync(
     path.resolve(__dirname, "..", "alerts/rules/rules-trading-modes.tf"),
     "utf8",
   );
   assert(
-    /\bfor\s*=\s*"5m"/.test(tradingModeRules),
+    /^(?![ \t]*#).*\bfor\s*=\s*"5m"/m.test(tradingModeRules),
     "trading-mode alerts should still page quickly after a sustained halt",
   );
   assert(
-    /\bkeep_firing_for\s*=\s*"1h"/.test(tradingModeRules),
+    /^(?![ \t]*#).*\bkeep_firing_for\s*=\s*"1h"/m.test(tradingModeRules),
     "trading-mode alerts should keep incidents open across short breaker flaps",
   );
 });


### PR DESCRIPTION
## The Problem

- USDT/USD hovered around peg and repeatedly tripped/recovered the breaker, causing many fresh Splunk On-Call SMS pages.
- The existing 24h `repeat_interval` only suppresses reminders while one alert group stays open; it does not suppress new pages after Grafana resolves and re-fires the alert.
- Since the repeat-policy apply, USDT/USD still produced about 11 Celo firing episodes and 2 fresh Monad firing episodes, so the noise came from flapping incident lifecycles.

## The Solution

- Keep trading-mode alerts firing for 1h after the source metric clears.
- This preserves the fast first page (`for = "5m"`) while keeping one incident open across short repeg dips.
- Add a regression assertion so trading-mode pages keep both protections: daily Splunk repeats and a 1h flapping cooldown.

## Validation

- `pnpm alerts:rules:lint:test`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
