### PR TITLE
perf(dashboard): defer chart loading and prefetch pool detail

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-stability-pool-tvl-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-stability-pool-tvl-chart.tsx
@@ -159,6 +159,7 @@ export function CdpStabilityPoolTvlChart({
           ? "Unable to load stability pool history"
           : "Not enough stability pool history yet"
       }
+      plotlyDeferMode="visible"
     />
   );
 }

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import localFont from "next/font/local";
 import { SessionProvider } from "next-auth/react";
@@ -8,6 +8,7 @@ import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
 import { DataFreshnessBanner } from "@/components/data-freshness-banner";
+import { ResourceHints } from "@/components/resource-hints";
 import { SessionErrorGuard } from "@/components/session-error-guard";
 import { SwrProvider } from "@/components/swr-provider";
 import { Analytics } from "@vercel/analytics/next";
@@ -48,6 +49,10 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  colorScheme: "dark",
+};
+
 export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
@@ -58,6 +63,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
+        <ResourceHints />
         <SessionProvider session={session}>
           <SessionErrorGuard />
           <SwrProvider>

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -337,6 +337,7 @@ function GlobalContent({
             anySnapshotsAllDailyError ||
             anySnapshotsAllDailyTruncated
           }
+          plotlyDeferMode="idle"
         />
         <VolumeOverTimeChart
           networkData={networkData}
@@ -350,6 +351,7 @@ function GlobalContent({
             anyBrokerSnapshotsAllDailyTruncated
           }
           fullVolumeSeries={aggregated.volumeSeries}
+          plotlyDeferMode="idle"
         />
       </div>
 

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -153,6 +153,7 @@ export function StablesHeroChart({
         hasError={hasError}
         hasSnapshotError={false}
         emptyMessage="No stablecoin supply data yet."
+        plotlyDeferMode="visible"
       />
       {capped ? (
         <p className="text-xs text-amber-400" role="status">

--- a/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
@@ -106,6 +106,7 @@ export function AggregatorBreakdownSection({
           chartHeightPx={230}
           yAxisTopPadding={0}
           customSortedHover
+          plotlyDeferMode="visible"
         />
       )}
       <AggregatorTable

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -282,6 +282,7 @@ function PoolChartArea({
           chartHeightPx={250}
           yAxisTopPadding={0}
           customSortedHover
+          plotlyDeferMode="visible"
         />
       </div>
       <div className="h-full lg:col-span-1">
@@ -325,6 +326,7 @@ function DailyVolumeChart({
           ? "No trader volume in this window."
           : "No legacy-v2 volume in this window."
       }
+      plotlyDeferMode="visible"
     />
   );
 }

--- a/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
@@ -107,7 +107,7 @@ afterEach(() => {
 });
 
 describe("GlobalPoolsTable pool-detail prefetch", () => {
-  it("preloads the pool detail query on row hover", () => {
+  it("preloads the pool detail query only on pool link hover", () => {
     act(() => {
       root.render(
         <GlobalPoolsTable
@@ -119,9 +119,22 @@ describe("GlobalPoolsTable pool-detail prefetch", () => {
     });
 
     const row = container.querySelector("tbody tr");
+    const link = container.querySelector("tbody a");
     expect(row).not.toBeNull();
+    expect(link).not.toBeNull();
+
     act(() => {
       row?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+    expect(mockPreloadGQL).not.toHaveBeenCalled();
+
+    act(() => {
+      link?.dispatchEvent(
         new MouseEvent("mouseover", {
           bubbles: true,
           relatedTarget: document.body,

--- a/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
@@ -1,0 +1,162 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Network } from "@/lib/networks";
+import type { Pool } from "@/lib/types";
+import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const mockPreloadGQL = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("@/lib/graphql", () => ({
+  preloadGQL: (...args: unknown[]) => mockPreloadGQL(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/pools",
+}));
+
+vi.mock("@/lib/weekend", () => ({
+  isWeekend: vi.fn(() => false),
+  isWeekendOracleStale: vi.fn(() => false),
+  FX_CLOSE_DAY: 5,
+  FX_CLOSE_HOUR_UTC: 21,
+  FX_REOPEN_DAY: 0,
+  FX_REOPEN_HOUR_UTC: 23,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { GlobalPoolsTable } from "@/components/global-pools-table";
+
+const CELO_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://example.com",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {
+    "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": "USDm",
+    "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf": "KESm",
+  },
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+const POOL_ID = "42220-0x0000000000000000000000000000000000000001";
+const BASE_POOL: Pool = {
+  id: POOL_ID,
+  chainId: 42220,
+  token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
+  token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1700000000",
+  updatedAtBlock: "1",
+  updatedAtTimestamp: "1700000000",
+  healthStatus: "OK",
+  limitStatus: "OK",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let previousActEnvironment: boolean | undefined;
+
+beforeEach(() => {
+  previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  mockSearchParams = new URLSearchParams();
+  mockPreloadGQL.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT =
+    previousActEnvironment ?? false;
+});
+
+describe("GlobalPoolsTable pool-detail prefetch", () => {
+  it("preloads the pool detail query on row hover", () => {
+    act(() => {
+      root.render(
+        <GlobalPoolsTable
+          entries={[
+            { pool: BASE_POOL, network: CELO_NETWORK, rates: new Map() },
+          ]}
+        />,
+      );
+    });
+
+    const row = container.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    act(() => {
+      row?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "celo-mainnet", chainId: 42220 }),
+      POOL_DETAIL_WITH_HEALTH,
+      { id: POOL_ID, chainId: 42220 },
+    );
+  });
+
+  it("preloads the same query on keyboard focus", () => {
+    act(() => {
+      root.render(
+        <GlobalPoolsTable
+          entries={[
+            { pool: BASE_POOL, network: CELO_NETWORK, rates: new Map() },
+          ]}
+        />,
+      );
+    });
+
+    const link = container.querySelector("tbody a");
+    expect(link).not.toBeNull();
+    act(() => {
+      link?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "celo-mainnet", chainId: 42220 }),
+      POOL_DETAIL_WITH_HEALTH,
+      { id: POOL_ID, chainId: 42220 },
+    );
+  });
+});

--- a/ui-dashboard/src/components/__tests__/resource-hints.test.ts
+++ b/ui-dashboard/src/components/__tests__/resource-hints.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  resourceHintOriginFromHasuraUrl,
+  resourceHintOriginsFromHasuraUrls,
+} from "@/components/resource-hints";
+
+describe("resource hints", () => {
+  it("derives unique HTTPS GraphQL origins from configured Hasura URLs", () => {
+    expect(
+      resourceHintOriginsFromHasuraUrls([
+        "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+        "https://indexer.hyperindex.xyz/testnet/v1/graphql",
+        "https://testnet.hyperindex.xyz/v1/graphql",
+        undefined,
+      ]),
+    ).toEqual([
+      "https://indexer.hyperindex.xyz",
+      "https://testnet.hyperindex.xyz",
+    ]);
+  });
+
+  it("skips relative proxies and local fixture endpoints", () => {
+    expect(resourceHintOriginFromHasuraUrl("/api/hasura/celo-mainnet")).toBe(
+      null,
+    );
+    expect(
+      resourceHintOriginFromHasuraUrl("http://127.0.0.1:4011/graphql"),
+    ).toBe(null);
+    expect(
+      resourceHintOriginFromHasuraUrl("https://localhost:4011/graphql"),
+    ).toBe(null);
+    expect(resourceHintOriginFromHasuraUrl("https://[::1]:4011/graphql")).toBe(
+      null,
+    );
+  });
+});

--- a/ui-dashboard/src/components/__tests__/use-deferred-mount.test.tsx
+++ b/ui-dashboard/src/components/__tests__/use-deferred-mount.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { useRef } from "react";
+import {
+  useDeferredMount,
+  type DeferredMountMode,
+} from "@/components/use-deferred-mount";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let previousActEnvironment: boolean | undefined;
+
+function Probe({
+  mode,
+  enabled = true,
+}: {
+  mode: DeferredMountMode;
+  enabled?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const mounted = useDeferredMount(mode, ref, enabled);
+  return <div ref={ref} data-mounted={mounted ? "yes" : "no"} />;
+}
+
+function mountedValue(): string | null {
+  return container.firstElementChild?.getAttribute("data-mounted") ?? null;
+}
+
+beforeEach(() => {
+  previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.unstubAllGlobals();
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT =
+    previousActEnvironment ?? false;
+});
+
+describe("useDeferredMount", () => {
+  it("mounts immediately in none mode", () => {
+    act(() => {
+      root.render(<Probe mode="none" />);
+    });
+    expect(mountedValue()).toBe("yes");
+  });
+
+  it("waits for idle mode before mounting", () => {
+    let idleCallback: (() => void) | null = null;
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: () => void) => {
+        idleCallback = callback;
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+
+    act(() => {
+      root.render(<Probe mode="idle" />);
+    });
+    expect(mountedValue()).toBe("no");
+
+    act(() => {
+      idleCallback?.();
+    });
+    expect(mountedValue()).toBe("yes");
+  });
+
+  it("waits for IntersectionObserver in visible mode", () => {
+    type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+    const observers: Array<{ callback: ObserverCallback; disconnect: Mock }> =
+      [];
+    class MockIntersectionObserver {
+      private readonly callback: ObserverCallback;
+      readonly disconnect = vi.fn();
+      constructor(callback: ObserverCallback) {
+        this.callback = callback;
+        observers.push({ callback, disconnect: this.disconnect });
+      }
+      observe = vi.fn();
+    }
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    act(() => {
+      root.render(<Probe mode="visible" />);
+    });
+    expect(mountedValue()).toBe("no");
+    expect(observers).toHaveLength(1);
+
+    act(() => {
+      observers[0]!.callback([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ]);
+    });
+    expect(mountedValue()).toBe("yes");
+    expect(observers[0]!.disconnect).toHaveBeenCalled();
+  });
+});

--- a/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
+++ b/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { formatUSD } from "@/lib/format";
 import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_CONFIG,
   ROW_CHART_HEIGHT_PX,
 } from "@/lib/plot";
+import { useDeferredMount } from "@/components/use-deferred-mount";
 import { buildTokenBreakdown } from "@/lib/bridge-flows/snapshots";
 import { RANGES, rangeKeyToDays, type RangeKey } from "@/lib/time-series";
 import type { OracleRateMap } from "@/lib/tokens";
@@ -30,12 +38,7 @@ const PIE_COLORS = [
 
 const Plot = dynamic(() => import("@/lib/react-plotly-basic"), {
   ssr: false,
-  loading: () => (
-    <div
-      className="animate-pulse rounded bg-slate-800/30"
-      style={{ height: ROW_CHART_HEIGHT_PX }}
-    />
-  ),
+  loading: () => <TokenBreakdownPlaceholder />,
 });
 
 interface BridgeTokenBreakdownChartProps {
@@ -53,9 +56,24 @@ interface BridgeTokenBreakdownChartProps {
   defaultRange?: RangeKey;
 }
 
-type BridgeTokenSlice = ReturnType<typeof buildTokenBreakdown>[number];
+type TokenBreakdownSlice = ReturnType<typeof buildTokenBreakdown>[number];
+type TokenBreakdownTrace = ReturnType<typeof buildTokenTrace>;
+type TokenBreakdownLayout = ReturnType<typeof buildTokenLayout>;
+type TokenBreakdownBodyState =
+  | { kind: "error" }
+  | { kind: "loading" }
+  | { kind: "empty" }
+  | {
+      kind: "ready";
+      ariaLabel: string;
+      shouldMountPlot: boolean;
+      textAlternative: string;
+      trace: TokenBreakdownTrace;
+      layout: TokenBreakdownLayout;
+      slices: TokenBreakdownSlice[];
+    };
 
-function buildBridgeTokenTrace(slices: BridgeTokenSlice[]) {
+function buildTokenTrace(slices: TokenBreakdownSlice[]) {
   return {
     type: "pie" as const,
     hole: 0.5,
@@ -74,7 +92,7 @@ function buildBridgeTokenTrace(slices: BridgeTokenSlice[]) {
   };
 }
 
-function buildBridgeTokenLayout() {
+function buildTokenLayout() {
   return {
     ...PLOTLY_BASE_LAYOUT,
     margin: { t: 8, r: 8, b: 8, l: 8 },
@@ -90,7 +108,7 @@ function rangeLabel(range: RangeKey) {
 
 function bridgeTokenTextAlternative(
   activeRangeLabel: string,
-  slices: BridgeTokenSlice[],
+  slices: TokenBreakdownSlice[],
   total: number,
 ) {
   const topSlice = slices[0];
@@ -126,16 +144,40 @@ export function BridgeTokenBreakdownChart({
 
   const total = slices.reduce((sum, s) => sum + s.usd, 0);
   const hasData = total > 0;
+  const plotRef = useRef<HTMLDivElement>(null);
+  const shouldMountPlot = useDeferredMount(
+    "visible",
+    plotRef,
+    !isLoading && !hasError && hasData,
+  );
 
-  const trace = useMemo(() => buildBridgeTokenTrace(slices), [slices]);
-
-  const layout = useMemo(buildBridgeTokenLayout, []);
+  const trace = useMemo(() => buildTokenTrace(slices), [slices]);
+  const layout = useMemo(() => buildTokenLayout(), []);
 
   // Match the "partial data" copy used on BridgeVolumeChart (via
   // TimeSeriesChartCard's `hasSnapshotError` branch). Only surface when the
   // "all" window is active — the bounded ranges don't touch the cap.
   const showCapNote = isCapped && range === "all";
   const activeRangeLabel = rangeLabel(range);
+  const bodyState: TokenBreakdownBodyState = hasError
+    ? { kind: "error" }
+    : isLoading
+      ? { kind: "loading" }
+      : !hasData
+        ? { kind: "empty" }
+        : {
+            kind: "ready",
+            ariaLabel: `Volume by token chart for ${activeRangeLabel}`,
+            shouldMountPlot,
+            textAlternative: bridgeTokenTextAlternative(
+              activeRangeLabel,
+              slices,
+              total,
+            ),
+            trace,
+            layout,
+            slices,
+          };
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
@@ -150,57 +192,7 @@ export function BridgeTokenBreakdownChart({
         </div>
         <BridgeRangePicker range={range} setRange={setRange} />
       </div>
-      {hasError ? (
-        <p className="text-sm text-slate-500">
-          Unable to load token breakdown.
-        </p>
-      ) : isLoading ? (
-        <div
-          className="animate-pulse rounded bg-slate-800/30"
-          style={{ height: ROW_CHART_HEIGHT_PX }}
-        />
-      ) : !hasData ? (
-        <div
-          className="flex items-center justify-center text-sm text-slate-500"
-          style={{ height: ROW_CHART_HEIGHT_PX }}
-        >
-          No priced volume in the selected window.
-        </div>
-      ) : (
-        <>
-          <Plot
-            ariaLabel={`Volume by token chart for ${activeRangeLabel}`}
-            textAlternative={bridgeTokenTextAlternative(
-              activeRangeLabel,
-              slices,
-              total,
-            )}
-            data={[trace]}
-            layout={layout}
-            config={PLOTLY_CONFIG}
-            style={{ width: "100%", height: ROW_CHART_HEIGHT_PX }}
-            useResizeHandler
-          />
-          <ul className="mt-3 grid gap-1.5 text-xs">
-            {slices.map((s, i) => (
-              <li
-                key={s.symbol}
-                className="flex items-center gap-2 text-slate-300"
-              >
-                <span
-                  aria-hidden="true"
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: PIE_COLORS[i % PIE_COLORS.length] }}
-                />
-                <span className="font-mono">{s.symbol}</span>
-                <span className="ml-auto font-mono text-slate-500">
-                  {formatUSD(s.usd)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+      <TokenBreakdownBody plotRef={plotRef} state={bodyState} />
     </section>
   );
 }
@@ -238,5 +230,77 @@ function BridgeRangePicker({
         );
       })}
     </div>
+  );
+}
+
+function TokenBreakdownBody({
+  plotRef,
+  state,
+}: {
+  plotRef: RefObject<HTMLDivElement | null>;
+  state: TokenBreakdownBodyState;
+}) {
+  if (state.kind === "error") {
+    return (
+      <p className="text-sm text-slate-500">Unable to load token breakdown.</p>
+    );
+  }
+  if (state.kind === "loading") return <TokenBreakdownPlaceholder />;
+  if (state.kind === "empty") {
+    return (
+      <div
+        className="flex items-center justify-center text-sm text-slate-500"
+        style={{ height: ROW_CHART_HEIGHT_PX }}
+      >
+        No priced volume in the selected window.
+      </div>
+    );
+  }
+  return (
+    <div ref={plotRef}>
+      {state.shouldMountPlot ? (
+        <Plot
+          ariaLabel={state.ariaLabel}
+          textAlternative={state.textAlternative}
+          data={[state.trace]}
+          layout={state.layout}
+          config={PLOTLY_CONFIG}
+          style={{ width: "100%", height: ROW_CHART_HEIGHT_PX }}
+          useResizeHandler
+        />
+      ) : (
+        <TokenBreakdownPlaceholder />
+      )}
+      <TokenBreakdownLegend slices={state.slices} />
+    </div>
+  );
+}
+
+function TokenBreakdownPlaceholder() {
+  return (
+    <div
+      className="animate-pulse rounded bg-slate-800/30"
+      style={{ height: ROW_CHART_HEIGHT_PX }}
+    />
+  );
+}
+
+function TokenBreakdownLegend({ slices }: { slices: TokenBreakdownSlice[] }) {
+  return (
+    <ul className="mt-3 grid gap-1.5 text-xs">
+      {slices.map((s, i) => (
+        <li key={s.symbol} className="flex items-center gap-2 text-slate-300">
+          <span
+            aria-hidden="true"
+            className="h-2.5 w-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: PIE_COLORS[i % PIE_COLORS.length] }}
+          />
+          <span className="font-mono">{s.symbol}</span>
+          <span className="ml-auto font-mono text-slate-500">
+            {formatUSD(s.usd)}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/ui-dashboard/src/components/bridge-volume-chart.tsx
+++ b/ui-dashboard/src/components/bridge-volume-chart.tsx
@@ -69,6 +69,7 @@ export function BridgeVolumeChart({
       hasError={hasError}
       hasSnapshotError={isCapped && range === "all"}
       emptyMessage="No bridge volume in the selected window."
+      plotlyDeferMode="visible"
     />
   );
 }

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 import { formatUSD } from "@/lib/format";
 import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
+import { useDeferredMount } from "@/components/use-deferred-mount";
 import {
   RANGES,
   SECONDS_PER_DAY,
@@ -289,15 +290,24 @@ function RevenueChartBody({
   ariaLabel: string;
   summary: string;
 }) {
+  const plotRef = useRef<HTMLDivElement>(null);
+  const shouldMountPlot = useDeferredMount(
+    "visible",
+    plotRef,
+    !isLoading && !showEmptyState,
+  );
+
   return (
     <div className="mt-4 -mx-2 sm:-mx-3">
-      <div role="figure" aria-label={ariaLabel}>
+      <div ref={plotRef} role="figure" aria-label={ariaLabel}>
         {isLoading ? (
           <PlotSkeleton />
         ) : showEmptyState ? (
           <div className="flex h-[220px] items-center justify-center text-sm text-slate-500">
             {emptyMessage}
           </div>
+        ) : !shouldMountPlot ? (
+          <PlotSkeleton />
         ) : (
           <Plot
             ariaLabel={ariaLabel}

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -1,9 +1,18 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { formatUSD } from "@/lib/format";
+import { formatUSD, normalizePoolIdForChain } from "@/lib/format";
+import { preloadGQL } from "@/lib/graphql";
 import { poolName } from "@/lib/tokens";
 import { type Pool } from "@/lib/types";
-import type { Network } from "@/lib/networks";
+import {
+  configuredNetworkIdForChainId,
+  NETWORKS,
+  type Network,
+} from "@/lib/networks";
+import {
+  POOL_DETAIL_WITH_HEALTH,
+  type PoolDetailResponse,
+} from "@/lib/queries";
 import { Row } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
 import { ChainIcon } from "@/components/chain-icon";
@@ -80,9 +89,10 @@ export function PoolRow({
     cdpPoolKeys?.has(key) ?? false,
     reservePoolKeys?.has(key) ?? false,
   );
+  const prefetchDetail = () => prefetchPoolDetail(entry);
 
   return (
-    <Row>
+    <Row onFocus={prefetchDetail} onMouseEnter={prefetchDetail}>
       <NameCell pool={pool} network={network} />
       {showVirtualPoolSource && <SourceCell pool={pool} />}
       <HealthCell status={effectiveStatus} details={healthDetails} />
@@ -118,6 +128,16 @@ export function PoolRow({
       <StrategyCell strategies={strategies} />
     </Row>
   );
+}
+
+function prefetchPoolDetail(entry: GlobalPoolEntry): void {
+  const networkId = configuredNetworkIdForChainId(entry.pool.chainId);
+  const network = networkId ? NETWORKS[networkId] : entry.network;
+  const id = normalizePoolIdForChain(entry.pool.id, network.chainId);
+  preloadGQL<PoolDetailResponse>(network, POOL_DETAIL_WITH_HEALTH, {
+    id,
+    chainId: network.chainId,
+  });
 }
 
 function Cell({

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -89,11 +89,14 @@ export function PoolRow({
     cdpPoolKeys?.has(key) ?? false,
     reservePoolKeys?.has(key) ?? false,
   );
-  const prefetchDetail = () => prefetchPoolDetail(entry);
 
   return (
-    <Row onFocus={prefetchDetail} onMouseEnter={prefetchDetail}>
-      <NameCell pool={pool} network={network} />
+    <Row>
+      <NameCell
+        pool={pool}
+        network={network}
+        onPrefetch={() => prefetchPoolDetail(entry)}
+      />
       {showVirtualPoolSource && <SourceCell pool={pool} />}
       <HealthCell status={effectiveStatus} details={healthDetails} />
       <UptimeCell pool={pool} />
@@ -152,7 +155,15 @@ function Cell({
   );
 }
 
-function NameCell({ pool, network }: { pool: Pool; network: Network }) {
+function NameCell({
+  pool,
+  network,
+  onPrefetch,
+}: {
+  pool: Pool;
+  network: Network;
+  onPrefetch: () => void;
+}) {
   return (
     <Cell className="">
       <div className="flex items-center gap-2">
@@ -160,6 +171,8 @@ function NameCell({ pool, network }: { pool: Pool; network: Network }) {
         <Link
           href={buildPoolDetailHref(pool.id)}
           className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
+          onFocus={onPrefetch}
+          onMouseEnter={onPrefetch}
         >
           {poolName(network, pool.token0, pool.token1)}
         </Link>

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -187,6 +187,7 @@ export function PoolTvlOverTimeChart({
       hasError={error}
       hasSnapshotError={false}
       shapes={shapes}
+      plotlyDeferMode="visible"
       emptyMessage={tvlEmptyMessage(error, historySupported, priceable)}
     />
   );

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -211,6 +211,7 @@ export function PoolVolumeOverTimeChart({
       hasSnapshotError={false}
       ranges={VOLUME_CHART_RANGES}
       shapes={shapes}
+      plotlyDeferMode="visible"
       emptyMessage={volumeEmptyMessage(error, historySupported, priceable)}
     />
   );

--- a/ui-dashboard/src/components/resource-hints.tsx
+++ b/ui-dashboard/src/components/resource-hints.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { preconnect, prefetchDNS } from "react-dom";
+import { clientEnv } from "@/env";
+
+const HASURA_URLS = [
+  clientEnv.NEXT_PUBLIC_HASURA_URL,
+  clientEnv.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA,
+  clientEnv.NEXT_PUBLIC_HASURA_URL_TESTNET,
+];
+
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+export function resourceHintOriginFromHasuraUrl(
+  hasuraUrl: string | undefined,
+): string | null {
+  if (!hasuraUrl) return null;
+  try {
+    const url = new URL(hasuraUrl);
+    if (url.protocol !== "https:" || isLocalHostname(url.hostname)) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resourceHintOriginsFromHasuraUrls(
+  hasuraUrls: readonly (string | undefined)[],
+): string[] {
+  const origins = new Set<string>();
+  for (const hasuraUrl of hasuraUrls) {
+    const origin = resourceHintOriginFromHasuraUrl(hasuraUrl);
+    if (origin) origins.add(origin);
+  }
+  return Array.from(origins);
+}
+
+export function ResourceHints() {
+  for (const origin of resourceHintOriginsFromHasuraUrls(HASURA_URLS)) {
+    preconnect(origin, { crossOrigin: "anonymous" });
+    prefetchDNS(origin);
+  }
+  return null;
+}

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -43,9 +43,21 @@ export function Table({
   );
 }
 
-export function Row({ children }: { children: ReactNode }) {
+export function Row({
+  children,
+  className,
+  ...props
+}: { children: ReactNode } & ComponentPropsWithoutRef<"tr">) {
   return (
-    <tr className="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+    <tr
+      className={[
+        "border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </tr>
   );

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -24,8 +24,13 @@ import {
   useCrossFade,
   useSortedHover,
 } from "@/components/time-series-chart-card-hooks";
+import {
+  useDeferredMount,
+  type DeferredMountMode,
+} from "@/components/use-deferred-mount";
 
 export type { BreakdownSeries };
+export type { DeferredMountMode as PlotlyDeferMode };
 
 // A skeleton rendered while the Plotly chunk is still loading. Without this
 // fallback there's a brief gap between `isLoading` flipping to false and the
@@ -133,6 +138,7 @@ interface TimeSeriesChartCardProps {
   shapes?: Plotly.Layout["shapes"];
   annotations?: Plotly.Layout["annotations"];
   yAxisReferenceValues?: readonly number[];
+  plotlyDeferMode?: DeferredMountMode;
 }
 
 // Intentional react-doctor suppression: chart shell + hover overlay + trace
@@ -163,6 +169,7 @@ export function TimeSeriesChartCard({
   shapes,
   annotations,
   yAxisReferenceValues = EMPTY_Y_AXIS_REFERENCE_VALUES,
+  plotlyDeferMode = "none",
 }: TimeSeriesChartCardProps) {
   const hasBreakdown = (breakdown?.length ?? 0) > 0;
   const isStacked = hasBreakdown && breakdownMode === "stacked";
@@ -435,6 +442,13 @@ export function TimeSeriesChartCard({
     );
 
   const showEmptyState = !isLoading && series.length === 0;
+  const shouldRenderPlot = !isLoading && !showEmptyState;
+  const shouldMountPlot = useDeferredMount(
+    plotlyDeferMode,
+    containerRef,
+    shouldRenderPlot,
+  );
+
   // Accessible name + non-visual summary for the chart (WCAG 1.1.1). Both are
   // derived from live props (title + active range + week-over-week change) so
   // they can never drift from the rendered series. The summary deliberately
@@ -558,6 +572,8 @@ export function TimeSeriesChartCard({
           >
             {emptyMessage}
           </div>
+        ) : !shouldMountPlot ? (
+          <PlotSkeleton heightPx={chartHeightPx} />
         ) : crossFadeEnabled && crossFadeData ? (
           <div style={{ position: "relative", height: chartHeightPx }}>
             {crossFadeData.map(({ key, combo, traces, layout }) => {

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -11,6 +11,7 @@ import type { OracleRateMap } from "@/lib/tokens";
 import {
   TimeSeriesChartCard,
   type BreakdownSeries,
+  type PlotlyDeferMode,
 } from "@/components/time-series-chart-card";
 import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
@@ -392,6 +393,7 @@ interface TvlOverTimeChartProps {
   isLoading: boolean;
   hasError: boolean;
   hasSnapshotError: boolean;
+  plotlyDeferMode?: PlotlyDeferMode;
 }
 
 export function TvlOverTimeChart({
@@ -402,6 +404,7 @@ export function TvlOverTimeChart({
   isLoading,
   hasError,
   hasSnapshotError,
+  plotlyDeferMode = "none",
 }: TvlOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
 
@@ -486,6 +489,7 @@ export function TvlOverTimeChart({
       hasError={hasError}
       hasSnapshotError={hasSnapshotError}
       emptyMessage={emptyMessage}
+      plotlyDeferMode={plotlyDeferMode}
     />
   );
 }

--- a/ui-dashboard/src/components/use-deferred-mount.ts
+++ b/ui-dashboard/src/components/use-deferred-mount.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useReducer, type RefObject } from "react";
+
+export type DeferredMountMode = "none" | "idle" | "visible";
+
+const IDLE_TIMEOUT_MS = 1_500;
+const VISIBLE_ROOT_MARGIN = "200px 0px";
+
+function requestIdle(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const requestIdleCallback = window.requestIdleCallback;
+  if (typeof requestIdleCallback === "function") {
+    const handle = requestIdleCallback(callback, {
+      timeout: IDLE_TIMEOUT_MS,
+    });
+    return () => window.cancelIdleCallback(handle);
+  }
+  const handle = globalThis.setTimeout(callback, 1);
+  return () => globalThis.clearTimeout(handle);
+}
+
+export function useDeferredMount(
+  mode: DeferredMountMode,
+  targetRef: RefObject<Element | null>,
+  enabled: boolean,
+): boolean {
+  const [shouldMount, dispatchMount] = useReducer(
+    (_current: boolean, next: boolean) => next,
+    enabled && mode === "none",
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      dispatchMount(false);
+      return;
+    }
+    if (mode === "none") {
+      dispatchMount(true);
+      return;
+    }
+
+    dispatchMount(false);
+    if (mode === "idle") {
+      return requestIdle(() => dispatchMount(true));
+    }
+
+    const target = targetRef.current;
+    if (!target || typeof IntersectionObserver === "undefined") {
+      dispatchMount(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          dispatchMount(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: VISIBLE_ROOT_MARGIN },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [enabled, mode, targetRef]);
+
+  return shouldMount;
+}

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -13,6 +13,7 @@ import type { Network } from "@/lib/networks";
 import {
   TimeSeriesChartCard,
   type BreakdownSeries,
+  type PlotlyDeferMode,
 } from "@/components/time-series-chart-card";
 import {
   SECONDS_PER_DAY,
@@ -566,6 +567,7 @@ interface VolumeOverTimeChartProps {
    */
   hasBrokerSnapshotError: boolean;
   fullVolumeSeries: DailyVolumeSeriesResult;
+  plotlyDeferMode?: PlotlyDeferMode;
 }
 
 // The four loading/error flags are independent: volume can load while
@@ -578,6 +580,7 @@ export function VolumeOverTimeChart({
   hasSnapshotError,
   hasBrokerSnapshotError,
   fullVolumeSeries,
+  plotlyDeferMode = "none",
 }: VolumeOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
 
@@ -682,6 +685,7 @@ export function VolumeOverTimeChart({
       hasError={hasError}
       hasSnapshotError={hasSnapshotError || visibleVolumePartial === true}
       emptyMessage={emptyMessage}
+      plotlyDeferMode={plotlyDeferMode}
     />
   );
 }

--- a/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
+++ b/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
@@ -80,6 +80,24 @@ describe("preloadGQL", () => {
     expect(swrPreloads()[key]).toBeUndefined();
   });
 
+  it("refreshes expiry when duplicate speculative preloads reuse the same request", async () => {
+    requestMock.mockResolvedValue({ pool_by_pk: { id: VARIABLES.id } });
+
+    preloadGQL(NETWORK, QUERY, VARIABLES, { ttlMs: 1_000 });
+    await vi.advanceTimersByTimeAsync(900);
+    preloadGQL(NETWORK, QUERY, VARIABLES, { ttlMs: 1_000 });
+
+    const key = serializedPreloadKey();
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect(swrPreloads()[key]).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(swrPreloads()[key]).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(swrPreloads()[key]).toBeUndefined();
+  });
+
   it("clears rejected speculative preloads without an unhandled rejection", async () => {
     requestMock.mockRejectedValue(new Error("Tier quota"));
 

--- a/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
+++ b/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+
+import { cache, serialize, SWRGlobalState } from "swr/_internal";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Network } from "@/lib/networks";
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock("graphql-request", () => ({
+  GraphQLClient: vi.fn(function GraphQLClientMock() {
+    return {
+      request: requestMock,
+    };
+  }),
+}));
+
+import { preloadGQL } from "@/lib/graphql";
+
+const NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+const QUERY = "query PoolDetail($id: String!) { pool_by_pk(id: $id) { id } }";
+const VARIABLES = { id: "42220-0x0000000000000000000000000000000000000001" };
+
+function serializedPreloadKey(): string {
+  return serialize([NETWORK.id, QUERY, VARIABLES])[0];
+}
+
+function swrPreloads(): Record<string, unknown> {
+  const state = SWRGlobalState.get(cache);
+  if (!state) throw new Error("SWR global state was not initialised");
+  return state[3] as Record<string, unknown>;
+}
+
+function clearSWRPreloads(): void {
+  const preloads = swrPreloads();
+  for (const key of Object.keys(preloads)) {
+    delete preloads[key];
+  }
+}
+
+describe("preloadGQL", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    requestMock.mockReset();
+    clearSWRPreloads();
+  });
+
+  afterEach(() => {
+    clearSWRPreloads();
+    vi.useRealTimers();
+  });
+
+  it("expires speculative SWR preloads that are not consumed", async () => {
+    requestMock.mockResolvedValue({ pool_by_pk: { id: VARIABLES.id } });
+
+    preloadGQL(NETWORK, QUERY, VARIABLES, { ttlMs: 1_000 });
+
+    const key = serializedPreloadKey();
+    expect(swrPreloads()[key]).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(swrPreloads()[key]).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(swrPreloads()[key]).toBeUndefined();
+  });
+
+  it("clears rejected speculative preloads without an unhandled rejection", async () => {
+    requestMock.mockRejectedValue(new Error("Tier quota"));
+
+    preloadGQL(NETWORK, QUERY, VARIABLES, { ttlMs: 1_000 });
+
+    const key = serializedPreloadKey();
+    expect(swrPreloads()[key]).toBeDefined();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(swrPreloads()[key]).toBeUndefined();
+  });
+});

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -82,11 +82,11 @@ export function preloadGQL<T>(
   const [serializedKey] = serialize(key);
   if (!serializedKey) return;
 
-  clearGQLPreloadTimer(serializedKey);
   const req = preload(key, () => requestGQL<T>(network, query, variables));
   if (req === undefined) return;
 
   const ttlMs = options.ttlMs ?? SPECULATIVE_PRELOAD_TTL_MS;
+  clearGQLPreloadTimer(serializedKey);
   gqlPreloadTimers.set(
     serializedKey,
     globalThis.setTimeout(() => clearGQLPreload(serializedKey), ttlMs),

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -1,6 +1,6 @@
 import { GraphQLClient } from "graphql-request";
 import { useMemo } from "react";
-import useSWR, { type SWRResponse } from "swr";
+import useSWR, { preload, type SWRResponse } from "swr";
 import type { ZodType } from "zod";
 import { useNetwork } from "@/components/network-provider";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
@@ -24,6 +24,56 @@ function getClient(network: Network): GraphQLClient {
   const client = new GraphQLClient(endpoint);
   clientCache.set(endpoint, client);
   return client;
+}
+
+type GqlVariables = Record<string, unknown> | undefined;
+type GqlKey = readonly [string, string, GqlVariables];
+
+function gqlKey(
+  network: Network,
+  query: string | null,
+  variables: GqlVariables,
+): GqlKey | null {
+  return query && network.hasuraUrl ? [network.id, query, variables] : null;
+}
+
+async function requestGQL<T>(
+  network: Network,
+  query: string,
+  variables: GqlVariables,
+  opts: Pick<UseGQLOptions<T>, "schema" | "timeoutMs"> = {},
+): Promise<T> {
+  const client = getClient(network);
+  const raw = await (opts.timeoutMs == null
+    ? variables !== undefined
+      ? client.request<T>(query, variables)
+      : client.request<T>(query)
+    : client.request<T>({
+        document: query,
+        ...(variables !== undefined ? { variables } : {}),
+        signal: AbortSignal.timeout(opts.timeoutMs),
+      }));
+  if (opts.schema != null) {
+    const result = opts.schema.safeParse(raw);
+    if (!result.success) {
+      // Pass the operation name (not the full GQL document) as the hint
+      // so Sentry titles stay readable.
+      const hint = query.match(/\b(?:query|mutation)\s+(\w+)/)?.[1];
+      throw new GraphQLSchemaError(result.error.issues, hint);
+    }
+    return result.data;
+  }
+  return raw;
+}
+
+export function preloadGQL<T>(
+  network: Network,
+  query: string,
+  variables?: Record<string, unknown>,
+): void {
+  const key = gqlKey(network, query, variables);
+  if (!key) return;
+  void preload(key, () => requestGQL<T>(network, query, variables));
 }
 
 // Pool-level data (oracle, reserves, health) doesn't move fast enough to
@@ -83,7 +133,6 @@ export function useGQL<T>(
   legacyOptions?: Omit<UseGQLOptions<T>, "refreshInterval">,
 ): SWRResponse<T> {
   const { network } = useNetwork();
-  const client = getClient(network);
 
   // Normalise the two calling conventions:
   //   (q, v, number, opts?)  — legacy positional refreshInterval
@@ -111,30 +160,11 @@ export function useGQL<T>(
   } = opts;
 
   async function fetcher(): Promise<T> {
-    const raw = await (timeoutMs == null
-      ? variables !== undefined
-        ? client.request<T>(query!, variables)
-        : client.request<T>(query!)
-      : client.request<T>({
-          document: query!,
-          ...(variables !== undefined ? { variables } : {}),
-          signal: AbortSignal.timeout(timeoutMs),
-        }));
-    if (schema != null) {
-      const result = schema.safeParse(raw);
-      if (!result.success) {
-        // Pass the operation name (not the full GQL document) as the hint
-        // so Sentry titles stay readable.
-        const hint = query?.match(/\b(?:query|mutation)\s+(\w+)/)?.[1];
-        throw new GraphQLSchemaError(result.error.issues, hint);
-      }
-      return result.data;
-    }
-    return raw;
+    return requestGQL<T>(network, query!, variables, { schema, timeoutMs });
   }
 
   const swrKey = useMemo(
-    () => (query && network.hasuraUrl ? [network.id, query, variables] : null),
+    () => gqlKey(network, query, variables),
     [network.id, network.hasuraUrl, query, variables],
   );
   const result = useSWR<T>(swrKey, fetcher, {

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -1,6 +1,7 @@
 import { GraphQLClient } from "graphql-request";
 import { useMemo } from "react";
 import useSWR, { preload, type SWRResponse } from "swr";
+import { cache, serialize, SWRGlobalState } from "swr/_internal";
 import type { ZodType } from "zod";
 import { useNetwork } from "@/components/network-provider";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
@@ -28,6 +29,10 @@ function getClient(network: Network): GraphQLClient {
 
 type GqlVariables = Record<string, unknown> | undefined;
 type GqlKey = readonly [string, string, GqlVariables];
+type PreloadTimer = ReturnType<typeof globalThis.setTimeout>;
+
+const SPECULATIVE_PRELOAD_TTL_MS = 5_000;
+const gqlPreloadTimers = new Map<string, PreloadTimer>();
 
 function gqlKey(
   network: Network,
@@ -70,10 +75,39 @@ export function preloadGQL<T>(
   network: Network,
   query: string,
   variables?: Record<string, unknown>,
+  options: { ttlMs?: number } = {},
 ): void {
   const key = gqlKey(network, query, variables);
   if (!key) return;
-  void preload(key, () => requestGQL<T>(network, query, variables));
+  const [serializedKey] = serialize(key);
+  if (!serializedKey) return;
+
+  clearGQLPreloadTimer(serializedKey);
+  const req = preload(key, () => requestGQL<T>(network, query, variables));
+  if (req === undefined) return;
+
+  const ttlMs = options.ttlMs ?? SPECULATIVE_PRELOAD_TTL_MS;
+  gqlPreloadTimers.set(
+    serializedKey,
+    globalThis.setTimeout(() => clearGQLPreload(serializedKey), ttlMs),
+  );
+  void Promise.resolve(req).catch(() => clearGQLPreload(serializedKey));
+}
+
+function clearGQLPreload(serializedKey: string): void {
+  clearGQLPreloadTimer(serializedKey);
+  const state = SWRGlobalState.get(cache);
+  const preloads = state?.[3];
+  if (preloads) {
+    delete preloads[serializedKey];
+  }
+}
+
+function clearGQLPreloadTimer(serializedKey: string): void {
+  const timer = gqlPreloadTimers.get(serializedKey);
+  if (timer == null) return;
+  globalThis.clearTimeout(timer);
+  gqlPreloadTimers.delete(serializedKey);
 }
 
 // Pool-level data (oracle, reserves, health) doesn't move fast enough to


### PR DESCRIPTION
## The Problem

- Batch C of #1107 still had the dashboard paying Plotly parse cost before users reached many charts.
- Pool-detail navigation from the global pools table waited until click-time to start the primary detail query.
- The app did not give browsers endpoint/resource hints for configured GraphQL origins or a native dark color-scheme hint.

## The Solution

- Add a shared deferred-mount hook so homepage charts wait for browser idle and below-fold charts wait for visibility while preserving the same skeleton height.
- Preload the pool-detail `POOL_DETAIL_WITH_HEALTH` SWR key on pools-table hover and keyboard focus.
- Add dark viewport metadata and configured Hasura-origin resource hints, skipping local/fixture endpoints.

## Details

- Uses the same `[network.id, query, variables]` SWR key for `preloadGQL` and `useGQL`, with the key memoized for normal polling.
- Keeps chart fallbacks at the exact Plotly area height so deferring parse does not introduce layout shift.
- Visible-gates bridge, pool, stables, volume, and CDP detail charts; homepage TVL/volume charts use idle gating.
- Derives resource-hint origins from public Hasura env URLs, dedupes them, and filters relative/local endpoints.

## Invariants

- Deferring Plotly must not resize chart cards before the plot mounts.
- Pool prefetch must use the same chain-aware normalized id and `POOL_DETAIL_WITH_HEALTH` variables as the pool detail page.
- Browser resource hints must follow configured GraphQL endpoints and avoid fixture/local endpoints.

## Degraded behavior

- If `requestIdleCallback` is unavailable, idle-gated charts fall back to a short timer.
- If `IntersectionObserver` is unavailable or the target ref is missing, visibility-gated charts mount immediately.
- If a network has no configured Hasura URL, the prefetch helper is a no-op through the shared GraphQL key guard.

## Intentional non-goals

- This does not add persisted SWR warm-start cache, GraphQL batching, or new SSR-prefetch coverage beyond the existing pool detail path.
- This does not change chart data queries or polling cadence.

## Validation

- `pnpm agent:quality-gate --run`
- Pre-push `pnpm agent:quality-gate --run`
- `pnpm --filter @mento-protocol/ui-dashboard test`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm dashboard:react-doctor:diff`
- `pnpm dashboard:build`
- `pnpm dashboard:size-limit`
- Browser verification against `http://127.0.0.1:3210/`: confirmed idle-gated homepage charts, fixed-height skeletons, configured resource hints, dark color-scheme metadata, pool hover/focus prefetch, pool navigation, and bridge charts mounting after scroll.
- `pnpm agent:autoreview --mode local --engine local`
- Fresh-context Codex subagent autoreview; accepted and fixed resource-hint endpoint findings.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] autoreview run
- [x] browser verification completed
- [x] PR readiness probe planned

Refs #1107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only performance and prefetch behavior; no auth or data-model changes, with tests for deferred mount, resource hints, preload TTL, and pool prefetch triggers.
> 
> **Overview**
> Improves initial load by **deferring Plotly** until charts are actually needed. A new `useDeferredMount` hook (`none` / `idle` / `visible`) gates mounting in `TimeSeriesChartCard` and standalone chart bodies; fixed-height skeletons stay in place so cards do not shift layout.
> 
> **Homepage** TVL and volume charts use `plotlyDeferMode="idle"`. **Below-fold** charts (bridge, pool detail, stables, volume, CDP, fee revenue) use `"visible"` (IntersectionObserver with ~200px margin).
> 
> **Global pools table** pool name links call `preloadGQL` for `POOL_DETAIL_WITH_HEALTH` on `mouseenter` and `focus`, using the same normalized pool id and SWR key as the detail page. `preloadGQL` is new shared fetch logic with a short TTL and cleanup for unused speculative preloads.
> 
> **Root layout** adds `ResourceHints` (`preconnect` / `prefetchDNS` for deduped HTTPS Hasura origins, skipping local/proxy URLs) and `viewport.colorScheme: "dark"`. `Table` `Row` now forwards extra `tr` props for future row handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44afb1c84931e1075565ad22b4366e1e0a07d255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->