### PR TITLE
fix(indexer): guard borrowing-fee replay double-count (#1083)

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1299,6 +1299,17 @@ type LiquityBorrowingRevenueDailySnapshot
   updatedAtTimestamp: BigInt!
 }
 
+# Replay guard for recordBorrowingFeeAndApplyCum (issue #1083): ensures a
+# given (chainId, blockNumber, logIndex) TroveOperation/BatchUpdated event
+# contributes its upfront fee to LiquityInstance.borrowingFeeCum and
+# LiquityBorrowingRevenueDailySnapshot.upfrontFee at most once. id is the
+# event's `eventId(chainId, blockNumber, logIndex)`. The row is written once
+# and never updated or deleted — a redelivered event finds it already
+# present and skips the fee application.
+type BorrowingFeeAppliedEvent {
+  id: ID!
+}
+
 type InterestBatch {
   id: ID!
   collateralId: String! @index

--- a/indexer-envio/src/handlers/liquity/borrowingRevenue.ts
+++ b/indexer-envio/src/handlers/liquity/borrowingRevenue.ts
@@ -1,4 +1,5 @@
 import type {
+  BorrowingFeeAppliedEvent,
   InterestRateBracket,
   LiquityBorrowingRevenueDailySnapshot,
   LiquityInstance,
@@ -27,6 +28,20 @@ type BorrowingRevenueBracketContext = BorrowingRevenueSnapshotContext & {
 };
 
 export type BorrowingRevenueContext = BorrowingRevenueBracketContext;
+
+// Read-only view of the replay guard, used by the preload warmer below.
+type BorrowingFeeAppliedEventReadContext = {
+  BorrowingFeeAppliedEvent: {
+    get: (id: string) => Promise<BorrowingFeeAppliedEvent | undefined>;
+  };
+};
+
+// Read/write view used by recordBorrowingFeeAndApplyCum to gate the write.
+type BorrowingFeeAppliedEventContext = BorrowingFeeAppliedEventReadContext & {
+  BorrowingFeeAppliedEvent: {
+    set: (entity: BorrowingFeeAppliedEvent) => void;
+  };
+};
 
 export const borrowingRevenueDailySnapshotId = (
   instanceId: string,
@@ -89,12 +104,23 @@ export async function recordBorrowingUpfrontFee(
 }
 
 export async function recordBorrowingFeeAndApplyCum(
-  context: BorrowingRevenueSnapshotContext,
+  context: BorrowingRevenueSnapshotContext & BorrowingFeeAppliedEventContext,
   instance: LiquityInstance,
   fee: bigint,
   timestamp: bigint,
   blockNumber: bigint,
+  // Replay guard key: eventId(chainId, blockNumber, logIndex) of the
+  // TroveOperation/BatchUpdated event carrying this fee. A redelivered event
+  // (reorg replay, backfill re-run) must not re-apply its fee — see
+  // BorrowingFeeAppliedEvent in schema.graphql.
+  appliedFeeEventId: string,
 ): Promise<LiquityInstance> {
+  if (fee <= ZERO) return instance;
+  const alreadyApplied =
+    await context.BorrowingFeeAppliedEvent.get(appliedFeeEventId);
+  if (alreadyApplied !== undefined) return instance;
+  context.BorrowingFeeAppliedEvent.set({ id: appliedFeeEventId });
+
   await recordBorrowingUpfrontFee(
     context,
     instance,
@@ -309,3 +335,14 @@ export const preloadBorrowingUpfrontFeeBucket =
 // Warm the daily-snapshot row recordBorrowingCollected reads (the event-day
 // bucket).
 export const preloadBorrowingCollectedBucket = preloadBorrowingRevenueDayBucket;
+
+// Warm the BorrowingFeeAppliedEvent row recordBorrowingFeeAndApplyCum's
+// replay guard reads, when a positive upfront fee is present.
+export async function preloadBorrowingFeeAppliedEvent(
+  context: BorrowingFeeAppliedEventReadContext,
+  appliedFeeEventId: string,
+  amount: bigint,
+): Promise<void> {
+  if (amount <= ZERO) return;
+  await context.BorrowingFeeAppliedEvent.get(appliedFeeEventId);
+}

--- a/indexer-envio/src/handlers/liquity/troveManager.ts
+++ b/indexer-envio/src/handlers/liquity/troveManager.ts
@@ -1,5 +1,5 @@
 import { indexer } from "../../indexer.js";
-import { asBigInt, eventId } from "../../helpers.js";
+import { asBigInt, eventId, eventIdFromEvent } from "../../helpers.js";
 import {
   getOrCreateLiquityInstance,
   preloadLiquityMarket,
@@ -85,6 +85,7 @@ indexer.onEvent(
           operation: Number(event.params._operation),
           annualInterestRate: event.params._annualInterestRate,
           upfrontFee: event.params._debtIncreaseFromUpfrontFee,
+          appliedFeeEventId: eventIdFromEvent(event),
           blockNumber: asBigInt(event.block.number),
           blockTimestamp: asBigInt(event.block.timestamp),
         }),
@@ -191,6 +192,7 @@ indexer.onEvent(
       event.params._debtIncreaseFromUpfrontFee,
       blockTimestamp,
       blockNumber,
+      eventIdFromEvent(event),
     );
     // TroveOperation only flips status — debt arrives in TroveUpdated.
     instance = applySystemDebtDelta(instance, prevTroveState, {
@@ -423,6 +425,7 @@ indexer.onEvent(
         blockNumber,
         blockTimestamp,
         upfrontFee: event.params._debtIncreaseFromUpfrontFee,
+        appliedFeeEventId: eventIdFromEvent(event),
         prevBatchRate: existing?.annualInterestRate ?? 0n,
         nextBatchRate: event.params._annualInterestRate,
         prevBatchDebt: existing?.debt ?? 0n,
@@ -530,6 +533,7 @@ indexer.onEvent(
       event.params._debtIncreaseFromUpfrontFee,
       blockTimestamp,
       blockNumber,
+      eventIdFromEvent(event),
     );
     context.LiquityInstance.set(
       touchLiquityInstance(instance, blockNumber, blockTimestamp),

--- a/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
@@ -2,6 +2,7 @@ import type { PendingBatchMembershipOperation, Trove } from "envio";
 import { pendingTroveKey } from "./keys.js";
 import { preloadLiquityMarket } from "./bootstrap.js";
 import {
+  preloadBorrowingFeeAppliedEvent,
   preloadBorrowingRevenueRollover,
   preloadBorrowingUpfrontFeeBucket,
 } from "./borrowingRevenue.js";
@@ -70,6 +71,7 @@ export async function preloadTroveOperation(
     operation: number;
     annualInterestRate: bigint;
     upfrontFee: bigint;
+    appliedFeeEventId: string;
     blockNumber: bigint;
     blockTimestamp: bigint;
   },
@@ -85,6 +87,11 @@ export async function preloadTroveOperation(
     args.collateralId,
     args.upfrontFee,
     args.blockTimestamp,
+  );
+  await preloadBorrowingFeeAppliedEvent(
+    context,
+    args.appliedFeeEventId,
+    args.upfrontFee,
   );
   if (args.operation === OP.REDEEM_COLLATERAL) {
     setPendingRedemption(context, {
@@ -112,6 +119,7 @@ export async function preloadBatchReplay(args: {
   blockNumber: bigint;
   blockTimestamp: bigint;
   upfrontFee: bigint;
+  appliedFeeEventId: string;
   prevBatchRate: bigint;
   nextBatchRate: bigint;
   prevBatchDebt: bigint;
@@ -142,6 +150,11 @@ export async function preloadBatchReplay(args: {
       args.collateralId,
       args.upfrontFee,
       args.blockTimestamp,
+    ),
+    preloadBorrowingFeeAppliedEvent(
+      args.context,
+      args.appliedFeeEventId,
+      args.upfrontFee,
     ),
     preloadInterestRateBracketDebt(args.context, {
       collateralId: args.collateralId,

--- a/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
@@ -76,23 +76,25 @@ export async function preloadTroveOperation(
     blockTimestamp: bigint;
   },
 ): Promise<void> {
-  const trove = await preloadTroveAndMarket(
-    context,
-    args.market,
-    args.collateralId,
-    args.troveId,
-  );
-  await preloadBorrowingUpfrontFeeBucket(
-    context,
-    args.collateralId,
-    args.upfrontFee,
-    args.blockTimestamp,
-  );
-  await preloadBorrowingFeeAppliedEvent(
-    context,
-    args.appliedFeeEventId,
-    args.upfrontFee,
-  );
+  const [trove] = await Promise.all([
+    preloadTroveAndMarket(
+      context,
+      args.market,
+      args.collateralId,
+      args.troveId,
+    ),
+    preloadBorrowingUpfrontFeeBucket(
+      context,
+      args.collateralId,
+      args.upfrontFee,
+      args.blockTimestamp,
+    ),
+    preloadBorrowingFeeAppliedEvent(
+      context,
+      args.appliedFeeEventId,
+      args.upfrontFee,
+    ),
+  ]);
   if (args.operation === OP.REDEEM_COLLATERAL) {
     setPendingRedemption(context, {
       ...args,

--- a/indexer-envio/src/handlers/liquity/troveManagerPreloadContext.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerPreloadContext.ts
@@ -1,5 +1,6 @@
 import type {
   BorrowerInfo,
+  BorrowingFeeAppliedEvent,
   InterestRateBracket,
   LiquityBorrowingRevenueDailySnapshot,
   PendingBatchMembershipOperation,
@@ -52,6 +53,9 @@ export type TroveManagerPreloadContext = Parameters<
     BorrowerInfo: {
       get: (id: string) => Promise<BorrowerInfo | undefined>;
       set: (entity: BorrowerInfo) => void;
+    };
+    BorrowingFeeAppliedEvent: {
+      get: (id: string) => Promise<BorrowingFeeAppliedEvent | undefined>;
     };
   };
 

--- a/indexer-envio/src/helpers.ts
+++ b/indexer-envio/src/helpers.ts
@@ -8,6 +8,13 @@ export const eventId = (
   logIndex: number,
 ): string => `${chainId}_${blockNumber}_${logIndex}`;
 
+/** eventId derived directly from an event's identity fields. */
+export const eventIdFromEvent = (event: {
+  chainId: number;
+  block: { number: number };
+  logIndex: number;
+}): string => eventId(event.chainId, event.block.number, event.logIndex);
+
 export const asAddress = (value: string): string => value.toLowerCase();
 
 /**

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -8,6 +8,7 @@ import {
   dayBucket,
   asBigInt,
   eventId,
+  eventIdFromEvent,
   extractAddressFromPoolId,
   hourBucket,
   makePoolId,
@@ -91,6 +92,15 @@ describe("indexer code quality invariants", () => {
     assert.notEqual(eventId(42220, 123, 4), eventId(42220, 124, 4));
     assert.notEqual(eventId(42220, 123, 4), eventId(42220, 123, 5));
     assert.equal(asBigInt(123), 123n);
+  });
+
+  it("derives the same collision-resistant ID from an event's identity fields", () => {
+    const event = { chainId: 42220, block: { number: 123 }, logIndex: 4 };
+    assert.equal(eventIdFromEvent(event), eventId(42220, 123, 4));
+    assert.notEqual(
+      eventIdFromEvent(event),
+      eventIdFromEvent({ ...event, logIndex: 5 }),
+    );
   });
 
   it("keeps pool IDs chain-namespaced and lowercased", () => {

--- a/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
+++ b/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
@@ -9,14 +9,15 @@
  * `bootstrapCollaterals` (bootstrapHandler.ts's onBlock target) is a plain
  * get-or-create and is idempotent by construction.
  *
- * The last test in this file pins a REAL gap found while writing this
- * coverage: `recordBorrowingFeeAndApplyCum` (borrowingRevenue.ts), called
- * unconditionally from both the `TroveOperation` and `BatchUpdated` handlers,
- * has no replay guard — a redelivered event with a nonzero
- * `_debtIncreaseFromUpfrontFee` double-counts `LiquityInstance.borrowingFeeCum`
- * and the `LiquityBorrowingRevenueDailySnapshot.upfrontFee` bucket. Filed as
- * follow-up issue #1083; this test pins CURRENT behavior, it does not assert
- * desired behavior.
+ * The last test in this file pins the fix for issue #1083:
+ * `recordBorrowingFeeAndApplyCum` (borrowingRevenue.ts), called from both the
+ * `TroveOperation` and `BatchUpdated` handlers, now gates its write on a
+ * `BorrowingFeeAppliedEvent` replay-guard row keyed by
+ * `eventId(chainId, blockNumber, logIndex)` — a redelivered event with a
+ * nonzero `_debtIncreaseFromUpfrontFee` finds its guard row already present
+ * and skips re-applying the fee, so `LiquityInstance.borrowingFeeCum` and the
+ * `LiquityBorrowingRevenueDailySnapshot.upfrontFee` bucket are unaffected by
+ * the replay.
  */
 import { strict as assert } from "assert";
 import type {
@@ -234,7 +235,7 @@ describe("Liquity batchReplay idempotency", () => {
     assert.equal(secondPassCollateral?.minDebt, MIN_DEBT);
   });
 
-  it("KNOWN GAP (#1083): replaying a BatchUpdated event with a nonzero upfront fee double-counts LiquityInstance.borrowingFeeCum AND LiquityBorrowingRevenueDailySnapshot.upfrontFee (pins current behavior)", async () => {
+  it("replaying a BatchUpdated event with a nonzero upfront fee does not double-count LiquityInstance.borrowingFeeCum or LiquityBorrowingRevenueDailySnapshot.upfrontFee (#1083)", async () => {
     let mockDb = MockDb.createMockDb();
     seedLoadedCollateral(mockDb);
     const fee = 10n * 10n ** 18n;
@@ -271,25 +272,18 @@ describe("Liquity batchReplay idempotency", () => {
     instance = mockDb.entities.LiquityInstance.get(collateralId);
     snapshot =
       mockDb.entities.LiquityBorrowingRevenueDailySnapshot.get(snapshotId);
-    // NOTE for whoever fixes #1083: once recordBorrowingFeeAndApplyCum is
-    // made replay-safe, BOTH expectations below must flip to `fee` (not
-    // `fee * 2n`) — recordBorrowingUpfrontFee (which writes the daily
-    // snapshot) and the borrowingFeeCum increment share the same missing
-    // replay guard. Leaving these assertions on the buggy value is
-    // intentional — it pins CURRENT behavior per issue #1054's workflow
-    // contract, not the desired behavior; it is deliberately not skipped so
-    // it forces an explicit update the moment #1083 lands.
+    // recordBorrowingFeeAndApplyCum's BorrowingFeeAppliedEvent replay guard
+    // (keyed on this event's eventId) is already set from the first
+    // delivery, so the redelivered event must not re-apply the fee.
     assert.equal(
       instance?.borrowingFeeCum,
-      fee * 2n,
-      "KNOWN GAP: recordBorrowingFeeAndApplyCum has no replay guard, so the " +
-        "fee is double-counted on redelivery — pinned here, not the desired behavior",
+      fee,
+      "borrowingFeeCum is unchanged by the replayed event — not doubled",
     );
     assert.equal(
       snapshot?.upfrontFee,
-      fee * 2n,
-      "KNOWN GAP: the daily snapshot's upfrontFee bucket is double-counted " +
-        "in lockstep with borrowingFeeCum — pinned here, not the desired behavior",
+      fee,
+      "daily snapshot upfrontFee is unchanged by the replayed event — not doubled",
     );
   });
 });

--- a/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
+++ b/indexer-envio/test/liquityBatchReplayIdempotency.test.ts
@@ -9,7 +9,7 @@
  * `bootstrapCollaterals` (bootstrapHandler.ts's onBlock target) is a plain
  * get-or-create and is idempotent by construction.
  *
- * The last test in this file pins the fix for issue #1083:
+ * The last two tests in this file pin the fix for issue #1083:
  * `recordBorrowingFeeAndApplyCum` (borrowingRevenue.ts), called from both the
  * `TroveOperation` and `BatchUpdated` handlers, now gates its write on a
  * `BorrowingFeeAppliedEvent` replay-guard row keyed by
@@ -17,7 +17,10 @@
  * nonzero `_debtIncreaseFromUpfrontFee` finds its guard row already present
  * and skips re-applying the fee, so `LiquityInstance.borrowingFeeCum` and the
  * `LiquityBorrowingRevenueDailySnapshot.upfrontFee` bucket are unaffected by
- * the replay.
+ * the replay. One test drives the `BatchUpdated` call site, the other drives
+ * `TroveOperation` — both route through the same shared function and
+ * `eventIdFromEvent` computation, but a wiring bug at either call site would
+ * only be caught by testing that site directly.
  */
 import { strict as assert } from "assert";
 import type {
@@ -29,6 +32,7 @@ import type {
 import { bootstrapCollaterals } from "../src/handlers/liquity/bootstrap";
 import { makeLiquityCollateral } from "../src/handlers/liquity/bootstrap";
 import { borrowingRevenueDailySnapshotId } from "../src/handlers/liquity/borrowingRevenue";
+import { dayBucket } from "../src/helpers";
 import {
   LIQUITY_MARKETS,
   makeCollateralId,
@@ -67,6 +71,7 @@ const MIN_DEBT = 100n * 10n ** 18n;
 const BATCH_MANAGER = "0x000000000000000000000000000000000000b0b0";
 const TROVE_ID = 1n;
 const TX_HASH = "0xbatchreplay";
+const TROVE_OP_TX_HASH = "0xtroveopreplay";
 
 function seedLoadedCollateral(mockDb: ReplayMockDb): void {
   mockDb.entities.LiquityCollateral.set({
@@ -91,6 +96,29 @@ function batchedTroveUpdatedEvent(logIndex: number) {
       logIndex,
       block: { number: 500, timestamp: 5_000 },
       transaction: { hash: TX_HASH },
+    },
+  });
+}
+
+function troveOperationEvent(args: {
+  logIndex: number;
+  debtIncreaseFromUpfrontFee?: bigint;
+}) {
+  return LiquityTroveManager.TroveOperation.createMockEvent({
+    _troveId: TROVE_ID,
+    _operation: OP.ADJUST_TROVE,
+    _annualInterestRate: 5n * 10n ** 16n,
+    _debtIncreaseFromRedist: 0n,
+    _debtIncreaseFromUpfrontFee: args.debtIncreaseFromUpfrontFee ?? 0n,
+    _debtChangeFromOperation: 0n,
+    _collIncreaseFromRedist: 0n,
+    _collChangeFromOperation: 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: 600, timestamp: 6_000 },
+      transaction: { hash: TROVE_OP_TX_HASH },
     },
   });
 }
@@ -275,6 +303,62 @@ describe("Liquity batchReplay idempotency", () => {
     // recordBorrowingFeeAndApplyCum's BorrowingFeeAppliedEvent replay guard
     // (keyed on this event's eventId) is already set from the first
     // delivery, so the redelivered event must not re-apply the fee.
+    assert.equal(
+      instance?.borrowingFeeCum,
+      fee,
+      "borrowingFeeCum is unchanged by the replayed event — not doubled",
+    );
+    assert.equal(
+      snapshot?.upfrontFee,
+      fee,
+      "daily snapshot upfrontFee is unchanged by the replayed event — not doubled",
+    );
+  });
+
+  it("replaying a TroveOperation event with a nonzero upfront fee does not double-count LiquityInstance.borrowingFeeCum or LiquityBorrowingRevenueDailySnapshot.upfrontFee (#1083)", async () => {
+    // Same invariant as the BatchUpdated test above, but for the
+    // TroveOperation call site: both handlers route through the shared
+    // recordBorrowingFeeAndApplyCum via the same eventIdFromEvent(event)
+    // computation, so this guards the TroveOperation wiring specifically.
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const fee = 10n * 10n ** 18n;
+    const snapshotId = borrowingRevenueDailySnapshotId(
+      collateralId,
+      dayBucket(6_000n),
+    );
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({ logIndex: 1, debtIncreaseFromUpfrontFee: fee }),
+      ],
+    });
+    let instance = mockDb.entities.LiquityInstance.get(collateralId);
+    assert.equal(
+      instance?.borrowingFeeCum,
+      fee,
+      "fee recorded once on first delivery",
+    );
+    let snapshot =
+      mockDb.entities.LiquityBorrowingRevenueDailySnapshot.get(snapshotId);
+    assert.equal(
+      snapshot?.upfrontFee,
+      fee,
+      "daily snapshot upfrontFee recorded once on first delivery",
+    );
+
+    // Replay the identical TroveOperation event a second time (same tx hash,
+    // same logIndex, same block).
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveOperationEvent({ logIndex: 1, debtIncreaseFromUpfrontFee: fee }),
+      ],
+    });
+    instance = mockDb.entities.LiquityInstance.get(collateralId);
+    snapshot =
+      mockDb.entities.LiquityBorrowingRevenueDailySnapshot.get(snapshotId);
     assert.equal(
       instance?.borrowingFeeCum,
       fee,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `recordBorrowingFeeAndApplyCum` bumped `LiquityInstance.borrowingFeeCum` via a bare `+=` on every `TroveOperation`/`BatchUpdated` handler invocation.
- `recordBorrowingUpfrontFee` (called from the same function) bumped `LiquityBorrowingRevenueDailySnapshot.upfrontFee` the same way.
- A redelivered event (reorg replay, backfill re-run) with a nonzero upfront fee therefore double-counted both surfaces — unlike the rest of the Liquity subtree, which already gates redelivery-sensitive accumulators (`PendingBatchedTroveUpdate` scratch rows, prev/next delta-tracking for `systemDebt`).

## The Solution

- Added a `BorrowingFeeAppliedEvent` replay-guard entity keyed on `eventId(chainId, blockNumber, logIndex)`. `recordBorrowingFeeAndApplyCum` now checks for an existing guard row before writing, and creates it on first application — so a given event contributes its upfront fee to both `borrowingFeeCum` and the daily snapshot at most once, mirroring the scratch-row idempotency pattern already used by `replayBatchedTroveUpdate`.

## Details

- Guard only fires for positive fees (`fee <= 0n` short-circuits before touching the guard row) — the overwhelming majority of `TroveOperation`/`BatchUpdated` events carry a zero upfront fee, so this avoids writing a marker row for every single event.
- Threaded the guard key through both call sites (`TroveOperation`, `BatchUpdated` in `troveManager.ts`) and their preload branches (`preloadTroveOperation`, `preloadBatchReplay` in `troveManagerPreload.ts`), including a preload warmer (`preloadBorrowingFeeAppliedEvent`) consistent with this subtree's existing "read-only preload warmer" convention — a missed warm would still be correct, just a lazier read.
- Added a tiny `eventIdFromEvent` helper (`src/helpers.ts`) so the guard-key computation stays a single line at each call site — the original 5-line `eventId(event.chainId, event.block.number, event.logIndex)` block pushed the `TroveOperation` handler over the repo's `max-lines-per-function` ESLint baseline (154 vs 150 lines).
- Non-goal (per issue): the `Trove`/`systemDebt` delta-tracking pattern is untouched.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test` — full suite green: 73 files, 1040 passed, 19 skipped (2 unrelated tests — `wormholeCompleteFlow`, Pool `dailySnapshot` — are pre-existing flakes under full-suite RPC load; both pass in isolation).
- `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean.
- Regression-guard sanity check: reverted the fix (schema + source, kept the flipped test) and confirmed `liquityBatchReplayIdempotency.test.ts`'s replay test fails against the pre-fix code with the old double-counted value (`20n*1e18` vs expected `10n*1e18`) — confirms the flipped assertion is a real regression guard, not a vacuous one.
- Flipped `liquityBatchReplayIdempotency.test.ts`'s "KNOWN GAP (#1083)" test to assert the fixed behavior (no double-count on `borrowingFeeCum` or the daily snapshot's `upfrontFee`) and rewrote its note describing the now-correct behavior. Grepped the rest of the suite for other assertions depending on the double-count — none found.
- `pnpm indexer:mutation` — 94.57% (break floor 92%). The new `eventIdFromEvent` helper's initial survivor (constant-return mutant) was closed with a direct unit test in `test/code-quality-invariants.test.ts`; remaining survivors (`tradingLimits.ts`, `classifyKind.ts`) are pre-existing and untouched by this PR.
- `pnpm agent:quality-gate` (via `--run --keep-going`) — all mapped commands passed (codegen ×3, trunk check, lint, typecheck, test:coverage, knip, code-health:deps, indexer:mutation).
- `pnpm agent:autoreview` (both `codex` and `local` engines) — clean, no actionable findings.
- `trunk fmt` — no issues.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.

Closes #1083

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cumulative revenue and daily snapshot metrics on replay paths; incorrect guard wiring could under-count fees, but scope is limited to positive upfront fees on two Liquity handlers with dedicated regression tests.
> 
> **Overview**
> Fixes **#1083** by making upfront borrowing-fee accounting **idempotent on event redelivery** (reorgs, backfill re-runs).
> 
> A new **`BorrowingFeeAppliedEvent`** schema entity acts as a replay guard keyed by **`eventId(chainId, blockNumber, logIndex)`**. **`recordBorrowingFeeAndApplyCum`** now skips work when that row already exists (and still no-ops for zero fees), so each fee-bearing event updates **`LiquityInstance.borrowingFeeCum`** and **`LiquityBorrowingRevenueDailySnapshot.upfrontFee`** at most once.
> 
> **`TroveOperation`** and **`BatchUpdated`** handlers pass **`eventIdFromEvent(event)`** into that path; preload warmers include **`preloadBorrowingFeeAppliedEvent`**. Tests that previously pinned the double-count bug now assert single-count behavior for both call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 259f746392743dcbf9f58776cefc7489eb4c3a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->