### PR TITLE
perf(quality-gate): parallelize the pre-push gate, fix warm-reuse, add a heartbeat

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -101,7 +101,7 @@ actions:
         Runs the path-aware agent quality gate before push. The gate maps the
         branch diff to the required local checks instead of always running the
         full monorepo pre-push suite.
-      run: git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --fail-fast --skip-if-fresh --base origin/main
+      run: git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main
       triggers:
         - git_hooks: [pre-push]
   enabled:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-05
+last_verified: 2026-07-06
 ---
 
 # Agent Quality Gate — Mechanics
@@ -120,16 +120,23 @@ concurrent logs do not interleave. The same dashboard `.next` serialization rule
 applies to prewarm.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
-`--fail-fast --skip-if-fresh`, so the hook stops on the first failed mapped
-command instead of burning through the rest of the suite, and it reuses a
-recent successful manual gate run when the fetched base commit, mapped command
-plan, gate implementation, changed paths, validated file content, package-risk
-state, and package-script acknowledgement are unchanged. For a push that
-intentionally changes package scripts or package-manager config, review the
-script/lifecycle diff first, then temporarily set
-`agent.qualityGate.allowPackageScriptChanges=true` in local git config for that
-push; a just-passed acknowledged manual gate can then satisfy the pre-push
-`--skip-if-fresh` check.
+`--parallel 3 --skip-if-fresh`, so the independent quality-phase members run
+concurrently (the heavy `test:coverage` suites and the gate self-test overlap
+instead of summing to the serial total), and it reuses a recent successful
+manual gate run when the fetched base commit, mapped command plan, gate
+implementation, changed paths, validated file content, and package-risk state
+are unchanged. Because it runs in parallel rather than `--fail-fast`, a red
+push runs the remaining in-flight members before failing (green pushes, the
+common case, get the full speedup). Package-script acknowledgement is folded out
+of the reuse key when there is no package-script risk, so a warm
+`pnpm agent:quality-gate --run` — even one passed `--allow-package-script-changes`
+defensively — satisfies the flag-less hook's `--skip-if-fresh` check, and
+warm-then-push then skips the mapped commands. When a push DOES change package
+scripts or package-manager config, the acknowledgement is part of the reuse key:
+review the script/lifecycle diff first, then set
+`agent.qualityGate.allowPackageScriptChanges=true` in local git config (seen by
+both the manual warm run and the hook) so a just-passed acknowledged manual gate
+can satisfy the `--skip-if-fresh` check.
 
 Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
 local dashboard browser tests, and dashboard React Doctor checks run through

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -52,11 +52,12 @@ required full-repo Trunk check on every
 PR. Normal `--run` mode executes independent quality-phase commands with
 bounded parallelism (`--parallel <n>`, default `auto` capped at 4 workers, or
 `AGENT_QUALITY_PARALLELISM`). Preflight, codegen, post-codegen install,
-Terraform init/validate chains, Playwright browser install, and shared-config
-build setup remain ordered. Dashboard `test:browser` and build-backed
-`size-limit` also stay serialized because both touch `ui-dashboard/.next`.
-`--fail-fast` stays sequential so it still stops before starting the next mapped
-command.
+Terraform init/validate chains, and shared-config build setup remain ordered
+prerequisites. Playwright browser install, dashboard `test:browser`, and
+build-backed `size-limit` stay serialized with each other, but are not global
+quality prerequisites: a browser setup failure still lets independent
+lint/typecheck/unit/knip feedback run. `--fail-fast` stays sequential so it
+still stops before starting the next mapped command.
 
 For non-trivial behavioral, workflow, security, data-flow, or UI batches, run
 the structured closeout review after the mapped gate and before pushing:

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1951,9 +1951,6 @@ is_quality_setup_command() {
   # they must finish before the independent quality pool starts. Keep this list
   # in sync with new setup-style commands added by the path mapper above.
   case "$command" in
-    "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium")
-      return 0
-      ;;
     "pnpm --filter @mento-protocol/monitoring-config build")
       return 0
       ;;
@@ -1967,10 +1964,15 @@ is_quality_setup_command() {
 
 is_quality_serial_command() {
   local command="$1"
-  # Dashboard browser tests start a Next dev server while size-limit runs a
-  # build-backed Turbo task. Both touch ui-dashboard/.next, so keep them
-  # mutually exclusive instead of letting the parallel pool overlap them.
+  # Dashboard browser setup/tests and size-limit must stay ordered relative to
+  # each other, but they are not prerequisites for lint/typecheck/unit/knip.
+  # Browser tests need Chromium installed first; browser tests start a Next dev
+  # server while size-limit runs a build-backed Turbo task, and both touch
+  # ui-dashboard/.next, so keep those two mutually exclusive.
   case "$command" in
+    "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium")
+      return 0
+      ;;
     "pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw")
       return 0
       ;;

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1813,10 +1813,6 @@ fi
 
 failures=0
 command_summaries=()
-supports_wait_n=false
-if help wait 2>/dev/null | grep -q -- "-n"; then
-  supports_wait_n=true
-fi
 
 format_duration() {
   local seconds="$1"
@@ -2035,7 +2031,7 @@ run_mapped_entries_parallel() {
   local i
   local status
   local elapsed
-  local phase_start_ts last_heartbeat_ts now_ts hb_cmd heartbeat_timer_pid
+  local phase_start_ts last_heartbeat_ts now_ts hb_cmd
   local heartbeat_interval=20
 
   if [[ "$total" -eq 0 ]]; then
@@ -2140,40 +2136,32 @@ run_mapped_entries_parallel() {
       fi
     fi
 
-    if [[ ${#active_pids[@]} -gt 0 && "$supports_wait_n" == true ]]; then
-      # Cap the block at the heartbeat interval so a single long-running tail
-      # command still produces periodic liveness output: a throwaway timer job
-      # makes `wait -n` return at least every heartbeat_interval even when no
-      # real command completes. A genuine completion still returns immediately;
-      # the timer is then killed and reaped.
-      sleep "$heartbeat_interval" &
-      heartbeat_timer_pid=$!
-      wait -n 2>/dev/null || true
-      kill "$heartbeat_timer_pid" 2>/dev/null || true
-      wait "$heartbeat_timer_pid" 2>/dev/null || true
-    elif [[ ${#active_pids[@]} -gt 0 ]]; then
-      # Polling cadence for shells without `wait -n` (e.g. macOS bash 3.x), NOT
-      # the heartbeat period — that is tracked separately by wall clock via
-      # heartbeat_interval, so a slower poll here does not change how often the
-      # liveness line prints.
+    # Poll on a short cadence instead of blocking on `wait -n`. A bare `wait -n`
+    # only wakes on completions, so a set of concurrently-slow commands would
+    # suppress the wall-clock heartbeat above; and capping `wait -n` with a timer
+    # job races with fast commands that finish mid-cycle (the timer becomes the
+    # next completion and delays recording them by a full interval). A 1s poll
+    # detects completions within ~1s — negligible for a gate whose parallel
+    # members run for seconds to minutes — and lets the heartbeat fire on time.
+    if [[ ${#active_pids[@]} -gt 0 ]]; then
       sleep 1
     fi
   done
 }
 
-abort_if_failed() {
-  # A failed ORDERED prerequisite (install / codegen / quality-setup /
-  # quality-serialized) must stop the run before its dependents execute, even
-  # when not --fail-fast. The independent parallel quality pool intentionally
-  # keeps going for speed, but ordered phases do not — otherwise a dependent
-  # (a typecheck needing a built dist, a browser test needing Chromium) fails
-  # for a derived reason and buries the real error.
-  if [[ "$failures" -gt 0 ]]; then
-    echo
-    echo "Stopping: a prerequisite phase failed before dependent checks ran." >&2
-    print_command_summary
-    exit 1
-  fi
+run_prerequisite_phase() {
+  # Ordered prerequisite phases (install / codegen / quality-setup) fail-fast
+  # WITHIN themselves: a failed step must stop before its dependents — and
+  # before later steps in the SAME phase (e.g. `terraform validate` after a
+  # failed `terraform init`) — run. This preserves the old --fail-fast
+  # prerequisite behavior even though the hook now drops global --fail-fast so
+  # the independent quality pool keeps going. Serialized dashboard checks and
+  # the parallel pool are NOT prerequisites (serialized only for the .next
+  # mutex), so they are run keep-going and still collect their own feedback.
+  local previous_fail_fast="$fail_fast"
+  fail_fast=true
+  run_mapped_entries_sequential "$@"
+  fail_fast="$previous_fail_fast"
 }
 
 run_quality_phase() {
@@ -2199,19 +2187,14 @@ run_quality_phase() {
     fi
   done
 
-  run_mapped_entries_sequential "quality setup" "${setup_entries[@]+"${setup_entries[@]}"}"
-  abort_if_failed
+  run_prerequisite_phase "quality setup" "${setup_entries[@]+"${setup_entries[@]}"}"
   run_mapped_entries_sequential "quality serialized" "${serial_entries[@]+"${serial_entries[@]}"}"
-  abort_if_failed
   run_mapped_entries_parallel "quality" "$quality_parallelism" "${parallel_entries[@]+"${parallel_entries[@]}"}"
 }
 
-run_mapped_entries_sequential "preflight" "${preflight_commands[@]+"${preflight_commands[@]}"}"
-abort_if_failed
-run_mapped_entries_sequential "codegen" "${codegen_commands[@]+"${codegen_commands[@]}"}"
-abort_if_failed
-run_mapped_entries_sequential "post-codegen" "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"
-abort_if_failed
+run_prerequisite_phase "preflight" "${preflight_commands[@]+"${preflight_commands[@]}"}"
+run_prerequisite_phase "codegen" "${codegen_commands[@]+"${codegen_commands[@]}"}"
+run_prerequisite_phase "post-codegen" "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"
 run_quality_phase
 
 print_command_summary

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1713,6 +1713,19 @@ command_plan_hash="$(hash_file "$command_plan_file")"
 implementation_hash="$(implementation_signature)"
 validated_content_hash="$(validation_content_signature)"
 
+# `allow_package_script_changes` only gates the pre-run package-script refusal,
+# which is a no-op unless `package_script_risk_changed`. Fold it out of the
+# freshness stamp in the common no-risk case so a warm manual run (which may pass
+# --allow-package-script-changes defensively) produces the SAME stamp as the
+# flag-less pre-push hook — otherwise warm-then-push never skips. When package
+# risk IS present, keep the real value so an unacknowledged hook run cannot reuse
+# an acknowledged manual run.
+if [[ "$package_script_risk_changed" == "true" ]]; then
+  stamp_allow_package_scripts="${allow_package_script_changes:-false}"
+else
+  stamp_allow_package_scripts="n/a"
+fi
+
 stamp_line() {
   printf 'v2\tbase=%s\tpaths=%s\tplan=%s\timplementation=%s\tcontent=%s\tpackageRisk=%s\tallowPackageScripts=%s\n' \
     "$base_oid" \
@@ -1721,7 +1734,7 @@ stamp_line() {
     "$implementation_hash" \
     "$validated_content_hash" \
     "$package_script_risk_changed" \
-    "${allow_package_script_changes:-false}"
+    "$stamp_allow_package_scripts"
 }
 
 current_stamp="$(stamp_line)"
@@ -2022,6 +2035,8 @@ run_mapped_entries_parallel() {
   local i
   local status
   local elapsed
+  local phase_start_ts last_heartbeat_ts now_ts hb_cmd heartbeat_timer_pid
+  local heartbeat_interval=20
 
   if [[ "$total" -eq 0 ]]; then
     return
@@ -2034,6 +2049,8 @@ run_mapped_entries_parallel() {
 
   echo
   echo "Running ${phase} commands with parallelism ${max_parallel}."
+  phase_start_ts="$(date +%s)"
+  last_heartbeat_ts="$phase_start_ts"
 
   while [[ "$completed" -lt "$total" ]]; do
     while [[ "$next_index" -lt "$total" && "${#active_pids[@]}" -lt "$max_parallel" ]]; do
@@ -2109,12 +2126,50 @@ run_mapped_entries_parallel() {
     active_status_files=("${next_active_status_files[@]+"${next_active_status_files[@]}"}")
     active_elapsed_files=("${next_active_elapsed_files[@]+"${next_active_elapsed_files[@]}"}")
 
+    # Heartbeat: while commands are still in flight, emit a periodic liveness
+    # line naming what is running so a slow member is visibly working, not hung.
+    if [[ ${#active_pids[@]} -gt 0 ]]; then
+      now_ts="$(date +%s)"
+      if [[ $((now_ts - last_heartbeat_ts)) -ge "$heartbeat_interval" ]]; then
+        printf '⏳ still running after %s (%d/%d done):\n' \
+          "$(format_duration $((now_ts - phase_start_ts)))" "$completed" "$total"
+        for hb_cmd in "${active_commands[@]}"; do
+          printf '    · %s\n' "$hb_cmd"
+        done
+        last_heartbeat_ts="$now_ts"
+      fi
+    fi
+
     if [[ ${#active_pids[@]} -gt 0 && "$supports_wait_n" == true ]]; then
+      # Cap the block at the heartbeat interval so a single long-running tail
+      # command still produces periodic liveness output: a throwaway timer job
+      # makes `wait -n` return at least every heartbeat_interval even when no
+      # real command completes. A genuine completion still returns immediately;
+      # the timer is then killed and reaped.
+      sleep "$heartbeat_interval" &
+      heartbeat_timer_pid=$!
       wait -n 2>/dev/null || true
+      kill "$heartbeat_timer_pid" 2>/dev/null || true
+      wait "$heartbeat_timer_pid" 2>/dev/null || true
     elif [[ ${#active_pids[@]} -gt 0 ]]; then
-      sleep 0.1
+      sleep 1
     fi
   done
+}
+
+abort_if_failed() {
+  # A failed ORDERED prerequisite (install / codegen / quality-setup /
+  # quality-serialized) must stop the run before its dependents execute, even
+  # when not --fail-fast. The independent parallel quality pool intentionally
+  # keeps going for speed, but ordered phases do not — otherwise a dependent
+  # (a typecheck needing a built dist, a browser test needing Chromium) fails
+  # for a derived reason and buries the real error.
+  if [[ "$failures" -gt 0 ]]; then
+    echo
+    echo "Stopping: a prerequisite phase failed before dependent checks ran." >&2
+    print_command_summary
+    exit 1
+  fi
 }
 
 run_quality_phase() {
@@ -2141,13 +2196,18 @@ run_quality_phase() {
   done
 
   run_mapped_entries_sequential "quality setup" "${setup_entries[@]+"${setup_entries[@]}"}"
+  abort_if_failed
   run_mapped_entries_sequential "quality serialized" "${serial_entries[@]+"${serial_entries[@]}"}"
+  abort_if_failed
   run_mapped_entries_parallel "quality" "$quality_parallelism" "${parallel_entries[@]+"${parallel_entries[@]}"}"
 }
 
 run_mapped_entries_sequential "preflight" "${preflight_commands[@]+"${preflight_commands[@]}"}"
+abort_if_failed
 run_mapped_entries_sequential "codegen" "${codegen_commands[@]+"${codegen_commands[@]}"}"
+abort_if_failed
 run_mapped_entries_sequential "post-codegen" "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"
+abort_if_failed
 run_quality_phase
 
 print_command_summary

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2152,6 +2152,10 @@ run_mapped_entries_parallel() {
       kill "$heartbeat_timer_pid" 2>/dev/null || true
       wait "$heartbeat_timer_pid" 2>/dev/null || true
     elif [[ ${#active_pids[@]} -gt 0 ]]; then
+      # Polling cadence for shells without `wait -n` (e.g. macOS bash 3.x), NOT
+      # the heartbeat period — that is tracked separately by wall clock via
+      # heartbeat_interval, so a slower poll here does not change how often the
+      # liveness line prints.
       sleep 1
     fi
   done

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1909,6 +1909,52 @@ assert_contains "+ pnpm exec turbo run size-limit --filter=@mento-protocol/ui-da
 assert_contains "All mapped commands passed."
 assert_not_contains "dashboard .next command overlapped"
 
+dashboard_setup_failure_repo="$(mktemp -d)"
+(
+  cd "$dashboard_setup_failure_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin tools ui-dashboard
+  printf 'fixture\n' > ui-dashboard/README.md
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  --filter\ @mento-protocol/ui-dashboard\ exec\ playwright\ install\ chromium)
+    echo "chromium install unavailable"
+    exit 1
+    ;;
+  exec\ turbo\ run\ lint*|exec\ turbo\ run\ typecheck*|exec\ turbo\ run\ knip*|--filter\ @mento-protocol/ui-dashboard\ test:coverage|code-health:deps)
+    printf 'ran\n' >> "${QUALITY_MARKER:?}"
+    ;;
+esac
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'ui-dashboard/README.md\n' > changed-paths.txt
+  if QUALITY_MARKER="$dashboard_setup_failure_repo/.tmp/quality-ran" \
+    PATH="$dashboard_setup_failure_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 8 \
+      > "$output_file" 2>&1; then
+    fail "gate did not fail when dashboard Chromium install failed"
+  fi
+  [[ -f "$dashboard_setup_failure_repo/.tmp/quality-ran" ]] ||
+    fail "independent quality pool did not run after dashboard Chromium install failed"
+)
+rm -rf "$dashboard_setup_failure_repo"
+assert_contains "chromium install unavailable"
+assert_contains "Running quality commands with parallelism 8."
+
 fresh_stamp_repo="$(mktemp -d)"
 (
   cd "$fresh_stamp_repo"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1932,14 +1932,18 @@ STUB
   git commit -qm init
   base_ref="$(git rev-parse --verify HEAD)"
   printf 'changed\n' >> README.md
+  # Warm WITH --allow-package-script-changes; the skip run below passes NO such
+  # flag (like the pre-push hook). With no package-script risk they must still
+  # share a freshness stamp, so the flag-less run skips (allowPackageScripts is
+  # folded out of the stamp when packageRisk is false).
   COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
-    "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run > "$output_file" 2>&1
+    "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --allow-package-script-changes > "$output_file" 2>&1
   git add README.md
   git commit -qm "commit validated content"
   COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --skip-if-fresh >> "$output_file" 2>&1
   [[ "$(cat "$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
-    fail "fresh gate stamp did not skip duplicate run"
+    fail "fresh gate stamp did not skip flag-less run after allow-flag warm"
 )
 rm -rf "$fresh_stamp_repo"
 assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1998,10 +1998,10 @@ rm -rf "$package_risk_fresh_stamp_repo"
 assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
 # A failed ORDERED prerequisite phase (here the preflight `pnpm install`) must
-# stop the run via abort_if_failed before the parallel quality pool executes.
-# This is the behavioral contract that replaced --fail-fast for the pre-push
-# hook: prerequisites still abort before their dependents, only the independent
-# quality pool keeps going.
+# stop the run before the parallel quality pool executes. Prerequisite phases
+# (preflight / codegen / quality-setup) run fail-fast even though the pre-push
+# hook drops global --fail-fast, so a failed install stops before its
+# dependents; only the independent quality pool keeps going.
 abort_prereq_repo="$(mktemp -d)"
 (
   cd "$abort_prereq_repo"
@@ -2042,7 +2042,7 @@ STUB
     fail "quality pool ran despite a failed prerequisite phase"
 )
 rm -rf "$abort_prereq_repo"
-assert_contains "Stopping: a prerequisite phase failed before dependent checks ran."
+assert_contains "Stopping after first failed mapped command (--fail-fast)."
 
 stale_stamp_repo="$(mktemp -d)"
 (

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1997,6 +1997,53 @@ STUB
 rm -rf "$package_risk_fresh_stamp_repo"
 assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
+# A failed ORDERED prerequisite phase (here the preflight `pnpm install`) must
+# stop the run via abort_if_failed before the parallel quality pool executes.
+# This is the behavioral contract that replaced --fail-fast for the pre-push
+# hook: prerequisites still abort before their dependents, only the independent
+# quality pool keeps going.
+abort_prereq_repo="$(mktemp -d)"
+(
+  cd "$abort_prereq_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin tools
+  printf 'fixture\n' > README.md
+  # Marks that the quality pool ran; it must NOT run if a prerequisite failed.
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+printf 'ran\n' > "${QUALITY_MARKER:?}"
+STUB
+  # Fail the preflight install; succeed for every other pnpm invocation.
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *install*) exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x bin/pnpm tools/trunk
+  git add .
+  git commit -qm init
+  printf 'packages/fixture/package.json\n' > changed-paths.txt
+  if QUALITY_MARKER="$abort_prereq_repo/.tmp/quality-ran" \
+    PATH="$abort_prereq_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 3 \
+      --allow-package-script-changes \
+      > "$output_file" 2>&1; then
+    fail "gate did not fail when the preflight prerequisite failed"
+  fi
+  [[ ! -f "$abort_prereq_repo/.tmp/quality-ran" ]] ||
+    fail "quality pool ran despite a failed prerequisite phase"
+)
+rm -rf "$abort_prereq_repo"
+assert_contains "Stopping: a prerequisite phase failed before dependent checks ran."
+
 stale_stamp_repo="$(mktemp -d)"
 (
   cd "$stale_stamp_repo"

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,6 @@
     "enabled": false
   },
   "globalDependencies": [
-    "package.json",
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     ".npmrc",
@@ -22,7 +21,9 @@
         "package.json",
         "eslint.config.*",
         "eslint-baseline.json",
-        "$TURBO_ROOT$/scripts/eslint-baseline-diff.mjs"
+        "$TURBO_ROOT$/scripts/eslint-baseline-diff.mjs",
+        "!AGENTS.md",
+        "!CLAUDE.md"
       ],
       "outputs": []
     },
@@ -33,7 +34,9 @@
         "package.json",
         "tsconfig*.json",
         "nest-cli.json",
-        "$TURBO_ROOT$/tsconfig*.json"
+        "$TURBO_ROOT$/tsconfig*.json",
+        "!AGENTS.md",
+        "!CLAUDE.md"
       ],
       "outputs": []
     },
@@ -46,13 +49,21 @@
         "jest.config.*",
         "tsconfig*.json",
         "$TURBO_ROOT$/indexer-envio/schema.graphql",
-        "$TURBO_ROOT$/scripts/envio-schema-stubs.graphql"
+        "$TURBO_ROOT$/scripts/envio-schema-stubs.graphql",
+        "!AGENTS.md",
+        "!CLAUDE.md"
       ],
       "outputs": []
     },
     "knip": {
       "cache": true,
-      "inputs": ["$TURBO_DEFAULT$", "package.json", "knip.json"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "package.json",
+        "knip.json",
+        "!AGENTS.md",
+        "!CLAUDE.md"
+      ],
       "outputs": []
     },
     "build": {
@@ -175,7 +186,9 @@
         "$TURBO_ROOT$/.npmrc",
         "$TURBO_ROOT$/.node-version",
         "$TURBO_ROOT$/scripts/check-react-doctor-diff.sh",
-        "$TURBO_ROOT$/turbo.json"
+        "$TURBO_ROOT$/turbo.json",
+        "!AGENTS.md",
+        "!CLAUDE.md"
       ],
       "env": ["REACT_DOCTOR_BASE_REF", "REACT_DOCTOR_BASE_CACHE_KEY"],
       "outputs": []
@@ -196,7 +209,9 @@
         "$TURBO_ROOT$/.npmrc",
         "$TURBO_ROOT$/.node-version",
         "$TURBO_ROOT$/scripts/check-react-doctor-score.sh",
-        "$TURBO_ROOT$/turbo.json"
+        "$TURBO_ROOT$/turbo.json",
+        "!AGENTS.md",
+        "!CLAUDE.md"
       ],
       "outputs": []
     }

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,7 @@
     "enabled": false
   },
   "globalDependencies": [
+    "package.json",
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     ".npmrc",


### PR DESCRIPTION
## The Problem

- The pre-push `agent-quality-gate` took ~7 min and repeatedly timed out / got killed under load, blocking pushes (hit acutely while shipping the ADR PR).
- It printed nothing for minutes, so you couldn't tell whether it was working, hung, or where it was stuck.

## The Solution

Attack both speed and observability: parallelize the hook (the biggest lever), fix the freshness stamp so a warm run actually lets the hook skip, add Turbo cache hygiene so benign edits are cache hits, and stream a heartbeat so the gate is visibly alive.

## Details

Root causes were traced to `file:line` by an investigation + an adversarial audit of the diff:

- **A — parallelize the hook.** The pre-push action passed `--fail-fast`, which forces fully-serial execution, so the heavy members (indexer/ui `test:coverage` + the gate self-test) summed instead of overlapping. The hook now uses `--parallel 3` (`.trunk/trunk.yaml`). Ordered prerequisite phases (preflight, codegen, quality-setup) fail-fast *within* the phase via a new `run_prerequisite_phase` helper — so a failed dependency (or `terraform init` before `validate`) stops before its dependents run — while the serialized dashboard checks and the parallel pool keep going (A's accepted trade). Cold gate ~7 min → ~3 min.
- **B — fix warm-then-push reuse.** The freshness stamp keyed on `allowPackageScripts`, so a warm run passed `--allow-package-script-changes` never matched the flag-less hook. Fold that field out of the stamp when there is no package-script risk (kept when there is), so a warm gate lets the hook `--skip-if-fresh`. **Verified end-to-end: this PR's own push skipped** (`"still fresh; skipping mapped commands"`). Locked by a self-test that warms with the flag and asserts the flag-less run skips.
- **E — Turbo cache hygiene.** Excluded `AGENTS.md`/`CLAUDE.md` (doc-only, never read by these tasks) from the `lint`/`typecheck`/`test`/`knip`/`react-doctor` task inputs, so a package doc edit is a cache HIT instead of a cold re-run. (An earlier commit also dropped root `package.json` from `globalDependencies`, but that was reverted after review — a root `postinstall`/config change that doesn't move the lockfile must still bust those mapped checks rather than reuse a stale cache.)
- **F — observability.** The parallel runner emits a 20 s heartbeat naming the in-flight commands + progress (`⏳ still running after 1m20s (5/6 done): …`). It polls on a 1 s cadence rather than blocking on `wait -n`, so the heartbeat fires on a wall-clock schedule (verified ticking every 20 s on a lone tail command) without the timer/`wait -n` race that could delay recording fast completions.

Docs updated: `docs/notes/agent-quality-gate-mechanics.md` (the hook-flags paragraph + stamp behavior).

## Validation

- `pnpm agent:quality-gate:test` → passes, including a new cross-flag stamp-reuse regression test.
- Empirical (unsandboxed gate runs): `Running quality commands with parallelism 3`; the heartbeat ticked at `42s / 1m2s / 1m22s` on the same lone tail command (the exact case it targets); a flag-less run reused an allow-flag warm stamp and skipped.
- This PR's own `git push` pre-push hook printed `Previous successful agent quality gate run is still fresh; skipping mapped commands`.
- `trunk fmt` + `trunk check` → No issues.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Architecture decision? This is a perf/observability change to existing gate machinery, not a new architectural decision (no new ADR).

## Ship Checklist

- [x] ship skill used
- [x] local review run (adversarial audit of the diff)
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-push developer workflow and gate orchestration (parallelism, fail-fast boundaries, freshness stamps); mistakes could skip checks or change failure ordering, though behavior is heavily regression-tested.
> 
> **Overview**
> **Pre-push quality gate** is faster and easier to watch: the Trunk hook now runs `agent-quality-gate.sh` with **`--parallel 3`** and **`--skip-if-fresh`** instead of **`--fail-fast`**, so heavy independent checks overlap. Ordered **preflight / codegen / post-codegen / quality-setup** phases still **fail fast within the phase** via `run_prerequisite_phase`, while the parallel quality pool and serialized dashboard steps keep running to collect feedback on failure.
> 
> **Warm reuse** is fixed: when there is no package-script risk, **`allowPackageScripts` is folded out of the success stamp** so a manual warm run (even with `--allow-package-script-changes`) matches the flag-less hook and **`--skip-if-fresh` can skip** the hook.
> 
> **Execution model** tweaks: Playwright Chromium install moves from global setup to **serialized dashboard-only** steps (browser install failure no longer blocks lint/typecheck/unit/knip). The parallel runner **polls every 1s** and prints a **20s heartbeat** of in-flight commands instead of relying on `wait -n`.
> 
> **Turbo** task inputs for lint/typecheck/test/knip/react-doctor **exclude `AGENTS.md` and `CLAUDE.md`** so doc-only edits stay cache hits. Docs and **`agent-quality-gate.test.sh`** add coverage for stamp reuse, prerequisite abort, and Chromium-install vs parallel pool behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458add940ff20879e835c42dcc892b6faf4b27a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->