### PR TITLE
fix(dashboard): reveal TVL hero variation (unpin breakdown axis)

### DIFF
--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -239,18 +239,8 @@ export function TimeSeriesChartCard({
           type: "scatter" as const,
           mode: "lines" as const,
           line: { color: "#6366f1", width: 2 },
-          // Area fill only for single-trace charts. With a breakdown the
-          // total is the top-of-envelope sum and the y-axis is truncated
-          // to a non-zero baseline to reveal a low-variance TVL band, so a
-          // fill draped from the total down to that baseline would flood
-          // the plot behind the per-chain lines and exaggerate the level.
-          // Keep the total a plain line there.
-          ...(hasBreakdown
-            ? {}
-            : {
-                fill: "tozeroy" as const,
-                fillcolor: "rgba(99,102,241,0.08)",
-              }),
+          fill: "tozeroy" as const,
+          fillcolor: "rgba(99,102,241,0.08)",
           hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
         };
     const breakdownTraces = (breakdown ?? []).map((b) => {

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -102,7 +102,9 @@ interface TimeSeriesChartCardProps {
    * Two effects:
    * - **Non-stacked / single-trace** charts: drives the explicit
    *   `yaxis.range` upper bound (`ymax + span * yAxisTopPadding`). The
-   *   bottom is pinned to 0 when a breakdown is present.
+   *   bottom is a tight, non-zero floor (`Math.max(0, ymin - span * 0.1)`)
+   *   whether or not a breakdown is present, so low-variance series stay
+   *   visible instead of flattening against a zero baseline.
    * - **Stacked** charts (breakdownMode === "stacked"): the y-axis
    *   uses Plotly autorange so trace toggling can re-fit, so this
    *   value is *not* read by the y-axis math. It still controls the
@@ -237,8 +239,18 @@ export function TimeSeriesChartCard({
           type: "scatter" as const,
           mode: "lines" as const,
           line: { color: "#6366f1", width: 2 },
-          fill: "tozeroy" as const,
-          fillcolor: "rgba(99,102,241,0.08)",
+          // Area fill only for single-trace charts. With a breakdown the
+          // total is the top-of-envelope sum and the y-axis is truncated
+          // to a non-zero baseline to reveal a low-variance TVL band, so a
+          // fill draped from the total down to that baseline would flood
+          // the plot behind the per-chain lines and exaggerate the level.
+          // Keep the total a plain line there.
+          ...(hasBreakdown
+            ? {}
+            : {
+                fill: "tozeroy" as const,
+                fillcolor: "rgba(99,102,241,0.08)",
+              }),
           hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
         };
     const breakdownTraces = (breakdown ?? []).map((b) => {
@@ -298,7 +310,12 @@ export function TimeSeriesChartCard({
       allYs.length > 0 ? allYs.reduce((a, b) => Math.max(a, b), -Infinity) : 1;
     const span = Math.max(ymax - ymin, ymax * 0.02, 1);
     const yRange: [number, number] = [
-      hasBreakdown ? 0 : Math.max(0, ymin - span * 0.1),
+      // Same tight, non-zero floor whether or not a breakdown is present.
+      // Pinning the breakdown baseline to 0 made a low-variance TVL
+      // envelope (~2% of a large total) move only 1-2px; the reduce-based
+      // `ymin` already folds in every breakdown point via `allYs`, so no
+      // small per-chain series is clipped off the bottom.
+      Math.max(0, ymin - span * 0.1),
       ymax + span * yAxisTopPadding,
     ];
 

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -295,8 +295,9 @@ export function TimeSeriesChartCard({
             }),
       };
     });
-    // Pull y-min toward 0 when a breakdown is present so smaller chains
-    // don't get clipped off the bottom edge by the total-tight range.
+    // Fold every breakdown series into the y-range inputs (`allYs` below)
+    // so `ymin` is data-driven and covers all chains — the tight, non-zero
+    // floor then can't clip a small chain off the bottom edge.
     const breakdownYs = (breakdown ?? []).flatMap((b) =>
       b.series.map((p) => p.value),
     );


### PR DESCRIPTION
## The Problem

- The home Total Value Locked hero read as a flatline / broken plot: with a per-chain breakdown the y-axis was hard-pinned to 0 and the total trace carried a `tozeroy` fill, so the lines hugged the top over a large empty filled area and real variation was invisible.

## The Solution

- Give the breakdown chart the same tight, non-zero y-floor that single-trace charts already use, so the lines spread across the plot and movement becomes visible. The area fill under the total line is retained.

## Details

- `time-series-chart-card.tsx`: drop the `hasBreakdown ? 0` y-floor so the breakdown case uses `Math.max(0, ymin - span*0.1)` (the reduce-based `ymin` already folds in every breakdown point, so no small chain is clipped off the bottom); fix the now-stale `yAxisTopPadding` prop doc. The `tozeroy` area fill under the total line is kept — with the range unpinned it no longer floods an empty plot.
- Scope: the TVL hero is the only lines-mode breakdown caller. Stacked charts (stables/volume) use Plotly autorange and are untouched; single-trace charts (bridge, pool, fee) keep their fill and were already on this y-floor.

## Validation

- Browser (localhost, live prod data, desktop + narrow): y-range no longer starts at 0 (measured `[≈353K, ≈3.51M]`), the `tozeroy` area fill under the total line is retained, three lines with visible undulation and a readable end-dip, no console errors, no horizontal overflow.
- `scripts/agent-quality-gate.sh --run` (lint, typecheck, coverage, knip, dep-cruiser, Playwright browser, React Doctor ×2, size-limit): green.

## Deferrals

- Sub-3% moves remain subtle: three series at very different magnitudes (~0.6M / 2.1M / 2.7M) share one linear axis, and keeping all chains visible (an explicit constraint of #1121) precludes zooming into the total. A percent-change / delta view is the real fix for fine small-move sensitivity — tracked in #1142.

Closes #1121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Plotly y-range logic for non-stacked breakdown charts; stacked and single-trace behavior is unchanged aside from aligned documentation.
> 
> **Overview**
> Fixes the home **Total Value Locked** hero looking flat when a per-chain breakdown is shown by using the same **tight, non-zero y-axis floor** as single-trace charts instead of pinning the bottom at **0**.
> 
> In `time-series-chart-card.tsx`, breakdown **lines** mode now always sets the lower bound to `Math.max(0, ymin - span * 0.1)` (removed `hasBreakdown ? 0`). `ymin` already includes every breakdown point via `allYs`, so smaller chains should not clip at the bottom. The `yAxisTopPadding` prop comment is updated to match. **Stacked** charts still use Plotly autorange and are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548db164253fdf6b507a97115fb71a980bb75467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->