### PR TITLE
fix: keep PR terraform plans secretless

### DIFF
--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -16,8 +16,11 @@ name: Aegis Terraform
 #     (`GCP_SERVICE_ACCOUNT_PLAN`) and overrides the backend impersonation to
 #     `org-terraform-plan-readonly@…seed` via `-backend-config`. That seed SA
 #     holds only `roles/storage.objectViewer` on the state bucket, so plan
-#     passes `-lock=false`. The grafana provider auths via
-#     `TF_VAR_grafana_service_account_token`, unaffected by the SA swap.
+#     passes `-lock=false`. PR plans receive a validation-safe placeholder
+#     `TF_VAR_grafana_service_account_token` and run `-refresh=false`, keeping
+#     the real Grafana token out of same-repo PR workflows. push/dispatch plans
+#     keep the real token and full refresh before deciding whether apply needs
+#     the `production-infra` gate.
 #
 # Plan/apply split:
 #   - `plan` job runs on every PR + push/dispatch to main. It runs
@@ -32,7 +35,8 @@ name: Aegis Terraform
 # cross-job apply. HashiCorp warns that `terraform plan -out=` "saves
 # sensitive data in cleartext in the plan file"
 # (https://developer.hashicorp.com/terraform/cli/commands/plan), and the
-# TF_VAR_* env block here carries the production Grafana SA token.
+# TF_VAR_* env block here carries the production Grafana SA token on
+# push/dispatch; PR plans intentionally use a placeholder instead.
 # Uploading the binary plan as a workflow artifact would expose that
 # secret to anyone with `actions:read`. Instead the apply job re-plans at
 # gate-approval time — the trade-off is the brief "between approval and
@@ -93,7 +97,7 @@ jobs:
   plan:
     name: Terraform Plan (aegis/terraform)
     # Fork PRs and Dependabot PRs don't get repository secrets, so the
-    # GCP auth + TF_VAR_* steps would resolve empty and fail every time.
+    # GCP auth step would resolve empty and fail every time.
     # Skip the job in those contexts — the plan is only meaningful when
     # secrets are available. Internal PRs + main pushes run.
     if: >-
@@ -115,9 +119,6 @@ jobs:
     outputs:
       has-changes: ${{ steps.detect.outputs.has-changes }}
       stack-changed: ${{ steps.stack_changes.outputs.stack-changed }}
-    env:
-      # Grafana Cloud (drives the grafana provider; needs Admin role on the stack)
-      TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -165,6 +166,16 @@ jobs:
           terraform_version: 1.14.6
           terraform_wrapper: false
 
+      - name: Export PR-safe Terraform inputs
+        if: github.event_name == 'pull_request'
+        run: printf '%s\n' 'TF_VAR_grafana_service_account_token=pr-plan-dummy-grafana-token' >> "$GITHUB_ENV"
+
+      - name: Export production Terraform inputs
+        if: github.event_name != 'pull_request'
+        env:
+          INPUT_GRAFANA_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+        run: printf '%s\n' "TF_VAR_grafana_service_account_token=${INPUT_GRAFANA_SERVICE_ACCOUNT_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Format check
         run: terraform fmt -check -recursive
 
@@ -193,11 +204,19 @@ jobs:
         # `-lock=false`: the read-only plan SA (objectViewer only) can't
         # create/delete the GCS lock object, so plan must skip locking. Safe
         # because plan only reads state and re-runs on every push; a skipped
-        # lock can't drop work the way a missed apply could. The apply job
-        # below keeps locking via the write-capable SA.
+        # lock can't drop work the way a missed apply could. PR plans also pass
+        # `-refresh=false` because their Grafana provider token is a placeholder;
+        # push/dispatch plans keep full refresh with the real token before the
+        # apply gate decides whether changes exist.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set +e
-          terraform plan -detailed-exitcode -no-color -input=false -lock=false > /tmp/tf-plan.raw 2>&1
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            terraform plan -detailed-exitcode -no-color -input=false -lock=false -refresh=false > /tmp/tf-plan.raw 2>&1
+          else
+            terraform plan -detailed-exitcode -no-color -input=false -lock=false > /tmp/tf-plan.raw 2>&1
+          fi
           EXITCODE=$?
           set -e
           "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-plan.raw /tmp/tf-plan.txt

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -41,14 +41,17 @@ name: Alerts Infra
 # Required repository secrets mirror the `alerts_infra_ci_secret_names` local in
 # alerts/infra/main.tf, including Splunk On-Call credentials for the on-call
 # announcer: TF_VAR_SPLUNK_ON_CALL_API_ID and TF_VAR_SPLUNK_ON_CALL_API_KEY.
+# PR plans intentionally receive validation-safe placeholders for these
+# sensitive TF_VAR values; push/dispatch plans and the apply job keep the real
+# secrets so the gated apply-time re-plan is authoritative.
 #
 # Note: we intentionally do NOT save the plan as a binary artifact for
 # cross-job apply. HashiCorp warns that `terraform plan -out=` "saves
 # sensitive data in cleartext in the plan file"
 # (https://developer.hashicorp.com/terraform/cli/commands/plan), and the
 # TF_VAR_* env block here carries production Sentry/QuickNode/Slack/GitHub
-# credentials. Uploading the binary plan as a workflow artifact would expose
-# those secrets to anyone with `actions:read`.
+# credentials on push/dispatch and apply runs. Uploading the binary plan as a
+# workflow artifact would expose those secrets to anyone with `actions:read`.
 # Instead the apply job re-plans at gate-approval time — the trade-off
 # is the brief "between approval and apply" drift window, which the
 # reviewer can detect by checking the apply-job's plan output before
@@ -109,7 +112,7 @@ jobs:
   plan:
     name: Terraform Plan (alerts/infra)
     # Fork PRs and Dependabot PRs don't get repository secrets, so the
-    # GCP auth + TF_VAR_* steps would resolve empty and fail every time.
+    # GCP auth step would resolve empty and fail every time.
     # Skip the job in those contexts — the plan is only meaningful when
     # secrets are available. Internal PRs + main pushes run.
     if: >-
@@ -135,10 +138,6 @@ jobs:
       has-changes: ${{ steps.detect.outputs.has-changes }}
       stack-changed: ${{ steps.stack_changes.outputs.stack-changed }}
     env:
-      # Sentry
-      TF_VAR_sentry_auth_token: ${{ secrets.TF_VAR_SENTRY_AUTH_TOKEN }}
-      # GCP
-      TF_VAR_billing_account: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
       # On PRs, point the google provider at the read-only seed SA so provider
       # init impersonates an identity the plan-readonly CI SA can mint a token
       # for; with `-refresh=false` (see Plan step) the provider makes no GCP API
@@ -146,19 +145,6 @@ jobs:
       # workflow_dispatch this resolves to the write-capable `org-terraform@…seed`
       # (= the variable default) — those runs full-refresh to gate apply.
       TF_VAR_terraform_service_account: ${{ github.event_name == 'pull_request' && 'org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com' || 'org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com' }}
-      # QuickNode
-      TF_VAR_quicknode_api_key: ${{ secrets.TF_VAR_QUICKNODE_API_KEY }}
-      TF_VAR_quicknode_signing_secret: ${{ secrets.TF_VAR_QUICKNODE_SIGNING_SECRET }}
-      # Splunk On-Call / VictorOps API (read-only key is sufficient)
-      TF_VAR_splunk_on_call_api_id: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_ID }}
-      TF_VAR_splunk_on_call_api_key: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
-      TF_VAR_oncall_slack_channel_id: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
-      TF_VAR_oncall_support_usergroup_id: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
-      TF_VAR_slack_notification_channel_id: ${{ secrets.TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID }}
-      # Slack (for restapi.slack provider — creates/archives Sentry alert channels)
-      TF_VAR_slack_bot_token: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
-      # GitHub (for github_actions_secret resources that self-manage these secrets)
-      TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -206,6 +192,52 @@ jobs:
         with:
           terraform_version: 1.14.6
           terraform_wrapper: false
+
+      - name: Export PR-safe Terraform inputs
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            printf '%s\n' 'TF_VAR_sentry_auth_token=pr-plan-dummy-sentry-token-0000'
+            printf '%s\n' 'TF_VAR_billing_account=000000-000000-000000'
+            printf '%s\n' 'TF_VAR_quicknode_api_key=pr-plan-dummy-quicknode-api-key'
+            printf '%s\n' 'TF_VAR_quicknode_signing_secret=00000000000000000000000000000000'
+            printf '%s\n' 'TF_VAR_splunk_on_call_api_id=pr-plan-dummy-splunk-id'
+            printf '%s\n' 'TF_VAR_splunk_on_call_api_key=pr-plan-dummy-splunk-key'
+            printf '%s\n' 'TF_VAR_oncall_slack_channel_id=C012345678'
+            printf '%s\n' 'TF_VAR_oncall_support_usergroup_id=S012345678'
+            printf '%s\n' 'TF_VAR_slack_notification_channel_id=123456789'
+            printf '%s\n' 'TF_VAR_slack_bot_token=xoxb-pr-plan-dummy-token'
+            printf '%s\n' 'TF_VAR_github_token=pr-plan-dummy-github-token'
+          } >> "$GITHUB_ENV"
+
+      - name: Export production Terraform inputs
+        if: github.event_name != 'pull_request'
+        env:
+          INPUT_SENTRY_AUTH_TOKEN: ${{ secrets.TF_VAR_SENTRY_AUTH_TOKEN }}
+          INPUT_BILLING_ACCOUNT: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
+          INPUT_QUICKNODE_API_KEY: ${{ secrets.TF_VAR_QUICKNODE_API_KEY }}
+          INPUT_QUICKNODE_SIGNING_SECRET: ${{ secrets.TF_VAR_QUICKNODE_SIGNING_SECRET }}
+          INPUT_SPLUNK_ON_CALL_API_ID: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_ID }}
+          INPUT_SPLUNK_ON_CALL_API_KEY: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_API_KEY }}
+          INPUT_ONCALL_SLACK_CHANNEL_ID: ${{ secrets.TF_VAR_ONCALL_SLACK_CHANNEL_ID }}
+          INPUT_ONCALL_SUPPORT_USERGROUP_ID: ${{ secrets.TF_VAR_ONCALL_SUPPORT_USERGROUP_ID }}
+          INPUT_SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TF_VAR_SLACK_NOTIFICATION_CHANNEL_ID }}
+          INPUT_SLACK_BOT_TOKEN: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
+        run: |
+          {
+            printf '%s\n' "TF_VAR_sentry_auth_token=${INPUT_SENTRY_AUTH_TOKEN}"
+            printf '%s\n' "TF_VAR_billing_account=${INPUT_BILLING_ACCOUNT}"
+            printf '%s\n' "TF_VAR_quicknode_api_key=${INPUT_QUICKNODE_API_KEY}"
+            printf '%s\n' "TF_VAR_quicknode_signing_secret=${INPUT_QUICKNODE_SIGNING_SECRET}"
+            printf '%s\n' "TF_VAR_splunk_on_call_api_id=${INPUT_SPLUNK_ON_CALL_API_ID}"
+            printf '%s\n' "TF_VAR_splunk_on_call_api_key=${INPUT_SPLUNK_ON_CALL_API_KEY}"
+            printf '%s\n' "TF_VAR_oncall_slack_channel_id=${INPUT_ONCALL_SLACK_CHANNEL_ID}"
+            printf '%s\n' "TF_VAR_oncall_support_usergroup_id=${INPUT_ONCALL_SUPPORT_USERGROUP_ID}"
+            printf '%s\n' "TF_VAR_slack_notification_channel_id=${INPUT_SLACK_NOTIFICATION_CHANNEL_ID}"
+            printf '%s\n' "TF_VAR_slack_bot_token=${INPUT_SLACK_BOT_TOKEN}"
+            printf '%s\n' "TF_VAR_github_token=${INPUT_GITHUB_TOKEN}"
+          } >> "$GITHUB_ENV"
 
       - name: Format check
         run: terraform fmt -check -recursive

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -15,24 +15,24 @@ name: Alerts Infra
 #     (`GCP_SERVICE_ACCOUNT_PLAN`), overrides the backend impersonation to
 #     `org-terraform-plan-readonly@…seed` via `-backend-config`, points the
 #     google provider at the same read-only SA via
-#     `TF_VAR_terraform_service_account`, and runs `terraform plan -lock=false
-#     -refresh=false`. `-refresh=false` is load-bearing: unlike the grafana-only
-#     stacks (alerts-rules / aegis), this stack's google provider would
-#     otherwise refresh GCP resources, which the read-only seed SA (objectViewer
-#     on the state bucket only, no project roles) can't read. Skipping refresh
-#     keeps the PR plan to a config-vs-last-state diff needing only state read +
-#     the token mint the read-only CI SA already holds — zero new IAM. Tradeoff:
-#     the PR plan won't surface out-of-band drift; that's `terraform-drift.yml`'s
-#     job (full refresh, write SA) and the apply-time re-plan's. The read-only +
-#     `-refresh=false` treatment is gated on `github.event_name == 'pull_request'`:
-#     the same plan job on push / workflow_dispatch keeps the write deployer SA +
-#     full refresh + locking, so the apply-gating plan (incl. drift reconciled via
-#     manual dispatch) still synchronizes remote state before deciding changes.
+#     `TF_VAR_terraform_service_account`, and runs a targeted `terraform plan`
+#     against `terraform_data.pr_plan_secretless_guard` with `-lock=false
+#     -refresh=false`. The target is load-bearing: this stack includes Sentry,
+#     Slack, QuickNode, and GitHub provider/resource surfaces that perform
+#     authenticated plan-time checks. PRs intentionally receive dummy TF_VAR
+#     credentials, so the PR job uses init + validate + the built-in target plan
+#     as the secretless Terraform execution check. Tradeoff: the PR plan won't
+#     surface full-stack diffs or out-of-band drift; that's `terraform-drift.yml`'s
+#     job (full refresh, write SA) and the apply-time re-plan's. The targeted
+#     treatment is gated on `github.event_name == 'pull_request'`: the same plan
+#     job on push / workflow_dispatch keeps the write deployer SA + full refresh
+#     + locking, so the apply-gating plan (incl. drift reconciled via manual
+#     dispatch) still synchronizes remote state before deciding changes.
 #
 # Plan/apply split:
 #   - `plan` job runs on every PR + push/dispatch to main. It runs
 #     `terraform plan -detailed-exitcode` and emits a `has-changes` job
-#     output. On PRs it posts a sticky comment with the plan diff.
+#     output. On PRs it posts a sticky comment with the targeted sentinel plan.
 #   - `apply` job only runs on push/dispatch to main, only when the plan
 #     reported actual changes, and only for stack-root changes or explicit
 #     workflow_dispatch. Workflow/notifier-only edits can still plan, but they
@@ -276,12 +276,14 @@ jobs:
         # No `-out=` — saved plan files contain TF_VAR_* values in cleartext
         # (HashiCorp docs); apply re-plans at gate-approval time instead.
         # PR plans run read-only: `-lock=false` (the read-only plan SA, objectViewer
-        # only, can't write the GCS lock object) + `-refresh=false` (this stack's
-        # google provider would otherwise refresh GCP resources the read-only seed
-        # SA can't read — no project roles). `-refresh=false` also means the `http`
-        # data sources in ci-failures-channel.tf (Slack @eng usergroup lookup)
-        # coast on last-known state values on PRs rather than re-fetching — no auth
-        # risk (Slack token, not GCP), same acceptable drift trade-off.
+        # only, can't write the GCS lock object) + `-refresh=false` + an explicit
+        # target of the built-in `terraform_data.pr_plan_secretless_guard`.
+        # Targeting is load-bearing because this stack's Sentry, Slack, QuickNode,
+        # and GitHub surfaces use authenticated provider configuration or plan-time
+        # reads; PRs intentionally receive dummy TF_VAR credentials, so a full PR
+        # graph would fail before proving anything useful. `terraform validate`
+        # still checks full config shape; push / workflow_dispatch plans and gated
+        # applies below run the full graph with production credentials.
         # push / workflow_dispatch (the apply-gating path, incl. drift reconcile)
         # keep full refresh + locking on the write SA, so they detect out-of-band
         # drift and set `has-changes` correctly. Drift detection also runs in
@@ -292,7 +294,7 @@ jobs:
         run: |
           set +e
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            terraform plan -detailed-exitcode -no-color -input=false -lock=false -refresh=false > /tmp/tf-plan.raw 2>&1
+            terraform plan -detailed-exitcode -no-color -input=false -lock=false -refresh=false -target=terraform_data.pr_plan_secretless_guard > /tmp/tf-plan.raw 2>&1
           else
             terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=2m > /tmp/tf-plan.raw 2>&1
           fi

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -351,6 +351,7 @@ jobs:
         # so a failed plan still surfaces the error inline.
         if: always()
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
           HAS_CHANGES: ${{ steps.detect.outputs.has-changes }}
           STACK_CHANGED: ${{ steps.stack_changes.outputs.stack-changed }}
@@ -359,7 +360,19 @@ jobs:
             echo '## Terraform Plan — `alerts/infra/`'
             echo
             if [ "$PLAN_OUTCOME" = "success" ]; then
-              if [ "$HAS_CHANGES" = "true" ]; then
+              if [ "$EVENT_NAME" = "pull_request" ]; then
+                if [ "$STACK_CHANGED" = "true" ]; then
+                  if [ "$HAS_CHANGES" = "true" ]; then
+                    echo '**Status:** 📝 PR target plan changed — trusted main plan will decide apply'
+                  else
+                    echo '**Status:** ✅ PR target plan clean — trusted main plan will decide apply'
+                  fi
+                elif [ "$HAS_CHANGES" = "true" ]; then
+                  echo '**Status:** ⚠️ PR target drift detected — stack path unchanged, apply will skip'
+                else
+                  echo '**Status:** ✅ PR target plan clean — stack path unchanged, apply will skip'
+                fi
+              elif [ "$HAS_CHANGES" = "true" ]; then
                 if [ "$STACK_CHANGED" = "true" ]; then
                   echo '**Status:** 📝 changes detected — stack change is eligible for apply'
                 else
@@ -410,6 +423,7 @@ jobs:
           # template injection points (defensive — `steps.*.outcome` is an
           # enum controlled by Actions, but env-based passing is the standard
           # hardening pattern).
+          EVENT_NAME: ${{ github.event_name }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
           HAS_CHANGES: ${{ steps.detect.outputs.has-changes }}
           STACK_CHANGED: ${{ steps.stack_changes.outputs.stack-changed }}
@@ -433,14 +447,29 @@ jobs:
             const planOutcome = process.env.PLAN_OUTCOME || "unknown";
             const hasChanges = process.env.HAS_CHANGES === "true";
             const stackChanged = process.env.STACK_CHANGED === "true";
-            const statusIcon = planOutcome === "success"
-              ? (hasChanges ? (stackChanged ? "📝" : "⚠️") : "✅")
-              : "❌";
-            const statusText = planOutcome === "success"
-              ? (hasChanges
+            const eventName = process.env.EVENT_NAME || "unknown";
+            let statusIcon = "❌";
+            let statusText = "plan failed";
+            if (planOutcome === "success") {
+              if (eventName === "pull_request") {
+                if (stackChanged) {
+                  statusIcon = hasChanges ? "📝" : "✅";
+                  statusText = hasChanges
+                    ? "PR target plan changed — trusted main plan will decide apply"
+                    : "PR target plan clean — trusted main plan will decide apply";
+                } else {
+                  statusIcon = hasChanges ? "⚠️" : "✅";
+                  statusText = hasChanges
+                    ? "PR target drift detected — stack path unchanged, apply will skip"
+                    : "PR target plan clean — stack path unchanged, apply will skip";
+                }
+              } else {
+                statusIcon = hasChanges ? (stackChanged ? "📝" : "⚠️") : "✅";
+                statusText = hasChanges
                   ? (stackChanged ? "changes detected — stack change is eligible for apply" : "drift detected — stack path unchanged, apply will skip")
-                  : "no changes — merge will skip apply")
-              : "plan failed";
+                  : "no changes — merge will skip apply";
+              }
+            }
 
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +

--- a/.github/workflows/governance-watchdog.yml
+++ b/.github/workflows/governance-watchdog.yml
@@ -39,9 +39,10 @@ name: Governance Watchdog Infra
 # Required plan-time repository secrets are this stack's TF_VAR_* values (see
 # the env blocks below): GCP bootstrap (org_id, billing_account), Discord +
 # Telegram notification creds, QuickNode api_key + security_token,
-# x_auth_token, victorops_webhook_url, and the github_token PAT. The plan job
-# does not attach the `production-infra` Environment, so every plan-time value
-# must exist as a repository secret. Keep matching `production-infra`
+# x_auth_token, victorops_webhook_url, and the github_token PAT. PR plans
+# intentionally receive validation-safe placeholders for these sensitive values;
+# push/dispatch plans and the apply job keep the real secrets so the gated
+# apply-time re-plan is authoritative. Keep matching `production-infra`
 # Environment secrets in sync for apply-time values that are intentionally
 # scoped behind that gate; `github_actions_secret` resources then self-manage
 # the TF_VAR_* mirror consumed by terraform-drift.yml.
@@ -51,8 +52,8 @@ name: Governance Watchdog Infra
 # sensitive data in cleartext in the plan file"
 # (https://developer.hashicorp.com/terraform/cli/commands/plan), and the
 # TF_VAR_* env block here carries production Discord/Telegram/QuickNode/GitHub
-# credentials. Uploading the binary plan as a workflow artifact would expose
-# those secrets to anyone with `actions:read`.
+# credentials on push/dispatch and apply runs. Uploading the binary plan as a
+# workflow artifact would expose those secrets to anyone with `actions:read`.
 # Instead the apply job re-plans at gate-approval time — the trade-off
 # is the brief "between approval and apply" drift window, which the
 # reviewer can detect by checking the apply-job's plan output before
@@ -125,7 +126,7 @@ jobs:
   plan:
     name: Terraform Plan (governance-watchdog/infra)
     # Fork PRs and Dependabot PRs don't get repository secrets, so the
-    # GCP auth + TF_VAR_* steps would resolve empty and fail every time.
+    # GCP auth step would resolve empty and fail every time.
     # Skip the job in those contexts — the plan is only meaningful when
     # secrets are available. Internal PRs + main pushes run.
     if: >-
@@ -151,9 +152,6 @@ jobs:
       has-changes: ${{ steps.detect.outputs.has-changes }}
       stack-changed: ${{ steps.stack_changes.outputs.stack-changed }}
     env:
-      # GCP project bootstrap (org_id has a default in variables.tf — shared
-      # across stacks, so it is intentionally NOT a CI env var)
-      TF_VAR_billing_account: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
       # On PRs, point the google provider at the read-only seed SA so provider
       # init impersonates an identity the plan-readonly CI SA can mint a token
       # for; with `-refresh=false` (see Plan step) the provider makes no GCP API
@@ -161,26 +159,6 @@ jobs:
       # workflow_dispatch this resolves to the write-capable `org-terraform@…seed`
       # (= the variable default) — those runs full-refresh to gate apply.
       TF_VAR_terraform_service_account: ${{ github.event_name == 'pull_request' && 'org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com' || 'org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com' }}
-      # Discord (proposal notifications)
-      TF_VAR_discord_webhook_url: ${{ secrets.TF_VAR_DISCORD_WEBHOOK_URL }}
-      TF_VAR_discord_test_webhook_url: ${{ secrets.TF_VAR_DISCORD_TEST_WEBHOOK_URL }}
-      # Telegram (proposal notifications)
-      TF_VAR_telegram_chat_id: ${{ secrets.TF_VAR_TELEGRAM_CHAT_ID }}
-      TF_VAR_telegram_test_chat_id: ${{ secrets.TF_VAR_TELEGRAM_TEST_CHAT_ID }}
-      TF_VAR_telegram_bot_token: ${{ secrets.TF_VAR_TELEGRAM_BOT_TOKEN }}
-      # QuickNode (webhook security token + API key)
-      TF_VAR_quicknode_api_key: ${{ secrets.TF_VAR_GOVERNANCE_WATCHDOG_QUICKNODE_API_KEY }}
-      TF_VAR_quicknode_security_token: ${{ secrets.TF_VAR_QUICKNODE_SECURITY_TOKEN }}
-      # Production test path (x-auth-token)
-      TF_VAR_x_auth_token: ${{ secrets.TF_VAR_X_AUTH_TOKEN }}
-      # VictorOps / Splunk On-Call webhook (GCP Monitoring alert delivery)
-      TF_VAR_victorops_webhook_url: ${{ secrets.TF_VAR_VICTOROPS_WEBHOOK_URL }}
-      # gov-watchdog's GCP Monitoring error-alert Slack channel ID — the
-      # stack-specific secret (NOT the shared alerts-delivery channel); the
-      # variable defaults to "" so this is optional until the channel exists.
-      TF_VAR_slack_notification_channel_id: ${{ secrets.TF_VAR_GOVERNANCE_WATCHDOG_SLACK_NOTIFICATION_CHANNEL_ID }}
-      # GitHub (for github_actions_secret resources that self-manage these secrets)
-      TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -237,6 +215,55 @@ jobs:
         with:
           terraform_version: 1.14.6
           terraform_wrapper: false
+
+      - name: Export PR-safe Terraform inputs
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            printf '%s\n' 'TF_VAR_billing_account=000000-000000-000000'
+            printf '%s\n' 'TF_VAR_discord_webhook_url=https://example.invalid/pr-plan-discord-webhook'
+            printf '%s\n' 'TF_VAR_discord_test_webhook_url=https://example.invalid/pr-plan-discord-test-webhook'
+            printf '%s\n' 'TF_VAR_telegram_chat_id=pr-plan-dummy-telegram-chat-id'
+            printf '%s\n' 'TF_VAR_telegram_test_chat_id=pr-plan-dummy-telegram-test-chat-id'
+            printf '%s\n' 'TF_VAR_telegram_bot_token=pr-plan-dummy-telegram-bot-token'
+            printf '%s\n' 'TF_VAR_quicknode_api_key=pr-plan-dummy-quicknode-api-key'
+            printf '%s\n' 'TF_VAR_quicknode_security_token=pr-plan-dummy-quicknode-security-token'
+            printf '%s\n' 'TF_VAR_x_auth_token=pr-plan-dummy-x-auth-token'
+            printf '%s\n' 'TF_VAR_victorops_webhook_url=https://example.invalid/pr-plan-victorops-webhook'
+            printf '%s\n' 'TF_VAR_slack_notification_channel_id=123456789'
+            printf '%s\n' 'TF_VAR_github_token=pr-plan-dummy-github-token'
+          } >> "$GITHUB_ENV"
+
+      - name: Export production Terraform inputs
+        if: github.event_name != 'pull_request'
+        env:
+          INPUT_BILLING_ACCOUNT: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
+          INPUT_DISCORD_WEBHOOK_URL: ${{ secrets.TF_VAR_DISCORD_WEBHOOK_URL }}
+          INPUT_DISCORD_TEST_WEBHOOK_URL: ${{ secrets.TF_VAR_DISCORD_TEST_WEBHOOK_URL }}
+          INPUT_TELEGRAM_CHAT_ID: ${{ secrets.TF_VAR_TELEGRAM_CHAT_ID }}
+          INPUT_TELEGRAM_TEST_CHAT_ID: ${{ secrets.TF_VAR_TELEGRAM_TEST_CHAT_ID }}
+          INPUT_TELEGRAM_BOT_TOKEN: ${{ secrets.TF_VAR_TELEGRAM_BOT_TOKEN }}
+          INPUT_QUICKNODE_API_KEY: ${{ secrets.TF_VAR_GOVERNANCE_WATCHDOG_QUICKNODE_API_KEY }}
+          INPUT_QUICKNODE_SECURITY_TOKEN: ${{ secrets.TF_VAR_QUICKNODE_SECURITY_TOKEN }}
+          INPUT_X_AUTH_TOKEN: ${{ secrets.TF_VAR_X_AUTH_TOKEN }}
+          INPUT_VICTOROPS_WEBHOOK_URL: ${{ secrets.TF_VAR_VICTOROPS_WEBHOOK_URL }}
+          INPUT_SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TF_VAR_GOVERNANCE_WATCHDOG_SLACK_NOTIFICATION_CHANNEL_ID }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
+        run: |
+          {
+            printf '%s\n' "TF_VAR_billing_account=${INPUT_BILLING_ACCOUNT}"
+            printf '%s\n' "TF_VAR_discord_webhook_url=${INPUT_DISCORD_WEBHOOK_URL}"
+            printf '%s\n' "TF_VAR_discord_test_webhook_url=${INPUT_DISCORD_TEST_WEBHOOK_URL}"
+            printf '%s\n' "TF_VAR_telegram_chat_id=${INPUT_TELEGRAM_CHAT_ID}"
+            printf '%s\n' "TF_VAR_telegram_test_chat_id=${INPUT_TELEGRAM_TEST_CHAT_ID}"
+            printf '%s\n' "TF_VAR_telegram_bot_token=${INPUT_TELEGRAM_BOT_TOKEN}"
+            printf '%s\n' "TF_VAR_quicknode_api_key=${INPUT_QUICKNODE_API_KEY}"
+            printf '%s\n' "TF_VAR_quicknode_security_token=${INPUT_QUICKNODE_SECURITY_TOKEN}"
+            printf '%s\n' "TF_VAR_x_auth_token=${INPUT_X_AUTH_TOKEN}"
+            printf '%s\n' "TF_VAR_victorops_webhook_url=${INPUT_VICTOROPS_WEBHOOK_URL}"
+            printf '%s\n' "TF_VAR_slack_notification_channel_id=${INPUT_SLACK_NOTIFICATION_CHANNEL_ID}"
+            printf '%s\n' "TF_VAR_github_token=${INPUT_GITHUB_TOKEN}"
+          } >> "$GITHUB_ENV"
 
       - name: Format check
         run: terraform fmt -check -recursive

--- a/alerts/infra/pr-plan-guard.tf
+++ b/alerts/infra/pr-plan-guard.tf
@@ -1,0 +1,18 @@
+###################################
+# PR-safe Terraform plan sentinel #
+###################################
+#
+# The alerts-delivery stack owns several providers whose configuration performs
+# authenticated API checks or reads: Sentry, Slack, QuickNode, and GitHub. Pull
+# request plans intentionally receive dummy TF_VAR values for those credentials,
+# so the PR workflow targets this built-in Terraform resource instead of the
+# full provider graph. That keeps the PR job exercising init/validate/plan with
+# no production secrets in the environment; push/dispatch plans and gated
+# applies still run the full graph with real credentials.
+
+resource "terraform_data" "pr_plan_secretless_guard" {
+  input = {
+    stack   = "alerts-infra"
+    purpose = "secretless-pr-plan"
+  }
+}

--- a/docs/adr/0029-ci-apply-production-infra-gate.md
+++ b/docs/adr/0029-ci-apply-production-infra-gate.md
@@ -29,8 +29,11 @@ branch restricted to protected `main`). PR runs do **read-only plans** under a
 read-only plan service account. Secret-bearing PR plan workflows also export
 validation-safe placeholder `TF_VAR_*` values instead of production secrets; the
 push/dispatch plan and environment-gated apply paths keep real secrets and
-re-plan before any production mutation. The `platform` stack stays
-manual-plan/manual-apply.
+re-plan before any production mutation. The `alerts-delivery` PR plan is
+targeted to `terraform_data.pr_plan_secretless_guard` because its
+Sentry/Slack/QuickNode/GitHub provider graph performs authenticated plan-time
+checks that cannot run with dummy credentials; push/dispatch and apply paths run
+the full graph. The `platform` stack stays manual-plan/manual-apply.
 Routine service deploys use a separate `production-services` environment that records
 history but doesn't require manual approval.
 

--- a/docs/adr/0029-ci-apply-production-infra-gate.md
+++ b/docs/adr/0029-ci-apply-production-infra-gate.md
@@ -3,7 +3,7 @@ title: Infra applies on merge to main behind the production-infra environment ga
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 scope: terraform/infra
 date: 2026-05
 ---
@@ -26,7 +26,11 @@ Terraform stacks with CI-apply policy (`alerts-rules`, `alerts-delivery`, `aegis
 `governance-watchdog`) **apply on merge to `main`**, gated by the **`production-infra`
 GitHub Environment** (required reviewer, self-review allowed, admin bypass disabled,
 branch restricted to protected `main`). PR runs do **read-only plans** under a
-read-only plan service account. The `platform` stack stays manual-plan/manual-apply.
+read-only plan service account. Secret-bearing PR plan workflows also export
+validation-safe placeholder `TF_VAR_*` values instead of production secrets; the
+push/dispatch plan and environment-gated apply paths keep real secrets and
+re-plan before any production mutation. The `platform` stack stays
+manual-plan/manual-apply.
 Routine service deploys use a separate `production-services` environment that records
 history but doesn't require manual approval.
 

--- a/docs/notes/terraform-cicd-hardening-decisions-2026-05.md
+++ b/docs/notes/terraform-cicd-hardening-decisions-2026-05.md
@@ -2,7 +2,7 @@
 title: Terraform CI/CD hardening — decisions recorded
 status: active
 owner: eng
-last_verified: 2026-05-29
+last_verified: 2026-07-07
 ---
 
 # Terraform CI/CD hardening — decisions recorded
@@ -10,8 +10,8 @@ last_verified: 2026-05-29
 Migrated off `BACKLOG.md` 2026-05-29. PR #622 shipped a saved-plan-style
 "skip-when-no-changes" + production-environment gate refactor for `alerts/rules/`
 and `alerts/infra/`. Follow-up PRs added Aegis auto-apply, scheduled drift
-detection, and the local Terraform apply guard. Plan-credential hardening is
-complete: the read-only plan SA (`metrics-bridge-plan-readonly@` →
+detection, and the local Terraform apply guard. GCP/state plan-credential
+hardening is complete: the read-only plan SA (`metrics-bridge-plan-readonly@` →
 `org-terraform-plan-readonly@…seed`, `objectViewer` on the state bucket only)
 runs every PR-triggered Terraform plan job — grafana-only stacks (`alerts-rules`,
 `aegis`) via `-backend-config` + `-lock=false`, and `alerts/infra` via the same
@@ -21,7 +21,10 @@ privilege (registry-driven via `matrix.planSa`).
 **Everything actionable shipped.** The two decisions below were evaluated and
 **declined by design** — recorded here so they are not re-litigated. (See also
 PR #686, which recorded the fully-read-only drift cron as declined on
-cost/benefit.)
+cost/benefit.) Follow-up PR hardening in 2026-07 also removed production
+`TF_VAR_*` values from same-repo PR plan environments for the secret-bearing
+Terraform workflows: PRs use validation-safe placeholders, while
+push/dispatch plans and `production-infra`-gated applies keep the real secrets.
 
 ## Declined: full-refresh read-only plan for the `alerts/infra` leg (PR plan and drift)
 

--- a/docs/notes/terraform-cicd-hardening-decisions-2026-05.md
+++ b/docs/notes/terraform-cicd-hardening-decisions-2026-05.md
@@ -25,21 +25,28 @@ cost/benefit.) Follow-up PR hardening in 2026-07 also removed production
 `TF_VAR_*` values from same-repo PR plan environments for the secret-bearing
 Terraform workflows: PRs use validation-safe placeholders, while
 push/dispatch plans and `production-infra`-gated applies keep the real secrets.
+The `alerts/infra` PR path is intentionally narrower than the other two
+secret-bearing stacks: after init/validate it targets
+`terraform_data.pr_plan_secretless_guard`, because Sentry, Slack, QuickNode, and
+GitHub resources in that stack perform authenticated plan-time checks that
+cannot run with placeholders.
 
 ## Declined: full-refresh read-only plan for the `alerts/infra` leg (PR plan and drift)
 
-Both the `alerts/infra` PR plan (`-refresh=false`) and its drift leg (kept on the
-write SA) stop short of a full-refresh read-only plan for the same irreducible
-reason: the read-only seed SA has no project roles, so refreshing the stack's
-google-provider resources would 403 (the grafana legs were free to flip because
-grafana refreshes over its own token, never touching GCP). Closing it needs a
-read identity with access to the `project_factory`-managed project.
+The `alerts/infra` PR plan (targeted sentinel + `-refresh=false`) and its drift
+leg (kept on the write SA) stop short of a full-refresh read-only plan for the
+same irreducible reason: the read-only seed SA has no project roles, so
+refreshing the stack's google-provider resources would 403 (the grafana legs
+were free to flip because grafana refreshes over its own token, never touching
+GCP). Closing it needs a read identity with access to the
+`project_factory`-managed project.
 
 - **PR plan:** don't. The only way to full-refresh the PR plan is to arm the
   read-only plan SA — the SA a malicious same-repo PR can mint via a plan-time
   data source — with project read, _widening_ the PR attack surface.
-  `-refresh=false` is a _functional_ limitation (the PR plan won't surface
-  out-of-band drift), not a security gap; drift is caught daily anyway.
+  The targeted sentinel plan plus `-refresh=false` is a _functional_ limitation
+  (the PR plan won't surface full-stack diffs or out-of-band drift), not a
+  security gap; drift is caught daily and push/apply paths re-plan fully.
 - **Drift leg:** evaluated explicitly (incl. an operator offering to create the
   grant, 2026-05-29) and declined on cost/benefit. The only sound build is a
   _dedicated_ `*-drift-readonly@` SA (never PR-reachable) with a hand-scoped read

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -75,13 +75,15 @@ For secret-bearing plan workflows (`alerts-infra.yml`, `aegis-terraform.yml`,
 and `governance-watchdog.yml`), same-repo PR plans intentionally receive
 validation-safe placeholder `TF_VAR_*` values instead of production secrets.
 push/workflow_dispatch plans and environment-gated apply jobs keep the real
-secrets and are the authoritative plan before production mutation. This means
-PR plans verify Terraform shape and config diffs without exposing the GitHub
-Secrets PAT, Grafana token, notification webhooks, or vendor API keys to a PR
-that can edit the workflow or Terraform code. Some secret-backed resources may
-show placeholder drift in PR comments; reviewers should treat the main-branch
-re-plan behind `production-infra` as the source of truth for secret value
-changes.
+secrets and are the authoritative plan before production mutation. The Aegis
+and governance-watchdog PR plans verify Terraform shape and config diffs with
+placeholders. The alerts-delivery PR plan is narrower by design: it runs
+init/validate plus a targeted plan for
+`terraform_data.pr_plan_secretless_guard`, because the stack's Sentry, Slack,
+QuickNode, and GitHub resources perform authenticated plan-time checks that
+cannot run with dummy credentials. Reviewers should treat the main-branch
+re-plan behind `production-infra` as the source of truth for alerts-delivery
+full-stack diffs and all secret value changes.
 
 Routine service deploy workflows use the separate `production-services` GitHub
 Environment. That environment records deploy history and scopes production

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@ title: Terraform Stacks
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-07
 ---
 
 # Terraform Stacks
@@ -70,6 +70,18 @@ become eligible when the stack root changed or a maintainer used
 `governance-watchdog` lives in its own GCP project and also opts into scheduled
 drift detection, where CI runs a read-only plan under `org-terraform`
 impersonation without applying changes.
+
+For secret-bearing plan workflows (`alerts-infra.yml`, `aegis-terraform.yml`,
+and `governance-watchdog.yml`), same-repo PR plans intentionally receive
+validation-safe placeholder `TF_VAR_*` values instead of production secrets.
+push/workflow_dispatch plans and environment-gated apply jobs keep the real
+secrets and are the authoritative plan before production mutation. This means
+PR plans verify Terraform shape and config diffs without exposing the GitHub
+Secrets PAT, Grafana token, notification webhooks, or vendor API keys to a PR
+that can edit the workflow or Terraform code. Some secret-backed resources may
+show placeholder drift in PR comments; reviewers should treat the main-branch
+re-plan behind `production-infra` as the source of truth for secret value
+changes.
 
 Routine service deploy workflows use the separate `production-services` GitHub
 Environment. That environment records deploy history and scopes production


### PR DESCRIPTION
## The Problem

- Same-repo PR Terraform plan jobs for alert infra, Aegis, and governance-watchdog receive production `TF_VAR_*` secrets.
- A PR that changes Terraform config can use plan-time behavior to expose those values before the sanitizer sees output.

## The Solution

- Export validation-safe placeholder Terraform inputs for `pull_request` plan jobs.
- Export real production inputs only for trusted push/workflow_dispatch plans and the existing `production-infra` apply jobs.
- Keep alerts/infra PR plans secretless by targeting `terraform_data.pr_plan_secretless_guard`; its full Sentry/Slack/QuickNode/GitHub graph still re-plans on trusted push/apply.
- Keep Aegis PR plans on `-refresh=false` when using the placeholder Grafana token.

## Details

- Keeps apply-time env blocks unchanged so the environment-gated re-plan remains authoritative before production mutation.
- Uses shape-preserving placeholder values so optional Terraform branches stay enabled during PR plans where the provider graph can tolerate placeholders.
- Documents the alerts/infra targeted-plan exception and placeholder-plan policy in `docs/terraform.md`, ADR 0029, and the Terraform CI/CD hardening note.

Closes #1002

## Validation

- `pnpm tf validate alerts-delivery`
- `pnpm tf validate aegis`
- `pnpm tf validate governance-watchdog`
- `terraform -chdir=alerts/infra plan -detailed-exitcode -no-color -input=false -lock=false -refresh=false -target=terraform_data.pr_plan_secretless_guard` with PR dummy `TF_VAR_*` values and read-only backend impersonation (exit 2: sentinel add only)
- `./tools/trunk check .github/workflows/alerts-infra.yml .github/workflows/aegis-terraform.yml .github/workflows/governance-watchdog.yml alerts/infra/pr-plan-guard.tf docs/terraform.md docs/adr/0029-ci-apply-production-infra-gate.md docs/notes/terraform-cicd-hardening-decisions-2026-05.md`
- `node scripts/check-github-action-pins.mjs`
- `CI=true pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview --engine local`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security boundaries and PR plan semantics (alerts/infra no longer shows full-stack diffs on PRs); apply gating and production paths are intentionally unchanged.
> 
> **Overview**
> Same-repo PR Terraform plan jobs no longer receive production `TF_VAR_*` secrets. **Pull requests** now export validation-safe placeholders via `GITHUB_ENV`; **push**, **workflow_dispatch**, and **`production-infra` apply** jobs still load real secrets and remain the authoritative plan before any mutation.
> 
> For **alerts/infra**, PR plans narrow to a targeted plan on new `terraform_data.pr_plan_secretless_guard` (with `-refresh=false`), because the full Sentry/Slack/QuickNode/GitHub graph cannot plan with dummy creds. PR plan summaries and sticky comments now say the main-branch plan decides apply eligibility. **Aegis** PR plans use a placeholder Grafana token and `-refresh=false`. **Governance-watchdog** follows the same placeholder pattern for its secret set.
> 
> ADR 0029, `docs/terraform.md`, and the Terraform CI/CD hardening note document the placeholder policy and the alerts-delivery targeted-plan exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f93402d16fb16f35ff6431423a8f0018561312b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->