### PR TITLE
Add head-scoped pr-ready override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,12 @@ so a real deferral can't hide behind an empty declaration. Two corollaries:
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.
 
-Hard stop: a PR is not all clear until `chatgpt-codex-connector[bot]` has left a 👍 reaction on the PR description for the current head. A Codex review comment on an older commit, elapsed grace time, green checks, or another actor's reaction does not satisfy this gate.
+Hard stop: a PR is not all clear until `chatgpt-codex-connector[bot]` has left
+a 👍 reaction on the PR description for the current head, unless a human
+maintainer has posted the exact head-scoped break-glass override documented in
+`docs/notes/pr-ready-state.md`. A Codex review comment on an older commit,
+elapsed grace time, green checks, or another actor's reaction does not satisfy
+this gate.
 
 Before signaling all-clear, both Claude Code and Codex babysitting flows must
 run the shared readiness probe:

--- a/docs/PLAN-ai-review-process.md
+++ b/docs/PLAN-ai-review-process.md
@@ -85,16 +85,28 @@ the repo's existing gates:
 4. `agent:autoreview` can prepare richer repo-context review bundles:
 
 - Add `pnpm agent:autoreview --prepare-bundle-dir <dir>`.
-- Write changed paths, patch files, copied selected checklists, and the global
+- Write changed paths, patch files, copied selected checklists, and the
   helper's `autoreview-prompt.md` into an out-of-worktree bundle directory.
 - Add `--feedback-pr <number>` to include `pr:feedback-state` JSON for
   feedback-fix batches.
 - Keep normal `pnpm agent:autoreview` behavior unchanged.
 
+5. `pr:ready-state` can report a human break-glass override for externally
+   blocked Codex approval:
+
+- Accept a PR comment command from a human `OWNER`, `MEMBER`, or
+  `COLLABORATOR`:
+  `/pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>`.
+- Apply it only to the Codex PR-description approval gate and only for the exact
+  current head SHA.
+- Report the gate as `overridden` with `readinessOverrides[]` evidence instead
+  of pretending Codex approved.
+- Keep checks, mergeability, requested changes, unresolved threads, and
+  unreplied comments fully blocking.
+
 ## Next PR
 
-Consider a human-only break-glass readiness override that is reported by
-`pr:ready-state`, not silently treated as all-clear.
+- None currently planned.
 
 ## Later PRs
 

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -44,6 +44,20 @@ Required blockers:
   reaction must be created at or after the current-head update lower bound:
   the head commit's GitHub push timestamp when available, otherwise the first
   current-head check/status observation timestamp.
+- A human break-glass override for the Codex PR-description approval gate only,
+  when Codex review is externally blocked after the rest of the required
+  readiness surface is clean. The override must be a PR comment from a GitHub
+  `OWNER`, `MEMBER`, or `COLLABORATOR` human author:
+
+  ```text
+  /pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>
+  ```
+
+  The override is scoped to the exact current head SHA, so any new push expires
+  it. It is reported as gate state `overridden` with `readinessOverrides[]`
+  evidence; it is not hidden as a normal Codex approval. It never overrides
+  failing or pending required checks, merge conflicts, draft state, requested
+  changes, unresolved review threads, or unreplied review comments.
 
 Optional signals:
 
@@ -187,6 +201,9 @@ Field expectations:
   needs `kind`, `name`, `state`, and `required: false`.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
+- `readinessOverrides[]`: active human break-glass overrides that affected a
+  gate. Each entry includes `gate`, exact `head`, `reason`, `author`, URL, and
+  timestamp. Empty means no override was applied.
 - `pr:feedback-state` adds `findings[]`: normalized review findings from inline
   review threads, root review comments, and actionable top-level bot comments or
   review bodies. Each entry has a stable `fingerprint`, `source`, `sourceId`,
@@ -258,10 +275,10 @@ reached, stop posting duplicate `@codex review` requests and inspect whether
 the limit reply is the current-head Codex result. If it is current-head and
 approval is still missing, treat the Codex PR-description approval as
 externally blocked even if `codexReviewSignal` reports `in_flight`; quota or
-settings must change, or the gate must be intentionally overridden. If the
-limit reply is only historical and the current head is `requested` or
-`in_flight` for another Codex signal, keep watching until Codex approves, posts
-new feedback, or the signal becomes stale.
+settings must change, or the gate must be intentionally overridden with the
+head-scoped comment syntax above. If the limit reply is only historical and the
+current head is `requested` or `in_flight` for another Codex signal, keep
+watching until Codex approves, posts new feedback, or the signal becomes stale.
 
 ## Babysitting Speed Discipline
 

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -28,6 +28,13 @@ const PENDING_VALUES = new Set([
   "WAITING",
 ]);
 const SKIPPED_VALUES = new Set(["NEUTRAL", "SKIPPED"]);
+const HUMAN_OVERRIDE_ASSOCIATIONS = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+const READINESS_OVERRIDE_COMMAND = "/pr-ready-override";
+const CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE = "codex-description-approval";
 
 function normalizeStatusValue(value) {
   return String(value ?? "")
@@ -384,6 +391,93 @@ function parseTimestamp(value) {
   return Number.isNaN(timestamp) ? null : timestamp;
 }
 
+function issueCommentAuthorAssociation(comment) {
+  return String(
+    comment.author_association ?? comment.authorAssociation ?? "",
+  ).toUpperCase();
+}
+
+function isHumanOverrideAuthor(comment) {
+  const login = comment.user?.login ?? comment.author?.login ?? "";
+  const type = comment.user?.type ?? comment.author?.type ?? "";
+  return (
+    !String(login).endsWith("[bot]") &&
+    type !== "Bot" &&
+    HUMAN_OVERRIDE_ASSOCIATIONS.has(issueCommentAuthorAssociation(comment))
+  );
+}
+
+function extractOverrideValue(body, key) {
+  const source = String(body ?? "");
+  const pattern = new RegExp(`(?:^|\\s)${key}=([^\\s]+)`, "i");
+  return source.match(pattern)?.[1] ?? null;
+}
+
+function extractOverrideReason(body) {
+  const match = String(body ?? "").match(/(?:^|\s)reason=(.+)$/i);
+  return match?.[1]?.trim() ?? "";
+}
+
+export function parseReadinessOverrideComment(comment, currentHeadOid = null) {
+  const body = String(comment.body ?? "");
+  if (
+    !body
+      .trimStart()
+      .match(new RegExp(`^${READINESS_OVERRIDE_COMMAND}\\b`, "i"))
+  ) {
+    return null;
+  }
+
+  const gate = extractOverrideValue(body, "gate")?.toLowerCase() ?? null;
+  const head = extractOverrideValue(body, "head");
+  const reason = extractOverrideReason(body);
+  const author = comment.user?.login ?? comment.author?.login ?? null;
+  const createdAt = comment.created_at ?? comment.createdAt ?? null;
+  const base = {
+    gate,
+    head,
+    reason,
+    author,
+    authorAssociation:
+      comment.author_association ?? comment.authorAssociation ?? null,
+    url: comment.html_url ?? comment.url ?? null,
+    createdAt,
+    state: "ignored",
+  };
+
+  if (!isHumanOverrideAuthor(comment)) {
+    return { ...base, reasonIgnored: "author_not_allowed" };
+  }
+  if (gate !== CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE) {
+    return { ...base, reasonIgnored: "unsupported_gate" };
+  }
+  if (!head || !currentHeadOid || head !== currentHeadOid) {
+    return { ...base, reasonIgnored: "head_mismatch" };
+  }
+  if (!reason) {
+    return { ...base, reasonIgnored: "missing_reason" };
+  }
+
+  return {
+    ...base,
+    state: "active",
+  };
+}
+
+function findActiveReadinessOverrides(
+  issueComments = [],
+  currentHeadOid = null,
+) {
+  return issueComments
+    .map((comment) => parseReadinessOverrideComment(comment, currentHeadOid))
+    .filter((override) => override?.state === "active")
+    .sort((a, b) => {
+      const aTime = parseTimestamp(a.createdAt) ?? 0;
+      const bTime = parseTimestamp(b.createdAt) ?? 0;
+      return bTime - aTime;
+    });
+}
+
 function currentHeadUpdatedAt(pr) {
   return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
 }
@@ -627,14 +721,26 @@ export function summarizeReadyState({
     reactions,
     headUpdatedAt,
   );
+  const currentHeadOid = pr.headRefOid ?? pr.headOid ?? null;
   const codexReviewSignal = classifyCodexReviewSignal({
     issueComments,
     reviews: pr.reviews ?? [],
     headUpdatedAt,
-    currentHeadOid: pr.headRefOid ?? pr.headOid ?? null,
+    currentHeadOid,
     codexApprovalReaction,
     codexInFlightReaction,
   });
+  const activeReadinessOverrides = findActiveReadinessOverrides(
+    issueComments,
+    currentHeadOid,
+  );
+  const codexDescriptionApprovalOverride = activeReadinessOverrides.find(
+    (override) =>
+      override.gate === CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE &&
+      override.head === currentHeadOid,
+  );
+  const codexDescriptionApprovalReady =
+    codexApprovalReaction || Boolean(codexDescriptionApprovalOverride);
 
   const mergeable = normalizeStatusValue(pr.mergeable) === "MERGEABLE";
   const reviewDecision = normalizeStatusValue(pr.reviewDecision);
@@ -720,9 +826,16 @@ export function summarizeReadyState({
 
   const gates = {
     codexDescriptionApproval: {
-      ready: codexApprovalReaction,
+      ready: codexDescriptionApprovalReady,
       required: true,
-      state: codexApprovalReaction ? "present" : "missing",
+      state: codexApprovalReaction
+        ? "present"
+        : codexDescriptionApprovalOverride
+          ? "overridden"
+          : "missing",
+      ...(codexDescriptionApprovalOverride
+        ? { override: codexDescriptionApprovalOverride }
+        : {}),
     },
     codexReviewSignal: {
       ready: ["approved", "in_flight"].includes(codexReviewSignal),
@@ -745,7 +858,7 @@ export function summarizeReadyState({
     },
   };
 
-  if (!codexApprovalReaction) {
+  if (!codexDescriptionApprovalReady) {
     requiredBlockers.push({
       kind: "gate",
       name: "Codex PR-description approval",
@@ -782,6 +895,7 @@ export function summarizeReadyState({
     unresolvedReviewThreads,
     unrepliedRootReviewComments,
     topLevelBotComments,
+    readinessOverrides: activeReadinessOverrides,
     codexApprovalReaction,
     codexReviewSignal,
   };

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -414,7 +414,7 @@ function extractOverrideValue(body, key) {
 }
 
 function extractOverrideReason(body) {
-  const match = String(body ?? "").match(/(?:^|\s)reason=(.+)$/i);
+  const match = String(body ?? "").match(/(?:^|\s)reason=(.+)$/im);
   return match?.[1]?.trim() ?? "";
 }
 
@@ -734,6 +734,8 @@ export function summarizeReadyState({
     issueComments,
     currentHeadOid,
   );
+  // Keep the gate/head check at the use site so later override types cannot
+  // satisfy this gate merely by appearing in the active override list.
   const codexDescriptionApprovalOverride = activeReadinessOverrides.find(
     (override) =>
       override.gate === CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE &&

--- a/scripts/pr-ready-state-format.mjs
+++ b/scripts/pr-ready-state-format.mjs
@@ -55,6 +55,9 @@ export function formatHuman(summary) {
     }`,
   );
   lines.push(`Codex review signal: ${summary.codexReviewSignal}`);
+  lines.push(
+    `Readiness overrides active: ${summary.readinessOverrides?.length ?? 0}`,
+  );
 
   const sections = [
     [
@@ -92,6 +95,14 @@ export function formatHuman(summary) {
         `${item.author ?? "bot"} ${item.url ?? ""} ${formatShortBody(
           item.body,
         )}`.trim(),
+    ],
+    [
+      "Readiness overrides",
+      summary.readinessOverrides ?? [],
+      (item) =>
+        `${item.gate} by ${item.author ?? "unknown"} for ${item.head}: ${
+          item.reason
+        } ${item.url ?? ""}`.trim(),
     ],
   ];
 
@@ -136,5 +147,6 @@ export function formatCompact(summary) {
     `unreplied=${summary.unrepliedRootReviewComments.length}`,
     `codex_approval=${summary.gates.codexDescriptionApproval.state}`,
     `codex_signal=${summary.codexReviewSignal}`,
+    `overrides=${summary.readinessOverrides?.length ?? 0}`,
   ].join(" ");
 }

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -945,6 +945,20 @@ test("parses only human current-head readiness override comments", () => {
   assertEqual(active.head, "abc123");
   assertEqual(active.reason, "Codex review quota exhausted after clean checks");
 
+  const multiline = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=Codex review quota exhausted after clean checks\n\nAdditional maintainer context.",
+      author_association: "MEMBER",
+      user: { login: "chapati23", type: "User" },
+    },
+    "abc123",
+  );
+  assertEqual(multiline.state, "active");
+  assertEqual(
+    multiline.reason,
+    "Codex review quota exhausted after clean checks",
+  );
+
   const mentionedCommand = parseReadinessOverrideComment(
     {
       body: "Please use /pr-ready-override gate=codex-description-approval head=abc123 reason=quoted example",
@@ -965,6 +979,17 @@ test("parses only human current-head readiness override comments", () => {
   );
   assertEqual(stale.state, "ignored");
   assertEqual(stale.reasonIgnored, "head_mismatch");
+
+  const unsupportedGate = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=some-other-gate head=abc123 reason=workaround",
+      author_association: "MEMBER",
+      user: { login: "chapati23", type: "User" },
+    },
+    "abc123",
+  );
+  assertEqual(unsupportedGate.state, "ignored");
+  assertEqual(unsupportedGate.reasonIgnored, "unsupported_gate");
 
   const bot = parseReadinessOverrideComment(
     {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -14,6 +14,7 @@ import {
   hasCodexInFlightReaction,
   classifyCodexReviewSignal,
   isCodexReviewRequestBody,
+  parseReadinessOverrideComment,
   summarizeReadyState,
   summarizeTerminalReadyState,
   splitRequiredAndOptionalChecks,
@@ -927,6 +928,127 @@ test("requires chatgpt-codex-connector +1 reaction exactly", () => {
   );
 });
 
+test("parses only human current-head readiness override comments", () => {
+  const active = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=Codex review quota exhausted after clean checks",
+      author_association: "MEMBER",
+      html_url: "https://github.com/example/comment",
+      user: { login: "chapati23", type: "User" },
+      created_at: "2026-05-21T13:24:00Z",
+    },
+    "abc123",
+  );
+
+  assertEqual(active.state, "active");
+  assertEqual(active.gate, "codex-description-approval");
+  assertEqual(active.head, "abc123");
+  assertEqual(active.reason, "Codex review quota exhausted after clean checks");
+
+  const mentionedCommand = parseReadinessOverrideComment(
+    {
+      body: "Please use /pr-ready-override gate=codex-description-approval head=abc123 reason=quoted example",
+      author_association: "MEMBER",
+      user: { login: "chapati23", type: "User" },
+    },
+    "abc123",
+  );
+  assertEqual(mentionedCommand, null);
+
+  const stale = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=codex-description-approval head=old123 reason=old head",
+      author_association: "MEMBER",
+      user: { login: "chapati23", type: "User" },
+    },
+    "abc123",
+  );
+  assertEqual(stale.state, "ignored");
+  assertEqual(stale.reasonIgnored, "head_mismatch");
+
+  const bot = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=nope",
+      author_association: "MEMBER",
+      user: { login: "automation[bot]", type: "Bot" },
+    },
+    "abc123",
+  );
+  assertEqual(bot.state, "ignored");
+  assertEqual(bot.reasonIgnored, "author_not_allowed");
+
+  const missingReason = parseReadinessOverrideComment(
+    {
+      body: "/pr-ready-override gate=codex-description-approval head=abc123",
+      author_association: "MEMBER",
+      user: { login: "chapati23", type: "User" },
+    },
+    "abc123",
+  );
+  assertEqual(missingReason.state, "ignored");
+  assertEqual(missingReason.reasonIgnored, "missing_reason");
+});
+
+test("readiness override clears only the Codex approval gate for the current head", () => {
+  const summary = summarizeReadyState({
+    pr: {
+      ...basePr,
+      statusCheckRollup: [
+        { name: "lint", conclusion: "SUCCESS", status: "COMPLETED" },
+      ],
+    },
+    issueComments: [
+      {
+        body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=Codex review quota exhausted after clean checks",
+        author_association: "MEMBER",
+        html_url: "https://github.com/example/comment",
+        user: { login: "chapati23", type: "User" },
+        created_at: "2026-05-21T13:24:00Z",
+      },
+    ],
+  });
+
+  assertEqual(summary.ready, true);
+  assertEqual(summary.codexApprovalReaction, false);
+  assertEqual(summary.gates.codexDescriptionApproval.ready, true);
+  assertEqual(summary.gates.codexDescriptionApproval.state, "overridden");
+  assertEqual(summary.readinessOverrides.length, 1);
+  assertEqual(
+    summary.required.blockers.some(
+      (blocker) => blocker.name === "Codex PR-description approval",
+    ),
+    false,
+  );
+});
+
+test("readiness override does not clear other required blockers", () => {
+  const summary = summarizeReadyState({
+    pr: {
+      ...basePr,
+      statusCheckRollup: [
+        { name: "test", conclusion: "FAILURE", status: "COMPLETED" },
+      ],
+    },
+    issueComments: [
+      {
+        body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=Codex unavailable",
+        author_association: "MEMBER",
+        user: { login: "chapati23", type: "User" },
+        created_at: "2026-05-21T13:24:00Z",
+      },
+    ],
+  });
+
+  assertEqual(summary.ready, false);
+  assertEqual(summary.gates.codexDescriptionApproval.state, "overridden");
+  assert(
+    summary.required.blockers.some(
+      (blocker) => blocker.kind === "check" && blocker.name === "test",
+    ),
+    "expected failed required check to remain blocking",
+  );
+});
+
 test("classifies Codex review signal as missing, requested, in flight, stale, or approved", () => {
   const headUpdatedAt = Date.parse("2026-05-21T13:22:23Z");
 
@@ -1684,7 +1806,34 @@ test("human output names the readiness verdict and codex reaction gate", () => {
   assert(output.includes("Codex review signal: missing"), output);
 });
 
-test("compact output includes only readiness counters and Codex signal state", () => {
+test("human and compact output report active readiness overrides", () => {
+  const summary = summarizeReadyState({
+    pr: { ...basePr, statusCheckRollup: [] },
+    issueComments: [
+      {
+        body: "/pr-ready-override gate=codex-description-approval head=abc123 reason=Codex quota exhausted",
+        author_association: "MEMBER",
+        html_url: "https://github.com/example/comment",
+        user: { login: "chapati23", type: "User" },
+        created_at: "2026-05-21T13:24:00Z",
+      },
+    ],
+  });
+  const human = formatHuman(summary);
+  const compact = formatCompact(summary);
+
+  assert(human.includes("Readiness overrides active: 1"), human);
+  assert(
+    human.includes(
+      "codex-description-approval by chapati23 for abc123: Codex quota exhausted",
+    ),
+    human,
+  );
+  assert(compact.includes("codex_approval=overridden"), compact);
+  assert(compact.includes("overrides=1"), compact);
+});
+
+test("compact output includes readiness counters and Codex signal state", () => {
   const output = formatCompact(
     summarizeReadyState({
       pr: { ...basePr, statusCheckRollup: [] },
@@ -1697,6 +1846,7 @@ test("compact output includes only readiness counters and Codex signal state", (
   assert(output.includes("required_blockers=1"), output);
   assert(output.includes("codex_approval=missing"), output);
   assert(output.includes("codex_signal=missing"), output);
+  assert(output.includes("overrides=0"), output);
 });
 
 if (failed > 0) {


### PR DESCRIPTION
## The Problem

- `pr:ready-state` treated missing Codex PR-description approval as an absolute blocker, even when Codex was externally unavailable.
- Agents needed a visible, auditable way to distinguish a maintainer break-glass decision from normal Codex approval.
- The review-process plan still listed this override as future work.

## The Solution

- Add a head-scoped `/pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>` PR comment command for human `OWNER`, `MEMBER`, or `COLLABORATOR` authors.
- Teach `pr:ready-state` to mark only the Codex PR-description approval gate as `overridden` and expose the evidence in human, compact, and JSON output.
- Document the break-glass contract and update the AI review-process plan.

## Safety / Scope

- The override is ignored for bots, unsupported gates, stale or missing head SHAs, and missing reasons.
- It does not override failing checks, merge conflicts, draft state, requested changes, unresolved threads, unreplied comments, or bot feedback.

## Validation

- `CI=true pnpm pr:ready-state:test`
- `CI=true pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Pre-push agent quality gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a deliberate bypass of a required readiness gate; scope is narrow (one gate, head-bound, human-only) but misuse or weak reasons could merge without Codex sign-off.
> 
> **Overview**
> Adds a **maintainer break-glass path** when Codex PR-description approval is missing but everything else is clean (e.g. Codex quota). Humans with `OWNER`/`MEMBER`/`COLLABORATOR` can post a PR comment:
> 
> `/pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>`
> 
> **`pr:ready-state`** now parses those comments, applies only the **Codex description-approval** gate for the **exact current head**, and surfaces **`readinessOverrides[]`** plus gate state **`overridden`** (not a fake Codex 👍). Human and compact CLI output include override counts and details.
> 
> **Docs** (`AGENTS.md`, `pr-ready-state.md`, AI review plan) describe the contract: overrides expire on new pushes; bots, wrong gates, head mismatch, and missing reasons are ignored; checks, mergeability, reviews, threads, and unreplied comments stay blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925b702477f4cd460fe27b3d89db143b5cb4bfdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->