### PR TITLE
Add indexed TVL hero view

### DIFF
--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -892,7 +892,39 @@ describe("TvlOverTimeChart render", () => {
     expect(html).not.toContain("Not enough history yet");
   });
 
-  it("renders current live TVL when every chain has no snapshot history yet", () => {
+  it("shows a specific indexed-mode empty message when visible TVL is all zero", () => {
+    const pool = makeTvlPool({
+      reserves0: "0",
+      reserves1: "0",
+    });
+    const zeroSnapshot = makeSnapshot({
+      reserves0: "0",
+      reserves1: "0",
+    });
+
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshotsAllDaily: [zeroSnapshot],
+          }),
+        ],
+        totalTvl: 0,
+        tvlPartial: false,
+        change7d: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+
+    expect(html).toContain("TVL is zero throughout this range");
+    expect(html).not.toContain("Not enough history yet");
+  });
+
+  it("renders current-point TVL data in indexed mode when every chain has no snapshot history yet", () => {
     const poolA = makeTvlPool({
       id: "pool-a",
       reserves0: HUNDRED,
@@ -926,6 +958,7 @@ describe("TvlOverTimeChart render", () => {
       }),
     );
 
+    expect(html).toContain("$300");
     expect(html).not.toContain("Not enough history yet");
     const traces = capturedPlotProps.data as Array<{
       name?: string;

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -936,10 +936,10 @@ describe("TvlOverTimeChart render", () => {
     const [t0, t1, t2] = [traces[0]!, traces[1]!, traces[2]!];
     expect(t0.name).toBe("Total");
     expect(t0.x).toHaveLength(1);
-    expect(t0.y).toEqual([300]);
+    expect(t0.y).toEqual([100]);
     expect(t1.name).toBe(TVL_NETWORK.label);
     expect(t1.x).toHaveLength(1);
-    expect(t1.y).toEqual([200]);
+    expect(t1.y).toEqual([100]);
     expect(t2.name).toBe(TVL_NETWORK_2.label);
     expect(t2.x).toHaveLength(1);
     expect(t2.y).toEqual([100]);
@@ -978,10 +978,75 @@ describe("TvlOverTimeChart render", () => {
     const [tr0, tr1] = [traces[0]!, traces[1]!];
     expect(tr0.name).toBe("Total");
     expect(tr0.x).toHaveLength(1);
-    expect(tr0.y).toEqual([200]);
+    expect(tr0.y).toEqual([100]);
     expect(tr1.name).toBe(TVL_NETWORK.label);
     expect(tr1.x).toHaveLength(1);
-    expect(tr1.y).toEqual([200]);
+    expect(tr1.y).toEqual([100]);
+  });
+
+  it("defaults to indexed traces so small relative TVL moves are visible across chain magnitudes", () => {
+    const today = dayAlignedNow();
+    const ago = today - 7 * SECONDS_PER_DAY;
+    const largePool = makeTvlPool({
+      id: "large-pool",
+      reserves0: "1020000000000000000000",
+      reserves1: "1020000000000000000000",
+    });
+    const smallPool = makeTvlPool({
+      id: "small-pool",
+      reserves0: "51000000000000000000",
+      reserves1: "51000000000000000000",
+    });
+    const largeAgo = makeSnapshot({
+      poolId: "large-pool",
+      timestamp: ago,
+      reserves0: "1000000000000000000000",
+      reserves1: "1000000000000000000000",
+    });
+    const smallAgo = makeSnapshot({
+      poolId: "small-pool",
+      timestamp: ago,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [largePool],
+            snapshotsAllDaily: [largeAgo],
+          }),
+          makeNetworkData({
+            network: TVL_NETWORK_2,
+            pools: [smallPool],
+            snapshotsAllDaily: [smallAgo],
+          }),
+        ],
+        totalTvl: 2_142,
+        tvlPartial: false,
+        change7d: 2,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+
+    expect(html).toMatch(/aria-pressed="true"[^>]*>Indexed</);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>USD</);
+    const traces = capturedPlotProps.data as Array<{
+      name?: string;
+      y: number[];
+      hovertemplate?: string;
+    }>;
+    expect(traces).toHaveLength(3);
+    for (const trace of traces) {
+      expect(trace.y[0]).toBeCloseTo(100, 6);
+      expect(trace.y.at(-1)).toBeCloseTo(102, 6);
+      expect(trace.hovertemplate).toContain("%{y:.2f} index");
+      expect(trace.hovertemplate).not.toContain("$%{y");
+    }
   });
 
   it("renders a skeleton (not the real value) in the hero while loading", () => {
@@ -1118,6 +1183,8 @@ describe("TvlOverTimeChart render", () => {
     expect(html).toMatch(/aria-pressed="true"[^>]*>1M</);
     expect(html).toMatch(/aria-pressed="false"[^>]*>1W</);
     expect(html).toMatch(/aria-pressed="false"[^>]*>All</);
+    expect(html).toMatch(/aria-pressed="true"[^>]*>Indexed</);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>USD</);
   });
 
   it("passes scrollZoom=false and displayModeBar=false to Plotly config", () => {

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -139,6 +139,10 @@ interface TimeSeriesChartCardProps {
   annotations?: Plotly.Layout["annotations"];
   yAxisReferenceValues?: readonly number[];
   plotlyDeferMode?: DeferredMountMode;
+  controls?: ReactNode;
+  valueHoverPrefix?: string;
+  valueHoverSuffix?: string;
+  valueHoverFormat?: string;
 }
 
 // Intentional react-doctor suppression: chart shell + hover overlay + trace
@@ -170,6 +174,10 @@ export function TimeSeriesChartCard({
   annotations,
   yAxisReferenceValues = EMPTY_Y_AXIS_REFERENCE_VALUES,
   plotlyDeferMode = "none",
+  controls,
+  valueHoverPrefix = "$",
+  valueHoverSuffix = "",
+  valueHoverFormat = ",.0f",
 }: TimeSeriesChartCardProps) {
   const hasBreakdown = (breakdown?.length ?? 0) > 0;
   const isStacked = hasBreakdown && breakdownMode === "stacked";
@@ -237,6 +245,9 @@ export function TimeSeriesChartCard({
     );
     const ys = series.map((point) => point.value);
     const tickformat = dateTickFormatForSeries(series);
+    const safeValueHoverPrefix = escapePlotText(valueHoverPrefix);
+    const safeValueHoverSuffix = escapePlotText(valueHoverSuffix);
+    const valueHoverTemplate = `${safeValueHoverPrefix}%{y:${valueHoverFormat}}${safeValueHoverSuffix}`;
     const totalTrace = isStacked
       ? null
       : {
@@ -248,7 +259,7 @@ export function TimeSeriesChartCard({
           line: { color: "#6366f1", width: 2 },
           fill: "tozeroy" as const,
           fillcolor: "rgba(99,102,241,0.08)",
-          hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
+          hovertemplate: `<b>${valueHoverTemplate}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
         };
     const breakdownTraces = (breakdown ?? []).map((b) => {
       // Escape `name` before it reaches Plotly's `name` and `hovertemplate`
@@ -288,7 +299,7 @@ export function TimeSeriesChartCard({
         ...(customSortedHover
           ? { hoverinfo: "none" as const }
           : {
-              hovertemplate: `${safeName}: $%{y:,.0f}<extra></extra>`,
+              hovertemplate: `${safeName}: ${valueHoverTemplate}<extra></extra>`,
             }),
       };
     });
@@ -418,6 +429,9 @@ export function TimeSeriesChartCard({
     shapes,
     annotations,
     yAxisReferenceValues,
+    valueHoverPrefix,
+    valueHoverSuffix,
+    valueHoverFormat,
   ]);
 
   // Cross-fade in stacked mode: pre-render every visibility combo (2^N
@@ -530,30 +544,33 @@ export function TimeSeriesChartCard({
           )}
         </div>
 
-        <div
-          role="group"
-          aria-label={rangeAriaLabel}
-          className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
-        >
-          {ranges.map((item) => {
-            const active = range === item.key;
-            return (
-              <button
-                key={item.key}
-                type="button"
-                aria-pressed={active}
-                onClick={() => onRangeChange(item.key)}
-                className={
-                  "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
-                  (active
-                    ? "bg-slate-700 text-white shadow-sm"
-                    : "text-slate-400 hover:text-slate-200")
-                }
-              >
-                {item.label}
-              </button>
-            );
-          })}
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {controls}
+          <div
+            role="group"
+            aria-label={rangeAriaLabel}
+            className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+          >
+            {ranges.map((item) => {
+              const active = range === item.key;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onRangeChange(item.key)}
+                  className={
+                    "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+                    (active
+                      ? "bg-slate-700 text-white shadow-sm"
+                      : "text-slate-400 hover:text-slate-200")
+                  }
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -22,6 +22,25 @@ import {
 } from "@/lib/time-series";
 
 type SeriesPoint = { timestamp: number; tvlUSD: number };
+type TvlChartMode = "indexed" | "absolute";
+
+type TvlChartData = {
+  fullSeries: TimeSeriesPoint[];
+  fullBreakdown: BreakdownSeries[];
+};
+
+type TvlChartValueProps =
+  | {
+      yAxisReferenceValues: readonly number[];
+      valueHoverPrefix: string;
+      valueHoverSuffix: string;
+      valueHoverFormat: string;
+    }
+  | {
+      valueHoverPrefix: string;
+      valueHoverSuffix: string;
+      valueHoverFormat: string;
+    };
 
 type PoolHistory = {
   pool: Pool;
@@ -76,6 +95,14 @@ export type ChainTvlSeries = {
   series: SeriesPoint[];
   nowTvl: number;
 };
+
+const TVL_CHART_MODES: ReadonlyArray<{
+  key: TvlChartMode;
+  label: string;
+}> = [
+  { key: "indexed", label: "Indexed" },
+  { key: "absolute", label: "USD" },
+];
 
 /**
  * Builds a forward-filled TVL time series. `bucketSeconds` selects the
@@ -378,6 +405,147 @@ function computeCurrentTvl(currentPools: CurrentPool[]): {
   return { nowTvl, perChainNowTvl };
 }
 
+function indexSeriesToWindowStart(
+  series: TimeSeriesPoint[],
+): TimeSeriesPoint[] {
+  const baselineIndex = series.findIndex((point) => point.value > 0);
+  if (baselineIndex === -1) return [];
+
+  const baseline = series[baselineIndex]!.value;
+  return series.slice(baselineIndex).map((point) => ({
+    timestamp: point.timestamp,
+    value: (point.value / baseline) * 100,
+  }));
+}
+
+function indexBreakdownToWindowStart(
+  breakdown: BreakdownSeries[],
+): BreakdownSeries[] {
+  const indexed: BreakdownSeries[] = [];
+  for (const entry of breakdown) {
+    const series = indexSeriesToWindowStart(entry.series);
+    if (series.length > 0) {
+      indexed.push({ ...entry, series });
+    }
+  }
+  return indexed;
+}
+
+function TvlModeControls({
+  chartMode,
+  onChartModeChange,
+}: {
+  chartMode: TvlChartMode;
+  onChartModeChange: (mode: TvlChartMode) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="TVL chart value mode"
+      className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+    >
+      {TVL_CHART_MODES.map((mode) => {
+        const active = chartMode === mode.key;
+        return (
+          <button
+            key={mode.key}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChartModeChange(mode.key)}
+            className={
+              "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+              (active
+                ? "bg-slate-700 text-white shadow-sm"
+                : "text-slate-400 hover:text-slate-200")
+            }
+          >
+            {mode.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function buildFullTvlChartData(networkData: NetworkData[]): TvlChartData {
+  // Always use UTC-day buckets. PoolDailySnapshot is a running aggregate
+  // updated throughout the day — forward-filling a midnight-stamped row into
+  // hourly sub-buckets would show today's current reserves for all past hours
+  // of the same day, distorting the intra-day trend.
+  const { series: base, nowTvl, byChain } = buildDailySeries(networkData);
+  if (base.length === 0 && nowTvl === 0) {
+    return { fullSeries: [], fullBreakdown: [] };
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const fullSeries = [
+    ...base.map((point) => ({
+      timestamp: point.timestamp,
+      value: point.tvlUSD,
+    })),
+    { timestamp: nowSec, value: nowTvl },
+  ];
+
+  const fullBreakdown: BreakdownSeries[] = byChain.map((entry) => ({
+    name: entry.network.label,
+    color: chainColor(entry.network.chainId),
+    series: [
+      ...entry.series.map((p) => ({
+        timestamp: p.timestamp,
+        value: p.tvlUSD,
+      })),
+      { timestamp: nowSec, value: entry.nowTvl },
+    ],
+  }));
+
+  return { fullSeries, fullBreakdown };
+}
+
+function filterBreakdownByRange(
+  breakdown: BreakdownSeries[],
+  range: RangeKey,
+): BreakdownSeries[] {
+  return breakdown.map((b) => ({
+    ...b,
+    series: filterSeriesByRange(b.series, range),
+  }));
+}
+
+function chartValuePropsForMode(chartMode: TvlChartMode): TvlChartValueProps {
+  if (chartMode === "indexed") {
+    return {
+      yAxisReferenceValues: [100],
+      valueHoverPrefix: "",
+      valueHoverSuffix: " index",
+      valueHoverFormat: ".2f",
+    };
+  }
+  return {
+    valueHoverPrefix: "$",
+    valueHoverSuffix: "",
+    valueHoverFormat: ",.0f",
+  };
+}
+
+function formatTvlHeadline(
+  isLoading: boolean,
+  tvlPartial: boolean | null,
+  totalTvl: number,
+): string {
+  if (isLoading) return "…";
+  if (tvlPartial === null) return "—";
+  if (tvlPartial) return `${formatUSD(totalTvl)} (partial)`;
+  return formatUSD(totalTvl);
+}
+
+function tvlEmptyMessage(hasError: boolean, hasSnapshotError: boolean): string {
+  if (hasError) return "Unable to load TVL history";
+  if (hasSnapshotError) {
+    return "Historical data partial — some chains failed to load";
+  }
+  return "Not enough history yet";
+}
+
 interface TvlOverTimeChartProps {
   networkData: NetworkData[];
   totalTvl: number;
@@ -407,43 +575,12 @@ export function TvlOverTimeChart({
   plotlyDeferMode = "none",
 }: TvlOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
+  const [chartMode, setChartMode] = useState<TvlChartMode>("indexed");
 
-  const { fullSeries, fullBreakdown } = useMemo<{
-    fullSeries: TimeSeriesPoint[];
-    fullBreakdown: BreakdownSeries[];
-  }>(() => {
-    // Always use UTC-day buckets. PoolDailySnapshot is a running aggregate
-    // updated throughout the day — forward-filling a midnight-stamped row into
-    // hourly sub-buckets would show today's current reserves for all past hours
-    // of the same day, distorting the intra-day trend.
-    const { series: base, nowTvl, byChain } = buildDailySeries(networkData);
-    if (base.length === 0 && nowTvl === 0) {
-      return { fullSeries: [], fullBreakdown: [] };
-    }
-
-    const nowSec = Math.floor(Date.now() / 1000);
-    const total = [
-      ...base.map((point) => ({
-        timestamp: point.timestamp,
-        value: point.tvlUSD,
-      })),
-      { timestamp: nowSec, value: nowTvl },
-    ];
-
-    const breakdown: BreakdownSeries[] = byChain.map((entry) => ({
-      name: entry.network.label,
-      color: chainColor(entry.network.chainId),
-      series: [
-        ...entry.series.map((p) => ({
-          timestamp: p.timestamp,
-          value: p.tvlUSD,
-        })),
-        { timestamp: nowSec, value: entry.nowTvl },
-      ],
-    }));
-
-    return { fullSeries: total, fullBreakdown: breakdown };
-  }, [networkData]);
+  const { fullSeries, fullBreakdown } = useMemo(
+    () => buildFullTvlChartData(networkData),
+    [networkData],
+  );
 
   // TVL is a stock — cutoff-based range filtering on UTC-day-stamped buckets
   // is fine: the headline shows current TVL (not a bar-sum), so no invariant
@@ -453,33 +590,30 @@ export function TvlOverTimeChart({
     [fullSeries, range],
   );
   const visibleBreakdown = useMemo<BreakdownSeries[]>(
-    () =>
-      fullBreakdown.map((b) => ({
-        ...b,
-        series: filterSeriesByRange(b.series, range),
-      })),
+    () => filterBreakdownByRange(fullBreakdown, range),
     [fullBreakdown, range],
   );
-
-  const headline = isLoading
-    ? "…"
-    : tvlPartial === null
-      ? "—"
-      : tvlPartial
-        ? `${formatUSD(totalTvl)} (partial)`
-        : formatUSD(totalTvl);
-  const emptyMessage = hasError
-    ? "Unable to load TVL history"
-    : hasSnapshotError
-      ? "Historical data partial — some chains failed to load"
-      : "Not enough history yet";
+  const indexedSeries = useMemo(
+    () => indexSeriesToWindowStart(visibleSeries),
+    [visibleSeries],
+  );
+  const indexedBreakdown = useMemo<BreakdownSeries[]>(
+    () => indexBreakdownToWindowStart(visibleBreakdown),
+    [visibleBreakdown],
+  );
+  const chartSeries = chartMode === "indexed" ? indexedSeries : visibleSeries;
+  const chartBreakdown =
+    chartMode === "indexed" ? indexedBreakdown : visibleBreakdown;
+  const chartValueProps = chartValuePropsForMode(chartMode);
+  const headline = formatTvlHeadline(isLoading, tvlPartial, totalTvl);
+  const emptyMessage = tvlEmptyMessage(hasError, hasSnapshotError);
 
   return (
     <TimeSeriesChartCard
       title="Total Value Locked"
       rangeAriaLabel="TVL chart time range"
-      series={visibleSeries}
-      breakdown={visibleBreakdown}
+      series={chartSeries}
+      breakdown={chartBreakdown}
       range={range}
       onRangeChange={setRange}
       headline={headline}
@@ -489,6 +623,13 @@ export function TvlOverTimeChart({
       hasError={hasError}
       hasSnapshotError={hasSnapshotError}
       emptyMessage={emptyMessage}
+      controls={
+        <TvlModeControls
+          chartMode={chartMode}
+          onChartModeChange={setChartMode}
+        />
+      }
+      {...chartValueProps}
       plotlyDeferMode={plotlyDeferMode}
     />
   );

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -606,7 +606,15 @@ export function TvlOverTimeChart({
     chartMode === "indexed" ? indexedBreakdown : visibleBreakdown;
   const chartValueProps = chartValuePropsForMode(chartMode);
   const headline = formatTvlHeadline(isLoading, tvlPartial, totalTvl);
-  const emptyMessage = tvlEmptyMessage(hasError, hasSnapshotError);
+  const hasZeroOnlyIndexedWindow =
+    chartMode === "indexed" &&
+    !hasError &&
+    !hasSnapshotError &&
+    visibleSeries.length > 0 &&
+    indexedSeries.length === 0;
+  const emptyMessage = hasZeroOnlyIndexedWindow
+    ? "TVL is zero throughout this range"
+    : tvlEmptyMessage(hasError, hasSnapshotError);
 
   return (
     <TimeSeriesChartCard


### PR DESCRIPTION
## The Problem

- The TVL hero plotted total, Celo, and Monad on one absolute dollar axis.
- Chain magnitudes differ enough that a 2-3% total move stayed visually subtle.
- The hero needed to keep the chain breakdown visible without clipping smaller chains.

## The Solution

- Make the TVL hero default to an indexed view where each visible series starts at 100 for the selected window.
- Add an `Indexed / USD` segmented control so operators can switch back to absolute dollar values.
- Reuse the shared chart card with value-specific hover formatting so indexed hovers read as index values and USD hovers keep dollar formatting.

## Details

- Indexed mode uses the first positive point in each visible series as its baseline and omits only series with no positive baseline.
- The total headline remains the live USD TVL, while the plot emphasizes relative movement.
- The indexed axis includes 100 as a reference input so low-variance windows stay centered around the baseline.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- src/components/__tests__/tvl-over-time-chart.test.ts src/components/__tests__/time-series-chart-card.a11y.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm dashboard:react-doctor:diff`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Browser checked default Indexed traces, USD toggle traces, and 320px control layout on `http://127.0.0.1:3210/`.

Closes #1142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard chart presentation and formatting only; TVL aggregation logic is largely refactored into helpers without changing headline USD semantics.
> 
> **Overview**
> The TVL hero chart now **defaults to indexed mode**: each visible series is rebased to **100** at the first positive point in the selected time window so relative moves stay visible when chain dollar magnitudes differ. An **Indexed / USD** control sits beside the range pills; the headline still shows live **USD** TVL.
> 
> `TimeSeriesChartCard` gains optional **`controls`** in the header and configurable **hover value formatting** (prefix/suffix/format) instead of hard-coded dollar hovers. Indexed mode passes a **100** y-axis reference and index-style tooltips; USD mode keeps dollar formatting.
> 
> Indexed-only empty copy (**"TVL is zero throughout this range"**) appears when the window has points but no positive baseline. Tests were updated for indexed trace values, default mode, and the new empty state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33a4d50d12ccd1cc1fab7b64d665c5c8e7b69aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->