### PR TITLE
chore(dashboard): bump react-plotly wrapper

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,8 +630,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.6)
       react-plotly.js:
-        specifier: ^2.6.0
-        version: 2.6.0(plotly.js@3.4.0(mapbox-gl@1.13.3))(react@19.2.6)
+        specifier: 3.0.0
+        version: 3.0.0(plotly.js@3.4.0(mapbox-gl@1.13.3))(react@19.2.6)
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -8709,11 +8709,11 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-plotly.js@2.6.0:
-    resolution: {integrity: sha512-g93xcyhAVCSt9kV1svqG1clAEdL6k3U+jjuSzfTV7owaSU9Go6Ph8bl25J+jKfKvIGAEYpe4qj++WHJuc9IaeA==}
+  react-plotly.js@3.0.0:
+    resolution: {integrity: sha512-4syFBxzhzDKG2ztbJNeKjjbgJj05kzJh5MB3lU1PuY2d2WHs/bfuaK06x5eJUgfMk5DMcuOXdV7UWRuew02ylw==}
     peerDependencies:
-      plotly.js: '>1.34.0'
-      react: '>0.13.0'
+      plotly.js: '>=3.0.0'
+      react: ^18.0.0 || ^19.0.0
 
   react-reconciler@0.33.0:
     resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
@@ -19841,7 +19841,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-plotly.js@2.6.0(plotly.js@3.4.0(mapbox-gl@1.13.3))(react@19.2.6):
+  react-plotly.js@3.0.0(plotly.js@3.4.0(mapbox-gl@1.13.3))(react@19.2.6):
     dependencies:
       plotly.js: 3.4.0(mapbox-gl@1.13.3)
       prop-types: 15.8.1

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -37,7 +37,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",
-    "react-plotly.js": "^2.6.0",
+    "react-plotly.js": "3.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "swr": "^2.4.1",

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -454,7 +454,7 @@ function selectOraclePlotData({
 
 /**
  * Memoized plot model: decimate → build trace data + layout, all referentially
- * stable. react-plotly.js 2.6 ref-compares `data`/`layout`/`config` in
+ * stable. react-plotly.js 3.0 ref-compares `data`/`layout`/`config` in
  * `componentDidUpdate` and skips `Plotly.react` when all three are unchanged,
  * so a 30s SWR repoll or a coalesced relayout whose decimated output is
  * identical no longer rebuilds + redraws the SVG (the dominant per-tick cost).


### PR DESCRIPTION
## The Problem

- The dashboard still used the `react-plotly.js` 2.6 wrapper while the rendered Plotly bundle is already on Plotly 3.x.
- Issue #877 asks for the wrapper migration with explicit peer, redraw, bundle-size, and browser-rendering evidence before accepting the dependency bump.

## The Solution

- Pin `ui-dashboard` to `react-plotly.js` 3.0.0 while leaving the lean `plotly.js-basic-dist-min` 3.4.0 render bundle and shared lazy wrapper unchanged.
- Verified the 3.0.0 compatibility surface: it drops Plotly <3 and React <18 support, adds Plotly 3 anywhere-event callbacks, and its peer range matches this dashboard's React 19 / Plotly 3 setup.
- Rechecked the wrapper redraw path: `factory.js` still ref-compares `data` / `layout` / `config` and `revision`, so the oracle redraw workaround remains valid and its comment now names 3.0.

## Invariants

- Chart code continues to import Plotly only through `@/lib/react-plotly-basic`.
- Plotly remains isolated in the async chart chunk; size-limit remains the bundle guard.
- The oracle chart's memoized model and redraw workaround remain in place because 3.0.0 preserves the wrapper update semantics.

## Degraded Behavior

- No Hasura query, SWR polling, API, loading/error state, or controlled-widget behavior changes.
- Protected address-book wealth-chart access remains auth-gated; public chart surfaces were browser-smoked locally.

## Checklist Notes

- Code-health: lockfile policy, knip, dependency-cruiser, Trunk, lint, typecheck, coverage, and React Doctor all passed through the agent quality gate.
- SWR/stateful-data/keyboard-a11y checklists were reviewed; this dependency bump does not alter hooks, query pagination, URL state, or controlled widget behavior.
- No deferrals.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard lint`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard build`
- `CI=true pnpm dashboard:size-limit`: all client JS 1.1 MB / 1.19 MB; Plotly chunk 291.36 kB / 320 kB. The documented baseline is 291,466 bytes.
- `CI=true pnpm --filter @mento-protocol/ui-dashboard test:browser`: 17 passed.
- Chrome DevTools MCP against `http://127.0.0.1:3210`: pool detail LPs, swaps, reserves, rebalances, liquidity, oracle, limits, breaches, and OLS tabs rendered Plotly SVGs; `/volume` and `/bridge-flows` rendered Plotly SVGs; no console errors on checked pages.
- `pnpm agent:quality-gate --run --allow-package-script-changes`: all mapped commands passed; pre-push reran the same gate and passed.
- `CI=true pnpm agent:autoreview`: clean deterministic local review.

Closes #877

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no runtime logic changes; peers already match React 19 and Plotly 3.4.
> 
> **Overview**
> Aligns the dashboard’s React Plotly wrapper with the **Plotly 3.x** bundle already in use by pinning **`react-plotly.js` to 3.0.0** in `ui-dashboard` and refreshing the lockfile.
> 
> There are **no chart or data-flow code changes** beyond a comment in `oracle-chart.tsx` that now references **3.0** for the wrapper’s ref-based `data`/`layout`/`config` update behavior (the memoized oracle model and redraw workaround are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1671b4a8c04df687ee5a01caeb5b1a6096ed6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->