### PR TITLE
fix: quiet expected rate feed dependency probes

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -91,7 +91,7 @@ pnpm deploy:indexer:logs --build              # build logs (useful when a deploy
 pnpm deploy:indexer:logs --follow             # tail (polls every 10s)
 ```
 
-`--limit` is clamped to 50 by the wrapper script (`scripts/deploy-indexer-logs.sh`); higher values are silently lowered. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
+`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the wrapper passes that flag through unchanged. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
 
 ## envio-cloud CLI cheat sheet
 

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -91,7 +91,7 @@ pnpm deploy:indexer:logs --build              # build logs (useful when a deploy
 pnpm deploy:indexer:logs --follow             # tail (polls every 10s)
 ```
 
-`--limit` is clamped to 50 by the wrapper script (`scripts/deploy-indexer-logs.sh`); higher values are silently lowered. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
+`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the wrapper passes that flag through unchanged. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
 
 ## envio-cloud CLI cheat sheet
 

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -652,7 +652,9 @@ function parseRateFeedBreakerStatus(raw: unknown): {
 // readContractWithBlockFallback cross-checks the terminating read on the
 // secondary node; if no fallback is set, a single-call blip surviving the
 // control read could truncate — self-healed by the next RateFeedDependenciesSet
-// or a process restart, and verified post-deploy against the known edges.
+// or a process restart, and verified post-deploy against the known edges. The
+// expected terminator probe logs archive-fallback failures at debug because
+// this caller immediately disambiguates them with the control read below.
 //
 // (Defined at file end so insertions don't shift the line-keyed ESLint baseline
 // entries for fetchBreakerDefaults / fetchBreakerFeedState above.)
@@ -696,6 +698,28 @@ type DepRead =
   | { kind: "addr"; addr: string }
   | { kind: "empty" }
   | { kind: "transient" };
+
+const ARCHIVE_FALLBACK_FAILED_MARKER = "[RPC_ARCHIVE_FALLBACK_FAILED]";
+
+/** @internal Exposed for a focused regression test. */
+export function _withRateFeedDependencyProbeLogger(log: RpcLogger): RpcLogger {
+  return {
+    debug: (...args: Parameters<RpcLogger["debug"]>) => log.debug(...args),
+    info: (...args: Parameters<RpcLogger["info"]>) => log.info(...args),
+    warn: (...args: Parameters<RpcLogger["warn"]>) => {
+      const [first] = args;
+      if (
+        typeof first === "string" &&
+        first.includes(ARCHIVE_FALLBACK_FAILED_MARKER)
+      ) {
+        log.debug(...(args as Parameters<RpcLogger["debug"]>));
+        return;
+      }
+      log.warn(...args);
+    },
+    error: (...args: Parameters<RpcLogger["error"]>) => log.error(...args),
+  };
+}
 
 /** True when `getRateFeeds()` returns at the requested block — proves the node
  * is responsive, so a sibling getter failure is a genuine contract revert
@@ -743,7 +767,7 @@ async function readDepAtIndex(
       },
       ctx.blockNumber,
       ctx.fallback,
-      ctx.log,
+      _withRateFeedDependencyProbeLogger(ctx.log),
     );
     if (usedLatestFallback) return { kind: "transient" };
     return { kind: "addr", addr: (result as string).toLowerCase() };

--- a/indexer-envio/test/breakers.test.ts
+++ b/indexer-envio/test/breakers.test.ts
@@ -17,6 +17,7 @@ import {
   _testHooks,
   fetchBreakerKind,
 } from "../src/rpc.ts";
+import { _withRateFeedDependencyProbeLogger } from "../src/rpc/breakers.ts";
 
 const FIXED_1 = 10n ** 24n;
 const noopLogger = {
@@ -25,6 +26,27 @@ const noopLogger = {
   warn: () => undefined,
   error: () => undefined,
 };
+
+describe("rateFeedDependencies probe logger", () => {
+  it("demotes expected archive-fallback failures without hiding other warnings", () => {
+    const debug: string[] = [];
+    const warn: string[] = [];
+    const logger = _withRateFeedDependencyProbeLogger({
+      debug: (msg: string) => debug.push(msg),
+      info: () => undefined,
+      warn: (msg: string) => warn.push(msg),
+      error: () => undefined,
+    });
+
+    logger.warn("[RPC_ARCHIVE_FALLBACK_FAILED] fn=rateFeedDependencies");
+    logger.warn("[RPC_BLOCK_RETRY] fn=rateFeedDependencies");
+
+    assert.deepEqual(debug, [
+      "[RPC_ARCHIVE_FALLBACK_FAILED] fn=rateFeedDependencies",
+    ]);
+    assert.deepEqual(warn, ["[RPC_BLOCK_RETRY] fn=rateFeedDependencies"]);
+  });
+});
 
 describe("nextMedianEMA — Fixidity formula mirroring MedianDeltaBreaker.shouldTrigger", () => {
   it("seeds EMA with currentMedian when previousEMA is 0 (contract line 182-186)", () => {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@lhci/cli": "^0.15.1",
     "@prometheus-io/lezer-promql": "0.311.3",
     "dependency-cruiser": "17.4.0",
-    "envio-cloud": "0.9.2",
+    "envio-cloud": "0.9.3",
     "eslint": "^10.0.2",
     "globals": "^17.4.0",
     "graphql": "16.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 17.4.0
         version: 17.4.0
       envio-cloud:
-        specifier: 0.9.2
-        version: 0.9.2
+        specifier: 0.9.3
+        version: 0.9.3
       eslint:
         specifier: ^10.0.2
         version: 10.0.3(jiti@2.7.0)(supports-color@5.5.0)
@@ -1152,28 +1152,28 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@envio-dev/envio-cloud-darwin-arm64@0.9.2':
-    resolution: {integrity: sha512-uIMZOi4lPAGL3kxldIp6dkmHXwhBGiijBPglFZ2m3pcRx60zQZdRQUBwEuAmi5eesW5Ldv98olXsTHc44LTRZw==}
+  '@envio-dev/envio-cloud-darwin-arm64@0.9.3':
+    resolution: {integrity: sha512-+7ESE2TGPnBmqJ6PILc89sQsbBNtJ2nN7YHN53QoYc3mYOD9zB9RiXE0CgP4X5bSjCmYLKc3e6W/Cue5+qwccA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/envio-cloud-darwin-x64@0.9.2':
-    resolution: {integrity: sha512-w+OVPrKWeM6u/f6szpJ+QsZkgy/vsm/6/r72m110uVBiEG+Wmj0kuhTVYlspGAoiNTK3pmd8eYs2ZrtIXwAX3g==}
+  '@envio-dev/envio-cloud-darwin-x64@0.9.3':
+    resolution: {integrity: sha512-CyXBcFuomcxoGyqMMAoF5bGVz2TO6f2aQVreJeXvNwidTctosi39omfWsB0TNUUR5QaRvsUcKcsnzvS/VGZiog==}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/envio-cloud-linux-arm64@0.9.2':
-    resolution: {integrity: sha512-+z9N0apw9TESEpVb9YpCiNahPV/TQdp8XodA9X6PGjOaljkIHEt69x+Tmnt/ZOnuS1OzySWm8A3EgidP+zA5Yg==}
+  '@envio-dev/envio-cloud-linux-arm64@0.9.3':
+    resolution: {integrity: sha512-DsMM+IVXWqNpi0HwJ0hQ3O0si/xoUqlxgbrerEediuJ+hktXzH2EuRdSutxd7MNU2b//ds7bLjHIfSoGEVfRGQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/envio-cloud-linux-x64@0.9.2':
-    resolution: {integrity: sha512-8aRDtzH++a0m4uXYnMvvhiHJ1xk9kNvInLjWH4yMj74FhvCKPwQDYNVlJc/19ZKmYUtuGTxQfRmVAwi73dIWkg==}
+  '@envio-dev/envio-cloud-linux-x64@0.9.3':
+    resolution: {integrity: sha512-8bu7Eaq6Im7AvT+9RAeNCypFFS/vHM7nUBWR3u+ZsOb+HbTOXP0xQDBMA9wY94sw7emgkFm9aPc/eqmsvQ0pgQ==}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/envio-cloud-win32-x64@0.9.2':
-    resolution: {integrity: sha512-5MLYUpFoOCdPk25HtFh6HQeUeIHraJ3MMPwYInnZ4gLhdMLjq+QBWnoGDVFlWO7DnXeQAZgd1miqmn7kvRAmVw==}
+  '@envio-dev/envio-cloud-win32-x64@0.9.3':
+    resolution: {integrity: sha512-vk7S4deFHuTCk6N7QZSo6GRIpcT3H7/Lik178ZOnKvfjBocJHo0DREA55v0PhjBqbDejWyc88AykEBiuIMJ2IQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5294,8 +5294,8 @@ packages:
   env-schema@7.0.0:
     resolution: {integrity: sha512-b8rdAwdFpekDxNAUNuT6KbV/QEX/pTBs0gjehEPmBUUteh9zBDm9zxFSQt55D29odo3rJt4feoWRqn4U/tzicw==}
 
-  envio-cloud@0.9.2:
-    resolution: {integrity: sha512-76PqmmuKo4pJRbKtX+0iBOQFqTpaMGicJPpDqFU7MuvY0IFrbQXgKnAh5achKGcd4tebymgKSt06r06qCZkvlA==}
+  envio-cloud@0.9.3:
+    resolution: {integrity: sha512-UPAOXU5dKj0BCFA6/bsgFEUPl5AeUlbz/0bwIIaBDiH9t8B7GvyX/RDtpdABJrrAM2GSmDEFDIpeatYLb+3K5g==}
     hasBin: true
 
   envio-darwin-arm64@3.0.0:
@@ -10061,19 +10061,19 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@envio-dev/envio-cloud-darwin-arm64@0.9.2':
+  '@envio-dev/envio-cloud-darwin-arm64@0.9.3':
     optional: true
 
-  '@envio-dev/envio-cloud-darwin-x64@0.9.2':
+  '@envio-dev/envio-cloud-darwin-x64@0.9.3':
     optional: true
 
-  '@envio-dev/envio-cloud-linux-arm64@0.9.2':
+  '@envio-dev/envio-cloud-linux-arm64@0.9.3':
     optional: true
 
-  '@envio-dev/envio-cloud-linux-x64@0.9.2':
+  '@envio-dev/envio-cloud-linux-x64@0.9.3':
     optional: true
 
-  '@envio-dev/envio-cloud-win32-x64@0.9.2':
+  '@envio-dev/envio-cloud-win32-x64@0.9.3':
     optional: true
 
   '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
@@ -14239,13 +14239,13 @@ snapshots:
     dependencies:
       ajv: 8.18.0
 
-  envio-cloud@0.9.2:
+  envio-cloud@0.9.3:
     optionalDependencies:
-      '@envio-dev/envio-cloud-darwin-arm64': 0.9.2
-      '@envio-dev/envio-cloud-darwin-x64': 0.9.2
-      '@envio-dev/envio-cloud-linux-arm64': 0.9.2
-      '@envio-dev/envio-cloud-linux-x64': 0.9.2
-      '@envio-dev/envio-cloud-win32-x64': 0.9.2
+      '@envio-dev/envio-cloud-darwin-arm64': 0.9.3
+      '@envio-dev/envio-cloud-darwin-x64': 0.9.3
+      '@envio-dev/envio-cloud-linux-arm64': 0.9.3
+      '@envio-dev/envio-cloud-linux-x64': 0.9.3
+      '@envio-dev/envio-cloud-win32-x64': 0.9.3
 
   envio-darwin-arm64@3.0.0:
     optional: true

--- a/scripts/deploy-indexer-logs.sh
+++ b/scripts/deploy-indexer-logs.sh
@@ -49,30 +49,6 @@ while [[ $# -gt 0 ]]; do
       ARGS+=("$1")
       shift
       ;;
-    --limit)
-      if [[ "${2:-}" =~ ^[0-9]+$ && "$2" -gt 50 ]]; then
-        echo "⚠️  envio-cloud deployment logs caps --limit at 50; using 50 instead of $2" >&2
-        ARGS+=(--limit 50)
-        shift 2
-      else
-        ARGS+=("$1")
-        shift
-        if [[ $# -gt 0 ]]; then
-          ARGS+=("$1")
-          shift
-        fi
-      fi
-      ;;
-    --limit=*)
-      limit="${1#--limit=}"
-      if [[ "$limit" =~ ^[0-9]+$ && "$limit" -gt 50 ]]; then
-        echo "⚠️  envio-cloud deployment logs caps --limit at 50; using 50 instead of $limit" >&2
-        ARGS+=(--limit=50)
-      else
-        ARGS+=("$1")
-      fi
-      shift
-      ;;
     *)
       ARGS+=("$1")
       shift


### PR DESCRIPTION
## The Problem

- `envio-cloud@0.9.2` could not fetch hosted deployment logs reliably enough to inspect current indexer runtime issues.
- The Celo breaker dependency walker emitted warning-level archive-fallback failures for expected `rateFeedDependencies(feed, i)` out-of-bounds terminator reads.

## The Solution

- Upgrade the workspace `envio-cloud` CLI to `0.9.3`, which restores hosted runtime/build log retrieval.
- Keep the breaker dependency walker fail-closed, but demote only the expected archive-fallback failure line from the terminator probe to debug while preserving other warnings.

## Details

- Adds a scoped logger wrapper for `rateFeedDependencies` slot probes only.
- Leaves the control `getRateFeeds()` read and all other RPC fallback warnings unchanged.
- Adds regression coverage that the scoped wrapper demotes `[RPC_ARCHIVE_FALLBACK_FAILED]` without hiding unrelated warning lines.

## Validation

- `pnpm agent:quality-gate --run` — passed
- pre-push `pnpm agent:quality-gate --run` hook — passed
- `CI=true pnpm agent:autoreview` — passed, no accepted/actionable findings
- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/breakers.test.ts` — passed
- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/rateFeedDependencies.test.ts` — passed
- `pnpm exec envio-cloud --version` — `envio-cloud 0.9.3`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and logging tweaks plus a dev CLI bump; breaker RPC semantics and fail-closed behavior are unchanged.
> 
> **Overview**
> Bumps **`envio-cloud` to 0.9.3** and stops capping **`pnpm deploy:indexer:logs --limit`** at 50 in the deploy wrapper so limits pass through to the CLI (default 100, max 100). Envio skill docs are updated to match.
> 
> For **`rateFeedDependencies`** terminator slot probes in **`breakers.ts`**, adds a scoped logger that rewrites **`[RPC_ARCHIVE_FALLBACK_FAILED]`** warnings to **debug** while leaving other RPC warnings (e.g. **`[RPC_BLOCK_RETRY]`**) at warn. The fail-closed control-read disambiguation is unchanged; only log noise for expected out-of-bounds reads is reduced. A focused unit test covers the wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0760533df882d00730d01a46ca5d5d4901a93f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->