### PR TITLE
fix(dashboard): scale stable sparklines by percent move

### DIFF
--- a/ui-dashboard/src/app/stables/_lib/sparkline.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/sparkline.test.ts
@@ -2,30 +2,53 @@ import { describe, expect, it } from "vitest";
 import { sparklinePoints } from "./sparkline";
 
 describe("sparklinePoints", () => {
-  it("maps a 2-point series to viewBox corners (pad-adjusted)", () => {
-    // 2 points → step = (240 - 4) / 1 = 236. First at x=2, last at x=238.
-    // min=0, max=100, span=100 → first y=2 + 36*1 = 38, last y=2 + 36*0 = 2.
-    const points = sparklinePoints([0, 100], 240, 40, 2);
-    expect(points).toBe("2.0,38.0 238.0,2.0");
+  it("maps unchanged supply to the vertical midpoint", () => {
+    const points = sparklinePoints([100, 100], 240, 40, 2);
+    expect(points).toBe("2.0,20.0 238.0,20.0");
   });
 
-  it("centers a flat series vertically (span=0 fallback)", () => {
-    // All values equal → span coerces to 1 → all y = pad (top). Acceptable
-    // visual: a flat line at the top edge. The empty-state placeholder
-    // catches the < 2 length case upstream.
+  it("centers a flat series vertically", () => {
     const points = sparklinePoints([50, 50, 50], 240, 40, 2);
-    // 3 points: step = 236/2 = 118. x = 2, 120, 238. y = 2 (top edge,
-    // since (v - min)/span = 0/1 = 0 → y = pad + 36*(1 - 0) = 38... wait
-    // that's the BOTTOM. Let me re-check: (v - min)/span = (50-50)/1 = 0,
-    // so y = 2 + 36*1 = 38. So actually it lands at the BOTTOM. OK.
-    expect(points).toBe("2.0,38.0 120.0,38.0 238.0,38.0");
+    expect(points).toBe("2.0,20.0 120.0,20.0 238.0,20.0");
   });
 
-  it("rescales an ascending series across the y axis", () => {
-    // 5 points, monotonic. Step x = 236/4 = 59. y for v=0 is 38, for
-    // v=100 is 2. Midpoint v=50 lands at y=20.
-    const points = sparklinePoints([0, 25, 50, 75, 100], 240, 40, 2);
-    expect(points).toBe("2.0,38.0 61.0,29.0 120.0,20.0 179.0,11.0 238.0,2.0");
+  it("uses a shared percent-change scale instead of per-card min-max", () => {
+    const smallMove = sparklinePoints([100, 103], 240, 40, 2);
+    const largeMove = sparklinePoints([100, 142], 240, 40, 2);
+
+    expect(smallMove).toBe("2.0,20.0 238.0,11.3");
+    expect(largeMove).toBe("2.0,20.0 238.0,2.6");
+  });
+
+  it("is invariant to absolute token supply scale", () => {
+    const smallToken = sparklinePoints([100, 103], 240, 40, 2);
+    const largeToken = sparklinePoints([1_000_000, 1_030_000], 240, 40, 2);
+
+    expect(largeToken).toBe(smallToken);
+  });
+
+  it("preserves rank order across small and large percent moves", () => {
+    const pointY = (points: string): number =>
+      Number(points.split(" ")[1]?.split(",")[1]);
+
+    const flat = pointY(sparklinePoints([100, 100.3], 240, 40, 2));
+    const modest = pointY(sparklinePoints([100, 101.67], 240, 40, 2));
+    const large = pointY(sparklinePoints([100, 110], 240, 40, 2));
+    const severe = pointY(sparklinePoints([100, 142], 240, 40, 2));
+
+    expect(flat).toBeGreaterThan(modest);
+    expect(modest).toBeGreaterThan(large);
+    expect(large).toBeGreaterThan(severe);
+  });
+
+  it("clips large negative moves to the chart edge", () => {
+    const points = sparklinePoints([100, 0], 240, 40, 2);
+    expect(points).toBe("2.0,20.0 238.0,38.0");
+  });
+
+  it("uses the first non-zero point as the percent baseline", () => {
+    const points = sparklinePoints([0, 100, 110], 240, 40, 2);
+    expect(points).toBe("2.0,38.0 120.0,20.0 238.0,7.4");
   });
 
   it("handles small fractional values without NaN", () => {

--- a/ui-dashboard/src/app/stables/_lib/sparkline.ts
+++ b/ui-dashboard/src/app/stables/_lib/sparkline.ts
@@ -5,7 +5,11 @@
 
 /**
  * Returns the `points` attribute string for a `<polyline>` SVG, mapping
- * `series` into a `w × h` viewBox with `pad` margin. Min-max normalized.
+ * `series` into a `w × h` viewBox with `pad` margin. The y-axis is a shared
+ * signed percent-change scale around the first non-zero value, so card
+ * amplitude remains comparable across tokens instead of stretching each
+ * token's own min/max to the full height. The scale uses a monotone log curve
+ * to keep sub-1% moves visible while preserving severity rank for large moves.
  *
  * Caller responsibilities:
  * - `series.length >= 2` (callers gate the render path on this and show
@@ -13,21 +17,48 @@
  * - `series` values are finite (`buildTokenUsdTimeSeries` enforces this
  *   via `parseWei` + multiplication by a Number rate).
  */
+const SPARKLINE_MAX_ABS_CHANGE_PCT = 50;
+const SPARKLINE_LOG_KNEE_PCT = 0.25;
+
 export function sparklinePoints(
   series: ReadonlyArray<number>,
   w: number,
   h: number,
   pad: number,
 ): string {
-  const min = Math.min(...series);
-  const max = Math.max(...series);
-  const span = max - min || 1;
+  const baseline = firstNonZero(series);
+  const denominator = Math.abs(baseline ?? 1);
   const step = (w - pad * 2) / (series.length - 1);
+  const midY = h / 2;
+  const halfHeight = (h - pad * 2) / 2;
+
   return series
     .map((v, i) => {
       const x = pad + i * step;
-      const y = pad + (h - pad * 2) * (1 - (v - min) / span);
+      const pctChange =
+        baseline === null ? 0 : ((v - baseline) / denominator) * 100;
+      const boundedPct = clamp(scaledPercentChange(pctChange), -1, 1);
+      const y = midY - boundedPct * halfHeight;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
+}
+
+function firstNonZero(series: ReadonlyArray<number>): number | null {
+  for (const value of series) {
+    if (value !== 0) return value;
+  }
+  return null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function scaledPercentChange(percentChange: number): number {
+  if (percentChange === 0) return 0;
+  const magnitude =
+    Math.log1p(Math.abs(percentChange) / SPARKLINE_LOG_KNEE_PCT) /
+    Math.log1p(SPARKLINE_MAX_ABS_CHANGE_PCT / SPARKLINE_LOG_KNEE_PCT);
+  return Math.sign(percentChange) * magnitude;
 }


### PR DESCRIPTION
## The Problem

- `/stables` per-token sparklines stretched each token's own min/max to the full SVG height.
- That made tiny supply wiggles look as visually severe as real contractions or expansions.

## The Solution

- Plot each sparkline against a shared signed percent-change scale from the first non-zero value.
- Use a monotone log curve capped at 50% so small moves stay visible while larger moves remain rankable by shape.

## Invariants

- Flat or all-zero series render at the vertical midpoint.
- Tokens with the same percent move render the same shape regardless of absolute USD supply size.
- Larger percent moves produce larger vertical amplitude until the 50% display cap.
- The existing no-rate and short-history placeholders remain unchanged.

## Degraded behavior

- Series with no non-zero baseline stay flat at the midpoint instead of producing `NaN`/`Infinity`.
- Launch-like `0 -> non-zero` series use the first non-zero value as the baseline and clip pre-baseline zeros to the chart edge.

## Intentional non-goals

- No changes to `/stables` layout density, card ordering, filtering, or URL state.
- No changes to Hasura queries, polling, or aggregate supply calculations.

## Validation

- `CI=true pnpm --filter @mento-protocol/ui-dashboard test -- src/app/stables/_lib/sparkline.test.ts`
- `CI=true pnpm dashboard:react-doctor:diff`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard lint`
- `CI=true pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `CI=true pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview -- --mode local --engine local --prompt-file docs/pr-checklists/stateful-data-ui.md --prompt-file docs/pr-checklists/code-health.md --prompt-file docs/pr-checklists/swr-polling-hasura.md`
- Fresh-context subagent autoreview: no findings
- Browser verified `http://127.0.0.1:3216/stables`: zero-change cards rendered with `yRange=0`; small USDm Celo `+0.27%` rendered with `yRange=9.4`; severe movers rendered much larger (`GBPm on Celo yRange=33`, `ZARm on Celo yRange=29.8`); no browser console errors.
- Saved browser evidence: `/private/tmp/stables-1122.a11y.txt`, `/private/tmp/stables-1122.png`

Closes #1122.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure presentation math in an isolated helper with expanded unit tests; no API, data, or auth changes.
> 
> **Overview**
> **`/stables` sparklines** no longer stretch each token’s series to fill the SVG height. **`sparklinePoints`** now maps Y from **signed percent change** vs the **first non-zero** point, with a **shared log curve** (knee ~0.25%, cap ±50%) so small wiggles and large contractions are visually comparable across cards.
> 
> Flat or zero-baseline series sit at the **vertical midpoint**; identical percent moves produce the same shape regardless of absolute supply; larger moves get more amplitude until clipped at the chart edge. Tests were rewritten to lock in midpoint behavior, scale invariance, rank ordering, clipping, and launch-style `0 → value` baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d46f8f7022b6eca5eae8e8c77f67e2ef4ccb1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->