### PR TITLE
Hide superseded cancelled readiness checks

### DIFF
--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -73,6 +73,49 @@ export function classifyCheck(check) {
   return "pending";
 }
 
+function checkRunOrderTimestampMs(check) {
+  // Use startedAt so delayed cancellation completion does not make a stale
+  // run appear newer than the passing run that superseded it.
+  const timestamp = check.startedAt ?? check.completedAt ?? null;
+  const parsed = Date.parse(timestamp ?? "");
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function checkIdentity(check) {
+  const appId =
+    check.appId ?? check.app_id ?? check.app?.id ?? check.app?.databaseId ?? "";
+  return [
+    checkDisplayName(check),
+    check.workflowName ?? check.workflow_name ?? "",
+    appId,
+  ].join("\0");
+}
+
+function suppressSupersededCancelledChecks(statusCheckRollup = []) {
+  const latestPassingTimeByIdentity = new Map();
+
+  for (const check of statusCheckRollup) {
+    if (classifyCheck(check) !== "pass") continue;
+    const timestampMs = checkRunOrderTimestampMs(check);
+    if (timestampMs === null) continue;
+    const identity = checkIdentity(check);
+    const previous = latestPassingTimeByIdentity.get(identity) ?? -Infinity;
+    if (timestampMs > previous) {
+      latestPassingTimeByIdentity.set(identity, timestampMs);
+    }
+  }
+
+  return statusCheckRollup.filter((check) => {
+    if (normalizeStatusValue(check.conclusion) !== "CANCELLED") return true;
+    const timestampMs = checkRunOrderTimestampMs(check);
+    if (timestampMs === null) return true;
+    const newerPassingTime = latestPassingTimeByIdentity.get(
+      checkIdentity(check),
+    );
+    return newerPassingTime === undefined || newerPassingTime <= timestampMs;
+  });
+}
+
 export function groupStatusChecks(statusCheckRollup = []) {
   const grouped = {
     pass: [],
@@ -81,7 +124,7 @@ export function groupStatusChecks(statusCheckRollup = []) {
     skipped: [],
   };
 
-  for (const check of statusCheckRollup) {
+  for (const check of suppressSupersededCancelledChecks(statusCheckRollup)) {
     const group = classifyCheck(check);
     grouped[group].push({
       name: checkDisplayName(check),
@@ -154,7 +197,7 @@ export function splitRequiredAndOptionalChecks(
   const optional = [];
   const seenRequiredContexts = new Set();
 
-  for (const check of statusCheckRollup) {
+  for (const check of suppressSupersededCancelledChecks(statusCheckRollup)) {
     const name = checkDisplayName(check);
     const matchedRequiredContext = requiredStatusContexts.find((context) =>
       checkMatchesRequiredContext(check, context),

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -465,6 +465,136 @@ test("groups status check rollup into stable pass/fail/pending/skipped buckets",
   );
 });
 
+test("hides cancelled check runs superseded by a newer passing run", () => {
+  const checks = [
+    {
+      name: "PR description format",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+      startedAt: "2026-07-06T15:32:37Z",
+      completedAt: "2026-07-06T15:32:43Z",
+    },
+    {
+      name: "PR description format",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+      startedAt: "2026-07-06T15:32:52Z",
+      completedAt: "2026-07-06T15:33:10Z",
+    },
+    {
+      name: "PR description format",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-07-06T15:32:57Z",
+      completedAt: "2026-07-06T15:33:09Z",
+    },
+  ];
+
+  const grouped = groupStatusChecks(checks);
+  const split = splitRequiredAndOptionalChecks(checks, [], {
+    requiredStatusContextsAvailable: true,
+  });
+
+  assertDeepEqual(
+    {
+      pass: grouped.pass.map((check) => check.name),
+      fail: grouped.fail.map((check) => check.name),
+      optional: split.optional.map((check) => `${check.name}:${check.state}`),
+    },
+    {
+      pass: ["PR description format"],
+      fail: [],
+      optional: ["PR description format:pass"],
+    },
+  );
+});
+
+test("keeps cancelled check runs without a newer passing replacement", () => {
+  const checks = [
+    {
+      name: "PR description format",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-07-06T15:32:37Z",
+      completedAt: "2026-07-06T15:32:43Z",
+    },
+    {
+      name: "PR description format",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+      startedAt: "2026-07-06T15:32:52Z",
+      completedAt: "2026-07-06T15:32:55Z",
+    },
+  ];
+
+  const grouped = groupStatusChecks(checks);
+  const split = splitRequiredAndOptionalChecks(checks, [], {
+    requiredStatusContextsAvailable: true,
+  });
+
+  assertDeepEqual(
+    {
+      pass: grouped.pass.map((check) => check.name),
+      fail: grouped.fail.map((check) => check.name),
+      optional: split.optional.map((check) => `${check.name}:${check.state}`),
+    },
+    {
+      pass: ["PR description format"],
+      fail: ["PR description format"],
+      optional: ["PR description format:pass", "PR description format:fail"],
+    },
+  );
+});
+
+test("keeps cancelled check runs when run timestamps are unavailable", () => {
+  const checks = [
+    {
+      name: "cancel-without-time",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+    },
+    {
+      name: "cancel-without-time",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-07-06T15:33:09Z",
+    },
+    {
+      name: "pass-without-time",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+    },
+    {
+      name: "pass-without-time",
+      workflowName: "PR Description",
+      status: "COMPLETED",
+      conclusion: "CANCELLED",
+      startedAt: "2026-07-06T15:32:52Z",
+    },
+  ];
+
+  const grouped = groupStatusChecks(checks);
+
+  assertDeepEqual(
+    {
+      pass: grouped.pass.map((check) => check.name),
+      fail: grouped.fail.map((check) => check.name),
+    },
+    {
+      pass: ["cancel-without-time", "pass-without-time"],
+      fail: ["cancel-without-time", "pass-without-time"],
+    },
+  );
+});
+
 test("splits known advisory checks into optional lag when branch protection data is unavailable", () => {
   const split = splitRequiredAndOptionalChecks([
     { name: "Code Quality", status: "COMPLETED", conclusion: "SUCCESS" },


### PR DESCRIPTION
## The Problem

- The readiness probe can report stale cancelled optional checks even when a newer same-head run for that check has passed.
- This makes ready PRs look like they still have optional action items.

## The Solution

- Suppress cancelled status-check entries when a newer passing run with the same check identity exists.
- Keep cancelled checks visible when there is no newer passing replacement.

## Details

- Uses check display name, workflow name, and app identity to match reruns.
- Orders reruns by start time so delayed cancellation completion does not keep stale noise visible.
- No docs update needed; the existing readiness docs describe optional lag generically and do not document cancelled rerun noise as operator-facing behavior.

## Validation

- `node scripts/pr-ready-state.test.mjs`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- pre-push `pnpm agent:quality-gate --run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to PR readiness status-check presentation; conservative when timestamps are absent, with offline unit tests for rerun/cancel scenarios.
> 
> **Overview**
> Fixes false **optional lag** on otherwise-ready PRs when GitHub still lists **cancelled** reruns alongside a newer **passing** run for the same check.
> 
> Adds `suppressSupersededCancelledChecks` in `pr-ready-state-core.mjs` and runs it before `groupStatusChecks` and `splitRequiredAndOptionalChecks`. **Cancelled** entries are dropped only when a **passing** run shares the same identity (display name, workflow name, app id) and started **after** that cancel; ordering uses **`startedAt`** so a late cancel completion does not look newer than the superseding pass.
> 
> Cancelled runs stay visible when there is no newer pass or when timestamps are missing. Unit tests cover superseded cancels, trailing cancels without a replacement, and missing-timestamp edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabf4c65f8f23cf846545e69e1e79f32b0a84e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->