### PR TITLE
Document freshness banner polling invariant

### DIFF
--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -50,6 +50,7 @@ Hasura silently caps every query at **1000 rows** (Envio hosted Hasura config). 
 - [ ] Test the error state (mock SWR with `error: new Error(...)`)
 - [ ] Test the populated state with both empty array and >0 entries
 - [ ] If the hook sets `revalidateOnFocus: false`, write a regression test that asserts the option is set — otherwise it gets removed in a future refactor
+- [ ] If the hook feeds a global freshness/degraded-data banner, test that the banner is driven by an observed fetch error after last-good data — not just elapsed data age or refresh-interval drift
 
 ## 6. Per-consumer error-channel isolation
 


### PR DESCRIPTION
## The Problem

- The SWR polling checklist covered hook error states but did not make the global freshness-banner invariant explicit.
- Without that reminder, a future polling change could reintroduce a banner driven by elapsed refresh time instead of a real failed fetch.

## The Solution

- Add a focused checklist item requiring tests for freshness/degraded-data banners to prove they are driven by observed fetch errors after last-good data.

## Details

- Docs-only follow-up from the freshness-banner fix in PR #1179.
- The new gate lives with the existing SWR polling test expectations.

## Validation

- `git diff --check`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:review-materiality`
- `CI=true pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a PR checklist; no runtime, auth, or data-path code is modified.
> 
> **Overview**
> **Docs-only follow-up** to the freshness-banner fix in PR #1179: the SWR + Hasura polling checklist now calls out a test invariant that was missing from section **5. Tests**.
> 
> When a polling hook feeds a **global freshness / degraded-data banner**, tests must show the banner turns on from an **observed fetch error while last-good data is still shown**—not from elapsed data age or refresh-interval drift alone. That keeps future polling work from reintroducing time-based “stale” banners without a real failed request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cfa57aad13419b9d5bad75b1de9f0c5b4033d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->