### PR TITLE
chore: add review materiality classifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,8 @@ Terraform apply. If any package manifest, `pnpm-lock.yaml`,
 `--allow-package-script-changes`. The narrow exception is a root `package.json`
 edit limited to root tooling scripts such as `scripts.agent:quality-gate`,
 `scripts.agent:quality-gate:test`, `scripts.agent:prewarm`,
-`scripts.agent:prewarm:test`, `scripts.agent:context-check`,
+`scripts.agent:prewarm:test`, `scripts.agent:review-materiality`,
+`scripts.agent:review-materiality:test`, `scripts.agent:context-check`,
 `scripts.agent:autoreview`, `scripts.issue:board`,
 `scripts.issue:board:test`, `scripts.issue:claim`, `scripts.issue:review`,
 `scripts.issue:release`, `scripts.pr:feedback-state`,
@@ -250,6 +251,19 @@ local deterministic engine because nested `codex exec` is unavailable there;
 pass `--engine codex`, `--engine claude`, or `AUTOREVIEW_ENGINE` to override.
 For a true Codex semantic pass from inside Codex, use `--prepare-only` and the
 Codex-native flow described by the global autoreview skill.
+
+To classify review depth and likely context-update requirements before or after
+the mapped gate, use:
+
+```bash
+pnpm agent:review-materiality
+```
+
+The command reports `trivial`, `standard`, or `full` materiality from changed
+path risk and diff size, plus whether the change likely needs AGENTS, README,
+runbook, checklist, or skill context updates. It is advisory: it helps choose
+review depth, but it does not replace `pnpm agent:quality-gate --run`,
+`pnpm agent:autoreview`, or `pnpm pr:ready-state`.
 
 To warm Turbo's local cache for the Turbo-backed package tasks mapped by the
 same gate without running deploy, Terraform, mutation, codegen, or install
@@ -434,6 +448,7 @@ pnpm code-health:history           # CodeScene-style git history report → repo
 pnpm code-health:duplication       # jscpd duplication report → reports/jscpd/ (advisory, never blocks)
 pnpm code-health:schema-diff       # GraphQL schema breaking-change diff vs origin/main (advisory, never blocks)
 pnpm code-health                   # Run knip + deps together (everything except history + duplication)
+pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
 pnpm agent:autoreview              # Structured closeout review; Codex sandbox defaults to --engine local, override with --engine claude/codex
 pnpm lockfile:lint                 # Lockfile integrity + registry check (blocking; no install needed)
 pnpm skew:check                    # Dependency version-skew check vs the pnpm catalog (blocking; no install needed)

--- a/docs/PLAN-ai-review-process.md
+++ b/docs/PLAN-ai-review-process.md
@@ -1,0 +1,78 @@
+---
+title: AI Review Process Integration Plan
+status: draft
+owner: eng
+canonical: false
+---
+
+# AI Review Process Integration Plan
+
+This plan captures the Cloudflare AI code-review integration ideas that fit this
+repo's current agent workflow. It is intentionally non-canonical: treat it as a
+roadmap and verify current repo behavior before copying anything into AGENTS,
+skills, or gates.
+
+## Current Baseline
+
+The repo already has a strong review loop:
+
+- `pnpm agent:quality-gate` maps changed paths to local validation commands and
+  checklists.
+- `pnpm agent:autoreview` runs closeout review at batch boundaries.
+- `pnpm --silent pr:feedback-state --pr <number> --json` projects review
+  feedback surfaces.
+- `pnpm pr:ready-state --pr <number> --json` is the final readiness source of
+  truth before all-clear.
+- Root `AGENTS.md` requires feedback-surface sweeps, explicit review-comment
+  replies, and batch-level sibling audits.
+
+## Target Shape
+
+Adopt the parts of Cloudflare's approach that improve signal without replacing
+the repo's existing gates:
+
+1. Classify review materiality as `trivial`, `standard`, or `full` from changed
+   path risk and diff size.
+2. Detect changes that likely require context updates, especially new commands,
+   scripts, env vars, hooks, workflow steps, deploy/codegen steps, and package
+   ownership changes.
+3. Promote PR feedback into normalized finding identities so follow-up rounds can
+   distinguish unresolved, replied, outdated, and current-head findings.
+4. Tighten review-specialist prompts with explicit "do not flag" exclusions to
+   reduce noisy or speculative findings.
+5. Enrich autoreview bundles with shared context files instead of relying on one
+   large prompt.
+
+## First PR
+
+Ship a repo-native materiality and context-drift slice:
+
+- Add `scripts/review-materiality.mjs`.
+- Expose it as `pnpm agent:review-materiality`.
+- Have it classify changed paths against a base ref and emit both human output
+  and JSON.
+- Flag likely context-update requirements for new root commands, scripts,
+  workflows, env examples, package-manager files, AGENTS/checklist files, and
+  docs/runbook paths.
+- Add tests for the classifier.
+- Route script changes through `pnpm agent:quality-gate`.
+- Document the new command in `AGENTS.md` and keep this plan as the roadmap.
+
+## Later PRs
+
+- Add `findings[]` to `pr:feedback-state` with stable fingerprints and section
+  extraction for multi-finding bot comments.
+- Add prompt-exclusion updates to the global `review` skill.
+- Teach `agent:autoreview` to prepare a richer review bundle directory with
+  changed paths, patch files, selected checklists, and any feedback ledger.
+- Consider a human-only break-glass readiness override that is reported by
+  `pr:ready-state`, not silently treated as all-clear.
+
+## Non-Goals
+
+- Do not add an external review service before the repo-local gates carry the
+  missing state.
+- Do not weaken `pr:ready-state`; review materiality affects review depth, not
+  final readiness.
+- Do not make optional bot lag a required blocker unless branch protection makes
+  it required for that PR.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "agent:quality-gate:test": "bash scripts/agent-quality-gate.test.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "agent:context-check": "node scripts/check-agent-context.mjs",
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "issue:board": "node scripts/agent-issue-board.mjs",

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -468,7 +468,7 @@ classify_root_package_json_changes() {
         echo "workspace"
         return
         ;;
-      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test)
+      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test)
         saw_tooling_script=true
         ;;
       /scripts)
@@ -626,6 +626,7 @@ add_root_tooling_package_script_checks() {
   add_command "bash scripts/check-agent-quality-gate-package-scripts.sh" "$reason"
   add_command "bash scripts/agent-quality-gate.test.sh" "$reason"
   add_command "node scripts/agent-prewarm.test.mjs" "$reason"
+  add_command "node scripts/review-materiality.test.mjs" "$reason"
   add_command "node scripts/agent-issue-board.test.mjs" "$reason"
   add_command "node scripts/pr-feedback-state.test.mjs" "$reason"
   add_command "node scripts/pr-ready-state.test.mjs" "$reason"
@@ -1386,6 +1387,9 @@ while IFS= read -r path; do
           ;;
         scripts/agent-prewarm.mjs|scripts/agent-prewarm.test.mjs)
           add_command "pnpm agent:prewarm:test" "agent prewarm helper changed"
+          ;;
+        scripts/review-materiality.mjs|scripts/review-materiality.test.mjs)
+          add_command "pnpm agent:review-materiality:test" "agent review materiality helper changed"
           ;;
         scripts/agent-issue-board.mjs|scripts/agent-issue-board.test.mjs)
           add_command "pnpm issue:board:test" "agent issue board helper changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -579,6 +579,8 @@ validator_repo="$(mktemp -d)"
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",
@@ -728,6 +730,8 @@ package_json_repo="$(mktemp -d)"
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",
@@ -759,6 +763,7 @@ assert_contains "- tooling"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package tooling script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package tooling script changed)"
 assert_contains "- node scripts/agent-prewarm.test.mjs (root package tooling script changed)"
+assert_contains "- node scripts/review-materiality.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/agent-issue-board.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-feedback-state.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-ready-state.test.mjs (root package tooling script changed)"
@@ -787,6 +792,8 @@ dedupe_quality_gate_alias_repo="$(mktemp -d)"
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",
@@ -835,6 +842,8 @@ lockfile_script_repo="$(mktemp -d)"
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",
@@ -866,6 +875,7 @@ assert_contains "- tooling"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package tooling script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package tooling script changed)"
 assert_contains "- node scripts/agent-prewarm.test.mjs (root package tooling script changed)"
+assert_contains "- node scripts/review-materiality.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/agent-issue-board.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-feedback-state.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-ready-state.test.mjs (root package tooling script changed)"
@@ -892,6 +902,8 @@ pr_ready_state_script_repo="$(mktemp -d)"
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "agent:prewarm": "node scripts/agent-prewarm.mjs",
     "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+    "agent:review-materiality": "node scripts/review-materiality.mjs",
+    "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",
@@ -923,6 +935,7 @@ assert_contains "- tooling"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package tooling script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package tooling script changed)"
 assert_contains "- node scripts/agent-prewarm.test.mjs (root package tooling script changed)"
+assert_contains "- node scripts/review-materiality.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/agent-issue-board.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-feedback-state.test.mjs (root package tooling script changed)"
 assert_contains "- node scripts/pr-ready-state.test.mjs (root package tooling script changed)"
@@ -2295,6 +2308,12 @@ assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
 
 run_gate "scripts/lockfile-lint.test.mjs"
 assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
+
+run_gate "scripts/review-materiality.mjs"
+assert_contains "- pnpm agent:review-materiality:test (agent review materiality helper changed)"
+
+run_gate "scripts/review-materiality.test.mjs"
+assert_contains "- pnpm agent:review-materiality:test (agent review materiality helper changed)"
 
 run_gate "scripts/agent-issue-board.mjs"
 assert_contains "- pnpm issue:board:test (agent issue board helper changed)"

--- a/scripts/check-agent-quality-gate-package-scripts.sh
+++ b/scripts/check-agent-quality-gate-package-scripts.sh
@@ -11,6 +11,8 @@ const expectedScripts = {
   "agent:quality-gate:test": "bash scripts/agent-quality-gate.test.sh",
   "agent:prewarm": "node scripts/agent-prewarm.mjs",
   "agent:prewarm:test": "node scripts/agent-prewarm.test.mjs",
+  "agent:review-materiality": "node scripts/review-materiality.mjs",
+  "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
   "agent:context-check": "node scripts/check-agent-context.mjs",
   "agent:autoreview": "./scripts/agent-autoreview.sh",
   "issue:board": "node scripts/agent-issue-board.mjs",

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -1,0 +1,613 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const TIER_ORDER = ["trivial", "standard", "full"];
+const DEFAULT_BASE = "origin/main";
+const DEFAULT_HEAD = "HEAD";
+const FULL_LINE_CHANGE_THRESHOLD = 800;
+const STANDARD_LINE_CHANGE_THRESHOLD = 200;
+const FULL_FILE_COUNT_THRESHOLD = 25;
+const STANDARD_FILE_COUNT_THRESHOLD = 8;
+
+function usage() {
+  return `Usage: pnpm agent:review-materiality [options]
+
+Classify the review depth and context-update risk for the current change.
+
+Options:
+  --base <ref>              Base ref. Default: ${DEFAULT_BASE}
+  --head <ref>              Head ref. Default: ${DEFAULT_HEAD}
+  --changed-paths-file <f>  Read changed paths from a newline-delimited file.
+                            Line counts are unavailable in this mode.
+  --json                    Emit JSON instead of human output.
+  -h, --help                Show this help.
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    base: DEFAULT_BASE,
+    head: DEFAULT_HEAD,
+    changedPathsFile: null,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--base":
+        args.base = argv[++index] ?? "";
+        if (!args.base) throw new Error("--base requires a ref");
+        break;
+      case "--head":
+        args.head = argv[++index] ?? "";
+        if (!args.head) throw new Error("--head requires a ref");
+        break;
+      case "--changed-paths-file":
+        args.changedPathsFile = argv[++index] ?? "";
+        if (!args.changedPathsFile) {
+          throw new Error("--changed-paths-file requires a file path");
+        }
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "-h":
+      case "--help":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function runGit(args) {
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+function tryGit(args) {
+  try {
+    return runGit(args);
+  } catch {
+    return "";
+  }
+}
+
+function gitErrorMessage(error) {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const stderr = error.stderr?.toString?.().trim();
+    if (stderr) return stderr;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function diffOutput(diffArgs, base, head) {
+  try {
+    return runGit(["diff", ...diffArgs, `${base}...${head}`]);
+  } catch (tripleDotError) {
+    try {
+      return runGit(["diff", ...diffArgs, base, head]);
+    } catch (twoDotError) {
+      throw new Error(
+        `unable to read git diff for ${base}..${head}: ${gitErrorMessage(twoDotError) || gitErrorMessage(tripleDotError)}`,
+        { cause: twoDotError },
+      );
+    }
+  }
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function changedPathsFromGit(base, head) {
+  const outputs = [diffOutput(["--name-only", "--no-renames"], base, head)];
+
+  if (head === "HEAD") {
+    outputs.push(
+      tryGit(["diff", "--name-only", "--no-renames"]),
+      tryGit(["diff", "--cached", "--name-only", "--no-renames"]),
+      tryGit(["ls-files", "--others", "--exclude-standard"]),
+    );
+  }
+
+  return uniqueSorted(
+    outputs
+      .join("\n")
+      .split("\n")
+      .map((line) => line.trim()),
+  );
+}
+
+function changedPathsFromFile(filePath) {
+  const output = readFileSync(filePath, "utf8");
+  return uniqueSorted(output.split("\n").map((line) => line.trim()));
+}
+
+function addNumstatOutput(stats, output) {
+  for (const line of output.split("\n")) {
+    if (!line.trim()) continue;
+    const [rawAdditions, rawDeletions, filePath] = line.split("\t");
+    const additions = Number.parseInt(rawAdditions, 10);
+    const deletions = Number.parseInt(rawDeletions, 10);
+    const previous = stats.get(filePath) ?? { additions: 0, deletions: 0 };
+    stats.set(filePath, {
+      additions:
+        previous.additions + (Number.isFinite(additions) ? additions : 0),
+      deletions:
+        previous.deletions + (Number.isFinite(deletions) ? deletions : 0),
+    });
+  }
+}
+
+function countTextLines(contents) {
+  if (contents.length === 0) return 0;
+  const newlineCount = contents.split("\n").length - 1;
+  return contents.endsWith("\n") ? newlineCount : newlineCount + 1;
+}
+
+function addUntrackedStats(stats, paths) {
+  for (const filePath of paths) {
+    if (stats.has(filePath)) continue;
+    let additions;
+    try {
+      additions = countTextLines(readFileSync(filePath, "utf8"));
+    } catch {
+      additions = 0;
+    }
+    stats.set(filePath, { additions, deletions: 0 });
+  }
+}
+
+function numstatFromGit(base, head) {
+  const stats = new Map();
+  addNumstatOutput(
+    stats,
+    diffOutput(["--numstat", "--no-renames"], base, head),
+  );
+
+  if (head === "HEAD") {
+    addNumstatOutput(stats, tryGit(["diff", "--numstat", "--no-renames"]));
+    addNumstatOutput(
+      stats,
+      tryGit(["diff", "--cached", "--numstat", "--no-renames"]),
+    );
+    addUntrackedStats(
+      stats,
+      tryGit(["ls-files", "--others", "--exclude-standard"])
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    );
+  }
+
+  return stats;
+}
+
+function readJsonAtRef(ref, filePath) {
+  if (ref === "HEAD") {
+    try {
+      return JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return JSON.parse(runGit(["show", `${ref}:${filePath}`]));
+  } catch {
+    return null;
+  }
+}
+
+function rootScriptChanges(base, head) {
+  const beforePackage = readJsonAtRef(base, "package.json");
+  const afterPackage = readJsonAtRef(head, "package.json");
+  if (beforePackage === null) {
+    throw new Error(`unable to read package.json at ${base}`);
+  }
+  if (afterPackage === null) {
+    throw new Error(`unable to read package.json at ${head}`);
+  }
+
+  const before = beforePackage.scripts ?? {};
+  const after = afterPackage.scripts ?? {};
+  const names = uniqueSorted([...Object.keys(before), ...Object.keys(after)]);
+
+  return names
+    .filter((name) => before[name] !== after[name])
+    .map((name) => ({
+      name,
+      before: before[name] ?? null,
+      after: after[name] ?? null,
+      kind:
+        before[name] === undefined
+          ? "added"
+          : after[name] === undefined
+            ? "removed"
+            : "changed",
+    }));
+}
+
+function tierMax(a, b) {
+  return TIER_ORDER[Math.max(TIER_ORDER.indexOf(a), TIER_ORDER.indexOf(b))];
+}
+
+function signal(filePath, tier, reason) {
+  return { path: filePath, tier, reason };
+}
+
+function isEnvExample(filePath) {
+  return /(^|\/)\.env(?:\.[A-Za-z0-9_-]+)*\.example$/.test(filePath);
+}
+
+function isPackageManagerPath(filePath) {
+  return (
+    filePath === "package.json" ||
+    filePath.endsWith("/package.json") ||
+    filePath === "pnpm-lock.yaml" ||
+    filePath.endsWith("/pnpm-lock.yaml") ||
+    filePath === "pnpm-workspace.yaml" ||
+    filePath.endsWith("/pnpm-workspace.yaml") ||
+    filePath === ".npmrc" ||
+    filePath.endsWith("/.npmrc") ||
+    filePath === ".node-version" ||
+    filePath.endsWith("/.node-version") ||
+    filePath === "pnpmfile.cjs" ||
+    filePath === ".pnpmfile.cjs" ||
+    filePath.startsWith("patches/")
+  );
+}
+
+function isAgentRuntimeContextPath(filePath) {
+  return (
+    filePath === ".codex/hooks.json" || filePath === ".claude/settings.json"
+  );
+}
+
+function isCanonicalContextPath(filePath) {
+  return (
+    filePath === "AGENTS.md" ||
+    filePath.endsWith("/AGENTS.md") ||
+    filePath === "CLAUDE.md" ||
+    filePath.endsWith("/CLAUDE.md") ||
+    filePath === "README.md" ||
+    filePath === "docs/context-standards.md" ||
+    filePath === "docs/deployment.md" ||
+    filePath.startsWith("docs/pr-checklists/") ||
+    filePath.startsWith(".agents/skills/") ||
+    filePath.startsWith(".agents/roles/") ||
+    filePath.startsWith(".claude/skills/") ||
+    isAgentRuntimeContextPath(filePath)
+  );
+}
+
+function isRepoToolingTestPath(filePath) {
+  return (
+    (filePath.startsWith("scripts/") || filePath.startsWith("tools/")) &&
+    /\.test\.(?:cjs|js|mjs|sh|ts|tsx)$/.test(filePath)
+  );
+}
+
+function classifyPath(filePath) {
+  if (filePath.startsWith("docs/PLAN-") || filePath.startsWith("docs/notes/")) {
+    return signal(
+      filePath,
+      "trivial",
+      "non-canonical planning or note document",
+    );
+  }
+
+  if (isPackageManagerPath(filePath)) {
+    return signal(filePath, "full", "package-manager or root command surface");
+  }
+
+  if (
+    filePath.startsWith(".github/workflows/") ||
+    filePath.startsWith(".github/actions/")
+  ) {
+    return signal(filePath, "full", "GitHub workflow or composite action");
+  }
+
+  if (
+    filePath.startsWith("scripts/") ||
+    filePath.startsWith("tools/") ||
+    filePath === "turbo.json" ||
+    filePath.startsWith(".trunk/")
+  ) {
+    return signal(filePath, "full", "agent, build, or repository tooling");
+  }
+
+  if (isCanonicalContextPath(filePath)) {
+    return signal(filePath, "full", "canonical agent or operator context");
+  }
+
+  if (
+    filePath.startsWith("terraform/") ||
+    filePath.startsWith("alerts/infra/") ||
+    filePath.startsWith("alerts/rules/") ||
+    filePath.startsWith("aegis/terraform/") ||
+    filePath.startsWith("aegis/grafana-agent/") ||
+    filePath.startsWith("aegis/bin/") ||
+    filePath === "aegis/app.yaml" ||
+    filePath === "aegis/config.yaml" ||
+    filePath.startsWith("governance-watchdog/infra/") ||
+    filePath === "terraform.stacks.json" ||
+    filePath === "cloudbuild.yaml" ||
+    filePath === ".gcloudignore"
+  ) {
+    return signal(filePath, "full", "infrastructure, alerting, or deploy path");
+  }
+
+  if (
+    filePath === "indexer-envio/schema.graphql" ||
+    filePath.startsWith("indexer-envio/config.") ||
+    filePath.startsWith("indexer-envio/src/handlers/") ||
+    filePath === "indexer-envio/src/EventHandlers.ts" ||
+    filePath === "indexer-envio/src/EventHandlersBridgeOnly.ts"
+  ) {
+    return signal(
+      filePath,
+      "full",
+      "indexer schema, config, or handler data flow",
+    );
+  }
+
+  if (
+    filePath.startsWith("ui-dashboard/src/app/api/") ||
+    filePath.startsWith("ui-dashboard/src/lib/") ||
+    filePath.startsWith("ui-dashboard/src/hooks/")
+  ) {
+    return signal(
+      filePath,
+      "full",
+      "dashboard API, GraphQL, polling, or UI state flow",
+    );
+  }
+
+  if (filePath.startsWith("docs/") || filePath === "README.md") {
+    return signal(filePath, "standard", "operator documentation");
+  }
+
+  if (
+    filePath.includes("/src/") ||
+    filePath.includes("/test/") ||
+    filePath.includes("/tests/") ||
+    filePath.endsWith(".test.ts") ||
+    filePath.endsWith(".test.tsx") ||
+    filePath.endsWith(".test.mjs")
+  ) {
+    return signal(filePath, "standard", "source or test code");
+  }
+
+  return signal(filePath, "standard", "changed repository file");
+}
+
+function contextRequirementSignals(paths, scriptChanges) {
+  const reasons = [];
+
+  if (scriptChanges.length > 0) {
+    reasons.push({
+      kind: "root-package-script",
+      detail: `root package scripts changed: ${scriptChanges.map((change) => change.name).join(", ")}`,
+    });
+  } else if (paths.includes("package.json")) {
+    reasons.push({
+      kind: "root-package-manifest",
+      detail: "root package manifest changed",
+    });
+  }
+
+  for (const filePath of paths) {
+    if (
+      (filePath.startsWith("scripts/") || filePath.startsWith("tools/")) &&
+      !isRepoToolingTestPath(filePath)
+    ) {
+      reasons.push({
+        kind: "repo-tooling",
+        detail: `${filePath} changed`,
+      });
+    } else if (
+      filePath.startsWith(".github/workflows/") ||
+      filePath.startsWith(".github/actions/")
+    ) {
+      reasons.push({
+        kind: "workflow",
+        detail: `${filePath} changed`,
+      });
+    } else if (filePath !== "package.json" && isPackageManagerPath(filePath)) {
+      reasons.push({
+        kind: "package-manager",
+        detail: `${filePath} changed`,
+      });
+    } else if (isEnvExample(filePath)) {
+      reasons.push({
+        kind: "env-example",
+        detail: `${filePath} changed`,
+      });
+    } else if (isAgentRuntimeContextPath(filePath)) {
+      reasons.push({
+        kind: "agent-context",
+        detail: `${filePath} changed`,
+      });
+    }
+  }
+
+  return reasons.filter(
+    (reason, index, all) =>
+      all.findIndex((candidate) => candidate.detail === reason.detail) ===
+      index,
+  );
+}
+
+function summarizeLineChanges(paths, numstat) {
+  let additions = 0;
+  let deletions = 0;
+
+  for (const filePath of paths) {
+    const stat = numstat.get(filePath);
+    additions += stat?.additions ?? 0;
+    deletions += stat?.deletions ?? 0;
+  }
+
+  return {
+    additions,
+    deletions,
+    total: additions + deletions,
+  };
+}
+
+function classifyBySize(fileCount, lineChanges) {
+  if (
+    fileCount >= FULL_FILE_COUNT_THRESHOLD ||
+    lineChanges >= FULL_LINE_CHANGE_THRESHOLD
+  ) {
+    return signal(
+      "__diff_size__",
+      "full",
+      `large diff (${fileCount} files, ${lineChanges} changed lines)`,
+    );
+  }
+
+  if (
+    fileCount >= STANDARD_FILE_COUNT_THRESHOLD ||
+    lineChanges >= STANDARD_LINE_CHANGE_THRESHOLD
+  ) {
+    return signal(
+      "__diff_size__",
+      "standard",
+      `moderate diff (${fileCount} files, ${lineChanges} changed lines)`,
+    );
+  }
+
+  return null;
+}
+
+function recommendedReview(tier) {
+  if (tier === "trivial") {
+    return [
+      "Run pnpm agent:quality-gate --run.",
+      "Skip semantic autoreview unless the change is deceptively risky.",
+    ];
+  }
+
+  if (tier === "standard") {
+    return [
+      "Run pnpm agent:quality-gate --run.",
+      "Run pnpm agent:autoreview before pushing.",
+    ];
+  }
+
+  return [
+    "Run pnpm agent:quality-gate --run.",
+    "Run pnpm agent:autoreview before pushing.",
+    "Read any mapped checklist and audit sibling surfaces before the next push.",
+  ];
+}
+
+export function analyzeMateriality({
+  paths,
+  numstat = new Map(),
+  scriptChanges = [],
+} = {}) {
+  const changedPaths = uniqueSorted(paths ?? []);
+  const pathSignals = changedPaths.map(classifyPath);
+  const lineChanges = summarizeLineChanges(changedPaths, numstat);
+  const sizeSignal = classifyBySize(changedPaths.length, lineChanges.total);
+  const allSignals = sizeSignal ? [...pathSignals, sizeSignal] : pathSignals;
+  const tier = allSignals.reduce(
+    (current, item) => tierMax(current, item.tier),
+    "trivial",
+  );
+  const contextReasons = contextRequirementSignals(changedPaths, scriptChanges);
+  const contextUpdatesPresent = changedPaths.some(isCanonicalContextPath);
+  const contextUpdateRequired = contextReasons.length > 0;
+
+  return {
+    tier,
+    changedFileCount: changedPaths.length,
+    lineChanges,
+    contextUpdateRequired,
+    contextUpdatesPresent,
+    contextUpdateMissing: contextUpdateRequired && !contextUpdatesPresent,
+    contextReasons,
+    pathSignals: allSignals,
+    rootScriptChanges: scriptChanges,
+    recommendedReview: recommendedReview(tier),
+  };
+}
+
+function renderHuman(report) {
+  const lines = [
+    `Review materiality: ${report.tier}`,
+    `Changed files: ${report.changedFileCount}`,
+    `Changed lines: +${report.lineChanges.additions} / -${report.lineChanges.deletions}`,
+    `Context update: ${
+      report.contextUpdateRequired
+        ? report.contextUpdatesPresent
+          ? "required and present"
+          : "required but not present"
+        : "not required"
+    }`,
+  ];
+
+  if (report.contextReasons.length > 0) {
+    lines.push("", "Context signals:");
+    for (const reason of report.contextReasons) {
+      lines.push(`- ${reason.detail}`);
+    }
+  }
+
+  lines.push("", "Materiality signals:");
+  for (const item of report.pathSignals) {
+    lines.push(`- ${item.tier}: ${item.path} (${item.reason})`);
+  }
+
+  lines.push("", "Recommended review:");
+  for (const item of report.recommendedReview) {
+    lines.push(`- ${item}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const paths = args.changedPathsFile
+    ? changedPathsFromFile(args.changedPathsFile)
+    : changedPathsFromGit(args.base, args.head);
+  const numstat = args.changedPathsFile
+    ? new Map()
+    : numstatFromGit(args.base, args.head);
+  const scriptChanges = paths.includes("package.json")
+    ? rootScriptChanges(args.base, args.head)
+    : [];
+  const report = analyzeMateriality({ paths, numstat, scriptChanges });
+
+  process.stdout.write(
+    args.json ? `${JSON.stringify(report, null, 2)}\n` : renderHuman(report),
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+export { parseArgs, renderHuman };

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  analyzeMateriality,
+  parseArgs,
+  renderHuman,
+} from "./review-materiality.mjs";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`ok ${name}\n`);
+    passed += 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`not ok ${name}\n  ${message}\n`);
+    failed += 1;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertIncludes(haystack, needle) {
+  assert(
+    haystack.includes(needle),
+    `expected ${JSON.stringify(haystack)} to include ${JSON.stringify(needle)}`,
+  );
+}
+
+function stats(entries) {
+  return new Map(Object.entries(entries));
+}
+
+function git(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+console.log("\nreview-materiality.mjs tests\n");
+
+test("classifies non-canonical plan-only edits as trivial", () => {
+  const report = analyzeMateriality({
+    paths: ["docs/PLAN-ai-review-process.md"],
+    numstat: stats({
+      "docs/PLAN-ai-review-process.md": { additions: 20, deletions: 0 },
+    }),
+  });
+
+  assertEqual(report.tier, "trivial");
+  assertEqual(report.contextUpdateRequired, false);
+  assertEqual(report.contextUpdateMissing, false);
+});
+
+test("classifies root script changes as full and requiring context", () => {
+  const report = analyzeMateriality({
+    paths: ["package.json", "scripts/review-materiality.mjs"],
+    scriptChanges: [
+      {
+        name: "agent:review-materiality",
+        before: null,
+        after: "node scripts/review-materiality.mjs",
+        kind: "added",
+      },
+    ],
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdatesPresent, false);
+  assertEqual(report.contextUpdateMissing, true);
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "agent:review-materiality",
+  );
+});
+
+test("recognizes context updates when canonical docs are present", () => {
+  const report = analyzeMateriality({
+    paths: ["package.json", "scripts/review-materiality.mjs", "AGENTS.md"],
+    scriptChanges: [
+      {
+        name: "agent:review-materiality",
+        before: null,
+        after: "node scripts/review-materiality.mjs",
+        kind: "added",
+      },
+    ],
+  });
+
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdatesPresent, true);
+  assertEqual(report.contextUpdateMissing, false);
+});
+
+test("recognizes scoped Claude context files as canonical context", () => {
+  const report = analyzeMateriality({
+    paths: ["scripts/review-materiality.mjs", "scripts/CLAUDE.md"],
+  });
+
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdatesPresent, true);
+  assertEqual(report.contextUpdateMissing, false);
+});
+
+test("classifies agent hook and permission configs as context", () => {
+  const report = analyzeMateriality({
+    paths: [".codex/hooks.json", ".claude/settings.json"],
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdatesPresent, true);
+  assertEqual(report.contextUpdateMissing, false);
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    ".codex/hooks.json changed",
+  );
+});
+
+test("does not require context updates for pure script test edits", () => {
+  const report = analyzeMateriality({
+    paths: ["scripts/review-materiality.test.mjs"],
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdateRequired, false);
+  assertEqual(report.contextUpdateMissing, false);
+});
+
+test("recognizes multi-segment environment example files", () => {
+  const report = analyzeMateriality({
+    paths: ["ui-dashboard/.env.production.local.example"],
+  });
+
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdateMissing, true);
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "ui-dashboard/.env.production.local.example changed",
+  );
+});
+
+test("classifies pnpmfile changes as package-manager risk", () => {
+  const report = analyzeMateriality({
+    paths: [
+      "pnpmfile.cjs",
+      ".pnpmfile.cjs",
+      "ui-dashboard/.npmrc",
+      "alerts/infra/onchain-event-handler/pnpm-lock.yaml",
+      "alerts/infra/onchain-event-handler/pnpm-workspace.yaml",
+      ".node-version",
+    ],
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdateMissing, true);
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "pnpmfile.cjs changed",
+  );
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    ".pnpmfile.cjs changed",
+  );
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "ui-dashboard/.npmrc changed",
+  );
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "alerts/infra/onchain-event-handler/pnpm-lock.yaml changed",
+  );
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    ".node-version changed",
+  );
+});
+
+test("classifies workspace package manifests as package-manager risk", () => {
+  const report = analyzeMateriality({
+    paths: ["ui-dashboard/package.json"],
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdateRequired, true);
+  assertEqual(report.contextUpdateMissing, true);
+  assertIncludes(
+    report.contextReasons.map((reason) => reason.detail).join("\n"),
+    "ui-dashboard/package.json changed",
+  );
+});
+
+test("classifies stateful indexer and dashboard data-flow paths as full", () => {
+  const report = analyzeMateriality({
+    paths: [
+      "indexer-envio/schema.graphql",
+      "indexer-envio/src/EventHandlersBridgeOnly.ts",
+      "ui-dashboard/src/lib/queries/liquity.ts",
+      "ui-dashboard/src/lib/use-table-sort.ts",
+    ],
+  });
+
+  assertEqual(report.tier, "full");
+});
+
+test("classifies Aegis runtime and deploy paths as full", () => {
+  const report = analyzeMateriality({
+    paths: [
+      "aegis/app.yaml",
+      "aegis/config.yaml",
+      "aegis/grafana-agent/config.alloy",
+      "aegis/bin/deploy.ts",
+    ],
+  });
+
+  assertEqual(report.tier, "full");
+});
+
+test("line-count threshold promotes otherwise simple docs to standard", () => {
+  const report = analyzeMateriality({
+    paths: ["docs/notes/example.md"],
+    numstat: stats({
+      "docs/notes/example.md": { additions: 201, deletions: 0 },
+    }),
+  });
+
+  assertEqual(report.tier, "standard");
+});
+
+test("parseArgs supports base/head/json and changed-path file", () => {
+  const parsed = parseArgs([
+    "--base",
+    "origin/main",
+    "--head",
+    "HEAD",
+    "--changed-paths-file",
+    "/tmp/paths.txt",
+    "--json",
+  ]);
+
+  assertEqual(parsed.base, "origin/main");
+  assertEqual(parsed.head, "HEAD");
+  assertEqual(parsed.changedPathsFile, "/tmp/paths.txt");
+  assertEqual(parsed.json, true);
+});
+
+test("renderHuman reports required but present context updates", () => {
+  const rendered = renderHuman(
+    analyzeMateriality({
+      paths: ["package.json", "AGENTS.md"],
+      scriptChanges: [
+        {
+          name: "agent:review-materiality",
+          before: null,
+          after: "node scripts/review-materiality.mjs",
+          kind: "added",
+        },
+      ],
+    }),
+  );
+
+  assertIncludes(rendered, "Review materiality: full");
+  assertIncludes(rendered, "Context update: required and present");
+});
+
+test("CLI reads changed paths from file and emits JSON", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-test-"));
+  const pathsFile = join(dir, "paths.txt");
+  writeFileSync(pathsFile, "docs/PLAN-ai-review-process.md\n", "utf8");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        new URL("./review-materiality.mjs", import.meta.url).pathname,
+        "--changed-paths-file",
+        pathsFile,
+        "--json",
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assertEqual(parsed.tier, "trivial");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI accumulates line counts across committed and unstaged changes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-git-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(join(dir, "example.md"), "one\n", "utf8");
+    git(dir, ["add", "example.md"]);
+    git(dir, ["commit", "-m", "base"]);
+
+    writeFileSync(join(dir, "example.md"), "one\ntwo\n", "utf8");
+    git(dir, ["add", "example.md"]);
+    git(dir, ["commit", "-m", "head"]);
+    // Unstaged: triggers the head === "HEAD" numstat accumulation branch.
+    writeFileSync(join(dir, "example.md"), "one\ntwo\nthree\n", "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "HEAD~1", "--head", "HEAD", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+      },
+    );
+
+    assertEqual(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assertEqual(parsed.changedFileCount, 1);
+    assertEqual(parsed.lineChanges.additions, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI falls back to two-dot diff when triple-dot has no merge base", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-git-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(join(dir, "base.md"), "base\n", "utf8");
+    git(dir, ["add", "base.md"]);
+    git(dir, ["commit", "-m", "base"]);
+    const base = git(dir, ["rev-parse", "HEAD"]).trim();
+
+    git(dir, ["checkout", "--orphan", "feature"]);
+    git(dir, ["rm", "-rf", "."]);
+    writeFileSync(join(dir, "feature.md"), "feature\n", "utf8");
+    git(dir, ["add", "feature.md"]);
+    git(dir, ["commit", "-m", "feature"]);
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", base, "--head", "HEAD", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+      },
+    );
+
+    assertEqual(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assertEqual(parsed.changedFileCount, 2);
+    assertEqual(parsed.lineChanges.additions, 1);
+    assertEqual(parsed.lineChanges.deletions, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI fails when neither triple-dot nor two-dot diff can read the base", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-git-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(join(dir, "example.md"), "one\n", "utf8");
+    git(dir, ["add", "example.md"]);
+    git(dir, ["commit", "-m", "base"]);
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "missing/ref", "--head", "HEAD", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+      },
+    );
+
+    assert(result.status !== 0, "expected missing base ref to fail");
+    assertIncludes(
+      result.stderr,
+      "unable to read git diff for missing/ref..HEAD",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI counts untracked files without trailing newlines", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-git-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(join(dir, "tracked.md"), "tracked\n", "utf8");
+    git(dir, ["add", "tracked.md"]);
+    git(dir, ["commit", "-m", "base"]);
+    writeFileSync(join(dir, "untracked.md"), "one", "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "HEAD", "--head", "HEAD", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+      },
+    );
+
+    assertEqual(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assertEqual(parsed.changedFileCount, 1);
+    assertEqual(parsed.lineChanges.additions, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI fails when script comparison cannot read base package.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-git-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+  const pathsFile = join(dir, "paths.txt");
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "true" } }, null, 2),
+      "utf8",
+    );
+    git(dir, ["add", "package.json"]);
+    git(dir, ["commit", "-m", "base"]);
+    writeFileSync(pathsFile, "package.json\n", "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--changed-paths-file",
+        pathsFile,
+        "--base",
+        "missing/ref",
+        "--head",
+        "HEAD",
+        "--json",
+      ],
+      {
+        cwd: dir,
+        encoding: "utf8",
+      },
+    );
+
+    assert(result.status !== 0, "expected missing package.json base to fail");
+    assertIncludes(result.stderr, "unable to read package.json at missing/ref");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## The Problem

- Agents do not have a cheap repo-native way to classify review depth before shipping a change.
- Workflow, script, and context changes can look like ordinary docs/tooling edits even when they should trigger broader review and context-drift checks.

## The Solution

- Add a `pnpm agent:review-materiality` helper that reports review depth and context-update signals for the current diff.
- Wire the helper into the agent quality gate, package-script validator, tests, and root instructions so it becomes part of the normal review workflow.

## Details

- Adds `scripts/review-materiality.mjs` with `trivial`, `standard`, and `full` materiality tiers based on changed path risk and diff size.
- Detects likely context-update requirements for root package scripts, repo tooling, workflows, package-manager files, and env examples.
- Supports `--json`, `--base`, `--head`, and `--changed-paths-file` for later machine consumers.
- Adds `docs/PLAN-ai-review-process.md` as a non-canonical roadmap so the broader Cloudflare-inspired review-process plan survives context compaction.

## Validation

- `node scripts/review-materiality.test.mjs`
- `pnpm lint:scripts`
- `bash scripts/check-agent-quality-gate-package-scripts.sh`
- `pnpm agent:review-materiality --json`
- `pnpm agent:autoreview --engine local`
- Fresh-context Codex-native autoreview found one P2 numstat aggregation issue; fixed with a regression test.
- `pnpm agent:quality-gate --run` after rebase onto current `origin/main`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to agent tooling, tests, and documentation; no production runtime, auth, or deploy behavior is modified.
> 
> **Overview**
> Introduces a **repo-native review materiality** helper so agents can judge how hard to review a change before relying on heavier gates.
> 
> **`scripts/review-materiality.mjs`** compares a base/head diff (or a path list) and emits **`trivial` / `standard` / `full`** tiers from path risk (tooling, infra, indexer/dashboard data paths, package-manager files, etc.) plus diff size thresholds. It also flags **likely context-update needs** (new root scripts, workflows, env examples, tooling) and whether canonical context files (e.g. `AGENTS.md`) appear in the same change. Output is human-readable or **`--json`**; it is **advisory** and does not replace `agent:quality-gate`, `agent:autoreview`, or `pr:ready-state`.
> 
> **Wiring:** root **`agent:review-materiality`** / **`agent:review-materiality:test`** scripts, **`check-agent-quality-gate-package-scripts.sh`** expectations, **`agent-quality-gate.sh`** (tooling-only root script exception, root tooling regression suite, path mapping for the new scripts), and matching **gate test** fixtures.
> 
> **Docs:** **`AGENTS.md`** documents usage; **`docs/PLAN-ai-review-process.md`** (non-canonical draft) records the broader AI review roadmap and marks this slice as the first PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d54e5d32780f3513013186212da830932fd4884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->