### PR TITLE
Document reserve-yield hosted replay proof

### DIFF
--- a/docs/notes/reserve-yield-indexer.md
+++ b/docs/notes/reserve-yield-indexer.md
@@ -3,7 +3,7 @@ title: Reserve-Yield Indexer Topology
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-06-29
+last_verified: 2026-07-03
 ---
 
 # Reserve-Yield Indexer Topology
@@ -66,9 +66,12 @@ first tracked movements from source-of-truth Ethereum logs for every wallet in:
 - `indexer-envio/src/handlers/susds/shared.ts`
 - `indexer-envio/src/handlers/steth/shared.ts`
 
-Use an archive-capable Ethereum RPC or an Envio HyperSync API token. The public
-RPCs checked on 2026-06-29 either rejected archive log ranges or required a
-token, so this PR does not claim hosted replay proof.
+Use an archive-capable Ethereum RPC or an Envio HyperSync API token for broad
+absence/range proofs. Public RPCs checked on 2026-06-29 rejected archive log
+ranges or required a token. PublicNode receipt lookups were enough to verify
+the first production movement rows on 2026-07-03, but broad negative scans may
+still need a token-authenticated archive endpoint or chunked provider-specific
+queries.
 
 Query these event signatures over bounded ranges through the archive RPC:
 
@@ -94,6 +97,41 @@ cast rpc --rpc-url "$ETHEREUM_ARCHIVE_RPC_URL" eth_getLogs \
   '[{"address":"0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84","fromBlock":"0x112a880","toBlock":"latest","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x000000000000000000000000d0697f70e79476195b742d5afab14be50f98cc1e",null]}]'
 ```
 
+### 2026-07-03 Production Proof
+
+Deployment `6bed96e` was freshly replayed with Ethereum reserve-yield enabled
+and promoted to the static production endpoint:
+
+```bash
+pnpm exec envio-cloud deployment status mento 6bed96e mento-protocol -o json
+pnpm exec envio-cloud indexer get mento mento-protocol -o json
+```
+
+The promoted deployment had non-empty
+`timestamp_caught_up_to_head_or_endblock` values on Ethereum `1`, Monad `143`,
+and Celo `42220`. Production GraphQL returned reserve-yield rows from the shared
+endpoint:
+
+```bash
+curl -sS 'https://indexer.hyperindex.xyz/2f3dd15/v1/graphql' \
+  -H 'content-type: application/json' \
+  --data-binary '{"query":"query FirstReserveRows { SusdsYieldMovement(limit: 3, order_by: {blockNumber: asc}) { id kind from to blockNumber txHash } StethYieldMovement(limit: 3, order_by: {blockNumber: asc}) { id kind from to blockNumber txHash } }"}'
+```
+
+First production rows and receipt checks:
+
+| Path                      | Wallet                                       |      Block | Tx                                                                   | Receipt proof                                                                                                                                                                                                                                                                                  |
+| ------------------------- | -------------------------------------------- | ---------: | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stETH `transfer_in`       | `0xd0697f70e79476195b742d5afab14be50f98cc1e` | `19111760` | `0x297cbad231aa43b915ade1b699b8b0257babe6fff0b62e564d422daace021731` | `cast receipt --rpc-url https://ethereum.publicnode.com 0x297cbad231aa43b915ade1b699b8b0257babe6fff0b62e564d422daace021731 --json` showed the stETH `Transfer` log at log index `0x163` from zero address to the tracked wallet.                                                               |
+| sUSDS `deposit`           | `0xd0697f70e79476195b742d5afab14be50f98cc1e` | `22994825` | `0x6108b1483149133cc9057b80b0dfcc0b5d167a03e784a72e9f3dbe5c55fd4b8a` | `cast receipt --rpc-url https://ethereum.publicnode.com 0x6108b1483149133cc9057b80b0dfcc0b5d167a03e784a72e9f3dbe5c55fd4b8a --json` showed the sUSDS `Deposit` log at log index `0x34b` with owner `0xd0697f70e79476195b742d5afab14be50f98cc1e`, followed by the corresponding mint `Transfer`. |
+| sUSDS `internal_transfer` | `0xd3d2e5c5af667da817b2d752d86c8f40c22137e1` | `25122170` | `0x68bd1f5caf51b8646f4c5d67633028e42404897691cdab13b5dfc71a922899f7` | `cast receipt --rpc-url https://ethereum.publicnode.com 0x68bd1f5caf51b8646f4c5d67633028e42404897691cdab13b5dfc71a922899f7 --json` showed the sUSDS `Transfer` log at log index `0x1c9` from `0xd0697f70e79476195b742d5afab14be50f98cc1e` to `0xd3d2e5c5af667da817b2d752d86c8f40c22137e1`.     |
+
+Production GraphQL returned no stETH movement rows for
+`0xd3d2e5c5af667da817b2d752d86c8f40c22137e1` as of the 2026-07-03 proof
+query. Public broad `eth_getLogs` scans for that absence were blocked by archive
+or range limits; use the archive scan shape above if the tracked wallet set
+changes or if an absence proof is needed for a future audit.
+
 ## Hosted Promotion Gate
 
 Do not promote a hosted reindex with Ethereum reserve-yield enabled until:
@@ -104,3 +142,7 @@ Do not promote a hosted reindex with Ethereum reserve-yield enabled until:
    up to head.
 4. The dashboard `/revenue` page shows restored reserve actuals from the
    shared endpoint and continues to label stale/partial data correctly.
+
+This gate was fulfilled for deployment `6bed96e` on 2026-07-03 after adding an
+archive-capable `ENVIO_RPC_URL_1` in Envio Cloud and promoting the caught-up
+deployment to production.

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -1,7 +1,11 @@
 # Mento v3 Envio HyperIndex Indexer
 
-Multichain Envio HyperIndex indexer for Mento v3 — Celo Mainnet (42220) and Monad Mainnet (143).
-Tracks FPMM pool activity, oracle health, trading limits, and rebalancer liveness. Ethereum reserve-yield accounting is isolated in a separate chain-1 config so historical replay cannot block the primary Celo + Monad indexer.
+Multichain Envio HyperIndex indexer for Mento v3 — Ethereum reserve-yield (1),
+Celo Mainnet (42220), and Monad Mainnet (143). Tracks FPMM pool activity,
+oracle health, trading limits, rebalancer liveness, and event-only
+sUSDS/stETH reserve-yield accounting in the shared production indexer. The
+historical sUSDS `onBlock` heartbeat is intentionally excluded from the hosted
+path.
 
 ## What It Does
 
@@ -28,21 +32,21 @@ Listens to on-chain events from Mento v3 contracts and writes structured entitie
 
 ### Entities Written
 
-| Entity group            | Description                                                                                                                                                                                |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Pool state              | `Pool`, `DeviationThresholdBreach`, `OracleSnapshot`, `TradingLimit`                                                                                                                       |
-| Pool activity           | `SwapEvent`, `LiquidityEvent`, `ReserveUpdate`, `RebalanceEvent`, `LiquidityPosition`, `FactoryDeployment`                                                                                 |
-| Pool rollups            | `PoolSnapshot`, `PoolDailySnapshot`, `PoolDailyVolumeSnapshot`, `PoolDailyFeeSnapshot`                                                                                                     |
-| Protocol fees           | `ProtocolFeeTransfer`                                                                                                                                                                      |
-| Legacy v2 / Broker      | `BrokerSwapEvent`, `BrokerDailySnapshot`, `BrokerExchangeDailySnapshot`, `BrokerTraderDailySnapshot`                                                                                       |
-| Broker aggregators      | `BrokerAggregatorDailySnapshot`, `BrokerAggregatorTraderDayMarker`, `BrokerVolumeWindowSnapshot`                                                                                           |
-| BiPoolManager           | `BiPoolExchange`, `BucketUpdate`                                                                                                                                                           |
-| VirtualPools            | `VirtualPoolLifecycle`                                                                                                                                                                     |
-| Open Liquidity Strategy | `OlsPool`, `OlsLiquidityEvent`, `OlsLifecycleEvent`                                                                                                                                        |
-| Circuit breakers        | `Breaker`, `BreakerConfig`, `BreakerTripEvent`, `RateFeedDependency`                                                                                                                       |
-| Bridge flows            | `BridgeTransfer`, `BridgeAttestation`, `BridgeDailySnapshot`, `BridgeBridger`, `WormholeNttManager`, `WormholeTransferDetail`, `WormholeDestPending`, `WormholeTransferPending`            |
-| Volume and participants | `TraderDailySnapshot`, `TraderPoolDailySnapshot`, `AggregatorDailySnapshot`, `VolumeWindowSnapshot`                                                                                        |
-| Reserve yield           | Isolated Ethereum config: `SusdsYieldMovement`, `SusdsCostBasisLot`, `SusdsPosition`, `SusdsYieldSummary`, `StethYieldMovement`, `StethCostBasisLot`, `StethPosition`, `StethYieldSummary` |
+| Entity group            | Description                                                                                                                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pool state              | `Pool`, `DeviationThresholdBreach`, `OracleSnapshot`, `TradingLimit`                                                                                                                                                |
+| Pool activity           | `SwapEvent`, `LiquidityEvent`, `ReserveUpdate`, `RebalanceEvent`, `LiquidityPosition`, `FactoryDeployment`                                                                                                          |
+| Pool rollups            | `PoolSnapshot`, `PoolDailySnapshot`, `PoolDailyVolumeSnapshot`, `PoolDailyFeeSnapshot`                                                                                                                              |
+| Protocol fees           | `ProtocolFeeTransfer`                                                                                                                                                                                               |
+| Legacy v2 / Broker      | `BrokerSwapEvent`, `BrokerDailySnapshot`, `BrokerExchangeDailySnapshot`, `BrokerTraderDailySnapshot`                                                                                                                |
+| Broker aggregators      | `BrokerAggregatorDailySnapshot`, `BrokerAggregatorTraderDayMarker`, `BrokerVolumeWindowSnapshot`                                                                                                                    |
+| BiPoolManager           | `BiPoolExchange`, `BucketUpdate`                                                                                                                                                                                    |
+| VirtualPools            | `VirtualPoolLifecycle`                                                                                                                                                                                              |
+| Open Liquidity Strategy | `OlsPool`, `OlsLiquidityEvent`, `OlsLifecycleEvent`                                                                                                                                                                 |
+| Circuit breakers        | `Breaker`, `BreakerConfig`, `BreakerTripEvent`, `RateFeedDependency`                                                                                                                                                |
+| Bridge flows            | `BridgeTransfer`, `BridgeAttestation`, `BridgeDailySnapshot`, `BridgeBridger`, `WormholeNttManager`, `WormholeTransferDetail`, `WormholeDestPending`, `WormholeTransferPending`                                     |
+| Volume and participants | `TraderDailySnapshot`, `TraderPoolDailySnapshot`, `AggregatorDailySnapshot`, `VolumeWindowSnapshot`                                                                                                                 |
+| Reserve yield           | Event-only Ethereum handlers in the shared config: `SusdsYieldMovement`, `SusdsCostBasisLot`, `SusdsPosition`, `SusdsYieldSummary`, `StethYieldMovement`, `StethCostBasisLot`, `StethPosition`, `StethYieldSummary` |
 
 ### Pool ID Format
 


### PR DESCRIPTION
## The Problem

- Issue #1017 remained open because PR #1028 shipped the event-only shared-indexer topology before hosted Ethereum replay and promotion could be proven.
- `indexer-envio/README.md` still described the older split reserve-yield topology.

## The Solution

- Record the July 3, 2026 production proof for Envio deployment `6bed96e`: caught-up hosted replay, static endpoint promotion, production GraphQL reserve-yield rows, and Ethereum receipt checks for the first tracked movements.
- Update the indexer README so it describes event-only Ethereum reserve-yield accounting in the shared production indexer.

## Validation

- `pnpm agent:quality-gate --run` (static checks passed; initial coverage under Node 24 timed out in unrelated indexer suites)
- `volta run --node 22.22.3 pnpm --filter @mento-protocol/indexer-envio test:coverage` (62 passed, 2 skipped; 1000 tests passed, 19 skipped)
- `volta run --node 22.22.3 pnpm agent:quality-gate --run --parallel 1`
- `pnpm agent:autoreview`
- Production Envio checks against deployment `6bed96e` and `https://indexer.hyperindex.xyz/2f3dd15/v1/graphql`

Closes #1017

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates to runbooks and README; no application or indexer code changes.
> 
> **Overview**
> **Documentation only** — closes the gap left after the shared-indexer topology shipped without a recorded hosted replay proof.
> 
> `docs/notes/reserve-yield-indexer.md` bumps `last_verified` to **2026-07-03**, clarifies that **PublicNode receipts** can verify first movement rows while **broad `eth_getLogs` scans** may still need archive RPC, and adds a **2026-07-03 Production Proof** section: deployment `6bed96e`, catch-up on chains 1/143/42220, production GraphQL sample query, a table of first stETH/sUSDS rows with `cast receipt` checks, and notes on stETH absence for one wallet. The **Hosted Promotion Gate** now states it was **fulfilled** for `6bed96e` after archive `ENVIO_RPC_URL_1` and promotion.
> 
> `indexer-envio/README.md` replaces the old **isolated chain-1 reserve-yield** description with **Ethereum (1) + Celo + Monad** in one production indexer, **event-only** sUSDS/stETH handlers in the shared config, and explicit exclusion of the historical sUSDS **`onBlock` heartbeat** on the hosted path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4aa24dbbdbb8fdfcfdfccb8c76b028740fb4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->