### PR TITLE
fix(dashboard): stop mobile numbers clipping mid-glyph

### DIFF
--- a/ui-dashboard/src/components/breakdown-tile.tsx
+++ b/ui-dashboard/src/components/breakdown-tile.tsx
@@ -75,11 +75,11 @@ export function BreakdownTile({
           </p>
         )}
         {subItems && (
-          <div className="mt-1.5 flex gap-3 text-sm font-mono">
+          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-sm font-mono">
             {subItems.map((s) => (
               <span key={s.label}>
                 <span className="text-slate-500">{s.label}</span>{" "}
-                <span className="text-slate-400">
+                <span className="text-slate-400 tabular-nums">
                   {s.value === null ? "N/A" : formatSub(s.value)}
                 </span>
               </span>

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -25,6 +25,12 @@ export function Table({
     <div
       className={[
         "overflow-x-auto rounded-lg border border-slate-800",
+        // Persistently-visible thin horizontal scrollbar so the scroll
+        // affordance is signalled at rest — mobile Safari/Chrome hide the
+        // native scrollbar until touched, which makes an off-screen column
+        // (e.g. a wide swap amount) read as a silent clip rather than
+        // scrollable content.
+        "[&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-slate-900 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-600 [scrollbar-width:thin]",
         scrollClassName,
       ]
         .filter(Boolean)
@@ -90,7 +96,10 @@ export function Td({
 }) {
   const cls = [
     "px-2 sm:px-4 py-1.5 sm:py-2",
-    mono && "font-mono",
+    // Numeric cells never wrap — an amount+symbol pair stays one intact
+    // unit (a squeezed column scrolls the whole table rather than breaking
+    // "22,900 cUSD" mid-value). tabular-nums keeps digit columns aligned.
+    mono && "font-mono whitespace-nowrap tabular-nums",
     small ? "text-[10px] sm:text-xs" : "text-xs sm:text-sm",
     muted ? "text-slate-400" : "text-slate-300",
     align === "right" && "text-right",

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -30,7 +30,7 @@ export function Table({
         // native scrollbar until touched, which makes an off-screen column
         // (e.g. a wide swap amount) read as a silent clip rather than
         // scrollable content.
-        "[&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-slate-900 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-600 [scrollbar-width:thin]",
+        "[&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-slate-900 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-600 [scrollbar-width:thin] [scrollbar-color:rgb(71_85_105)_rgb(15_23_42)]",
         scrollClassName,
       ]
         .filter(Boolean)


### PR DESCRIPTION
## The Problem

- At 375px the home Swap Fees 30-day sub-value clipped (`$1.8` from `$1.8K`) and Recent Swaps amounts truncated mid-digit (`22,90`), at rest, with no scroll affordance.
- A phone operator reads a **wrong** number, not a missing one — a correctness bug on financial values.

## The Solution

- Let the 24h/7d/30d sub-value row wrap instead of clipping; keep numeric table cells intact (nowrap) and add a visible scrollbar so a wide table's horizontal scroll is signalled rather than silent.

## Details

- `breakdown-tile.tsx`: the sub-value row `flex gap-3` → `flex flex-wrap gap-x-3 gap-y-0.5` (+ `tabular-nums`), so 24h/7d/30d drop to a second line inside the tile instead of the 30d value bleeding past the edge. Deliberately did **not** add `min-w-0` to the tile root — that would relocate the clip onto the mono headline (a regression in the same bug class).
- `table.tsx`: mono `Td` cells → `whitespace-nowrap tabular-nums` (an amount+symbol stays one intact unit; the table scrolls rather than breaking a value); the `overflow-x-auto` wrapper gets a persistently-visible thin scrollbar (webkit pseudo-classes + `scrollbar-width: thin`).
- Caveat: on very long tables the horizontal scrollbar sits below the fold, so the affordance is strongest on shorter tables; the amount is always intact and reachable either way.

## Validation

- Browser (localhost, true 375px device emulation): no page horizontal overflow; Swap Fees sub-values wrap to a second line and the mono headline stays fully within its tile (measured `scrollWidth == clientWidth`, no bleed); Recent Swaps amounts are `nowrap` + fully reachable via the now-visible scroll; spot-checked `/pools` and `/cdps` tables at 375px — pages fit, tables scroll within their wrappers, no new clipping.
- `scripts/agent-quality-gate.sh --run` (lint, typecheck, coverage, knip, dep-cruiser, Playwright browser, React Doctor ×2, size-limit): green.

## Deferrals

- iOS Safari / WebKit render overlay scrollbars that ignore `::-webkit-scrollbar` styling, so the at-rest scroll cue this PR adds shows only on desktop + Android. A robust iOS-visible cue (scroll-shadow / edge-fade across the shared `Table`) is tracked in #1145.

Closes #1125
