### PR TITLE
docs: document Sentry tunnel 429s

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -3,7 +3,7 @@ title: Monitoring Dashboard Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-08
+last_verified: 2026-07-09
 ---
 
 # AGENTS.md — Monitoring Dashboard
@@ -104,6 +104,14 @@ The required local data env is:
 Other Vercel vars, Blob vars, cron secrets, and automation-bypass secrets are
 not needed for ordinary localhost UI review unless the task directly touches
 that route.
+
+Production Sentry telemetry is tunneled through `/monitoring` (see
+`next.config.ts`). During production browser verification, a
+`POST /monitoring?...` 429 with an `x-sentry-rate-limits` response such as
+`transaction_usage_exceeded` is Sentry quota noise, not an indexer or dashboard
+data failure, when the page data requests still return 200 and the UI renders
+normally. Report it separately and keep verifying the data surface. Treat
+non-Sentry 429s or failed GraphQL/API requests as real regressions.
 
 Logged-out verification:
 


### PR DESCRIPTION
## The Problem

- Production browser verification can surface a `POST /monitoring?...` 429 that looks like a dashboard or indexer failure.
- The existing dashboard agent instructions did not explain how to distinguish Sentry tunnel quota noise from real data request failures.

## The Solution

- Document that `/monitoring` is the dashboard's Sentry tunnel and that Sentry `x-sentry-rate-limits` transaction quota responses should be reported separately when page data requests are healthy.

## Details

- Adds the guidance next to the dashboard's local/prod verification instructions in `ui-dashboard/AGENTS.md`.
- Keeps failed GraphQL/API requests classified as real regressions.

## Validation

- `pnpm agent:quality-gate --run`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no runtime or config behavior changes.
> 
> **Overview**
> Updates **`ui-dashboard/AGENTS.md`** so agents doing production browser checks know how to read **`POST /monitoring`** failures.
> 
> It states that production Sentry goes through the **`/monitoring`** tunnel (`next.config.ts` **`tunnelRoute`**) and that a **429** with **`x-sentry-rate-limits`** (e.g. **`transaction_usage_exceeded`**) is **Sentry quota noise**, not indexer/dashboard breakage, when GraphQL/API data requests still return **200** and the UI looks fine—log that separately and keep validating the data surface. **Non-Sentry 429s** and failed GraphQL/API calls stay **real regressions**.
> 
> Also bumps **`last_verified`** to **2026-07-09**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f6ac64451bb6fd66fe571849e65212a62b45c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->