### PR TITLE
Fix pnpm action Node 20 annotation

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -9,7 +9,7 @@ description: Setup pnpm + Node + install deps (frozen lockfile)
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .node-version

--- a/.github/workflows/publish-config.yml
+++ b/.github/workflows/publish-config.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version


### PR DESCRIPTION
## The Problem

- The publish-config dry run succeeded but emitted a GitHub Actions warning because pnpm/action-setup v4 still declares a Node 20 action runtime.
- The shared pnpm install composite action had the same stale v4 pin, so other workflows can surface the same annotation.

## The Solution

- Update both stale pnpm/action-setup pins to v6.0.9, which declares node24 in action.yml.
- Reuse the same pinned v6.0.9 SHA already present in supply-chain workflows.

## Validation

- ./tools/trunk check .github/actions/pnpm-install/action.yml .github/workflows/publish-config.yml
- node scripts/check-github-action-pins.mjs
- pnpm agent:quality-gate --run
- Pre-push hook reran the mapped agent quality gate and passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin updates with no application or publish logic changes.
> 
> **Overview**
> Bumps **pnpm/action-setup** from **v4** to **v6.0.9** (same commit SHA already used in supply-chain workflows) in the shared **pnpm-install** composite action and in **publish-config**, so CI no longer warns about the action declaring a Node 20 runtime.
> 
> Install behavior is unchanged: still **setup-node** from `.node-version` with pnpm cache and `pnpm install --frozen-lockfile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5324b5c5fbb350c0025fe3a3b094c403174879a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->