### PR TITLE
dashboard: decompose fetchNetworkData behind characterization tests

### DIFF
--- a/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import type { Network } from "@/lib/networks";
+import type { Pool } from "@/lib/types";
+import { assembleNetworkData, resolveWindowErrors } from "../assemble";
+
+// An arbitrary but realistic epoch anchor — large enough that every
+// window's `from` bound (up to 30 days back) stays comfortably positive.
+const NOW = 1_700_000_000;
+const WINDOWS = {
+  w24h: { from: NOW - 86_400, to: NOW },
+  w7d: { from: NOW - 7 * 86_400, to: NOW },
+  w30d: { from: NOW - 30 * 86_400, to: NOW },
+};
+
+describe("resolveWindowErrors — precedence matrix", () => {
+  it("no issues at all: every window is clean", () => {
+    const result = resolveWindowErrors({
+      windows: WINDOWS,
+      oldestFetchedTs: 0,
+      paginationIssue: null,
+      mutableTailIssue: null,
+      mutableTailFrom: 0,
+    });
+
+    expect(result).toEqual({
+      snapshotsError: null,
+      snapshots7dError: null,
+      snapshots30dError: null,
+    });
+  });
+
+  it("pagination issue present but every window is fully covered: no errors", () => {
+    const paginationIssue = new Error("truncated");
+    const result = resolveWindowErrors({
+      windows: WINDOWS,
+      oldestFetchedTs: 0, // covers every window's `from` bound
+      paginationIssue,
+      mutableTailIssue: null,
+      mutableTailFrom: 0,
+    });
+
+    expect(result).toEqual({
+      snapshotsError: null,
+      snapshots7dError: null,
+      snapshots30dError: null,
+    });
+  });
+
+  it("truncated-but-not-errored: pagination issue degrades only windows it falls short of", () => {
+    const paginationIssue = new Error("truncated");
+    // oldestFetchedTs sits between the 24h and 7d bounds — 24h is covered,
+    // 7d/30d are not.
+    const oldestFetchedTs = WINDOWS.w24h.from - 1;
+    const result = resolveWindowErrors({
+      windows: WINDOWS,
+      oldestFetchedTs,
+      paginationIssue,
+      mutableTailIssue: null,
+      mutableTailFrom: 0,
+    });
+
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).toBe(paginationIssue);
+    expect(result.snapshots30dError).toBe(paginationIssue);
+  });
+
+  it("mutable-tail issue present but no window reaches the mutable range: no errors", () => {
+    const mutableTailIssue = new Error("tail refresh failed");
+    const result = resolveWindowErrors({
+      windows: WINDOWS,
+      oldestFetchedTs: 0,
+      paginationIssue: null,
+      mutableTailIssue,
+      // Every window's `to` bound sits at or before mutableTailFrom, so
+      // `windowTo > mutableTailFrom` is false for all three.
+      mutableTailFrom: WINDOWS.w30d.to,
+    });
+
+    expect(result).toEqual({
+      snapshotsError: null,
+      snapshots7dError: null,
+      snapshots30dError: null,
+    });
+  });
+
+  it("errored-tail: mutable-tail issue degrades every window that extends into the mutable range", () => {
+    const mutableTailIssue = new Error("tail refresh failed");
+    const result = resolveWindowErrors({
+      windows: WINDOWS,
+      oldestFetchedTs: 0,
+      paginationIssue: null,
+      mutableTailIssue,
+      // Every window's `to` bound is the same "now" anchor, so all three
+      // extend past a cutoff set well before it.
+      mutableTailFrom: WINDOWS.w24h.from - 1,
+    });
+
+    expect(result.snapshotsError).toBe(mutableTailIssue);
+    expect(result.snapshots7dError).toBe(mutableTailIssue);
+    expect(result.snapshots30dError).toBe(mutableTailIssue);
+  });
+
+  it("precedence: mutable-tail issue wins over a pagination issue on the same window", () => {
+    const paginationIssue = new Error("truncated");
+    const mutableTailIssue = new Error("tail refresh failed");
+    // A synthetic window set (independent `to` bounds per window — unlike
+    // the real caller, which shares one "now" `to` across all three) lets
+    // this test isolate a single window where BOTH conditions hold from a
+    // window where only pagination applies.
+    const customWindows = {
+      w24h: { from: 50, to: 1000 },
+      w7d: { from: 50, to: 500 },
+      w30d: { from: 50, to: 500 },
+    };
+    const result = resolveWindowErrors({
+      windows: customWindows,
+      // > every window's `from` (50), so pagination alone would flag all three.
+      oldestFetchedTs: 200,
+      paginationIssue,
+      mutableTailIssue,
+      // Only w24h's `to` (1000) exceeds this.
+      mutableTailFrom: 600,
+    });
+
+    // w24h: both conditions hold — mutable-tail wins.
+    expect(result.snapshotsError).toBe(mutableTailIssue);
+    // w7d/w30d: mutable-tail doesn't apply (`to` <= mutableTailFrom), so the
+    // pagination issue applies instead.
+    expect(result.snapshots7dError).toBe(paginationIssue);
+    expect(result.snapshots30dError).toBe(paginationIssue);
+  });
+});
+
+describe("assembleNetworkData — pure composition", () => {
+  const network: Network = {
+    id: "celo-mainnet",
+    label: "Celo",
+    chainId: 42220,
+    contractsNamespace: null,
+    hasuraUrl: "https://hasura.example.com/v1/graphql",
+    hasuraSecret: "",
+    explorerBaseUrl: "https://celoscan.io",
+    tokenSymbols: {},
+    addressLabels: {},
+    local: false,
+    hasVirtualPools: false,
+    testnet: false,
+  };
+
+  const fulfilled = <T>(value: T): PromiseSettledResult<T> => ({
+    status: "fulfilled",
+    value,
+  });
+  const rejected = (reason: unknown): PromiseSettledResult<never> => ({
+    status: "rejected",
+    reason,
+  });
+
+  const baseArgs = {
+    network,
+    windows: WINDOWS,
+    pools: [] as Pool[],
+    snapshotTailNowMs: WINDOWS.w24h.to * 1000,
+    feeSnapshotsResult: fulfilled({
+      rows: [],
+      truncated: false,
+      error: null,
+    }),
+    snapshotsAllDailyResult: fulfilled({
+      rows: [],
+      truncated: false,
+      error: null,
+    }),
+    brokerSnapshotsAllDailyResult: fulfilled({
+      rows: [],
+      truncated: false,
+      error: null,
+    }),
+    lpResult: fulfilled({ rows: [], truncated: false, error: null }),
+    olsResult: fulfilled({ OlsPool: [] }),
+    cdpPoolIds: new Set<string>(),
+    reservePoolIds: new Set<string>(),
+    strategyError: null,
+  };
+
+  it("assembles a fully-healthy NetworkData with no I/O", () => {
+    const result = assembleNetworkData(baseArgs);
+
+    expect(result.network).toBe(network);
+    expect(result.snapshotWindows).toBe(WINDOWS);
+    expect(result.pools).toEqual([]);
+    expect(result.error).toBeNull();
+    expect(result.feeSnapshotsError).toBeNull();
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.brokerSnapshotsAllDailyError).toBeNull();
+    expect(result.lpError).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.olsPoolIds).toEqual(new Set());
+    expect(result.uniqueLpAddresses).toEqual([]);
+    expect(result.rates).toBeInstanceOf(Map);
+  });
+
+  it("propagates a rejected source straight through to its error channel", () => {
+    const lpErr = new Error("LP query down");
+    const result = assembleNetworkData({
+      ...baseArgs,
+      lpResult: rejected(lpErr),
+    });
+
+    expect(result.lpError).toBe(lpErr);
+    expect(result.uniqueLpAddresses).toBeNull();
+    // Unrelated slices are unaffected.
+    expect(result.feeSnapshotsError).toBeNull();
+  });
+});

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
@@ -212,4 +212,24 @@ describe("assembleNetworkData — pure composition", () => {
     // Unrelated slices are unaffected.
     expect(result.feeSnapshotsError).toBeNull();
   });
+
+  it("mutable-tail error in a fulfilled snapshot result degrades every current window", () => {
+    const tailErr = new Error("tail refresh failed");
+    const result = assembleNetworkData({
+      ...baseArgs,
+      snapshotsAllDailyResult: fulfilled({
+        rows: [],
+        truncated: false,
+        error: null,
+        mutableTailError: tailErr,
+      }),
+      // mutableTailFrom sits just below every window's `to` bound, so all
+      // three windows extend into the mutable range and inherit the error.
+      snapshotTailNowMs: WINDOWS.w24h.to * 1000 - 1,
+    });
+
+    expect(result.snapshotsError).toBe(tailErr);
+    expect(result.snapshots7dError).toBe(tailErr);
+    expect(result.snapshots30dError).toBe(tailErr);
+  });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/characterization-fixtures.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/characterization-fixtures.ts
@@ -1,0 +1,135 @@
+// Shared fixtures and GraphQL request-mock plumbing for the
+// `fetchNetworkData` characterization suites (#1055):
+//   - fetch.characterization.sources.test.ts
+//   - fetch.characterization.windows.test.ts
+// Not a .test file, so vitest doesn't collect it as a suite. Each suite
+// still declares its own `vi.mock` blocks — those are hoisted per test
+// file by the vitest transform and cannot live in a shared module.
+
+import { GraphQLClient } from "graphql-request";
+import { vi } from "vitest";
+import type { Network } from "@/lib/networks";
+import type { Pool } from "@/lib/types";
+
+export const CELO_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  hasVirtualPools: false,
+  testnet: false,
+};
+
+// Chain 143 — the only chain `usesRuntimeStrategyProbe` treats as a fallback
+// strategy candidate (`strategy-probe-scope.ts`).
+export const MONAD_NETWORK: Network = {
+  ...CELO_NETWORK,
+  id: "monad-mainnet",
+  label: "Monad",
+  chainId: 143,
+  hasuraUrl: "https://hasura-monad.example.com/v1/graphql",
+  explorerBaseUrl: "https://monadscan.com",
+};
+
+export const WINDOWS = {
+  w24h: { from: 0, to: 1000 },
+  w7d: { from: 0, to: 7000 },
+  w30d: { from: 0, to: 30000 },
+};
+
+/** Oracle-eligible FPMM pool — enough for `buildOracleRateMap` to price the
+ * FX leg so the happy-path fee aggregation doesn't trip the empty-rates
+ * guard (mirrors the fixture in `use-protocol-fees.test.ts`). */
+export function makePool(id: string, overrides: Partial<Pool> = {}): Pool {
+  return {
+    id,
+    chainId: 42220,
+    token0: "USDm",
+    token1: "EURm",
+    source: "FPMM",
+    oraclePrice: "1140000000000000000000000",
+    oracleOk: true,
+    createdAtBlock: "1",
+    createdAtTimestamp: "1000",
+    updatedAtBlock: "2",
+    updatedAtTimestamp: "2000",
+    ...overrides,
+  } as Pool;
+}
+
+// Maps each query's operation name to its GraphQL response key and a
+// default (empty, successful) response — so a test only needs to override
+// the one source it cares about and every other source resolves cleanly.
+const DEFAULT_RESPONSES: Record<string, Record<string, unknown>> = {
+  AllPoolsWithHealth: { Pool: [] },
+  AllPoolsBreachRollup: { Pool: [] },
+  AllPoolsHealthCursor: { Pool: [] },
+  AllPoolsRebalanceThresholdsKnown: { Pool: [] },
+  AllPoolsVpOracleFreshness: { Pool: [] },
+  AllPoolsVpDeprecation: { BiPoolExchange: [] },
+  AllPoolsVpLifecycleDeprecation: { VirtualPoolLifecycle: [] },
+  AllOlsPools: { OlsPool: [] },
+  AllCdpPools: { CdpPool: [] },
+  PoolDailyFeeSnapshotsPage: { PoolDailyFeeSnapshot: [] },
+  PoolDailySnapshotsAll: { PoolDailySnapshot: [] },
+  BrokerDailySnapshotsAll: { BrokerDailySnapshot: [] },
+  UniqueLpAddresses: { LiquidityPosition: [] },
+};
+
+function extractQuery(arg: unknown): string {
+  if (typeof arg === "string") return arg;
+  if (arg && typeof arg === "object" && "document" in arg) {
+    const doc = (arg as { document: unknown }).document;
+    if (typeof doc === "string") return doc;
+  }
+  return "";
+}
+
+function queryNameOf(document: string): string {
+  return /query\s+(\w+)/.exec(document)?.[1] ?? "";
+}
+
+type Reply = Record<string, unknown> | { reject: unknown };
+
+export function reject(reason: unknown): Reply {
+  return { reject: reason };
+}
+
+function isRejectReply(reply: Reply): reply is { reject: unknown } {
+  return "reject" in reply;
+}
+
+/**
+ * Installs a per-operation-name request mock. `overrides[name]` may be a
+ * fixed reply, or a function of the call index (0-based, per operation name)
+ * for pagination sequences. Any operation not overridden gets its default
+ * empty/successful response from `DEFAULT_RESPONSES`.
+ */
+export function installGraphQLMock(
+  overrides: Partial<Record<string, Reply | ((callIndex: number) => Reply)>>,
+): void {
+  const callCounts = new Map<string, number>();
+  (
+    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+  ).mockImplementation((arg: unknown) => {
+    const name = queryNameOf(extractQuery(arg));
+    const index = callCounts.get(name) ?? 0;
+    callCounts.set(name, index + 1);
+    const override = overrides[name];
+    const reply: Reply =
+      override === undefined
+        ? (DEFAULT_RESPONSES[name] ?? {})
+        : typeof override === "function"
+          ? override(index)
+          : override;
+    return isRejectReply(reply)
+      ? Promise.reject(reply.reject)
+      : Promise.resolve(reply);
+  });
+}

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
@@ -2,19 +2,16 @@
 // These pin the orchestrator's output BEFORE its internals are decomposed
 // into per-source fetch modules + a pure `assembleNetworkData`. They must
 // keep passing UNCHANGED once that refactor lands — only mechanical renames
-// are allowed on this file afterward.
+// are allowed on this file afterward. Shared fixtures live in
+// `characterization-fixtures.ts`; the window-precedence and empty-network
+// cases live in `fetch.characterization.windows.test.ts`.
 //
-// Coverage matrix:
+// Coverage matrix (this file):
 //   - all 13 Promise.allSettled sources succeeding together
 //   - each of those 13 sources failing alone (the other 12 stay healthy)
 //   - the top-level pools query failing
-//   - the per-window pagination-truncation vs mutable-tail-error precedence,
-//     both the truncated-but-not-errored case and the errored-tail case
-//   - an empty network (zero pools)
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Network } from "@/lib/networks";
-import type { Pool } from "@/lib/types";
 
 const { mockDetectProbedStrategies } = vi.hoisted(() => ({
   mockDetectProbedStrategies: vi.fn(),
@@ -35,136 +32,20 @@ vi.mock("graphql-request", () => {
   return { GraphQLClient: MockGraphQLClient };
 });
 
-import { GraphQLClient } from "graphql-request";
 import {
   fetchNetworkData,
   incrementalRowCache,
   partialPageLastCapturedAt,
   warnedCapKeys,
 } from "../fetch";
-
-const CELO_NETWORK: Network = {
-  id: "celo-mainnet",
-  label: "Celo",
-  chainId: 42220,
-  contractsNamespace: null,
-  hasuraUrl: "https://hasura.example.com/v1/graphql",
-  hasuraSecret: "",
-  explorerBaseUrl: "https://celoscan.io",
-  tokenSymbols: {},
-  addressLabels: {},
-  local: false,
-  hasVirtualPools: false,
-  testnet: false,
-};
-
-// Chain 143 — the only chain `usesRuntimeStrategyProbe` treats as a fallback
-// strategy candidate (`strategy-probe-scope.ts`).
-const MONAD_NETWORK: Network = {
-  ...CELO_NETWORK,
-  id: "monad-mainnet",
-  label: "Monad",
-  chainId: 143,
-  hasuraUrl: "https://hasura-monad.example.com/v1/graphql",
-  explorerBaseUrl: "https://monadscan.com",
-};
-
-const WINDOWS = {
-  w24h: { from: 0, to: 1000 },
-  w7d: { from: 0, to: 7000 },
-  w30d: { from: 0, to: 30000 },
-};
-
-/** Oracle-eligible FPMM pool — enough for `buildOracleRateMap` to price the
- * FX leg so the happy-path fee aggregation doesn't trip the empty-rates
- * guard (mirrors the fixture in `use-protocol-fees.test.ts`). */
-function makePool(id: string, overrides: Partial<Pool> = {}): Pool {
-  return {
-    id,
-    chainId: 42220,
-    token0: "USDm",
-    token1: "EURm",
-    source: "FPMM",
-    oraclePrice: "1140000000000000000000000",
-    oracleOk: true,
-    createdAtBlock: "1",
-    createdAtTimestamp: "1000",
-    updatedAtBlock: "2",
-    updatedAtTimestamp: "2000",
-    ...overrides,
-  } as Pool;
-}
-
-// Maps each query's operation name to its GraphQL response key and a
-// default (empty, successful) response — so a test only needs to override
-// the one source it cares about and every other source resolves cleanly.
-const DEFAULT_RESPONSES: Record<string, Record<string, unknown>> = {
-  AllPoolsWithHealth: { Pool: [] },
-  AllPoolsBreachRollup: { Pool: [] },
-  AllPoolsHealthCursor: { Pool: [] },
-  AllPoolsRebalanceThresholdsKnown: { Pool: [] },
-  AllPoolsVpOracleFreshness: { Pool: [] },
-  AllPoolsVpDeprecation: { BiPoolExchange: [] },
-  AllPoolsVpLifecycleDeprecation: { VirtualPoolLifecycle: [] },
-  AllOlsPools: { OlsPool: [] },
-  AllCdpPools: { CdpPool: [] },
-  PoolDailyFeeSnapshotsPage: { PoolDailyFeeSnapshot: [] },
-  PoolDailySnapshotsAll: { PoolDailySnapshot: [] },
-  BrokerDailySnapshotsAll: { BrokerDailySnapshot: [] },
-  UniqueLpAddresses: { LiquidityPosition: [] },
-};
-
-function extractQuery(arg: unknown): string {
-  if (typeof arg === "string") return arg;
-  if (arg && typeof arg === "object" && "document" in arg) {
-    const doc = (arg as { document: unknown }).document;
-    if (typeof doc === "string") return doc;
-  }
-  return "";
-}
-
-function queryNameOf(document: string): string {
-  return /query\s+(\w+)/.exec(document)?.[1] ?? "";
-}
-
-type Reply = Record<string, unknown> | { reject: unknown };
-
-function reject(reason: unknown): Reply {
-  return { reject: reason };
-}
-
-function isRejectReply(reply: Reply): reply is { reject: unknown } {
-  return "reject" in reply;
-}
-
-/**
- * Installs a per-operation-name request mock. `overrides[name]` may be a
- * fixed reply, or a function of the call index (0-based, per operation name)
- * for pagination sequences. Any operation not overridden gets its default
- * empty/successful response from `DEFAULT_RESPONSES`.
- */
-function installGraphQLMock(
-  overrides: Partial<Record<string, Reply | ((callIndex: number) => Reply)>>,
-): void {
-  const callCounts = new Map<string, number>();
-  (
-    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
-  ).mockImplementation((arg: unknown) => {
-    const name = queryNameOf(extractQuery(arg));
-    const index = callCounts.get(name) ?? 0;
-    callCounts.set(name, index + 1);
-    const override = overrides[name];
-    const reply: Reply =
-      override === undefined
-        ? (DEFAULT_RESPONSES[name] ?? {})
-        : typeof override === "function"
-          ? override(index)
-          : override;
-    return isRejectReply(reply)
-      ? Promise.reject(reply.reject)
-      : Promise.resolve(reply);
-  });
-}
+import {
+  CELO_NETWORK,
+  installGraphQLMock,
+  makePool,
+  MONAD_NETWORK,
+  reject,
+  WINDOWS,
+} from "./characterization-fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -482,170 +363,5 @@ describe("fetchNetworkData characterization — each source failing alone", () =
     expect(result.strategyError).toBe(err);
     expect(result.reservePoolIds).toEqual(new Set());
     expect(result.cdpPoolIds).toEqual(new Set());
-  });
-});
-
-describe("fetchNetworkData characterization — window error precedence", () => {
-  const makeDaily = (timestamp: number, poolId = "pool-window") => ({
-    poolId,
-    timestamp: String(timestamp),
-    reserves0: "0",
-    reserves1: "0",
-    swapCount: 1,
-    swapVolume0: "1000000000000000000",
-    swapVolume1: "2000000000000000000",
-  });
-
-  it("truncated-but-not-errored: pagination cap hit, no per-window error for windows fully covered", async () => {
-    // 12-hour spacing so 1000 rows (the pagination cap) spans far more than
-    // 30 real days — every window is covered by preserved rows, so hitting
-    // the cap flags `snapshotsAllDailyTruncated` without an `error` and
-    // without degrading any individual window.
-    const now = Math.floor(Date.now() / 1000);
-    const pool = makePool("42220-0xtrunc", { id: "pool-window" });
-    let rowCursor = 0;
-    installGraphQLMock({
-      AllPoolsWithHealth: { Pool: [pool] },
-      PoolDailySnapshotsAll: () => ({
-        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
-          makeDaily(now - rowCursor++ * 43200),
-        ),
-      }),
-    });
-
-    const result = await fetchNetworkData(CELO_NETWORK, {
-      w24h: { from: now - 86400, to: now },
-      w7d: { from: now - 7 * 86400, to: now },
-      w30d: { from: now - 30 * 86400, to: now },
-    });
-
-    expect(result.snapshotsAllDailyTruncated).toBe(true);
-    expect(result.snapshotsAllDailyError).toBeNull();
-    expect(result.snapshotsError).toBeNull();
-    expect(result.snapshots7dError).toBeNull();
-    expect(result.snapshots30dError).toBeNull();
-  });
-
-  it("truncated-but-not-errored: truncation alone degrades only the windows it falls short of", async () => {
-    // Every page is completely full (never a short page) so the loop only
-    // stops by hitting the pagination safety cap — truncation, not a fetch
-    // error. With 1-second row spacing, 100 pages x 1000 rows only reaches
-    // ~1.16 days back: within the 24h window's bound, but short of the
-    // 7d/30d bounds, so only those two pick up the synthetic truncation
-    // error while `error` stays null throughout.
-    const now = Math.floor(Date.now() / 1000);
-    const pool = makePool("42220-0xtrunc-window", { id: "pool-window" });
-    let rowCursor = 0;
-    installGraphQLMock({
-      AllPoolsWithHealth: { Pool: [pool] },
-      PoolDailySnapshotsAll: () => ({
-        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
-          makeDaily(now - rowCursor++),
-        ),
-      }),
-    });
-
-    const result = await fetchNetworkData(CELO_NETWORK, {
-      w24h: { from: now - 86400, to: now },
-      w7d: { from: now - 7 * 86400, to: now },
-      w30d: { from: now - 30 * 86400, to: now },
-    });
-
-    expect(result.snapshotsAllDailyTruncated).toBe(true);
-    expect(result.snapshotsAllDailyError).toBeNull();
-    expect(result.snapshotsError).toBeNull();
-    expect(result.snapshots7dError).not.toBeNull();
-    expect(result.snapshots7dError?.message).toMatch(/truncated/i);
-    expect(result.snapshots30dError).toBe(result.snapshots7dError);
-  });
-
-  it("errored-tail: mid-loop pagination failure only degrades windows beyond the salvaged rows", async () => {
-    const now = Math.floor(Date.now() / 1000);
-    const pool = makePool("42220-0xmiderr", { id: "pool-window" });
-    // Page 1: 1000 rows at 12h spacing (~500 days) — covers all 3 windows.
-    installGraphQLMock({
-      AllPoolsWithHealth: { Pool: [pool] },
-      PoolDailySnapshotsAll: (callIndex: number) =>
-        callIndex === 0
-          ? {
-              PoolDailySnapshot: Array.from({ length: 1000 }, (_, i) =>
-                makeDaily(now - i * 43200),
-              ),
-            }
-          : reject(new Error("upstream timeout on page 2")),
-    });
-
-    const result = await fetchNetworkData(CELO_NETWORK, {
-      w24h: { from: now - 86400, to: now },
-      w7d: { from: now - 7 * 86400, to: now },
-      w30d: { from: now - 30 * 86400, to: now },
-    });
-
-    expect(result.snapshotsAllDailyError).not.toBeNull();
-    expect(result.snapshotsAllDailyTruncated).toBe(true);
-    // All three windows sit inside the ~500d of salvaged rows.
-    expect(result.snapshotsError).toBeNull();
-    expect(result.snapshots7dError).toBeNull();
-    expect(result.snapshots30dError).toBeNull();
-  });
-
-  it("errored-tail: incremental mutable-tail refresh failure degrades every current window", async () => {
-    const now = Math.floor(Date.now() / 1000);
-    const todayMidnight = Math.floor(now / 86400) * 86400;
-    const pool = makePool("42220-0xtail", { id: "pool-tail" });
-    incrementalRowCache.set("celo-mainnet:PoolDailySnapshot", {
-      variablesKey: "pool-tail",
-      rows: [
-        makeDaily(todayMidnight, "pool-tail"),
-        makeDaily(todayMidnight - 60 * 86400, "pool-tail"),
-      ],
-      refreshAfterTimestamp: todayMidnight - 86400,
-    });
-    const tailErr = new Error("incremental tail timeout");
-    installGraphQLMock({
-      AllPoolsWithHealth: { Pool: [pool] },
-      PoolDailySnapshotsAll: reject(tailErr),
-    });
-
-    const result = await fetchNetworkData(CELO_NETWORK, {
-      w24h: { from: now - 86400, to: now },
-      w7d: { from: now - 7 * 86400, to: now },
-      w30d: { from: now - 30 * 86400, to: now },
-    });
-
-    // Cached history is preserved, but the mutable tail failure degrades
-    // every window that reaches into the mutable UTC-day range — all three.
-    expect(result.snapshotsAllDailyError).toBe(tailErr);
-    expect(result.snapshotsError).toBe(tailErr);
-    expect(result.snapshots7dError).toBe(tailErr);
-    expect(result.snapshots30dError).toBe(tailErr);
-  });
-});
-
-describe("fetchNetworkData characterization — empty network", () => {
-  it("returns a fully-healthy, all-empty NetworkData when the network has zero pools", async () => {
-    installGraphQLMock({ AllPoolsWithHealth: { Pool: [] } });
-
-    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
-
-    expect(result.error).toBeNull();
-    expect(result.pools).toEqual([]);
-    expect(result.snapshots).toEqual([]);
-    expect(result.snapshots7d).toEqual([]);
-    expect(result.snapshots30d).toEqual([]);
-    expect(result.snapshotsAllDaily).toEqual([]);
-    expect(result.snapshotsAllDailyTruncated).toBe(false);
-    expect(result.snapshotsAllDailyError).toBeNull();
-    expect(result.brokerSnapshotsAllDaily).toEqual([]);
-    expect(result.olsPoolIds).toEqual(new Set());
-    expect(result.cdpPoolIds).toEqual(new Set());
-    expect(result.reservePoolIds).toEqual(new Set());
-    expect(result.strategyError).toBeNull();
-    // No pools means the empty-rates guard does not fire (it only applies
-    // when pools exist but rate resolution failed).
-    expect(result.ratesError).toBeNull();
-    expect(result.uniqueLpAddresses).toEqual([]);
-    expect(result.uniqueLpAddressesTruncated).toBe(false);
-    expect(result.lpError).toBeNull();
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.test.ts
@@ -1,0 +1,651 @@
+// Characterization tests for `fetchNetworkData`'s current behavior (#1055).
+// These pin the orchestrator's output BEFORE its internals are decomposed
+// into per-source fetch modules + a pure `assembleNetworkData`. They must
+// keep passing UNCHANGED once that refactor lands — only mechanical renames
+// are allowed on this file afterward.
+//
+// Coverage matrix:
+//   - all 13 Promise.allSettled sources succeeding together
+//   - each of those 13 sources failing alone (the other 12 stay healthy)
+//   - the top-level pools query failing
+//   - the per-window pagination-truncation vs mutable-tail-error precedence,
+//     both the truncated-but-not-errored case and the errored-tail case
+//   - an empty network (zero pools)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Network } from "@/lib/networks";
+import type { Pool } from "@/lib/types";
+
+const { mockDetectProbedStrategies } = vi.hoisted(() => ({
+  mockDetectProbedStrategies: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/strategy-detection", () => ({
+  detectProbedStrategies: mockDetectProbedStrategies,
+}));
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+import { GraphQLClient } from "graphql-request";
+import {
+  fetchNetworkData,
+  incrementalRowCache,
+  partialPageLastCapturedAt,
+  warnedCapKeys,
+} from "../fetch";
+
+const CELO_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  hasVirtualPools: false,
+  testnet: false,
+};
+
+// Chain 143 — the only chain `usesRuntimeStrategyProbe` treats as a fallback
+// strategy candidate (`strategy-probe-scope.ts`).
+const MONAD_NETWORK: Network = {
+  ...CELO_NETWORK,
+  id: "monad-mainnet",
+  label: "Monad",
+  chainId: 143,
+  hasuraUrl: "https://hasura-monad.example.com/v1/graphql",
+  explorerBaseUrl: "https://monadscan.com",
+};
+
+const WINDOWS = {
+  w24h: { from: 0, to: 1000 },
+  w7d: { from: 0, to: 7000 },
+  w30d: { from: 0, to: 30000 },
+};
+
+/** Oracle-eligible FPMM pool — enough for `buildOracleRateMap` to price the
+ * FX leg so the happy-path fee aggregation doesn't trip the empty-rates
+ * guard (mirrors the fixture in `use-protocol-fees.test.ts`). */
+function makePool(id: string, overrides: Partial<Pool> = {}): Pool {
+  return {
+    id,
+    chainId: 42220,
+    token0: "USDm",
+    token1: "EURm",
+    source: "FPMM",
+    oraclePrice: "1140000000000000000000000",
+    oracleOk: true,
+    createdAtBlock: "1",
+    createdAtTimestamp: "1000",
+    updatedAtBlock: "2",
+    updatedAtTimestamp: "2000",
+    ...overrides,
+  } as Pool;
+}
+
+// Maps each query's operation name to its GraphQL response key and a
+// default (empty, successful) response — so a test only needs to override
+// the one source it cares about and every other source resolves cleanly.
+const DEFAULT_RESPONSES: Record<string, Record<string, unknown>> = {
+  AllPoolsWithHealth: { Pool: [] },
+  AllPoolsBreachRollup: { Pool: [] },
+  AllPoolsHealthCursor: { Pool: [] },
+  AllPoolsRebalanceThresholdsKnown: { Pool: [] },
+  AllPoolsVpOracleFreshness: { Pool: [] },
+  AllPoolsVpDeprecation: { BiPoolExchange: [] },
+  AllPoolsVpLifecycleDeprecation: { VirtualPoolLifecycle: [] },
+  AllOlsPools: { OlsPool: [] },
+  AllCdpPools: { CdpPool: [] },
+  PoolDailyFeeSnapshotsPage: { PoolDailyFeeSnapshot: [] },
+  PoolDailySnapshotsAll: { PoolDailySnapshot: [] },
+  BrokerDailySnapshotsAll: { BrokerDailySnapshot: [] },
+  UniqueLpAddresses: { LiquidityPosition: [] },
+};
+
+function extractQuery(arg: unknown): string {
+  if (typeof arg === "string") return arg;
+  if (arg && typeof arg === "object" && "document" in arg) {
+    const doc = (arg as { document: unknown }).document;
+    if (typeof doc === "string") return doc;
+  }
+  return "";
+}
+
+function queryNameOf(document: string): string {
+  return /query\s+(\w+)/.exec(document)?.[1] ?? "";
+}
+
+type Reply = Record<string, unknown> | { reject: unknown };
+
+function reject(reason: unknown): Reply {
+  return { reject: reason };
+}
+
+function isRejectReply(reply: Reply): reply is { reject: unknown } {
+  return "reject" in reply;
+}
+
+/**
+ * Installs a per-operation-name request mock. `overrides[name]` may be a
+ * fixed reply, or a function of the call index (0-based, per operation name)
+ * for pagination sequences. Any operation not overridden gets its default
+ * empty/successful response from `DEFAULT_RESPONSES`.
+ */
+function installGraphQLMock(
+  overrides: Partial<Record<string, Reply | ((callIndex: number) => Reply)>>,
+): void {
+  const callCounts = new Map<string, number>();
+  (
+    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+  ).mockImplementation((arg: unknown) => {
+    const name = queryNameOf(extractQuery(arg));
+    const index = callCounts.get(name) ?? 0;
+    callCounts.set(name, index + 1);
+    const override = overrides[name];
+    const reply: Reply =
+      override === undefined
+        ? (DEFAULT_RESPONSES[name] ?? {})
+        : typeof override === "function"
+          ? override(index)
+          : override;
+    return isRejectReply(reply)
+      ? Promise.reject(reply.reject)
+      : Promise.resolve(reply);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDetectProbedStrategies.mockResolvedValue({
+    cdpPoolIds: new Set<string>(),
+    reservePoolIds: new Set<string>(),
+  });
+  incrementalRowCache.clear();
+  warnedCapKeys.clear();
+  partialPageLastCapturedAt.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchNetworkData characterization — all sources succeed", () => {
+  it("assembles pools, fees, snapshots, badges, and LP data from every source", async () => {
+    const pool = makePool("42220-0xpool");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsBreachRollup: {
+        Pool: [
+          {
+            id: pool.id,
+            breachCount: 2,
+            healthBinarySeconds: "100",
+            healthTotalSeconds: "200",
+          },
+        ],
+      },
+      AllPoolsHealthCursor: {
+        Pool: [
+          {
+            id: pool.id,
+            lastOracleSnapshotTimestamp: "1000",
+            lastDeviationRatio: "5",
+          },
+        ],
+      },
+      AllPoolsRebalanceThresholdsKnown: {
+        Pool: [
+          {
+            id: pool.id,
+            rebalanceThresholdAbove: 100,
+            rebalanceThresholdBelow: 100,
+            rebalanceThresholdsKnown: true,
+            tokenDecimalsKnown: true,
+            degenerateReserves: false,
+            breakerTripped: false,
+          },
+        ],
+      },
+      AllPoolsVpOracleFreshness: {
+        Pool: [
+          {
+            id: pool.id,
+            lastOracleReportAt: "1000",
+            medianLive: true,
+            oracleFreshnessWindow: "300",
+          },
+        ],
+      },
+      AllOlsPools: { OlsPool: [{ poolId: "42220-0xols" }] },
+      AllCdpPools: {
+        CdpPool: [{ poolId: pool.id, strategyAddress: "0xabc" }],
+      },
+      UniqueLpAddresses: { LiquidityPosition: [{ address: "0xa" }] },
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.pools).toHaveLength(1);
+    expect(result.pools[0]).toMatchObject({
+      id: pool.id,
+      breachCount: 2,
+      lastOracleSnapshotTimestamp: "1000",
+      rebalanceThresholdsKnown: true,
+      lastOracleReportAt: "1000",
+    });
+    expect(result.olsPoolIds).toEqual(new Set(["42220-0xols"]));
+    expect(result.fees).not.toBeNull();
+    expect(result.uniqueLpAddresses).toEqual(["0xa"]);
+    expect(result.strategyError).toBeNull();
+    expect(result.feeSnapshotsError).toBeNull();
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.brokerSnapshotsAllDailyError).toBeNull();
+    expect(result.lpError).toBeNull();
+  });
+});
+
+describe("fetchNetworkData characterization — top-level pools query fails", () => {
+  it("returns emptyNetworkData shape with the pools error surfaced", async () => {
+    const poolsErr = new Error("pools query failed");
+    installGraphQLMock({ AllPoolsWithHealth: reject(poolsErr) });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBe(poolsErr);
+    expect(result.pools).toEqual([]);
+    expect(result.snapshots).toEqual([]);
+    expect(result.fees).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.olsPoolIds).toEqual(new Set());
+    expect(result.cdpPoolIds).toEqual(new Set());
+    expect(result.reservePoolIds).toEqual(new Set());
+  });
+});
+
+describe("fetchNetworkData characterization — each source failing alone", () => {
+  it("fee snapshots: feeSnapshotsError set, fees null, everything else healthy", async () => {
+    const pool = makePool("42220-0xfee");
+    const err = new Error("fee snapshots down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailyFeeSnapshotsPage: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.feeSnapshotsError).toBe(err);
+    expect(result.fees).toBeNull();
+    expect(result.snapshotsAllDailyError).toBeNull();
+  });
+
+  it("daily snapshots: snapshotsAllDailyError set on all three windows (no rows salvaged)", async () => {
+    const pool = makePool("42220-0xdaily");
+    const err = new Error("daily snapshots down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.snapshotsAllDailyError).toBe(err);
+    expect(result.snapshotsError).toBe(err);
+    expect(result.snapshots7dError).toBe(err);
+    expect(result.snapshots30dError).toBe(err);
+    expect(result.snapshotsAllDaily).toEqual([]);
+  });
+
+  it("broker daily snapshots: brokerSnapshotsAllDailyError set, other slices healthy", async () => {
+    const pool = makePool("42220-0xbroker");
+    const err = new Error("broker snapshots down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      BrokerDailySnapshotsAll: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.brokerSnapshotsAllDailyError).toBe(err);
+    expect(result.brokerSnapshotsAllDaily).toEqual([]);
+    expect(result.snapshotsAllDailyError).toBeNull();
+  });
+
+  it("LP addresses: lpError set, uniqueLpAddresses null, pools/fees unaffected", async () => {
+    const pool = makePool("42220-0xlp");
+    const err = new Error("LP query down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      UniqueLpAddresses: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.lpError).toBe(err);
+    expect(result.uniqueLpAddresses).toBeNull();
+    expect(result.fees).not.toBeNull();
+  });
+
+  it("OLS pools: strategyError set, olsPoolIds empty", async () => {
+    const pool = makePool("42220-0xols-fail");
+    const err = new Error("OLS query down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllOlsPools: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBe(err);
+    expect(result.olsPoolIds).toEqual(new Set());
+  });
+
+  it("breach rollup: fails open — no error channel, rollup fields stay undefined", async () => {
+    const pool = makePool("42220-0xbreach-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsBreachRollup: reject(new Error("breach rollup down")),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.pools[0]).not.toHaveProperty("breachCount");
+  });
+
+  it("health cursor: fails open — no error channel, cursor fields stay undefined", async () => {
+    const pool = makePool("42220-0xcursor-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsHealthCursor: reject(new Error("health cursor down")),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.pools[0]).not.toHaveProperty("lastOracleSnapshotTimestamp");
+  });
+
+  it("rebalance-thresholds-known: fails open — flags stay undefined", async () => {
+    const pool = makePool("42220-0xthresh-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsRebalanceThresholdsKnown: reject(
+        new Error("thresholds known down"),
+      ),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.pools[0]).not.toHaveProperty("rebalanceThresholdsKnown");
+  });
+
+  it("VP oracle freshness: fails open — freshness fields stay undefined", async () => {
+    const pool = makePool("42220-0xfresh-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsVpOracleFreshness: reject(new Error("vp freshness down")),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBeNull();
+    expect(result.pools[0]).not.toHaveProperty("lastOracleReportAt");
+  });
+
+  it("VP deprecation (exchange rows): fails open — lifecycle deprecation still applies", async () => {
+    const pool = makePool("42220-0xvpdep-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsVpDeprecation: reject(new Error("vp deprecation down")),
+      AllPoolsVpLifecycleDeprecation: {
+        VirtualPoolLifecycle: [{ poolId: pool.id }],
+      },
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.pools[0]).toMatchObject({ wrappedExchangeDeprecated: true });
+    expect(result.pools[0]).not.toHaveProperty("wrappedExchangeMinimumReports");
+  });
+
+  it("VP lifecycle deprecation: fails open — exchange-row deprecation still applies", async () => {
+    const pool = makePool("42220-0xvplife-fail");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllPoolsVpLifecycleDeprecation: reject(
+        new Error("vp lifecycle deprecation down"),
+      ),
+      AllPoolsVpDeprecation: {
+        BiPoolExchange: [{ wrappedByPoolId: pool.id, isDeprecated: true }],
+      },
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.pools[0]).toMatchObject({ wrappedExchangeDeprecated: true });
+  });
+
+  it("indexed CDP pools (Celo): strategyError set, cdpPoolIds empty", async () => {
+    const pool = makePool("42220-0xcdp-fail", {
+      rebalancerAddress: "0x000000000000000000000000000000000000d0d0",
+    });
+    const err = new Error("CdpPool query down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllCdpPools: reject(err),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBe(err);
+    expect(result.cdpPoolIds).toEqual(new Set());
+  });
+
+  it("fallback strategy probe (non-Celo): strategyError set, reservePoolIds empty", async () => {
+    const pool = makePool("143-0xprobe-fail", {
+      chainId: 143,
+      rebalancerAddress: "0x000000000000000000000000000000000000d0d0",
+    });
+    const err = new Error("strategy probe down");
+    mockDetectProbedStrategies.mockRejectedValueOnce(err);
+    installGraphQLMock({ AllPoolsWithHealth: { Pool: [pool] } });
+
+    const result = await fetchNetworkData(MONAD_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.strategyError).toBe(err);
+    expect(result.reservePoolIds).toEqual(new Set());
+    expect(result.cdpPoolIds).toEqual(new Set());
+  });
+});
+
+describe("fetchNetworkData characterization — window error precedence", () => {
+  const makeDaily = (timestamp: number, poolId = "pool-window") => ({
+    poolId,
+    timestamp: String(timestamp),
+    reserves0: "0",
+    reserves1: "0",
+    swapCount: 1,
+    swapVolume0: "1000000000000000000",
+    swapVolume1: "2000000000000000000",
+  });
+
+  it("truncated-but-not-errored: pagination cap hit, no per-window error for windows fully covered", async () => {
+    // 12-hour spacing so 1000 rows (the pagination cap) spans far more than
+    // 30 real days — every window is covered by preserved rows, so hitting
+    // the cap flags `snapshotsAllDailyTruncated` without an `error` and
+    // without degrading any individual window.
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xtrunc", { id: "pool-window" });
+    let rowCursor = 0;
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: () => ({
+        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
+          makeDaily(now - rowCursor++ * 43200),
+        ),
+      }),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).toBeNull();
+    expect(result.snapshots30dError).toBeNull();
+  });
+
+  it("truncated-but-not-errored: truncation alone degrades only the windows it falls short of", async () => {
+    // Every page is completely full (never a short page) so the loop only
+    // stops by hitting the pagination safety cap — truncation, not a fetch
+    // error. With 1-second row spacing, 100 pages x 1000 rows only reaches
+    // ~1.16 days back: within the 24h window's bound, but short of the
+    // 7d/30d bounds, so only those two pick up the synthetic truncation
+    // error while `error` stays null throughout.
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xtrunc-window", { id: "pool-window" });
+    let rowCursor = 0;
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: () => ({
+        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
+          makeDaily(now - rowCursor++),
+        ),
+      }),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).not.toBeNull();
+    expect(result.snapshots7dError?.message).toMatch(/truncated/i);
+    expect(result.snapshots30dError).toBe(result.snapshots7dError);
+  });
+
+  it("errored-tail: mid-loop pagination failure only degrades windows beyond the salvaged rows", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xmiderr", { id: "pool-window" });
+    // Page 1: 1000 rows at 12h spacing (~500 days) — covers all 3 windows.
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: (callIndex: number) =>
+        callIndex === 0
+          ? {
+              PoolDailySnapshot: Array.from({ length: 1000 }, (_, i) =>
+                makeDaily(now - i * 43200),
+              ),
+            }
+          : reject(new Error("upstream timeout on page 2")),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyError).not.toBeNull();
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    // All three windows sit inside the ~500d of salvaged rows.
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).toBeNull();
+    expect(result.snapshots30dError).toBeNull();
+  });
+
+  it("errored-tail: incremental mutable-tail refresh failure degrades every current window", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const todayMidnight = Math.floor(now / 86400) * 86400;
+    const pool = makePool("42220-0xtail", { id: "pool-tail" });
+    incrementalRowCache.set("celo-mainnet:PoolDailySnapshot", {
+      variablesKey: "pool-tail",
+      rows: [
+        makeDaily(todayMidnight, "pool-tail"),
+        makeDaily(todayMidnight - 60 * 86400, "pool-tail"),
+      ],
+      refreshAfterTimestamp: todayMidnight - 86400,
+    });
+    const tailErr = new Error("incremental tail timeout");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: reject(tailErr),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    // Cached history is preserved, but the mutable tail failure degrades
+    // every window that reaches into the mutable UTC-day range — all three.
+    expect(result.snapshotsAllDailyError).toBe(tailErr);
+    expect(result.snapshotsError).toBe(tailErr);
+    expect(result.snapshots7dError).toBe(tailErr);
+    expect(result.snapshots30dError).toBe(tailErr);
+  });
+});
+
+describe("fetchNetworkData characterization — empty network", () => {
+  it("returns a fully-healthy, all-empty NetworkData when the network has zero pools", async () => {
+    installGraphQLMock({ AllPoolsWithHealth: { Pool: [] } });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.pools).toEqual([]);
+    expect(result.snapshots).toEqual([]);
+    expect(result.snapshots7d).toEqual([]);
+    expect(result.snapshots30d).toEqual([]);
+    expect(result.snapshotsAllDaily).toEqual([]);
+    expect(result.snapshotsAllDailyTruncated).toBe(false);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.brokerSnapshotsAllDaily).toEqual([]);
+    expect(result.olsPoolIds).toEqual(new Set());
+    expect(result.cdpPoolIds).toEqual(new Set());
+    expect(result.reservePoolIds).toEqual(new Set());
+    expect(result.strategyError).toBeNull();
+    // No pools means the empty-rates guard does not fire (it only applies
+    // when pools exist but rate resolution failed).
+    expect(result.ratesError).toBeNull();
+    expect(result.uniqueLpAddresses).toEqual([]);
+    expect(result.uniqueLpAddressesTruncated).toBe(false);
+    expect(result.lpError).toBeNull();
+  });
+});

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
@@ -1,0 +1,227 @@
+// Characterization tests for `fetchNetworkData`'s current behavior (#1055).
+// These pin the orchestrator's output BEFORE its internals are decomposed
+// into per-source fetch modules + a pure `assembleNetworkData`. They must
+// keep passing UNCHANGED once that refactor lands — only mechanical renames
+// are allowed on this file afterward. Shared fixtures live in
+// `characterization-fixtures.ts`; the per-source success/failure matrix
+// lives in `fetch.characterization.sources.test.ts`.
+//
+// Coverage matrix (this file):
+//   - the per-window pagination-truncation vs mutable-tail-error precedence,
+//     both the truncated-but-not-errored case and the errored-tail case
+//   - an empty network (zero pools)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDetectProbedStrategies } = vi.hoisted(() => ({
+  mockDetectProbedStrategies: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/strategy-detection", () => ({
+  detectProbedStrategies: mockDetectProbedStrategies,
+}));
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+import {
+  fetchNetworkData,
+  incrementalRowCache,
+  partialPageLastCapturedAt,
+  warnedCapKeys,
+} from "../fetch";
+import {
+  CELO_NETWORK,
+  installGraphQLMock,
+  makePool,
+  reject,
+  WINDOWS,
+} from "./characterization-fixtures";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDetectProbedStrategies.mockResolvedValue({
+    cdpPoolIds: new Set<string>(),
+    reservePoolIds: new Set<string>(),
+  });
+  incrementalRowCache.clear();
+  warnedCapKeys.clear();
+  partialPageLastCapturedAt.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchNetworkData characterization — window error precedence", () => {
+  const makeDaily = (timestamp: number, poolId = "pool-window") => ({
+    poolId,
+    timestamp: String(timestamp),
+    reserves0: "0",
+    reserves1: "0",
+    swapCount: 1,
+    swapVolume0: "1000000000000000000",
+    swapVolume1: "2000000000000000000",
+  });
+
+  it("truncated-but-not-errored: pagination cap hit, no per-window error for windows fully covered", async () => {
+    // 12-hour spacing so 1000 rows (the pagination cap) spans far more than
+    // 30 real days — every window is covered by preserved rows, so hitting
+    // the cap flags `snapshotsAllDailyTruncated` without an `error` and
+    // without degrading any individual window.
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xtrunc", { id: "pool-window" });
+    let rowCursor = 0;
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: () => ({
+        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
+          makeDaily(now - rowCursor++ * 43200),
+        ),
+      }),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).toBeNull();
+    expect(result.snapshots30dError).toBeNull();
+  });
+
+  it("truncated-but-not-errored: truncation alone degrades only the windows it falls short of", async () => {
+    // Every page is completely full (never a short page) so the loop only
+    // stops by hitting the pagination safety cap — truncation, not a fetch
+    // error. With 1-second row spacing, 100 pages x 1000 rows only reaches
+    // ~1.16 days back: within the 24h window's bound, but short of the
+    // 7d/30d bounds, so only those two pick up the synthetic truncation
+    // error while `error` stays null throughout.
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xtrunc-window", { id: "pool-window" });
+    let rowCursor = 0;
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: () => ({
+        PoolDailySnapshot: Array.from({ length: 1000 }, () =>
+          makeDaily(now - rowCursor++),
+        ),
+      }),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).not.toBeNull();
+    expect(result.snapshots7dError?.message).toMatch(/truncated/i);
+    expect(result.snapshots30dError).toBe(result.snapshots7dError);
+  });
+
+  it("errored-tail: mid-loop pagination failure only degrades windows beyond the salvaged rows", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const pool = makePool("42220-0xmiderr", { id: "pool-window" });
+    // Page 1: 1000 rows at 12h spacing (~500 days) — covers all 3 windows.
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: (callIndex: number) =>
+        callIndex === 0
+          ? {
+              PoolDailySnapshot: Array.from({ length: 1000 }, (_, i) =>
+                makeDaily(now - i * 43200),
+              ),
+            }
+          : reject(new Error("upstream timeout on page 2")),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyError).not.toBeNull();
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    // All three windows sit inside the ~500d of salvaged rows.
+    expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots7dError).toBeNull();
+    expect(result.snapshots30dError).toBeNull();
+  });
+
+  it("errored-tail: incremental mutable-tail refresh failure degrades every current window", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const todayMidnight = Math.floor(now / 86400) * 86400;
+    const pool = makePool("42220-0xtail", { id: "pool-tail" });
+    incrementalRowCache.set("celo-mainnet:PoolDailySnapshot", {
+      variablesKey: "pool-tail",
+      rows: [
+        makeDaily(todayMidnight, "pool-tail"),
+        makeDaily(todayMidnight - 60 * 86400, "pool-tail"),
+      ],
+      refreshAfterTimestamp: todayMidnight - 86400,
+    });
+    const tailErr = new Error("incremental tail timeout");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      PoolDailySnapshotsAll: reject(tailErr),
+    });
+
+    const result = await fetchNetworkData(CELO_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    // Cached history is preserved, but the mutable tail failure degrades
+    // every window that reaches into the mutable UTC-day range — all three.
+    expect(result.snapshotsAllDailyError).toBe(tailErr);
+    expect(result.snapshotsError).toBe(tailErr);
+    expect(result.snapshots7dError).toBe(tailErr);
+    expect(result.snapshots30dError).toBe(tailErr);
+  });
+});
+
+describe("fetchNetworkData characterization — empty network", () => {
+  it("returns a fully-healthy, all-empty NetworkData when the network has zero pools", async () => {
+    installGraphQLMock({ AllPoolsWithHealth: { Pool: [] } });
+
+    const result = await fetchNetworkData(CELO_NETWORK, WINDOWS);
+
+    expect(result.error).toBeNull();
+    expect(result.pools).toEqual([]);
+    expect(result.snapshots).toEqual([]);
+    expect(result.snapshots7d).toEqual([]);
+    expect(result.snapshots30d).toEqual([]);
+    expect(result.snapshotsAllDaily).toEqual([]);
+    expect(result.snapshotsAllDailyTruncated).toBe(false);
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.brokerSnapshotsAllDaily).toEqual([]);
+    expect(result.olsPoolIds).toEqual(new Set());
+    expect(result.cdpPoolIds).toEqual(new Set());
+    expect(result.reservePoolIds).toEqual(new Set());
+    expect(result.strategyError).toBeNull();
+    // No pools means the empty-rates guard does not fire (it only applies
+    // when pools exist but rate resolution failed).
+    expect(result.ratesError).toBeNull();
+    expect(result.uniqueLpAddresses).toEqual([]);
+    expect(result.uniqueLpAddressesTruncated).toBe(false);
+    expect(result.lpError).toBeNull();
+  });
+});

--- a/ui-dashboard/src/lib/network-fetcher/assemble.ts
+++ b/ui-dashboard/src/lib/network-fetcher/assemble.ts
@@ -240,6 +240,9 @@ function deriveSnapshotSlice(args: {
   // affect a specific window if we didn't fetch far enough back to cover its
   // `from` bound. Rows come in newest-first, so the last element is the
   // oldest we fetched.
+  // POSITIVE_INFINITY when empty: ensures oldestFetchedTs > windowFrom is
+  // always true, so a pagination issue (error or truncation) degrades every
+  // window — we have no salvaged rows to prove any window is covered.
   const oldestFetchedTs =
     snapshotsAllDaily.length > 0
       ? Number(snapshotsAllDaily[snapshotsAllDaily.length - 1]!.timestamp)

--- a/ui-dashboard/src/lib/network-fetcher/assemble.ts
+++ b/ui-dashboard/src/lib/network-fetcher/assemble.ts
@@ -1,0 +1,359 @@
+// Pure assembly of the final `NetworkData` payload from already-resolved
+// per-source results. Owns two jobs that must stay decoupled from I/O so
+// they can be unit-tested directly: (1) deriving each field's value/error/
+// truncation state from its Promise.allSettled result, and (2) the window
+// error-precedence matrix — whether a 24h/7d/30d window is degraded by
+// pagination truncation, a mutable-tail refresh failure, or neither. See
+// `resolveWindowErrors` for the precedence rule itself.
+
+import type { Network } from "@/lib/networks";
+import {
+  aggregateProtocolFees,
+  type ProtocolFeeSummary,
+} from "@/lib/protocol-fees";
+import { buildOracleRateMap, type OracleRateMap } from "@/lib/tokens";
+import type { Pool, PoolDailyFeeSnapshot } from "@/lib/types";
+import { filterSnapshotsToWindow, type TimeRange } from "@/lib/volume";
+import { SECONDS_PER_DAY } from "./constants";
+import { toError } from "./errors";
+import { mutableDayCutoff } from "./pagination";
+import type {
+  BrokerDailySnapshotRow,
+  NetworkData,
+  OlsPoolsResult,
+  PaginatedPageResult,
+  SnapshotPageResult,
+} from "./types";
+
+/**
+ * Per-window error precedence: a window is degraded by the mutable-tail
+ * refresh failure if the window extends into the mutable UTC-day range;
+ * otherwise it's degraded by pagination truncation/error only if we didn't
+ * fetch back far enough to cover the window's lower bound. Mutable-tail
+ * issues take precedence because rows inside the window may now be stale
+ * even though older history is intact; pagination issues only matter when
+ * the window's `from` bound falls outside what we actually fetched.
+ */
+export function resolveWindowErrors(args: {
+  windows: { w24h: TimeRange; w7d: TimeRange; w30d: TimeRange };
+  oldestFetchedTs: number;
+  paginationIssue: Error | null;
+  mutableTailIssue: Error | null;
+  mutableTailFrom: number;
+}): {
+  snapshotsError: Error | null;
+  snapshots7dError: Error | null;
+  snapshots30dError: Error | null;
+} {
+  const {
+    windows,
+    oldestFetchedTs,
+    paginationIssue,
+    mutableTailIssue,
+    mutableTailFrom,
+  } = args;
+  const windowError = (windowFrom: number, windowTo: number): Error | null =>
+    mutableTailIssue !== null && windowTo > mutableTailFrom
+      ? mutableTailIssue
+      : paginationIssue !== null && oldestFetchedTs > windowFrom
+        ? paginationIssue
+        : null;
+  return {
+    snapshotsError: windowError(windows.w24h.from, windows.w24h.to),
+    snapshots7dError: windowError(windows.w7d.from, windows.w7d.to),
+    snapshots30dError: windowError(windows.w30d.from, windows.w30d.to),
+  };
+}
+
+function deriveFeeSlice(args: {
+  feeSnapshotsResult: PromiseSettledResult<
+    PaginatedPageResult<PoolDailyFeeSnapshot>
+  >;
+  pools: Pool[];
+  rates: OracleRateMap;
+  network: Network;
+}): {
+  feeSnapshots: PoolDailyFeeSnapshot[];
+  feeSnapshotsError: Error | null;
+  feeSnapshotsTruncated: boolean;
+  fees: ProtocolFeeSummary | null;
+  ratesError: Error | null;
+} {
+  const { feeSnapshotsResult, pools, rates, network } = args;
+  const feeSnapshots =
+    feeSnapshotsResult.status === "fulfilled"
+      ? feeSnapshotsResult.value.rows
+      : [];
+  const feeSnapshotsError =
+    feeSnapshotsResult.status === "rejected"
+      ? toError(feeSnapshotsResult.reason)
+      : (feeSnapshotsResult.value.error ?? null);
+  // Cap-exhaustion: helper returns `truncated: true, error: null`. We still
+  // aggregate from the rows we did fetch; consumers gate on this flag to
+  // mark the all-time total approximate.
+  const feeSnapshotsTruncated =
+    feeSnapshotsResult.status === "fulfilled" &&
+    feeSnapshotsResult.value.truncated;
+  // Rates failure on the homepage SSR path: rates are derived from `pools`
+  // (no separate query), so a query-level rates failure already early-
+  // returned via the pools-fetch catch in `fetchNetworkData`. The remaining
+  // failure mode is an empty rate map despite non-empty pools — every
+  // oracle pool has `oracleOk: false` or no oracle pools exist on this
+  // chain — which would silently mis-price FX-token slots. Match the hook's
+  // fail-loud invariant: blank the tile instead of a confidently-wrong total.
+  const ratesError =
+    pools.length > 0 && rates.size === 0
+      ? new Error(
+          `Oracle rates unavailable for ${network.label} — FX-token fees can't be priced`,
+        )
+      : null;
+  const fees =
+    feeSnapshotsResult.status === "fulfilled" &&
+    feeSnapshotsResult.value.error === null &&
+    ratesError === null
+      ? aggregateProtocolFees(feeSnapshots, rates)
+      : null;
+  return {
+    feeSnapshots,
+    feeSnapshotsError,
+    feeSnapshotsTruncated,
+    fees,
+    ratesError,
+  };
+}
+
+function deriveBrokerSlice(
+  result: PromiseSettledResult<PaginatedPageResult<BrokerDailySnapshotRow>>,
+): {
+  brokerSnapshotsAllDaily: BrokerDailySnapshotRow[];
+  brokerSnapshotsAllDailyTruncated: boolean;
+  brokerSnapshotsAllDailyError: Error | null;
+} {
+  // Legacy v2 daily volume — already filtered to `routedViaV3Router=false`
+  // server-side, so no client-side disambiguation is needed.
+  return {
+    brokerSnapshotsAllDaily:
+      result.status === "fulfilled" ? result.value.rows : [],
+    brokerSnapshotsAllDailyTruncated:
+      result.status === "fulfilled" && result.value.truncated,
+    brokerSnapshotsAllDailyError:
+      result.status === "rejected"
+        ? toError(result.reason)
+        : (result.value.error ?? null),
+  };
+}
+
+function deriveLpSlice(
+  result: PromiseSettledResult<PaginatedPageResult<{ address: string }>>,
+): {
+  uniqueLpAddresses: string[] | null;
+  uniqueLpAddressesTruncated: boolean;
+  lpError: Error | null;
+} {
+  // fetchAllLpAddressPages deduplicates by address.toLowerCase() internally,
+  // so the rows are already unique — no second Set pass needed.
+  return {
+    uniqueLpAddresses:
+      result.status === "fulfilled"
+        ? result.value.rows.map((r) => r.address)
+        : null,
+    uniqueLpAddressesTruncated:
+      result.status === "fulfilled" && result.value.truncated,
+    lpError:
+      result.status === "rejected"
+        ? toError(result.reason)
+        : (result.value.error ?? null),
+  };
+}
+
+function deriveOlsPoolIds(
+  result: PromiseSettledResult<OlsPoolsResult>,
+): Set<string> {
+  return result.status === "fulfilled"
+    ? new Set((result.value.OlsPool ?? []).map((p) => p.poolId))
+    : new Set<string>();
+}
+
+/**
+ * Derives the snapshotsAllDaily/snapshots7d/snapshots30d/snapshots slices
+ * plus their per-window errors. Window-specific arrays are derived in-memory
+ * from `snapshotsAllDaily` — no separate requests, no server-side cap. If
+ * pagination truncated (hit MAX_PAGES or mid-loop fetch failure) we keep the
+ * most-recent rows we did fetch: 24h/7d/30d derive correctly from those and
+ * "All" is flagged as partial.
+ */
+function deriveSnapshotSlice(args: {
+  nowSeconds: number;
+  snapshotsAllDailyResult: PromiseSettledResult<SnapshotPageResult>;
+  snapshotTailNowMs: number;
+}): {
+  snapshotsAllDaily: NetworkData["snapshotsAllDaily"];
+  snapshotsAllDailyTruncated: boolean;
+  snapshotsAllDailyError: Error | null;
+  snapshots: NetworkData["snapshots"];
+  snapshots7d: NetworkData["snapshots7d"];
+  snapshots30d: NetworkData["snapshots30d"];
+  snapshotsError: Error | null;
+  snapshots7dError: Error | null;
+  snapshots30dError: Error | null;
+} {
+  const { nowSeconds, snapshotsAllDailyResult, snapshotTailNowMs } = args;
+  const snapshotsAllDaily =
+    snapshotsAllDailyResult.status === "fulfilled"
+      ? snapshotsAllDailyResult.value.rows
+      : [];
+  const snapshotsAllDailyTruncated =
+    snapshotsAllDailyResult.status === "fulfilled"
+      ? snapshotsAllDailyResult.value.truncated
+      : false;
+  const snapshotsAllDailyError =
+    snapshotsAllDailyResult.status === "rejected"
+      ? toError(snapshotsAllDailyResult.reason)
+      : (snapshotsAllDailyResult.value.error ?? null);
+
+  // PoolDailySnapshot rows are UTC-midnight-aligned incremental aggregates
+  // (one row per pool per UTC day). Anchoring on today's UTC midnight gives
+  // exactly 1/7/30 daily rows per KPI window without overcounting.
+  //
+  // `nowSeconds` is the caller's snapshot of "now" (`windows.w24h.to`), so
+  // deriving todayMidnight from it keeps all three windows consistent with
+  // the same clock tick rather than calling Date.now() again.
+  const todayMidnight =
+    Math.floor(nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const dw24h: TimeRange = {
+    from: todayMidnight,
+    to: todayMidnight + SECONDS_PER_DAY,
+  };
+  const dw7d: TimeRange = {
+    from: todayMidnight - 6 * SECONDS_PER_DAY,
+    to: todayMidnight + SECONDS_PER_DAY,
+  };
+  const dw30d: TimeRange = {
+    from: todayMidnight - 29 * SECONDS_PER_DAY,
+    to: todayMidnight + SECONDS_PER_DAY,
+  };
+
+  const snapshots7d = filterSnapshotsToWindow(snapshotsAllDaily, dw7d);
+  const snapshots30d = filterSnapshotsToWindow(snapshotsAllDaily, dw30d);
+
+  // Per-window error detection. Pagination issues (error or truncation) only
+  // affect a specific window if we didn't fetch far enough back to cover its
+  // `from` bound. Rows come in newest-first, so the last element is the
+  // oldest we fetched.
+  const oldestFetchedTs =
+    snapshotsAllDaily.length > 0
+      ? Number(snapshotsAllDaily[snapshotsAllDaily.length - 1]!.timestamp)
+      : Number.POSITIVE_INFINITY;
+  const paginationIssue: Error | null =
+    snapshotsAllDailyError ??
+    (snapshotsAllDailyTruncated
+      ? new Error(
+          "Snapshot pagination truncated before reaching the requested window",
+        )
+      : null);
+  const mutableTailIssue: Error | null =
+    snapshotsAllDailyResult.status === "fulfilled"
+      ? (snapshotsAllDailyResult.value.mutableTailError ?? null)
+      : null;
+  const mutableTailFrom = mutableDayCutoff(snapshotTailNowMs);
+
+  const { snapshotsError, snapshots7dError, snapshots30dError } =
+    resolveWindowErrors({
+      windows: { w24h: dw24h, w7d: dw7d, w30d: dw30d },
+      oldestFetchedTs,
+      paginationIssue,
+      mutableTailIssue,
+      mutableTailFrom,
+    });
+
+  return {
+    snapshotsAllDaily,
+    snapshotsAllDailyTruncated,
+    snapshotsAllDailyError,
+    snapshots: filterSnapshotsToWindow(snapshotsAllDaily, dw24h),
+    snapshots7d,
+    snapshots30d,
+    snapshotsError,
+    snapshots7dError,
+    snapshots30dError,
+  };
+}
+
+export type AssembleNetworkDataArgs = {
+  network: Network;
+  windows: { w24h: TimeRange; w7d: TimeRange; w30d: TimeRange };
+  pools: Pool[];
+  snapshotTailNowMs: number;
+  feeSnapshotsResult: PromiseSettledResult<
+    PaginatedPageResult<PoolDailyFeeSnapshot>
+  >;
+  snapshotsAllDailyResult: PromiseSettledResult<SnapshotPageResult>;
+  brokerSnapshotsAllDailyResult: PromiseSettledResult<
+    PaginatedPageResult<BrokerDailySnapshotRow>
+  >;
+  lpResult: PromiseSettledResult<PaginatedPageResult<{ address: string }>>;
+  olsResult: PromiseSettledResult<OlsPoolsResult>;
+  cdpPoolIds: Set<string>;
+  reservePoolIds: Set<string>;
+  strategyError: Error | null;
+};
+
+/**
+ * Pure assembly of the final `NetworkData` payload from fully-merged `pools`
+ * and each source's settled result. Never performs I/O — safe to unit test
+ * directly with hand-built `PromiseSettledResult`s (see
+ * `__tests__/assemble.test.ts`), which is what gives the window
+ * error-precedence matrix direct coverage instead of riding along
+ * `fetchNetworkData`'s full GraphQL-mock characterization tests.
+ */
+export function assembleNetworkData(
+  args: AssembleNetworkDataArgs,
+): NetworkData {
+  const {
+    network,
+    windows,
+    pools,
+    snapshotTailNowMs,
+    feeSnapshotsResult,
+    snapshotsAllDailyResult,
+    brokerSnapshotsAllDailyResult,
+    lpResult,
+    olsResult,
+    cdpPoolIds,
+    reservePoolIds,
+    strategyError,
+  } = args;
+
+  const rates = buildOracleRateMap(pools, network);
+  const feeSlice = deriveFeeSlice({
+    feeSnapshotsResult,
+    pools,
+    rates,
+    network,
+  });
+  const snapshotSlice = deriveSnapshotSlice({
+    nowSeconds: windows.w24h.to,
+    snapshotsAllDailyResult,
+    snapshotTailNowMs,
+  });
+  const brokerSlice = deriveBrokerSlice(brokerSnapshotsAllDailyResult);
+  const lpSlice = deriveLpSlice(lpResult);
+  const olsPoolIds = deriveOlsPoolIds(olsResult);
+
+  return {
+    network,
+    snapshotWindows: windows,
+    pools,
+    ...snapshotSlice,
+    ...brokerSlice,
+    olsPoolIds,
+    cdpPoolIds,
+    reservePoolIds,
+    strategyError,
+    ...feeSlice,
+    poolLabels: new Map(),
+    ...lpSlice,
+    rates,
+    error: null,
+  };
+}

--- a/ui-dashboard/src/lib/network-fetcher/errors.ts
+++ b/ui-dashboard/src/lib/network-fetcher/errors.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalizes a `Promise.allSettled` rejection reason (which may be any
+ * thrown value) to an `Error` instance. Shared by the per-source derive
+ * helpers so a non-`Error` throw (e.g. a rejected string) still lands in a
+ * `NetworkData` error channel as a real `Error`.
+ */
+export function toError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason));
+}

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -9,54 +9,23 @@
 import { GraphQLClient } from "graphql-request";
 import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 import type { Network } from "@/lib/networks";
-import {
-  ALL_POOLS_BREACH_ROLLUP,
-  ALL_POOLS_HEALTH_CURSOR,
-  ALL_POOLS_REBALANCE_THRESHOLDS_KNOWN,
-  ALL_POOLS_VP_DEPRECATION,
-  ALL_POOLS_VP_LIFECYCLE_DEPRECATION,
-  ALL_POOLS_VP_ORACLE_FRESHNESS,
-  ALL_POOLS_WITH_HEALTH,
-  ALL_OLS_POOLS,
-  ALL_CDP_POOLS,
-} from "@/lib/queries";
-import { aggregateProtocolFees } from "@/lib/protocol-fees";
-import { activeReservePoolIdsFromKnownStrategies } from "@/lib/strategy-contracts";
-import { usesRuntimeStrategyProbe } from "@/lib/strategy-probe-scope";
+import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
 import {
   buildSnapshotWindows,
-  filterSnapshotsToWindow,
-  shouldQueryPoolSnapshots,
   type SnapshotWindows,
   type TimeRange,
 } from "@/lib/volume";
-import type { Pool, CdpPool } from "@/lib/types";
-import { isFpmm, buildOracleRateMap } from "@/lib/tokens";
-import type {
-  NetworkData,
-  OlsPoolsResult,
-  PoolBreachRollupResult,
-  PoolHealthCursorResult,
-  PoolRebalanceThresholdsKnownResult,
-  PoolsVpOracleFreshnessResult,
-  SerializableError,
-  SnapshotPageResult,
-  VpLifecycleDeprecationResult,
-} from "./types";
+import type { Pool } from "@/lib/types";
+import { isFpmm } from "@/lib/tokens";
+import type { NetworkData, SerializableError } from "./types";
+import { mergePoolSources } from "./merge-pools";
+import { fetchNetworkSources, type TimedRequest } from "./sources";
 import {
-  mergeDeprecatedVirtualPools,
-  type VpExchangeDeprecationResult,
-} from "./vp-deprecation";
-import {
-  REQUEST_TIMEOUT_MS,
-  fetchAllBrokerDailySnapshotPages,
-  fetchAllDailySnapshotPages,
-  fetchAllFeeSnapshotPages,
-  fetchAllLpAddressPages,
-  mutableDayCutoff,
-} from "./pagination";
-
-import { SECONDS_PER_DAY } from "./constants";
+  resolveStrategyIds,
+  resolveStrategyError,
+} from "./strategy-resolution";
+import { assembleNetworkData } from "./assemble";
+import { REQUEST_TIMEOUT_MS } from "./pagination";
 
 export { SNAPSHOT_PAGE_SIZE } from "./constants";
 export {
@@ -151,7 +120,6 @@ const emptyNetworkData = (
 ): NetworkData => blankNetworkData(network, snapshotWindows, { error });
 
 /** @internal Exported for testing only. */
-// eslint-disable-next-line complexity, max-lines-per-function, sonarjs/cognitive-complexity -- Existing network orchestrator owns many fail-open slices; keep the exception visible in source instead of carrying a churn-prone baseline tuple.
 export async function fetchNetworkData(
   network: Network,
   windows: { w24h: TimeRange; w7d: TimeRange; w30d: TimeRange },
@@ -163,7 +131,10 @@ export async function fetchNetworkData(
   // object-form at every call site. Re-binds on every invocation so each
   // request gets its own timer (a shared signal would abort the rest of
   // the parallel batch when any single request exceeded the budget).
-  const timed = <T>(document: string, variables?: Record<string, unknown>) =>
+  const timed: TimedRequest = <T>(
+    document: string,
+    variables?: Record<string, unknown>,
+  ) =>
     client.request<T>({
       document,
       ...(variables !== undefined ? { variables } : {}),
@@ -189,520 +160,49 @@ export async function fetchNetworkData(
   const fpmmPoolIds = pools.flatMap((p) => (isFpmm(p) ? [p.id] : []));
   const snapshotTailNowMs = windows.w24h.to * 1000;
 
-  const emptySnapshotPage: SnapshotPageResult = {
-    rows: [],
-    truncated: false,
-    error: null,
-  };
-  const [
-    feeSnapshotsResult,
-    snapshotsAllDailyResult,
-    brokerSnapshotsAllDailyResult,
-    lpResult,
-    olsResult,
-    breachRollupResult,
-    healthCursorResult,
-    rebalanceThresholdsKnownResult,
-    vpOracleFreshnessResult,
-    vpDeprecationResult,
-    vpLifecycleDeprecationResult,
-    indexedCdpPoolsResult,
-    fallbackStrategiesResult,
-  ] = await Promise.allSettled([
-    fetchAllFeeSnapshotPages(client, network.chainId, network.id),
-    shouldQueryPoolSnapshots(poolIds)
-      ? fetchAllDailySnapshotPages(
-          client,
-          poolIds,
-          network.id,
-          snapshotTailNowMs,
-        )
-      : Promise.resolve(emptySnapshotPage),
-    // Legacy v2 daily volume rollup (Broker.Swap with `routedViaV3Router=false`).
-    // Filtered server-side by chainId — only Celo has a Broker today, but
-    // querying on every chain is harmless (Monad simply returns 0 rows).
-    fetchAllBrokerDailySnapshotPages(client, network.chainId, network.id),
-    fpmmPoolIds.length > 0
-      ? fetchAllLpAddressPages(client, fpmmPoolIds, network.id)
-      : Promise.resolve({
-          rows: [] as { address: string }[],
-          truncated: false,
-          error: null,
-        }),
-    timed<OlsPoolsResult>(ALL_OLS_POOLS, chainVariables),
-    // Uptime rollup — isolated from ALL_POOLS_WITH_HEALTH so a schema-
-    // lag fail degrades just the uptime column to "—", not the entire
-    // pools page.
-    timed<PoolBreachRollupResult>(ALL_POOLS_BREACH_ROLLUP, chainVariables),
-    // Live-tail cursor is isolated so schema-lag does not hide persisted uptime counters.
-    timed<PoolHealthCursorResult>(ALL_POOLS_HEALTH_CURSOR, chainVariables),
-    // Data-trust / degenerate-classification flags. Isolated so schema-lag
-    // degrades thresholds, USD math, and degenerate health without failing
-    // the main pool list; split sides are needed for `isNeverRebalance`.
-    timed<PoolRebalanceThresholdsKnownResult>(
-      ALL_POOLS_REBALANCE_THRESHOLDS_KNOWN,
-      chainVariables,
-    ),
-    // Isolate VP freshness so schema lag drops only VP staleness state.
-    timed<PoolsVpOracleFreshnessResult>(
-      ALL_POOLS_VP_ORACLE_FRESHNESS,
-      chainVariables,
-    ),
-    timed<VpExchangeDeprecationResult>(
-      ALL_POOLS_VP_DEPRECATION,
-      chainVariables,
-    ),
-    timed<VpLifecycleDeprecationResult>(
-      ALL_POOLS_VP_LIFECYCLE_DEPRECATION,
-      chainVariables,
-    ),
-    // CDP badges are Celo-only and come from indexed CdpPool rows. The
-    // runtime probe is a non-Celo Reserve fallback and must not produce CDP
-    // badges.
-    requestIndexedCdpPools(network, timed),
-    requestFallbackStrategies(network, pools),
-  ]);
-
-  // Merge the rollup fields into the pool objects. On failure (including
-  // the phased-rollout "field not found" window) we leave the fields
-  // undefined and the uptime column falls back to "—".
-  if (breachRollupResult.status === "fulfilled") {
-    const rollupById = new Map(
-      (breachRollupResult.value.Pool ?? []).map((r) => [r.id, r]),
-    );
-    pools = pools.map((p) => {
-      const r = rollupById.get(p.id);
-      return r == null
-        ? p
-        : {
-            ...p,
-            breachCount: r.breachCount,
-            healthBinarySeconds: r.healthBinarySeconds,
-            // BOTH fields come from the rollup so the numerator/denominator
-            // pair is a same-query snapshot — no falling back to
-            // ALL_POOLS_WITH_HEALTH's `healthTotalSeconds`, which would
-            // pair counters captured at different polling cycles.
-            healthTotalSeconds: r.healthTotalSeconds,
-          };
-    });
-  }
-
-  // Merge live-tail cursor fields; on schema-lag, persisted health counters remain usable.
-  if (healthCursorResult.status === "fulfilled") {
-    const cursorById = new Map(
-      (healthCursorResult.value.Pool ?? []).map((r) => [r.id, r]),
-    );
-    pools = pools.map((p) => {
-      const r = cursorById.get(p.id);
-      return r == null
-        ? p
-        : {
-            ...p,
-            lastOracleSnapshotTimestamp: r.lastOracleSnapshotTimestamp,
-            lastDeviationRatio: r.lastDeviationRatio,
-          };
-    });
-  }
-
-  // Merge isolated flags. On schema-lag, fields stay undefined and consumers
-  // use conservative fallbacks instead of failing the whole pool list.
-  if (rebalanceThresholdsKnownResult.status === "fulfilled") {
-    const knownById = new Map(
-      (rebalanceThresholdsKnownResult.value.Pool ?? []).map((r) => [r.id, r]),
-    );
-    pools = pools.map((p) => {
-      const r = knownById.get(p.id);
-      return r == null
-        ? p
-        : {
-            ...p,
-            rebalanceThresholdAbove: r.rebalanceThresholdAbove,
-            rebalanceThresholdBelow: r.rebalanceThresholdBelow,
-            rebalanceThresholdsKnown: r.rebalanceThresholdsKnown,
-            tokenDecimalsKnown: r.tokenDecimalsKnown,
-            degenerateReserves: r.degenerateReserves,
-            breakerTripped: r.breakerTripped,
-          };
-    });
-  }
-
-  if (vpOracleFreshnessResult.status === "fulfilled") {
-    const freshnessById = new Map(
-      (vpOracleFreshnessResult.value.Pool ?? []).map((r) => [r.id, r]),
-    );
-    pools = pools.map((p) => {
-      const r = freshnessById.get(p.id);
-      return r == null
-        ? p
-        : {
-            ...p,
-            lastOracleReportAt: r.lastOracleReportAt,
-            medianLive: r.medianLive,
-            oracleFreshnessWindow: r.oracleFreshnessWindow,
-          };
-    });
-  }
-
-  pools = mergeDeprecatedVirtualPools(
+  const sources = await fetchNetworkSources({
+    client,
+    network,
+    timed,
+    chainVariables,
     pools,
-    vpDeprecationResult.status === "fulfilled"
-      ? (vpDeprecationResult.value.BiPoolExchange ?? [])
-      : [],
-    vpLifecycleDeprecationResult.status === "fulfilled"
-      ? (vpLifecycleDeprecationResult.value.VirtualPoolLifecycle ?? [])
-      : [],
-  );
+    poolIds,
+    fpmmPoolIds,
+    snapshotTailNowMs,
+  });
 
-  const rates = buildOracleRateMap(pools, network);
-
-  const feeSnapshots =
-    feeSnapshotsResult.status === "fulfilled"
-      ? feeSnapshotsResult.value.rows
-      : [];
-  const feeSnapshotsError =
-    feeSnapshotsResult.status === "rejected"
-      ? toError(feeSnapshotsResult.reason)
-      : (feeSnapshotsResult.value.error ?? null);
-  // Cap-exhaustion: helper returns `truncated: true, error: null`. We still
-  // aggregate from the rows we did fetch; consumers gate on this flag to
-  // mark the all-time total approximate.
-  const feeSnapshotsTruncated =
-    feeSnapshotsResult.status === "fulfilled" &&
-    feeSnapshotsResult.value.truncated;
-  // Rates failure on the homepage SSR path: rates are derived from `pools`
-  // (no separate query), so a query-level rates failure already early-
-  // returned via the `pools` catch above. The remaining failure mode is
-  // `buildOracleRateMap` returning an empty map even when `pools` has
-  // rows — i.e., every oracle pool has `oracleOk: false` or no oracle
-  // pools exist on this chain. That silently mis-prices FX-token slots
-  // in `aggregateProtocolFees` since `tokenToUSD` returns null for
-  // unknown symbols and only USD-pegged tokens contribute. Match the
-  // hook's fail-loud invariant: if we expected rates and got none, set
-  // `ratesError` so consumers blank the tile rather than render a
-  // confidently-wrong (understated) total.
-  const ssrRatesError =
-    pools.length > 0 && rates.size === 0
-      ? new Error(
-          `Oracle rates unavailable for ${network.label} — FX-token fees can't be priced`,
-        )
-      : null;
-  const fees =
-    feeSnapshotsResult.status === "fulfilled" &&
-    feeSnapshotsResult.value.error === null &&
-    ssrRatesError === null
-      ? aggregateProtocolFees(feeSnapshots, rates)
-      : null;
-
-  // Single source of truth: the paginated daily-rollup fetch. Window-specific
-  // arrays are derived in-memory — no separate requests, no server-side cap.
-  // If pagination truncated (hit MAX_PAGES or mid-loop fetch failure) we keep
-  // the most-recent rows we did fetch: 24h/7d/30d derive correctly from those
-  // and "All" is flagged as partial.
-  const snapshotsAllDaily =
-    snapshotsAllDailyResult.status === "fulfilled"
-      ? snapshotsAllDailyResult.value.rows
-      : [];
-  const snapshotsAllDailyTruncated =
-    snapshotsAllDailyResult.status === "fulfilled"
-      ? snapshotsAllDailyResult.value.truncated
-      : false;
-  const snapshotsAllDailyError =
-    snapshotsAllDailyResult.status === "rejected"
-      ? toError(snapshotsAllDailyResult.reason)
-      : (snapshotsAllDailyResult.value.error ?? null);
-
-  // Legacy v2 daily volume — already filtered to `routedViaV3Router=false`
-  // server-side, so no client-side disambiguation is needed.
-  const brokerSnapshotsAllDaily =
-    brokerSnapshotsAllDailyResult.status === "fulfilled"
-      ? brokerSnapshotsAllDailyResult.value.rows
-      : [];
-  const brokerSnapshotsAllDailyTruncated =
-    brokerSnapshotsAllDailyResult.status === "fulfilled"
-      ? brokerSnapshotsAllDailyResult.value.truncated
-      : false;
-  const brokerSnapshotsAllDailyError =
-    brokerSnapshotsAllDailyResult.status === "rejected"
-      ? toError(brokerSnapshotsAllDailyResult.reason)
-      : (brokerSnapshotsAllDailyResult.value.error ?? null);
-
-  // PoolDailySnapshot rows are UTC-midnight-aligned incremental aggregates
-  // (one row per pool per UTC day). Anchoring on today's UTC midnight gives
-  // exactly 1/7/30 daily rows per KPI window without overcounting.
-  //
-  // `windows.w24h.to` is the caller's snapshot of "now", so deriving
-  // todayMidnight from it keeps all three windows consistent with the same
-  // clock tick rather than calling Date.now() again.
-  const todayMidnight =
-    Math.floor(windows.w24h.to / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  const dw24h: TimeRange = {
-    from: todayMidnight,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-  const dw7d: TimeRange = {
-    from: todayMidnight - 6 * SECONDS_PER_DAY,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-  const dw30d: TimeRange = {
-    from: todayMidnight - 29 * SECONDS_PER_DAY,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-
-  const snapshots7d = filterSnapshotsToWindow(snapshotsAllDaily, dw7d);
-  const snapshots30d = filterSnapshotsToWindow(snapshotsAllDaily, dw30d);
-
-  // Per-window error detection. Pagination issues (error or truncation) only
-  // affect a specific window if we didn't fetch far enough back to cover its
-  // `from` bound. With a mid-loop failure after page 1 (~1000 most-recent
-  // daily rows ≈ 2.7 years per pool) the 24h/7d/30d windows remain fully
-  // covered. Rows come in newest-first, so the last element is the oldest
-  // we fetched.
-  const oldestFetchedTs =
-    snapshotsAllDaily.length > 0
-      ? Number(snapshotsAllDaily[snapshotsAllDaily.length - 1]!.timestamp)
-      : Number.POSITIVE_INFINITY;
-  const paginationIssue: Error | null =
-    snapshotsAllDailyError ??
-    (snapshotsAllDailyTruncated
-      ? new Error(
-          "Snapshot pagination truncated before reaching the requested window",
-        )
-      : null);
-  const mutableTailIssue: Error | null =
-    snapshotsAllDailyResult.status === "fulfilled"
-      ? (snapshotsAllDailyResult.value.mutableTailError ?? null)
-      : null;
-  const mutableTailFrom = mutableDayCutoff(snapshotTailNowMs);
-  const windowError = (windowFrom: number, windowTo: number): Error | null =>
-    mutableTailIssue !== null && windowTo > mutableTailFrom
-      ? mutableTailIssue
-      : paginationIssue !== null && oldestFetchedTs > windowFrom
-        ? paginationIssue
-        : null;
-  const snapshotsError = windowError(dw24h.from, dw24h.to);
-  const snapshots7dError = windowError(dw7d.from, dw7d.to);
-  const snapshots30dError = windowError(dw30d.from, dw30d.to);
-
-  // fetchAllLpAddressPages deduplicates by address.toLowerCase() internally,
-  // so the rows are already unique — no second Set pass needed.
-  const uniqueLpAddresses =
-    lpResult.status === "fulfilled"
-      ? lpResult.value.rows.map((r) => r.address)
-      : null;
-  const uniqueLpAddressesTruncated =
-    lpResult.status === "fulfilled" && lpResult.value.truncated;
-
-  const olsPoolIds =
-    olsResult.status === "fulfilled"
-      ? new Set((olsResult.value.OlsPool ?? []).map((p) => p.poolId))
-      : new Set<string>();
+  // Merge the isolated per-source fields into the pool objects. On failure
+  // (including the phased-rollout "field not found" window) each merge
+  // leaves its fields undefined and the corresponding UI falls back to "—".
+  pools = mergePoolSources(pools, sources);
 
   const { cdpPoolIds, reservePoolIds } = resolveStrategyIds({
     network,
     pools,
-    indexedCdpPoolsResult,
-    fallbackStrategiesResult,
+    indexedCdpPoolsResult: sources.indexedCdpPools,
+    fallbackStrategiesResult: sources.fallbackStrategies,
   });
   const strategyError = resolveStrategyError({
     network,
-    olsResult,
-    indexedCdpPoolsResult,
-    fallbackStrategiesResult,
+    olsResult: sources.ols,
+    indexedCdpPoolsResult: sources.indexedCdpPools,
+    fallbackStrategiesResult: sources.fallbackStrategies,
   });
 
-  return {
+  return assembleNetworkData({
     network,
-    snapshotWindows: windows,
+    windows,
     pools,
-    snapshots: filterSnapshotsToWindow(snapshotsAllDaily, dw24h),
-    snapshots7d,
-    snapshots30d,
-    snapshotsAllDaily,
-    snapshotsAllDailyTruncated,
-    brokerSnapshotsAllDaily,
-    brokerSnapshotsAllDailyTruncated,
-    olsPoolIds,
+    snapshotTailNowMs,
+    feeSnapshotsResult: sources.feeSnapshots,
+    snapshotsAllDailyResult: sources.snapshotsAllDaily,
+    brokerSnapshotsAllDailyResult: sources.brokerSnapshotsAllDaily,
+    lpResult: sources.lp,
+    olsResult: sources.ols,
     cdpPoolIds,
     reservePoolIds,
     strategyError,
-    fees,
-    feeSnapshots,
-    feeSnapshotsError,
-    feeSnapshotsTruncated,
-    ratesError: ssrRatesError,
-    poolLabels: new Map(),
-    uniqueLpAddresses,
-    rates,
-    error: null,
-    // Per-window errors — only set when the specific window is incomplete.
-    // See the `windowError` helper above.
-    snapshotsError,
-    snapshots7dError,
-    snapshots30dError,
-    snapshotsAllDailyError,
-    brokerSnapshotsAllDailyError,
-    uniqueLpAddressesTruncated,
-    lpError:
-      lpResult.status === "rejected"
-        ? toError(lpResult.reason)
-        : (lpResult.value.error ?? null),
-  };
-}
-
-const INDEXED_CDP_POOL_CHAIN_IDS = new Set([42220]);
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-type TimedRequest = <T>(
-  document: string,
-  variables?: Record<string, unknown>,
-) => Promise<T>;
-
-type CdpPoolsResponse = {
-  CdpPool: Pick<CdpPool, "poolId" | "strategyAddress">[];
-};
-
-type ProbedStrategies = {
-  cdpPoolIds: Set<string>;
-  reservePoolIds: Set<string>;
-};
-
-type StrategyIdsArgs = {
-  network: Network;
-  pools: Pool[];
-  indexedCdpPoolsResult: PromiseSettledResult<CdpPoolsResponse>;
-  fallbackStrategiesResult: PromiseSettledResult<Readonly<ProbedStrategies>>;
-};
-
-type StrategyErrorArgs = {
-  network: Network;
-  olsResult: PromiseSettledResult<OlsPoolsResult>;
-  indexedCdpPoolsResult: PromiseSettledResult<CdpPoolsResponse>;
-  fallbackStrategiesResult: PromiseSettledResult<Readonly<ProbedStrategies>>;
-};
-
-function usesIndexedCdpPools(network: Pick<Network, "chainId">): boolean {
-  return INDEXED_CDP_POOL_CHAIN_IDS.has(network.chainId);
-}
-
-function hasRebalancerAddress(pool: Pool): boolean {
-  const rebalancer = pool.rebalancerAddress;
-  return (
-    rebalancer !== undefined &&
-    /^0x[a-fA-F0-9]{40}$/.test(rebalancer) &&
-    rebalancer.toLowerCase() !== ZERO_ADDRESS
-  );
-}
-
-function activeCdpPoolIdsFromIndexedRows(
-  pools: Pool[],
-  cdpPools: Pick<CdpPool, "poolId" | "strategyAddress">[],
-): Set<string> {
-  const activeRebalancerByPoolId = new Map<string, string>();
-  for (const pool of pools) {
-    if (!hasRebalancerAddress(pool)) continue;
-    const rebalancer = pool.rebalancerAddress;
-    if (rebalancer === undefined) continue;
-    activeRebalancerByPoolId.set(pool.id, rebalancer.toLowerCase());
-  }
-
-  const cdpPoolIds = new Set<string>();
-  for (const cdpPool of cdpPools) {
-    const activeRebalancer = activeRebalancerByPoolId.get(cdpPool.poolId);
-    if (activeRebalancer === undefined) continue;
-    if (cdpPool.strategyAddress?.toLowerCase() !== activeRebalancer) continue;
-    cdpPoolIds.add(cdpPool.poolId);
-  }
-  return cdpPoolIds;
-}
-
-function emptyStrategyIds(): ProbedStrategies {
-  return {
-    cdpPoolIds: new Set<string>(),
-    reservePoolIds: new Set<string>(),
-  };
-}
-
-function requestIndexedCdpPools(
-  network: Network,
-  timed: TimedRequest,
-): Promise<CdpPoolsResponse> {
-  if (!usesIndexedCdpPools(network)) return Promise.resolve({ CdpPool: [] });
-  return timed<CdpPoolsResponse>(ALL_CDP_POOLS, { chainId: network.chainId });
-}
-
-async function requestFallbackStrategies(
-  network: Network,
-  pools: Pool[],
-): Promise<Readonly<ProbedStrategies>> {
-  if (!usesRuntimeStrategyProbe(network)) return emptyStrategyIds();
-  const { detectProbedStrategies } = await import("@/lib/strategy-detection");
-  return detectProbedStrategies(network, pools);
-}
-
-function resolveStrategyIds({
-  network,
-  pools,
-  indexedCdpPoolsResult,
-  fallbackStrategiesResult,
-}: StrategyIdsArgs): ProbedStrategies {
-  const fallbackStrategies =
-    fallbackStrategiesResult.status === "fulfilled"
-      ? fallbackStrategiesResult.value
-      : emptyStrategyIds();
-  const knownReservePoolIds = activeReservePoolIdsFromKnownStrategies(
-    network,
-    pools,
-  );
-
-  if (!usesIndexedCdpPools(network)) {
-    return {
-      cdpPoolIds: new Set<string>(),
-      reservePoolIds: new Set([
-        ...knownReservePoolIds,
-        ...fallbackStrategies.reservePoolIds,
-      ]),
-    };
-  }
-
-  const cdpPoolIds =
-    indexedCdpPoolsResult.status === "fulfilled"
-      ? activeCdpPoolIdsFromIndexedRows(
-          pools,
-          indexedCdpPoolsResult.value.CdpPool ?? [],
-        )
-      : new Set<string>();
-
-  return {
-    cdpPoolIds,
-    // Indexed Celo has positive CDP rows and canonical contracts-derived
-    // Reserve strategy addresses. Unknown active rebalancers stay unbadged
-    // instead of being inferred as Reserve from the absence of an OLS/CDP row.
-    reservePoolIds: knownReservePoolIds,
-  };
-}
-
-function resolveStrategyError({
-  network,
-  olsResult,
-  indexedCdpPoolsResult,
-  fallbackStrategiesResult,
-}: StrategyErrorArgs): Error | null {
-  if (olsResult.status === "rejected") return toError(olsResult.reason);
-  if (
-    usesIndexedCdpPools(network) &&
-    indexedCdpPoolsResult.status === "rejected"
-  )
-    return toError(indexedCdpPoolsResult.reason);
-  if (
-    usesRuntimeStrategyProbe(network) &&
-    fallbackStrategiesResult.status === "rejected"
-  )
-    return toError(fallbackStrategiesResult.reason);
-  return null;
-}
-
-function toError(reason: unknown): Error {
-  return reason instanceof Error ? reason : new Error(String(reason));
+  });
 }
 
 /**

--- a/ui-dashboard/src/lib/network-fetcher/merge-pools.ts
+++ b/ui-dashboard/src/lib/network-fetcher/merge-pools.ts
@@ -1,0 +1,137 @@
+// Pure pool-merge helpers for fetchNetworkData's isolated per-source queries.
+// Each function folds one Promise.allSettled result into `pools` by id; on
+// `rejected` the pools pass through unchanged so a single schema-lag failure
+// only drops that source's fields, not the whole pool list.
+
+import type { Pool } from "@/lib/types";
+import { mergeDeprecatedVirtualPools } from "./vp-deprecation";
+import type { NetworkSources } from "./sources";
+import type {
+  PoolBreachRollupResult,
+  PoolHealthCursorResult,
+  PoolRebalanceThresholdsKnownResult,
+  PoolsVpOracleFreshnessResult,
+} from "./types";
+
+/** Merges uptime rollup fields (breachCount / health seconds) into `pools`. */
+function mergeBreachRollup(
+  pools: Pool[],
+  result: PromiseSettledResult<PoolBreachRollupResult>,
+): Pool[] {
+  if (result.status !== "fulfilled") return pools;
+  const rollupById = new Map((result.value.Pool ?? []).map((r) => [r.id, r]));
+  return pools.map((p) => {
+    const r = rollupById.get(p.id);
+    return r == null
+      ? p
+      : {
+          ...p,
+          breachCount: r.breachCount,
+          healthBinarySeconds: r.healthBinarySeconds,
+          // BOTH fields come from the rollup so the numerator/denominator
+          // pair is a same-query snapshot — no falling back to
+          // ALL_POOLS_WITH_HEALTH's `healthTotalSeconds`, which would
+          // pair counters captured at different polling cycles.
+          healthTotalSeconds: r.healthTotalSeconds,
+        };
+  });
+}
+
+/** Merges live-tail cursor fields (oracle snapshot timestamp / deviation). */
+function mergeHealthCursor(
+  pools: Pool[],
+  result: PromiseSettledResult<PoolHealthCursorResult>,
+): Pool[] {
+  if (result.status !== "fulfilled") return pools;
+  const cursorById = new Map((result.value.Pool ?? []).map((r) => [r.id, r]));
+  return pools.map((p) => {
+    const r = cursorById.get(p.id);
+    return r == null
+      ? p
+      : {
+          ...p,
+          lastOracleSnapshotTimestamp: r.lastOracleSnapshotTimestamp,
+          lastDeviationRatio: r.lastDeviationRatio,
+        };
+  });
+}
+
+/** Merges rebalance-threshold / degenerate-classification flags. */
+function mergeRebalanceThresholdsKnown(
+  pools: Pool[],
+  result: PromiseSettledResult<PoolRebalanceThresholdsKnownResult>,
+): Pool[] {
+  if (result.status !== "fulfilled") return pools;
+  const knownById = new Map((result.value.Pool ?? []).map((r) => [r.id, r]));
+  return pools.map((p) => {
+    const r = knownById.get(p.id);
+    return r == null
+      ? p
+      : {
+          ...p,
+          rebalanceThresholdAbove: r.rebalanceThresholdAbove,
+          rebalanceThresholdBelow: r.rebalanceThresholdBelow,
+          rebalanceThresholdsKnown: r.rebalanceThresholdsKnown,
+          tokenDecimalsKnown: r.tokenDecimalsKnown,
+          degenerateReserves: r.degenerateReserves,
+          breakerTripped: r.breakerTripped,
+        };
+  });
+}
+
+/** Merges VP oracle-freshness fields (staleness state). */
+function mergeVpOracleFreshness(
+  pools: Pool[],
+  result: PromiseSettledResult<PoolsVpOracleFreshnessResult>,
+): Pool[] {
+  if (result.status !== "fulfilled") return pools;
+  const freshnessById = new Map(
+    (result.value.Pool ?? []).map((r) => [r.id, r]),
+  );
+  return pools.map((p) => {
+    const r = freshnessById.get(p.id);
+    return r == null
+      ? p
+      : {
+          ...p,
+          lastOracleReportAt: r.lastOracleReportAt,
+          medianLive: r.medianLive,
+          oracleFreshnessWindow: r.oracleFreshnessWindow,
+        };
+  });
+}
+
+/**
+ * Applies every isolated per-source merge, in order, plus the VP-deprecation
+ * merge (owned by `./vp-deprecation`). On any individual source's rejection
+ * that source's fields simply stay undefined on the affected pools.
+ */
+export function mergePoolSources(
+  pools: Pool[],
+  sources: Pick<
+    NetworkSources,
+    | "breachRollup"
+    | "healthCursor"
+    | "rebalanceThresholdsKnown"
+    | "vpOracleFreshness"
+    | "vpDeprecation"
+    | "vpLifecycleDeprecation"
+  >,
+): Pool[] {
+  let merged = mergeBreachRollup(pools, sources.breachRollup);
+  merged = mergeHealthCursor(merged, sources.healthCursor);
+  merged = mergeRebalanceThresholdsKnown(
+    merged,
+    sources.rebalanceThresholdsKnown,
+  );
+  merged = mergeVpOracleFreshness(merged, sources.vpOracleFreshness);
+  return mergeDeprecatedVirtualPools(
+    merged,
+    sources.vpDeprecation.status === "fulfilled"
+      ? (sources.vpDeprecation.value.BiPoolExchange ?? [])
+      : [],
+    sources.vpLifecycleDeprecation.status === "fulfilled"
+      ? (sources.vpLifecycleDeprecation.value.VirtualPoolLifecycle ?? [])
+      : [],
+  );
+}

--- a/ui-dashboard/src/lib/network-fetcher/sources.ts
+++ b/ui-dashboard/src/lib/network-fetcher/sources.ts
@@ -1,0 +1,232 @@
+// Fires the 13-way parallel fan-out behind `fetchNetworkData`: fee/daily/
+// broker snapshots, LP addresses, OLS pools, breach rollup, health cursor,
+// rebalance-threshold-known, VP oracle freshness, VP deprecation x2, indexed
+// CDP pools, and fallback strategy probes. Each branch is isolated behind
+// `Promise.allSettled` so one query's schema-lag or timeout degrades only
+// its own slice instead of failing the whole pool list.
+
+import type { GraphQLClient } from "graphql-request";
+import type { Network } from "@/lib/networks";
+import {
+  ALL_CDP_POOLS,
+  ALL_OLS_POOLS,
+  ALL_POOLS_BREACH_ROLLUP,
+  ALL_POOLS_HEALTH_CURSOR,
+  ALL_POOLS_REBALANCE_THRESHOLDS_KNOWN,
+  ALL_POOLS_VP_DEPRECATION,
+  ALL_POOLS_VP_LIFECYCLE_DEPRECATION,
+  ALL_POOLS_VP_ORACLE_FRESHNESS,
+} from "@/lib/queries";
+import { usesRuntimeStrategyProbe } from "@/lib/strategy-probe-scope";
+import type { Pool, PoolDailyFeeSnapshot } from "@/lib/types";
+import { shouldQueryPoolSnapshots } from "@/lib/volume";
+import {
+  fetchAllBrokerDailySnapshotPages,
+  fetchAllDailySnapshotPages,
+  fetchAllFeeSnapshotPages,
+  fetchAllLpAddressPages,
+} from "./pagination";
+import {
+  emptyStrategyIds,
+  usesIndexedCdpPools,
+  type CdpPoolsResponse,
+  type ProbedStrategies,
+} from "./strategy-resolution";
+import type {
+  BrokerDailySnapshotRow,
+  OlsPoolsResult,
+  PaginatedPageResult,
+  PoolBreachRollupResult,
+  PoolHealthCursorResult,
+  PoolRebalanceThresholdsKnownResult,
+  PoolsVpOracleFreshnessResult,
+  SnapshotPageResult,
+  VpLifecycleDeprecationResult,
+} from "./types";
+import type { VpExchangeDeprecationResult } from "./vp-deprecation";
+
+export type TimedRequest = <T>(
+  document: string,
+  variables?: Record<string, unknown>,
+) => Promise<T>;
+
+export type NetworkSources = {
+  feeSnapshots: PromiseSettledResult<PaginatedPageResult<PoolDailyFeeSnapshot>>;
+  snapshotsAllDaily: PromiseSettledResult<SnapshotPageResult>;
+  brokerSnapshotsAllDaily: PromiseSettledResult<
+    PaginatedPageResult<BrokerDailySnapshotRow>
+  >;
+  lp: PromiseSettledResult<PaginatedPageResult<{ address: string }>>;
+  ols: PromiseSettledResult<OlsPoolsResult>;
+  breachRollup: PromiseSettledResult<PoolBreachRollupResult>;
+  healthCursor: PromiseSettledResult<PoolHealthCursorResult>;
+  rebalanceThresholdsKnown: PromiseSettledResult<PoolRebalanceThresholdsKnownResult>;
+  vpOracleFreshness: PromiseSettledResult<PoolsVpOracleFreshnessResult>;
+  vpDeprecation: PromiseSettledResult<VpExchangeDeprecationResult>;
+  vpLifecycleDeprecation: PromiseSettledResult<VpLifecycleDeprecationResult>;
+  indexedCdpPools: PromiseSettledResult<CdpPoolsResponse>;
+  fallbackStrategies: PromiseSettledResult<Readonly<ProbedStrategies>>;
+};
+
+function requestIndexedCdpPools(
+  network: Network,
+  timed: TimedRequest,
+): Promise<CdpPoolsResponse> {
+  if (!usesIndexedCdpPools(network)) return Promise.resolve({ CdpPool: [] });
+  return timed<CdpPoolsResponse>(ALL_CDP_POOLS, { chainId: network.chainId });
+}
+
+async function requestFallbackStrategies(
+  network: Network,
+  pools: Pool[],
+): Promise<Readonly<ProbedStrategies>> {
+  if (!usesRuntimeStrategyProbe(network)) return emptyStrategyIds();
+  const { detectProbedStrategies } = await import("@/lib/strategy-detection");
+  return detectProbedStrategies(network, pools);
+}
+
+type SourcesArgs = {
+  client: GraphQLClient;
+  network: Network;
+  timed: TimedRequest;
+  chainVariables: Record<string, unknown>;
+  pools: Pool[];
+  poolIds: string[];
+  fpmmPoolIds: string[];
+  snapshotTailNowMs: number;
+};
+
+// Positional tuple matching `fetchNetworkSources`'s destructure order below —
+// kept as its own function so the 13-item fan-out (with its per-branch
+// isolation rationale) stays readable as one literal instead of folded into
+// a larger function body.
+function buildSourcePromises(
+  args: SourcesArgs,
+): [
+  Promise<PaginatedPageResult<PoolDailyFeeSnapshot>>,
+  Promise<SnapshotPageResult>,
+  Promise<PaginatedPageResult<BrokerDailySnapshotRow>>,
+  Promise<PaginatedPageResult<{ address: string }>>,
+  Promise<OlsPoolsResult>,
+  Promise<PoolBreachRollupResult>,
+  Promise<PoolHealthCursorResult>,
+  Promise<PoolRebalanceThresholdsKnownResult>,
+  Promise<PoolsVpOracleFreshnessResult>,
+  Promise<VpExchangeDeprecationResult>,
+  Promise<VpLifecycleDeprecationResult>,
+  Promise<CdpPoolsResponse>,
+  Promise<Readonly<ProbedStrategies>>,
+] {
+  const {
+    client,
+    network,
+    timed,
+    chainVariables,
+    pools,
+    poolIds,
+    fpmmPoolIds,
+    snapshotTailNowMs,
+  } = args;
+  const emptySnapshotPage: SnapshotPageResult = {
+    rows: [],
+    truncated: false,
+    error: null,
+  };
+
+  return [
+    fetchAllFeeSnapshotPages(client, network.chainId, network.id),
+    shouldQueryPoolSnapshots(poolIds)
+      ? fetchAllDailySnapshotPages(
+          client,
+          poolIds,
+          network.id,
+          snapshotTailNowMs,
+        )
+      : Promise.resolve(emptySnapshotPage),
+    // Legacy v2 daily volume rollup (Broker.Swap with `routedViaV3Router=false`).
+    // Filtered server-side by chainId — only Celo has a Broker today, but
+    // querying on every chain is harmless (Monad simply returns 0 rows).
+    fetchAllBrokerDailySnapshotPages(client, network.chainId, network.id),
+    fpmmPoolIds.length > 0
+      ? fetchAllLpAddressPages(client, fpmmPoolIds, network.id)
+      : Promise.resolve({
+          rows: [] as { address: string }[],
+          truncated: false,
+          error: null,
+        }),
+    timed<OlsPoolsResult>(ALL_OLS_POOLS, chainVariables),
+    // Uptime rollup — isolated from ALL_POOLS_WITH_HEALTH so a schema-
+    // lag fail degrades just the uptime column to "—", not the entire
+    // pools page.
+    timed<PoolBreachRollupResult>(ALL_POOLS_BREACH_ROLLUP, chainVariables),
+    // Live-tail cursor is isolated so schema-lag does not hide persisted uptime counters.
+    timed<PoolHealthCursorResult>(ALL_POOLS_HEALTH_CURSOR, chainVariables),
+    // Data-trust / degenerate-classification flags. Isolated so schema-lag
+    // degrades thresholds, USD math, and degenerate health without failing
+    // the main pool list; split sides are needed for `isNeverRebalance`.
+    timed<PoolRebalanceThresholdsKnownResult>(
+      ALL_POOLS_REBALANCE_THRESHOLDS_KNOWN,
+      chainVariables,
+    ),
+    // Isolate VP freshness so schema lag drops only VP staleness state.
+    timed<PoolsVpOracleFreshnessResult>(
+      ALL_POOLS_VP_ORACLE_FRESHNESS,
+      chainVariables,
+    ),
+    timed<VpExchangeDeprecationResult>(
+      ALL_POOLS_VP_DEPRECATION,
+      chainVariables,
+    ),
+    timed<VpLifecycleDeprecationResult>(
+      ALL_POOLS_VP_LIFECYCLE_DEPRECATION,
+      chainVariables,
+    ),
+    // CDP badges are Celo-only and come from indexed CdpPool rows. The
+    // runtime probe is a non-Celo Reserve fallback and must not produce CDP
+    // badges.
+    requestIndexedCdpPools(network, timed),
+    requestFallbackStrategies(network, pools),
+  ];
+}
+
+/**
+ * Fires the 13 isolated data-source queries and returns their settled
+ * results keyed by name. `pools` is the already-fetched `ALL_POOLS_WITH_HEALTH`
+ * result — needed by the fallback strategy probe — and `poolIds`/`fpmmPoolIds`
+ * are derived from it by the caller.
+ */
+export async function fetchNetworkSources(
+  args: SourcesArgs,
+): Promise<NetworkSources> {
+  const [
+    feeSnapshots,
+    snapshotsAllDaily,
+    brokerSnapshotsAllDaily,
+    lp,
+    ols,
+    breachRollup,
+    healthCursor,
+    rebalanceThresholdsKnown,
+    vpOracleFreshness,
+    vpDeprecation,
+    vpLifecycleDeprecation,
+    indexedCdpPools,
+    fallbackStrategies,
+  ] = await Promise.allSettled(buildSourcePromises(args));
+
+  return {
+    feeSnapshots,
+    snapshotsAllDaily,
+    brokerSnapshotsAllDaily,
+    lp,
+    ols,
+    breachRollup,
+    healthCursor,
+    rebalanceThresholdsKnown,
+    vpOracleFreshness,
+    vpDeprecation,
+    vpLifecycleDeprecation,
+    indexedCdpPools,
+    fallbackStrategies,
+  };
+}

--- a/ui-dashboard/src/lib/network-fetcher/strategy-resolution.ts
+++ b/ui-dashboard/src/lib/network-fetcher/strategy-resolution.ts
@@ -1,0 +1,143 @@
+// Resolves the CDP / Reserve pool-id sets and the strategy-classification
+// error channel for `fetchNetworkData`. Isolated so schema-lag on the
+// indexed CdpPool query, or a failed runtime strategy probe, degrades
+// badges without failing the main pool list.
+
+import type { Network } from "@/lib/networks";
+import { activeReservePoolIdsFromKnownStrategies } from "@/lib/strategy-contracts";
+import { usesRuntimeStrategyProbe } from "@/lib/strategy-probe-scope";
+import type { CdpPool, Pool } from "@/lib/types";
+import { toError } from "./errors";
+import type { OlsPoolsResult } from "./types";
+
+const INDEXED_CDP_POOL_CHAIN_IDS = new Set([42220]);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export type CdpPoolsResponse = {
+  CdpPool: Pick<CdpPool, "poolId" | "strategyAddress">[];
+};
+
+export type ProbedStrategies = {
+  cdpPoolIds: Set<string>;
+  reservePoolIds: Set<string>;
+};
+
+type StrategyIdsArgs = {
+  network: Network;
+  pools: Pool[];
+  indexedCdpPoolsResult: PromiseSettledResult<CdpPoolsResponse>;
+  fallbackStrategiesResult: PromiseSettledResult<Readonly<ProbedStrategies>>;
+};
+
+type StrategyErrorArgs = {
+  network: Network;
+  olsResult: PromiseSettledResult<OlsPoolsResult>;
+  indexedCdpPoolsResult: PromiseSettledResult<CdpPoolsResponse>;
+  fallbackStrategiesResult: PromiseSettledResult<Readonly<ProbedStrategies>>;
+};
+
+export function usesIndexedCdpPools(
+  network: Pick<Network, "chainId">,
+): boolean {
+  return INDEXED_CDP_POOL_CHAIN_IDS.has(network.chainId);
+}
+
+export function emptyStrategyIds(): ProbedStrategies {
+  return {
+    cdpPoolIds: new Set<string>(),
+    reservePoolIds: new Set<string>(),
+  };
+}
+
+function hasRebalancerAddress(pool: Pool): boolean {
+  const rebalancer = pool.rebalancerAddress;
+  return (
+    rebalancer !== undefined &&
+    /^0x[a-fA-F0-9]{40}$/.test(rebalancer) &&
+    rebalancer.toLowerCase() !== ZERO_ADDRESS
+  );
+}
+
+function activeCdpPoolIdsFromIndexedRows(
+  pools: Pool[],
+  cdpPools: Pick<CdpPool, "poolId" | "strategyAddress">[],
+): Set<string> {
+  const activeRebalancerByPoolId = new Map<string, string>();
+  for (const pool of pools) {
+    if (!hasRebalancerAddress(pool)) continue;
+    const rebalancer = pool.rebalancerAddress;
+    if (rebalancer === undefined) continue;
+    activeRebalancerByPoolId.set(pool.id, rebalancer.toLowerCase());
+  }
+
+  const cdpPoolIds = new Set<string>();
+  for (const cdpPool of cdpPools) {
+    const activeRebalancer = activeRebalancerByPoolId.get(cdpPool.poolId);
+    if (activeRebalancer === undefined) continue;
+    if (cdpPool.strategyAddress?.toLowerCase() !== activeRebalancer) continue;
+    cdpPoolIds.add(cdpPool.poolId);
+  }
+  return cdpPoolIds;
+}
+
+export function resolveStrategyIds({
+  network,
+  pools,
+  indexedCdpPoolsResult,
+  fallbackStrategiesResult,
+}: StrategyIdsArgs): ProbedStrategies {
+  const fallbackStrategies =
+    fallbackStrategiesResult.status === "fulfilled"
+      ? fallbackStrategiesResult.value
+      : emptyStrategyIds();
+  const knownReservePoolIds = activeReservePoolIdsFromKnownStrategies(
+    network,
+    pools,
+  );
+
+  if (!usesIndexedCdpPools(network)) {
+    return {
+      cdpPoolIds: new Set<string>(),
+      reservePoolIds: new Set([
+        ...knownReservePoolIds,
+        ...fallbackStrategies.reservePoolIds,
+      ]),
+    };
+  }
+
+  const cdpPoolIds =
+    indexedCdpPoolsResult.status === "fulfilled"
+      ? activeCdpPoolIdsFromIndexedRows(
+          pools,
+          indexedCdpPoolsResult.value.CdpPool ?? [],
+        )
+      : new Set<string>();
+
+  return {
+    cdpPoolIds,
+    // Indexed Celo has positive CDP rows and canonical contracts-derived
+    // Reserve strategy addresses. Unknown active rebalancers stay unbadged
+    // instead of being inferred as Reserve from the absence of an OLS/CDP row.
+    reservePoolIds: knownReservePoolIds,
+  };
+}
+
+export function resolveStrategyError({
+  network,
+  olsResult,
+  indexedCdpPoolsResult,
+  fallbackStrategiesResult,
+}: StrategyErrorArgs): Error | null {
+  if (olsResult.status === "rejected") return toError(olsResult.reason);
+  if (
+    usesIndexedCdpPools(network) &&
+    indexedCdpPoolsResult.status === "rejected"
+  )
+    return toError(indexedCdpPoolsResult.reason);
+  if (
+    usesRuntimeStrategyProbe(network) &&
+    fallbackStrategiesResult.status === "rejected"
+  )
+    return toError(fallbackStrategiesResult.reason);
+  return null;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `fetchNetworkData` in `ui-dashboard/src/lib/network-fetcher/fetch.ts` was one ~200-line function doing four jobs: firing 13 isolated `Promise.allSettled` source queries, merging their results into `pools`, resolving CDP/reserve strategy ids, and assembling the 20+-field `NetworkData` return — including the subtle pagination-truncation vs mutable-tail error precedence per window.
- Only one narrow test file existed for the directory (`vp-deprecation.test.ts`); the orchestrator and its error-precedence logic had no direct coverage, so a regression there would show up as a wrong degraded-state banner, not a crash.
- The file was on the size watchlist (#1036) and every function inside it exceeded a readable single-purpose size.

## The Solution

- Added a characterization test suite (`__tests__/fetch.characterization.test.ts`) that pins `fetchNetworkData`'s current output — before any production change — for all-sources-succeed, each of the 13 sources failing alone, the top-level pools-query failure, the window error-precedence matrix (both truncated-but-not-errored and errored-tail), and an empty network.
- Split the orchestrator into per-source modules plus a pure `assembleNetworkData` that owns the error/truncation precedence, with direct unit tests on that precedence matrix (`__tests__/assemble.test.ts`) that need no GraphQL mocking at all.
- `fetch.ts` is now a thin ~70-line orchestrator that wires the pieces together; the public API is unchanged.

## Details

- New files under `ui-dashboard/src/lib/network-fetcher/`:
  - `sources.ts` — `fetchNetworkSources`, the 13-way `Promise.allSettled` fan-out (fee/daily/broker snapshots, LP addresses, OLS pools, breach rollup, health cursor, rebalance-threshold-known, VP oracle freshness, VP deprecation ×2, indexed CDP pools, fallback strategies).
  - `merge-pools.ts` — the four per-source pool-merge helpers plus `mergePoolSources`, which also invokes the existing `mergeDeprecatedVirtualPools` from `vp-deprecation.ts`.
  - `strategy-resolution.ts` — `resolveStrategyIds` / `resolveStrategyError` (mechanically moved from `fetch.ts`, unchanged).
  - `assemble.ts` — pure `assembleNetworkData` plus the exported `resolveWindowErrors` precedence function and small per-slice derive helpers (fees/rates, snapshots, broker, LP, OLS).
  - `errors.ts` — shared `toError` helper used by the new modules.
- `fetch.ts` now only: fetches pools, calls `fetchNetworkSources`, merges pools via `mergePoolSources`, resolves strategy ids/error, and calls `assembleNetworkData`. `fetchAllNetworks`, `isNetworkDataFullyHealthy`, `blankNetworkData`, and all pagination re-exports are untouched.
- Two-phase, separate commits: the characterization test commit landed first with zero production changes; the decomposition commit followed and the characterization tests pass **unchanged**.
- No function in the directory exceeds ~80 lines (the 13-way fan-out's promise-array construction was split into its own `buildSourcePromises` helper to stay under that bar).
- Public API, SWR/polling behavior, GraphQL query strings, and Hasura pagination discipline are all unchanged — this is a pure refactor of fetch composition.
- One `react-doctor` dead-code hit surfaced mid-refactor: the four individual pool-merge functions became unused exports once `mergePoolSources` was the only external caller, so they're now file-private (`react-doctor --full --score --offline` is back to 100/100).

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test` — 221 test files, 3422 tests passed (includes both new test files: 20 characterization tests + 8 precedence-matrix unit tests).
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean.
- `pnpm --filter @mento-protocol/ui-dashboard test:browser` — passed via the quality gate routing.
- `pnpm agent:quality-gate --run --keep-going` — all mapped commands passed: trunk check, lint, typecheck, `test:coverage`, knip, `code-health:deps` (dependency-cruiser, 0 violations), Playwright browser suite, `react-doctor:diff`, `react-doctor:score` (100/100), `size-limit`.
- Coverage floors in `ui-dashboard/vitest.config.ts` unchanged and not lowered — full-suite coverage after this PR: statements 84.79%, branches 76.01%, functions 84.94%, lines 86.91% (all above the configured floors; the new modules are individually at ~97–100%).
- `docs/pr-checklists/swr-polling-hasura.md` and `docs/pr-checklists/stateful-data-ui.md` were flagged by the quality-gate mapper because `ui-dashboard` changed, but neither applies: no SWR hook, GraphQL query string, schema field, or table/UI state was touched — this is a pure internal composition refactor of an existing server-side fetcher.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.


Closes #1055

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large internal refactor of dashboard data assembly and per-window error precedence, but behavior is pinned by extensive characterization tests and the external fetch API is unchanged.
> 
> **Overview**
> **Refactors** the dashboard network fetch orchestrator so `fetch.ts` only loads pools, fans out parallel sources, merges pool enrichments, resolves strategy badges, and delegates final `NetworkData` shaping to new modules (`sources`, `merge-pools`, `strategy-resolution`, `assemble`, `errors`).
> 
> **Adds** characterization tests that lock in current `fetchNetworkData` behavior (all sources succeed, each source failing alone, pools-query failure, snapshot window error precedence, empty network) plus direct unit tests for `resolveWindowErrors` / `assembleNetworkData` without GraphQL mocks.
> 
> **Extracts** snapshot **24h/7d/30d** degradation rules into exported `resolveWindowErrors` (mutable-tail failures beat pagination truncation when both apply).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795fd1e27ee3492893cb55e466a0a11c20b42377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->