### PR TITLE
docs: record review process metrics check-in

### DIFF
--- a/docs/metrics/review-process-after-1045-comparison-2026-07-07.md
+++ b/docs/metrics/review-process-after-1045-comparison-2026-07-07.md
@@ -1,0 +1,86 @@
+---
+title: Review Process Metrics After PR 1045
+status: active
+owner: eng
+canonical: false
+last_verified: 2026-07-07
+---
+
+# Review Process Metrics After PR 1045
+
+Source files:
+
+- `docs/metrics/review-process-baseline-pre-1034-2026-07-03.json`
+- `docs/metrics/review-process-after-1045-first-10-2026-07-07.json`
+- `docs/metrics/review-process-after-1045-first-20-2026-07-07.json`
+
+The triggers for issues #1066 and #1067 are satisfied: PR #1045 merged at
+2026-07-03T17:40:00Z, and more than 20 PRs have merged after it.
+
+## Summary
+
+| Metric                            | Baseline: 20 before #1034 | First 10 after #1045 | First 20 after #1045 |
+| --------------------------------- | ------------------------: | -------------------: | -------------------: |
+| Median open-to-merge hours        |                      8.89 |                 0.78 |                 1.27 |
+| Median commits after first review |                         2 |                    1 |                    1 |
+| Top-level comments                |                       129 |                   31 |                   60 |
+| Inline review roots               |                        96 |                   28 |                   51 |
+| Inline roots without replies      |                         1 |                    0 |                    0 |
+| Human review-request comments     |                        35 |                    1 |                    1 |
+| Candidate findings                |                       107 |                   36 |                   67 |
+| Codex usage-limit comments        |                         0 |                    3 |                    3 |
+
+## Manual Classification
+
+The collector's `candidateFindings` value is intentionally broad: it counts
+finding-like top-level bot comments and finding-like inline review comments. I
+classified the underlying GitHub comments and their replies in the generated
+after-change JSON files.
+
+| Classification  | First 10 | First 20 |
+| --------------- | -------: | -------: |
+| accepted        |       22 |       45 |
+| valid-wont-fix  |        3 |        3 |
+| duplicate-stale |        3 |        3 |
+| noise           |        8 |       16 |
+
+The most common heuristic-noise source is a top-level Claude review summary
+that includes words such as "findings" or "review" but is not itself a
+discrete finding. Those summaries can still be useful review rollups; they are
+only noisy for `candidateFindings` as a discrete-finding metric.
+Duplicate-stale entries were mainly duplicated reports of the same root issue
+from multiple bot reviewers.
+
+## Interpretation
+
+Reply coverage improved. The after-change cohorts have zero unreplied inline
+roots, compared with one unreplied inline root in the baseline.
+
+Loop count improved. Median commits after first review dropped from 2 to 1 in
+both after-change cohorts.
+
+Open-to-merge timing improved materially. The first-20 median fell from 8.89h
+to 1.27h. The first-10 median was 0.78h, so the first-20 sample stayed in the
+same direction after more PRs landed.
+
+Candidate volume improved, but not all of the change is quality signal. First-20
+candidate findings fell from 107 to 67. Of those 67, 45 were accepted fixes, 3
+were valid evidence-backed won't-fix decisions, 3 were duplicate/stale reports,
+and 16 were heuristic noise from top-level review summaries.
+
+Codex usage-limit comments regressed from 0 to 3. Those comments did not leave
+unreplied inline roots in the sampled PRs, but they are a throughput and
+readiness risk worth tracking separately from finding quality.
+
+## Recommendation
+
+Keep the review-process changes. The first-20 check-in shows better reply
+coverage, fewer post-review commits, faster merge timing, and fewer candidate
+findings than the baseline. Do not revert based on this sample.
+
+Follow-up ideas:
+
+- Teach the collector to separate top-level review summaries from discrete
+  findings so `candidateFindings` is less noisy.
+- Track Codex usage-limit comments as their own reliability metric rather than
+  treating them as review-quality findings.

--- a/docs/metrics/review-process-after-1045-first-10-2026-07-07.json
+++ b/docs/metrics/review-process-after-1045-first-10-2026-07-07.json
@@ -1,0 +1,502 @@
+{
+  "schemaVersion": 1,
+  "repo": "mento-protocol/monitoring-monorepo",
+  "collectedAt": "2026-07-07T04:52:10.044Z",
+  "cohort": {
+    "mode": "after-pr",
+    "beforePr": null,
+    "afterPr": {
+      "mergedAt": "2026-07-03T17:40:00Z",
+      "number": 1045,
+      "title": "Harden Claude workflow trigger scope",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1045"
+    },
+    "limit": 10,
+    "pullRequestNumbers": [
+      1065, 1069, 1068, 1082, 1072, 1075, 1077, 1078, 1086, 1074
+    ]
+  },
+  "summary": {
+    "pullRequests": 10,
+    "medianDurationHours": 0.78,
+    "medianCommitsAfterFirstReview": 1,
+    "totals": {
+      "comments": 31,
+      "inlineReviewRoots": 28,
+      "inlineReviewReplies": 28,
+      "inlineRootsWithoutReplies": 0,
+      "humanReviewRequests": 1,
+      "candidateFindings": 36,
+      "codexUsageLimitComments": 3,
+      "codexApprovalComments": 1,
+      "claudeSummaryComments": 8
+    }
+  },
+  "pullRequests": [
+    {
+      "number": 1065,
+      "title": "docs: document workflow docs drift checks",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1065",
+      "createdAt": "2026-07-03T17:45:09Z",
+      "mergedAt": "2026-07-03T17:47:44Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 0.04,
+      "changedFiles": 1,
+      "additions": 13,
+      "deletions": 0,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 0,
+        "candidateFindings": 0,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1069,
+      "title": "docs: re-verify SPEC.md against current reality",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1069",
+      "createdAt": "2026-07-03T18:08:23Z",
+      "mergedAt": "2026-07-03T18:10:59Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 0.04,
+      "changedFiles": 5,
+      "additions": 199,
+      "deletions": 176,
+      "commits": 3,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 0,
+        "candidateFindings": 0,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1068,
+      "title": "Add review process metrics baseline",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1068",
+      "createdAt": "2026-07-03T17:56:59Z",
+      "mergedAt": "2026-07-03T18:12:10Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 0.25,
+      "changedFiles": 7,
+      "additions": 1693,
+      "deletions": 0,
+      "commits": 3,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 9,
+        "byBots": 4,
+        "byHumans": 5
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 5,
+        "reviewInlineReplies": 5,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 2,
+        "inlineReviewBotRoots": 5,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 5,
+        "candidateFindings": 6,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1082,
+      "title": "fix(ci): skip Lighthouse when Vercel cancels the build via its Ignored Build Step",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1082",
+      "createdAt": "2026-07-05T14:35:25Z",
+      "mergedAt": "2026-07-05T14:53:44Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 0.31,
+      "changedFiles": 1,
+      "additions": 117,
+      "deletions": 0,
+      "commits": 4,
+      "commitsAfterFirstReview": 3,
+      "reviews": {
+        "submissions": 9,
+        "byBots": 4,
+        "byHumans": 5
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 5,
+        "reviewInlineReplies": 5,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 5,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 5,
+        "candidateFindings": 6,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1072,
+      "title": "fix: governance-watchdog fails closed on missing replay bucket",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1072",
+      "createdAt": "2026-07-05T13:01:09Z",
+      "mergedAt": "2026-07-05T14:54:22Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 1.89,
+      "changedFiles": 6,
+      "additions": 119,
+      "deletions": 18,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 8,
+        "byBots": 4,
+        "byHumans": 4
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 4,
+        "reviewInlineReplies": 4,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 4,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 4,
+        "candidateFindings": 5,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1075,
+      "title": "fix(governance-watchdog): retry transient Discord/Telegram delivery failures",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1075",
+      "createdAt": "2026-07-05T13:18:57Z",
+      "mergedAt": "2026-07-05T14:54:43Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 1.6,
+      "changedFiles": 7,
+      "additions": 703,
+      "deletions": 8,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 6,
+        "byBots": 3,
+        "byHumans": 3
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 3,
+        "reviewInlineReplies": 3,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 3,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 3,
+        "candidateFindings": 4,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1077,
+      "title": "dashboard: decompose fetchNetworkData behind characterization tests",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1077",
+      "createdAt": "2026-07-05T13:40:14Z",
+      "mergedAt": "2026-07-05T14:54:46Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 1.24,
+      "changedFiles": 10,
+      "additions": 1889,
+      "deletions": 542,
+      "commits": 4,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 6,
+        "byBots": 3,
+        "byHumans": 3
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 3,
+        "reviewInlineReplies": 3,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 3,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 3,
+        "candidateFindings": 4,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1078,
+      "title": "alerts: dead-letter Safe alerts on Slack retry exhaustion + redrive tool",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1078",
+      "createdAt": "2026-07-05T13:42:10Z",
+      "mergedAt": "2026-07-05T15:25:49Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 1.73,
+      "changedFiles": 11,
+      "additions": 1204,
+      "deletions": 4,
+      "commits": 3,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 12,
+        "byBots": 5,
+        "byHumans": 7
+      },
+      "comments": {
+        "topLevel": 5,
+        "reviewInlineRoots": 7,
+        "reviewInlineReplies": 7,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 7,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 7,
+        "candidateFindings": 8,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1086,
+      "title": "test(indexer): cover self-heal + FPMM lifecycle must-cover scenarios",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1086",
+      "createdAt": "2026-07-05T15:30:19Z",
+      "mergedAt": "2026-07-05T15:38:23Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 0.13,
+      "changedFiles": 7,
+      "additions": 1444,
+      "deletions": 0,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 0,
+        "candidateFindings": 1,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1074,
+      "title": "fix: isolate one pool's failure from MedianUpdated fan-out",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1074",
+      "createdAt": "2026-07-05T13:14:48Z",
+      "mergedAt": "2026-07-05T16:19:38Z",
+      "collectedAt": "2026-07-07T04:52:10.044Z",
+      "durationHours": 3.08,
+      "changedFiles": 2,
+      "additions": 98,
+      "deletions": 14,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 2,
+        "byBots": 1,
+        "byHumans": 1
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 1,
+        "reviewInlineReplies": 1,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 1
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 2,
+        "inlineReviewBotRoots": 1,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 1,
+        "candidateFindings": 2,
+        "codexComments": 1,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 1,
+        "claudeSummaryComments": 1
+      }
+    }
+  ],
+  "manualClassification": {
+    "required": true,
+    "status": "classified",
+    "classifiedAt": "2026-07-07",
+    "method": "Reviewed the underlying GitHub finding-like top-level and inline review comments plus their agent replies. Top-level bot review summaries that contained words like findings/review but no discrete finding were classified as noise.",
+    "categories": ["accepted", "valid-wont-fix", "duplicate-stale", "noise"],
+    "counts": {
+      "accepted": 22,
+      "valid-wont-fix": 3,
+      "duplicate-stale": 3,
+      "noise": 8
+    },
+    "byPullRequest": [
+      {
+        "number": 1065,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "No finding-like candidates."
+      },
+      {
+        "number": 1069,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "No finding-like candidates."
+      },
+      {
+        "number": 1068,
+        "accepted": 4,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 1,
+        "noise": 1,
+        "note": "Four fixed findings; one duplicate cohort-completeness report; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1082,
+        "accepted": 5,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Five fixed workflow findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1072,
+        "accepted": 4,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Four fixed vendored-source parity findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1075,
+        "accepted": 3,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Three fixed retry/test clarity findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1077,
+        "accepted": 3,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Three fixed dashboard fetcher/test findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1078,
+        "accepted": 3,
+        "valid-wont-fix": 2,
+        "duplicate-stale": 2,
+        "noise": 1,
+        "note": "Three fixed findings; two valid evidence-backed wont-fix replies; two duplicate archive-idempotency reports; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1086,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Top-level Claude review summary only; no inline finding."
+      },
+      {
+        "number": 1074,
+        "accepted": 0,
+        "valid-wont-fix": 1,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "One evidence-backed wont-fix reply; top-level Claude review summary counted as noise."
+      }
+    ]
+  }
+}

--- a/docs/metrics/review-process-after-1045-first-20-2026-07-07.json
+++ b/docs/metrics/review-process-after-1045-first-20-2026-07-07.json
@@ -1,0 +1,953 @@
+{
+  "schemaVersion": 1,
+  "repo": "mento-protocol/monitoring-monorepo",
+  "collectedAt": "2026-07-07T04:52:11.107Z",
+  "cohort": {
+    "mode": "after-pr",
+    "beforePr": null,
+    "afterPr": {
+      "mergedAt": "2026-07-03T17:40:00Z",
+      "number": 1045,
+      "title": "Harden Claude workflow trigger scope",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1045"
+    },
+    "limit": 20,
+    "pullRequestNumbers": [
+      1065, 1069, 1068, 1082, 1072, 1075, 1077, 1078, 1086, 1074, 1080, 1085,
+      1076, 1087, 1088, 1091, 1084, 1092, 1090, 1093
+    ]
+  },
+  "summary": {
+    "pullRequests": 20,
+    "medianDurationHours": 1.27,
+    "medianCommitsAfterFirstReview": 1,
+    "totals": {
+      "comments": 60,
+      "inlineReviewRoots": 51,
+      "inlineReviewReplies": 51,
+      "inlineRootsWithoutReplies": 0,
+      "humanReviewRequests": 1,
+      "candidateFindings": 67,
+      "codexUsageLimitComments": 3,
+      "codexApprovalComments": 1,
+      "claudeSummaryComments": 16
+    }
+  },
+  "pullRequests": [
+    {
+      "number": 1065,
+      "title": "docs: document workflow docs drift checks",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1065",
+      "createdAt": "2026-07-03T17:45:09Z",
+      "mergedAt": "2026-07-03T17:47:44Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.04,
+      "changedFiles": 1,
+      "additions": 13,
+      "deletions": 0,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 0,
+        "candidateFindings": 0,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1069,
+      "title": "docs: re-verify SPEC.md against current reality",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1069",
+      "createdAt": "2026-07-03T18:08:23Z",
+      "mergedAt": "2026-07-03T18:10:59Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.04,
+      "changedFiles": 5,
+      "additions": 199,
+      "deletions": 176,
+      "commits": 3,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 0,
+        "candidateFindings": 0,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1068,
+      "title": "Add review process metrics baseline",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1068",
+      "createdAt": "2026-07-03T17:56:59Z",
+      "mergedAt": "2026-07-03T18:12:10Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.25,
+      "changedFiles": 7,
+      "additions": 1693,
+      "deletions": 0,
+      "commits": 3,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 9,
+        "byBots": 4,
+        "byHumans": 5
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 5,
+        "reviewInlineReplies": 5,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 2,
+        "inlineReviewBotRoots": 5,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 5,
+        "candidateFindings": 6,
+        "codexComments": 1,
+        "codexUsageLimitComments": 1,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1082,
+      "title": "fix(ci): skip Lighthouse when Vercel cancels the build via its Ignored Build Step",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1082",
+      "createdAt": "2026-07-05T14:35:25Z",
+      "mergedAt": "2026-07-05T14:53:44Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.31,
+      "changedFiles": 1,
+      "additions": 117,
+      "deletions": 0,
+      "commits": 4,
+      "commitsAfterFirstReview": 3,
+      "reviews": {
+        "submissions": 9,
+        "byBots": 4,
+        "byHumans": 5
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 5,
+        "reviewInlineReplies": 5,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 5,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 5,
+        "candidateFindings": 6,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1072,
+      "title": "fix: governance-watchdog fails closed on missing replay bucket",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1072",
+      "createdAt": "2026-07-05T13:01:09Z",
+      "mergedAt": "2026-07-05T14:54:22Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.89,
+      "changedFiles": 6,
+      "additions": 119,
+      "deletions": 18,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 8,
+        "byBots": 4,
+        "byHumans": 4
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 4,
+        "reviewInlineReplies": 4,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 4,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 4,
+        "candidateFindings": 5,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1075,
+      "title": "fix(governance-watchdog): retry transient Discord/Telegram delivery failures",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1075",
+      "createdAt": "2026-07-05T13:18:57Z",
+      "mergedAt": "2026-07-05T14:54:43Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.6,
+      "changedFiles": 7,
+      "additions": 703,
+      "deletions": 8,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 6,
+        "byBots": 3,
+        "byHumans": 3
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 3,
+        "reviewInlineReplies": 3,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 3,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 3,
+        "candidateFindings": 4,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1077,
+      "title": "dashboard: decompose fetchNetworkData behind characterization tests",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1077",
+      "createdAt": "2026-07-05T13:40:14Z",
+      "mergedAt": "2026-07-05T14:54:46Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.24,
+      "changedFiles": 10,
+      "additions": 1889,
+      "deletions": 542,
+      "commits": 4,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 6,
+        "byBots": 3,
+        "byHumans": 3
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 3,
+        "reviewInlineReplies": 3,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 3,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 3,
+        "candidateFindings": 4,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1078,
+      "title": "alerts: dead-letter Safe alerts on Slack retry exhaustion + redrive tool",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1078",
+      "createdAt": "2026-07-05T13:42:10Z",
+      "mergedAt": "2026-07-05T15:25:49Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.73,
+      "changedFiles": 11,
+      "additions": 1204,
+      "deletions": 4,
+      "commits": 3,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 12,
+        "byBots": 5,
+        "byHumans": 7
+      },
+      "comments": {
+        "topLevel": 5,
+        "reviewInlineRoots": 7,
+        "reviewInlineReplies": 7,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 7,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 7,
+        "candidateFindings": 8,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1086,
+      "title": "test(indexer): cover self-heal + FPMM lifecycle must-cover scenarios",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1086",
+      "createdAt": "2026-07-05T15:30:19Z",
+      "mergedAt": "2026-07-05T15:38:23Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.13,
+      "changedFiles": 7,
+      "additions": 1444,
+      "deletions": 0,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 0,
+        "candidateFindings": 1,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1074,
+      "title": "fix: isolate one pool's failure from MedianUpdated fan-out",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1074",
+      "createdAt": "2026-07-05T13:14:48Z",
+      "mergedAt": "2026-07-05T16:19:38Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 3.08,
+      "changedFiles": 2,
+      "additions": 98,
+      "deletions": 14,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 2,
+        "byBots": 1,
+        "byHumans": 1
+      },
+      "comments": {
+        "topLevel": 4,
+        "reviewInlineRoots": 1,
+        "reviewInlineReplies": 1,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 1
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 2,
+        "inlineReviewBotRoots": 1,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 1,
+        "candidateFindings": 2,
+        "codexComments": 1,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 1,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1080,
+      "title": "test: fixture coverage for sanitize-terraform-output.sh",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1080",
+      "createdAt": "2026-07-05T14:04:45Z",
+      "mergedAt": "2026-07-05T16:40:16Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 2.59,
+      "changedFiles": 8,
+      "additions": 682,
+      "deletions": 7,
+      "commits": 4,
+      "commitsAfterFirstReview": 3,
+      "reviews": {
+        "submissions": 6,
+        "byBots": 3,
+        "byHumans": 3
+      },
+      "comments": {
+        "topLevel": 8,
+        "reviewInlineRoots": 3,
+        "reviewInlineReplies": 3,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 3,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 3,
+        "candidateFindings": 4,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1085,
+      "title": "test(indexer): Liquity lifecycle, batch-replay idempotency, per-chain fallback, namespacing, Wormhole drain scenarios",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1085",
+      "createdAt": "2026-07-05T15:09:38Z",
+      "mergedAt": "2026-07-05T16:48:28Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.65,
+      "changedFiles": 5,
+      "additions": 1532,
+      "deletions": 0,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 12,
+        "byBots": 6,
+        "byHumans": 6
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 6,
+        "reviewInlineReplies": 6,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 6,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 6,
+        "candidateFindings": 7,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1076,
+      "title": "ci: gate scripts/*.sh with shellcheck via trunk",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1076",
+      "createdAt": "2026-07-05T13:21:13Z",
+      "mergedAt": "2026-07-05T16:55:34Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 3.57,
+      "changedFiles": 22,
+      "additions": 120,
+      "deletions": 5,
+      "commits": 4,
+      "commitsAfterFirstReview": 3,
+      "reviews": {
+        "submissions": 8,
+        "byBots": 3,
+        "byHumans": 5
+      },
+      "comments": {
+        "topLevel": 5,
+        "reviewInlineRoots": 5,
+        "reviewInlineReplies": 5,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 5,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 5,
+        "candidateFindings": 6,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1087,
+      "title": "fix(governance-watchdog): parametrize function memory/timeout, add instance bounds",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1087",
+      "createdAt": "2026-07-05T15:42:41Z",
+      "mergedAt": "2026-07-05T17:00:01Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.29,
+      "changedFiles": 2,
+      "additions": 35,
+      "deletions": 2,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 0,
+        "candidateFindings": 1,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1088,
+      "title": "docs: archive completed PLAN files; fix stale README copy",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1088",
+      "createdAt": "2026-07-05T15:46:57Z",
+      "mergedAt": "2026-07-05T17:00:32Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.23,
+      "changedFiles": 9,
+      "additions": 96,
+      "deletions": 8,
+      "commits": 1,
+      "commitsAfterFirstReview": null,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 1,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 0,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 0,
+        "candidateFindings": 0,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1091,
+      "title": "integration-probes: remove inert OKX/Rango adapters",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1091",
+      "createdAt": "2026-07-05T15:56:51Z",
+      "mergedAt": "2026-07-05T17:00:36Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.06,
+      "changedFiles": 7,
+      "additions": 2,
+      "deletions": 53,
+      "commits": 1,
+      "commitsAfterFirstReview": 0,
+      "reviews": {
+        "submissions": 0,
+        "byBots": 0,
+        "byHumans": 0
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 0,
+        "reviewInlineReplies": 0,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 0,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 0,
+        "candidateFindings": 1,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1084,
+      "title": "test(indexer): close oracle fan-out + breaker-graph scenario gaps (#1052)",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1084",
+      "createdAt": "2026-07-05T14:39:38Z",
+      "mergedAt": "2026-07-05T17:09:42Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 2.5,
+      "changedFiles": 1,
+      "additions": 542,
+      "deletions": 0,
+      "commits": 3,
+      "commitsAfterFirstReview": 2,
+      "reviews": {
+        "submissions": 8,
+        "byBots": 4,
+        "byHumans": 4
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 4,
+        "reviewInlineReplies": 4,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 4,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 4,
+        "candidateFindings": 5,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1092,
+      "title": "dashboard: single immutable-sort helper; remove homepage-og.ts toSorted()",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1092",
+      "createdAt": "2026-07-05T16:51:13Z",
+      "mergedAt": "2026-07-05T17:19:58Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.48,
+      "changedFiles": 17,
+      "additions": 141,
+      "deletions": 57,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 2,
+        "byBots": 1,
+        "byHumans": 1
+      },
+      "comments": {
+        "topLevel": 3,
+        "reviewInlineRoots": 1,
+        "reviewInlineReplies": 1,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 1,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 1,
+        "candidateFindings": 2,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    },
+    {
+      "number": 1090,
+      "title": "docs: root AGENTS.md token diet, CLAUDE.md symlink, alerts routing fix",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1090",
+      "createdAt": "2026-07-05T15:55:29Z",
+      "mergedAt": "2026-07-05T17:21:08Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 1.43,
+      "changedFiles": 6,
+      "additions": 302,
+      "deletions": 246,
+      "commits": 4,
+      "commitsAfterFirstReview": 3,
+      "reviews": {
+        "submissions": 4,
+        "byBots": 2,
+        "byHumans": 2
+      },
+      "comments": {
+        "topLevel": 1,
+        "reviewInlineRoots": 2,
+        "reviewInlineReplies": 2,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 0,
+        "inlineReviewBotRoots": 2,
+        "findingLikeTopLevel": 0,
+        "findingLikeInline": 2,
+        "candidateFindings": 2,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 0
+      }
+    },
+    {
+      "number": 1093,
+      "title": "ci: extract the baseline-resolve block into a composite action",
+      "url": "https://github.com/mento-protocol/monitoring-monorepo/pull/1093",
+      "createdAt": "2026-07-05T17:10:53Z",
+      "mergedAt": "2026-07-05T17:37:43Z",
+      "collectedAt": "2026-07-07T04:52:11.107Z",
+      "durationHours": 0.45,
+      "changedFiles": 2,
+      "additions": 85,
+      "deletions": 64,
+      "commits": 2,
+      "commitsAfterFirstReview": 1,
+      "reviews": {
+        "submissions": 4,
+        "byBots": 2,
+        "byHumans": 2
+      },
+      "comments": {
+        "topLevel": 2,
+        "reviewInlineRoots": 2,
+        "reviewInlineReplies": 2,
+        "reviewInlineRootsWithoutReplies": 0,
+        "humanReviewRequests": 0
+      },
+      "botReviewSignals": {
+        "topLevelReviewBotComments": 1,
+        "inlineReviewBotRoots": 2,
+        "findingLikeTopLevel": 1,
+        "findingLikeInline": 2,
+        "candidateFindings": 3,
+        "codexComments": 0,
+        "codexUsageLimitComments": 0,
+        "codexApprovalComments": 0,
+        "claudeSummaryComments": 1
+      }
+    }
+  ],
+  "manualClassification": {
+    "required": true,
+    "status": "classified",
+    "classifiedAt": "2026-07-07",
+    "method": "Reviewed the underlying GitHub finding-like top-level and inline review comments plus their agent replies. Top-level bot review summaries that contained words like findings/review but no discrete finding were classified as noise.",
+    "categories": ["accepted", "valid-wont-fix", "duplicate-stale", "noise"],
+    "counts": {
+      "accepted": 45,
+      "valid-wont-fix": 3,
+      "duplicate-stale": 3,
+      "noise": 16
+    },
+    "byPullRequest": [
+      {
+        "number": 1065,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "No finding-like candidates."
+      },
+      {
+        "number": 1069,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "No finding-like candidates."
+      },
+      {
+        "number": 1068,
+        "accepted": 4,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 1,
+        "noise": 1,
+        "note": "Four fixed findings; one duplicate cohort-completeness report; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1082,
+        "accepted": 5,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Five fixed workflow findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1072,
+        "accepted": 4,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Four fixed vendored-source parity findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1075,
+        "accepted": 3,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Three fixed retry/test clarity findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1077,
+        "accepted": 3,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Three fixed dashboard fetcher/test findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1078,
+        "accepted": 3,
+        "valid-wont-fix": 2,
+        "duplicate-stale": 2,
+        "noise": 1,
+        "note": "Three fixed findings; two valid evidence-backed wont-fix replies; two duplicate archive-idempotency reports; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1086,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Top-level Claude review summary only; no inline finding."
+      },
+      {
+        "number": 1074,
+        "accepted": 0,
+        "valid-wont-fix": 1,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "One evidence-backed wont-fix reply; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1080,
+        "accepted": 3,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Three fixed sanitize-output findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1085,
+        "accepted": 6,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Six fixed indexer scenario-test findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1076,
+        "accepted": 5,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Five fixed ShellCheck/gate findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1087,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Top-level Claude review summary only; no inline finding."
+      },
+      {
+        "number": 1088,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "No finding-like candidates."
+      },
+      {
+        "number": 1091,
+        "accepted": 0,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Top-level Claude review summary only; no inline finding."
+      },
+      {
+        "number": 1084,
+        "accepted": 4,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Four fixed indexer scenario-test findings; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1092,
+        "accepted": 1,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "One fixed immutable-sort test finding; top-level Claude review summary counted as noise."
+      },
+      {
+        "number": 1090,
+        "accepted": 2,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 0,
+        "note": "Two fixed context-canonicalization findings."
+      },
+      {
+        "number": 1093,
+        "accepted": 2,
+        "valid-wont-fix": 0,
+        "duplicate-stale": 0,
+        "noise": 1,
+        "note": "Two fixed CI composite-action findings; top-level Claude review summary counted as noise."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## The Problem

- The review-process changes after #1045 needed scheduled first-10 and first-20 check-ins before we could judge whether the process improved or regressed.
- The issues were intentionally held in `needs-grooming` until enough PRs had merged after #1045.

## The Solution

- Validated that more than 20 PRs have now merged after #1045.
- Generated the first-10 and first-20 review-process metrics artifacts, classified candidate findings, and added a comparison note against the pre-#1034 baseline.

## Details

- First-20 median open-to-merge time fell from 8.89h to 1.27h.
- First-20 median commits after first review fell from 2 to 1.
- Inline roots without replies fell from 1 to 0.
- Candidate findings fell from 107 to 67; manual classification records 45 accepted, 3 valid-wont-fix, 3 duplicate-stale, and 16 heuristic-noise entries.
- Recommendation: keep the review-process changes; separately track Codex usage-limit comments and improve the collector's summary-vs-finding separation.

## Validation

- `node scripts/review-process-metrics.mjs --after-pr 1045 --limit 10 --output docs/metrics/review-process-after-1045-first-10-2026-07-07.json`
- `node scripts/review-process-metrics.mjs --after-pr 1045 --limit 20 --output docs/metrics/review-process-after-1045-first-20-2026-07-07.json`
- JSON classification total check for both generated artifacts
- `CI=true pnpm agent:context-check`
- `CI=true pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview -- --mode local --engine local`
- Fresh-context subagent classification audit: no blocking findings

Closes #1066.
Closes #1067.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static JSON metrics only; no runtime or application code changes.
> 
> **Overview**
> Adds the scheduled **first-10 and first-20** review-process metrics snapshots for PRs merged after **#1045**, plus a comparison write-up against the pre-#1034 baseline.
> 
> The new JSON artifacts include cohort summaries and **manual classification** of `candidateFindings` (accepted, valid-wont-fix, duplicate-stale, noise). The comparison doc concludes **keep** the review-process changes: faster median open-to-merge, fewer post-review commits, full inline reply coverage, and lower candidate volume—with follow-ups to split review summaries from discrete findings and track Codex usage-limit comments separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf49017e097ea650e62ce865ffa9d1c2aeebedbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->