### PR TITLE
fix(governance-watchdog): retry transient Discord/Telegram delivery failures

### DIFF
--- a/governance-watchdog/src/event-notifications/__tests__/send-discord-notification.test.ts
+++ b/governance-watchdog/src/event-notifications/__tests__/send-discord-notification.test.ts
@@ -1,0 +1,156 @@
+import { EmbedBuilder, HTTPError, RateLimitError } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSend, mockWebhookClientCtor, MockWebhookClient, mockConfig } =
+  vi.hoisted(() => {
+    const mockSend = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+    const mockWebhookClientCtor =
+      vi.fn<(data: unknown, options?: unknown) => void>();
+    class MockWebhookClient {
+      constructor(data: unknown, options?: unknown) {
+        mockWebhookClientCtor(data, options);
+      }
+      send(...args: unknown[]): Promise<unknown> {
+        return mockSend(...args);
+      }
+    }
+    const mockConfig: {
+      DISCORD_WEBHOOK_URL_SECRET_ID: string;
+      DISCORD_TEST_WEBHOOK_URL_SECRET_ID: string | undefined;
+    } = {
+      DISCORD_WEBHOOK_URL_SECRET_ID: "discord-webhook-url",
+      DISCORD_TEST_WEBHOOK_URL_SECRET_ID: "discord-test-webhook-url",
+    };
+    return { mockSend, mockWebhookClientCtor, MockWebhookClient, mockConfig };
+  });
+
+vi.mock("discord.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("discord.js")>();
+  return { ...actual, WebhookClient: MockWebhookClient };
+});
+
+const mockGetSecret = vi.fn();
+vi.mock("../../utils/get-secret.js", () => ({ default: mockGetSecret }));
+
+vi.mock("../../config.js", () => ({ default: mockConfig }));
+
+function make5xxError(status = 503): HTTPError {
+  return new HTTPError(
+    status,
+    "Service Unavailable",
+    "POST",
+    "https://discord.com/api/webhooks/1/token",
+    {},
+  );
+}
+
+const embed = new EmbedBuilder().setTitle("Proposal created");
+
+describe("sendDiscordNotification", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.NODE_ENV;
+    mockConfig.DISCORD_WEBHOOK_URL_SECRET_ID = "discord-webhook-url";
+    mockConfig.DISCORD_TEST_WEBHOOK_URL_SECRET_ID = "discord-test-webhook-url";
+    mockGetSecret.mockResolvedValue("https://discord.com/api/webhooks/1/token");
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it("delivers exactly once when a 5xx failure is followed by success", async () => {
+    mockSend
+      .mockRejectedValueOnce(make5xxError(503))
+      .mockResolvedValueOnce(undefined);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await sendDiscordNotification("content", embed);
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a terminal 4xx failure", async () => {
+    const terminal = make5xxError(400);
+    mockSend.mockRejectedValue(terminal);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await expect(sendDiscordNotification("content", embed)).rejects.toBe(
+      terminal,
+    );
+    expect(mockSend).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry a RateLimitError (discord.js already queues 429s internally)", async () => {
+    const rateLimitError = new RateLimitError({
+      global: false,
+      hash: "hash",
+      limit: 5,
+      majorParameter: "1",
+      method: "POST",
+      retryAfter: 1000,
+      route: "/webhooks/1/token",
+      sublimitTimeout: 0,
+      timeToReset: 1000,
+      url: "https://discord.com/api/webhooks/1/token",
+      scope: "user",
+    });
+    mockSend.mockRejectedValue(rateLimitError);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await expect(sendDiscordNotification("content", embed)).rejects.toBe(
+      rateLimitError,
+    );
+    expect(mockSend).toHaveBeenCalledOnce();
+  });
+
+  it("selects the production webhook secret by default", async () => {
+    mockSend.mockResolvedValue(undefined);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await sendDiscordNotification("content", embed);
+
+    expect(mockGetSecret).toHaveBeenCalledWith("discord-webhook-url");
+  });
+
+  it("selects the test webhook secret in development", async () => {
+    process.env.NODE_ENV = "development";
+    mockSend.mockResolvedValue(undefined);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await sendDiscordNotification("content", embed);
+
+    expect(mockGetSecret).toHaveBeenCalledWith("discord-test-webhook-url");
+  });
+
+  it("disables discord.js's own internal REST retries so this module owns the retry budget", async () => {
+    mockSend.mockResolvedValue(undefined);
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await sendDiscordNotification("content", embed);
+
+    const options = mockWebhookClientCtor.mock.calls[0]?.[1] as
+      | { rest?: { retries?: number } }
+      | undefined;
+    expect(options?.rest?.retries).toBe(0);
+  });
+
+  it("throws without sending when the dev test webhook secret id is missing", async () => {
+    process.env.NODE_ENV = "development";
+    mockConfig.DISCORD_TEST_WEBHOOK_URL_SECRET_ID = undefined;
+    const { default: sendDiscordNotification } =
+      await import("../send-discord-notification.js");
+
+    await expect(sendDiscordNotification("content", embed)).rejects.toThrow(
+      "DISCORD_TEST_WEBHOOK_URL_SECRET_ID env var is not set",
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/governance-watchdog/src/event-notifications/__tests__/send-discord-notification.test.ts
+++ b/governance-watchdog/src/event-notifications/__tests__/send-discord-notification.test.ts
@@ -34,10 +34,10 @@ vi.mock("../../utils/get-secret.js", () => ({ default: mockGetSecret }));
 
 vi.mock("../../config.js", () => ({ default: mockConfig }));
 
-function make5xxError(status = 503): HTTPError {
+function makeHTTPError(status = 503): HTTPError {
   return new HTTPError(
     status,
-    "Service Unavailable",
+    "HTTP Error",
     "POST",
     "https://discord.com/api/webhooks/1/token",
     {},
@@ -62,7 +62,7 @@ describe("sendDiscordNotification", () => {
 
   it("delivers exactly once when a 5xx failure is followed by success", async () => {
     mockSend
-      .mockRejectedValueOnce(make5xxError(503))
+      .mockRejectedValueOnce(makeHTTPError(503))
       .mockResolvedValueOnce(undefined);
     const { default: sendDiscordNotification } =
       await import("../send-discord-notification.js");
@@ -73,7 +73,7 @@ describe("sendDiscordNotification", () => {
   });
 
   it("does not retry a terminal 4xx failure", async () => {
-    const terminal = make5xxError(400);
+    const terminal = makeHTTPError(400);
     mockSend.mockRejectedValue(terminal);
     const { default: sendDiscordNotification } =
       await import("../send-discord-notification.js");
@@ -137,9 +137,10 @@ describe("sendDiscordNotification", () => {
     await sendDiscordNotification("content", embed);
 
     const options = mockWebhookClientCtor.mock.calls[0]?.[1] as
-      | { rest?: { retries?: number } }
+      | { rest?: { retries?: number; timeout?: number } }
       | undefined;
     expect(options?.rest?.retries).toBe(0);
+    expect(options?.rest?.timeout).toBe(3000);
   });
 
   it("throws without sending when the dev test webhook secret id is missing", async () => {

--- a/governance-watchdog/src/event-notifications/__tests__/send-telegram-notification.test.ts
+++ b/governance-watchdog/src/event-notifications/__tests__/send-telegram-notification.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockConfig } = vi.hoisted(() => {
+  const mockConfig: {
+    TELEGRAM_BOT_TOKEN_SECRET_ID: string;
+    TELEGRAM_CHAT_ID: string;
+    TELEGRAM_TEST_CHAT_ID: string | undefined;
+  } = {
+    TELEGRAM_BOT_TOKEN_SECRET_ID: "telegram-bot-token",
+    TELEGRAM_CHAT_ID: "prod-chat-id",
+    TELEGRAM_TEST_CHAT_ID: "test-chat-id",
+  };
+  return { mockConfig };
+});
+
+vi.mock("../../config.js", () => ({ default: mockConfig }));
+
+const mockGetSecret = vi.fn();
+vi.mock("../../utils/get-secret.js", () => ({ default: mockGetSecret }));
+
+function telegramResponse(status: number): Response {
+  return new Response(JSON.stringify({ description: "error" }), { status });
+}
+
+type FetchMock = ReturnType<typeof vi.fn<typeof fetch>>;
+
+function requestChatId(fetchMock: FetchMock, callIndex: number): string {
+  const init = fetchMock.mock.calls[callIndex]?.[1];
+  const body = init?.body;
+  if (typeof body !== "string") {
+    throw new TypeError("Expected the fetch call to send a JSON string body");
+  }
+  const parsed = JSON.parse(body) as { chat_id: string };
+  return parsed.chat_id;
+}
+
+describe("sendTelegramNotification", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.NODE_ENV;
+    mockConfig.TELEGRAM_CHAT_ID = "prod-chat-id";
+    mockConfig.TELEGRAM_TEST_CHAT_ID = "test-chat-id";
+    mockGetSecret.mockResolvedValue("bot-token");
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+    vi.unstubAllGlobals();
+  });
+
+  it("delivers exactly once when a 5xx failure is followed by success", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(telegramResponse(503))
+      .mockResolvedValueOnce(telegramResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await sendTelegramNotification("<b>hello</b>");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on a non-OK response and does not retry a terminal 4xx", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(400));
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await expect(sendTelegramNotification("<b>hello</b>")).rejects.toThrow(
+      "Failed to send telegram notification:",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry a 429 response (retry_after can exceed our retry budget)", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(429));
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await expect(sendTelegramNotification("<b>hello</b>")).rejects.toThrow(
+      "Failed to send telegram notification:",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("selects the production chat id by default", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await sendTelegramNotification("<b>hello</b>");
+
+    expect(requestChatId(fetchMock, 0)).toBe("prod-chat-id");
+  });
+
+  it("selects the test chat id in development", async () => {
+    process.env.NODE_ENV = "development";
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await sendTelegramNotification("<b>hello</b>");
+
+    expect(requestChatId(fetchMock, 0)).toBe("test-chat-id");
+  });
+
+  it("throws without sending when the dev test chat id is missing", async () => {
+    process.env.NODE_ENV = "development";
+    mockConfig.TELEGRAM_TEST_CHAT_ID = undefined;
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: sendTelegramNotification } =
+      await import("../send-telegram-notification.js");
+
+    await expect(sendTelegramNotification("<b>hello</b>")).rejects.toThrow(
+      "TELEGRAM_TEST_CHAT_ID env var is not set",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/governance-watchdog/src/event-notifications/send-discord-notification.ts
+++ b/governance-watchdog/src/event-notifications/send-discord-notification.ts
@@ -1,6 +1,24 @@
-import { EmbedBuilder, WebhookClient } from "discord.js";
+import {
+  DiscordAPIError,
+  EmbedBuilder,
+  HTTPError,
+  RateLimitError,
+  WebhookClient,
+} from "discord.js";
 import config from "../config.js";
 import getSecret from "../utils/get-secret.js";
+import { sendWithRetry } from "../utils/send-with-retry.js";
+
+/**
+ * Per-attempt timeout for the underlying discord.js REST call. discord.js's
+ * `@discordjs/rest` retries network/5xx failures internally (3 times by
+ * default, 15s timeout each) *before* ever throwing — left alone, our own
+ * retry loop below would multiply on top of that hidden retry budget. We
+ * disable discord.js's internal retries (`rest.retries: 0`) so this module
+ * owns the whole retry budget, and cap each attempt's timeout so 3 attempts
+ * (1 try + 2 retries) stay well under the 60s Cloud Function timeout.
+ */
+const DISCORD_REQUEST_TIMEOUT_MS = 3000;
 
 /**
  * Generic Discord notification function that can be reused by different event handlers
@@ -25,10 +43,37 @@ export default async function sendDiscordNotification(
     ? config.DISCORD_TEST_WEBHOOK_URL_SECRET_ID
     : config.DISCORD_WEBHOOK_URL_SECRET_ID;
 
-  await new WebhookClient({
-    url: await getSecret(discordWebhookUrlSecretId),
-  }).send({
-    content: content,
-    embeds: [embed],
-  });
+  const webhookClient = new WebhookClient(
+    { url: await getSecret(discordWebhookUrlSecretId) },
+    { rest: { retries: 0, timeout: DISCORD_REQUEST_TIMEOUT_MS } },
+  );
+
+  await sendWithRetry(
+    () =>
+      webhookClient.send({
+        content: content,
+        embeds: [embed],
+      }),
+    { isRetryable: isRetryableDiscordError },
+  );
+}
+
+/**
+ * Classifies a Discord send failure as retryable (5xx / network) or terminal
+ * (4xx auth/payload). `RateLimitError` is excluded on purpose: discord.js's
+ * `WebhookClient` already queues and waits out 429s internally, and only
+ * throws `RateLimitError` once it has given up on that internal handling —
+ * retrying again here would double-handle the same rate limit.
+ */
+function isRetryableDiscordError(error: unknown): boolean {
+  if (error instanceof RateLimitError) {
+    return false;
+  }
+
+  if (error instanceof DiscordAPIError || error instanceof HTTPError) {
+    return error.status >= 500 && error.status <= 599;
+  }
+
+  // Anything else (network failures, timeouts, DNS errors) is transient.
+  return true;
 }

--- a/governance-watchdog/src/event-notifications/send-telegram-notification.ts
+++ b/governance-watchdog/src/event-notifications/send-telegram-notification.ts
@@ -1,5 +1,12 @@
 import config from "../config.js";
 import getSecret from "../utils/get-secret.js";
+import { sendWithRetry } from "../utils/send-with-retry.js";
+
+/**
+ * Per-attempt timeout so 3 attempts (1 try + 2 retries) stay well under the
+ * 60s Cloud Function timeout, mirroring the cap on the Discord send.
+ */
+const TELEGRAM_REQUEST_TIMEOUT_MS = 3000;
 
 /**
  * Sends a pre-formatted HTML message to Telegram
@@ -31,16 +38,59 @@ export default async function sendTelegramNotification(
     parse_mode: "HTML",
   };
 
+  await sendWithRetry(() => attemptSendTelegramMessage(botUrl, payload), {
+    isRetryable: isRetryableTelegramError,
+  });
+}
+
+/**
+ * A failed Telegram `sendMessage` call, carrying the HTTP status so the
+ * retry layer can tell a transient failure from a terminal one.
+ */
+class TelegramApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "TelegramApiError";
+  }
+}
+
+async function attemptSendTelegramMessage(
+  botUrl: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
   const response = await fetch(botUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(TELEGRAM_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
     const errorData = await response.text();
-    throw new Error(`Failed to send telegram notification: ${errorData}`);
+    throw new TelegramApiError(
+      `Failed to send telegram notification: ${errorData}`,
+      response.status,
+    );
   }
+}
+
+/**
+ * Classifies a Telegram send failure as retryable (5xx / network) or
+ * terminal (4xx, including 429). Telegram's flood-control 429 response
+ * carries a `parameters.retry_after` that can exceed our whole retry budget
+ * (unlike discord.js, nothing here parses or honors it), so — same as
+ * Discord — 429 is treated as terminal rather than retried blind.
+ */
+function isRetryableTelegramError(error: unknown): boolean {
+  if (error instanceof TelegramApiError) {
+    return error.status >= 500 && error.status <= 599;
+  }
+
+  // Network-level failures (fetch rejecting, including our own timeout) are transient.
+  return true;
 }

--- a/governance-watchdog/src/events/__tests__/event-handler-factory.retry.test.ts
+++ b/governance-watchdog/src/events/__tests__/event-handler-factory.retry.test.ts
@@ -1,0 +1,166 @@
+import { EmbedBuilder, HTTPError } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEventHandler,
+  type EventHandlerConfig,
+} from "../event-handler-factory.js";
+import {
+  EventType,
+  type ProposalCreatedEvent,
+  type QuicknodeEvent,
+} from "../types.js";
+
+// Exercises the REAL send-discord-notification.js / send-telegram-notification.js
+// modules (including the retry logic) end to end, mocking only the transport
+// (discord.js's WebhookClient and global fetch). This is deliberately
+// different from event-handler-factory.test.ts, which mocks the send
+// functions themselves to isolate factory-level behavior.
+
+const { mockSend, MockWebhookClient, mockDiscordConfig } = vi.hoisted(() => {
+  const mockSend = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+  class MockWebhookClient {
+    send(...args: unknown[]): Promise<unknown> {
+      return mockSend(...args);
+    }
+  }
+  const mockDiscordConfig = {
+    DISCORD_WEBHOOK_URL_SECRET_ID: "discord-webhook-url",
+    DISCORD_TEST_WEBHOOK_URL_SECRET_ID: "discord-test-webhook-url",
+  };
+  return { mockSend, MockWebhookClient, mockDiscordConfig };
+});
+
+vi.mock("discord.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("discord.js")>();
+  return { ...actual, WebhookClient: MockWebhookClient };
+});
+
+vi.mock("../../config.js", () => ({
+  default: {
+    ...mockDiscordConfig,
+    TELEGRAM_BOT_TOKEN_SECRET_ID: "telegram-bot-token",
+    TELEGRAM_CHAT_ID: "prod-chat-id",
+    TELEGRAM_TEST_CHAT_ID: "test-chat-id",
+  },
+}));
+
+vi.mock("../../utils/get-secret.js", () => ({
+  default: vi.fn().mockResolvedValue("secret-value"),
+}));
+
+function telegramResponse(status: number): Response {
+  return new Response(JSON.stringify({ description: "ok" }), { status });
+}
+
+function make5xxError(): HTTPError {
+  return new HTTPError(
+    503,
+    "Service Unavailable",
+    "POST",
+    "https://discord.com/api/webhooks/1/token",
+    {},
+  );
+}
+
+const event: QuicknodeEvent & ProposalCreatedEvent = {
+  address: "0x47036d78bb3169b4f5560dd77bf93f4412a59852",
+  blockHash: "0xdeadbeef",
+  blockNumber: "1",
+  logIndex: "0",
+  name: EventType.ProposalCreated,
+  transactionHash: "0xabc",
+  proposalId: BigInt(1),
+  proposer: "0x1234567890123456789012345678901234567890",
+  calldatas: "0x",
+  description: "{}",
+  endBlock: BigInt(100),
+  signatures: "",
+  startBlock: BigInt(1),
+  targets: "0x1234567890123456789012345678901234567890",
+  values: BigInt(0),
+  version: 1,
+};
+
+const config: EventHandlerConfig<typeof event> = {
+  eventType: EventType.ProposalCreated,
+  validateEvent: (value: unknown): value is typeof event =>
+    (value as QuicknodeEvent).name === EventType.ProposalCreated,
+  getDiscordMessage: () => ({
+    content: "Proposal created",
+    embed: new EmbedBuilder().setTitle("Proposal created"),
+  }),
+  getTelegramMessage: () => ({
+    toHTML: (title: string) => `<b>${title}</b>`,
+  }),
+  emoji: "GOV",
+};
+
+interface StructuredErrorLog {
+  severity: string;
+  message: string;
+}
+
+function loggedErrors(): StructuredErrorLog[] {
+  const calls = vi.mocked(console.error).mock.calls as unknown[][];
+  return calls.map((call) => {
+    const line = call[0];
+    if (typeof line !== "string") {
+      throw new TypeError("Expected console.error to receive a string log");
+    }
+    return JSON.parse(line) as StructuredErrorLog;
+  });
+}
+
+describe("createEventHandler with the real retry-wrapped send functions", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockSend.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("exhausts Discord retries, logs ERROR with event context, and still delivers Telegram", async () => {
+    mockSend.mockRejectedValue(make5xxError());
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const handler = createEventHandler(config);
+    await handler(event);
+
+    // Discord retried (1 initial + 2 retries = 3 attempts) then gave up.
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    // Per-channel isolation: the real, retry-wrapped Telegram send still runs.
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const errors = loggedErrors();
+    expect(errors).toHaveLength(1);
+    const [entry] = errors;
+    expect(entry.severity).toBe("ERROR");
+    expect(entry.message).toContain(
+      "Failed to send Discord notification for ProposalCreated event:",
+    );
+  }, 10_000);
+
+  it("delivers Discord successfully after a transient 5xx and does not log an error", async () => {
+    mockSend
+      .mockRejectedValueOnce(make5xxError())
+      .mockResolvedValueOnce(undefined);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(telegramResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const handler = createEventHandler(config);
+    await handler(event);
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(loggedErrors()).toHaveLength(0);
+  });
+});

--- a/governance-watchdog/src/utils/__tests__/send-with-retry.test.ts
+++ b/governance-watchdog/src/utils/__tests__/send-with-retry.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendWithRetry } from "../send-with-retry.js";
+
+describe("sendWithRetry", () => {
+  it("returns the result on the first successful attempt without retrying", async () => {
+    const attempt = vi.fn().mockResolvedValue("ok");
+
+    const result = await sendWithRetry(attempt, {
+      isRetryable: () => true,
+      baseDelayMs: 1,
+    });
+
+    expect(result).toBe("ok");
+    expect(attempt).toHaveBeenCalledOnce();
+  });
+
+  it("retries a retryable failure and resolves once the attempt succeeds", async () => {
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await sendWithRetry(attempt, {
+      isRetryable: () => true,
+      baseDelayMs: 1,
+    });
+
+    expect(result).toBe("ok");
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when isRetryable reports the error as terminal", async () => {
+    const terminalError = new Error("terminal");
+    const attempt = vi.fn().mockRejectedValue(terminalError);
+
+    await expect(
+      sendWithRetry(attempt, { isRetryable: () => false, baseDelayMs: 1 }),
+    ).rejects.toBe(terminalError);
+    expect(attempt).toHaveBeenCalledOnce();
+  });
+
+  it("throws the last error once maxRetries is exhausted", async () => {
+    const lastError = new Error("still failing");
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockRejectedValueOnce(new Error("second failure"))
+      .mockRejectedValueOnce(lastError);
+
+    await expect(
+      sendWithRetry(attempt, {
+        isRetryable: () => true,
+        maxRetries: 2,
+        baseDelayMs: 1,
+      }),
+    ).rejects.toBe(lastError);
+    expect(attempt).toHaveBeenCalledTimes(3);
+  });
+
+  it("calls onAttemptFailed with the attempt index and retry decision", async () => {
+    const onAttemptFailed = vi.fn();
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockResolvedValueOnce("ok");
+
+    await sendWithRetry(attempt, {
+      isRetryable: () => true,
+      baseDelayMs: 1,
+      onAttemptFailed,
+    });
+
+    expect(onAttemptFailed).toHaveBeenCalledTimes(1);
+    expect(onAttemptFailed).toHaveBeenCalledWith(expect.any(Error), 0, true);
+  });
+});

--- a/governance-watchdog/src/utils/send-with-retry.ts
+++ b/governance-watchdog/src/utils/send-with-retry.ts
@@ -1,0 +1,63 @@
+/**
+ * Bounded in-process retry for a single delivery attempt (Discord or
+ * Telegram sends). Callers classify their own errors via `isRetryable` —
+ * discord.js's `WebhookClient` and the raw Telegram `fetch` call have
+ * different error shapes and different rate-limit semantics (discord.js
+ * queues 429s internally; Telegram does not), so classification stays
+ * transport-specific. This helper only owns the generic bounded-attempt loop
+ * with capped exponential backoff.
+ *
+ * Retry budget: with the defaults below (2 retries, 250ms base delay
+ * doubling per attempt), the *added* backoff latency for one exhausted
+ * delivery is 250ms + 500ms = 750ms. This helper only bounds the delay
+ * *between* attempts — callers are responsible for bounding each attempt's
+ * own duration (e.g. a per-request timeout) so that attempts × per-attempt
+ * timeout + backoff stays well under the 60s Cloud Function timeout (see
+ * infra/cloud_function.tf).
+ */
+interface SendWithRetryOptions {
+  /** Returns true if a failed attempt should be retried. */
+  isRetryable: (error: unknown) => boolean;
+  /** Called after each failed attempt, before the (possible) retry delay. */
+  onAttemptFailed?: (
+    error: unknown,
+    attempt: number,
+    willRetry: boolean,
+  ) => void;
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BASE_DELAY_MS = 250;
+
+export async function sendWithRetry<T>(
+  attempt: () => Promise<T>,
+  options: SendWithRetryOptions,
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+
+  for (let attemptNumber = 0; attemptNumber <= maxRetries; attemptNumber++) {
+    try {
+      return await attempt();
+    } catch (error) {
+      const isLastAttempt = attemptNumber === maxRetries;
+      const willRetry = !isLastAttempt && options.isRetryable(error);
+      options.onAttemptFailed?.(error, attemptNumber, willRetry);
+
+      if (!willRetry) {
+        throw error;
+      }
+
+      await sleep(baseDelayMs * 2 ** attemptNumber);
+    }
+  }
+
+  // Unreachable: every loop iteration either returns or throws above.
+  throw new Error("sendWithRetry: exhausted retries without a terminal error");
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}

--- a/governance-watchdog/src/utils/send-with-retry.ts
+++ b/governance-watchdog/src/utils/send-with-retry.ts
@@ -30,6 +30,10 @@ interface SendWithRetryOptions {
 
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_BASE_DELAY_MS = 250;
+// With current callers (maxRetries: 2) this never binds — sleeps top out at
+// 500ms. It's a ceiling for future callers that raise maxRetries, so backoff
+// can't grow unbounded and blow the Cloud Function timeout.
+const MAX_DELAY_MS = 5000;
 
 export async function sendWithRetry<T>(
   attempt: () => Promise<T>,
@@ -50,7 +54,7 @@ export async function sendWithRetry<T>(
         throw error;
       }
 
-      await sleep(baseDelayMs * 2 ** attemptNumber);
+      await sleep(Math.min(baseDelayMs * 2 ** attemptNumber, MAX_DELAY_MS));
     }
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `send-discord-notification.ts` and `send-telegram-notification.ts` had no retry — a single transient 5xx or network blip permanently dropped a governance alert.
- Delivery modules had zero direct tests: nothing exercised the dev/prod webhook-URL selection, the throw-on-missing-dev-secret guard, or the Telegram non-OK path.
- The dedup `set()` in `event-deduplication.ts` runs before delivery (by design), so without retry a transient failure was indistinguishable from a genuinely dropped notification.

## The Solution

- Added a small local `sendWithRetry` helper (`governance-watchdog/src/utils/send-with-retry.ts`) that both send functions wrap their transport call with. It retries up to 2 times with capped exponential backoff (250ms, 500ms), classifying each failure as retryable or terminal via a caller-supplied predicate.
- Discord classifies 5xx/network as retryable, 4xx and `RateLimitError` as terminal. Telegram classifies 5xx/network as retryable, all 4xx (including 429) as terminal.
- Per-channel isolation and the dedup `set()` ordering are untouched.

## Details

- **Vendoring decision (issue's decision point):** I did **not** vendor the retry core from `alerts/infra/onchain-event-handler/src/slack.ts`. That engine is tightly coupled to axios error shapes and Slack-specific classification (`SlackApiError`, "ratelimited"/"fatal_error" strings), which don't transfer to discord.js's `WebhookClient` (its own error classes) or raw `fetch` (Telegram). Since this PR doesn't touch `slack.ts`, the byte-identical vendored-file pattern (designed for code two standalone Cloud Function roots both consume) would be a one-directional mismatch. A ~45-line local helper (`sendWithRetry`) matches the existing code density in this package and avoids touching a second live alert path (`onchain-event-handler`) that's out of this issue's scope.
- **Discord retry-budget correction:** `@discordjs/rest` already retries network/5xx failures internally (3× by default, 15s timeout each) *before* throwing. Left alone, wrapping that in another retry loop would silently multiply the retry budget (up to ~4× the intended attempts) and risk the Cloud Function's 60s timeout combined with the durable QuickNode dedup window — i.e. retrying could make a hung Discord outage *worse*, not better. Fixed by constructing `WebhookClient` with `rest: { retries: 0, timeout: 3000 }` so discord.js issues exactly one HTTP attempt per `sendWithRetry` attempt, and each attempt is capped at 3s. Telegram's `fetch` call got a matching `AbortSignal.timeout(3000)` for the same reason (nothing bounded a hung request before).
- **Telegram 429:** Telegram's flood-control 429 response carries a `parameters.retry_after` that can exceed our whole retry budget, and this PR doesn't parse it. Rather than retry blind (and likely burn both retries before the server-mandated window elapses), 429 is treated as terminal for Telegram too — same as Discord's `RateLimitError` handling.
- Retry budget: 3 attempts × 3s timeout + backoff (250ms + 500ms) ≈ 9.75s worst case per channel, well under the 60s Cloud Function timeout (`governance-watchdog/infra/cloud_function.tf:21-23`).
- Exhausted retries still throw, which `event-handler-factory.ts`'s existing catch/`logError` wiring turns into an ERROR-severity log with event context (unchanged) — this still feeds the `cloud-function-errors` alert policy.
- No new dependencies; no lockfile change needed.

## Validation

- `pnpm gov-watchdog:test` — 106/106 tests pass (17 files), including new tests: 5xx-then-200 delivers exactly once (Discord + Telegram), exhaustion logs ERROR with event context via the real retry-wrapped send functions + still delivers Telegram (per-channel isolation preserved), dev/prod webhook-URL and chat-id selection, throw-on-missing-dev-secret preserved, Telegram non-OK/429 terminal path, `RateLimitError` not double-retried, `retries: 0` REST-client regression test.
- `pnpm gov-watchdog:typecheck` — pass.
- `pnpm gov-watchdog:lint` — pass.
- `pnpm agent:quality-gate --run` — all mapped commands pass (trunk check, lint, typecheck, test:coverage, knip, code-health:deps).
- `pnpm agent:autoreview` — clean on the final diff, after fixing the discord.js internal-retry multiplication and Telegram 429 `retry_after` issues described above.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1048

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the governance alert delivery path and retry semantics for external APIs; behavior is bounded and per-channel isolation is unchanged, but missed or delayed alerts remain operationally sensitive.
> 
> **Overview**
> Adds bounded retries so a single transient 5xx or network blip no longer permanently drops governance Discord/Telegram alerts after dedup has already committed.
> 
> A new **`sendWithRetry`** helper (up to 2 retries, capped exponential backoff) wraps both send paths. **Discord** turns off discord.js’s internal REST retries (`rest.retries: 0`) and caps each attempt at 3s so the app owns the full retry budget and stays under the Cloud Function timeout; 5xx/network retry, 4xx and `RateLimitError` do not. **Telegram** uses the same 3s per-attempt timeout, throws a status-bearing `TelegramApiError`, and retries only 5xx (429 and other 4xx are terminal).
> 
> New Vitest coverage exercises the retry helper, each send module (dev/prod routing, missing dev config), and end-to-end handler behavior when Discord exhausts retries while Telegram still delivers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a31b9f62a8bf90383d39745782c1e0ff71e33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->