### PR TITLE
refactor(indexer): decompose upsertPool into named heal-stage functions

### DIFF
--- a/indexer-envio/eslint-baseline.json
+++ b/indexer-envio/eslint-baseline.json
@@ -35,20 +35,6 @@
     "linePreview": "*/ | export function recordHealthSample( | pool: Pool,"
   },
   {
-    "file": "src/pool.ts",
-    "ruleId": "complexity",
-    "message": "Async arrow function has a complexity of 57. Maximum allowed is 15.",
-    "line": 315,
-    "linePreview": "existing?: { pool: Pool | undefined }; | }): Promise<Pool> => { | const initialBase = existingOverride"
-  },
-  {
-    "file": "src/pool.ts",
-    "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 34 to the 18 allowed.",
-    "line": 315,
-    "linePreview": "existing?: { pool: Pool | undefined }; | }): Promise<Pool> => { | const initialBase = existingOverride"
-  },
-  {
     "file": "src/pool/snapshots.ts",
     "ruleId": "complexity",
     "message": "Async arrow function has a complexity of 18. Maximum allowed is 15.",

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -339,6 +339,31 @@ async function healPoolFees(
   return healedFees;
 }
 
+/** Resolve the pool's final `referenceRateFeedID` for this event (caller
+ * param > self-heal > existing persisted value) and, when a pool's rate feed
+ * is assigned for the first time (the ""→set transition), recompute
+ * `breakerTripped` from the feed's current breaker configs — otherwise a
+ * pool that first appears while the feed is already halted would read
+ * `false` until the next BreakerBox transition. The steady-state gate (only
+ * fires on that one transition) lives inside `breakerTrippedOnFeedAssign`. */
+async function resolveFeedIdAndBreakerHalt(
+  context: PoolContext,
+  chainId: number,
+  existing: Pool,
+  referenceRateFeedID: string | undefined,
+  healedFeedId: string | undefined,
+): Promise<{ finalReferenceRateFeedID: string; breakerTripped: boolean }> {
+  const finalReferenceRateFeedID =
+    referenceRateFeedID ?? healedFeedId ?? existing.referenceRateFeedID;
+  const breakerTripped = await breakerTrippedOnFeedAssign(
+    context,
+    chainId,
+    existing,
+    finalReferenceRateFeedID,
+  );
+  return { finalReferenceRateFeedID, breakerTripped };
+}
+
 // eslint-disable-next-line max-lines-per-function -- Existing pool upsert pipeline remains intentionally centralized for atomic state updates.
 export const upsertPool = async ({
   context,
@@ -463,20 +488,14 @@ export const upsertPool = async ({
   );
   const healedFees = await healPoolFees(context, existing, chainId, poolAddr);
 
-  // When a pool's rate feed is assigned for the first time (factory param or
-  // self-heal), recompute `breakerTripped` from the feed's current breaker
-  // configs — otherwise a pool that first appears while the feed is already
-  // halted would read `false` until the next BreakerBox transition. The gate
-  // (only the "" -> set transition) lives in the helper to keep upsertPool's
-  // cognitive complexity flat.
-  const finalReferenceRateFeedID =
-    referenceRateFeedID ?? healedFeedId ?? existing.referenceRateFeedID;
-  const breakerTripped = await breakerTrippedOnFeedAssign(
-    context,
-    chainId,
-    existing,
-    finalReferenceRateFeedID,
-  );
+  const { finalReferenceRateFeedID, breakerTripped } =
+    await resolveFeedIdAndBreakerHalt(
+      context,
+      chainId,
+      existing,
+      referenceRateFeedID,
+      healedFeedId,
+    );
 
   const next: Pool = {
     ...existing,

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -265,16 +265,17 @@ const defaultPool = (
  * `DEFAULT_ORACLE_FIELDS` (extracted to avoid the spread-clobber bug — see
  * the `DEFAULT_ORACLE_FIELDS` doc above); the caller applies it directly in
  * the field-merge stage. */
-async function healReferenceRateFeed(
-  context: { effect: EffectCaller },
-  existing: Pool,
-  chainId: number,
-  poolAddr: string,
-  blockNumber: bigint,
-): Promise<{
+async function healReferenceRateFeed(args: {
+  context: { effect: EffectCaller };
+  existing: Pool;
+  chainId: number;
+  poolAddr: string;
+  blockNumber: bigint;
+}): Promise<{
   healedFeedId: string | undefined;
   healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
 }> {
+  const { context, existing, chainId, poolAddr, blockNumber } = args;
   let healedFeedId: string | undefined;
   let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
   if (
@@ -346,13 +347,15 @@ async function healPoolFees(
  * pool that first appears while the feed is already halted would read
  * `false` until the next BreakerBox transition. The steady-state gate (only
  * fires on that one transition) lives inside `breakerTrippedOnFeedAssign`. */
-async function resolveFeedIdAndBreakerHalt(
-  context: PoolContext,
-  chainId: number,
-  existing: Pool,
-  referenceRateFeedID: string | undefined,
-  healedFeedId: string | undefined,
-): Promise<{ finalReferenceRateFeedID: string; breakerTripped: boolean }> {
+async function resolveFeedIdAndBreakerHalt(args: {
+  context: PoolContext;
+  chainId: number;
+  existing: Pool;
+  referenceRateFeedID: string | undefined;
+  healedFeedId: string | undefined;
+}): Promise<{ finalReferenceRateFeedID: string; breakerTripped: boolean }> {
+  const { context, chainId, existing, referenceRateFeedID, healedFeedId } =
+    args;
   const finalReferenceRateFeedID =
     referenceRateFeedID ?? healedFeedId ?? existing.referenceRateFeedID;
   const breakerTripped = await breakerTrippedOnFeedAssign(
@@ -362,6 +365,164 @@ async function resolveFeedIdAndBreakerHalt(
     finalReferenceRateFeedID,
   );
   return { finalReferenceRateFeedID, breakerTripped };
+}
+
+/** Resolve `token0Decimals` / `token1Decimals` / `tokenDecimalsKnown` for the
+ * field-merge stage. OR-merges `tokenDecimalsKnown` so a self-healed `true`
+ * survives a later caller passing `false` (e.g. a factory replay that
+ * blipped). Symmetrically gates the decimal field writes: when the incoming
+ * pair is unknown but the existing pair is known, keep the known values.
+ * Without this gate, a known-6/18 pool getting a re-blipped factory payload
+ * `{18, 18, false}` would clobber the real decimals to 18/18 while the
+ * OR-merge held the flag at `true` — locking in wrong scaling. */
+function resolveTokenDecimalsFields(
+  existing: Pool,
+  tokenDecimals:
+    | {
+        token0Decimals: number;
+        token1Decimals: number;
+        tokenDecimalsKnown: boolean;
+      }
+    | undefined,
+): {
+  token0Decimals: number;
+  token1Decimals: number;
+  tokenDecimalsKnown: boolean;
+} {
+  return {
+    token0Decimals:
+      tokenDecimals && tokenDecimals.tokenDecimalsKnown
+        ? tokenDecimals.token0Decimals
+        : existing.tokenDecimalsKnown
+          ? existing.token0Decimals
+          : (tokenDecimals?.token0Decimals ?? existing.token0Decimals),
+    token1Decimals:
+      tokenDecimals && tokenDecimals.tokenDecimalsKnown
+        ? tokenDecimals.token1Decimals
+        : existing.tokenDecimalsKnown
+          ? existing.token1Decimals
+          : (tokenDecimals?.token1Decimals ?? existing.token1Decimals),
+    tokenDecimalsKnown:
+      tokenDecimals?.tokenDecimalsKnown || existing.tokenDecimalsKnown,
+  };
+}
+
+/** Merge order for the healed/delta partials applied over `existing`+base
+ * fields: healed fields first, then the caller's explicit `oracleDelta`
+ * (which wins on overlap), then healed fees. Split out of the `next`
+ * builder purely to keep that function's complexity budget clear — no
+ * change in merge order or precedence. */
+function mergeHealedDeltas(
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
+  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
+  healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined,
+): Partial<Pool> {
+  return {
+    ...(healedOracleDelta ?? {}),
+    ...(oracleDelta ?? {}),
+    ...(healedFees ?? {}),
+  };
+}
+
+/** `createdAtBlock`/`createdAtTimestamp` are stamped once on first touch
+ * (existing value at the schema-default `0n` sentinel) and preserved on
+ * every subsequent event. */
+function nextCreatedAt(
+  existing: Pool,
+  blockNumber: bigint,
+  blockTimestamp: bigint,
+): { createdAtBlock: bigint; createdAtTimestamp: bigint } {
+  return {
+    createdAtBlock:
+      existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
+    createdAtTimestamp:
+      existing.createdAtTimestamp === 0n
+        ? blockTimestamp
+        : existing.createdAtTimestamp,
+  };
+}
+
+/** Field-merge stage: builds the next Pool row from `existing` plus every
+ * heal/delta input gathered by the earlier stages. Merge order is
+ * significant and preserved exactly from the prior inline implementation:
+ * healed fields first, then the caller's explicit `oracleDelta` (which wins
+ * on overlap), then `referenceRateFeedID`/`breakerTripped` applied AFTER the
+ * spread chain so an `oracleDelta` that omits the field can't clobber it. */
+function buildMergedPool(args: {
+  existing: Pool;
+  chainId: number;
+  token0: string | undefined;
+  token1: string | undefined;
+  source: PoolUpdateSource;
+  reservesDelta: { reserve0: bigint; reserve1: bigint } | undefined;
+  swapDelta: { volume0: bigint; volume1: bigint } | undefined;
+  rebalanceDelta: boolean | undefined;
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined;
+  finalReferenceRateFeedID: string;
+  breakerTripped: boolean;
+  tokenDecimals:
+    | {
+        token0Decimals: number;
+        token1Decimals: number;
+        tokenDecimalsKnown: boolean;
+      }
+    | undefined;
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+}): Pool {
+  const {
+    existing,
+    chainId,
+    token0,
+    token1,
+    source,
+    reservesDelta,
+    swapDelta,
+    rebalanceDelta,
+    healedOracleDelta,
+    oracleDelta,
+    healedFees,
+    finalReferenceRateFeedID,
+    breakerTripped,
+    tokenDecimals,
+    blockNumber,
+    blockTimestamp,
+  } = args;
+  return {
+    ...existing,
+    chainId,
+    token0: token0 ?? existing.token0,
+    token1: token1 ?? existing.token1,
+    source: pickPreferredSource(existing.source, source),
+    reserves0: reservesDelta?.reserve0 ?? existing.reserves0,
+    reserves1: reservesDelta?.reserve1 ?? existing.reserves1,
+    swapCount: existing.swapCount + (swapDelta ? 1 : 0),
+    notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
+    notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
+    rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
+    // Merge healed fields first, then explicit delta takes precedence
+    ...mergeHealedDeltas(healedOracleDelta, oracleDelta, healedFees),
+    // `referenceRateFeedID` is applied AFTER the spread chain so the
+    // value isn't clobbered by an oracleDelta that omits it (the field
+    // is no longer in DEFAULT_ORACLE_FIELDS — callers can't include it
+    // in the spread). Priority: caller-supplied param (FPMM factory) >
+    // self-heal > existing.
+    referenceRateFeedID: finalReferenceRateFeedID,
+    breakerTripped,
+    ...resolveTokenDecimalsFields(existing, tokenDecimals),
+    // `wrappedExchangeId` is owned by `selfHealWrappedExchangeId` above —
+    // the helper updates `existing` in place (returns a new object on
+    // healing, original on no-op) so the spread carries the field through.
+    ...nextCreatedAt(existing, blockNumber, blockTimestamp),
+    updatedAtBlock: blockNumber,
+    updatedAtTimestamp: blockTimestamp,
+  };
 }
 
 // eslint-disable-next-line max-lines-per-function -- Existing pool upsert pipeline remains intentionally centralized for atomic state updates.
@@ -479,80 +640,42 @@ export const upsertPool = async ({
   // (invertRateFeed self-heal already happened above via
   // `selfHealInvertRateFeed(context, existingInitial)` — its result is in
   // `existing` and flows through the `...existing` spread into `next`.)
-  const { healedFeedId, healedOracleDelta } = await healReferenceRateFeed(
+  const { healedFeedId, healedOracleDelta } = await healReferenceRateFeed({
     context,
     existing,
     chainId,
     poolAddr,
     blockNumber,
-  );
+  });
   const healedFees = await healPoolFees(context, existing, chainId, poolAddr);
 
   const { finalReferenceRateFeedID, breakerTripped } =
-    await resolveFeedIdAndBreakerHalt(
+    await resolveFeedIdAndBreakerHalt({
       context,
       chainId,
       existing,
       referenceRateFeedID,
       healedFeedId,
-    );
+    });
 
-  const next: Pool = {
-    ...existing,
+  const next: Pool = buildMergedPool({
+    existing,
     chainId,
-    token0: token0 ?? existing.token0,
-    token1: token1 ?? existing.token1,
-    source: pickPreferredSource(existing.source, source),
-    reserves0: reservesDelta?.reserve0 ?? existing.reserves0,
-    reserves1: reservesDelta?.reserve1 ?? existing.reserves1,
-    swapCount: existing.swapCount + (swapDelta ? 1 : 0),
-    notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
-    notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
-    rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
-    // Merge healed fields first, then explicit delta takes precedence
-    ...(healedOracleDelta ?? {}),
-    ...(oracleDelta ?? {}),
-    ...(healedFees ?? {}),
-    // `referenceRateFeedID` is applied AFTER the spread chain so the
-    // value isn't clobbered by an oracleDelta that omits it (the field
-    // is no longer in DEFAULT_ORACLE_FIELDS — callers can't include it
-    // in the spread). Priority: caller-supplied param (FPMM factory) >
-    // self-heal > existing.
-    referenceRateFeedID: finalReferenceRateFeedID,
+    token0,
+    token1,
+    source,
+    reservesDelta,
+    swapDelta,
+    rebalanceDelta,
+    healedOracleDelta,
+    oracleDelta,
+    healedFees,
+    finalReferenceRateFeedID,
     breakerTripped,
-    // OR-merge `tokenDecimalsKnown` so a self-healed `true` survives a
-    // later caller passing `false` (e.g. a factory replay that blipped).
-    // Symmetrically, gate the decimal field writes: when the incoming pair
-    // is unknown but the existing pair is known, keep the known values.
-    // Without this gate, a known-6/18 pool getting a re-blipped factory
-    // payload `{18, 18, false}` would clobber the real decimals to 18/18
-    // while the OR-merge held the flag at `true` — locking in wrong scaling.
-    token0Decimals:
-      tokenDecimals && tokenDecimals.tokenDecimalsKnown
-        ? tokenDecimals.token0Decimals
-        : existing.tokenDecimalsKnown
-          ? existing.token0Decimals
-          : (tokenDecimals?.token0Decimals ?? existing.token0Decimals),
-    token1Decimals:
-      tokenDecimals && tokenDecimals.tokenDecimalsKnown
-        ? tokenDecimals.token1Decimals
-        : existing.tokenDecimalsKnown
-          ? existing.token1Decimals
-          : (tokenDecimals?.token1Decimals ?? existing.token1Decimals),
-    tokenDecimalsKnown:
-      tokenDecimals?.tokenDecimalsKnown || existing.tokenDecimalsKnown,
-    // `wrappedExchangeId` is owned by `selfHealWrappedExchangeId` above —
-    // the helper updates `existing` in place (returns a new object on
-    // healing, original on no-op) so the spread carries the field through.
-    createdAtBlock:
-      existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
-    createdAtTimestamp:
-      existing.createdAtTimestamp === 0n
-        ? blockTimestamp
-        : existing.createdAtTimestamp,
-    updatedAtBlock: blockNumber,
-    updatedAtTimestamp: blockTimestamp,
-  };
+    tokenDecimals,
+    blockNumber,
+    blockTimestamp,
+  });
 
   // Use contract-provided priceDifference when available (passed via oracleDelta
   // from fetchRebalancingState). Only fall back to local recomputation when the

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -2,22 +2,14 @@
 // Pool upsert logic and public pool-module re-exports
 // ---------------------------------------------------------------------------
 
-import type { EffectCaller, Pool } from "envio";
-import { UNKNOWN_ORACLE_REPORTERS } from "./constants.js";
+import type { Pool } from "envio";
 import { extractAddressFromPoolId, isVirtualPool } from "./helpers.js";
 import {
   classifyExactZeroReserves,
   computePriceDifference,
   hasDegenerateReserves,
 } from "./priceDifference.js";
-import {
-  compactFees,
-  feesEffect,
-  referenceRateFeedIDEffect,
-  reportExpiryEffect,
-} from "./rpc/effects.js";
 import { recordBreachTransition } from "./deviationBreach.js";
-import { breakerTrippedOnFeedAssign } from "./breakers.js";
 import {
   computeHealthStatus,
   isNeverRebalance,
@@ -25,12 +17,19 @@ import {
   nextOpenBreachEntryThreshold,
   nextOpenBreachPeak,
 } from "./pool/health.js";
-import { pickPreferredSource, type PoolUpdateSource } from "./pool/sources.js";
+import type { PoolUpdateSource } from "./pool/sources.js";
 import {
   selfHealInvertRateFeed,
   selfHealTokenDecimals,
   selfHealWrappedExchangeId,
 } from "./pool/self-heal.js";
+import {
+  DEFAULT_ORACLE_FIELDS,
+  buildMergedPool,
+  healPoolFees,
+  healReferenceRateFeed,
+  resolveFeedIdAndBreakerHalt,
+} from "./pool/upsert-stages.js";
 import type { PoolContext } from "./pool/types.js";
 
 export {
@@ -61,6 +60,7 @@ export {
   selfHealWrappedExchangeId,
 } from "./pool/self-heal.js";
 export type { PoolContext, SnapshotContext } from "./pool/types.js";
+export { DEFAULT_ORACLE_FIELDS } from "./pool/upsert-stages.js";
 export { upsertDailySnapshot, upsertSnapshot } from "./pool/snapshots.js";
 
 // ---------------------------------------------------------------------------
@@ -118,77 +118,6 @@ export async function maybePreloadPool(
   await Promise.all(ids.map((id) => preloadPoolAndOpenBreach(context, id)));
   return true;
 }
-
-/** Default oracle field values (for VirtualPools or when RPC call fails).
- *
- * Excludes static VP oracle config (`referenceRateFeedID`,
- * `oracleFreshnessWindow`) on purpose — those are set ONCE at pool creation
- * or via the BiPoolExchange→Pool mirror. Including them here would mean
- * callers spreading `{...DEFAULT_ORACLE_FIELDS, ...overrides}` as
- * `oracleDelta` could clobber healed values back to defaults via the `next`
- * builder's spread order. `defaultPool` initializes those fields directly
- * below; persisted updates flow via the dedicated mirror / heal helpers. */
-export const DEFAULT_ORACLE_FIELDS = {
-  oracleOk: false,
-  oraclePrice: 0n,
-  oracleTimestamp: 0n,
-  oracleTxHash: "",
-  oracleExpiry: 0n,
-  oracleNumReporters: UNKNOWN_ORACLE_REPORTERS,
-  lastMedianPrice: 0n,
-  lastMedianAt: 0n,
-  medianLive: true,
-  lastOracleReportAt: 0n,
-  prevMedianPrice: 0n,
-  prevMedianAt: 0n,
-  lastOracleJumpBps: "0.0000",
-  lastOracleJumpAt: 0n,
-  invertRateFeed: false,
-  // false = unread (schema default); true = real on-chain value persisted.
-  // While false, upsertPool's self-heal retries the effect on every event.
-  invertRateFeedKnown: false,
-  degenerateReserves: false,
-  priceDifference: 0n,
-  rebalanceThreshold: 0,
-  rebalanceThresholdAbove: 0,
-  rebalanceThresholdBelow: 0,
-  // Mirrors `invertRateFeedKnown`: false until factory seed or
-  // `RebalanceThresholdUpdated` lands real values; gates state-sync self-heal.
-  rebalanceThresholdsKnown: false,
-  lastRebalancedAt: 0n,
-  deviationBreachStartedAt: 0n,
-  currentOpenBreachPeak: 0n,
-  currentOpenBreachEntryThreshold: 0,
-  healthStatus: "N/A" as string,
-  limitStatus: "N/A" as string,
-  limitPressure0: "0.0000" as string,
-  limitPressure1: "0.0000" as string,
-  lpFee: -1,
-  protocolFee: -1,
-  rebalanceReward: -1,
-  rebalancerAddress: "" as string,
-  rebalanceLivenessStatus: "N/A" as string,
-  token0Decimals: 18,
-  token1Decimals: 18,
-  // Mirrors `invertRateFeedKnown`: false until factory seeds real values
-  // (or `selfHealTokenDecimals` lands them); true once persisted. While
-  // false, `selfHealTokenDecimals` retries on every event that touches
-  // this pool so a deploy-time RPC blip doesn't permanently keep
-  // non-18-decimal pools at the schema default 18/18.
-  tokenDecimalsKnown: false,
-  // Diagnostic only — see schema.graphql comment. NOT a freshness signal.
-  lastFreshReporterAt: 0n,
-  // Health score accumulators
-  healthTotalSeconds: 0n,
-  healthBinarySeconds: 0n,
-  lastOracleSnapshotTimestamp: 0n,
-  lastDeviationRatio: "-1",
-  lastEffectivenessRatio: "-1",
-  hasHealthData: false,
-  cumulativeBreachSeconds: 0n,
-  cumulativeCriticalSeconds: 0n,
-  breachCount: 0,
-};
 
 type OracleDelta = Partial<typeof DEFAULT_ORACLE_FIELDS>;
 
@@ -254,276 +183,6 @@ const defaultPool = (
   updatedAtBlock: 0n,
   updatedAtTimestamp: 0n,
 });
-
-/** Self-heal `referenceRateFeedID` when it was missed at pool creation
- * (transient RPC failure). Retries via `referenceRateFeedIDEffect`; when a
- * feed resolves, also fetches its current `oracleExpiry` via
- * `reportExpiryEffect`. No-op (both fields `undefined`) for VirtualPools,
- * pools no event has touched yet (`source === ""`), or pools that already
- * carry a feed. `healedFeedId` is returned separately from
- * `healedOracleDelta` because `referenceRateFeedID` is no longer part of
- * `DEFAULT_ORACLE_FIELDS` (extracted to avoid the spread-clobber bug — see
- * the `DEFAULT_ORACLE_FIELDS` doc above); the caller applies it directly in
- * the field-merge stage. */
-async function healReferenceRateFeed(args: {
-  context: { effect: EffectCaller };
-  existing: Pool;
-  chainId: number;
-  poolAddr: string;
-  blockNumber: bigint;
-}): Promise<{
-  healedFeedId: string | undefined;
-  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
-}> {
-  const { context, existing, chainId, poolAddr, blockNumber } = args;
-  let healedFeedId: string | undefined;
-  let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
-  if (
-    existing.referenceRateFeedID === "" &&
-    existing.source !== "" &&
-    !isVirtualPool(existing)
-  ) {
-    const rateFeedID = await context.effect(referenceRateFeedIDEffect, {
-      chainId,
-      poolAddress: poolAddr,
-    });
-    if (rateFeedID) {
-      healedFeedId = rateFeedID;
-      const expiry = await context.effect(reportExpiryEffect, {
-        chainId,
-        rateFeedID,
-        blockNumber,
-      });
-      if (expiry !== null) {
-        healedOracleDelta = { oracleExpiry: expiry };
-      }
-    }
-  }
-  return { healedFeedId, healedOracleDelta };
-}
-
-/** Self-heal `lpFee` / `protocolFee` / `rebalanceReward` when any of them are
- * still at the -1 "not yet attempted" sentinel. Retries now; once a
- * successful read lands — even if the real fee is 0 — the caller persists it
- * and stops retrying. `fetchFees` (behind `feesEffect`) also stamps -2 on any
- * getter that rejects with "returned no data" (contract doesn't implement
- * it), and -2 is excluded from the retry gate so older FPMM deployments
- * missing `rebalanceIncentive()` don't thrash forever. No-op for
- * VirtualPools or pools no event has touched yet. */
-async function healPoolFees(
-  context: { effect: EffectCaller },
-  existing: Pool,
-  chainId: number,
-  poolAddr: string,
-): Promise<
-  | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
-  | undefined
-> {
-  let healedFees:
-    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
-    | undefined;
-  if (
-    (existing.lpFee === -1 ||
-      existing.protocolFee === -1 ||
-      existing.rebalanceReward === -1) &&
-    existing.source !== "" &&
-    !isVirtualPool(existing)
-  ) {
-    const fees = await context.effect(feesEffect, {
-      chainId,
-      poolAddress: poolAddr,
-    });
-    if (fees) {
-      healedFees = compactFees(fees);
-    }
-  }
-  return healedFees;
-}
-
-/** Resolve the pool's final `referenceRateFeedID` for this event (caller
- * param > self-heal > existing persisted value) and, when a pool's rate feed
- * is assigned for the first time (the ""→set transition), recompute
- * `breakerTripped` from the feed's current breaker configs — otherwise a
- * pool that first appears while the feed is already halted would read
- * `false` until the next BreakerBox transition. The steady-state gate (only
- * fires on that one transition) lives inside `breakerTrippedOnFeedAssign`. */
-async function resolveFeedIdAndBreakerHalt(args: {
-  context: PoolContext;
-  chainId: number;
-  existing: Pool;
-  referenceRateFeedID: string | undefined;
-  healedFeedId: string | undefined;
-}): Promise<{ finalReferenceRateFeedID: string; breakerTripped: boolean }> {
-  const { context, chainId, existing, referenceRateFeedID, healedFeedId } =
-    args;
-  const finalReferenceRateFeedID =
-    referenceRateFeedID ?? healedFeedId ?? existing.referenceRateFeedID;
-  const breakerTripped = await breakerTrippedOnFeedAssign(
-    context,
-    chainId,
-    existing,
-    finalReferenceRateFeedID,
-  );
-  return { finalReferenceRateFeedID, breakerTripped };
-}
-
-/** Resolve `token0Decimals` / `token1Decimals` / `tokenDecimalsKnown` for the
- * field-merge stage. OR-merges `tokenDecimalsKnown` so a self-healed `true`
- * survives a later caller passing `false` (e.g. a factory replay that
- * blipped). Symmetrically gates the decimal field writes: when the incoming
- * pair is unknown but the existing pair is known, keep the known values.
- * Without this gate, a known-6/18 pool getting a re-blipped factory payload
- * `{18, 18, false}` would clobber the real decimals to 18/18 while the
- * OR-merge held the flag at `true` — locking in wrong scaling. */
-function resolveTokenDecimalsFields(
-  existing: Pool,
-  tokenDecimals:
-    | {
-        token0Decimals: number;
-        token1Decimals: number;
-        tokenDecimalsKnown: boolean;
-      }
-    | undefined,
-): {
-  token0Decimals: number;
-  token1Decimals: number;
-  tokenDecimalsKnown: boolean;
-} {
-  return {
-    token0Decimals:
-      tokenDecimals && tokenDecimals.tokenDecimalsKnown
-        ? tokenDecimals.token0Decimals
-        : existing.tokenDecimalsKnown
-          ? existing.token0Decimals
-          : (tokenDecimals?.token0Decimals ?? existing.token0Decimals),
-    token1Decimals:
-      tokenDecimals && tokenDecimals.tokenDecimalsKnown
-        ? tokenDecimals.token1Decimals
-        : existing.tokenDecimalsKnown
-          ? existing.token1Decimals
-          : (tokenDecimals?.token1Decimals ?? existing.token1Decimals),
-    tokenDecimalsKnown:
-      tokenDecimals?.tokenDecimalsKnown || existing.tokenDecimalsKnown,
-  };
-}
-
-/** Merge order for the healed/delta partials applied over `existing`+base
- * fields: healed fields first, then the caller's explicit `oracleDelta`
- * (which wins on overlap), then healed fees. Split out of the `next`
- * builder purely to keep that function's complexity budget clear — no
- * change in merge order or precedence. */
-function mergeHealedDeltas(
-  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
-  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
-  healedFees:
-    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
-    | undefined,
-): Partial<Pool> {
-  return {
-    ...(healedOracleDelta ?? {}),
-    ...(oracleDelta ?? {}),
-    ...(healedFees ?? {}),
-  };
-}
-
-/** `createdAtBlock`/`createdAtTimestamp` are stamped once on first touch
- * (existing value at the schema-default `0n` sentinel) and preserved on
- * every subsequent event. */
-function nextCreatedAt(
-  existing: Pool,
-  blockNumber: bigint,
-  blockTimestamp: bigint,
-): { createdAtBlock: bigint; createdAtTimestamp: bigint } {
-  return {
-    createdAtBlock:
-      existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
-    createdAtTimestamp:
-      existing.createdAtTimestamp === 0n
-        ? blockTimestamp
-        : existing.createdAtTimestamp,
-  };
-}
-
-/** Field-merge stage: builds the next Pool row from `existing` plus every
- * heal/delta input gathered by the earlier stages. Merge order is
- * significant and preserved exactly from the prior inline implementation:
- * healed fields first, then the caller's explicit `oracleDelta` (which wins
- * on overlap), then `referenceRateFeedID`/`breakerTripped` applied AFTER the
- * spread chain so an `oracleDelta` that omits the field can't clobber it. */
-function buildMergedPool(args: {
-  existing: Pool;
-  chainId: number;
-  token0: string | undefined;
-  token1: string | undefined;
-  source: PoolUpdateSource;
-  reservesDelta: { reserve0: bigint; reserve1: bigint } | undefined;
-  swapDelta: { volume0: bigint; volume1: bigint } | undefined;
-  rebalanceDelta: boolean | undefined;
-  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
-  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
-  healedFees:
-    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
-    | undefined;
-  finalReferenceRateFeedID: string;
-  breakerTripped: boolean;
-  tokenDecimals:
-    | {
-        token0Decimals: number;
-        token1Decimals: number;
-        tokenDecimalsKnown: boolean;
-      }
-    | undefined;
-  blockNumber: bigint;
-  blockTimestamp: bigint;
-}): Pool {
-  const {
-    existing,
-    chainId,
-    token0,
-    token1,
-    source,
-    reservesDelta,
-    swapDelta,
-    rebalanceDelta,
-    healedOracleDelta,
-    oracleDelta,
-    healedFees,
-    finalReferenceRateFeedID,
-    breakerTripped,
-    tokenDecimals,
-    blockNumber,
-    blockTimestamp,
-  } = args;
-  return {
-    ...existing,
-    chainId,
-    token0: token0 ?? existing.token0,
-    token1: token1 ?? existing.token1,
-    source: pickPreferredSource(existing.source, source),
-    reserves0: reservesDelta?.reserve0 ?? existing.reserves0,
-    reserves1: reservesDelta?.reserve1 ?? existing.reserves1,
-    swapCount: existing.swapCount + (swapDelta ? 1 : 0),
-    notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
-    notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
-    rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
-    // Merge healed fields first, then explicit delta takes precedence
-    ...mergeHealedDeltas(healedOracleDelta, oracleDelta, healedFees),
-    // `referenceRateFeedID` is applied AFTER the spread chain so the
-    // value isn't clobbered by an oracleDelta that omits it (the field
-    // is no longer in DEFAULT_ORACLE_FIELDS — callers can't include it
-    // in the spread). Priority: caller-supplied param (FPMM factory) >
-    // self-heal > existing.
-    referenceRateFeedID: finalReferenceRateFeedID,
-    breakerTripped,
-    ...resolveTokenDecimalsFields(existing, tokenDecimals),
-    // `wrappedExchangeId` is owned by `selfHealWrappedExchangeId` above —
-    // the helper updates `existing` in place (returns a new object on
-    // healing, original on no-op) so the spread carries the field through.
-    ...nextCreatedAt(existing, blockNumber, blockTimestamp),
-    updatedAtBlock: blockNumber,
-    updatedAtTimestamp: blockTimestamp,
-  };
-}
 
 // eslint-disable-next-line max-lines-per-function -- Existing pool upsert pipeline remains intentionally centralized for atomic state updates.
 export const upsertPool = async ({

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -2,7 +2,7 @@
 // Pool upsert logic and public pool-module re-exports
 // ---------------------------------------------------------------------------
 
-import type { Pool } from "envio";
+import type { EffectCaller, Pool } from "envio";
 import { UNKNOWN_ORACLE_REPORTERS } from "./constants.js";
 import { extractAddressFromPoolId, isVirtualPool } from "./helpers.js";
 import {
@@ -255,6 +255,90 @@ const defaultPool = (
   updatedAtTimestamp: 0n,
 });
 
+/** Self-heal `referenceRateFeedID` when it was missed at pool creation
+ * (transient RPC failure). Retries via `referenceRateFeedIDEffect`; when a
+ * feed resolves, also fetches its current `oracleExpiry` via
+ * `reportExpiryEffect`. No-op (both fields `undefined`) for VirtualPools,
+ * pools no event has touched yet (`source === ""`), or pools that already
+ * carry a feed. `healedFeedId` is returned separately from
+ * `healedOracleDelta` because `referenceRateFeedID` is no longer part of
+ * `DEFAULT_ORACLE_FIELDS` (extracted to avoid the spread-clobber bug — see
+ * the `DEFAULT_ORACLE_FIELDS` doc above); the caller applies it directly in
+ * the field-merge stage. */
+async function healReferenceRateFeed(
+  context: { effect: EffectCaller },
+  existing: Pool,
+  chainId: number,
+  poolAddr: string,
+  blockNumber: bigint,
+): Promise<{
+  healedFeedId: string | undefined;
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+}> {
+  let healedFeedId: string | undefined;
+  let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  if (
+    existing.referenceRateFeedID === "" &&
+    existing.source !== "" &&
+    !isVirtualPool(existing)
+  ) {
+    const rateFeedID = await context.effect(referenceRateFeedIDEffect, {
+      chainId,
+      poolAddress: poolAddr,
+    });
+    if (rateFeedID) {
+      healedFeedId = rateFeedID;
+      const expiry = await context.effect(reportExpiryEffect, {
+        chainId,
+        rateFeedID,
+        blockNumber,
+      });
+      if (expiry !== null) {
+        healedOracleDelta = { oracleExpiry: expiry };
+      }
+    }
+  }
+  return { healedFeedId, healedOracleDelta };
+}
+
+/** Self-heal `lpFee` / `protocolFee` / `rebalanceReward` when any of them are
+ * still at the -1 "not yet attempted" sentinel. Retries now; once a
+ * successful read lands — even if the real fee is 0 — the caller persists it
+ * and stops retrying. `fetchFees` (behind `feesEffect`) also stamps -2 on any
+ * getter that rejects with "returned no data" (contract doesn't implement
+ * it), and -2 is excluded from the retry gate so older FPMM deployments
+ * missing `rebalanceIncentive()` don't thrash forever. No-op for
+ * VirtualPools or pools no event has touched yet. */
+async function healPoolFees(
+  context: { effect: EffectCaller },
+  existing: Pool,
+  chainId: number,
+  poolAddr: string,
+): Promise<
+  | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+  | undefined
+> {
+  let healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined;
+  if (
+    (existing.lpFee === -1 ||
+      existing.protocolFee === -1 ||
+      existing.rebalanceReward === -1) &&
+    existing.source !== "" &&
+    !isVirtualPool(existing)
+  ) {
+    const fees = await context.effect(feesEffect, {
+      chainId,
+      poolAddress: poolAddr,
+    });
+    if (fees) {
+      healedFees = compactFees(fees);
+    }
+  }
+  return healedFees;
+}
+
 // eslint-disable-next-line max-lines-per-function -- Existing pool upsert pipeline remains intentionally centralized for atomic state updates.
 export const upsertPool = async ({
   context,
@@ -365,66 +449,19 @@ export const upsertPool = async ({
   // `isVirtualPool`) so FPMM-only paths pay the cost.
   const existing = await selfHealTokenDecimals(context, wrappedHealed);
 
-  // Self-heal: if referenceRateFeedID is missing (transient RPC failure at
-  // pool creation), retry now so oracle events can start flowing.
   // Use the raw address (not the namespaced poolId) for RPC calls.
   const poolAddr = extractAddressFromPoolId(poolId);
-  // `healedFeedId` is split from `healedOracleDelta` because
-  // `referenceRateFeedID` is no longer part of `DEFAULT_ORACLE_FIELDS`
-  // (extracted to avoid the spread-clobber bug — see DEFAULT_ORACLE_FIELDS
-  // doc above). Applied directly in the `next` builder below.
-  let healedFeedId: string | undefined;
-  let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
-  if (
-    existing.referenceRateFeedID === "" &&
-    existing.source !== "" &&
-    !isVirtualPool(existing)
-  ) {
-    const rateFeedID = await context.effect(referenceRateFeedIDEffect, {
-      chainId,
-      poolAddress: poolAddr,
-    });
-    if (rateFeedID) {
-      healedFeedId = rateFeedID;
-      const expiry = await context.effect(reportExpiryEffect, {
-        chainId,
-        rateFeedID,
-        blockNumber,
-      });
-      if (expiry !== null) {
-        healedOracleDelta = { oracleExpiry: expiry };
-      }
-    }
-  }
-
   // (invertRateFeed self-heal already happened above via
   // `selfHealInvertRateFeed(context, existingInitial)` — its result is in
   // `existing` and flows through the `...existing` spread into `next`.)
-
-  // Self-heal: if fees are still at the -1 "not yet attempted" sentinel,
-  // retry now. Once we get a successful read — even if the real fees are
-  // 0 — we persist the result and stop retrying. fetchFees also stamps
-  // -2 on any getter that rejects with "returned no data" (contract
-  // doesn't implement it), and -2 is excluded here so we don't thrash
-  // forever on older FPMM deployments missing rebalanceIncentive().
-  let healedFees:
-    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
-    | undefined;
-  if (
-    (existing.lpFee === -1 ||
-      existing.protocolFee === -1 ||
-      existing.rebalanceReward === -1) &&
-    existing.source !== "" &&
-    !isVirtualPool(existing)
-  ) {
-    const fees = await context.effect(feesEffect, {
-      chainId,
-      poolAddress: poolAddr,
-    });
-    if (fees) {
-      healedFees = compactFees(fees);
-    }
-  }
+  const { healedFeedId, healedOracleDelta } = await healReferenceRateFeed(
+    context,
+    existing,
+    chainId,
+    poolAddr,
+    blockNumber,
+  );
+  const healedFees = await healPoolFees(context, existing, chainId, poolAddr);
 
   // When a pool's rate feed is assigned for the first time (factory param or
   // self-heal), recompute `breakerTripped` from the feed's current breaker

--- a/indexer-envio/src/pool/upsert-stages.ts
+++ b/indexer-envio/src/pool/upsert-stages.ts
@@ -1,0 +1,365 @@
+// ---------------------------------------------------------------------------
+// upsertPool heal-stage helpers (issue #1056 decomposition)
+//
+// Named stages of the `upsertPool` pipeline in `src/pool.ts`, in call order:
+// fee/feed heal (`healReferenceRateFeed`, `healPoolFees`), breaker-halt
+// recompute (`resolveFeedIdAndBreakerHalt`), and the field-merge builder
+// (`buildMergedPool`). The three earlier self-heal stages (invert-heal,
+// wrapped-exchange link, decimals heal) live in `./self-heal.ts`.
+// ---------------------------------------------------------------------------
+
+import type { EffectCaller, Pool } from "envio";
+import { UNKNOWN_ORACLE_REPORTERS } from "../constants.js";
+import { isVirtualPool } from "../helpers.js";
+import {
+  compactFees,
+  feesEffect,
+  referenceRateFeedIDEffect,
+  reportExpiryEffect,
+} from "../rpc/effects.js";
+import { breakerTrippedOnFeedAssign } from "../breakers.js";
+import { pickPreferredSource, type PoolUpdateSource } from "./sources.js";
+import type { PoolContext } from "./types.js";
+
+/** Default oracle field values (for VirtualPools or when RPC call fails).
+ *
+ * Excludes static VP oracle config (`referenceRateFeedID`,
+ * `oracleFreshnessWindow`) on purpose — those are set ONCE at pool creation
+ * or via the BiPoolExchange→Pool mirror. Including them here would mean
+ * callers spreading `{...DEFAULT_ORACLE_FIELDS, ...overrides}` as
+ * `oracleDelta` could clobber healed values back to defaults via the `next`
+ * builder's spread order. `defaultPool` (in `src/pool.ts`) initializes those
+ * fields directly; persisted updates flow via the dedicated mirror / heal
+ * helpers. */
+export const DEFAULT_ORACLE_FIELDS = {
+  oracleOk: false,
+  oraclePrice: 0n,
+  oracleTimestamp: 0n,
+  oracleTxHash: "",
+  oracleExpiry: 0n,
+  oracleNumReporters: UNKNOWN_ORACLE_REPORTERS,
+  lastMedianPrice: 0n,
+  lastMedianAt: 0n,
+  medianLive: true,
+  lastOracleReportAt: 0n,
+  prevMedianPrice: 0n,
+  prevMedianAt: 0n,
+  lastOracleJumpBps: "0.0000",
+  lastOracleJumpAt: 0n,
+  invertRateFeed: false,
+  // false = unread (schema default); true = real on-chain value persisted.
+  // While false, upsertPool's self-heal retries the effect on every event.
+  invertRateFeedKnown: false,
+  degenerateReserves: false,
+  priceDifference: 0n,
+  rebalanceThreshold: 0,
+  rebalanceThresholdAbove: 0,
+  rebalanceThresholdBelow: 0,
+  // Mirrors `invertRateFeedKnown`: false until factory seed or
+  // `RebalanceThresholdUpdated` lands real values; gates state-sync self-heal.
+  rebalanceThresholdsKnown: false,
+  lastRebalancedAt: 0n,
+  deviationBreachStartedAt: 0n,
+  currentOpenBreachPeak: 0n,
+  currentOpenBreachEntryThreshold: 0,
+  healthStatus: "N/A" as string,
+  limitStatus: "N/A" as string,
+  limitPressure0: "0.0000" as string,
+  limitPressure1: "0.0000" as string,
+  lpFee: -1,
+  protocolFee: -1,
+  rebalanceReward: -1,
+  rebalancerAddress: "" as string,
+  rebalanceLivenessStatus: "N/A" as string,
+  token0Decimals: 18,
+  token1Decimals: 18,
+  // Mirrors `invertRateFeedKnown`: false until factory seeds real values
+  // (or `selfHealTokenDecimals` lands them); true once persisted. While
+  // false, `selfHealTokenDecimals` retries on every event that touches
+  // this pool so a deploy-time RPC blip doesn't permanently keep
+  // non-18-decimal pools at the schema default 18/18.
+  tokenDecimalsKnown: false,
+  // Diagnostic only — see schema.graphql comment. NOT a freshness signal.
+  lastFreshReporterAt: 0n,
+  // Health score accumulators
+  healthTotalSeconds: 0n,
+  healthBinarySeconds: 0n,
+  lastOracleSnapshotTimestamp: 0n,
+  lastDeviationRatio: "-1",
+  lastEffectivenessRatio: "-1",
+  hasHealthData: false,
+  cumulativeBreachSeconds: 0n,
+  cumulativeCriticalSeconds: 0n,
+  breachCount: 0,
+};
+
+/** Self-heal `referenceRateFeedID` when it was missed at pool creation
+ * (transient RPC failure). Retries via `referenceRateFeedIDEffect`; when a
+ * feed resolves, also fetches its current `oracleExpiry` via
+ * `reportExpiryEffect`. No-op (both fields `undefined`) for VirtualPools,
+ * pools no event has touched yet (`source === ""`), or pools that already
+ * carry a feed. `healedFeedId` is returned separately from
+ * `healedOracleDelta` because `referenceRateFeedID` is no longer part of
+ * `DEFAULT_ORACLE_FIELDS` (extracted to avoid the spread-clobber bug — see
+ * the `DEFAULT_ORACLE_FIELDS` doc above); the caller applies it directly in
+ * the field-merge stage. */
+export async function healReferenceRateFeed(args: {
+  context: { effect: EffectCaller };
+  existing: Pool;
+  chainId: number;
+  poolAddr: string;
+  blockNumber: bigint;
+}): Promise<{
+  healedFeedId: string | undefined;
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+}> {
+  const { context, existing, chainId, poolAddr, blockNumber } = args;
+  let healedFeedId: string | undefined;
+  let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  if (
+    existing.referenceRateFeedID === "" &&
+    existing.source !== "" &&
+    !isVirtualPool(existing)
+  ) {
+    const rateFeedID = await context.effect(referenceRateFeedIDEffect, {
+      chainId,
+      poolAddress: poolAddr,
+    });
+    if (rateFeedID) {
+      healedFeedId = rateFeedID;
+      const expiry = await context.effect(reportExpiryEffect, {
+        chainId,
+        rateFeedID,
+        blockNumber,
+      });
+      if (expiry !== null) {
+        healedOracleDelta = { oracleExpiry: expiry };
+      }
+    }
+  }
+  return { healedFeedId, healedOracleDelta };
+}
+
+/** Self-heal `lpFee` / `protocolFee` / `rebalanceReward` when any of them are
+ * still at the -1 "not yet attempted" sentinel. Retries now; once a
+ * successful read lands — even if the real fee is 0 — the caller persists it
+ * and stops retrying. `fetchFees` (behind `feesEffect`) also stamps -2 on any
+ * getter that rejects with "returned no data" (contract doesn't implement
+ * it), and -2 is excluded from the retry gate so older FPMM deployments
+ * missing `rebalanceIncentive()` don't thrash forever. No-op for
+ * VirtualPools or pools no event has touched yet. */
+export async function healPoolFees(
+  context: { effect: EffectCaller },
+  existing: Pool,
+  chainId: number,
+  poolAddr: string,
+): Promise<
+  | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+  | undefined
+> {
+  let healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined;
+  if (
+    (existing.lpFee === -1 ||
+      existing.protocolFee === -1 ||
+      existing.rebalanceReward === -1) &&
+    existing.source !== "" &&
+    !isVirtualPool(existing)
+  ) {
+    const fees = await context.effect(feesEffect, {
+      chainId,
+      poolAddress: poolAddr,
+    });
+    if (fees) {
+      healedFees = compactFees(fees);
+    }
+  }
+  return healedFees;
+}
+
+/** Resolve the pool's final `referenceRateFeedID` for this event (caller
+ * param > self-heal > existing persisted value) and, when a pool's rate feed
+ * is assigned for the first time (the ""→set transition), recompute
+ * `breakerTripped` from the feed's current breaker configs — otherwise a
+ * pool that first appears while the feed is already halted would read
+ * `false` until the next BreakerBox transition. The steady-state gate (only
+ * fires on that one transition) lives inside `breakerTrippedOnFeedAssign`. */
+export async function resolveFeedIdAndBreakerHalt(args: {
+  context: PoolContext;
+  chainId: number;
+  existing: Pool;
+  referenceRateFeedID: string | undefined;
+  healedFeedId: string | undefined;
+}): Promise<{ finalReferenceRateFeedID: string; breakerTripped: boolean }> {
+  const { context, chainId, existing, referenceRateFeedID, healedFeedId } =
+    args;
+  const finalReferenceRateFeedID =
+    referenceRateFeedID ?? healedFeedId ?? existing.referenceRateFeedID;
+  const breakerTripped = await breakerTrippedOnFeedAssign(
+    context,
+    chainId,
+    existing,
+    finalReferenceRateFeedID,
+  );
+  return { finalReferenceRateFeedID, breakerTripped };
+}
+
+/** Resolve `token0Decimals` / `token1Decimals` / `tokenDecimalsKnown` for the
+ * field-merge stage. OR-merges `tokenDecimalsKnown` so a self-healed `true`
+ * survives a later caller passing `false` (e.g. a factory replay that
+ * blipped). Symmetrically gates the decimal field writes: when the incoming
+ * pair is unknown but the existing pair is known, keep the known values.
+ * Without this gate, a known-6/18 pool getting a re-blipped factory payload
+ * `{18, 18, false}` would clobber the real decimals to 18/18 while the
+ * OR-merge held the flag at `true` — locking in wrong scaling. */
+function resolveTokenDecimalsFields(
+  existing: Pool,
+  tokenDecimals:
+    | {
+        token0Decimals: number;
+        token1Decimals: number;
+        tokenDecimalsKnown: boolean;
+      }
+    | undefined,
+): {
+  token0Decimals: number;
+  token1Decimals: number;
+  tokenDecimalsKnown: boolean;
+} {
+  return {
+    token0Decimals:
+      tokenDecimals && tokenDecimals.tokenDecimalsKnown
+        ? tokenDecimals.token0Decimals
+        : existing.tokenDecimalsKnown
+          ? existing.token0Decimals
+          : (tokenDecimals?.token0Decimals ?? existing.token0Decimals),
+    token1Decimals:
+      tokenDecimals && tokenDecimals.tokenDecimalsKnown
+        ? tokenDecimals.token1Decimals
+        : existing.tokenDecimalsKnown
+          ? existing.token1Decimals
+          : (tokenDecimals?.token1Decimals ?? existing.token1Decimals),
+    tokenDecimalsKnown:
+      tokenDecimals?.tokenDecimalsKnown || existing.tokenDecimalsKnown,
+  };
+}
+
+/** Merge order for the healed/delta partials applied over `existing`+base
+ * fields: healed fields first, then the caller's explicit `oracleDelta`
+ * (which wins on overlap), then healed fees. Split out of the `next`
+ * builder purely to keep that function's complexity budget clear — no
+ * change in merge order or precedence. */
+function mergeHealedDeltas(
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
+  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined,
+  healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined,
+): Partial<Pool> {
+  return {
+    ...(healedOracleDelta ?? {}),
+    ...(oracleDelta ?? {}),
+    ...(healedFees ?? {}),
+  };
+}
+
+/** `createdAtBlock`/`createdAtTimestamp` are stamped once on first touch
+ * (existing value at the schema-default `0n` sentinel) and preserved on
+ * every subsequent event. */
+function nextCreatedAt(
+  existing: Pool,
+  blockNumber: bigint,
+  blockTimestamp: bigint,
+): { createdAtBlock: bigint; createdAtTimestamp: bigint } {
+  return {
+    createdAtBlock:
+      existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
+    createdAtTimestamp:
+      existing.createdAtTimestamp === 0n
+        ? blockTimestamp
+        : existing.createdAtTimestamp,
+  };
+}
+
+/** Field-merge stage: builds the next Pool row from `existing` plus every
+ * heal/delta input gathered by the earlier stages. Merge order is
+ * significant and preserved exactly from the prior inline implementation:
+ * healed fields first, then the caller's explicit `oracleDelta` (which wins
+ * on overlap), then `referenceRateFeedID`/`breakerTripped` applied AFTER the
+ * spread chain so an `oracleDelta` that omits the field can't clobber it. */
+export function buildMergedPool(args: {
+  existing: Pool;
+  chainId: number;
+  token0: string | undefined;
+  token1: string | undefined;
+  source: PoolUpdateSource;
+  reservesDelta: { reserve0: bigint; reserve1: bigint } | undefined;
+  swapDelta: { volume0: bigint; volume1: bigint } | undefined;
+  rebalanceDelta: boolean | undefined;
+  healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined;
+  finalReferenceRateFeedID: string;
+  breakerTripped: boolean;
+  tokenDecimals:
+    | {
+        token0Decimals: number;
+        token1Decimals: number;
+        tokenDecimalsKnown: boolean;
+      }
+    | undefined;
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+}): Pool {
+  const {
+    existing,
+    chainId,
+    token0,
+    token1,
+    source,
+    reservesDelta,
+    swapDelta,
+    rebalanceDelta,
+    healedOracleDelta,
+    oracleDelta,
+    healedFees,
+    finalReferenceRateFeedID,
+    breakerTripped,
+    tokenDecimals,
+    blockNumber,
+    blockTimestamp,
+  } = args;
+  return {
+    ...existing,
+    chainId,
+    token0: token0 ?? existing.token0,
+    token1: token1 ?? existing.token1,
+    source: pickPreferredSource(existing.source, source),
+    reserves0: reservesDelta?.reserve0 ?? existing.reserves0,
+    reserves1: reservesDelta?.reserve1 ?? existing.reserves1,
+    swapCount: existing.swapCount + (swapDelta ? 1 : 0),
+    notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
+    notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
+    rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
+    // Merge healed fields first, then explicit delta takes precedence
+    ...mergeHealedDeltas(healedOracleDelta, oracleDelta, healedFees),
+    // `referenceRateFeedID` is applied AFTER the spread chain so the
+    // value isn't clobbered by an oracleDelta that omits it (the field
+    // is no longer in DEFAULT_ORACLE_FIELDS — callers can't include it
+    // in the spread). Priority: caller-supplied param (FPMM factory) >
+    // self-heal > existing.
+    referenceRateFeedID: finalReferenceRateFeedID,
+    breakerTripped,
+    ...resolveTokenDecimalsFields(existing, tokenDecimals),
+    // `wrappedExchangeId` is owned by `selfHealWrappedExchangeId`, called by
+    // the `upsertPool` orchestrator before this stage. The helper returns a
+    // new object on heal, the original on no-op, so the spread carries the
+    // field through without `buildMergedPool` needing to touch it.
+    ...nextCreatedAt(existing, blockNumber, blockTimestamp),
+    updatedAtBlock: blockNumber,
+    updatedAtTimestamp: blockTimestamp,
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `upsertPool` (`indexer-envio/src/pool.ts`) is the write path for every FPMM/VirtualPool mutation, but ESLint measured its complexity at 57 (budget 15) and cognitive complexity at 34 (budget 18) — both grandfathered in `eslint-baseline.json`.
- The function mixed six pipeline concerns (self-heal reads, breaker-halt recompute, and the full field-merge builder) inline, making it hard to reason about or safely extend.
- Behavior needed to stay byte-for-byte identical — this is the hottest write path in the indexer, so any drift risks silent production data corruption.

## The Solution

- Decomposed `upsertPool` into named, individually-readable stage functions, each mechanically extracted (no logic changes) from the prior inline code, verified stage-by-stage against the issue #1053 characterization tests before every commit.
- `upsertPool` is now a thin orchestrator: three self-heal stages (already extracted in prior work) plus the newly-extracted fee/feed heal, breaker-halt recompute, and field-merge stages.
- Retired the two `src/pool.ts` complexity / cognitive-complexity entries from `eslint-baseline.json` now that both `upsertPool` and every extracted helper are within budget.

## Details

Pipeline order preserved exactly (no reordering, no new short-circuits):

1. **invert-heal** — `selfHealInvertRateFeed` (pre-existing, `src/pool/self-heal.ts`). Unchanged.
2. **wrapped-exchange link** — `selfHealWrappedExchangeId` (pre-existing, same file, guarded by `hasCompleteWrappedExchangeLink`). Unchanged — not touched per the issue's hard rule.
3. **decimals heal** — `selfHealTokenDecimals` (pre-existing, same file). Unchanged.
4. **fee/feed heal** (new) — `healReferenceRateFeed` (pool row + chainId/poolAddr/blockNumber in → `{ healedFeedId, healedOracleDelta }` out) and `healPoolFees` (pool row + chainId/poolAddr in → `healedFees` partial out). Same gates, same effect calls as the removed inline blocks.
5. **breaker-halt recompute** (new) — `resolveFeedIdAndBreakerHalt` (existing pool + caller/healed feed IDs in → `{ finalReferenceRateFeedID, breakerTripped }` out). Same `??` precedence (caller param > self-heal > existing) and same `breakerTrippedOnFeedAssign` call.
6. **field merge** (new) — `buildMergedPool` (existing pool + every heal/delta input in → merged `Pool` row out). Same merge order: healed fields → caller `oracleDelta` → healed fees → `referenceRateFeedID`/`breakerTripped` applied after the spread chain → decimals → timestamps. Three further sub-helpers were split out of this stage purely to clear its own complexity/line budget (no behavior change): `resolveTokenDecimalsFields` (the OR-merge + known-pair gate), `mergeHealedDeltas` (the three-way spread), `nextCreatedAt` (first-touch stamping).

Two functions from commits 1-2 (`healReferenceRateFeed`, `resolveFeedIdAndBreakerHalt`) were tightened from five positional params to an args object during the field-merge commit — the extraction surfaced `max-params` violations that weren't visible until that stage's lint run.

Not touched: `hasCompleteWrappedExchangeLink` (`src/pool/self-heal.ts:501-535`), `recordBreachTransition`/deviation-breach math (`src/deviationBreach.ts`, already has its own grandfathered eslint-disable), and `computeHealthStatus`/breach helpers (`src/pool/health.ts`). None of the price-difference/degenerate-reserve/breach-pipeline logic in the tail of `upsertPool` needed extraction — after the three commits above, `upsertPool`'s own complexity was already within budget.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test` — baseline (pre-change, clean run): 1016 passed, 19 skipped, 0 failed (68 files passed, 2 skipped). After all four commits: 1016 passed, 19 skipped, 0 failed (68 files passed, 2 skipped) — identical counts.
- Targeted re-run after every commit of the 10 test files covering this code path (`test/upsertPoolStages.test.ts`, `upsertPoolIdempotency.test.ts`, `wrappedExchangeGate.test.ts`, `stateSyncReconcile.test.ts`, `fpmmBatchOrdering.test.ts`, `tradingLimitConfigChange.test.ts`, `pool.test.ts`, `biPoolManager.test.ts`, `healthStatusParity.test.ts`, `self-heal.test.ts`): 139/139 passed, no assertion changes, every time.
- `test/healthStatusParity.test.ts` explicitly green (27/27).
- `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean.
- `pnpm --filter @mento-protocol/indexer-envio lint` — clean, zero new baseline entries anywhere in the package; the two `src/pool.ts` entries are gone.
- `pnpm agent:quality-gate --run` — all mapped commands pass (trunk check, lint, typecheck, `test:coverage`, knip, code-health:deps). Coverage floors not lowered.
- `pnpm agent:autoreview -- --engine claude --mode branch --base origin/main` — clean, no accepted findings (confidence 0.93, "patch is correct").

Note on sandbox flakiness: isolated full-suite runs in this sandboxed dev environment occasionally show 2-13 unrelated test timeouts (`Test timed out in 60000ms`) under full parallel load — a different random subset of files each run (bridge handlers, breaker handlers, swap-reserves, snapshot boundary tests), never anything touching `pool.ts`/self-heal/breach code. The reported final run above was a clean one matching baseline exactly; this is flagged here for transparency, not as a regression.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1056

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the indexer’s central pool write path (oracle self-heal, fees, breaker halt, field merge); risk is mitigated by mechanical extraction and existing characterization tests, but any subtle merge-order drift could corrupt persisted pool state.
> 
> **Overview**
> Splits the oversized **`upsertPool`** path in `pool.ts` into a thin orchestrator that calls named stages in **`pool/upsert-stages.ts`**, without changing pipeline order or merge rules.
> 
> **`DEFAULT_ORACLE_FIELDS`** moves to the new module and is still re-exported from `pool.ts` so handler imports stay the same. New exports include **`healReferenceRateFeed`**, **`healPoolFees`**, **`resolveFeedIdAndBreakerHalt`**, and **`buildMergedPool`** (with small helpers for token decimals, healed deltas, and created-at stamping). Price-difference, degenerate-reserve, and breach logic remain in **`upsertPool`**.
> 
> Removes the two grandfathered **`src/pool.ts`** complexity / cognitive-complexity entries from **`eslint-baseline.json`** now that **`upsertPool`** is within lint budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa0057366fcd237fc953f6865dc218dd8469e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->