### PR TITLE
docs: document Terraform deploy queue drain

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -130,6 +130,13 @@ a terminal state. If approval was granted before the apply job existed, GitHub
 can require a fresh `production-infra` approval after the plan creates the apply
 job.
 
+If an older queued or waiting run is intentionally approved because it carries
+needed state reconciliation, keep watching the same deploy workflow until every
+queued `main` run reaches a terminal state. Later queued jobs can pass the
+`production-infra` gate without an obvious second prompt, so do not call a drift
+issue fixed from the first successful apply alone. Verify the live resource and
+run `terraform-drift.yml` before closing the drift issue.
+
 ## GitHub Environment Setup
 
 Pre-merge requirement for the production-environment split in issue #762:


### PR DESCRIPTION
## The Problem

- Terraform deploy queue guidance explained how to handle obsolete blockers, but not the case where an older queued run is intentionally approved to reconcile real state.
- That gap can make a drift fix look complete after the first successful apply even though later queued `main` runs still need to drain.

## The Solution

- Document the intentional-approval queue-drain path: keep watching the deploy workflow until every queued `main` run reaches terminal state, verify the live resource, and run Terraform drift detection before closing the drift issue.

## Details

- Adds the rule next to the existing Terraform deploy queue guidance in `docs/terraform.md`.
- No runtime or workflow code changes.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- Pre-push hook reran the mapped quality gate successfully.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to operational guidance; no workflow, Terraform, or runtime behavior is modified.
> 
> **Overview**
> Extends the Terraform deploy queue runbook in `docs/terraform.md` for the case where an **older queued run is deliberately approved** to reconcile real state—not just obsolete blockers to cancel.
> 
> Operators must **keep watching the deploy workflow until every queued `main` run finishes**, because later jobs may clear `production-infra` without a second obvious approval. The doc warns against closing drift from the **first successful apply alone** and adds explicit closure steps: **verify the live resource** and run **`terraform-drift.yml`** before resolving the drift issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c17cd11b3d102323a4ce7b339ed72422bd52fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->