### PR TITLE
Fix dashboard nav on mobile

### DIFF
--- a/ui-dashboard/src/__tests__/a11y/responsive-nav.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/responsive-nav.a11y.test.tsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
+import { ResponsiveNav } from "@/components/responsive-nav";
+
+const mockUseSession = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("@/components/auth-status", () => ({
+  AuthStatus: ({
+    variant = "inline",
+    onClose,
+  }: {
+    variant?: string;
+    onClose?: () => void;
+  }) => (
+    <button type="button" data-auth-status={variant} onClick={onClose}>
+      Sign in
+    </button>
+  ),
+}));
+
+describe("ResponsiveNav a11y", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({ data: null });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    mockUseSession.mockReset();
+  });
+
+  function renderNav() {
+    act(() => {
+      root.render(
+        <nav aria-label="Main navigation">
+          <ResponsiveNav />
+        </nav>,
+      );
+    });
+  }
+
+  function menuButton(): HTMLButtonElement {
+    const button = container.querySelector("button[aria-controls]");
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("menu button not found");
+    }
+    return button;
+  }
+
+  it("closed and open disclosure states pass axe", async () => {
+    renderNav();
+
+    expect(menuButton().getAttribute("aria-expanded")).toBe("false");
+    expect((await axe(container)).violations).toEqual([]);
+
+    act(() => {
+      menuButton().click();
+    });
+
+    expect(menuButton().getAttribute("aria-expanded")).toBe("true");
+    expect((await axe(container)).violations).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -5,8 +5,7 @@ import { SessionProvider } from "next-auth/react";
 import { getAuthSession } from "@/auth";
 import { NetworkProvider } from "@/components/network-provider";
 import { AddressLabelsProvider } from "@/components/address-labels-provider";
-import { NavLinks } from "@/components/nav-links";
-import { AuthStatus } from "@/components/auth-status";
+import { ResponsiveNav } from "@/components/responsive-nav";
 import { DataFreshnessBanner } from "@/components/data-freshness-banner";
 import { ResourceHints } from "@/components/resource-hints";
 import { SessionErrorGuard } from "@/components/session-error-guard";
@@ -71,11 +70,10 @@ export default async function RootLayout({
               <NetworkProvider>
                 <AddressLabelsProvider>
                   <nav
-                    className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
+                    className="border-b border-slate-800 px-3 py-2 sm:px-6 sm:py-3"
                     aria-label="Main navigation"
                   >
-                    <NavLinks />
-                    <AuthStatus />
+                    <ResponsiveNav />
                   </nav>
                   <DataFreshnessBanner />
                   <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -79,6 +79,14 @@ function signInLink() {
   return link as HTMLAnchorElement;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   originalPushState = window.history.pushState;
   originalReplaceState = window.history.replaceState;
@@ -191,6 +199,21 @@ describe("AuthStatus sign-in href", () => {
       "/sign-in?callbackUrl=%2Fpools%3FpoolsSort%3Dtvl%26poolsDir%3Ddesc",
     );
   });
+
+  it("calls onClose when the panel sign-in link is activated", () => {
+    setup("/pools");
+    const onClose = vi.fn();
+
+    act(() => {
+      root?.render(<AuthStatus variant="panel" onClose={onClose} />);
+    });
+
+    const link = signInLink();
+    link.addEventListener("click", (event) => event.preventDefault());
+    link.click();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("AuthStatus sign-out", () => {
@@ -222,6 +245,43 @@ describe("AuthStatus sign-out", () => {
     expect(predicate("address-labels:all")).toBe(true);
     expect(predicate(["address-labels", "future-namespace"])).toBe(true);
     expect(predicate("other-cache-key")).toBe(false);
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes immediately and disables sign-out while the async sign-out is pending", async () => {
+    setup("/address-book");
+    const onClose = vi.fn();
+    const pendingMutate = deferred<void>();
+    mockMutate.mockReturnValueOnce(pendingMutate.promise);
+    mockUseSession.mockReturnValue({
+      data: { user: { email: "agent@mentolabs.xyz" } },
+      status: "authenticated",
+    });
+
+    act(() => {
+      root?.render(<AuthStatus variant="panel" onClose={onClose} />);
+    });
+
+    const button = container?.querySelector("button");
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("sign-out button not found");
+    }
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(button.disabled).toBe(true);
+    expect(mockSignOut).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pendingMutate.resolve();
+      await pendingMutate.promise;
+      await Promise.resolve();
+    });
+
     expect(mockSignOut).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui-dashboard/src/components/__tests__/nav-links.test.tsx
+++ b/ui-dashboard/src/components/__tests__/nav-links.test.tsx
@@ -2,23 +2,31 @@ import { describe, it, expect, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { NavLinks } from "@/components/nav-links";
 
-// Stub NetworkAwareLink so we can inspect rendered output without Next.js routing
-vi.mock("@/components/network-aware-link", () => ({
-  NetworkAwareLink: ({
-    href,
-    children,
-  }: {
-    href: string;
-    children: React.ReactNode;
-  }) => <a href={href}>{children}</a>,
-}));
-
 const mockUseSession = vi.fn();
 vi.mock("next-auth/react", () => ({
   useSession: () => mockUseSession(),
 }));
 
 describe("NavLinks", () => {
+  const publicHrefs = [
+    "/",
+    "/pools",
+    "/volume",
+    "/stables",
+    "/bridge-flows",
+    "/cdps",
+  ];
+
+  function hrefsForSession(session: unknown): string[] {
+    mockUseSession.mockReturnValue({ data: session });
+    const html = renderToStaticMarkup(<NavLinks />);
+    return Array.from(html.matchAll(/href="([^"]+)"/g), (match) => {
+      const href = match[1];
+      if (!href) throw new Error("matched href capture was empty");
+      return href;
+    });
+  }
+
   it("shows protected links when user is authenticated", () => {
     mockUseSession.mockReturnValue({
       data: { user: { email: "alice@mentolabs.xyz" } },
@@ -68,5 +76,31 @@ describe("NavLinks", () => {
     );
     expect(hrefs.indexOf("/volume")).toBe(hrefs.indexOf("/pools") + 1);
     expect(hrefs.indexOf("/stables")).toBe(hrefs.indexOf("/volume") + 1);
+  });
+
+  it("keeps public link order stable across auth states", () => {
+    const loggedOutPublic = hrefsForSession(null).filter((href) =>
+      publicHrefs.includes(href),
+    );
+    const loggedInPublic = hrefsForSession({
+      user: { email: "alice@mentolabs.xyz" },
+    }).filter((href) => publicHrefs.includes(href));
+
+    expect(loggedOutPublic).toEqual(publicHrefs);
+    expect(loggedInPublic).toEqual(publicHrefs);
+  });
+
+  it("appends authenticated links after every public link", () => {
+    const hrefs = hrefsForSession({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+
+    expect(hrefs).toEqual([
+      ...publicHrefs,
+      "/integrations",
+      "/revenue",
+      "/address-book",
+      "/entities",
+    ]);
   });
 });

--- a/ui-dashboard/src/components/__tests__/responsive-nav.test.tsx
+++ b/ui-dashboard/src/components/__tests__/responsive-nav.test.tsx
@@ -15,8 +15,16 @@ vi.mock("next-auth/react", () => ({
 }));
 
 vi.mock("@/components/auth-status", () => ({
-  AuthStatus: ({ variant = "inline" }: { variant?: string }) => (
-    <div data-auth-status={variant}>Auth</div>
+  AuthStatus: ({
+    variant = "inline",
+    onClose,
+  }: {
+    variant?: string;
+    onClose?: () => void;
+  }) => (
+    <button type="button" data-auth-status={variant} onClick={onClose}>
+      Auth
+    </button>
   ),
 }));
 
@@ -114,6 +122,28 @@ describe("ResponsiveNav", () => {
     act(() => {
       firstLink.click();
     });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(panelById(panelId)).toBeNull();
+  });
+
+  it("closes the mobile menu when panel auth status activates", () => {
+    renderNav();
+
+    const button = menuButton();
+    const panelId = button.getAttribute("aria-controls")!;
+    act(() => {
+      button.click();
+    });
+
+    const authButton = panelById(panelId)?.querySelector("[data-auth-status]");
+    if (!(authButton instanceof HTMLButtonElement)) {
+      throw new Error("panel auth button not found");
+    }
+
+    act(() => {
+      authButton.click();
+    });
+
     expect(button.getAttribute("aria-expanded")).toBe("false");
     expect(panelById(panelId)).toBeNull();
   });

--- a/ui-dashboard/src/components/__tests__/responsive-nav.test.tsx
+++ b/ui-dashboard/src/components/__tests__/responsive-nav.test.tsx
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ResponsiveNav } from "@/components/responsive-nav";
+
+const mockUseSession = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("@/components/auth-status", () => ({
+  AuthStatus: ({ variant = "inline" }: { variant?: string }) => (
+    <div data-auth-status={variant}>Auth</div>
+  ),
+}));
+
+describe("ResponsiveNav", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({ data: null });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    mockUseSession.mockReset();
+  });
+
+  function renderNav() {
+    act(() => {
+      root.render(<ResponsiveNav />);
+    });
+  }
+
+  function menuButton(): HTMLButtonElement {
+    const button = container.querySelector("button");
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("menu button not found");
+    }
+    return button;
+  }
+
+  function panelById(id: string): HTMLElement | null {
+    return container.ownerDocument.getElementById(id);
+  }
+
+  it("opens a mobile menu with ordered public links and panel auth status", () => {
+    renderNav();
+
+    const button = menuButton();
+    const panelId = button.getAttribute("aria-controls");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(panelId).toBeTruthy();
+    expect(panelById(panelId!)).toBeNull();
+
+    act(() => {
+      button.click();
+    });
+
+    const panel = panelById(panelId!);
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(panel).not.toBeNull();
+    expect(
+      panel
+        ?.querySelector("[data-auth-status]")
+        ?.getAttribute("data-auth-status"),
+    ).toBe("panel");
+    expect(
+      Array.from(panel?.querySelectorAll("a") ?? [], (link) =>
+        link.getAttribute("href"),
+      ),
+    ).toEqual(["/pools", "/volume", "/stables", "/bridge-flows", "/cdps"]);
+  });
+
+  it("closes the mobile menu on Escape and link activation", () => {
+    renderNav();
+
+    const button = menuButton();
+    const panelId = button.getAttribute("aria-controls")!;
+
+    act(() => {
+      button.click();
+    });
+    expect(panelById(panelId)).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(panelById(panelId)).toBeNull();
+
+    act(() => {
+      button.click();
+    });
+    const firstLink = panelById(panelId)?.querySelector("a");
+    if (!(firstLink instanceof HTMLAnchorElement)) {
+      throw new Error("mobile nav link not found");
+    }
+    firstLink.addEventListener("click", (event) => event.preventDefault());
+
+    act(() => {
+      firstLink.click();
+    });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(panelById(panelId)).toBeNull();
+  });
+});

--- a/ui-dashboard/src/components/auth-status.tsx
+++ b/ui-dashboard/src/components/auth-status.tsx
@@ -28,7 +28,11 @@ export function buildSignInHref(pathname: string, search: string): string {
   return `${SIGN_IN_PATH}?callbackUrl=${encodeURIComponent(callback)}`;
 }
 
-export function AuthStatus() {
+type AuthStatusProps = {
+  variant?: "inline" | "panel";
+};
+
+export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
   const { data: session, status } = useSession();
   const { mutate } = useSWRConfig();
   const liveLocation = useLiveLocation();
@@ -58,7 +62,11 @@ export function AuthStatus() {
     return (
       <Link
         href={renderHref}
-        className="ml-auto text-xs text-slate-400 hover:text-white transition-colors"
+        className={
+          variant === "panel"
+            ? "block rounded-md border border-slate-800 bg-slate-900/80 px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:border-slate-700 hover:text-white"
+            : "ml-auto text-xs text-slate-400 hover:text-white transition-colors"
+        }
       >
         Sign in
       </Link>
@@ -73,8 +81,22 @@ export function AuthStatus() {
   };
 
   return (
-    <div className="ml-auto flex items-center gap-3">
-      <span className="text-xs text-slate-400">{session.user?.email}</span>
+    <div
+      className={
+        variant === "panel"
+          ? "flex items-center justify-between gap-3 rounded-md border border-slate-800 bg-slate-900/80 px-3 py-2"
+          : "ml-auto flex items-center gap-3"
+      }
+    >
+      <span
+        className={
+          variant === "panel"
+            ? "text-xs text-slate-400"
+            : "hidden max-w-44 truncate text-xs text-slate-400 xl:inline"
+        }
+      >
+        {session.user?.email}
+      </span>
       <button
         type="button"
         onClick={handleSignOut}

--- a/ui-dashboard/src/components/auth-status.tsx
+++ b/ui-dashboard/src/components/auth-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useSWRConfig } from "swr";
 import Link from "next/link";
@@ -30,12 +30,14 @@ export function buildSignInHref(pathname: string, search: string): string {
 
 type AuthStatusProps = {
   variant?: "inline" | "panel";
+  onClose?: () => void;
 };
 
-export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
+export function AuthStatus({ variant = "inline", onClose }: AuthStatusProps) {
   const { data: session, status } = useSession();
   const { mutate } = useSWRConfig();
   const liveLocation = useLiveLocation();
+  const [signingOut, setSigningOut] = useState(false);
 
   // Attach the authenticated user's email to every Sentry event so issues
   // are filterable by who's affected. Internal-only tool (mentolabs.xyz
@@ -62,6 +64,7 @@ export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
     return (
       <Link
         href={renderHref}
+        {...(onClose ? { onClick: onClose } : {})}
         className={
           variant === "panel"
             ? "block rounded-md border border-slate-800 bg-slate-900/80 px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:border-slate-700 hover:text-white"
@@ -74,10 +77,17 @@ export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
   }
 
   const handleSignOut = async () => {
-    await mutate((key: unknown) => isAddressLabelsSWRKey(key), undefined, {
-      revalidate: false,
-    });
-    await signOut();
+    if (signingOut) return;
+    onClose?.();
+    setSigningOut(true);
+    try {
+      await mutate((key: unknown) => isAddressLabelsSWRKey(key), undefined, {
+        revalidate: false,
+      });
+      await signOut();
+    } finally {
+      setSigningOut(false);
+    }
   };
 
   return (
@@ -91,7 +101,7 @@ export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
       <span
         className={
           variant === "panel"
-            ? "text-xs text-slate-400"
+            ? "min-w-0 flex-1 truncate text-xs text-slate-400"
             : "hidden max-w-44 truncate text-xs text-slate-400 xl:inline"
         }
       >
@@ -100,7 +110,8 @@ export function AuthStatus({ variant = "inline" }: AuthStatusProps) {
       <button
         type="button"
         onClick={handleSignOut}
-        className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+        disabled={signingOut}
+        className="text-xs text-slate-500 transition-colors hover:text-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
       >
         Sign out
       </button>

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -3,79 +3,68 @@
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 
-export function NavLinks() {
+type NavLinkItem = {
+  href: string;
+  label: string;
+  kind: "brand" | "section";
+};
+
+export const PUBLIC_NAV_LINKS: readonly NavLinkItem[] = [
+  { href: "/", label: "Mento Analytics", kind: "brand" },
+  { href: "/pools", label: "Pools", kind: "section" },
+  { href: "/volume", label: "Volume", kind: "section" },
+  { href: "/stables", label: "Stables", kind: "section" },
+  { href: "/bridge-flows", label: "Bridges", kind: "section" },
+  { href: "/cdps", label: "CDPs", kind: "section" },
+];
+
+const AUTH_NAV_LINKS: readonly NavLinkItem[] = [
+  { href: "/integrations", label: "Integrations", kind: "section" },
+  { href: "/revenue", label: "Revenue", kind: "section" },
+  { href: "/address-book", label: "Addresses", kind: "section" },
+  { href: "/entities", label: "Entities", kind: "section" },
+];
+
+type NavLinksProps = {
+  includeBrand?: boolean;
+  linkClassName?: string;
+  brandClassName?: string;
+  onNavigate?: () => void;
+};
+
+const desktopBrandClassName =
+  "text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors";
+const desktopLinkClassName =
+  "text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors";
+
+export function NavLinks({
+  includeBrand = true,
+  linkClassName = desktopLinkClassName,
+  brandClassName = desktopBrandClassName,
+  onNavigate,
+}: NavLinksProps = {}) {
   const { data: session } = useSession();
+  const publicLinks = includeBrand
+    ? PUBLIC_NAV_LINKS
+    : PUBLIC_NAV_LINKS.slice(1);
+  const links = session ? [...publicLinks, ...AUTH_NAV_LINKS] : publicLinks;
 
   return (
     <>
-      <Link
-        href="/"
-        className="text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors"
-      >
-        Mento Analytics
-      </Link>
-      <Link
-        href="/pools"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Pools
-      </Link>
-      <Link
-        href="/volume"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Volume
-      </Link>
-      <Link
-        href="/stables"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Stables
-      </Link>
-      <Link
-        href="/bridge-flows"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Bridges
-      </Link>
-      {session && (
-        <Link
-          href="/integrations"
-          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-        >
-          Integrations
-        </Link>
-      )}
-      <Link
-        href="/cdps"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        CDPs
-      </Link>
-      {session && (
-        <Link
-          href="/revenue"
-          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-        >
-          Revenue
-        </Link>
-      )}
-      {session && (
-        <Link
-          href="/address-book"
-          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-        >
-          Addresses
-        </Link>
-      )}
-      {session && (
-        <Link
-          href="/entities"
-          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-        >
-          Entities
-        </Link>
-      )}
+      {links.map((link) => {
+        const navigateProps = onNavigate ? { onClick: onNavigate } : {};
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={link.kind === "brand" ? brandClassName : linkClassName}
+            {...navigateProps}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
     </>
   );
 }

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -9,8 +9,14 @@ type NavLinkItem = {
   kind: "brand" | "section";
 };
 
-export const PUBLIC_NAV_LINKS: readonly NavLinkItem[] = [
-  { href: "/", label: "Mento Analytics", kind: "brand" },
+export const BRAND_NAV_LINK: NavLinkItem = {
+  href: "/",
+  label: "Mento Analytics",
+  kind: "brand",
+};
+
+const PUBLIC_NAV_LINKS: readonly NavLinkItem[] = [
+  BRAND_NAV_LINK,
   { href: "/pools", label: "Pools", kind: "section" },
   { href: "/volume", label: "Volume", kind: "section" },
   { href: "/stables", label: "Stables", kind: "section" },

--- a/ui-dashboard/src/components/responsive-nav.tsx
+++ b/ui-dashboard/src/components/responsive-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useId, useState } from "react";
 import { AuthStatus } from "@/components/auth-status";
-import { NavLinks, PUBLIC_NAV_LINKS } from "@/components/nav-links";
+import { BRAND_NAV_LINK, NavLinks } from "@/components/nav-links";
 
 const mobileLinkClassName =
   "rounded-md px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-slate-800 hover:text-white focus:bg-slate-800 focus:text-white";
@@ -11,7 +11,6 @@ const mobileLinkClassName =
 export function ResponsiveNav() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const mobilePanelId = useId();
-  const brandLink = PUBLIC_NAV_LINKS[0]!;
 
   useEffect(() => {
     if (!mobileOpen) return undefined;
@@ -32,11 +31,11 @@ export function ResponsiveNav() {
     <div className="w-full">
       <div className="flex items-center gap-3 lg:hidden">
         <Link
-          href={brandLink.href}
+          href={BRAND_NAV_LINK.href}
           className="text-base font-bold text-white transition-colors hover:text-indigo-400"
           onClick={closeMobileMenu}
         >
-          {brandLink.label}
+          {BRAND_NAV_LINK.label}
         </Link>
         <button
           type="button"
@@ -61,7 +60,7 @@ export function ResponsiveNav() {
               onNavigate={closeMobileMenu}
             />
           </div>
-          <AuthStatus variant="panel" />
+          <AuthStatus variant="panel" onClose={closeMobileMenu} />
         </div>
       )}
 

--- a/ui-dashboard/src/components/responsive-nav.tsx
+++ b/ui-dashboard/src/components/responsive-nav.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useId, useState } from "react";
+import { AuthStatus } from "@/components/auth-status";
+import { NavLinks, PUBLIC_NAV_LINKS } from "@/components/nav-links";
+
+const mobileLinkClassName =
+  "rounded-md px-3 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-slate-800 hover:text-white focus:bg-slate-800 focus:text-white";
+
+export function ResponsiveNav() {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const mobilePanelId = useId();
+  const brandLink = PUBLIC_NAV_LINKS[0]!;
+
+  useEffect(() => {
+    if (!mobileOpen) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMobileOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [mobileOpen]);
+
+  const closeMobileMenu = () => setMobileOpen(false);
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-3 lg:hidden">
+        <Link
+          href={brandLink.href}
+          className="text-base font-bold text-white transition-colors hover:text-indigo-400"
+          onClick={closeMobileMenu}
+        >
+          {brandLink.label}
+        </Link>
+        <button
+          type="button"
+          className="ml-auto rounded-md border border-slate-700 px-3 py-2 text-xs font-medium text-slate-200 transition-colors hover:border-slate-500 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          aria-expanded={mobileOpen}
+          aria-controls={mobilePanelId}
+          onClick={() => setMobileOpen((open) => !open)}
+        >
+          {mobileOpen ? "Close" : "Menu"}
+        </button>
+      </div>
+
+      {mobileOpen && (
+        <div
+          id={mobilePanelId}
+          className="mt-3 grid gap-3 border-t border-slate-800 pt-3 lg:hidden"
+        >
+          <div className="grid gap-1">
+            <NavLinks
+              includeBrand={false}
+              linkClassName={mobileLinkClassName}
+              onNavigate={closeMobileMenu}
+            />
+          </div>
+          <AuthStatus variant="panel" />
+        </div>
+      )}
+
+      <div className="hidden items-center gap-4 lg:flex">
+        <NavLinks />
+        <AuthStatus />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## The Problem

- On narrow screens the primary dashboard nav wrapped into a cramped multi-line row.
- Authenticated-only links changed the public link order, which pushed `CDPs` away from the rest of the public navigation.
- The auth controls had no compact panel layout, so the header could overflow at tablet widths.

## The Solution

- Add a responsive dashboard nav that keeps small and tablet widths to a brand + menu button, with the full row only at desktop width.
- Keep public links in one stable order for logged-out and logged-in users, appending authenticated links after all public links.
- Reuse `AuthStatus` with an explicit panel variant for the compact menu.

## Details

- `ResponsiveNav` handles menu state, `aria-expanded` / `aria-controls`, Escape close, and link-activation close.
- `NavLinks` now has a shared public-link source of truth plus optional rendering props for compact and desktop layouts.
- The desktop signed-in email stays hidden until `xl` so the full row remains overflow-free at the first desktop breakpoint.

## Validation

- `pnpm agent:quality-gate --run`
- pre-push quality gate rerun
- `CI=true pnpm agent:autoreview`
- Browser checked logged-out 320px compact menu, signed-in 375px compact menu, signed-in 768px compact menu, and signed-in 1024px desktop row.

Closes #1124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header/navigation changes with existing auth and sign-out cache clearing preserved; no API or security logic changes.
> 
> **Overview**
> Replaces the wrapping header row (`NavLinks` + `AuthStatus`) with **`ResponsiveNav`**: below `lg`, users get brand + Menu/Close with a disclosure panel; at `lg+`, the full link row returns.
> 
> **`NavLinks`** is refactored around shared `PUBLIC_NAV_LINKS` / `AUTH_NAV_LINKS` so public routes stay in one order whether logged in or out, with auth-only links appended after all public items (fixing `CDPs` no longer being split by protected links). It accepts `includeBrand`, custom classes, and `onNavigate` for the mobile drawer.
> 
> **`AuthStatus`** gains `variant="inline" | "panel"` and optional `onClose` (closes the menu on sign-in click or immediately on sign-out), panel styling, email hidden until `xl` on desktop, and a disabled sign-out state while logout is in flight.
> 
> Adds unit tests for nav ordering, responsive menu behavior, panel auth callbacks, and an axe a11y test for open/closed menu states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198cac269c2c3048e01d40eb36649fd003ea61cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->