### PR TITLE
docs: archive completed PLAN files; fix stale README copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain
 
 ## Packages
 
-| Package                                         | Description                                                                          |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [`indexer-envio`](./indexer-envio/)             | Envio HyperIndex indexer — Celo + Monad multichain                                   |
-| [`ui-dashboard`](./ui-dashboard/)               | Next.js 16 + Plotly.js dashboard with multi-chain network switching                  |
-| [`metrics-bridge`](./metrics-bridge/)           | Hasura → Prometheus exporter for v3 alert rules                                      |
-| [`shared-config`](./shared-config/)             | Shared deployment config (chain ID → treb namespace mappings)                        |
-| [`aegis`](./aegis/)                             | App Engine v2 alerting service + Aegis Grafana dashboards                            |
-| [`governance-watchdog`](./governance-watchdog/) | Cloud Function watching Mento Governance events → Discord/Telegram (own GCP project) |
+| Package                                         | Description                                                                                                 |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [`indexer-envio`](./indexer-envio/)             | Envio HyperIndex indexer — Celo + Monad multichain                                                          |
+| [`ui-dashboard`](./ui-dashboard/)               | Next.js 16 + Plotly.js multi-chain dashboard — all chains shown together, network derived from the pool URL |
+| [`metrics-bridge`](./metrics-bridge/)           | Hasura → Prometheus exporter for v3 alert rules                                                             |
+| [`shared-config`](./shared-config/)             | Shared deployment config (chain ID → treb namespace mappings)                                               |
+| [`aegis`](./aegis/)                             | App Engine v2 alerting service + Aegis Grafana dashboards                                                   |
+| [`governance-watchdog`](./governance-watchdog/) | Cloud Function watching Mento Governance events → Discord/Telegram (own GCP project)                        |
 
 ## Architecture
 

--- a/docs/CODE-REVIEW-UI-DASHBOARD.md
+++ b/docs/CODE-REVIEW-UI-DASHBOARD.md
@@ -1,3 +1,14 @@
+---
+title: "Code Review — ui-dashboard"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "One-off review snapshot of ui-dashboard from 2026-03-05; applied refactors already landed and the codebase has moved on since. Not a standing checklist."
+---
+
+> **ARCHIVED** — Point-in-time review artifact, not a standing checklist. Applied refactors already landed; the codebase has moved on since 2026-03-05.
+
 # Code Review — `ui-dashboard`
 
 > Reviewed by Giskard · 2026-03-05  

--- a/docs/PLAN-celo-mainnet-indexer.md
+++ b/docs/PLAN-celo-mainnet-indexer.md
@@ -1,3 +1,14 @@
+---
+title: "Plan: Celo Mainnet Envio Indexer"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Celo Mainnet FPMM/VirtualPool indexing shipped and is live (mento-v3-celo-mainnet, 100% synced). See docs/ROADMAP.md → Indexer → 'Envio indexer: Celo Mainnet config' and 'Envio hosted deployment: mento-v3-celo-mainnet live, 100% synced'."
+---
+
+> **ARCHIVED** — This document is a planning artifact from before Celo Mainnet indexing shipped. The "Current state" section below (Mento v3 contracts NOT yet on Celo Mainnet) is historical and no longer true — v3 FPMM/VirtualPool contracts are live on Celo Mainnet today. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Plan: Celo Mainnet Envio Indexer
 
 ## Context

--- a/docs/PLAN-oracle-health-state-DOD.md
+++ b/docs/PLAN-oracle-health-state-DOD.md
@@ -1,3 +1,14 @@
+---
+title: "Oracle & Health State — Definition of Done"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Definition-of-done checklist for docs/PLAN-oracle-health-state.md; every item shipped even though the checkboxes below were never ticked. See docs/ROADMAP.md → 'Oracle health state'."
+---
+
+> **ARCHIVED** — Companion checklist to [`docs/PLAN-oracle-health-state.md`](./PLAN-oracle-health-state.md). The feature shipped; the unchecked boxes below are stale, not outstanding work. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Oracle & Health State — Definition of Done
 
 ## Checklist

--- a/docs/PLAN-oracle-health-state.md
+++ b/docs/PLAN-oracle-health-state.md
@@ -1,3 +1,14 @@
+---
+title: "Plan: Oracle & Health State in the Indexer + Dashboard"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Oracle health state shipped in full — healthStatus/oracleOk/oraclePrice/priceDifference/rebalanceThreshold on Pool, HealthBadge/HealthPanel in the dashboard. See docs/ROADMAP.md → Indexer/Dashboard → 'Oracle health state'."
+---
+
+> **ARCHIVED** — This planning document is superseded by shipped work. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Plan: Oracle & Health State in the Indexer + Dashboard
 
 ## Goal

--- a/docs/PLAN-oracle-snapshot-chart.md
+++ b/docs/PLAN-oracle-snapshot-chart.md
@@ -1,3 +1,14 @@
+---
+title: "Plan: OracleSnapshot Chart — Oracle Price History Timeline"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "OracleSnapshot chart shipped on the pool detail Analytics tab. See docs/ROADMAP.md → Dashboard → 'Oracle chart on analytics tab'."
+---
+
+> **ARCHIVED** — This planning document is superseded by shipped work. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Plan: OracleSnapshot Chart — Oracle Price History Timeline
 
 **Feature:** Oracle price history chart on pool detail page (Analytics tab, FPMM pools only)

--- a/docs/PLAN-rebalancer-liveness.md
+++ b/docs/PLAN-rebalancer-liveness.md
@@ -1,3 +1,14 @@
+---
+title: "Plan: Rebalancer Liveness & Effectiveness"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Rebalancer liveness + effectiveness shipped (RebalanceEvent fields, RebalancerBadge/RebalancerPanel). See docs/ROADMAP.md → Indexer/Dashboard → 'Rebalancer liveness' and 'RebalancerBadge + RebalancerPanel'."
+---
+
+> **ARCHIVED** — This planning document is superseded by shipped work. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Plan: Rebalancer Liveness & Effectiveness
 
 **Feature:** Track whether rebalancers are active and whether rebalances are actually improving oracle health

--- a/docs/PLAN-stream-c-dashboard.md
+++ b/docs/PLAN-stream-c-dashboard.md
@@ -1,3 +1,14 @@
+---
+title: "Stream C: Dashboard Components for Trading Limits & Rebalancer Liveness"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Trading-limit and rebalancer-liveness dashboard components shipped (LimitBadge/LimitPanel, RebalancerBadge/RebalancerPanel). The 'Status: Planned' line below is stale. See docs/ROADMAP.md → Dashboard."
+---
+
+> **ARCHIVED** — This planning document is superseded by shipped work; the "Status: Planned" line below is historical. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Stream C: Dashboard Components for Trading Limits & Rebalancer Liveness
 
 **Date:** 2026-03-05  

--- a/docs/PLAN-trading-limit-tracking.md
+++ b/docs/PLAN-trading-limit-tracking.md
@@ -1,3 +1,14 @@
+---
+title: "Plan: Trading Limit Tracking"
+status: archived
+owner: eng
+canonical: false
+archived: 2026-07-05
+archived_reason: "Trading limit tracking shipped (TradingLimit entity, limitStatus/limitPressure, LimitBadge/LimitPanel). See docs/ROADMAP.md → Indexer/Dashboard → 'TradingLimit entity' and 'LimitBadge + LimitPanel'."
+---
+
+> **ARCHIVED** — This planning document is superseded by shipped work. See [`docs/ROADMAP.md`](./ROADMAP.md) for current state.
+
 # Plan: Trading Limit Tracking
 
 **Feature:** Index trading limit state, compute `limitPressure`, display warn/crit badges per Roman's spec


### PR DESCRIPTION
## The Problem

- Completed `docs/PLAN-*.md` files (Celo Mainnet indexer, oracle health state + its DOD checklist, oracle snapshot chart, rebalancer liveness, trading-limit tracking, stream-c dashboard) describe shipped work as still-open or in-progress, with no file-level signal that they're historical.
- `docs/CODE-REVIEW-UI-DASHBOARD.md` is an undated review artifact sitting in `docs/` root with no classification.
- `README.md:12` claims the dashboard has "multi-chain network switching," but there is no switcher — all chains render together and the active network derives from the pool ID in the URL.

## The Solution

- Add YAML frontmatter (`status: archived`, `canonical: false`, `archived`, `archived_reason`) plus a visible `> **ARCHIVED**` banner to each completed PLAN file and to `docs/CODE-REVIEW-UI-DASHBOARD.md`, each pointing at the specific `docs/ROADMAP.md` line(s) that shipped the feature. This mirrors the existing precedent in `docs/envio-hosted-migration.md` — one mechanism, applied uniformly, no new directory needed.
- Reword `README.md:12` to describe the actual multi-chain behavior.

## Details

- Archived: `PLAN-celo-mainnet-indexer.md`, `PLAN-oracle-health-state.md`, `PLAN-oracle-health-state-DOD.md`, `PLAN-oracle-snapshot-chart.md`, `PLAN-rebalancer-liveness.md`, `PLAN-stream-c-dashboard.md`, `PLAN-trading-limit-tracking.md`, `CODE-REVIEW-UI-DASHBOARD.md`.
- Left untouched: `PLAN-ai-review-process.md` (already `status: draft` / `canonical: false`, not completed) and `PLAN-cdps-monitoring.md` (still has open follow-up work per `docs/ROADMAP.md` — TCR/ICR live-risk refinements and the CDP indexer promote/backfill step are still unchecked).
- No file moves — content is preserved in place (`git mv` wasn't needed since no path changed); a repo-wide `grep -rn` confirmed no other file links to these filenames, so nothing else needed updating.
- `canonical: false` on every archived file, per the issue's guardrail — `scripts/check-agent-context.mjs` doesn't currently scan `docs/**/*.md` by frontmatter (it validates a fixed `managedContextFiles` list), but the frontmatter is written to be safe if that ever changes.
- `docs/context-standards.md` and `docs/ROADMAP.md` are untouched — no archive directory was introduced, and ROADMAP's status semantics weren't touched, only referenced from the new `archived_reason` pointers.
- `AGENTS.md` restructuring is explicitly out of scope (separate issue).

## Validation

- `pnpm agent:context-check` → `Agent context check passed (18 managed files).`
- `./tools/trunk fmt docs/ README.md` → reformatted `README.md` table, no other changes.
- `pnpm agent:quality-gate --run` → `All mapped commands passed.` (`./tools/trunk check` on all 9 changed files)
- `pnpm agent:autoreview --mode local --engine claude` → `autoreview clean: no accepted/actionable findings reported`; overall correctness score 0.93, all `archived_reason` → ROADMAP pointers and the README network-derivation claim verified against `ui-dashboard/src/components/network-provider.tsx`.
- `git grep -rn` for each archived filename across `AGENTS.md`, `docs/`, `.agents/`, and package `AGENTS.md` files → no other references found.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, deployment, or security impact.
> 
> **Overview**
> Marks **eight shipped or obsolete docs** as historical without moving files: seven completed `docs/PLAN-*.md` plans plus `docs/CODE-REVIEW-UI-DASHBOARD.md` each get YAML frontmatter (`status: archived`, `canonical: false`, `archived_reason` pointing at `docs/ROADMAP.md`) and a visible **ARCHIVED** banner so readers are not misled by stale “planned” or open-checklist content.
> 
> **README** `ui-dashboard` row is updated to drop the incorrect “multi-chain network switching” wording and describe the real behavior: all chains shown together, with network derived from the pool URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28509acf287a090114fbbeb0ef6a6519f134eb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->