### PR TITLE
docs(dashboard): document RSC prefetch test filtering

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -162,6 +162,10 @@ built app (`next build` plus `next start`) instead of dev mode. It allocates the
 same fixture ports up front, starts the Hasura fixture before `next build`,
 bakes the live fixture GraphQL URL into the production build, and then runs the
 same Playwright suite against `next start` while reusing that fixture server.
+When a browser test asserts that an interaction did not refetch the current
+route payload, filter `?_rsc=` requests to the route under test. Production
+`next/link` may prefetch unrelated navigation targets after page load; those
+background RSC requests should not fail current-route no-refetch assertions.
 Use `PLAYWRIGHT_NEXT_START_TIMEOUT_MS` to tune the production `next start`
 timeout; `PLAYWRIGHT_NEXT_TIMEOUT_MS` remains the dev-server timeout knob.
 For local macOS agent runs that can bind localhost outside the sandbox but hit


### PR DESCRIPTION
## The Problem

- Dashboard browser-test guidance did not call out that production `next/link` may emit unrelated RSC prefetch requests.
- Future no-refetch assertions could accidentally fail on background navigation prefetches instead of the route interaction under test.

## The Solution

- Document that browser tests should scope `?_rsc=` no-refetch assertions to the current route under test.

## Details

- Adds the note beside the existing `test:browser:production` guidance in `ui-dashboard/AGENTS.md`.
- This is a docs-only reflection follow-up from PR #1169.

## Validation

- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:review-materiality`
- `CI=true pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or test code changes.
> 
> **Overview**
> Adds guidance next to the existing **`pnpm test:browser:production`** section in `ui-dashboard/AGENTS.md` so authors know how to write reliable **no-refetch** assertions.
> 
> When a test checks that an interaction did **not** refetch the current route’s RSC payload, it should only count **`?_rsc=`** requests whose URL matches the **route under test**. In production builds, **`next/link`** can prefetch other navigation targets after load; those background RSC requests are unrelated to the interaction and should not fail a current-route no-refetch check.
> 
> This is a **docs-only** follow-up (aligned with filtering already used in browser tests such as `dashboard-flows.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22947ab52e05f5a66d4289f8d5e152fe5ffb936d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->