### PR TITLE
dashboard: single immutable-sort helper; remove homepage-og.ts toSorted()

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -34,11 +34,11 @@ This is mandatory for cross-layer/stateful UI work. The checklist exists because
 
 `tsconfig.json` sets `"target": "ES2017"`. There's no `browserslist` override or polyfill installed. The TS `lib: ["dom", "dom.iterable", "esnext"]` provides type definitions for ES2023+ methods, so they compile cleanly — but at runtime they throw `TypeError: <fn> is not a function` on Safari ≤15 / Chrome ≤109 / Firefox ≤114.
 
-**Never use** in client-shipped code: `Array.prototype.toSorted`, `findLast`, `findLastIndex`, `with`, `Object.groupBy`, `String.prototype.isWellFormed`, etc. Use the ES2017-safe forms instead (`[...arr].sort(...)`, manual loops). PR #371 was flagged 5× on `arr.toSorted()` sites; reverted to `[...arr].sort()` with inline `react-doctor-disable-next-line react-doctor/js-tosorted-immutable` disables.
+**Never use** in client-shipped code: `Array.prototype.toSorted`, `findLast`, `findLastIndex`, `with`, `Object.groupBy`, `String.prototype.isWellFormed`, etc. Use the ES2017-safe forms instead (manual loops; for an immutable sort, `sortedCopy(arr, comparator)` from `@/lib/immutable-sort`). PR #371 was flagged 5× on `arr.toSorted()` sites; reverted to `[...arr].sort()` with inline `react-doctor-disable-next-line react-doctor/js-tosorted-immutable` disables. `sortedCopy` centralizes that workaround (and the disable) in one place — new immutable-sort call sites should use it instead of hand-rolling `[...arr].sort(...)`. An ESLint `no-restricted-properties` rule (`eslint.config.mjs`) bans `toSorted`/`toReversed`/`toSpliced` outright in `src/**`, scoped off the server-only paths below and tests.
 
 **Server-only paths where ES2023+ IS safe** (run on Node ≥20): `app/api/**/route.ts`, OG helpers (`lib/homepage-og.ts`, `lib/pool-og.ts`), `*.test.ts(x)`. Anything imported by a `"use client"` component, or by code that flows into one (e.g. `lib/tag-suggestions.ts` → `address-label-form.tsx`), ships to the browser.
 
-If we ever raise the TS target to ES2022+ or install a global polyfill (`core-js`), all existing `react-doctor/js-tosorted-immutable` inline disables become candidates for cleanup.
+If we ever raise the TS target to ES2022+ or install a global polyfill (`core-js`), the `react-doctor/js-tosorted-immutable` disable inside `sortedCopy` (and the ESLint restriction above) become candidates for cleanup.
 
 ## Commands
 

--- a/ui-dashboard/eslint.config.mjs
+++ b/ui-dashboard/eslint.config.mjs
@@ -190,6 +190,46 @@ export default tseslint.config(
       "sonarjs/no-collapsible-if": "off",
     },
   },
+  // Backstop for AGENTS.md "Browser target — ES2017, no polyfill": these
+  // ES2023 Array methods compile fine (the TS `lib` includes `esnext`) but
+  // throw at runtime on Safari <=15 / Chrome <=109. `toSorted` use `sortedCopy`
+  // from `@/lib/immutable-sort` instead; `toReversed`/`toSpliced` use
+  // `[...arr].reverse()` / manual copy. Excludes the paths AGENTS.md's
+  // "Browser target" section names as ES2023+-safe (Node >=20, never bundled
+  // to the browser) and tests. Deliberately narrower than the broader
+  // server-only surface in "Server vs client module boundaries" (e.g.
+  // `bridge-flows-og.ts`, `opengraph-image.tsx`) — widen the ignore list if a
+  // future PR needs ES2023+ there instead of hand-rolling the ES2017 form.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/app/api/**/route.ts",
+      "src/lib/homepage-og.ts",
+      "src/lib/pool-og.ts",
+      "**/__tests__/**",
+      "**/*.test.{ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        {
+          property: "toSorted",
+          message:
+            "requires Safari 16+/Chrome 110+; use sortedCopy() from '@/lib/immutable-sort' instead.",
+        },
+        {
+          property: "toReversed",
+          message:
+            "requires Safari 16+/Chrome 110+; use `[...arr].reverse()` instead.",
+        },
+        {
+          property: "toSpliced",
+          message:
+            "requires Safari 16+/Chrome 110+; use a manual copy instead.",
+        },
+      ],
+    },
+  },
   {
     ignores: [
       "**/node_modules/**",

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-stability-pool-tvl-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-stability-pool-tvl-chart.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { parseWei } from "@/lib/format";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { escapePlotText } from "@/lib/plot";
 import {
   filterSeriesByRange,
@@ -32,8 +33,8 @@ export function buildStabilityPoolTvlSeries(
 ): TimeSeriesPoint[] {
   // Query returns desc (newest-first) to preserve recent rows when the
   // 1000-row cap kicks in. Reverse here so Plotly receives chronological.
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  const sorted = [...snapshots].sort(
+  const sorted = sortedCopy(
+    snapshots,
     (a, b) => Number(a.timestamp) - Number(b.timestamp),
   );
   const series = sorted.map((snap) => ({

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
@@ -10,6 +10,7 @@ import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import { formatTimestamp, parseWei, relativeTime } from "@/lib/format";
 import { useGQL } from "@/lib/graphql";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { POOL_LP_POSITIONS } from "@/lib/queries";
 import { normalizeSearch } from "@/lib/table-search";
 import { isFpmm, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
@@ -87,10 +88,7 @@ export function LpsTab({
         },
       ];
     });
-    // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-    // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-    // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-    return [...filtered].sort((a, b) =>
+    return sortedCopy(filtered, (a, b) =>
       a.netLiquidity === b.netLiquidity
         ? 0
         : a.netLiquidity > b.netLiquidity

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
@@ -23,6 +23,7 @@ import {
   formatUSD,
   relativeTime,
 } from "@/lib/format";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { useGQL } from "@/lib/graphql";
 import {
   POOL_REBALANCE_REWARDS,
@@ -117,14 +118,11 @@ export function computeRewardThresholds(
     const v = r ? Number(r) : Number.NaN;
     return Number.isFinite(v) && v > 0 ? [v] : [];
   });
-  // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-  // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  const values = [...finite].sort((a, b) => a - b);
+  const values = sortedCopy(finite, (a, b) => a - b);
   if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
   const med = median(values);
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  const deviations = [...values.map((v) => Math.abs(v - med))].sort(
+  const deviations = sortedCopy(
+    values.map((v) => Math.abs(v - med)),
     (a, b) => a - b,
   );
   const mad = median(deviations);
@@ -285,10 +283,8 @@ export function RebalancesTab({
     const raw = (chartData?.RebalanceEvent ?? []).filter(
       (r) => r.effectivenessRatio != null && r.effectivenessRatio !== "",
     );
-    // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-    // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-    // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-    return [...raw].sort(
+    return sortedCopy(
+      raw,
       (a, b) => Number(a.blockTimestamp) - Number(b.blockTimestamp),
     );
   }, [chartData]);

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -6,6 +6,7 @@ import type { AddressEntry } from "@/lib/address-labels-shared";
 import { TagInput } from "@/components/tag-input";
 import { SUGGESTED_TAGS, getUsedTags } from "@/lib/tag-suggestions";
 import { isValidAddress } from "@/lib/format";
+import { sortedCopy } from "@/lib/immutable-sort";
 
 // Pure helpers (exported for testing and re-exported via address-label-editor
 // for back-compat with existing test imports).
@@ -226,10 +227,7 @@ export function AddressLabelForm(props: Props) {
   const tagSuggestions = useMemo(() => {
     const used = getUsedTags(customEntries);
     const all = new Set([...SUGGESTED_TAGS, ...used]);
-    // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-    // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-    // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-    return [...Array.from(all)].sort((a, b) => a.localeCompare(b));
+    return sortedCopy(Array.from(all), (a, b) => a.localeCompare(b));
   }, [customEntries]);
 
   // When editing an existing contract row (not a new address, no custom label yet),

--- a/ui-dashboard/src/components/global-pools-table/sort.ts
+++ b/ui-dashboard/src/components/global-pools-table/sort.ts
@@ -1,4 +1,5 @@
 import { computeEffectiveStatus, computePoolUptimePct } from "@/lib/health";
+import { sortedCopy } from "@/lib/immutable-sort";
 import type { Network } from "@/lib/networks";
 import type { SortDir } from "@/lib/table-sort";
 import { poolName, type OracleRateMap } from "@/lib/tokens";
@@ -78,10 +79,7 @@ export function sortGlobalPools(
     tvlChangeWoWByKey,
   }: GlobalSortContext,
 ): GlobalPoolEntry[] {
-  // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-  // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  return [...entries].sort((a, b) => {
+  return sortedCopy(entries, (a, b) => {
     const aKey = globalPoolKey(a);
     const bKey = globalPoolKey(b);
     let cmp = 0;

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { canValueTvl, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshot } from "@/lib/types";
@@ -49,10 +50,8 @@ export function PoolTvlOverTimeChart({
 
   const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
     if (snapshots.length === 0) return [];
-    // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-    // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-    // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-    const sorted = [...snapshots].sort(
+    const sorted = sortedCopy(
+      snapshots,
       (a, b) => Number(a.timestamp) - Number(b.timestamp),
     );
     // Skip points where TVL is unknowable (untrusted decimals → null) so the

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -7,6 +7,7 @@ import {
   snapshotWindow7d,
   snapshotWindow30d,
 } from "@/lib/volume";
+import { sortedCopy } from "@/lib/immutable-sort";
 import type { Network } from "@/lib/networks";
 import { canPricePool, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
@@ -53,10 +54,8 @@ export function PoolVolumeOverTimeChart({
   // which the headline would then render as a real-looking "$0.00".
   const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
     if (!priceable || snapshots.length === 0) return [];
-    // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-    // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-    // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-    const sorted = [...snapshots].sort(
+    const sorted = sortedCopy(
+      snapshots,
       (a, b) => Number(a.timestamp) - Number(b.timestamp),
     );
     const points: TimeSeriesPoint[] = [];

--- a/ui-dashboard/src/components/revenue-by-pool-table.tsx
+++ b/ui-dashboard/src/components/revenue-by-pool-table.tsx
@@ -3,6 +3,7 @@
 import { useMemo, type ReactNode } from "react";
 import Link from "next/link";
 import { formatUSD, truncateAddress } from "@/lib/format";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { poolName } from "@/lib/tokens";
 import { Table, Row } from "@/components/table";
 import { SortableTh } from "@/components/sortable-th";
@@ -168,10 +169,7 @@ function sortRows(
   sortKey: SortKey,
   sortDir: SortDir,
 ): PoolFeeRow[] {
-  // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-  // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  return [...rows].sort((a, b) => {
+  return sortedCopy(rows, (a, b) => {
     const aV = rowSortValue(a, sortKey);
     const bV = rowSortValue(b, sortKey);
     if (aV == null && bV == null) return 0;

--- a/ui-dashboard/src/components/time-series-chart-card-hooks.ts
+++ b/ui-dashboard/src/components/time-series-chart-card-hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { escapePlotText } from "@/lib/plot";
 import type {
   BreakdownSeries,
@@ -245,12 +246,7 @@ export function useSortedHover(params: {
           },
         ];
       });
-      // ES2023 `Array.prototype.toSorted` would be cleaner but requires
-      // Safari 16+ / Chrome 110+; the dashboard's compile target is
-      // ES2017 with no polyfill, so keep the cloned `sort()` form to
-      // stay compatible with older browsers (codex P2, PR #371).
-      // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-      const sorted = [...points].sort((a, b) => b.value - a.value);
+      const sorted = sortedCopy(points, (a, b) => b.value - a.value);
       const xRaw = rawPoints[0]?.x;
       const dayLabel =
         typeof xRaw === "string" || typeof xRaw === "number"

--- a/ui-dashboard/src/lib/__tests__/immutable-sort.test.ts
+++ b/ui-dashboard/src/lib/__tests__/immutable-sort.test.ts
@@ -32,4 +32,18 @@ describe("sortedCopy", () => {
       { key: "b", order: 0 },
     ]);
   });
+
+  it("handles an empty array", () => {
+    const input: number[] = [];
+    const result = sortedCopy(input, (a, b) => a - b);
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles a single-element array", () => {
+    const input = [42];
+    const result = sortedCopy(input, (a, b) => a - b);
+
+    expect(result).toEqual([42]);
+  });
 });

--- a/ui-dashboard/src/lib/__tests__/immutable-sort.test.ts
+++ b/ui-dashboard/src/lib/__tests__/immutable-sort.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sortedCopy } from "../immutable-sort";
+
+describe("sortedCopy", () => {
+  it("returns a new array sorted by the comparator", () => {
+    const input = [3, 1, 2];
+    const result = sortedCopy(input, (a, b) => a - b);
+
+    expect(result).toEqual([1, 2, 3]);
+    expect(result).not.toBe(input);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [3, 1, 2];
+    sortedCopy(input, (a, b) => a - b);
+
+    expect(input).toEqual([3, 1, 2]);
+  });
+
+  it("passes the comparator through untouched, preserving stability", () => {
+    const input = [
+      { key: "b", order: 0 },
+      { key: "a", order: 1 },
+      { key: "a", order: 0 },
+    ];
+
+    const result = sortedCopy(input, (a, b) => a.key.localeCompare(b.key));
+
+    expect(result).toEqual([
+      { key: "a", order: 1 },
+      { key: "a", order: 0 },
+      { key: "b", order: 0 },
+    ]);
+  });
+});

--- a/ui-dashboard/src/lib/bridge-flows/sort.ts
+++ b/ui-dashboard/src/lib/bridge-flows/sort.ts
@@ -3,6 +3,7 @@ import {
   transferDeliveryDurationSec,
 } from "@/lib/bridge-status";
 import type { OracleRateMap } from "@/lib/tokens";
+import { sortedCopy } from "@/lib/immutable-sort";
 import type { SortDir } from "@/lib/table-sort";
 import type { BridgeTransfer } from "@/lib/types";
 import {
@@ -90,10 +91,7 @@ export function sortTransfers(
   sortDir: SortDir,
   rates: OracleRateMap,
 ): BridgeTransfer[] {
-  // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-  // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  return [...transfers].sort((a, b) => {
+  return sortedCopy(transfers, (a, b) => {
     switch (sortKey) {
       case "provider":
         return compareString(a.provider, b.provider, sortDir);

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { sortedCopy } from "@/lib/immutable-sort";
 import { NETWORKS, NETWORK_IDS, type Network } from "@/lib/networks";
 import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import {
@@ -677,13 +678,14 @@ function priceTvlAtBucket(
 function computeDailyTvlSeries(entries: PriceableEntry[]): number[] {
   const histories: TvlHistory[] = [];
   for (const { pool, slice } of entries) {
-    const points = slice.daily
-      .flatMap((d) =>
+    const points = sortedCopy(
+      slice.daily.flatMap((d) =>
         d.poolId === pool.id
           ? [{ ts: Number(d.timestamp), r0: d.reserves0, r1: d.reserves1 }]
           : [],
-      )
-      .toSorted((a, b) => a.ts - b.ts);
+      ),
+      (a, b) => a.ts - b.ts,
+    );
     // Pool has no snapshots in the 35d window. Since PoolDailySnapshot is
     // written on swap activity, zero snapshots means the pool has been
     // dormant — reserves in `pool.reserves0/1` haven't changed since the

--- a/ui-dashboard/src/lib/immutable-sort.ts
+++ b/ui-dashboard/src/lib/immutable-sort.ts
@@ -1,0 +1,14 @@
+/**
+ * ES2023 `Array.prototype.toSorted` requires Safari 16+/Chrome 110+; the
+ * dashboard's TS target is ES2017 with no polyfill (see the "Browser
+ * target" section in `ui-dashboard/AGENTS.md`). This is the single
+ * spread+sort implementation of that workaround — callers should use it
+ * instead of hand-rolling `[...arr].sort(comparator)` at every call site.
+ */
+export function sortedCopy<T>(
+  arr: readonly T[],
+  comparator: (a: T, b: T) => number,
+): T[] {
+  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
+  return [...arr].sort(comparator);
+}

--- a/ui-dashboard/src/lib/tag-suggestions.ts
+++ b/ui-dashboard/src/lib/tag-suggestions.ts
@@ -1,4 +1,5 @@
 import type { AddressEntryRecord } from "@/lib/address-labels";
+import { sortedCopy } from "@/lib/immutable-sort";
 
 export const SUGGESTED_TAGS = [
   // Behavioral
@@ -39,8 +40,5 @@ export function getUsedTags(entries: AddressEntryRecord[]): string[] {
       set.add(tag);
     }
   }
-  // ES2023 `toSorted` requires Safari 16+/Chrome 110+; TS target is
-  // ES2017 with no polyfill — keep the spread+sort form (codex P2).
-  // react-doctor-disable-next-line react-doctor/js-tosorted-immutable
-  return [...Array.from(set)].sort((a, b) => a.localeCompare(b));
+  return sortedCopy(Array.from(set), (a, b) => a.localeCompare(b));
 }

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -355,7 +355,7 @@ function poolTvlViaOracleRates(
  *     }
  *
  * Caller pattern for sorts (untrusted to bottom of descending order):
- *     pools.toSorted((a, b) =>
+ *     sortedCopy(pools, (a, b) =>
  *       (poolTvlUSD(b) ?? Number.NEGATIVE_INFINITY) -
  *       (poolTvlUSD(a) ?? Number.NEGATIVE_INFINITY))
  */


### PR DESCRIPTION
## The Problem

- The ES2017 "spread+sort instead of `toSorted`" workaround was hand-copied at 11 call sites (each with its own 3-line rationale comment + `react-doctor-disable-next-line` pragma), so the same fix has to be re-derived every time a new sort site is added.
- `lib/homepage-og.ts:686` called `.toSorted(...)` directly — safe today since it's server-only, but nothing stopped a future client reuse from silently reintroducing the ES2023 runtime crash the rest of the codebase guards against.
- No machine check existed to catch a new `toSorted`/`toReversed`/`toSpliced` call landing in client-shipped code in the future.

## The Solution

- Added `sortedCopy<T>(arr, comparator)` in `ui-dashboard/src/lib/immutable-sort.ts` — the single spread+sort implementation, with the ES2017 rationale comment living once instead of 11 times. Comparators are passed through untouched; behavior is unchanged everywhere.
- Converted every call site (and `homepage-og.ts`'s `toSorted()`) to use `sortedCopy`, removing the duplicated comments and per-site react-doctor disables.
- Added an ESLint `no-restricted-properties` rule banning `toSorted`/`toReversed`/`toSpliced` in `src/**`, scoped off the documented server-only paths (`app/api/**/route.ts`, `lib/homepage-og.ts`, `lib/pool-og.ts`) and tests.

## Details

- Call sites converted: `lib/tag-suggestions.ts`, `components/global-pools-table/sort.ts`, `components/pool-tvl-over-time-chart.tsx`, `components/pool-volume-over-time-chart.tsx`, `components/address-label-form.tsx`, `lib/bridge-flows/sort.ts`, `components/revenue-by-pool-table.tsx`, `app/pool/[poolId]/_tabs/rebalances-tab.tsx` (3 sites — one more than the issue listed; a third spread+sort in the same function, `deviations`, carried the same disable pragma and was swept too), `app/pool/[poolId]/_tabs/lps-tab.tsx`, `components/time-series-chart-card-hooks.ts` (same workaround, slightly different wording, not in the issue's list but caught by grepping the disable pragma), and `app/cdps/[symbol]/_components/cdp-stability-pool-tvl-chart.tsx` (found via the same grep, carried only the bare disable pragma without the full rationale paragraph). Also updated the illustrative `.toSorted()` example in `lib/tokens.ts`'s JSDoc to `sortedCopy` so it doesn't model the banned pattern.
- `lib/` does not import from `components/` — the helper is a leaf module with zero dependencies, importable from every listed call site.
- The ESLint rule matches on property name only (no type info), so in principle it could false-positive on a non-array object with a same-named property; `toSorted`/`toReversed`/`toSpliced` are ES2023-specific names unlikely to collide in this codebase, and no such collision exists today.
- The rule's server-only exemption list intentionally matches only what `AGENTS.md`'s "Browser target" section names as ES2023-safe today (`app/api/**/route.ts`, `lib/homepage-og.ts`, `lib/pool-og.ts`), not the broader "Server vs client module boundaries" list (e.g. `lib/bridge-flows-og.ts`, `opengraph-image.tsx`). No current code in those extra paths uses the banned methods; a future PR that needs ES2023+ there can widen the ignore list alongside updating `AGENTS.md`. Noted directly in the eslint.config.mjs comment.
- Updated `ui-dashboard/AGENTS.md`'s "Browser target" section to name `sortedCopy`/`@/lib/immutable-sort` as the canonical immutable-sort form and describe the new ESLint backstop, so the doc doesn't keep steering future contributors toward hand-rolling the workaround.
- Non-goal per the issue: did not sweep the ~20 pre-existing `[...arr].sort()` sites that never carried the duplicated rationale comment/disable pragma (e.g. `snapshot-chart.tsx`, `liquidity-chart.tsx`, `trove-sort.ts`) — those are already ES2017-safe and out of this PR's mechanical scope.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test` — 223 test files / 3426 tests passed (includes the new `immutable-sort.test.ts`).
- `pnpm --filter @mento-protocol/ui-dashboard lint` — clean.
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean.
- `pnpm --filter @mento-protocol/ui-dashboard react-doctor:diff` / `react-doctor:score` — 100/100, no issues.
- `pnpm agent:quality-gate` (`--run`) — all mapped commands passed, including `test:coverage`, `knip`, `code-health:deps`, `size-limit`, and the Playwright `test:browser` suite (17/17; hit the documented rare webServer-startup flake once, passed clean on retry).
- `pnpm agent:autoreview --engine claude` — clean after two rounds of fixes (AGENTS.md doc drift, one missed call site, an added scoping comment).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1063

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with unchanged sort semantics; adds lint/docs guardrails for browser compatibility, not business logic changes.
> 
> **Overview**
> Introduces **`sortedCopy`** in `@/lib/immutable-sort` as the single ES2017-safe immutable sort (`[...arr].sort`) and replaces duplicated spread+sort blocks (and their per-site `react-doctor` disables) across charts, tables, bridge/pool sort helpers, tag suggestions, and **`homepage-og.ts`** (which had been using **`.toSorted()`**).
> 
> Adds an ESLint **`no-restricted-properties`** backstop on **`toSorted` / `toReversed` / `toSpliced`** under `src/**`, with exemptions for documented server-only paths and tests. **`AGENTS.md`** now points contributors at **`sortedCopy`** instead of hand-rolling the workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f26a0fc8f99ae71756a540970b5a36f2145291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->