### PR TITLE
test(indexer): Liquity lifecycle, batch-replay idempotency, per-chain fallback, namespacing, Wormhole drain scenarios

### DIFF
--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -1128,3 +1128,191 @@ describe("rate-limit fallback skips secondary below known archive horizon", () =
     assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 900n), true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-chain fallback: both failure modes on real chain ids, state isolated
+// ---------------------------------------------------------------------------
+//
+// `getFallbackRpcClient(chainId)` resolves `ENVIO_RPC_FALLBACK_URL_<chainId>`
+// per real chain id (covered in rpcClient.test.ts); this block covers the
+// consuming mechanism — `readContractWithBlockFallback` — for the two
+// documented failure modes (archive-depth and rate-limit) using real mainnet
+// chain ids instead of a synthetic one, and asserts the per-chain archive
+// horizon / cooldown state (keyed by chainId) never leaks across chains.
+describe("per-chain fallback: archive-depth and rate-limit, isolated across chains", () => {
+  const baseArgs = {
+    address: "0xtest",
+    abi: [],
+    functionName: "foo",
+  };
+  const CELO = 42220;
+  const MONAD = 143;
+
+  let originalDelayFn: typeof _testHooks.delayFn;
+  let originalNowFn: typeof _testHooks.nowFn;
+  beforeAll(() => {
+    originalDelayFn = _testHooks.delayFn;
+    originalNowFn = _testHooks.nowFn;
+    _testHooks.delayFn = async () => {};
+    _testHooks.nowFn = () => 0;
+  });
+  afterAll(() => {
+    _testHooks.delayFn = originalDelayFn;
+    _testHooks.nowFn = originalNowFn;
+  });
+  beforeEach(() => {
+    _resetFallbackArchiveDepth();
+    _testHooks.resetFallbackRuntimeState();
+  });
+
+  it("archive-depth failure falls through to the fallback client on both Celo and Monad", async () => {
+    for (const chainId of [CELO, MONAD]) {
+      const primary = mockClient(async () => {
+        throw new Error("querying historical state");
+      });
+      const fallback = mockClient(async () => "archive-ok");
+
+      const res = await readContractWithBlockFallback(
+        chainId,
+        primary,
+        baseArgs,
+        500n,
+        fallback,
+      );
+      assert.equal(res.result, "archive-ok");
+      assert.equal(res.usedFallback, true);
+    }
+  });
+
+  it("rate-limited primary falls through to the fallback client on both Celo and Monad", async () => {
+    for (const chainId of [CELO, MONAD]) {
+      const primary = mockClient(async () => {
+        throw new Error("rate limit");
+      });
+      const fallback = mockClient(async () => "rate-limit-ok");
+
+      const res = await readContractWithBlockFallback(
+        chainId,
+        primary,
+        baseArgs,
+        500n,
+        fallback,
+      );
+      assert.equal(res.result, "rate-limit-ok");
+      assert.equal(res.usedFallback, true);
+    }
+  });
+
+  it("an archive-depth horizon recorded for one chain does not gate the fallback for another chain", async () => {
+    // Celo's fallback proves it lacks archive depth below block 500.
+    const celoPrimary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const celoFallback = mockClient(async () => {
+      throw new Error(
+        "Invalid parameters were provided to the RPC method. Double check you have provided the correct parameters.",
+      );
+    });
+    await assert.rejects(() =>
+      readContractWithBlockFallback(
+        CELO,
+        celoPrimary,
+        baseArgs,
+        500n,
+        celoFallback,
+      ),
+    );
+    assert.equal(
+      fallbackLikelyHasBlock(CELO, 200n),
+      false,
+      "Celo's fallback is now known to lack archive depth below 500",
+    );
+
+    // Monad — a chain that has recorded NO archive miss — must still be
+    // allowed to use its fallback at the same (or an even lower) block.
+    // A shared/global horizon map would incorrectly gate this call too.
+    assert.equal(
+      fallbackLikelyHasBlock(MONAD, 200n),
+      true,
+      "Monad's archive horizon must be tracked independently of Celo's",
+    );
+    let monadFallbackCalls = 0;
+    const monadPrimary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const monadFallback = mockClient(async () => {
+      monadFallbackCalls++;
+      return "monad-served";
+    });
+    const res = await readContractWithBlockFallback(
+      MONAD,
+      monadPrimary,
+      baseArgs,
+      200n,
+      monadFallback,
+    );
+    assert.equal(res.result, "monad-served");
+    assert.equal(monadFallbackCalls, 1);
+  });
+
+  it("a rate-limit cooldown started for one chain does not skip the fallback for another chain", async () => {
+    // Trip Celo's fallback into cooldown via a rate-limited secondary.
+    const celoPrimary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const celoFallback = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    await assert.rejects(() =>
+      readContractWithBlockFallback(
+        CELO,
+        celoPrimary,
+        baseArgs,
+        900n,
+        celoFallback,
+      ),
+    );
+
+    // A subsequent Celo call within the cooldown window must skip the
+    // fallback and surface the primary's rate-limit error directly.
+    let celoFallbackCallsDuringCooldown = 0;
+    const celoPrimaryAgain = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const celoFallbackAgain = mockClient(async () => {
+      celoFallbackCallsDuringCooldown++;
+      return "should-not-be-called";
+    });
+    await assert.rejects(() =>
+      readContractWithBlockFallback(
+        CELO,
+        celoPrimaryAgain,
+        baseArgs,
+        900n,
+        celoFallbackAgain,
+      ),
+    );
+    assert.equal(celoFallbackCallsDuringCooldown, 0);
+
+    // Monad's fallback must be unaffected by Celo's cooldown — the cooldown
+    // key is `${chainId}:${fn}`, so a shared/global cooldown would wrongly
+    // skip this call too.
+    const monadPrimary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    let monadFallbackCalls = 0;
+    const monadFallback = mockClient(async () => {
+      monadFallbackCalls++;
+      return "monad-served";
+    });
+    const res = await readContractWithBlockFallback(
+      MONAD,
+      monadPrimary,
+      baseArgs,
+      900n,
+      monadFallback,
+    );
+    assert.equal(res.result, "monad-served");
+    assert.equal(monadFallbackCalls, 1);
+  });
+});

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -1165,42 +1165,77 @@ describe("per-chain fallback: archive-depth and rate-limit, isolated across chai
     _testHooks.resetFallbackRuntimeState();
   });
 
-  it("archive-depth failure falls through to the fallback client on both Celo and Monad", async () => {
-    for (const chainId of [CELO, MONAD]) {
-      const primary = mockClient(async () => {
-        throw new Error("querying historical state");
-      });
-      const fallback = mockClient(async () => "archive-ok");
+  // Split per-chain (rather than looping over [CELO, MONAD] in one `it`) so
+  // a failure in one chain's fallback path is attributed unambiguously —
+  // e.g. "Celo archive-depth" vs "Monad archive-depth" — instead of a
+  // generic assertion failure that requires re-running to find which
+  // iteration broke.
+  it("archive-depth failure falls through to the fallback client on Celo", async () => {
+    const primary = mockClient(async () => {
+      throw new Error("querying historical state");
+    });
+    const fallback = mockClient(async () => "archive-ok");
 
-      const res = await readContractWithBlockFallback(
-        chainId,
-        primary,
-        baseArgs,
-        500n,
-        fallback,
-      );
-      assert.equal(res.result, "archive-ok");
-      assert.equal(res.usedFallback, true);
-    }
+    const res = await readContractWithBlockFallback(
+      CELO,
+      primary,
+      baseArgs,
+      500n,
+      fallback,
+    );
+    assert.equal(res.result, "archive-ok");
+    assert.equal(res.usedFallback, true);
   });
 
-  it("rate-limited primary falls through to the fallback client on both Celo and Monad", async () => {
-    for (const chainId of [CELO, MONAD]) {
-      const primary = mockClient(async () => {
-        throw new Error("rate limit");
-      });
-      const fallback = mockClient(async () => "rate-limit-ok");
+  it("archive-depth failure falls through to the fallback client on Monad", async () => {
+    const primary = mockClient(async () => {
+      throw new Error("querying historical state");
+    });
+    const fallback = mockClient(async () => "archive-ok");
 
-      const res = await readContractWithBlockFallback(
-        chainId,
-        primary,
-        baseArgs,
-        500n,
-        fallback,
-      );
-      assert.equal(res.result, "rate-limit-ok");
-      assert.equal(res.usedFallback, true);
-    }
+    const res = await readContractWithBlockFallback(
+      MONAD,
+      primary,
+      baseArgs,
+      500n,
+      fallback,
+    );
+    assert.equal(res.result, "archive-ok");
+    assert.equal(res.usedFallback, true);
+  });
+
+  it("rate-limited primary falls through to the fallback client on Celo", async () => {
+    const primary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const fallback = mockClient(async () => "rate-limit-ok");
+
+    const res = await readContractWithBlockFallback(
+      CELO,
+      primary,
+      baseArgs,
+      500n,
+      fallback,
+    );
+    assert.equal(res.result, "rate-limit-ok");
+    assert.equal(res.usedFallback, true);
+  });
+
+  it("rate-limited primary falls through to the fallback client on Monad", async () => {
+    const primary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const fallback = mockClient(async () => "rate-limit-ok");
+
+    const res = await readContractWithBlockFallback(
+      MONAD,
+      primary,
+      baseArgs,
+      500n,
+      fallback,
+    );
+    assert.equal(res.result, "rate-limit-ok");
+    assert.equal(res.usedFallback, true);
   });
 
   it("an archive-depth horizon recorded for one chain does not gate the fallback for another chain", async () => {

--- a/indexer-envio/test/crossChainNamespacing.test.ts
+++ b/indexer-envio/test/crossChainNamespacing.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #1054 scenario 5 — multichain namespacing: the same contract address
+ * emitting on two chains must produce two distinct `{chainId}-{address}`
+ * entities with zero field bleed. Covers both the "pool" variant (FPMM pools
+ * deploy on both Celo and Monad) and the "trove" variant (Liquity entity ID
+ * construction, since Liquity itself only deploys on Celo today — see
+ * `LIQUITY_CHAIN_ID` in `src/handlers/liquity/config.ts` — so the collision
+ * guarantee is pinned at the ID-construction level rather than through a
+ * live two-chain handler run).
+ */
+import { strict as assert } from "assert";
+import {
+  _clearMockERC20Decimals,
+  _clearMockRebalanceThresholds,
+  _clearMockRebalancingStates,
+  _clearMockReserves,
+  _setMockERC20Decimals,
+  _setMockRebalanceThresholds,
+  _setMockRebalancingState,
+} from "../src/EventHandlers.ts";
+import { makePoolId } from "../src/helpers.ts";
+import {
+  makeCollateralId,
+  LIQUITY_MARKETS,
+} from "../src/handlers/liquity/config.ts";
+import { makeTroveId } from "../src/handlers/liquity/troves.ts";
+import {
+  indexerTestHelpers,
+  type EntityReader,
+  type MockDbWith,
+} from "./helpers/indexerTestHarness.js";
+
+type MockDb = MockDbWith<{
+  Pool: EntityReader<{ id: string; reserves0: bigint; reserves1: bigint }>;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+
+const POOL_ADDR = "0x00000000000000000000000000000000000000fa";
+const TOKEN0 = "0x00000000000000000000000000000000000004a0";
+const TOKEN1 = "0x00000000000000000000000000000000000004a1";
+const CELO = 42220;
+const MONAD = 143;
+
+async function deployAndUpdateReserves(
+  mockDb: MockDb,
+  chainId: number,
+  reserve0: bigint,
+  reserve1: bigint,
+) {
+  _setMockERC20Decimals(chainId, TOKEN0, 18);
+  _setMockERC20Decimals(chainId, TOKEN1, 18);
+  _setMockRebalanceThresholds(chainId, POOL_ADDR, { above: 5000, below: 5000 });
+  _setMockRebalancingState(chainId, POOL_ADDR, null);
+
+  const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0: TOKEN0,
+    token1: TOKEN1,
+    fpmmProxy: POOL_ADDR,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId,
+      logIndex: 1,
+      srcAddress: "0x00000000000000000000000000000000000000cc",
+      block: { number: 1_000, timestamp: 10_000 },
+    },
+  });
+  let db = await FPMMFactory.FPMMDeployed.processEvent({
+    event: deployEvent,
+    mockDb,
+  });
+
+  const updateEvent = FPMM.UpdateReserves.createMockEvent({
+    reserve0,
+    reserve1,
+    blockTimestamp: 10_100,
+    mockEventData: {
+      chainId,
+      srcAddress: POOL_ADDR,
+      logIndex: 2,
+      block: { number: 1_001, timestamp: 10_100 },
+    },
+  });
+  db = await FPMM.UpdateReserves.processEvent({
+    event: updateEvent,
+    mockDb: db,
+  });
+  return db;
+}
+
+describe("Multichain namespacing — pool variant", () => {
+  afterEach(() => {
+    _clearMockReserves();
+    _clearMockERC20Decimals();
+    _clearMockRebalancingStates();
+    _clearMockRebalanceThresholds();
+  });
+
+  it("the same FPMM proxy address on Celo and Monad produces two distinct Pool rows with zero field bleed", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployAndUpdateReserves(
+      mockDb,
+      CELO,
+      100n * 10n ** 18n,
+      200n * 10n ** 18n,
+    );
+    mockDb = await deployAndUpdateReserves(
+      mockDb,
+      MONAD,
+      999n * 10n ** 18n,
+      888n * 10n ** 18n,
+    );
+
+    const celoPoolId = makePoolId(CELO, POOL_ADDR);
+    const monadPoolId = makePoolId(MONAD, POOL_ADDR);
+    assert.notEqual(celoPoolId, monadPoolId, "namespaced ids differ per chain");
+
+    const celoPool = mockDb.entities.Pool.get(celoPoolId);
+    const monadPool = mockDb.entities.Pool.get(monadPoolId);
+    assert.ok(celoPool, "Celo Pool row exists");
+    assert.ok(monadPool, "Monad Pool row exists");
+
+    assert.equal(celoPool?.reserves0, 100n * 10n ** 18n);
+    assert.equal(celoPool?.reserves1, 200n * 10n ** 18n);
+    assert.equal(
+      monadPool?.reserves0,
+      999n * 10n ** 18n,
+      "Monad's reserves are untouched by the Celo UpdateReserves event",
+    );
+    assert.equal(monadPool?.reserves1, 888n * 10n ** 18n);
+  });
+});
+
+describe("Multichain namespacing — trove variant (ID-construction guarantee)", () => {
+  // Liquity's LIQUITY_MARKETS are Celo-only today (see config.ts's hardcoded
+  // LIQUITY_CHAIN_ID) — there is no real second-chain deployment to drive
+  // through the harness. The collision-resistance guarantee lives in the ID
+  // construction helpers themselves (`makeCollateralId` / `makeTroveId`),
+  // which is what the handlers rely on if Liquity ever ships on a second
+  // chain with the same deterministic (CREATE3) addresses.
+  it("makeCollateralId namespaces the same troveManager address per chain", () => {
+    const market = LIQUITY_MARKETS[0]!;
+    const collateralIdCelo = makeCollateralId(market);
+    const collateralIdOtherChain = makeCollateralId({
+      ...market,
+      chainId: 143,
+    });
+    assert.notEqual(collateralIdCelo, collateralIdOtherChain);
+    assert.equal(collateralIdCelo, `${market.chainId}-${market.troveManager}`);
+    assert.equal(collateralIdOtherChain, `143-${market.troveManager}`);
+  });
+
+  it("makeTroveId composes on top of the chain-namespaced collateralId, so the same troveId never collides across chains", () => {
+    const market = LIQUITY_MARKETS[0]!;
+    const collateralIdCelo = makeCollateralId(market);
+    const collateralIdOtherChain = makeCollateralId({
+      ...market,
+      chainId: 143,
+    });
+
+    const troveIdCelo = makeTroveId(collateralIdCelo, "0x1");
+    const troveIdOtherChain = makeTroveId(collateralIdOtherChain, "0x1");
+    assert.notEqual(
+      troveIdCelo,
+      troveIdOtherChain,
+      "the same on-chain troveId 0x1 under the same troveManager address must resolve to distinct rows per chain",
+    );
+  });
+});

--- a/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
+++ b/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Issue #1054 scenario 3 — batchReplay idempotency: replaying already-seen
+ * `BatchUpdated`/bootstrap events must not double-count.
+ *
+ * `replayBatchedTroveUpdate` (src/handlers/liquity/batchReplay.ts) consumes
+ * `PendingBatchedTroveUpdate` scratch rows and deletes each one after
+ * replaying it — so a second delivery of the same `BatchUpdated` event finds
+ * no matching pending rows and must not re-apply the debt/systemDebt delta.
+ * `bootstrapCollaterals` (bootstrapHandler.ts's onBlock target) is a plain
+ * get-or-create and is idempotent by construction.
+ *
+ * The last test in this file pins a REAL gap found while writing this
+ * coverage: `recordBorrowingFeeAndApplyCum` (borrowingRevenue.ts), called
+ * unconditionally from both the `TroveOperation` and `BatchUpdated` handlers,
+ * has no replay guard — a redelivered event with a nonzero
+ * `_debtIncreaseFromUpfrontFee` double-counts `LiquityInstance.borrowingFeeCum`
+ * and the `LiquityBorrowingRevenueDailySnapshot.upfrontFee` bucket. Filed as
+ * follow-up issue #1083; this test pins CURRENT behavior, it does not assert
+ * desired behavior.
+ */
+import { strict as assert } from "assert";
+import type { LiquityCollateral, LiquityInstance, Trove } from "envio";
+import { bootstrapCollaterals } from "../src/handlers/liquity/bootstrap";
+import { makeLiquityCollateral } from "../src/handlers/liquity/bootstrap";
+import {
+  LIQUITY_MARKETS,
+  makeCollateralId,
+} from "../src/handlers/liquity/config";
+import { OP } from "../src/handlers/liquity/operations";
+import { pendingTroveKey } from "../src/handlers/liquity/keys";
+import {
+  indexerTestHelpers,
+  processMockEvents,
+  type EntityCollection,
+  type MockDbWith,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+
+type PendingBatchedTroveUpdate = {
+  id: string;
+  troveId: string;
+};
+
+type ReplayMockDb = MockDbWith<{
+  LiquityCollateral: WritableEntity<LiquityCollateral>;
+  LiquityInstance: WritableEntity<LiquityInstance>;
+  Trove: WritableEntity<Trove>;
+  PendingBatchedTroveUpdate: EntityCollection<PendingBatchedTroveUpdate>;
+}>;
+
+const TestHelpers = indexerTestHelpers<ReplayMockDb>();
+const { MockDb, LiquityTroveManager } = TestHelpers;
+
+const market = LIQUITY_MARKETS[0]!;
+const collateralId = makeCollateralId(market);
+const MIN_DEBT = 100n * 10n ** 18n;
+const BATCH_MANAGER = "0x000000000000000000000000000000000000b0b0";
+const TROVE_ID = 1n;
+const TX_HASH = "0xbatchreplay";
+
+function seedLoadedCollateral(mockDb: ReplayMockDb): void {
+  mockDb.entities.LiquityCollateral.set({
+    ...makeLiquityCollateral(market, 0n, 0n),
+    systemParamsLoaded: true,
+    minDebt: MIN_DEBT,
+  });
+}
+
+function batchedTroveUpdatedEvent(logIndex: number) {
+  return LiquityTroveManager.BatchedTroveUpdated.createMockEvent({
+    _troveId: TROVE_ID,
+    _interestBatchManager: BATCH_MANAGER,
+    _batchDebtShares: 1_000n,
+    _coll: 500n * 10n ** 18n,
+    _stake: 500n * 10n ** 18n,
+    _snapshotOfTotalCollRedist: 0n,
+    _snapshotOfTotalDebtRedist: 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex,
+      block: { number: 500, timestamp: 5_000 },
+      transaction: { hash: TX_HASH },
+    },
+  });
+}
+
+function batchUpdatedEvent(args: {
+  logIndex: number;
+  debtIncreaseFromUpfrontFee?: bigint;
+}) {
+  return LiquityTroveManager.BatchUpdated.createMockEvent({
+    _interestBatchManager: BATCH_MANAGER,
+    _operation: OP.SET_INTEREST_BATCH_MANAGER,
+    _debt: 1_000n * 10n ** 18n,
+    _coll: 500n * 10n ** 18n,
+    _annualInterestRate: 5n * 10n ** 16n,
+    _annualManagementFee: 0n,
+    _totalDebtShares: 1_000n,
+    _debtIncreaseFromUpfrontFee: args.debtIncreaseFromUpfrontFee ?? 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: 500, timestamp: 5_000 },
+      transaction: { hash: TX_HASH },
+    },
+  });
+}
+
+describe("Liquity batchReplay idempotency", () => {
+  it("replaying the same BatchUpdated event does not double-apply the debt/systemDebt delta", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+
+    // First delivery: BatchedTroveUpdated (writes the pending scratch row)
+    // then BatchUpdated (replays it, consuming + deleting the scratch row).
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [batchedTroveUpdatedEvent(1), batchUpdatedEvent({ logIndex: 2 })],
+    });
+
+    const troveEntityId = `${collateralId}-0x1`;
+    const pendingId = pendingTroveKey(
+      market.chainId,
+      TX_HASH,
+      collateralId,
+      "0x1",
+    );
+
+    let trove = mockDb.entities.Trove.get(troveEntityId);
+    let instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      trove?.debt,
+      1_000n * 10n ** 18n,
+      "batch share debt applied once",
+    );
+    assert.equal(trove?.status, "active");
+    assert.equal(
+      instance?.systemDebt,
+      1_000n * 10n ** 18n,
+      "systemDebt reflects the trove entering the batch exactly once",
+    );
+    assert.equal(
+      mockDb.entities.PendingBatchedTroveUpdate.get(pendingId),
+      undefined,
+      "the scratch row is consumed after the first replay",
+    );
+
+    // Second delivery of the SAME BatchUpdated event (e.g. a reorg/backfill
+    // redelivering an already-seen block). No matching PendingBatchedTroveUpdate
+    // row exists anymore, so the replay loop must be a no-op this time.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [batchUpdatedEvent({ logIndex: 2 })],
+    });
+
+    trove = mockDb.entities.Trove.get(troveEntityId);
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      trove?.debt,
+      1_000n * 10n ** 18n,
+      "trove debt is unchanged by the replayed event — not doubled",
+    );
+    assert.equal(
+      instance?.systemDebt,
+      1_000n * 10n ** 18n,
+      "systemDebt is unchanged by the replayed event — not doubled",
+    );
+  });
+
+  it("bootstrapCollaterals is idempotent: a second call does not create duplicate or drifted rows", async () => {
+    const mockDb = MockDb.createMockDb();
+    await bootstrapCollaterals(
+      {
+        LiquityCollateral: mockDb.entities.LiquityCollateral,
+        LiquityInstance: mockDb.entities.LiquityInstance,
+      },
+      1_000n,
+      10_000n,
+    );
+    const firstPassInstance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.ok(firstPassInstance, "instance bootstrapped on first call");
+
+    // Mutate the instance the way a later handler would, then call
+    // bootstrapCollaterals again (simulating the onBlock heartbeat firing a
+    // second time, e.g. a re-sync from an earlier checkpoint).
+    mockDb.entities.LiquityInstance.set({
+      ...firstPassInstance!,
+      systemDebt: 42n,
+    });
+    await bootstrapCollaterals(
+      {
+        LiquityCollateral: mockDb.entities.LiquityCollateral,
+        LiquityInstance: mockDb.entities.LiquityInstance,
+      },
+      2_000n,
+      20_000n,
+    );
+
+    const secondPassInstance =
+      mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      secondPassInstance?.systemDebt,
+      42n,
+      "existing instance is preserved verbatim — bootstrap never overwrites live state",
+    );
+  });
+
+  it("KNOWN GAP (#1083): replaying a BatchUpdated event with a nonzero upfront fee double-counts LiquityInstance.borrowingFeeCum (pins current behavior)", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const fee = 10n * 10n ** 18n;
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        batchedTroveUpdatedEvent(1),
+        batchUpdatedEvent({ logIndex: 2, debtIncreaseFromUpfrontFee: fee }),
+      ],
+    });
+    let instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      instance?.borrowingFeeCum,
+      fee,
+      "fee recorded once on first delivery",
+    );
+
+    // Replay the identical event a second time.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        batchUpdatedEvent({ logIndex: 2, debtIncreaseFromUpfrontFee: fee }),
+      ],
+    });
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    // NOTE for whoever fixes #1083: once recordBorrowingFeeAndApplyCum is
+    // made replay-safe, this expectation must flip to `fee` (not `fee * 2n`).
+    // Leaving this assertion on the buggy value is intentional — it pins
+    // CURRENT behavior per issue #1054's workflow contract, not the desired
+    // behavior; it is deliberately not skipped so it forces an explicit
+    // update the moment #1083 lands.
+    assert.equal(
+      instance?.borrowingFeeCum,
+      fee * 2n,
+      "KNOWN GAP: recordBorrowingFeeAndApplyCum has no replay guard, so the " +
+        "fee is double-counted on redelivery — pinned here, not the desired behavior",
+    );
+  });
+});

--- a/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
+++ b/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
@@ -19,19 +19,27 @@
  * desired behavior.
  */
 import { strict as assert } from "assert";
-import type { LiquityCollateral, LiquityInstance, Trove } from "envio";
+import type {
+  LiquityBorrowingRevenueDailySnapshot,
+  LiquityCollateral,
+  LiquityInstance,
+  Trove,
+} from "envio";
 import { bootstrapCollaterals } from "../src/handlers/liquity/bootstrap";
 import { makeLiquityCollateral } from "../src/handlers/liquity/bootstrap";
+import { borrowingRevenueDailySnapshotId } from "../src/handlers/liquity/borrowingRevenue";
 import {
   LIQUITY_MARKETS,
   makeCollateralId,
 } from "../src/handlers/liquity/config";
 import { OP } from "../src/handlers/liquity/operations";
 import { pendingTroveKey } from "../src/handlers/liquity/keys";
+import { makeTroveId } from "../src/handlers/liquity/troves";
 import {
   indexerTestHelpers,
   processMockEvents,
   type EntityCollection,
+  type EntityReader,
   type MockDbWith,
   type WritableEntity,
 } from "./helpers/indexerTestHarness.js";
@@ -46,6 +54,7 @@ type ReplayMockDb = MockDbWith<{
   LiquityInstance: WritableEntity<LiquityInstance>;
   Trove: WritableEntity<Trove>;
   PendingBatchedTroveUpdate: EntityCollection<PendingBatchedTroveUpdate>;
+  LiquityBorrowingRevenueDailySnapshot: EntityReader<LiquityBorrowingRevenueDailySnapshot>;
 }>;
 
 const TestHelpers = indexerTestHelpers<ReplayMockDb>();
@@ -120,7 +129,7 @@ describe("Liquity batchReplay idempotency", () => {
       events: [batchedTroveUpdatedEvent(1), batchUpdatedEvent({ logIndex: 2 })],
     });
 
-    const troveEntityId = `${collateralId}-0x1`;
+    const troveEntityId = makeTroveId(collateralId, "0x1");
     const pendingId = pendingTroveKey(
       market.chainId,
       TX_HASH,
@@ -181,13 +190,23 @@ describe("Liquity batchReplay idempotency", () => {
     );
     const firstPassInstance = mockDb.entities.LiquityInstance.get(collateralId);
     assert.ok(firstPassInstance, "instance bootstrapped on first call");
+    const firstPassCollateral =
+      mockDb.entities.LiquityCollateral.get(collateralId);
+    assert.ok(firstPassCollateral, "collateral bootstrapped on first call");
 
-    // Mutate the instance the way a later handler would, then call
-    // bootstrapCollaterals again (simulating the onBlock heartbeat firing a
-    // second time, e.g. a re-sync from an earlier checkpoint).
+    // Mutate the instance and collateral the way a later handler would, then
+    // call bootstrapCollaterals again (simulating the onBlock heartbeat
+    // firing a second time, e.g. a re-sync from an earlier checkpoint).
+    // `bootstrapCollaterals` guards both rows with the same `existing ??`
+    // pattern, so both must survive the second call untouched.
     mockDb.entities.LiquityInstance.set({
       ...firstPassInstance!,
       systemDebt: 42n,
+    });
+    mockDb.entities.LiquityCollateral.set({
+      ...firstPassCollateral!,
+      systemParamsLoaded: true,
+      minDebt: MIN_DEBT,
     });
     await bootstrapCollaterals(
       {
@@ -205,12 +224,21 @@ describe("Liquity batchReplay idempotency", () => {
       42n,
       "existing instance is preserved verbatim — bootstrap never overwrites live state",
     );
+    const secondPassCollateral =
+      mockDb.entities.LiquityCollateral.get(collateralId);
+    assert.equal(
+      secondPassCollateral?.systemParamsLoaded,
+      true,
+      "existing collateral is preserved verbatim — bootstrap never overwrites live state",
+    );
+    assert.equal(secondPassCollateral?.minDebt, MIN_DEBT);
   });
 
-  it("KNOWN GAP (#1083): replaying a BatchUpdated event with a nonzero upfront fee double-counts LiquityInstance.borrowingFeeCum (pins current behavior)", async () => {
+  it("KNOWN GAP (#1083): replaying a BatchUpdated event with a nonzero upfront fee double-counts LiquityInstance.borrowingFeeCum AND LiquityBorrowingRevenueDailySnapshot.upfrontFee (pins current behavior)", async () => {
     let mockDb = MockDb.createMockDb();
     seedLoadedCollateral(mockDb);
     const fee = 10n * 10n ** 18n;
+    const snapshotId = borrowingRevenueDailySnapshotId(collateralId, 0n);
 
     mockDb = await processMockEvents({
       mockDb,
@@ -225,6 +253,13 @@ describe("Liquity batchReplay idempotency", () => {
       fee,
       "fee recorded once on first delivery",
     );
+    let snapshot =
+      mockDb.entities.LiquityBorrowingRevenueDailySnapshot.get(snapshotId);
+    assert.equal(
+      snapshot?.upfrontFee,
+      fee,
+      "daily snapshot upfrontFee recorded once on first delivery",
+    );
 
     // Replay the identical event a second time.
     mockDb = await processMockEvents({
@@ -234,17 +269,27 @@ describe("Liquity batchReplay idempotency", () => {
       ],
     });
     instance = mockDb.entities.LiquityInstance.get(collateralId);
+    snapshot =
+      mockDb.entities.LiquityBorrowingRevenueDailySnapshot.get(snapshotId);
     // NOTE for whoever fixes #1083: once recordBorrowingFeeAndApplyCum is
-    // made replay-safe, this expectation must flip to `fee` (not `fee * 2n`).
-    // Leaving this assertion on the buggy value is intentional — it pins
-    // CURRENT behavior per issue #1054's workflow contract, not the desired
-    // behavior; it is deliberately not skipped so it forces an explicit
-    // update the moment #1083 lands.
+    // made replay-safe, BOTH expectations below must flip to `fee` (not
+    // `fee * 2n`) — recordBorrowingUpfrontFee (which writes the daily
+    // snapshot) and the borrowingFeeCum increment share the same missing
+    // replay guard. Leaving these assertions on the buggy value is
+    // intentional — it pins CURRENT behavior per issue #1054's workflow
+    // contract, not the desired behavior; it is deliberately not skipped so
+    // it forces an explicit update the moment #1083 lands.
     assert.equal(
       instance?.borrowingFeeCum,
       fee * 2n,
       "KNOWN GAP: recordBorrowingFeeAndApplyCum has no replay guard, so the " +
         "fee is double-counted on redelivery — pinned here, not the desired behavior",
+    );
+    assert.equal(
+      snapshot?.upfrontFee,
+      fee * 2n,
+      "KNOWN GAP: the daily snapshot's upfrontFee bucket is double-counted " +
+        "in lockstep with borrowingFeeCum — pinned here, not the desired behavior",
     );
   });
 });

--- a/indexer-envio/test/liquityTroveLifecycle.test.ts
+++ b/indexer-envio/test/liquityTroveLifecycle.test.ts
@@ -1,0 +1,612 @@
+/**
+ * Issue #1054 scenario 1 — Liquity trove lifecycle driven through the real
+ * handlers (harness/processEvent), asserting Trove + LiquityInstance +
+ * StabilityPool accumulators stay consistent at each step:
+ *
+ *   open -> adjust -> liquidate -> redistribution
+ *
+ * plus the Bold-fork rebalance-vs-user-redemption conflation (CLAUDE.md
+ * "Rebalance redemptions are conflated with user redemptions today").
+ *
+ * Existing `test/liquity.test.ts` coverage for this handler subtree drives
+ * mostly pure helper functions (transitionOpenedTrove, applySystemDebtDelta,
+ * etc.) directly, not through the harness. Per repo convention ("MockDb-based
+ * multi-entity assertions are unreliable for heal logic — assert entity state
+ * after processEvent"), this file closes that gap by driving
+ * LiquityTroveManager events end-to-end and asserting persisted entity state.
+ */
+import { strict as assert } from "assert";
+import type {
+  LiquidationEvent,
+  LiquityCollateral,
+  LiquityInstance,
+  RedemptionEvent,
+  StabilityPoolLossAccumulator,
+  StabilityPoolLossScale,
+  Trove,
+} from "envio";
+import { makeLiquityCollateral } from "../src/handlers/liquity/bootstrap";
+import {
+  LIQUITY_MARKETS,
+  makeCollateralId,
+} from "../src/handlers/liquity/config";
+import { OP } from "../src/handlers/liquity/operations";
+import { makeTroveId } from "../src/handlers/liquity/troves";
+import {
+  indexerTestHelpers,
+  processMockEvents,
+  type EntityReader,
+  type MockDbWith,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+
+type LifecycleMockDb = MockDbWith<{
+  LiquityCollateral: WritableEntity<LiquityCollateral>;
+  LiquityInstance: WritableEntity<LiquityInstance>;
+  Trove: WritableEntity<Trove>;
+  LiquidationEvent: EntityReader<LiquidationEvent>;
+  RedemptionEvent: EntityReader<RedemptionEvent>;
+  StabilityPoolLossAccumulator: WritableEntity<StabilityPoolLossAccumulator>;
+  StabilityPoolLossScale: EntityReader<StabilityPoolLossScale>;
+}>;
+
+const TestHelpers = indexerTestHelpers<LifecycleMockDb>();
+const { MockDb, LiquityTroveManager, LiquityStabilityPool } = TestHelpers;
+
+const market = LIQUITY_MARKETS[0]!;
+const collateralId = makeCollateralId(market);
+const MIN_DEBT = 100n * 10n ** 18n;
+
+/** Seed a fully-loaded LiquityCollateral row so trove status classification
+ * (statusFromCollateral) resolves to active/zombie/redeemed deterministically
+ * instead of always falling back to "zombie" (systemParamsLoaded === false). */
+function seedLoadedCollateral(mockDb: LifecycleMockDb): void {
+  mockDb.entities.LiquityCollateral.set({
+    ...makeLiquityCollateral(market, 0n, 0n),
+    systemParamsLoaded: true,
+    minDebt: MIN_DEBT,
+  });
+}
+
+function troveOperationEvent(args: {
+  troveId: bigint;
+  operation: number;
+  annualInterestRate?: bigint;
+  debtIncreaseFromRedist?: bigint;
+  debtIncreaseFromUpfrontFee?: bigint;
+  debtChangeFromOperation?: bigint;
+  collIncreaseFromRedist?: bigint;
+  collChangeFromOperation?: bigint;
+  blockNumber: number;
+  blockTimestamp: number;
+  logIndex: number;
+  txHash: string;
+  to?: string | null;
+}) {
+  return LiquityTroveManager.TroveOperation.createMockEvent({
+    _troveId: args.troveId,
+    _operation: args.operation,
+    _annualInterestRate: args.annualInterestRate ?? 0n,
+    _debtIncreaseFromRedist: args.debtIncreaseFromRedist ?? 0n,
+    _debtIncreaseFromUpfrontFee: args.debtIncreaseFromUpfrontFee ?? 0n,
+    _debtChangeFromOperation: args.debtChangeFromOperation ?? 0n,
+    _collIncreaseFromRedist: args.collIncreaseFromRedist ?? 0n,
+    _collChangeFromOperation: args.collChangeFromOperation ?? 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: args.blockNumber, timestamp: args.blockTimestamp },
+      transaction: { hash: args.txHash, to: args.to ?? null },
+    },
+  });
+}
+
+function troveUpdatedEvent(args: {
+  troveId: bigint;
+  debt: bigint;
+  coll: bigint;
+  stake: bigint;
+  annualInterestRate?: bigint;
+  snapshotOfTotalCollRedist?: bigint;
+  snapshotOfTotalDebtRedist?: bigint;
+  blockNumber: number;
+  blockTimestamp: number;
+  logIndex: number;
+  txHash: string;
+}) {
+  return LiquityTroveManager.TroveUpdated.createMockEvent({
+    _troveId: args.troveId,
+    _debt: args.debt,
+    _coll: args.coll,
+    _stake: args.stake,
+    _annualInterestRate: args.annualInterestRate ?? 0n,
+    _snapshotOfTotalCollRedist: args.snapshotOfTotalCollRedist ?? 0n,
+    _snapshotOfTotalDebtRedist: args.snapshotOfTotalDebtRedist ?? 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: args.blockNumber, timestamp: args.blockTimestamp },
+      transaction: { hash: args.txHash },
+    },
+  });
+}
+
+describe("Liquity trove lifecycle — harness-driven multi-entity consistency", () => {
+  it("open -> adjust: Trove.debt and LiquityInstance.systemDebt track the delta exactly once", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveId = 1n;
+    const troveEntityId = makeTroveId(collateralId, "0x1");
+
+    // OPEN: TroveOperation(OPEN_TROVE) + TroveUpdated(debt=1000, coll=500) in
+    // one tx — matches the real on-chain emission order.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 1,
+          txHash: "0xopen",
+        }),
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_000n * 10n ** 18n,
+          coll: 500n * 10n ** 18n,
+          stake: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 2,
+          txHash: "0xopen",
+        }),
+      ],
+    });
+
+    let trove = mockDb.entities.Trove.get(troveEntityId);
+    let instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(trove?.status, "active", "opened trove is active");
+    assert.equal(trove?.debt, 1_000n * 10n ** 18n);
+    assert.equal(instance?.systemDebt, 1_000n * 10n ** 18n);
+    assert.equal(instance?.activeTroveCount, 1);
+    assert.equal(instance?.troveOpenedCountBucket, 1);
+
+    // ADJUST: borrow more — debt 1000 -> 1500, coll 500 -> 600.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId,
+          operation: OP.ADJUST_TROVE,
+          debtChangeFromOperation: 500n * 10n ** 18n,
+          collChangeFromOperation: 100n * 10n ** 18n,
+          blockNumber: 101,
+          blockTimestamp: 1_100,
+          logIndex: 1,
+          txHash: "0xadjust",
+        }),
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_500n * 10n ** 18n,
+          coll: 600n * 10n ** 18n,
+          stake: 600n * 10n ** 18n,
+          blockNumber: 101,
+          blockTimestamp: 1_100,
+          logIndex: 2,
+          txHash: "0xadjust",
+        }),
+      ],
+    });
+
+    trove = mockDb.entities.Trove.get(troveEntityId);
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(trove?.status, "active", "adjusted trove stays active");
+    assert.equal(trove?.debt, 1_500n * 10n ** 18n);
+    assert.equal(
+      instance?.systemDebt,
+      1_500n * 10n ** 18n,
+      "systemDebt reflects the +500 delta exactly once, not the full new debt added on top",
+    );
+    // activeTroveCount must NOT double-increment on a same-status update.
+    assert.equal(instance?.activeTroveCount, 1);
+  });
+
+  it("liquidate: trove closes, activeTroveCount/systemDebt decrement, and a survivor absorbs redistribution via ordinary TroveUpdated", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveAId = 10n;
+    const troveBId = 11n;
+    const troveAEntityId = makeTroveId(collateralId, "0xa");
+    const troveBEntityId = makeTroveId(collateralId, "0xb");
+
+    // Open trove A (to be liquidated) and trove B (the survivor).
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId: troveAId,
+          operation: OP.OPEN_TROVE,
+          blockNumber: 200,
+          blockTimestamp: 2_000,
+          logIndex: 1,
+          txHash: "0xopenA",
+        }),
+        troveUpdatedEvent({
+          troveId: troveAId,
+          debt: 1_500n * 10n ** 18n,
+          coll: 600n * 10n ** 18n,
+          stake: 600n * 10n ** 18n,
+          blockNumber: 200,
+          blockTimestamp: 2_000,
+          logIndex: 2,
+          txHash: "0xopenA",
+        }),
+        troveOperationEvent({
+          troveId: troveBId,
+          operation: OP.OPEN_TROVE,
+          blockNumber: 201,
+          blockTimestamp: 2_100,
+          logIndex: 1,
+          txHash: "0xopenB",
+        }),
+        troveUpdatedEvent({
+          troveId: troveBId,
+          debt: 800n * 10n ** 18n,
+          coll: 400n * 10n ** 18n,
+          stake: 400n * 10n ** 18n,
+          blockNumber: 201,
+          blockTimestamp: 2_100,
+          logIndex: 2,
+          txHash: "0xopenB",
+        }),
+      ],
+    });
+
+    let instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(instance?.systemDebt, 2_300n * 10n ** 18n, "both troves open");
+    assert.equal(instance?.activeTroveCount, 2);
+
+    // LIQUIDATE trove A: TroveOperation(LIQUIDATE) + the aggregate
+    // Liquidation event (real contracts fire both).
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId: troveAId,
+          operation: OP.LIQUIDATE,
+          collChangeFromOperation: -600n * 10n ** 18n,
+          debtChangeFromOperation: -1_500n * 10n ** 18n,
+          blockNumber: 202,
+          blockTimestamp: 2_200,
+          logIndex: 1,
+          txHash: "0xliquidateA",
+        }),
+        LiquityTroveManager.Liquidation.createMockEvent({
+          _debtOffsetBySP: 300n * 10n ** 18n,
+          _debtRedistributed: 1_200n * 10n ** 18n,
+          _boldGasCompensation: 0n,
+          _collGasCompensation: 0n,
+          _collSentToSP: 120n * 10n ** 18n,
+          _collRedistributed: 480n * 10n ** 18n,
+          _collSurplus: 0n,
+          _L_ETH: 500n,
+          _L_boldDebt: 700n,
+          _price: 10n ** 18n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.troveManager,
+            logIndex: 2,
+            block: { number: 202, timestamp: 2_200 },
+            transaction: { hash: "0xliquidateA" },
+          },
+        }),
+      ],
+    });
+
+    const troveA = mockDb.entities.Trove.get(troveAEntityId);
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(troveA?.status, "liquidated");
+    assert.equal(troveA?.liquidatedDebt, 1_500n * 10n ** 18n);
+    assert.equal(troveA?.liquidatedColl, 600n * 10n ** 18n);
+    assert.equal(
+      instance?.systemDebt,
+      800n * 10n ** 18n,
+      "liquidated trove's debt is removed from systemDebt exactly once",
+    );
+    assert.equal(
+      instance?.activeTroveCount,
+      1,
+      "activeTroveCount decrements for the liquidated trove only",
+    );
+    assert.equal(instance?.liqCountCum, 1);
+    assert.equal(instance?.liqDebtOffsetCum, 300n * 10n ** 18n);
+    assert.equal(instance?.liqDebtRedistributedCum, 1_200n * 10n ** 18n);
+    assert.equal(instance?.liqCollSentToSpCum, 120n * 10n ** 18n);
+    assert.equal(instance?.liqCollRedistributedCum, 480n * 10n ** 18n);
+    assert.equal(instance?.latestTotalCollRedist, 500n);
+    assert.equal(instance?.latestTotalDebtRedist, 700n);
+
+    const liquidationEvent = mockDb.entities.LiquidationEvent.get(
+      `${market.chainId}_202_2`,
+    );
+    assert.ok(liquidationEvent, "LiquidationEvent row is written");
+    assert.equal(liquidationEvent?.debtOffsetBySP, 300n * 10n ** 18n);
+
+    // REDISTRIBUTION: trove B is untouched by the liquidation itself — the
+    // indexer never computes redistribution math, it just persists whatever
+    // snapshot the next TroveUpdated for trove B carries. Simulate the
+    // on-chain redistribution having bumped trove B's debt/coll and having
+    // caught its snapshot up to the new L_ETH/L_boldDebt accumulator values
+    // from the Liquidation event above.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId: troveBId,
+          operation: OP.APPLY_PENDING_DEBT,
+          blockNumber: 203,
+          blockTimestamp: 2_300,
+          logIndex: 1,
+          txHash: "0xredistB",
+        }),
+        troveUpdatedEvent({
+          troveId: troveBId,
+          debt: 900n * 10n ** 18n,
+          coll: 450n * 10n ** 18n,
+          stake: 400n * 10n ** 18n,
+          snapshotOfTotalCollRedist: 500n,
+          snapshotOfTotalDebtRedist: 700n,
+          blockNumber: 203,
+          blockTimestamp: 2_300,
+          logIndex: 2,
+          txHash: "0xredistB",
+        }),
+      ],
+    });
+
+    const troveB = mockDb.entities.Trove.get(troveBEntityId);
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(troveB?.status, "active", "survivor stays active");
+    assert.equal(
+      troveB?.debt,
+      900n * 10n ** 18n,
+      "survivor's debt reflects the redistribution bump",
+    );
+    assert.equal(troveB?.coll, 450n * 10n ** 18n);
+    assert.equal(
+      troveB?.snapshotOfTotalCollRedist,
+      500n,
+      "redistribution snapshot persisted verbatim from the event",
+    );
+    assert.equal(troveB?.snapshotOfTotalDebtRedist, 700n);
+    assert.equal(
+      instance?.systemDebt,
+      900n * 10n ** 18n,
+      "systemDebt absorbs the redistribution-driven delta exactly once, regardless of cause",
+    );
+    assert.equal(
+      instance?.activeTroveCount,
+      1,
+      "activeTroveCount unaffected by a same-status debt update",
+    );
+  });
+
+  it("stability pool absorbs part of a liquidation: LiquidationEvent + StabilityPoolLossAccumulator/Scale stay consistent", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    mockDb.entities.StabilityPoolLossAccumulator.set({
+      id: collateralId,
+      chainId: market.chainId,
+      collateralId,
+      currentP: 1_000n,
+      currentScale: 0n,
+      totalBoldDeposits: 10_000n,
+    });
+    const troveId = 20n;
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE,
+          blockNumber: 300,
+          blockTimestamp: 3_000,
+          logIndex: 1,
+          txHash: "0xopenC",
+        }),
+        troveUpdatedEvent({
+          troveId,
+          debt: 500n * 10n ** 18n,
+          coll: 300n * 10n ** 18n,
+          stake: 300n * 10n ** 18n,
+          blockNumber: 300,
+          blockTimestamp: 3_000,
+          logIndex: 2,
+          txHash: "0xopenC",
+        }),
+      ],
+    });
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({
+          troveId,
+          operation: OP.LIQUIDATE,
+          collChangeFromOperation: -300n * 10n ** 18n,
+          debtChangeFromOperation: -500n * 10n ** 18n,
+          blockNumber: 301,
+          blockTimestamp: 3_100,
+          logIndex: 1,
+          txHash: "0xliquidateC",
+        }),
+        LiquityTroveManager.Liquidation.createMockEvent({
+          _debtOffsetBySP: 500n * 10n ** 18n,
+          _debtRedistributed: 0n,
+          _boldGasCompensation: 0n,
+          _collGasCompensation: 0n,
+          _collSentToSP: 300n * 10n ** 18n,
+          _collRedistributed: 0n,
+          _collSurplus: 0n,
+          _L_ETH: 0n,
+          _L_boldDebt: 0n,
+          _price: 10n ** 18n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.troveManager,
+            logIndex: 2,
+            block: { number: 301, timestamp: 3_100 },
+            transaction: { hash: "0xliquidateC" },
+          },
+        }),
+        LiquityStabilityPool.S_Updated.createMockEvent({
+          _S: 0n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.stabilityPool,
+            logIndex: 3,
+            block: { number: 301, timestamp: 3_100 },
+            transaction: { hash: "0xliquidateC" },
+          },
+        }),
+        LiquityStabilityPool.P_Updated.createMockEvent({
+          _P: 900n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.stabilityPool,
+            logIndex: 4,
+            block: { number: 301, timestamp: 3_100 },
+            transaction: { hash: "0xliquidateC" },
+          },
+        }),
+        LiquityStabilityPool.StabilityPoolBoldBalanceUpdated.createMockEvent({
+          _newBalance: 9_500n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.stabilityPool,
+            logIndex: 5,
+            block: { number: 301, timestamp: 3_100 },
+            transaction: { hash: "0xliquidateC" },
+          },
+        }),
+      ],
+    });
+
+    const instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(instance?.liqDebtOffsetCum, 500n * 10n ** 18n);
+    assert.equal(instance?.liqCollSentToSpCum, 300n * 10n ** 18n);
+
+    const accumulator =
+      mockDb.entities.StabilityPoolLossAccumulator.get(collateralId);
+    assert.equal(
+      accumulator?.currentP,
+      900n,
+      "StabilityPoolLossAccumulator.currentP reflects the pool share dilution",
+    );
+    assert.equal(accumulator?.totalBoldDeposits, 9_500n);
+
+    const scale = mockDb.entities.StabilityPoolLossScale.get(
+      `${collateralId}-0`,
+    );
+    assert.equal(
+      scale?.liquidationLossSum,
+      100n,
+      "liquidation loss is classified into the scale-0 bucket (1000-900=100)",
+    );
+    assert.equal(scale?.rebalanceLossSum, 0n);
+  });
+
+  it("redemption: rebalance-driven (CDPLiquidityStrategy tx.to) and user redemptions both count toward the total, only rebalance increments the rebalance-specific cumulative buckets", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+
+    function redemptionEvent(args: {
+      blockNumber: number;
+      logIndex: number;
+      txHash: string;
+      to: string | null;
+      actualBoldAmount: bigint;
+      ethFee: bigint;
+    }) {
+      return LiquityTroveManager.Redemption.createMockEvent({
+        _attemptedBoldAmount: args.actualBoldAmount,
+        _actualBoldAmount: args.actualBoldAmount,
+        _ETHSent: args.actualBoldAmount,
+        _ETHFee: args.ethFee,
+        _price: 10n ** 18n,
+        _redemptionPrice: 10n ** 18n,
+        mockEventData: {
+          chainId: market.chainId,
+          srcAddress: market.troveManager,
+          logIndex: args.logIndex,
+          block: { number: args.blockNumber, timestamp: args.blockNumber * 10 },
+          transaction: { hash: args.txHash, to: args.to },
+        },
+      });
+    }
+
+    // Rebalance-driven redemption: tx.to === CDPLiquidityStrategy address.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        redemptionEvent({
+          blockNumber: 400,
+          logIndex: 1,
+          txHash: "0xrebalanceRedeem",
+          to: market.cdpLiquidityStrategy,
+          actualBoldAmount: 100n * 10n ** 18n,
+          ethFee: 1n * 10n ** 18n,
+        }),
+      ],
+    });
+    // User-driven redemption: tx.to is some other address, different block.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        redemptionEvent({
+          blockNumber: 401,
+          logIndex: 1,
+          txHash: "0xuserRedeem",
+          to: "0x00000000000000000000000000000000009999",
+          actualBoldAmount: 40n * 10n ** 18n,
+          ethFee: 2n * 10n ** 17n,
+        }),
+      ],
+    });
+
+    const rebalanceEvent = mockDb.entities.RedemptionEvent.get(
+      `${market.chainId}_400_1`,
+    );
+    const userEvent = mockDb.entities.RedemptionEvent.get(
+      `${market.chainId}_401_1`,
+    );
+    assert.equal(rebalanceEvent?.isRebalance, true);
+    assert.equal(userEvent?.isRebalance, false);
+
+    const instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      instance?.redemptionCountCum,
+      2,
+      "both redemptions count toward the total",
+    );
+    assert.equal(
+      instance?.redemptionDebtCum,
+      140n * 10n ** 18n,
+      "total redemption debt sums both",
+    );
+    assert.equal(
+      instance?.rebalanceRedemptionCountCum,
+      1,
+      "only the CDPLiquidityStrategy-tx redemption counts as rebalance-driven",
+    );
+    assert.equal(
+      instance?.rebalanceRedemptionDebtCum,
+      100n * 10n ** 18n,
+      "rebalance subset excludes the user redemption's debt",
+    );
+  });
+});

--- a/indexer-envio/test/liquityTroveLifecycle.test.ts
+++ b/indexer-envio/test/liquityTroveLifecycle.test.ts
@@ -307,6 +307,7 @@ describe("Liquity trove lifecycle — harness-driven multi-entity consistency", 
     });
 
     const troveA = mockDb.entities.Trove.get(troveAEntityId);
+    assert.ok(troveA, "liquidated trove exists");
     instance = mockDb.entities.LiquityInstance.get(collateralId);
     assert.equal(troveA?.status, "liquidated");
     assert.equal(troveA?.liquidatedDebt, 1_500n * 10n ** 18n);

--- a/indexer-envio/test/wormholeCompleteFlow.test.ts
+++ b/indexer-envio/test/wormholeCompleteFlow.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Issue #1054 scenario 6 (Wormhole half) — after a COMPLETE NTT transfer flow
+ * (source TransferSentDetailed+Digest, dest ReceivedMessage, dest
+ * MessageAttestedTo, dest TransferRedeemed), both scratch tables —
+ * `WormholeTransferPending` (source-side pairing scratch) and
+ * `WormholeDestPending` (dest-side transceiver-digest scratch) — must end at
+ * zero rows. `test/bridgeHandlers.test.ts` already asserts individual scratch
+ * rows are consumed by id; this file adds the end-to-end `getAll().length ===
+ * 0` assertion across both tables for a full round trip, which no existing
+ * test does.
+ */
+import { strict as assert } from "assert";
+import { findByNttManager } from "../src/wormhole/nttAddresses.js";
+import {
+  indexerTestHelpers,
+  type EntityCollection,
+  type EntityReader,
+  type MockDbWith,
+} from "./helpers/indexerTestHarness.js";
+
+// Side-effect: register handlers with Envio.
+import "../src/EventHandlers.ts";
+
+type MockDb = MockDbWith<{
+  BridgeTransfer: EntityReader<{
+    id: string;
+    status: string;
+    sourceChainId?: number;
+    destChainId?: number;
+  }>;
+  WormholeTransferPending: EntityCollection<{ id: string }>;
+  WormholeDestPending: EntityCollection<{ id: string }>;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const {
+  MockDb,
+  WormholeNttManager: TestWormholeNttManager,
+  WormholeTransceiver: TestWormholeTransceiver,
+} = TestHelpers;
+
+// Celo USDm entry — stable across generations of the manifest (same pattern
+// as test/bridgeHandlers.test.ts).
+function celoEntry() {
+  const e = findByNttManager(
+    42220,
+    "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+  );
+  assert.ok(e, "manifest lookup failed — did generateNttAddresses.mjs run?");
+  return e!;
+}
+function monadEntry() {
+  const e = findByNttManager(143, "0xa4096343485a44c0f8d05ae6da311c18d63e38bc");
+  assert.ok(e, "manifest lookup failed — did generateNttAddresses.mjs run?");
+  return e!;
+}
+
+function padAddr(addr: string): string {
+  return "0x" + "0".repeat(24) + addr.toLowerCase().replace(/^0x/, "");
+}
+
+const RECIPIENT_20 = "0x1111111111111111111111111111111111111111";
+const REFUND_20 = "0x2222222222222222222222222222222222222222";
+const SENDER_20 = "0xabcdef0123456789abcdef0123456789abcdef00";
+const MANAGER_DIGEST =
+  "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+const TRANSCEIVER_DIGEST =
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const SOURCE_TX_HASH =
+  "0x3333333333333333333333333333333333333333333333333333333333333333";
+const DEST_TX_HASH =
+  "0x4444444444444444444444444444444444444444444444444444444444444444";
+
+function mockEventData(args: {
+  chainId: number;
+  manager: string;
+  logIndex: number;
+  txHash: string;
+  txFrom?: string;
+  blockNumber?: number;
+  blockTimestamp?: number;
+}) {
+  return {
+    chainId: args.chainId,
+    srcAddress: args.manager,
+    logIndex: args.logIndex,
+    transaction: { hash: args.txHash, from: args.txFrom ?? SENDER_20 },
+    block: {
+      number: args.blockNumber ?? 100,
+      timestamp: args.blockTimestamp ?? 1_700_000_000,
+    },
+  };
+}
+
+describe("Wormhole complete transfer flow — pending scratch fully drains", () => {
+  it("source pairing + dest ReceivedMessage/MessageAttestedTo/TransferRedeemed leaves both scratch tables at 0 rows", async () => {
+    const celo = celoEntry();
+    const monad = monadEntry();
+    let mockDb = MockDb.createMockDb();
+
+    // --- Source chain (Celo): TransferSentDetailed + TransferSentDigest ---
+    const detailEvent =
+      TestWormholeNttManager.TransferSentDetailed.createMockEvent({
+        recipient: padAddr(RECIPIENT_20),
+        refundAddress: padAddr(REFUND_20),
+        amount: 1_000n,
+        fee: 0n,
+        recipientChain: 48, // Monad
+        msgSequence: 7n,
+        mockEventData: mockEventData({
+          chainId: celo.chainId,
+          manager: celo.nttManagerProxy,
+          logIndex: 4,
+          txHash: SOURCE_TX_HASH,
+        }),
+      });
+    mockDb = await TestWormholeNttManager.TransferSentDetailed.processEvent({
+      event: detailEvent,
+      mockDb,
+    });
+    const digestEvent =
+      TestWormholeNttManager.TransferSentDigest.createMockEvent({
+        digest: MANAGER_DIGEST,
+        mockEventData: mockEventData({
+          chainId: celo.chainId,
+          manager: celo.nttManagerProxy,
+          logIndex: 6,
+          txHash: SOURCE_TX_HASH,
+        }),
+      });
+    mockDb = await TestWormholeNttManager.TransferSentDigest.processEvent({
+      event: digestEvent,
+      mockDb,
+    });
+
+    assert.equal(
+      mockDb.entities.WormholeTransferPending.getAll().length,
+      0,
+      "source-side scratch is drained once the digest event pairs it",
+    );
+    const afterSource = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(afterSource?.status, "SENT");
+
+    // --- Dest chain (Monad): ReceivedMessage (transceiver-layer digest) ---
+    const receivedEvent =
+      TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: TRANSCEIVER_DIGEST,
+        emitterChainId: 14, // Celo
+        emitterAddress: padAddr(celo.transceiverProxy),
+        sequence: 7n,
+        mockEventData: mockEventData({
+          chainId: monad.chainId,
+          manager: monad.transceiverProxy,
+          logIndex: 5,
+          txHash: DEST_TX_HASH,
+        }),
+      });
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: receivedEvent,
+      mockDb,
+    });
+    assert.equal(
+      mockDb.entities.WormholeDestPending.getAll().length,
+      1,
+      "dest-side scratch is written pending the manager-layer MessageAttestedTo",
+    );
+
+    // --- Dest chain: MessageAttestedTo (manager-layer digest, same tx, higher logIndex) ---
+    const attestedEvent =
+      TestWormholeNttManager.MessageAttestedTo.createMockEvent({
+        digest: MANAGER_DIGEST,
+        transceiver: monad.transceiverProxy,
+        index: 0n,
+        mockEventData: mockEventData({
+          chainId: monad.chainId,
+          manager: monad.nttManagerProxy,
+          logIndex: 7,
+          txHash: DEST_TX_HASH,
+        }),
+      });
+    mockDb = await TestWormholeNttManager.MessageAttestedTo.processEvent({
+      event: attestedEvent,
+      mockDb,
+    });
+    assert.equal(
+      mockDb.entities.WormholeDestPending.getAll().length,
+      0,
+      "MessageAttestedTo drains the WormholeDestPending scratch",
+    );
+
+    // --- Dest chain: TransferRedeemed completes delivery ---
+    const redeemedEvent =
+      TestWormholeNttManager.TransferRedeemed.createMockEvent({
+        digest: MANAGER_DIGEST,
+        mockEventData: mockEventData({
+          chainId: monad.chainId,
+          manager: monad.nttManagerProxy,
+          logIndex: 8,
+          txHash: DEST_TX_HASH,
+        }),
+      });
+    mockDb = await TestWormholeNttManager.TransferRedeemed.processEvent({
+      event: redeemedEvent,
+      mockDb,
+    });
+
+    const finalTransfer = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(finalTransfer?.status, "DELIVERED");
+    assert.equal(finalTransfer?.sourceChainId, celo.chainId);
+    assert.equal(finalTransfer?.destChainId, monad.chainId);
+
+    assert.equal(
+      mockDb.entities.WormholeTransferPending.getAll().length,
+      0,
+      "WormholeTransferPending has 0 rows after a complete round trip",
+    );
+    assert.equal(
+      mockDb.entities.WormholeDestPending.getAll().length,
+      0,
+      "WormholeDestPending has 0 rows after a complete round trip",
+    );
+  });
+});

--- a/indexer-envio/test/wormholeCompleteFlow.test.ts
+++ b/indexer-envio/test/wormholeCompleteFlow.test.ts
@@ -50,6 +50,10 @@ function celoEntry() {
   return e!;
 }
 function monadEntry() {
+  // Same proxy address as celoEntry() — intentional: CREATE3 deployment
+  // means the same deterministic address on both chains. The manifest
+  // lookup keys on (chainId, address), so it still returns distinct
+  // per-chain entries.
   const e = findByNttManager(143, "0xa4096343485a44c0f8d05ae6da311c18d63e38bc");
   assert.ok(e, "manifest lookup failed — did generateNttAddresses.mjs run?");
   return e!;


### PR DESCRIPTION
## The Problem

- Issue #1054 lists six must-cover scenarios for the Liquity/CDP handler subtree and cross-cutting indexer behaviors (RPC fallback, multichain namespacing, reserve-yield), but several were only partially exercised — mostly via pure-function unit tests rather than through the real handlers.
- Trove lifecycle transitions (open/adjust/liquidate/redistribution), batch-replay idempotency, and a complete Wormhole NTT round-trip had no harness-driven, multi-entity assertions pinning current behavior.
- Per-chain RPC fallback and cross-chain namespacing were covered generically/single-chain but not proven not to leak state across real chain ids.

## The Solution

- Triaged all 6 scenarios against existing tests (table below), then added harness-driven tests (`processEvent`/`processMockEvents`, asserting entity state — never MockDb-only assertions) closing every partial/missing gap.
- While writing the batch-replay idempotency coverage, found a real replay double-count bug in `recordBorrowingFeeAndApplyCum`; per the issue's bug-handling instructions, pinned the current (buggy) behavior in a test rather than changing production code, and filed a follow-up issue (#1083).

## Details

### Triage table

| # | Scenario | Status before this PR | Evidence | Closed by |
|---|---|---|---|---|
| 1 | Trove lifecycle open→adjust→liquidate→redistribution (+ Bold-fork rebalance-vs-redemption conflation) | Partial — pure-function tests only (`transitionOpenedTrove`, `applySystemDebtDelta`, etc.), no harness-driven multi-entity run | `test/liquity.test.ts` (no `processMockEvents` call for `TroveOperation`/`TroveUpdated`/`Liquidation`/`Redemption`) | `test/liquityTroveLifecycle.test.ts` (new) |
| 2 | Stability-pool loss attribution across a scale change | Covered | `test/liquity.test.ts:937-1095` — harness-driven `Liquidation` + `StabilityPool` events, both event-orderings, scale 0→1 | No new work needed |
| 3 | `batchReplay` idempotency (replaying already-seen events → no double-counting) | Missing | No test exercised `BatchUpdated` replay or `bootstrapCollaterals` re-invocation | `test/liquityBatchReplayIdempotency.test.ts` (new) — also surfaced a real gap, see Deferrals |
| 4 | RPC block-fallback: archive-depth + rate-limit → `ENVIO_RPC_FALLBACK_URL_<chainId>`, per chain | Partial — mechanism thoroughly tested with a synthetic chain id; per-chain env-var resolution thoroughly tested separately (`rpcClient.test.ts`); no test proved per-chain state (archive horizon, rate-limit cooldown) doesn't leak across real chains | `test/blockFallback.test.ts` (pre-existing, synthetic `TEST_CHAIN_ID`/`HORIZON_CHAIN`) | `test/blockFallback.test.ts` — new `describe("per-chain fallback...")` block using real Celo/Monad chain ids |
| 5 | Multichain namespacing: same address on two chains → distinct `{chainId}-{address}` entities, zero bleed (pool + trove variants) | Partial — `poolDailyFeeSnapshot.test.ts` covers the snapshot entity cross-chain; the base `Pool` entity and the Liquity/trove ID-construction guarantee were untested | `test/poolDailyFeeSnapshot.test.ts:426` | `test/crossChainNamespacing.test.ts` (new) — pool variant harness-driven (FPMM on Celo+Monad); trove variant at the `makeCollateralId`/`makeTroveId` ID-construction level (Liquity is Celo-only in production config today, so a live two-chain handler run isn't reachable) |
| 6 | Wormhole NTT transfer flow drains `WormholeTransferPending`/`WormholeDestPending` to 0 rows | Partial — `bridgeHandlers.test.ts` asserts individual scratch rows are consumed by id at each step; no test ran a full source+dest round trip and asserted `getAll().length === 0` on both tables | `test/bridgeHandlers.test.ts` | `test/wormholeCompleteFlow.test.ts` (new) |

(Scenario 6's other half — Ethereum reserve-yield event-only indexing with no `onBlock` heartbeat — is already covered by `test/susds.test.ts`/`test/steth.test.ts`'s event-level tests, and the "no heartbeat" invariant is a structural fact: `indexer.onBlock` has exactly one call site in the whole package, `src/handlers/liquity/bootstrapHandler.ts`, scoped to Celo/Monad only — verified via `grep -rn "onBlock" src`. No new test added for that half; flagged here for the triage record.)

### Notes

- All new tests drive the real handlers via `test/helpers/indexerTestHarness.ts` (`processEvent`/`processMockEvents`), honoring the preload/process double-pass and asserting persisted entity state — never MockDb-only assertions.
- Mocking stayed at the effect layer (Liquity's `SystemParams`/`PriceFeed` RPC effects degrade gracefully through the hermetic mock HTTP server with no special mocking needed); no real RPC was touched (hermetic guard stayed green throughout).
- `test/blockFallback.test.ts` was extended rather than split — it was already ~1,130 lines before this PR (test files are exempt from the 1,000-line hard cap; the issue explicitly named this file to extend). New suites (`liquityTroveLifecycle`, `liquityBatchReplayIdempotency`, `crossChainNamespacing`, `wormholeCompleteFlow`) are each new, focused files under the 600-line soft cap.
- **Coverage floor acceptance-criterion override**: per team-lead direction, `indexer-envio/vitest.config.ts`'s coverage floors are intentionally NOT re-pinned in this PR — three parallel scenario-coverage PRs touching the same handler subtree would conflict on the floor numbers and each would under-measure relative to the combined result. The re-pin is tracked as #1081 and should land after all three scenario PRs merge.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test` — 1015 passed, 19 pre-existing skipped, 0 failed.
- `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean.
- `pnpm exec turbo run lint --filter=@mento-protocol/indexer-envio` — clean (fixed one `prefer-const` violation surfaced by the new tests).
- `pnpm exec turbo run knip --filter=@mento-protocol/indexer-envio` — no new unused-export findings from this PR's files.
- `pnpm code-health:deps` — no dependency-cruiser violations.
- `pnpm --filter @mento-protocol/indexer-envio test -- --coverage` (informational only, not re-pinned per the Deferrals override) — statements 50.88%/branches 45.69%/functions 60.23%/lines 51.62%, all above the current floors (47/42/56/48).
- `pnpm agent:quality-gate` (`--run`, invoked by the pre-push gate) — all mapped commands passed.
- `pnpm agent:autoreview` — one finding on the first pass (objecting to a test asserting a known bug's current buggy value as "passing"); addressed by strengthening the in-test documentation of why that assertion is intentional and what must change when #1083 lands (the underlying instruction from issue #1054 explicitly calls for pinning current behavior rather than fixing production code). Second pass: clean.

## Deferrals

- #1081 — Re-pin `indexer-envio/vitest.config.ts` coverage floors upward per the `floor(measured) - 2` convention, after all three scenario-coverage PRs (Liquity/cross-cutting, and the other two scenario-domain PRs) have merged.
- #1083 — `recordBorrowingFeeAndApplyCum` (Liquity `TroveOperation`/`BatchUpdated` handlers) has no replay guard; a redelivered event with a nonzero upfront fee double-counts `LiquityInstance.borrowingFeeCum` and the corresponding daily-snapshot bucket. Pinned in `test/liquityBatchReplayIdempotency.test.ts`, not fixed here.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1054

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new and extended tests; indexer behavior is unchanged except documenting the known upfront-fee replay issue in assertions.
> 
> **Overview**
> Adds **test-only** coverage for issue **#1054** — no production handler or RPC code changes.
> 
> **Liquity:** New harness-driven suites exercise trove **open → adjust → liquidate → redistribution**, stability-pool loss on liquidation, and **rebalance vs user** redemption bucketing via real `LiquityTroveManager` / stability-pool events. Batch replay idempotency asserts redelivered `BatchUpdated` does not double-count debt/`systemDebt` and that `bootstrapCollaterals` is get-or-create safe; a separate test **documents current buggy replay behavior** for upfront fees (follow-up **#1083**).
> 
> **Cross-cutting:** `blockFallback.test.ts` gains Celo/Monad cases proving archive-depth and rate-limit fallback paths work per chain and that **archive horizons and rate-limit cooldowns do not leak** across chain ids. `crossChainNamespacing.test.ts` pins distinct `{chainId}-address` **Pool** rows for the same FPMM proxy on two chains and ID helpers for Liquity troves.
> 
> **Wormhole:** End-to-end Celo→Monad NTT flow asserts both `WormholeTransferPending` and `WormholeDestPending` drain to **zero rows** after delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b0ab333276a18dc5901e4686bede451ffa8dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->