### PR TITLE
alerts: dead-letter Safe alerts on Slack retry exhaustion + redrive tool

### DIFF
--- a/alerts/infra/onchain-event-handler/README.md
+++ b/alerts/infra/onchain-event-handler/README.md
@@ -215,6 +215,23 @@ For local development, you'll need to set up environment variables. The function
 - **Routing**: Routes security events to alerts channels, operational events to events channels
 - **Error Handling**: Continues processing other events if one fails
 
+### Dead-lettering & redrive
+
+If Slack delivery for an event exhausts its retries, the rendered payload is
+persisted to the same GCS bucket used for QuickNode nonce replay protection,
+under a `dead-letter/` prefix (see `src/dead-letter.ts`), instead of being
+lost. The write logs `"Dead-lettered Safe alert after Slack delivery
+failure"` at ERROR — this is covered by the existing
+`onchain_handler_errors_policy` Cloud Monitoring alert (see
+`alerts/infra/monitoring.tf`), since it fires alongside the same event's
+`"Error processing log"` entry.
+
+To re-deliver dead-lettered alerts, run `pnpm deadletter:redrive` (requires
+`QUICKNODE_REPLAY_BUCKET` and `SLACK_BOT_TOKEN` in the environment, plus an
+authenticated `gcloud` CLI session for GCS access). It reposts each
+dead-lettered payload to its original Slack channel, then archives it to
+`dead-letter/done/` so re-runs don't repost it.
+
 ## Troubleshooting
 
 ### Build Issues

--- a/alerts/infra/onchain-event-handler/src/dead-letter.test.ts
+++ b/alerts/infra/onchain-event-handler/src/dead-letter.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QuickNodeDecodedLog } from "./types";
+
+const loggerMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    error: loggerMocks.error,
+  },
+}));
+
+const originalReplayBucket = process.env.QUICKNODE_REPLAY_BUCKET;
+
+const LOG_ENTRY: QuickNodeDecodedLog = {
+  address: "0x123",
+  name: "AddedOwner",
+  transactionHash: "0xtx1",
+  blockHash: "0xblock1",
+  blockNumber: "100",
+  logIndex: "0",
+};
+
+const SLACK_MESSAGE = { text: "hello", blocks: [] };
+
+const metadataTokenUrl =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+function metadataTokenResponse(): Response {
+  return new Response(
+    JSON.stringify({ access_token: "metadata-token", expires_in: 300 }),
+    { status: 200, statusText: "OK" },
+  );
+}
+
+function uploadResponse(status = 200, statusText = "OK"): Response {
+  return new Response("{}", { status, statusText });
+}
+
+async function loadWriteDeadLetter() {
+  vi.resetModules();
+  return (await import("./dead-letter")).writeDeadLetter;
+}
+
+describe("writeDeadLetter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.QUICKNODE_REPLAY_BUCKET = "replay-bucket";
+  });
+
+  afterEach(() => {
+    if (originalReplayBucket === undefined) {
+      delete process.env.QUICKNODE_REPLAY_BUCKET;
+    } else {
+      process.env.QUICKNODE_REPLAY_BUCKET = originalReplayBucket;
+    }
+    vi.resetModules();
+  });
+
+  it("logs ERROR and does not throw when the bucket is not configured", async () => {
+    delete process.env.QUICKNODE_REPLAY_BUCKET;
+    const fetchMock = vi.fn<typeof fetch>();
+    const writeDeadLetter = await loadWriteDeadLetter();
+
+    await expect(
+      writeDeadLetter(
+        {
+          logEntry: LOG_ENTRY,
+          slackMessage: SLACK_MESSAGE,
+          multisigKey: "SOLO_CELO",
+          channelId: "Calerts",
+          chain: "celo",
+          failureReason: "Slack postMessage failed after all retries",
+        },
+        { fetchImpl: fetchMock },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(loggerMocks.error).toHaveBeenCalledWith("Dead-letter write failed", {
+      reason: "dead_letter_bucket_not_configured",
+      transactionHash: "0xtx1",
+    });
+  });
+
+  it("uploads the rendered payload under the dead-letter/ prefix and logs the distinct marker", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(uploadResponse());
+    const writeDeadLetter = await loadWriteDeadLetter();
+
+    await writeDeadLetter(
+      {
+        logEntry: LOG_ENTRY,
+        slackMessage: SLACK_MESSAGE,
+        multisigKey: "SOLO_CELO",
+        channelId: "Calerts",
+        chain: "celo",
+        failureReason: "Slack postMessage failed after all retries",
+      },
+      { fetchImpl: fetchMock },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]).toEqual([
+      metadataTokenUrl,
+      { headers: { "metadata-flavor": "Google" } },
+    ]);
+
+    const [uploadUrl, uploadInit] = fetchMock.mock.calls[1];
+    expect(String(uploadUrl)).toMatch(
+      /^https:\/\/storage\.googleapis\.com\/upload\/storage\/v1\/b\/replay-bucket\/o\?uploadType=media&name=dead-letter%2F0xtx1-0-\d+\.json$/,
+    );
+    expect(uploadInit).toMatchObject({
+      method: "POST",
+      headers: {
+        authorization: "Bearer metadata-token",
+        "content-type": "application/json",
+      },
+    });
+
+    const body = JSON.parse(uploadInit?.body as string);
+    expect(body).toMatchObject({
+      failureReason: "Slack postMessage failed after all retries",
+      eventName: "AddedOwner",
+      transactionHash: "0xtx1",
+      chain: "celo",
+      multisigKey: "SOLO_CELO",
+      channelId: "Calerts",
+      logEntry: LOG_ENTRY,
+      slackMessage: SLACK_MESSAGE,
+    });
+    expect(typeof body.deadLetteredAt).toBe("string");
+
+    // Never persist the Slack bot token into the dead-letter object.
+    expect(JSON.stringify(body)).not.toMatch(/xoxb/);
+
+    expect(loggerMocks.error).toHaveBeenCalledWith(
+      "Dead-lettered Safe alert after Slack delivery failure",
+      expect.objectContaining({
+        reason: "dead_lettered",
+        transactionHash: "0xtx1",
+        eventName: "AddedOwner",
+        chain: "celo",
+        multisigKey: "SOLO_CELO",
+        channelId: "Calerts",
+        failureReason: "Slack postMessage failed after all retries",
+      }),
+    );
+  });
+
+  it("logs ERROR and does not throw when the upload response is not ok", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(metadataTokenResponse())
+      .mockResolvedValueOnce(uploadResponse(500, "Internal Server Error"));
+    const writeDeadLetter = await loadWriteDeadLetter();
+
+    await expect(
+      writeDeadLetter(
+        {
+          logEntry: LOG_ENTRY,
+          slackMessage: SLACK_MESSAGE,
+          multisigKey: "SOLO_CELO",
+          channelId: "Calerts",
+          chain: "celo",
+          failureReason: "Slack postMessage failed after all retries",
+        },
+        { fetchImpl: fetchMock },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(loggerMocks.error).toHaveBeenCalledWith("Dead-letter write failed", {
+      reason: "dead_letter_write_failed",
+      status: 500,
+      statusText: "Internal Server Error",
+      transactionHash: "0xtx1",
+    });
+  });
+
+  it("logs ERROR and does not throw when the write is aborted via signal", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const fetchMock = vi.fn<typeof fetch>(async (_url, init) => {
+      if ((init as RequestInit | undefined)?.signal?.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+      return metadataTokenResponse();
+    });
+    const writeDeadLetter = await loadWriteDeadLetter();
+
+    await expect(
+      writeDeadLetter(
+        {
+          logEntry: LOG_ENTRY,
+          slackMessage: SLACK_MESSAGE,
+          multisigKey: "SOLO_CELO",
+          channelId: "Calerts",
+          chain: "celo",
+          failureReason: "Slack postMessage failed after all retries",
+        },
+        { fetchImpl: fetchMock, signal: abortController.signal },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(loggerMocks.error).toHaveBeenCalledWith("Dead-letter write failed", {
+      reason: "dead_letter_write_failed",
+      error: "The operation was aborted.",
+      transactionHash: "0xtx1",
+    });
+  });
+
+  it("logs ERROR and does not throw when the fetch itself rejects", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("network unreachable"));
+    const writeDeadLetter = await loadWriteDeadLetter();
+
+    await expect(
+      writeDeadLetter(
+        {
+          logEntry: LOG_ENTRY,
+          slackMessage: SLACK_MESSAGE,
+          multisigKey: "SOLO_CELO",
+          channelId: "Calerts",
+          chain: "celo",
+          failureReason: "Slack postMessage failed after all retries",
+        },
+        { fetchImpl: fetchMock },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(loggerMocks.error).toHaveBeenCalledWith("Dead-letter write failed", {
+      reason: "dead_letter_write_failed",
+      error: "network unreachable",
+      transactionHash: "0xtx1",
+    });
+  });
+});

--- a/alerts/infra/onchain-event-handler/src/dead-letter.ts
+++ b/alerts/infra/onchain-event-handler/src/dead-letter.ts
@@ -1,0 +1,127 @@
+/**
+ * Dead-letter persistence for Safe/multisig alerts that exhaust Slack
+ * delivery retries. Reuses the same GCS bucket + metadata-server auth as
+ * QuickNode nonce replay protection (quicknode-replay-protection.ts), under
+ * a distinct "dead-letter/" prefix, instead of provisioning new infra.
+ *
+ * Redrive path: scripts/redrive-onchain-deadletter.mjs lists objects under
+ * this prefix, reposts them to Slack, then archives them under
+ * "dead-letter/done/".
+ */
+
+import { logger } from "./logger";
+import { getMetadataAccessToken } from "./quicknode-replay-protection";
+import type { SlackMessage } from "./slack";
+import type { QuickNodeDecodedLog } from "./types";
+
+const STORAGE_UPLOAD_BASE_URL =
+  "https://storage.googleapis.com/upload/storage/v1/b";
+
+const DEAD_LETTER_PREFIX = "dead-letter/";
+
+type Fetch = typeof fetch;
+
+interface DeadLetterInput {
+  logEntry: QuickNodeDecodedLog;
+  slackMessage: SlackMessage;
+  multisigKey: string;
+  channelId: string;
+  chain: string;
+  failureReason: string;
+}
+
+interface WriteDeadLetterOptions {
+  bucketName?: string;
+  fetchImpl?: Fetch;
+  /**
+   * Bounds both the metadata-token fetch and the GCS upload so a stalled
+   * write can't eat into the webhook's response budget indefinitely — see
+   * deadLetterIfSlackDeliveryFailed in process-events.ts, which supplies a
+   * short fixed-timeout signal independent of the overall request budget.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Persist a dead-lettered Safe alert to GCS so it can be redriven later.
+ * Never throws: a write failure here must not crash the batch, so every
+ * failure path logs at ERROR and returns instead of rejecting.
+ */
+export async function writeDeadLetter(
+  input: DeadLetterInput,
+  options: WriteDeadLetterOptions = {},
+): Promise<void> {
+  const bucketName =
+    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
+  const transactionHash = input.logEntry.transactionHash;
+
+  if (!bucketName) {
+    logger.error("Dead-letter write failed", {
+      reason: "dead_letter_bucket_not_configured",
+      transactionHash,
+    });
+    return;
+  }
+
+  const objectName = `${DEAD_LETTER_PREFIX}${transactionHash}-${input.logEntry.logIndex}-${Date.now()}.json`;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  try {
+    const accessToken = await getMetadataAccessToken(fetchImpl, options.signal);
+    const uploadUrl = new URL(
+      `${STORAGE_UPLOAD_BASE_URL}/${encodeURIComponent(bucketName)}/o`,
+    );
+    uploadUrl.searchParams.set("uploadType", "media");
+    uploadUrl.searchParams.set("name", objectName);
+
+    const response = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        deadLetteredAt: new Date().toISOString(),
+        failureReason: input.failureReason,
+        eventName: input.logEntry.name,
+        transactionHash,
+        chain: input.chain,
+        multisigKey: input.multisigKey,
+        channelId: input.channelId,
+        logEntry: input.logEntry,
+        slackMessage: input.slackMessage,
+      }),
+      signal: options.signal,
+    });
+
+    if (!response.ok) {
+      logger.error("Dead-letter write failed", {
+        reason: "dead_letter_write_failed",
+        status: response.status,
+        statusText: response.statusText,
+        transactionHash,
+      });
+      return;
+    }
+
+    // Distinct, grep-able marker for operators: this ERROR means a Safe
+    // alert could not be delivered to Slack but IS safely persisted and
+    // redrivable — see scripts/redrive-onchain-deadletter.mjs.
+    logger.error("Dead-lettered Safe alert after Slack delivery failure", {
+      reason: "dead_lettered",
+      objectName,
+      transactionHash,
+      eventName: input.logEntry.name,
+      chain: input.chain,
+      multisigKey: input.multisigKey,
+      channelId: input.channelId,
+      failureReason: input.failureReason,
+    });
+  } catch (error) {
+    logger.error("Dead-letter write failed", {
+      reason: "dead_letter_write_failed",
+      error: error instanceof Error ? error.message : String(error),
+      transactionHash,
+    });
+  }
+}

--- a/alerts/infra/onchain-event-handler/src/dead-letter.ts
+++ b/alerts/infra/onchain-event-handler/src/dead-letter.ts
@@ -10,12 +10,12 @@
  */
 
 import { logger } from "./logger";
-import { getMetadataAccessToken } from "./quicknode-replay-protection";
+import {
+  getMetadataAccessToken,
+  STORAGE_UPLOAD_BASE_URL,
+} from "./quicknode-replay-protection";
 import type { SlackMessage } from "./slack";
 import type { QuickNodeDecodedLog } from "./types";
-
-const STORAGE_UPLOAD_BASE_URL =
-  "https://storage.googleapis.com/upload/storage/v1/b";
 
 const DEAD_LETTER_PREFIX = "dead-letter/";
 

--- a/alerts/infra/onchain-event-handler/src/process-events.test.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.test.ts
@@ -81,6 +81,12 @@ vi.mock("./slack", async () => {
   };
 });
 
+// Mock dead-letter writes so failure tests don't try to hit GCS.
+const writeDeadLetterMock = vi.fn(async () => undefined);
+vi.mock("./dead-letter", () => ({
+  writeDeadLetter: writeDeadLetterMock,
+}));
+
 const SOLO_CELO_ADDR = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const AMBIGUOUS_ADDR = "0xcccccccccccccccccccccccccccccccccccccccc";
 
@@ -90,6 +96,7 @@ describe("processEvents - ChainDetectionError handling", () => {
     loggerErrorMock.mockClear();
     loggerInfoMock.mockClear();
     loggerWarnMock.mockClear();
+    writeDeadLetterMock.mockClear();
   });
 
   it("logs ChainDetectionError but does NOT throw; returns successful events only", async () => {
@@ -605,6 +612,95 @@ describe("processEvents - ChainDetectionError handling", () => {
         skipped: 2,
       });
       expect(sendMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dead-letters the rendered Slack payload when retries are exhausted", async () => {
+    const { processEvents } = await import("./process-events");
+    const { buildEventContext } = await import("./build-event-context");
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
+    sendMock.mockClear();
+    sendMock.mockRejectedValueOnce(
+      new Error("Slack postMessage failed after all retries"),
+    );
+
+    const logs = [
+      {
+        address: SOLO_CELO_ADDR,
+        name: "AddedOwner",
+        transactionHash: "0xtx-deadletter",
+        blockHash: "0xblockGood",
+        blockNumber: "101",
+        logIndex: "1",
+        owner: "0xowner1",
+      },
+    ];
+
+    const context = buildEventContext(logs);
+    const result = await processEvents(logs, context);
+
+    expect(result).toEqual({ processedEvents: [], skipped: 0 });
+    expect(writeDeadLetterMock).toHaveBeenCalledTimes(1);
+    expect(writeDeadLetterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        multisigKey: "SOLO_CELO",
+        channelId: "Calerts",
+        chain: "celo",
+        failureReason: "Slack postMessage failed after all retries",
+        logEntry: expect.objectContaining({
+          transactionHash: "0xtx-deadletter",
+          name: "AddedOwner",
+        }),
+        slackMessage: { text: "test", blocks: [] },
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("does not dead-letter when the failure is our own budget abort, not a Slack failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const { processEvents } = await import("./process-events");
+      const { buildEventContext } = await import("./build-event-context");
+      const { sendToSlack } = await import("./slack");
+      const sendMock = vi.mocked(sendToSlack);
+      sendMock.mockClear();
+      sendMock.mockImplementation(
+        async (_botToken, _channelId, _message, signal?: AbortSignal) =>
+          new Promise((_, reject) => {
+            signal?.addEventListener("abort", () => {
+              reject(new Error("aborted"));
+            });
+          }),
+      );
+
+      const logs = [
+        {
+          address: SOLO_CELO_ADDR,
+          name: "AddedOwner",
+          transactionHash: "0xtx-aborted",
+          blockHash: "0xblockGood",
+          blockNumber: "101",
+          logIndex: "1",
+          owner: "0xowner1",
+        },
+      ];
+
+      const context = buildEventContext(logs);
+      const resultPromise = processEvents(logs, context, {
+        budgetMs: 10,
+        now: () => 0,
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(resultPromise).resolves.toEqual({
+        processedEvents: [],
+        skipped: 1,
+      });
+      expect(writeDeadLetterMock).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/alerts/infra/onchain-event-handler/src/process-events.test.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.test.ts
@@ -660,7 +660,12 @@ describe("processEvents - ChainDetectionError handling", () => {
     );
   });
 
-  it("does not dead-letter when the failure is our own budget abort, not a Slack failure", async () => {
+  it("dead-letters the rendered Slack payload even when the failure is our own budget abort", async () => {
+    // The QuickNode nonce is already reserved by the time processEvents runs
+    // (see index.ts), so there is no redelivery to fall back on if a Slack
+    // send that was cut short by our own processing-budget abort is dropped
+    // instead of dead-lettered — see the invariant note on
+    // deadLetterIfSlackDeliveryFailed.
     vi.useFakeTimers();
     try {
       const { processEvents } = await import("./process-events");
@@ -700,7 +705,20 @@ describe("processEvents - ChainDetectionError handling", () => {
         processedEvents: [],
         skipped: 1,
       });
-      expect(writeDeadLetterMock).not.toHaveBeenCalled();
+      expect(writeDeadLetterMock).toHaveBeenCalledTimes(1);
+      expect(writeDeadLetterMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          multisigKey: "SOLO_CELO",
+          channelId: "Calerts",
+          chain: "celo",
+          failureReason: "aborted",
+          logEntry: expect.objectContaining({
+            transactionHash: "0xtx-aborted",
+            name: "AddedOwner",
+          }),
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/alerts/infra/onchain-event-handler/src/process-events.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.ts
@@ -182,10 +182,7 @@ export async function processEvents(
               logEntry,
               fallbackAbortController.signal.aborted,
             );
-            await deadLetterIfSlackDeliveryFailed(
-              error,
-              fallbackAbortController.signal.aborted,
-            );
+            await deadLetterIfSlackDeliveryFailed(error);
             skipped += 1;
           } finally {
             clearTimeout(fallbackAbortTimer);
@@ -221,10 +218,7 @@ export async function processEvents(
         }
       } catch (error) {
         logProcessingError(error, logEntry, abortController.signal.aborted);
-        await deadLetterIfSlackDeliveryFailed(
-          error,
-          abortController.signal.aborted,
-        );
+        await deadLetterIfSlackDeliveryFailed(error);
         if (abortController.signal.aborted) {
           skipped += 1;
           const nextLog = logsToProcess[index + 1];
@@ -301,16 +295,18 @@ function logProcessingError(
 }
 
 /**
- * Dead-letters the rendered Slack payload when the per-event failure is a
- * genuine Slack delivery failure (retries exhausted) — never for our own
- * budget-driven aborts, since those don't reach exhaustion and there is
- * nothing "final" about them.
+ * Dead-letters the rendered Slack payload whenever `sendToSlack` threw —
+ * including when our own processing-budget abort cut a send short mid-flight,
+ * not just when Slack's own retries were exhausted. The QuickNode nonce is
+ * already reserved by the time this runs (see index.ts), so there is no
+ * "next attempt" from QuickNode to fall back on: skipping the write on the
+ * abort path would silently drop an already-rendered alert with no trace,
+ * which is exactly the failure mode this dead-letter path exists to avoid.
+ * The write below is bounded by its own independent timeout, so it can't be
+ * blocked by whatever caused the outer abort.
  */
-async function deadLetterIfSlackDeliveryFailed(
-  error: unknown,
-  aborted: boolean,
-): Promise<void> {
-  if (!(error instanceof SlackDeliveryFailedError) || aborted) {
+async function deadLetterIfSlackDeliveryFailed(error: unknown): Promise<void> {
+  if (!(error instanceof SlackDeliveryFailedError)) {
     return;
   }
   const writeAbortController = new AbortController();

--- a/alerts/infra/onchain-event-handler/src/process-events.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.ts
@@ -1,7 +1,9 @@
 import type { EventContext } from "./build-event-context";
 import config from "./config";
+import { writeDeadLetter } from "./dead-letter";
 import { logger } from "./logger";
 import { formatSlackMessage, sendToSlack } from "./slack";
+import type { SlackMessage } from "./slack";
 import type {
   ProcessedEvent,
   QuickNodeDecodedLog,
@@ -17,6 +19,12 @@ import {
 
 const DEFAULT_PROCESSING_BUDGET_MS = 270_000;
 const FALLBACK_HEADROOM_MS = 10_000;
+// Bounds the dead-letter GCS write independently of the overall request
+// budget so a stalled write can't push the response past the Cloud
+// Function's timeout (which would make QuickNode retry the whole batch and
+// duplicate already-delivered alerts). Small and fixed rather than "whatever
+// budget remains" — the write should either complete quickly or fail fast.
+const DEAD_LETTER_WRITE_TIMEOUT_MS = 5_000;
 
 interface ProcessEventsOptions {
   /**
@@ -48,6 +56,25 @@ class ChainDetectionError extends Error {
   ) {
     super(message);
     this.name = "ChainDetectionError";
+  }
+}
+
+/**
+ * Error thrown when sendToSlack exhausts retries (or is aborted) after the
+ * Slack message has already been rendered. Carries the rendered payload so
+ * the per-event catch below can dead-letter it instead of losing the alert.
+ */
+class SlackDeliveryFailedError extends Error {
+  constructor(
+    message: string,
+    public readonly logEntry: QuickNodeDecodedLog,
+    public readonly slackMessage: SlackMessage,
+    public readonly multisigKey: string,
+    public readonly channelId: string,
+    public readonly chain: string,
+  ) {
+    super(message);
+    this.name = "SlackDeliveryFailedError";
   }
 }
 
@@ -155,6 +182,10 @@ export async function processEvents(
               logEntry,
               fallbackAbortController.signal.aborted,
             );
+            await deadLetterIfSlackDeliveryFailed(
+              error,
+              fallbackAbortController.signal.aborted,
+            );
             skipped += 1;
           } finally {
             clearTimeout(fallbackAbortTimer);
@@ -190,6 +221,10 @@ export async function processEvents(
         }
       } catch (error) {
         logProcessingError(error, logEntry, abortController.signal.aborted);
+        await deadLetterIfSlackDeliveryFailed(
+          error,
+          abortController.signal.aborted,
+        );
         if (abortController.signal.aborted) {
           skipped += 1;
           const nextLog = logsToProcess[index + 1];
@@ -260,8 +295,44 @@ function logProcessingError(
     transactionHash: safe.transactionHash,
     eventName: safe.name,
     chainDetectionFailure: error instanceof ChainDetectionError,
+    slackDeliveryFailure: error instanceof SlackDeliveryFailedError,
     aborted,
   });
+}
+
+/**
+ * Dead-letters the rendered Slack payload when the per-event failure is a
+ * genuine Slack delivery failure (retries exhausted) — never for our own
+ * budget-driven aborts, since those don't reach exhaustion and there is
+ * nothing "final" about them.
+ */
+async function deadLetterIfSlackDeliveryFailed(
+  error: unknown,
+  aborted: boolean,
+): Promise<void> {
+  if (!(error instanceof SlackDeliveryFailedError) || aborted) {
+    return;
+  }
+  const writeAbortController = new AbortController();
+  const writeAbortTimer = setTimeout(
+    () => writeAbortController.abort(),
+    DEAD_LETTER_WRITE_TIMEOUT_MS,
+  );
+  try {
+    await writeDeadLetter(
+      {
+        logEntry: error.logEntry,
+        slackMessage: error.slackMessage,
+        multisigKey: error.multisigKey,
+        channelId: error.channelId,
+        chain: error.chain,
+        failureReason: error.message,
+      },
+      { signal: writeAbortController.signal },
+    );
+  } finally {
+    clearTimeout(writeAbortTimer);
+  }
 }
 
 function isPendingExecutionFallback(
@@ -421,7 +492,18 @@ async function processEvent(
   );
 
   // 7. Send to Slack
-  await sendToSlack(config.SLACK_BOT_TOKEN, channelId, slackMessage, signal);
+  try {
+    await sendToSlack(config.SLACK_BOT_TOKEN, channelId, slackMessage, signal);
+  } catch (error) {
+    throw new SlackDeliveryFailedError(
+      error instanceof Error ? error.message : String(error),
+      logEntry,
+      slackMessage,
+      multisigKey,
+      channelId,
+      chain,
+    );
+  }
 
   logger.info("Event processed successfully", {
     multisigKey,

--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -131,7 +131,15 @@ async function replayProtectionSetup(
   };
 }
 
-async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
+// Exported so dead-letter.ts (dead-lettering after Slack delivery failure)
+// can reuse the same metadata-server auth + token cache instead of its own
+// copy — both write into the same GCS bucket, just under different prefixes.
+// `signal` is optional and unused by this module's own call site below; it
+// exists so dead-letter.ts can bound the token fetch under its own timeout.
+export async function getMetadataAccessToken(
+  fetchImpl: Fetch,
+  signal?: AbortSignal,
+): Promise<string> {
   if (
     cachedMetadataToken &&
     cachedMetadataToken.expiresAtMs - METADATA_TOKEN_REFRESH_SKEW_MS >
@@ -144,6 +152,7 @@ async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
     headers: {
       "metadata-flavor": "Google",
     },
+    signal,
   });
 
   if (!response.ok) {

--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -3,7 +3,9 @@ import { logger } from "./logger";
 
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
-const STORAGE_UPLOAD_BASE_URL =
+// Exported so dead-letter.ts can reuse it instead of duplicating the string —
+// both modules upload to the same GCS bucket via this endpoint.
+export const STORAGE_UPLOAD_BASE_URL =
   "https://storage.googleapis.com/upload/storage/v1/b";
 const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
 

--- a/alerts/infra/onchain-event-handler/src/slack.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.ts
@@ -20,7 +20,8 @@ interface SlackBlock {
   }>;
 }
 
-interface SlackMessage {
+// Exported so dead-letter.ts can type the rendered payload it persists.
+export interface SlackMessage {
   text: string;
   blocks: SlackBlock[];
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "alerts:oncall:build": "pnpm --filter @mento-protocol/alerts-oncall-announcer build",
     "alerts:oncall:typecheck": "pnpm --filter @mento-protocol/alerts-oncall-announcer typecheck",
     "alerts:oncall:test": "pnpm --filter @mento-protocol/alerts-oncall-announcer test",
+    "deadletter:redrive": "node scripts/redrive-onchain-deadletter.mjs",
+    "deadletter:redrive:test": "node scripts/redrive-onchain-deadletter.test.mjs",
     "gov-watchdog:build": "pnpm --filter @mento-protocol/governance-watchdog build",
     "gov-watchdog:typecheck": "pnpm --filter @mento-protocol/governance-watchdog typecheck",
     "gov-watchdog:test": "pnpm --filter @mento-protocol/governance-watchdog test:unit",

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1453,6 +1453,9 @@ while IFS= read -r path; do
         scripts/notify-terraform-apply.mjs|scripts/notify-terraform-apply.test.mjs)
           add_command "node scripts/notify-terraform-apply.test.mjs" "Terraform apply Slack notifier changed"
           ;;
+        scripts/redrive-onchain-deadletter.mjs|scripts/redrive-onchain-deadletter.test.mjs)
+          add_command "node scripts/redrive-onchain-deadletter.test.mjs" "onchain dead-letter redrive tool changed"
+          ;;
         scripts/verify-github-environment-protection.mjs|scripts/verify-github-environment-protection.test.mjs)
           add_command "node scripts/verify-github-environment-protection.test.mjs" "GitHub environment protection checker changed"
           ;;

--- a/scripts/redrive-onchain-deadletter.mjs
+++ b/scripts/redrive-onchain-deadletter.mjs
@@ -118,13 +118,36 @@ async function postToSlack({ slackToken, channel, message, fetchImpl }) {
   }
 }
 
+function doneObjectName(objectName) {
+  return `${DEAD_LETTER_DONE_PREFIX}${objectName.slice(DEAD_LETTER_PREFIX.length)}`;
+}
+
+/**
+ * Cheap existence check (metadata GET, no "alt=media" body fetch) for a
+ * "dead-letter/done/<name>" object. Used to make redrive idempotent across a
+ * partial archive failure from a prior run: if the done copy already
+ * exists, the source event was already reposted to Slack, so a rerun must
+ * not post it again.
+ */
+async function doneObjectExists({ bucket, doneName, accessToken, fetchImpl }) {
+  const url = new URL(
+    `${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o/${encodeURIComponent(doneName)}`,
+  );
+  const response = await fetchImpl(url, { headers: authHeaders(accessToken) });
+  if (response.status === 404) {
+    return false;
+  }
+  await parseJsonResponse(response, url);
+  return true;
+}
+
 async function archiveDeadLetterObject({
   bucket,
   objectName,
   accessToken,
   fetchImpl,
 }) {
-  const doneName = `${DEAD_LETTER_DONE_PREFIX}${objectName.slice(DEAD_LETTER_PREFIX.length)}`;
+  const doneName = doneObjectName(objectName);
   const copyUrl = new URL(
     `${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o/${encodeURIComponent(
       objectName,
@@ -154,6 +177,12 @@ async function archiveDeadLetterObject({
  * Reposts one dead-lettered event to Slack, then archives it. Archiving only
  * happens after a successful repost — a Slack failure here must leave the
  * object in place so the next redrive attempt can retry it.
+ *
+ * Idempotent against a partial archive from a prior run (copy to
+ * "dead-letter/done/" succeeded but the delete of the original failed): if
+ * the done copy already exists, the repost is skipped and only the archive
+ * steps (copy + delete) are retried, so a rerun after that kind of partial
+ * failure can't post the same alert to Slack a second time.
  */
 async function redriveDeadLetterObject({
   bucket,
@@ -162,18 +191,28 @@ async function redriveDeadLetterObject({
   accessToken,
   fetchImpl,
 }) {
-  const payload = await getObjectJson({
+  const alreadyPosted = await doneObjectExists({
     bucket,
-    objectName,
+    doneName: doneObjectName(objectName),
     accessToken,
     fetchImpl,
   });
-  await postToSlack({
-    slackToken,
-    channel: payload.channelId,
-    message: payload.slackMessage,
-    fetchImpl,
-  });
+
+  if (!alreadyPosted) {
+    const payload = await getObjectJson({
+      bucket,
+      objectName,
+      accessToken,
+      fetchImpl,
+    });
+    await postToSlack({
+      slackToken,
+      channel: payload.channelId,
+      message: payload.slackMessage,
+      fetchImpl,
+    });
+  }
+
   await archiveDeadLetterObject({ bucket, objectName, accessToken, fetchImpl });
 }
 

--- a/scripts/redrive-onchain-deadletter.mjs
+++ b/scripts/redrive-onchain-deadletter.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Redrive tool for the onchain-event-handler dead-letter queue.
+ *
+ * The Cloud Function (alerts/infra/onchain-event-handler) writes a dead-letter
+ * object to GCS (under the "dead-letter/" prefix of the same bucket used for
+ * QuickNode nonce replay protection) whenever it exhausts Slack delivery
+ * retries for a Safe/multisig alert. This script:
+ *
+ *   1. Lists undone dead-letter objects (excludes "dead-letter/done/").
+ *   2. Reposts each one's rendered Slack payload to its original channel,
+ *      using the same SLACK_BOT_TOKEN source as the function itself.
+ *   3. Archives successfully-redriven objects to "dead-letter/done/" so a
+ *      re-run doesn't repost them.
+ *
+ * GCS access uses an operator's own gcloud credentials (`gcloud auth
+ * print-access-token`) rather than the function's metadata-server token,
+ * since this runs off-platform. Requires `gcloud auth login` (see
+ * alerts/infra/scripts/check-gcloud-login.sh for the same prerequisite used
+ * elsewhere in this repo).
+ *
+ * Usage:
+ *   QUICKNODE_REPLAY_BUCKET=<bucket> SLACK_BOT_TOKEN=<token> \
+ *     node scripts/redrive-onchain-deadletter.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const DEAD_LETTER_PREFIX = "dead-letter/";
+const DEAD_LETTER_DONE_PREFIX = "dead-letter/done/";
+const STORAGE_API_BASE = "https://storage.googleapis.com/storage/v1/b";
+
+function defaultGetAccessToken() {
+  return execFileSync("gcloud", ["auth", "print-access-token"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function authHeaders(accessToken) {
+  return { Authorization: `Bearer ${accessToken}` };
+}
+
+async function parseJsonResponse(response, url) {
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ${url}: ${raw}`);
+  }
+  return raw ? JSON.parse(raw) : {};
+}
+
+/**
+ * Lists dead-letter object names, excluding the "done/" archive prefix.
+ * Follows GCS list pagination via nextPageToken.
+ */
+async function listDeadLetterObjects({ bucket, accessToken, fetchImpl }) {
+  const objectNames = [];
+  let pageToken;
+
+  do {
+    const url = new URL(`${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o`);
+    url.searchParams.set("prefix", DEAD_LETTER_PREFIX);
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken);
+    }
+
+    const response = await fetchImpl(url, {
+      headers: authHeaders(accessToken),
+    });
+    const body = await parseJsonResponse(response, url);
+
+    for (const item of body.items ?? []) {
+      if (!item.name.startsWith(DEAD_LETTER_DONE_PREFIX)) {
+        objectNames.push(item.name);
+      }
+    }
+
+    pageToken = body.nextPageToken;
+  } while (pageToken);
+
+  return objectNames;
+}
+
+async function getObjectJson({ bucket, objectName, accessToken, fetchImpl }) {
+  const url = new URL(
+    `${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o/${encodeURIComponent(objectName)}`,
+  );
+  url.searchParams.set("alt", "media");
+
+  const response = await fetchImpl(url, { headers: authHeaders(accessToken) });
+  return parseJsonResponse(response, url);
+}
+
+async function postToSlack({ slackToken, channel, message, fetchImpl }) {
+  const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${slackToken}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      channel,
+      text: message.text,
+      blocks: message.blocks,
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  });
+
+  const body = await parseJsonResponse(
+    response,
+    "https://slack.com/api/chat.postMessage",
+  );
+  if (body.ok !== true) {
+    throw new Error(
+      `Slack chat.postMessage failed: ${body.error ?? "unknown"}`,
+    );
+  }
+}
+
+async function archiveDeadLetterObject({
+  bucket,
+  objectName,
+  accessToken,
+  fetchImpl,
+}) {
+  const doneName = `${DEAD_LETTER_DONE_PREFIX}${objectName.slice(DEAD_LETTER_PREFIX.length)}`;
+  const copyUrl = new URL(
+    `${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o/${encodeURIComponent(
+      objectName,
+    )}/copyTo/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(doneName)}`,
+  );
+  const copyResponse = await fetchImpl(copyUrl, {
+    method: "POST",
+    headers: authHeaders(accessToken),
+    body: "{}",
+  });
+  await parseJsonResponse(copyResponse, copyUrl);
+
+  const deleteUrl = new URL(
+    `${STORAGE_API_BASE}/${encodeURIComponent(bucket)}/o/${encodeURIComponent(objectName)}`,
+  );
+  const deleteResponse = await fetchImpl(deleteUrl, {
+    method: "DELETE",
+    headers: authHeaders(accessToken),
+  });
+  if (!deleteResponse.ok) {
+    const raw = await deleteResponse.text();
+    throw new Error(`HTTP ${deleteResponse.status} from ${deleteUrl}: ${raw}`);
+  }
+}
+
+/**
+ * Reposts one dead-lettered event to Slack, then archives it. Archiving only
+ * happens after a successful repost — a Slack failure here must leave the
+ * object in place so the next redrive attempt can retry it.
+ */
+async function redriveDeadLetterObject({
+  bucket,
+  objectName,
+  slackToken,
+  accessToken,
+  fetchImpl,
+}) {
+  const payload = await getObjectJson({
+    bucket,
+    objectName,
+    accessToken,
+    fetchImpl,
+  });
+  await postToSlack({
+    slackToken,
+    channel: payload.channelId,
+    message: payload.slackMessage,
+    fetchImpl,
+  });
+  await archiveDeadLetterObject({ bucket, objectName, accessToken, fetchImpl });
+}
+
+async function main(
+  env = process.env,
+  { getAccessToken = defaultGetAccessToken, fetchImpl = fetch } = {},
+) {
+  const bucket = env.QUICKNODE_REPLAY_BUCKET;
+  if (!bucket) {
+    throw new Error("QUICKNODE_REPLAY_BUCKET is required");
+  }
+  const slackToken = env.SLACK_BOT_TOKEN;
+  if (!slackToken) {
+    throw new Error("SLACK_BOT_TOKEN is required");
+  }
+
+  const accessToken = getAccessToken();
+  const objectNames = await listDeadLetterObjects({
+    bucket,
+    accessToken,
+    fetchImpl,
+  });
+
+  if (objectNames.length === 0) {
+    console.log("No dead-lettered events to redrive.");
+    return { redriven: 0, failed: 0 };
+  }
+
+  let redriven = 0;
+  let failed = 0;
+  for (const objectName of objectNames) {
+    try {
+      // Sequential, low-volume redrive sweep — parallelizing risks Slack rate limits.
+      await redriveDeadLetterObject({
+        bucket,
+        objectName,
+        slackToken,
+        accessToken,
+        fetchImpl,
+      });
+      console.log(`Redrove ${objectName}`);
+      redriven += 1;
+    } catch (error) {
+      console.error(`Failed to redrive ${objectName}: ${error.message}`);
+      failed += 1;
+    }
+  }
+
+  console.log(
+    `Redrove ${redriven}/${objectNames.length} dead-lettered event(s); ${failed} failed.`,
+  );
+  return { redriven, failed };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main()
+    .then(({ failed }) => {
+      if (failed > 0) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}
+
+export {
+  archiveDeadLetterObject,
+  getObjectJson,
+  listDeadLetterObjects,
+  main,
+  postToSlack,
+  redriveDeadLetterObject,
+};

--- a/scripts/redrive-onchain-deadletter.test.mjs
+++ b/scripts/redrive-onchain-deadletter.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+
+import {
+  listDeadLetterObjects,
+  main,
+  redriveDeadLetterObject,
+} from "./redrive-onchain-deadletter.mjs";
+
+const BUCKET = "test-bucket";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+/**
+ * In-memory fake of the GCS JSON API (list/get-media/copyTo/delete) plus
+ * Slack's chat.postMessage, keyed on URL shape. `objects` is a mutable Map
+ * the test can inspect afterwards to confirm archiving happened (or didn't).
+ */
+function createFakeTransport(objects) {
+  const slackCalls = [];
+
+  const fetchImpl = async (url, init = {}) => {
+    const parsed = new URL(url);
+    const method = init.method ?? "GET";
+
+    if (parsed.hostname === "slack.com") {
+      const body = JSON.parse(init.body);
+      slackCalls.push(body);
+      if (body.channel === "FAIL_CHANNEL") {
+        return jsonResponse({ ok: false, error: "channel_not_found" });
+      }
+      return jsonResponse({ ok: true });
+    }
+
+    const listMatch = parsed.pathname === `/storage/v1/b/${BUCKET}/o`;
+    if (listMatch && method === "GET") {
+      const prefix = parsed.searchParams.get("prefix") ?? "";
+      const items = [...objects.keys()]
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => ({ name }));
+      return jsonResponse({ items });
+    }
+
+    const copyMatch = parsed.pathname.match(
+      new RegExp(
+        `^/storage/v1/b/${BUCKET}/o/([^/]+)/copyTo/b/${BUCKET}/o/([^/]+)$`,
+      ),
+    );
+    if (copyMatch && method === "POST") {
+      const src = decodeURIComponent(copyMatch[1]);
+      const dst = decodeURIComponent(copyMatch[2]);
+      assert.ok(objects.has(src), `copy source ${src} must exist`);
+      objects.set(dst, objects.get(src));
+      return jsonResponse({ name: dst });
+    }
+
+    const objectMatch = parsed.pathname.match(
+      new RegExp(`^/storage/v1/b/${BUCKET}/o/([^/]+)$`),
+    );
+    if (
+      objectMatch &&
+      method === "GET" &&
+      parsed.searchParams.get("alt") === "media"
+    ) {
+      const name = decodeURIComponent(objectMatch[1]);
+      if (!objects.has(name)) return new Response("not found", { status: 404 });
+      return jsonResponse(objects.get(name));
+    }
+    if (objectMatch && method === "DELETE") {
+      const name = decodeURIComponent(objectMatch[1]);
+      objects.delete(name);
+      return new Response(null, { status: 204 });
+    }
+
+    throw new Error(`Unhandled fake request: ${method} ${parsed.toString()}`);
+  };
+
+  return { fetchImpl, slackCalls };
+}
+
+// listDeadLetterObjects: excludes the done/ archive prefix and follows
+// nextPageToken pagination.
+{
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url.toString());
+    if (calls.length === 1) {
+      return jsonResponse({
+        items: [
+          { name: "dead-letter/a.json" },
+          { name: "dead-letter/done/old.json" },
+        ],
+        nextPageToken: "page2",
+      });
+    }
+    return jsonResponse({ items: [{ name: "dead-letter/b.json" }] });
+  };
+
+  const names = await listDeadLetterObjects({
+    bucket: BUCKET,
+    accessToken: "token",
+    fetchImpl,
+  });
+
+  assert.deepEqual(names, ["dead-letter/a.json", "dead-letter/b.json"]);
+  assert.equal(calls.length, 2);
+  assert.ok(calls[1].includes("pageToken=page2"));
+}
+
+// redriveDeadLetterObject: reposts to the persisted channel, then archives
+// under dead-letter/done/ and removes the original.
+{
+  const objects = new Map([
+    [
+      "dead-letter/0xtx1-0-123.json",
+      { channelId: "Calerts", slackMessage: { text: "hi", blocks: [] } },
+    ],
+  ]);
+  const { fetchImpl, slackCalls } = createFakeTransport(objects);
+
+  await redriveDeadLetterObject({
+    bucket: BUCKET,
+    objectName: "dead-letter/0xtx1-0-123.json",
+    slackToken: "xoxb-test",
+    accessToken: "token",
+    fetchImpl,
+  });
+
+  assert.deepEqual(slackCalls, [
+    {
+      channel: "Calerts",
+      text: "hi",
+      blocks: [],
+      unfurl_links: false,
+      unfurl_media: false,
+    },
+  ]);
+  assert.equal(objects.has("dead-letter/0xtx1-0-123.json"), false);
+  assert.equal(objects.has("dead-letter/done/0xtx1-0-123.json"), true);
+}
+
+// redriveDeadLetterObject: a Slack repost failure must NOT archive the
+// object — it stays in place so a later redrive attempt can retry it.
+{
+  const objects = new Map([
+    [
+      "dead-letter/0xtx2-0-456.json",
+      { channelId: "FAIL_CHANNEL", slackMessage: { text: "hi", blocks: [] } },
+    ],
+  ]);
+  const { fetchImpl } = createFakeTransport(objects);
+
+  await assert.rejects(
+    redriveDeadLetterObject({
+      bucket: BUCKET,
+      objectName: "dead-letter/0xtx2-0-456.json",
+      slackToken: "xoxb-test",
+      accessToken: "token",
+      fetchImpl,
+    }),
+    /channel_not_found/,
+  );
+
+  assert.equal(objects.has("dead-letter/0xtx2-0-456.json"), true);
+  assert.equal(objects.has("dead-letter/done/0xtx2-0-456.json"), false);
+}
+
+// main(): end-to-end sweep across a mix of a redrivable and a failing object,
+// sourcing the Slack token from env (same as the function) and the GCS
+// access token from an injected getAccessToken (standing in for gcloud).
+{
+  const objects = new Map([
+    [
+      "dead-letter/0xtx3-0-1.json",
+      { channelId: "Calerts", slackMessage: { text: "ok", blocks: [] } },
+    ],
+    [
+      "dead-letter/0xtx4-0-2.json",
+      { channelId: "FAIL_CHANNEL", slackMessage: { text: "bad", blocks: [] } },
+    ],
+  ]);
+  const { fetchImpl } = createFakeTransport(objects);
+
+  const result = await main(
+    { QUICKNODE_REPLAY_BUCKET: BUCKET, SLACK_BOT_TOKEN: "xoxb-test" },
+    { getAccessToken: () => "fake-access-token", fetchImpl },
+  );
+
+  assert.deepEqual(result, { redriven: 1, failed: 1 });
+  assert.equal(objects.has("dead-letter/done/0xtx3-0-1.json"), true);
+  assert.equal(objects.has("dead-letter/0xtx4-0-2.json"), true);
+}
+
+// main(): requires the same env sources the function uses.
+{
+  await assert.rejects(
+    main({ SLACK_BOT_TOKEN: "xoxb-test" }, { getAccessToken: () => "token" }),
+    /QUICKNODE_REPLAY_BUCKET is required/,
+  );
+  await assert.rejects(
+    main(
+      { QUICKNODE_REPLAY_BUCKET: BUCKET },
+      { getAccessToken: () => "token" },
+    ),
+    /SLACK_BOT_TOKEN is required/,
+  );
+}
+
+// main(): no dead-lettered objects is a clean no-op.
+{
+  const objects = new Map();
+  const { fetchImpl } = createFakeTransport(objects);
+  const result = await main(
+    { QUICKNODE_REPLAY_BUCKET: BUCKET, SLACK_BOT_TOKEN: "xoxb-test" },
+    { getAccessToken: () => "fake-access-token", fetchImpl },
+  );
+  assert.deepEqual(result, { redriven: 0, failed: 0 });
+}
+
+console.log("redrive-onchain-deadletter tests passed");

--- a/scripts/redrive-onchain-deadletter.test.mjs
+++ b/scripts/redrive-onchain-deadletter.test.mjs
@@ -67,6 +67,12 @@ function createFakeTransport(objects) {
       if (!objects.has(name)) return new Response("not found", { status: 404 });
       return jsonResponse(objects.get(name));
     }
+    if (objectMatch && method === "GET") {
+      // Metadata-only GET (the "done/" marker existence check).
+      const name = decodeURIComponent(objectMatch[1]);
+      if (!objects.has(name)) return new Response("not found", { status: 404 });
+      return jsonResponse({ name });
+    }
     if (objectMatch && method === "DELETE") {
       const name = decodeURIComponent(objectMatch[1]);
       objects.delete(name);
@@ -164,6 +170,92 @@ function createFakeTransport(objects) {
 
   assert.equal(objects.has("dead-letter/0xtx2-0-456.json"), true);
   assert.equal(objects.has("dead-letter/done/0xtx2-0-456.json"), false);
+}
+
+// redriveDeadLetterObject: a done marker already present (copy succeeded,
+// delete failed on a prior run) must skip the repost and only retry the
+// archive steps.
+{
+  const objects = new Map([
+    [
+      "dead-letter/0xtx5-0-1.json",
+      { channelId: "Calerts", slackMessage: { text: "hi", blocks: [] } },
+    ],
+    [
+      "dead-letter/done/0xtx5-0-1.json",
+      { channelId: "Calerts", slackMessage: { text: "hi", blocks: [] } },
+    ],
+  ]);
+  const { fetchImpl, slackCalls } = createFakeTransport(objects);
+
+  await redriveDeadLetterObject({
+    bucket: BUCKET,
+    objectName: "dead-letter/0xtx5-0-1.json",
+    slackToken: "xoxb-test",
+    accessToken: "token",
+    fetchImpl,
+  });
+
+  assert.deepEqual(slackCalls, []);
+  assert.equal(objects.has("dead-letter/0xtx5-0-1.json"), false);
+  assert.equal(objects.has("dead-letter/done/0xtx5-0-1.json"), true);
+}
+
+// redriveDeadLetterObject: reruns after a delete failure never repost to
+// Slack a second time — the done marker from the first attempt's successful
+// copy short-circuits every retry until the delete finally succeeds.
+{
+  const objects = new Map([
+    [
+      "dead-letter/0xtx6-0-1.json",
+      { channelId: "Calerts", slackMessage: { text: "hi", blocks: [] } },
+    ],
+  ]);
+  const { fetchImpl: baseFetch, slackCalls } = createFakeTransport(objects);
+  let deleteAttempts = 0;
+  const flakyDeleteFetch = async (url, init = {}) => {
+    const parsed = new URL(url);
+    if (
+      parsed.hostname !== "slack.com" &&
+      (init.method ?? "GET") === "DELETE"
+    ) {
+      deleteAttempts += 1;
+      return new Response("boom", { status: 500 });
+    }
+    return baseFetch(url, init);
+  };
+  const redrive = () =>
+    redriveDeadLetterObject({
+      bucket: BUCKET,
+      objectName: "dead-letter/0xtx6-0-1.json",
+      slackToken: "xoxb-test",
+      accessToken: "token",
+      fetchImpl: flakyDeleteFetch,
+    });
+
+  // First run: copy succeeds, delete fails -> archive rejects, but Slack was
+  // reposted once.
+  await assert.rejects(redrive(), /HTTP 500/);
+  assert.equal(slackCalls.length, 1);
+  assert.equal(objects.has("dead-letter/0xtx6-0-1.json"), true);
+  assert.equal(objects.has("dead-letter/done/0xtx6-0-1.json"), true);
+
+  // Second run: done marker exists -> repost is skipped; delete still fails.
+  await assert.rejects(redrive(), /HTTP 500/);
+  assert.equal(slackCalls.length, 1);
+  assert.equal(deleteAttempts, 2);
+
+  // Third run: delete finally succeeds -> archive completes, still no
+  // duplicate repost.
+  await redriveDeadLetterObject({
+    bucket: BUCKET,
+    objectName: "dead-letter/0xtx6-0-1.json",
+    slackToken: "xoxb-test",
+    accessToken: "token",
+    fetchImpl: baseFetch,
+  });
+  assert.equal(slackCalls.length, 1);
+  assert.equal(objects.has("dead-letter/0xtx6-0-1.json"), false);
 }
 
 // main(): end-to-end sweep across a mix of a redrivable and a failing object,


### PR DESCRIPTION
## The Problem

- `alerts/infra/onchain-event-handler/src/slack.ts` retries Slack delivery 3x (~7s worst case), then throws; today that error is only logged and the handler still returns HTTP 200 so QuickNode never redelivers.
- Because the QuickNode nonce is reserved before processing, even a QuickNode-side redelivery would be rejected as a replay — a Slack outage longer than ~7s permanently drops a Safe/multisig security alert with no trace.
- There was no redrive path: once dropped, the only recovery was manually re-checking on-chain activity.

## The Solution

On a Slack delivery failure (retries exhausted), the handler now persists the fully-rendered Slack payload plus event metadata to the same GCS bucket already used for QuickNode nonce replay protection, under a `dead-letter/` prefix — no new infra. The write happens inside the existing per-event failure handling, is guarded so a write failure can't crash the batch, and logs a distinct ERROR marker (`reason: "dead_lettered"`) that rides the same Cloud Monitoring alert already wired up for this function's error logs. A new root script, `pnpm deadletter:redrive`, lists dead-lettered objects, reposts each one to its original Slack channel, and archives it to `dead-letter/done/` once redelivered.

## Details

- `alerts/infra/onchain-event-handler/src/dead-letter.ts` (new): `writeDeadLetter()` uploads the rendered Slack payload + event metadata (tx hash, event name, chain, multisig key, channel, failure reason, timestamps) to GCS. Reuses `getMetadataAccessToken` (now exported) from `quicknode-replay-protection.ts` for the same metadata-server auth. Never throws — every failure path (missing bucket, non-2xx response, fetch rejection) logs at ERROR and returns.
- `alerts/infra/onchain-event-handler/src/process-events.ts`: `processEvent` now wraps `sendToSlack` and throws a new `SlackDeliveryFailedError` carrying the rendered message + routing context on failure. Both per-event catch sites (the main loop and the budget-headroom fallback path) call a small `deadLetterIfSlackDeliveryFailed()` helper that dead-letters any `SlackDeliveryFailedError`, **including** ones caused by our own processing-budget abort cutting a send short — the QuickNode nonce is already reserved by then, so there is no redelivery to fall back on, and the payload is already rendered. The malformed-entry filter, HTTP-200-on-partial-failure contract, and nonce-reservation ordering are all untouched.
- `alerts/infra/onchain-event-handler/src/slack.ts`: exported the previously-private `SlackMessage` type so it can be threaded through the new error/dead-letter path.
- `scripts/redrive-onchain-deadletter.mjs` (new, + `.test.mjs`): lists undone `dead-letter/` objects (paginated, excludes `dead-letter/done/`), reposts each rendered payload to its persisted `channelId` using `SLACK_BOT_TOKEN` from the environment (same source the function uses), then archives via GCS copy+delete. Redrive is idempotent across a partial archive failure: before reposting, it checks whether `dead-letter/done/<name>` already exists (copy succeeded, delete failed on a prior run) and skips the repost if so, only retrying the copy+delete. A Slack repost failure leaves the object in place for the next sweep instead of archiving it. GCS access uses the operator's own `gcloud auth print-access-token` (this runs off-platform, unlike the function's metadata-server token). Wired as `pnpm deadletter:redrive` / `pnpm deadletter:redrive:test`, plus a routing entry in `scripts/agent-quality-gate.sh` so future edits to the tool re-run its tests automatically.
- `alerts/infra/onchain-event-handler/README.md`: documented the dead-letter + redrive flow.

## Validation

- `pnpm alerts:handler:test` — pass (17 files, 120 tests, including new `dead-letter.test.ts` and the new `process-events.test.ts` cases covering retry-exhaustion dead-lettering and budget-abort dead-lettering).
- `pnpm alerts:handler:typecheck` — pass.
- `pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage` — pass; global thresholds (78/69/82/78) still clear at 81.4/71.7/84.5/81.6% (`dead-letter.ts` itself at 100/83/100/100).
- `pnpm --filter @mento-protocol/alerts-onchain-event-handler lint` / `knip` — pass.
- `node scripts/redrive-onchain-deadletter.test.mjs` — pass (list pagination + done-prefix exclusion, happy-path redrive+archive, Slack-failure-does-not-archive, done-marker idempotency on a fresh repost and across repeated delete-failure reruns, `main()` end-to-end sweep with mixed success/failure, missing-env-var guards).
- `pnpm alerts:infra:plan` — **not run**: this worktree has no `terraform.tfvars`, and no Terraform files were touched in this PR (see Deferrals).
- `pnpm agent:quality-gate --run` — pass (full mapped sweep across the touched-package blast radius from the `package.json` script additions: handler test/typecheck/lint/knip, ui-dashboard/indexer-envio/metrics-bridge/integration-probes/monitoring-config/governance-watchdog/aegis builds+coverage, `trunk check --all`, `code-health:deps`, and all root-script tests).
- Operator alerting mechanism (investigated, not added): the onchain-event-handler has no Sentry SDK wiring (Sentry's `sentry-bridge` only fires on Sentry *issues*, which this function never reports). The existing `google_monitoring_alert_policy.onchain_handler_errors_policy` in `alerts/infra/monitoring.tf` already pages on any `"Error processing log"` ERROR from this function within 5 minutes — since dead-lettering runs inside the same per-event catch that always emits that exact log line (via the unchanged `logProcessingError`), every dead-lettered event already triggers that alert. No new Grafana/log-based rule was needed.

## Deferrals

- The GCS bucket reused for dead-letter objects (`webhook_replay_nonces`) has two unconditional `lifecycle_rule` blocks in `alerts/infra/onchain-event-handler/main.tf` that delete every object after 1 day (needed for nonce cleanup). Left un-prefix-scoped, this would also delete dead-lettered alerts before they can be redriven. Fixing it means adding `matches_prefix` to those rules, which is a Terraform change to a stack this worktree can't `plan`/verify (no `terraform.tfvars`) — tracked in [#1073](https://github.com/mento-protocol/monitoring-monorepo/issues/1073) instead of touched blind here.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1051

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Safe/multisig alert delivery and failure handling on a security-sensitive path; mitigations include non-throwing dead-letter writes, bounded timeouts, and an operator redrive tool, but misconfiguration or the deferred 1-day GCS lifecycle on dead-letter objects could still lose alerts before redrive.
> 
> **Overview**
> When Slack delivery fails after the message is already rendered, the onchain event handler **persists the alert to GCS** instead of dropping it silently. Failed sends are wrapped in `SlackDeliveryFailedError`; per-event catch paths call `deadLetterIfSlackDeliveryFailed`, which uploads the rendered payload and routing metadata under `dead-letter/` in the existing `QUICKNODE_REPLAY_BUCKET`, with a **5s bounded write** and ERROR logs (`reason: "dead_lettered"`) for operators. This covers retry exhaustion and **budget-abort** mid-send, since QuickNode nonce replay protection blocks redelivery.
> 
> **`writeDeadLetter`** reuses exported GCS auth from `quicknode-replay-protection.ts`; **`SlackMessage`** is exported for typing. A new **`pnpm deadletter:redrive`** script lists pending objects, reposts to the saved Slack channel via `gcloud` credentials, and archives to `dead-letter/done/` with idempotency for partial failures. README, root scripts, quality-gate routing, and tests are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c73d0802d0d58a57dbd59656c12da30e025b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

