### PR TITLE
fix: refine dashboard chart a11y summaries

### DIFF
--- a/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
@@ -103,4 +103,22 @@ describe("IntelWealthChart accessibility", () => {
       "Wealth trajectory chart with 2 portfolio snapshots. It starts at 180d ago $100.00 and ends at Now $250.00.",
     );
   });
+
+  it("uses singular copy for a one-snapshot wealth plot", () => {
+    mockSwrData = {
+      ...makeRecord(),
+      portfolio: {
+        "0d_ago": {
+          ts: 1_765_000_000,
+          data: { tokens: [{ symbol: "CELO", usd: 250 }] },
+        },
+      },
+    };
+
+    render();
+
+    expect(container?.querySelector(".sr-only")?.textContent).toBe(
+      "Wealth trajectory chart with 1 portfolio snapshot. Snapshot: Now $250.00.",
+    );
+  });
 });

--- a/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IntelWealthRecord } from "@/lib/intel-wealth";
+
+let mockSwrData: IntelWealthRecord | null = null;
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
+}));
+
+vi.mock("swr", () => ({
+  default: () => ({ data: mockSwrData }),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot({
+      ariaLabel,
+      textAlternative,
+    }: {
+      ariaLabel: string;
+      textAlternative: string;
+    }) {
+      return (
+        <div data-testid="plot" aria-label={ariaLabel}>
+          {textAlternative}
+        </div>
+      );
+    },
+}));
+
+import { IntelWealthChart } from "@/app/address-book/[address]/_components/intel-wealth-chart";
+
+const ADDRESS = "0x" + "a".repeat(40);
+
+function makeRecord(): IntelWealthRecord {
+  return {
+    address: ADDRESS,
+    fetchedAt: "2026-07-01T12:00:00.000Z",
+    sources: ["arkham"],
+    balances: {
+      addresses: {},
+      totalBalance: { ethereum: 250 },
+      totalBalance24hAgo: { ethereum: 200 },
+      balances: {},
+    },
+    portfolio: {
+      "180d_ago": {
+        ts: 1_750_000_000,
+        data: { tokens: [{ symbol: "CELO", usd: 100 }] },
+      },
+      "0d_ago": {
+        ts: 1_765_000_000,
+        data: { tokens: [{ symbol: "CELO", usd: 250 }] },
+      },
+    },
+    version: 1,
+  };
+}
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+
+function render() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<IntelWealthChart address={ADDRESS} />);
+  });
+}
+
+beforeEach(() => {
+  mockSwrData = makeRecord();
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  root = null;
+  container?.remove();
+  container = null;
+  mockSwrData = null;
+});
+
+describe("IntelWealthChart accessibility", () => {
+  it("wraps the wealth plot in a named figure with an sr-only text alternative", () => {
+    render();
+
+    const figure = container?.querySelector('[role="figure"]');
+    expect(figure?.getAttribute("aria-label")).toBe("Wealth trajectory chart");
+    expect(container?.querySelector(".sr-only")?.textContent).toBe(
+      "Wealth trajectory chart with 2 portfolio snapshots. It starts at 180d ago $100.00 and ends at Now $250.00.",
+    );
+  });
+});

--- a/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
@@ -148,13 +148,15 @@ function sparkTrace(points: ChartPoint[]) {
 function wealthChartTextAlternative(points: readonly ChartPoint[]) {
   const firstPoint = points[0];
   const lastPoint = points[points.length - 1];
-  return `Wealth trajectory chart with ${points.length} portfolio snapshots.${
-    firstPoint && lastPoint
-      ? ` It starts at ${firstPoint.label} ${formatUSD(
-          firstPoint.usd,
-        )} and ends at ${lastPoint.label} ${formatUSD(lastPoint.usd)}.`
-      : ""
-  }`;
+  const snapshotNoun =
+    points.length === 1 ? "portfolio snapshot" : "portfolio snapshots";
+  if (!firstPoint) {
+    return `Wealth trajectory chart with ${points.length} ${snapshotNoun}.`;
+  }
+  if (!lastPoint || firstPoint === lastPoint) {
+    return `Wealth trajectory chart with ${points.length} ${snapshotNoun}. Snapshot: ${firstPoint.label} ${formatUSD(firstPoint.usd)}.`;
+  }
+  return `Wealth trajectory chart with ${points.length} ${snapshotNoun}. It starts at ${firstPoint.label} ${formatUSD(firstPoint.usd)} and ends at ${lastPoint.label} ${formatUSD(lastPoint.usd)}.`;
 }
 
 export function IntelWealthChart({ address }: { address: string }) {

--- a/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
@@ -145,6 +145,18 @@ function sparkTrace(points: ChartPoint[]) {
   };
 }
 
+function wealthChartTextAlternative(points: readonly ChartPoint[]) {
+  const firstPoint = points[0];
+  const lastPoint = points[points.length - 1];
+  return `Wealth trajectory chart with ${points.length} portfolio snapshots.${
+    firstPoint && lastPoint
+      ? ` It starts at ${firstPoint.label} ${formatUSD(
+          firstPoint.usd,
+        )} and ends at ${lastPoint.label} ${formatUSD(lastPoint.usd)}.`
+      : ""
+  }`;
+}
+
 export function IntelWealthChart({ address }: { address: string }) {
   const { status } = useSession();
   const { data } = useSWR<IntelWealthRecord | null>(
@@ -169,8 +181,7 @@ export function IntelWealthChart({ address }: { address: string }) {
   );
   if (points.length === 0) return null;
   const summaryText = buildSummaryText(data);
-  const firstPoint = points[0];
-  const lastPoint = points[points.length - 1];
+  const chartTextAlternative = wealthChartTextAlternative(points);
 
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900">
@@ -185,15 +196,18 @@ export function IntelWealthChart({ address }: { address: string }) {
         )}
       </div>
       <div className="p-5">
-        <Plot
-          ariaLabel="Wealth trajectory chart"
-          textAlternative={`Wealth trajectory chart with ${points.length} portfolio snapshots.${firstPoint && lastPoint ? ` It starts at ${firstPoint.label} ${formatUSD(firstPoint.usd)} and ends at ${lastPoint.label} ${formatUSD(lastPoint.usd)}.` : ""}`}
-          data={[sparkTrace(points)]}
-          layout={SPARK_LAYOUT}
-          config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
-          style={{ width: "100%", height: 160 }}
-          useResizeHandler
-        />
+        <div role="figure" aria-label="Wealth trajectory chart">
+          <Plot
+            ariaLabel="Wealth trajectory chart"
+            textAlternative={chartTextAlternative}
+            data={[sparkTrace(points)]}
+            layout={SPARK_LAYOUT}
+            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            style={{ width: "100%", height: 160 }}
+            useResizeHandler
+          />
+        </div>
+        <p className="sr-only">{chartTextAlternative}</p>
         {summaryText && (
           <p className="mt-2 text-xs text-slate-400">{summaryText}</p>
         )}

--- a/ui-dashboard/src/components/__tests__/breach-history-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breach-history-chart.test.tsx
@@ -75,4 +75,27 @@ describe("BreachHistoryChart", () => {
     expect(customdata?.[0]).toBe("1h 15m");
     expect(customdata?.[1]).toBe("15m");
   });
+
+  it("summarizes long-but-non-critical closed breaches as non-critical, not within grace", () => {
+    const html = renderToStaticMarkup(
+      <BreachHistoryChart
+        breaches={[
+          {
+            ...BASE_BREACH,
+            id: "closed-low-severity",
+            endedAt: "1704490201",
+            endedAtBlock: "2",
+            durationSeconds: "3601",
+            criticalDurationSeconds: "0",
+            peakPriceDifference: "10400",
+            endedByEvent: "rebalance",
+            endedByTxHash: "0xend",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("1 non-critical closed");
+    expect(html).not.toContain("1 within grace");
+  });
 });

--- a/ui-dashboard/src/components/__tests__/breach-history-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breach-history-chart.test.tsx
@@ -95,7 +95,7 @@ describe("BreachHistoryChart", () => {
       />,
     );
 
-    expect(html).toContain("1 non-critical closed");
+    expect(html).toContain("1 non-critical closed in the Within grace series");
     expect(html).not.toContain("1 within grace");
   });
 });

--- a/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildRevenueChartFigure,
   revenueChartEmptyMessage,
+  revenueChartSummary,
   revenueWeekOverWeekChangePct,
 } from "@/components/fee-over-time-chart";
 import type { CanonicalRevenueDailyPoint } from "@/lib/canonical-revenue";
@@ -55,6 +56,38 @@ describe("revenueChartEmptyMessage", () => {
   it("uses partial-data copy when input failures explain the empty chart", () => {
     expect(revenueChartEmptyMessage(["Swap fee history failed to load."])).toBe(
       "Revenue history is partial because some inputs failed to load",
+    );
+  });
+});
+
+describe("revenueChartSummary", () => {
+  it("includes the partial-data caveat for non-empty chart summaries", () => {
+    expect(
+      revenueChartSummary({
+        isLoading: false,
+        hasAnyRevenue: true,
+        partialReasons: ["Reserve yield failed to load."],
+        activeRangeLabel: "30D",
+        headline: "≈ $123.45",
+        change: null,
+      }),
+    ).toBe(
+      "Total revenue over the 30D range: ≈ $123.45. Revenue data is partial because some inputs failed to load.",
+    );
+  });
+
+  it("keeps complete non-empty summaries free of partial-data caveats", () => {
+    expect(
+      revenueChartSummary({
+        isLoading: false,
+        hasAnyRevenue: true,
+        partialReasons: [],
+        activeRangeLabel: "1W",
+        headline: "$210.00",
+        change: 4.2,
+      }),
+    ).toBe(
+      "Total revenue over the 1W range: $210.00, up 4.20% week-over-week.",
     );
   });
 });

--- a/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
@@ -13,6 +13,7 @@ const {
   buildOracleXaxis,
   buildOraclePlotData,
   buildOracleLayout,
+  oracleAltText,
 } = __test__;
 
 // ---------------------------------------------------------------------------
@@ -147,6 +148,38 @@ describe("formatOracleChartHoverText", () => {
       token1Symbol: "USDC",
     });
     expect(breach).toContain("would have tripped at the time");
+  });
+});
+
+describe("oracleAltText", () => {
+  it("describes daily mode as daily candles instead of raw price samples", () => {
+    expect(
+      oracleAltText({
+        sym0: "USDm",
+        sym1: "USDC",
+        pointCount: 31,
+        pointKind: "daily candle",
+        breakerReady: true,
+        hasPersistedBands: false,
+      }),
+    ).toBe(
+      "Oracle price versus breaker band for USDm/USDC: 31 daily candles plotted, each colored by whether it sat inside its breaker band.",
+    );
+  });
+
+  it("keeps raw mode described as price samples", () => {
+    expect(
+      oracleAltText({
+        sym0: "USDm",
+        sym1: "USDC",
+        pointCount: 1,
+        pointKind: "price sample",
+        breakerReady: false,
+        hasPersistedBands: true,
+      }),
+    ).toBe(
+      "Oracle price versus breaker band for USDm/USDC: 1 price sample plotted, with samples colored by breaker-band membership only where a persisted band exists.",
+    );
   });
 });
 

--- a/ui-dashboard/src/components/breach-history-chart.tsx
+++ b/ui-dashboard/src/components/breach-history-chart.tsx
@@ -185,7 +185,7 @@ export function BreachHistoryChart({ breaches }: Props) {
     trace(ongoing, "Ongoing", "#8b5cf6"),
   ].filter((t) => t.x.length > 0);
 
-  const breachSummary = `Deviation breach history: ${breaches.length} breaches plotted — ${closedCritical.length} critical closed, ${closedNonCritical.length} non-critical closed, ${ongoing.length} ongoing. Marker height is the breach duration on a log scale.`;
+  const breachSummary = `Deviation breach history: ${breaches.length} breaches plotted — ${closedCritical.length} critical closed, ${closedNonCritical.length} non-critical closed in the Within grace series, ${ongoing.length} ongoing. Marker height is the breach duration on a log scale.`;
 
   return (
     <>

--- a/ui-dashboard/src/components/breach-history-chart.tsx
+++ b/ui-dashboard/src/components/breach-history-chart.tsx
@@ -104,7 +104,7 @@ export function BreachHistoryChart({ breaches }: Props) {
   // amber "Within grace" colouring stays accurate ("not critical") even
   // for the long-but-low ones.
   const closedCritical: Marker[] = [];
-  const closedInGrace: Marker[] = [];
+  const closedNonCritical: Marker[] = [];
   const ongoing: Marker[] = [];
 
   for (const b of breaches) {
@@ -150,7 +150,7 @@ export function BreachHistoryChart({ breaches }: Props) {
     };
     if (isOpen) ongoing.push(marker);
     else if (critical > 0) closedCritical.push(marker);
-    else closedInGrace.push(marker);
+    else closedNonCritical.push(marker);
   }
 
   const trace = (markers: Marker[], name: string, color: string) => ({
@@ -181,11 +181,11 @@ export function BreachHistoryChart({ breaches }: Props) {
 
   const data = [
     trace(closedCritical, "Past grace (CRITICAL)", "#ef4444"),
-    trace(closedInGrace, "Within grace", "#f59e0b"),
+    trace(closedNonCritical, "Within grace", "#f59e0b"),
     trace(ongoing, "Ongoing", "#8b5cf6"),
   ].filter((t) => t.x.length > 0);
 
-  const breachSummary = `Deviation breach history: ${breaches.length} breaches plotted — ${closedCritical.length} past the 1-hour grace (critical), ${closedInGrace.length} within grace, ${ongoing.length} ongoing. Marker height is the breach duration on a log scale.`;
+  const breachSummary = `Deviation breach history: ${breaches.length} breaches plotted — ${closedCritical.length} critical closed, ${closedNonCritical.length} non-critical closed, ${ongoing.length} ongoing. Marker height is the breach duration on a log scale.`;
 
   return (
     <>

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -88,6 +88,41 @@ export function revenueChartEmptyMessage(
     : "No revenue history indexed yet";
 }
 
+export function revenueChartSummary({
+  isLoading,
+  hasAnyRevenue,
+  partialReasons,
+  activeRangeLabel,
+  headline,
+  change,
+}: {
+  isLoading: boolean;
+  hasAnyRevenue: boolean;
+  partialReasons: readonly string[];
+  activeRangeLabel: string;
+  headline: string;
+  change: number | null;
+}): string {
+  if (isLoading) return "Total revenue chart is loading.";
+  if (!hasAnyRevenue) {
+    return partialReasons.length > 0
+      ? `Total revenue chart: revenue data is partially unavailable for the ${activeRangeLabel} range.`
+      : `Total revenue chart: no revenue in the ${activeRangeLabel} range.`;
+  }
+
+  const trend =
+    change === null
+      ? ""
+      : `, ${change >= 0 ? "up" : "down"} ${Math.abs(change).toFixed(
+          2,
+        )}% week-over-week`;
+  const partialCaveat =
+    partialReasons.length > 0
+      ? " Revenue data is partial because some inputs failed to load."
+      : "";
+  return `Total revenue over the ${activeRangeLabel} range: ${headline}${trend}.${partialCaveat}`;
+}
+
 function buildTrace(args: {
   xs: string[];
   y: Array<number | null>;
@@ -360,19 +395,14 @@ export function TotalRevenueChart({
   const activeRangeLabel =
     RANGES.find((item) => item.key === range)?.label ?? String(range);
   const chartAriaLabel = `Total revenue chart, ${activeRangeLabel} range`;
-  const chartSummary = isLoading
-    ? "Total revenue chart is loading."
-    : !hasAnyRevenue
-      ? partialReasons.length > 0
-        ? `Total revenue chart: revenue data is partially unavailable for the ${activeRangeLabel} range.`
-        : `Total revenue chart: no revenue in the ${activeRangeLabel} range.`
-      : `Total revenue over the ${activeRangeLabel} range: ${headline}${
-          change === null
-            ? ""
-            : `, ${change >= 0 ? "up" : "down"} ${Math.abs(change).toFixed(
-                2,
-              )}% week-over-week`
-        }.`;
+  const chartSummary = revenueChartSummary({
+    isLoading,
+    hasAnyRevenue,
+    partialReasons,
+    activeRangeLabel,
+    headline,
+    change,
+  });
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -433,23 +433,35 @@ function selectOraclePlotData({
   baseline: number | null;
   thresholdRatio: number | null;
   breakerConfigStatus: BreakerConfigStatus;
-}): OraclePlotData {
+}): {
+  plotData: OraclePlotData;
+  summaryPointCount: number;
+  summaryPointKind: "daily candle" | "price sample";
+} {
   const daily = resolveDailyView({ visibleRange, showAll, dailyCandles });
   if (daily.active) {
-    return buildDailyPlotData({
-      candles: daily.candles,
+    return {
+      plotData: buildDailyPlotData({
+        candles: daily.candles,
+        baseline,
+        thresholdRatio,
+      }),
+      summaryPointCount: daily.candles.length,
+      summaryPointKind: "daily candle",
+    };
+  }
+  return {
+    plotData: buildOraclePlotData({
+      snapshots: visibleSnapshots,
+      token0Symbol,
+      token1Symbol,
       baseline,
       thresholdRatio,
-    });
-  }
-  return buildOraclePlotData({
-    snapshots: visibleSnapshots,
-    token0Symbol,
-    token1Symbol,
-    baseline,
-    thresholdRatio,
-    breakerConfigStatus,
-  });
+      breakerConfigStatus,
+    }),
+    summaryPointCount: visibleSnapshots.length,
+    summaryPointKind: "price sample",
+  };
 }
 
 /**
@@ -494,7 +506,7 @@ function useOracleChartModel({
     thresholdRatio,
     breakerConfigStatus,
   );
-  const plotData = useMemo(
+  const selectedPlot = useMemo(
     () =>
       selectOraclePlotData({
         visibleRange,
@@ -519,6 +531,7 @@ function useOracleChartModel({
       breakerConfigStatus,
     ],
   );
+  const plotData = selectedPlot.plotData;
   const shapes = useMemo(
     () => buildOracleShapes(plotData.yMax, baseline, thresholdRatio),
     [plotData.yMax, baseline, thresholdRatio],
@@ -541,26 +554,42 @@ function useOracleChartModel({
     () => [plotData.deviationTrace],
     [plotData.deviationTrace],
   );
-  return { traceData, layout };
+  return {
+    traceData,
+    layout,
+    summaryPointCount: selectedPlot.summaryPointCount,
+    summaryPointKind: selectedPlot.summaryPointKind,
+  };
 }
 
-function oracleAltText(
-  sym0: string,
-  sym1: string,
-  sampleCount: number,
-  breakerReady: boolean,
-  hasPersistedBands: boolean,
-): string {
-  const samples = `${sampleCount} price sample${sampleCount === 1 ? "" : "s"}`;
-  // Coverage tiers: with a live breaker config every sample is colored; with
-  // only persisted at-the-time bands, coverage is partial (samples predating a
+function oracleAltText({
+  sym0,
+  sym1,
+  pointCount,
+  pointKind,
+  breakerReady,
+  hasPersistedBands,
+}: {
+  sym0: string;
+  sym1: string;
+  pointCount: number;
+  pointKind: "daily candle" | "price sample";
+  breakerReady: boolean;
+  hasPersistedBands: boolean;
+}): string {
+  const plottedPoints = `${pointCount} ${pointKind}${
+    pointCount === 1 ? "" : "s"
+  }`;
+  const pointPlural = pointKind === "daily candle" ? "candles" : "samples";
+  // Coverage tiers: with a live breaker config every point is colored; with
+  // only persisted at-the-time bands, coverage is partial (points predating a
   // stored band aren't colored); with neither there is no band context at all.
   const bandClause = breakerReady
     ? ", each colored by whether it sat inside its breaker band"
     : hasPersistedBands
-      ? ", with samples colored by breaker-band membership only where a persisted band exists"
+      ? `, with ${pointPlural} colored by breaker-band membership only where a persisted band exists`
       : "; breaker band data is currently unavailable";
-  return `Oracle price versus breaker band for ${sym0}/${sym1}: ${samples} plotted${bandClause}.`;
+  return `Oracle price versus breaker band for ${sym0}/${sym1}: ${plottedPoints} plotted${bandClause}.`;
 }
 
 export function OracleChart({
@@ -597,19 +626,20 @@ export function OracleChart({
   );
 
   // Decimate + build a memoized, referentially-stable trace/layout (see hook).
-  const { traceData, layout } = useOracleChartModel({
-    snapshots,
-    visibleRange,
-    showAll,
-    dailyCandles,
-    token0Symbol,
-    token1Symbol,
-    baseline,
-    thresholdRatio,
-    breakerConfigStatus,
-    applyInitialRange,
-    uirevision,
-  });
+  const { traceData, layout, summaryPointCount, summaryPointKind } =
+    useOracleChartModel({
+      snapshots,
+      visibleRange,
+      showAll,
+      dailyCandles,
+      token0Symbol,
+      token1Symbol,
+      baseline,
+      thresholdRatio,
+      breakerConfigStatus,
+      applyInitialRange,
+      uirevision,
+    });
 
   // One React state update per animation frame instead of per wheel tick;
   // `uirevision` (= `${networkId}:${poolId}`) cancels a pending frame on a
@@ -638,13 +668,14 @@ export function OracleChart({
     (s) => s.breakerBaselineAtSnapshot != null,
   );
 
-  const oracleSummary = oracleAltText(
-    token0Symbol,
-    token1Symbol,
-    snapshots.length,
-    breakerConfigStatus === "ready",
+  const oracleSummary = oracleAltText({
+    sym0: token0Symbol,
+    sym1: token1Symbol,
+    pointCount: summaryPointCount,
+    pointKind: summaryPointKind,
+    breakerReady: breakerConfigStatus === "ready",
     hasPersistedBands,
-  );
+  });
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
@@ -1084,4 +1115,5 @@ export const __test__ = {
   buildOracleXaxis,
   buildOraclePlotData,
   buildOracleLayout,
+  oracleAltText,
 };


### PR DESCRIPTION
## The Problem

- Several dashboard chart text alternatives were present but could drift from what the chart actually plotted.
- The address-book wealth chart did not use the same named figure plus hidden summary pattern as the other Plotly charts.

## The Solution

- Keep chart summaries tied to the actual plotted mode, partial-data state, and breach classification while adding a matching hidden summary for the wealth chart.

## Details

- Oracle summaries now distinguish raw price samples from daily candles when the chart switches resolution.
- Revenue summaries now mention partial data even when there is non-empty plotted revenue.
- Breach-history summaries now describe closed markers as critical or non-critical instead of treating every non-critical marker as within grace.
- The intel wealth chart now has an outer `role="figure"` and sr-only chart summary, matching the dashboard chart pattern without changing visible UI.
- Non-goal: #1151's remaining Plotly keyboard-control replacement work is not included; the issue is being closed separately as won't fix because the current `role="figure"` treatment keeps controls in the accessibility tree and a bespoke visible replacement is not worth the added UI/maintenance cost.

Closes #1148.
Closes #1153.
Refs #1151.

## Validation

- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Browser verification on `http://127.0.0.1:3210`:
  - Oracle chart summary switched from `price samples` to `daily candles` after selecting Plotly's `All` range.
  - Breach-history page exposed the updated critical/non-critical hidden summary.
  - Authenticated `/revenue` exposed the partial-data caveat in the hidden total-revenue chart summary.
  - Address wealth chart could not mount locally without Upstash intel env; covered by component test.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility copy and test-only refactors; no auth, API, or chart data pipeline changes.
> 
> **Overview**
> Tightens **hidden and Plotly text alternatives** on several dashboard charts so screen-reader copy matches what is actually on screen, not stale assumptions.
> 
> **Oracle** summaries now use the active view: **daily candles** vs **raw price samples**, with counts taken from the selected plot path rather than total snapshot length. **Total revenue** summary logic moves into `revenueChartSummary`, including a **partial-data caveat** when some inputs failed even if the chart still shows revenue. **Breach history** keeps the amber “Within grace” series but rewrites the sr-only summary to count **critical closed** vs **non-critical closed** (so long, low-severity closures are not described as “within grace”). **Intel wealth** gains the same **`role="figure"` + sr-only** pattern as other Plotly charts, with `wealthChartTextAlternative` handling one vs many portfolio snapshots.
> 
> Adds/extends unit tests for wealth chart a11y, breach summary wording, revenue summaries, and `oracleAltText`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcdeab0e8bf0f4ba034ce8e22f24adc45ef6bbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->