### PR TITLE
fix: isolate one pool's failure from MedianUpdated fan-out

### DIFF
--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -537,21 +537,41 @@ indexer.onEvent(
     await Promise.all(
       // eslint-disable-next-line max-lines-per-function -- Existing per-pool fan-out preserves oracle, breach, health, and snapshot updates together.
       poolIds.map(async (poolId) => {
-        const initial = await context.Pool.get(poolId);
-        if (!initial) return;
-        const existing = await selfHealTokenDecimals(
-          context,
-          await selfHealInvertRateFeed(context, initial),
-        );
+        let existing: Pool;
+        let oracleExpiry: bigint;
+        try {
+          const initial = await context.Pool.get(poolId);
+          if (!initial) return;
+          existing = await selfHealTokenDecimals(
+            context,
+            await selfHealInvertRateFeed(context, initial),
+          );
 
-        const oracleExpiry =
-          existing.oracleExpiry > 0n
-            ? existing.oracleExpiry
-            : ((await context.effect(reportExpiryEffect, {
-                chainId: event.chainId,
-                rateFeedID,
-                blockNumber,
-              })) ?? existing.oracleExpiry);
+          oracleExpiry =
+            existing.oracleExpiry > 0n
+              ? existing.oracleExpiry
+              : ((await context.effect(reportExpiryEffect, {
+                  chainId: event.chainId,
+                  rateFeedID,
+                  blockNumber,
+                })) ?? existing.oracleExpiry);
+        } catch (error) {
+          // Mirrors the OracleReported isolation fix (#871, see
+          // processOracleReportedPool above): these reads/self-heals happen
+          // before this pool queues any writes, so one pool's malformed id or
+          // transient RPC self-heal failure can be skipped without
+          // committing partial state for that pool or rejecting the whole
+          // Promise.all — sibling pools on the same feed must still update.
+          // Any failure once writes may already be queued still propagates
+          // (uncaught below) and fails the event, same as before this fix.
+          // Same log level as the OracleReported isolation path (`.warn`)
+          // so the two mirrored failure classes triage consistently.
+          context.log.warn(
+            `sortedOracles.medianUpdatedPoolFailed pool=${poolId} feed=${rateFeedID} chain=${event.chainId}: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          );
+          return;
+        }
 
         const lineage = computeMedianLineageNext(
           existing,

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -1053,4 +1053,68 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
       "failing pool must not be updated via holdCursor - pre-write failure path must be taken",
     );
   });
+
+  it("SortedOracles.MedianUpdated isolates one pool's failure from sibling updates", async () => {
+    let mockDb = MockDb.createMockDb();
+    const goodPoolId = makePoolId(
+      CHAIN_ID,
+      "0x00000000000000000000000000000000000000d4",
+    );
+    // Malformed id forces the per-pool decimals self-heal to throw when it
+    // tries to extract the raw pool address. The sibling pool on the same
+    // feed must still receive the median update.
+    const failingPoolId = `${CHAIN_ID}-bad-median-pool-id`;
+    mockDb = mockDb.entities.Pool.set(
+      makePool({
+        id: goodPoolId,
+        referenceRateFeedID: FEED,
+        invertRateFeedKnown: true,
+        tokenDecimalsKnown: true,
+        oracleExpiry: 1_700_010_000n,
+      }),
+    );
+    mockDb = mockDb.entities.Pool.set(
+      makePool({
+        id: failingPoolId,
+        referenceRateFeedID: FEED,
+        invertRateFeedKnown: true,
+        tokenDecimalsKnown: false,
+        oracleExpiry: 1_700_010_000n,
+      }),
+    );
+
+    const newMedian = 1_190_000_000_000_000_000_000_000n;
+    mockDb = await SortedOracles.MedianUpdated.processEvent({
+      event: SortedOracles.MedianUpdated.createMockEvent({
+        token: FEED,
+        value: newMedian,
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 9,
+          srcAddress: "0xefb84935239dacdecf7c5ba76d8de40b077b7b33",
+          block: { number: 303, timestamp: 1_700_002_100 },
+        },
+      }),
+      mockDb,
+    });
+
+    const goodPool = mockDb.entities.Pool.get(goodPoolId) as
+      | { oraclePrice: bigint; oracleTimestamp: bigint }
+      | undefined;
+    assert.equal(
+      goodPool?.oraclePrice,
+      newMedian,
+      "healthy sibling pool still receives the median update",
+    );
+    assert.equal(goodPool?.oracleTimestamp, 1_700_002_100n);
+
+    const failingPool = mockDb.entities.Pool.get(failingPoolId) as
+      | { oraclePrice: bigint }
+      | undefined;
+    assert.notEqual(
+      failingPool?.oraclePrice,
+      newMedian,
+      "failing pool's decimals self-heal throw must not update oraclePrice or reject the batch",
+    );
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `MedianUpdated`'s per-pool fan-out in the SortedOracles handler had no equivalent to the `OracleReported` pre-write isolation fixed in #871.
- If any awaited call in the pre-write phase (self-heal, `reportExpiry` effect) threw for one pool, the whole `Promise.all` rejected — every sibling pool's write in that batch was lost, not just the failing pool's.
- Most effects on this path return `null` sentinels on failure rather than throwing, but that isn't provably universal (e.g. a malformed pool id throws in `extractAddressFromPoolId`).

## The Solution

Wrap the same pre-write unit of work (`Pool.get`, `selfHealInvertRateFeed`/`selfHealTokenDecimals`, the `reportExpiry` effect) in a try/catch, mirroring `processOracleReportedPool`'s isolation shape exactly. A caught failure logs the pool id + feed and skips just that pool; the sibling pools in the same `Promise.all` batch still get their writes. Any failure after this pre-write phase (i.e. once writes may already be queued) still propagates uncaught and fails the event — same durability guarantee as before this change.

## Details

- `indexer-envio/src/handlers/sortedOracles.ts`: the `MedianUpdated` handler's per-pool `poolIds.map(...)` callback now wraps `Pool.get` → self-heal → `reportExpiryEffect` in a `try { ... } catch (error) { context.log.warn(...); return; }`, identical in shape/boundary to the existing `processOracleReportedPool` try/catch a few hundred lines above it in the same file.
- Log message: `sortedOracles.medianUpdatedPoolFailed pool=<id> feed=<feed> chain=<chainId>: <reason>`, following the `<area>.<event>` convention that feeds Loki-based alerting. Logged at `.warn` — same level as the mirrored `OracleReported` isolation path, so both failure classes triage consistently.
- Preload semantics (`context.isPreload` guard) and the co-fetched `getPoolsByFeed`/`getBreakerConfigsByFeed` batching are untouched — the change only wraps the existing per-pool unit of work, no restructuring of the fan-out.
- Do-not-touch respected: no scope creep into #856 (median-vs-reporter-quote semantics).

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test` — 1001 passed, 19 skipped (pre-existing reserve-yield skips, unrelated), 0 failed.
- `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean, no errors.
- `pnpm agent:quality-gate` (`--run --keep-going`) — all 10 mapped commands passed: lint, typecheck, `test:coverage` (coverage floors intact, not lowered), `knip`, `code-health:deps`, `trunk check`, indexer codegen, reserve-yield test.
- Regression test added in `indexer-envio/test/breakerHandlers.test.ts` ("SortedOracles.MedianUpdated isolates one pool's failure from sibling updates"): drives `MedianUpdated` across 2 pools on one feed, one pool's id malformed so `extractAddressFromPoolId` throws inside the decimals self-heal (mocked at the effect/self-heal layer, not viem — the RPC layer is never touched). Verified by manually reverting the handler fix locally: the same test then fails (`Promise.all` rejection crashes the whole batch), confirming the test is regression-effective.
- Closeout review (`pnpm agent:autoreview --engine claude --mode local`) run twice: first pass flagged a log-level mismatch (`.error` vs the mirrored path's `.warn`) — fixed. Second pass: only a P3 cosmetic note about the *pre-existing, already-shipped* `OracleReported` message format (bracketed vs. dotted convention) — out of scope for this issue, not applied (see Deferrals).

## Deferrals

- None. (The autoreview's cosmetic note about retrofitting the *existing* `OracleReported` log message format is not a deferred requirement of this issue — #1050's acceptance criteria only concern `MedianUpdated`'s new log call, which already follows the `<area>.<event>` convention.)

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow handler resilience change with mirrored OracleReported behavior; failures after writes still fail the event, and a regression test covers the batch-isolation path.
> 
> **Overview**
> **MedianUpdated** no longer lets one pool’s pre-write failure abort updates for every other pool on the same rate feed.
> 
> The per-pool callback now wraps **`Pool.get`**, invert/decimals **self-heal**, and the **`reportExpiry`** effect in a **try/catch**, matching the **OracleReported** isolation from #871. On failure it logs **`sortedOracles.medianUpdatedPoolFailed`** at **warn** and skips only that pool; siblings in the same **`Promise.all`** still get median/oracle/breach/snapshot writes. Errors after that phase (once writes may be queued) still fail the event unchanged.
> 
> A regression test drives **MedianUpdated** with one malformed pool id (decimals self-heal throws) and asserts the healthy sibling still receives **`oraclePrice`** / **`oracleTimestamp`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c322810a57ea39e5ef6574b149710f50f341332e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->