### PR TITLE
feat(dashboard): accessible pools-table diagnostics + non-color health encoding

### DIFF
--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -55,6 +55,7 @@ import {
   formatFee,
   hasFeeData,
 } from "@/components/global-pools-table/formatting";
+import { uptimeColorClass, uptimeTierGlyph } from "@/lib/health";
 
 const CELO_NETWORK: Network = {
   id: "celo-mainnet",
@@ -511,6 +512,67 @@ describe("GlobalPoolsTable — TVL cell", () => {
     );
     expect(html).toContain("Week-over-week TVL change: </span>-1.10%");
     expect(html).toContain("text-red-400");
+  });
+});
+
+describe("GlobalPoolsTable — Uptime cell a11y (#1116 / #1117)", () => {
+  // 95% → "good" tier (90-99 band). No lastOracleSnapshotTimestamp, so the
+  // live open-interval carry is skipped and pct reads the stored counters
+  // directly (9500 / 10000).
+  const UPTIME_POOL = {
+    id: "uptime-pool",
+    healthBinarySeconds: "9500",
+    healthTotalSeconds: "10000",
+    breachCount: 0,
+  };
+
+  it("routes the uptime diagnostic through an accessible tooltip, not a native title", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry(UPTIME_POOL)]} />,
+    );
+    // Diagnostic is exposed via role="tooltip" + aria-describedby (keyboard /
+    // tap reachable), never a native `title` tooltip.
+    expect(html).toContain('role="tooltip"');
+    expect(html).toContain("95.000% uptime (oracle freshness");
+    expect(html).toContain("aria-describedby");
+    expect(html).not.toContain('title="95.000% uptime');
+  });
+
+  it("exposes a non-color severity signal (shape glyph + sr-only tier label)", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry(UPTIME_POOL)]} />,
+    );
+    // sr-only tier name so the severity is announced without relying on color.
+    expect(html).toContain("good uptime");
+    // The tier glyph is rendered but hidden from the a11y tree.
+    expect(html).toContain("◆");
+    // The uptime number itself stays on a neutral, non-alarm color.
+    expect(html).toContain("text-slate-200");
+  });
+});
+
+describe("uptime severity encoding (#1117)", () => {
+  it("keeps the uptime number off the emerald/amber/red alarm palette", () => {
+    for (const pct of [99.9, 95, 80, 50]) {
+      const cls = uptimeColorClass(pct);
+      expect(cls).not.toMatch(/emerald|amber|red|yellow/);
+    }
+    // Non-finite guard still resolves to a neutral muted class.
+    expect(uptimeColorClass(Number.NaN)).not.toMatch(
+      /emerald|amber|red|yellow/,
+    );
+  });
+
+  it("maps each tier to a visually distinct, colorblind-safe glyph", () => {
+    const glyphs = [99.5, 95, 80, 50].map((p) => uptimeTierGlyph(p)?.glyph);
+    expect(glyphs).toEqual(["●", "◆", "▲", "■"]);
+    // Four distinct silhouettes.
+    expect(new Set(glyphs).size).toBe(4);
+    // Every tier carries an accessible label for its aria-hidden glyph.
+    for (const pct of [99.5, 95, 80, 50]) {
+      expect(uptimeTierGlyph(pct)?.label).toMatch(/uptime$/);
+    }
+    expect(uptimeTierGlyph(Number.NaN)).toBeNull();
   });
 });
 

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -538,6 +538,17 @@ describe("GlobalPoolsTable — Uptime cell a11y (#1116 / #1117)", () => {
     expect(html).not.toContain('title="95.000% uptime');
   });
 
+  it("routes the health diagnostic through an accessible tooltip, not a native title", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry(UPTIME_POOL)]} />,
+    );
+    // Both the Health badge and the Uptime cell moved their diagnostics off the
+    // native `title` into the accessible Tooltip (role="tooltip" +
+    // aria-describedby), so at least two tooltips render in the row.
+    const tooltipCount = (html.match(/role="tooltip"/g) || []).length;
+    expect(tooltipCount).toBeGreaterThanOrEqual(2);
+  });
+
   it("exposes a non-color severity signal (shape glyph + sr-only tier label)", () => {
     const html = renderToStaticMarkup(
       <GlobalPoolsTable entries={[makeEntry(UPTIME_POOL)]} />,
@@ -546,8 +557,10 @@ describe("GlobalPoolsTable — Uptime cell a11y (#1116 / #1117)", () => {
     expect(html).toContain("good uptime");
     // The tier glyph is rendered but hidden from the a11y tree.
     expect(html).toContain("◆");
-    // The uptime number itself stays on a neutral, non-alarm color.
-    expect(html).toContain("text-slate-200");
+    // The uptime number itself stays on a neutral, non-alarm color. Assert the
+    // class is on the uptime value specifically (text-slate-200 also appears on
+    // other cells), so this can't pass on an unrelated column.
+    expect(html).toContain('text-slate-200">95.00%');
   });
 });
 

--- a/ui-dashboard/src/components/badges.tsx
+++ b/ui-dashboard/src/components/badges.tsx
@@ -70,15 +70,17 @@ export function SourceBadge({
   // pure-presentation component).
   const isVirtual = source.includes("virtual") || Boolean(wrappedExchangeId);
   const label = isVirtual ? "Virtual" : "FPMM";
-  // Color follows the same predicate as the label so non-virtual non-fpmm
-  // sources (e.g. `oracle_reported` on a synthetic test fixture) get a
-  // consistent FPMM/indigo treatment instead of FPMM-label-with-Virtual-
-  // color (round 7 cursor finding).
+  // Pool TYPE, not health STATE — so both variants stay off the emerald/amber/
+  // red alarm palette reserved for HealthBadge/LimitBadge. Virtual = neutral
+  // slate, FPMM = indigo; the color follows the same predicate as the label so
+  // non-virtual non-fpmm sources (e.g. `oracle_reported` on a synthetic test
+  // fixture) get a consistent FPMM/indigo treatment instead of an
+  // FPMM-label-with-Virtual-color mismatch (round 7 cursor finding).
   return (
     <span
       className={`rounded px-2 py-0.5 text-xs font-medium ${
         isVirtual
-          ? "bg-emerald-500/20 text-emerald-300"
+          ? "bg-slate-500/20 text-slate-300"
           : "bg-indigo-500/20 text-indigo-300"
       }`}
     >
@@ -132,12 +134,13 @@ export function LimitBadge({ status }: { status: string }) {
 
 export function KindBadge({ kind }: { kind: string }) {
   const isMint = kind === "MINT";
+  // MINT / BURN are routine liquidity ops, not alarm states — keep them off the
+  // emerald/amber/red palette (which would read as OK/WARN severity). The kind
+  // text carries the meaning; sky vs slate just distinguishes the two.
   return (
     <span
       className={`rounded px-2 py-0.5 text-xs font-medium ${
-        isMint
-          ? "bg-emerald-500/20 text-emerald-300"
-          : "bg-amber-500/20 text-amber-300"
+        isMint ? "bg-sky-500/20 text-sky-300" : "bg-slate-500/20 text-slate-300"
       }`}
     >
       {kind}

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -13,8 +13,10 @@ import {
   computePoolUptimePct,
   resolveLimitStatus,
   uptimeColorClass,
+  uptimeTierGlyph,
 } from "@/lib/health";
 import { combinedTooltip } from "@/lib/pool-table-utils";
+import { Tooltip } from "@/components/tooltip";
 import { buildPoolDetailHref } from "@/lib/routing";
 import {
   formatFee,
@@ -167,10 +169,12 @@ function SourceCell({ pool }: { pool: Pool }) {
 function HealthCell({ status, details }: { status: string; details: string }) {
   return (
     <Cell className="">
-      <span title={details} className="inline-flex cursor-help">
+      {/* Diagnostic lives in the accessible Tooltip (role="tooltip" +
+          aria-describedby on a focusable trigger) instead of a native `title`,
+          so it is reachable by keyboard Tab and by tap on touch devices. */}
+      <Tooltip content={details}>
         <HealthBadge status={status} />
-        <span className="sr-only">{details}</span>
-      </span>
+      </Tooltip>
     </Cell>
   );
 }
@@ -187,14 +191,26 @@ function UptimeCell({ pool }: { pool: Pool }) {
   }
   const breachCount = pool.breachCount ?? 0;
   const breachLabel = breachCount === 1 ? "breach" : "breaches";
+  const tier = uptimeTierGlyph(pct);
+  const diagnostic = `${pct.toFixed(3)}% uptime (oracle freshness + price within tolerance) · ${breachCount} lifetime price-deviation ${breachLabel}`;
   return (
     <Cell className={className}>
-      <span
-        className={uptimeColorClass(pct)}
-        title={`${pct.toFixed(3)}% uptime (oracle freshness + price within tolerance) · ${breachCount} lifetime price-deviation ${breachLabel}`}
-      >
-        {pct.toFixed(2)}%
-      </span>
+      {/* Diagnostic moved off the native `title` into the accessible Tooltip
+          (keyboard- + tap-reachable). Severity is encoded by a shape-distinct
+          glyph (grayscale/deuteranopia safe) with an sr-only tier label; the
+          number stays a neutral non-alarm color so it can't contradict the
+          row's Health badge. */}
+      <Tooltip content={diagnostic} align="right">
+        <span className="inline-flex items-center gap-1">
+          {tier && (
+            <span aria-hidden="true" className="text-[10px] text-slate-400">
+              {tier.glyph}
+            </span>
+          )}
+          <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
+          {tier && <span className="sr-only">{tier.label}</span>}
+        </span>
+      </Tooltip>
     </Cell>
   );
 }

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -14,6 +14,7 @@ import {
   computeWindowUptimePct,
   liveHealthCounters,
   uptimeColorClass,
+  uptimeTierGlyph,
 } from "@/lib/health";
 import { isFxPool } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
@@ -56,6 +57,24 @@ type DailyAnchorRow = {
   cumulativeHealthBinarySeconds?: string | undefined;
   cumulativeHealthTotalSeconds?: string | undefined;
 };
+
+/**
+ * Shape-distinct, color-independent uptime tier signal (see `uptimeTierGlyph`):
+ * the number itself is a neutral non-alarm color, so severity is carried by the
+ * glyph + sr-only label to stay legible in grayscale / for deuteranopia.
+ */
+function UptimeTierMarker({ pct }: { pct: number }) {
+  const tier = uptimeTierGlyph(pct);
+  if (!tier) return null;
+  return (
+    <>
+      <span aria-hidden="true" className="mr-1 text-[10px] text-slate-400">
+        {tier.glyph}
+      </span>
+      <span className="sr-only">{tier.label} </span>
+    </>
+  );
+}
 
 export function UptimeValue({ pool }: { pool: Pool }) {
   const isVirtual = isVirtualPool(pool);
@@ -129,6 +148,7 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   return (
     <span className="flex flex-col gap-0.5">
       <span className="font-medium">
+        <UptimeTierMarker pct={pct} />
         <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
         <span className="ml-1 text-xs text-slate-500">all-time</span>
       </span>

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -440,22 +440,41 @@ export function pressureColorClass(pressure: number): string {
 }
 
 /**
- * Tailwind text-color class for an uptime percentage (0–100). Tier
- * thresholds are intentionally coarse — we want "red = page someone"
- * not "red = SLO budget touched". Adjust upward once breach attribution
- * is solid and we have a real three-nines target.
- *
- *   >99%   → emerald
- *   90-99% → yellow
- *   70-90% → amber
- *   <70%   → red
+ * Non-alarm text color for an uptime percentage. Uptime is a rolling
+ * reliability metric, NOT a live health STATE, so it deliberately does NOT
+ * spend the emerald/amber/red alarm palette that HealthBadge / LimitBadge
+ * reserve for actual state. Painting a low-uptime-but-currently-OK pool's
+ * number red would contradict its green Health badge on the same row; keeping
+ * the number neutral makes that contradiction impossible. Severity is instead
+ * carried by a shape-distinct, color-independent glyph (`uptimeTierGlyph`) so
+ * it stays legible in grayscale / for deuteranopia.
  */
 export function uptimeColorClass(pct: number): string {
-  if (!Number.isFinite(pct)) return "text-slate-500";
-  if (pct > 99) return "text-emerald-400";
-  if (pct >= 90) return "text-yellow-400";
-  if (pct >= 70) return "text-amber-400";
-  return "text-red-400";
+  return Number.isFinite(pct) ? "text-slate-200" : "text-slate-500";
+}
+
+export interface UptimeTierGlyph {
+  /** Shape-distinct, colorblind-safe glyph for the uptime tier. */
+  glyph: string;
+  /** Accessible tier name (sr-only / tooltip) — the glyph is aria-hidden. */
+  label: string;
+}
+
+/**
+ * Shape-only severity signal for pool uptime, mirroring the coarse tier
+ * boundaries the old color scale used (>99 / 90-99 / 70-90 / <70). Four
+ * maximally-distinct silhouettes — circle, diamond, triangle, square (the
+ * classic matplotlib-marker set) — so the tier is distinguishable WITHOUT
+ * color (grayscale + deuteranopia safe). Color is intentionally absent here
+ * and in `uptimeColorClass`, which also guarantees the uptime cell can never
+ * contradict the row's Health badge hue.
+ */
+export function uptimeTierGlyph(pct: number): UptimeTierGlyph | null {
+  if (!Number.isFinite(pct)) return null;
+  if (pct > 99) return { glyph: "●", label: "excellent uptime" };
+  if (pct >= 90) return { glyph: "◆", label: "good uptime" };
+  if (pct >= 70) return { glyph: "▲", label: "degraded uptime" };
+  return { glyph: "■", label: "poor uptime" };
 }
 
 /** Clamp `binary / total` to a percentage, returning `null` when the


### PR DESCRIPTION
## The Problem

- Pool health/limit **diagnostics were delivered via the HTML `title` attribute** — visible only on desktop mouse-hover, never on touch or keyboard focus. An on-call operator on a phone saw a red CRITICAL badge with no way to read why. (#1116)
- The **Uptime column encoded a 4-tier threshold in color alone** (emerald/yellow/amber/red) with no shape/icon, and those alarm hues were also spent on non-state decoration (Virtual pool type, MINT/BURN badges) — diluting the alarm channel and giving a deuteranopic operator a uniform column of numbers. (#1117)

## The Solution

- Move the diagnostics into the app's existing accessible `Tooltip` (keyboard- and touch-reachable), and re-encode uptime severity by **shape** with the number taken off the alarm palette, reserving emerald/amber/red for real state.

## Details

- **#1116**: `HealthCell` and `UptimeCell` (`pool-row.tsx`) now use `Tooltip` (a focusable `<button>` trigger, `role="tooltip"`, `aria-describedby`) instead of `title`; the native `title` + a redundant manual `sr-only` span are removed and the exact diagnostic text is preserved. The trigger takes focus on Tab and on tap, so the diagnostic is reachable on keyboard and touch. Generic `Td` timestamp titles and the trivial "TVL Δ WoW" label (which already has an sr-only sibling) were intentionally left un-converted.
- **#1117**: `uptimeColorClass` now returns a neutral slate (never an alarm hue); `UptimeCell` renders a shape-distinct tier glyph (● excellent / ◆ good / ▲ degraded / ■ poor) with an `sr-only` tier label. Because the uptime cell carries **zero state color**, it structurally cannot contradict the Health badge. Alarm hues are reserved for state by neutralizing `SourceBadge` "Virtual" (emerald → slate) and `KindBadge` MINT/BURN (emerald/amber → sky/slate). Genuine state badges (Health, Limit) keep their alarm hues. The pool-header uptime widget got the same glyph for parity (it shares `uptimeColorClass`).
- Scope boundary: `TvlCell`'s week-over-week Δ keeps emerald/red — it's directional data that already carries a `+`/`−` sign (a non-color signal) and wasn't named in #1117; flag if you want all directional deltas neutralized too.

## Validation

- Browser (localhost, /pools): focusing an Uptime/Health trigger by keyboard opens the tooltip with the full diagnostic (was mouse-only); under a grayscale filter the tier glyphs (●▲■) distinguish rows with all color removed; every uptime number is neutral slate; the Virtual badge is no longer emerald. sr-only tier labels ("excellent/degraded/poor uptime") present.
- `scripts/agent-quality-gate.sh --run` (lint, typecheck, coverage, knip, dep-cruiser, Playwright browser, React Doctor ×2, size-limit): green.

## Deferrals

- None

Closes #1116
Closes #1117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and accessibility changes in the dashboard UI with regression tests; no auth, API, or data-path changes.
> 
> **Overview**
> Pool table **Health** and **Uptime** diagnostics move from native `title` hovers to the shared **`Tooltip`** (keyboard/touch reachable via `role="tooltip"` and `aria-describedby`), with the same diagnostic copy as before.
> 
> **Uptime** no longer uses emerald/amber/red on the percentage: `uptimeColorClass` is neutral slate, and coarse tiers are shown with shape glyphs (**● ◆ ▲ ■**) plus **sr-only** tier labels via new `uptimeTierGlyph` in `health.ts`. The pool header uptime widget gets the same glyph treatment.
> 
> To keep alarm colors for real state only, **Virtual** `SourceBadge` and **MINT/BURN** `KindBadge` palettes are shifted off emerald/amber; Health/Limit badges are unchanged. TVL week-over-week delta coloring is untouched.
> 
> Tests lock in tooltip vs `title`, glyph tiers, and non-alarm uptime colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69194ade6737b2e30110234aedeae2f5494d19fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->