### PR TITLE
docs(adr): add architecture decision records + an ADR reminder gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,3 +34,4 @@ When you keep it, CI requires each item to be "None" or link a GitHub issue.
 - [ ] The Solution is plain English and understandable before reading the diff.
 - [ ] Deeper implementation details come after the opening two sections.
 - [ ] Every knowing deferral is listed under Deferrals with a GitHub issue link.
+- [ ] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,15 @@ Context authority, placement, and metadata rules live in
 and non-canonical notes/plans as historical input that must be verified before
 use.
 
+Architecture decisions and the rationale behind the system's shape are recorded
+in [`docs/adr/`](docs/adr/README.md) — read the ADR that governs a subsystem
+before changing how it is built. When your change **makes** an architectural
+decision (it constrains future work, had a real alternative, and the why is not
+obvious from the code), record a new ADR in the same PR. `pnpm adr:check` and the
+agent quality gate remind you on architectural surfaces (new package, Terraform
+stack, or workflow); the when/how procedure is
+[`docs/pr-checklists/architecture-decisions.md`](docs/pr-checklists/architecture-decisions.md).
+
 ## Cross-Protocol Context
 
 For any protocol-level question that crosses beyond this monitoring repo, first
@@ -313,6 +322,8 @@ pnpm lockfile:lint                 # Lockfile integrity + registry check (blocki
 pnpm skew:check                    # Dependency version-skew check vs the pnpm catalog (blocking; no install needed)
 pnpm sanitize:test                 # Fixture tests for scripts/sanitize-terraform-output.sh (terraform output secret redaction)
 pnpm override:prune-report          # pnpm.overrides + minimumReleaseAgeExclude pruning report (advisory; no install needed)
+pnpm adr:check                      # Advisory ADR reminder for architectural changes (new package/stack/workflow); --strict to hard-gate
+pnpm adr:check:test                 # Offline tests for the ADR reminder trigger logic
 node scripts/check-github-action-pins.mjs  # Verify workflow/composite-action `uses:` refs are SHA-pinned
 node scripts/check-hermetic-vitest-setup.mjs  # Verify all workspace Vitest network guards are byte-identical
 node scripts/file-size-watchlist.mjs  # Refresh source file-size watchlist; use --format issue for GitHub Issues, not BACKLOG.md

--- a/aegis/AGENTS.md
+++ b/aegis/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Aegis
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `aegis`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## Scope
 
 `aegis/` polls configured on-chain view calls and exposes Prometheus metrics for Grafana dashboards and alerts.

--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-21
 
 # AGENTS.md — Alerts
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `alerts`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## Scope
 
 `alerts/` is the domain folder for all alert plumbing. Two independent Terraform stacks live here:

--- a/docs/adr/0001-monorepo-independent-deploys.md
+++ b/docs/adr/0001-monorepo-independent-deploys.md
@@ -1,0 +1,52 @@
+---
+title: One pnpm+Turbo monorepo with independently deployed services
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: repo-wide
+date: 2026-03
+---
+
+# ADR 0001 — One pnpm+Turbo monorepo with independently deployed services
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** repo-wide
+
+## Context
+
+Mento's v3 monitoring is not one app: it is an indexer, a dashboard, a metrics
+exporter, alerting stacks, and several small services that share chain/token
+metadata and evolve together but ship to different platforms (Envio, Vercel,
+Cloud Run, App Engine, Cloud Functions). We needed shared config and atomic
+cross-cutting changes without a release dance across separate repos.
+
+## Decision
+
+Keep everything in one pnpm-workspace + Turbo monorepo. Packages share code
+through workspace packages (notably `@mento-protocol/monitoring-config`), but
+each service owns its own deploy path and deploys **independently** — a change
+to one package does not redeploy the others.
+
+## Alternatives considered
+
+- **Polyrepo (one repo per service)** — rejected: shared chain/token metadata
+  would drift across repos, and a schema-to-UI change would span multiple PRs
+  with no atomic review.
+- **Monorepo with a single coupled deploy** — rejected: the indexer changes
+  rarely and the dashboard changes constantly; coupling them wastes builds and
+  couples blast radius.
+
+## Consequences
+
+- Cross-package invariants (schema → query → UI) can be changed and reviewed in
+  one PR; the repo leans into this with mandatory cross-layer checklists (ADR 0008).
+- Each service needs its own skip/ignore logic so unrelated changes don't trigger
+  its deploy (see ADR 0019 for the dashboard's path-aware Vercel skip).
+- Turbo caches per-package tasks; CI routes checks by changed path.
+
+## Evidence
+
+- `6e001aac` (2026-03-04) initial monorepo setup (Envio indexer + Next.js dashboard).
+- `4737c55e` Vercel deployment automation; PR #188 consolidated per-package checks into one CI workflow.
+- Package map in [`AGENTS.md`](../../AGENTS.md); topology in [`SPEC.md`](../../SPEC.md).

--- a/docs/adr/0002-envio-hosted-indexer.md
+++ b/docs/adr/0002-envio-hosted-indexer.md
@@ -1,0 +1,49 @@
+---
+title: Envio HyperIndex Hosted is the indexer; deploy via a dedicated envio branch
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: repo-wide
+date: 2026-03
+---
+
+# ADR 0002 — Envio HyperIndex Hosted is the indexer; deploy via a dedicated `envio` branch
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** repo-wide (indexer topology)
+
+## Context
+
+We need historical + live indexing of FPMM pools, oracles, breakers, the v2
+Broker, bridges, and reserve-yield across Celo, Monad, and Ethereum, exposed as a
+queryable API — without running our own indexing infrastructure or archival RPC.
+
+## Decision
+
+Use **Envio HyperIndex on Envio's Hosted Service** as the indexer. The production
+indexer is driven by a dedicated `envio` deploy branch that Envio watches; code
+lands on `main` normally and is pushed to `envio` only when the indexer changes.
+Deployments are built, synced, verified, and then **explicitly promoted** to the
+static production endpoint, with a defined rollback path.
+
+## Alternatives considered
+
+- **Self-hosted subgraph / custom indexer** — rejected: operational burden of
+  archival nodes, reorg handling, and sync ops we don't want to own.
+- **Auto-deploy the indexer on every `main` push** — rejected: indexer changes are
+  rare; a deploy branch avoids constant reindexes and keeps promotion deliberate.
+
+## Consequences
+
+- A promote step gates production: sync a deployment, verify rows, then promote —
+  the endpoint hash is static and doesn't change on redeploy.
+- Schema-additive changes must ship as one PR that resyncs and promotes **before**
+  merge, or the dashboard breaks (see the schema-single-PR discipline).
+- Rollback is re-promote-if-live else rebuild+resync; both are scripted.
+
+## Evidence
+
+- `e6ed54ea` (2026-03-04) Envio hosted migration plan; `1ec14042` deploy-branch strategy.
+- Full workflow + rollback in [`docs/deployment.md`](../deployment.md); `deploy:indexer*` scripts.
+- Indexer scope in [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md).

--- a/docs/adr/0003-hasura-graphql-read-api.md
+++ b/docs/adr/0003-hasura-graphql-read-api.md
@@ -1,0 +1,47 @@
+---
+title: Hasura auto-generated GraphQL over Postgres is the read API
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: repo-wide
+date: 2026-03
+---
+
+# ADR 0003 — Hasura auto-generated GraphQL over Postgres is the read API
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** repo-wide (data access)
+
+## Context
+
+The indexer writes entities to Postgres; the dashboard, metrics-bridge, and
+integration-probes all need to read them. We did not want to hand-build and
+maintain a bespoke API layer over the indexer's tables.
+
+## Decision
+
+Read through the **Hasura GraphQL API that Envio auto-generates** over the
+indexer's Postgres tables. All consumers query Hasura; there is no custom read
+service between the database and the clients.
+
+## Alternatives considered
+
+- **A hand-written REST/GraphQL service** — rejected: duplicates schema knowledge
+  the indexer already owns, and adds a service to run and keep in sync.
+- **Clients query Postgres directly** — rejected: couples every client to DB
+  credentials and physical schema, and loses Hasura's query shaping.
+
+## Consequences
+
+- The GraphQL schema is a generated artifact of the Envio schema — schema changes
+  propagate straight to query and UI types (hence ADR 0008's cross-layer checklist).
+- Hasura's `_aggregate` is available but deliberately **not** used for hot paths;
+  we precompute snapshot entities instead (ADR 0014, ADR 0020).
+- Verify production behavior via Hasura introspection, not the indexer CLI, because
+  parallel deploys can prune a CLI-reported entry mid-serve.
+
+## Evidence
+
+- `257f08f1`, `b1169451` (2026-03-04) early Hasura wiring + unconfigured-URL handling.
+- Endpoint + topology in [`SPEC.md`](../../SPEC.md); no-aggregate rule in [`docs/pr-checklists/swr-polling-hasura.md`](../pr-checklists/swr-polling-hasura.md).

--- a/docs/adr/0004-two-alert-planes.md
+++ b/docs/adr/0004-two-alert-planes.md
@@ -1,0 +1,53 @@
+---
+title: Two alert planes — Grafana metric thresholds and event-driven delivery
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: repo-wide
+date: 2026-04
+---
+
+# ADR 0004 — Two alert planes: Grafana metric thresholds and event-driven delivery
+
+**Status:** Accepted (Apr–May 2026), in force.
+**Scope:** repo-wide (alerting)
+
+## Context
+
+Two fundamentally different things need alerting. Some signals are **continuous
+metrics** crossing thresholds (pool health, oracle staleness, TCR/ICR, rebalancer
+liveness, service health). Others are **discrete on-chain events** that must fire
+exactly once when they happen (multisig actions, governance events). One
+mechanism cannot serve both well: thresholds need a metrics store and evaluation;
+events need a webhook that reacts to a specific log.
+
+## Decision
+
+Run **two alert planes**:
+
+1. **Metric-threshold plane** — protocol data becomes Prometheus/Grafana metrics
+   (via Aegis for v2 and metrics-bridge for v3) and Grafana alert rules evaluate
+   thresholds and route to Slack/Splunk On-Call.
+2. **Event-driven plane** — QuickNode webhooks → Cloud Function → Slack for
+   on-chain multisig events, a Sentry→Slack bridge for app errors, and an on-call
+   rotation announcer; governance-watchdog delivers to Discord/Telegram.
+
+## Alternatives considered
+
+- **One plane for everything** — rejected: polling for discrete events is laggy and
+  lossy; threshold logic bolted onto webhooks is fragile.
+- **Alert directly off the database** — rejected: the DB has no evaluation/routing
+  engine; that is exactly why metrics-bridge exists (ADR 0027).
+
+## Consequences
+
+- Alert plumbing lives under `alerts/` in two Terraform roots split by cadence and
+  blast radius (`alerts/rules` daily; `alerts/infra` monthly) — see ADR 0028.
+- Grafana routing is **per-rule**, not a single channel; Slack templates use the
+  Alertmanager funcmap, not sprig.
+
+## Evidence
+
+- metrics-bridge PR #153 (2026-04-17); alerts stack integration PR #514 (2026-05-25); event delivery CI PR #558.
+- [`alerts/AGENTS.md`](../../alerts/AGENTS.md), [`SPEC.md`](../../SPEC.md) §Alerting.

--- a/docs/adr/0005-context-as-product.md
+++ b/docs/adr/0005-context-as-product.md
@@ -1,0 +1,52 @@
+---
+title: Context is product — canonical authority model with a metadata contract
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: repo-wide
+date: 2026-07
+---
+
+# ADR 0005 — Context is product: canonical authority model with a metadata contract
+
+**Status:** Accepted (Jul 2026; roots from Mar 2026 AGENTS hierarchy), in force.
+**Scope:** repo-wide (ci/process)
+
+## Context
+
+This repo is built and operated largely by agents. Their instructions (AGENTS.md,
+SPEC, checklists, notes, plans) accumulated fast and started to contradict each
+other. An agent that follows a stale plan as if it were current truth ships the
+wrong thing. We needed an explicit rule for which documents are binding and which
+are just history.
+
+## Decision
+
+Treat context as part of the product with a two-tier **authority model**:
+**canonical** context (AGENTS.md files, SPEC.md, PR checklists, deployment docs,
+skills/roles) is current operating truth; **non-canonical** context (PLANs, notes,
+archived docs, backlog) is history that must be re-verified before acting. Managed
+files carry YAML frontmatter (`title`, `status`, `owner`, `canonical`,
+`last_verified`), and `pnpm agent:context-check` enforces the contract, including a
+90-day staleness window on canonical files.
+
+## Alternatives considered
+
+- **Flat docs, trust-by-recency** — rejected: agents can't reliably tell a live
+  runbook from an abandoned plan; recency lies after a revert.
+- **Delete all historical docs** — rejected: rationale and intent are valuable; the
+  fix is labeling authority, not erasing history.
+
+## Consequences
+
+- These ADRs are canonical context and are enrolled in the staleness check — that
+  enrollment is the "is this still true?" enforcement.
+- New canonical files are auto-discovered by `canonical: true` frontmatter in the
+  discovery roots (root/nested `AGENTS.md`, `SPEC.md`, `docs/**`, `.agents/**`).
+- Root `AGENTS.md` is kept lean; detail lives in the most specific owning file.
+
+## Evidence
+
+- [`docs/context-standards.md`](../context-standards.md); enforcement in `scripts/check-agent-context.mjs`.
+- PR #1079 (SPEC under the authority model), PR #1090 (root AGENTS token diet), PR #1088 (archive completed PLANs).

--- a/docs/adr/0006-github-issues-backlog.md
+++ b/docs/adr/0006-github-issues-backlog.md
@@ -1,0 +1,48 @@
+---
+title: GitHub Issues are the canonical agent work queue, not BACKLOG.md
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-05
+---
+
+# ADR 0006 — GitHub Issues are the canonical agent work queue, not `BACKLOG.md`
+
+**Status:** Accepted (May–Jun 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+A long-lived `BACKLOG.md` accumulated work items, but agents can't safely _claim_
+a markdown bullet: two sessions grab the same line, nothing tracks who's active,
+and there's no queryable "what's ready" state. Agent-driven work needs a queue
+with atomic claim + state.
+
+## Decision
+
+**GitHub Issues are the canonical active-work queue.** Ready work is
+`label:agent-ready`; a helper (`pnpm issue:claim`) atomically flips labels
+(`agent-ready` → `agent-active` → `in-pr`) and syncs a workboard. `BACKLOG.md` is
+demoted to transition storage only; durable context lives in `AGENTS.md`,
+checklists, notes, or tests.
+
+## Alternatives considered
+
+- **Keep `BACKLOG.md` as the queue** — rejected: no atomic claim, no state labels,
+  no ownership; duplication between the file and reality goes stale immediately.
+- **A third-party project tool** — rejected: Issues already integrate with PRs,
+  labels, and the agents' GitHub tooling.
+
+## Consequences
+
+- Queue-state labels are mutually exclusive (`needs-grooming`, `agent-ready`,
+  `agent-active`, `in-pr`); an agent runs `issue:claim` before substantive edits.
+- Deferrals from a PR must become a labeled issue — the enforcement point for the
+  "don't silently drop scope" rule.
+
+## Evidence
+
+- Backlog→Issues migrations PR #662, #673 (2026-05-28); issue workboard helper PR #984 (2026-06-17).
+- Lifecycle in [`docs/notes/agent-issue-workflow.md`](../notes/agent-issue-workflow.md); rules in [`AGENTS.md`](../../AGENTS.md).

--- a/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
+++ b/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
@@ -1,0 +1,51 @@
+---
+title: Local agent quality gate plus pr:ready-state merge oracle and Codex gate
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-05
+---
+
+# ADR 0007 — Local agent quality gate + `pr:ready-state` merge oracle + Codex approval gate
+
+**Status:** Accepted (Apr–Jun 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+Agent-authored PRs failed CI in slow, expensive loops, and "is this PR actually
+ready?" was answered by eyeballing a noisy checks UI where advisory bots lag the
+real status. We needed a cheap local pre-flight and a single machine-readable
+definition of "ready to merge".
+
+## Decision
+
+Two mechanisms:
+
+- **Local agent quality gate** (`pnpm agent:quality-gate`) maps changed paths to
+  the exact package checks + checklists and runs them locally before push. It is
+  local-only (never deploys) and refuses to run on package-manifest/lockfile
+  changes without explicit review.
+- **`pnpm pr:ready-state`** is the **single merge oracle**: required CI green +
+  threads resolved + a Codex 👍 on the PR description for the current head. Advisory
+  bot lag (e.g. Cursor) does not block unless branch protection requires it.
+
+## Alternatives considered
+
+- **Trust the GitHub checks UI by eye** — rejected: advisory bots trail the status
+  rollup and produce false "not ready" / false "all clear" reads.
+- **CI-only, no local gate** — rejected: CI failures are far more expensive than the
+  same check run locally in seconds.
+
+## Consequences
+
+- A PR is not "clean" until `pr:ready-state` says so _and_ Codex has reacted 👍 on
+  the current head; a review on an older commit does not satisfy the gate.
+- Review is a batch-boundary verifier, not the inner edit loop.
+
+## Evidence
+
+- Aggregate CI PR #188; ready-state gate wiring PR #818 (2026-06-09).
+- Mechanics in [`docs/notes/agent-quality-gate-mechanics.md`](../notes/agent-quality-gate-mechanics.md) and [`docs/notes/pr-ready-state.md`](../notes/pr-ready-state.md).

--- a/docs/adr/0008-mandatory-hazard-checklists.md
+++ b/docs/adr/0008-mandatory-hazard-checklists.md
@@ -1,0 +1,50 @@
+---
+title: Cross-layer and stateful changes must run dedicated PR checklists
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-05
+---
+
+# ADR 0008 — Cross-layer / stateful changes must run dedicated PR checklists
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+The repo repeatedly burned review cycles on the same failure class: a change to
+the Envio schema, an entity writer, generated types, or paginated/sortable UI
+state would ship without defining its invariants or degraded-mode behavior, and
+the query→UI layer was assumed to "just catch up". Reviews were being asked to
+_define_ the design instead of catch misses.
+
+## Decision
+
+Any change touching stateful data flow across layers (schema/entities, handlers,
+generated types/queries, paginated or sortable UI state, partial-failure behavior)
+**must run the dedicated PR checklist before opening or updating the PR** — chiefly
+[`docs/pr-checklists/stateful-data-ui.md`](../pr-checklists/stateful-data-ui.md).
+Invariants, degraded-mode behavior, and interaction tests are authored up front,
+not discovered in review.
+
+## Alternatives considered
+
+- **Rely on reviewers to catch these** — rejected: that makes review define the
+  invariants for the first time, which is exactly what kept failing.
+- **One giant root rule** — rejected: hazard-specific checklists are actionable;
+  a wall of prose is not.
+
+## Consequences
+
+- Checklists are canonical context (ADR 0005); package `AGENTS.md` files hard-link
+  to the relevant one and mark it mandatory.
+- Recurring automated-review hazards are canonicalized so bots don't re-litigate
+  settled patterns.
+
+## Evidence
+
+- [`docs/pr-checklists/stateful-data-ui.md`](../pr-checklists/stateful-data-ui.md), [`docs/pr-checklists/recurring-review-patterns.md`](../pr-checklists/recurring-review-patterns.md).
+- Enforced from [`AGENTS.md`](../../AGENTS.md) and each package `AGENTS.md` "Before Opening PRs" section.

--- a/docs/adr/0009-supply-chain-hardening.md
+++ b/docs/adr/0009-supply-chain-hardening.md
@@ -1,0 +1,49 @@
+---
+title: Supply-chain hardening — release-age gate, lockfile-lint, SHA-pinned Actions
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-05
+---
+
+# ADR 0009 — Supply-chain hardening: release-age gate, lockfile-lint, SHA-pinned Actions
+
+**Status:** Accepted (Apr–Jun 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+A monitoring system that watches money is a supply-chain target. Two attack
+vectors matter most here: a freshly published malicious package version pulled in
+by a range, and a mutated GitHub Action tag executing arbitrary code in CI.
+
+## Decision
+
+Adopt a defense-in-depth posture:
+
+- **`minimumReleaseAge`** in `pnpm-workspace.yaml` refuses registry versions
+  younger than 3 days (`@mento-protocol/*` exempted; frozen-lockfile installs
+  unaffected).
+- **`pnpm lockfile:lint`** validates lockfile integrity + registry provenance,
+  with no install needed, as a blocking gate.
+- **SHA-pin every GitHub Action** `uses:` ref, enforced by
+  `scripts/check-github-action-pins.mjs`.
+
+## Alternatives considered
+
+- **Trust the registry and tags** — rejected: tag mutation and same-day malicious
+  releases are real, cheap attacks against exactly this kind of repo.
+- **Manual vigilance** — rejected: unenforced posture rots; each control is a gate.
+
+## Consequences
+
+- Override ranges re-resolve on fresh lockfiles, so migrations pin exact versions
+  (a range once silently bumped undici and broke Discord delivery).
+- An advisory pruning report keeps `pnpm.overrides` + release-age exclusions honest.
+
+## Evidence
+
+- `minimumReleaseAge` PR #418; lockfile-lint PR #447; enforce-pinned-actions PR #922; early action pins PR #177.
+- Guards in `pnpm-workspace.yaml`, `scripts/check-github-action-pins.mjs`, [`docs/pr-checklists/recurring-review-patterns.md`](../pr-checklists/recurring-review-patterns.md).

--- a/docs/adr/0010-required-checks-no-paths-filters.md
+++ b/docs/adr/0010-required-checks-no-paths-filters.md
@@ -1,0 +1,46 @@
+---
+title: Required CI checks carry no paths filters; only advisory jobs may
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-04
+---
+
+# ADR 0010 — Required CI checks carry no `paths:` filters; only advisory jobs may
+
+**Status:** Accepted (Apr 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+GitHub branch protection waits for a required check to _report_. If that check is
+gated by a `paths:` filter, a PR that doesn't touch those paths never runs it, so
+the check stays **pending forever** and the PR can never satisfy protection.
+`paths:` also has a 300-file cap that silently mis-classifies large PRs.
+
+## Decision
+
+**Required checks (and sticky-comment / security-gate jobs) must not use `paths:`
+filters.** They run on every PR via a single required sentinel job that internally
+routes to the right per-package work. Advisory, non-required, non-comment
+workflows may use `paths:` to save cost.
+
+## Alternatives considered
+
+- **`paths:` on required checks to save minutes** — rejected: creates permanently
+  pending PRs and unsafe skips on the exact checks that must always report.
+- **Mark everything required** — rejected: advisory jobs should stay cheap and
+  skippable; the distinction is the point.
+
+## Consequences
+
+- Terraform/package routing lives inside the sentinel (backed by
+  `terraform.stacks.json`, ADR 0028), not in workflow `paths:` YAML.
+- Advisory cost is controlled with path filters + Blacksmith runner tuning instead.
+
+## Evidence
+
+- Path-filter unification PR #176; Blacksmith cost/advisory split PR #813.
+- Rule in [`docs/pr-checklists/ci-workflow-gates.md`](../pr-checklists/ci-workflow-gates.md); CI model in [`docs/terraform.md`](../terraform.md) §CI Model.

--- a/docs/adr/0011-shared-config-single-source-of-truth.md
+++ b/docs/adr/0011-shared-config-single-source-of-truth.md
@@ -1,0 +1,47 @@
+---
+title: shared-config is the single source of truth for chain and token metadata
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: shared-config
+date: 2026-03
+---
+
+# ADR 0011 — `shared-config` is the single source of truth for chain/token metadata
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** shared-config
+
+## Context
+
+Chain slugs, explorer URLs, treb deployment namespaces, and token-symbol
+derivation are needed by the dashboard, indexer, and metrics-bridge alike. When
+each package carried its own copy, they drifted — a renamed token or a new chain
+had to be fixed in several places, and some were missed.
+
+## Decision
+
+`@mento-protocol/monitoring-config` (`shared-config/`) is the **single source of
+truth** for chain metadata, deployment namespaces, token/pool label derivation,
+the FX calendar, and shared ABIs. Consumers import from it; no package duplicates
+chain slugs, explorer URLs, or token labels.
+
+## Alternatives considered
+
+- **Per-package copies** — rejected: guaranteed drift; the bug that motivated this.
+- **A remote config service** — rejected: this is static build-time metadata; a
+  workspace package is simpler and versioned with the code.
+
+## Consequences
+
+- Exported shapes are a change surface: dashboard, indexer, and bridge typechecks
+  are part of any `shared-config` change, and config edits need a cross-reference test.
+- `shared-config` stays low-dependency because it is imported into client bundles.
+- The indexer is the **one** sanctioned exception: it vendors a mirror because Envio
+  builds it outside the pnpm workspace (ADR 0013).
+
+## Evidence
+
+- Namespace extraction `204dd1ab` and contracts-package adoption `a77979d0` (2026-03); no-duplication rule PR #209.
+- [`shared-config/AGENTS.md`](../../shared-config/AGENTS.md).

--- a/docs/adr/0012-one-multichain-indexer.md
+++ b/docs/adr/0012-one-multichain-indexer.md
@@ -1,0 +1,48 @@
+---
+title: One multichain indexer project; Ethereum reserve-yield is event-only
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-03
+---
+
+# ADR 0012 — One multichain indexer project; Ethereum reserve-yield is event-only
+
+**Status:** Accepted (Mar 2026; reserve-yield added Jun 2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+Mento runs on Celo and Monad, with reserve-yield positions (sUSDS, stETH) on
+Ethereum. We could run a separate indexer per chain, but the dashboard shows all
+chains together and the entity model is shared. Ethereum is needed only for
+yield accounting, not full pool indexing.
+
+## Decision
+
+Run **one Envio project** that indexes Celo + Monad FPMM/oracle/broker/bridge
+events and Ethereum reserve-yield in the same hosted deployment
+(`config.multichain.mainnet.yaml`). Ethereum is **event-only** (sUSDS/stETH
+handlers); the historical sUSDS `onBlock` heartbeat is intentionally excluded from
+the hosted path. IDs are chain-namespaced so entities don't collide.
+
+## Alternatives considered
+
+- **One indexer per chain** — rejected: triples deploy/ops surface and forces the
+  dashboard to fan out queries across endpoints for a unified view.
+- **Full Ethereum indexing** — rejected: only yield accounting is needed there;
+  event-only keeps sync cheap and avoids an archival-block heartbeat.
+
+## Consequences
+
+- A single static Hasura endpoint serves all chains; network is derived from the
+  pool URL in the UI.
+- Adding a chain means new config + namespaced IDs, not a new deployment.
+- Reserve-yield has its own test entry point (`indexer:reserve-yield:test`).
+
+## Evidence
+
+- Multichain analysis `adbe96bb` + namespaced-ID model `48fa96dc` (2026-03); reserve-yield slice PR #882 (2026-06).
+- [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md), `config.multichain.mainnet.yaml`.

--- a/docs/adr/0013-vendored-shared-config-mirror.md
+++ b/docs/adr/0013-vendored-shared-config-mirror.md
@@ -1,0 +1,48 @@
+---
+title: The indexer vendors a mirror of shared-config because Envio builds outside the workspace
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-03
+---
+
+# ADR 0013 — The indexer vendors a mirror of `shared-config`, not a workspace link
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+ADR 0011 makes `shared-config` the single source of truth, and every other package
+imports it directly. The indexer cannot: **Envio's hosted builder compiles the
+indexer outside the pnpm workspace**, so a `workspace:*` link to
+`@mento-protocol/monitoring-config` is not resolvable at hosted build time.
+
+## Decision
+
+The indexer **vendors a copy** of the pieces it needs —
+`config/deployment-namespaces.json` and the token-filter logic mirrored in
+`src/feeToken.ts` (`buildKnownTokenMeta`) — rather than importing the workspace
+package. This is a deliberate, documented mirror: when the source policy changes in
+`shared-config`, both copies are updated in the same change.
+
+## Alternatives considered
+
+- **`workspace:*` import like everyone else** — rejected: breaks the Envio hosted
+  build, which runs outside the workspace.
+- **Bundle shared-config into the indexer at build** — rejected: adds a build step
+  Envio's hosted pipeline doesn't run; the vendored JSON/TS is simpler and reviewable.
+
+## Consequences
+
+- This is the **one** sanctioned violation of "no duplication" (ADR 0011); it is
+  called out as a mirror-not-debt so reviewers don't try to "DRY" it away.
+- The indexer layers a stricter fee-token policy at its call site on top of the
+  mirror; drift is a review hazard, so both sides move together.
+
+## Evidence
+
+- `indexer-envio/config/deployment-namespaces.json`, `src/feeToken.ts`, and the workspace-boundary note at `src/contractAddresses.ts:14-18`.
+- [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md) §Dependencies.

--- a/docs/adr/0014-snapshot-entities-no-aggregate.md
+++ b/docs/adr/0014-snapshot-entities-no-aggregate.md
@@ -1,0 +1,47 @@
+---
+title: Precompute snapshot and rollup entities; never rely on Hasura _aggregate
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-03
+---
+
+# ADR 0014 — Precompute snapshot/rollup entities; never rely on Hasura `_aggregate`
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** indexer-envio (constrains ui-dashboard reads)
+
+## Context
+
+The dashboard needs aggregates: daily volume, TVL over time, per-pool rollups.
+Hasura exposes `_aggregate` queries, but running them on hot read paths over
+growing event tables is slow, unbounded, and couples UI latency to table size.
+
+## Decision
+
+**Precompute aggregates as first-class snapshot/rollup entities in the indexer**
+(e.g. pool snapshots, `BrokerDailySnapshot`, deviation-breach history) and have the
+UI read those rows. Hasura `_aggregate` is **not** used on dashboard hot paths;
+where the UI must combine rows it paginates and aggregates client-side at current
+scale (ADR 0020).
+
+## Alternatives considered
+
+- **`_aggregate` at query time** — rejected: latency grows with history and load;
+  the DB does work the indexer can do once at write time.
+- **A separate analytics warehouse** — rejected: overkill for the current entity
+  volume; snapshot entities keep one system.
+
+## Consequences
+
+- New KPIs usually mean a new snapshot entity + handler, which is a schema-additive
+  change and therefore triggers the cross-layer checklist (ADR 0008) and a
+  resync-before-merge (ADR 0002).
+- Writer correctness matters: snapshot handlers get pure-function tests (ADR 0016).
+
+## Evidence
+
+- Pool snapshot analytics `adab67af` (2026-03-05); Broker daily snapshots for the v2/v3 volume split (ADR 0017).
+- No-aggregate rule in [`docs/pr-checklists/swr-polling-hasura.md`](../pr-checklists/swr-polling-hasura.md).

--- a/docs/adr/0015-abi-vendoring-and-address-drift-gate.md
+++ b/docs/adr/0015-abi-vendoring-and-address-drift-gate.md
@@ -1,0 +1,48 @@
+---
+title: Vendor ABIs from the contracts package and gate config addresses on a drift check
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-05
+---
+
+# ADR 0015 — Vendor ABIs from the contracts package; gate every config address on a drift check
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+Envio config YAML hard-codes contract addresses and the handlers need ABIs. If a
+config address silently stops matching `@mento-protocol/contracts` (a rename, a
+redeploy, a typo), the indexer indexes the wrong thing and the failure is invisible
+until data looks wrong downstream.
+
+## Decision
+
+**Vendor ABIs** from `@mento-protocol/contracts` via `pnpm generate:abis` (with a
+few hand-vendored minimal subsets, e.g. ERC20 and Wormhole NTT), and **gate every
+hex address** in `config*.yaml` with `scripts/checkYamlAddresses.mjs`: each must
+resolve to `@mento-protocol/contracts`, `config/nttAddresses.json`, or an explicit
+inline allowlist. The check runs in CI before codegen.
+
+## Alternatives considered
+
+- **Hand-maintain ABIs and addresses** — rejected: drifts from the published
+  contracts package; the bug is silent.
+- **Trust the contracts package at runtime only** — rejected: a drift check that
+  runs in <1s at build time catches renames before they ship.
+
+## Consequences
+
+- Bumping `@mento-protocol/contracts` starts with running the address drift check —
+  a renamed entry surfaces immediately.
+- ERC20/NTT subsets are intentionally excluded from the generator (hand-vendored);
+  that exception is documented in the generator header.
+
+## Evidence
+
+- YAML address drift check PR #486 (2026-05-20); `scripts/generateAbis.mjs`, `scripts/checkYamlAddresses.mjs`.
+- [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md) §Key Files.

--- a/docs/adr/0016-effect-rpc-split-and-heal-stages.md
+++ b/docs/adr/0016-effect-rpc-split-and-heal-stages.md
@@ -1,0 +1,47 @@
+---
+title: Split effects and RPC from handlers; decompose upsertPool into pure heal-stages
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-07
+---
+
+# ADR 0016 — Split effects/RPC from handlers; decompose `upsertPool` into pure heal-stages
+
+**Status:** Accepted (evolved through 2026; heal-stage decomposition Jul 2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+Handlers mix event decoding, RPC reads (for state a log doesn't carry), and entity
+writes. Envio's `mockDb` can't observe multiple `set()` calls to the same id within
+a single handler, so logic that heals pool state across several writes is hard to
+test through the handler surface — and untested heal logic silently corrupts derived
+state.
+
+## Decision
+
+Keep a **layer split** — RPC/effect primitives (the `rpc/` modules behind the
+`rpc.ts` barrel) separated from event handlers — and decompose the pool-healing
+path (`upsertPool`) into **named, pure heal-stage functions**. The heal logic is
+tested as pure functions, not through `mockDb`.
+
+## Alternatives considered
+
+- **One monolithic handler with inline RPC** — rejected: untestable heal logic and
+  tangled effect/decoding concerns.
+- **Rely on `mockDb` integration tests** — rejected: `mockDb` can't see intra-handler
+  multi-`set()`, so it gives false confidence on exactly the heal paths that matter.
+
+## Consequences
+
+- Derived-state correctness is covered by pure-function tests + targeted Stryker
+  mutation baselines rather than brittle handler mocks.
+- New RPC primitives go behind the `rpc.ts` barrel, not inline in handlers.
+
+## Evidence
+
+- `upsertPool` heal-stage decomposition PR #1094 (2026-07-05); `src/rpc/`, `src/rpc.ts`.
+- [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md).

--- a/docs/adr/0017-broker-denormalization-volume-dedup.md
+++ b/docs/adr/0017-broker-denormalization-volume-dedup.md
@@ -1,0 +1,47 @@
+---
+title: Denormalize the v2 Broker swap path to de-duplicate router-routed volume
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-05
+---
+
+# ADR 0017 — Denormalize the v2 Broker swap path to de-duplicate router-routed volume
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+The homepage shows a v2/v3 volume split. But a v3 router-driven swap also settles
+through the legacy v2 Broker (`Broker → BiPoolManager`), so the same economic
+volume appears as both a `VirtualPool.Swap` (v3) and a Broker `Swap` (v2). Counting
+both double-counts volume.
+
+## Decision
+
+Denormalize each Broker `Swap` at index time with a boolean
+`routedViaV3Router` (`tx.to == Routerv300`). The homepage chart excludes Broker
+rows that were router-driven, because those are already counted on the v3 side.
+The Broker is indexed on Celo only (there is no Broker on Monad).
+
+## Alternatives considered
+
+- **Aggregate/deduplicate at query time in the dashboard** — rejected: pushes chain
+  knowledge into the UI and re-does the join on every read.
+- **Don't index the v2 Broker at all** — rejected: the genuine v2-only volume leg is
+  real and needed for the split.
+
+## Consequences
+
+- The de-dup rule is a data invariant carried on the entity, not a UI filter —
+  changing the router address or split logic is a cross-layer change.
+- Related fee-revenue accounting has its own de-dup concerns (Mento-stable fee legs);
+  keep them distinct from volume.
+
+## Evidence
+
+- Homepage v3(Router)+v2(Broker) volume split PR #318 (2026-05-04).
+- [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md) §Contract Types (Broker).

--- a/docs/adr/0018-indexer-observability-loki.md
+++ b/docs/adr/0018-indexer-observability-loki.md
@@ -1,0 +1,45 @@
+---
+title: Indexer observability is structured logs to Loki and Grafana, not Sentry
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: indexer-envio
+date: 2026-04
+---
+
+# ADR 0018 — Indexer observability is structured logs → Loki → Grafana, not Sentry
+
+**Status:** Accepted (2026), in force.
+**Scope:** indexer-envio
+
+## Context
+
+The indexer runs on Envio's hosted platform, where we don't control the process to
+install a Sentry SDK the way we do for the dashboard or the alert Cloud Functions.
+We still need to see handler errors and act on them.
+
+## Decision
+
+Indexer observability is **structured logging**: handlers emit
+`context.log.error` with an `<area>.<event>` convention; Envio ships those to Loki,
+and Grafana queries/deduplicates them for alerting. There is **no Sentry** in the
+indexer.
+
+## Alternatives considered
+
+- **Sentry in the indexer** — rejected: doesn't fit the hosted Envio runtime; the
+  log→Loki→Grafana path is already available and integrates with the metric plane.
+- **Silent failures + downstream data checks** — rejected: too slow and indirect;
+  structured error logs give a first-class signal.
+
+## Consequences
+
+- Error visibility depends on log discipline: use the `<area>.<event>` naming so
+  Grafana dedup/queries work.
+- This keeps the indexer's alerting inside the Grafana plane (ADR 0004) rather than
+  introducing a second error backend.
+
+## Evidence
+
+- Indexer logging convention and Loki/Grafana path documented in [`indexer-envio/AGENTS.md`](../../indexer-envio/AGENTS.md); Sentry is used only by the dashboard and `alerts/infra` (ADR 0004).

--- a/docs/adr/0019-vercel-path-aware-deploys.md
+++ b/docs/adr/0019-vercel-path-aware-deploys.md
@@ -1,0 +1,48 @@
+---
+title: Dashboard deploys on Vercel Git integration with a path-aware skip script
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-03
+---
+
+# ADR 0019 — Dashboard deploys on Vercel Git integration with a path-aware skip script
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+The dashboard is the one service that changes constantly, so it should auto-deploy
+on `main`. But it lives in a monorepo (ADR 0001): a `terraform/` or `indexer-envio/`
+push must not rebuild and redeploy the dashboard, and a docs-only PR must not burn a
+preview build.
+
+## Decision
+
+Deploy the dashboard through **Vercel's native Git integration on `main`**, gated by
+a **path-aware ignore-build script** (`ui-dashboard/scripts/vercel-ignore-build.sh`,
+wired via `ui-dashboard/vercel.json`). The script decides skip-vs-build by diffing
+against the right anchor (previous preview SHA, merge-base, or GitHub compare when
+Vercel strips `.git`), watching `ui-dashboard/`, `shared-config/`, and workspace
+dependency metadata.
+
+## Alternatives considered
+
+- **Deploy on every push** — rejected: wastes builds and couples the dashboard to
+  unrelated changes.
+- **Encode the skip in Terraform** — rejected: keeping it in `vercel.json` lets the
+  skip logic be reviewed and tested alongside the dashboard code it protects.
+
+## Consequences
+
+- The skip script has several fallback anchors because Vercel's env is inconsistent
+  (first push before `gh pr create` lacks PR id/previous SHA); it fails **open**
+  (builds) when it can't prove a deploy is dashboard-clean.
+- Env-only production changes need a manual `vercel deploy --prod` from the repo root.
+
+## Evidence
+
+- Deploy model + skip anchors in [`docs/deployment.md`](../deployment.md) §Dashboard Deployment; `ui-dashboard/scripts/vercel-ignore-build.sh`, `ui-dashboard/vercel.json`.

--- a/docs/adr/0020-swr-polling-read-model.md
+++ b/docs/adr/0020-swr-polling-read-model.md
@@ -1,0 +1,46 @@
+---
+title: Read model is SWR polling plus client-side aggregation at current pool scale
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-03
+---
+
+# ADR 0020 — Read model: SWR polling + client-side aggregation at current pool scale
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+The dashboard needs near-real-time data from Hasura. Two questions: how to keep it
+fresh, and how to compute the 24h volume tiles/table. Live subscriptions add a
+stateful transport; server-side aggregation runs into the no-`_aggregate` rule
+(ADR 0014).
+
+## Decision
+
+Use **SWR polling** against Hasura for freshness (simple request/refetch, no
+websocket transport), and **aggregate the 24h volume view client-side** from
+snapshot queries. At the current scale (~30–50 pools) this is explicitly acceptable
+and is a documented review exclusion — reviewers must **not** flag it as a
+scalability bug unless the assumptions change materially.
+
+## Alternatives considered
+
+- **GraphQL subscriptions / websockets** — rejected: adds a stateful transport and
+  reconnection logic for data that polling refreshes fine.
+- **Server-side `_aggregate`** — rejected by ADR 0014; unbounded query cost.
+
+## Consequences
+
+- The scale assumption is the load-bearing caveat: if pools grow a lot, polling
+  frequency rises, or latency/cost regresses, revisit and likely move aggregation to
+  snapshot entities.
+- Polling discipline (intervals, dedupe) is a review surface for stateful UI changes.
+
+## Evidence
+
+- Polling discipline in [`docs/pr-checklists/swr-polling-hasura.md`](../pr-checklists/swr-polling-hasura.md); the 30–50-pool exclusion in [`docs/pr-checklists/review-prompt-exclusions.md`](../pr-checklists/review-prompt-exclusions.md) and [`AGENTS.md`](../../AGENTS.md).

--- a/docs/adr/0021-dashboard-state-upstash-blob.md
+++ b/docs/adr/0021-dashboard-state-upstash-blob.md
@@ -1,0 +1,48 @@
+---
+title: Dashboard mutable state lives in Upstash Redis with Vercel Blob backups
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-03
+---
+
+# ADR 0021 — Dashboard mutable state lives in Upstash Redis with Vercel Blob backups
+
+**Status:** Accepted (Mar 2026; forensic reports May 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+The dashboard has a little first-party mutable state that the indexer does not own:
+the address book (wallet → label) and long-form forensic reports attached to
+addresses. It's low-volume key/value data that needs to survive project recreation,
+on a serverless (Vercel) runtime.
+
+## Decision
+
+Store this state in **Upstash Redis** (`labels` and `reports` hashes) and back it up
+**daily to Vercel Blob** via a `03:00 UTC` cron defined in `ui-dashboard/vercel.json`.
+Backup/restore use Vercel Blob OIDC through the project-linked store — no static
+`BLOB_READ_WRITE_TOKEN`. There is no relational database.
+
+## Alternatives considered
+
+- **A managed Postgres/relational DB** — rejected: overkill for two hashes; adds a
+  stateful dependency and ops surface to a serverless app.
+- **Put it in the indexer's Postgres** — rejected: this is first-party dashboard
+  state, not indexed on-chain data; mixing them couples unrelated lifecycles.
+
+## Consequences
+
+- The Blob store is a **team-level** resource so it survives project recreation; the
+  snapshot JSON carries `addresses` + `reports` side by side and doubles as the
+  import shape.
+- Forensic reports are pushed to the `reports` hash via management tooling, never
+  round-tripped through copy-paste (they identify individuals).
+
+## Evidence
+
+- Address book + Upstash + Terraform `0b4908d5` (2026-03-06); forensic-report tab PR #330 (2026-05-07).
+- Storage + backup detail in [`docs/deployment.md`](../deployment.md) §Address Book & Backup Cron; [`ui-dashboard/AGENTS.md`](../../ui-dashboard/AGENTS.md).

--- a/docs/adr/0022-authjs-google-shared-preview-secrets.md
+++ b/docs/adr/0022-authjs-google-shared-preview-secrets.md
@@ -1,0 +1,49 @@
+---
+title: Auth.js with Google; previews share prod auth secrets behind Deployment Protection
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-03
+---
+
+# ADR 0022 — Auth.js + Google; previews share prod auth secrets behind Deployment Protection
+
+**Status:** Accepted (Mar 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+Most of the dashboard is public, but some surfaces are gated: editing address
+labels, `/address-book`, `/entities`, and some `/volume`/`/integrations` controls.
+We need Google-based login that also works on Vercel preview deployments, where
+Google OAuth callbacks land on the production domain.
+
+## Decision
+
+Use **Auth.js v5 with Google OAuth**. Preview deployments receive the **same**
+`AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET`/`AUTH_SECRET` as production, because the
+`redirectProxyUrl` flow requires the signed state JWE to verify against the same
+`AUTH_SECRET` on both ends. This is made safe by two controls: **Vercel Deployment
+Protection** (only team members reach a preview URL) and **fork PRs producing no
+preview deployments**.
+
+## Alternatives considered
+
+- **Separate secrets per environment** — rejected: breaks the `redirectProxyUrl`
+  preview-auth flow (would need a different OAuth client + domain-local state).
+- **No auth on previews** — rejected: the prior bypass relied solely on Deployment
+  Protection; app-level auth is the stronger posture.
+
+## Consequences
+
+- If either control (Deployment Protection, fork-preview-off) is loosened, treat all
+  three shared secrets as exposed and rotate them via Terraform.
+- `CRON_SECRET` is production-only, so a compromised preview can't forge Bearer auth
+  against prod backup endpoints. `AUTH_SECRET_PREV` supports graceful rotation.
+
+## Evidence
+
+- Google OAuth + Auth.js `4c970a0b`, `redirectProxyUrl` `92ff92ba` (2026-03); rotation support PR #1003.
+- Full rationale in [`docs/deployment.md`](../deployment.md) §Security Posture — Preview Deployments and `terraform/dashboard.tf`.

--- a/docs/adr/0023-es2017-no-polyfill.md
+++ b/docs/adr/0023-es2017-no-polyfill.md
@@ -1,0 +1,50 @@
+---
+title: Ship ES2017 with no polyfill; ban immutable-array methods via lint and sortedCopy
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-05
+---
+
+# ADR 0023 — Ship ES2017 with no polyfill; ban immutable-array methods
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+The dashboard's `tsconfig` targets `ES2017` with no `browserslist` override and no
+polyfill, but its TS `lib` includes ES2023+ type definitions. So `arr.toSorted()`
+**compiles clean** and then throws `TypeError` at runtime on older Safari/Chrome/
+Firefox. This bit PR #371 five times on `toSorted()` sites.
+
+## Decision
+
+Keep the **ES2017 target with no polyfill** and forbid the ES2023+ immutable-array
+methods (`toSorted`, `toReversed`, `toSpliced`, etc.) in client-shipped code. An
+ESLint `no-restricted-properties` rule bans them in `src/**`; the sanctioned
+immutable sort is `sortedCopy(arr, cmp)` from `@/lib/immutable-sort`, which
+centralizes the `[...arr].sort()` workaround and its lint disable in one place.
+Server-only paths (`app/api/**`, OG helpers, tests) run on Node ≥20 and may use
+ES2023+.
+
+## Alternatives considered
+
+- **Raise the target to ES2022+ or add `core-js`** — deferred, not rejected: it
+  would let the ban relax, but it's a bundle-size + browser-support decision not yet
+  made. Until then, the ban holds.
+- **Fix sites ad hoc as they're flagged** — rejected: PR #371 proved this recurs; a
+  lint rule + one helper stops the whole class.
+
+## Consequences
+
+- New immutable-sort call sites use `sortedCopy`, not hand-rolled `[...arr].sort()`.
+- If the target is ever raised, the ESLint restriction and the helper's react-doctor
+  disable become cleanup candidates.
+
+## Evidence
+
+- `toSorted` flag origin PR #371; single immutable-sort helper PR #1092 (2026-07-05).
+- Rule + safe/unsafe path list in [`ui-dashboard/AGENTS.md`](../../ui-dashboard/AGENTS.md) §Browser target.

--- a/docs/adr/0024-plotly-basic-dist-bundle-budgets.md
+++ b/docs/adr/0024-plotly-basic-dist-bundle-budgets.md
@@ -1,0 +1,45 @@
+---
+title: Plotly.js basic-dist plus enforced bundle-size budgets
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-03
+---
+
+# ADR 0024 — Plotly.js `basic-dist` + enforced bundle-size budgets
+
+**Status:** Accepted (2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+Plotly is a heavy charting library and the dashboard ships a lot of charts. The
+full Plotly distribution is large and includes trace types (e.g. `scattergl`/WebGL)
+the dashboard doesn't use. Unbudgeted, the chart layer silently bloats the bundle.
+
+## Decision
+
+Use Plotly's **`basic-dist`** build (no `scattergl`/WebGL traces) and enforce
+**bundle-size budgets** via `pnpm dashboard:size-limit` after build. Charts render
+through `react-plotly`, and observed chart lag is treated as JS/main-thread work,
+not GPU paint.
+
+## Alternatives considered
+
+- **Full `plotly.js` dist** — rejected: ships trace types we don't use and blows the
+  size budget.
+- **A lighter charting library** — rejected: Plotly's feature set fits the analytics
+  needs; the fix is trimming the dist and budgeting size, not switching libraries.
+
+## Consequences
+
+- Anything needing a WebGL trace type would require reconsidering the dist and its
+  size impact — not a silent import.
+- `size-limit` runs against the built `.next`, so per-PR worktrees must build before
+  the size check can find output.
+
+## Evidence
+
+- Plotly present since initial setup `6e001aac`; `basic-dist` + `size-limit` budgets in [`ui-dashboard/AGENTS.md`](../../ui-dashboard/AGENTS.md) and `ui-dashboard` size-limit config.

--- a/docs/adr/0025-fixture-browser-tests-react-doctor.md
+++ b/docs/adr/0025-fixture-browser-tests-react-doctor.md
@@ -1,0 +1,50 @@
+---
+title: Fixture-driven browser tests, visual snapshots, and a react-doctor score gate
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ui-dashboard
+date: 2026-05
+---
+
+# ADR 0025 — Fixture-driven browser tests + visual snapshots + a react-doctor score gate
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** ui-dashboard
+
+## Context
+
+Dashboard regressions are usually interaction and rendering bugs — a chart that
+stops wiring to table state, a control that breaks under a session, a layout that
+shifts — which unit tests over pure functions never catch. We also kept re-shipping
+the same React anti-patterns.
+
+## Decision
+
+Two gates:
+
+- **Fixture-driven Playwright browser tests** (`test:browser`, plus a build-backed
+  `test:browser:production`) exercise real interactions, with **visual snapshots**
+  re-baselined only on a deliberate UI change.
+- **react-doctor** runs as a **score gate** (must end at 100) plus a per-PR diff gate
+  (`react-doctor:diff`) wired into the local quality gate and CI.
+
+## Alternatives considered
+
+- **Unit tests only** — rejected: they don't observe rendering/interaction, which is
+  where dashboard bugs live.
+- **Manual UI review only** — rejected: doesn't scale and misses visual regressions;
+  snapshots make them mechanical.
+
+## Consequences
+
+- The diff gate scans whole touched files, so pre-existing warnings in a file you
+  edit can block the PR — fix or scope them.
+- Browser tests have a small flake rate; warm the Turbo cache so the pre-push gate
+  cache-hits rather than re-running them.
+
+## Evidence
+
+- Browser interaction suite PR #403 (2026-05-13); react-doctor PR-diff gate PR #367 (2026-05-09).
+- Commands + gates in [`ui-dashboard/AGENTS.md`](../../ui-dashboard/AGENTS.md); [`docs/pr-checklists/stateful-data-ui.md`](../pr-checklists/stateful-data-ui.md).

--- a/docs/adr/0026-aegis-nestjs-app-engine.md
+++ b/docs/adr/0026-aegis-nestjs-app-engine.md
@@ -1,0 +1,46 @@
+---
+title: Aegis is a NestJS App Engine service polling view calls into Prometheus
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: aegis
+date: 2026-05
+---
+
+# ADR 0026 — Aegis is a NestJS App Engine service polling view calls into Prometheus
+
+**Status:** Accepted (May 2026, migrated into this repo), in force.
+**Scope:** aegis
+
+## Context
+
+Mento v2 alerting predates this monorepo. It polls a set of on-chain view calls on
+a schedule and exposes them as Prometheus metrics for Grafana. It was migrated in as
+a working service (`aegis/`) rather than rebuilt.
+
+## Decision
+
+Keep Aegis as a **NestJS service on Google App Engine** that polls configured view
+calls and serves `/metrics` for Grafana dashboards and alert rules. Its deploy runs
+through the `production-services` environment. RPC posture is a deliberate
+primary-then-single-fallback with **no breaker and no backoff** (metrics are already
+polled on a schedule; backoff would silently extend stale windows).
+
+## Alternatives considered
+
+- **Rebuild v2 alerting on Cloud Run / Cloud Functions** — rejected: Aegis already
+  worked; migrating it preserved behavior and the existing App Engine shape.
+- **Fold v2 metrics into metrics-bridge** — rejected: metrics-bridge is v3 Hasura→
+  Prometheus; Aegis polls v2 view calls directly. Different sources, different service.
+
+## Consequences
+
+- The Aegis Grafana dashboard is owned in `aegis/terraform/`, but its service-health
+  **alert rules** live in `alerts/rules/` (moved there 2026-06; see ADR 0028).
+- `*_balanceOf` gauges are whole-token units — never divide by `1e6` in PromQL.
+- Prometheus labels stay bounded (fixed `contract`/`functionName`/`chain` set).
+
+## Evidence
+
+- Aegis monorepo migration PR #443 (2026-05-19); RPC posture + label discipline in [`aegis/AGENTS.md`](../../aegis/AGENTS.md).

--- a/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
+++ b/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
@@ -1,0 +1,46 @@
+---
+title: A Hasura to Prometheus bridge exists so v3 DB data can drive Grafana alerts
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: metrics-bridge
+date: 2026-04
+---
+
+# ADR 0027 — A Hasura→Prometheus bridge exists so v3 DB data can drive Grafana alerts
+
+**Status:** Accepted (Apr 2026), in force.
+**Scope:** metrics-bridge
+
+## Context
+
+The v3 alert plane (ADR 0004) evaluates thresholds in Grafana over Prometheus. But
+the v3 signals — pool health, oracle staleness, CDP TCR/ICR, rebalancer liveness —
+live in the indexer's Postgres behind Hasura, not in Prometheus. Grafana can't
+threshold data it can't scrape.
+
+## Decision
+
+Run a small **`metrics-bridge`** service that reads Hasura/Envio data (and a few RPC
+rebalance probes) and exposes them as **Prometheus gauges** for Grafana alert rules.
+Prometheus labels must have **bounded cardinality** — never tx hashes, user
+addresses, or pool-specific free text.
+
+## Alternatives considered
+
+- **Alert directly off the database** — rejected: the DB has no threshold-evaluation
+  or routing engine; that's exactly the gap the bridge fills.
+- **Push metrics from the dashboard/indexer** — rejected: mixes read-path and
+  export-path concerns; a dedicated exporter keeps the metric surface deliberate.
+
+## Consequences
+
+- New gauges must justify their labels; one narrow exception (`last_oracle_update_url`
+  on oracle timestamp gauges) is documented and must not be generalized.
+- GraphQL failures and RPC probe failures are separate error channels — never
+  collapsed into one boolean. Runs on Cloud Run (`/health`, not `/healthz`).
+
+## Evidence
+
+- metrics-bridge introduced PR #153 (2026-04-17); label + error-channel rules in [`metrics-bridge/AGENTS.md`](../../metrics-bridge/AGENTS.md).

--- a/docs/adr/0028-terraform-stack-registry.md
+++ b/docs/adr/0028-terraform-stack-registry.md
@@ -1,0 +1,49 @@
+---
+title: Terraform ownership is a registry with roots split by cadence and blast radius
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: terraform/infra
+date: 2026-05
+---
+
+# ADR 0028 — Terraform ownership is a registry (`terraform.stacks.json`) with roots split by cadence
+
+**Status:** Accepted (May 2026), in force.
+**Scope:** terraform/infra
+
+## Context
+
+Infrastructure spans the dashboard platform, alert rules, event-driven alert
+delivery, Aegis dashboards, and governance-watchdog — each a different provider,
+change cadence, and blast radius. Inferring stack ownership from directory names is
+error-prone (a bare `TF_VAR` in one workflow once clobbered a same-named sibling
+stack's variable), and a single mega-state couples unrelated changes.
+
+## Decision
+
+Register every Terraform root in a machine-readable **`terraform.stacks.json`**
+(path, state prefix, ownership, plan/apply policy) and keep **separate roots with
+separate GCS state**, split by cadence and blast radius: `platform`, `alerts-rules`
+(daily), `alerts-delivery` (monthly), `aegis`, `governance-watchdog`. CI and scripts
+ask the registry which stacks changed; ownership is never inferred from directory
+names.
+
+## Alternatives considered
+
+- **One monolithic Terraform state** — rejected: couples daily alert-threshold edits
+  to rare platform changes; one bad plan risks everything.
+- **Directory-name ownership convention** — rejected: not machine-checkable and
+  already caused a cross-stack variable clobber.
+
+## Consequences
+
+- Cross-stack resource moves are import-then-`state rm` (state can't cross backends),
+  as done for the Aegis service-health rule group move into `alerts-rules`.
+- Terraform path routing lives in the registry, consumed by the required CI sentinel
+  (ADR 0010), not duplicated in workflow YAML.
+
+## Evidence
+
+- Stack ownership refactor PR #603 (2026-05-27); registry table in [`docs/terraform.md`](../terraform.md); [`terraform/AGENTS.md`](../../terraform/AGENTS.md), [`alerts/AGENTS.md`](../../alerts/AGENTS.md).

--- a/docs/adr/0029-ci-apply-production-infra-gate.md
+++ b/docs/adr/0029-ci-apply-production-infra-gate.md
@@ -1,0 +1,51 @@
+---
+title: Infra applies on merge to main behind the production-infra environment gate
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: terraform/infra
+date: 2026-05
+---
+
+# ADR 0029 — Infra applies on merge to `main` behind the `production-infra` environment gate
+
+**Status:** Accepted (May–Jun 2026), in force.
+**Scope:** terraform/infra
+
+## Context
+
+Manual `terraform apply` from laptops is unauditable and drifts from what's in the
+repo. For a sole-maintainer workflow we still want a human approval step and a
+recorded deploy history, without requiring a second person for routine service
+rollouts.
+
+## Decision
+
+Terraform stacks with CI-apply policy (`alerts-rules`, `alerts-delivery`, `aegis`,
+`governance-watchdog`) **apply on merge to `main`**, gated by the **`production-infra`
+GitHub Environment** (required reviewer, self-review allowed, admin bypass disabled,
+branch restricted to protected `main`). PR runs do **read-only plans** under a
+read-only plan service account. The `platform` stack stays manual-plan/manual-apply.
+Routine service deploys use a separate `production-services` environment that records
+history but doesn't require manual approval.
+
+## Alternatives considered
+
+- **Manual applies only** — rejected: unauditable, drift-prone, and not agent-runnable.
+- **Auto-apply with no approval** — rejected: production infra needs a human gate;
+  the environment's required-reviewer + self-review setting satisfies it for one
+  maintainer.
+
+## Consequences
+
+- Local `pnpm tf apply` on CI-applied stacks is guarded (clean `main` at
+  `origin/main`, or the deliberate `--force-local-apply`).
+- The deployer's Workload Identity Federation is ref-gated to `refs/heads/main`
+  (non-`main` refs 403); worktrees lack `terraform.tfvars`, so run TF from `main`.
+- Agents never apply without explicit human approval; plan first, surface the diff.
+
+## Evidence
+
+- Alerts-infra CI plan/apply PR #558 (2026-05-26); governance-watchdog CI apply PR #1001; environment split issue #762.
+- CI model + environment setup in [`docs/terraform.md`](../terraform.md).

--- a/docs/adr/0030-iac-before-cli-secrets.md
+++ b/docs/adr/0030-iac-before-cli-secrets.md
@@ -1,0 +1,48 @@
+---
+title: All secrets are managed by IaC; agents never touch them with CLI commands
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: terraform/infra
+date: 2026-05
+---
+
+# ADR 0030 — All secrets are managed by IaC; agents never touch them with CLI commands
+
+**Status:** Accepted (2026), in force.
+**Scope:** terraform/infra
+
+## Context
+
+Secrets span GitHub Actions, Vercel, GCP Secret Manager, Upstash, and Grafana. When
+a secret is set with a one-off CLI command (`gh secret set`, `vercel env add`,
+`gcloud secrets versions add`), the source of truth silently moves out of the repo:
+the next `terraform apply` either reverts it or drifts, and no reviewer sees the
+change. Agents are especially prone to reaching for the quick CLI fix.
+
+## Decision
+
+**Every secret is modeled in the owning IaC** (a Terraform variable/resource in its
+stack, or a documented owning integration such as the Vercel Blob store) and
+delivered by a **human-approved plan/apply**. Agents must **not** create, rotate, or
+overwrite secrets with CLI commands. If a secret can't be represented in IaC yet,
+stop and add the IaC path (or ask), rather than using a CLI workaround.
+
+## Alternatives considered
+
+- **CLI for "just this one" secret** — rejected: creates untracked drift and a second
+  source of truth; the whole failure mode this prevents.
+- **Secrets in the repo** — rejected: obviously; IaC references them, it doesn't store
+  plaintext.
+
+## Consequences
+
+- Secret changes ship as a Terraform diff + docs update in the same PR, reviewable
+  and applied through `production-infra` (ADR 0029).
+- The Vercel Blob OIDC variables are the one integration-owned exception, documented
+  as such.
+
+## Evidence
+
+- Secrets Rule in [`AGENTS.md`](../../AGENTS.md) and [`terraform/AGENTS.md`](../../terraform/AGENTS.md); env-var ownership table in [`docs/deployment.md`](../deployment.md).

--- a/docs/adr/0031-governance-watchdog-standalone-root.md
+++ b/docs/adr/0031-governance-watchdog-standalone-root.md
@@ -1,0 +1,47 @@
+---
+title: governance-watchdog stays a standalone source root in its own GCP project
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: governance-watchdog
+date: 2026-06
+---
+
+# ADR 0031 — governance-watchdog stays a standalone source root in its own GCP project
+
+**Status:** Accepted (Jun 2026), in force.
+**Scope:** governance-watchdog
+
+## Context
+
+governance-watchdog is a pre-existing Cloud Function that watches Mento Governance
+on-chain events and notifies Discord/Telegram. It was brought into the monorepo for
+visibility, but it deploys via its own Cloud Build path and runs in its own GCP
+project, distinct from the monitoring project.
+
+## Decision
+
+Integrate it as a **standalone source root**: it keeps its **own `pnpm-lock.yaml`**,
+its own Cloud Build deploy, and a **dedicated GCP project** (project-factory Terraform
+in `governance-watchdog/infra/`). It is not wired into the root workspace build the
+way the first-party packages are.
+
+## Alternatives considered
+
+- **Fold it into the root pnpm workspace and shared build** — rejected: it deploys
+  through Cloud Build as a standalone function and lives in a different GCP project;
+  forcing it into the workspace build buys nothing and risks its lockfile.
+- **Leave it in a separate repo** — rejected: co-locating gives shared visibility,
+  CI drift detection, and one place to find monitoring code.
+
+## Consequences
+
+- Its lockfile is maintained independently (a range once bumped undici and broke
+  Discord delivery; it's pinned exact — see the supply-chain override discipline).
+- Its Terraform is a registered stack with CI apply-on-merge + daily drift detection
+  under `org-terraform` impersonation (ADR 0028/0029).
+
+## Evidence
+
+- Monorepo integration PR #819 (2026-06-10); undici pin PR #831; stack row in [`docs/terraform.md`](../terraform.md); [`governance-watchdog/README.md`](../../governance-watchdog/README.md).

--- a/docs/adr/0032-integration-probes-quote-only.md
+++ b/docs/adr/0032-integration-probes-quote-only.md
@@ -1,0 +1,48 @@
+---
+title: Integration probes are quote-only, evidence-gated, and TTL-degraded
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: integration-probes
+date: 2026-06
+---
+
+# ADR 0032 — Integration probes are quote-only, evidence-gated, and TTL-degraded
+
+**Status:** Accepted (Jun 2026), in force.
+**Scope:** integration-probes
+
+## Context
+
+The `/integrations` page shows whether third-party aggregators and cross-chain
+routers can actually route through Mento v3. Verifying this by executing swaps would
+cost real money and risk funds; trusting an aggregator's self-reported source label
+would produce false "supported" claims.
+
+## Decision
+
+Probes are **quote-only** (read-only): they request quotes and **only mark a route
+`pass` on hard evidence** — a `Routerv300` or a registered v3 pool/VirtualPool
+address in the response — never from a source label alone. Missing credentials return
+`needs_key` (not `fail`); unsupported chains return `unsupported`. The latest snapshot
+is published to Upstash (`integration-probes:latest`) and **expires after 3 days**, so
+a broken scheduled run degrades the dashboard to stale/missing instead of showing
+false-green health forever.
+
+## Alternatives considered
+
+- **Funded canary swaps** — rejected: costs money and risks funds; explicitly requires
+  a new design review before adding.
+- **Trust aggregator source labels** — rejected: produces false positives; evidence is
+  the only thing that proves a real Mento route.
+
+## Consequences
+
+- Quote attempts and error retries are capped so an aggregator outage can't exhaust an
+  API quota or starve the scheduled writer before it publishes degraded results.
+- Adapter credentials are Terraform-managed and optional; the probe fails soft.
+
+## Evidence
+
+- Integration probes added PR #728 (2026-06-02); pass/degradation rules in [`integration-probes/AGENTS.md`](../../integration-probes/AGENTS.md); snapshot wiring in [`docs/deployment.md`](../deployment.md) §Aggregator Integration Probes.

--- a/docs/adr/0033-adr-process-and-gate.md
+++ b/docs/adr/0033-adr-process-and-gate.md
@@ -1,0 +1,73 @@
+---
+title: Architectural decisions are recorded as ADRs, enforced by a reminder gate
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+scope: ci/process
+date: 2026-07
+---
+
+# ADR 0033 — Architectural decisions are recorded as ADRs, enforced by a reminder gate
+
+**Status:** Accepted (Jul 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+The repo's architecture was carried only in people's heads and in scattered
+AGENTS.md rules, so onboarding humans and agents re-litigated settled decisions
+or violated them without knowing a decision existed. ADRs 0001–0032 captured the
+backlog of past decisions — but a static log rots: new decisions get made in PRs
+and never recorded, and "we should write that down" is the first thing a busy
+session drops.
+
+## Decision
+
+Architectural decisions are recorded as ADRs under `docs/adr/`, and the process
+is enforced, not just documented:
+
+- **When** to write one is defined by a three-part test and a trigger-surface
+  list in [`docs/pr-checklists/architecture-decisions.md`](../pr-checklists/architecture-decisions.md).
+- **A reminder gate** — `scripts/check-adr-reminder.mjs` (`pnpm adr:check`) —
+  detects high-signal architectural changes (new package/service, new Terraform
+  stack, new CI/deploy workflow) that ship without an ADR and prints a reminder.
+  The agent quality gate runs it on those surfaces, so a normal pre-push flow
+  surfaces it automatically.
+- **The PR template** asks "Architecture decision?" so authors consciously
+  answer yes (link the ADR) or no (why).
+
+The gate is **advisory by default** (self-suppressing: silent unless a real
+trigger has no accompanying ADR); `--strict` exits non-zero for teams that want
+a hard CI block.
+
+## Alternatives considered
+
+- **Docs-only ("please remember to write ADRs")** — rejected: unenforced process
+  rots; the whole point is that the reminder is impossible to forget.
+- **Hard-block every PR touching an architectural path** — rejected: most such
+  PRs are threshold tweaks or reorders, not decisions; false positives would
+  train everyone to ignore the gate. Advisory + self-suppressing keeps the signal
+  credible, with `--strict` available when a team opts in.
+- **A dedicated CI required check** — deferred: required checks carry no `paths:`
+  filters here (ADR 0010) and hard-gating on "did you decide something?" is
+  false-positive-prone; the local gate + PR-template prompt is the right altitude
+  for now.
+
+## Consequences
+
+- Adding a new package, Terraform stack, or workflow without an ADR triggers a
+  visible reminder; the escape hatch is an explicit `no ADR needed: <reason>` on
+  the PR.
+- ADRs are canonical context (ADR 0005), so each is enrolled in the 90-day
+  re-verification check — the log stays honest over time.
+- `pnpm adr:check` is a repo command; `scripts/check-adr-reminder.test.mjs`
+  covers its trigger logic.
+
+## Evidence
+
+- `scripts/check-adr-reminder.mjs`, `scripts/check-adr-reminder.test.mjs`,
+  `docs/pr-checklists/architecture-decisions.md`, the `adr:check` script in
+  `package.json`, the `terraform.stacks.json` / workspace / workflow routing in
+  `scripts/agent-quality-gate.sh`, and the "Architecture decision?" line in
+  `.github/pull_request_template.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,145 @@
+---
+title: Architecture Decision Records
+status: active
+owner: eng
+canonical: false
+---
+
+# Architecture Decision Records
+
+This is the decision log for the monitoring monorepo: the **why** behind the
+architecture, so a new human or agent can understand how the system got its
+shape without archaeology through 1000+ merged PRs.
+
+Each ADR records one decision that (a) constrains how future work must be done,
+(b) had a real alternative, and (c) whose rationale is not obvious from reading
+the code at the call site. Bug fixes, dependency bumps, one-off features, and
+no-direction refactors are deliberately **not** here — they are noise at this
+altitude.
+
+## How to read this
+
+- **Onboarding?** Skim the `repo-wide` and `ci / process` groups first (ADRs
+  0001–0010) — that is the system in ten decisions. Then read the group for
+  whatever package you are about to touch.
+- **About to change something?** Find the ADR that governs it. If your change
+  contradicts an accepted ADR, that is a design conversation, not a drive-by edit.
+- An ADR tells you _why_. It is **not** a substitute for verifying current
+  behavior in code, config, or a live endpoint before you act — see
+  [`docs/context-standards.md`](../context-standards.md).
+
+## Lifecycle
+
+Frontmatter `status` follows the repo metadata contract (`active` = in force;
+`archived` = superseded/deprecated). The ADR's own lifecycle (Accepted /
+Superseded by ADR-NNNN) lives in the body's **Status** line. In-force ADRs are
+`canonical: true` and enrolled in the 90-day re-verification check — that is the
+enforcement behind "is this still true?". Supersede an ADR by adding a new one
+and flipping the old one to `status: archived` with a `superseded_by:` pointer;
+do not silently rewrite history.
+
+## Adding an ADR
+
+Making an architectural decision in a PR? Record it here, in the same PR. The
+"does this need an ADR / how do I write one" procedure lives in
+[`docs/pr-checklists/architecture-decisions.md`](../pr-checklists/architecture-decisions.md);
+`pnpm adr:check` reminds you when a change adds a package, Terraform stack, or
+workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
+
+## Index
+
+### repo-wide
+
+| ADR                                          | Decision                                                                            |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [0001](0001-monorepo-independent-deploys.md) | One pnpm+Turbo monorepo; each service deploys independently                         |
+| [0002](0002-envio-hosted-indexer.md)         | Envio HyperIndex **Hosted** is the indexer; deploy via a dedicated `envio` branch   |
+| [0003](0003-hasura-graphql-read-api.md)      | Hasura auto-GraphQL over Postgres is the read API                                   |
+| [0004](0004-two-alert-planes.md)             | Two alert planes: Grafana metric thresholds + event-driven QuickNode→Cloud Function |
+| [0005](0005-context-as-product.md)           | Context is product: canonical/non-canonical authority model + metadata contract     |
+
+### ci / process
+
+| ADR                                                 | Decision                                                                        |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [0006](0006-github-issues-backlog.md)               | GitHub Issues (not `BACKLOG.md`) are the canonical agent work queue             |
+| [0007](0007-agent-quality-gate-and-merge-oracle.md) | Local agent quality gate + `pr:ready-state` merge oracle + Codex approval gate  |
+| [0008](0008-mandatory-hazard-checklists.md)         | Cross-layer/stateful changes must run the dedicated PR checklists before review |
+| [0009](0009-supply-chain-hardening.md)              | Supply-chain posture: release-age gate, lockfile-lint, SHA-pinned Actions       |
+| [0010](0010-required-checks-no-paths-filters.md)    | Required CI checks carry no `paths:` filters; only advisory jobs may            |
+| [0033](0033-adr-process-and-gate.md)                | ADRs record architectural decisions, enforced by a reminder gate                |
+
+### shared-config
+
+| ADR                                                  | Decision                                                               |
+| ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| [0011](0011-shared-config-single-source-of-truth.md) | `shared-config` is the single source of truth for chain/token metadata |
+
+### indexer-envio
+
+| ADR                                                  | Decision                                                                           |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [0012](0012-one-multichain-indexer.md)               | One multichain indexer project; Ethereum reserve-yield is event-only               |
+| [0013](0013-vendored-shared-config-mirror.md)        | The indexer vendors a mirror of `shared-config` (it builds outside the workspace)  |
+| [0014](0014-snapshot-entities-no-aggregate.md)       | Precompute snapshot/rollup entities; never rely on Hasura `_aggregate`             |
+| [0015](0015-abi-vendoring-and-address-drift-gate.md) | Vendor ABIs from the contracts package; gate every config address on a drift check |
+| [0016](0016-effect-rpc-split-and-heal-stages.md)     | Split effects/RPC from handlers; decompose `upsertPool` into pure heal-stages      |
+| [0017](0017-broker-denormalization-volume-dedup.md)  | Denormalize the v2 Broker swap path to de-duplicate router-routed volume           |
+| [0018](0018-indexer-observability-loki.md)           | Indexer observability is structured logs → Loki → Grafana, not Sentry              |
+
+### ui-dashboard
+
+| ADR                                                  | Decision                                                                          |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [0019](0019-vercel-path-aware-deploys.md)            | Dashboard deploys on Vercel Git integration with a path-aware skip script         |
+| [0020](0020-swr-polling-read-model.md)               | Read model is SWR polling + client-side aggregation at current pool scale         |
+| [0021](0021-dashboard-state-upstash-blob.md)         | Dashboard state lives in Upstash Redis with Vercel Blob backups, not a DB         |
+| [0022](0022-authjs-google-shared-preview-secrets.md) | Auth.js + Google; preview shares prod auth secrets behind Deployment Protection   |
+| [0023](0023-es2017-no-polyfill.md)                   | Ship ES2017 with no polyfill; ban immutable-array methods via lint + `sortedCopy` |
+| [0024](0024-plotly-basic-dist-bundle-budgets.md)     | Plotly.js `basic-dist` + enforced bundle-size budgets                             |
+| [0025](0025-fixture-browser-tests-react-doctor.md)   | Fixture-driven browser tests + visual snapshots + a react-doctor score gate       |
+
+### aegis
+
+| ADR                                     | Decision                                                                |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| [0026](0026-aegis-nestjs-app-engine.md) | Aegis is a NestJS App Engine service polling view calls into Prometheus |
+
+### metrics-bridge
+
+| ADR                                                 | Decision                                                                 |
+| --------------------------------------------------- | ------------------------------------------------------------------------ |
+| [0027](0027-metrics-bridge-hasura-to-prometheus.md) | A Hasura→Prometheus bridge exists so v3 DB data can drive Grafana alerts |
+
+### terraform / infra
+
+| ADR                                            | Decision                                                                                |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [0028](0028-terraform-stack-registry.md)       | Terraform ownership is a registry (`terraform.stacks.json`) with roots split by cadence |
+| [0029](0029-ci-apply-production-infra-gate.md) | Infra applies on merge to `main` behind the `production-infra` environment gate         |
+| [0030](0030-iac-before-cli-secrets.md)         | All secrets are managed by IaC; agents never touch them with CLI commands               |
+
+### governance-watchdog
+
+| ADR                                                 | Decision                                                                  |
+| --------------------------------------------------- | ------------------------------------------------------------------------- |
+| [0031](0031-governance-watchdog-standalone-root.md) | governance-watchdog stays a standalone source root in its own GCP project |
+
+### integration-probes
+
+| ADR                                           | Decision                                                            |
+| --------------------------------------------- | ------------------------------------------------------------------- |
+| [0032](0032-integration-probes-quote-only.md) | Integration probes are quote-only, evidence-gated, and TTL-degraded |
+
+## Not yet recorded / needs verification
+
+These are candidate decisions left out of the first pass — record them if they
+prove load-bearing, or delete this note when it goes stale:
+
+- **CDP / Liquity-v2 fork monitoring model** (silent `BoldDebtUpdated`,
+  rebalance/redemption conflation) — currently captured in indexer notes and
+  memory; may deserve its own ADR once the v2-fork monitoring surface stabilizes.
+- **Aegis single-fallback RPC posture** (no breaker, no backoff) — documented in
+  [`aegis/AGENTS.md`](../../aegis/AGENTS.md); left as package rule, not an ADR.
+- **Weekend FX-calendar KPI conventions** (7d/WoW over 24h) — a product/data
+  convention in `shared-config` `fx-calendar.json`; borderline for ADR status.

--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -3,7 +3,7 @@ title: Agent Context Standards
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-05
+last_verified: 2026-07-06
 ---
 
 # Agent Context Standards
@@ -18,6 +18,7 @@ Canonical context describes the system and operating rules as they are today. Ag
 
 - `AGENTS.md` and nested `*/AGENTS.md` files: operational instructions scoped to the repo or a directory.
 - `SPEC.md`: the technical specification of the monitoring system's architecture, data flow, and endpoints.
+- `docs/adr/*.md`: architecture decision records — the _why_ behind the system's shape. Each in-force ADR is current operating truth; superseded ones carry `status: archived`. The index is `docs/adr/README.md`.
 - `docs/pr-checklists/*.md`: mandatory review checklists for known hazard classes.
 - `docs/deployment.md`: current deployment workflow.
 - `.agents/skills/**/SKILL.md`: reusable agent procedures.

--- a/docs/pr-checklists/architecture-decisions.md
+++ b/docs/pr-checklists/architecture-decisions.md
@@ -1,0 +1,83 @@
+---
+title: Architecture Decision Records — when and how
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+---
+
+# Architecture Decision Records — when and how
+
+Architectural decisions are recorded as ADRs under [`docs/adr/`](../adr/README.md).
+This checklist answers the two questions the ADR log depends on: **does this
+change need an ADR, and if so how do I write one.** Read it when a PR touches an
+architecturally significant surface (the quality gate and
+`pnpm adr:check` will remind you).
+
+## Does this change need an ADR?
+
+Write an ADR when your change makes a decision that meets **all three** tests:
+
+1. **It constrains future work** — someone could later do the opposite and be
+   wrong, without realizing a decision was already made.
+2. **There was a real alternative** — a road not taken, not the only option.
+3. **The "why" is not obvious from the code** — reading the diff shows _what_,
+   not _why this way_.
+
+If all three hold, add an ADR **in the same PR that makes the decision**. Do not
+defer it to a follow-up — the rationale is freshest now, and the next session
+reads the ADR as ground truth.
+
+**Not an ADR:** bug fixes, dependency bumps, one-off features, refactors that
+change no direction, or anything a code comment at the site already fully
+explains. When in doubt, prefer recording it — a thin ADR beats a silent
+decision — but do not manufacture ADRs for non-decisions.
+
+## Trigger surfaces (the gate watches these)
+
+These changes almost always encode a decision. `pnpm adr:check` (and the agent
+quality gate) flags them when no ADR accompanies the diff:
+
+- **A new package/service** — a new top-level directory with its own
+  `AGENTS.md` / `package.json`.
+- **A new Terraform stack** — a new entry in `terraform.stacks.json`.
+- **A new CI/deploy workflow** — a new file under `.github/workflows/` (a new
+  required check, deploy path, or gate).
+
+Other high-signal-but-not-auto-detected decisions: swapping a hosting platform
+or datastore, adding an alert plane, changing the read/query model, changing the
+deploy/promotion model, or introducing a repo-wide policy (a new gate,
+supply-chain control, or context rule).
+
+## How to write one
+
+1. Copy the shape of a recent ADR (e.g. `docs/adr/0001-*.md`). Sections:
+   **Status · Context · Decision · Alternatives considered · Consequences ·
+   Evidence.**
+2. Number it with the next free `NNNN` and a kebab-case title:
+   `docs/adr/NNNN-short-title.md`.
+3. Frontmatter follows the repo metadata contract (enforced by
+   `pnpm agent:context-check`): `status: active` for an in-force decision
+   (`archived` for a superseded one), `canonical: true`, `owner: eng`,
+   `last_verified: <today>`, plus `scope:` and `date:`. **Do not** use
+   `status: accepted` — that is not a valid contract status; put "Accepted" in
+   the body's Status line instead.
+4. Cite real evidence: the PR number(s) / commit(s) and the canonical file(s)
+   that now enforce the decision.
+5. Add a row to the matching scope group in
+   [`docs/adr/README.md`](../adr/README.md).
+6. Add or confirm the one-line `docs/adr/` pointer in the owning package's
+   `AGENTS.md`.
+
+## Superseding a decision
+
+Do not silently rewrite an ADR when reality changes. Add a **new** ADR that makes
+the new decision, then flip the old one to `status: archived` with a
+`superseded_by: ADR-NNNN` line and a body note. History stays legible.
+
+## When an ADR is genuinely not needed
+
+If the gate flags a trigger surface but the change is not a decision (e.g. a new
+workflow that only reformats logs, a stack-file reorder), that is fine — say so
+on the PR's **"Architecture decision?"** line with a one-line reason. A
+won't-record with a reason is complete; a silent skip is not.

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -12,6 +12,15 @@ Across the last 20 PRs, review findings clustered into the categories below. **S
 
 ## Patterns
 
+### Architecture decisions — `docs/pr-checklists/architecture-decisions.md`
+
+tldr: if a PR makes an architectural decision (constrains future work · had a
+real alternative · the why isn't obvious from the code), it records an ADR under
+`docs/adr/` in the same PR. High-signal triggers — a new package/service, a new
+Terraform stack, a new CI/deploy workflow — are flagged by `pnpm adr:check` and
+the agent quality gate. A won't-record needs a one-line reason on the PR's
+"Architecture decision?" line. Full rules in the linked checklist.
+
 ### Prompt exclusions — `docs/pr-checklists/review-prompt-exclusions.md`
 
 tldr: before re-raising a stale or speculative review finding, check the

--- a/governance-watchdog/README.md
+++ b/governance-watchdog/README.md
@@ -1,5 +1,7 @@
 # 🐕 Governance Watchdog
 
+> **Architecture decisions** for this service live in [`docs/adr/`](../docs/adr/README.md) (scope: `governance-watchdog`) — read the relevant ADR before changing how it deploys or is structured; it records the _why_ the code can't.
+
 <!-- markdown-link-check-disable -->
 
 A system that monitors Mento Governance events on-chain and sends notifications about them to Discord and Telegram. Mento Devs can view the [full project spec in our Notion.](https://www.notion.so/mentolabs/Governance-Watchdog-d168a8110a53430a90e2f5ab65f103f5?pvs=4)

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Envio Indexer
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `indexer-envio`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## What This Is
 
 Envio HyperIndex indexer for Mento v3 FPMM (Fixed Product Market Maker) pools on Celo + Monad (multichain). Also indexes the Mento v2 Broker on Celo (legacy `Broker → BiPoolManager` swap path) for the homepage v2/v3 volume split. Ethereum reserve-yield entities run in the same hosted project through event-only sUSDS/stETH handlers; the historical sUSDS onBlock heartbeat is intentionally excluded.

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-06-01
 
 # integration-probes
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `integration-probes`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 `@mento-protocol/integration-probes` runs quote-only checks against DEX
 aggregators and cross-chain routers. It publishes the latest snapshot to
 Upstash Redis for the dashboard `/integrations` page.

--- a/metrics-bridge/AGENTS.md
+++ b/metrics-bridge/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Metrics Bridge
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `metrics-bridge`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## Scope
 
 `metrics-bridge/` exports Hasura/Envio data and rebalance probes as Prometheus gauges for Grafana alerting.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "agent:review-materiality": "node scripts/review-materiality.mjs",
     "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
     "agent:context-check": "node scripts/check-agent-context.mjs",
+    "adr:check": "node scripts/check-adr-reminder.mjs",
+    "adr:check:test": "node scripts/check-adr-reminder.test.mjs",
     "agent:autoreview": "./scripts/agent-autoreview.sh",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Scripts
 
+> **Architecture decisions** behind these scripts live in [`docs/adr/`](../docs/adr/README.md) (scopes: `ci/process`, `terraform/infra`) — read the relevant ADR before changing how something here works; it records the _why_ the code can't.
+
 ## Scope
 
 `scripts/` contains deploy wrappers, agent quality gates, code-health checks, and repo maintenance utilities.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1611,11 +1611,18 @@ while IFS= read -r path; do
       add_workspace_quality_commands "Node version changed"
       ;;
     */package.json)
-      # A top-level package.json not handled by an earlier package route is a
+      # A TOP-LEVEL package.json not handled by an earlier package route is a
       # new standalone service root (governance-watchdog-style: package.json but
-      # possibly no AGENTS.md). The reminder self-suppresses on an edit to an
-      # existing package.json, so this only nags on a genuinely new service.
-      add_adr_reminder "top-level package.json changed — ADR reminder (a new package/service likely needs an ADR)"
+      # possibly no AGENTS.md). Restrict to a single path segment — a nested
+      # `pkg/sub/package.json` is a workspace member covered by the
+      # pnpm-workspace.yaml route, not a new top-level service. The reminder
+      # self-suppresses on an edit to an existing package.json anyway.
+      case "$path" in
+        */*/*) ;;
+        *)
+          add_adr_reminder "top-level package.json changed — ADR reminder (a new package/service likely needs an ADR)"
+          ;;
+      esac
       ;;
   esac
 done < "$changed_paths_file"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -468,7 +468,7 @@ classify_root_package_json_changes() {
         echo "workspace"
         return
         ;;
-      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/sanitize:test)
+      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
         saw_tooling_script=true
         ;;
       /scripts)
@@ -1206,6 +1206,7 @@ while IFS= read -r path; do
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
       add_command "node scripts/check-github-action-pins.mjs" "GitHub Actions workflow/action changed"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "workflow/action changed — ADR reminder (a new workflow likely needs an ADR)"
       case "$path" in
         .github/workflows/ci.yml)
           add_surface "workspace"
@@ -1552,6 +1553,8 @@ while IFS= read -r path; do
       add_terraform_validate_commands "aegis/terraform" "Terraform stack registry changed"
       add_terraform_validate_commands "governance-watchdog/infra" "Terraform stack registry changed"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "Terraform stack registry changed"
+      add_checklist "docs/pr-checklists/architecture-decisions.md" "Terraform stack registry changed — a new stack likely needs an ADR"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "Terraform stack registry changed — ADR reminder"
       ;;
     package.json)
       root_package_json_class="$(get_root_package_json_class)"
@@ -1572,6 +1575,7 @@ while IFS= read -r path; do
       add_surface "workspace"
       add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
       add_workspace_quality_commands "workspace dependency/config changed"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
       ;;
     patches/*)
       add_surface "workspace"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -634,6 +634,7 @@ add_root_tooling_package_script_checks() {
   add_command "node scripts/lockfile-lint.test.mjs" "$reason"
   add_command "node scripts/version-skew-check.test.mjs" "$reason"
   add_command "node scripts/override-prune-report.test.mjs" "$reason"
+  add_command "node scripts/check-adr-reminder.test.mjs" "$reason"
 }
 
 add_indexer_post_codegen_install() {
@@ -1434,6 +1435,9 @@ while IFS= read -r path; do
           ;;
         scripts/check-deploy-root-anchors.test.mjs)
           add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy root-anchor test changed"
+          ;;
+        scripts/check-adr-reminder.mjs|scripts/check-adr-reminder.test.mjs)
+          add_command "pnpm adr:check:test" "ADR reminder helper changed"
           ;;
         scripts/agent-prewarm.mjs|scripts/agent-prewarm.test.mjs)
           add_command "pnpm agent:prewarm:test" "agent prewarm helper changed"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -637,6 +637,17 @@ add_root_tooling_package_script_checks() {
   add_command "node scripts/check-adr-reminder.test.mjs" "$reason"
 }
 
+# Advisory ADR reminder, fed the gate's own base/head + changed-path set so the
+# checker evaluates exactly what the gate routed (including a precomputed
+# --changed-paths-file set). Self-suppressing, so safe to route broadly.
+add_adr_reminder() {
+  local reason="$1"
+  local cmd="node scripts/check-adr-reminder.mjs"
+  cmd="$cmd --base $(quote_path "$base_ref") --head $(quote_path "$head_ref")"
+  cmd="$cmd --include-untracked --changed-paths-file $(quote_path "$changed_paths_file")"
+  add_command "$cmd" "$reason"
+}
+
 add_indexer_post_codegen_install() {
   add_post_codegen_command "pnpm install --frozen-lockfile" "link generated package after indexer codegen"
 }
@@ -1207,7 +1218,7 @@ while IFS= read -r path; do
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
       add_command "node scripts/check-github-action-pins.mjs" "GitHub Actions workflow/action changed"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "workflow/action changed — ADR reminder (a new workflow likely needs an ADR)"
+      add_adr_reminder "workflow/action changed — ADR reminder (a new workflow likely needs an ADR)"
       case "$path" in
         .github/workflows/ci.yml)
           add_surface "workspace"
@@ -1377,7 +1388,7 @@ while IFS= read -r path; do
           # is a brand-new standalone service (governance-watchdog-style) added
           # without a pnpm-workspace.yaml change. The reminder self-suppresses on
           # an edit to an existing AGENTS.md, so this only nags on a new one.
-          add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "scoped AGENTS.md changed — ADR reminder (a new package/service likely needs an ADR)"
+          add_adr_reminder "scoped AGENTS.md changed — ADR reminder (a new package/service likely needs an ADR)"
           ;;
         docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md)
           add_command "pnpm agent:context-check" "agent context standards changed"
@@ -1566,7 +1577,7 @@ while IFS= read -r path; do
       add_terraform_validate_commands "governance-watchdog/infra" "Terraform stack registry changed"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "Terraform stack registry changed"
       add_checklist "docs/pr-checklists/architecture-decisions.md" "Terraform stack registry changed — a new stack likely needs an ADR"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "Terraform stack registry changed — ADR reminder"
+      add_adr_reminder "Terraform stack registry changed — ADR reminder"
       ;;
     package.json)
       root_package_json_class="$(get_root_package_json_class)"
@@ -1587,7 +1598,7 @@ while IFS= read -r path; do
       add_surface "workspace"
       add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
       add_workspace_quality_commands "workspace dependency/config changed"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
+      add_adr_reminder "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
       ;;
     patches/*)
       add_surface "workspace"
@@ -1598,6 +1609,13 @@ while IFS= read -r path; do
       add_surface "workspace"
       add_preflight_command "pnpm install --frozen-lockfile" "Node version changed"
       add_workspace_quality_commands "Node version changed"
+      ;;
+    */package.json)
+      # A top-level package.json not handled by an earlier package route is a
+      # new standalone service root (governance-watchdog-style: package.json but
+      # possibly no AGENTS.md). The reminder self-suppresses on an edit to an
+      # existing package.json, so this only nags on a genuinely new service.
+      add_adr_reminder "top-level package.json changed — ADR reminder (a new package/service likely needs an ADR)"
       ;;
   esac
 done < "$changed_paths_file"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1207,7 +1207,7 @@ while IFS= read -r path; do
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
       add_command "node scripts/check-github-action-pins.mjs" "GitHub Actions workflow/action changed"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "workflow/action changed — ADR reminder (a new workflow likely needs an ADR)"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "workflow/action changed — ADR reminder (a new workflow likely needs an ADR)"
       case "$path" in
         .github/workflows/ci.yml)
           add_surface "workspace"
@@ -1371,7 +1371,15 @@ while IFS= read -r path; do
     docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md|SPEC.md)
       add_surface "docs"
       case "$path" in
-        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md|AGENTS.md|*/AGENTS.md)
+        AGENTS.md|*/AGENTS.md)
+          add_command "pnpm agent:context-check" "agent context standards changed"
+          # A scoped AGENTS.md reaching this route (not an earlier package route)
+          # is a brand-new standalone service (governance-watchdog-style) added
+          # without a pnpm-workspace.yaml change. The reminder self-suppresses on
+          # an edit to an existing AGENTS.md, so this only nags on a new one.
+          add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "scoped AGENTS.md changed — ADR reminder (a new package/service likely needs an ADR)"
+          ;;
+        docs/context-standards.md|docs/pr-checklists/recurring-review-patterns.md)
           add_command "pnpm agent:context-check" "agent context standards changed"
           ;;
         SPEC.md)
@@ -1558,7 +1566,7 @@ while IFS= read -r path; do
       add_terraform_validate_commands "governance-watchdog/infra" "Terraform stack registry changed"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "Terraform stack registry changed"
       add_checklist "docs/pr-checklists/architecture-decisions.md" "Terraform stack registry changed — a new stack likely needs an ADR"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "Terraform stack registry changed — ADR reminder"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "Terraform stack registry changed — ADR reminder"
       ;;
     package.json)
       root_package_json_class="$(get_root_package_json_class)"
@@ -1579,7 +1587,7 @@ while IFS= read -r path; do
       add_surface "workspace"
       add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
       add_workspace_quality_commands "workspace dependency/config changed"
-      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref")" "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
+      add_command "node scripts/check-adr-reminder.mjs --base $(quote_path "$base_ref") --head $(quote_path "$head_ref") --include-untracked" "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
       ;;
     patches/*)
       add_surface "workspace"

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Advisory ADR reminder gate.
+ *
+ * Architectural decisions in this repo are recorded as ADRs under `docs/adr/`
+ * (see ADR 0005 / ADR 0033 and `docs/pr-checklists/architecture-decisions.md`).
+ * The failure mode this guards against is a PR that makes a genuine
+ * architectural decision — a new package/service, a new Terraform stack, a new
+ * CI/deploy workflow — and forgets to record why.
+ *
+ * It detects a small set of HIGH-SIGNAL architectural triggers in the diff vs a
+ * base ref and, when none of them are accompanied by a new ADR, prints a
+ * reminder. It is deliberately self-suppressing: it stays silent when there is
+ * no trigger, or when the same diff already adds an ADR — so it is safe to run
+ * on every push without becoming noise the reader learns to ignore.
+ *
+ * Advisory by default (exit 0). Pass `--strict` to exit non-zero on an
+ * un-accompanied trigger so a CI job can hard-gate if a team wants that.
+ *
+ * Usage: node scripts/check-adr-reminder.mjs [--base <ref>] [--strict]
+ */
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Pure trigger detection — kept free of git/IO so it is directly testable.
+ * @param {{addedFiles: string[], stacksAddsNewStack: boolean, workspaceAddsPackage: boolean}} input
+ * @returns {{surface: string, why: string}[]}
+ */
+export function detectAdrTriggers({
+  addedFiles = [],
+  stacksAddsNewStack = false,
+  workspaceAddsPackage = false,
+}) {
+  const triggers = [];
+  for (const file of addedFiles) {
+    const scoped = /^([^/]+)\/AGENTS\.md$/.exec(file);
+    if (scoped) {
+      triggers.push({
+        surface: file,
+        why: `new package/service "${scoped[1]}/" (new scoped AGENTS.md)`,
+      });
+    }
+    if (/^\.github\/workflows\/.+\.ya?ml$/.test(file)) {
+      triggers.push({
+        surface: file,
+        why: "new GitHub Actions workflow (new CI/deploy path or required check)",
+      });
+    }
+  }
+  if (stacksAddsNewStack) {
+    triggers.push({
+      surface: "terraform.stacks.json",
+      why: "a new Terraform stack was registered",
+    });
+  }
+  if (workspaceAddsPackage) {
+    triggers.push({
+      surface: "pnpm-workspace.yaml",
+      why: "a workspace package was added",
+    });
+  }
+  return triggers;
+}
+
+/**
+ * True when the same diff already adds a numbered ADR (README changes do not
+ * count) — the decision is being recorded, so stay quiet.
+ * @param {string[]} addedFiles
+ * @returns {boolean}
+ */
+export function adrBeingWritten(addedFiles = []) {
+  return addedFiles.some((file) => /^docs\/adr\/\d{4}-.+\.md$/.test(file));
+}
+
+function git(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" });
+  } catch {
+    return "";
+  }
+}
+
+function lines(text) {
+  return text.split("\n").filter(Boolean);
+}
+
+function baseExists(base) {
+  try {
+    execFileSync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `${base}^{commit}`],
+      {
+        stdio: "ignore",
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Collect the diff facts the pure detector needs. */
+export function collectGitState(base) {
+  const added = new Set([
+    ...lines(git(["diff", "--diff-filter=A", "--name-only", base, "--"])),
+    ...lines(git(["ls-files", "--others", "--exclude-standard"])),
+  ]);
+  const addedFiles = [...added];
+
+  // A new stack entry shows up as an added object with a "path" key.
+  const stacksDiff = git(["diff", base, "--", "terraform.stacks.json"]);
+  const stacksIsNew = addedFiles.includes("terraform.stacks.json");
+  const stacksAddsNewStack =
+    stacksIsNew ||
+    lines(stacksDiff).some((line) => /^\+.*"path"\s*:/.test(line));
+
+  // A new workspace package shows up as an added `- <glob>` list item.
+  const workspaceDiff = git(["diff", base, "--", "pnpm-workspace.yaml"]);
+  const workspaceAddsPackage = lines(workspaceDiff).some((line) =>
+    /^\+\s*-\s+\S/.test(line),
+  );
+
+  return { addedFiles, stacksAddsNewStack, workspaceAddsPackage };
+}
+
+function main(argv) {
+  let base = process.env.AGENT_QUALITY_BASE || "origin/main";
+  let strict = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--base") base = argv[++i];
+    else if (argv[i] === "--strict") strict = true;
+  }
+
+  if (!baseExists(base)) {
+    // Nothing to diff against (e.g. base not fetched) — do not block, do not nag.
+    console.log(
+      `[adr-reminder] base ref '${base}' not found; skipping (advisory).`,
+    );
+    return 0;
+  }
+
+  const state = collectGitState(base);
+  if (adrBeingWritten(state.addedFiles)) {
+    return 0; // A decision is being recorded — quiet.
+  }
+
+  const triggers = detectAdrTriggers(state);
+  if (triggers.length === 0) {
+    return 0; // No architectural trigger — quiet.
+  }
+
+  console.log(
+    "\n[adr-reminder] This change touches an architecturally significant surface but adds no ADR:",
+  );
+  for (const t of triggers) {
+    console.log(`  • ${t.surface} — ${t.why}`);
+  }
+  console.log(
+    "Does it encode an architectural decision (constrains future work · had a real\n" +
+      "alternative · the why is not obvious from the code)? If yes, record it under\n" +
+      'docs/adr/ in this PR. If not, note why on the PR\'s "Architecture decision?" line.\n' +
+      "Procedure: docs/pr-checklists/architecture-decisions.md\n",
+  );
+
+  return strict ? 1 : 0;
+}
+
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -231,9 +231,11 @@ function main(argv) {
     else if (argv[i] === "--strict") strict = true;
     else if (argv[i] === "--include-untracked") includeUntracked = true;
   }
-  // A gate that defaults --head to the working tree passes "" or "HEAD"; treat
-  // "HEAD" as "diff against the commit" and anything falsy as the working tree.
-  if (head === "HEAD" && !baseExists("HEAD")) head = "";
+  // The gate's --head defaults to "HEAD", meaning "the current checkout". Treat
+  // that (and empty) as the WORKING TREE so staged/uncommitted edits to
+  // pnpm-workspace.yaml / terraform.stacks.json and not-yet-committed new files
+  // are seen. Only an explicit non-HEAD ref reads that ref's committed content.
+  if (head === "HEAD") head = "";
 
   if (!baseExists(base)) {
     // Nothing to diff against (e.g. base not fetched) — do not block, do not nag.

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -19,7 +19,13 @@
  * Advisory by default (exit 0). Pass `--strict` to exit non-zero on a trigger
  * that has no accompanying ADR so a CI job can hard-gate if a team wants that.
  *
- * Usage: node scripts/check-adr-reminder.mjs [--base <ref>] [--strict]
+ * Usage: node scripts/check-adr-reminder.mjs [--base <ref>] [--head <ref>]
+ *          [--strict] [--include-untracked]
+ *
+ * The agent quality gate passes its own `--head` and `--include-untracked` so
+ * the reminder sees exactly what the gate sees (committed + staged + untracked
+ * high-signal files). Standalone runs default to committed/staged only, so an
+ * unrelated untracked scratch file never nags.
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -164,26 +170,47 @@ function baseExists(base) {
   }
 }
 
+function headContent(head, path) {
+  return head ? git(["show", `${head}:${path}`]) : readHead(path);
+}
+
 /**
- * Collect the diff facts the pure detector needs. Added files come from the
- * base diff only (committed + staged additions) — untracked working-tree files
- * are deliberately excluded so local scratch files never trigger a reminder.
+ * Collect the diff facts the pure detector needs.
+ *
+ * Added files come from the base→head diff (committed + staged additions). When
+ * `includeUntracked` is set — which the quality gate passes so this checker sees
+ * exactly the gate's changed-path set — untracked new files are added too, so a
+ * not-yet-committed new package/workflow is not invisible during a local gate
+ * run. Standalone runs leave it off, so an unrelated untracked scratch file
+ * never nags.
  */
-export function collectGitState(base) {
-  const addedFiles = lines(
-    git(["diff", "--diff-filter=A", "--name-only", base, "--"]),
-  );
+export function collectGitState(
+  base,
+  { head = "", includeUntracked = false } = {},
+) {
+  const diffArgs = head
+    ? ["diff", "--diff-filter=A", "--name-only", base, head, "--"]
+    : ["diff", "--diff-filter=A", "--name-only", base, "--"];
+  const added = new Set(lines(git(diffArgs)));
+  if (includeUntracked) {
+    for (const file of lines(
+      git(["ls-files", "--others", "--exclude-standard"]),
+    )) {
+      added.add(file);
+    }
+  }
+  const addedFiles = [...added];
 
   // Compare declared stacks/packages between base and head so only a genuinely
   // new registration triggers — not a path edit, a reformat, or an unrelated
   // list section that happens to share YAML `- item` syntax.
   const stacksAddsNewStack = hasNewEntry(
     extractStackIds(git(["show", `${base}:terraform.stacks.json`])),
-    extractStackIds(readHead("terraform.stacks.json")),
+    extractStackIds(headContent(head, "terraform.stacks.json")),
   );
   const workspaceAddsPackage = hasNewEntry(
     extractPackagesList(git(["show", `${base}:pnpm-workspace.yaml`])),
-    extractPackagesList(readHead("pnpm-workspace.yaml")),
+    extractPackagesList(headContent(head, "pnpm-workspace.yaml")),
   );
 
   return { addedFiles, stacksAddsNewStack, workspaceAddsPackage };
@@ -195,11 +222,18 @@ function printSurfaces(triggers) {
 
 function main(argv) {
   let base = process.env.AGENT_QUALITY_BASE || "origin/main";
+  let head = "";
   let strict = false;
+  let includeUntracked = false;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--base") base = argv[++i];
+    else if (argv[i] === "--head") head = argv[++i] ?? "";
     else if (argv[i] === "--strict") strict = true;
+    else if (argv[i] === "--include-untracked") includeUntracked = true;
   }
+  // A gate that defaults --head to the working tree passes "" or "HEAD"; treat
+  // "HEAD" as "diff against the commit" and anything falsy as the working tree.
+  if (head === "HEAD" && !baseExists("HEAD")) head = "";
 
   if (!baseExists(base)) {
     // Nothing to diff against (e.g. base not fetched) — do not block, do not nag.
@@ -209,7 +243,7 @@ function main(argv) {
     return 0;
   }
 
-  const state = collectGitState(base);
+  const state = collectGitState(base, { head, includeUntracked });
   const triggers = detectAdrTriggers(state);
   if (triggers.length === 0) {
     return 0; // No architectural trigger — quiet.

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -9,17 +9,20 @@
  * CI/deploy workflow — and forgets to record why.
  *
  * It detects a small set of HIGH-SIGNAL architectural triggers in the diff vs a
- * base ref and, when none of them are accompanied by a new ADR, prints a
- * reminder. It is deliberately self-suppressing: it stays silent when there is
- * no trigger, or when the same diff already adds an ADR — so it is safe to run
- * on every push without becoming noise the reader learns to ignore.
+ * base ref. Detection is intentionally precise (a real new package / stack, not
+ * a reformat or an unrelated list edit) because the tool's only value is
+ * credibility: a nag that cries wolf gets ignored. It stays silent when there
+ * is no trigger; when a trigger is present it prints — either a full reminder
+ * (no ADR in the change) or a lighter "confirm each surface is covered" note
+ * (an ADR is present, so the author is clearly ADR-aware).
  *
- * Advisory by default (exit 0). Pass `--strict` to exit non-zero on an
- * un-accompanied trigger so a CI job can hard-gate if a team wants that.
+ * Advisory by default (exit 0). Pass `--strict` to exit non-zero on a trigger
+ * that has no accompanying ADR so a CI job can hard-gate if a team wants that.
  *
  * Usage: node scripts/check-adr-reminder.mjs [--base <ref>] [--strict]
  */
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 /**
@@ -64,13 +67,68 @@ export function detectAdrTriggers({
 }
 
 /**
- * True when the same diff already adds a numbered ADR (README changes do not
- * count) — the decision is being recorded, so stay quiet.
+ * True when the change adds a numbered ADR (README changes do not count).
  * @param {string[]} addedFiles
  * @returns {boolean}
  */
 export function adrBeingWritten(addedFiles = []) {
-  return addedFiles.some((file) => /^docs\/adr\/\d{4}-.+\.md$/.test(file));
+  return addedFiles.some((file) => /^docs\/adr\/\d{4}-[^/]+\.md$/.test(file));
+}
+
+/**
+ * Stack identifiers (`stacks[].id`) declared in a terraform.stacks.json blob.
+ * Returns [] for empty/unparsable input so a missing base file degrades to
+ * "everything in head is new" without throwing.
+ * @param {string} jsonText
+ * @returns {string[]}
+ */
+export function extractStackIds(jsonText) {
+  if (!jsonText.trim()) return [];
+  try {
+    const parsed = JSON.parse(jsonText);
+    if (!Array.isArray(parsed?.stacks)) return [];
+    return parsed.stacks
+      .map((stack) => stack?.id)
+      .filter((id) => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Package globs under the top-level `packages:` key of a pnpm-workspace.yaml
+ * blob. Only the `packages:` list — NOT `minimumReleaseAgeExclude`,
+ * `ignoredBuiltDependencies`, or the other `- item` sections that share YAML
+ * list syntax.
+ * @param {string} yamlText
+ * @returns {string[]}
+ */
+export function extractPackagesList(yamlText) {
+  const out = [];
+  let inPackages = false;
+  for (const raw of yamlText.split("\n")) {
+    if (/^packages:\s*$/.test(raw)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    if (raw.trim() === "") continue; // blank line stays inside the block
+    if (/^\S/.test(raw)) break; // next top-level key ends the block
+    const item = /^\s+-\s+(.+?)\s*$/.exec(raw);
+    if (item) out.push(item[1].replace(/^["']|["']$/g, ""));
+  }
+  return out;
+}
+
+/**
+ * Whether `headList` contains an entry absent from `baseList`.
+ * @param {string[]} baseList
+ * @param {string[]} headList
+ * @returns {boolean}
+ */
+export function hasNewEntry(baseList, headList) {
+  const base = new Set(baseList);
+  return headList.some((entry) => !base.has(entry));
 }
 
 function git(args) {
@@ -85,14 +143,20 @@ function lines(text) {
   return text.split("\n").filter(Boolean);
 }
 
+function readHead(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
 function baseExists(base) {
   try {
     execFileSync(
       "git",
       ["rev-parse", "--verify", "--quiet", `${base}^{commit}`],
-      {
-        stdio: "ignore",
-      },
+      { stdio: "ignore" },
     );
     return true;
   } catch {
@@ -100,28 +164,33 @@ function baseExists(base) {
   }
 }
 
-/** Collect the diff facts the pure detector needs. */
+/**
+ * Collect the diff facts the pure detector needs. Added files come from the
+ * base diff only (committed + staged additions) — untracked working-tree files
+ * are deliberately excluded so local scratch files never trigger a reminder.
+ */
 export function collectGitState(base) {
-  const added = new Set([
-    ...lines(git(["diff", "--diff-filter=A", "--name-only", base, "--"])),
-    ...lines(git(["ls-files", "--others", "--exclude-standard"])),
-  ]);
-  const addedFiles = [...added];
+  const addedFiles = lines(
+    git(["diff", "--diff-filter=A", "--name-only", base, "--"]),
+  );
 
-  // A new stack entry shows up as an added object with a "path" key.
-  const stacksDiff = git(["diff", base, "--", "terraform.stacks.json"]);
-  const stacksIsNew = addedFiles.includes("terraform.stacks.json");
-  const stacksAddsNewStack =
-    stacksIsNew ||
-    lines(stacksDiff).some((line) => /^\+.*"path"\s*:/.test(line));
-
-  // A new workspace package shows up as an added `- <glob>` list item.
-  const workspaceDiff = git(["diff", base, "--", "pnpm-workspace.yaml"]);
-  const workspaceAddsPackage = lines(workspaceDiff).some((line) =>
-    /^\+\s*-\s+\S/.test(line),
+  // Compare declared stacks/packages between base and head so only a genuinely
+  // new registration triggers — not a path edit, a reformat, or an unrelated
+  // list section that happens to share YAML `- item` syntax.
+  const stacksAddsNewStack = hasNewEntry(
+    extractStackIds(git(["show", `${base}:terraform.stacks.json`])),
+    extractStackIds(readHead("terraform.stacks.json")),
+  );
+  const workspaceAddsPackage = hasNewEntry(
+    extractPackagesList(git(["show", `${base}:pnpm-workspace.yaml`])),
+    extractPackagesList(readHead("pnpm-workspace.yaml")),
   );
 
   return { addedFiles, stacksAddsNewStack, workspaceAddsPackage };
+}
+
+function printSurfaces(triggers) {
+  for (const t of triggers) console.log(`  • ${t.surface} — ${t.why}`);
 }
 
 function main(argv) {
@@ -141,25 +210,33 @@ function main(argv) {
   }
 
   const state = collectGitState(base);
-  if (adrBeingWritten(state.addedFiles)) {
-    return 0; // A decision is being recorded — quiet.
-  }
-
   const triggers = detectAdrTriggers(state);
   if (triggers.length === 0) {
     return 0; // No architectural trigger — quiet.
   }
 
+  if (adrBeingWritten(state.addedFiles)) {
+    // An ADR is present, so the author is ADR-aware. Still list the surfaces —
+    // a second, uncovered decision must not be silently skipped — but never fail.
+    console.log(
+      "\n[adr-reminder] Architectural surface(s) changed and an ADR is present in this change — confirm each is covered by an ADR:",
+    );
+    printSurfaces(triggers);
+    console.log(
+      "If a surface above is a separate new decision without its own ADR, add one.\n" +
+        "Procedure: docs/pr-checklists/architecture-decisions.md\n",
+    );
+    return 0;
+  }
+
   console.log(
     "\n[adr-reminder] This change touches an architecturally significant surface but adds no ADR:",
   );
-  for (const t of triggers) {
-    console.log(`  • ${t.surface} — ${t.why}`);
-  }
+  printSurfaces(triggers);
   console.log(
     "Does it encode an architectural decision (constrains future work · had a real\n" +
       "alternative · the why is not obvious from the code)? If yes, record it under\n" +
-      'docs/adr/ in this PR. If not, note why on the PR\'s "Architecture decision?" line.\n' +
+      'docs/adr/ in this change. If not, note why on the PR\'s "Architecture decision?" line.\n' +
       "Procedure: docs/pr-checklists/architecture-decisions.md\n",
   );
 

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -209,11 +209,14 @@ export function collectGitState(
   { head = "", includeUntracked = false, changedPathsFile = "" } = {},
 ) {
   let added;
+  // When a path set is supplied it is the AUTHORITATIVE scope; `candidates`
+  // stays null otherwise so standalone runs keep their git-diff behavior.
+  let candidates = null;
   if (changedPathsFile) {
     // Consume the gate's authoritative changed-path set instead of recomputing.
     // A path is "added" when it does not exist at base, so a modified
     // AGENTS.md/package.json (this very PR) is correctly not a new service.
-    const candidates = lines(readHead(changedPathsFile));
+    candidates = lines(readHead(changedPathsFile));
     added = new Set(candidates.filter((path) => !existsAtBase(base, path)));
   } else {
     const diffArgs = head
@@ -221,30 +224,47 @@ export function collectGitState(
       : ["diff", "--diff-filter=A", "--name-only", base, "--"];
     added = new Set(lines(git(diffArgs)));
   }
-  // Untracked files belong to the WORKING TREE, so only fold them in for a
-  // working-tree run (no explicit head). Mixing the current checkout's untracked
-  // files into an explicit `--head <ref>` diff would let an unrelated local ADR
-  // draft suppress the reminder for the selected ref.
-  if (includeUntracked && !head) {
+  // Untracked files belong to the WORKING TREE. Fold them in only for a
+  // working-tree run WITHOUT an authoritative scope: an explicit `--head` or a
+  // `--changed-paths-file` defines what to evaluate, and mixing in the current
+  // checkout's untracked files (e.g. a local ADR draft) would wrongly
+  // suppress/trigger the reminder for that scope.
+  if (includeUntracked && !head && !changedPathsFile) {
     for (const file of lines(
       git(["ls-files", "--others", "--exclude-standard"]),
     )) {
       added.add(file);
     }
   }
-  const addedFiles = [...added];
+  // A service marker (`<dir>/AGENTS.md` or `<dir>/package.json`) only signals a
+  // NEW package/service when its top-level directory did not already exist at
+  // base — adding docs/AGENTS.md to the existing docs/ tree is documentation,
+  // not a new service (the checklist defines the trigger as a *new* top-level
+  // directory). A pure rename of a top-level dir/workflow (delete+add in the
+  // gate's --no-renames set) still reads as a new surface here; that is an
+  // accepted advisory-only limitation, since a rename is itself structural.
+  const addedFiles = [...added].filter((file) => {
+    const svc = /^([^/]+)\/(?:AGENTS\.md|package\.json)$/.exec(file);
+    return !(svc && existsAtBase(base, svc[1]));
+  });
 
-  // Compare declared stacks/packages between base and head so only a genuinely
-  // new registration triggers — not a path edit, a reformat, or an unrelated
-  // list section that happens to share YAML `- item` syntax.
-  const stacksAddsNewStack = hasNewEntry(
-    extractStackIds(git(["show", `${base}:terraform.stacks.json`])),
-    extractStackIds(headContent(head, "terraform.stacks.json")),
-  );
-  const workspaceAddsPackage = hasNewEntry(
-    extractPackagesList(git(["show", `${base}:pnpm-workspace.yaml`])),
-    extractPackagesList(headContent(head, "pnpm-workspace.yaml")),
-  );
+  // Registry/workspace content checks compare declared stacks/packages between
+  // base and head so only a genuinely new registration triggers. When a path
+  // set was supplied, only run a check when its file is in that set — a run
+  // scoped to other paths must not flag a stack/package change outside it.
+  const inScope = (file) => !candidates || candidates.includes(file);
+  const stacksAddsNewStack =
+    inScope("terraform.stacks.json") &&
+    hasNewEntry(
+      extractStackIds(git(["show", `${base}:terraform.stacks.json`])),
+      extractStackIds(headContent(head, "terraform.stacks.json")),
+    );
+  const workspaceAddsPackage =
+    inScope("pnpm-workspace.yaml") &&
+    hasNewEntry(
+      extractPackagesList(git(["show", `${base}:pnpm-workspace.yaml`])),
+      extractPackagesList(headContent(head, "pnpm-workspace.yaml")),
+    );
 
   return { addedFiles, stacksAddsNewStack, workspaceAddsPackage };
 }

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -192,7 +192,11 @@ export function collectGitState(
     ? ["diff", "--diff-filter=A", "--name-only", base, head, "--"]
     : ["diff", "--diff-filter=A", "--name-only", base, "--"];
   const added = new Set(lines(git(diffArgs)));
-  if (includeUntracked) {
+  // Untracked files belong to the WORKING TREE, so only fold them in for a
+  // working-tree run (no explicit head). Mixing the current checkout's untracked
+  // files into an explicit `--head <ref>` diff would let an unrelated local ADR
+  // draft suppress the reminder for the selected ref.
+  if (includeUntracked && !head) {
     for (const file of lines(
       git(["ls-files", "--others", "--exclude-standard"]),
     )) {

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -20,12 +20,15 @@
  * that has no accompanying ADR so a CI job can hard-gate if a team wants that.
  *
  * Usage: node scripts/check-adr-reminder.mjs [--base <ref>] [--head <ref>]
- *          [--strict] [--include-untracked]
+ *          [--strict] [--include-untracked] [--changed-paths-file <file>]
  *
- * The agent quality gate passes its own `--head` and `--include-untracked` so
- * the reminder sees exactly what the gate sees (committed + staged + untracked
- * high-signal files). Standalone runs default to committed/staged only, so an
- * unrelated untracked scratch file never nags.
+ * The agent quality gate passes its own `--head`, `--include-untracked`, and
+ * `--changed-paths-file` so the reminder evaluates exactly the gate's
+ * changed-path set — including a precomputed set routed via
+ * `agent-quality-gate --changed-paths-file`. A path from that set counts as a
+ * new file when it does not exist at base. Standalone runs (no file) fall back
+ * to `git diff` and default to committed/staged only, so an unrelated untracked
+ * scratch file never nags.
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -42,20 +45,26 @@ export function detectAdrTriggers({
   workspaceAddsPackage = false,
 }) {
   const triggers = [];
+  // A new top-level service root announces itself with a new AGENTS.md and/or a
+  // new package.json (a standalone service like governance-watchdog has a
+  // package.json but no AGENTS.md). Collect by dir so one new service is one
+  // trigger regardless of which marker files it added.
+  const serviceDirs = new Set();
   for (const file of addedFiles) {
-    const scoped = /^([^/]+)\/AGENTS\.md$/.exec(file);
-    if (scoped) {
-      triggers.push({
-        surface: file,
-        why: `new package/service "${scoped[1]}/" (new scoped AGENTS.md)`,
-      });
-    }
+    const svc = /^([^/]+)\/(?:AGENTS\.md|package\.json)$/.exec(file);
+    if (svc) serviceDirs.add(svc[1]);
     if (/^\.github\/workflows\/.+\.ya?ml$/.test(file)) {
       triggers.push({
         surface: file,
         why: "new GitHub Actions workflow (new CI/deploy path or required check)",
       });
     }
+  }
+  for (const dir of serviceDirs) {
+    triggers.push({
+      surface: `${dir}/`,
+      why: `new package/service "${dir}/" (new AGENTS.md/package.json)`,
+    });
   }
   if (stacksAddsNewStack) {
     triggers.push({
@@ -174,6 +183,17 @@ function headContent(head, path) {
   return head ? git(["show", `${head}:${path}`]) : readHead(path);
 }
 
+function existsAtBase(base, path) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${base}:${path}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Collect the diff facts the pure detector needs.
  *
@@ -186,12 +206,21 @@ function headContent(head, path) {
  */
 export function collectGitState(
   base,
-  { head = "", includeUntracked = false } = {},
+  { head = "", includeUntracked = false, changedPathsFile = "" } = {},
 ) {
-  const diffArgs = head
-    ? ["diff", "--diff-filter=A", "--name-only", base, head, "--"]
-    : ["diff", "--diff-filter=A", "--name-only", base, "--"];
-  const added = new Set(lines(git(diffArgs)));
+  let added;
+  if (changedPathsFile) {
+    // Consume the gate's authoritative changed-path set instead of recomputing.
+    // A path is "added" when it does not exist at base, so a modified
+    // AGENTS.md/package.json (this very PR) is correctly not a new service.
+    const candidates = lines(readHead(changedPathsFile));
+    added = new Set(candidates.filter((path) => !existsAtBase(base, path)));
+  } else {
+    const diffArgs = head
+      ? ["diff", "--diff-filter=A", "--name-only", base, head, "--"]
+      : ["diff", "--diff-filter=A", "--name-only", base, "--"];
+    added = new Set(lines(git(diffArgs)));
+  }
   // Untracked files belong to the WORKING TREE, so only fold them in for a
   // working-tree run (no explicit head). Mixing the current checkout's untracked
   // files into an explicit `--head <ref>` diff would let an unrelated local ADR
@@ -229,11 +258,14 @@ function main(argv) {
   let head = "";
   let strict = false;
   let includeUntracked = false;
+  let changedPathsFile = "";
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--base") base = argv[++i];
     else if (argv[i] === "--head") head = argv[++i] ?? "";
     else if (argv[i] === "--strict") strict = true;
     else if (argv[i] === "--include-untracked") includeUntracked = true;
+    else if (argv[i] === "--changed-paths-file")
+      changedPathsFile = argv[++i] ?? "";
   }
   // The gate's --head defaults to "HEAD", meaning "the current checkout". Treat
   // that (and empty) as the WORKING TREE so staged/uncommitted edits to
@@ -249,7 +281,11 @@ function main(argv) {
     return 0;
   }
 
-  const state = collectGitState(base, { head, includeUntracked });
+  const state = collectGitState(base, {
+    head,
+    includeUntracked,
+    changedPathsFile,
+  });
   const triggers = detectAdrTriggers(state);
   if (triggers.length === 0) {
     return 0; // No architectural trigger — quiet.

--- a/scripts/check-adr-reminder.test.mjs
+++ b/scripts/check-adr-reminder.test.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Offline tests for the pure logic in check-adr-reminder.mjs.
+ * Run: node scripts/check-adr-reminder.test.mjs  (or `pnpm adr:check:test`)
+ */
+import assert from "node:assert/strict";
+
+import { adrBeingWritten, detectAdrTriggers } from "./check-adr-reminder.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+  console.log(`ok - ${name}`);
+}
+
+check("new scoped AGENTS.md triggers a new-package reminder", () => {
+  const t = detectAdrTriggers({ addedFiles: ["payments/AGENTS.md"] });
+  assert.equal(t.length, 1);
+  assert.match(t[0].why, /new package\/service "payments\/"/);
+});
+
+check(
+  "editing an existing package (not an added file) does NOT trigger",
+  () => {
+    // The gate feeds only ADDED files here; a modified AGENTS.md is not added.
+    const t = detectAdrTriggers({ addedFiles: [] });
+    assert.equal(t.length, 0);
+  },
+);
+
+check("a new workflow file triggers a reminder", () => {
+  const t = detectAdrTriggers({
+    addedFiles: [".github/workflows/deploy-thing.yml"],
+  });
+  assert.equal(t.length, 1);
+  assert.match(t[0].why, /new GitHub Actions workflow/);
+});
+
+check("existing workflow dir but nested non-yaml does not trigger", () => {
+  const t = detectAdrTriggers({ addedFiles: [".github/workflows/README.md"] });
+  assert.equal(t.length, 0);
+});
+
+check("a new terraform stack triggers a reminder", () => {
+  const t = detectAdrTriggers({ addedFiles: [], stacksAddsNewStack: true });
+  assert.equal(t.length, 1);
+  assert.equal(t[0].surface, "terraform.stacks.json");
+});
+
+check("a new workspace package triggers a reminder", () => {
+  const t = detectAdrTriggers({ addedFiles: [], workspaceAddsPackage: true });
+  assert.equal(t.length, 1);
+  assert.equal(t[0].surface, "pnpm-workspace.yaml");
+});
+
+check("multiple triggers accumulate", () => {
+  const t = detectAdrTriggers({
+    addedFiles: ["svc/AGENTS.md", ".github/workflows/x.yaml"],
+    stacksAddsNewStack: true,
+    workspaceAddsPackage: true,
+  });
+  assert.equal(t.length, 4);
+});
+
+check("adrBeingWritten true when a numbered ADR is added", () => {
+  assert.equal(adrBeingWritten(["docs/adr/0034-new-thing.md"]), true);
+});
+
+check("adrBeingWritten ignores the ADR index README", () => {
+  assert.equal(adrBeingWritten(["docs/adr/README.md"]), false);
+});
+
+check("adrBeingWritten false when no ADR added", () => {
+  assert.equal(adrBeingWritten(["ui-dashboard/src/app/page.tsx"]), false);
+});
+
+console.log(`\n${passed} checks passed`);

--- a/scripts/check-adr-reminder.test.mjs
+++ b/scripts/check-adr-reminder.test.mjs
@@ -69,6 +69,33 @@ check("multiple triggers accumulate", () => {
   assert.equal(t.length, 4);
 });
 
+check("a package.json-only service root triggers (no AGENTS.md)", () => {
+  // governance-watchdog-style: package.json but no AGENTS.md.
+  const t = detectAdrTriggers({ addedFiles: ["newsvc/package.json"] });
+  assert.equal(t.length, 1);
+  assert.match(t[0].why, /new package\/service "newsvc\/"/);
+});
+
+check(
+  "AGENTS.md + package.json for the same dir is one trigger (deduped)",
+  () => {
+    const t = detectAdrTriggers({
+      addedFiles: ["newsvc/AGENTS.md", "newsvc/package.json"],
+    });
+    assert.equal(t.length, 1);
+    assert.equal(t[0].surface, "newsvc/");
+  },
+);
+
+check("a nested package.json is not a top-level service root", () => {
+  // A new workspace member under an existing package registers via
+  // pnpm-workspace.yaml (workspaceAddsPackage), not this top-level detection.
+  const t = detectAdrTriggers({
+    addedFiles: ["alerts/infra/newthing/package.json"],
+  });
+  assert.equal(t.length, 0);
+});
+
 check("adrBeingWritten true when a numbered ADR is added", () => {
   assert.equal(adrBeingWritten(["docs/adr/0034-new-thing.md"]), true);
 });

--- a/scripts/check-adr-reminder.test.mjs
+++ b/scripts/check-adr-reminder.test.mjs
@@ -5,7 +5,13 @@
  */
 import assert from "node:assert/strict";
 
-import { adrBeingWritten, detectAdrTriggers } from "./check-adr-reminder.mjs";
+import {
+  adrBeingWritten,
+  detectAdrTriggers,
+  extractPackagesList,
+  extractStackIds,
+  hasNewEntry,
+} from "./check-adr-reminder.mjs";
 
 let passed = 0;
 function check(name, fn) {
@@ -74,5 +80,89 @@ check("adrBeingWritten ignores the ADR index README", () => {
 check("adrBeingWritten false when no ADR added", () => {
   assert.equal(adrBeingWritten(["ui-dashboard/src/app/page.tsx"]), false);
 });
+
+check("extractStackIds reads stacks[].id", () => {
+  const json = JSON.stringify({
+    stacks: [{ id: "platform" }, { id: "aegis" }],
+  });
+  assert.deepEqual(extractStackIds(json), ["platform", "aegis"]);
+});
+
+check("extractStackIds tolerates empty/garbage input", () => {
+  assert.deepEqual(extractStackIds(""), []);
+  assert.deepEqual(extractStackIds("not json"), []);
+  assert.deepEqual(extractStackIds("{}"), []);
+});
+
+check("extractPackagesList reads only the packages: block", () => {
+  const yaml = [
+    "packages:",
+    "  - shared-config",
+    "  - ui-dashboard",
+    "",
+    "minimumReleaseAgeExclude:",
+    '  - "@mento-protocol/*"',
+    "ignoredBuiltDependencies:",
+    "  - sharp",
+  ].join("\n");
+  // The `- @mento-protocol/*` and `- sharp` items must NOT leak in.
+  assert.deepEqual(extractPackagesList(yaml), [
+    "shared-config",
+    "ui-dashboard",
+  ]);
+});
+
+check("extractPackagesList strips quotes", () => {
+  const yaml = [
+    "packages:",
+    "  - 'alerts/infra/oncall-announcer'",
+    "catalog:",
+  ].join("\n");
+  assert.deepEqual(extractPackagesList(yaml), [
+    "alerts/infra/oncall-announcer",
+  ]);
+});
+
+check("hasNewEntry true only when head has an unseen entry", () => {
+  assert.equal(hasNewEntry(["a", "b"], ["a", "b"]), false);
+  assert.equal(hasNewEntry(["a", "b"], ["a", "b", "c"]), true);
+  assert.equal(hasNewEntry(["a", "b"], ["a"]), false); // removal is not an add
+});
+
+check("editing an existing stack path does not read as a new stack", () => {
+  const base = JSON.stringify({
+    stacks: [{ id: "platform", path: "terraform" }],
+  });
+  const head = JSON.stringify({
+    stacks: [{ id: "platform", path: "infra/tf" }],
+  });
+  assert.equal(
+    hasNewEntry(extractStackIds(base), extractStackIds(head)),
+    false,
+  );
+});
+
+check(
+  "adding a minimumReleaseAgeExclude entry is not a workspace package add",
+  () => {
+    const base = [
+      "packages:",
+      "  - shared-config",
+      "minimumReleaseAgeExclude:",
+      "  - tar",
+    ].join("\n");
+    const head = [
+      "packages:",
+      "  - shared-config",
+      "minimumReleaseAgeExclude:",
+      "  - tar",
+      "  - undici",
+    ].join("\n");
+    assert.equal(
+      hasNewEntry(extractPackagesList(base), extractPackagesList(head)),
+      false,
+    );
+  },
+);
 
 console.log(`\n${passed} checks passed`);

--- a/scripts/check-agent-quality-gate-package-scripts.sh
+++ b/scripts/check-agent-quality-gate-package-scripts.sh
@@ -14,6 +14,8 @@ const expectedScripts = {
   "agent:review-materiality": "node scripts/review-materiality.mjs",
   "agent:review-materiality:test": "node scripts/review-materiality.test.mjs",
   "agent:context-check": "node scripts/check-agent-context.mjs",
+  "adr:check": "node scripts/check-adr-reminder.mjs",
+  "adr:check:test": "node scripts/check-adr-reminder.test.mjs",
   "agent:autoreview": "./scripts/agent-autoreview.sh",
   "issue:board": "node scripts/agent-issue-board.mjs",
   "issue:board:test": "node scripts/agent-issue-board.test.mjs",

--- a/shared-config/AGENTS.md
+++ b/shared-config/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Shared Config
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `shared-config`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## Scope
 
 `shared-config/` is the source of truth for chain metadata, deployment namespaces, token/pool label derivation, FX calendar data, and shared ABIs.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Terraform
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `terraform/infra`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## Scope
 
 `terraform/` is the `platform` stack registered in `terraform.stacks.json`. It manages production infrastructure for the monitoring dashboard, Upstash, the monitoring GCP project/APIs, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, Workload Identity Federation, and repo-level GitHub Actions secrets owned by the platform stack. Alert ownership lives in `alerts/` (`alerts/rules/` for protocol Grafana rules/global routing, `alerts/infra/` for event-driven delivery) and `aegis/terraform/` (Aegis dashboard + service-health alert).

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -8,6 +8,8 @@ last_verified: 2026-05-20
 
 # AGENTS.md — Monitoring Dashboard
 
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `ui-dashboard`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+
 ## What This Is
 
 Next.js 16 monitoring dashboard for Mento v3 pools. Displays real-time pool data (reserves, swaps, mints, burns) using Plotly.js charts, sourced from Hasura GraphQL.


### PR DESCRIPTION
## The Problem

- The repo's architectural decisions lived only in people's heads and scattered `AGENTS.md` rules, so onboarding humans and agents re-litigated settled choices — or violated them without knowing a decision existed.
- New decisions made in PRs were never written down, and "we should document that" is the first thing a busy session drops.

## The Solution

- Add `docs/adr/` — a decision log of 33 ADRs (32 past decisions across the repo and its sub-modules, plus one recording the ADR process itself), grouped by scope, each stating in plain English what was decided, why, what was rejected, and when.
- Make the process non-forgettable: a when/how checklist, an advisory reminder gate (`pnpm adr:check`) wired into the agent quality gate on architectural surfaces, a PR-template prompt, and a `docs/adr/` pointer in every package `AGENTS.md`.

## Details

- **Structure (the "both" answer):** one central `docs/adr/` log, one file per decision (`NNNN-kebab.md`), each carrying a `scope:` field; the index groups by scope so you get a per-module reading path without scattering files. Chosen over per-package ADR dirs (cross-cutting decisions would have no home) and over one giant file (one-file-per-decision matches the repo memory/context model, stays greppable, and can be superseded individually).
- **Granularity:** each ADR passes a three-part bar — constrains future work · had a real alternative · the why isn't obvious from the code. Bug fixes, dep bumps, and one-off features are deliberately excluded; PR clusters collapse to one ADR.
- **Metadata contract:** frontmatter uses `status: active` (the repo contract enforced by `agent:context-check`); the ADR lifecycle (Accepted / Superseded) lives in the body's Status line, so `status: accepted` never trips the gate. All in-force ADRs are `canonical: true` and enrolled in the 90-day re-verification window.
- **The gate:** `scripts/check-adr-reminder.mjs` (`pnpm adr:check`) detects high-signal triggers — a new package/service (new scoped `AGENTS.md`), a new Terraform stack (`terraform.stacks.json`), a new workflow — and stays silent unless a trigger ships without an ADR. Advisory by default (exit 0); `--strict` exits non-zero for CI hard-gating. Wired into `scripts/agent-quality-gate.sh` on the stack-registry / workspace / workflow routing; `adr:check` + `adr:check:test` added to the gate's tooling-script allowlist, the package-scripts validator, and its `expectedScripts` map.
- **Discoverability:** root `AGENTS.md` rule + Quick Commands entry, `docs/pr-checklists/architecture-decisions.md`, a `recurring-review-patterns.md` entry, the context authority map, the PR template, and per-package `AGENTS.md` pointers.
- **Evidence:** every ADR cites real PR numbers / commits mined from the repo history (e.g. #209, #318, #371, #443, #514, #558, #603, #728, #819, #882, #1092).

## Validation

- `pnpm agent:context-check` → passes (61 managed files; all 33 ADRs + the new checklist validated against the metadata contract).
- `pnpm agent:quality-gate --run` → `passed (exit 0)`.
- `bash scripts/agent-quality-gate.test.sh` → exit 0 (gate routing unchanged for existing paths).
- `node scripts/check-adr-reminder.test.mjs` → 10 checks pass.
- `pnpm adr:check` self-suppresses on this PR (it adds ADRs) — verified exit 0, no output.
- Gate wiring verified via `--changed-paths-file` dry-runs: `terraform.stacks.json` surfaces the ADR checklist + `adr:check`; a new workflow runs `adr:check`.
- `trunk fmt` + `trunk check` → No issues across all changed files.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Architecture decision? This PR is the ADR log itself; ADR 0033 records the decision to adopt the ADR process + gate.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and advisory tooling only; no runtime, auth, or deploy behavior changes. Gate is advisory by default and self-suppresses when ADRs are present.
> 
> **Overview**
> Introduces a **central architecture decision log** under `docs/adr/` — 33 numbered ADRs (0001–0033) that capture past repo-wide and package-level choices in Context / Decision / Alternatives / Consequences form, plus an index README and **ADR 0033** documenting the ADR process itself.
> 
> **Process and enforcement:** Adds `docs/pr-checklists/architecture-decisions.md`, extends the PR template with an “Architecture decision?” checkbox, treats in-force ADRs as **canonical context** in `docs/context-standards.md`, and points package `AGENTS.md` files at the ADR index. **`pnpm adr:check`** (`scripts/check-adr-reminder.mjs`) advisories when diffs add a new service, Terraform stack, workspace package, or workflow without a numbered ADR; **`--strict`** can fail CI. The agent quality gate routes that reminder on workflow, stack-registry, workspace, and new top-level `AGENTS.md` / `package.json` changes, with unit tests in `check-adr-reminder.test.mjs`.
> 
> Root **`AGENTS.md`** and recurring review patterns now describe when to write ADRs; root **`package.json`** registers `adr:check` scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba2409ca44b7bfa3d02321c000e88b20b9b9b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->