### PR TITLE
fix(ci,terraform): Lighthouse Vercel-skip race (#991) + metrics-bridge drift (#990)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -202,18 +202,52 @@ jobs:
               await new Promise(r => setTimeout(r, pollIntervalMs));
             }
 
-            // Timed out: fail rather than audit a stale branch alias.
-            // A branch alias can still resolve to the previous successful
-            // deployment for that branch, so falling back would silently pass
-            // Lighthouse against stale code and miss the missing current preview.
+            // Timed out — before failing, check whether the latest push actually
+            // changed dashboard-affecting paths. When an earlier commit in the PR
+            // touched the dashboard and a follow-up push doesn't, Vercel's
+            // incremental-skip fires (vercel-ignore-build.sh) and posts no new
+            // preview for the new head SHA. In that case the prior preview already
+            // reflects the current dashboard state, so skipping Lighthouse is
+            // correct and safe. Fail closed if the diff check itself errors out
+            // (assume dashboard changed to avoid silently missing a real preview).
+            // (See issue #991.)
+            core.info(`Timed out after ${maxWaitMs / 1000}s. Checking if the latest push changed dashboard-affecting files…`);
+            let dashboardChangedInLatestPush = true;
+            try {
+              const { data: compare } = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                base: `${sha}~1`,
+                head: sha,
+              });
+              // Mirror vercel-ignore-build.sh#dashboard_paths exactly.
+              const dashboardPaths = [
+                'ui-dashboard/', 'shared-config/', 'package.json',
+                'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'patches/', '.lighthouserc.cjs',
+              ];
+              const changedFiles = (compare.files || []).map(f => f.filename);
+              dashboardChangedInLatestPush = changedFiles.some(file =>
+                dashboardPaths.some(p =>
+                  file === p || file.startsWith(p.endsWith('/') ? p : p + '/')
+                )
+              );
+              core.info(`Latest push changed ${changedFiles.length} file(s); dashboard-affecting: ${dashboardChangedInLatestPush}`);
+            } catch (e) {
+              core.warning(`Could not compare ${sha}~1..${sha}: ${e.message}. Failing closed.`);
+            }
+            if (!dashboardChangedInLatestPush) {
+              core.info(`Latest push did not change dashboard-affecting paths — Vercel correctly skipped this build. The prior preview still reflects the current dashboard state. Skipping Lighthouse.`);
+              core.setOutput('vercel_skipped', 'true');
+              return;
+            }
             core.setFailed(`Timed out waiting for a successful Vercel preview deployment for SHA ${sha}. Check the Vercel deployment logs.`);
 
       - name: Install dependencies (includes @lhci/cli)
-        if: steps.decide.outputs.run == 'true'
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true'
         uses: ./.github/actions/pnpm-install
 
       - name: Install Chromium dependencies
-        if: steps.decide.outputs.run == 'true'
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true'
         run: |
           # lhci autorun launches Chromium via puppeteer internally.
           # The required system libraries are not present on the runner by default.
@@ -224,7 +258,7 @@ jobs:
             libxcomposite1 libxdamage1 libxfixes3 libxkbcommon0 libxrandr2
 
       - name: Run Lighthouse CI
-        if: steps.decide.outputs.run == 'true'
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true'
         env:
           # The bypass secret is passed via lhci's --collect.settings.extraHeaders
           # rather than the URL query string so it does NOT end up in the
@@ -281,7 +315,7 @@ jobs:
         # non-zero. Without it, a hard performance-budget failure (once those
         # graduate from `warn` to `error`) would skip the SSO diagnostic and
         # leave the engineer staring at a generic assertion failure.
-        if: steps.decide.outputs.run == 'true' && always()
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true' && always()
         env:
           PREVIEW_URL: ${{ steps.vercel-url.outputs.preview_url }}
         run: node ui-dashboard/scripts/assert-lhci-finalurl.mjs
@@ -304,7 +338,7 @@ jobs:
         # job) can never restore another arch's Chromium — binaries are
         # arch-specific and a cross-arch restore would fail at exec time,
         # not install time.
-        if: steps.decide.outputs.run == 'true' && always()
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true' && always()
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
@@ -331,7 +365,7 @@ jobs:
         #
         # On a cache hit (see prior step) this is a fast no-op that just
         # verifies the chromium binary is present.
-        if: steps.decide.outputs.run == 'true' && always()
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true' && always()
         working-directory: ui-dashboard
         run: pnpm exec playwright install chromium
 
@@ -353,7 +387,7 @@ jobs:
         # `always()` mirrors the audited-page guard: don't silently skip
         # the INP gate when an earlier step (lhci accessibility, the bypass
         # guard) fails.
-        if: steps.decide.outputs.run == 'true' && always()
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true' && always()
         env:
           BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           PREVIEW_URL: ${{ steps.vercel-url.outputs.preview_url }}
@@ -365,7 +399,7 @@ jobs:
           BYPASS_HEADERS_JSON="$BYPASS_HEADERS_JSON" node ui-dashboard/scripts/measure-inp.mjs
 
       - name: Post Lighthouse results as PR comment
-        if: steps.decide.outputs.run == 'true' && always()
+        if: steps.decide.outputs.run == 'true' && steps.vercel-url.outputs.vercel_skipped != 'true' && always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/terraform/metrics-bridge.tf
+++ b/terraform/metrics-bridge.tf
@@ -79,11 +79,24 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
   }
 
   lifecycle {
-    # Image rollouts are triggered by `gcloud run services update` from the
-    # deploy path (scripts/deploy-bridge.sh and the GitHub workflow), not by
-    # terraform. Ignoring the attribute here means `pnpm infra:apply` won't
-    # revert a freshly-deployed image back to the bootstrap placeholder.
-    ignore_changes = [template[0].containers[0].image]
+    # Image rollouts happen out-of-band via `gcloud run services update`
+    # (scripts/deploy-bridge.sh / the CI workflow), not via terraform.
+    # That command also stamps gcloud bookkeeping fields and a revision suffix
+    # that terraform does not manage, causing perpetual drift on every
+    # `pnpm infra:plan` run. Extend ignore_changes to cover those fields per
+    # the policy in terraform/AGENTS.md: "Keep lifecycle.ignore_changes for
+    # images and Cloud Run API bookkeeping fields when rollouts happen through
+    # deploy scripts or workflows." (See issue #990.)
+    #
+    # NOTE: `template[0].scaling` (min=1 max=1) is intentionally NOT listed —
+    # that block is terraform-managed and must keep tracking real drift.
+    ignore_changes = [
+      template[0].containers[0].image,
+      template[0].revision,
+      client,
+      client_version,
+      scaling, # service-level scaling block (API default; distinct from template[0].scaling)
+    ]
   }
 }
 


### PR DESCRIPTION
## The Problem

- When a PR has an earlier dashboard commit followed by a non-dashboard follow-up push, the Lighthouse workflow's 5-minute Vercel wait times out and fails — Vercel's incremental build skip fires for the new HEAD (correct behavior), but the workflow had no way to distinguish "Vercel skipped intentionally" from "deployment genuinely missing" (#991).
- Running `pnpm infra:plan` after any `gcloud run services update metrics-bridge` produces perpetual drift on `template[0].revision`, `client`, `client_version`, and the service-level `scaling` block — fields stamped by gcloud that Terraform does not own (#990).

## The Solution

- In the Vercel wait step's timeout handler, compare `sha~1..sha` via the GitHub API to check whether the latest push actually touched dashboard-affecting paths. If it didn't, set `vercel_skipped=true` and return (skip Lighthouse gracefully); otherwise fail as before. All 8 downstream steps gate on `vercel_skipped != 'true'`.
- Extend `lifecycle.ignore_changes` in `metrics-bridge.tf` to cover `template[0].revision`, `client`, `client_version`, and the service-level `scaling` block (distinct from `template[0].scaling`, which Terraform still manages and intentionally tracks).

## Details

- The `vercel_skipped` output path is only reached on timeout AND latest push not touching dashboard paths — so a real missing deployment still fails closed (the diff check itself errors → `dashboardChangedInLatestPush` stays `true` → `setFailed`).
- `template[0].scaling` (min=1 max=1) is intentionally **not** in `ignore_changes` — it is Terraform-owned and must track drift. Only the service-level `scaling` block (an API default field) is suppressed.
- The `dashboardPaths` list in the GitHub script mirrors `vercel-ignore-build.sh#dashboard_paths` exactly.

## Validation

- `trunk check .github/workflows/lighthouse.yml terraform/metrics-bridge.tf` — passed ✓
- `node scripts/check-github-action-pins.mjs` — passed ✓
- `terraform fmt -check -recursive` — passed ✓ (formatting unchanged)

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK4bnLjbDHArgocRg4C27t)_