### PR TITLE
feat(dashboard): give Plotly charts accessible names + text alternatives

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -129,7 +129,7 @@
     "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'PoolTabPanel' has too many lines (122). Maximum allowed is 100.",
-    "line": 476,
+    "line": 451,
     "linePreview": " | function PoolTabPanel({ | tab,"
   },
   {
@@ -150,14 +150,14 @@
     "file": "src/app/pool/[poolId]/_tabs/lps-tab.tsx",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 202,
+    "line": 200,
     "linePreview": "<tbody> | {pagedPositions.map((position) => { | const fmtTok = ("
   },
   {
     "file": "src/app/pool/[poolId]/_tabs/lps-tab.tsx",
     "ruleId": "complexity",
     "message": "Function 'LpsTab' has a complexity of 32. Maximum allowed is 15.",
-    "line": 41,
+    "line": 42,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing tab keeps LP pagination, totals, and degraded-count copy in one route-owned surface. | export function LpsTab({ | poolId,"
   },
   {
@@ -213,14 +213,14 @@
     "file": "src/components/address-label-form.tsx",
     "ruleId": "complexity",
     "message": "Function 'AddressLabelForm' has a complexity of 32. Maximum allowed is 15.",
-    "line": 160,
+    "line": 161,
     "linePreview": "// react-doctor-disable-next-line react-doctor/prefer-useReducer, react-doctor/no-giant-component | export function AddressLabelForm(props: Props) { | const {"
   },
   {
     "file": "src/components/address-label-form.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'AddressLabelForm' has too many lines (275). Maximum allowed is 100.",
-    "line": 160,
+    "line": 161,
     "linePreview": "// react-doctor-disable-next-line react-doctor/prefer-useReducer, react-doctor/no-giant-component | export function AddressLabelForm(props: Props) { | const {"
   },
   {
@@ -257,13 +257,6 @@
     "message": "Refactor this function to reduce its Cognitive Complexity from 33 to the 18 allowed.",
     "line": 75,
     "linePreview": "// react-doctor-disable-next-line react-doctor/prefer-useReducer, react-doctor/no-giant-component | export function AddressReportEditor(props: Props) { | const { address, onSavingChange, onDeletingCha"
-  },
-  {
-    "file": "src/components/breach-history-chart.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'BreachHistoryChart' has too many lines (116). Maximum allowed is 100.",
-    "line": 43,
-    "linePreview": "*/ | export function BreachHistoryChart({ breaches }: Props) { | if (breaches.length === 0) return null;"
   },
   {
     "file": "src/components/breach-history-panel.tsx",
@@ -304,28 +297,28 @@
     "file": "src/components/global-pools-table/sort.ts",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 58. Maximum allowed is 15.",
-    "line": 84,
-    "linePreview": "// react-doctor-disable-next-line react-doctor/js-tosorted-immutable | return [...entries].sort((a, b) => { | const aKey = globalPoolKey(a);"
+    "line": 82,
+    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const aKey = globalPoolKey(a);"
   },
   {
     "file": "src/components/global-pools-table/sort.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 65 to the 18 allowed.",
-    "line": 84,
-    "linePreview": "// react-doctor-disable-next-line react-doctor/js-tosorted-immutable | return [...entries].sort((a, b) => { | const aKey = globalPoolKey(a);"
+    "line": 82,
+    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const aKey = globalPoolKey(a);"
   },
   {
     "file": "src/components/lp-concentration-chart.tsx",
     "ruleId": "complexity",
     "message": "Function 'LpConcentrationChart' has a complexity of 25. Maximum allowed is 15.",
-    "line": 55,
+    "line": 62,
     "linePreview": " | export function LpConcentrationChart({ | positions,"
   },
   {
     "file": "src/components/lp-concentration-chart.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'LpConcentrationChart' has too many lines (201). Maximum allowed is 100.",
-    "line": 55,
+    "line": 62,
     "linePreview": " | export function LpConcentrationChart({ | positions,"
   },
   {
@@ -360,14 +353,7 @@
     "file": "src/components/reserve-chart.tsx",
     "ruleId": "complexity",
     "message": "Function 'ReserveChart' has a complexity of 17. Maximum allowed is 15.",
-    "line": 27,
-    "linePreview": " | export function ReserveChart({ | rows,"
-  },
-  {
-    "file": "src/components/reserve-chart.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'ReserveChart' has too many lines (103). Maximum allowed is 100.",
-    "line": 27,
+    "line": 47,
     "linePreview": " | export function ReserveChart({ | rows,"
   },
   {
@@ -381,7 +367,7 @@
     "file": "src/components/time-series-chart-card-hooks.ts",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 199,
+    "line": 200,
     "linePreview": "event?: { clientX?: number; clientY?: number }; | }) => { | if (!enabled) return;"
   },
   {
@@ -465,21 +451,21 @@
     "file": "src/lib/homepage-og.ts",
     "ruleId": "complexity",
     "message": "Async function 'fetchHomepageOgDataUncached' has a complexity of 35. Maximum allowed is 15.",
-    "line": 281,
+    "line": 282,
     "linePreview": " | export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | null> { | const configuredChains = NETWORK_IDS.flatMap((id) => {"
   },
   {
     "file": "src/lib/homepage-og.ts",
     "ruleId": "max-lines-per-function",
     "message": "Async function 'fetchHomepageOgDataUncached' has too many lines (141). Maximum allowed is 100.",
-    "line": 281,
+    "line": 282,
     "linePreview": " | export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | null> { | const configuredChains = NETWORK_IDS.flatMap((id) => {"
   },
   {
     "file": "src/lib/homepage-og.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 40 to the 18 allowed.",
-    "line": 281,
+    "line": 282,
     "linePreview": " | export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | null> { | const configuredChains = NETWORK_IDS.flatMap((id) => {"
   },
   {

--- a/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
@@ -116,7 +116,7 @@ describe("LiquidityChart", () => {
     expect(usdmQuotePlot?.data?.[1]?.y).toEqual([200]);
   });
 
-  it("wraps the plot in role=img with a token-aware accessible name and sr-only summary (WCAG 1.1.1)", () => {
+  it("wraps the plot in role=figure with a token-aware accessible name and sr-only summary (WCAG 1.1.1)", () => {
     const html = renderToStaticMarkup(
       <LiquidityChart
         snapshots={[
@@ -134,7 +134,7 @@ describe("LiquidityChart", () => {
       />,
     );
 
-    expect(html).toContain('role="img"');
+    expect(html).toContain('role="figure"');
     expect(html).toContain(
       'aria-label="Pool reserves over time chart for USDm and TESTm"',
     );

--- a/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
@@ -115,4 +115,30 @@ describe("LiquidityChart", () => {
     expect(usdmQuotePlot?.data?.[0]?.y).toEqual([200]);
     expect(usdmQuotePlot?.data?.[1]?.y).toEqual([200]);
   });
+
+  it("wraps the plot in role=img with a token-aware accessible name and sr-only summary (WCAG 1.1.1)", () => {
+    const html = renderToStaticMarkup(
+      <LiquidityChart
+        snapshots={[
+          snapshot({
+            reserves0: "200000000000000000000",
+            reserves1: "100000000000000000000",
+          }),
+        ]}
+        pool={{
+          ...BASE_POOL,
+          oraclePrice: "2000000000000000000000000",
+        }}
+        token0Symbol="USDm"
+        token1Symbol="TESTm"
+      />,
+    );
+
+    expect(html).toContain('role="img"');
+    expect(html).toContain(
+      'aria-label="Pool reserves over time chart for USDm and TESTm"',
+    );
+    expect(html).toContain("sr-only");
+    expect(html).toContain("Pool reserves over time for USDm and TESTm");
+  });
 });

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
@@ -40,11 +40,12 @@ function render(
 }
 
 describe("TimeSeriesChartCard accessibility (WCAG 1.1.1)", () => {
-  it("exposes the plot as role=img with a dynamic, non-empty accessible name", () => {
+  it("exposes the plot as role=figure with a dynamic, non-empty accessible name", () => {
     const html = render();
-    // role="img" turns the SVG internals presentational; the aria-label is the
-    // chart's accessible name and reflects the live range so it can't go stale.
-    expect(html).toContain('role="img"');
+    // role="figure" gives the chart the aria-label as its accessible name
+    // (which reflects the live range so it can't go stale) while keeping the
+    // interactive Plotly controls and axis/legend text in the a11y tree.
+    expect(html).toContain('role="figure"');
     expect(html).toContain('aria-label="Total Value Locked chart, 1W range"');
   });
 

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
@@ -53,11 +53,15 @@ describe("TimeSeriesChartCard accessibility (WCAG 1.1.1)", () => {
     expect(html).toContain('aria-label="Total Value Locked chart, All range"');
   });
 
-  it("carries a visually-hidden text alternative summarizing latest value + trend", () => {
+  it("carries a visually-hidden text alternative summarizing range + trend", () => {
     const html = render();
     expect(html).toContain("sr-only");
+    // The summary describes range + trend direction, deliberately without a
+    // specific value: consumers denominate their headline differently (dollar
+    // totals, per-day latest, token amounts), so a single formatter here would
+    // mislabel some of them.
     expect(html).toContain(
-      "Total Value Locked: latest value $2.69M over the 1W range, up 3.10% week-over-week.",
+      "Total Value Locked chart over the 1W range, up 3.10% week-over-week.",
     );
   });
 

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Render the Plot as an inert marker — the accessible name / text alternative
+// live on the container the card controls, not inside Plotly's SVG.
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot() {
+      return React.createElement("div", { "data-testid": "plot" });
+    },
+}));
+
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import type { TimeSeriesPoint } from "@/lib/time-series";
+
+const SERIES: TimeSeriesPoint[] = [
+  { timestamp: 1_000, value: 1_000_000 },
+  { timestamp: 2_000, value: 2_690_000 },
+];
+
+function render(
+  overrides: Partial<React.ComponentProps<typeof TimeSeriesChartCard>> = {},
+): string {
+  const props: React.ComponentProps<typeof TimeSeriesChartCard> = {
+    title: "Total Value Locked",
+    rangeAriaLabel: "TVL chart time range",
+    series: SERIES,
+    range: "7d",
+    onRangeChange: () => {},
+    headline: "$2.69M",
+    change: 3.1,
+    isLoading: false,
+    hasError: false,
+    hasSnapshotError: false,
+    emptyMessage: "Not enough history yet",
+    ...overrides,
+  };
+  return renderToStaticMarkup(React.createElement(TimeSeriesChartCard, props));
+}
+
+describe("TimeSeriesChartCard accessibility (WCAG 1.1.1)", () => {
+  it("exposes the plot as role=img with a dynamic, non-empty accessible name", () => {
+    const html = render();
+    // role="img" turns the SVG internals presentational; the aria-label is the
+    // chart's accessible name and reflects the live range so it can't go stale.
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Total Value Locked chart, 1W range"');
+  });
+
+  it("re-labels when the active range changes so the name tracks the series", () => {
+    const html = render({ range: "all" });
+    expect(html).toContain('aria-label="Total Value Locked chart, All range"');
+  });
+
+  it("carries a visually-hidden text alternative summarizing latest value + trend", () => {
+    const html = render();
+    expect(html).toContain("sr-only");
+    expect(html).toContain(
+      "Total Value Locked: latest value $2.69M over the 1W range, up 3.10% week-over-week.",
+    );
+  });
+
+  it("describes a negative change as a downward trend", () => {
+    const html = render({ change: -4.2 });
+    expect(html).toContain("down 4.20% week-over-week");
+  });
+
+  it("summarizes the loading state instead of a stale value", () => {
+    const html = render({ isLoading: true });
+    expect(html).toContain('aria-label="Total Value Locked chart, 1W range"');
+    expect(html).toContain("Total Value Locked chart is loading.");
+  });
+
+  it("summarizes the empty state with the empty message", () => {
+    const html = render({ series: [], change: null });
+    expect(html).toContain("Total Value Locked chart: Not enough history yet");
+  });
+});

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -494,9 +494,9 @@ describe("VolumeOverTimeChart render", () => {
     expect(html).not.toContain("Volume (24h)");
   });
 
-  it("exposes the chart as role=img with a non-empty accessible name (WCAG 1.1.1)", () => {
+  it("exposes the chart as role=figure with a non-empty accessible name (WCAG 1.1.1)", () => {
     const html = renderChart();
-    expect(html).toContain('role="img"');
+    expect(html).toContain('role="figure"');
     expect(html).toMatch(/aria-label="Volume chart, [^"]+ range"/);
   });
 

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -494,6 +494,12 @@ describe("VolumeOverTimeChart render", () => {
     expect(html).not.toContain("Volume (24h)");
   });
 
+  it("exposes the chart as role=img with a non-empty accessible name (WCAG 1.1.1)", () => {
+    const html = renderChart();
+    expect(html).toContain('role="img"');
+    expect(html).toMatch(/aria-label="Volume chart, [^"]+ range"/);
+  });
+
   it("starts with the 1M range active by default", () => {
     const html = renderChart();
     expect(html).toMatch(/aria-pressed="true"[^>]*>1M</);

--- a/ui-dashboard/src/components/breach-history-chart.tsx
+++ b/ui-dashboard/src/components/breach-history-chart.tsx
@@ -20,6 +20,57 @@ import { formatDurationShort } from "@/lib/bridge-status";
 
 const Plot = dynamic(() => import("@/lib/react-plotly-basic"), { ssr: false });
 
+function makeBreachHistoryLayout(grace: number) {
+  return {
+    ...PLOTLY_BASE_LAYOUT,
+    autosize: true,
+    height: 260,
+    margin: { l: 56, r: 16, t: 8, b: 40 },
+    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
+    yaxis: {
+      ...PLOTLY_AXIS_DEFAULTS,
+      type: "log" as const,
+      title: { text: "Breach duration", standoff: 8 },
+      // Nice log ticks: 1s, 10s, 1min, 10min, 1h, 6h, 1d.
+      tickvals: [1, 10, 60, 600, 3600, 21600, 86400],
+      ticktext: ["1s", "10s", "1m", "10m", "1h", "6h", "1d"],
+    },
+    legend: { ...PLOTLY_LEGEND, orientation: "h" as const, y: -0.25 },
+    hovermode: "closest" as const,
+    // Draw a thin amber reference line at the 1h grace boundary so
+    // the split between amber and red markers is visually obvious.
+    shapes: [
+      {
+        type: "line" as const,
+        xref: "paper" as const,
+        x0: 0,
+        x1: 1,
+        yref: "y" as const,
+        y0: grace,
+        y1: grace,
+        line: { color: "#f59e0b", width: 1, dash: "dot" as const },
+      },
+    ],
+    annotations: [
+      {
+        xref: "paper" as const,
+        yref: "y" as const,
+        x: 1,
+        // Plotly quirk: shapes auto-transform `y` to log coordinates
+        // when the axis is type: "log", but annotations don't —
+        // pass log10(value) explicitly, otherwise the label renders
+        // at 10^3600 (way off-chart).
+        y: Math.log10(grace),
+        xanchor: "right" as const,
+        yanchor: "bottom" as const,
+        text: "1h grace",
+        showarrow: false,
+        font: { size: 10, color: "#f59e0b" },
+      },
+    ],
+  };
+}
+
 interface Props {
   breaches: DeviationThresholdBreach[];
 }
@@ -134,62 +185,24 @@ export function BreachHistoryChart({ breaches }: Props) {
     trace(ongoing, "Ongoing", "#8b5cf6"),
   ].filter((t) => t.x.length > 0);
 
+  const breachSummary = `Deviation breach history: ${breaches.length} breaches plotted — ${closedCritical.length} past the 1-hour grace (critical), ${closedInGrace.length} within grace, ${ongoing.length} ongoing. Marker height is the breach duration on a log scale.`;
+
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 sm:p-5">
-      <Plot
-        data={data}
-        layout={{
-          ...PLOTLY_BASE_LAYOUT,
-          autosize: true,
-          height: 260,
-          margin: { l: 56, r: 16, t: 8, b: 40 },
-          xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
-          yaxis: {
-            ...PLOTLY_AXIS_DEFAULTS,
-            type: "log",
-            title: { text: "Breach duration", standoff: 8 },
-            // Nice log ticks: 1s, 10s, 1min, 10min, 1h, 6h, 1d.
-            tickvals: [1, 10, 60, 600, 3600, 21600, 86400],
-            ticktext: ["1s", "10s", "1m", "10m", "1h", "6h", "1d"],
-          },
-          legend: { ...PLOTLY_LEGEND, orientation: "h", y: -0.25 },
-          hovermode: "closest",
-          // Draw a thin amber reference line at the 1h grace boundary so
-          // the split between amber and red markers is visually obvious.
-          shapes: [
-            {
-              type: "line",
-              xref: "paper",
-              x0: 0,
-              x1: 1,
-              yref: "y",
-              y0: grace,
-              y1: grace,
-              line: { color: "#f59e0b", width: 1, dash: "dot" },
-            },
-          ],
-          annotations: [
-            {
-              xref: "paper",
-              yref: "y",
-              x: 1,
-              // Plotly quirk: shapes auto-transform `y` to log coordinates
-              // when the axis is type: "log", but annotations don't —
-              // pass log10(value) explicitly, otherwise the label renders
-              // at 10^3600 (way off-chart).
-              y: Math.log10(grace),
-              xanchor: "right",
-              yanchor: "bottom",
-              text: "1h grace",
-              showarrow: false,
-              font: { size: 10, color: "#f59e0b" },
-            },
-          ],
-        }}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%" }}
-      />
-    </div>
+    <>
+      <div
+        role="img"
+        aria-label="Deviation breach history chart"
+        className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 sm:p-5"
+      >
+        <Plot
+          data={data}
+          layout={makeBreachHistoryLayout(grace)}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%" }}
+        />
+      </div>
+      <p className="sr-only">{breachSummary}</p>
+    </>
   );
 }
 

--- a/ui-dashboard/src/components/breach-history-chart.tsx
+++ b/ui-dashboard/src/components/breach-history-chart.tsx
@@ -189,6 +189,10 @@ export function BreachHistoryChart({ breaches }: Props) {
 
   return (
     <>
+      {/* role="img" sits on the card here (not a bare plot wrapper) because this
+          chart has no visible <h3> and no interactive controls — the whole card
+          is the image. Charts that have an <h3> scope role="img" to the plot so
+          the heading stays in the a11y tree. */}
       <div
         role="img"
         aria-label="Deviation breach history chart"

--- a/ui-dashboard/src/components/breach-history-chart.tsx
+++ b/ui-dashboard/src/components/breach-history-chart.tsx
@@ -189,12 +189,13 @@ export function BreachHistoryChart({ breaches }: Props) {
 
   return (
     <>
-      {/* role="img" sits on the card here (not a bare plot wrapper) because this
-          chart has no visible <h3> and no interactive controls — the whole card
-          is the image. Charts that have an <h3> scope role="img" to the plot so
-          the heading stays in the a11y tree. */}
+      {/* role="figure" sits on the card here (not a bare plot wrapper) because
+          this chart has no visible <h3> — the whole card carries the
+          accessible name. Unlike role="img", role="figure" doesn't make its
+          descendants presentational, so Plotly's interactive controls and
+          axis/legend text stay in the a11y tree. */}
       <div
-        role="img"
+        role="figure"
         aria-label="Deviation breach history chart"
         className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 sm:p-5"
       >

--- a/ui-dashboard/src/components/effectiveness-chart.tsx
+++ b/ui-dashboard/src/components/effectiveness-chart.tsx
@@ -97,6 +97,13 @@ export function EffectivenessChart({ events }: EffectivenessChartProps) {
 
   if (events.length < 2) return null;
 
+  const latestPct = Number(events[events.length - 1]!.effectivenessRatio) * 100;
+  const effectivenessSummary = `Rebalance effectiveness trend: ${
+    events.length
+  } rebalances plotted. Latest effectiveness ${latestPct.toFixed(
+    1,
+  )}% (100% = landed exactly on the rebalance boundary).`;
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-1">
@@ -108,13 +115,16 @@ export function EffectivenessChart({ events }: EffectivenessChartProps) {
         oracle). Below 100% = control loop under-correcting. Negative =
         rebalance made deviation worse.
       </p>
-      <Plot
-        data={[trace]}
-        layout={STATIC_LAYOUT}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 300 }}
-        useResizeHandler
-      />
+      <div role="img" aria-label="Rebalance effectiveness trend chart">
+        <Plot
+          data={[trace]}
+          layout={STATIC_LAYOUT}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%", height: 300 }}
+          useResizeHandler
+        />
+      </div>
+      <p className="sr-only">{effectivenessSummary}</p>
     </div>
   );
 }

--- a/ui-dashboard/src/components/effectiveness-chart.tsx
+++ b/ui-dashboard/src/components/effectiveness-chart.tsx
@@ -115,7 +115,7 @@ export function EffectivenessChart({ events }: EffectivenessChartProps) {
         oracle). Below 100% = control loop under-correcting. Negative =
         rebalance made deviation worse.
       </p>
-      <div role="img" aria-label="Rebalance effectiveness trend chart">
+      <div role="figure" aria-label="Rebalance effectiveness trend chart">
         <Plot
           data={[trace]}
           layout={STATIC_LAYOUT}

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -291,7 +291,7 @@ function RevenueChartBody({
 }) {
   return (
     <div className="mt-4 -mx-2 sm:-mx-3">
-      <div role="img" aria-label={ariaLabel}>
+      <div role="figure" aria-label={ariaLabel}>
         {isLoading ? (
           <PlotSkeleton />
         ) : showEmptyState ? (

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -351,7 +351,9 @@ export function TotalRevenueChart({
   const chartSummary = isLoading
     ? "Total revenue chart is loading."
     : !hasAnyRevenue
-      ? `Total revenue chart: no revenue in the ${activeRangeLabel} range.`
+      ? partialReasons.length > 0
+        ? `Total revenue chart: revenue data is partially unavailable for the ${activeRangeLabel} range.`
+        : `Total revenue chart: no revenue in the ${activeRangeLabel} range.`
       : `Total revenue over the ${activeRangeLabel} range: ${headline}${
           change === null
             ? ""

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -279,29 +279,36 @@ function RevenueChartBody({
   showEmptyState,
   emptyMessage,
   figure,
+  ariaLabel,
+  summary,
 }: {
   isLoading: boolean;
   showEmptyState: boolean;
   emptyMessage: ReactNode;
   figure: RevenueChartFigure;
+  ariaLabel: string;
+  summary: string;
 }) {
   return (
     <div className="mt-4 -mx-2 sm:-mx-3">
-      {isLoading ? (
-        <PlotSkeleton />
-      ) : showEmptyState ? (
-        <div className="flex h-[220px] items-center justify-center text-sm text-slate-500">
-          {emptyMessage}
-        </div>
-      ) : (
-        <Plot
-          data={figure.traces}
-          layout={figure.layout}
-          config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
-          style={{ width: "100%", height: 220 }}
-          useResizeHandler
-        />
-      )}
+      <div role="img" aria-label={ariaLabel}>
+        {isLoading ? (
+          <PlotSkeleton />
+        ) : showEmptyState ? (
+          <div className="flex h-[220px] items-center justify-center text-sm text-slate-500">
+            {emptyMessage}
+          </div>
+        ) : (
+          <Plot
+            data={figure.traces}
+            layout={figure.layout}
+            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            style={{ width: "100%", height: 220 }}
+            useResizeHandler
+          />
+        )}
+      </div>
+      <p className="sr-only">{summary}</p>
     </div>
   );
 }
@@ -338,6 +345,21 @@ export function TotalRevenueChart({
   const hasAnyRevenue = series.some((point) => point.availableRevenueUsd !== 0);
   const showEmptyState = !isLoading && !hasAnyRevenue;
 
+  const activeRangeLabel =
+    RANGES.find((item) => item.key === range)?.label ?? String(range);
+  const chartAriaLabel = `Total revenue chart, ${activeRangeLabel} range`;
+  const chartSummary = isLoading
+    ? "Total revenue chart is loading."
+    : !hasAnyRevenue
+      ? `Total revenue chart: no revenue in the ${activeRangeLabel} range.`
+      : `Total revenue over the ${activeRangeLabel} range: ${headline}${
+          change === null
+            ? ""
+            : `, ${change >= 0 ? "up" : "down"} ${Math.abs(change).toFixed(
+                2,
+              )}% week-over-week`
+        }.`;
+
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -359,6 +381,8 @@ export function TotalRevenueChart({
         showEmptyState={showEmptyState}
         emptyMessage={revenueChartEmptyMessage(partialReasons)}
         figure={figure}
+        ariaLabel={chartAriaLabel}
+        summary={chartSummary}
       />
     </section>
   );

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -160,7 +160,7 @@ export function LiquidityChart({
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}
       </div>
       <div
-        role="img"
+        role="figure"
         aria-label={`Pool reserves over time chart for ${token0Symbol} and ${token1Symbol}`}
       >
         <Plot

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -147,6 +147,10 @@ export function LiquidityChart({
     ? "Estimated using current oracle price — balanced pool = lines overlap"
     : null;
 
+  const reservesSummary = `Pool reserves over time for ${token0Symbol} and ${token1Symbol}: ${
+    timestamps.length
+  } snapshots plotted${useUsd ? ", USD-normalized" : ""}.`;
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <div className="flex items-baseline gap-2 mb-3">
@@ -155,21 +159,27 @@ export function LiquidityChart({
         </h3>
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}
       </div>
-      <Plot
-        data={[trace0, trace1]}
-        layout={{
-          ...makeLayout(useUsd),
-          shapes: fxPoolWeekendBands({
-            pool,
-            network,
-            from: range.from,
-            to: range.to,
-          }),
-        }}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 320 }}
-        useResizeHandler
-      />
+      <div
+        role="img"
+        aria-label={`Pool reserves over time chart for ${token0Symbol} and ${token1Symbol}`}
+      >
+        <Plot
+          data={[trace0, trace1]}
+          layout={{
+            ...makeLayout(useUsd),
+            shapes: fxPoolWeekendBands({
+              pool,
+              network,
+              from: range.from,
+              to: range.to,
+            }),
+          }}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%", height: 320 }}
+          useResizeHandler
+        />
+      </div>
+      <p className="sr-only">{reservesSummary}</p>
     </div>
   );
 }

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -52,6 +52,13 @@ export function resolvePieLabel(
   return resolved === truncated ? truncated : resolved;
 }
 
+const fmtUsd = (v: number) =>
+  v >= 1_000_000
+    ? `$${(v / 1_000_000).toFixed(2)}M`
+    : v >= 1_000
+      ? `$${(v / 1_000).toFixed(1)}K`
+      : `$${v.toFixed(2)}`;
+
 export function LpConcentrationChart({
   positions,
   totalLiquidity,
@@ -171,19 +178,14 @@ export function LpConcentrationChart({
         : reserves0Raw * feedVal + reserves1Raw
       : null;
 
-  const fmtUsd = (v: number) =>
-    v >= 1_000_000
-      ? `$${(v / 1_000_000).toFixed(2)}M`
-      : v >= 1_000
-        ? `$${(v / 1_000).toFixed(1)}K`
-        : `$${v.toFixed(2)}`;
-
   const fmtReserve = (v: number, sym: string) =>
     v >= 1_000_000
       ? `${(v / 1_000_000).toFixed(2)}M ${sym}`
       : v >= 1_000
         ? `${(v / 1_000).toFixed(1)}K ${sym}`
         : `${v.toFixed(2)} ${sym}`;
+
+  const concentrationSummary = `LP concentration: ${totalPositions} liquidity providers. Top holder ${topShare}% of the pool, top 3 hold ${top3Share}%. Herfindahl-Hirschman Index ${hhi.toFixed(0)}.`;
 
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4">
@@ -194,7 +196,11 @@ export function LpConcentrationChart({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0 flex-1 lg:max-w-3xl">
           <div className="flex flex-col items-start gap-4 xl:flex-row xl:items-start">
-            <div className="w-full max-w-[360px] shrink-0">
+            <div
+              role="img"
+              aria-label="LP concentration pie chart"
+              className="w-full max-w-[360px] shrink-0"
+            >
               <Plot
                 data={[trace]}
                 layout={layout}
@@ -203,6 +209,7 @@ export function LpConcentrationChart({
                 useResizeHandler
               />
             </div>
+            <p className="sr-only">{concentrationSummary}</p>
 
             <div className="min-w-0 flex-1 xl:pt-2">
               <div className="mb-2 text-[10px] font-medium uppercase tracking-wider text-slate-500">

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -185,7 +185,7 @@ export function LpConcentrationChart({
         ? `${(v / 1_000).toFixed(1)}K ${sym}`
         : `${v.toFixed(2)} ${sym}`;
 
-  const concentrationSummary = `LP concentration: ${totalPositions} liquidity providers. Top holder ${topShare}% of the pool, top 3 hold ${top3Share}%. Herfindahl-Hirschman Index ${hhi.toFixed(0)}.`;
+  const concentrationSummary = `LP concentration for ${sym0 ?? "Token 0"}/${sym1 ?? "Token 1"}: ${totalPositions} liquidity providers. Top holder ${topShare}% of the pool, top 3 hold ${top3Share}%. Herfindahl-Hirschman Index ${hhi.toFixed(0)}.`;
 
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4">
@@ -198,7 +198,7 @@ export function LpConcentrationChart({
           <div className="flex flex-col items-start gap-4 xl:flex-row xl:items-start">
             <div
               role="img"
-              aria-label="LP concentration pie chart"
+              aria-label={`LP concentration pie chart${sym0 && sym1 ? ` for ${sym0} and ${sym1}` : ""}`}
               className="w-full max-w-[360px] shrink-0"
             >
               <Plot

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -59,6 +59,14 @@ const fmtUsd = (v: number) =>
       ? `$${(v / 1_000).toFixed(1)}K`
       : `$${v.toFixed(2)}`;
 
+function lpChartName(sym0?: string, sym1?: string): string {
+  return `LP concentration pie chart${sym0 && sym1 ? ` for ${sym0} and ${sym1}` : ""}`;
+}
+
+function lpPairLabel(sym0?: string, sym1?: string): string {
+  return `${sym0 ?? "Token 0"}/${sym1 ?? "Token 1"}`;
+}
+
 export function LpConcentrationChart({
   positions,
   totalLiquidity,
@@ -185,7 +193,7 @@ export function LpConcentrationChart({
         ? `${(v / 1_000).toFixed(1)}K ${sym}`
         : `${v.toFixed(2)} ${sym}`;
 
-  const concentrationSummary = `LP concentration for ${sym0 ?? "Token 0"}/${sym1 ?? "Token 1"}: ${totalPositions} liquidity providers. Top holder ${topShare}% of the pool, top 3 hold ${top3Share}%. Herfindahl-Hirschman Index ${hhi.toFixed(0)}.`;
+  const concentrationSummary = `LP concentration for ${lpPairLabel(sym0, sym1)}: ${totalPositions} liquidity providers. Top holder ${topShare}% of the pool, top 3 hold ${top3Share}%. Herfindahl-Hirschman Index ${hhi.toFixed(0)}.`;
 
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4">
@@ -198,7 +206,7 @@ export function LpConcentrationChart({
           <div className="flex flex-col items-start gap-4 xl:flex-row xl:items-start">
             <div
               role="img"
-              aria-label={`LP concentration pie chart${sym0 && sym1 ? ` for ${sym0} and ${sym1}` : ""}`}
+              aria-label={lpChartName(sym0, sym1)}
               className="w-full max-w-[360px] shrink-0"
             >
               <Plot

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -205,7 +205,7 @@ export function LpConcentrationChart({
         <div className="min-w-0 flex-1 lg:max-w-3xl">
           <div className="flex flex-col items-start gap-4 xl:flex-row xl:items-start">
             <div
-              role="img"
+              role="figure"
               aria-label={lpChartName(sym0, sym1)}
               className="w-full max-w-[360px] shrink-0"
             >

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -619,6 +619,10 @@ export function OracleChart({
     (s) => s.breakerBaselineAtSnapshot != null,
   );
 
+  const oracleSummary = `Oracle price versus breaker band for ${token0Symbol}/${token1Symbol}: ${snapshots.length} price sample${
+    snapshots.length === 1 ? "" : "s"
+  } plotted, colored by whether each sample sat inside its breaker band.`;
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
@@ -634,24 +638,30 @@ export function OracleChart({
           breakerConfig?.breakerKind === "MEDIAN_DELTA" ? "median EMA" : "peg"
         }
       />
-      <Plot
-        data={traceData}
-        layout={layout}
-        config={ORACLE_CHART_CONFIG}
-        style={PLOT_STYLE}
-        useResizeHandler
-        onRelayout={handleRelayout}
-        onInitialized={(_figure, graphDiv) => {
-          cleanupWheelRef.current?.();
-          cleanupWheelRef.current = attachOracleWheelHandler(
-            graphDiv as unknown as HTMLElement,
-          );
-        }}
-        onPurge={() => {
-          cleanupWheelRef.current?.();
-          cleanupWheelRef.current = null;
-        }}
-      />
+      <div
+        role="img"
+        aria-label={`Oracle price versus breaker band chart for ${token0Symbol}/${token1Symbol}`}
+      >
+        <Plot
+          data={traceData}
+          layout={layout}
+          config={ORACLE_CHART_CONFIG}
+          style={PLOT_STYLE}
+          useResizeHandler
+          onRelayout={handleRelayout}
+          onInitialized={(_figure, graphDiv) => {
+            cleanupWheelRef.current?.();
+            cleanupWheelRef.current = attachOracleWheelHandler(
+              graphDiv as unknown as HTMLElement,
+            );
+          }}
+          onPurge={() => {
+            cleanupWheelRef.current?.();
+            cleanupWheelRef.current = null;
+          }}
+        />
+      </div>
+      <p className="sr-only">{oracleSummary}</p>
     </div>
   );
 }

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -656,7 +656,7 @@ export function OracleChart({
         }
       />
       <div
-        role="img"
+        role="figure"
         aria-label={`Oracle price versus breaker band chart for ${token0Symbol}/${token1Symbol}`}
       >
         <Plot

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -548,14 +548,19 @@ function oracleAltText(
   sym0: string,
   sym1: string,
   sampleCount: number,
-  bandsAvailable: boolean,
+  breakerReady: boolean,
+  hasPersistedBands: boolean,
 ): string {
   const samples = `${sampleCount} price sample${sampleCount === 1 ? "" : "s"}`;
-  return `Oracle price versus breaker band for ${sym0}/${sym1}: ${samples} plotted${
-    bandsAvailable
-      ? ", colored by whether each sample sat inside its breaker band"
-      : "; breaker band data is currently unavailable"
-  }.`;
+  // Coverage tiers: with a live breaker config every sample is colored; with
+  // only persisted at-the-time bands, coverage is partial (samples predating a
+  // stored band aren't colored); with neither there is no band context at all.
+  const bandClause = breakerReady
+    ? ", each colored by whether it sat inside its breaker band"
+    : hasPersistedBands
+      ? ", with samples colored by breaker-band membership only where a persisted band exists"
+      : "; breaker band data is currently unavailable";
+  return `Oracle price versus breaker band for ${sym0}/${sym1}: ${samples} plotted${bandClause}.`;
 }
 
 export function OracleChart({
@@ -637,7 +642,8 @@ export function OracleChart({
     token0Symbol,
     token1Symbol,
     snapshots.length,
-    hasPersistedBands || breakerConfigStatus === "ready",
+    breakerConfigStatus === "ready",
+    hasPersistedBands,
   );
 
   return (

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -544,6 +544,20 @@ function useOracleChartModel({
   return { traceData, layout };
 }
 
+function oracleAltText(
+  sym0: string,
+  sym1: string,
+  sampleCount: number,
+  bandsAvailable: boolean,
+): string {
+  const samples = `${sampleCount} price sample${sampleCount === 1 ? "" : "s"}`;
+  return `Oracle price versus breaker band for ${sym0}/${sym1}: ${samples} plotted${
+    bandsAvailable
+      ? ", colored by whether each sample sat inside its breaker band"
+      : "; breaker band data is currently unavailable"
+  }.`;
+}
+
 export function OracleChart({
   snapshots,
   token0Symbol = "Token 0",
@@ -619,9 +633,12 @@ export function OracleChart({
     (s) => s.breakerBaselineAtSnapshot != null,
   );
 
-  const oracleSummary = `Oracle price versus breaker band for ${token0Symbol}/${token1Symbol}: ${snapshots.length} price sample${
-    snapshots.length === 1 ? "" : "s"
-  } plotted, colored by whether each sample sat inside its breaker band.`;
+  const oracleSummary = oracleAltText(
+    token0Symbol,
+    token1Symbol,
+    snapshots.length,
+    hasPersistedBands || breakerConfigStatus === "ready",
+  );
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -17,6 +17,26 @@ import {
 // Plotly must be loaded client-side only (no SSR)
 const Plot = dynamic(() => import("@/lib/react-plotly-basic"), { ssr: false });
 
+function makeReserveChartLayout(yAxisTitle: string) {
+  return {
+    ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
+    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_HOURLY),
+    yaxis: { title: { text: yAxisTitle }, ...PLOTLY_AXIS_DEFAULTS },
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.25,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, r: 16, b: 8, l: 48 },
+    autosize: true,
+    dragmode: "pan" as const,
+  };
+}
+
 interface ReserveChartProps {
   rows: ReserveUpdate[];
   token0: string | null;
@@ -105,27 +125,13 @@ export function ReserveChart({
     yaxis: "y" as const,
   };
 
-  const layout = {
-    ...PLOTLY_BASE_LAYOUT,
-    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
-    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_HOURLY),
-    yaxis: { title: { text: yAxisTitle }, ...PLOTLY_AXIS_DEFAULTS },
-    legend: {
-      ...PLOTLY_LEGEND,
-      orientation: "h" as const,
-      x: 0.5,
-      y: -0.25,
-      xanchor: "center" as const,
-      yanchor: "top" as const,
-    },
-    margin: { t: 8, r: 16, b: 8, l: 48 },
-    autosize: true,
-    dragmode: "pan" as const,
-  };
+  const layout = makeReserveChartLayout(yAxisTitle);
 
   const subtitle = useUsd
     ? "Estimated using current oracle price — balanced pool = lines overlap"
     : null;
+
+  const reserveSummary = `Reserve history for ${sym0} and ${sym1}: ${rows.length} snapshots plotted.`;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
@@ -133,13 +139,19 @@ export function ReserveChart({
         <h3 className="text-sm font-medium text-slate-400">Reserve History</h3>
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}
       </div>
-      <Plot
-        data={[trace0, trace1]}
-        layout={layout}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 320 }}
-        useResizeHandler
-      />
+      <div
+        role="img"
+        aria-label={`Reserve history chart for ${sym0} and ${sym1}`}
+      >
+        <Plot
+          data={[trace0, trace1]}
+          layout={layout}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%", height: 320 }}
+          useResizeHandler
+        />
+      </div>
+      <p className="sr-only">{reserveSummary}</p>
     </div>
   );
 }

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -140,7 +140,7 @@ export function ReserveChart({
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}
       </div>
       <div
-        role="img"
+        role="figure"
         aria-label={`Reserve history chart for ${sym0} and ${sym1}`}
       >
         <Plot

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -196,7 +196,7 @@ export function SnapshotChart({
         Daily Swap Volume
       </h3>
       <div
-        role="img"
+        role="figure"
         aria-label={`Daily swap volume chart for ${token0Symbol} and ${token1Symbol}`}
       >
         <Plot

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -184,18 +184,29 @@ export function SnapshotChart({
     yaxis: "y2" as const,
   };
 
+  const lastCumSwaps = cumSwaps.length > 0 ? cumSwaps[cumSwaps.length - 1]! : 0;
+  const swapVolumeSummary = `Daily swap volume for ${token0Symbol} and ${token1Symbol}: ${
+    days.length
+  } days plotted, ${lastCumSwaps.toLocaleString()} cumulative swaps.`;
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Daily Swap Volume
       </h3>
-      <Plot
-        data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
-        layout={makeSnapshotLayout(shapes)}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 380 }}
-        useResizeHandler
-      />
+      <div
+        role="img"
+        aria-label={`Daily swap volume chart for ${token0Symbol} and ${token1Symbol}`}
+      >
+        <Plot
+          data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
+          layout={makeSnapshotLayout(shapes)}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%", height: 380 }}
+          useResizeHandler
+        />
+      </div>
+      <p className="sr-only">{swapVolumeSummary}</p>
     </div>
   );
 }

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -184,7 +184,8 @@ export function SnapshotChart({
     yaxis: "y2" as const,
   };
 
-  const lastCumSwaps = cumSwaps.length > 0 ? cumSwaps[cumSwaps.length - 1]! : 0;
+  const lastCumSwaps =
+    cumSwaps.length > 0 ? (cumSwaps[cumSwaps.length - 1] ?? 0) : 0;
   const swapVolumeSummary = `Daily swap volume for ${token0Symbol} and ${token1Symbol}: ${
     days.length
   } days plotted, ${lastCumSwaps.toLocaleString()} cumulative swaps.`;

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -454,12 +454,14 @@ export function TimeSeriesChartCard({
       : `, ${change >= 0 ? "up" : "down"} ${Math.abs(change).toFixed(
           2,
         )}% ${changeLabel}`;
+  const partialSummary =
+    hasError || hasSnapshotError ? "; some data failed to load" : "";
   const chartAriaLabel = `${title} chart, ${activeRangeLabel} range`;
   const chartSummary = isLoading
     ? `${title} chart is loading.`
     : series.length === 0
       ? `${title} chart: ${emptyMessage}`
-      : `${title} chart over the ${activeRangeLabel} range${changeSummary}.`;
+      : `${title} chart over the ${activeRangeLabel} range${changeSummary}${partialSummary}.`;
 
   return (
     <section

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -455,7 +455,7 @@ export function TimeSeriesChartCard({
           2,
         )}% ${changeLabel}`;
   const partialSummary =
-    hasError || hasSnapshotError ? "; some data failed to load" : "";
+    hasError || hasSnapshotError ? "; showing partial data" : "";
   const chartAriaLabel = `${title} chart, ${activeRangeLabel} range`;
   const chartSummary = isLoading
     ? `${title} chart is loading.`

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { formatUSD } from "@/lib/format";
 import {
   escapePlotText,
   PLOTLY_BASE_LAYOUT,
@@ -436,6 +437,32 @@ export function TimeSeriesChartCard({
 
   const showEmptyState = !isLoading && series.length === 0;
 
+  // Accessible name + non-visual summary for the chart (WCAG 1.1.1). Both are
+  // derived from live props (title + active range + latest plotted value +
+  // week-over-week change) so they can never drift from the rendered series.
+  // `formatUSD` matches the dollar-denominated headline every consumer of this
+  // card uses (TVL / volume / bridged volume). `role="img"` on the plot
+  // container turns the SVG internals presentational; the concise `aria-label`
+  // names the chart and the sr-only sibling below carries the data summary.
+  const activeRangeLabel =
+    ranges.find((item) => item.key === range)?.label ?? String(range);
+  const latestValue =
+    series.length > 0 ? series[series.length - 1]!.value : null;
+  const changeSummary =
+    change === null || isLoading || hasError
+      ? ""
+      : `, ${change >= 0 ? "up" : "down"} ${Math.abs(change).toFixed(
+          2,
+        )}% ${changeLabel}`;
+  const chartAriaLabel = `${title} chart, ${activeRangeLabel} range`;
+  const chartSummary = isLoading
+    ? `${title} chart is loading.`
+    : latestValue === null
+      ? `${title} chart: ${emptyMessage}`
+      : `${title}: latest value ${formatUSD(
+          latestValue,
+        )} over the ${activeRangeLabel} range${changeSummary}.`;
+
   return (
     <section
       className={
@@ -517,7 +544,12 @@ export function TimeSeriesChartCard({
         </div>
       </div>
 
-      <div ref={containerRef} className="relative mt-4 -mx-2 sm:-mx-3">
+      <div
+        ref={containerRef}
+        role="img"
+        aria-label={chartAriaLabel}
+        className="relative mt-4 -mx-2 sm:-mx-3"
+      >
         {isLoading ? (
           <PlotSkeleton heightPx={chartHeightPx} />
         ) : showEmptyState ? (
@@ -592,6 +624,10 @@ export function TimeSeriesChartCard({
         )}
         {customSortedHover && hover && <CustomSortedTooltip hover={hover} />}
       </div>
+      {/* Non-visual text alternative for the chart. Sits outside the
+          role="img" container (whose descendants are presentational to AT) so
+          screen readers announce the data summary as regular page content. */}
+      <p className="sr-only">{chartSummary}</p>
       {useCustomLegend && (
         <CustomLegend
           breakdown={breakdown ?? []}

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -442,9 +442,10 @@ export function TimeSeriesChartCard({
   // does NOT restate a specific value: consumers denominate their headline
   // differently (dollar range-totals, per-day latest, token amounts), so a
   // single formatter here would mislabel some of them — the trend direction +
-  // range is the always-accurate signal. `role="img"` on the plot container
-  // turns the SVG internals presentational; the concise `aria-label` names the
-  // chart and the sr-only sibling below carries the summary.
+  // range is the always-accurate signal. `role="figure"` on the plot container
+  // gives it the concise `aria-label` as its accessible name and the sr-only
+  // sibling below carries the summary, while leaving the interactive Plotly
+  // controls (range selector/slider, legend) and axis text in the a11y tree.
   const activeRangeLabel =
     ranges.find((item) => item.key === range)?.label ?? String(range);
   const changeSummary =
@@ -543,7 +544,7 @@ export function TimeSeriesChartCard({
 
       <div
         ref={containerRef}
-        role="img"
+        role="figure"
         aria-label={chartAriaLabel}
         className="relative mt-4 -mx-2 sm:-mx-3"
       >
@@ -622,8 +623,9 @@ export function TimeSeriesChartCard({
         {customSortedHover && hover && <CustomSortedTooltip hover={hover} />}
       </div>
       {/* Non-visual text alternative for the chart. Sits outside the
-          role="img" container (whose descendants are presentational to AT) so
-          screen readers announce the data summary as regular page content. */}
+          role="figure" container so screen readers announce the data summary
+          as regular page content, alongside the figure's own accessible
+          controls and axis/legend text. */}
       <p className="sr-only">{chartSummary}</p>
       {useCustomLegend && (
         <CustomLegend

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
-import { formatUSD } from "@/lib/format";
 import {
   escapePlotText,
   PLOTLY_BASE_LAYOUT,
@@ -438,16 +437,16 @@ export function TimeSeriesChartCard({
   const showEmptyState = !isLoading && series.length === 0;
 
   // Accessible name + non-visual summary for the chart (WCAG 1.1.1). Both are
-  // derived from live props (title + active range + latest plotted value +
-  // week-over-week change) so they can never drift from the rendered series.
-  // `formatUSD` matches the dollar-denominated headline every consumer of this
-  // card uses (TVL / volume / bridged volume). `role="img"` on the plot
-  // container turns the SVG internals presentational; the concise `aria-label`
-  // names the chart and the sr-only sibling below carries the data summary.
+  // derived from live props (title + active range + week-over-week change) so
+  // they can never drift from the rendered series. The summary deliberately
+  // does NOT restate a specific value: consumers denominate their headline
+  // differently (dollar range-totals, per-day latest, token amounts), so a
+  // single formatter here would mislabel some of them — the trend direction +
+  // range is the always-accurate signal. `role="img"` on the plot container
+  // turns the SVG internals presentational; the concise `aria-label` names the
+  // chart and the sr-only sibling below carries the summary.
   const activeRangeLabel =
     ranges.find((item) => item.key === range)?.label ?? String(range);
-  const latestValue =
-    series.length > 0 ? series[series.length - 1]!.value : null;
   const changeSummary =
     change === null || isLoading || hasError
       ? ""
@@ -457,11 +456,9 @@ export function TimeSeriesChartCard({
   const chartAriaLabel = `${title} chart, ${activeRangeLabel} range`;
   const chartSummary = isLoading
     ? `${title} chart is loading.`
-    : latestValue === null
+    : series.length === 0
       ? `${title} chart: ${emptyMessage}`
-      : `${title}: latest value ${formatUSD(
-          latestValue,
-        )} over the ${activeRangeLabel} range${changeSummary}.`;
+      : `${title} chart over the ${activeRangeLabel} range${changeSummary}.`;
 
   return (
     <section


### PR DESCRIPTION
## The Problem

- None of the dashboard's Plotly charts exposed an accessible name or a non-visual alternative — a screen reader announced them as unlabelled graphics (fails WCAG 1.1.1 Level A on a public dashboard).

## The Solution

- Every chart wrapper now has `role="img"` + a descriptive, dynamic `aria-label` (reflecting title + active range) plus a visually-hidden text summary of the plotted data, so assistive-tech users get the trend/value information sighted users do.

## Details

- Shared `time-series-chart-card.tsx`: `role="img"` + a dynamic aria-label ("&lt;title&gt; chart, &lt;range&gt; range") on the plot container + an sr-only summary derived from live props (latest value + week-over-week). One change covers all 6 consumers (TVL, Volume, Pool TVL, Pool Volume, Bridge Volume, Bridge Token Breakdown). The aria-label re-labels when the range changes, so it can't go stale.
- The 8 standalone Plotly charts (breach-history, effectiveness, fee-over-time, liquidity, lp-concentration, oracle, reserve, snapshot) each wrap their `<Plot>` in a `role="img"` container with a data/token-aware aria-label + sr-only summary. Charts with a visible `<h3>` keep the heading outside `role="img"`.
- `role="img"` is a container-level attribute (not Plotly internals), so it's in scope even under the existing axe Plotly exclusion.
- Two chart functions (BreachHistoryChart, ReserveChart) crossed `max-lines` once the summaries were added; rather than inflate the eslint baseline, they were **refactored down** (inline Plotly layouts extracted to module-level helpers) and the 2 now-resolved baseline entries pruned via the official `lint:baseline:update` (prune-only, verified).
- a11y test coverage added (chart wrappers expose `role="img"` + a non-empty accessible name; the shared card's label re-labels on range change).

## Validation

- Browser (localhost): home TVL + Volume charts announce "…chart, 1M range" with a live sr-only data summary; clicking a range pill re-labels the aria-label (`1M range → All range`), proving it's dynamic. Pool detail: Pool TVL + Volume + the standalone LP-concentration pie all expose `role="img"` + a data-aware name.
- `scripts/agent-quality-gate.sh --run` (lint, typecheck, coverage, knip, dep-cruiser, Playwright browser, React Doctor ×2, size-limit): green.

## Deferrals

- `src/app/address-book/[address]/_components/intel-wealth-chart.tsx` has the same 1.1.1 gap but was outside this issue's enumerated file list; tracked in #1148.
- The standalone charts' interactive Plotly range controls (rangeselector/rangeslider) sit inside the `role="img"` wrapper, so they're presentational to AT. `role="img"` is the correct WCAG 1.1.1 pattern here; making those controls keyboard-accessible means replacing Plotly's internal controls with React controls (out of scope) — tracked in #1151.

Closes #1115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer accessibility markup and tests only; no auth, API, or data-path changes. Slight risk of redundant or noisy screen-reader output if summaries overlap visible headings.
> 
> **Overview**
> Addresses **WCAG 1.1.1** by giving dashboard Plotly charts an accessible name and a non-visual summary instead of unlabeled graphics.
> 
> **Shared time-series cards** (`time-series-chart-card.tsx`): the plot container gets `role="figure"`, a dynamic `aria-label` (`<title> chart, <range> range`), and an `sr-only` paragraph for loading, empty, trend, and partial-data states—covering TVL, volume, bridge, and related consumers in one place.
> 
> **Standalone charts** (breach history, effectiveness, fee/revenue, liquidity, LP concentration, oracle, reserve, snapshot, volume-over-time) wrap `<Plot>` the same way with token- or data-aware labels and `sr-only` summaries. **`role="figure"`** is used so Plotly axis/legend text stays in the accessibility tree (called out explicitly vs `role="img"`).
> 
> **Refactors**: inline Plotly layouts move to helpers in `breach-history-chart` and `reserve-chart` to stay under line limits; **`eslint-baseline.json`** is pruned/updated for those fixes and line shifts elsewhere.
> 
> **Tests**: new `time-series-chart-card.a11y.test.tsx` plus assertions on liquidity and volume charts for `role="figure"`, `aria-label`, and sr-only content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918a4f97b9161e63b940e06b58f96d524a8daa80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->