### PR TITLE
docs: bring SPEC.md under the context-authority model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -861,6 +861,10 @@ jobs:
         run: node scripts/check-hermetic-vitest-setup.test.mjs
       - name: Deviation threshold drift suite
         run: node scripts/check-deviation-threshold-drift.test.mjs
+      - name: Agent context checker unit tests
+        # Behavioral coverage of scripts/check-agent-context.mjs's pure
+        # helpers: frontmatter parsing and the last_verified staleness window.
+        run: node scripts/check-agent-context.test.mjs
       - name: PR description validator suite
         run: node scripts/check-pr-description.test.mjs
       - name: Deploy root-anchor regression suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,18 @@ jobs:
               # if only the new workflow file is touched (no script change).
               - .github/workflows/**
               - .github/actions/pnpm-install/**
+              # Managed context files that scripts/check-agent-context.mjs
+              # enforces (frontmatter + last_verified staleness policy). A
+              # PR that only touches one of these otherwise has no CI job
+              # that runs the checker, so a stale/missing last_verified could
+              # merge silently. Mirrors managedContextFiles in that script.
+              - SPEC.md
+              - AGENTS.md
+              - "*/AGENTS.md"
+              - docs/context-standards.md
+              - docs/pr-checklists/recurring-review-patterns.md
+              - .agents/skills/*/SKILL.md
+              - .agents/roles/*.md
             # Dependency manifest and pnpm catalog/lifecycle policy drift.
             # This runs independently of package quality jobs so a manifest-only
             # PR cannot satisfy the required `ci` sentinel while bypassing the
@@ -865,6 +877,11 @@ jobs:
         # Behavioral coverage of scripts/check-agent-context.mjs's pure
         # helpers: frontmatter parsing and the last_verified staleness window.
         run: node scripts/check-agent-context.test.mjs
+      - name: Agent context checker
+        # Runs the actual check-agent-context.mjs enforcement pass (managed
+        # frontmatter + last_verified staleness policy) — the unit tests
+        # above only cover the pure helpers in isolation.
+        run: pnpm agent:context-check
       - name: PR description validator suite
         run: node scripts/check-pr-description.test.mjs
       - name: Deploy root-anchor regression suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,18 +234,25 @@ jobs:
               # if only the new workflow file is touched (no script change).
               - .github/workflows/**
               - .github/actions/pnpm-install/**
-              # Managed context files that scripts/check-agent-context.mjs
-              # enforces (frontmatter + last_verified staleness policy). A
-              # PR that only touches one of these otherwise has no CI job
-              # that runs the checker, so a stale/missing last_verified could
-              # merge silently. Mirrors managedContextFiles in that script.
+              # check-agent-context inputs. The checker discovers canonical
+              # (frontmatter-managed) markdown across these roots — SPEC.md,
+              # AGENTS.md at any depth, docs/**, .agents/** — and separately
+              # validates SessionEnd hooks (.codex/hooks.json,
+              # .claude/settings.json) and .claude/skills mirror parity. A PR
+              # touching only one of these files must still run the checker
+              # in CI. docs/**/*.md is deliberately broad: discovery means
+              # any docs markdown can opt into canonical enforcement, and
+              # the scripts job is cheap. The checker's remaining inputs
+              # (scripts/*.sh guards, workflow revision-suffix guard) are
+              # already covered by the script/workflow globs above.
               - SPEC.md
               - AGENTS.md
-              - "*/AGENTS.md"
-              - docs/context-standards.md
-              - docs/pr-checklists/recurring-review-patterns.md
-              - .agents/skills/*/SKILL.md
-              - .agents/roles/*.md
+              - "**/AGENTS.md"
+              - "docs/**/*.md"
+              - ".agents/**"
+              - ".claude/skills/**"
+              - .claude/settings.json
+              - .codex/hooks.json
             # Dependency manifest and pnpm catalog/lifecycle policy drift.
             # This runs independently of package quality jobs so a manifest-only
             # PR cannot satisfy the required `ci` sentinel while bypassing the

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -28,11 +28,12 @@ name: Supply Chain
 #    updates a labeled GitHub issue for sub-high advisories, so stale
 #    resolution-time override floors stay visible without blocking merges.
 #
-# The weekly report job doubles as the repo's scheduled-report slot: it also
-# runs `pnpm agent:context-check` so the canonical-context last_verified
-# staleness policy — which expires with time, not with a diff — is evaluated
-# on a calendar cadence instead of only when a PR happens to touch context
-# files.
+# This workflow also hosts the repo's scheduled-report slot: a dedicated
+# weekly context-staleness job runs scripts/check-agent-context.mjs so the
+# canonical-context last_verified policy — which expires with time, not with
+# a diff — is evaluated on a calendar cadence instead of only when a PR
+# happens to touch context files. It is a separate job from the advisory
+# report so a stale doc can never abort supply-chain tracking.
 #
 # What this does NOT cover: sigstore attestations / SLSA provenance. pnpm 10
 # has no `audit signatures` equivalent, and `npm audit signatures` requires a
@@ -170,6 +171,33 @@ jobs:
         # must be "catalog:" or exactly the catalog version.
         run: node scripts/version-skew-check.mjs
 
+  context-staleness-report:
+    name: context staleness report (scheduled)
+    # Same weekly cron + default-branch manual dispatch gate as the moderate
+    # advisory report, but its own job on purpose: last_verified expires with
+    # time, not with a diff — a canonical doc can pass its 90-day window
+    # without any PR touching context files, so the path-filtered ci.yml
+    # scripts job alone can never catch calendar expiry. Isolating the check
+    # means a stale doc fails only this job (surfacing via
+    # notify-slack-on-main-failure.yml like the other scheduled gates) and
+    # never aborts the advisory-report steps next door.
+    if: >-
+      github.event.schedule == '17 7 * * 1' ||
+      (github.event_name == 'workflow_dispatch' &&
+        github.ref_name == github.event.repository.default_branch)
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          # No pnpm install — scripts/check-agent-context.mjs is pure Node.js
+          # (node builtins + a sibling helper module), same sub-30s pattern
+          # as the lockfile-lint job.
+      - name: Agent context staleness check
+        run: node scripts/check-agent-context.mjs
+
   moderate-advisory-report:
     name: moderate advisory report (non-blocking)
     # Weekly cron + default-branch manual dispatch only — never on pull_request,
@@ -192,15 +220,6 @@ jobs:
           node-version-file: .node-version
           # No pnpm install — same as the blocking audit job. Audit queries the
           # hosted advisory DB directly from the committed lockfile.
-      - name: Agent context staleness check
-        # last_verified expires with time, not with a diff: a canonical doc
-        # can pass its 90-day window without any PR touching context files,
-        # so the path-filtered ci.yml scripts job alone can never catch
-        # calendar expiry. This weekly run is the time-based backstop.
-        # Zero-dependency Node script (no pnpm install needed); a failure
-        # fails the job and surfaces via notify-slack-on-main-failure.yml
-        # like the other scheduled supply-chain gates.
-        run: pnpm agent:context-check
       - name: pnpm audit (moderate+, report only)
         # Exit 1 means advisories found, which is the expected report case.
         # The script step below fails if pnpm returns a registry error payload.

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -28,6 +28,12 @@ name: Supply Chain
 #    updates a labeled GitHub issue for sub-high advisories, so stale
 #    resolution-time override floors stay visible without blocking merges.
 #
+# The weekly report job doubles as the repo's scheduled-report slot: it also
+# runs `pnpm agent:context-check` so the canonical-context last_verified
+# staleness policy — which expires with time, not with a diff — is evaluated
+# on a calendar cadence instead of only when a PR happens to touch context
+# files.
+#
 # What this does NOT cover: sigstore attestations / SLSA provenance. pnpm 10
 # has no `audit signatures` equivalent, and `npm audit signatures` requires a
 # package-lock.json (we use pnpm-lock.yaml). If we ever want that layer,
@@ -186,6 +192,15 @@ jobs:
           node-version-file: .node-version
           # No pnpm install — same as the blocking audit job. Audit queries the
           # hosted advisory DB directly from the committed lockfile.
+      - name: Agent context staleness check
+        # last_verified expires with time, not with a diff: a canonical doc
+        # can pass its 90-day window without any PR touching context files,
+        # so the path-filtered ci.yml scripts job alone can never catch
+        # calendar expiry. This weekly run is the time-based backstop.
+        # Zero-dependency Node script (no pnpm install needed); a failure
+        # fails the job and surfaces via notify-slack-on-main-failure.yml
+        # like the other scheduled supply-chain gates.
+        run: pnpm agent:context-check
       - name: pnpm audit (moderate+, report only)
         # Exit 1 means advisories found, which is the expected report case.
         # The script step below fails if pnpm returns a registry error payload.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,3 +1,11 @@
+---
+title: Mento v3 Monitoring Technical Specification
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-03
+---
+
 # Mento v3 Monitoring — Technical Specification
 
 Last updated: 2026-07-03

--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -3,7 +3,7 @@ title: Agent Context Standards
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-05
 ---
 
 # Agent Context Standards
@@ -17,6 +17,7 @@ This repo treats context as part of the product. Source code is what runs in pro
 Canonical context describes the system and operating rules as they are today. Agents may rely on it when making implementation decisions.
 
 - `AGENTS.md` and nested `*/AGENTS.md` files: operational instructions scoped to the repo or a directory.
+- `SPEC.md`: the technical specification of the monitoring system's architecture, data flow, and endpoints.
 - `docs/pr-checklists/*.md`: mandatory review checklists for known hazard classes.
 - `docs/deployment.md`: current deployment workflow.
 - `.agents/skills/**/SKILL.md`: reusable agent procedures.
@@ -24,6 +25,8 @@ Canonical context describes the system and operating rules as they are today. Ag
 - Package READMEs when they describe current commands or runtime behavior.
 
 Canonical context must stay internally consistent. If two canonical files conflict, fix the conflict before relying on either one.
+
+Root `README.md` is deliberately excluded from the metadata contract for now: it's a GitHub-rendered landing page, and a raw `---\nkey: value\n---` frontmatter block would render as literal text at the top of the repo homepage. Bringing it into `scripts/check-agent-context.mjs` would need a comment-based marker the check can parse instead — tracked in #1071 rather than built speculatively here.
 
 ### Non-Canonical Context
 
@@ -47,6 +50,7 @@ Rules:
 - `canonical: false` means the file is history, intent, or notes.
 - `owner` is the accountable reviewer for future cleanup.
 - `last_verified` is required for canonical files whose correctness depends on external systems or current repo structure.
+- `pnpm agent:context-check` fails once a `canonical: true` file's `last_verified` is more than 90 days old. Re-verify the content and bump the date; don't extend the window to make the check pass.
 
 ## Placement Rules
 
@@ -58,4 +62,4 @@ Rules:
 
 ## Maintenance Checks
 
-Run `pnpm agent:context-check` to verify managed metadata, scoped AGENTS coverage, skill mirrors, and Cloud Run revision suffix guardrails. Skill mirrors must match their canonical `.agents/skills` source except for documented runtime-specific provenance literals, such as forensic-report writes using `source: "Codex"` in the Codex skill and `source: "claude"` in the Claude skill.
+Run `pnpm agent:context-check` to verify managed metadata (including the `last_verified` staleness window), scoped AGENTS coverage, skill mirrors, and Cloud Run revision suffix guardrails. Skill mirrors must match their canonical `.agents/skills` source except for documented runtime-specific provenance literals, such as forensic-report writes using `source: "Codex"` in the Codex skill and `source: "claude"` in the Claude skill.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1333,10 +1333,10 @@ while IFS= read -r path; do
       add_surface "ui-dashboard"
       add_checklist "docs/pr-checklists/code-health.md" "Lighthouse CI budget config changed"
       ;;
-    docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md)
+    docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md|SPEC.md)
       add_surface "docs"
       case "$path" in
-        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md|AGENTS.md|*/AGENTS.md)
+        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md|AGENTS.md|*/AGENTS.md|SPEC.md)
           add_command "pnpm agent:context-check" "agent context standards changed"
           ;;
       esac
@@ -1382,8 +1382,9 @@ while IFS= read -r path; do
         scripts/agent-autoreview.mjs)
           add_command "bash scripts/agent-autoreview.test.sh" "agent autoreview helper changed"
           ;;
-        scripts/check-agent-context.mjs)
+        scripts/check-agent-context.mjs|scripts/check-agent-context-helpers.mjs|scripts/check-agent-context.test.mjs)
           add_command "pnpm agent:context-check" "agent context checker changed"
+          add_command "node scripts/check-agent-context.test.mjs" "agent context checker changed"
           ;;
         scripts/check-deploy-root-anchors.test.mjs)
           add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy root-anchor test changed"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1336,8 +1336,11 @@ while IFS= read -r path; do
     docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md|SPEC.md)
       add_surface "docs"
       case "$path" in
-        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md|AGENTS.md|*/AGENTS.md|SPEC.md)
+        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md|AGENTS.md|*/AGENTS.md)
           add_command "pnpm agent:context-check" "agent context standards changed"
+          ;;
+        SPEC.md)
+          add_command "pnpm agent:context-check" "technical specification changed"
           ;;
       esac
       ;;

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1342,9 +1342,15 @@ while IFS= read -r path; do
         SPEC.md)
           add_command "pnpm agent:context-check" "technical specification changed"
           ;;
+        docs/*.md)
+          # check-agent-context.mjs discovers canonical files across all of
+          # docs/**/*.md, so any docs markdown change may affect the
+          # frontmatter/staleness policy — route it through the check.
+          add_command "pnpm agent:context-check" "docs markdown may be canonical (frontmatter discovery)"
+          ;;
       esac
       ;;
-    .agents/skills/*|.agents/roles/*|.claude/skills/*|.claude/settings.json|.codex/hooks.json)
+    .agents/*|.claude/skills/*|.claude/settings.json|.codex/hooks.json)
       add_surface "agent-context"
       add_command "pnpm agent:context-check" "agent context files changed"
       ;;

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2220,6 +2220,13 @@ run_gate "SPEC.md"
 assert_contains "- docs"
 assert_contains "- pnpm agent:context-check (technical specification changed)"
 
+# Any docs markdown may carry canonical: true frontmatter (discovery in
+# check-agent-context.mjs), so a discovered doc path must route through the
+# context check locally, not just in CI.
+run_gate "docs/terraform.md"
+assert_contains "- docs"
+assert_contains "- pnpm agent:context-check (docs markdown may be canonical (frontmatter discovery))"
+
 run_gate ".codex/hooks.json"
 assert_contains "- agent-context"
 assert_contains "- pnpm agent:context-check (agent context files changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2216,6 +2216,10 @@ run_gate "docs/pr-checklists/recurring-review-patterns.md"
 assert_contains "- docs"
 assert_contains "- pnpm agent:context-check (agent context standards changed)"
 
+run_gate "SPEC.md"
+assert_contains "- docs"
+assert_contains "- pnpm agent:context-check (agent context standards changed)"
+
 run_gate ".codex/hooks.json"
 assert_contains "- agent-context"
 assert_contains "- pnpm agent:context-check (agent context files changed)"
@@ -2386,6 +2390,18 @@ assert_contains "- node scripts/check-pr-description.test.mjs (PR description va
 run_gate "scripts/agent-autoreview.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview helper changed)"
+
+run_gate "scripts/check-agent-context.mjs"
+assert_contains "- pnpm agent:context-check (agent context checker changed)"
+assert_contains "- node scripts/check-agent-context.test.mjs (agent context checker changed)"
+
+run_gate "scripts/check-agent-context-helpers.mjs"
+assert_contains "- pnpm agent:context-check (agent context checker changed)"
+assert_contains "- node scripts/check-agent-context.test.mjs (agent context checker changed)"
+
+run_gate "scripts/check-agent-context.test.mjs"
+assert_contains "- pnpm agent:context-check (agent context checker changed)"
+assert_contains "- node scripts/check-agent-context.test.mjs (agent context checker changed)"
 
 run_gate "scripts/check-deviation-threshold-drift.mjs"
 assert_contains "- node scripts/check-deviation-threshold-drift.mjs (deviation threshold drift checker changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2218,7 +2218,7 @@ assert_contains "- pnpm agent:context-check (agent context standards changed)"
 
 run_gate "SPEC.md"
 assert_contains "- docs"
-assert_contains "- pnpm agent:context-check (agent context standards changed)"
+assert_contains "- pnpm agent:context-check (technical specification changed)"
 
 run_gate ".codex/hooks.json"
 assert_contains "- agent-context"

--- a/scripts/check-agent-context-helpers.mjs
+++ b/scripts/check-agent-context-helpers.mjs
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for check-agent-context.mjs.
+ * Extracted as a separate module so the script and its test file can both
+ * import the real implementations instead of duplicating them — the main
+ * script scans live repo state (git ls-files, real settings/hook files) and
+ * isn't a good target for end-to-end fixture tests.
+ */
+
+/**
+ * Number of days a canonical file's `last_verified` may age before
+ * check-agent-context.mjs treats it as stale.
+ */
+export const STALE_AFTER_DAYS = 90;
+
+/**
+ * Tolerance, in days, for a `last_verified` date that resolves to appearing
+ * one UTC day in the future. `daysSince` compares a UTC-midnight date
+ * against the check's UTC clock, so a contributor in a timezone ahead of
+ * UTC (up to UTC+14) who stamps their own local "today" can see it land on
+ * UTC "tomorrow" until UTC midnight arrives. One day of slack absorbs the
+ * maximum real-world skew without weakening the future-date guard against
+ * genuinely bogus dates (a real typo lands further out than this).
+ */
+export const FUTURE_SKEW_TOLERANCE_DAYS = 1;
+
+/**
+ * Parse the YAML-ish frontmatter block (`---\nkey: value\n---`) from a
+ * file's content. Returns null when the content has no frontmatter block.
+ * @param {string} content
+ * @returns {Record<string, string> | null}
+ */
+export function parseFrontmatter(content) {
+  if (!content.startsWith("---\n")) return null;
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  const raw = content.slice(4, end);
+  const data = {};
+  for (const line of raw.split("\n")) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (match) data[match[1]] = match[2].trim().replace(/^["']|["']$/g, "");
+  }
+  return data;
+}
+
+/**
+ * Days elapsed between a `YYYY-MM-DD` date string and `now`. Returns null
+ * when `dateString` isn't a strict `YYYY-MM-DD` date — including calendar
+ * dates that don't exist (e.g. `2026-02-31`), which `Date.UTC` would
+ * otherwise silently normalize into the following month instead of
+ * rejecting.
+ * @param {string} dateString
+ * @param {Date} [now]
+ * @returns {number | null}
+ */
+export function daysSince(dateString, now = new Date()) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
+  if (!match) return null;
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  const diffMs = now.getTime() - parsed.getTime();
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+}

--- a/scripts/check-agent-context-helpers.mjs
+++ b/scripts/check-agent-context-helpers.mjs
@@ -64,6 +64,57 @@ export function parseFrontmatter(content) {
 }
 
 /**
+ * Whether a tracked file path is eligible for canonical-context discovery.
+ * Discovery roots: AGENTS.md and SPEC.md at the repo root, AGENTS.md in any
+ * directory, docs markdown at any depth, and .agents markdown (skills,
+ * roles). Mirrors under .claude/skills are excluded on purpose: the checker
+ * enforces byte-parity between each mirror and its canonical .agents source,
+ * so their metadata is already enforced transitively.
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isCanonicalDiscoveryPath(filePath) {
+  return (
+    filePath === "AGENTS.md" ||
+    filePath === "SPEC.md" ||
+    filePath.endsWith("/AGENTS.md") ||
+    (filePath.startsWith("docs/") && filePath.endsWith(".md")) ||
+    (filePath.startsWith(".agents/") && filePath.endsWith(".md"))
+  );
+}
+
+/**
+ * Discover the canonical (frontmatter-managed) context files: every path in
+ * `filePaths` that sits in a discovery root and whose frontmatter declares
+ * `canonical: true`. This derives the enforced set from the repo itself so
+ * new canonical files can't silently escape the staleness policy.
+ * @param {string[]} filePaths
+ * @param {(filePath: string) => string} readFile
+ * @returns {string[]}
+ */
+export function discoverCanonicalFiles(filePaths, readFile) {
+  return filePaths.filter((filePath) => {
+    if (!isCanonicalDiscoveryPath(filePath)) return false;
+    const data = parseFrontmatter(readFile(filePath));
+    return data?.canonical === "true";
+  });
+}
+
+/**
+ * Core context files that discovery failed to find. Discovery derives the
+ * enforced set from `canonical: true` frontmatter, so stripping a file's
+ * frontmatter would otherwise silently unmanage it — the caller fails the
+ * check for every file returned here.
+ * @param {string[]} coreFiles
+ * @param {string[]} discoveredFiles
+ * @returns {string[]}
+ */
+export function missingCoreContextFiles(coreFiles, discoveredFiles) {
+  const discovered = new Set(discoveredFiles);
+  return coreFiles.filter((file) => !discovered.has(file));
+}
+
+/**
  * Days elapsed between a `YYYY-MM-DD` date string and `now`. Returns null
  * when `dateString` isn't a strict `YYYY-MM-DD` date — including calendar
  * dates that don't exist (e.g. `2026-02-31`), which `Date.UTC` would

--- a/scripts/check-agent-context-helpers.mjs
+++ b/scripts/check-agent-context-helpers.mjs
@@ -24,6 +24,27 @@ export const STALE_AFTER_DAYS = 90;
 export const FUTURE_SKEW_TOLERANCE_DAYS = 1;
 
 /**
+ * Classify a `last_verified` age (in days, as returned by `daysSince`)
+ * against the staleness policy window. This is the pure decision logic
+ * behind check-agent-context.mjs's `requireMetadata` future/stale checks,
+ * extracted so the comparisons themselves get direct regression coverage.
+ * @param {number} age
+ * @param {{staleAfterDays?: number, toleranceDays?: number}} [options]
+ * @returns {"ok" | "stale" | "future"}
+ */
+export function assessStaleness(
+  age,
+  {
+    staleAfterDays = STALE_AFTER_DAYS,
+    toleranceDays = FUTURE_SKEW_TOLERANCE_DAYS,
+  } = {},
+) {
+  if (age < -toleranceDays) return "future";
+  if (age > staleAfterDays) return "stale";
+  return "ok";
+}
+
+/**
  * Parse the YAML-ish frontmatter block (`---\nkey: value\n---`) from a
  * file's content. Returns null when the content has no frontmatter block.
  * @param {string} content

--- a/scripts/check-agent-context.mjs
+++ b/scripts/check-agent-context.mjs
@@ -4,6 +4,13 @@ import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+import {
+  daysSince,
+  FUTURE_SKEW_TOLERANCE_DAYS,
+  parseFrontmatter,
+  STALE_AFTER_DAYS,
+} from "./check-agent-context-helpers.mjs";
+
 const repoRoot = process.cwd();
 const failures = [];
 const requiredMetadataKeys = ["title", "status", "owner", "canonical"];
@@ -99,22 +106,8 @@ function trackedFiles(dir, predicate = () => true, { required = false } = {}) {
   return files;
 }
 
-function parseFrontmatter(filePath) {
-  const content = read(filePath);
-  if (!content.startsWith("---\n")) return null;
-  const end = content.indexOf("\n---\n", 4);
-  if (end === -1) return null;
-  const raw = content.slice(4, end);
-  const data = {};
-  for (const line of raw.split("\n")) {
-    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (match) data[match[1]] = match[2].trim().replace(/^["']|["']$/g, "");
-  }
-  return data;
-}
-
 function requireMetadata(filePath) {
-  const data = parseFrontmatter(filePath);
+  const data = parseFrontmatter(read(filePath));
   if (!data) {
     fail(`${filePath}: missing YAML frontmatter`);
     return;
@@ -130,6 +123,19 @@ function requireMetadata(filePath) {
   }
   if (data.canonical === "true" && !data.last_verified) {
     fail(`${filePath}: canonical files require last_verified`);
+  } else if (data.canonical === "true" && data.last_verified) {
+    const age = daysSince(data.last_verified);
+    if (age === null) {
+      fail(
+        `${filePath}: last_verified '${data.last_verified}' is not a valid YYYY-MM-DD date`,
+      );
+    } else if (age < -FUTURE_SKEW_TOLERANCE_DAYS) {
+      fail(`${filePath}: last_verified ${data.last_verified} is in the future`);
+    } else if (age > STALE_AFTER_DAYS) {
+      fail(
+        `${filePath}: last_verified ${data.last_verified} is ${age} days old, exceeds the ${STALE_AFTER_DAYS}-day policy window`,
+      );
+    }
   }
 }
 
@@ -158,6 +164,7 @@ const claudeSkillFiles = trackedFiles(
 
 const managedContextFiles = [
   "AGENTS.md",
+  "SPEC.md",
   ...scopedAgentDirs.map((dir) => `${dir}/AGENTS.md`),
   "docs/context-standards.md",
   "docs/pr-checklists/recurring-review-patterns.md",

--- a/scripts/check-agent-context.mjs
+++ b/scripts/check-agent-context.mjs
@@ -7,6 +7,8 @@ import process from "node:process";
 import {
   assessStaleness,
   daysSince,
+  discoverCanonicalFiles,
+  missingCoreContextFiles,
   parseFrontmatter,
   STALE_AFTER_DAYS,
 } from "./check-agent-context-helpers.mjs";
@@ -146,7 +148,9 @@ function requireMetadata(filePath) {
 
 const scopedAgentDirs = [
   "aegis",
+  "alerts",
   "indexer-envio",
+  "integration-probes",
   "metrics-bridge",
   "shared-config",
   "terraform",
@@ -167,7 +171,19 @@ const claudeSkillFiles = trackedFiles(
   },
 );
 
-const managedContextFiles = [
+// The enforced set is discovered, not hardcoded: every tracked markdown file
+// in the discovery roots (see isCanonicalDiscoveryPath) whose frontmatter
+// declares `canonical: true` gets full metadata + staleness enforcement, so
+// new canonical files are picked up automatically.
+const managedContextFiles = discoverCanonicalFiles(trackedFiles("."), (file) =>
+  exists(file) ? read(file) : "",
+);
+
+// Minimum-presence assertion: these core files must always be discovered.
+// Without this, stripping a core file's frontmatter (or its `canonical:
+// true` flag) would silently drop it out of the discovered set instead of
+// failing the check.
+const coreContextFiles = [
   "AGENTS.md",
   "SPEC.md",
   ...scopedAgentDirs.map((dir) => `${dir}/AGENTS.md`),
@@ -179,14 +195,23 @@ const managedContextFiles = [
   }),
 ];
 
-for (const file of managedContextFiles) {
+for (const file of missingCoreContextFiles(
+  coreContextFiles,
+  managedContextFiles,
+)) {
   if (!exists(file)) {
     fail(`${file}: required managed context file is missing`);
   } else {
-    requireMetadata(file);
-    if (read(file).includes("/Users/")) {
-      fail(`${file}: managed context must not include /Users paths`);
-    }
+    fail(
+      `${file}: core context file must keep canonical: true frontmatter (discovery no longer finds it)`,
+    );
+  }
+}
+
+for (const file of managedContextFiles) {
+  requireMetadata(file);
+  if (read(file).includes("/Users/")) {
+    fail(`${file}: managed context must not include /Users paths`);
   }
 }
 

--- a/scripts/check-agent-context.mjs
+++ b/scripts/check-agent-context.mjs
@@ -5,8 +5,8 @@ import path from "node:path";
 import process from "node:process";
 
 import {
+  assessStaleness,
   daysSince,
-  FUTURE_SKEW_TOLERANCE_DAYS,
   parseFrontmatter,
   STALE_AFTER_DAYS,
 } from "./check-agent-context-helpers.mjs";
@@ -129,12 +129,17 @@ function requireMetadata(filePath) {
       fail(
         `${filePath}: last_verified '${data.last_verified}' is not a valid YYYY-MM-DD date`,
       );
-    } else if (age < -FUTURE_SKEW_TOLERANCE_DAYS) {
-      fail(`${filePath}: last_verified ${data.last_verified} is in the future`);
-    } else if (age > STALE_AFTER_DAYS) {
-      fail(
-        `${filePath}: last_verified ${data.last_verified} is ${age} days old, exceeds the ${STALE_AFTER_DAYS}-day policy window`,
-      );
+    } else {
+      const staleness = assessStaleness(age);
+      if (staleness === "future") {
+        fail(
+          `${filePath}: last_verified ${data.last_verified} is in the future`,
+        );
+      } else if (staleness === "stale") {
+        fail(
+          `${filePath}: last_verified ${data.last_verified} is ${age} days old, exceeds the ${STALE_AFTER_DAYS}-day policy window`,
+        );
+      }
     }
   }
 }

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -228,12 +228,12 @@ console.log("\ncanonical-context discovery");
 const canonicalContent =
   "---\ntitle: T\nstatus: active\nowner: eng\ncanonical: true\nlast_verified: 2026-07-03\n---\n\n# T\n";
 
-function discoverIn(files) {
+function discoverFrom(files) {
   return discoverCanonicalFiles(Object.keys(files), (file) => files[file]);
 }
 
 test("discovers a canonical file in a nested docs path", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "docs/notes/deep/topology.md": canonicalContent,
   });
   assert(
@@ -243,7 +243,7 @@ test("discovers a canonical file in a nested docs path", () => {
 });
 
 test("discovers AGENTS.md in any package directory", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "alerts/AGENTS.md": canonicalContent,
     "integration-probes/AGENTS.md": canonicalContent,
   });
@@ -254,7 +254,7 @@ test("discovers AGENTS.md in any package directory", () => {
 });
 
 test("does not enforce non-canonical files", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "docs/guide.md":
       "---\ntitle: G\nstatus: active\nowner: eng\ncanonical: false\n---\n",
     "docs/plain.md": "# no frontmatter\n",
@@ -266,7 +266,7 @@ test("does not enforce non-canonical files", () => {
 });
 
 test("ignores canonical frontmatter outside the discovery roots", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "ui-dashboard/README.md": canonicalContent,
   });
   assert(
@@ -276,7 +276,7 @@ test("ignores canonical frontmatter outside the discovery roots", () => {
 });
 
 test("minimum-presence fires when a core file loses its frontmatter", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "AGENTS.md": "# frontmatter stripped\n",
     "SPEC.md": canonicalContent,
   });
@@ -288,7 +288,7 @@ test("minimum-presence fires when a core file loses its frontmatter", () => {
 });
 
 test("minimum-presence passes when every core file is discovered", () => {
-  const discovered = discoverIn({
+  const discovered = discoverFrom({
     "AGENTS.md": canonicalContent,
     "SPEC.md": canonicalContent,
   });

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -4,8 +4,9 @@
  *
  * The script itself scans live repo state (git ls-files, real settings/hook
  * files) and exits the process on failure, so it isn't a good target for a
- * synthetic-fixture end-to-end harness. Instead this tests the pure parsing
- * and staleness helpers from check-agent-context-helpers.mjs directly.
+ * synthetic-fixture end-to-end harness. Instead this tests the pure parsing,
+ * staleness, and canonical-discovery helpers from
+ * check-agent-context-helpers.mjs directly.
  *
  * Run: node scripts/check-agent-context.test.mjs
  * CI:  .github/workflows/ci.yml  (scripts job)
@@ -14,7 +15,9 @@
 import {
   assessStaleness,
   daysSince,
+  discoverCanonicalFiles,
   FUTURE_SKEW_TOLERANCE_DAYS,
+  missingCoreContextFiles,
   parseFrontmatter,
   STALE_AFTER_DAYS,
 } from "./check-agent-context-helpers.mjs";
@@ -209,6 +212,90 @@ test("a last_verified beyond the future-skew tolerance fails (age === -FUTURE_SK
   assert(
     status === "future",
     `expected 'future' beyond the tolerance, got ${status}`,
+  );
+});
+
+// ── canonical-context discovery ───────────────────────────────────────────────
+//
+// check-agent-context.mjs derives the enforced set by discovery: tracked
+// markdown in the discovery roots with `canonical: true` frontmatter. These
+// tests drive discoverCanonicalFiles with a synthetic file map (same reader
+// contract the script uses), so a new canonical file can't escape the policy
+// and a stripped-frontmatter core file can't silently drop out.
+
+console.log("\ncanonical-context discovery");
+
+const canonicalContent =
+  "---\ntitle: T\nstatus: active\nowner: eng\ncanonical: true\nlast_verified: 2026-07-03\n---\n\n# T\n";
+
+function discoverIn(files) {
+  return discoverCanonicalFiles(Object.keys(files), (file) => files[file]);
+}
+
+test("discovers a canonical file in a nested docs path", () => {
+  const discovered = discoverIn({
+    "docs/notes/deep/topology.md": canonicalContent,
+  });
+  assert(
+    discovered.includes("docs/notes/deep/topology.md"),
+    `expected nested docs file to be discovered, got ${JSON.stringify(discovered)}`,
+  );
+});
+
+test("discovers AGENTS.md in any package directory", () => {
+  const discovered = discoverIn({
+    "alerts/AGENTS.md": canonicalContent,
+    "integration-probes/AGENTS.md": canonicalContent,
+  });
+  assert(
+    discovered.length === 2,
+    `expected both package AGENTS.md files, got ${JSON.stringify(discovered)}`,
+  );
+});
+
+test("does not enforce non-canonical files", () => {
+  const discovered = discoverIn({
+    "docs/guide.md":
+      "---\ntitle: G\nstatus: active\nowner: eng\ncanonical: false\n---\n",
+    "docs/plain.md": "# no frontmatter\n",
+  });
+  assert(
+    discovered.length === 0,
+    `expected non-canonical files to be skipped, got ${JSON.stringify(discovered)}`,
+  );
+});
+
+test("ignores canonical frontmatter outside the discovery roots", () => {
+  const discovered = discoverIn({
+    "ui-dashboard/README.md": canonicalContent,
+  });
+  assert(
+    discovered.length === 0,
+    `expected files outside the discovery roots to be skipped, got ${JSON.stringify(discovered)}`,
+  );
+});
+
+test("minimum-presence fires when a core file loses its frontmatter", () => {
+  const discovered = discoverIn({
+    "AGENTS.md": "# frontmatter stripped\n",
+    "SPEC.md": canonicalContent,
+  });
+  const missing = missingCoreContextFiles(["AGENTS.md", "SPEC.md"], discovered);
+  assert(
+    missing.length === 1 && missing[0] === "AGENTS.md",
+    `expected AGENTS.md to be reported missing, got ${JSON.stringify(missing)}`,
+  );
+});
+
+test("minimum-presence passes when every core file is discovered", () => {
+  const discovered = discoverIn({
+    "AGENTS.md": canonicalContent,
+    "SPEC.md": canonicalContent,
+  });
+  const missing = missingCoreContextFiles(["AGENTS.md", "SPEC.md"], discovered);
+  assert(
+    missing.length === 0,
+    `expected no missing core files, got ${JSON.stringify(missing)}`,
   );
 });
 

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -12,6 +12,7 @@
  */
 
 import {
+  assessStaleness,
   daysSince,
   FUTURE_SKEW_TOLERANCE_DAYS,
   parseFrontmatter,
@@ -169,6 +170,45 @@ test("a last_verified past the window is flagged stale", () => {
   assert(
     age > STALE_AFTER_DAYS,
     `expected last_verified ${isoDate} to exceed the ${STALE_AFTER_DAYS}-day window, got age ${age}`,
+  );
+});
+
+// ── assessStaleness (requireMetadata's enforcement branch) ────────────────────
+//
+// check-agent-context.mjs's requireMetadata calls assessStaleness(age) with
+// no options, so it always enforces the real STALE_AFTER_DAYS /
+// FUTURE_SKEW_TOLERANCE_DAYS window. These tests exercise assessStaleness at
+// exactly the same boundaries requireMetadata does, so a `<` → `<=` flip (or
+// a dropped negation) on either comparison fails a test here.
+
+console.log("\nassessStaleness");
+
+test("a last_verified within the stale window passes (age === STALE_AFTER_DAYS)", () => {
+  const status = assessStaleness(STALE_AFTER_DAYS);
+  assert(status === "ok", `expected 'ok' at the boundary, got ${status}`);
+});
+
+test("a last_verified beyond the stale window fails (age === STALE_AFTER_DAYS + 1)", () => {
+  const status = assessStaleness(STALE_AFTER_DAYS + 1);
+  assert(
+    status === "stale",
+    `expected 'stale' one day past the window, got ${status}`,
+  );
+});
+
+test("a last_verified within the future-skew tolerance passes (age === -FUTURE_SKEW_TOLERANCE_DAYS)", () => {
+  const status = assessStaleness(-FUTURE_SKEW_TOLERANCE_DAYS);
+  assert(
+    status === "ok",
+    `expected 'ok' at the future-tolerance boundary, got ${status}`,
+  );
+});
+
+test("a last_verified beyond the future-skew tolerance fails (age === -FUTURE_SKEW_TOLERANCE_DAYS - 1)", () => {
+  const status = assessStaleness(-FUTURE_SKEW_TOLERANCE_DAYS - 1);
+  assert(
+    status === "future",
+    `expected 'future' beyond the tolerance, got ${status}`,
   );
 });
 

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for scripts/check-agent-context.mjs.
+ *
+ * The script itself scans live repo state (git ls-files, real settings/hook
+ * files) and exits the process on failure, so it isn't a good target for a
+ * synthetic-fixture end-to-end harness. Instead this tests the pure parsing
+ * and staleness helpers from check-agent-context-helpers.mjs directly.
+ *
+ * Run: node scripts/check-agent-context.test.mjs
+ * CI:  .github/workflows/ci.yml  (scripts job)
+ */
+
+import {
+  daysSince,
+  FUTURE_SKEW_TOLERANCE_DAYS,
+  parseFrontmatter,
+  STALE_AFTER_DAYS,
+} from "./check-agent-context-helpers.mjs";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \x1b[32m✔\x1b[0m ${name}`);
+    passed++;
+  } catch (/** @type {unknown} */ err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`  \x1b[31m✖\x1b[0m ${name}`);
+    console.error(`    ${msg}`);
+    failed++;
+  }
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(msg);
+}
+
+// ── parseFrontmatter tests ────────────────────────────────────────────────────
+
+console.log("\nparseFrontmatter");
+
+test("parses a valid frontmatter block", () => {
+  const data = parseFrontmatter(
+    "---\ntitle: Spec\nstatus: active\nowner: eng\ncanonical: true\nlast_verified: 2026-07-03\n---\n\n# Spec\n",
+  );
+  assert(data !== null, "expected frontmatter to parse");
+  assert(data.title === "Spec", `expected title 'Spec', got ${data.title}`);
+  assert(
+    data.last_verified === "2026-07-03",
+    `expected last_verified '2026-07-03', got ${data.last_verified}`,
+  );
+});
+
+test("returns null when content has no frontmatter", () => {
+  const data = parseFrontmatter("# Spec\n\nNo frontmatter here.\n");
+  assert(data === null, "expected null for content without frontmatter");
+});
+
+test("returns null when the closing delimiter is missing", () => {
+  const data = parseFrontmatter("---\ntitle: Spec\n\n# Spec\n");
+  assert(data === null, "expected null for unterminated frontmatter block");
+});
+
+test("strips surrounding quotes from values", () => {
+  const data = parseFrontmatter(
+    "---\ntitle: \"Quoted Title\"\nowner: 'eng'\n---\n",
+  );
+  assert(
+    data.title === "Quoted Title",
+    `expected unquoted title, got ${JSON.stringify(data.title)}`,
+  );
+  assert(
+    data.owner === "eng",
+    `expected unquoted owner, got ${JSON.stringify(data.owner)}`,
+  );
+});
+
+// ── daysSince tests ───────────────────────────────────────────────────────────
+
+console.log("\ndaysSince");
+
+test("returns 0 for today's date", () => {
+  const now = new Date("2026-07-05T12:00:00Z");
+  const age = daysSince("2026-07-05", now);
+  assert(age === 0, `expected 0, got ${age}`);
+});
+
+test("returns the correct day count for a past date", () => {
+  const now = new Date("2026-07-05T00:00:00Z");
+  const age = daysSince("2026-04-01", now);
+  assert(age === 95, `expected 95, got ${age}`);
+});
+
+test("returns a negative number for a future date", () => {
+  // check-agent-context.mjs's requireMetadata rejects last_verified more
+  // than FUTURE_SKEW_TOLERANCE_DAYS in the future (verification can't
+  // happen in the future) — daysSince itself just reports the (possibly
+  // negative) elapsed days.
+  const now = new Date("2026-07-05T00:00:00Z");
+  const age = daysSince("2099-01-01", now);
+  assert(age < 0, `expected a negative age, got ${age}`);
+});
+
+test("a same-local-day last_verified stays within the future-skew tolerance", () => {
+  // A contributor east of UTC (up to UTC+14) can stamp their own local
+  // "today" and have it land on UTC "tomorrow" until UTC midnight — e.g.
+  // 2026-07-05 00:30 in Europe/Berlin (UTC+2) is 2026-07-04T22:30:00Z.
+  // requireMetadata must not reject that as "in the future".
+  const now = new Date("2026-07-04T22:30:00Z");
+  const age = daysSince("2026-07-05", now);
+  assert(
+    age >= -FUTURE_SKEW_TOLERANCE_DAYS,
+    `expected age within the future-skew tolerance, got ${age}`,
+  );
+});
+
+test("a multi-day-future last_verified exceeds the tolerance", () => {
+  const now = new Date("2026-07-05T00:00:00Z");
+  const age = daysSince("2026-07-08", now);
+  assert(
+    age < -FUTURE_SKEW_TOLERANCE_DAYS,
+    `expected age to exceed the future-skew tolerance, got ${age}`,
+  );
+});
+
+test("returns null for an unparsable date", () => {
+  const age = daysSince("not-a-date", new Date("2026-07-05T00:00:00Z"));
+  assert(age === null, `expected null, got ${age}`);
+});
+
+test("returns null for a calendar date that doesn't exist", () => {
+  // Date.UTC silently normalizes 2026-02-31 into 2026-03-03; daysSince must
+  // reject it instead of treating the typo as a valid date.
+  const age = daysSince("2026-02-31", new Date("2026-07-05T00:00:00Z"));
+  assert(age === null, `expected null, got ${age}`);
+});
+
+// ── staleness policy window ───────────────────────────────────────────────────
+
+console.log("\nstaleness policy window");
+
+test("STALE_AFTER_DAYS is a positive number of days", () => {
+  assert(
+    Number.isInteger(STALE_AFTER_DAYS) && STALE_AFTER_DAYS > 0,
+    `expected a positive integer, got ${STALE_AFTER_DAYS}`,
+  );
+});
+
+test("a last_verified within the window is not stale", () => {
+  const now = new Date("2026-07-05T00:00:00Z");
+  const age = daysSince("2026-07-03", now);
+  assert(
+    age <= STALE_AFTER_DAYS,
+    `expected a fresh last_verified to stay within the window, got age ${age}`,
+  );
+});
+
+test("a last_verified past the window is flagged stale", () => {
+  const now = new Date("2026-07-05T00:00:00Z");
+  const staleDate = new Date(now);
+  staleDate.setUTCDate(staleDate.getUTCDate() - (STALE_AFTER_DAYS + 1));
+  const isoDate = staleDate.toISOString().slice(0, 10);
+  const age = daysSince(isoDate, now);
+  assert(
+    age > STALE_AFTER_DAYS,
+    `expected last_verified ${isoDate} to exceed the ${STALE_AFTER_DAYS}-day window, got age ${age}`,
+  );
+});
+
+// ── summary ───────────────────────────────────────────────────────────────────
+
+console.log(
+  `\n${passed + failed} tests: \x1b[32m${passed} passed\x1b[0m${failed > 0 ? `, \x1b[31m${failed} failed\x1b[0m` : ""}\n`,
+);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `SPEC.md` is a 33KB authoritative-looking spec, but it carries no metadata and isn't scanned by `scripts/check-agent-context.mjs` — it can rot silently the way it already did once (~10 weeks stale until the 2026-07-03 audit rewrote it).
- `scripts/check-agent-context.mjs` had no age-based staleness enforcement at all: `last_verified` only had to be *present*, never *current*, for any canonical file.
- The local pre-push gate (`scripts/agent-quality-gate.sh`) had no routing rule that would map a `SPEC.md`-only diff to `pnpm agent:context-check`.

## The Solution

- Added YAML frontmatter to `SPEC.md` (`status: active`, `owner: eng`, `canonical: true`, `last_verified: 2026-07-03` — the date of the already-merged content-verification rewrite, PR #1069).
- Added `SPEC.md` to `check-agent-context.mjs`'s managed-file list and introduced a real staleness window: any `canonical: true` file's `last_verified` older than 90 days now fails the check (previously only presence was checked).
- Documented the canonical-file addition and the staleness window in `docs/context-standards.md`, and explicitly decided **not** to bring root `README.md` in yet (see Details).
- Wired `SPEC.md` into `scripts/agent-quality-gate.sh`'s docs routing so a `SPEC.md`-only PR maps to `pnpm agent:context-check` locally, with a routing regression test.

## Details

- **Staleness window**: picked 90 days (~1 quarter). All existing canonical files (`AGENTS.md`, skill/role files, etc.) are currently 40-46 days old, so this doesn't fail anything today — it's a forward-looking guard, not a retroactive one. The rule and its rationale are documented in `docs/context-standards.md`'s Metadata Contract section.
- **Pure-helper extraction**: `check-agent-context.mjs` had no test sibling and is tightly coupled to live repo state (git ls-files, real `.claude/settings.json`, etc.), which makes it a poor target for a synthetic end-to-end fixture test. Following the same pattern already used for `check-notifier-coverage.mjs`, the frontmatter parser and the new staleness calculation were extracted into `scripts/check-agent-context-helpers.mjs`, unit-tested directly in a new `scripts/check-agent-context.test.mjs` (mirrors the repo's existing hand-rolled `test()`/`assert()` harness), and wired into the CI `scripts` job.
- **`README.md` decision**: root `README.md` renders as the GitHub repo landing page. A literal `---\nkey: value\n---` frontmatter block would render as visible text (two horizontal rules + raw `key: value` lines) at the top of that page — it isn't hidden the way Jekyll frontmatter is on GitHub Pages. Bringing it under the same mechanism would need a comment-based marker instead (HTML comments don't render), which is a real but separate build. Filed as #1071 rather than invented speculatively here.
- **Content duplication**: the issue's non-goal is re-verifying SPEC.md content line-by-line (already done in #1069) or restructuring the doc — no new duplicated values were found or touched.
- **Self-review findings (fixed before push)**: four rounds of internal Codex autoreview against this diff caught five real bugs before they shipped:
  1. `SPEC.md` wasn't reachable from `scripts/agent-quality-gate.sh`'s routing table, so a `SPEC.md`-only PR would've silently skipped `pnpm agent:context-check` in the local gate — fixed by extending the existing `docs/*` routing case, with a new `agent-quality-gate.test.sh` assertion.
  2. `daysSince` used `new Date(...)` directly, which silently normalizes impossible calendar dates (e.g. `2026-02-31` → `2026-03-03`) instead of rejecting them — fixed with a strict regex + UTC year/month/day round-trip check, with a regression test.
  3. A future `last_verified` (e.g. a typo like `2099-01-01`) produced a negative "age" that always passed the staleness check, permanently bypassing it — fixed by rejecting age below a tolerance as "in the future" in `requireMetadata`, with a regression test.
  4. The newly extracted `check-agent-context-helpers.mjs` and `check-agent-context.test.mjs` files weren't covered by the same routing case as `check-agent-context.mjs`, so future edits to just the helpers/test would only run generic lint, not the real check or its unit tests — fixed by widening that case's path list, with routing regression tests for all three paths.
  5. The future-date check compared a UTC-midnight `last_verified` against the exact current instant, so a contributor east of UTC (up to UTC+14) stamping their own local "today" could see it resolve to UTC "tomorrow" until UTC midnight, falsely rejecting a valid same-day date — fixed with a documented 1-day `FUTURE_SKEW_TOLERANCE_DAYS` (the maximum real-world UTC offset skew), with regression tests for both the in-tolerance and genuinely-future cases.

## Validation

```
$ pnpm agent:context-check
Agent context check passed (19 managed files).

$ node scripts/check-agent-context.mjs
Agent context check passed (19 managed files).

$ node scripts/check-agent-context.test.mjs
14 tests: 14 passed

$ pnpm agent:quality-gate:test
agent quality gate tests passed

$ pnpm lint:scripts
(no errors)

$ pnpm code-health:deps
✔ no dependency violations found (944 modules, 1139 dependencies cruised)

$ node scripts/check-github-action-pins.mjs
All 24 workflow/composite-action YAML files use pinned external actions.

$ pnpm skew:check
ok: all catalog-pinned packages aligned (viem)

$ ./tools/trunk fmt/check <8 touched files>
Checked 8 files, ✔ No issues

$ git push -u origin agent/1057-spec-governance   # pre-push hook ran the full mapped cascade
All mapped commands passed.
```

Manual out-of-policy simulation (not committed): locally edited `SPEC.md`'s `last_verified` to `2026-01-01` and re-ran `node scripts/check-agent-context.mjs` — it failed with `SPEC.md: last_verified 2026-01-01 is 185 days old, exceeds the 90-day policy window`, then reverted the edit and confirmed the check passes again.

`pnpm agent:quality-gate` (dry run) mapped a large cascade of package-level commands (turbo lint/typecheck/coverage across 7 packages, 4 Terraform stack validations, aegis build/test/forge) because this PR edits `.github/workflows/ci.yml`, which the gate treats as a "central CI workflow changed" surface regardless of how small the edit is. That full cascade ran automatically as the local pre-push gate on `git push` and passed end to end (`All mapped commands passed.`).

Ran `pnpm agent:autoreview` (Codex engine) four times against the local diff (plus one earlier no-op attempt in branch mode before anything was committed): pass 1 found findings #1 and #2 above, pass 2 (on that fixed diff) found findings #3 and #4, pass 3 found finding #5, and pass 4 on the fully fixed diff is clean.

Closes #1057

## Deferrals

- #1071 — bring root `README.md` under the context-authority model (needs a comment-based marker mechanism instead of visible frontmatter; deliberately not built here to avoid inventing a heavy mechanism speculatively).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation governance, CI path filters, and a Node checker script—no runtime product or auth/data paths.
> 
> **Overview**
> Brings **`SPEC.md`** under the same canonical metadata contract as other agent context (YAML frontmatter with **`last_verified`**) and tightens **`check-agent-context.mjs`** so **`canonical: true`** files must stay within a **90-day** verification window—not merely have a date present.
> 
> The checker now **discovers** managed markdown from repo paths (`SPEC.md`, `AGENTS.md`, `docs/**/*.md`, `.agents/**`) instead of a mostly hardcoded list, with a **core-file guard** so stripping frontmatter on pinned files fails loudly. Parsing, date math, and staleness rules live in **`check-agent-context-helpers.mjs`** with unit tests; **`docs/context-standards.md`** documents the policy and defers root **`README.md`** (#1071).
> 
> **CI and local gates** run the context check when relevant paths change (`ci.yml` path filters, new scripts-job steps), add a **weekly scheduled** staleness job in **`supply-chain.yml`** (calendar expiry without a doc-touching PR), and extend **`agent-quality-gate.sh`** routing for `SPEC.md`, arbitrary docs markdown, and checker/helper edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cfdf50e9c8b10f4122f754b85e8b7f93215923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->