### PR TITLE
fix(ci): skip Lighthouse when Vercel cancels the build via its Ignored Build Step

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -91,6 +91,11 @@ jobs:
       # `deployments: read` lets the job query the GitHub Deployments API to
       # find the Vercel preview URL without needing a Vercel API token.
       deployments: read
+      # `statuses: read` lets the wait step read the combined commit status to
+      # detect Vercel's "Canceled by Ignored Build Step" verdict. Without it
+      # the lookup 403s and (by design) degrades to the timeout path, so the
+      # ignored-build skip would silently never engage.
+      statuses: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -391,6 +396,42 @@ jobs:
                 );
               }
               if (ignoredBuild) {
+                // Do NOT trust the verdict when this push touches the ignore
+                // machinery itself: a buggy (or malicious) edit to the skip
+                // logic could make Vercel report "ignored" for a SHA that
+                // really changes the dashboard, and silently skipping would
+                // suppress the audit exactly when it matters. Fall through to
+                // the polling/timeout path instead, which fails loudly and
+                // forces the change to prove itself.
+                const ignoreMachineryPaths = [
+                  "ui-dashboard/scripts/vercel-ignore-build.sh",
+                  "ui-dashboard/vercel.json",
+                ];
+                try {
+                  const latestPush = await latestPushTouchedDashboard();
+                  const touchedMachinery = (latestPush.files ?? []).filter(f =>
+                    ignoreMachineryPaths.includes(f),
+                  );
+                  if (touchedMachinery.length > 0) {
+                    core.warning(
+                      `Vercel reported "Canceled by Ignored Build Step" for ${sha}, but this ` +
+                        `push touches the ignore machinery (${touchedMachinery.join(", ")}) — ` +
+                        "not trusting the verdict; continuing to poll (will fail loudly on timeout).",
+                    );
+                    core.info(`No active preview yet — retrying in ${pollIntervalMs / 1000}s...`);
+                    await new Promise(r => setTimeout(r, pollIntervalMs));
+                    continue;
+                  }
+                } catch (error) {
+                  core.warning(
+                    `Could not verify the pushed file list before honoring Vercel's ignored-build ` +
+                      `verdict (${error instanceof Error ? error.message : String(error)}) — ` +
+                      "not trusting the verdict; continuing to poll.",
+                  );
+                  core.info(`No active preview yet — retrying in ${pollIntervalMs / 1000}s...`);
+                  await new Promise(r => setTimeout(r, pollIntervalMs));
+                  continue;
+                }
                 core.notice(
                   `Vercel canceled the build for ${sha} via its Ignored Build Step — ` +
                     "no preview will be posted for this SHA, so there is no new " +

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -396,20 +396,29 @@ jobs:
                 );
               }
               if (ignoredBuild) {
-                // Do NOT trust the verdict when this push touches the ignore
+                // Do NOT trust the verdict when the PR touches the ignore
                 // machinery itself: a buggy (or malicious) edit to the skip
                 // logic could make Vercel report "ignored" for a SHA that
                 // really changes the dashboard, and silently skipping would
-                // suppress the audit exactly when it matters. Fall through to
-                // the polling/timeout path instead, which fails loudly and
-                // forces the change to prove itself.
+                // suppress the audit exactly when it matters. Deliberately
+                // FULL-PR-scoped (not latest-push-scoped): once any commit in
+                // the PR modifies the machinery, that modified script is what
+                // Vercel runs for every subsequent head, so no head in the PR
+                // may vouch for its own skip — even a later push that only
+                // touches unrelated files. Falls through to the polling/
+                // timeout path, which fails loudly and forces the change to
+                // prove itself.
                 const ignoreMachineryPaths = [
                   "ui-dashboard/scripts/vercel-ignore-build.sh",
                   "ui-dashboard/vercel.json",
                 ];
                 try {
-                  const latestPush = await latestPushTouchedDashboard();
-                  const touchedMachinery = (latestPush.files ?? []).filter(f =>
+                  const pullNumber = context.payload.pull_request?.number;
+                  const pullRequestFiles =
+                    typeof pullNumber === "number"
+                      ? await changedFilesForPullRequest(pullNumber)
+                      : (await latestPushTouchedDashboard()).files ?? [];
+                  const touchedMachinery = pullRequestFiles.filter(f =>
                     ignoreMachineryPaths.includes(f),
                   );
                   if (touchedMachinery.length > 0) {

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -36,6 +36,11 @@ on:
     # is nothing for Lighthouse to measure anyway. The in-job filter/decide
     # steps are kept (they also skip forks + dependabot). Keep this list in
     # sync with the in-job `filters:` block and vercel-ignore-build.sh.
+    # NOTE: the ignore script also diffs incrementally against the branch's
+    # previous deployment, so Vercel can skip a SHA even when these globs
+    # match (e.g. a change under ui-dashboard/scripts/ that is not a build
+    # input). The wait step honors Vercel's per-SHA "Canceled by Ignored
+    # Build Step" status and skips instead of timing out in that case.
     paths:
       - ui-dashboard/**
       - shared-config/**
@@ -251,6 +256,32 @@ jobs:
               return active?.environment_url ?? null;
             }
 
+            // Vercel's ignoreCommand (ui-dashboard/scripts/vercel-ignore-build.sh)
+            // diffs incrementally against the branch's previous deployment, so it
+            // can legitimately skip a SHA even when the branch as a whole touches
+            // a path in `dashboardPaths` (e.g. an operator script under
+            // ui-dashboard/scripts/ that is not a build input). When it skips, no
+            // GitHub Deployment is ever created for the SHA — only a commit
+            // status: context "Vercel", state "success", description
+            // "Canceled by Ignored Build Step". Without honoring that verdict,
+            // this wait step polls for a preview that will never exist and fails
+            // by timeout. Treat the status as authoritative: no new preview means
+            // no new dashboard bundle to audit, so the (advisory) check skips.
+            async function vercelIgnoredBuild() {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              });
+              return (data.statuses ?? []).some(
+                s =>
+                  s.context === "Vercel" &&
+                  s.state === "success" &&
+                  /ignored build step/i.test(s.description ?? ""),
+              );
+            }
+
             async function latestPushTouchedDashboard() {
               const pullRequest = context.payload.pull_request;
               const action = context.payload.action;
@@ -343,6 +374,32 @@ jobs:
                   core.setOutput("skip_lighthouse", "false");
                   return;
                 }
+              }
+
+              // No preview yet — check whether Vercel has already ruled this
+              // SHA out via its Ignored Build Step before polling again. A
+              // pending/absent Vercel status means a build may still be
+              // starting, so keep polling in that case.
+              if (await vercelIgnoredBuild()) {
+                core.notice(
+                  `Vercel canceled the build for ${sha} via its Ignored Build Step — ` +
+                    "no preview will be posted for this SHA, so there is no new " +
+                    "dashboard bundle to audit. Skipping Lighthouse.",
+                );
+                try {
+                  const priorPreview = await findPriorSuccessfulPreviewForCurrentDashboard();
+                  core.info(
+                    priorPreview
+                      ? `Prior preview ${priorPreview.previewUrl} (${priorPreview.sha}) still covers the current dashboard bundle.`
+                      : "No prior branch preview exists; the branch has never produced a dashboard-affecting change per Vercel.",
+                  );
+                } catch (error) {
+                  core.info(
+                    `Prior-preview lookup skipped: ${error instanceof Error ? error.message : String(error)}`,
+                  );
+                }
+                core.setOutput("skip_lighthouse", "true");
+                return;
               }
 
               core.info(`No active preview yet — retrying in ${pollIntervalMs / 1000}s...`);

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -379,8 +379,18 @@ jobs:
               // No preview yet — check whether Vercel has already ruled this
               // SHA out via its Ignored Build Step before polling again. A
               // pending/absent Vercel status means a build may still be
-              // starting, so keep polling in that case.
-              if (await vercelIgnoredBuild()) {
+              // starting, so keep polling in that case. A status-API error is
+              // treated the same as "no verdict yet" so it cannot bypass the
+              // 5-minute timeout backstop below.
+              let ignoredBuild = false;
+              try {
+                ignoredBuild = await vercelIgnoredBuild();
+              } catch (error) {
+                core.info(
+                  `Vercel status lookup failed (will keep polling): ${error instanceof Error ? error.message : String(error)}`,
+                );
+              }
+              if (ignoredBuild) {
                 core.notice(
                   `Vercel canceled the build for ${sha} via its Ignored Build Step — ` +
                     "no preview will be posted for this SHA, so there is no new " +
@@ -390,7 +400,7 @@ jobs:
                   const priorPreview = await findPriorSuccessfulPreviewForCurrentDashboard();
                   core.info(
                     priorPreview
-                      ? `Prior preview ${priorPreview.previewUrl} (${priorPreview.sha}) still covers the current dashboard bundle.`
+                      ? `Prior successful preview ${priorPreview.previewUrl} at ${priorPreview.sha} still covers the current dashboard bundle.`
                       : "No prior branch preview exists; the branch has never produced a dashboard-affecting change per Vercel.",
                   );
                 } catch (error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The Lighthouse workflow's "Wait for Vercel preview deployment" step polls for a preview and fails by timeout when Vercel's Ignored Build Step canceled the build for the head SHA — no preview will ever exist in that case.
- Vercel's ignore script diffs incrementally against the branch's previous deployment, so it legitimately skips SHAs even when the workflow's `dashboardPaths` globs match (e.g. an operator script under `ui-dashboard/scripts/` that is not a build input); two open PRs (#1076, #1080) are currently red on exactly this.
- The existing timeout fallback only rescues the case where a *prior* branch preview exists; a branch whose every push was skipped has none, so it fails even after correctly concluding the push touched no dashboard inputs.

## The Solution

- Inside the polling loop, honor Vercel's authoritative per-SHA verdict: when the commit status `Vercel` is `success` with description "Canceled by Ignored Build Step", there is no new dashboard bundle to audit — set `skip_lighthouse=true` and exit cleanly instead of timing out.

## Details

- New `vercelIgnoredBuild()` helper reads the combined commit status for the head SHA (`getCombinedStatusForRef`) and matches context `Vercel` + state `success` + `/ignored build step/i`. A pending/absent Vercel status keeps polling, so a build that is merely slow is unaffected.
- The check runs each loop iteration after the deployment lookup, so a race where Vercel posts the status late is covered; the 5-minute timeout fallback is kept unchanged as the backstop for status-API hiccups.
- On skip, the step logs whether a prior branch preview still covers the bundle (informational; lookup failures are caught and logged, never fatal).
- All downstream steps already gate on `skip_lighthouse != 'true'`, so no other step changes were needed.
- Comment on the workflow-level `paths:` block updated to document that Vercel may skip a listed path via its incremental diff and that the wait step honors that verdict.
- Verified the exact status shape against PR #1076's head SHA: `{"context":"Vercel","state":"success","description":"Canceled by Ignored Build Step"}`, with zero GitHub Deployments created for the branch.

## Validation

- `trunk check --filter=actionlint .github/workflows/lighthouse.yml` — no issues.
- `node scripts/check-github-action-pins.mjs` — all 24 workflow/composite files pinned.
- `trunk fmt` — clean.
- Failure reproduction evidence: lighthouse run on PR #1076 (`agent/1047-shell-lint-gate`) timed out after "Latest push did not touch dashboard inputs, but no prior successful Preview deployment could be proven current"; the new status check short-circuits exactly that path.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the advisory Lighthouse workflow’s wait/skip logic; ignore-machinery edits still force polling/timeout rather than silent skip.
> 
> **Overview**
> Fixes **Lighthouse CI** timing out when Vercel never posts a preview because its **Ignored Build Step** canceled the build for the head SHA (incremental ignore can skip SHAs even when workflow `paths:` match).
> 
> The **Wait for Vercel preview** loop now reads combined commit statuses (`statuses: read`) and, when context `Vercel` is success with an "ignored build step" description, sets **`skip_lighthouse=true`** and exits cleanly instead of polling until failure. Pending or missing Vercel status still polls; status API errors keep polling toward the existing 5-minute timeout.
> 
> **Fail-closed guard:** if the PR ever touches `vercel-ignore-build.sh` or `vercel.json`, the ignored-build verdict is **not** honored (full-PR file list), so a bad skip script cannot silently suppress audits. Workflow comments document Vercel’s incremental ignore vs. the `paths:` filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fdb3d926985d3fa26c8e3a1452163288592a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->