### PR TITLE
fix: align trading-mode page repeat interval

### DIFF
--- a/alerts/rules/notification-policies.tf
+++ b/alerts/rules/notification-policies.tf
@@ -366,7 +366,7 @@ resource "grafana_notification_policy" "all" {
         group_by        = ["alertname", "chain", "rateFeed"]
         group_wait      = "30s"
         group_interval  = "5m"
-        repeat_interval = "24h"
+        repeat_interval = "1d"
 
         matcher {
           label = "severity"

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -409,7 +409,7 @@ test("trading-mode Splunk pages repeat slowly per rate feed", () => {
     "trading-mode pages should keep resolve and group updates prompt",
   );
   assert(
-    /\brepeat_interval\s*=\s*"24h"/.test(splunkPolicy),
+    /\brepeat_interval\s*=\s*"1d"/.test(splunkPolicy),
     "trading-mode pages should not repeat SMS/pager notifications more than daily",
   );
   assert(


### PR DESCRIPTION
## The Problem

- The alerts-rules drift report showed Terraform would change trading-mode Splunk On-Call page policies from Grafana live state back to `24h`.
- That would reintroduce drift for a setting that live Grafana already has as `1d`.

## The Solution

- Align the Terraform notification policy with live state by setting the trading-mode page repeat interval to `1d`.
- Update the alert-rules lint test that guards the slow daily repeat interval for trading-mode pages.

## Validation

- `CI=true pnpm alerts:rules:lint`
- `CI=true pnpm alerts:rules:lint:test`
- `CI=true pnpm tf validate alerts-rules`
- `terraform plan -var-file=/Users/chapati/code/mento/monitoring-monorepo/alerts/rules/terraform.tfvars -no-color` confirmed the #1023 notification-policy repeat-interval diff is gone; that local var-file still showed an unrelated sensitive Splunk On-Call contact-point block difference, so CI plan remains the stack-wide source of truth.
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:review-materiality`
- `CI=true pnpm agent:autoreview`
- pre-push `pnpm agent:quality-gate --run`

Closes #1023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Equivalent duration string only; no change to who gets paged or how often reminders fire in practice.
> 
> **Overview**
> Fixes **Terraform drift** on trading-mode prod **Splunk On-Call** page policies by changing `repeat_interval` from **`24h`** to **`1d`**, matching what Grafana already has in live state so applies no longer fight the drift report (#1023).
> 
> The alert-rules lint test that guards trading-mode Splunk paging behavior is updated to expect **`1d`** instead of **`24h`**; paging semantics (at most daily SMS/pager repeats) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939d201023c395d8ba906c32b0a656035fe3b91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->