### PR TITLE
docs: capture terraform secret strategy lessons

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -74,6 +74,15 @@ separate advisory state: report it in the readiness output, but do not hold the
 all-clear on it unless the Cursor check or review is required by branch
 protection.
 
+Some non-required workflows still post review feedback that can become required
+repo-policy blockers after the required status surface is already green. For
+example, an in-progress `auto-review` job does not block by status alone, but it
+can later create inline threads, unreplied review comments, or actionable
+top-level bot feedback. When a review-producing optional workflow is still in
+progress, treat an otherwise-clean readiness snapshot as provisional: wait for
+that workflow to finish or rerun `pr:feedback-state` after it reaches a terminal
+state before signaling final all-clear.
+
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via
@@ -258,9 +267,12 @@ Field expectations:
    context; deployment/status bot comments may be informational.
 7. If ready-state `ready` is false, fix or wait only on `required.blockers` and
    required `gates`.
-8. Report optional lag separately, especially Cursor Bugbot lag.
-9. Signal all-clear only after final ready-state `ready` is true for the
-   current head.
+8. If a non-required review-producing workflow is still in progress, wait for it
+   or rerun `pr:feedback-state` after it finishes before treating the result as
+   final.
+9. Report optional lag separately, especially Cursor Bugbot lag.
+10. Signal all-clear only after final ready-state `ready` is true for the
+    current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
 Differences between Claude `Monitor` wiring and Codex polling should stay

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -78,10 +78,11 @@ Some non-required workflows still post review feedback that can become required
 repo-policy blockers after the required status surface is already green. For
 example, an in-progress `auto-review` job does not block by status alone, but it
 can later create inline threads, unreplied review comments, or actionable
-top-level bot feedback. When a review-producing optional workflow is still in
-progress, treat an otherwise-clean readiness snapshot as provisional: wait for
-that workflow to finish or rerun `pr:feedback-state` after it reaches a terminal
-state before signaling final all-clear.
+top-level bot feedback. The probe result remains the readiness source of truth:
+do not block `ready` on those workflows unless branch protection makes them
+required. If one is visibly in progress during handoff, report it as optional
+lag; when you are still babysitting the PR anyway, rerun `pr:feedback-state`
+after it reaches a terminal state so late feedback is not missed.
 
 ## Expected CLI contract
 
@@ -267,12 +268,12 @@ Field expectations:
    context; deployment/status bot comments may be informational.
 7. If ready-state `ready` is false, fix or wait only on `required.blockers` and
    required `gates`.
-8. If a non-required review-producing workflow is still in progress, wait for it
-   or rerun `pr:feedback-state` after it finishes before treating the result as
-   final.
-9. Report optional lag separately, especially Cursor Bugbot lag.
-10. Signal all-clear only after final ready-state `ready` is true for the
-    current head.
+8. Report optional lag separately, especially Cursor Bugbot lag and visibly
+   in-progress review-producing workflows. If you are still watching the PR when
+   one finishes, rerun `pr:feedback-state` to catch late feedback; do not treat
+   the optional workflow status itself as a blocker.
+9. Signal all-clear only after final ready-state `ready` is true for the
+   current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
 Differences between Claude `Monitor` wiring and Codex polling should stay

--- a/docs/notes/terraform-secret-strategy-2026-07.md
+++ b/docs/notes/terraform-secret-strategy-2026-07.md
@@ -34,6 +34,16 @@ terminal output redacts them.
 | `aegis`               | Provider auth (`grafana_service_account_token`)                                                                                                                                                                                            | Full config-vs-state plan with placeholder TF_VAR and `-refresh=false`                                                                                       | Same secretless Grafana-token posture as alerts-rules, but this stack has no PR-plan Grafana data-source reads that force authentication before the diff. Re-check this assumption on Grafana provider major-version bumps.                                                                       |
 | `governance-watchdog` | Provider auth (`github_token`, QuickNode API key); configured runtime secrets (Discord/Telegram/QuickNode/VictorOps/x-auth); non-secret IDs (`billing_account`, Slack notification channel ID)                                             | Full config-vs-state plan with placeholder TF_VARs and `-refresh=false`                                                                                      | Uses Google/archive/local resources plus QuickNode/GitHub surfaces; placeholders keep same-repo PR jobs secretless. Trusted main/apply plans remain authoritative for secret values and refreshed remote state.                                                                                   |
 
+## Static external identifiers
+
+Replacing live provider data-source reads with static external IDs can keep
+same-repo PR plans secretless, but only when ownership is explicit. If the
+referenced object is owned by another Terraform stack, pin the identifier in the
+owning stack so destroy/recreate preserves the same ID. If the object is
+external or not yet Terraform-managed, document that ownership next to the
+static ID and verify the reference with a trusted or read-only plan before
+shipping.
+
 ## Write-only and ephemeral support
 
 Terraform `sensitive = true` only affects display. It does not remove values


### PR DESCRIPTION
## The Problem

- PR #1189 exposed two small process lessons that were easy to miss from existing docs.
- Agents can call a PR ready before optional review-producing workflows finish and then get fresh review blockers afterward.
- Static external IDs are useful for secretless Terraform PR plans, but the ownership rule needs to be explicit.

## The Solution

- Document the provisional-readiness rule for pending review-producing optional workflows, and document the ownership rule for static Terraform external identifiers.

## Details

- `docs/notes/pr-ready-state.md` now says an in-progress optional workflow like `auto-review` does not block by status alone, but final all-clear should wait for it or rerun `pr:feedback-state` once it reaches terminal state.
- `docs/notes/terraform-secret-strategy-2026-07.md` now says static external IDs should be pinned in the owning Terraform stack when Terraform-managed, or documented as external/unmanaged when not.

## Validation

- `pnpm agent:quality-gate --run`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to internal runbooks; no runtime, CI, or Terraform behavior is modified.
> 
> **Overview**
> **Documentation-only** updates that capture two operational lessons from recent work.
> 
> **`pr-ready-state.md`** clarifies that optional workflows such as **`auto-review`** must not block `ready` on workflow status alone, but can still produce **late** repo-policy feedback (threads, unreplied comments, bot comments). Agents should report in-progress jobs as **optional lag** and **rerun `pr:feedback-state`** after terminal state when still babysitting—without treating the optional check as a blocker unless branch protection requires it. Step 8 of the agent workflow is aligned with this.
> 
> **`terraform-secret-strategy-2026-07.md`** adds a **Static external identifiers** section: secretless PR plans that pin IDs instead of live data-source reads need **explicit ownership**—pin in the **owning Terraform stack** when another stack manages the object, or **document external/unmanaged** references and validate with a trusted/read-only plan before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24504de4acb9e0141f44e7695f6cc555c4451103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->