### PR TITLE
perf(dashboard): code-split markdown editor + add per-chunk size budgets

### DIFF
--- a/ui-dashboard/.size-limit.cjs
+++ b/ui-dashboard/.size-limit.cjs
@@ -16,8 +16,10 @@
 // 4. Update the comments below with the new baseline + date.
 //
 // BASELINE (measured 2026-07-06 with Next.js 16.2.6 + Turbopack):
-//   All client JS chunks (brotli): 1,085,606 bytes (1.03 MB)
-//   All CSS (brotli):              10,987 bytes (10.7 KB)
+//   All client JS chunks (brotli):     1,094,742 bytes (1.04 MB)
+//   Plotly chunk (brotli):               291,466 bytes
+//   Markdown editor chunk (brotli):       44,130 bytes
+//   All CSS (brotli):                     10,987 bytes (10.7 KB)
 
 const fs = process.getBuiltinModule("node:fs");
 const path = process.getBuiltinModule("node:path");
@@ -133,6 +135,36 @@ function manifestPathsOrFallback(extension, prefixes, fallbackGlob) {
   return [fallbackGlob];
 }
 
+// Pin a single logical chunk by a stable content marker instead of a filename.
+// Turbopack content-hashes filenames every build (see header), so a named budget
+// can't key on the filename; we read each manifest-referenced JS asset and select
+// the one whose source contains `marker`. This lets us guard individual chunks —
+// the Plotly bundle and the lazy markdown-editor bundle — so a regression trips a
+// tight per-chunk budget rather than hiding inside the aggregate. If a marker ever
+// stops matching (renamed/removed), we return a non-existent sentinel path so
+// size-limit reports 0 bytes and passes, leaving the aggregate budget as backstop
+// rather than crashing the whole run on an empty path list.
+function chunkContaining(marker, label) {
+  const assets = collectManifestReferencedStaticAssets({
+    extension: ".js",
+    prefixes: ["static/chunks/"],
+  });
+  const cwd = process.cwd();
+  const matches = assets.filter((asset) => {
+    try {
+      return fs.readFileSync(path.resolve(cwd, asset), "utf8").includes(marker);
+    } catch {
+      return false;
+    }
+  });
+
+  if (matches.length === 0) {
+    return [`${DIST_DIR}/static/chunks/__no_${label}_chunk_matched__.js`];
+  }
+
+  return matches;
+}
+
 /** @type {import('size-limit').SizeLimitConfig} */
 const config = [
   {
@@ -147,7 +179,10 @@ const config = [
     // traces are used) cut the client JS from 1,702,785 → 1,085,606 bytes brotli
     // (−36%). See docs/notes/ui-dashboard-performance-plan.md (P1).
     //
-    // Baseline: 1,085,606 bytes  Budget: ×1.10 = 1,194,167 bytes → 1190 KB.
+    // Baseline: 1,094,742 bytes  Budget: 1190 KB. (Was 1,085,606 after the P1
+    // plotly swap; lazy-splitting the markdown editor in P4 moved ~44 KB brotli off
+    // the data-page critical path but added ~9 KB of async chunk-boundary overhead
+    // to this all-chunks total — the per-chunk budgets below track the real wins.)
     // Keep this tight so a regression back to the full plotly.js build fails CI.
     name: "All client JS chunks",
     path: manifestPathsOrFallback(
@@ -156,6 +191,31 @@ const config = [
       ".next/static/chunks/**/*.js",
     ),
     limit: "1190 kB",
+  },
+  {
+    // Plotly chunk, pinned by content (the "js-plotly-plot" DOM class the bundle
+    // emits) so it survives Turbopack's per-build content hashing. Guards P1: the
+    // lean plotly.js-basic-dist-min build is ~291 KB brotli; reintroducing the full
+    // plotly.js (mapbox-gl + WebGL) balloons this chunk past the budget and fails CI
+    // here, before it hides inside the 1190 KB aggregate.
+    //
+    // Baseline: 291,466 bytes  Budget: ×1.10 = 320,613 bytes → 320 KB
+    name: "Plotly chunk (js-plotly-plot)",
+    path: chunkContaining("js-plotly-plot", "plotly"),
+    limit: "320 kB",
+  },
+  {
+    // Markdown-editor chunk, pinned by the "react-markdown" marker. Guards P4: the
+    // react-markdown + remark-gfm + rehype-sanitize pipeline is lazy-loaded via
+    // next/dynamic from address-link.tsx, so it lives in its own ~44 KB brotli async
+    // chunk instead of shipping on every page that renders an AddressLink. If a
+    // static import re-merges it into a shared chunk, the matched chunk's size jumps
+    // well past this budget and fails CI.
+    //
+    // Baseline: 44,130 bytes  Budget: ×1.10 = 48,543 bytes → 49 KB
+    name: "Markdown editor chunk (react-markdown)",
+    path: chunkContaining("react-markdown", "markdown"),
+    limit: "49 kB",
   },
   {
     // Manifest-referenced CSS emitted under .next/static/ (single Tailwind v4 bundle).
@@ -168,7 +228,11 @@ const config = [
 ];
 
 Object.defineProperty(config, "_private", {
-  value: { collectManifestReferencedStaticAssets, manifestPathsOrFallback },
+  value: {
+    collectManifestReferencedStaticAssets,
+    manifestPathsOrFallback,
+    chunkContaining,
+  },
 });
 
 module.exports = config;

--- a/ui-dashboard/.size-limit.cjs
+++ b/ui-dashboard/.size-limit.cjs
@@ -162,6 +162,19 @@ function chunkContaining(marker, label) {
     return [`${DIST_DIR}/static/chunks/__no_${label}_chunk_matched__.js`];
   }
 
+  if (matches.length > 1) {
+    // Exactly one chunk is expected. A silent multi-match would make the budget
+    // measure the SUM of several chunks — which could hide a regression if a
+    // re-split scattered the code into individually-small chunks. Surface it so
+    // the "one logical chunk" assumption can't break unnoticed.
+    process.stderr.write(
+      `[size-limit] warning: marker "${marker}" matched ${matches.length} chunks ` +
+        `(${matches.map((asset) => path.basename(asset)).join(", ")}); the "${label}" ` +
+        `budget now measures their combined size. Investigate a bundling/dedup change ` +
+        `before trusting this budget.\n`,
+    );
+  }
+
   return matches;
 }
 

--- a/ui-dashboard/src/components/address-link.tsx
+++ b/ui-dashboard/src/components/address-link.tsx
@@ -2,12 +2,24 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { useSession } from "next-auth/react";
 import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
-import { AddressLabelEditor } from "@/components/address-label-editor";
 import { explorerAddressUrl } from "@/lib/tokens";
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
+
+// Lazy-load the label/report editor, which pulls in the react-markdown +
+// remark-gfm + rehype-sanitize pipeline. That heavy chunk should only ship when a
+// signed-in user actually opens the editor — it stays off every page that merely
+// renders an AddressLink (pools, volume, cdps, stables, bridge-flows).
+const AddressLabelEditor = dynamic(
+  () =>
+    import("@/components/address-label-editor").then(
+      (m) => m.AddressLabelEditor,
+    ),
+  { ssr: false },
+);
 
 type Props = {
   address: string;


### PR DESCRIPTION
## The Problem

- The `react-markdown` + `remark-gfm` + `rehype-sanitize` pipeline (~44 KB brotli) shipped in the shared chunk of **every page that renders an `AddressLink`** — `/pools`, `/volume`, `/cdps`, `/stables`, `/bridge-flows` — via a static import chain (`AddressLink → AddressLabelEditor → AddressReportEditor → MarkdownRenderer`), even though the label/report editor only opens when a signed-in user clicks the edit pencil.
- The Plotly bundle win from #1109 and this split are only guarded by the all-chunks **aggregate** size budget, which can't catch a per-chunk regression (re-bundling the full `plotly.js`, or markdown re-merging into a shared chunk) — the aggregate stays flat while a page's critical path quietly regresses.

## The Solution

- Lazy-load `AddressLabelEditor` via `next/dynamic({ ssr: false })` from `address-link.tsx`, moving the markdown pipeline into its **own async chunk fetched only on the edit gesture** — off the critical path of all five data pages. (The `/address-book/[address]` route keeps its direct import; the editor is that page's whole point.)
- Add two **content-matched** per-chunk `size-limit` budgets — Plotly (`js-plotly-plot`, 320 KB) and the markdown editor (`react-markdown`, 49 KB). Turbopack content-hashes filenames every build, so they match on chunk *content*, not filename, and trip a tight per-chunk budget instead of letting a regression hide in the aggregate.

## Details

- The markdown pipeline is now a standalone **44 KB brotli** async chunk (`js-plotly-plot` chunk is 291 KB brotli after the #1109 basic-dist swap). The all-chunks aggregate ticked **+9 KB** (async chunk-boundary overhead) — expected, and exactly why per-chunk budgets are the right guard here.
- `chunkContaining(marker, label)` reads each manifest-referenced JS asset and selects the one whose source contains the marker; if a marker ever stops matching it returns a non-existent sentinel path so size-limit reports 0 (passes) rather than crashing, with the aggregate budget as backstop. Exposed on `_private` alongside the existing helpers.
- The isolation guard is implicit in the tight markdown budget: if a static import re-merges the pipeline into a shared chunk, the matched chunk's size jumps well past 49 KB and CI fails.

## Validation

- All four `size-limit` budgets green: aggregate 1,094,742 / 1,190,000 · Plotly 291,466 / 320,000 · markdown 44,130 / 49,000 · CSS 10,987 / 12,000.
- `typecheck` clean · `react-doctor` **100/100** · address-link + label/report editor tests (49) pass. The `next/dynamic` named-export split is the same proven pattern the 11 chart components use.

## Context

Completes **Batch A** of the ui-dashboard performance epic (#1107), after the Plotly anchor #1109. Full roadmap: `docs/notes/ui-dashboard-performance-plan.md` (G1, P4).

Closes #1110. Closes #1111. Refs #1107.

## Follow-ups

Batch B (pool-detail CLS 0.25 fix) is filed and next: #1112 (skeleton height + SSR-prefetch) and #1113 (`/volume` loading.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundle-splitting and CI size guards on the dashboard UI; no auth, API, or data-path changes beyond deferring editor JS until user interaction.
> 
> **Overview**
> **Moves the address label/report editor (and its `react-markdown` stack) off the critical path** for pages that only render `AddressLink`, and **adds CI budgets that target individual async chunks** instead of relying on the all-JS total alone.
> 
> `AddressLabelEditor` is now loaded with `next/dynamic({ ssr: false })` from `address-link.tsx`, so the markdown pipeline ships in a separate chunk only when a signed-in user opens the editor—not on pools, volume, CDPs, stables, or bridge-flows listings.
> 
> `.size-limit.cjs` gains `chunkContaining(marker, label)` to find chunks by stable source markers (Turbopack hashes filenames every build). New limits guard the Plotly bundle (`js-plotly-plot`, 320 KB) and the markdown editor (`react-markdown`, 49 KB); aggregate JS baseline comments are updated to ~1.09 MB brotli (+~9 KB from async chunk overhead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c81c111fe1f118a6db0fdbcdd17d5a26609061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->