### PR TITLE
fix(dashboard): announce volume warning panels

### DIFF
--- a/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insights.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insights.test.tsx
@@ -130,6 +130,14 @@ describe("V3FlowInsights", () => {
     );
     expect(text).not.toContain("No directional corridors in this window.");
     expect(text).not.toContain("No outlier swaps in this window.");
+
+    const statuses = Array.from(
+      handle.container.querySelectorAll('[role="status"]'),
+    ).map((element) => element.textContent);
+    expect(statuses).toEqual([
+      "Corridor data may be incomplete; top-query cap reached.",
+      "Outlier data may be incomplete; top-query cap reached.",
+    ]);
   });
 
   it("links outlier volume values to txs without a separate tx column", () => {

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -245,7 +245,13 @@ function PanelMessage({
   return (
     <p
       className={"py-8 text-center text-sm " + tone}
-      role={variant === "error" ? "alert" : undefined}
+      role={
+        variant === "error"
+          ? "alert"
+          : variant === "warn"
+            ? "status"
+            : undefined
+      }
     >
       {message}
     </p>


### PR DESCRIPTION
## The Problem

- Volume insight warning messages are dynamic status text, but the `warn` PanelMessage variant did not expose a live-region role.
- Screen reader users could miss capped/partial-data warnings when those warning states appear.

## The Solution

- Give `warn` PanelMessage instances `role="status"` while preserving `role="alert"` for errors and no role for muted copy.
- Add a regression assertion covering the two capped volume insight warnings.

## Validation

- `CI=true pnpm --filter @mento-protocol/ui-dashboard test -- v3-flow-insights`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Browser verified `http://127.0.0.1:3211/volume`: page rendered, no console errors, live data did not enter the capped-warning branch.
- Lighthouse snapshot on `/volume`: accessibility 94, best-practices 100, SEO 75, agentic browsing 100. Remaining failed audits were existing page-level issues: color contrast, no main landmark, and no meta description.

## Checklist Notes

- Reviewed `docs/pr-checklists/code-health.md`; no package boundary, dependency, or route-private import changes.
- Reviewed `docs/pr-checklists/swr-polling-hasura.md`; no Hasura/SWR/query behavior changed.
- Reviewed `docs/pr-checklists/stateful-data-ui.md`; no stateful data flow, URL state, pagination, sorting, or degraded-data behavior changed.
- Reviewed `docs/pr-checklists/keyboard-a11y-controlled-widgets.md`; no controlled-widget keyboard behavior changed.

Closes #1132

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only accessibility markup and a targeted test; no data fetching, routing, or business logic changes.
> 
> **Overview**
> Volume insight **partial-data warnings** (top-query cap reached) are now exposed as live regions so assistive tech can announce them when they appear.
> 
> `PanelMessage` assigns **`role="status"`** for the `warn` variant, while **`role="alert"`** for errors and no role for muted copy stay unchanged. A test asserts both corridor and outlier cap messages render inside `[role="status"]` elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0745ae2f432fbf1b4ccb58d5391067d0e6a4d675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->