### PR TITLE
docs: add review prompt exclusions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,11 +413,13 @@ For process or policy-router PRs, build a coverage matrix before implementation.
 ## Recurring PR-review patterns
 
 Recurring automated-review hazards are canonicalized in
-`docs/pr-checklists/recurring-review-patterns.md`. Read that checklist when a
-change touches cross-layer state, CI/deploy behavior, code-health rules,
-dashboard interaction flows, security headers, package-manager behavior, or
-other review-prone surfaces. Keep root instructions as routing context; put the
-detailed rules in the checklist.
+`docs/pr-checklists/recurring-review-patterns.md`. Explicit repo-local review
+exclusions live in `docs/pr-checklists/review-prompt-exclusions.md`; reviewers
+should treat that file as the "do not flag" layer before re-raising old or
+speculative findings. Read those checklists when a change touches cross-layer
+state, CI/deploy behavior, code-health rules, dashboard interaction flows,
+security headers, package-manager behavior, or other review-prone surfaces. Keep
+root instructions as routing context; put the detailed rules in the checklists.
 
 ## Quick Commands
 
@@ -544,7 +546,7 @@ Each package has its own `AGENTS.md` (Claude Code reads them as `CLAUDE.md` via 
 
 - Current expected scale is roughly **30–50 total pools**.
 - At this size, client-side aggregation for the 24h volume tiles/table is acceptable with the current polling setup.
-- Do **not** flag the current snapshot-query aggregation path as a scalability issue in PR reviews unless assumptions change materially (e.g. significantly more pools, much higher polling frequency, or observed latency/cost regressions in production).
+- Do **not** flag the current snapshot-query aggregation path as a scalability issue in PR reviews unless assumptions change materially (e.g. significantly more pools, much higher polling frequency, or observed latency/cost regressions in production). The canonical exclusion lives in `docs/pr-checklists/review-prompt-exclusions.md`.
 
 ## Repo conventions
 

--- a/docs/PLAN-ai-review-process.md
+++ b/docs/PLAN-ai-review-process.md
@@ -70,21 +70,25 @@ the repo's existing gates:
 - Include state fields for current-head, outdated, replied, unresolved, and
   blocking status.
 
-## Next PR
-
-Add prompt-exclusion updates to the global `review` skill:
+3. Prompt-exclusion guidance now lives in
+   `docs/pr-checklists/review-prompt-exclusions.md`:
 
 - Translate recurring accepted/rejected review noise into explicit "do not
   flag" guidance.
-- Keep prompt changes outside this repo unless the owning global skill lives in
-  repo-local context.
-- Use `findings[]` from `pr:feedback-state` to identify repeated false-positive
-  patterns before changing prompts.
+- Keep prompt changes repo-local unless the user explicitly asks for an
+  out-of-repo global skill edit.
+- Route review agents from `AGENTS.md` and
+  `docs/pr-checklists/recurring-review-patterns.md` to the exclusion checklist.
+- Use `findings[]` from `pr:feedback-state` as the feedback-state source of
+  truth before reviving older findings.
+
+## Next PR
+
+Teach `agent:autoreview` to prepare a richer review bundle directory with
+changed paths, patch files, selected checklists, and any feedback ledger.
 
 ## Later PRs
 
-- Teach `agent:autoreview` to prepare a richer review bundle directory with
-  changed paths, patch files, selected checklists, and any feedback ledger.
 - Consider a human-only break-glass readiness override that is reported by
   `pr:ready-state`, not silently treated as all-clear.
 

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -3,7 +3,7 @@ title: Recurring PR Review Patterns
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-03
 ---
 
 # Recurring PR Review Patterns
@@ -11,6 +11,14 @@ last_verified: 2026-05-20
 Across the last 20 PRs, review findings clustered into the categories below. **Subsections with a linked checklist (`— docs/pr-checklists/X.md`)** treat the checklist as canonical — the inline tldr is a routing hint, not the source of truth. Subsections without a link are inline-canonical (no upstream checklist yet — candidates for future extraction).
 
 ## Patterns
+
+### Prompt exclusions — `docs/pr-checklists/review-prompt-exclusions.md`
+
+tldr: before re-raising a stale or speculative review finding, check the
+repo-local exclusion list. Feedback state, optional bot lag, non-canonical plan
+files, global skill ownership, docs-only browser verification, advisory gates,
+and dashboard scale assumptions all have narrower "do not flag" rules there.
+Full rules in the linked checklist.
 
 ### SWR + Hasura polling — `docs/pr-checklists/swr-polling-hasura.md`
 

--- a/docs/pr-checklists/review-prompt-exclusions.md
+++ b/docs/pr-checklists/review-prompt-exclusions.md
@@ -1,0 +1,93 @@
+---
+title: Review Prompt Exclusions
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-03
+---
+
+# Review Prompt Exclusions
+
+Use this checklist as repo-local "do not flag" guidance for human and agent
+reviews. It is intentionally narrow: each exclusion exists because the repo has
+a more precise source of truth, gate, or operating rule elsewhere.
+
+These exclusions do not suppress findings when the underlying assumption has
+changed. If a reviewer has current evidence that an exclusion no longer holds,
+flag the concrete regression and cite the evidence.
+
+## Feedback State
+
+- Do not treat stale, outdated, resolved, or replied findings as current
+  blockers when `pnpm --silent pr:feedback-state --pr <number> --json` marks
+  them non-blocking. Use the ledger's `findings[]` state fields instead of
+  re-reading old review text as if it applies to the current head.
+- Do not require a fresh review reply for a comment that already has an
+  explicit fixed or won't-fix reply. If new code reintroduces the same issue,
+  open a new finding against the current diff instead of reviving the old one.
+- Do not count clean, informational, or advisory top-level bot comments as
+  review blockers. They are part of the required feedback sweep, but they only
+  block when they contain actionable current-head findings or when branch
+  protection marks the related check as required.
+- Do not block all-clear on optional bot lag. `pnpm pr:ready-state --pr
+<number> --json` is the readiness source of truth, and its required-only
+  result decides readiness. Advisory lag should be reported separately.
+
+## Scope And Ownership
+
+- Do not flag a repo PR for failing to edit the global `~/.agents/skills/review`
+  skill. This repo can ship repo-local context and wrappers; global skill
+  changes belong in the owning skill store unless the user explicitly asks for
+  an out-of-repo edit.
+- Do not flag non-canonical roadmap files, such as `docs/PLAN-*`, as live
+  operating truth. They can drift as planning artifacts. Canonical review
+  context lives in `AGENTS.md`, package `AGENTS.md` files, `docs/pr-checklists/`,
+  scripts, workflows, and tested command behavior.
+- Do not require a GitHub issue for a well-evidenced won't-fix decision. The
+  deferral rule requires issues for knowingly deferred work, not for findings
+  that are rejected because they are false, obsolete, already covered by an
+  existing gate, or outside the repo's ownership boundary.
+- Do not require browser verification for docs-only or non-UI tooling changes.
+  Browser verification is mandatory when a PR changes UI behavior, frontend
+  build/runtime paths, browser tests, visual output, or dashboard interaction
+  flows.
+
+## Existing Guardrails
+
+- Do not ask for another ad hoc quality command when `pnpm agent:quality-gate
+--run` has mapped and executed the applicable local checks for the changed
+  paths. Flag missing targeted checks only when the gate mapping is incomplete
+  for the diff or when a package-specific `AGENTS.md` requires an extra command.
+- Do not flag a missing context-doc update solely because a file under
+  `docs/PLAN-*` changed. Flag context drift when the diff introduces or changes
+  commands, scripts, env vars, hooks, deploy/codegen steps, ownership routing,
+  required workflow order, or checklist behavior without updating the canonical
+  docs that agents actually read.
+- Do not treat weekly or advisory gates as per-PR blockers unless the workflow is
+  branch-protection-required for the PR. Examples include mutation testing,
+  duplication reports, and schema-diff comments when their check status is
+  advisory.
+
+## Repo-Specific False Positives
+
+- Do not flag the current dashboard snapshot-query aggregation path as a
+  scalability issue while expected scale remains roughly 30-50 pools and the
+  current polling setup has no observed latency or cost regression. Re-open the
+  issue only if pool count, polling frequency, data volume, or production
+  performance changes materially.
+- Do not flag client-side aggregation for the existing 24h volume tiles/table on
+  scale grounds under the same assumptions. If the query shape changes to cross
+  Hasura row caps or starts mixing deploy-window-sensitive schema fields into a
+  primary page query, use the SWR/Hasura checklist instead.
+
+## Reviewer Workflow
+
+- Start from current state: base branch, current head SHA, `pr:feedback-state`,
+  `pr:ready-state`, and the changed files. Avoid carrying forward stale
+  conclusions from older pushes.
+- When a repeated false positive appears, prefer adding a narrow exclusion here
+  and linking the precise source of truth over broad prompt wording that could
+  hide real regressions.
+- When an exclusion relies on an assumption, name the assumption and the
+  evidence that would invalidate it. A future reviewer should know when to stop
+  applying the exclusion.


### PR DESCRIPTION
## The Problem

- Recurring review guidance had canonical "what to flag" patterns, but the repo lacked an explicit "do not flag" layer for stale or speculative findings.
- The prompt-exclusion roadmap still pointed at the global review skill, even though this repo can only ship repo-owned review context.
- Review agents needed one repo-local source of truth for feedback-state, advisory-gate, docs-only, and dashboard-scale false positives.

## The Solution

- Add `docs/pr-checklists/review-prompt-exclusions.md` as canonical repo-local exclusion guidance.
- Route `AGENTS.md` and `docs/pr-checklists/recurring-review-patterns.md` to the exclusion checklist.
- Update `docs/PLAN-ai-review-process.md` so prompt exclusions are implemented and the next slice is the richer autoreview bundle.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic engine in Codex sandbox; clean)

Docs-only change; no browser verification path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-routing only; no runtime, auth, or deploy behavior changes.
> 
> **Overview**
> Adds **`docs/pr-checklists/review-prompt-exclusions.md`** as the repo-local **“do not flag”** layer for human and agent reviews—covering feedback ledger semantics (`pr:feedback-state` / `pr:ready-state`), scope/ownership (global skills, `docs/PLAN-*`, deferrals vs won’t-fix), existing guardrails (`agent:quality-gate`, advisory CI), dashboard scale false positives, and reviewer workflow.
> 
> **`AGENTS.md`** and **`docs/pr-checklists/recurring-review-patterns.md`** now route reviewers to that checklist before re-raising stale or speculative findings; dashboard scale guidance points at the same canonical exclusion.
> 
> **`docs/PLAN-ai-review-process.md`** records prompt exclusions as shipped and moves the next slice to a richer **`agent:autoreview`** review bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 331cfe673d4e44bcf75c49b37a9bc6d6814bd7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->