### PR TITLE
test(indexer): re-pin coverage floors after scenario-test wave

### DIFF
--- a/indexer-envio/vitest.config.ts
+++ b/indexer-envio/vitest.config.ts
@@ -42,7 +42,8 @@ export default defineConfig({
         "src/handlers/steth/**/*.ts",
         "src/rpc/susds.ts",
       ],
-      // Floors = floor(measured) - 2, measured 2026-06-15.
+      // Floors = floor(measured) - 2, measured 2026-07-05, after the
+      // must-cover scenario-test wave (#1052, #1053, #1054) landed on main.
       //
       // The ~12.4k lines under src/handlers/** were previously excluded from
       // coverage entirely — exercised end-to-end by the integration harness
@@ -56,15 +57,15 @@ export default defineConfig({
       // paths, not rare-event branches — the bucket's job is visibility plus a
       // regression ratchet, not a high bar. Raising it is follow-up work.
       thresholds: {
-        statements: 47,
-        branches: 42,
-        functions: 56,
-        lines: 48,
+        statements: 49,
+        branches: 44,
+        functions: 59,
+        lines: 50,
         "src/handlers/**/*.ts": {
-          statements: 22,
-          branches: 14,
-          functions: 29,
-          lines: 22,
+          statements: 24,
+          branches: 18,
+          functions: 32,
+          lines: 24,
         },
         // Re-pins the pre-#925 non-handler floor so a coverage regression in
         // well-tested code (rpc.ts, pool.ts, helpers.ts, src/pool/**, src/rpc/**,
@@ -72,18 +73,18 @@ export default defineConfig({
         // the global pool. Two globs are needed: picomatch's !(handlers) extglob
         // requires a child segment, so "src/!(handlers)/**/*.ts" covers non-handler
         // subdirs but silently misses direct children of src/. "src/*.ts" fills
-        // that gap. Floors = floor(measured) - 2.
+        // that gap. Floors = floor(measured) - 2, measured 2026-07-05.
         "src/*.ts": {
-          statements: 74,
-          branches: 71,
-          functions: 76,
-          lines: 77,
+          statements: 76,
+          branches: 72,
+          functions: 79,
+          lines: 79,
         },
         "src/!(handlers)/**/*.ts": {
-          statements: 65,
-          branches: 52,
+          statements: 67,
+          branches: 54,
           functions: 75,
-          lines: 66,
+          lines: 69,
         },
       },
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The three must-cover scenario-test PRs (#1052, #1053, #1054, merged as #1084, #1086, #1085) deliberately left `indexer-envio/vitest.config.ts` coverage floors untouched to avoid three-way merge conflicts and under-counting.
- Now that all three are on `main`, the floors no longer reflect the indexer's actual (higher) coverage, so the gate isn't ratcheting.

## The Solution

- Re-measured full-suite coverage on `main` and raised every floor to `floor(measured) - 2` per the repo convention, never lowering an existing floor.

## Details

- Measured with `pnpm --filter @mento-protocol/indexer-envio test:coverage` (1039 tests, 73 files). Ran it 3 times to check for flake: the first run measured marginally higher (likely first-run warm-up variance), the second and third were byte-identical, so the floors are pinned off the stable, reproducible (and more conservative) pair of runs.
- Floor table (`floor(measured) - 2`, all raised, none lowered):

  | Bucket | Metric | Before | After | Measured |
  |---|---|---|---|---|
  | Global | Statements | 47 | 49 | 51.95% |
  | Global | Branches | 42 | 44 | 46.92% |
  | Global | Functions | 56 | 59 | 61.05% |
  | Global | Lines | 48 | 50 | 52.76% |
  | `src/handlers/**/*.ts` | Statements | 22 | 24 | 26.01% |
  | `src/handlers/**/*.ts` | Branches | 14 | 18 | 20.74% |
  | `src/handlers/**/*.ts` | Functions | 29 | 32 | 34.65% |
  | `src/handlers/**/*.ts` | Lines | 22 | 24 | 26.57% |
  | `src/*.ts` | Statements | 74 | 76 | 78.42% |
  | `src/*.ts` | Branches | 71 | 72 | 74.79% |
  | `src/*.ts` | Functions | 76 | 79 | 81.45% |
  | `src/*.ts` | Lines | 77 | 79 | 81.1% |
  | `src/!(handlers)/**/*.ts` | Statements | 65 | 67 | 69.81% |
  | `src/!(handlers)/**/*.ts` | Branches | 52 | 54 | 56.33% |
  | `src/!(handlers)/**/*.ts` | Functions | 75 | 75 | 77.64% |
  | `src/!(handlers)/**/*.ts` | Lines | 66 | 69 | 71.2% |

- `src/!(handlers)/**/*.ts` functions floor is unchanged: `floor(77.64) - 2 = 75`, which equals the existing floor exactly (not a lowering case — just no headroom to raise this round).
- Updated the `measured YYYY-MM-DD` date comments in both threshold blocks to 2026-07-05 and referenced the closing issues (#1052, #1053, #1054) in the top comment, matching the existing comment style.
- Scope: only `indexer-envio/vitest.config.ts` changed — no source or test changes.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test:coverage` — 1039 passed / 19 skipped, all coverage thresholds (global + 3 glob buckets) pass at the new floors, zero threshold errors.
- `pnpm --filter @mento-protocol/indexer-envio typecheck` — passes.
- `./tools/trunk fmt` / pre-push quality gate — passes (ran automatically on push: codegen, install, trunk check, hermetic-vitest check, lint, typecheck, test:coverage, knip, code-health:deps all green).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1081

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to test coverage floors; no runtime, auth, or production logic is touched.
> 
> **Overview**
> Raises **Vitest coverage thresholds** in `indexer-envio/vitest.config.ts` so CI matches current full-suite measurements after the must-cover scenario tests (#1052, #1053, #1054) landed on `main`.
> 
> Every bucket uses the existing **`floor(measured) - 2`** rule: global gates and the `src/handlers/**/*.ts`, `src/*.ts`, and `src/!(handlers)/**/*.ts` pools all move up by a few points (non-handler **functions** stays at 75). Comments now record measurement date **2026-07-05** and why the re-pin happened. No indexer source or test files change—only the coverage ratchet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0137e98ec18e4a2a2d3d283f118e098c66508fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->