### PR TITLE
fix(governance-watchdog): parametrize function memory/timeout, add instance bounds

### DIFF
--- a/governance-watchdog/infra/cloud_function.tf
+++ b/governance-watchdog/infra/cloud_function.tf
@@ -18,9 +18,11 @@ resource "google_cloudfunctions2_function" "watchdog_notifications" {
   }
 
   service_config {
-    available_memory      = "512M"
+    available_memory      = "${var.memory_mb}M"
     service_account_email = module.governance_watchdog.service_account_email
-    timeout_seconds       = 60
+    timeout_seconds       = var.timeout_seconds
+    max_instance_count    = var.max_instances
+    min_instance_count    = var.min_instances
 
     # 🔒 Security Note: Checkov recommends to only allow this function to be called from a cloud load balancer.
     # We're making a conscious security tradeoff here for lower complexity and faster delivery. It seems unlikely

--- a/governance-watchdog/infra/variables.tf
+++ b/governance-watchdog/infra/variables.tf
@@ -35,6 +35,37 @@ variable "function_entry_point" {
   default = "governanceWatchdog"
 }
 
+# Mirrors the sibling alerts/infra/onchain-event-handler and oncall-announcer
+# modules' variable names for consistency. Defaults match current behavior so
+# the only plan diff from parametrizing is the new instance bounds below.
+variable "memory_mb" {
+  description = "Memory allocation for the function in MB"
+  type        = number
+  default     = 512
+}
+
+variable "timeout_seconds" {
+  description = "Cloud Function timeout in seconds"
+  type        = number
+  default     = 60
+}
+
+variable "min_instances" {
+  description = "Minimum number of Cloud Function instances"
+  type        = number
+  default     = 0
+}
+
+# Single QuickNode webhook stream (governance events only, low volume) with no
+# fan-out to other consumers. Capped low so a webhook flood or misconfigured
+# retry storm can't scale cost unbounded, mirroring the "keep this low" intent
+# on the sibling functions' max_instances default.
+variable "max_instances" {
+  description = "Maximum number of Cloud Function instances. Keep this low; a single QuickNode webhook stream should never need to burst wide, and an unbounded cap would let a webhook flood or retry storm scale cost without limit."
+  type        = number
+  default     = 3
+}
+
 # You can look this up via:
 #  `gcloud secrets list`
 variable "discord_webhook_url_secret_id" {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `governance-watchdog/infra/cloud_function.tf` hardcodes `available_memory = "512M"` and `timeout_seconds = 60`, unlike every sibling Cloud Function module.
- The function sets no `min_instance_count` / `max_instance_count`, so its public, `allUsers`-invokable webhook endpoint (auth is HMAC in-function, a documented tradeoff) can scale instances without bound.
- This makes the function's cost exposure inconsistent with the alerts/infra `onchain-event-handler` and `oncall-announcer` modules, which already parametrize this shape.

## The Solution

- Added `memory_mb`, `timeout_seconds`, `min_instances`, and `max_instances` as variables in `governance-watchdog/infra/variables.tf`, mirroring the sibling modules' variable names/defaults for consistency.
- Wired `cloud_function.tf`'s `service_config` block to reference them, adding the new `max_instance_count` / `min_instance_count` attributes that were previously unset.

## Details

- `memory_mb` defaults to `512` (used as `"${var.memory_mb}M"`) and `timeout_seconds` defaults to `60` — both equal current behavior, so neither produces a plan diff.
- `min_instances` defaults to `0` (also current behavior — Gen2 functions default to 0 when unset).
- `max_instances` defaults to `3`, which is new (previously unbounded/unset). Justification: this function backs a single QuickNode webhook stream for Mento Governance events only — no fan-out to other consumers, low intrinsic event volume. A small explicit cap (3) absorbs bursts/retries without letting a webhook flood or misconfigured retry storm scale cost unbounded, while still allowing a few concurrent invocations. This mirrors the "keep it low" intent behind `oncall-announcer`'s own `max_instances = 1` default (an even tighter case, since that function also needs to avoid racing on shared rotation state — not a constraint here).
- Ingress (`ALLOW_ALL`) and the `allUsers` invoker binding are unchanged — that tradeoff is documented in-file and out of scope here (see #1009 for QuickNode secret wiring in the same file; this PR does not touch that).
- No changes to `terraform.stacks.json` — the stack is already registered with `drift: scheduled`.

## Validation

```
$ pnpm tf validate governance-watchdog
Success! The configuration is valid.

$ pnpm agent:quality-gate --run
✓ ./tools/trunk check governance-watchdog/infra/cloud_function.tf governance-watchdog/infra/variables.tf
✓ terraform fmt -check -recursive
✓ terraform init -backend=false -input=false
✓ terraform validate -no-color
All mapped commands passed.

$ pnpm agent:autoreview --mode local
overall: patch is correct (0.87) — no actionable findings.
```

`pnpm gov-watchdog:tf:plan` was intentionally **not** run locally — this worktree has no `terraform.tfvars`/credentials, and per the issue's risk notes, apply is CI-driven on merge behind the `production-infra` GitHub Environment gate. The CI plan should show only the new `min_instance_count`/`max_instance_count` addition; memory/timeout defaults are unchanged so they produce no diff. Please review that CI plan output before approving the gate.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Refs #1009 (QuickNode key secret mirroring + deploy-eligibility narrowing — same file, different scope; coordinate, don't collide).

Closes #1060

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Terraform-only change that alters production scaling limits on a publicly invokable webhook; low blast radius but worth confirming CI plan shows only the new instance bounds.
> 
> **Overview**
> **Governance-watchdog** Cloud Function infra now takes **memory**, **timeout**, and **min/max instance** settings from Terraform variables (same pattern as `onchain-event-handler` and `oncall-announcer`) instead of hardcoding `512M` and `60s` and leaving scaling uncapped.
> 
> Defaults keep memory and timeout behavior the same; **`max_instances` defaults to 3**, which is the only expected plan change—capping burst scale on the public QuickNode webhook endpoint against flood/retry-driven cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cee4a14d22d990bcb89b4b09119925b5ae0ea5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->