### PR TITLE
integration-probes: remove inert OKX/Rango adapters

### DIFF
--- a/.github/workflows/integration-probes.yml
+++ b/.github/workflows/integration-probes.yml
@@ -29,10 +29,6 @@ jobs:
       ONEINCH_API_KEY: ${{ secrets.ONEINCH_API_KEY }}
       SQUID_INTEGRATOR_ID: ${{ secrets.SQUID_INTEGRATOR_ID }}
       SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-      RANGO_API_KEY: ${{ secrets.RANGO_API_KEY }}
-      OKX_DEX_API_KEY: ${{ secrets.OKX_DEX_API_KEY }}
-      OKX_DEX_SECRET: ${{ secrets.OKX_DEX_SECRET }}
-      OKX_DEX_PASSPHRASE: ${{ secrets.OKX_DEX_PASSPHRASE }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/pnpm-install

--- a/README.md
+++ b/README.md
@@ -247,10 +247,6 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | `SQUID_INTEGRATOR_ID`           | Squid integrator id; probes return `needs_key` without it                                   |
 | `SQUID_CELO_RPC_URL`            | Optional Celo RPC override for Squid Uniswap-liquidity discovery sizing (defaults to Forno) |
 | `SOCKET_API_KEY`                | Optional Socket quote API key                                                               |
-| `RANGO_API_KEY`                 | Optional Rango quote API key                                                                |
-| `OKX_DEX_API_KEY`               | Optional OKX DEX API key                                                                    |
-| `OKX_DEX_SECRET`                | Optional OKX DEX signing secret                                                             |
-| `OKX_DEX_PASSPHRASE`            | Optional OKX DEX passphrase                                                                 |
 
 Production env vars are managed by Terraform except the Blob OIDC variables, which are managed by the Vercel store integration. See [`terraform/`](./terraform/).
 

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -84,9 +84,8 @@ pnpm --filter @mento-protocol/integration-probes knip
   when writing snapshots.
 - Adapter credentials are optional at the infrastructure layer and should
   surface as `needs_key` when missing: `LIFI_API_KEY`, `OPENOCEAN_API_KEY`,
-  `ZEROX_API_KEY`, `ONEINCH_API_KEY`, `SQUID_INTEGRATOR_ID`,
-  `SOCKET_API_KEY`, `RANGO_API_KEY`, `OKX_DEX_API_KEY`, `OKX_DEX_SECRET`, and
-  `OKX_DEX_PASSPHRASE`.
+  `ZEROX_API_KEY`, `ONEINCH_API_KEY`, `SQUID_INTEGRATOR_ID`, and
+  `SOCKET_API_KEY`.
 - `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with
   `x-lifi-api-key`; keep it server-side and Terraform-managed.
 - `FLYTRADE_API_KEY` authenticates the Fly.trade follow-up requests behind

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1320,7 +1320,6 @@ describe("aggregator quote builders", () => {
       "squid",
       "openocean",
       "kyberswap",
-      "okx",
       "1inch",
       "0x",
       "cow-swap",
@@ -1328,7 +1327,6 @@ describe("aggregator quote builders", () => {
       "relay",
       "odos",
       "socket",
-      "rango",
       "rubic",
       "debridge",
     ]);

--- a/integration-probes/src/__tests__/volumeSignals.test.ts
+++ b/integration-probes/src/__tests__/volumeSignals.test.ts
@@ -9,7 +9,6 @@ describe("volumeSignalsForAdapters", () => {
       adapters: [
         adapter("openocean"),
         adapter("kyberswap"),
-        adapter("okx"),
         adapter("lifi"),
         adapter("socket"),
         adapter("rubic"),
@@ -34,7 +33,6 @@ describe("volumeSignalsForAdapters", () => {
             protocols: [
               { name: "OpenOcean", total30d: 327_881_227 },
               { name: "KyberSwap", total30d: 6_970_000_000 },
-              { name: "OKX DEX", total30d: 5_275_000_000 },
             ],
           }),
         );
@@ -52,10 +50,6 @@ describe("volumeSignalsForAdapters", () => {
     expect(signals.get("kyberswap")).toMatchObject({
       valueUsd: 6_970_000_000,
       sourceProtocol: "KyberSwap",
-    });
-    expect(signals.get("okx")).toMatchObject({
-      valueUsd: 5_275_000_000,
-      sourceProtocol: "OKX DEX",
     });
     expect(signals.get("lifi")).toMatchObject({
       window: "30d",

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -62,7 +62,6 @@ export const AGGREGATOR_ADAPTERS: AggregatorAdapter[] = [
   squidAdapter(),
   openOceanAdapter(),
   kyberAdapter(),
-  okxAdapter(),
   oneInchAdapter(),
   zeroXAdapter(),
   excludedAdapter(
@@ -82,7 +81,6 @@ export const AGGREGATOR_ADAPTERS: AggregatorAdapter[] = [
     "Public chain metadata currently lists neither Celo nor Monad.",
   ),
   socketAdapter(),
-  rangoAdapter(),
   rubicAdapter(),
   excludedAdapter(
     "debridge",
@@ -241,36 +239,6 @@ function kyberAdapter(): AggregatorAdapter {
       getRequest(kyberUrl(input), {
         "x-client-id": "mento-integration-probes",
       }),
-  };
-}
-
-function okxAdapter(): AggregatorAdapter {
-  return {
-    id: "okx",
-    label: "OKX DEX API",
-    kind: "dex",
-    tier: 2,
-    credentialEnv: ["OKX_DEX_API_KEY", "OKX_DEX_SECRET", "OKX_DEX_PASSPHRASE"],
-    support: { 42220: "unsupported", 143: "supported" },
-    researchNote:
-      "OKX docs list Monad but not Celo; signed API probing is required.",
-    nextStep:
-      "Implement OKX request signing before enabling live quote probes.",
-  };
-}
-
-function rangoAdapter(): AggregatorAdapter {
-  return {
-    id: "rango",
-    label: "Rango",
-    kind: "cross_chain",
-    tier: 2,
-    credentialEnv: ["RANGO_API_KEY"],
-    support: { 42220: "unknown", 143: "unknown" },
-    researchNote:
-      "Rango metadata requires an API key; chain support is probed when configured.",
-    nextStep:
-      "Add Rango quote endpoint mapping once API credentials are available.",
   };
 }
 

--- a/integration-probes/src/volumeSignals.ts
+++ b/integration-probes/src/volumeSignals.ts
@@ -55,7 +55,6 @@ const VOLUME_SOURCES: Record<string, VolumeSource> = {
   ),
   openocean: defillama("dex-aggregators", "OpenOcean"),
   kyberswap: defillama("dex-aggregators", "KyberSwap"),
-  okx: defillama("dex-aggregators", "OKX DEX"),
   "1inch": defillama("dex-aggregators", "1inch"),
   "0x": defillama("dex-aggregators", "0x Aggregator"),
   "cow-swap": defillama("dex-aggregators", "CoWSwap"),
@@ -68,7 +67,6 @@ const VOLUME_SOURCES: Record<string, VolumeSource> = {
   ),
   odos: defillama("dex-aggregators", "ODOS"),
   socket: defillama("bridge-aggregators", "Bungee", "bridge-aggregator"),
-  rango: defillama("bridge-aggregators", "Rango", "bridge-aggregator"),
   rubic: defillama("bridge-aggregators", "Rubic", "bridge-aggregator"),
   debridge: unavailable(
     "direct-bridge",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `okxAdapter`/`rangoAdapter` in `integration-probes/src/adapters.ts` registered as aggregators but had no `quote` function — only `nextStep` placeholders — so they could never `pass`.
- README.md and `integration-probes/AGENTS.md` documented `OKX_DEX_API_KEY`/`OKX_DEX_SECRET`/`OKX_DEX_PASSPHRASE`/`RANGO_API_KEY` as if wired, inviting operators to provision secrets for probes that can never run.
- Decision made 2026-07-03: remove rather than implement.

## The Solution

- Delete the two adapter registrations and their factory functions from `adapters.ts`, and their volume-signal mappings from `volumeSignals.ts`.
- Remove the four env-var doc rows from `README.md` and `integration-probes/AGENTS.md`.
- Remove the matching secret wiring from `.github/workflows/integration-probes.yml`.

## Details

- No OKX/Rango-specific types or helpers existed outside `adapters.ts`/`volumeSignals.ts` (both adapters had no `quote` builder, so `adapterRequests.ts`/`adapterRunner.ts`/`adapterTypes.ts` needed no changes).
- **Terraform**: `terraform/` never managed `OKX_DEX_*`/`RANGO_API_KEY` (confirmed via `grep -rn "OKX\|RANGO" terraform/` — no hits; `terraform/github-secrets.tf` mirrors only `LIFI_API_KEY` and `SQUID_INTEGRATOR_ID` into repo Actions secrets, the same pattern `SOCKET_API_KEY` already follows without Terraform). No Terraform changes are needed and none were made; `pnpm tf validate` was not required since nothing in `terraform/` changed.
- The removed workflow env lines only referenced repo-level GitHub Actions secrets (`secrets.OKX_DEX_API_KEY` etc.) directly — deleting the now-orphaned secret values themselves (if any exist) is a GitHub UI/ops follow-up, not a code change.
- **Dashboard graceful degradation**: checked `ui-dashboard/src/app/integrations/_components/integration-probes-table.tsx` and `ui-dashboard/src/lib/integration-probes.ts`. Aggregator `id` is validated as a plain `z.string()` (not an enum), and the table renders every `snapshot.aggregators[]` entry generically by whatever `id`/`label`/`kind`/`tier` the stored snapshot carries. A historical Upstash snapshot with `okx`/`rango` rows will continue to render correctly — no crash, no special-casing to remove.

## Validation

```
pnpm integrations:probe:test        # 8 files / 80 tests passed
pnpm code-health:knip                # exit 0 (pre-existing unrelated warn-level findings only, confirmed via git stash diff)
grep -rn "OKX\|RANGO\|okx\|rango" --include='*.ts' --include='*.md' --include='*.yml' --include='*.tf' . | grep -v node_modules
                                     # zero matches
pnpm agent:quality-gate --run       # all mapped commands passed (trunk check, action-pin check,
                                     # integration-probes lint/typecheck/test:coverage/knip, code-health:deps)
pnpm agent:autoreview -- --mode local --engine claude
                                     # clean: no accepted/actionable findings
git push (foreground pre-push gate) # passed: trunk check, action-pin check, lint/typecheck/
                                     # test:coverage/knip, code-health:deps
```

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1064

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Probe-only and documentation changes with no auth or production runtime paths; historical snapshots that still list `okx`/`rango` should keep rendering generically on the dashboard.
> 
> **Overview**
> Removes **OKX DEX** and **Rango** from integration probes because they were registered aggregators with no live `quote` implementation—only `nextStep` placeholders—so they could never pass a probe while still documenting API keys for operators.
> 
> **`AGGREGATOR_ADAPTERS`** no longer includes `okxAdapter()` / `rangoAdapter()` or their factory functions; dashboard adapter order and volume-signal mappings drop `okx` and `rango` accordingly. Tests are updated to match the slimmer adapter list.
> 
> Docs and CI stop advertising **`OKX_DEX_*`** and **`RANGO_API_KEY`**: rows come out of `README.md` and `integration-probes/AGENTS.md`, and the matching `secrets.*` env wiring is removed from `.github/workflows/integration-probes.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56d27dd34a5247ad0213354360dd860e0abbfcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->