### PR TITLE
fix: exclude Monad rebalancer volume

### DIFF
--- a/indexer-envio/config/protocolActors.json
+++ b/indexer-envio/config/protocolActors.json
@@ -8,6 +8,12 @@
       "category": "rebalancer"
     },
     {
+      "chainId": 143,
+      "address": "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976",
+      "label": "monad-x-chain-rebalancer",
+      "category": "rebalancer"
+    },
+    {
       "chainId": 99999,
       "address": "0x0000000000000000000000000000000000000a11",
       "label": "test-protocol-actor",

--- a/indexer-envio/config/protocolActors.json
+++ b/indexer-envio/config/protocolActors.json
@@ -9,7 +9,7 @@
     },
     {
       "chainId": 143,
-      "address": "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976",
+      "address": "0xaa8299FC6A685B5f9Ce9bdA8d0B3ea3D54731976",
       "label": "monad-x-chain-rebalancer",
       "category": "rebalancer"
     },

--- a/indexer-envio/test/protocol-actors.test.ts
+++ b/indexer-envio/test/protocol-actors.test.ts
@@ -17,7 +17,7 @@ const CELO_OPEN_LIQUIDITY_STRATEGY =
   "0x54e2ae8c8448912e17ce0b2453bafb7b0d80e40f";
 const CELO_PROTOCOL_FEE_RECIPIENT =
   "0x0dd57f6f181d0469143fe9380762d8a112e96e4a";
-const CELO_MENTO_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
+const X_CHAIN_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 
 // Real Monad addresses + an NTT transceiver proxy from nttAddresses.json.
 const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";
@@ -42,15 +42,17 @@ describe("isProtocolOwnedAddress", () => {
     );
   });
 
-  it("flags manual Celo protocol actor EOAs as protocol-owned callers", () => {
-    assert.equal(
-      isProtocolOwnedAddress(CHAIN_CELO, CELO_MENTO_REBALANCER_EOA),
-      true,
-    );
-    assert.equal(
-      isProtocolActorEntryPoint(CHAIN_CELO, CELO_MENTO_REBALANCER_EOA),
-      true,
-    );
+  it("flags manual cross-chain rebalancer EOAs as protocol-owned callers", () => {
+    for (const chainId of [CHAIN_CELO, CHAIN_MONAD]) {
+      assert.equal(
+        isProtocolOwnedAddress(chainId, X_CHAIN_REBALANCER_EOA),
+        true,
+      );
+      assert.equal(
+        isProtocolActorEntryPoint(chainId, X_CHAIN_REBALANCER_EOA),
+        true,
+      );
+    }
   });
 
   it("flags Monad protocol contracts (FPMMFactory, ReserveV2)", () => {

--- a/indexer-envio/test/protocol-actors.test.ts
+++ b/indexer-envio/test/protocol-actors.test.ts
@@ -9,6 +9,9 @@ const CHAIN_CELO = 42220;
 const CHAIN_MONAD = 143;
 const CHAIN_TEST_FIXTURE = 99999;
 
+// Manual protocol actor override shared by Celo and Monad.
+const X_CHAIN_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
+
 // Real Celo addresses (lowercased) — must stay in @mento-protocol/contracts.
 const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
 const CELO_BIPOOLMANAGER = "0x22d9db95e6ae61c104a7b6f6c78d7993b94ec901";
@@ -17,7 +20,6 @@ const CELO_OPEN_LIQUIDITY_STRATEGY =
   "0x54e2ae8c8448912e17ce0b2453bafb7b0d80e40f";
 const CELO_PROTOCOL_FEE_RECIPIENT =
   "0x0dd57f6f181d0469143fe9380762d8a112e96e4a";
-const X_CHAIN_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 
 // Real Monad addresses + an NTT transceiver proxy from nttAddresses.json.
 const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";

--- a/indexer-envio/test/volumeSnapshots.test.ts
+++ b/indexer-envio/test/volumeSnapshots.test.ts
@@ -16,18 +16,22 @@ import {
   type VolumeContext,
 } from "../src/volumeSnapshots.js";
 
-// Real addresses on Celo (chain 42220).
-const CHAIN = 42220;
+// Real addresses on Celo (chain 42220) unless a test names a different chain.
+const CHAIN_CELO = 42220;
+const CHAIN_MONAD = 143;
+const CHAIN = CHAIN_CELO;
 const TRADER_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const TRADER_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const SQUID = "0xce16f69375520ab01377ce7b88f5ba8c48f8d666";
 const LIFI = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
+const ZEROX_MONAD = "0x0000000000001ff3684f28c67538d4d072c22734";
 const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
 const MENTO_REBALANCER_EOA = "0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976";
 const POOL_ADDR_1 = "0x1111111111111111111111111111111111111111";
 const POOL_ADDR_2 = "0x2222222222222222222222222222222222222222";
 const POOL_ID_1 = `${CHAIN}-${POOL_ADDR_1}`;
 const POOL_ID_2 = `${CHAIN}-${POOL_ADDR_2}`;
+const MONAD_POOL_ID_1 = `${CHAIN_MONAD}-${POOL_ADDR_1}`;
 
 const ONE_USD = 10n ** 18n;
 const DAY_2026_05_04 = 1778457600n; // UTC midnight 2026-05-04
@@ -497,41 +501,59 @@ describe("applyVolumeSnapshots", () => {
     assert.equal(ad.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
   });
 
-  it("manual Mento rebalancer signer is protocol volume even through an aggregator", async () => {
-    const { context, store } = makeContext();
-    const pool = fakePool();
+  it("manual cross-chain rebalancer signer is protocol volume even through an aggregator", async () => {
+    const cases = [
+      {
+        chainId: CHAIN_CELO,
+        poolId: POOL_ID_1,
+        pool: fakePool(),
+        txTo: SQUID,
+        aggregator: "squid",
+      },
+      {
+        chainId: CHAIN_MONAD,
+        poolId: MONAD_POOL_ID_1,
+        pool: fakePool({ id: MONAD_POOL_ID_1, chainId: CHAIN_MONAD }),
+        txTo: ZEROX_MONAD,
+        aggregator: "0x",
+      },
+    ];
 
-    await applyVolumeSnapshots({
-      context,
-      chainId: CHAIN,
-      poolId: POOL_ID_1,
-      pool,
-      caller: MENTO_REBALANCER_EOA,
-      txTo: SQUID,
-      volumeUsdWei: 1_000n * ONE_USD,
-      amounts: buyToken1,
-      blockTimestamp: DAY_2026_05_04 + 100n,
-      blockNumber: 0n,
-    });
+    for (const testCase of cases) {
+      const { context, store } = makeContext();
 
-    const td = store.TraderDailySnapshot.get(
-      `${CHAIN}-${MENTO_REBALANCER_EOA}-${DAY_2026_05_04}`,
-    )!;
-    assert.equal(td.isProtocolActor, true);
-    const ad = store.AggregatorDailySnapshot.get(
-      `${CHAIN}-squid-${DAY_2026_05_04}`,
-    )!;
-    assert.equal(ad.swapCount, 0);
-    assert.equal(ad.swapCountIncludingProtocolActors, 1);
-    assert.equal(ad.volumeUsdWei, 0n);
-    assert.equal(ad.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
-    const pd = store.PoolDailyVolumeSnapshot.get(
-      `${CHAIN}-${POOL_ID_1}-${DAY_2026_05_04}`,
-    )!;
-    assert.equal(pd.swapCount, 0);
-    assert.equal(pd.swapCountIncludingProtocolActors, 1);
-    assert.equal(pd.volumeUsdWei, 0n);
-    assert.equal(pd.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
+      await applyVolumeSnapshots({
+        context,
+        chainId: testCase.chainId,
+        poolId: testCase.poolId,
+        pool: testCase.pool,
+        caller: MENTO_REBALANCER_EOA,
+        txTo: testCase.txTo,
+        volumeUsdWei: 1_000n * ONE_USD,
+        amounts: buyToken1,
+        blockTimestamp: DAY_2026_05_04 + 100n,
+        blockNumber: 0n,
+      });
+
+      const td = store.TraderDailySnapshot.get(
+        `${testCase.chainId}-${MENTO_REBALANCER_EOA}-${DAY_2026_05_04}`,
+      )!;
+      assert.equal(td.isProtocolActor, true);
+      const ad = store.AggregatorDailySnapshot.get(
+        `${testCase.chainId}-${testCase.aggregator}-${DAY_2026_05_04}`,
+      )!;
+      assert.equal(ad.swapCount, 0);
+      assert.equal(ad.swapCountIncludingProtocolActors, 1);
+      assert.equal(ad.volumeUsdWei, 0n);
+      assert.equal(ad.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
+      const pd = store.PoolDailyVolumeSnapshot.get(
+        `${testCase.chainId}-${testCase.poolId}-${DAY_2026_05_04}`,
+      )!;
+      assert.equal(pd.swapCount, 0);
+      assert.equal(pd.swapCountIncludingProtocolActors, 1);
+      assert.equal(pd.volumeUsdWei, 0n);
+      assert.equal(pd.volumeUsdWeiIncludingProtocolActors, 1_000n * ONE_USD);
+    }
   });
 
   it("direct-entry Broker txTo does not hide the signer as protocol volume", async () => {


### PR DESCRIPTION
## The Problem

- The Monad x-chain rebalancer EOA `0xaa8299fc6a685b5f9ce9bda8d0b3ea3d54731976` was still classified as organic volume on the dashboard.
- The same actor was already excluded on Celo, so cross-chain rebalancer activity could inflate Monad-facing organic volume and trader views.

## The Solution

- Add the rebalancer EOA as a chain-scoped manual protocol actor for Monad mainnet (`143`), so indexer volume rollups mark it as non-organic protocol volume.
- Extend protocol-actor and volume-rollup regression coverage to prove this address is excluded from primary organic volume on both Celo and Monad while still counted in the including-protocol-actors totals.

## Details

### Invariants

- Manual protocol actor overrides are chain-scoped; the same EOA must be listed for every chain where it should be treated as protocol-controlled.
- Organic volume excludes `isProtocolActor` rows from primary swap/count/volume fields and preserves those rows in the `IncludingProtocolActors` fields.
- The dashboard's organic/all toggle continues to consume the existing `isProtocolActor` data path; no schema or query shape changed.

### Degraded Behavior

- Existing indexed rows keep their prior classification until the indexer deployment reprocesses/reindexes them.
- There is no dashboard fallback change in this PR; if Hasura/query failures occur, existing volume-page degraded behavior is unchanged.

### Intentional Non-Goals

- No UI copy, query, or schema changes.
- No manual production data mutation outside the normal indexer deploy/reindex path.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test -- test/protocol-actors.test.ts test/volumeSnapshots.test.ts` passed; the package script ran the full indexer suite: 75 files passed, 1055 tests passed, 27 skipped.
- `pnpm agent:quality-gate --run` passed all mapped commands: indexer codegen, frozen install, targeted Trunk check, indexer mutation, lint, typecheck, coverage, knip, and code-health deps.
- `CI=true pnpm agent:autoreview` passed with no accepted/actionable findings.
- `CI=true pnpm agent:review-materiality` reported `standard` and no context update required.
- `CI=true pnpm agent:prewarm --base origin/main` completed.
- Chrome DevTools MCP live `/volume` smoke: page loaded, V2 tab click navigated to `?venue=v2`, loading cleared, and no console errors were reported. The current prod page still shows `0xaa82...1976` in the V3 7d view before this indexer change is deployed/reindexed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only protocol-actor override plus test updates; no schema, handler, or dashboard query changes—effect depends on indexer deploy/reindex.
> 
> **Overview**
> Adds a **chain-scoped manual protocol actor** for Monad mainnet (`143`) so the shared x-chain rebalancer EOA `0xaa82…1976` is treated like the existing Celo override: swaps signed by that address count as **non-organic protocol volume** (primary organic fields stay at zero; `IncludingProtocolActors` totals still include them).
> 
> Tests are generalized from Celo-only to **Celo + Monad**, covering `isProtocolOwnedAddress` / `isProtocolActorEntryPoint` and volume rollups when the rebalancer trades **through aggregators** (Squid on Celo, 0x on Monad).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721d70cb20d14794ee0f29a005c30a16ca8fee1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->