### PR TITLE
docs: document Terraform deploy queue blockers

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -86,6 +86,14 @@ use the workflow run for the full sanitized plan. The default destination is
 `#ci-failures`; set the repository variable `TERRAFORM_APPLY_SLACK_CHANNEL` to
 route these summaries to another public channel.
 
+If a post-merge Terraform deploy workflow stays `pending` with no jobs, inspect
+that workflow's run queue before waiting on the current run. Older `waiting` or
+`pending` runs in the same deploy concurrency group can block the current merge
+commit. Confirm the older runs are obsolete, cancel them, then watch the current
+run until both plan and apply reach a terminal state. If approval was granted
+before the apply job existed, GitHub can require a fresh `production-infra`
+approval after the plan creates the apply job.
+
 ## GitHub Environment Setup
 
 Pre-merge requirement for the production-environment split in issue #762:


### PR DESCRIPTION
## The Problem

- Post-merge Terraform deploy babysits can stall when an older environment-gated run is still occupying the workflow concurrency lane.
- Operators may keep waiting on the current run without realizing it has no jobs yet.

## The Solution

- Document the queue inspection and obsolete-run cancellation workflow, plus the fresh `production-infra` approval wrinkle after plan creates apply.

## Details

- Adds a note to `docs/terraform.md` near the CI apply behavior for `production-infra`-gated Terraform stacks.
- Captures the Governance Watchdog deploy queue behavior observed after PR #1035 merged.
- UI/browser verification is not applicable for this docs-only change.

## Validation

- `./tools/trunk check docs/terraform.md`
- `git diff --check`
- `/Users/chapati/.volta/bin/pnpm agent:quality-gate --run`
- `/Users/chapati/.volta/bin/pnpm agent:autoreview` (local deterministic engine; no actionable findings)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no workflow, infrastructure, or application code impact.
> 
> **Overview**
> Adds operator guidance in **`docs/terraform.md`** (after the Slack apply-pending section) for when a post-merge Terraform workflow looks stuck **`pending` with no jobs**.
> 
> The new text tells reviewers to check the **workflow run queue** for older **`waiting`/`pending`** runs in the same **deploy concurrency group**, cancel obsolete ones, then follow the current run through plan and apply. It also notes that **`production-infra`** approval granted **before** the apply job exists may require **re-approval** once plan creates that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4ccfb99a1ad38f9031f858bcf8a203956b48c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->