### PR TITLE
chore: add feedback findings ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,9 +371,10 @@ run the shared readiness probe:
 pnpm pr:ready-state --pr <number> --json
 ```
 
-For feedback-only sweeps where the agent needs unresolved threads, unreplied
-root review comments, blocking top-level bot feedback, and Codex review gates
-without shelling out to ad hoc `gh api` calls, use:
+For feedback-only sweeps where the agent needs normalized `findings[]`,
+unresolved threads, unreplied root review comments, blocking top-level bot
+feedback, and Codex review gates without shelling out to ad hoc `gh api` calls,
+use:
 
 ```bash
 pnpm --silent pr:feedback-state --pr <number> --json

--- a/docs/PLAN-ai-review-process.md
+++ b/docs/PLAN-ai-review-process.md
@@ -43,9 +43,9 @@ the repo's existing gates:
 5. Enrich autoreview bundles with shared context files instead of relying on one
    large prompt.
 
-## First PR
+## Shipped PRs
 
-Ship a repo-native materiality and context-drift slice:
+1. PR #1034 shipped a repo-native materiality and context-drift slice:
 
 - Add `scripts/review-materiality.mjs`.
 - Expose it as `pnpm agent:review-materiality`.
@@ -58,10 +58,22 @@ Ship a repo-native materiality and context-drift slice:
 - Route script changes through `pnpm agent:quality-gate`.
 - Document the new command in `AGENTS.md` and keep this plan as the roadmap.
 
+## Next PR
+
+Add a feedback findings ledger to `pr:feedback-state`:
+
+- Emit `findings[]` entries with stable fingerprints for feedback surfaces.
+- Normalize inline review threads, root review comments, and top-level bot
+  findings into one list.
+- Preserve readiness semantics: `findings[]` explains feedback state but
+  `pr:ready-state` remains the final all-clear gate.
+- Extract separate entries from multi-finding bot review comments when they use
+  table or severity-section formats.
+- Include state fields for current-head, outdated, replied, unresolved, and
+  blocking status.
+
 ## Later PRs
 
-- Add `findings[]` to `pr:feedback-state` with stable fingerprints and section
-  extraction for multi-finding bot comments.
 - Add prompt-exclusion updates to the global `review` skill.
 - Teach `agent:autoreview` to prepare a richer review bundle directory with
   changed paths, patch files, selected checklists, and any feedback ledger.

--- a/docs/PLAN-ai-review-process.md
+++ b/docs/PLAN-ai-review-process.md
@@ -58,9 +58,7 @@ the repo's existing gates:
 - Route script changes through `pnpm agent:quality-gate`.
 - Document the new command in `AGENTS.md` and keep this plan as the roadmap.
 
-## Next PR
-
-Add a feedback findings ledger to `pr:feedback-state`:
+2. PR #1037 shipped a feedback findings ledger to `pr:feedback-state`:
 
 - Emit `findings[]` entries with stable fingerprints for feedback surfaces.
 - Normalize inline review threads, root review comments, and top-level bot
@@ -72,9 +70,19 @@ Add a feedback findings ledger to `pr:feedback-state`:
 - Include state fields for current-head, outdated, replied, unresolved, and
   blocking status.
 
+## Next PR
+
+Add prompt-exclusion updates to the global `review` skill:
+
+- Translate recurring accepted/rejected review noise into explicit "do not
+  flag" guidance.
+- Keep prompt changes outside this repo unless the owning global skill lives in
+  repo-local context.
+- Use `findings[]` from `pr:feedback-state` to identify repeated false-positive
+  patterns before changing prompts.
+
 ## Later PRs
 
-- Add prompt-exclusion updates to the global `review` skill.
 - Teach `agent:autoreview` to prepare a richer review bundle directory with
   changed paths, patch files, selected checklists, and any feedback ledger.
 - Consider a human-only break-glass readiness override that is reported by

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -66,8 +66,8 @@ protection.
 `--watch --compact` for low-noise foreground babysitting. `pnpm
 pr:feedback-state` is the feedback-only projection for unresolved threads,
 unreplied root review comments, blocking top-level bot feedback, contextual
-top-level bot comments, and Codex gates; it is intended to replace ad hoc
-read-only `gh api` scraping during review sweeps.
+top-level bot comments, normalized `findings[]`, and Codex gates; it is
+intended to replace ad hoc read-only `gh api` scraping during review sweeps.
 
 Suggested invocation:
 
@@ -187,6 +187,14 @@ Field expectations:
   needs `kind`, `name`, `state`, and `required: false`.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
+- `pr:feedback-state` adds `findings[]`: normalized review findings from inline
+  review threads, root review comments, and actionable top-level bot comments or
+  review bodies. Each entry has a stable `fingerprint`, `source`, `sourceId`,
+  `author`, URL/location fields, a short `title`/`excerpt`, `state`, and
+  booleans for `currentHead`, `outdated`, `replied`, `unresolved`, and
+  `blocking`. Use it as the feedback ledger for batching and deduplicating
+  review follow-ups; do not treat it as a replacement for the final
+  `pr:ready-state` all-clear gate.
 - `codexReviewSignal`: current-head Codex review state. Values are
   `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
   means a current-head `@codex review` request exists but no bot reaction or

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -114,6 +114,16 @@ function findingSourceId(id, index = null) {
   return index === null ? sourceId : `${sourceId}#${index + 1}`;
 }
 
+function feedbackCommentKey(comment) {
+  return [
+    comment.id ?? "",
+    comment.url ?? "",
+    comment.commitOid ?? "",
+    comment.author ?? "",
+    normalizeText(comment.body ?? ""),
+  ].join("\0");
+}
+
 function buildFinding({
   source,
   sourceId = null,
@@ -274,10 +284,10 @@ function botCommentSections(comment) {
 }
 
 function botCommentFindings(comments = [], pr, blockingComments = []) {
-  const blockingSet = new Set(blockingComments);
+  const blockingKeys = new Set(blockingComments.map(feedbackCommentKey));
   return comments.filter(isActionableReviewBotComment).flatMap((comment) => {
     const currentHead = isCurrentHeadComment(comment, pr);
-    const blocking = blockingSet.has(comment);
+    const blocking = blockingKeys.has(feedbackCommentKey(comment));
     const source = comment.commitOid
       ? "top-level-bot-review"
       : "top-level-bot-comment";

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+
+const FINDING_EXCERPT_LENGTH = 240;
+
 function gateReady(gate) {
   return gate?.required === false || Boolean(gate?.ready ?? true);
 }
@@ -69,6 +73,262 @@ function isActionableReviewBotComment(comment) {
   return false;
 }
 
+function normalizeText(value) {
+  return String(value ?? "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_~>#|-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function excerpt(value) {
+  const normalized = normalizeText(value);
+  if (normalized.length <= FINDING_EXCERPT_LENGTH) return normalized;
+  return `${normalized.slice(0, FINDING_EXCERPT_LENGTH - 1).trimEnd()}...`;
+}
+
+function titleFromText(value) {
+  const normalized = normalizeText(value);
+  const sentence = normalized.split(/(?<=[.!?])\s+/)[0] ?? normalized;
+  return sentence.length <= 120
+    ? sentence
+    : `${sentence.slice(0, 119).trimEnd()}...`;
+}
+
+function fingerprint(parts) {
+  const input = parts
+    .map((part) =>
+      String(part ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase(),
+    )
+    .join("\0");
+  return `feedback:${createHash("sha256").update(input).digest("hex").slice(0, 16)}`;
+}
+
+function findingSourceId(id, index = null) {
+  if (id === null || id === undefined || id === "") return null;
+  const sourceId = String(id);
+  return index === null ? sourceId : `${sourceId}#${index + 1}`;
+}
+
+function buildFinding({
+  source,
+  sourceId = null,
+  author = null,
+  url = null,
+  path = null,
+  line = null,
+  title = "",
+  body = "",
+  state,
+  currentHead = null,
+  outdated = null,
+  replied = null,
+  unresolved = null,
+  blocking = false,
+}) {
+  const findingText = normalizeText(body || title);
+  const titleText = titleFromText(title || body);
+  return {
+    fingerprint: fingerprint([source, author, path, line, findingText]),
+    source,
+    sourceId,
+    author,
+    url,
+    path,
+    line,
+    title: titleText,
+    excerpt: excerpt(body || title),
+    state,
+    currentHead,
+    outdated,
+    replied,
+    unresolved,
+    blocking,
+  };
+}
+
+function reviewThreadFindings(reviewThreads = []) {
+  return reviewThreads.map((thread) => {
+    const unresolved = thread.isResolved === false;
+    const outdated = Boolean(thread.isOutdated);
+    const state = unresolved
+      ? outdated
+        ? "unresolved-outdated"
+        : "unresolved"
+      : outdated
+        ? "resolved-outdated"
+        : "resolved";
+    return buildFinding({
+      source: "review-thread",
+      sourceId: findingSourceId(thread.id),
+      author: thread.author ?? null,
+      url: thread.url ?? null,
+      path: thread.path ?? null,
+      line: thread.line ?? null,
+      title: thread.body ?? "",
+      body: thread.body ?? "",
+      state,
+      currentHead: outdated ? false : true,
+      outdated,
+      replied: null,
+      unresolved,
+      blocking: unresolved,
+    });
+  });
+}
+
+function rootReviewCommentFindings(rootReviewComments = []) {
+  return rootReviewComments.map((comment) => {
+    const replied = Boolean(comment.replied);
+    return buildFinding({
+      source: "review-comment",
+      sourceId: findingSourceId(comment.id),
+      author: comment.author ?? null,
+      url: comment.url ?? null,
+      path: comment.path ?? null,
+      line: comment.line ?? null,
+      title: comment.body ?? "",
+      body: comment.body ?? "",
+      state: replied ? "replied" : "unreplied",
+      currentHead: null,
+      outdated: null,
+      replied,
+      unresolved: !replied,
+      blocking: !replied,
+    });
+  });
+}
+
+function tableCells(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  const cells = trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => normalizeText(cell));
+  if (cells.length < 2) return null;
+  if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) return null;
+  return cells;
+}
+
+function isPriorityOrSeverity(value) {
+  return /(?:\b[Pp][0-3]\b|\b(?:Critical|High|Medium|Low)\s+Severity\b)/.test(
+    value,
+  );
+}
+
+function tableFindings(body) {
+  const findings = [];
+  for (const line of String(body ?? "").split(/\r?\n/)) {
+    const cells = tableCells(line);
+    if (!cells) continue;
+    const numbered = /^\d+$/.test(cells[0] ?? "");
+    const priorityCell = cells.findIndex(isPriorityOrSeverity);
+    if (!numbered && priorityCell < 0) continue;
+
+    const contentCells = numbered ? cells.slice(1) : cells;
+    const title = contentCells.filter(Boolean).join(" ");
+    if (!title || /^severity\s+issue\b/i.test(title)) continue;
+    findings.push({ title, body: title });
+  }
+  return findings;
+}
+
+function sectionStart(line) {
+  return /^\s*(?:[-*]\s*)?(?:#{1,6}\s*)?(?:\[[Pp][0-3]\]|\b[Pp][0-3]\s+Badge\b|\*\*\s*(?:Critical|High|Medium|Low)\s+Severity\s*\*\*|\b(?:Critical|High|Medium|Low)\s+Severity\b)/.test(
+    line,
+  );
+}
+
+function sectionFindings(body) {
+  const lines = String(body ?? "").split(/\r?\n/);
+  const starts = lines
+    .map((line, index) => (sectionStart(line) ? index : -1))
+    .filter((index) => index >= 0);
+  if (starts.length === 0) return [];
+
+  return starts.map((start, index) => {
+    const end = starts[index + 1] ?? lines.length;
+    const section = lines.slice(start, end).join("\n").trim();
+    return {
+      title: lines[start],
+      body: section,
+    };
+  });
+}
+
+function botCommentSections(comment) {
+  const body = String(comment.body ?? "");
+  const tableSections = tableFindings(body);
+  if (tableSections.length > 0) return tableSections;
+
+  const headingSections = sectionFindings(body);
+  if (headingSections.length > 0) return headingSections;
+
+  return [{ title: body, body }];
+}
+
+function botCommentFindings(comments = [], pr, blockingComments = []) {
+  const blockingSet = new Set(blockingComments);
+  return comments.filter(isActionableReviewBotComment).flatMap((comment) => {
+    const currentHead = isCurrentHeadComment(comment, pr);
+    const blocking = blockingSet.has(comment);
+    const source = comment.commitOid
+      ? "top-level-bot-review"
+      : "top-level-bot-comment";
+    return botCommentSections(comment).map((section, index) =>
+      buildFinding({
+        source,
+        sourceId: findingSourceId(comment.id, index),
+        author: comment.author ?? null,
+        url: comment.url ?? null,
+        title: section.title,
+        body: section.body,
+        state: blocking
+          ? "blocking-current-head"
+          : currentHead
+            ? "current-head"
+            : "stale",
+        currentHead,
+        outdated: currentHead ? false : true,
+        replied: null,
+        unresolved: blocking,
+        blocking,
+      }),
+    );
+  });
+}
+
+export function buildFeedbackFindings(readyState, blockingTopLevelBotComments) {
+  const reviewThreads =
+    readyState.reviewThreads ??
+    (readyState.unresolvedReviewThreads ?? []).map((thread) => ({
+      ...thread,
+      isResolved: false,
+    }));
+  const rootReviewComments =
+    readyState.rootReviewComments ??
+    (readyState.unrepliedRootReviewComments ?? []).map((comment) => ({
+      ...comment,
+      replied: false,
+    }));
+
+  return [
+    ...reviewThreadFindings(reviewThreads),
+    ...rootReviewCommentFindings(rootReviewComments),
+    ...botCommentFindings(
+      readyState.topLevelBotComments ?? [],
+      readyState.pr,
+      blockingTopLevelBotComments,
+    ),
+  ];
+}
+
 export function summarizeFeedbackState(readyState) {
   const gates = readyState.gates ?? {};
   const requiredBlockers = readyState.required?.blockers ?? [];
@@ -92,6 +352,10 @@ export function summarizeFeedbackState(readyState) {
     (comment) =>
       isCurrentHeadComment(comment, readyState.pr) &&
       isActionableReviewBotComment(comment),
+  );
+  const findings = buildFeedbackFindings(
+    readyState,
+    blockingTopLevelBotComments,
   );
   const feedbackSurfacesReady =
     unresolvedReviewThreads.length === 0 &&
@@ -121,12 +385,15 @@ export function summarizeFeedbackState(readyState) {
     unrepliedRootReviewComments,
     blockingTopLevelBotComments,
     topLevelBotComments,
+    findings,
     counts: {
       requiredFeedbackBlockers: feedbackBlockers.length,
       unresolvedReviewThreads: unresolvedReviewThreads.length,
       unrepliedRootReviewComments: unrepliedRootReviewComments.length,
       blockingTopLevelBotComments: blockingTopLevelBotComments.length,
       topLevelBotComments: topLevelBotComments.length,
+      findings: findings.length,
+      blockingFindings: findings.filter((finding) => finding.blocking).length,
     },
   };
 }

--- a/scripts/pr-feedback-state.mjs
+++ b/scripts/pr-feedback-state.mjs
@@ -59,7 +59,11 @@ async function main() {
 
     for (;;) {
       try {
-        const readyState = await fetchReadyState({ prArg, repoArg });
+        const readyState = await fetchReadyState({
+          prArg,
+          repoArg,
+          includeFeedbackDetails: true,
+        });
         process.stdout.write(
           renderFeedbackState(summarizeFeedbackState(readyState), { watch }),
         );

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
-import { summarizeFeedbackState } from "./pr-feedback-state-core.mjs";
+import {
+  buildFeedbackFindings,
+  summarizeFeedbackState,
+} from "./pr-feedback-state-core.mjs";
 import {
   parseFeedbackArgs,
   renderFeedbackState,
@@ -138,7 +141,135 @@ test("summarizes only feedback blockers and counts", () => {
     unrepliedRootReviewComments: 1,
     blockingTopLevelBotComments: 0,
     topLevelBotComments: 1,
+    findings: 2,
+    blockingFindings: 2,
   });
+});
+
+test("normalizes feedback surfaces into findings with state flags", () => {
+  const currentHead = "b".repeat(40);
+  const findings = buildFeedbackFindings(
+    {
+      pr: {
+        headRefOid: currentHead,
+        headUpdatedAt: "2026-06-05T16:30:00Z",
+      },
+      reviewThreads: [
+        {
+          id: "thread-1",
+          path: "scripts/example.mjs",
+          line: 12,
+          isResolved: false,
+          isOutdated: true,
+          author: "cursor[bot]",
+          url: "https://github.example/thread-1",
+          body: "[P2] Fix stale thread",
+        },
+        {
+          id: "thread-2",
+          path: "scripts/example.mjs",
+          line: 20,
+          isResolved: true,
+          isOutdated: false,
+          author: "alice",
+          url: "https://github.example/thread-2",
+          body: "Resolved already",
+        },
+      ],
+      rootReviewComments: [
+        {
+          id: 111,
+          path: "scripts/example.mjs",
+          line: 30,
+          replied: false,
+          author: "claude[bot]",
+          url: "https://github.example/comment-111",
+          body: "Please reply to this.",
+        },
+        {
+          id: 112,
+          path: "scripts/example.mjs",
+          line: 31,
+          replied: true,
+          author: "claude[bot]",
+          url: "https://github.example/comment-112",
+          body: "Already handled.",
+        },
+      ],
+      topLevelBotComments: [
+        {
+          id: 456,
+          author: "chatgpt-codex-connector[bot]",
+          updatedAt: "2026-06-05T16:31:00Z",
+          body: "| # | Severity | Issue |\n| 1 | [P1] | Fix one |\n| 2 | [P2] | Fix two |",
+        },
+      ],
+    },
+    [
+      {
+        id: 456,
+        author: "chatgpt-codex-connector[bot]",
+        updatedAt: "2026-06-05T16:31:00Z",
+        body: "| # | Severity | Issue |\n| 1 | [P1] | Fix one |\n| 2 | [P2] | Fix two |",
+      },
+    ],
+  );
+
+  assertEqual(findings.length, 6);
+  assertDeepEqual(
+    findings.map((finding) => finding.state),
+    [
+      "unresolved-outdated",
+      "resolved",
+      "unreplied",
+      "replied",
+      "current-head",
+      "current-head",
+    ],
+  );
+  assertEqual(findings[0].blocking, true);
+  assertEqual(findings[0].currentHead, false);
+  assertEqual(findings[2].replied, false);
+  assertEqual(findings[3].blocking, false);
+  assertEqual(findings[4].sourceId, "456#1");
+  assertEqual(findings[5].title, "[P2] Fix two");
+});
+
+test("keeps top-level bot finding fingerprints stable across repeated comments", () => {
+  const base = {
+    pr: {
+      headRefOid: "b".repeat(40),
+      headUpdatedAt: "2026-06-05T16:30:00Z",
+    },
+  };
+  const first = buildFeedbackFindings({
+    ...base,
+    topLevelBotComments: [
+      {
+        id: 456,
+        author: "cursor[bot]",
+        updatedAt: "2026-06-05T16:31:00Z",
+        body: "**High Severity**\nFix the parser branch.",
+      },
+    ],
+  });
+  const repeated = buildFeedbackFindings({
+    ...base,
+    topLevelBotComments: [
+      {
+        id: 789,
+        author: "cursor[bot]",
+        updatedAt: "2026-06-05T16:45:00Z",
+        body: "**High Severity**\nFix the parser branch.",
+      },
+    ],
+  });
+
+  assertEqual(first.length, 1);
+  assertEqual(repeated.length, 1);
+  assertEqual(first[0].fingerprint, repeated[0].fingerprint);
+  assertEqual(first[0].sourceId, "456#1");
+  assertEqual(repeated[0].sourceId, "789#1");
 });
 
 test("includes requested-change review blockers in feedback blockers", () => {

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -223,14 +223,16 @@ test("normalizes feedback surfaces into findings with state flags", () => {
       "resolved",
       "unreplied",
       "replied",
-      "current-head",
-      "current-head",
+      "blocking-current-head",
+      "blocking-current-head",
     ],
   );
   assertEqual(findings[0].blocking, true);
   assertEqual(findings[0].currentHead, false);
   assertEqual(findings[2].replied, false);
   assertEqual(findings[3].blocking, false);
+  assertEqual(findings[4].blocking, true);
+  assertEqual(findings[5].blocking, true);
   assertEqual(findings[4].sourceId, "456#1");
   assertEqual(findings[5].title, "[P2] Fix two");
 });

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -191,21 +191,25 @@ export function splitRequiredAndOptionalChecks(
 }
 
 export function findUnresolvedReviewThreads(reviewThreads = []) {
-  return reviewThreads
+  return summarizeReviewThreads(reviewThreads)
     .filter((thread) => thread.isResolved === false)
-    .map((thread) => {
-      const firstComment = thread.comments?.nodes?.[0] ?? thread.comments?.[0];
-      return {
-        id: thread.id,
-        path: thread.path ?? null,
-        line: thread.line ?? thread.startLine ?? null,
-        isOutdated: Boolean(thread.isOutdated),
-        author:
-          firstComment?.author?.login ?? firstComment?.user?.login ?? null,
-        url: firstComment?.url ?? null,
-        body: firstComment?.body ?? "",
-      };
-    });
+    .map(({ isResolved: _isResolved, ...thread }) => thread);
+}
+
+export function summarizeReviewThreads(reviewThreads = []) {
+  return reviewThreads.map((thread) => {
+    const firstComment = thread.comments?.nodes?.[0] ?? thread.comments?.[0];
+    return {
+      id: thread.id,
+      path: thread.path ?? null,
+      line: thread.line ?? thread.startLine ?? null,
+      isOutdated: Boolean(thread.isOutdated),
+      isResolved: Boolean(thread.isResolved),
+      author: firstComment?.author?.login ?? firstComment?.user?.login ?? null,
+      url: firstComment?.url ?? null,
+      body: firstComment?.body ?? "",
+    };
+  });
 }
 
 export function findUnrepliedRootReviewComments(
@@ -213,11 +217,35 @@ export function findUnrepliedRootReviewComments(
   ignoredAuthors = [],
   allowedReplyAuthors = null,
 ) {
+  const repliedRootIds = repliedRootReviewCommentIds(
+    reviewComments,
+    allowedReplyAuthors,
+  );
+  const ignoredAuthorSet = new Set(ignoredAuthors.filter(Boolean));
+
+  return reviewComments
+    .filter((comment) => commentIsRootReviewComment(comment))
+    .filter((comment) => !ignoredAuthorSet.has(comment.user?.login))
+    .filter((comment) => !repliedRootIds.has(comment.id))
+    .map(reviewCommentSummary);
+}
+
+function commentIsRootReviewComment(comment) {
+  return (
+    comment.in_reply_to_id === undefined || comment.in_reply_to_id === null
+  );
+}
+
+function repliedRootReviewCommentIds(
+  reviewComments = [],
+  allowedReplyAuthors = null,
+) {
   const allowedReplyAuthorSet =
     allowedReplyAuthors === null
       ? null
       : new Set(allowedReplyAuthors.filter(Boolean));
-  const repliedRootIds = new Set(
+
+  return new Set(
     reviewComments
       .filter((comment) => {
         const rootId = comment.in_reply_to_id;
@@ -229,6 +257,30 @@ export function findUnrepliedRootReviewComments(
       })
       .map((comment) => comment.in_reply_to_id),
   );
+}
+
+function reviewCommentSummary(comment, { replied = undefined } = {}) {
+  const summary = {
+    id: comment.id,
+    path: comment.path ?? null,
+    line: comment.line ?? comment.original_line ?? null,
+    author: comment.user?.login ?? null,
+    url: comment.html_url ?? comment.url ?? null,
+    body: comment.body ?? "",
+  };
+  if (replied !== undefined) summary.replied = replied;
+  return summary;
+}
+
+export function summarizeRootReviewComments(
+  reviewComments = [],
+  ignoredAuthors = [],
+  allowedReplyAuthors = null,
+) {
+  const repliedRootIds = repliedRootReviewCommentIds(
+    reviewComments,
+    allowedReplyAuthors,
+  );
   const ignoredAuthorSet = new Set(ignoredAuthors.filter(Boolean));
 
   return reviewComments
@@ -237,15 +289,11 @@ export function findUnrepliedRootReviewComments(
         comment.in_reply_to_id === undefined || comment.in_reply_to_id === null,
     )
     .filter((comment) => !ignoredAuthorSet.has(comment.user?.login))
-    .filter((comment) => !repliedRootIds.has(comment.id))
-    .map((comment) => ({
-      id: comment.id,
-      path: comment.path ?? null,
-      line: comment.line ?? comment.original_line ?? null,
-      author: comment.user?.login ?? null,
-      url: comment.html_url ?? comment.url ?? null,
-      body: comment.body ?? "",
-    }));
+    .map((comment) =>
+      reviewCommentSummary(comment, {
+        replied: repliedRootIds.has(comment.id),
+      }),
+    );
 }
 
 export function findTopLevelBotComments(issueComments = []) {
@@ -529,6 +577,7 @@ export function summarizeReadyState({
   requiredStatusContexts = [],
   requiredStatusContextsError = null,
   requiredStatusContextsAvailable = requiredStatusContexts.length > 0,
+  includeFeedbackDetails = false,
 }) {
   const statusChecks = groupStatusChecks(pr.statusCheckRollup ?? []);
   const splitChecks = splitRequiredAndOptionalChecks(
@@ -536,11 +585,17 @@ export function summarizeReadyState({
     requiredStatusContexts,
     { requiredStatusContextsAvailable },
   );
-  const unresolvedReviewThreads = findUnresolvedReviewThreads(reviewThreads);
-  const unrepliedRootReviewComments = findUnrepliedRootReviewComments(
+  const reviewThreadSummaries = summarizeReviewThreads(reviewThreads);
+  const unresolvedReviewThreads = reviewThreadSummaries
+    .filter((thread) => thread.isResolved === false)
+    .map(({ isResolved: _isResolved, ...thread }) => thread);
+  const rootReviewComments = summarizeRootReviewComments(
     reviewComments,
     [pr.author?.login],
     [pr.author?.login, BOT_APPROVER],
+  );
+  const unrepliedRootReviewComments = rootReviewComments.filter(
+    (comment) => comment.replied === false,
   );
   const topLevelBotComments = [
     ...findTopLevelBotComments(issueComments),
@@ -687,18 +742,18 @@ export function summarizeReadyState({
     items: optionalItems,
   };
   const ready = required.ready;
-  const summary = ready
+  const summaryText = ready
     ? optional.items.length > 0
       ? `Required gates are clear; ${optional.items.length} optional signal(s) still need attention.`
       : "Required gates are clear."
     : `${required.blockers.length} required blocker(s) remain.`;
 
-  return {
+  const readyStateSummary = {
     ready,
     required,
     optional,
     gates,
-    summary,
+    summary: summaryText,
     pr: summaryPr(pr, headUpdatedAt),
     statusChecks,
     requiredStatusContexts,
@@ -708,4 +763,11 @@ export function summarizeReadyState({
     codexApprovalReaction,
     codexReviewSignal,
   };
+
+  if (includeFeedbackDetails) {
+    readyStateSummary.reviewThreads = reviewThreadSummaries;
+    readyStateSummary.rootReviewComments = rootReviewComments;
+  }
+
+  return readyStateSummary;
 }

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -272,7 +272,7 @@ function reviewCommentSummary(comment, { replied = undefined } = {}) {
   return summary;
 }
 
-export function summarizeRootReviewComments(
+function summarizeRootReviewComments(
   reviewComments = [],
   ignoredAuthors = [],
   allowedReplyAuthors = null,

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -747,7 +747,11 @@ async function fetchRequiredStatusContexts({
   };
 }
 
-export async function fetchReadyState({ prArg, repoArg }) {
+export async function fetchReadyState({
+  prArg,
+  repoArg,
+  includeFeedbackDetails = false,
+}) {
   const prViewArgs = [
     "pr",
     "view",
@@ -859,6 +863,7 @@ export async function fetchReadyState({ prArg, repoArg }) {
     requiredStatusContexts: requiredStatusContexts.contexts,
     requiredStatusContextsError: requiredStatusContexts.error,
     requiredStatusContextsAvailable: requiredStatusContexts.error === null,
+    includeFeedbackDetails,
   });
 }
 

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -792,6 +792,60 @@ test("summarize ready state ignores self-authored roots but not reviewer self-re
   );
 });
 
+test("feedback detail summaries are opt-in for ready-state output", () => {
+  const input = {
+    pr: {
+      ...basePr,
+      statusCheckRollup: [
+        { name: "lint", conclusion: "SUCCESS", status: "COMPLETED" },
+      ],
+    },
+    reactions: [
+      {
+        content: "+1",
+        created_at: "2026-05-21T13:23:00Z",
+        user: { login: "chatgpt-codex-connector[bot]" },
+      },
+    ],
+    reviewComments: [
+      {
+        id: 11,
+        body: "root with author reply",
+        path: "b.ts",
+        line: 2,
+        user: { login: "reviewer" },
+      },
+      {
+        id: 12,
+        in_reply_to_id: 11,
+        body: "fixed",
+        user: { login: "chapati23" },
+      },
+    ],
+    reviewThreads: [
+      {
+        id: "thread-1",
+        path: "b.ts",
+        line: 2,
+        isResolved: true,
+        comments: [{ author: { login: "reviewer" }, body: "handled" }],
+      },
+    ],
+  };
+
+  const defaultSummary = summarizeReadyState(input);
+  assertEqual(Object.hasOwn(defaultSummary, "reviewThreads"), false);
+  assertEqual(Object.hasOwn(defaultSummary, "rootReviewComments"), false);
+
+  const detailedSummary = summarizeReadyState({
+    ...input,
+    includeFeedbackDetails: true,
+  });
+  assertEqual(detailedSummary.reviewThreads.length, 1);
+  assertEqual(detailedSummary.rootReviewComments.length, 1);
+  assertEqual(detailedSummary.rootReviewComments[0].replied, true);
+});
+
 test("filters top-level issue comments down to bots", () => {
   const bots = findTopLevelBotComments([
     { id: 1, body: "human", user: { login: "alice", type: "User" } },


### PR DESCRIPTION
## The Problem

- PR feedback sweeps still require agents to reconcile unresolved threads, root review comments, and top-level bot reports from separate JSON arrays.
- Multi-finding bot comments are hard to deduplicate across review rounds because the current feedback projection has no stable finding identity.
- The durable AI review integration plan needed its next repo-native slice after the materiality classifier landed.

## The Solution

- Add a normalized `findings[]` ledger to `pr:feedback-state` with stable fingerprints, source metadata, short excerpts, and state flags for current-head, outdated, replied, unresolved, and blocking feedback.
- Keep `pr:ready-state` readiness semantics unchanged while letting `pr:feedback-state` opt into richer review-thread and root-comment details for feedback sweeps.

## Details

- Extracts separate findings from actionable top-level bot comments when they use markdown tables or severity sections.
- Preserves the legacy `unresolvedReviewThreads` and `unrepliedRootReviewComments` shapes while adding opt-in `reviewThreads` and `rootReviewComments` detail for feedback-state consumers.
- Updates the AI review integration plan and readiness docs so agents treat `findings[]` as the feedback ledger, not as the final all-clear gate.
- Fixes one current-session autoreview finding by keeping detailed feedback state out of default `pr:ready-state` JSON.

## Validation

- `node scripts/pr-feedback-state.test.mjs`
- `node scripts/pr-ready-state.test.mjs`
- `pnpm lint:scripts`
- `pnpm agent:review-materiality --json`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview --engine local`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to PR feedback CLI scripts, tests, and agent docs; readiness gating behavior is explicitly preserved and covered by tests.
> 
> **Overview**
> Adds a **`findings[]` feedback ledger** to `pnpm pr:feedback-state` so agents can work from one normalized list instead of stitching together separate thread, root-comment, and bot arrays.
> 
> Each finding gets a stable **`fingerprint`**, source metadata, short title/excerpt, and flags for **current-head**, **outdated**, **replied**, **unresolved**, and **blocking**. Actionable top-level bot comments are **split into multiple findings** when they use markdown tables or severity/P-badge sections. **`pr:ready-state` readiness is unchanged**; detailed `reviewThreads` / `rootReviewComments` are only included when feedback-state fetches with **`includeFeedbackDetails: true`**, so default ready-state JSON stays lean.
> 
> Docs and the AI review plan now describe `findings[]` as the sweep ledger while **`pr:ready-state` remains the all-clear gate**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e42fdc0218abf9e555046b0de3bfa440be1597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->