### PR TITLE
chore: require autoreview helper in Codex Cloud setup/maintenance and document requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -584,7 +584,12 @@ to spawn unavailable nested `codex exec`; explicit `--engine` arguments and
 forked.
 
 Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
-`~/.claude` directories. Configure the Codex Cloud environment setup script as:
+`~/.claude` directories. The cloud image/environment must therefore install the
+shared global autoreview skill at `~/.agents/skills/autoreview` (or set
+`AUTOREVIEW_HELPER` to its executable helper) before repo setup or maintenance
+runs. Both scripts fail fast when the helper is missing because PR shipping
+requires `pnpm agent:autoreview` as the structured batch-boundary review.
+Configure the Codex Cloud environment setup script as:
 
 ```bash
 ./scripts/codex-cloud-setup.sh
@@ -614,7 +619,8 @@ prewarmed Trunk cache.
 
 Codex Cloud maintenance runs when Codex resumes a cached container after
 checking out the task branch. It skips apt/tool installation, re-establishes
-repo-local git state, refreshes `origin/main`, syncs branch lockfile changes via
+repo-local git state, refreshes `origin/main`, verifies that the global
+autoreview helper is still present, syncs branch lockfile changes via
 `CI=true pnpm install --frozen-lockfile --prefer-offline`, regenerates Envio
 types, and runs `pnpm agent:context-check`.
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,17 @@ Also configure the optional maintenance script for cached container resumes:
 ```
 
 That path performs the frozen install, Envio codegen, and agent-context check
-inside the cloud container, while relying only on repo-visible files. The
-maintenance path runs after Codex checks out the task branch in a cached
-container; it refreshes `origin/main`, syncs branch lockfile changes with
-`pnpm install --frozen-lockfile --prefer-offline`, reruns Envio codegen, and
-validates the agent context.
+inside the cloud container, while relying only on repo-visible files plus the
+shared global autoreview skill. Codex Cloud does not inherit a developer's local
+`~/.agents` directory, so install or bake `~/.agents/skills/autoreview` into the
+environment before setup/maintenance runs, or set `AUTOREVIEW_HELPER` to the
+executable helper path. The setup and maintenance scripts fail fast when that
+helper is missing because PR shipping requires `pnpm agent:autoreview`.
+
+The maintenance path runs after Codex checks out the task branch in a cached
+container; it refreshes `origin/main`, verifies the autoreview helper, syncs
+branch lockfile changes with `pnpm install --frozen-lockfile --prefer-offline`,
+reruns Envio codegen, and validates the agent context.
 
 If you install manually, verify the dashboard can resolve its Sentry package
 after `pnpm install`:

--- a/scripts/codex-cloud-maintenance.sh
+++ b/scripts/codex-cloud-maintenance.sh
@@ -60,6 +60,28 @@ activate_package_manager() {
   pnpm --version
 }
 
+ensure_autoreview_helper() {
+  local helper="${AUTOREVIEW_HELPER:-$HOME/.agents/skills/autoreview/scripts/autoreview}"
+
+  echo "==> Verifying global autoreview helper"
+  if [[ -x "$helper" ]]; then
+    return 0
+  fi
+
+  cat >&2 <<MSG
+error: the global autoreview skill helper is required for cached Codex Cloud
+maintenance:
+  ${helper}
+
+Codex Cloud does not inherit a developer's local ~/.agents directory. Install or
+bake the shared autoreview skill into the environment at
+~/.agents/skills/autoreview before running maintenance, or set AUTOREVIEW_HELPER
+to the executable helper path. Without it, \`pnpm agent:autoreview\` cannot run
+before PR updates.
+MSG
+  return 1
+}
+
 echo "==> Marking repository safe for git"
 git config --global --add safe.directory "$REPO_ROOT" || true
 
@@ -71,6 +93,7 @@ echo "==> Configuring repository git hooks"
 git config core.hooksPath .trunk/hooks
 
 activate_package_manager
+ensure_autoreview_helper
 
 echo "==> Syncing workspace dependencies for the checked-out branch"
 CI=true pnpm install --frozen-lockfile --prefer-offline

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -329,6 +329,27 @@ MSG
   return 1
 }
 
+ensure_autoreview_helper() {
+  local helper="${AUTOREVIEW_HELPER:-$HOME/.agents/skills/autoreview/scripts/autoreview}"
+
+  echo "==> Verifying global autoreview helper"
+  if [[ -x "$helper" ]]; then
+    return 0
+  fi
+
+  cat >&2 <<MSG
+error: the global autoreview skill helper is required for Codex Cloud agent work:
+  ${helper}
+
+Codex Cloud does not inherit a developer's local ~/.agents directory. Install or
+bake the shared autoreview skill into the environment at
+~/.agents/skills/autoreview before running this setup script, or set
+AUTOREVIEW_HELPER to the executable helper path. The repo ship flow depends on
+\`pnpm agent:autoreview\` as a batch-boundary review before opening PRs.
+MSG
+  return 1
+}
+
 echo "==> Marking repository safe for git"
 git config --global --add safe.directory "$REPO_ROOT" || true
 
@@ -353,6 +374,7 @@ pnpm --version
 
 prewarm_trunk
 install_trunk_tools
+ensure_autoreview_helper
 
 echo "==> Installing workspace dependencies"
 CI=true pnpm install --frozen-lockfile

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -372,9 +372,9 @@ if command -v corepack >/dev/null 2>&1; then
 fi
 pnpm --version
 
+ensure_autoreview_helper
 prewarm_trunk
 install_trunk_tools
-ensure_autoreview_helper
 
 echo "==> Installing workspace dependencies"
 CI=true pnpm install --frozen-lockfile


### PR DESCRIPTION
## The Problem

- Codex Cloud images do not inherit a developer's `~/.agents` global skills, but this repo's ship flow depends on the shared autoreview helper.
- Setup and cached-container maintenance could continue without proving `pnpm agent:autoreview` would work for PR and babysit workflows.

## The Solution

- Verify the autoreview helper exists and is executable during Codex Cloud setup and maintenance, using `AUTOREVIEW_HELPER` or the same default helper path as `scripts/agent-autoreview.sh`.
- Fail with an actionable error before expensive setup work proceeds when the helper is missing.
- Document the Codex Cloud requirement in `AGENTS.md` and `README.md` so the image is installed or baked with the shared skill before setup/maintenance runs.

## Testing

- `./tools/trunk check AGENTS.md README.md scripts/codex-cloud-maintenance.sh scripts/codex-cloud-setup.sh`
- `bash -n scripts/codex-cloud-setup.sh scripts/codex-cloud-maintenance.sh`
- `pnpm lint:scripts`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` failed because the global helper is not installed in this container, which is the missing-helper condition this change enforces.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and bootstrap-script guards only; no application runtime or auth/data paths change.
> 
> **Overview**
> Codex Cloud must ship with the global autoreview skill because containers do not get a developer's `~/.agents` tree, yet PR shipping depends on `pnpm agent:autoreview`.
> 
> **Setup and maintenance** now call `ensure_autoreview_helper()` (same default as `scripts/agent-autoreview.sh`, overridable via `AUTOREVIEW_HELPER`) and **fail fast** with an actionable error if the helper is missing or not executable—before Trunk prewarm/install on setup and before `pnpm install` on maintenance.
> 
> **AGENTS.md** and **README.md** document baking `~/.agents/skills/autoreview` (or setting `AUTOREVIEW_HELPER`) into the cloud image before running those scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c1dbeb7464c3c1feaeeccfeb0a08c01abdf232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

