### PR TITLE
feat(dashboard): add session-gated Entities nav link

### DIFF
--- a/ui-dashboard/src/components/__tests__/nav-links.test.tsx
+++ b/ui-dashboard/src/components/__tests__/nav-links.test.tsx
@@ -30,6 +30,8 @@ describe("NavLinks", () => {
     expect(html).toContain("/integrations");
     expect(html).toContain("Revenue");
     expect(html).toContain("/revenue");
+    expect(html).toContain("Entities");
+    expect(html).toContain("/entities");
   });
 
   it("hides protected links when user is not authenticated", () => {
@@ -41,6 +43,8 @@ describe("NavLinks", () => {
     expect(html).not.toContain("/integrations");
     expect(html).not.toContain("Revenue");
     expect(html).not.toContain("/revenue");
+    expect(html).not.toContain("Entities");
+    expect(html).not.toContain("/entities");
   });
 
   it("always shows Pools and home links regardless of auth", () => {

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -68,6 +68,14 @@ export function NavLinks() {
           Addresses
         </Link>
       )}
+      {session && (
+        <Link
+          href="/entities"
+          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+        >
+          Entities
+        </Link>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## The Problem

- The `/entities` feature (auth-gated search list + detail pages, already built and tested) had no inbound nav link — it was reachable only by typing the URL.
- Every sibling auth-gated route (Integrations, Revenue, Addresses) has a session-gated nav link; Entities was the lone orphan.

## The Solution

- Add a session-gated **Entities** link to the top nav, styled identically to the other session-gated links and placed next to Addresses (both are address/entity surfaces).

## Details

- `nav-links.tsx`: `{session && <Link href="/entities" …>Entities</Link>}` using the exact className the other session-gated links use.
- `nav-links.test.tsx`: assert `Entities`/`/entities` render when authenticated and are absent when not.
- Scope: the nav link only. The active-route indicator is a separate issue and is intentionally out of scope here.

## Validation

- `nav-links.test.tsx` (unit): authenticated → Entities present; unauthenticated → Entities absent. This deterministically covers the acceptance criterion.
- Browser (localhost, logged-out): Entities absent, all four session-gated links hidden, the 5 public links + "Sign in" present, nav renders cleanly. The signed-in browser pass was not run because the local Auth.js JWT mint is blocked by policy in this environment; the unit test covers the signed-in case.
- `scripts/agent-quality-gate.sh --run` (lint, typecheck, coverage, knip, dep-cruiser, Playwright browser, React Doctor ×2, size-limit): green.

## Deferrals

- None

Closes #1126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change with no auth or data logic; behavior is covered by existing nav-link tests.
> 
> **Overview**
> Adds a **session-gated “Entities”** link in the top nav so `/entities` is discoverable like Integrations, Revenue, and Addresses.
> 
> The link uses the same styling as other auth-only items and sits next to **Addresses**. Unit tests now expect **Entities** and `/entities` when signed in, and their absence when logged out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f03c344331ac759bf9cfb1c18eb4bc3f4a01f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->