### PR TITLE
docs: document workflow docs drift checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,6 +429,19 @@ Treat code review as a batch-boundary verifier, not as the inner edit loop. When
 
 For process or policy-router PRs, build a coverage matrix before implementation. Use `AGENTS.md`, `docs/pr-checklists/*`, CI path filters, package scripts, and existing command docs to map each changed-path class to its required commands, checklist prompts, refusal guards, and regression tests. Run cheap targeted checks while editing; reserve broad local reviews and external bot reviews for completed batches.
 
+## Docs Drift On Workflow Changes
+
+When adding or changing a command, script, env var, deploy step, hook, or
+canonical operator workflow, audit the full live workflow surface before pushing.
+Search `AGENTS.md`, package `AGENTS.md` files, `README.md`, `docs/**`,
+`.agents/skills/**`, `.claude/skills/**`, `.claude/commands/**`, deploy and
+rollback scripts, and babysit commands for the old sequence. Update every
+operator path that could still send an agent or human through stale steps.
+
+Treat deploy, rollback, and babysit flows as one family: if a new promotion gate
+is added to the deploy path, the rollback checklist and monitor/babysit prompt
+usually need the same gate.
+
 ## Recurring PR-review patterns
 
 Recurring automated-review hazards are canonicalized in


### PR DESCRIPTION
## The Problem

- Workflow changes can update one operator path while leaving sibling deploy, rollback, babysit, or skill paths stale.
- Reviewers and future agents need a canonical reminder to audit the full live workflow surface when a command or deploy sequence changes.

## The Solution

- Add a root `AGENTS.md` workflow-drift rule that lists the shared docs, skills, commands, deploy scripts, rollback scripts, and babysit prompts that need to be checked together.

## Details

- Keeps the guidance next to the existing review-loop discipline section.
- Calls out deploy, rollback, and babysit flows as one workflow family when a promotion gate changes.

## Validation

- `CI=true volta run --node 22.22.3 pnpm agent:quality-gate --run`
- `CI=true volta run --node 22.22.3 pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to root agent instructions; no runtime, CI, or application code is modified.
> 
> **Overview**
> Adds a **Docs Drift On Workflow Changes** section to root `AGENTS.md`, placed after **Review-loop discipline**.
> 
> The new rule tells agents and operators to search the full live workflow surface—`AGENTS.md`, package `AGENTS.md`, `README.md`, `docs/**`, skills, Claude commands, deploy/rollback scripts, and babysit prompts—and update any path that still documents an old sequence when a command, script, env var, deploy step, hook, or canonical workflow changes.
> 
> It also states that **deploy**, **rollback**, and **babysit** flows should stay aligned: a new promotion gate on deploy should usually appear in rollback checklists and monitor/babysit prompts too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1128073cfe8e7d7675b0485569cd3ec4b63b7972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->