### PR TITLE
docs: use configured ElevenLabs key file

### DIFF
--- a/docs/notes/spoken-attention-nudge.md
+++ b/docs/notes/spoken-attention-nudge.md
@@ -20,12 +20,12 @@ repo-standard key file path so behavior does not depend on shell startup files
 or stripped environment variables:
 
 ```bash
-sag --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "hey, i need your approval to deploy the Alloy collector"
+sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval to deploy the Alloy collector"
 ```
 
 `sag` needs network access to ElevenLabs, a readable ElevenLabs API key, and the
 local audio device. Store the key for agent nudges in
-`$HOME/.config/sag/elevenlabs-api-key` with mode `0600`, then invoke `sag` with
+`$HOME/.config/elevenlabs_api_key` with mode `0600`, then invoke `sag` with
 `--api-key-file`. This is required for Codex because it does not reliably
 inherit shell startup files, and its environment policy strips secret-like
 variables such as `ELEVENLABS_API_KEY`, even when they exist in `.zshrc`. Claude
@@ -38,8 +38,8 @@ developer machine. Use this fallback order:
 ```bash
 msg="hey, i need your feedback on the deploy"
 sent=0
-if command -v sag >/dev/null 2>&1 && [ -r "$HOME/.config/sag/elevenlabs-api-key" ]; then
-  sag --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "$msg" && sent=1
+if command -v sag >/dev/null 2>&1 && [ -r "$HOME/.config/elevenlabs_api_key" ]; then
+  sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "$msg" && sent=1
 fi
 if [ "$sent" -eq 0 ] && command -v say >/dev/null 2>&1; then
   say "$msg" && sent=1


### PR DESCRIPTION
## The Problem

- The spoken-nudge runbook still pointed agents at an older ElevenLabs key-file path.
- Codex strips `ELEVENLABS_API_KEY`, so future nudges need the documented key-file command to match the configured machine state.

## The Solution

- Update the canonical spoken-attention nudge note to use `~/.config/elevenlabs_api_key` for `sag --api-key-file`.

## Details

- The fallback shell snippet now checks the same key file path before invoking `sag`.
- This is a docs-only workflow correction; no runtime code changes.

## Validation

- `git diff --check`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only workflow correction with no runtime or application code changes.
> 
> **Overview**
> Updates the **spoken attention nudge** runbook so agents use the configured ElevenLabs key file at `~/.config/elevenlabs_api_key` instead of `~/.config/sag/elevenlabs-api-key`.
> 
> The change applies to the canonical `sag --api-key-file` example, the documented storage location and permissions, and the fallback shell snippet’s readability check and `sag` invocation—so Codex/Claude nudges stay consistent when env vars like `ELEVENLABS_API_KEY` are stripped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4953f64df4ca8a791cc2ca93c5ce704b223b3e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->