### PR TITLE
Harden Claude workflow trigger scope

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,37 +26,33 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.review.author_association)
       ) ||
       (
         github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # id-token: write is required by anthropics/claude-code-action itself — the
-    # action exchanges a GitHub OIDC token for a short-lived GitHub App token via
-    # Anthropic's /github-app-token-exchange endpoint (see src/github/token.ts in
-    # the pinned action SHA). It is not related to Bedrock/Vertex/Foundry OIDC
-    # (CLAUDE_CODE_OAUTH_TOKEN handles the Anthropic API auth). To drop this
-    # permission, pass an explicit github_token input to the action instead.
+    # Review-only: the explicit github_token input below uses the workflow-scoped
+    # GITHUB_TOKEN, so the action cannot exchange OIDC for a broader GitHub App
+    # token and this job does not need id-token: write.
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       actions: read
-      id-token: write
     steps:
       # Third-party actions are pinned to an immutable commit SHA (not a tag)
       # so upstream tag retargeting or a compromised release cannot silently run
@@ -67,6 +63,7 @@ jobs:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           # The inline-comment MCP server is gated behind explicit --allowedTools:


### PR DESCRIPTION
## The Problem

- The on-demand Claude workflow could be triggered by collaborator-associated actors, including write-role bot-style accounts.
- That job also used write-capable repository contents permissions plus OIDC token exchange, so prompt-driven review input had broader mutation capability than needed.
- Issue #875 has a maintainer decision to apply both the narrower trigger gate and review-only token scope.

## The Solution

- Restrict the on-demand Claude job trigger gate to `OWNER` and `MEMBER` authors.
- Make the on-demand job review-only by using the workflow-scoped GitHub token, setting `contents: read`, and removing `id-token: write`.
- Leave the automatic PR review job and all pinned action SHAs unchanged.

## Details

- Closes #875.
- Implements the maintainer-selected Option A+B.
- The sibling `auto-review` job remains byte-identical except for line-number shifts caused by the on-demand job edit.
- The companion deployer WIF escalation path referenced in #875 was already closed by #957, so this PR removes the remaining unnecessary write/OIDC surface from the on-demand job.

## Validation

- `grep -c COLLABORATOR .github/workflows/claude.yml` -> `0`
- `./tools/trunk fmt .github/workflows/claude.yml`
- `./tools/trunk check .github/workflows/claude.yml`
- `CI=true pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only security hardening with narrower triggers and reduced token permissions; no application runtime changes.
> 
> **Overview**
> Tightens the **on-demand** `claude` job in `.github/workflows/claude.yml` so `@claude` only runs for **`OWNER` and `MEMBER`** authors ( **`COLLABORATOR` removed** from all four trigger branches).
> 
> The same job is made **review-only**: **`contents: write` → `contents: read`**, **`id-token: write` removed**, and **`github_token: ${{ github.token }}`** passed into `anthropic/claude-code-action` so it uses the workflow token instead of OIDC → GitHub App token exchange. Comments document that rationale.
> 
> The **`auto-review`** job is unchanged aside from line shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a07f6eb7604cef08fd9c0fd67b3af8b12a29ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->