### PR TITLE
Speed up worktree setup checks

### DIFF
--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -27,6 +27,15 @@ Worktrunk-created worktrees (`wt switch --create` / `wt switch -c`) run the
 same setup script automatically through `.config/wt.toml` as a blocking
 `pre-start` hook before any launch command configured with `-x` starts.
 
+The setup script optimizes repeated local worktrees by keeping dependency graph
+validity, `shared-config` build validity, Playwright Chromium availability, and
+Envio codegen on separate markers backed by real output checks. A source-only
+`shared-config` change does not force a dependency relink, and an
+already-installed Playwright Chromium binary does not rerun the installer for
+every fresh macOS worktree. Linux still requires a per-worktree successful
+Playwright installer marker because `--with-deps` also provisions host libraries
+there.
+
 ## Claude Code on the web setup
 
 Claude Code on the web sessions run in a hosted container that does not inherit

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,14 +45,17 @@ hash_inputs() {
 }
 
 playwright_chromium_present() {
-  pnpm --filter @mento-protocol/ui-dashboard exec node -e \
+  (cd ui-dashboard && node -e \
     "const { chromium } = require('@playwright/test'); require('fs').accessSync(chromium.executablePath());" \
-    >/dev/null 2>&1
+    >/dev/null 2>&1)
+}
+
+playwright_host_deps_required() {
+  [ "$(uname -s)" = "Linux" ]
 }
 
 dashboard_sentry_present() {
-  pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')" \
-    >/dev/null 2>&1
+  (cd ui-dashboard && node -e "require.resolve('@sentry/nextjs/package.json')" >/dev/null 2>&1)
 }
 
 echo "▶ Configuring git hooks..."
@@ -69,7 +72,21 @@ fi
 echo "▶ Installing dependencies..."
 deps_marker="node_modules/.setup-deps.sha256"
 deps_marker_pending=0
+deps_install_ran=0
+deps_had_node_modules=0
+[ -d node_modules ] && deps_had_node_modules=1
 deps_hash="$(
+  hash_inputs \
+    pnpm-lock.yaml \
+    pnpm-workspace.yaml \
+    package.json \
+    .npmrc \
+    pnpmfile.cjs \
+    patches \
+    ./*/package.json \
+    alerts/infra/*/package.json || true
+)"
+legacy_deps_hash="$(
   hash_inputs \
     pnpm-lock.yaml \
     pnpm-workspace.yaml \
@@ -82,14 +99,16 @@ deps_hash="$(
     shared-config/src \
     shared-config/tsconfig.json || true
 )"
-if [ -d node_modules ] && [ -s shared-config/dist/chains.js ] &&
+if [ -d node_modules ] &&
   [ -n "$deps_hash" ] &&
-  [ "$(cat "$deps_marker" 2>/dev/null)" = "$deps_hash" ] &&
+  { [ "$(cat "$deps_marker" 2>/dev/null)" = "$deps_hash" ] ||
+    [ "$(cat "$deps_marker" 2>/dev/null)" = "$legacy_deps_hash" ]; } &&
   dashboard_sentry_present; then
-  echo "  deps + shared-config build are up to date; skipping pnpm install"
+  echo "  dependencies are up to date; skipping pnpm install"
+  deps_marker_pending=1
 else
   CI=true pnpm install --frozen-lockfile --prefer-offline
-  pnpm --filter @mento-protocol/monitoring-config build
+  deps_install_ran=1
   deps_marker_pending=1
 fi
 
@@ -99,13 +118,42 @@ if [ "$deps_marker_pending" -eq 1 ] && [ -n "$deps_hash" ]; then
   printf '%s' "$deps_hash" >"$deps_marker"
 fi
 
+echo "▶ Building shared-config when needed..."
+shared_config_marker="node_modules/.setup-shared-config.sha256"
+shared_config_hash="$(hash_inputs shared-config/src shared-config/tsconfig.json || true)"
+if [ -s shared-config/dist/chains.js ] &&
+  [ -n "$shared_config_hash" ] &&
+  [ "$(cat "$shared_config_marker" 2>/dev/null)" = "$shared_config_hash" ]; then
+  echo "  shared-config build is up to date; skipping"
+elif [ "$deps_install_ran" -eq 1 ] &&
+  [ "$deps_had_node_modules" -eq 0 ] &&
+  [ -s shared-config/dist/chains.js ]; then
+  echo "  shared-config was built during pnpm install; refreshing marker"
+  if [ -n "$shared_config_hash" ]; then
+    printf '%s' "$shared_config_hash" >"$shared_config_marker"
+  fi
+else
+  pnpm --filter @mento-protocol/monitoring-config build
+  if [ ! -s shared-config/dist/chains.js ]; then
+    echo "error: shared-config build did not produce shared-config/dist/chains.js." >&2
+    exit 1
+  fi
+  if [ -n "$shared_config_hash" ]; then
+    printf '%s' "$shared_config_hash" >"$shared_config_marker"
+  fi
+fi
+
 echo "▶ Installing Playwright Chromium and host dependencies (ui-dashboard browser tests)..."
 playwright_marker="node_modules/.setup-playwright-chromium.sha256"
 playwright_hash="$(hash_inputs pnpm-lock.yaml ui-dashboard/package.json || true)"
-if [ -n "$playwright_hash" ] &&
-  [ "$(cat "$playwright_marker" 2>/dev/null)" = "$playwright_hash" ] &&
-  playwright_chromium_present; then
-  echo "  Playwright Chromium install is up to date; skipping"
+if playwright_chromium_present &&
+  { ! playwright_host_deps_required ||
+    { [ -n "$playwright_hash" ] &&
+      [ "$(cat "$playwright_marker" 2>/dev/null)" = "$playwright_hash" ]; }; }; then
+  echo "  Playwright Chromium executable is available; skipping installer"
+  if [ -n "$playwright_hash" ]; then
+    printf '%s' "$playwright_hash" >"$playwright_marker"
+  fi
 else
   if pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium; then
     if [ -n "$playwright_hash" ]; then


### PR DESCRIPTION
## The Problem

- Creating local worktrees through Worktrunk spends too much time in setup, especially when dependencies and Playwright Chromium are already available locally.
- The setup cache boundaries mixed dependency validity with shared-config build validity, so source-only shared-config changes could force unnecessary dependency work.

## The Solution

- Split the setup checks so dependency install, shared-config build, Playwright browser availability, and Envio codegen each validate only the output they own.
- Keep the local setup contract intact while skipping repeated Playwright installer work on macOS and avoiding pnpm startup overhead for simple dashboard dependency probes.

## Details

- Preserves the existing full-workspace pnpm install contract for fresh worktrees because pnpm's link step is the actual floor for a fully ready checkout.
- Migrates the old dependency marker shape so existing worktrees do not pay a one-time reinstall just because shared-config moved to its own marker.
- Keeps Linux Playwright setup conservative: a matching successful installer marker is still required because Playwright's `--with-deps` also provisions host libraries there.
- Documents the updated setup mechanics in `docs/notes/worktree-and-web-setup.md`.

## Validation

- `./scripts/setup.sh`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview -- --mode local --engine local`
- Fresh-context Codex autoreview: no findings after the Linux Playwright host-dependency fix.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only local bootstrap scripting and docs; behavior is additive caching with conservative Linux Playwright rules.
> 
> **Overview**
> **Speeds up `./scripts/setup.sh`** for repeat worktrees by giving dependency install, `shared-config` build, Playwright Chromium, and Envio codegen **separate SHA256 markers** instead of tying deps to a shared-config build.
> 
> **Dependency skip** no longer hashes `shared-config` sources; existing worktrees still match via a **legacy deps marker** so they avoid a one-time reinstall. **`shared-config`** is built only when its marker or `dist/chains.js` is stale, with a path that refreshes the marker when install already produced the build on a fresh tree.
> 
> **Playwright** probes use direct `ui-dashboard` `node` checks (less `pnpm` overhead). If the Chromium binary is already on disk, the installer is skipped on **macOS**; on **Linux**, a matching successful install marker is still required because `--with-deps` provisions host libraries.
> 
> `docs/notes/worktree-and-web-setup.md` documents the updated caching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0613239c55b7571a0c691d5d4e8fbb75bd03ad84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->