### PR TITLE
ci: gate scripts/*.sh with shellcheck via trunk

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,10 +1,13 @@
 # Trunk's shellcheck sandbox lints one file at a time (sandbox_type:
 # copy_targets), so sibling scripts sourced via `${SCRIPT_DIR}/...` (resolved
 # from BASH_SOURCE at runtime) never exist alongside the target being
-# checked. That makes SC1091 ("not following") a permanent false positive
-# here rather than a fixable finding — every scripts/*/get-project-vars.sh +
-# common.sh sourcing pattern in this repo hits it. (The SC2154 cascade this
-# also causes, for variables the sourced file defines, is disabled per-file
-# instead — see the affected scripts — to keep SC2154 active everywhere
-# else.)
-disable=SC1091
+# checked, producing an unavoidable SC1091 ("not following") false positive.
+# A repo-wide disable here would also hide a genuinely missing sourced file,
+# so SC1091 is instead disabled per-line, immediately above each affected
+# `source` call, with a comment naming the false-positive cause. See:
+# alerts/infra/onchain-event-handler/scripts/{deploy,get-logs,
+# get-project-vars,tail-logs,test-healthcheck,test-local}.sh,
+# alerts/infra/scripts/{check-gcloud-login,common,fix-webhook-state,
+# get-webhook-filter-function,set-up-terraform}.sh,
+# governance-watchdog/bin/{deploy-via-gcloud,get-logs,set-up-terraform,
+# test-deployed-function}.sh.

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# Trunk's shellcheck sandbox lints one file at a time (sandbox_type:
+# copy_targets), so sibling scripts sourced via `${SCRIPT_DIR}/...` (resolved
+# from BASH_SOURCE at runtime) never exist alongside the target being
+# checked. That makes SC1091 ("not following") a permanent false positive
+# here rather than a fixable finding — every scripts/*/get-project-vars.sh +
+# common.sh sourcing pattern in this repo hits it. (The SC2154 cascade this
+# also causes, for variables the sourced file defines, is disabled per-file
+# instead — see the affected scripts — to keep SC2154 active everywhere
+# else.)
+disable=SC1091

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -88,6 +88,7 @@ lint:
     - codespell@2.4.1
     - actionlint@1.7.8
     - yamllint@1.38.0
+    - shellcheck@0.11.0
 
 actions:
   disabled:

--- a/alerts/infra/onchain-event-handler/scripts/deploy.sh
+++ b/alerts/infra/onchain-event-handler/scripts/deploy.sh
@@ -46,6 +46,7 @@ ROOT_DIR="$(cd "${MODULE_DIR}/.." && pwd)"
 # Source common utilities
 if [[ -f "${ROOT_DIR}/scripts/common.sh" ]]; then
 	# shellcheck source=../../scripts/common.sh
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${ROOT_DIR}/scripts/common.sh"
 else
 	# Can't use error() function here since we haven't sourced common.sh yet
@@ -220,8 +221,10 @@ main() {
 	if [[ -f "${SCRIPT_DIR}/get-project-vars.sh" ]]; then
 		# Source the script to get variables (suppress output unless verbose)
 		if [[ ${VERBOSE:-0} -eq 1 ]]; then
+			# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 			source "${SCRIPT_DIR}/get-project-vars.sh" --verbose
 		else
+			# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 			source "${SCRIPT_DIR}/get-project-vars.sh" >/dev/null 2>&1
 		fi
 	else

--- a/alerts/infra/onchain-event-handler/scripts/get-logs.sh
+++ b/alerts/infra/onchain-event-handler/scripts/get-logs.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# function_name, region, project_id are defined by get-project-vars.sh,
-# sourced below; `set -u` catches them at runtime if that ever changes.
-# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting
 
 # Fetches the latest logs for the Cloud Function and displays them in the terminal.
+# function_name, region, project_id are defined by get-project-vars.sh,
+# sourced below; `set -u` catches them at runtime if that ever changes.
+# shellcheck disable=SC2154
 get_function_logs() {
 	# Load common utilities and project variables
 	script_dir=$(dirname "$0")

--- a/alerts/infra/onchain-event-handler/scripts/get-logs.sh
+++ b/alerts/infra/onchain-event-handler/scripts/get-logs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# function_name, region, project_id are defined by get-project-vars.sh,
+# sourced below; `set -u` catches them at runtime if that ever changes.
+# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting

--- a/alerts/infra/onchain-event-handler/scripts/get-logs.sh
+++ b/alerts/infra/onchain-event-handler/scripts/get-logs.sh
@@ -4,13 +4,18 @@ set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting
 
 # Fetches the latest logs for the Cloud Function and displays them in the terminal.
-# function_name, region, project_id are defined by get-project-vars.sh,
-# sourced below; `set -u` catches them at runtime if that ever changes.
-# shellcheck disable=SC2154
+# function_name, region, and project_id (referenced throughout below) are
+# defined by get-project-vars.sh, sourced inside this function; `set -u`
+# catches them at runtime if that ever changes. Disable scoped to this
+# function (not file-wide) so an unrelated undefined-variable typo
+# elsewhere still flags.
+# shellcheck disable=SC2154 # covers: function_name, region, project_id
 get_function_logs() {
 	# Load common utilities and project variables
 	script_dir=$(dirname "$0")
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/../../scripts/common.sh"
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/get-project-vars.sh"
 
 	# Start spinner while fetching logs

--- a/alerts/infra/onchain-event-handler/scripts/get-project-vars.sh
+++ b/alerts/infra/onchain-event-handler/scripts/get-project-vars.sh
@@ -80,6 +80,9 @@ set_project_id() {
 	# insensitive on some surfaces).
 	if [[ $(echo "${project_id}" | wc -l) -gt 1 ]]; then
 		error "Multiple GCP projects matched name '${project_name}':"
+		# Prefixing every line of a multi-line value; bash parameter expansion
+		# doesn't do per-line substitution.
+		# shellcheck disable=SC2001
 		echo "${project_id}" | sed 's/^/  - /' >&2
 		error "Refusing to proceed — narrow the project_name in variables.tf or set a specific project ID manually."
 		exit 1

--- a/alerts/infra/onchain-event-handler/scripts/get-project-vars.sh
+++ b/alerts/infra/onchain-event-handler/scripts/get-project-vars.sh
@@ -47,6 +47,7 @@ ROOT_DIR="$(cd "${MODULE_DIR}/.." && pwd)"
 
 # Source common utilities
 # shellcheck source=../../scripts/common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${ROOT_DIR}/scripts/common.sh"
 
 set_project_id() {

--- a/alerts/infra/onchain-event-handler/scripts/tail-logs.sh
+++ b/alerts/infra/onchain-event-handler/scripts/tail-logs.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# function_name, project_id are defined by get-project-vars.sh, sourced
-# below; `set -u` catches them at runtime if that ever changes.
-# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting
@@ -10,10 +7,17 @@ set -u          # Treat unset variables as an error when substituting
 # Usage: tail-logs.sh [filter]
 # Example: tail-logs.sh "severity>=ERROR"
 # Example: tail-logs.sh "jsonPayload.multisigKey=mento"
+# function_name and project_id (referenced throughout below) are defined by
+# get-project-vars.sh, sourced inside this function; `set -u` catches them
+# at runtime if that ever changes. Disable scoped to this function (not
+# file-wide) so an unrelated undefined-variable typo elsewhere still flags.
+# shellcheck disable=SC2154 # covers: function_name, project_id
 tail_function_logs() {
 	# Load common utilities and project variables
 	script_dir=$(dirname "$0")
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/../../scripts/common.sh"
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/get-project-vars.sh"
 
 	# Optional filter (first argument)

--- a/alerts/infra/onchain-event-handler/scripts/tail-logs.sh
+++ b/alerts/infra/onchain-event-handler/scripts/tail-logs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# function_name, project_id are defined by get-project-vars.sh, sourced
+# below; `set -u` catches them at runtime if that ever changes.
+# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting

--- a/alerts/infra/onchain-event-handler/scripts/test-healthcheck.sh
+++ b/alerts/infra/onchain-event-handler/scripts/test-healthcheck.sh
@@ -26,6 +26,7 @@ ROOT_DIR="$(cd "${MODULE_DIR}/.." && pwd)"
 
 # Source common utilities
 # shellcheck source=../../scripts/common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${ROOT_DIR}/scripts/common.sh"
 
 # Check for required tools

--- a/alerts/infra/onchain-event-handler/scripts/test-local.sh
+++ b/alerts/infra/onchain-event-handler/scripts/test-local.sh
@@ -45,6 +45,7 @@ if [[ ! -f "${ROOT_DIR}/scripts/common.sh" ]]; then
 fi
 
 # shellcheck source=../../scripts/common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${ROOT_DIR}/scripts/common.sh"
 
 # Check requirements

--- a/alerts/infra/scripts/check-gcloud-login.sh
+++ b/alerts/infra/scripts/check-gcloud-login.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 # Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${SCRIPT_DIR}/common.sh"
 
 # Checks for an active Google Cloud login and application-default credentials.

--- a/alerts/infra/scripts/common.sh
+++ b/alerts/infra/scripts/common.sh
@@ -267,6 +267,7 @@ validate_non_negative_int() {
 _common_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "${_common_script_dir}/spinner.sh" ]]; then
 	# shellcheck source=scripts/spinner.sh
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${_common_script_dir}/spinner.sh"
 fi
 unset _common_script_dir

--- a/alerts/infra/scripts/fix-webhook-state.sh
+++ b/alerts/infra/scripts/fix-webhook-state.sh
@@ -34,6 +34,7 @@ set -euo pipefail
 # Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${SCRIPT_DIR}/common.sh"
 
 echo -e "${YELLOW}QuickNode Webhook State Repair Tool${NC}"

--- a/alerts/infra/scripts/get-webhook-filter-function.sh
+++ b/alerts/infra/scripts/get-webhook-filter-function.sh
@@ -37,6 +37,7 @@ set -euo pipefail
 # Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${SCRIPT_DIR}/common.sh"
 
 PROJECT_ROOT=$(get_project_root)

--- a/alerts/infra/scripts/set-up-terraform.sh
+++ b/alerts/infra/scripts/set-up-terraform.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 # Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common.sh
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "${SCRIPT_DIR}/common.sh"
 
 # Checks if the user has the "Service Account Token Creator" role in the Terraform Seed Project
@@ -130,6 +131,7 @@ ${sa_result}"
 set_up_terraform() {
 	script_dir=$(dirname "$0")
 	# shellcheck source=check-gcloud-login.sh
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/check-gcloud-login.sh"
 
 	check_tools "terraform" "jq" "gcloud"

--- a/alerts/infra/scripts/spinner.sh
+++ b/alerts/infra/scripts/spinner.sh
@@ -44,6 +44,8 @@ start_spinner() {
 	local message="${1:-Loading...}"
 	local delay=0.1
 
+	# Literal spinner glyphs (pipe/slash/dash/backslash), not an escape attempt.
+	# shellcheck disable=SC1003
 	local spin_string='|/-\'
 
 	# Hide cursor

--- a/governance-watchdog/bin/deploy-via-gcloud.sh
+++ b/governance-watchdog/bin/deploy-via-gcloud.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
-# function_name, function_entry_point, terraform_service_account,
-# project_id, region, project_service_account are defined by
-# get-project-vars.sh, sourced below; `set -u` catches them at runtime if
-# that ever changes.
-# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting
 
 # Deploys the Cloud Function using gcloud.
 # Requires an environment arg (e.g., staging, production).
+# function_name, function_entry_point, terraform_service_account,
+# project_id, region, and project_service_account (referenced throughout
+# below) are defined by get-project-vars.sh, sourced inside this function;
+# `set -u` catches them at runtime if that ever changes. Disable scoped to
+# this function (not file-wide) so an unrelated undefined-variable typo
+# elsewhere still flags.
+# shellcheck disable=SC2154 # covers: function_name, function_entry_point, terraform_service_account, project_id, region, project_service_account
 deploy_via_gcloud() {
 	printf "\n"
 
 	# Load the project variables
 	script_dir=$(dirname "$0")
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/get-project-vars.sh"
 
 	# Deploy the Google Cloud Function

--- a/governance-watchdog/bin/deploy-via-gcloud.sh
+++ b/governance-watchdog/bin/deploy-via-gcloud.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# function_name, function_entry_point, terraform_service_account,
+# project_id, region, project_service_account are defined by
+# get-project-vars.sh, sourced below; `set -u` catches them at runtime if
+# that ever changes.
+# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting

--- a/governance-watchdog/bin/get-logs.sh
+++ b/governance-watchdog/bin/get-logs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# function_name, region, project_id are defined by get-project-vars.sh,
+# sourced below; `set -u` catches them at runtime if that ever changes.
+# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting

--- a/governance-watchdog/bin/get-logs.sh
+++ b/governance-watchdog/bin/get-logs.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
-# function_name, region, project_id are defined by get-project-vars.sh,
-# sourced below; `set -u` catches them at runtime if that ever changes.
-# shellcheck disable=SC2154
 set -e          # Fail on any error
 set -o pipefail # Ensure piped commands propagate exit codes properly
 set -u          # Treat unset variables as an error when substituting
 
 # Fetches the latest logs for the Cloud Function and displays them in the terminal.
+# function_name, region, and project_id (referenced throughout below) are
+# defined by get-project-vars.sh, sourced inside this function; `set -u`
+# catches them at runtime if that ever changes. Disable scoped to this
+# function (not file-wide) so an unrelated undefined-variable typo
+# elsewhere still flags.
+# shellcheck disable=SC2154 # covers: function_name, region, project_id
 get_function_logs() {
 	# Load the project variables
 	script_dir=$(dirname "$0")
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/get-project-vars.sh"
 
 	printf "\n"

--- a/governance-watchdog/bin/set-up-terraform.sh
+++ b/governance-watchdog/bin/set-up-terraform.sh
@@ -56,6 +56,7 @@ check_gcloud_iam_permissions() {
 
 set_up_terraform() {
 	script_dir=$(dirname "$0")
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "${script_dir}/check-gcloud-login.sh"
 
 	if ! command -v terraform &>/dev/null; then

--- a/governance-watchdog/bin/test-deployed-function.sh
+++ b/governance-watchdog/bin/test-deployed-function.sh
@@ -14,6 +14,7 @@ echo "🔍 Validating Google Cloud project configuration..."
 
 # Source the project variables to get the correct project information
 # This script will ensure we're in the right project and cache the values
+# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 source "$(dirname "$0")/get-project-vars.sh"
 
 # Validate that we have a project_id from the sourced script
@@ -21,6 +22,7 @@ if [[ -z ${project_id-} ]]; then
 	echo "⚠️  No project ID found. Clearing cache and re-initializing project configuration..."
 	"$(dirname "$0")/get-project-vars.sh" --invalidate-cache
 	# Re-source to get the updated project_id
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "$(dirname "$0")/get-project-vars.sh"
 
 	# Check again after cache invalidation
@@ -38,6 +40,7 @@ if [[ ${current_gcloud_project} != "${project_id}" ]]; then
 	"$(dirname "$0")/get-project-vars.sh" --invalidate-cache
 
 	# Re-source to get the updated configuration
+	# shellcheck disable=SC1091 # runtime-resolved path; absent from Trunk's single-file sandbox copy
 	source "$(dirname "$0")/get-project-vars.sh"
 
 	# Verify the fix worked

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -690,7 +690,28 @@ trunk_requires_full_scan() {
   while IFS= read -r path; do
     [[ -e "$path" ]] || return 0
     case "$path" in
+      # .trunk/trunk.yaml (enabled linters, ignores) already lands here via
+      # .trunk/*, so it gets the unfiltered full scan below; no separate
+      # .shellcheckrc-style case is needed for it.
       .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|patches/*|.npmrc|*/.npmrc|pnpmfile.cjs|.pnpmfile.cjs|.node-version|*/package.json)
+        return 0
+        ;;
+    esac
+  done < "$changed_paths_file"
+
+  return 1
+}
+
+trunk_requires_shellcheck_full_scan() {
+  local path
+  while IFS= read -r path; do
+    case "$path" in
+      # .shellcheckrc disables/options apply repo-wide, but a targeted Trunk
+      # check only lints the config file itself (a no-op) rather than the
+      # *.sh targets it governs. Force a repo-wide, ShellCheck-only scan so
+      # an edit here (e.g. loosening a disable) is validated against every
+      # script instead of passing trivially.
+      .shellcheckrc)
         return 0
         ;;
     esac
@@ -718,6 +739,10 @@ add_trunk_check_command() {
     prepend_command "$trunk_command" "changed existing paths should pass targeted Trunk checks"
   else
     prepend_command "./tools/trunk check --all" "changed paths could not be mapped to targeted Trunk checks"
+  fi
+
+  if trunk_requires_shellcheck_full_scan; then
+    prepend_command "./tools/trunk check --all --filter=shellcheck" "ShellCheck config changed; re-validate every script it governs"
   fi
 }
 
@@ -1332,6 +1357,13 @@ while IFS= read -r path; do
     .lighthouserc.cjs)
       add_surface "ui-dashboard"
       add_checklist "docs/pr-checklists/code-health.md" "Lighthouse CI budget config changed"
+      ;;
+    .shellcheckrc)
+      # The repo-wide `./tools/trunk check --all --filter=shellcheck` command
+      # itself is added by add_trunk_check_command (see
+      # trunk_requires_shellcheck_full_scan) since it depends on the full
+      # changed-paths set, not just this one path.
+      add_surface "tooling"
       ;;
     docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md)
       add_surface "docs"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -824,12 +824,12 @@ compact_turbo_quality_commands() {
         existing_packages="${turbo_group_packages[$group_index]}"
         read -r -a existing_package_array <<< "$existing_packages"
         if ! list_contains_word "$package_name" "${existing_package_array[@]}"; then
-          turbo_group_packages[$group_index]="${existing_packages} ${package_name}"
+          turbo_group_packages[group_index]="${existing_packages} ${package_name}"
         fi
 
         existing_reasons="${turbo_group_reasons[$group_index]}"
         if ! reason_list_contains "$existing_reasons" "$reason"; then
-          turbo_group_reasons[$group_index]="${existing_reasons}; ${reason}"
+          turbo_group_reasons[group_index]="${existing_reasons}; ${reason}"
         fi
       else
         turbo_group_tasks+=("$task")

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Single-quoted strings below are literal substrings asserted against
+# scripts/agent-quality-gate.sh's source text (e.g. turbo's `$TURBO_ROOT$`
+# token, `"$(...)"` snippets); expanding them would break the assertions
+# they're meant to check for.
+# shellcheck disable=SC2016
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
@@ -235,7 +240,7 @@ normalize_expected_command() {
     *"pnpm --filter @mento-protocol/"*" lint"*|*"pnpm --filter @mento-protocol/"*" typecheck"*|*"pnpm --filter @mento-protocol/"*" test"*|*"pnpm --filter @mento-protocol/"*" knip"*)
       package_name="${expected#*pnpm --filter }"
       package_name="${package_name%% *}"
-      task_name="${expected#*pnpm --filter ${package_name} }"
+      task_name="${expected#*pnpm --filter "${package_name}" }"
       task_name="${task_name%% *}"
       case "$task_name" in
         lint|typecheck|test|test:browser|knip)

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3,6 +3,8 @@
 # scripts/agent-quality-gate.sh's source text (e.g. turbo's `$TURBO_ROOT$`
 # token, `"$(...)"` snippets); expanding them would break the assertions
 # they're meant to check for.
+# Trade-off (accepted): this disables SC2016 file-wide, so a future
+# genuinely-unexpanded `$var` typo in this file won't be flagged.
 # shellcheck disable=SC2016
 set -euo pipefail
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1649,7 +1649,18 @@ run_gate ".trunk/trunk.yaml"
 assert_contains "- tooling"
 assert_contains "- node scripts/check-github-action-pins.mjs (Trunk workflow/action setup changed)"
 assert_contains "- pnpm agent:quality-gate:test (agent quality gate trunk hook changed)"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck"
+
+# .shellcheckrc disables/options apply repo-wide, so a targeted single-file
+# Trunk check on it alone is a no-op; the gate must additionally route to a
+# full ShellCheck-only scan (see trunk_requires_shellcheck_full_scan) or a
+# future disable/option change here could pass local checks without
+# re-validating the scripts it governs.
+run_gate ".shellcheckrc"
+assert_contains "- tooling"
+assert_contains "- ./tools/trunk check --all --filter=shellcheck (ShellCheck config changed; re-validate every script it governs)"
+assert_not_contains "- ./tools/trunk check --all ("
 
 run_gate "turbo.json"
 assert_contains "- tooling"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,7 @@ deps_hash="$(
     .npmrc \
     pnpmfile.cjs \
     patches \
-    */package.json \
+    ./*/package.json \
     alerts/infra/*/package.json \
     shared-config/src \
     shared-config/tsconfig.json || true

--- a/ui-dashboard/scripts/intel-marathon/upload-drafts.sh
+++ b/ui-dashboard/scripts/intel-marathon/upload-drafts.sh
@@ -48,7 +48,7 @@ upload_one() {
   local fname
   fname=$(basename "$draft_path")
   local addr="${fname%%-*}"  # 0x… prefix before first dash
-  local slug="${fname#${addr}-}"
+  local slug="${fname#"${addr}"-}"
   slug="${slug%.md}"
 
   # Mirror the API route's validation — this writer bypasses the route, so


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `scripts/*.sh` (~14 deploy/ops wrappers: `deploy-dashboard.sh`, `deploy-bridge.sh`, 7x `deploy-indexer-*.sh`, `setup.sh`, etc.) had no lint or syntax gate at all — a broken wrapper could merge silently and only surface mid-incident.
- `.trunk/trunk.yaml` enabled checkov/prettier/markdownlint/trufflehog/osv-scanner/codespell/actionlint/yamllint, but no shellcheck/shfmt.
- `alerts/infra/*.sh` and `governance-watchdog/bin/*.sh` had `bash -n` checks in `ci.yml`, but `scripts/*.sh` had nothing.

## The Solution

Enabled `shellcheck` in `.trunk/trunk.yaml`'s lint config. The required "Code Quality" GitHub Actions job (`.github/workflows/trunk.yml`) already runs `./tools/trunk check --ci --all` on every PR and every push to `main`, so this one line makes shellcheck run against **every tracked `.sh` file in the repo** (not just changed ones) as part of that existing required check — no `ci.yml` edits needed. Fixed every real finding shellcheck turned up across `scripts/`, `alerts/infra/`, and `governance-watchdog/bin/`.

## Details

- **Guarantee established**: `trunk.yml`'s `Code Quality` job runs `trunk check --ci --all` (full repo, not `--changed`), so a syntax error introduced in *any* tracked `.sh` file — not just ones touched by a given PR — will fail that required check. Verified locally: introducing a deliberate unclosed `if` in `scripts/setup.sh` makes both `bash -n` and `trunk check --filter=shellcheck` fail (reverted before commit, not part of the diff).
- **New `.shellcheckrc`** (repo root): disables `SC1091` repo-wide. Trunk's shellcheck lint runs with `sandbox_type: copy_targets` — it lints one file at a time in an isolated sandbox — so any script that sources a sibling via a runtime-resolved path (`source "${SCRIPT_DIR}/../../scripts/common.sh"`) never finds it in that sandbox. This is a structural false positive for this repo's `get-project-vars.sh` + `common.sh` sourcing pattern, not a fixable bug (confirmed: even running shellcheck directly from the full checkout with `--external-sources` resolves it cleanly — the sandbox isolation is the only issue).
- **`SC2154` cascade** (variables the sourced file defines, e.g. `project_id`, `function_name`) is *not* disabled repo-wide — that would silence a genuinely useful check everywhere. Instead it's disabled with narrow, per-file `# shellcheck disable=SC2154` directives on exactly the 4 scripts that hit it (`alerts/infra/onchain-event-handler/scripts/{get-logs,tail-logs}.sh`, `governance-watchdog/bin/{deploy-via-gcloud,get-logs}.sh`), each with a comment naming the sourced variables. All 4 already run under `set -u`, so a genuinely missing variable still fails loudly at runtime.
- **Behavior-relevant fixes** (as called out by the issue's do-not-touch guidance) — two quoting fixes, both safer with no behavior change for the existing call sites:
  - `scripts/agent-quality-gate.test.sh:238`: `${expected#*pnpm --filter ${package_name} }` → `${expected#*pnpm --filter "${package_name}" }` (quotes the inner expansion so it's matched literally, not as a glob pattern).
  - `ui-dashboard/scripts/intel-marathon/upload-drafts.sh:51`: `${fname#${addr}-}` → `${fname#"${addr}"-}` (same fix).
  - Neither is a deploy wrapper and neither touches `"$@"` argument-forwarding; `deploy-indexer-*.sh`, `deploy-dashboard.sh`, and `deploy-bridge.sh` were already shellcheck-clean — no changes needed there.
- **Cosmetic-only fixes** (no behavior change): `scripts/agent-quality-gate.sh:827,832` drops an unnecessary `$` inside an array subscript (`arr[$i]=` → `arr[i]=`, already arithmetic context); `scripts/setup.sh:80` hardens a glob (`*/package.json` → `./*/package.json`) so a hypothetical top-level dir name starting with `-` can't be misread as an option — verified the matched file set is identical before/after.
- **Narrow inline disables** for two intentional constructs: `alerts/infra/scripts/spinner.sh:47` (`SC1003`, a literal `|/-\` spinner-glyph string, not an unterminated escape) and `alerts/infra/onchain-event-handler/scripts/get-project-vars.sh:83` (`SC2001`, `sed` used to prefix every line of a multi-line value — bash parameter expansion doesn't do that).
- Non-goal, not attempted: rewriting shell scripts in Node; `shfmt`/reformatting (out of scope per issue).
- **Closeout review findings, both resolved (not deferred)**: the closeout autoreview raised one finding (SC2154 disabled repo-wide was too broad) — fixed by narrowing to per-file directives on only the 4 affected scripts (see above). A second-pass autoreview finding claimed `SC1090` ("can't follow non-constant source") would also fire and wasn't suppressed; re-verified directly against the affected file (`trunk check --filter=shellcheck alerts/infra/onchain-event-handler/scripts/get-logs.sh` and native `shellcheck`) and confirmed zero findings — shellcheck's `SCRIPTDIR` heuristic already resolves these scripts' `${SCRIPT_DIR}/...` sourcing patterns to `SC1091` (suppressed), never `SC1090`. Treated as incorrect and not actioned.

## Validation

- `trunk check --all --filter=shellcheck` → `Checked 58 files / No issues` (was 79 findings across 8 files before fixes).
- `for f in scripts/*.sh; do bash -n "$f"; done` → all pass, no output.
- `pnpm agent:quality-gate` (`bash scripts/agent-quality-gate.sh --run`) → all mapped commands passed, including `./tools/trunk check --all` and `pnpm agent:quality-gate:test`.
- `./tools/trunk check --all` (every linter, not just shellcheck) → `Checked 1565 files / No issues`.
- Deliberate-syntax-error probe (local only, reverted): appended an unclosed `if` to `scripts/setup.sh` → both `bash -n` (exit 2) and `trunk check --filter=shellcheck` (SC1009/SC1073) failed as expected; restored before committing.
- Pre-push gate (`agent-quality-gate-pre-push` trunk hook) ran on `git push` and passed, including the full `bash -n` set over every changed shell script.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1047

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI linting, documented ShellCheck suppressions, and minor quoting hardening; deploy wrappers were already clean and runtime behavior is unchanged aside from safer string matching.
> 
> **Overview**
> Adds **ShellCheck** (`shellcheck@0.11.0`) to Trunk so the existing required **Code Quality** job lints tracked `*.sh` files repo-wide, closing the gap where root `scripts/*.sh` had no static shell gate.
> 
> Introduces **`.shellcheckrc`** documenting why Trunk’s per-file sandbox triggers **SC1091** on runtime `source` paths, and applies **narrow inline disables** across `alerts/infra/`, `governance-watchdog/bin/`, and related ops scripts (**SC1091** at `source` lines, **SC2154** only on the few scripts that use variables from sourced `get-project-vars.sh`, plus small **SC1003** / **SC2001** / **SC2016** exceptions).
> 
> Includes a few **safe quoting** tweaks (`agent-quality-gate.test.sh`, `upload-drafts.sh`, `setup.sh` glob) and updates **`scripts/agent-quality-gate.sh`** so edits to `.shellcheckrc` trigger `./tools/trunk check --all --filter=shellcheck` (config-only targeted checks would otherwise be a no-op), with matching tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5500a95945501f7aa5346920f9f734824230b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->