### PR TITLE
fix: governance-watchdog fails closed on missing replay bucket

### DIFF
--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -1,6 +1,14 @@
 import crypto from "crypto";
 import { logger } from "./logger";
 
+// SIBLING FILE — kept in behavioral parity with (not byte-identical to):
+//   governance-watchdog/src/utils/quicknode-replay-protection.ts
+// Both must fail closed (5xx, no event processing) when the replay bucket is
+// unconfigured; see the "missing-bucket parity" test in
+// vendored-source-drift.test.ts (both packages). This copy cannot be
+// byte-identical to the sibling: it logs via the GCP structured logger above,
+// while the governance-watchdog copy logs via plain console.* and relies on
+// its caller (index.ts) to emit the paging-severity log.
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
 const STORAGE_UPLOAD_BASE_URL =

--- a/alerts/infra/onchain-event-handler/src/vendored-source-drift.test.ts
+++ b/alerts/infra/onchain-event-handler/src/vendored-source-drift.test.ts
@@ -47,7 +47,8 @@ describe("vendored shared-source files stay byte-identical", () => {
 // above, the sibling via console.*) — see the header comment on both files.
 // This test instead pins the one contract that must stay in parity: neither
 // function may process a webhook when the replay bucket is unconfigured.
-// Keep this literal identical to the assertion in
+// Keep the resolves.toEqual and fetchMock.not.toHaveBeenCalled assertions
+// below literal-identical to the missing-bucket case in
 // governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts.
 describe("quicknode-replay-protection.ts missing-bucket parity", () => {
   const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
@@ -66,17 +67,20 @@ describe("quicknode-replay-protection.ts missing-bucket parity", () => {
   });
 
   it("fails closed like the governance-watchdog copy when the bucket is unset", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
     const { reserveQuickNodeNonce } =
       await import("./quicknode-replay-protection");
 
     await expect(
       reserveQuickNodeNonce("nonce-1", "1700000000", {
-        fetchImpl: vi.fn<typeof fetch>(),
+        fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({
       valid: false,
       status: 500,
       message: "Server configuration error",
     });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/alerts/infra/onchain-event-handler/src/vendored-source-drift.test.ts
+++ b/alerts/infra/onchain-event-handler/src/vendored-source-drift.test.ts
@@ -1,11 +1,15 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const packageRoot = join(__dirname, "..");
 const repoRoot = join(packageRoot, "..", "..", "..");
 
 const read = (path: string) => readFileSync(path, "utf8");
+
+vi.mock("./logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn() },
+}));
 
 describe("vendored shared-source files stay byte-identical", () => {
   it("quicknode-hmac.ts matches the governance-watchdog copy", () => {
@@ -35,5 +39,44 @@ describe("vendored shared-source files stay byte-identical", () => {
         ),
       ),
     );
+  });
+});
+
+// quicknode-replay-protection.ts is NOT byte-identical to the
+// governance-watchdog copy (this package logs via the GCP structured logger
+// above, the sibling via console.*) — see the header comment on both files.
+// This test instead pins the one contract that must stay in parity: neither
+// function may process a webhook when the replay bucket is unconfigured.
+// Keep this literal identical to the assertion in
+// governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts.
+describe("quicknode-replay-protection.ts missing-bucket parity", () => {
+  const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
+
+  beforeEach(() => {
+    delete process.env.QUICKNODE_REPLAY_BUCKET;
+  });
+
+  afterEach(() => {
+    if (originalReplayBucket === undefined) {
+      delete process.env.QUICKNODE_REPLAY_BUCKET;
+    } else {
+      process.env.QUICKNODE_REPLAY_BUCKET = originalReplayBucket;
+    }
+    vi.resetModules();
+  });
+
+  it("fails closed like the governance-watchdog copy when the bucket is unset", async () => {
+    const { reserveQuickNodeNonce } =
+      await import("./quicknode-replay-protection");
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: vi.fn<typeof fetch>(),
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
   });
 });

--- a/governance-watchdog/src/index.ts
+++ b/governance-watchdog/src/index.ts
@@ -163,14 +163,6 @@ const handleQuicknodeWebhook = async (
       res.status(replay.status).send(replay.message);
       return;
     }
-    if (replay.skipped) {
-      // Bucket misconfigured (e.g. a gcloud-only deploy without the Terraform
-      // env var): the webhook was processed WITHOUT replay protection. Page so
-      // the gap gets fixed, but never drop the alert.
-      logError("QuickNode replay protection disabled:", {
-        reason: replay.skipped,
-      });
-    }
   }
 
   let eventsProcessed = 0;

--- a/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
+++ b/governance-watchdog/src/utils/__tests__/quicknode-replay-protection.test.ts
@@ -65,7 +65,7 @@ describe("reserveQuickNodeNonce", () => {
     vi.resetModules();
   });
 
-  it("degrades open without calling metadata when the replay bucket is missing", async () => {
+  it("fails closed without calling metadata when the replay bucket is missing", async () => {
     delete process.env.QUICKNODE_REPLAY_BUCKET;
     const fetchMock = vi.fn<typeof fetch>();
     const reserveQuickNodeNonce = await loadReserveQuickNodeNonce();
@@ -75,11 +75,15 @@ describe("reserveQuickNodeNonce", () => {
         fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({
-      valid: true,
-      skipped: "QUICKNODE_REPLAY_BUCKET not configured",
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "QUICKNODE_REPLAY_BUCKET is not configured",
+    );
   });
 
   it("reserves a nonce by writing a conditional object to the replay bucket", async () => {

--- a/governance-watchdog/src/utils/__tests__/vendored-source-drift.test.ts
+++ b/governance-watchdog/src/utils/__tests__/vendored-source-drift.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const packageRoot = join(__dirname, "..", "..", "..");
 const repoRoot = join(packageRoot, "..");
@@ -24,5 +24,44 @@ describe("vendored shared-source files stay byte-identical", () => {
         ),
       ),
     );
+  });
+});
+
+// quicknode-replay-protection.ts is NOT byte-identical to the
+// onchain-event-handler copy (this package logs via console.*, the sibling
+// via a GCP structured logger it depends on) — see the header comment on
+// both files. This test instead pins the one contract that must stay in
+// parity: neither function may process a webhook when the replay bucket is
+// unconfigured. Keep this literal identical to the assertion in
+// alerts/infra/onchain-event-handler/src/quicknode-replay-protection.test.ts.
+describe("quicknode-replay-protection.ts missing-bucket parity", () => {
+  const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
+
+  beforeEach(() => {
+    delete process.env.QUICKNODE_REPLAY_BUCKET;
+  });
+
+  afterEach(() => {
+    if (originalReplayBucket === undefined) {
+      delete process.env.QUICKNODE_REPLAY_BUCKET;
+    } else {
+      process.env.QUICKNODE_REPLAY_BUCKET = originalReplayBucket;
+    }
+    vi.resetModules();
+  });
+
+  it("fails closed like the onchain-event-handler copy when the bucket is unset", async () => {
+    const { reserveQuickNodeNonce } =
+      await import("../quicknode-replay-protection.js");
+
+    await expect(
+      reserveQuickNodeNonce("nonce-1", "1700000000", {
+        fetchImpl: vi.fn<typeof fetch>(),
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
   });
 });

--- a/governance-watchdog/src/utils/__tests__/vendored-source-drift.test.ts
+++ b/governance-watchdog/src/utils/__tests__/vendored-source-drift.test.ts
@@ -32,7 +32,8 @@ describe("vendored shared-source files stay byte-identical", () => {
 // via a GCP structured logger it depends on) — see the header comment on
 // both files. This test instead pins the one contract that must stay in
 // parity: neither function may process a webhook when the replay bucket is
-// unconfigured. Keep this literal identical to the assertion in
+// unconfigured. Keep the resolves.toEqual and fetchMock.not.toHaveBeenCalled
+// assertions below literal-identical to the missing-bucket case in
 // alerts/infra/onchain-event-handler/src/quicknode-replay-protection.test.ts.
 describe("quicknode-replay-protection.ts missing-bucket parity", () => {
   const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
@@ -51,17 +52,20 @@ describe("quicknode-replay-protection.ts missing-bucket parity", () => {
   });
 
   it("fails closed like the onchain-event-handler copy when the bucket is unset", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
     const { reserveQuickNodeNonce } =
       await import("../quicknode-replay-protection.js");
 
     await expect(
       reserveQuickNodeNonce("nonce-1", "1700000000", {
-        fetchImpl: vi.fn<typeof fetch>(),
+        fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({
       valid: false,
       status: 500,
       message: "Server configuration error",
     });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/governance-watchdog/src/utils/quicknode-replay-protection.ts
+++ b/governance-watchdog/src/utils/quicknode-replay-protection.ts
@@ -1,5 +1,14 @@
 import crypto from "crypto";
 
+// SIBLING FILE — kept in behavioral parity with (not byte-identical to):
+//   alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+// Both must fail closed (5xx, no event processing) when the replay bucket is
+// unconfigured; see the "missing-bucket parity" test in
+// src/utils/__tests__/vendored-source-drift.test.ts. This copy cannot be
+// byte-identical to the sibling: that package logs via a GCP structured
+// logger (an extra dependency this package doesn't carry), while this one
+// logs via plain console.* and relies on the caller (index.ts) to emit the
+// paging-severity log.
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
 const STORAGE_UPLOAD_BASE_URL =
@@ -9,7 +18,7 @@ const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
 type Fetch = typeof fetch;
 
 type ReplayProtectionResult =
-  | { valid: true; skipped?: string }
+  | { valid: true }
   | { valid: false; status: number; message: string; replayed?: boolean };
 
 interface ReplayProtectionOptions {
@@ -29,10 +38,8 @@ export async function reserveQuickNodeNonce(
   const bucketName =
     options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
   if (!bucketName) {
-    // Degrade open: without a configured bucket we cannot dedupe, but failing
-    // every signed webhook (500) would drop governance alerts. Process the
-    // webhook and surface the misconfiguration so the call site can page.
-    return { valid: true, skipped: "QUICKNODE_REPLAY_BUCKET not configured" };
+    console.error("QUICKNODE_REPLAY_BUCKET is not configured");
+    return serverConfigurationError();
   }
 
   const {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- With `QUICKNODE_REPLAY_BUCKET` unset, `governance-watchdog` processed the QuickNode webhook anyway (fail open, just logging the gap), while the `onchain-event-handler` sibling returns a 5xx and refuses to process the event (fail closed) for the same condition.
- The two `quicknode-replay-protection.ts` copies had no drift guard for this behavior, so the divergence went unnoticed since #872 gave governance-watchdog its own durable nonce mechanism.

## The Solution

- `governance-watchdog`'s `reserveQuickNodeNonce` now returns the same `{ valid: false, status: 500, message: "Server configuration error" }` shape as the sibling when the bucket is unset, logging an ERROR first. The existing caller in `index.ts` already turns any `!valid` result into a 5xx response before any event is processed, so no caller-side behavior change was needed there beyond deleting the now-dead `skipped` handling.
- Both `quicknode-replay-protection.ts` files gained a "missing-bucket parity" test (in each package's `vendored-source-drift.test.ts`) asserting they fail closed identically.

## Details

- **Terraform verified, not changed.** `governance-watchdog/infra/cloud_function.tf` already sets `QUICKNODE_REPLAY_BUCKET = google_storage_bucket.quicknode_replay_nonces.name` unconditionally in `environment_variables`, and the function resource `depends_on` the bucket's IAM binding — the bucket env var was never actually missing in a real deploy. Confirmed with `pnpm tf validate governance-watchdog` (read-only; no plan/apply run, per the no-tfvars constraint in worktrees).
- **Byte-identity vs. parity test.** The two files can't be made byte-identical without new scope creep: `onchain-event-handler` depends on `@google-cloud/logging` for structured logging (used inside the file itself), while `governance-watchdog` logs via plain `console.*` inside this file and relies on its caller's separate `logError` helper for the ERROR-severity Slack-paging log. Unifying those logging strategies is a bigger change than this issue calls for, so each file instead got a header comment naming its sibling, and a dedicated parity test pinning the one contract that must match: missing bucket -> `{ valid: false, status: 500, message: "Server configuration error" }` with no fetch calls.
- **Local-dev ergonomics unaffected.** Both packages already gate `reserveQuickNodeNonce` invocation behind their existing `NODE_ENV !== "development"` production check in `index.ts` (unchanged) — in local dev the function is never called, so no new env flag was needed.
- **Dead code removed.** The `skipped` field on `ReplayProtectionResult` and its handling in `governance-watchdog/src/index.ts` (the "replay protection disabled, page but still process" branch) are gone, since the branch that produced `skipped` no longer exists.
- Did not touch nonce reservation ordering or HMAC/timestamp validation in either function, per the issue's do-not-touch list.

## Validation

- `pnpm gov-watchdog:test` -> 87/87 passed
- `pnpm alerts:handler:test` -> 114/114 passed
- `pnpm tf validate governance-watchdog` -> `Success! The configuration is valid.`
- `pnpm agent:quality-gate` (run for real, not just dry-run: trunk check, lint, typecheck, both packages' test:coverage, knip, code-health:deps) -> all mapped commands passed
- `pnpm agent:autoreview` -> clean, no actionable findings

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1049

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook handling on a security-sensitive path: misconfigured deploys will stop processing governance alerts instead of accepting them without replay protection.
> 
> **Overview**
> Aligns **governance-watchdog** QuickNode replay protection with **onchain-event-handler**: when `QUICKNODE_REPLAY_BUCKET` is unset, `reserveQuickNodeNonce` now returns **500 / "Server configuration error"** and does not call GCS (no fail-open `skipped` path).
> 
> Removes the **`replay.skipped`** branch in `governance-watchdog/src/index.ts` that previously logged a paging error but still processed webhooks without nonce reservation. Documents that the two vendored `quicknode-replay-protection.ts` siblings stay behaviorally aligned but not byte-identical (different logging).
> 
> Adds **missing-bucket parity** tests in both packages’ `vendored-source-drift.test.ts` and updates the governance-watchdog unit test to expect fail-closed behavior and an error log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976be2fe04b88cf31e7f0e693a9bb411a866cb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->