### PR TITLE
docs: enroll README in context metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain [Envio HyperIndex](https://docs.envio.dev/) indexer paired with a Next.js 16 + Plotly.js dashboard.
 
+<!-- agent-context: title="Mento Monitoring Monorepo" status=active owner=eng canonical=true last_verified=2026-07-06 -->
+
 **Live dashboard:** [monitoring.mento.org](https://monitoring.mento.org)
 
 ## Packages

--- a/docs/adr/0005-context-as-product.md
+++ b/docs/adr/0005-context-as-product.md
@@ -27,9 +27,9 @@ Treat context as part of the product with a two-tier **authority model**:
 **canonical** context (AGENTS.md files, SPEC.md, PR checklists, deployment docs,
 skills/roles) is current operating truth; **non-canonical** context (PLANs, notes,
 archived docs, backlog) is history that must be re-verified before acting. Managed
-files carry YAML frontmatter (`title`, `status`, `owner`, `canonical`,
-`last_verified`), and `pnpm agent:context-check` enforces the contract, including a
-90-day staleness window on canonical files.
+files carry metadata (`title`, `status`, `owner`, `canonical`, `last_verified`),
+and `pnpm agent:context-check` enforces the contract, including a 90-day
+staleness window on canonical files.
 
 ## Alternatives considered
 
@@ -44,6 +44,8 @@ files carry YAML frontmatter (`title`, `status`, `owner`, `canonical`,
   enrollment is the "is this still true?" enforcement.
 - New canonical files are auto-discovered by `canonical: true` frontmatter in the
   discovery roots (root/nested `AGENTS.md`, `SPEC.md`, `docs/**`, `.agents/**`).
+  Root `README.md` uses the same metadata keys in a hidden `agent-context`
+  comment so the GitHub landing page does not render YAML frontmatter.
 - Root `AGENTS.md` is kept lean; detail lives in the most specific owning file.
 
 ## Evidence

--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -24,17 +24,21 @@ Canonical context describes the system and operating rules as they are today. Ag
 - `.agents/skills/**/SKILL.md`: reusable agent procedures.
 - `.agents/roles/*.md`: opt-in role definitions for verification and standards review.
 - Package READMEs when they describe current commands or runtime behavior.
+- Root `README.md`: the repo landing page and current setup/operator overview.
+  It uses an invisible `agent-context` HTML comment for metadata so GitHub does
+  not render a raw YAML frontmatter block on the repo homepage.
+- `docs/notes/*.md` files that canonical files explicitly delegate current
+  operating rules to. These notes must carry `canonical: true` frontmatter and
+  are enforced like other canonical docs.
 
 Canonical context must stay internally consistent. If two canonical files conflict, fix the conflict before relying on either one.
-
-Root `README.md` is deliberately excluded from the metadata contract for now: it's a GitHub-rendered landing page, and a raw `---\nkey: value\n---` frontmatter block would render as literal text at the top of the repo homepage. Bringing it into `scripts/check-agent-context.mjs` would need a comment-based marker the check can parse instead — tracked in #1071 rather than built speculatively here.
 
 ### Non-Canonical Context
 
 Non-canonical context is useful history, intent, notes, or hypotheses. Agents may read it for rationale, but must verify current behavior in code, config, deployment state, or canonical docs before acting.
 
 - `docs/PLAN-*.md`
-- `docs/notes/*.md`
+- `docs/notes/*.md` files without `canonical: true` frontmatter
 - archived docs
 - roadmap/backlog entries
 - historical PR review notes
@@ -43,7 +47,11 @@ Non-canonical context is allowed to be stale or contradictory. It should not be 
 
 ## Metadata Contract
 
-Managed context files use YAML frontmatter with `title`, `status`, `owner`, `canonical`, and `last_verified` for canonical files.
+Managed context files use YAML frontmatter with `title`, `status`, `owner`, `canonical`, and `last_verified` for canonical files. Root `README.md` uses the same keys in an invisible HTML comment instead:
+
+```html
+<!-- agent-context: title="Mento Monitoring Monorepo" status=active owner=eng canonical=true last_verified=YYYY-MM-DD -->
+```
 
 Rules:
 

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -2,6 +2,7 @@
 title: Codex Agent Skills — Mechanics
 status: active
 owner: eng
+canonical: true
 last_verified: 2026-07-06
 ---
 

--- a/docs/notes/codex-cloud-setup.md
+++ b/docs/notes/codex-cloud-setup.md
@@ -1,3 +1,11 @@
+---
+title: Codex Cloud Setup and Maintenance
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-06
+---
+
 # Codex Cloud Setup and Maintenance
 
 Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or

--- a/docs/notes/cross-protocol-context.md
+++ b/docs/notes/cross-protocol-context.md
@@ -2,6 +2,7 @@
 title: Cross-Protocol Context
 status: active
 owner: eng
+canonical: true
 last_verified: 2026-07-06
 ---
 

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -2,6 +2,7 @@
 title: PR Ready State
 status: active
 owner: eng
+canonical: true
 last_verified: 2026-06-05
 ---
 

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -2,6 +2,7 @@
 title: New Worktree / Clone Setup and Claude Code on the Web Setup
 status: active
 owner: eng
+canonical: true
 last_verified: 2026-07-06
 ---
 

--- a/scripts/check-agent-context.mjs
+++ b/scripts/check-agent-context.mjs
@@ -17,6 +17,7 @@ const repoRoot = process.cwd();
 const failures = [];
 const requiredMetadataKeys = ["title", "status", "owner", "canonical"];
 const validStatuses = new Set(["active", "archived", "draft"]);
+const readmeContextMarkerPattern = /<!--\s*agent-context:\s*([\s\S]*?)-->/i;
 
 function fail(message) {
   failures.push(message);
@@ -82,6 +83,28 @@ function hasExecutableLine(content, pattern) {
     );
 }
 
+function parseFieldList(raw) {
+  const data = {};
+  const fieldPattern = /([A-Za-z0-9_-]+)=("([^"]*)"|'([^']*)'|[^\s]+)/g;
+  for (const match of raw.matchAll(fieldPattern)) {
+    data[match[1]] = (match[3] ?? match[4] ?? match[2]).trim();
+  }
+  return data;
+}
+
+function parseReadmeContextMarker(content) {
+  const match = readmeContextMarkerPattern.exec(content);
+  if (!match) return null;
+  return parseFieldList(match[1]);
+}
+
+function parseContextMetadata(filePath, content) {
+  const frontmatter = parseFrontmatter(content);
+  if (frontmatter) return frontmatter;
+  if (filePath === "README.md") return parseReadmeContextMarker(content);
+  return null;
+}
+
 function trackedFiles(dir, predicate = () => true, { required = false } = {}) {
   if (required && !exists(dir)) {
     fail(`${dir}: expected directory is missing or unreadable (ENOENT)`);
@@ -109,13 +132,15 @@ function trackedFiles(dir, predicate = () => true, { required = false } = {}) {
 }
 
 function requireMetadata(filePath) {
-  const data = parseFrontmatter(read(filePath));
+  const data = parseContextMetadata(filePath, read(filePath));
   if (!data) {
-    fail(`${filePath}: missing YAML frontmatter`);
+    fail(
+      `${filePath}: missing context metadata${filePath === "README.md" ? " (YAML frontmatter or hidden agent-context marker)" : ""}`,
+    );
     return;
   }
   for (const key of requiredMetadataKeys) {
-    if (!data[key]) fail(`${filePath}: missing frontmatter key '${key}'`);
+    if (!data[key]) fail(`${filePath}: missing metadata key '${key}'`);
   }
   if (data.status && !validStatuses.has(data.status)) {
     fail(`${filePath}: invalid status '${data.status}'`);
@@ -158,6 +183,17 @@ const scopedAgentDirs = [
   "ui-dashboard",
 ];
 
+const delegatedOperatingRuleNotes = [
+  "docs/notes/agent-issue-workflow.md",
+  "docs/notes/agent-quality-gate-mechanics.md",
+  "docs/notes/codex-agent-skills.md",
+  "docs/notes/codex-cloud-setup.md",
+  "docs/notes/cross-protocol-context.md",
+  "docs/notes/pr-ready-state.md",
+  "docs/notes/spoken-attention-nudge.md",
+  "docs/notes/worktree-and-web-setup.md",
+];
+
 const canonicalSkillFiles = trackedFiles(
   ".agents/skills",
   (file) => !file.endsWith("/"),
@@ -174,10 +210,22 @@ const claudeSkillFiles = trackedFiles(
 // The enforced set is discovered, not hardcoded: every tracked markdown file
 // in the discovery roots (see isCanonicalDiscoveryPath) whose frontmatter
 // declares `canonical: true` gets full metadata + staleness enforcement, so
-// new canonical files are picked up automatically.
-const managedContextFiles = discoverCanonicalFiles(trackedFiles("."), (file) =>
+// new canonical files are picked up automatically. Root README.md uses a
+// hidden metadata marker instead of visible frontmatter, so it is enrolled
+// with the same metadata parser used by requireMetadata.
+const trackedRepoFiles = trackedFiles(".");
+const managedContextFiles = discoverCanonicalFiles(trackedRepoFiles, (file) =>
   exists(file) ? read(file) : "",
 );
+if (trackedRepoFiles.includes("README.md")) {
+  const readmeMetadata = parseContextMetadata("README.md", read("README.md"));
+  if (
+    readmeMetadata?.canonical === "true" &&
+    !managedContextFiles.includes("README.md")
+  ) {
+    managedContextFiles.push("README.md");
+  }
+}
 
 // Minimum-presence assertion: these core files must always be discovered.
 // Without this, stripping a core file's frontmatter (or its `canonical:
@@ -185,14 +233,16 @@ const managedContextFiles = discoverCanonicalFiles(trackedFiles("."), (file) =>
 // failing the check.
 const coreContextFiles = [
   "AGENTS.md",
+  "README.md",
   "SPEC.md",
   ...scopedAgentDirs.map((dir) => `${dir}/AGENTS.md`),
   "docs/context-standards.md",
   "docs/pr-checklists/recurring-review-patterns.md",
-  // docs/notes/* canonical notes (agent-quality-gate-mechanics,
-  // spoken-attention-nudge) are deliberately NOT pinned here: they are
-  // procedural notes managed via frontmatter discovery, and removing their
-  // frontmatter is the legitimate demote-from-canonical operation.
+  // Root-delegated operating-rule notes are pinned because root AGENTS.md or
+  // another canonical entry point sends agents there for current behavior.
+  // Other docs/notes/* canonical notes remain discovery-managed; removing
+  // their frontmatter is the legitimate demote-from-canonical operation.
+  ...delegatedOperatingRuleNotes,
   ...canonicalSkillFiles.filter((file) => file.endsWith("/SKILL.md")),
   ...trackedFiles(".agents/roles", (file) => file.endsWith(".md"), {
     required: true,
@@ -207,7 +257,7 @@ for (const file of missingCoreContextFiles(
     fail(`${file}: required managed context file is missing`);
   } else {
     fail(
-      `${file}: core context file must keep canonical: true frontmatter (discovery no longer finds it)`,
+      `${file}: core context file must keep canonical: true metadata (discovery no longer finds it)`,
     );
   }
 }

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -485,6 +485,55 @@ test("fails when root README has neither frontmatter nor marker", () => {
   }
 });
 
+test("fails when root README marker demotes canonical metadata", () => {
+  try {
+    runContextCheckFixture(
+      `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=false last_verified=${isoDateWithOffset(0)} -->\n`,
+    );
+    throw new Error(
+      "expected context check to fail for demoted README metadata",
+    );
+  } catch (/** @type {unknown} */ err) {
+    const maybeError =
+      err && typeof err === "object"
+        ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
+            err
+          )
+        : {};
+    const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
+    assert(
+      output.includes(
+        "README.md: core context file must keep canonical: true metadata",
+      ),
+      `expected demoted README metadata failure, got ${JSON.stringify(output || maybeError.message)}`,
+    );
+  }
+});
+
+test("fails when root README marker is missing required metadata keys", () => {
+  try {
+    runContextCheckFixture(
+      `# Root README\n\n<!-- agent-context: title="Root README" canonical=true last_verified=${isoDateWithOffset(0)} -->\n`,
+    );
+    throw new Error(
+      "expected context check to fail for incomplete README metadata",
+    );
+  } catch (/** @type {unknown} */ err) {
+    const maybeError =
+      err && typeof err === "object"
+        ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
+            err
+          )
+        : {};
+    const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
+    assert(
+      output.includes("README.md: missing metadata key 'status'") &&
+        output.includes("README.md: missing metadata key 'owner'"),
+      `expected missing key failures, got ${JSON.stringify(output || maybeError.message)}`,
+    );
+  }
+});
+
 test("continues to support root README YAML frontmatter", () => {
   const output = runContextCheckFixture(canonicalContextFile("Root README"));
   assert(

--- a/scripts/check-agent-context.test.mjs
+++ b/scripts/check-agent-context.test.mjs
@@ -6,11 +6,18 @@
  * files) and exits the process on failure, so it isn't a good target for a
  * synthetic-fixture end-to-end harness. Instead this tests the pure parsing,
  * staleness, and canonical-discovery helpers from
- * check-agent-context-helpers.mjs directly.
+ * check-agent-context-helpers.mjs directly, plus a small fixture harness for
+ * README-specific metadata discovery that lives in the main script.
  *
  * Run: node scripts/check-agent-context.test.mjs
  * CI:  .github/workflows/ci.yml  (scripts job)
  */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   assessStaleness,
@@ -42,6 +49,155 @@ function test(name, fn) {
 
 function assert(condition, msg) {
   if (!condition) throw new Error(msg);
+}
+
+const checkerScriptPath = fileURLToPath(
+  new URL("./check-agent-context.mjs", import.meta.url),
+);
+
+function isoDateWithOffset(offsetDays) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+  return date.toISOString().slice(0, 10);
+}
+
+function canonicalContextFile(title, lastVerified = isoDateWithOffset(0)) {
+  return `---\ntitle: ${title}\nstatus: active\nowner: eng\ncanonical: true\nlast_verified: ${lastVerified}\n---\n\n# ${title}\n`;
+}
+
+function writeFixtureFile(root, filePath, content) {
+  const absolutePath = path.join(root, filePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function writeFixtureJson(root, filePath, value) {
+  writeFixtureFile(root, filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createContextCheckFixture(readmeContent) {
+  const root = mkdtempSync(path.join(tmpdir(), "check-agent-context-"));
+
+  writeFixtureFile(root, "AGENTS.md", canonicalContextFile("Agents"));
+  writeFixtureFile(root, "SPEC.md", canonicalContextFile("Spec"));
+  writeFixtureFile(root, "README.md", readmeContent);
+  writeFixtureFile(
+    root,
+    "docs/context-standards.md",
+    canonicalContextFile("Context Standards"),
+  );
+  writeFixtureFile(
+    root,
+    "docs/pr-checklists/recurring-review-patterns.md",
+    canonicalContextFile("Recurring Review Patterns"),
+  );
+  for (const note of [
+    "agent-issue-workflow",
+    "agent-quality-gate-mechanics",
+    "codex-agent-skills",
+    "codex-cloud-setup",
+    "cross-protocol-context",
+    "pr-ready-state",
+    "spoken-attention-nudge",
+    "worktree-and-web-setup",
+  ]) {
+    writeFixtureFile(
+      root,
+      `docs/notes/${note}.md`,
+      canonicalContextFile(`${note} Note`),
+    );
+  }
+
+  for (const dir of [
+    "aegis",
+    "alerts",
+    "indexer-envio",
+    "integration-probes",
+    "metrics-bridge",
+    "shared-config",
+    "terraform",
+    "scripts",
+    "ui-dashboard",
+  ]) {
+    writeFixtureFile(
+      root,
+      `${dir}/AGENTS.md`,
+      canonicalContextFile(`${dir} Agents`),
+    );
+  }
+
+  const skill = canonicalContextFile("Demo Skill");
+  writeFixtureFile(root, ".agents/skills/demo/SKILL.md", skill);
+  writeFixtureFile(root, ".claude/skills/demo/SKILL.md", skill);
+  writeFixtureFile(
+    root,
+    ".agents/roles/reviewer.md",
+    canonicalContextFile("Reviewer Role"),
+  );
+
+  writeFixtureFile(
+    root,
+    ".github/workflows/metrics-bridge.yml",
+    'jobs:\n  deploy:\n    steps:\n      - run: |\n          --revision-suffix="r-${GITHUB_SHA::7}-${GITHUB_RUN_ID}"\n',
+  );
+  writeFixtureFile(
+    root,
+    "scripts/deploy-bridge.sh",
+    'REVISION_SUFFIX="r-${TAG}-$(date +%s)"\n',
+  );
+  writeFixtureFile(
+    root,
+    "scripts/agent-session-end-hook.sh",
+    "#!/usr/bin/env bash\n",
+  );
+  writeFixtureJson(root, ".codex/hooks.json", {
+    hooks: {
+      SessionEnd: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "bash -lc 'repo=$(git rev-parse --show-toplevel) && exec bash \"$repo/scripts/agent-session-end-hook.sh\"'",
+            },
+          ],
+        },
+      ],
+    },
+  });
+  writeFixtureJson(root, ".claude/settings.json", {
+    permissions: { allow: [] },
+    hooks: {
+      SessionEnd: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                'bash "${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh"',
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: root, stdio: "ignore" });
+  return root;
+}
+
+function runContextCheckFixture(readmeContent) {
+  const root = createContextCheckFixture(readmeContent);
+  try {
+    return execFileSync(process.execPath, [checkerScriptPath], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 }
 
 // ── parseFrontmatter tests ────────────────────────────────────────────────────
@@ -297,6 +453,76 @@ test("minimum-presence passes when every core file is discovered", () => {
     missing.length === 0,
     `expected no missing core files, got ${JSON.stringify(missing)}`,
   );
+});
+
+// ── README metadata discovery in the live checker ─────────────────────────────
+//
+// Root README.md is intentionally outside the generic frontmatter discovery
+// roots because visible YAML frontmatter renders poorly on the GitHub repo
+// homepage. The live checker has a README-only hidden marker path, so these
+// tests run the actual script in a minimal tracked repo fixture.
+
+console.log("\nREADME metadata discovery");
+
+test("fails when root README has neither frontmatter nor marker", () => {
+  try {
+    runContextCheckFixture("# Root README\n\nNo metadata here.\n");
+    throw new Error("expected context check to fail without README metadata");
+  } catch (/** @type {unknown} */ err) {
+    const maybeError =
+      err && typeof err === "object"
+        ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
+            err
+          )
+        : {};
+    const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
+    assert(
+      output.includes(
+        "README.md: core context file must keep canonical: true metadata",
+      ),
+      `expected missing README metadata failure, got ${JSON.stringify(output || maybeError.message)}`,
+    );
+  }
+});
+
+test("continues to support root README YAML frontmatter", () => {
+  const output = runContextCheckFixture(canonicalContextFile("Root README"));
+  assert(
+    output.includes("Agent context check passed"),
+    `expected README frontmatter to pass, got ${JSON.stringify(output)}`,
+  );
+});
+
+test("supports a hidden root README agent-context marker", () => {
+  const output = runContextCheckFixture(
+    `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=true last_verified=${isoDateWithOffset(0)} -->\n`,
+  );
+  assert(
+    output.includes("Agent context check passed"),
+    `expected README marker to pass, got ${JSON.stringify(output)}`,
+  );
+});
+
+test("applies staleness checks to a hidden root README marker", () => {
+  const staleDate = isoDateWithOffset(-(STALE_AFTER_DAYS + 1));
+  try {
+    runContextCheckFixture(
+      `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=true last_verified=${staleDate} -->\n`,
+    );
+    throw new Error("expected context check to fail for stale README metadata");
+  } catch (/** @type {unknown} */ err) {
+    const maybeError =
+      err && typeof err === "object"
+        ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
+            err
+          )
+        : {};
+    const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
+    assert(
+      output.includes(`README.md: last_verified ${staleDate} is`),
+      `expected stale README marker failure, got ${JSON.stringify(output || maybeError.message)}`,
+    );
+  }
 });
 
 // ── summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The Problem

- Root `README.md` needed context-authority metadata, but visible YAML frontmatter would render on the GitHub repo homepage.
- Root `AGENTS.md` delegates current operating rules to several `docs/notes/*.md` files that were not all enrolled in canonical staleness checks.

## The Solution

- Add hidden `agent-context` metadata support for root `README.md` and make README a required managed context file.
- Formalize delegated operating-rule notes as canonical context, then enroll the delegated notes in the metadata check.

## Details

- `scripts/check-agent-context.mjs` now parses the README-only hidden marker while preserving YAML frontmatter support everywhere else.
- Delegated operating-rule notes are pinned in the core managed-context set so removing their canonical metadata fails the check instead of silently demoting them.
- `docs/context-standards.md` and ADR 0005 now document the README metadata exception and delegated-note policy.

Closes #1106.
Closes #1071.

## Validation

- `node scripts/check-agent-context.test.mjs`
- `pnpm agent:context-check`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview --prepare-bundle-dir /private/tmp/monitoring-autoreview-1106-1071 -- --prepare-only --mode local --bundle-output /private/tmp/monitoring-autoreview-1106-1071/autoreview-prompt.md`
- `pnpm agent:autoreview -- --engine local --mode local`
- Fresh-context subagent autoreview: no findings

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation metadata and the agent context CI script; no production runtime or data-path behavior.
> 
> **Overview**
> Extends the **canonical context** contract so root `README.md` and root-delegated `docs/notes/*` operating rules are enforced by `pnpm agent:context-check`, without showing YAML on the GitHub repo homepage.
> 
> Root `README.md` now carries the same metadata keys (`title`, `status`, `owner`, `canonical`, `last_verified`) in a hidden `<!-- agent-context: ... -->` HTML comment. `scripts/check-agent-context.mjs` parses that marker (YAML frontmatter on README still works), treats `README.md` as a required core managed file, and applies the usual staleness rules.
> 
> Several notes that `AGENTS.md` points to for current behavior—e.g. codex setup, PR ready state, worktree setup—get `canonical: true` frontmatter and are **pinned** in the core managed set so stripping metadata fails the check instead of silently demoting them. `docs/context-standards.md` and ADR 0005 document the README exception and delegated-note policy.
> 
> Fixture-based tests in `check-agent-context.test.mjs` cover missing/demoted/incomplete README metadata, hidden markers, and staleness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e469f48848f614b00fc9a3d084f9f78699b347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->