### PR TITLE
Document median freshness invariant

### DIFF
--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -3,7 +3,7 @@ title: Envio Indexer Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-06
 ---
 
 # AGENTS.md — Envio Indexer
@@ -156,6 +156,12 @@ These rules come from PRs #184 and #194 — Codex flagged both as P1.
 
 - Block-keyed RPC caches (oracle reads, etc.) MUST be size-bounded. PR #184 fixed an OOM where the indexer cached one entry per block forever
 - Use an LRU or evict on block height advance; never an unbounded `Map`
+
+### Median-derived deviation freshness
+
+- Any local recomputation from `lastMedianPrice` must use the full fresh-live-median gate, not just `medianLive` or non-zero `lastMedianPrice`.
+- Use `hasFreshLiveMedian(pool, eventTimestamp)` for sibling paths that derive price difference, breach, health, or snapshot state from the indexed median. That predicate requires a non-zero median, `medianLive`, `oracleOk`, known `oracleExpiry`, known `lastOracleReportAt`, and `lastOracleReportAt + oracleExpiry > eventTimestamp`.
+- Add stale-anchor regression coverage for every sibling path that can recompute median-derived deviation without a contract-provided `priceDifference` (for example `OracleReported` fan-out and `upsertPool` calls from swap/mint/burn/update-reserves/fee-only events). A fresh non-median reporter must not extend a stale median anchor.
 
 ### File-size budget
 


### PR DESCRIPTION
## The Problem

- The last backlog PR found an indexer oracle freshness invariant only during review.
- Future indexer changes could repeat the same mistake if they gate local median-derived deviation math on `medianLive` alone.

## The Solution

- Add the full median freshness rule to the indexer package instructions so future agents apply it before opening review.

## Details

- Documents that local recomputation from `lastMedianPrice` must use `hasFreshLiveMedian(pool, eventTimestamp)`.
- Calls out sibling paths that need stale-anchor regression coverage, including `OracleReported` fan-out and `upsertPool` event paths without contract-provided `priceDifference`.
- Updates the canonical context `last_verified` date after re-checking the current indexer rule.

## Validation

- `pnpm agent:quality-gate --run` passed.
- `CI=true pnpm agent:autoreview` passed with no actionable findings.
- Pre-push mapped quality gate passed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no indexer handler or schema behavior is modified.
> 
> **Overview**
> Adds a **Median-derived deviation freshness** subsection to `indexer-envio/AGENTS.md` so future indexer work follows the same rule that came out of recent review: local math from `lastMedianPrice` must go through **`hasFreshLiveMedian(pool, eventTimestamp)`**, not weaker checks like `medianLive` or a non-zero median alone.
> 
> The new text spells out what that predicate requires (live median, oracle health, expiry, and report timestamp) and calls for **stale-anchor regression tests** on sibling paths that recompute deviation without an on-chain `priceDifference`—for example `OracleReported` fan-out and `upsertPool` from swap/mint/burn/update-reserves/fee-only handlers.
> 
> Also bumps the doc frontmatter **`last_verified`** date to 2026-07-06. No runtime indexer code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e319f68bf934351adbc7e94644ea6cb2f4b979e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->