### PR TITLE
docs: continue root AGENTS.md line diet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,20 +30,9 @@ use.
 ## Cross-Protocol Context
 
 For any protocol-level question that crosses beyond this monitoring repo, first
-read the private `mento-master-context` router when the checkout is available:
-
-```text
-../mento-master-context/.agents/mento-context/README.md
-```
-
-This applies before broad repo searches for questions about contracts,
-deployments, addresses, ABIs, live on-chain state, stable supply, reserve data,
-monitoring data semantics, Aegis/Grafana metrics, docs, the whitepaper, business
-model, or legal/risk framing. Load only the relevant master-context card(s), then
-return to this repo for implementation details. It is a router, not live truth;
-verify current values through the source-specific repo, API, RPC, or dashboard
-path it points to. When answering, mention which master-context card you used or
-state that the checkout was unavailable.
+read the private `mento-master-context` router when the checkout is available.
+See `docs/notes/cross-protocol-context.md` for the router path, what it covers,
+and the verify-before-use rule.
 
 ## Secrets Rule (IaC Before CLI)
 
@@ -63,23 +52,10 @@ finished, or plan feedback is required), send a brief spoken nudge with `sag` in
 addition to the normal chat message. See `docs/notes/spoken-attention-nudge.md`
 for the fallback ladder, key-file setup, and pre-approval constraints.
 
-> **Any PR that adds or changes stateful data flow across layers must ship with explicit invariants, degraded-mode behavior, and interaction tests before opening.**
-
-This repo has already paid the tax for learning this the hard way.
-
-If your change touches any combination of:
-
-- Envio schema/entities
-- event handlers / entity writers
-- generated types / GraphQL queries / dashboard types
-- paginated or sortable UI state
-- partial failure behavior (missing counts, stale RPC, missing txHash, etc.)
-
-then you are expected to run the dedicated PR checklist before opening or updating the PR:
+Any PR that adds or changes stateful data flow across layers must run the
+dedicated PR checklist before opening or updating the PR:
 
 - **Checklist:** `docs/pr-checklists/stateful-data-ui.md`
-
-Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
 
 ## Issue-Driven Backlog
 
@@ -145,10 +121,9 @@ pnpm agent:prewarm --base origin/main  # warm Turbo's local cache for the same m
 The gate is local-only (never deploy or Terraform apply) and refuses `--run`
 when package manifests, the lockfile, `.npmrc`, pnpmfile, or `patches/**`
 changed until you review the script/lifecycle diff and pass
-`--allow-package-script-changes`. The Trunk pre-push hook delegates to this
-same gate with `--fail-fast --skip-if-fresh`. For parallelism knobs, Turbo
-caching rules, the package-script refusal exceptions, and Codex-native review
-bundle prep, see `docs/notes/agent-quality-gate-mechanics.md`.
+`--allow-package-script-changes`. For parallelism knobs, Turbo caching rules,
+the pre-push hook delegation, the package-script refusal exceptions, and
+Codex-native review bundle prep, see `docs/notes/agent-quality-gate-mechanics.md`.
 
 ## PR description standard
 
@@ -416,17 +391,9 @@ Each package has its own `AGENTS.md` (Claude Code reads them as `CLAUDE.md` via 
 
 - Indexer needs Docker for local dev (Postgres + Hasura containers)
 - Dashboard localhost UI review defaults to the live production Envio endpoint
-  when `NEXT_PUBLIC_HASURA_URL` is unset, so fresh worktrees should verify
-  against real pool/CDP data by default. Set `NEXT_PUBLIC_HASURA_URL` only when
-  a task explicitly needs a non-prod or fixture endpoint. Hosted testnet
-  networks require `NEXT_PUBLIC_SHOW_TESTNET_NETWORKS=true` plus the
-  per-network endpoint env (`NEXT_PUBLIC_HASURA_URL_TESTNET` for Monad Testnet
-  or `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA` for Celo Sepolia); leave them unset
-  unless the task explicitly needs testnet UI coverage. Real
-  address-label/authenticated surfaces also need `UPSTASH_REDIS_REST_URL`,
-  `UPSTASH_REDIS_REST_TOKEN`, and local Auth.js placeholders (`AUTH_SECRET`,
-  `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`). See `ui-dashboard/AGENTS.md` for the
-  logged-in/logged-out verification workflow and local session-cookie recipe.
+  when `NEXT_PUBLIC_HASURA_URL` is unset. See `ui-dashboard/AGENTS.md` for
+  testnet env vars, Upstash/Auth.js local setup, and the logged-in/logged-out
+  verification workflow.
 - Production env vars are managed by Terraform except Vercel Blob OIDC variables, which are managed by the Vercel store integration — see `terraform/terraform.tfvars.example`
 - See root README.md for full env var documentation
 
@@ -454,86 +421,26 @@ lives in `.codex/config.toml`; local personal Codex settings still belong in
 
 `autoreview` is pinned in this repo through `scripts/agent-autoreview.mjs` and
 exposed with `pnpm agent:autoreview`; Claude Code also has `/autoreview` as a
-thin command shim. The repo adapter detects active Codex sandbox sessions and
-uses the helper's local deterministic engine by default so the command does not
-try to spawn unavailable nested `codex exec`; explicit `--engine` arguments and
-`AUTOREVIEW_ENGINE` still take precedence. `AUTOREVIEW_HELPER` is an escape
-hatch for intentional local testing or replacement, not a Cloud prerequisite.
-The adapter also exposes `--prepare-bundle-dir <dir>` to create a repo-context
-review bundle with changed paths, patch files, selected checklists, optional
-`--feedback-pr` feedback state, and the helper's prepared prompt.
-Keep the repo-local helper as the source of truth for this repo's required
-ship gate; update it deliberately when taking upstream improvements from a
-personal/global skill.
-
-Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
-`~/.claude` directories; setup and maintenance rely on the repo-local helper at
-`scripts/agent-autoreview.mjs`, which fails fast if missing. PR shipping
-requires `pnpm agent:autoreview` as the structured batch-boundary review.
-Configure the environment setup script as `./scripts/codex-cloud-setup.sh` and
-the optional maintenance script as `./scripts/codex-cloud-maintenance.sh`. Full
-mechanics (GitHub CLI bootstrap, Trunk/Foundry install and mirror knobs, OSV
-egress check, maintenance fast-path) live in
-`docs/notes/codex-cloud-setup.md`.
-
-For workflow continuity, this repo includes thin repo-local `ship` and
-`babysit-pr` skill adapters under `.agents/skills/` with matching
-`.claude/skills/` mirrors. They preserve the familiar command names while
-backing the behavior with repo-visible commands: `pnpm agent:quality-gate`,
-`pnpm agent:autoreview` when available, and `pnpm pr:ready-state`.
-
-### SessionEnd hook (reflect nudge)
-
-`scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/reflect` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
-
-- Claude wiring: `.claude/settings.json` → `hooks.SessionEnd`.
-- Codex wiring: `.codex/hooks.json`. Codex auto-disables new hooks until trusted; on first encounter, codex either prompts to trust or you mirror the entry into `~/.codex/hooks.json` and toggle `enabled = true` (set the hash) in `[hooks.state]` of `~/.codex/config.toml`. Or pass `--dangerously-bypass-hook-trust` for automation.
-
-### Status-polling commands use `Monitor`, not `/loop`
-
-For commands that watch a long-running external process (Envio sync, PR CI, deploy progress, etc.), prefer the `Monitor` tool over `/loop` + cron. Monitor runs a single shell script that polls internally at 30–60s and only emits stdout lines (== notifications) on state changes worth surfacing. Cron / `/loop` fires a full Stop turn per interval, which triggers a macOS notification regardless of whether anything changed — a 60-min sync produces ~12 idle notifications, vs 2–3 with Monitor. `babysit-indexer-deploy` and `babysit-pr` are the canonical examples; if you find yourself writing a new "watch X every Y minutes" command, model it on those.
+thin command shim. Codex Cloud setup/maintenance use
+`./scripts/codex-cloud-setup.sh` / `./scripts/codex-cloud-maintenance.sh`. See
+`docs/notes/codex-agent-skills.md` for the autoreview engine-detection and
+bundle-prep mechanics, Codex Cloud setup detail, the `ship`/`babysit-pr` skill
+adapters, the SessionEnd reflect-nudge hook, and why status-polling commands
+use `Monitor` instead of `/loop`.
 
 ## New Worktree / Clone Setup
 
-After creating a new worktree manually or cloning the repo, run:
-
-```bash
-./scripts/setup.sh
-```
-
-This ensures deps are installed, Playwright Chromium is available for dashboard
-browser tests, and Envio codegen has produced the generated type facade
-required for `indexer-envio` TypeScript to compile.
-Worktrunk-created worktrees (`wt switch --create` / `wt switch -c`) run the
-same setup script automatically through `.config/wt.toml` as a blocking
-`pre-start` hook before any `--execute` command starts.
+After creating a new worktree manually or cloning the repo, run
+`./scripts/setup.sh`. See `docs/notes/worktree-and-web-setup.md` for what it
+installs/verifies and the Worktrunk `pre-start` hook wiring.
 
 ## Claude Code on the web setup
 
-Claude Code on the web sessions run in a hosted container that does not inherit
-the user's local `~/.claude` skills or shell environment. The repo bootstraps
-itself through a SessionStart hook (`.claude/settings.json` →
-`.claude/hooks/session-start.sh`) that delegates to:
-
-```bash
-./scripts/claude-code-web-setup.sh
-```
-
-The script is gated on `$CLAUDE_CODE_REMOTE` so it is a no-op for local Claude
-Code sessions. It performs the same install + codegen contract as
-`./scripts/setup.sh` plus a Playwright Chromium install for the dashboard
-browser fixture suite. The Playwright step is non-fatal: hosted environments
-that restrict outbound access to `cdn.playwright.dev` will skip the download
-and warn instead of failing the bootstrap.
-
-Repo-local `ship` and `babysit-pr` skill adapters live under `.claude/skills/`
-(mirrored under `.agents/skills/` for Codex), so the familiar `/ship` and
-`/babysit-pr` workflows resolve to repo-visible commands (`pnpm
-agent:quality-gate`, `pnpm agent:autoreview`, `pnpm pr:ready-state`) without
-needing a developer's personal skills present. When the Claude `Monitor` tool
-is unavailable in the hosted session, the `babysit-pr` skill falls back to
-`pnpm pr:ready-state --pr <number> --watch --compact` as the foreground watch
-loop.
+Claude Code on the web sessions run in a hosted container that bootstraps
+itself through a SessionStart hook delegating to
+`./scripts/claude-code-web-setup.sh`. See `docs/notes/worktree-and-web-setup.md`
+for the hosted-container bootstrap contract, the Playwright fallback behavior,
+and the `babysit-pr` `Monitor` fallback.
 
 ## Pre-Push Checklist (MANDATORY for server-side work)
 
@@ -559,10 +466,7 @@ Before pushing any cross-layer or stateful UI change, also read and apply:
 
 - **`docs/pr-checklists/stateful-data-ui.md`**
 
-**Common traps:**
-
-- `codespell` flags short variable names that match common abbreviations (e.g. a two-letter loop var that looks like a misspelling). Use descriptive names like `netData` to avoid this.
-- `trunk check <file>` only checks the specified files. That is fine for the path-aware local agent gate, but use `--all` when you need to manually reproduce CI's full-repo Trunk job.
-- If `indexer-envio typecheck` fails with "Cannot find module 'generated'", run `./scripts/setup.sh` first
+See `docs/notes/agent-quality-gate-mechanics.md` for common local-gate traps
+(codespell false positives, `trunk check` scoping, missing `generated` module).
 
 For package-specific workflows (promoting a deployment, adding a contract to the indexer, dashboard chart wiring, infrastructure changes), see the relevant package's `AGENTS.md` — they own the procedural detail.

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -151,3 +151,9 @@ size-limit reads `.next/` output; the local gate relies on that dependency
 instead of mapping a separate dashboard build command for size-limit checks.
 High-risk or cross-layer commands stay outside Turbo, including codegen,
 install, dep-cruiser, coverage floors, mutation baselines, and Terraform.
+
+## Common local-gate traps
+
+- `codespell` flags short variable names that match common abbreviations (e.g. a two-letter loop var that looks like a misspelling). Use descriptive names like `netData` to avoid this.
+- `trunk check <file>` only checks the specified files. That is fine for the path-aware local agent gate, but use `--all` when you need to manually reproduce CI's full-repo Trunk job.
+- If `indexer-envio typecheck` fails with "Cannot find module 'generated'", run `./scripts/setup.sh` first

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -1,0 +1,61 @@
+---
+title: Codex Agent Skills — Mechanics
+status: active
+owner: eng
+last_verified: 2026-07-06
+---
+
+# Codex Agent Skills
+
+The invocation pointer (where skills live, autoreview command, Codex Cloud
+scripts) lives in the "Codex Agent Skills" section of root `AGENTS.md`. This
+note holds the underlying mechanics.
+
+Repo-tracked project skills live under `.agents/skills/`. Keep durable,
+team-shareable project workflows there instead of relying on local-only
+`~/.codex` or `~/.claude` state. Cross-project personal skills belong in
+`~/.agents/skills` and should be exposed to both agents through the
+`~/.codex/skills` and `~/.claude/skills` mirrors. Project-level Codex MCP config
+lives in `.codex/config.toml`; local personal Codex settings still belong in
+`~/.codex/config.toml`.
+
+`autoreview` is pinned in this repo through `scripts/agent-autoreview.mjs` and
+exposed with `pnpm agent:autoreview`; Claude Code also has `/autoreview` as a
+thin command shim. The repo adapter detects active Codex sandbox sessions and
+uses the helper's local deterministic engine by default so the command does not
+try to spawn unavailable nested `codex exec`; explicit `--engine` arguments and
+`AUTOREVIEW_ENGINE` still take precedence. `AUTOREVIEW_HELPER` is an escape
+hatch for intentional local testing or replacement, not a Cloud prerequisite.
+The adapter also exposes `--prepare-bundle-dir <dir>` to create a repo-context
+review bundle with changed paths, patch files, selected checklists, optional
+`--feedback-pr` feedback state, and the helper's prepared prompt.
+Keep the repo-local helper as the source of truth for this repo's required
+ship gate; update it deliberately when taking upstream improvements from a
+personal/global skill.
+
+Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
+`~/.claude` directories; setup and maintenance rely on the repo-local helper at
+`scripts/agent-autoreview.mjs`, which fails fast if missing. PR shipping
+requires `pnpm agent:autoreview` as the structured batch-boundary review.
+Configure the environment setup script as `./scripts/codex-cloud-setup.sh` and
+the optional maintenance script as `./scripts/codex-cloud-maintenance.sh`. Full
+mechanics (GitHub CLI bootstrap, Trunk/Foundry install and mirror knobs, OSV
+egress check, maintenance fast-path) live in
+`docs/notes/codex-cloud-setup.md`.
+
+For workflow continuity, this repo includes thin repo-local `ship` and
+`babysit-pr` skill adapters under `.agents/skills/` with matching
+`.claude/skills/` mirrors. They preserve the familiar command names while
+backing the behavior with repo-visible commands: `pnpm agent:quality-gate`,
+`pnpm agent:autoreview` when available, and `pnpm pr:ready-state`.
+
+## SessionEnd hook (reflect nudge)
+
+`scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/reflect` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
+
+- Claude wiring: `.claude/settings.json` → `hooks.SessionEnd`.
+- Codex wiring: `.codex/hooks.json`. Codex auto-disables new hooks until trusted; on first encounter, codex either prompts to trust or you mirror the entry into `~/.codex/hooks.json` and toggle `enabled = true` (set the hash) in `[hooks.state]` of `~/.codex/config.toml`. Or pass `--dangerously-bypass-hook-trust` for automation.
+
+## Status-polling commands use `Monitor`, not `/loop`
+
+For commands that watch a long-running external process (Envio sync, PR CI, deploy progress, etc.), prefer the `Monitor` tool over `/loop` + cron. Monitor runs a single shell script that polls internally at 30–60s and only emits stdout lines (== notifications) on state changes worth surfacing. Cron / `/loop` fires a full Stop turn per interval, which triggers a macOS notification regardless of whether anything changed — a 60-min sync produces ~12 idle notifications, vs 2–3 with Monitor. `babysit-indexer-deploy` and `babysit-pr` are the canonical examples; if you find yourself writing a new "watch X every Y minutes" command, model it on those.

--- a/docs/notes/cross-protocol-context.md
+++ b/docs/notes/cross-protocol-context.md
@@ -1,0 +1,24 @@
+---
+title: Cross-Protocol Context
+status: active
+owner: eng
+last_verified: 2026-07-06
+---
+
+# Cross-Protocol Context
+
+For any protocol-level question that crosses beyond this monitoring repo, first
+read the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for questions about contracts,
+deployments, addresses, ABIs, live on-chain state, stable supply, reserve data,
+monitoring data semantics, Aegis/Grafana metrics, docs, the whitepaper, business
+model, or legal/risk framing. Load only the relevant master-context card(s), then
+return to this repo for implementation details. It is a router, not live truth;
+verify current values through the source-specific repo, API, RPC, or dashboard
+path it points to. When answering, mention which master-context card you used or
+state that the checkout was unavailable.

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -1,0 +1,54 @@
+---
+title: New Worktree / Clone Setup and Claude Code on the Web Setup
+status: active
+owner: eng
+last_verified: 2026-07-06
+---
+
+# New Worktree / Clone Setup and Claude Code on the Web Setup
+
+The invocation pointers live in the "New Worktree / Clone Setup" and "Claude
+Code on the web setup" sections of root `AGENTS.md`. This note holds the
+underlying mechanics.
+
+## New Worktree / Clone Setup
+
+After creating a new worktree manually or cloning the repo, run:
+
+```bash
+./scripts/setup.sh
+```
+
+This ensures deps are installed, Playwright Chromium is available for dashboard
+browser tests, and Envio codegen has produced the generated type facade
+required for `indexer-envio` TypeScript to compile.
+Worktrunk-created worktrees (`wt switch --create` / `wt switch -c`) run the
+same setup script automatically through `.config/wt.toml` as a blocking
+`pre-start` hook before any `--execute` command starts.
+
+## Claude Code on the web setup
+
+Claude Code on the web sessions run in a hosted container that does not inherit
+the user's local `~/.claude` skills or shell environment. The repo bootstraps
+itself through a SessionStart hook (`.claude/settings.json` →
+`.claude/hooks/session-start.sh`) that delegates to:
+
+```bash
+./scripts/claude-code-web-setup.sh
+```
+
+The script is gated on `$CLAUDE_CODE_REMOTE` so it is a no-op for local Claude
+Code sessions. It performs the same install + codegen contract as
+`./scripts/setup.sh` plus a Playwright Chromium install for the dashboard
+browser fixture suite. The Playwright step is non-fatal: hosted environments
+that restrict outbound access to `cdn.playwright.dev` will skip the download
+and warn instead of failing the bootstrap.
+
+Repo-local `ship` and `babysit-pr` skill adapters live under `.claude/skills/`
+(mirrored under `.agents/skills/` for Codex), so the familiar `/ship` and
+`/babysit-pr` workflows resolve to repo-visible commands (`pnpm
+agent:quality-gate`, `pnpm agent:autoreview`, `pnpm pr:ready-state`) without
+needing a developer's personal skills present. When the Claude `Monitor` tool
+is unavailable in the hosted session, the `babysit-pr` skill falls back to
+`pnpm pr:ready-state --pr <number> --watch --compact` as the foreground watch
+loop.

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -6,6 +6,8 @@ Use this checklist for any PR that changes stateful data flow across layers.
 
 > **Any PR that adds or changes stateful data flow across layers must ship with explicit invariants, degraded-mode behavior, and interaction tests before opening.**
 
+This repo has already paid the tax for learning this the hard way.
+
 If the change touches any combination of:
 
 - Envio schema/entities
@@ -15,6 +17,8 @@ If the change touches any combination of:
 - partial failure behavior (count query failure, stale RPC, missing metadata, old rows after schema rollout)
 
 then this checklist is mandatory.
+
+Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
 
 ---
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Root `AGENTS.md` was still 566 lines after #1058's diet (785 -> 566), above the `docs/context-standards.md` guidance and the `<= ~450` target from #1058's own scope note.
- The 566-line file still had repeatable-procedure prose (cross-protocol router usage, Codex Agent Skills mechanics, worktree/web-session bootstrap detail) inline in root instead of in `docs/notes/`, plus some content duplicated verbatim elsewhere (the stateful-data-ui checklist gate, dashboard testnet env vars already in `ui-dashboard/AGENTS.md`).

## The Solution

- Move more repeatable-procedure prose verbatim into `docs/notes/` (new files: `cross-protocol-context.md`, `codex-agent-skills.md`, `worktree-and-web-setup.md`), following the exact "verbatim move + 2-3 line pointer" pattern #1058 established for `docs/notes/codex-cloud-setup.md`.
- Trim prose that duplicated content already canonical elsewhere (the stateful-data-ui operating-rule blockquote already at the top of `docs/pr-checklists/stateful-data-ui.md`; the dashboard testnet/Auth.js env-var detail already in `ui-dashboard/AGENTS.md`) down to short pointers, preserving the two sentences that were unique to root by moving them verbatim into the checklist file.
- Move the Pre-Push Checklist's "Common traps" bullets verbatim into the existing `docs/notes/agent-quality-gate-mechanics.md` note.
- Root `AGENTS.md`: 566 -> 472 lines, zero information loss.

## Details

- Protected per the issue: Operating Rule, Secrets Rule, the PR-workflow/ship section family (`PR description standard` through `Recurring PR-review patterns`), Issue-Driven Backlog, package-routing index, and the Quick Commands reference block are all untouched.
- New `docs/notes/*.md` files do NOT carry `canonical: true` frontmatter, per the explicit task instruction for this issue (matching the non-canonical precedent of `docs/notes/codex-cloud-setup.md` from #1058). They do carry lightweight `title`/`status`/`owner`/`last_verified` frontmatter (no `canonical` key), matching the majority pattern already used by several other `docs/notes/*.md` files (e.g. `pr-ready-state.md`, `file-size-watch.md`) — this satisfies `pnpm agent:context-check` without pulling them into the staleness-enforced canonical set.
- Grepped repo-wide (`AGENTS.md`, `docs/`, `.agents/`, `.claude/`) for anchors/links into the moved sections; found none (no anchor-style links reference these headings elsewhere).
- Did not touch root `AGENTS.md`'s `last_verified` frontmatter, matching repo precedent for docs-only edits that don't change canonical facts.
- Non-goal (per issue): package-level `AGENTS.md` files were read for cross-reference but not edited.

## Validation

```
wc -l AGENTS.md
# 472 (was 566)

pnpm agent:context-check
# Agent context check passed (27 managed files).

pnpm agent:quality-gate --run
# All mapped commands passed (trunk check on changed docs, agent:context-check).

./tools/trunk fmt --all
# Checked 1387 files — No issues (no diff)
```

`pnpm agent:autoreview` raised one finding (see Deferrals) that conflicts with
this issue's explicit "no `canonical: true`" instruction; documented below
rather than silently resolved either way.

## Deferrals

- `pnpm agent:autoreview` flagged (P2, confidence 0.86) that the new `docs/notes/*.md` files this PR delegates operating rules to are not `canonical: true`, so `scripts/check-agent-context.mjs`'s staleness enforcement doesn't cover them even though root `AGENTS.md` now depends on them — tracked in #1106 for a maintainer to set the actual policy (this PR's task instructions explicitly required NOT adding `canonical: true`, citing a `codex-cloud-setup.md` precedent from #1058 that on inspection is mixed: two of the three #1058-created notes actually do carry `canonical: true`).
- Root `AGENTS.md` lands at 472 lines rather than the `<= ~450` target — tracked by #1089 itself (this PR uses `Refs #1089` rather than `Closes #1089` for that reason). The remaining ~472 lines are dominated by protected sections (Operating Rule, Secrets Rule, the PR-workflow family, Issue-Driven Backlog, package-routing index, and Quick Commands total ~321 of the 472 lines); the non-protected remainder (Overview, Agent Quality Gate, Environment, Claude Code Slash Commands, Pre-Push Checklist) is already fairly lean after this pass.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Refs #1089
