### PR TITLE
Show freshness banner only on fetch errors

### DIFF
--- a/ui-dashboard/src/components/__tests__/data-freshness-banner.test.tsx
+++ b/ui-dashboard/src/components/__tests__/data-freshness-banner.test.tsx
@@ -47,7 +47,7 @@ function render() {
 
 describe("DataFreshnessBanner", () => {
   it("appears when an active polling key has last-good data and a failed refresh", () => {
-    cleanupFreshness = registerSWRFreshnessKey("polling-key", 30_000);
+    cleanupFreshness = registerSWRFreshnessKey("polling-key");
     recordSWRFreshnessSuccess("polling-key", { refreshInterval: 30_000 });
     render();
     expect(container.textContent).toBe("");
@@ -63,8 +63,8 @@ describe("DataFreshnessBanner", () => {
     expect(container.textContent).toContain("last-good data from 5s ago");
   });
 
-  it("appears when active polling data is older than its refresh interval", () => {
-    cleanupFreshness = registerSWRFreshnessKey("slow-key", 30_000);
+  it("stays hidden when active polling data is only older than its refresh interval", () => {
+    cleanupFreshness = registerSWRFreshnessKey("slow-key");
     recordSWRFreshnessSuccess("slow-key", { refreshInterval: 30_000 });
     render();
 
@@ -73,7 +73,6 @@ describe("DataFreshnessBanner", () => {
       vi.advanceTimersByTime(10_000);
     });
 
-    expect(container.textContent).toContain("Data may be stale");
-    expect(container.textContent).toContain("last-good data from 50s ago");
+    expect(container.textContent).toBe("");
   });
 });

--- a/ui-dashboard/src/components/__tests__/swr-provider.test.tsx
+++ b/ui-dashboard/src/components/__tests__/swr-provider.test.tsx
@@ -137,7 +137,7 @@ describe("SwrProvider freshness tracking", () => {
     expect(container.textContent).toContain("last-good data from 1s ago");
   });
 
-  it("records per-hook onSuccess refreshes when SWR data is unchanged", async () => {
+  it("keeps successful unchanged SWR data from showing an overdue-only banner", async () => {
     const onSuccess = vi.fn();
     const triggerRef: TriggerRef = { current: null };
 
@@ -154,7 +154,8 @@ describe("SwrProvider freshness tracking", () => {
       vi.advanceTimersByTime(31_000);
     });
 
-    expect(container.textContent).toContain("Data may be stale");
+    expect(container.textContent).not.toContain("Latest refresh failed");
+    expect(container.textContent).not.toContain("Data may be stale");
 
     await act(async () => {
       await triggerRef.current?.();
@@ -162,6 +163,7 @@ describe("SwrProvider freshness tracking", () => {
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("custom ready");
+    expect(container.textContent).not.toContain("Latest refresh failed");
     expect(container.textContent).not.toContain("Data may be stale");
   });
 });

--- a/ui-dashboard/src/components/data-freshness-banner.tsx
+++ b/ui-dashboard/src/components/data-freshness-banner.tsx
@@ -32,16 +32,14 @@ export function DataFreshnessBanner() {
   }, []);
 
   const currentNow = Math.max(now, Date.now());
-  const status = getSWRFreshnessStatus(currentNow);
+  const status = getSWRFreshnessStatus();
   if (status === null) return null;
 
   const age = formatAge(currentNow - status.lastUpdatedAt);
   const sourceCount =
-    status.staleCount === 1
+    status.failedCount === 1
       ? "1 data source"
-      : `${status.staleCount} data sources`;
-  const prefix =
-    status.failedCount > 0 ? "Latest refresh failed" : "Data may be stale";
+      : `${status.failedCount} data sources`;
 
   return (
     <div
@@ -50,8 +48,8 @@ export function DataFreshnessBanner() {
       className="border-b border-amber-400/20 bg-amber-950/30 px-3 py-2 text-xs text-amber-100 sm:px-6"
     >
       <div className="mx-auto max-w-7xl">
-        {prefix}. Showing last-good data from {age} ago across {sourceCount}.
-        Retrying automatically.
+        Latest refresh failed. Showing last-good data from {age} ago across{" "}
+        {sourceCount}. Retrying automatically.
         {status.lastErrorMessage ? (
           <span className="sr-only">
             {" "}

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -68,7 +68,7 @@ const freshnessMiddleware: Middleware = (useSWRNext) => {
 
     useEffect(() => {
       if (freshnessKey === null || refreshIntervalMs === null) return;
-      return registerSWRFreshnessKey(freshnessKey, refreshIntervalMs);
+      return registerSWRFreshnessKey(freshnessKey);
     }, [freshnessKey, refreshIntervalMs]);
 
     useEffect(() => {

--- a/ui-dashboard/src/lib/__tests__/swr-freshness.test.ts
+++ b/ui-dashboard/src/lib/__tests__/swr-freshness.test.ts
@@ -25,27 +25,21 @@ describe("SWR freshness status", () => {
     vi.useRealTimers();
   });
 
-  it("marks active polling data stale once it is older than its refresh interval", () => {
-    const unregister = registerSWRFreshnessKey(["celo", "query"], REFRESH_MS);
+  it("does not mark active polling data stale only because it is older than its refresh interval", () => {
+    const unregister = registerSWRFreshnessKey(["celo", "query"]);
     recordSWRFreshnessSuccess(["celo", "query"], {
       refreshInterval: REFRESH_MS,
     });
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS)).toBeNull();
-
-    const status = getSWRFreshnessStatus(NOW + REFRESH_MS + 1);
-    expect(status).toMatchObject({
-      failedCount: 0,
-      lastUpdatedAt: NOW,
-      staleCount: 1,
-    });
+    expect(getSWRFreshnessStatus()).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
 
     unregister();
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
   });
 
   it("marks last-good data stale when a later refresh fails", () => {
-    registerSWRFreshnessKey(["bridge", "query"], REFRESH_MS);
+    registerSWRFreshnessKey(["bridge", "query"]);
     recordSWRFreshnessSuccess(["bridge", "query"], {
       refreshInterval: REFRESH_MS,
     });
@@ -55,43 +49,56 @@ describe("SWR freshness status", () => {
       refreshInterval: REFRESH_MS,
     });
 
-    expect(getSWRFreshnessStatus(NOW + 5_000)).toMatchObject({
+    expect(getSWRFreshnessStatus()).toMatchObject({
       failedCount: 1,
       lastErrorMessage: "Tier quota",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
   it("preserves success metadata across inactive periods for the same key", () => {
-    const unregister = registerSWRFreshnessKey("remount-key", REFRESH_MS);
+    const unregister = registerSWRFreshnessKey("remount-key");
     recordSWRFreshnessSuccess("remount-key", {
       refreshInterval: REFRESH_MS,
     });
     unregister();
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
 
-    registerSWRFreshnessKey("remount-key", REFRESH_MS);
+    registerSWRFreshnessKey("remount-key");
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toMatchObject({
-      failedCount: 0,
+    expect(getSWRFreshnessStatus()).toBeNull();
+
+    vi.setSystemTime(NOW + REFRESH_MS + 2);
+    recordSWRFreshnessError(new Error("remount failed"), "remount-key", {
+      refreshInterval: REFRESH_MS,
+    });
+
+    expect(getSWRFreshnessStatus()).toMatchObject({
+      failedCount: 1,
+      lastErrorMessage: "remount failed",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
-  it("keeps a success recorded before registration and activates it on subscribe", () => {
+  it("keeps a success recorded before registration and uses it for later failures", () => {
     recordSWRFreshnessSuccess("fast-key", { refreshInterval: REFRESH_MS });
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
 
-    registerSWRFreshnessKey("fast-key", REFRESH_MS);
+    registerSWRFreshnessKey("fast-key");
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toMatchObject({
-      failedCount: 0,
+    expect(getSWRFreshnessStatus()).toBeNull();
+
+    vi.setSystemTime(NOW + REFRESH_MS + 2);
+    recordSWRFreshnessError(new Error("fast key failed"), "fast-key", {
+      refreshInterval: REFRESH_MS,
+    });
+
+    expect(getSWRFreshnessStatus()).toMatchObject({
+      failedCount: 1,
+      lastErrorMessage: "fast key failed",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
@@ -99,7 +106,7 @@ describe("SWR freshness status", () => {
     const swrKey = ["celo", "query", { chainId: 42220 }];
     const serializedKey = unstable_serialize(swrKey);
 
-    registerSWRFreshnessKey(swrKey, REFRESH_MS);
+    registerSWRFreshnessKey(swrKey);
     recordSWRFreshnessSuccess(serializedKey, {
       refreshInterval: REFRESH_MS,
     });
@@ -109,11 +116,10 @@ describe("SWR freshness status", () => {
       refreshInterval: REFRESH_MS,
     });
 
-    expect(getSWRFreshnessStatus(NOW + 5_000)).toMatchObject({
+    expect(getSWRFreshnessStatus()).toMatchObject({
       failedCount: 1,
       lastErrorMessage: "poll failed",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
@@ -125,26 +131,25 @@ describe("SWR freshness status", () => {
     recordSWRFreshnessSuccess("one-shot");
     recordSWRFreshnessError("not active", "one-shot-error");
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
   });
 
   it("records refresh failures for active keys without a refresh interval", () => {
-    registerSWRFreshnessKey("manual-key", null);
+    registerSWRFreshnessKey("manual-key");
     recordSWRFreshnessSuccess("manual-key");
 
     vi.setSystemTime(NOW + 1_000);
     recordSWRFreshnessError("not an Error instance", "manual-key");
 
-    expect(getSWRFreshnessStatus(NOW + 1_000)).toMatchObject({
+    expect(getSWRFreshnessStatus()).toMatchObject({
       failedCount: 1,
       lastErrorMessage: "Unknown refresh error",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
   it("seeds fallback data without clearing later refresh failures", () => {
-    registerSWRFreshnessKey("seeded-key", REFRESH_MS);
+    registerSWRFreshnessKey("seeded-key");
     seedSWRFreshnessData("seeded-key", { refreshInterval: REFRESH_MS });
 
     vi.setSystemTime(NOW + 1_000);
@@ -153,37 +158,41 @@ describe("SWR freshness status", () => {
     });
     seedSWRFreshnessData("seeded-key", { refreshInterval: REFRESH_MS });
 
-    expect(getSWRFreshnessStatus(NOW + 1_000)).toMatchObject({
+    expect(getSWRFreshnessStatus()).toMatchObject({
       failedCount: 1,
       lastErrorMessage: "refresh failed",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
   });
 
   it("keeps duplicate registrations active until the final unregister", () => {
-    const unregisterFirst = registerSWRFreshnessKey("shared-key", REFRESH_MS);
-    const unregisterSecond = registerSWRFreshnessKey("shared-key", null);
+    const unregisterFirst = registerSWRFreshnessKey("shared-key");
+    const unregisterSecond = registerSWRFreshnessKey("shared-key");
     recordSWRFreshnessSuccess("shared-key", { refreshInterval: REFRESH_MS });
+
+    vi.setSystemTime(NOW + 1_000);
+    recordSWRFreshnessError(new Error("shared failed"), "shared-key", {
+      refreshInterval: REFRESH_MS,
+    });
 
     unregisterFirst();
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toMatchObject({
-      failedCount: 0,
+    expect(getSWRFreshnessStatus()).toMatchObject({
+      failedCount: 1,
+      lastErrorMessage: "shared failed",
       lastUpdatedAt: NOW,
-      staleCount: 1,
     });
 
     unregisterSecond();
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
   });
 
   it("cleans empty registrations and tolerates repeated unregister calls", () => {
-    const unregister = registerSWRFreshnessKey("empty-key", REFRESH_MS);
+    const unregister = registerSWRFreshnessKey("empty-key");
 
     unregister();
     unregister();
 
-    expect(getSWRFreshnessStatus(NOW + REFRESH_MS + 1)).toBeNull();
+    expect(getSWRFreshnessStatus()).toBeNull();
   });
 });

--- a/ui-dashboard/src/lib/swr-freshness.ts
+++ b/ui-dashboard/src/lib/swr-freshness.ts
@@ -6,14 +6,12 @@ type SwrFreshnessEntry = {
   lastErrorAt: number | null;
   lastErrorMessage: string | null;
   lastSuccessAt: number | null;
-  refreshIntervalMs: number | null;
 };
 
 export type SwrFreshnessStatus = {
   failedCount: number;
   lastErrorMessage: string | null;
   lastUpdatedAt: number;
-  staleCount: number;
 };
 
 type Listener = () => void;
@@ -39,35 +37,23 @@ function emit() {
   for (const listener of listeners) listener();
 }
 
-function upsertEntry(
-  normalizedKey: string,
-  refreshIntervalMs: number | null,
-): SwrFreshnessEntry {
+function upsertEntry(normalizedKey: string): SwrFreshnessEntry {
   const existing = entries.get(normalizedKey);
-  if (existing) {
-    if (refreshIntervalMs !== null) {
-      existing.refreshIntervalMs = refreshIntervalMs;
-    }
-    return existing;
-  }
+  if (existing) return existing;
   const next: SwrFreshnessEntry = {
     activeCount: 0,
     key: normalizedKey,
     lastErrorAt: null,
     lastErrorMessage: null,
     lastSuccessAt: null,
-    refreshIntervalMs,
   };
   entries.set(normalizedKey, next);
   return next;
 }
 
-export function registerSWRFreshnessKey(
-  key: unknown,
-  refreshIntervalMs: number | null,
-): () => void {
+export function registerSWRFreshnessKey(key: unknown): () => void {
   const normalizedKey = normalizeSWRFreshnessKey(key);
-  const entry = upsertEntry(normalizedKey, refreshIntervalMs);
+  const entry = upsertEntry(normalizedKey);
   entry.activeCount += 1;
   emit();
   return () => {
@@ -92,11 +78,8 @@ export function recordSWRFreshnessSuccess(
   const refreshIntervalMs = readRefreshIntervalMs(config);
   const entry =
     entries.get(normalizedKey) ??
-    (refreshIntervalMs !== null
-      ? upsertEntry(normalizedKey, refreshIntervalMs)
-      : null);
+    (refreshIntervalMs !== null ? upsertEntry(normalizedKey) : null);
   if (!entry) return;
-  if (refreshIntervalMs !== null) entry.refreshIntervalMs = refreshIntervalMs;
   entry.lastSuccessAt = Date.now();
   entry.lastErrorAt = null;
   entry.lastErrorMessage = null;
@@ -111,12 +94,9 @@ export function seedSWRFreshnessData(
   const refreshIntervalMs = readRefreshIntervalMs(config);
   const entry =
     entries.get(normalizedKey) ??
-    (refreshIntervalMs !== null
-      ? upsertEntry(normalizedKey, refreshIntervalMs)
-      : null);
+    (refreshIntervalMs !== null ? upsertEntry(normalizedKey) : null);
   if (!entry) return;
   if (entry.lastSuccessAt !== null || entry.lastErrorAt !== null) return;
-  if (refreshIntervalMs !== null) entry.refreshIntervalMs = refreshIntervalMs;
   entry.lastSuccessAt = Date.now();
   emit();
 }
@@ -130,11 +110,8 @@ export function recordSWRFreshnessError(
   const refreshIntervalMs = readRefreshIntervalMs(config);
   const entry =
     entries.get(normalizedKey) ??
-    (refreshIntervalMs !== null
-      ? upsertEntry(normalizedKey, refreshIntervalMs)
-      : null);
+    (refreshIntervalMs !== null ? upsertEntry(normalizedKey) : null);
   if (!entry) return;
-  if (refreshIntervalMs !== null) entry.refreshIntervalMs = refreshIntervalMs;
   entry.lastErrorAt = Date.now();
   entry.lastErrorMessage =
     error instanceof Error ? error.message : "Unknown refresh error";
@@ -150,32 +127,23 @@ export function getSWRFreshnessVersion(): number {
   return snapshotVersion;
 }
 
-export function getSWRFreshnessStatus(
-  now = Date.now(),
-): SwrFreshnessStatus | null {
+export function getSWRFreshnessStatus(): SwrFreshnessStatus | null {
   let failedCount = 0;
   let lastErrorMessage: string | null = null;
   let lastUpdatedAt = Number.POSITIVE_INFINITY;
-  let staleCount = 0;
 
   for (const entry of entries.values()) {
     if (entry.activeCount <= 0 || entry.lastSuccessAt === null) continue;
     const failedAfterSuccess =
       entry.lastErrorAt !== null && entry.lastErrorAt > entry.lastSuccessAt;
-    const olderThanRefresh =
-      entry.refreshIntervalMs !== null &&
-      now - entry.lastSuccessAt > entry.refreshIntervalMs;
-    if (!failedAfterSuccess && !olderThanRefresh) continue;
-    staleCount += 1;
-    if (failedAfterSuccess) {
-      failedCount += 1;
-      lastErrorMessage = entry.lastErrorMessage;
-    }
+    if (!failedAfterSuccess) continue;
+    failedCount += 1;
+    lastErrorMessage = entry.lastErrorMessage;
     lastUpdatedAt = Math.min(lastUpdatedAt, entry.lastSuccessAt);
   }
 
-  if (staleCount === 0 || !Number.isFinite(lastUpdatedAt)) return null;
-  return { failedCount, lastErrorMessage, lastUpdatedAt, staleCount };
+  if (failedCount === 0 || !Number.isFinite(lastUpdatedAt)) return null;
+  return { failedCount, lastErrorMessage, lastUpdatedAt };
 }
 
 export function resetSWRFreshnessForTests(): void {


### PR DESCRIPTION
## The Problem

- The global dashboard freshness banner appears when polling data is merely older than its refresh interval.
- That makes backgrounded tabs and delayed polling look like user-facing data incidents even when no fetch failed.

## The Solution

- Show the global freshness banner only after an active tracked SWR source has last-good data and a later refresh error.
- Keep the last-good-data fallback copy for real failures, but remove the overdue-only `Data may be stale` state.

## Details

- Simplifies the SWR freshness store to track failed-after-success sources instead of refresh-interval age.
- Keeps freshness tracking scoped to interval-polling SWR keys through the provider.
- Updates banner/provider/store tests to cover the retained fetch-error path and the removed overdue-only path.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/swr-freshness.test.ts src/components/__tests__/data-freshness-banner.test.tsx src/components/__tests__/swr-provider.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `git diff --check`
- Browser verification at `http://127.0.0.1:3210/`: no freshness banner on successful load, no console errors, live GraphQL requests returned 200.
- `pnpm agent:quality-gate --run`
- `bash scripts/agent-autoreview.sh --engine local`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to banner visibility and freshness heuristics; real fetch-failure messaging is preserved and covered by tests.
> 
> **Overview**
> The global **Data freshness** banner no longer appears when polling data is simply past its refresh interval (e.g. backgrounded tabs or slow timers). It now shows only when an actively tracked SWR source has **last-good data** and a **later refresh failed**.
> 
> The freshness store drops refresh-interval age and `staleCount`; `getSWRFreshnessStatus()` reports sources with `failedAfterSuccess` only. `registerSWRFreshnessKey` no longer takes a refresh interval. Banner copy is always **Latest refresh failed** with last-good age—**Data may be stale** is removed. Provider and unit/integration tests cover the error path and the removed overdue-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65d031e8e84b1646af3c29c262d0241f9a27b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->