### PR TITLE
Add iOS-visible table scroll cue

### DIFF
--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -26,6 +26,38 @@ main,
   overflow-x: hidden;
 }
 
+/* Horizontal table scroll cue for WebKit/iOS overlay scrollbars.
+   The first two local backgrounds cover the edge shadows at the scroll ends;
+   the final two scroll backgrounds provide the visible left/right affordance
+   only when more content exists off-screen. */
+.table-scroll-cue {
+  --table-scroll-surface: rgb(15 23 42);
+  --table-scroll-shadow: rgb(148 163 184 / 0.32);
+
+  background:
+    linear-gradient(
+        to right,
+        var(--table-scroll-surface) 35%,
+        rgb(15 23 42 / 0)
+      )
+      left center / 2.5rem 100% no-repeat local,
+    linear-gradient(to left, var(--table-scroll-surface) 35%, rgb(15 23 42 / 0))
+      right center / 2.5rem 100% no-repeat local,
+    radial-gradient(
+        farthest-side at 0 50%,
+        var(--table-scroll-shadow),
+        rgb(148 163 184 / 0)
+      )
+      left center / 1rem 100% no-repeat scroll,
+    radial-gradient(
+        farthest-side at 100% 50%,
+        var(--table-scroll-shadow),
+        rgb(148 163 184 / 0)
+      )
+      right center / 1rem 100% no-repeat scroll;
+  background-color: var(--table-scroll-surface);
+}
+
 /* Plotly range selector buttons: smaller tap targets on mobile */
 @media (max-width: 640px) {
   .js-plotly-plot .rangeselector .button {

--- a/ui-dashboard/src/components/__tests__/table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/table.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Table, Row, Th, Td } from "@/components/table";
+
+function renderTable(scrollClassName?: string): string {
+  const scrollProps = scrollClassName ? { scrollClassName } : {};
+  return renderToStaticMarkup(
+    <Table aria-label="Example table" {...scrollProps}>
+      <thead>
+        <Row>
+          <Th>Asset</Th>
+          <Th align="right">Amount</Th>
+        </Row>
+      </thead>
+      <tbody>
+        <Row>
+          <Td>USDm</Td>
+          <Td mono align="right">
+            1,000,000
+          </Td>
+        </Row>
+      </tbody>
+    </Table>,
+  );
+}
+
+describe("Table", () => {
+  it("adds the shared horizontal scroll cue to the scroll wrapper", () => {
+    const html = renderTable();
+
+    expect(html).toContain("table-scroll-cue");
+    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("scrollbar-width:thin");
+    expect(html).toContain('aria-label="Example table"');
+  });
+
+  it("preserves scrollClassName overrides for specific tables", () => {
+    const html = renderTable("xl:overflow-x-clip");
+
+    expect(html).toContain("table-scroll-cue");
+    expect(html).toContain("xl:overflow-x-clip");
+  });
+});

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -24,12 +24,10 @@ export function Table({
   return (
     <div
       className={[
-        "overflow-x-auto rounded-lg border border-slate-800",
-        // Persistently-visible thin horizontal scrollbar so the scroll
-        // affordance is signalled at rest — mobile Safari/Chrome hide the
-        // native scrollbar until touched, which makes an off-screen column
-        // (e.g. a wide swap amount) read as a silent clip rather than
-        // scrollable content.
+        "table-scroll-cue overflow-x-auto rounded-lg border border-slate-800",
+        // Desktop engines can show a persistent thin scrollbar. WebKit on iOS
+        // hides overlay scrollbars at rest, so `.table-scroll-cue` adds the
+        // always-visible edge affordance there.
         "[&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-slate-900 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-600 [scrollbar-width:thin] [scrollbar-color:rgb(71_85_105)_rgb(15_23_42)]",
         scrollClassName,
       ]


### PR DESCRIPTION
## The Problem

- Wide dashboard tables rely on horizontal scrolling at small mobile widths.
- iOS/WebKit hides overlay scrollbars at rest, so off-screen columns can look silently clipped.
- The existing styled scrollbar helps desktop and Android Chrome, but not the primary iOS Safari case.

## The Solution

- Add a shared pure-CSS table scroll cue using local/scroll background layers on the `Table` overflow wrapper.
- Keep the existing persistent thin scrollbar styling for engines that honor it.
- Preserve `scrollClassName` overrides so table-specific overflow behavior, such as the CDP trove table breakpoint override, still works.

## Details

- The local cover gradients hide the left/right shadows at their respective scroll ends.
- The wrapper has a solid `slate-900` surface token so the cover gradients match across card backgrounds.
- Fitting tables keep the same class, but both edge shadows are covered when no horizontal overflow exists.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- src/components/__tests__/table.test.tsx`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `./tools/trunk check ui-dashboard/src/components/table.tsx ui-dashboard/src/app/globals.css ui-dashboard/src/components/__tests__/table.test.tsx`
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Browser checked 320px scrollable All Pools table with visible right-edge cue, 414px fitting table with no false cue, and no page-level horizontal overflow.

Closes #1145

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on the table scroll wrapper with unit tests; no auth, data, or API changes.
> 
> **Overview**
> Improves **mobile horizontal table scrolling** when iOS Safari hides overlay scrollbars at rest, so wide columns no longer look silently clipped.
> 
> Adds a shared **`.table-scroll-cue`** style in `globals.css` (layered local/scroll backgrounds with edge shadows that hide at scroll ends) and applies it on the shared `Table` scroll wrapper alongside the existing thin scrollbar styling. **`scrollClassName`** overrides (e.g. CDP trove `xl:overflow-x-clip`) are unchanged.
> 
> Adds **`table.test.tsx`** to assert the scroll wrapper includes `table-scroll-cue`, overflow/scrollbar classes, and optional `scrollClassName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac15346fa5b44bb0e4eefa6c8cc08ce03ca499b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->