### PR TITLE
docs: document in-pr follow-up issue closeout

### DIFF
--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -3,7 +3,7 @@ title: Agent Issue Workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-28
+last_verified: 2026-07-08
 ---
 
 # Agent Issue Workflow
@@ -75,6 +75,12 @@ Routing labels:
 
 For partial work, keep the issue open. Remove `in-pr` after merge and set
 `agent-ready` or `needs-grooming` based on the remaining acceptance criteria.
+
+If a follow-up PR fully closes an issue that is already labeled `in-pr` from an
+earlier partial PR, `pnpm issue:review` will refuse because the issue is no
+longer `agent-active`. Do not churn labels just to satisfy the helper. Add a
+fresh issue comment linking the final PR, use a closing keyword in the PR body,
+and run `pnpm issue:board sync` after merge.
 
 ## Workboard Commands
 


### PR DESCRIPTION
## The Problem

- A follow-up PR can fully close an issue that is already labeled `in-pr` from an earlier partial PR.
- In that state, `pnpm issue:review` refuses because the issue is no longer `agent-active`.
- The canonical issue workflow did not say how to close out that edge case without unnecessary label churn.

## The Solution

- Document the follow-up path in the canonical issue workflow note.
- Tell agents to keep labels stable, add a fresh issue comment linking the final PR, use a closing keyword in the PR body, and run `pnpm issue:board sync` after merge.
- Refresh the note verification date.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- `./tools/trunk fmt --all`
- `git diff --check`

## Deferrals

None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the canonical agent issue workflow; no runtime or tooling behavior is modified.
> 
> **Overview**
> Adds guidance to **`docs/notes/agent-issue-workflow.md`** for when a **second PR** finishes an issue that is already **`in-pr`** after a partial merge. In that state **`pnpm issue:review`** is expected to refuse (the issue is not **`agent-active`**), so the note tells agents **not** to relabel just to satisfy the helper.
> 
> The documented closeout is: comment on the issue with a link to the final PR, use a **closing keyword** in that PR body, then run **`pnpm issue:board sync`** after merge. **`last_verified`** is updated to **2026-07-08**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba3bf17c61c779001ae45474239715f41d14635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->