### PR TITLE
docs: align deploy and ship agent guidance

### DIFF
--- a/.agents/skills/deploy-indexer/SKILL.md
+++ b/.agents/skills/deploy-indexer/SKILL.md
@@ -153,8 +153,10 @@ re-pushing.
 ### Phase 2b — Wait for sync to catch up (90 min hard ceiling)
 
 Once registered, the wrapper polls every 10 s and exits 0 when all chains
-report caught-up. Foreground is fine here; the noisy progress table is the
-work product.
+report caught-up. In `--compact` mode it prints the first sample, stable sync
+state changes, cadence checkpoints, and caught-up state while suppressing idle
+volatile progress changes. Drop `--compact` only when the full per-poll table
+is useful in a human terminal.
 
 Watch sync in the active rollout/session and do not leave a background process
 running when you finish.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -115,8 +115,11 @@ Rules:
   references after `The Solution`.
 - Use issue closure references only when the PR fully satisfies the issue.
 
-For substantial work, default to a draft PR unless the user asked for a ready
-PR.
+For normal monitoring-monorepo ship requests, especially `ship it` or a complete
+ship loop, open or convert the PR as ready-for-review once the local gate passes.
+Use draft only when the user explicitly asks for draft/PR-only handling or when
+required validation/review is intentionally still pending, and state that reason
+in the PR body and final summary.
 
 Include this marker when practical:
 

--- a/.claude/skills/deploy-indexer/SKILL.md
+++ b/.claude/skills/deploy-indexer/SKILL.md
@@ -153,8 +153,10 @@ re-pushing.
 ### Phase 2b — Wait for sync to catch up (90 min hard ceiling)
 
 Once registered, the wrapper polls every 10 s and exits 0 when all chains
-report caught-up. Foreground is fine here; the noisy progress table is the
-work product.
+report caught-up. In `--compact` mode it prints the first sample, stable sync
+state changes, cadence checkpoints, and caught-up state while suppressing idle
+volatile progress changes. Drop `--compact` only when the full per-poll table
+is useful in a human terminal.
 
 Watch sync in the active rollout/session and do not leave a background process
 running when you finish.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -115,8 +115,11 @@ Rules:
   references after `The Solution`.
 - Use issue closure references only when the PR fully satisfies the issue.
 
-For substantial work, default to a draft PR unless the user asked for a ready
-PR.
+For normal monitoring-monorepo ship requests, especially `ship it` or a complete
+ship loop, open or convert the PR as ready-for-review once the local gate passes.
+Use draft only when the user explicitly asks for draft/PR-only handling or when
+required validation/review is intentionally still pending, and state that reason
+in the PR body and final summary.
 
 Include this marker when practical:
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -18,6 +18,9 @@ last_verified: 2026-05-20
 
 - Shell scripts use `set -euo pipefail`.
 - Parse JSON with Node, jq, or structured tooling. Do not scrape JSON with grep or sed.
+- Compact/watch scripts must keep machine state and cadence metadata separate
+  from human display strings. Gate emissions on stable fields, not volatile
+  counters, block heights, or formatted progress lines.
 - Deploy scripts must refuse dirty working trees before mutating external systems.
 - Do not add `--no-verify` to git commands. Local hooks encode repo policy.
 - New deploy scripts must print the target, commit, and rollback or verification command before/after mutation.


### PR DESCRIPTION
## The Problem

- Reflection after PR #1198 found stale agent guidance around compact deploy watches and monitoring-monorepo ship behavior.
- The stale text could recreate the same noisy deploy-watch output and draft-PR detours that the latest workflow fixes were meant to avoid.

## The Solution

- Align the deploy-indexer skills with the current sparse `--compact` sync-watch behavior.
- Align the repo-local ship skills with ready-for-review PRs for normal `ship it` / complete ship-loop requests.
- Add a scripts guidance rule to keep compact watcher state/cadence metadata separate from human display strings.

## Details

- Docs-only follow-up after PR #1198.
- No dependency/runtime changes. The Envio 3.2.1 upgrade recommendation for the `envio_checkpoints_pkey` duplicate-key error remains a separate follow-up.

## Validation

- `git diff --check`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- pre-push `pnpm agent:quality-gate --run`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill text only; no runtime, deploy, or application code changes.
> 
> **Overview**
> Docs-only follow-up to keep agent skills and `scripts/AGENTS.md` in sync with recent deploy-watch and ship workflow fixes.
> 
> **Deploy-indexer** (`.agents` and `.claude` copies): Phase 2b no longer treats the full per-poll status table as the default agent output. It now documents that `--compact` prints the first sample, stable sync-state changes, cadence checkpoints, and caught-up state while hiding idle volatile progress; full table output is opt-in for human terminals.
> 
> **Ship** skills: Replaces the default of opening substantial work as **draft** PRs with **ready-for-review** once the local quality gate passes for normal `ship it` / complete ship loops. Draft is reserved for explicit user request or when validation/review is still intentionally pending (with that called out in the PR body/summary).
> 
> **Scripts guidance**: Adds an operating rule that compact/watch scripts must separate machine state and cadence metadata from display strings, and gate emissions on stable fields—not volatile counters, heights, or formatted progress lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9739de18443ff9ce6a361ff7742b51405034d7cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->