### PR TITLE
test(indexer): cover self-heal + FPMM lifecycle must-cover scenarios

### DIFF
--- a/indexer-envio/test/fpmmBatchOrdering.test.ts
+++ b/indexer-envio/test/fpmmBatchOrdering.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import {
+  indexerTestHelpers,
+  processMockEvents,
+  type EntityCollection,
+  type MockDbWith,
+  type MockEventData,
+} from "./helpers/indexerTestHarness.js";
+import { createMockEventData } from "./helpers/eventFixtures.js";
+import { makePoolId } from "../src/helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 4 — a pool created by the factory and swapped within
+// the same processing batch: ordering holds (Envio's (block, logIndex)
+// ordering governs processing, not array position), and no orphan rows
+// appear (the Swap must attach to the pool the factory created, not spawn
+// a second default Pool via `getOrCreatePool`'s fallback).
+//
+// `events` is submitted to `processMockEvents` with the Swap listed BEFORE
+// the FPMMDeployed event in the array on purpose — proving the assertions
+// below hold because of Envio's block/logIndex ordering, not because the
+// test happened to list events in processing order.
+// ---------------------------------------------------------------------------
+
+type MockDb = MockDbWith<{
+  Pool: EntityCollection;
+  FactoryDeployment: EntityCollection;
+  SwapEvent: EntityCollection;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+
+const CHAIN_ID = 42220;
+const FACTORY_ADDRESS = "0x00000000000000000000000000000000000000cc";
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000fa";
+const TOKEN0 = "0x0000000000000000000000000000000000000003";
+const TOKEN1 = "0x0000000000000000000000000000000000000004";
+const IMPLEMENTATION = "0x00000000000000000000000000000000000000bc";
+// Deploy and Swap land in DIFFERENT blocks of the same batch on purpose
+// (a real deploy-then-swap sequence spans blocks). This makes `createdAtBlock`
+// an order-sensitive witness: `upsertPool` stamps it on first touch and
+// preserves it afterward, so if Envio processed the Swap before the Deploy
+// (array order, not (block, logIndex) order), `createdAtBlock` would read
+// the SWAP's block instead of the DEPLOY's — a fact that stays otherwise
+// invisible in token0/token1/swapCount, which converge to the same value
+// regardless of processing order (see the codex finding this fixed).
+const DEPLOY_BLOCK = 5_000;
+const SWAP_BLOCK = 5_001;
+const BLOCK_TIMESTAMP = 1_700_500_000;
+
+function mockEventData(
+  logIndex: number,
+  srcAddress: string,
+  blockNumber: number,
+): MockEventData {
+  return createMockEventData({
+    chainId: CHAIN_ID,
+    logIndex,
+    srcAddress,
+    blockNumber,
+    blockTimestamp: BLOCK_TIMESTAMP + (blockNumber - DEPLOY_BLOCK),
+  });
+}
+
+describe("pool created + swapped in the same batch (issue #1053 scenario 4)", () => {
+  it("Swap attaches to the factory-created pool; no orphan Pool/SwapEvent rows appear", async () => {
+    const mockDb = MockDb.createMockDb();
+
+    const swapEvent = FPMM.Swap.createMockEvent({
+      sender: TOKEN0,
+      to: TOKEN1,
+      amount0In: 1_000_000_000_000_000_000n,
+      amount1In: 0n,
+      amount0Out: 0n,
+      amount1Out: 2_000_000_000_000_000_000n,
+      mockEventData: mockEventData(0, POOL_ADDRESS, SWAP_BLOCK),
+    });
+    const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+      token0: TOKEN0,
+      token1: TOKEN1,
+      fpmmProxy: POOL_ADDRESS,
+      fpmmImplementation: IMPLEMENTATION,
+      mockEventData: mockEventData(0, FACTORY_ADDRESS, DEPLOY_BLOCK),
+    });
+
+    // Deliberately listed Swap-before-Deploy: processing order must still
+    // follow (block, logIndex), not array position.
+    await processMockEvents({ mockDb, events: [swapEvent, deployEvent] });
+
+    const poolId = makePoolId(CHAIN_ID, POOL_ADDRESS);
+    const pools = mockDb.entities.Pool.getAll();
+    assert.equal(pools.length, 1, "exactly one Pool row — no orphan default");
+    const pool = pools[0] as {
+      id: string;
+      token0?: string;
+      token1?: string;
+      swapCount: number;
+      source: string;
+      createdAtBlock: bigint;
+    };
+    assert.equal(pool.id, poolId);
+    assert.equal(pool.token0, TOKEN0);
+    assert.equal(pool.token1, TOKEN1);
+    assert.equal(pool.swapCount, 1);
+    // Order-sensitive witness: `upsertPool` stamps `createdAtBlock` on first
+    // touch only. If the Swap had actually been processed before the
+    // Deploy (array order, not (block, logIndex) order), this would read
+    // SWAP_BLOCK instead — token0/token1/swapCount alone can't detect that
+    // regression because they converge to the same value either way.
+    assert.equal(
+      pool.createdAtBlock,
+      BigInt(DEPLOY_BLOCK),
+      "createdAtBlock must be stamped by the deploy (the true first event), not by an out-of-order Swap",
+    );
+
+    const deployments = mockDb.entities.FactoryDeployment.getAll();
+    assert.equal(deployments.length, 1);
+    assert.equal((deployments[0] as { poolId: string }).poolId, poolId);
+
+    const swaps = mockDb.entities.SwapEvent.getAll();
+    assert.equal(swaps.length, 1, "exactly one SwapEvent row — no orphan");
+    assert.equal((swaps[0] as { poolId: string }).poolId, poolId);
+  });
+});

--- a/indexer-envio/test/helpers/makePool.ts
+++ b/indexer-envio/test/helpers/makePool.ts
@@ -50,6 +50,16 @@ export function makePool(overrides: Partial<Pool> = {}): Pool {
     // shared fixture must carry it too. Override to true for halt tests.
     breakerTripped: false,
     wrappedExchangeId: "",
+    // Also excluded from DEFAULT_ORACLE_FIELDS (spread-clobber guard — see
+    // pool.ts). Without an explicit default here the field is `undefined`
+    // at runtime despite the `Pool` type marking it required: TS can't
+    // catch the gap because the trailing `...overrides` spread makes the
+    // object literal's required-field check permissive. `undefined` is
+    // silently fine for tests that call self-heal helpers directly, but a
+    // Pool row seeded straight into the real Envio harness (`mockDb.entities
+    // .Pool.set(...)`) fails entity-schema validation on write, surfacing as
+    // an opaque worker crash rather than a normal assertion failure.
+    referenceRateFeedID: "",
     createdAtBlock: 0n,
     createdAtTimestamp: 0n,
     updatedAtBlock: 0n,

--- a/indexer-envio/test/stateSyncReconcile.test.ts
+++ b/indexer-envio/test/stateSyncReconcile.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import type { Pool } from "envio";
+import {
+  indexerTestHelpers,
+  type MockDbWith,
+  type MockEventData,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+import { createMockEventData } from "./helpers/eventFixtures.js";
+import {
+  _clearMockRebalancingStates,
+  _setMockRebalancingState,
+} from "../src/EventHandlers.ts";
+import { makePool } from "./helpers/makePool.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 5 — `FPMM.UpdateReserves` state-sync reconcile when
+// the on-chain read (`getRebalancingState` RPC, standing in for the
+// contract's live state) disagrees with the Pool row's currently-persisted
+// (accumulated) `priceDifference` / `rebalanceThreshold` / `oraclePrice`.
+//
+// `rebalanceThresholdsKnown: false` forces `tryDeriveRebalanceState` to
+// return null every time (it gates on this flag), so the handler always
+// falls through to the RPC — letting the test pin that the RPC's fresh
+// values win over whatever was persisted, rather than the stale figures
+// surviving the event.
+// ---------------------------------------------------------------------------
+
+type MockDb = MockDbWith<{ Pool: WritableEntity }>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, FPMM } = TestHelpers;
+
+const CHAIN_ID = 42220;
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000fe";
+
+function updateReservesEvent(): unknown {
+  const data: MockEventData = createMockEventData({
+    chainId: CHAIN_ID,
+    logIndex: 1,
+    srcAddress: POOL_ADDRESS,
+    blockNumber: 900,
+    blockTimestamp: 1_700_900_000,
+  });
+  return FPMM.UpdateReserves.createMockEvent({
+    reserve0: 900_000n * 10n ** 18n,
+    reserve1: 1_100_000n * 10n ** 18n,
+    blockTimestamp: 1_700_900_000n,
+    mockEventData: data,
+  });
+}
+
+describe("state-sync reconcile (issue #1053 scenario 5)", () => {
+  afterEach(() => {
+    _clearMockRebalancingStates();
+  });
+
+  it("adopts the on-chain getRebalancingState read over stale accumulated priceDifference/threshold/oraclePrice", async () => {
+    // Stale, previously-persisted values a naive "keep accumulating"
+    // implementation might otherwise hold onto.
+    const staleFixture = makePool({
+      id: makePoolId(CHAIN_ID, POOL_ADDRESS),
+      chainId: CHAIN_ID,
+      token0: "0x00000000000000000000000000000000000000b0",
+      token1: "0x00000000000000000000000000000000000000b1",
+      tokenDecimalsKnown: true,
+      invertRateFeedKnown: true,
+      invertRateFeed: false,
+      rebalanceThresholdsKnown: false, // forces RPC fallback every time
+      rebalanceThreshold: 100, // stale
+      priceDifference: 9_999n, // stale
+      oraclePrice: 42n, // stale
+      reserves0: 1_000_000n * 10n ** 18n,
+      reserves1: 1_000_000n * 10n ** 18n,
+      referenceRateFeedID: "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a",
+      oracleFreshnessWindow: 3_600n,
+    });
+
+    // Fresh on-chain state disagrees with every one of those stale fields.
+    _setMockRebalancingState(CHAIN_ID, POOL_ADDRESS, {
+      oraclePriceNumerator: 2n * 10n ** 24n,
+      oraclePriceDenominator: 1n,
+      rebalanceThreshold: 250,
+      priceDifference: 555n,
+    });
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = mockDb.entities.Pool.set(staleFixture);
+
+    mockDb = await FPMM.UpdateReserves.processEvent({
+      event: updateReservesEvent(),
+      mockDb,
+    });
+
+    const pool = mockDb.entities.Pool.get(staleFixture.id) as Pool;
+    assert.ok(pool);
+    assert.equal(
+      pool.priceDifference,
+      555n,
+      "priceDifference must reconcile to the fresh on-chain read",
+    );
+    assert.equal(
+      pool.rebalanceThreshold,
+      250,
+      "rebalanceThreshold must reconcile to the fresh on-chain read",
+    );
+    assert.equal(
+      pool.oraclePrice,
+      2n * 10n ** 24n * 1_000_000n, // ORACLE_ADAPTER_SCALE_FACTOR
+      "oraclePrice must reconcile to the fresh on-chain read, not the stale value",
+    );
+    // Reserves themselves always reconcile to the event's own params
+    // (the contract's ground truth), regardless of the RPC path above.
+    assert.equal(pool.reserves0, 900_000n * 10n ** 18n);
+    assert.equal(pool.reserves1, 1_100_000n * 10n ** 18n);
+  });
+});

--- a/indexer-envio/test/tradingLimitConfigChange.test.ts
+++ b/indexer-envio/test/tradingLimitConfigChange.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import {
+  indexerTestHelpers,
+  type EntityReader,
+  type MockDbWith,
+  type MockEventData,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+import { createMockEventData } from "./helpers/eventFixtures.js";
+import { setHttpRpcMock } from "../src/rpc/http-test-mocks.js";
+import {
+  _clearMockVpExchangeIds,
+  _setMockVpExchangeId,
+} from "../src/EventHandlers.ts";
+import { makePool } from "./helpers/makePool.ts";
+import { makePoolId } from "../src/helpers.ts";
+import { tradingLimitId } from "../src/tradingLimits.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 6 — trading limits are keyed on (poolId, token), and a
+// governance config change mid-window must NOT reset the accumulated
+// netflow for a still-enabled window (`resetTradingLimitState` — see
+// src/tradingLimits.ts). This exercises the real `FPMM.TradingLimitConfigured`
+// handler through the harness, driven off a prior `FPMM.Swap`-derived
+// TradingLimit row (the RPC-authoritative netflow source), and proves the
+// OTHER token's key is untouched by a config change scoped to one token.
+// ---------------------------------------------------------------------------
+
+type MockDb = MockDbWith<{
+  Pool: WritableEntity;
+  TradingLimit: EntityReader;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, FPMM } = TestHelpers;
+
+const CHAIN_ID = 42220;
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000d0";
+const TOKEN0 = "0x00000000000000000000000000000000000000d1";
+const TOKEN1 = "0x00000000000000000000000000000000000000d2";
+const INTERNAL_UNIT = 10n ** 15n; // TradingLimitsV2 15-decimal internal scale
+
+function mockGetTradingLimits(
+  token: string,
+  limits: {
+    limit0: bigint;
+    limit1: bigint;
+    netflow0: bigint;
+    netflow1: bigint;
+    lastUpdated0?: number;
+    lastUpdated1?: number;
+  },
+): void {
+  setHttpRpcMock({
+    group: "tradingLimits",
+    chainId: CHAIN_ID,
+    address: POOL_ADDRESS,
+    functionName: "getTradingLimits",
+    callArgs: [token],
+    result: [
+      { limit0: limits.limit0, limit1: limits.limit1, decimals: 15 },
+      {
+        lastUpdated0: limits.lastUpdated0 ?? 100,
+        lastUpdated1: limits.lastUpdated1 ?? 100,
+        netflow0: limits.netflow0,
+        netflow1: limits.netflow1,
+      },
+    ],
+  });
+}
+
+function healedFpmmPool() {
+  return makePool({
+    id: makePoolId(CHAIN_ID, POOL_ADDRESS),
+    chainId: CHAIN_ID,
+    token0: TOKEN0,
+    token1: TOKEN1,
+    tokenDecimalsKnown: true,
+    invertRateFeedKnown: true,
+    source: "fpmm_factory",
+    wrappedExchangeId: "",
+    reserves0: 1_000_000n * 10n ** 18n,
+    reserves1: 1_000_000n * 10n ** 18n,
+    referenceRateFeedID: "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a",
+    lpFee: 25,
+    protocolFee: 15,
+    rebalanceReward: 3,
+  });
+}
+
+function swapEvent(logIndex: number, blockNumber: number) {
+  const data: MockEventData = createMockEventData({
+    chainId: CHAIN_ID,
+    logIndex,
+    srcAddress: POOL_ADDRESS,
+    blockNumber,
+    blockTimestamp: 1_700_000_000 + blockNumber,
+  });
+  return FPMM.Swap.createMockEvent({
+    sender: TOKEN0,
+    to: TOKEN1,
+    amount0In: 1_000_000_000_000_000_000n,
+    amount1In: 0n,
+    amount0Out: 0n,
+    amount1Out: 2_000_000_000_000_000_000n,
+    mockEventData: data,
+  });
+}
+
+type TradingLimitRow = {
+  limit0: bigint;
+  limit1: bigint;
+  netflow0: bigint;
+  netflow1: bigint;
+  lastUpdated0: bigint;
+  lastUpdated1: bigint;
+};
+
+describe("Trading-limit config change mid-window (issue #1053 scenario 6)", () => {
+  beforeEach(() => {
+    _clearMockVpExchangeIds();
+    _setMockVpExchangeId(CHAIN_ID, POOL_ADDRESS, null); // permanent "not a VP"
+  });
+
+  it("preserves accumulated netflow for its own key and leaves the other token's key untouched", async () => {
+    // Distinct per-token state — token0 near its limit, token1 comfortably
+    // inside its window with a negative netflow — proving the two keys
+    // don't bleed into each other.
+    mockGetTradingLimits(TOKEN0, {
+      limit0: 1_000n * INTERNAL_UNIT,
+      limit1: 0n,
+      netflow0: 800n * INTERNAL_UNIT,
+      netflow1: 0n,
+    });
+    mockGetTradingLimits(TOKEN1, {
+      limit0: 500n * INTERNAL_UNIT,
+      limit1: 500n * INTERNAL_UNIT,
+      netflow0: 100n * INTERNAL_UNIT,
+      netflow1: -50n * INTERNAL_UNIT,
+    });
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = mockDb.entities.Pool.set(healedFpmmPool());
+
+    mockDb = await FPMM.Swap.processEvent({
+      event: swapEvent(1, 200),
+      mockDb,
+    });
+
+    const poolId = makePoolId(CHAIN_ID, POOL_ADDRESS);
+    const token0IdBefore = tradingLimitId(poolId, TOKEN0);
+    const token1IdBefore = tradingLimitId(poolId, TOKEN1);
+    const token0Before = mockDb.entities.TradingLimit.get(
+      token0IdBefore,
+    ) as TradingLimitRow;
+    const token1Before = mockDb.entities.TradingLimit.get(
+      token1IdBefore,
+    ) as TradingLimitRow;
+    assert.ok(token0Before);
+    assert.ok(token1Before);
+    assert.equal(token0Before.netflow0, 800n * INTERNAL_UNIT);
+    assert.equal(token1Before.netflow0, 100n * INTERNAL_UNIT);
+    assert.equal(token1Before.netflow1, -50n * INTERNAL_UNIT);
+
+    // Governance doubles token0's limit0 mid-window. limit1 stays enabled
+    // (nonzero) too, so `resetTradingLimitState` must preserve BOTH sides'
+    // netflow, not just reset both to 0.
+    const configured = FPMM.TradingLimitConfigured.createMockEvent({
+      token: TOKEN0,
+      config: { limit0: 2_000n * INTERNAL_UNIT, limit1: 10n * INTERNAL_UNIT },
+      mockEventData: createMockEventData({
+        chainId: CHAIN_ID,
+        logIndex: 2,
+        srcAddress: POOL_ADDRESS,
+        blockNumber: 300,
+        blockTimestamp: 1_700_000_300,
+      }),
+    });
+    mockDb = await FPMM.TradingLimitConfigured.processEvent({
+      event: configured,
+      mockDb,
+    });
+
+    const token0After = mockDb.entities.TradingLimit.get(
+      token0IdBefore,
+    ) as TradingLimitRow;
+    assert.ok(token0After);
+    assert.equal(token0After.limit0, 2_000n * INTERNAL_UNIT, "limit0 updates");
+    assert.equal(token0After.limit1, 10n * INTERNAL_UNIT, "limit1 updates");
+    assert.equal(
+      token0After.netflow0,
+      800n * INTERNAL_UNIT,
+      "netflow0 must survive the config change (both new limits nonzero)",
+    );
+    assert.equal(
+      token0After.netflow1,
+      0n,
+      "netflow1 stays at its prior (zero) value",
+    );
+    assert.equal(token0After.lastUpdated0, 0n, "window resets on reconfigure");
+    assert.equal(token0After.lastUpdated1, 0n);
+
+    // token1's row is a completely separate key — must be byte-identical
+    // to its pre-reconfigure state.
+    const token1After = mockDb.entities.TradingLimit.get(
+      token1IdBefore,
+    ) as TradingLimitRow;
+    assert.deepEqual(token1After, token1Before);
+
+    // Pool.limitStatus/limitPressure reflect the NEW config against the
+    // PRESERVED netflow (800/2000 = 40% pressure on token0's window).
+    const pool = mockDb.entities.Pool.get(poolId) as {
+      limitStatus: string;
+      limitPressure0: string;
+    };
+    assert.equal(pool.limitPressure0, "0.4000");
+    assert.equal(pool.limitStatus, "OK");
+  });
+});

--- a/indexer-envio/test/upsertPoolIdempotency.test.ts
+++ b/indexer-envio/test/upsertPoolIdempotency.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import type { Pool } from "envio";
+import {
+  indexerTestHelpers,
+  type MockDbWith,
+  type MockEventData,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+import { createMockEventData } from "./helpers/eventFixtures.js";
+import {
+  _clearMockVpExchangeIds,
+  _setMockVpExchangeId,
+} from "../src/EventHandlers.ts";
+import { makePool } from "./helpers/makePool.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 3 — idempotency. Re-processing an already-healed pool
+// must clobber no field: replaying the exact same event twice (a reorg
+// replay / resync overlap) has to leave the Pool row byte-for-byte
+// identical, and repeated live events afterward must not let the healed
+// self-heal fields drift even though cumulative counters keep advancing.
+//
+// Fixture is deliberately "fully healed" up front (all self-heal flags
+// already known) and set up so `tryDeriveRebalanceState` succeeds without
+// any RPC fallback — the only effect the handler can reach is
+// `vpExchangeIdEffect` (upsertPool's wrapped-exchange probe runs
+// unconditionally even for FPMMs), which is mocked to its permanent
+// "not a VP" result.
+// ---------------------------------------------------------------------------
+
+type MockDb = MockDbWith<{ Pool: WritableEntity }>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, FPMM } = TestHelpers;
+
+const CHAIN_ID = 42220;
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000ff";
+const FEED = "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a";
+
+function healedFpmmPool(): Pool {
+  return makePool({
+    id: makePoolId(CHAIN_ID, POOL_ADDRESS),
+    chainId: CHAIN_ID,
+    token0: "0x00000000000000000000000000000000000000b0",
+    token1: "0x00000000000000000000000000000000000000b1",
+    token0Decimals: 6,
+    token1Decimals: 18,
+    tokenDecimalsKnown: true,
+    source: "fpmm_swap",
+    wrappedExchangeId: "",
+    reserves0: 1_000_000n * 10n ** 6n,
+    reserves1: 1_000_000n * 10n ** 18n,
+    rebalanceThresholdsKnown: true,
+    rebalanceThresholdAbove: 500,
+    rebalanceThresholdBelow: 500,
+    rebalanceThreshold: 500,
+    invertRateFeedKnown: true,
+    invertRateFeed: false,
+    oracleOk: true,
+    medianLive: true,
+    lastMedianPrice: 10n ** 24n,
+    oracleExpiry: 999_999_999n,
+    lastOracleReportAt: 1_700_000_000n,
+    referenceRateFeedID: FEED,
+    oracleFreshnessWindow: 3_600n,
+    oracleNumReporters: 3,
+    lpFee: 25,
+    protocolFee: 15,
+    rebalanceReward: 3,
+    breakerTripped: false,
+    hasHealthData: true,
+    createdAtBlock: 90n,
+    createdAtTimestamp: 1_699_000_000n,
+  });
+}
+
+function updateReservesEvent(logIndex: number, blockNumber: number) {
+  const blockTimestamp = 1_700_000_500 + blockNumber;
+  const data: MockEventData = createMockEventData({
+    chainId: CHAIN_ID,
+    logIndex,
+    srcAddress: POOL_ADDRESS,
+    blockNumber,
+    blockTimestamp,
+  });
+  return FPMM.UpdateReserves.createMockEvent({
+    reserve0: 1_050_000n * 10n ** 6n,
+    reserve1: 950_000n * 10n ** 18n,
+    blockTimestamp: BigInt(blockTimestamp),
+    mockEventData: data,
+  });
+}
+
+describe("upsertPool idempotency (issue #1053 scenario 3)", () => {
+  beforeEach(() => {
+    _clearMockVpExchangeIds();
+    _setMockVpExchangeId(CHAIN_ID, POOL_ADDRESS, null); // permanent "not a VP"
+  });
+
+  it("replaying the exact same UpdateReserves event twice leaves the Pool row byte-for-byte identical", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = mockDb.entities.Pool.set(healedFpmmPool());
+
+    const event = updateReservesEvent(1, 200);
+    mockDb = await FPMM.UpdateReserves.processEvent({ event, mockDb });
+    const poolId = makePoolId(CHAIN_ID, POOL_ADDRESS);
+    const afterFirst = mockDb.entities.Pool.get(poolId) as Pool;
+    assert.ok(afterFirst);
+
+    // Replay: same event object, same mockDb chain (simulates a reorg
+    // replay / resync re-delivering an already-processed block range).
+    mockDb = await FPMM.UpdateReserves.processEvent({ event, mockDb });
+    const afterReplay = mockDb.entities.Pool.get(poolId) as Pool;
+    assert.ok(afterReplay);
+
+    for (const key of Object.keys(afterFirst) as (keyof Pool)[]) {
+      assert.deepEqual(
+        afterReplay[key],
+        afterFirst[key],
+        `expected Pool.${String(key)} unchanged on exact-event replay`,
+      );
+    }
+  });
+
+  it("self-heal fields stay pinned across repeated live events even while cumulative counters advance", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = mockDb.entities.Pool.set(healedFpmmPool());
+    const poolId = makePoolId(CHAIN_ID, POOL_ADDRESS);
+
+    const healFields = (pool: Pool) => ({
+      token0Decimals: pool.token0Decimals,
+      token1Decimals: pool.token1Decimals,
+      tokenDecimalsKnown: pool.tokenDecimalsKnown,
+      invertRateFeed: pool.invertRateFeed,
+      invertRateFeedKnown: pool.invertRateFeedKnown,
+      referenceRateFeedID: pool.referenceRateFeedID,
+      wrappedExchangeId: pool.wrappedExchangeId,
+      lpFee: pool.lpFee,
+      protocolFee: pool.protocolFee,
+      rebalanceReward: pool.rebalanceReward,
+      breakerTripped: pool.breakerTripped,
+    });
+
+    mockDb = await FPMM.UpdateReserves.processEvent({
+      event: updateReservesEvent(1, 200),
+      mockDb,
+    });
+    const afterFirst = mockDb.entities.Pool.get(poolId) as Pool;
+    const pinnedFields = healFields(afterFirst);
+
+    mockDb = await FPMM.UpdateReserves.processEvent({
+      event: updateReservesEvent(2, 300),
+      mockDb,
+    });
+    const afterSecond = mockDb.entities.Pool.get(poolId) as Pool;
+
+    mockDb = await FPMM.UpdateReserves.processEvent({
+      event: updateReservesEvent(3, 400),
+      mockDb,
+    });
+    const afterThird = mockDb.entities.Pool.get(poolId) as Pool;
+
+    assert.deepEqual(healFields(afterSecond), pinnedFields);
+    assert.deepEqual(healFields(afterThird), pinnedFields);
+
+    // Sanity check the fixture actually exercised a live event each time
+    // (reserves tracked the latest UpdateReserves params, not frozen).
+    assert.equal(afterThird.reserves0, 1_050_000n * 10n ** 6n);
+    assert.equal(afterThird.reserves1, 950_000n * 10n ** 18n);
+  });
+});

--- a/indexer-envio/test/upsertPoolStages.test.ts
+++ b/indexer-envio/test/upsertPoolStages.test.ts
@@ -1,0 +1,498 @@
+import assert from "node:assert/strict";
+import type { BiPoolExchange, Pool } from "envio";
+import { describe, it } from "vitest";
+import { upsertPool } from "../src/pool.ts";
+import type { PoolContext } from "../src/pool/types.ts";
+import {
+  feesEffect,
+  invertRateFeedEffect,
+  numReportersEffect,
+  poolExchangeEffect,
+  referenceRateFeedIDEffect,
+  reportExpiryEffect,
+  tokenDecimalsScalingEffect,
+  vpExchangeIdEffect,
+} from "../src/rpc/effects.ts";
+import { makePool } from "./helpers/makePool.ts";
+import { makePoolId } from "../src/helpers.ts";
+import type { PoolUpdateSource } from "../src/pool/sources.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 2 — `upsertPool` heal-stage characterization.
+//
+// Goal: pin the CURRENT per-field output of each self-heal stage inside
+// `upsertPool` so the planned decomposition (issue #1056) can diff its
+// refactored output against these fixtures and prove behavior-preservation.
+//
+// Style: call `upsertPool` directly (like the existing `upsertPool breaker
+// halt` / `upsertPool degenerate reserves` describe blocks in pool.test.ts)
+// with a hand-built `PoolContext` rather than the MockDb harness — this lets
+// each test isolate exactly one heal stage by fully controlling every
+// `context.effect` response, and the "keep reserves at 0/0, oraclePrice at
+// 0n" fixture shape reliably routes `upsertPool` through its early-return
+// "frozen priceDifference, skip breach pipeline" branch. That keeps every
+// field OTHER than the stage under test byte-for-byte predictable without
+// hand-reimplementing the breach/health pipeline in the test.
+// ---------------------------------------------------------------------------
+
+const CHAIN_ID = 42220;
+const FEED = "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a";
+const CONSTANT_SUM_MAINNET = "0xdebed1f6f6ce9f6e73aa25f95acbffe2397550fb";
+
+type EffectOverride = readonly [unknown, (input: never) => unknown];
+
+/** Route `context.effect` calls by the effect definition's identity. Any
+ * stage not explicitly overridden gets a safe "already healed / not
+ * applicable" default so it never fires — unexpected calls throw instead of
+ * silently returning something misleading. */
+function routedEffect(
+  overrides: readonly EffectOverride[],
+): PoolContext["effect"] {
+  const table = new Map<unknown, (input: never) => unknown>(overrides);
+  return (async (effectDef: unknown, input: never) => {
+    const handler = table.get(effectDef);
+    if (handler) return handler(input);
+    if (effectDef === vpExchangeIdEffect) return null;
+    if (effectDef === invertRateFeedEffect) return -1;
+    if (effectDef === tokenDecimalsScalingEffect) return null;
+    if (effectDef === referenceRateFeedIDEffect) return null;
+    if (effectDef === reportExpiryEffect) return null;
+    if (effectDef === feesEffect) return null;
+    if (effectDef === poolExchangeEffect) return null;
+    if (effectDef === numReportersEffect) return 2;
+    throw new Error(
+      `upsertPoolStages test: unmocked effect invoked (${String(effectDef)})`,
+    );
+  }) as PoolContext["effect"];
+}
+
+function makeContext(effect: PoolContext["effect"]): {
+  context: PoolContext;
+  writtenPools: Pool[];
+  writtenExchanges: BiPoolExchange[];
+} {
+  const writtenPools: Pool[] = [];
+  const writtenExchanges: BiPoolExchange[] = [];
+  const context = {
+    effect,
+    Pool: {
+      get: async () => undefined,
+      set: (entity: Pool) => writtenPools.push(entity),
+    },
+    DeviationThresholdBreach: {
+      get: async () => undefined,
+      set: () => undefined,
+    },
+    BiPoolExchange: {
+      get: async () => undefined,
+      set: (entity: BiPoolExchange) => writtenExchanges.push(entity),
+    },
+    BreakerConfig: { getWhere: async () => [] },
+    Breaker: { get: async () => ({ id: "b", kind: "MEDIAN_DELTA" }) },
+    RateFeedDependency: { getWhere: async () => [] },
+  } as unknown as PoolContext;
+  return { context, writtenPools, writtenExchanges };
+}
+
+/** Baseline FPMM pool fixture that routes `upsertPool` through its
+ * early-return "frozen priceDifference" branch: `oraclePrice` stays at the
+ * schema default 0n (so `canRecompute` is false) and reserves are 0/0 (so
+ * `classifyExactZeroReserves` deterministically classifies non-degenerate).
+ * With no `oracleDelta` passed either, `priceDifferenceTrustworthy` is
+ * false and `upsertPool` returns immediately after the heal pipeline —
+ * healthStatus/breach fields are never touched, so every field not
+ * overridden here is provably stable across stage tests. */
+function baselinePool(overrides: Partial<Pool> = {}): Pool {
+  return makePool({
+    id: makePoolId(CHAIN_ID, "0x00000000000000000000000000000000000abc"),
+    chainId: CHAIN_ID,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    oraclePrice: 0n,
+    oracleOk: false,
+    hasHealthData: false,
+    invertRateFeedKnown: true,
+    invertRateFeed: false,
+    tokenDecimalsKnown: true,
+    token0Decimals: 18,
+    token1Decimals: 18,
+    wrappedExchangeId: "",
+    referenceRateFeedID: FEED,
+    oracleFreshnessWindow: 3_600n,
+    oracleNumReporters: 4,
+    breakerTripped: false,
+    lpFee: 10,
+    protocolFee: 5,
+    rebalanceReward: 2,
+    createdAtBlock: 5n,
+    createdAtTimestamp: 1_699_999_000n,
+    updatedAtBlock: 5n,
+    updatedAtTimestamp: 1_699_999_000n,
+    ...overrides,
+  });
+}
+
+async function runUpsert(
+  context: PoolContext,
+  existing: Pool,
+  args: {
+    blockNumber?: bigint;
+    blockTimestamp?: bigint;
+    source?: PoolUpdateSource;
+  } = {},
+): Promise<Pool> {
+  return upsertPool({
+    context,
+    chainId: existing.chainId,
+    poolId: existing.id,
+    // Pass the SAME source the fixture already carries (by priority) so
+    // `pickPreferredSource` is a no-op and `next.source` stays predictable.
+    source: args.source ?? (existing.source as PoolUpdateSource),
+    blockNumber: args.blockNumber ?? 10n,
+    blockTimestamp: args.blockTimestamp ?? 1_700_000_100n,
+    txHash: "0xabc",
+    existing: { pool: existing },
+  });
+}
+
+/** Assert every Pool field is byte-identical between `before` and `after`
+ * except the explicitly-named changed fields (checked separately by each
+ * test). Iterating `Object.keys` over the full fixture makes this
+ * exhaustive: any future stage that starts touching an extra field fails
+ * this assertion until the test is updated on purpose. */
+function assertUnchangedExcept(
+  before: Pool,
+  after: Pool,
+  changed: readonly (keyof Pool)[],
+): void {
+  const changedSet = new Set<keyof Pool>(changed);
+  for (const key of Object.keys(before) as (keyof Pool)[]) {
+    if (changedSet.has(key)) continue;
+    assert.deepEqual(
+      after[key],
+      before[key],
+      `expected Pool.${String(key)} to stay unchanged (before=${before[key]}, after=${after[key]})`,
+    );
+  }
+}
+
+describe("upsertPool heal-stage characterization (issue #1053 scenario 2)", () => {
+  it("invert-heal stage: decodes a true readback and touches no other field", async () => {
+    const existing = baselinePool({
+      invertRateFeedKnown: false,
+      invertRateFeed: false,
+    });
+    const { context } = makeContext(
+      routedEffect([[invertRateFeedEffect, () => 1]]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.invertRateFeed, true);
+    assert.equal(result.invertRateFeedKnown, true);
+    assertUnchangedExcept(existing, result, [
+      "invertRateFeed",
+      "invertRateFeedKnown",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("invert-heal stage: an RPC miss (-1 unknown sentinel) leaves the pool unhealed", async () => {
+    const existing = baselinePool({
+      invertRateFeedKnown: false,
+      invertRateFeed: false,
+    });
+    const { context } = makeContext(
+      routedEffect([[invertRateFeedEffect, () => -1]]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.invertRateFeed, false);
+    assert.equal(result.invertRateFeedKnown, false);
+    assertUnchangedExcept(existing, result, [
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("decimals-heal-on-null-effect stage: a partial RPC miss leaves BOTH decimals unset (no half-pinned state)", async () => {
+    const existing = baselinePool({
+      tokenDecimalsKnown: false,
+      token0Decimals: 18,
+      token1Decimals: 18,
+    });
+    const { context } = makeContext(
+      routedEffect([
+        [
+          tokenDecimalsScalingEffect,
+          (input: { fn: string }) =>
+            input.fn === "decimals0" ? 10n ** 6n : null,
+        ],
+      ]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    // Paired pinning: one succeeded (6dp) but the other RPC missed, so
+    // neither decimal is persisted and `tokenDecimalsKnown` stays false —
+    // the next event retries both.
+    assert.equal(result.token0Decimals, 18);
+    assert.equal(result.token1Decimals, 18);
+    assert.equal(result.tokenDecimalsKnown, false);
+    assertUnchangedExcept(existing, result, [
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("decimals-heal stage: both RPC reads succeed, decimals land and tokenDecimalsKnown flips true", async () => {
+    const existing = baselinePool({
+      tokenDecimalsKnown: false,
+      token0Decimals: 18,
+      token1Decimals: 18,
+    });
+    const { context } = makeContext(
+      routedEffect([
+        [
+          tokenDecimalsScalingEffect,
+          (input: { fn: string }) =>
+            input.fn === "decimals0" ? 10n ** 6n : 10n ** 18n,
+        ],
+      ]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.token0Decimals, 6);
+    assert.equal(result.token1Decimals, 18);
+    assert.equal(result.tokenDecimalsKnown, true);
+    assertUnchangedExcept(existing, result, [
+      "token0Decimals",
+      "tokenDecimalsKnown",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("fee-heal stage: -1 sentinels resolve to real fee values, independent of feed/breaker state", async () => {
+    const existing = baselinePool({
+      lpFee: -1,
+      protocolFee: -1,
+      rebalanceReward: -1,
+    });
+    const { context } = makeContext(
+      routedEffect([
+        [
+          feesEffect,
+          () => ({ lpFee: 25, protocolFee: 15, rebalanceReward: 3 }),
+        ],
+      ]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.lpFee, 25);
+    assert.equal(result.protocolFee, 15);
+    assert.equal(result.rebalanceReward, 3);
+    // Isolated: referenceRateFeedID was already assigned, so the coupled
+    // feed/breaker-recompute gate never fires alongside this stage.
+    assert.equal(result.referenceRateFeedID, existing.referenceRateFeedID);
+    assert.equal(result.breakerTripped, existing.breakerTripped);
+    assertUnchangedExcept(existing, result, [
+      "lpFee",
+      "protocolFee",
+      "rebalanceReward",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("feed-heal + breaker-halt recompute stage: the '' -> assigned transition mirrors both together", async () => {
+    // `upsertPool`'s feed self-heal and its breaker-halt recompute share the
+    // same gate (`existing.referenceRateFeedID === ""`), so pinning one
+    // without the other would misrepresent current behavior — a pool
+    // getting its first feed assignment always re-evaluates halt state in
+    // the same event.
+    const existing = baselinePool({
+      referenceRateFeedID: "",
+      breakerTripped: false,
+    });
+    const { context } = makeContext(
+      routedEffect([
+        [referenceRateFeedIDEffect, () => FEED],
+        [reportExpiryEffect, () => 3_600n],
+      ]),
+    );
+    // The feed is already halted at assignment time.
+    (
+      context as unknown as {
+        BreakerConfig: { getWhere: () => Promise<unknown[]> };
+      }
+    ).BreakerConfig.getWhere = async () => [
+      {
+        chainId: CHAIN_ID,
+        rateFeedID: FEED,
+        enabled: true,
+        status: "TRIPPED",
+        breaker_id: "b",
+      },
+    ];
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.referenceRateFeedID, FEED);
+    assert.equal(result.oracleExpiry, 3_600n);
+    assert.equal(result.breakerTripped, true);
+    assertUnchangedExcept(existing, result, [
+      "referenceRateFeedID",
+      "oracleExpiry",
+      "breakerTripped",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+
+  it("wrapped-exchange-link heal stage: a VirtualPool mirrors feed/freshness/reporters and disables the FPMM-only stages", async () => {
+    const vpAddress = "0x00000000000000000000000000000000000bee";
+    const poolId = makePoolId(CHAIN_ID, vpAddress);
+    const exchangeId = "0x" + "22".repeat(32);
+    // VPs never get invert/fee/feed-and-breaker self-heal — pin that they
+    // stay at their unhealed sentinels through this stage.
+    const existing = baselinePool({
+      id: poolId,
+      source: "virtual_pool_factory",
+      wrappedExchangeId: "",
+      referenceRateFeedID: "",
+      oracleFreshnessWindow: 0n,
+      oracleNumReporters: -1,
+      invertRateFeedKnown: false,
+      invertRateFeed: false,
+      lpFee: -1,
+      protocolFee: -1,
+      rebalanceReward: -1,
+      breakerTripped: false,
+    });
+    const { context, writtenExchanges } = makeContext(
+      routedEffect([
+        [
+          vpExchangeIdEffect,
+          () => ({
+            exchangeProvider: "0x00000000000000000000000000000000000cde",
+            exchangeId,
+          }),
+        ],
+        [
+          poolExchangeEffect,
+          () => ({
+            asset0: existing.token0,
+            asset1: existing.token1,
+            pricingModule: CONSTANT_SUM_MAINNET,
+            bucket0: 100n,
+            bucket1: 100n,
+            lastBucketUpdate: 1_699_999_500n,
+            spread: 300n,
+            referenceRateFeedID: FEED,
+            referenceRateResetFrequency: 300n,
+            minimumReports: 3n,
+            stablePoolResetSize: 1_000n,
+          }),
+        ],
+        [numReportersEffect, () => 5],
+      ]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.wrappedExchangeId, exchangeId);
+    assert.equal(result.referenceRateFeedID, FEED);
+    assert.equal(result.oracleFreshnessWindow, 300n);
+    assert.equal(result.oracleNumReporters, 5);
+    // FPMM-only stages stay untouched for a VP (isVirtualPool gate).
+    assert.equal(result.invertRateFeedKnown, false);
+    assert.equal(result.lpFee, -1);
+    assert.equal(result.protocolFee, -1);
+    assert.equal(result.rebalanceReward, -1);
+    assert.equal(result.breakerTripped, false);
+    assertUnchangedExcept(existing, result, [
+      "wrappedExchangeId",
+      "referenceRateFeedID",
+      "oracleFreshnessWindow",
+      "oracleNumReporters",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+
+    assert.equal(writtenExchanges.length, 1);
+    const exchange = writtenExchanges[0]!;
+    assert.equal(exchange.wrappedByPoolId, poolId);
+    assert.equal(exchange.referenceRateFeedID, FEED);
+    assert.equal(exchange.referenceRateResetFrequency, 300n);
+  });
+
+  it("all stages together: an FPMM whose factory-time RPC fan-out entirely failed heals every field in one event", async () => {
+    const existing = baselinePool({
+      invertRateFeedKnown: false,
+      invertRateFeed: false,
+      tokenDecimalsKnown: false,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      referenceRateFeedID: "",
+      oracleNumReporters: -1,
+      lpFee: -1,
+      protocolFee: -1,
+      rebalanceReward: -1,
+      breakerTripped: false,
+      wrappedExchangeId: "", // stays "" — bytecode probe below confirms non-VP
+    });
+    const { context } = makeContext(
+      routedEffect([
+        [invertRateFeedEffect, () => 1],
+        [
+          tokenDecimalsScalingEffect,
+          (input: { fn: string }) =>
+            input.fn === "decimals0" ? 10n ** 6n : 10n ** 18n,
+        ],
+        [referenceRateFeedIDEffect, () => FEED],
+        [reportExpiryEffect, () => 7_200n],
+        [
+          feesEffect,
+          () => ({ lpFee: 20, protocolFee: 10, rebalanceReward: 1 }),
+        ],
+        // Bytecode probe confirms "not a VP" — the wrapped-exchange stage
+        // participates in the pipeline as a documented no-op.
+        [vpExchangeIdEffect, () => null],
+      ]),
+    );
+
+    const result = await runUpsert(context, existing);
+
+    assert.equal(result.invertRateFeed, true);
+    assert.equal(result.invertRateFeedKnown, true);
+    assert.equal(result.token0Decimals, 6);
+    assert.equal(result.token1Decimals, 18);
+    assert.equal(result.tokenDecimalsKnown, true);
+    assert.equal(result.referenceRateFeedID, FEED);
+    assert.equal(result.oracleExpiry, 7_200n);
+    assert.equal(result.lpFee, 20);
+    assert.equal(result.protocolFee, 10);
+    assert.equal(result.rebalanceReward, 1);
+    assert.equal(result.breakerTripped, false); // feed's own breaker was OK
+    assert.equal(result.wrappedExchangeId, ""); // confirmed non-VP, no-op
+    assertUnchangedExcept(existing, result, [
+      "invertRateFeed",
+      "invertRateFeedKnown",
+      "token0Decimals",
+      "tokenDecimalsKnown",
+      "referenceRateFeedID",
+      "oracleExpiry",
+      "lpFee",
+      "protocolFee",
+      "rebalanceReward",
+      "updatedAtBlock",
+      "updatedAtTimestamp",
+    ]);
+  });
+});

--- a/indexer-envio/test/wrappedExchangeGate.test.ts
+++ b/indexer-envio/test/wrappedExchangeGate.test.ts
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import {
+  indexerTestHelpers,
+  type EntityReader,
+  type MockDbWith,
+  type MockEventData,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+import { createMockEventData } from "./helpers/eventFixtures.js";
+import {
+  _clearMockNumReporters,
+  _clearMockPoolExchanges,
+  _clearMockTokenDecimalsScaling,
+  _clearMockVpExchangeIds,
+  _setMockNumReporters,
+  _setMockPoolExchange,
+  _setMockTokenDecimalsScaling,
+  _setMockVpExchangeId,
+} from "../src/EventHandlers.ts";
+import type { PoolExchangeStruct } from "../src/rpc/biPoolManager.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Issue #1053 scenario 1 — `hasCompleteWrappedExchangeLink` gate
+// (`src/pool/self-heal.ts:501-535`), driven end-to-end through the harness.
+//
+// The other 4 sub-conditions of the gate (BiPoolExchange row missing/back-
+// link mismatch, feed-ID mismatch, freshness-window mismatch, reporter-count
+// staleness) are already exercised — each one false-in-isolation triggering
+// a targeted repair — by test/biPoolManager.test.ts:
+//   - "reverse-link backfill: ExchangeCreated AFTER VP heals fills tokens..."
+//   - "repairs already-linked VirtualPools whose Pool feed is stale"
+//   - "repairs already-linked VirtualPools whose reporter count is a legacy zero"
+//   - "marks already-linked legacy-zero VirtualPool reporter counts unknown..."
+//   - "links deprecated exchange stubs during VirtualPool heal" (isDeprecated
+//     stub short-circuit branch)
+// What's missing — and what this file closes — is the "all conditions true"
+// half of the acceptance criterion: proving the gate short-circuits and the
+// heal does NOT re-fire once the link is fully consistent.
+// ---------------------------------------------------------------------------
+
+type MockDb = MockDbWith<{
+  Pool: WritableEntity;
+  BiPoolExchange: EntityReader;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, BiPoolManager, VirtualPool } = TestHelpers;
+
+const CHAIN_ID = 42220;
+const BIPOOL_MANAGER_ADDRESS = "0x22d9db95e6ae61c104a7b6f6c78d7993b94ec901";
+const VP_ADDRESS = "0x000000000000000000000000000000000000beef";
+const ASSET0 = "0x00000000000000000000000000000000000000a0";
+const ASSET1 = "0x00000000000000000000000000000000000000a1";
+const CONSTANT_SUM_MAINNET = "0xdebed1f6f6ce9f6e73aa25f95acbffe2397550fb";
+const EXCHANGE_A = "0x" + "11".repeat(32);
+const FEED_A = "0x000000000000000000000000000000000000bea1";
+const EXCHANGE_B = "0x" + "22".repeat(32); // "poison" — must never be adopted.
+const FEED_B = "0x000000000000000000000000000000000000bea2";
+
+function mockEventData(logIndex: number, blockNumber: number): MockEventData {
+  return createMockEventData({
+    chainId: CHAIN_ID,
+    logIndex,
+    srcAddress: VP_ADDRESS,
+    blockNumber,
+    blockTimestamp: 1_700_000_000 + blockNumber,
+  });
+}
+
+function structFor(exchangeId: string, feed: string): PoolExchangeStruct {
+  return {
+    asset0: ASSET0,
+    asset1: ASSET1,
+    pricingModule: CONSTANT_SUM_MAINNET,
+    bucket0: 1_000_000n,
+    bucket1: 2_000_000n,
+    lastBucketUpdate: 1_700_001_000n,
+    spread: 5n * 10n ** 21n,
+    referenceRateFeedID: feed,
+    referenceRateResetFrequency: 360n,
+    minimumReports: 3n,
+    stablePoolResetSize: 100_000n,
+  };
+}
+
+function mockVpAs(exchangeId: string, feed: string): void {
+  _setMockVpExchangeId(CHAIN_ID, VP_ADDRESS, {
+    exchangeProvider: BIPOOL_MANAGER_ADDRESS,
+    exchangeId,
+  });
+  _setMockPoolExchange(
+    CHAIN_ID,
+    BIPOOL_MANAGER_ADDRESS,
+    exchangeId,
+    structFor(exchangeId, feed),
+  );
+  // A positive, resolved reporter count is required for the gate's
+  // reporter-count condition to ever settle true — without this,
+  // `oracleNumReporters` stays at the -1 "unknown" sentinel forever and
+  // `needsOracleReporterCountRefresh` keeps reporting incomplete, which
+  // would mask the "heal fires exactly once" claim these tests make.
+  _setMockNumReporters(CHAIN_ID, feed, 3);
+}
+
+function swapEvent(logIndex: number, blockNumber: number) {
+  return VirtualPool.Swap.createMockEvent({
+    sender: ASSET0,
+    amount0In: 1_000_000n,
+    amount1In: 0n,
+    amount0Out: 0n,
+    amount1Out: 990_000n,
+    to: ASSET1,
+    mockEventData: mockEventData(logIndex, blockNumber),
+  });
+}
+
+type PoolRow = {
+  wrappedExchangeId?: string;
+  referenceRateFeedID: string;
+  oracleFreshnessWindow: bigint;
+  oracleNumReporters: number;
+  token0?: string;
+  token1?: string;
+  token0Decimals: number;
+  token1Decimals: number;
+};
+
+/** Narrow a Pool row down to the fields `hasCompleteWrappedExchangeLink`
+ * actually gates on. `updatedAtBlock`/`updatedAtTimestamp` always advance
+ * with the event, so a whole-row comparison across events would be a false
+ * negative for the "steady state" claim these tests make. */
+function linkFields(pool: PoolRow): Omit<PoolRow, never> {
+  const {
+    wrappedExchangeId,
+    referenceRateFeedID,
+    oracleFreshnessWindow,
+    oracleNumReporters,
+    token0,
+    token1,
+    token0Decimals,
+    token1Decimals,
+  } = pool;
+  return {
+    wrappedExchangeId,
+    referenceRateFeedID,
+    oracleFreshnessWindow,
+    oracleNumReporters,
+    token0,
+    token1,
+    token0Decimals,
+    token1Decimals,
+  };
+}
+
+describe("hasCompleteWrappedExchangeLink gate (issue #1053 scenario 1)", () => {
+  beforeEach(() => {
+    _clearMockPoolExchanges();
+    _clearMockVpExchangeIds();
+    _clearMockTokenDecimalsScaling();
+    _clearMockNumReporters();
+    _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals0", 10n ** 6n);
+    _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals1", 10n ** 18n);
+  });
+
+  it("condition A (incomplete: no wrappedExchangeId/tokens yet) — first event heals from scratch", async () => {
+    mockVpAs(EXCHANGE_A, FEED_A);
+    let mockDb = MockDb.createMockDb();
+
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(0, 100),
+      mockDb,
+    });
+
+    const poolId = makePoolId(CHAIN_ID, VP_ADDRESS);
+    const pool = mockDb.entities.Pool.get(poolId) as PoolRow | undefined;
+    assert.ok(pool, "Pool must exist after the healing Swap");
+    assert.equal(pool!.wrappedExchangeId, EXCHANGE_A.toLowerCase());
+    assert.equal(pool!.referenceRateFeedID, FEED_A);
+    assert.equal(pool!.token0, ASSET0);
+    assert.equal(pool!.token1, ASSET1);
+  });
+
+  it("all conditions true — the heal fires exactly once; later events do not re-derive the link", async () => {
+    mockVpAs(EXCHANGE_A, FEED_A);
+    let mockDb = MockDb.createMockDb();
+
+    // Event 1: heals from scratch (condition A false -> heal fires).
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(0, 100),
+      mockDb,
+    });
+    const poolId = makePoolId(CHAIN_ID, VP_ADDRESS);
+    const afterFirstHeal = mockDb.entities.Pool.get(poolId) as
+      | PoolRow
+      | undefined;
+    assert.ok(afterFirstHeal);
+    assert.equal(afterFirstHeal!.wrappedExchangeId, EXCHANGE_A.toLowerCase());
+    assert.equal(afterFirstHeal!.referenceRateFeedID, FEED_A);
+    assert.equal(afterFirstHeal!.oracleFreshnessWindow, 360n);
+
+    // Event 2: link is now fully consistent (all gate conditions true) —
+    // steady-state re-processing must not drift any field.
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(1, 200),
+      mockDb,
+    });
+    const afterSteadyState = mockDb.entities.Pool.get(poolId) as
+      | PoolRow
+      | undefined;
+    assert.ok(afterSteadyState);
+    assert.deepEqual(
+      linkFields(afterSteadyState!),
+      linkFields(afterFirstHeal!),
+    );
+
+    // Event 3: flip the VP-bytecode-probe and PoolExchange mocks to a
+    // DIFFERENT ("poisoned") exchange/feed. If the gate incorrectly
+    // re-evaluated the heal (bypassing its short-circuit), the Pool row
+    // would adopt EXCHANGE_B/FEED_B here. Because all 4 conditions were
+    // already true, `hasCompleteWrappedExchangeLink` must return true and
+    // `selfHealWrappedExchangeId` must return the pool unchanged — proving
+    // the heal fired exactly once (at event 1) for this pool's lifetime.
+    mockVpAs(EXCHANGE_B, FEED_B);
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(2, 300),
+      mockDb,
+    });
+    const afterPoisonedMock = mockDb.entities.Pool.get(poolId) as
+      | PoolRow
+      | undefined;
+    assert.ok(afterPoisonedMock);
+    assert.equal(
+      afterPoisonedMock!.wrappedExchangeId,
+      EXCHANGE_A.toLowerCase(),
+      "gate must short-circuit — wrappedExchangeId must not adopt the poisoned mock",
+    );
+    assert.equal(afterPoisonedMock!.referenceRateFeedID, FEED_A);
+    assert.equal(afterPoisonedMock!.oracleFreshnessWindow, 360n);
+
+    const exchangeRow = mockDb.entities.BiPoolExchange.get(
+      `${CHAIN_ID}-${EXCHANGE_A.toLowerCase()}`,
+    );
+    assert.ok(exchangeRow, "the original BiPoolExchange row must remain");
+    const poisonedRow = mockDb.entities.BiPoolExchange.get(
+      `${CHAIN_ID}-${EXCHANGE_B.toLowerCase()}`,
+    );
+    assert.equal(
+      poisonedRow,
+      undefined,
+      "the poisoned exchange must never get seeded once the link is complete",
+    );
+  });
+
+  it("BiPoolExchange row seeded via ExchangeCreated then VP heals — back-link condition already true short-circuits the seed RPC on the next event", async () => {
+    // Complementary ordering to the "condition A" test above: exchange
+    // exists FIRST (BiPoolManager.ExchangeCreated), then the VP heals
+    // against it. Confirms the gate's back-link condition (BiPoolExchange
+    // row present AND wrappedByPoolId === pool.id) is satisfied by the
+    // heal's own write, not just by a subsequent independent event.
+    mockVpAs(EXCHANGE_A, FEED_A);
+    let mockDb = MockDb.createMockDb();
+
+    const created = BiPoolManager.ExchangeCreated.createMockEvent({
+      exchangeId: EXCHANGE_A,
+      asset0: ASSET0,
+      asset1: ASSET1,
+      pricingModule: CONSTANT_SUM_MAINNET,
+      mockEventData: createMockEventData({
+        chainId: CHAIN_ID,
+        logIndex: 0,
+        srcAddress: BIPOOL_MANAGER_ADDRESS,
+        blockNumber: 100,
+        blockTimestamp: 1_700_000_000,
+      }),
+    });
+    mockDb = await BiPoolManager.ExchangeCreated.processEvent({
+      event: created,
+      mockDb,
+    });
+
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(1, 200),
+      mockDb,
+    });
+    const poolId = makePoolId(CHAIN_ID, VP_ADDRESS);
+    const healed = mockDb.entities.Pool.get(poolId) as PoolRow | undefined;
+    assert.ok(healed);
+    assert.equal(healed!.wrappedExchangeId, EXCHANGE_A.toLowerCase());
+
+    // Poison the mocks and process one more event — the back-link is
+    // already correct, so this must be a no-op exactly like the test above.
+    mockVpAs(EXCHANGE_B, FEED_B);
+    mockDb = await VirtualPool.Swap.processEvent({
+      event: swapEvent(2, 300),
+      mockDb,
+    });
+    const stillHealed = mockDb.entities.Pool.get(poolId) as PoolRow | undefined;
+    assert.ok(stillHealed);
+    assert.deepEqual(linkFields(stillHealed!), linkFields(healed!));
+  });
+});


### PR DESCRIPTION
## The Problem

- Issue #1053's 7 must-cover scenarios for the pool self-heal (`src/pool/self-heal.ts`, `src/pool.ts`) and FPMM lifecycle (`src/handlers/fpmm/*`) domains weren't mapped to existing tests, so it was unclear which gaps actually needed closing before the planned `upsertPool` decomposition (#1056) could safely land.
- `upsertPool` (complexity-57, grandfathered in `eslint-baseline.json`) had no per-stage characterization — a refactor there had no cheap way to prove behavior-preservation field-by-field.
- The `hasCompleteWrappedExchangeLink` gate's "fully-healed, don't re-heal" steady state (the highest-risk pattern per `indexer-envio/CLAUDE.md`) had no test proving the heal fires exactly once over a pool's lifetime.

## The Solution

- Triaged all 7 scenarios against the existing suite (table below), then added 6 new harness/unit test files closing every missing or partial gap — no production handler code changed.
- Along the way, found and fixed a latent gap in the shared `test/helpers/makePool.ts` fixture (missing `referenceRateFeedID` default) that crashes the real Envio test harness the moment a hand-built Pool row is seeded into it directly — a test-infra fix, not a handler change.

## Details

### Triage table

| # | Scenario | Status (before) | Evidence | New test file |
|---|---|---|---|---|
| 1 | `hasCompleteWrappedExchangeLink`: each of the 4 gate sub-conditions false individually → repair fires; all true → heal fires exactly once | **Partial** | `test/biPoolManager.test.ts` already covers each sub-condition false in isolation (back-link missing: "reverse-link backfill..."; feed mismatch: "repairs already-linked VirtualPools whose Pool feed is stale"; freshness mismatch: same describe block; reporter-count staleness: "repairs already-linked VirtualPools whose reporter count is a legacy zero" + "...unknown when numRates fails"; deprecated-stub short-circuit: "links deprecated exchange stubs during VirtualPool heal"). Missing: a test proving the gate short-circuits and does **not** re-fire once fully consistent. | `test/wrappedExchangeGate.test.ts` (closed) |
| 2 | Each `upsertPool` heal stage in isolation (invert, wrapped-exchange link, decimals-on-null-effect, fee/feed, breaker-halt) + one all-stages event | **Missing** | `test/pool.test.ts`'s `upsertPool breaker halt` / `degenerate reserves` describes exercise `upsertPool` directly but only for the breaker/degenerate-reserve paths, not a full per-stage characterization. | `test/upsertPoolStages.test.ts` (closed — 7 tests, field-by-field pinning) |
| 3 | Idempotency: re-processing an already-healed pool / exact-event replay clobbers no field | **Missing** | No existing test replays an event or asserts full-row stability across repeated processing. | `test/upsertPoolIdempotency.test.ts` (closed) |
| 4 | Pool created by the factory and swapped within the same batch — ordering holds, no orphan rows | **Missing** | `test/dynamicRegistration.test.ts` tests `contractRegister` in isolation and separately smoke-tests each handler; no test drives FPMMDeployed + Swap through one `processMockEvents` batch. | `test/fpmmBatchOrdering.test.ts` (closed) |
| 5 | `state-sync` reconcile when the on-chain read disagrees with accumulated state | **Missing** | `test/swap-reserves.test.ts` proves UpdateReserves adopts fresh on-chain reserves, but nothing exercises the RPC-fallback path (`tryDeriveRebalanceState` unavailable) disagreeing with stale persisted `priceDifference`/`rebalanceThreshold`/`oraclePrice`. | `test/stateSyncReconcile.test.ts` (closed) |
| 6 | Trading-limit config change mid-window — per-key state, netflow not reset | **Partial** | `test/tradingLimits.test.ts` unit-tests `resetTradingLimitState`/`buildTradingLimitEntity` thoroughly at the pure-function level, but no test drives the real `FPMM.TradingLimitConfigured` handler through the harness or proves per-(poolId,token)-key isolation. | `test/tradingLimitConfigChange.test.ts` (closed) |
| 7 | Swap with a fee-leg on a Mento-stable token — fee leg attributed, not just swap indexed | **Covered** | `test/stablesFeeLeg.test.ts` directly and thoroughly drives `handleYieldSplitInflow` (the fee-leg handler): pegged path, FX path, non-pool-sender rejection, non-FPMM-source rejection, replay-idempotency, wrong-recipient rejection — all asserting `ProtocolFeeTransfer` + `PoolDailyFeeSnapshot` rows, exactly the "attributed, not just indexed" bar. No new test added. | — |

`src/handlers/broker.ts` / `test/broker.test.ts` (also listed in the issue) cover the legacy v2 Broker→BiPoolManager path exhaustively (1076 lines) but scenarios 4–7 are v3 FPMM/VirtualPool-specific per their own descriptions (`TradingLimitConfigured`, `state-sync.ts` don't exist on the Broker path) — out of scope here.

### upsertPool characterization style (scenario 2)

`test/upsertPoolStages.test.ts` calls `upsertPool` directly with a hand-built `PoolContext` (same established pattern as `pool.test.ts`'s `upsertPool breaker halt` / `degenerate reserves` describes) rather than the MockDb harness, so each test can fully control every `context.effect` response and isolate exactly one heal stage. The fixture keeps `oraclePrice: 0n` and balanced 0/0 reserves so `upsertPool` reliably takes its early-return "frozen priceDifference, skip breach pipeline" branch — this makes every field *other* than the stage under test byte-for-byte predictable without re-implementing the breach/health pipeline in the test. A shared `assertUnchangedExcept` helper iterates every `Pool` key so any future stage that starts touching an extra field fails the test until updated on purpose.

### Gate steady-state test (scenario 1)

`test/wrappedExchangeGate.test.ts`'s "heal fires exactly once" test heals a VirtualPool from scratch, re-processes a second event (asserts no drift), then **poisons** the `vpExchangeIdEffect`/`poolExchangeEffect` mocks to a different exchange/feed and processes a third event — proving `hasCompleteWrappedExchangeLink` short-circuits (the pool does **not** adopt the poisoned mock) rather than merely happening to converge on the same values.

### Idempotency (scenario 3)

`test/upsertPoolIdempotency.test.ts` seeds a fully-healed pool, drives `FPMM.UpdateReserves` through the harness, then replays the **exact same event object** a second time and asserts every `Pool` field is byte-identical. A second test drives 3 live (non-replay) events and asserts the self-heal fields (decimals, invert, feed, wrapped-exchange-id, fees, breaker) stay pinned while cumulative fields (reserves) keep tracking the latest event.

### Batch ordering (scenario 4)

`test/fpmmBatchOrdering.test.ts` submits FPMMFactory.FPMMDeployed and FPMM.Swap to a single `processMockEvents` call, **listed Swap-before-Deploy in the array on purpose**, with the two events in *different* blocks of the same batch. `pool.createdAtBlock` is the load-bearing, order-sensitive assertion — `token0`/`token1`/`swapCount` alone converge to the same values regardless of processing order (verified this by an isolated sanity run forcing genuinely-reversed processing, which the `createdAtBlock` assertion correctly failed on before I added it — not part of this diff).

### Trading-limit keying (scenario 6)

`test/tradingLimitConfigChange.test.ts` seeds two independent `TradingLimit` rows (keyed `${poolId}-${token}`) via a mocked `getTradingLimits` RPC per token, reconfigures **one** token's limits mid-window, and asserts: the reconfigured key's netflow survives (both new limits nonzero, per `resetTradingLimitState`), `lastUpdated0/1` resets, and the untouched token's row is byte-identical to before — proving the composite key doesn't bleed across tokens.

### Deviation from the acceptance criteria (team-lead override)

Per the launching instructions, the "coverage floors re-pinned upward" acceptance criterion is **overridden** — `indexer-envio/vitest.config.ts`'s thresholds are intentionally left untouched (three parallel scenario-test branches landing in quick succession would conflict on the same lines, and each would under-measure against the others' contributions). The re-pin is tracked separately as #1081 (see Deferrals). Coverage floors still pass comfortably with these additions (measured: statements 51.85%, branches 46.79%, functions 60.93%, lines 52.66% vs. floors of 47/42/56/48).

### Test-infra fix: `makePool()` missing `referenceRateFeedID` default

`test/helpers/makePool.ts` never set `referenceRateFeedID` (it's deliberately excluded from `DEFAULT_ORACLE_FIELDS` in production code to avoid a spread-clobber bug — see `pool.ts`'s doc comment — but the shared test fixture never picked up its own explicit default the way it does for the other excluded fields like `breakerTripped`/`wrappedExchangeId`). Every existing caller either overrides it explicitly or never touches the real Envio harness, so the gap was invisible until `test/stateSyncReconcile.test.ts` seeded a hand-built Pool row straight into `mockDb.entities.Pool.set(...)` — the real Envio test harness's entity-schema validation rejects `undefined` for this required `string` field, surfacing as an opaque `Worker exited with code 1` crash rather than a normal assertion failure. Added the missing default (`referenceRateFeedID: ""`, matching production's `defaultPool()`); ran the full 1016-test suite before and after to confirm zero regressions.

## Validation

```
pnpm --filter @mento-protocol/indexer-envio test        # 1016 passed, 19 skipped, 0 failed
pnpm --filter @mento-protocol/indexer-envio typecheck    # clean
pnpm --filter @mento-protocol/indexer-envio test:coverage  # thresholds pass (statements 51.85/47, branches 46.79/42, functions 60.93/56, lines 52.66/48)
pnpm agent:quality-gate --run                            # all mapped commands passed (trunk check, lint, typecheck, coverage, knip, dep-cruiser)
pnpm agent:autoreview                                     # 1 finding fixed (ordering test wasn't actually order-sensitive — added a createdAtBlock discriminator, verified by a throwaway forced-reversed-order run that the new assertion genuinely fails without the fix); 1 finding verified false (claimed fpmmBatchOrdering.test.ts needs an EventHandlers.ts side-effect import — empirically false: the file passes in complete single-file isolation with real Pool/FactoryDeployment/SwapEvent rows created, because Envio's TestIndexer worker bootstraps the configured handler entrypoint itself, independent of the calling test file's own imports)
```

## Deferrals

- #1081 — re-pin `indexer-envio/vitest.config.ts` coverage floors upward per the `floor(measured) - 2` convention (overridden here to avoid conflicting with parallel scenario-test PRs landing on the same lines).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1053

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and a shared test fixture default; indexer runtime behavior is unchanged.
> 
> **Overview**
> Adds **six new test files** that close the remaining gaps from issue **#1053** before a planned `upsertPool` refactor—**no production handler changes**.
> 
> **Wrapped-exchange gate** (`wrappedExchangeGate.test.ts`): proves `hasCompleteWrappedExchangeLink` short-circuits after a full heal (including “poisoned” RPC mocks) so VirtualPool link fields are not re-derived.
> 
> **`upsertPool` characterization** (`upsertPoolStages.test.ts`): seven direct `upsertPool` tests pin each self-heal stage (invert, decimals, fees, feed/breaker, VP link, all-stages) with field-by-field `assertUnchangedExcept`.
> 
> **Idempotency & batch ordering** (`upsertPoolIdempotency.test.ts`, `fpmmBatchOrdering.test.ts`): exact-event replay must not clobber Pool rows; factory deploy + swap in one batch must respect **(block, logIndex)** order (Swap listed first on purpose) with a single Pool and `createdAtBlock` from deploy.
> 
> **RPC reconcile & trading limits** (`stateSyncReconcile.test.ts`, `tradingLimitConfigChange.test.ts`): `UpdateReserves` adopts fresh `getRebalancingState` over stale persisted rebalance fields; `TradingLimitConfigured` preserves per-token netflow and leaves the other token’s row untouched.
> 
> **Fixture fix** (`makePool.ts`): default `referenceRateFeedID: ""` so hand-seeded Pool rows pass Envio harness entity validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6498968ec937c4540343ae79c0a7c9d2757c6259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->