### PR TITLE
perf(dashboard): cache the / and /pools SSR fan-out, strip unread fee rows

### DIFF
--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -182,8 +182,15 @@ chainId}]` — the server must reproduce the exact normalized id + `network.id`
 ### Tier 3 — Efficiency / cost / polish (low user-facing speed, but cheap or strategic)
 
 - **P7 · Cache `fetchAllNetworks` server-side** (L, medium — _origin CPU + Envio quota_,
-  not LCP). It re-runs on every request (dynamic render + uncached `graphql-request`
-  POST). **Gotcha the naive fix misses:** `NetworkData` carries `Set` (olsPoolIds…) and
+  not LCP). **Shipped** (2026-07-09): `src/lib/network-fetcher/server-cache.ts` wraps the
+  fan-out in `unstable_cache` (30s TTL) with an explicit dehydrate→rehydrate transform
+  for the Map/Set fields, caches healthy payloads only (degraded ones pass through
+  uncached via an error carrier so `N/A` tiles are never pinned for the TTL), and strips
+  the unread raw `feeSnapshots` rows from the `/` + `/pools` Flight payload. Note the
+  impact re-rating vs. this plan's original scoring: a 2026-07-09 re-measure showed the
+  homepage document _streaming_ until 0.9–1.9s (the fan-out runs inside the streamed
+  RSC content, not TTFB), so this was in fact the homepage LCP lever, not just cost.
+  Original analysis for context: `NetworkData` carries `Set` (olsPoolIds…) and
   `Map` (oracle `rates`, `poolLabels`) fields; `unstable_cache` JSON-serializes and
   **silently drops** them (`JSON.stringify(new Map())==='{}'`) → lost strategy badges +
   oracle rates. Requires a serialize→plain→rehydrate transform, or Next 16 `"use cache"`

--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -134,7 +134,8 @@ out explicitly.
     <0.05 needs per-pool-type height tuning (FPMM vs virtual pools differ). Mirror the
     fix in `loading.tsx`.
   - **P2b · SSR-prefetch the pool overview** (M–L). Apply the proven
-    `fetchAllNetworks → SWR fallbackData` pattern (from `/` and `/pools`) to
+    SSR-payload → SWR `fallbackData` pattern (from `/` and `/pools`, now served
+    through `fetchInitialNetworkData` in `network-fetcher/server-cache.ts`) to
     `/pool/[id]`. The server _already_ round-trips the endpoint every request for OG
     metadata (`fetchPoolForMetadata`, `unstable_cache({revalidate:60})`), so the
     infra template exists — but the OG payload is transformed, so add a raw-shape

--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -185,7 +185,10 @@ chainId}]` — the server must reproduce the exact normalized id + `network.id`
   not LCP). **Shipped** (2026-07-09): `src/lib/network-fetcher/server-cache.ts` wraps the
   fan-out in `unstable_cache` (30s TTL) with an explicit dehydrate→rehydrate transform
   for the Map/Set fields, caches healthy payloads only (degraded ones pass through
-  uncached via an error carrier so `N/A` tiles are never pinned for the TTL), and strips
+  uncached via an error carrier — cold misses only, since `unstable_cache` serves stale
+  entries and swallows background-revalidation errors; a `fetchedAt` age gate bounds
+  served staleness at ~90s with a foreground refetch, covering the stale-serve path so
+  `N/A` tiles are never pinned), and strips
   the unread raw `feeSnapshots` rows from the `/` + `/pools` Flight payload. Note the
   impact re-rating vs. this plan's original scoring: a 2026-07-09 re-measure showed the
   homepage document _streaming_ until 0.9–1.9s (the fan-out runs inside the streamed

--- a/ui-dashboard/src/app/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.server.test.tsx
@@ -4,9 +4,9 @@ import HomePage, { generateMetadata } from "../page";
 
 type GlobalPageProps = { initialNetworkData?: unknown };
 
-const { mockFetchAllNetworks, mockFetchHomepageOgData, mockGlobalPage } =
+const { mockFetchInitialNetworkData, mockFetchHomepageOgData, mockGlobalPage } =
   vi.hoisted(() => ({
-    mockFetchAllNetworks: vi.fn(),
+    mockFetchInitialNetworkData: vi.fn(),
     mockFetchHomepageOgData: vi.fn(),
     mockGlobalPage: vi.fn((props: GlobalPageProps) => {
       void props;
@@ -14,8 +14,8 @@ const { mockFetchAllNetworks, mockFetchHomepageOgData, mockGlobalPage } =
     }),
   }));
 
-vi.mock("@/lib/fetch-all-networks", () => ({
-  fetchAllNetworks: mockFetchAllNetworks,
+vi.mock("@/lib/network-fetcher/server-cache", () => ({
+  fetchInitialNetworkData: mockFetchInitialNetworkData,
 }));
 
 vi.mock("@/lib/homepage-og", () => ({
@@ -43,7 +43,7 @@ const homepageOgData = {
 };
 
 beforeEach(() => {
-  mockFetchAllNetworks.mockReset();
+  mockFetchInitialNetworkData.mockReset();
   mockFetchHomepageOgData.mockReset();
   mockGlobalPage.mockClear();
 });
@@ -87,7 +87,7 @@ describe("HomePage route metadata", () => {
 describe("HomePage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
-    mockFetchAllNetworks.mockResolvedValueOnce(initialNetworkData);
+    mockFetchInitialNetworkData.mockResolvedValueOnce(initialNetworkData);
 
     renderToStaticMarkup(await HomePage());
 
@@ -95,7 +95,9 @@ describe("HomePage server component", () => {
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
-    mockFetchAllNetworks.mockRejectedValueOnce(new Error("network fanout"));
+    mockFetchInitialNetworkData.mockRejectedValueOnce(
+      new Error("network fanout"),
+    );
 
     renderToStaticMarkup(await HomePage());
 

--- a/ui-dashboard/src/app/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.server.test.tsx
@@ -87,11 +87,17 @@ describe("HomePage route metadata", () => {
 describe("HomePage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
-    mockFetchInitialNetworkData.mockResolvedValueOnce(initialNetworkData);
+    mockFetchInitialNetworkData.mockResolvedValueOnce({
+      networks: initialNetworkData,
+      fetchedAtMs: 1_700_000_000_000,
+    });
 
     renderToStaticMarkup(await HomePage());
 
-    expect(mockGlobalPage).toHaveBeenCalledWith({ initialNetworkData });
+    expect(mockGlobalPage).toHaveBeenCalledWith({
+      initialNetworkData,
+      initialNetworkDataFetchedAtMs: 1_700_000_000_000,
+    });
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
@@ -103,6 +109,7 @@ describe("HomePage server component", () => {
 
     expect(mockGlobalPage).toHaveBeenCalledWith({
       initialNetworkData: undefined,
+      initialNetworkDataFetchedAtMs: undefined,
     });
   });
 });

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -40,8 +40,10 @@ const SECONDS_PER_DAY = 86_400;
 
 export default function GlobalPage({
   initialNetworkData,
+  initialNetworkDataFetchedAtMs,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   // First paint uses `initialNetworkData` via SWR's `fallbackData`; on
   // back-navigation the populated SWR cache wins, which is the right call —
@@ -51,7 +53,10 @@ export default function GlobalPage({
   // anyway, and the next `refreshInterval` tick will refresh either way.
   return (
     <Suspense>
-      <GlobalContent initialNetworkData={initialNetworkData} />
+      <GlobalContent
+        initialNetworkData={initialNetworkData}
+        initialNetworkDataFetchedAtMs={initialNetworkDataFetchedAtMs}
+      />
     </Suspense>
   );
 }
@@ -106,10 +111,15 @@ function perPoolTvlWindow(
 // eslint-disable-next-line max-lines-per-function -- Homepage coordinates network data polling, KPI aggregation, and global pool table in one route surface.
 function GlobalContent({
   initialNetworkData,
+  initialNetworkDataFetchedAtMs,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
-  const { networkData, isLoading } = useAllNetworksData(initialNetworkData);
+  const { networkData, isLoading } = useAllNetworksData(
+    initialNetworkData,
+    initialNetworkDataFetchedAtMs,
+  );
 
   // Whether any network has a top-level, rates, snapshot, or pagination
   // failure. Used to show N/A / "partial data" in KPI tiles rather than

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import GlobalPage from "./page-client";
 import { fetchHomepageOgData } from "@/lib/homepage-og";
-import { fetchAllNetworks } from "@/lib/fetch-all-networks";
+import { fetchInitialNetworkData } from "@/lib/network-fetcher/server-cache";
 import { formatUSD } from "@/lib/format";
 
 // Dynamic OG metadata — scoped to the homepage so other routes (/pool/...,
@@ -78,10 +78,13 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage() {
   // SSR the initial dashboard payload so first paint renders without a
-  // 14-fan-out GraphQL waterfall. `fetchAllNetworks` uses Promise.allSettled
-  // internally and returns per-network fallback on failure, so it won't
-  // throw — but guard anyway in case a truly unexpected error bubbles up;
+  // 14-fan-out GraphQL waterfall. Served from a 30s cross-request cache
+  // (healthy payloads only — degraded ones pass through uncached, and the
+  // underlying `fetchAllNetworks` uses Promise.allSettled internally so it
+  // won't throw). Guard anyway in case a truly unexpected error bubbles up;
   // an undefined initial payload just reverts to the client-only code path.
-  const initialNetworkData = await fetchAllNetworks().catch(() => undefined);
+  const initialNetworkData = await fetchInitialNetworkData().catch(
+    () => undefined,
+  );
   return <GlobalPage initialNetworkData={initialNetworkData} />;
 }

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -78,8 +78,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage() {
   // SSR the initial dashboard payload so first paint renders without a
-  // 14-fan-out GraphQL waterfall. Served from a 30s cross-request cache
-  // (healthy payloads only — degraded ones pass through uncached, and the
+  // 14-fan-out GraphQL waterfall. Served from a cross-request cache (30s TTL,
+  // ~90s worst-case staleness via the fetchedAt age gate in server-cache;
+  // healthy payloads only — degraded ones are never cached, and the
   // underlying `fetchAllNetworks` uses Promise.allSettled internally so it
   // won't throw). Guard anyway in case a truly unexpected error bubbles up;
   // an undefined initial payload just reverts to the client-only code path.

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -79,13 +79,18 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function HomePage() {
   // SSR the initial dashboard payload so first paint renders without a
   // 14-fan-out GraphQL waterfall. Served from a cross-request cache (30s TTL,
-  // ~90s worst-case staleness via the fetchedAt age gate in server-cache;
-  // healthy payloads only — degraded ones are never cached, and the
-  // underlying `fetchAllNetworks` uses Promise.allSettled internally so it
-  // won't throw). Guard anyway in case a truly unexpected error bubbles up;
-  // an undefined initial payload just reverts to the client-only code path.
-  const initialNetworkData = await fetchInitialNetworkData().catch(
-    () => undefined,
+  // up to 5min served staleness — the client hook revalidates on mount when
+  // the payload is older than its fresh-enough bound, so stale numbers last
+  // ~1-2s, not until the next poll; healthy payloads only — degraded ones
+  // are never cached, and the underlying `fetchAllNetworks` uses
+  // Promise.allSettled internally so it won't throw). Guard anyway in case a
+  // truly unexpected error bubbles up; an undefined initial payload just
+  // reverts to the client-only code path.
+  const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  return (
+    <GlobalPage
+      initialNetworkData={initialPayload?.networks}
+      initialNetworkDataFetchedAtMs={initialPayload?.fetchedAtMs}
+    />
   );
-  return <GlobalPage initialNetworkData={initialNetworkData} />;
 }

--- a/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
@@ -28,11 +28,17 @@ beforeEach(() => {
 describe("PoolsPage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
-    mockFetchInitialNetworkData.mockResolvedValueOnce(initialNetworkData);
+    mockFetchInitialNetworkData.mockResolvedValueOnce({
+      networks: initialNetworkData,
+      fetchedAtMs: 1_700_000_000_000,
+    });
 
     renderToStaticMarkup(await PoolsPage());
 
-    expect(mockPoolsPageClient).toHaveBeenCalledWith({ initialNetworkData });
+    expect(mockPoolsPageClient).toHaveBeenCalledWith({
+      initialNetworkData,
+      initialNetworkDataFetchedAtMs: 1_700_000_000_000,
+    });
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
@@ -44,6 +50,7 @@ describe("PoolsPage server component", () => {
 
     expect(mockPoolsPageClient).toHaveBeenCalledWith({
       initialNetworkData: undefined,
+      initialNetworkDataFetchedAtMs: undefined,
     });
   });
 });

--- a/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
@@ -4,16 +4,16 @@ import PoolsPage from "../page";
 
 type PoolsPageProps = { initialNetworkData?: unknown };
 
-const { mockFetchAllNetworks, mockPoolsPageClient } = vi.hoisted(() => ({
-  mockFetchAllNetworks: vi.fn(),
+const { mockFetchInitialNetworkData, mockPoolsPageClient } = vi.hoisted(() => ({
+  mockFetchInitialNetworkData: vi.fn(),
   mockPoolsPageClient: vi.fn((props: PoolsPageProps) => {
     void props;
     return null;
   }),
 }));
 
-vi.mock("@/lib/fetch-all-networks", () => ({
-  fetchAllNetworks: mockFetchAllNetworks,
+vi.mock("@/lib/network-fetcher/server-cache", () => ({
+  fetchInitialNetworkData: mockFetchInitialNetworkData,
 }));
 
 vi.mock("../_components/pools-page-client", () => ({
@@ -21,14 +21,14 @@ vi.mock("../_components/pools-page-client", () => ({
 }));
 
 beforeEach(() => {
-  mockFetchAllNetworks.mockReset();
+  mockFetchInitialNetworkData.mockReset();
   mockPoolsPageClient.mockClear();
 });
 
 describe("PoolsPage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
-    mockFetchAllNetworks.mockResolvedValueOnce(initialNetworkData);
+    mockFetchInitialNetworkData.mockResolvedValueOnce(initialNetworkData);
 
     renderToStaticMarkup(await PoolsPage());
 
@@ -36,7 +36,9 @@ describe("PoolsPage server component", () => {
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
-    mockFetchAllNetworks.mockRejectedValueOnce(new Error("network fanout"));
+    mockFetchInitialNetworkData.mockRejectedValueOnce(
+      new Error("network fanout"),
+    );
 
     renderToStaticMarkup(await PoolsPage());
 

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -41,12 +41,17 @@ import { SenderCell } from "@/components/sender-cell";
 
 export function PoolsPageClient({
   initialNetworkData,
+  initialNetworkDataFetchedAtMs,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   return (
     <Suspense>
-      <PoolsContent initialNetworkData={initialNetworkData} />
+      <PoolsContent
+        initialNetworkData={initialNetworkData}
+        initialNetworkDataFetchedAtMs={initialNetworkDataFetchedAtMs}
+      />
     </Suspense>
   );
 }
@@ -54,18 +59,24 @@ export function PoolsPageClient({
 // eslint-disable-next-line max-lines-per-function -- Existing page component owns network data, table controls, and degraded-count messaging.
 function PoolsContent({
   initialNetworkData,
+  initialNetworkDataFetchedAtMs,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   "use memo";
 
   // `initialNetworkData` lets first paint render the full pools table from
   // SSR data instead of a 3-row `<Skeleton />` — fixes the 0.49 CLS that
   // lhci flagged on this route (BACKLOG "Lighthouse CI Follow-Ups"). The
-  // hook's `fallbackData` branch turns off mount revalidation on a cold
-  // SWR cache, so the first paint also fires zero client GraphQL requests.
-  const { networkData, isLoading: poolsLoading } =
-    useAllNetworksData(initialNetworkData);
+  // hook's `fallbackData` branch turns off mount revalidation on a cold SWR
+  // cache when the payload is fresh (< SSR_FRESH_ENOUGH_MS), so that first
+  // paint fires zero client GraphQL requests; older SSR payloads paint
+  // instantly and revalidate immediately.
+  const { networkData, isLoading: poolsLoading } = useAllNetworksData(
+    initialNetworkData,
+    initialNetworkDataFetchedAtMs,
+  );
   const searchParams = useSearchParams();
   const { replace } = useRouter();
 

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -22,8 +22,11 @@ export const metadata: Metadata = {
 };
 
 export default async function PoolsPage() {
-  const initialNetworkData = await fetchInitialNetworkData().catch(
-    () => undefined,
+  const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  return (
+    <PoolsPageClient
+      initialNetworkData={initialPayload?.networks}
+      initialNetworkDataFetchedAtMs={initialPayload?.fetchedAtMs}
+    />
   );
-  return <PoolsPageClient initialNetworkData={initialNetworkData} />;
 }

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -6,9 +6,10 @@ import { fetchInitialNetworkData } from "@/lib/network-fetcher/server-cache";
 // full pools table. Without this, the client renders a 3-row `<Skeleton />`
 // then swaps in a ~27-row table when SWR resolves, pushing the swaps section
 // below it down by ~1 200 px — measured CLS 0.4896 on the lhci /pools run
-// (BACKLOG "Lighthouse CI Follow-Ups"). The payload is served from a 30s
-// cross-request cache (healthy payloads only — degraded ones pass through
-// uncached, and the underlying `fetchAllNetworks` uses `Promise.allSettled`
+// (BACKLOG "Lighthouse CI Follow-Ups"). The payload is served from a
+// cross-request cache (30s TTL, ~90s worst-case staleness via the fetchedAt
+// age gate in server-cache; healthy payloads only — degraded ones are never
+// cached, and the underlying `fetchAllNetworks` uses `Promise.allSettled`
 // internally so it degrades per-network on failure); the catch only fires on
 // truly unexpected errors, and an undefined initial payload falls back to
 // the existing client-only path.

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next";
 import { PoolsPageClient } from "./_components/pools-page-client";
-import { fetchAllNetworks } from "@/lib/fetch-all-networks";
+import { fetchInitialNetworkData } from "@/lib/network-fetcher/server-cache";
 
 // SSR the initial cross-chain pool list so first paint already contains the
 // full pools table. Without this, the client renders a 3-row `<Skeleton />`
 // then swaps in a ~27-row table when SWR resolves, pushing the swaps section
 // below it down by ~1 200 px — measured CLS 0.4896 on the lhci /pools run
-// (BACKLOG "Lighthouse CI Follow-Ups"). `fetchAllNetworks` uses
-// `Promise.allSettled` internally and degrades per-network on failure, so
-// the catch only fires on truly unexpected errors; an undefined initial
-// payload falls back to the existing client-only path.
+// (BACKLOG "Lighthouse CI Follow-Ups"). The payload is served from a 30s
+// cross-request cache (healthy payloads only — degraded ones pass through
+// uncached, and the underlying `fetchAllNetworks` uses `Promise.allSettled`
+// internally so it degrades per-network on failure); the catch only fires on
+// truly unexpected errors, and an undefined initial payload falls back to
+// the existing client-only path.
 export const revalidate = 60;
 
 export const metadata: Metadata = {
@@ -19,6 +21,8 @@ export const metadata: Metadata = {
 };
 
 export default async function PoolsPage() {
-  const initialNetworkData = await fetchAllNetworks().catch(() => undefined);
+  const initialNetworkData = await fetchInitialNetworkData().catch(
+    () => undefined,
+  );
   return <PoolsPageClient initialNetworkData={initialNetworkData} />;
 }

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   fetchNetworkData,
   fetchAllNetworks,
+  shouldSkipMountRevalidation,
   showInitialSkeleton,
+  SSR_FRESH_ENOUGH_MS,
   warnedCapKeys,
   partialPageLastCapturedAt,
 } from "../use-all-networks-data";
@@ -1496,6 +1498,55 @@ describe("fetchAllNetworks — orchestration", () => {
       expect(result.error).toEqual({ message: "string rejection" });
       expect(result.error).not.toBeInstanceOf(Error);
     }
+  });
+});
+
+describe("shouldSkipMountRevalidation", () => {
+  const base = {
+    hasFallback: true,
+    allHealthy: true,
+    isCacheCold: true,
+    fallbackFetchedAtMs: 1_700_000_000_000,
+    nowMs: 1_700_000_000_000,
+  };
+
+  it("skips the mount fetch for a fresh, healthy payload on a cold cache", () => {
+    expect(
+      shouldSkipMountRevalidation({
+        ...base,
+        nowMs: base.fallbackFetchedAtMs + SSR_FRESH_ENOUGH_MS - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("revalidates when the SSR payload is older than the fresh-enough bound", () => {
+    // The server cache serves up to MAX_SERVED_STALENESS_MS of staleness so
+    // sparse-traffic visitors get an instant paint; this gate is what keeps
+    // that staleness on screen for only the ~1-2s the refetch takes.
+    expect(
+      shouldSkipMountRevalidation({
+        ...base,
+        nowMs: base.fallbackFetchedAtMs + SSR_FRESH_ENOUGH_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("revalidates when the payload age is unknown (safe default)", () => {
+    expect(
+      shouldSkipMountRevalidation({ ...base, fallbackFetchedAtMs: undefined }),
+    ).toBe(false);
+  });
+
+  it("revalidates for degraded payloads and warm caches regardless of freshness", () => {
+    expect(shouldSkipMountRevalidation({ ...base, allHealthy: false })).toBe(
+      false,
+    );
+    expect(shouldSkipMountRevalidation({ ...base, isCacheCold: false })).toBe(
+      false,
+    );
+    expect(shouldSkipMountRevalidation({ ...base, hasFallback: false })).toBe(
+      false,
+    );
   });
 });
 

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -16,6 +16,40 @@ type AllNetworksResult = {
   error: Error | null;
 };
 
+/**
+ * SSR payloads younger than this skip mount revalidation entirely (first
+ * paint fires 0 client GraphQL requests). Older ones still paint instantly
+ * from `fallbackData` but revalidate immediately — the server cache serves
+ * up to 5 min of staleness (MAX_SERVED_STALENESS_MS, tuned for production's
+ * sparse ~15-min-gap traffic), and without this gate that staleness would
+ * sit on screen until the next poll interval.
+ */
+export const SSR_FRESH_ENOUGH_MS = 60_000;
+
+/**
+ * Pure gate for the mount-revalidation skip: only a healthy, fresh-enough
+ * SSR payload landing on a cold SWR cache may suppress the mount fetch.
+ * Extracted so the composition is unit-testable without a render harness.
+ */
+export function shouldSkipMountRevalidation({
+  hasFallback,
+  allHealthy,
+  isCacheCold,
+  fallbackFetchedAtMs,
+  nowMs,
+}: {
+  hasFallback: boolean;
+  allHealthy: boolean;
+  isCacheCold: boolean;
+  fallbackFetchedAtMs: number | undefined;
+  nowMs: number;
+}): boolean {
+  const isFreshEnough =
+    fallbackFetchedAtMs !== undefined &&
+    nowMs - fallbackFetchedAtMs < SSR_FRESH_ENOUGH_MS;
+  return hasFallback && allHealthy && isCacheCold && isFreshEnough;
+}
+
 // Re-exports so long-established import sites keep working
 // (`import { NetworkData, fetchAllNetworks, warnedCapKeys, ... } from
 // "@/hooks/use-all-networks-data"`). New code should import directly from
@@ -46,12 +80,20 @@ export {
  * - On any SSR degradation (per-slice or per-chain error), let SWR
  *   revalidate on mount so partial `N/A` metrics recover immediately
  *   instead of being pinned until the next poll.
+ * - On a STALE-but-healthy SSR payload (the server cache serves up to
+ *   MAX_SERVED_STALENESS_MS of staleness so sparse-traffic visitors get an
+ *   instant paint), let SWR revalidate on mount so the stale numbers are on
+ *   screen only for the ~1-2s the refetch takes, not until the next poll.
  *
  * Options are applied at this hook's call site rather than an ancestor
  * `SWRConfig` so they don't cascade to any other `useSWR` in the tree.
  */
 export function useAllNetworksData(
   fallbackData?: NetworkData[],
+  /** Fetch-completion time of `fallbackData`
+   *  (`fetchInitialNetworkData().fetchedAtMs`). Omitted/unknown counts as
+   *  stale — revalidate-on-mount is the safe default. */
+  fallbackFetchedAtMs?: number,
 ): AllNetworksResult {
   const { cache } = useSWRConfig();
   const allHealthy =
@@ -62,8 +104,13 @@ export function useAllNetworksData(
   // older than the SSR payload. The read is synchronous and idempotent —
   // `cache.get` doesn't mutate state.
   const isCacheCold = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data === undefined;
-  const skipRevalidation =
-    fallbackData !== undefined && allHealthy && isCacheCold;
+  const skipRevalidation = shouldSkipMountRevalidation({
+    hasFallback: fallbackData !== undefined,
+    allHealthy,
+    isCacheCold,
+    fallbackFetchedAtMs,
+    nowMs: Date.now(),
+  });
 
   // Seed before `useSWR`: degraded SSR payloads intentionally revalidate on
   // mount, and that immediate fetch must still use the incremental snapshot

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -1,24 +1,34 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Network } from "@/lib/networks";
 import type { NetworkData } from "@/lib/network-fetcher/types";
 
-const { mockFetchAllNetworks, cacheCallbackOutcomes } = vi.hoisted(() => ({
-  mockFetchAllNetworks: vi.fn(),
-  /** Records whether each unstable_cache callback invocation resolved
-   *  (cacheable) or threw (never written to the cache). */
-  cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
-}));
+const { mockFetchAllNetworks, cacheCallbackOutcomes, staleCacheEntry } =
+  vi.hoisted(() => ({
+    mockFetchAllNetworks: vi.fn(),
+    /** Records whether each unstable_cache callback invocation resolved
+     *  (cacheable) or threw (never written to the cache). */
+    cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
+    /** When armed, the unstable_cache mock returns this value WITHOUT
+     *  invoking the callback — mirroring Next's stale-hit path, where the
+     *  cached entry is served immediately and the background revalidation
+     *  (including any error it throws) is swallowed. */
+    staleCacheEntry: { value: undefined as unknown },
+  }));
 
 // next/cache needs the Next.js incremental-cache runtime; outside it the repo
 // convention is an identity wrapper (see pool-detail-ssr.test.ts). This one
 // additionally records resolve/throw so tests can assert which payloads would
-// have been written to the shared cache.
+// have been written to the shared cache, and can serve an armed stale entry
+// to simulate `unstable_cache`'s serve-stale-while-background-revalidate.
 vi.mock("next/cache", () => ({
   unstable_cache:
     <TArgs extends unknown[], TResult>(
       fn: (...args: TArgs) => Promise<TResult>,
     ) =>
     async (...args: TArgs): Promise<TResult> => {
+      if (staleCacheEntry.value !== undefined) {
+        return staleCacheEntry.value as TResult;
+      }
       try {
         const result = await fn(...args);
         cacheCallbackOutcomes.push("resolved");
@@ -91,6 +101,11 @@ function healthyNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
 beforeEach(() => {
   mockFetchAllNetworks.mockReset();
   cacheCallbackOutcomes.length = 0;
+  staleCacheEntry.value = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("dehydrate/rehydrate round-trip", () => {
@@ -165,5 +180,67 @@ describe("fetchInitialNetworkData", () => {
     mockFetchAllNetworks.mockRejectedValueOnce(new Error("boom"));
 
     await expect(fetchInitialNetworkData()).rejects.toThrow("boom");
+  });
+
+  // Stale-hit path: `unstable_cache` serves stale entries and swallows
+  // background-revalidation errors, so only the fetchedAt age gate bounds
+  // what visitors actually see (MAX_SERVED_STALENESS_MS = 90s).
+  describe("fetchedAt age gate", () => {
+    const NOW = 1_700_000_000_000;
+    /** Cached-entry shape as written by the cache callback: dehydrated,
+     *  fee-rows stripped, with the fetch-completion timestamp. */
+    function staleEntry(ageMs: number, overrides: Partial<NetworkData> = {}) {
+      return {
+        fetchedAt: NOW - ageMs,
+        networks: [
+          dehydrateNetworkData(
+            healthyNetworkData({ feeSnapshots: [], ...overrides }),
+          ),
+        ],
+      };
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+    });
+
+    it("serves a cached payload younger than 90s without refetching", async () => {
+      staleCacheEntry.value = staleEntry(89_000);
+
+      const result = await fetchInitialNetworkData();
+
+      expect(mockFetchAllNetworks).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    });
+
+    it("foreground-refetches a cached payload older than 90s", async () => {
+      // Distinguishable stale rate — the assertion below proves the fresh
+      // payload wins, not the pinned cache entry.
+      staleCacheEntry.value = staleEntry(90_001, {
+        rates: new Map([["42220:cUSD", 999]]),
+      });
+      mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
+
+      const result = await fetchInitialNetworkData();
+
+      expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+      expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    });
+
+    it("surfaces a fresh degraded payload past 90s instead of the stale healthy one", async () => {
+      staleCacheEntry.value = staleEntry(90_001);
+      mockFetchAllNetworks.mockResolvedValueOnce([
+        healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
+      ]);
+
+      const [data] = await fetchInitialNetworkData();
+
+      expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+      // Error channel intact → client mount revalidation fires, instead of
+      // the stale healthy payload masking a live outage.
+      expect(data!.ratesError).toEqual({ message: "oracle query failed" });
+    });
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -128,6 +128,12 @@ describe("dehydrate/rehydrate round-trip", () => {
     });
     expect(roundTripped.network).toEqual(network);
     expect(roundTripped.snapshotWindows).toEqual(windows);
+
+    // Schema-evolution net: full deep equality so a future Map/Set field on
+    // `NetworkData` that the dehydrate/rehydrate pair doesn't handle fails
+    // here (it would silently flatten to `{}` in the JSON round-trip)
+    // instead of shipping lost data.
+    expect(roundTripped).toEqual(data);
   });
 });
 

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/lib/network-fetcher/fetch", async (importOriginal) => ({
 import {
   dehydrateNetworkData,
   fetchInitialNetworkData,
+  MAX_SERVED_STALENESS_MS,
   rehydrateNetworkData,
 } from "@/lib/network-fetcher/server-cache";
 import { blankNetworkData } from "@/lib/network-fetcher/fetch";
@@ -211,8 +212,8 @@ describe("fetchInitialNetworkData", () => {
       vi.setSystemTime(NOW);
     });
 
-    it("serves a cached payload younger than 90s without refetching", async () => {
-      staleCacheEntry.value = staleEntry(89_000);
+    it("serves a cached payload younger than the staleness bound without refetching", async () => {
+      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS - 1_000);
 
       const result = await fetchInitialNetworkData();
 
@@ -221,10 +222,10 @@ describe("fetchInitialNetworkData", () => {
       expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
     });
 
-    it("foreground-refetches a cached payload older than 90s", async () => {
+    it("foreground-refetches a cached payload older than the staleness bound", async () => {
       // Distinguishable stale rate — the assertion below proves the fresh
       // payload wins, not the pinned cache entry.
-      staleCacheEntry.value = staleEntry(90_001, {
+      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1, {
         rates: new Map([["42220:cUSD", 999]]),
       });
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
@@ -235,8 +236,8 @@ describe("fetchInitialNetworkData", () => {
       expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
     });
 
-    it("surfaces a fresh degraded payload past 90s instead of the stale healthy one", async () => {
-      staleCacheEntry.value = staleEntry(90_001);
+    it("surfaces a fresh degraded payload past the staleness bound instead of the stale healthy one", async () => {
+      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1);
       mockFetchAllNetworks.mockResolvedValueOnce([
         healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
       ]);
@@ -247,6 +248,22 @@ describe("fetchInitialNetworkData", () => {
       // Error channel intact → client mount revalidation fires, instead of
       // the stale healthy payload masking a live outage.
       expect(data!.ratesError).toEqual({ message: "oracle query failed" });
+    });
+
+    it("coalesces concurrent over-age refetches into one upstream fan-out", async () => {
+      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1, {
+        rates: new Map([["42220:cUSD", 999]]),
+      });
+      mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
+
+      const [first, second] = await Promise.all([
+        fetchInitialNetworkData(),
+        fetchInitialNetworkData(),
+      ]);
+
+      expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+      expect(first[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      expect(second[0]!.rates.get("42220:cUSD")).toBe(1.0004);
     });
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -171,9 +171,10 @@ describe("fetchInitialNetworkData", () => {
 
     const result = await fetchInitialNetworkData();
 
-    expect(result).toHaveLength(1);
-    expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
-    expect(result[0]!.olsPoolIds.has("0xols")).toBe(true);
+    expect(result.networks).toHaveLength(1);
+    expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    expect(result.networks[0]!.olsPoolIds.has("0xols")).toBe(true);
+    expect(result.fetchedAtMs).toBeGreaterThan(0);
     expect(cacheCallbackOutcomes).toEqual(["resolved"]);
   });
 
@@ -182,7 +183,7 @@ describe("fetchInitialNetworkData", () => {
       healthyNetworkData({ feeSnapshotsTruncated: true }),
     ]);
 
-    const [data] = await fetchInitialNetworkData();
+    const [data] = (await fetchInitialNetworkData()).networks;
 
     expect(data!.feeSnapshots).toEqual([]);
     expect(data!.feeSnapshotsError).toBeNull();
@@ -194,10 +195,14 @@ describe("fetchInitialNetworkData", () => {
       healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
     ]);
 
-    const [data] = await fetchInitialNetworkData();
+    const { networks, fetchedAtMs } = await fetchInitialNetworkData();
 
-    expect(data!.ratesError).toEqual({ message: "oracle query failed" });
-    expect(data!.rates.get("42220:cUSD")).toBe(1.0004);
+    expect(networks[0]!.ratesError).toEqual({ message: "oracle query failed" });
+    expect(networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    // Degraded payloads are fetched in-band, so they report as fresh —
+    // the client freshness gate must not re-fetch a just-fetched payload
+    // for staleness reasons (the degraded path already revalidates).
+    expect(fetchedAtMs).toBeGreaterThan(0);
     expect(cacheCallbackOutcomes).toEqual(["threw"]);
   });
 
@@ -206,7 +211,7 @@ describe("fetchInitialNetworkData", () => {
 
     const result = await fetchInitialNetworkData();
 
-    expect(result).toEqual([]);
+    expect(result.networks).toEqual([]);
     expect(cacheCallbackOutcomes).toEqual(["threw"]);
   });
 
@@ -218,7 +223,8 @@ describe("fetchInitialNetworkData", () => {
 
   // Stale-hit path: `unstable_cache` serves stale entries and swallows
   // background-revalidation errors, so only the fetchedAt age gate bounds
-  // what visitors actually see (MAX_SERVED_STALENESS_MS = 90s).
+  // what the server will serve (MAX_SERVED_STALENESS_MS); staleness within
+  // that bound is handled client-side by the hook's freshness gate.
   describe("fetchedAt age gate", () => {
     const NOW = 1_700_000_000_000;
     /** Cached-entry shape as written by the cache callback: dehydrated,
@@ -245,8 +251,11 @@ describe("fetchInitialNetworkData", () => {
       const result = await fetchInitialNetworkData();
 
       expect(mockFetchAllNetworks).not.toHaveBeenCalled();
-      expect(result).toHaveLength(1);
-      expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      expect(result.networks).toHaveLength(1);
+      expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      // The served entry's real fetch time crosses to the client so the
+      // hook's freshness gate can decide to revalidate on mount.
+      expect(result.fetchedAtMs).toBe(NOW - (MAX_SERVED_STALENESS_MS - 1_000));
     });
 
     it("foreground-refetches a cached payload older than the staleness bound", async () => {
@@ -260,7 +269,7 @@ describe("fetchInitialNetworkData", () => {
       const result = await fetchInitialNetworkData();
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
-      expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
     });
 
     it("surfaces a fresh degraded payload past the staleness bound instead of the stale healthy one", async () => {
@@ -269,7 +278,7 @@ describe("fetchInitialNetworkData", () => {
         healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
       ]);
 
-      const [data] = await fetchInitialNetworkData();
+      const [data] = (await fetchInitialNetworkData()).networks;
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
       // Error channel intact → client mount revalidation fires, instead of
@@ -289,8 +298,8 @@ describe("fetchInitialNetworkData", () => {
       ]);
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
-      expect(first[0]!.rates.get("42220:cUSD")).toBe(1.0004);
-      expect(second[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      expect(first.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+      expect(second.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
     });
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -2,18 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Network } from "@/lib/networks";
 import type { NetworkData } from "@/lib/network-fetcher/types";
 
-const { mockFetchAllNetworks, cacheCallbackOutcomes, staleCacheEntry } =
-  vi.hoisted(() => ({
-    mockFetchAllNetworks: vi.fn(),
-    /** Records whether each unstable_cache callback invocation resolved
-     *  (cacheable) or threw (never written to the cache). */
-    cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
-    /** When armed, the unstable_cache mock returns this value WITHOUT
-     *  invoking the callback — mirroring Next's stale-hit path, where the
-     *  cached entry is served immediately and the background revalidation
-     *  (including any error it throws) is swallowed. */
-    staleCacheEntry: { value: undefined as unknown },
-  }));
+const {
+  mockFetchAllNetworks,
+  cacheCallbackOutcomes,
+  staleCacheEntry,
+  capturedCacheKeyParts,
+} = vi.hoisted(() => ({
+  mockFetchAllNetworks: vi.fn(),
+  /** Records whether each unstable_cache callback invocation resolved
+   *  (cacheable) or threw (never written to the cache). */
+  cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
+  /** When armed, the unstable_cache mock returns this value WITHOUT
+   *  invoking the callback — mirroring Next's stale-hit path, where the
+   *  cached entry is served immediately and the background revalidation
+   *  (including any error it throws) is swallowed. */
+  staleCacheEntry: { value: undefined as unknown },
+  /** Key parts passed to unstable_cache at module init — asserted so the
+   *  deploy/config salt can't silently disappear. */
+  capturedCacheKeyParts: [] as string[][],
+}));
 
 // next/cache needs the Next.js incremental-cache runtime; outside it the repo
 // convention is an identity wrapper (see pool-detail-ssr.test.ts). This one
@@ -21,11 +28,12 @@ const { mockFetchAllNetworks, cacheCallbackOutcomes, staleCacheEntry } =
 // have been written to the shared cache, and can serve an armed stale entry
 // to simulate `unstable_cache`'s serve-stale-while-background-revalidate.
 vi.mock("next/cache", () => ({
-  unstable_cache:
-    <TArgs extends unknown[], TResult>(
-      fn: (...args: TArgs) => Promise<TResult>,
-    ) =>
-    async (...args: TArgs): Promise<TResult> => {
+  unstable_cache: <TArgs extends unknown[], TResult>(
+    fn: (...args: TArgs) => Promise<TResult>,
+    keyParts?: string[],
+  ) => {
+    if (keyParts) capturedCacheKeyParts.push(keyParts);
+    return async (...args: TArgs): Promise<TResult> => {
       if (staleCacheEntry.value !== undefined) {
         return staleCacheEntry.value as TResult;
       }
@@ -37,7 +45,8 @@ vi.mock("next/cache", () => ({
         cacheCallbackOutcomes.push("threw");
         throw err;
       }
-    },
+    };
+  },
 }));
 
 vi.mock("@/lib/network-fetcher/fetch", async (importOriginal) => ({
@@ -135,6 +144,24 @@ describe("dehydrate/rehydrate round-trip", () => {
     // here (it would silently flatten to `{}` in the JSON round-trip)
     // instead of shipping lost data.
     expect(roundTripped).toEqual(data);
+  });
+});
+
+describe("cache key salting", () => {
+  it("salts the unstable_cache key with a deploy marker and the configured network ids", () => {
+    // Captured at module init by the next/cache mock. A deploy that changes
+    // the configured network set or ships new payload-shape code must never
+    // hit an entry written by older code — Vercel's Data Cache persists
+    // across deployments within an environment.
+    expect(capturedCacheKeyParts).toHaveLength(1);
+    const parts = capturedCacheKeyParts[0]!;
+    expect(parts[0]).toBe("all-networks-ssr");
+    // Deploy salt: VERCEL_GIT_COMMIT_SHA in prod, "dev" locally/in tests.
+    expect(parts[1]).toBeTruthy();
+    // Config salt: pipe-joined configured network ids (may be "" when no
+    // network env is configured in the test environment — the join itself
+    // must still be present as a distinct key part).
+    expect(parts).toHaveLength(3);
   });
 });
 

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Network } from "@/lib/networks";
+import type { NetworkData } from "@/lib/network-fetcher/types";
+
+const { mockFetchAllNetworks, cacheCallbackOutcomes } = vi.hoisted(() => ({
+  mockFetchAllNetworks: vi.fn(),
+  /** Records whether each unstable_cache callback invocation resolved
+   *  (cacheable) or threw (never written to the cache). */
+  cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
+}));
+
+// next/cache needs the Next.js incremental-cache runtime; outside it the repo
+// convention is an identity wrapper (see pool-detail-ssr.test.ts). This one
+// additionally records resolve/throw so tests can assert which payloads would
+// have been written to the shared cache.
+vi.mock("next/cache", () => ({
+  unstable_cache:
+    <TArgs extends unknown[], TResult>(
+      fn: (...args: TArgs) => Promise<TResult>,
+    ) =>
+    async (...args: TArgs): Promise<TResult> => {
+      try {
+        const result = await fn(...args);
+        cacheCallbackOutcomes.push("resolved");
+        return result;
+      } catch (err) {
+        cacheCallbackOutcomes.push("threw");
+        throw err;
+      }
+    },
+}));
+
+vi.mock("@/lib/network-fetcher/fetch", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/network-fetcher/fetch")>()),
+  fetchAllNetworks: mockFetchAllNetworks,
+}));
+
+import {
+  dehydrateNetworkData,
+  fetchInitialNetworkData,
+  rehydrateNetworkData,
+} from "@/lib/network-fetcher/server-cache";
+import { blankNetworkData } from "@/lib/network-fetcher/fetch";
+
+const network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://example.invalid/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://example.invalid",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: true,
+} as Network;
+
+const windows = {
+  w24h: { from: 0, to: 86_400 },
+  w7d: { from: 0, to: 604_800 },
+  w30d: { from: 0, to: 2_592_000 },
+};
+
+function healthyNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
+  return blankNetworkData(network, windows, {
+    rates: new Map([["42220:cUSD", 1.0004]]),
+    poolLabels: new Map([
+      [
+        "0xabc",
+        {
+          id: "0xabc",
+          token0: "0x1",
+          token1: "0x2",
+          source: "fpmm",
+        } as NetworkData["poolLabels"] extends Map<string, infer V> ? V : never,
+      ],
+    ]),
+    olsPoolIds: new Set(["0xols"]),
+    cdpPoolIds: new Set(["0xcdp"]),
+    reservePoolIds: new Set(["0xres"]),
+    feeSnapshots: [
+      { id: "fee-1" } as NetworkData["feeSnapshots"][number],
+      { id: "fee-2" } as NetworkData["feeSnapshots"][number],
+    ],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  mockFetchAllNetworks.mockReset();
+  cacheCallbackOutcomes.length = 0;
+});
+
+describe("dehydrate/rehydrate round-trip", () => {
+  it("restores Map and Set fields through a JSON round-trip", () => {
+    const data = healthyNetworkData();
+
+    const roundTripped = rehydrateNetworkData(
+      // JSON round-trip mirrors what unstable_cache does to cached values
+      // (JSON.parse of the stored body) — the exact step that silently turns
+      // a raw Map/Set into `{}`.
+      JSON.parse(JSON.stringify(dehydrateNetworkData(data))),
+    );
+
+    expect(roundTripped.rates).toEqual(new Map([["42220:cUSD", 1.0004]]));
+    expect(roundTripped.olsPoolIds).toEqual(new Set(["0xols"]));
+    expect(roundTripped.cdpPoolIds).toEqual(new Set(["0xcdp"]));
+    expect(roundTripped.reservePoolIds).toEqual(new Set(["0xres"]));
+    expect(roundTripped.poolLabels.get("0xabc")).toMatchObject({
+      id: "0xabc",
+    });
+    expect(roundTripped.network).toEqual(network);
+    expect(roundTripped.snapshotWindows).toEqual(windows);
+  });
+});
+
+describe("fetchInitialNetworkData", () => {
+  it("returns the rehydrated healthy payload and marks it cacheable", async () => {
+    mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
+
+    const result = await fetchInitialNetworkData();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    expect(result[0]!.olsPoolIds.has("0xols")).toBe(true);
+    expect(cacheCallbackOutcomes).toEqual(["resolved"]);
+  });
+
+  it("strips raw feeSnapshots rows but keeps the fee outcome fields", async () => {
+    mockFetchAllNetworks.mockResolvedValueOnce([
+      healthyNetworkData({ feeSnapshotsTruncated: true }),
+    ]);
+
+    const [data] = await fetchInitialNetworkData();
+
+    expect(data!.feeSnapshots).toEqual([]);
+    expect(data!.feeSnapshotsError).toBeNull();
+    expect(data!.feeSnapshotsTruncated).toBe(true);
+  });
+
+  it("still returns a degraded payload but never caches it", async () => {
+    mockFetchAllNetworks.mockResolvedValueOnce([
+      healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
+    ]);
+
+    const [data] = await fetchInitialNetworkData();
+
+    expect(data!.ratesError).toEqual({ message: "oracle query failed" });
+    expect(data!.rates.get("42220:cUSD")).toBe(1.0004);
+    expect(cacheCallbackOutcomes).toEqual(["threw"]);
+  });
+
+  it("treats an empty payload as degraded instead of pinning it", async () => {
+    mockFetchAllNetworks.mockResolvedValueOnce([]);
+
+    const result = await fetchInitialNetworkData();
+
+    expect(result).toEqual([]);
+    expect(cacheCallbackOutcomes).toEqual(["threw"]);
+  });
+
+  it("rethrows unexpected errors from the fetch", async () => {
+    mockFetchAllNetworks.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(fetchInitialNetworkData()).rejects.toThrow("boom");
+  });
+});

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -89,9 +89,14 @@ class DegradedNetworkDataError extends Error {
   }
 }
 
-async function fetchDehydratedInitialNetworkData(): Promise<
-  DehydratedNetworkData[]
-> {
+/** Cached wrapper shape: `fetchedAt` (Date.now() at fetch completion) rides
+ *  along so `fetchInitialNetworkData` can age-gate stale cache hits. */
+interface CachedNetworkPayload {
+  fetchedAt: number;
+  networks: DehydratedNetworkData[];
+}
+
+async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload> {
   const data = await fetchAllNetworks();
   const dehydrated = data.map((networkData) =>
     stripFeeSnapshotRows(dehydrateNetworkData(networkData)),
@@ -101,32 +106,52 @@ async function fetchDehydratedInitialNetworkData(): Promise<
   if (data.length === 0 || !data.every(isNetworkDataFullyHealthy)) {
     throw new DegradedNetworkDataError(dehydrated);
   }
-  return dehydrated;
+  return { fetchedAt: Date.now(), networks: dehydrated };
 }
 
-// 30s revalidate: half the pool-detail/OG 60s TTL because this payload IS the
-// page (KPI tiles + pools table), not a preview. Client-side freshness after
-// first paint is owned by the SWR poll (SNAPSHOT_REFRESH_MS); the healthy-
-// payload mount-revalidation skip in `useAllNetworksData` means SSR staleness
-// is user-visible until that first poll, so keep the TTL tight.
+// 30s revalidate — but NOT a staleness bound: on dynamic renders
+// `unstable_cache` serves a stale entry immediately and revalidates in the
+// background, and it swallows background-revalidation errors (including our
+// `DegradedNetworkDataError`), keeping the stale entry served. So the first
+// request after an idle gap gets an arbitrarily old payload, and once one
+// healthy entry exists a degraded upstream never surfaces through this
+// wrapper alone. The `fetchedAt` age gate in `fetchInitialNetworkData` is
+// what bounds served staleness and re-opens the degraded-error channel.
 const cachedFetch = unstable_cache(
   fetchDehydratedInitialNetworkData,
   ["all-networks-ssr"],
   { revalidate: 30, tags: ["all-networks-ssr"] },
 );
 
+// 3× the 30s TTL: under steady traffic the serve-stale-while-revalidate
+// window keeps real staleness ≈ one TTL, so this bound only bites after idle
+// gaps (first visitor after a quiet stretch) or sustained degradation —
+// exactly the cases where a foreground refetch is worth the latency.
+const MAX_SERVED_STALENESS_MS = 90_000;
+
 /**
  * Cached drop-in for `fetchAllNetworks()` in the `/` and `/pools` Server
- * Components. Healthy payloads are served from a 30s shared cache; degraded
- * payloads (any per-chain or per-slice error) bypass the cache entirely so
- * the next request retries upstream — mirroring the client hook, which
- * revalidates degraded fallbacks on mount. Raw `feeSnapshots` rows are
- * stripped (see `stripFeeSnapshotRows`); use `fetchAllNetworks` directly if a
- * future server consumer needs them.
+ * Components. Healthy payloads are served from a shared `unstable_cache`
+ * entry (30s TTL, ~90s worst-case served staleness); degraded payloads (any
+ * per-chain or per-slice error) are thrown out of the cache callback so they
+ * are never written to the cache. That bypass alone only covers cold misses —
+ * on a stale hit `unstable_cache` swallows the revalidation error — so the
+ * `fetchedAt` age gate below discards cache results older than
+ * `MAX_SERVED_STALENESS_MS` and refetches in the foreground, giving idle-gap
+ * visitors fresh data and letting a sustained outage surface as the fresh
+ * degraded payload (error channels intact → the client hook's mount
+ * revalidation fires) instead of a pinned last-healthy one. Raw
+ * `feeSnapshots` rows are stripped (see `stripFeeSnapshotRows`); use
+ * `fetchAllNetworks` directly if a future server consumer needs them.
  */
 export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
   try {
-    return (await cachedFetch()).map(rehydrateNetworkData);
+    const cached = await cachedFetch();
+    const payload =
+      Date.now() - cached.fetchedAt > MAX_SERVED_STALENESS_MS
+        ? await fetchDehydratedInitialNetworkData()
+        : cached;
+    return payload.networks.map(rehydrateNetworkData);
   } catch (err) {
     if (err instanceof DegradedNetworkDataError) {
       return err.payload.map(rehydrateNetworkData);

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -84,9 +84,20 @@ function stripFeeSnapshotRows(
  * TTL (it would otherwise trap every visitor on `N/A` tiles until expiry).
  */
 class DegradedNetworkDataError extends Error {
-  constructor(readonly payload: DehydratedNetworkData[]) {
+  declare readonly payload: DehydratedNetworkData[];
+
+  constructor(payload: DehydratedNetworkData[]) {
     super("degraded network data payload — not cached");
     this.name = "DegradedNetworkDataError";
+    // Non-enumerable: `unstable_cache`'s swallowed-error path console.errors
+    // the whole error object during background revalidation, and an
+    // enumerable payload would dump the multi-hundred-KB dehydrated
+    // dashboard into server logs on every stale revalidation while upstream
+    // is degraded. The foreground catch still reads it by name.
+    Object.defineProperty(this, "payload", {
+      value: payload,
+      enumerable: false,
+    });
   }
 }
 

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -16,6 +16,7 @@ import {
   isNetworkDataFullyHealthy,
 } from "@/lib/network-fetcher/fetch";
 import type { NetworkData, PoolLabel } from "@/lib/network-fetcher/types";
+import { NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 
 /**
  * `NetworkData` with every non-JSON field rewritten to a JSON round-trip-safe
@@ -117,9 +118,22 @@ async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload
 // healthy entry exists a degraded upstream never surfaces through this
 // wrapper alone. The `fetchedAt` age gate in `fetchInitialNetworkData` is
 // what bounds served staleness and re-opens the degraded-error channel.
+// Vercel's Data Cache persists across deployments within an environment, and
+// `unstable_cache` keys only on this wrapper's source + the explicit parts —
+// not on `fetchAllNetworks`'s env-derived network set or the dehydrated
+// payload shape. Salt the key with the deployment SHA (fresh entry per
+// deploy — one fan-out per deploy is cheap insurance against a new build
+// reading an old-shape payload) and the configured network ids (covers
+// env-only config changes and local dev where no SHA exists).
+const CACHE_KEY_PARTS = [
+  "all-networks-ssr",
+  process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+  NETWORK_IDS.filter(isConfiguredNetworkId).join("|"),
+];
+
 const cachedFetch = unstable_cache(
   fetchDehydratedInitialNetworkDataCoalesced,
-  ["all-networks-ssr"],
+  CACHE_KEY_PARTS,
   { revalidate: 30, tags: ["all-networks-ssr"] },
 );
 

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -127,7 +127,23 @@ const cachedFetch = unstable_cache(
 // window keeps real staleness ≈ one TTL, so this bound only bites after idle
 // gaps (first visitor after a quiet stretch) or sustained degradation —
 // exactly the cases where a foreground refetch is worth the latency.
-const MAX_SERVED_STALENESS_MS = 90_000;
+// Exported so tests derive their boundary fixtures from the real constant.
+export const MAX_SERVED_STALENESS_MS = 90_000;
+
+// Coalesce concurrent age-gate refetches within this isolate — a burst of
+// first-visitors-after-idle would otherwise each launch their own full
+// fan-out. This matches the coalescing scope of `unstable_cache`'s own
+// background revalidation (per-isolate via `pendingRevalidates`);
+// cross-instance duplication remains possible and is bounded by the
+// number of warm instances.
+let inFlightRefetch: Promise<CachedNetworkPayload> | null = null;
+
+function refetchInitialNetworkDataCoalesced(): Promise<CachedNetworkPayload> {
+  inFlightRefetch ??= fetchDehydratedInitialNetworkData().finally(() => {
+    inFlightRefetch = null;
+  });
+  return inFlightRefetch;
+}
 
 /**
  * Cached drop-in for `fetchAllNetworks()` in the `/` and `/pools` Server
@@ -149,7 +165,7 @@ export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
     const cached = await cachedFetch();
     const payload =
       Date.now() - cached.fetchedAt > MAX_SERVED_STALENESS_MS
-        ? await fetchDehydratedInitialNetworkData()
+        ? await refetchInitialNetworkDataCoalesced()
         : cached;
     return payload.networks.map(rehydrateNetworkData);
   } catch (err) {

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -136,9 +136,9 @@ const CACHE_KEY_PARTS = [
   process.env.VERCEL_DEPLOYMENT_ID ??
     process.env.VERCEL_GIT_COMMIT_SHA ??
     "dev",
-  NETWORK_IDS.filter(isConfiguredNetworkId)
-    .map((id) => `${id}=${NETWORKS[id].hasuraUrl}`)
-    .join("|"),
+  NETWORK_IDS.flatMap((id) =>
+    isConfiguredNetworkId(id) ? [`${id}=${NETWORKS[id].hasuraUrl}`] : [],
+  ).join("|"),
 ];
 
 const cachedFetch = unstable_cache(

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -16,7 +16,7 @@ import {
   isNetworkDataFullyHealthy,
 } from "@/lib/network-fetcher/fetch";
 import type { NetworkData, PoolLabel } from "@/lib/network-fetcher/types";
-import { NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
+import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 
 /**
  * `NetworkData` with every non-JSON field rewritten to a JSON round-trip-safe
@@ -121,14 +121,24 @@ async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload
 // Vercel's Data Cache persists across deployments within an environment, and
 // `unstable_cache` keys only on this wrapper's source + the explicit parts —
 // not on `fetchAllNetworks`'s env-derived network set or the dehydrated
-// payload shape. Salt the key with the deployment SHA (fresh entry per
-// deploy — one fan-out per deploy is cheap insurance against a new build
-// reading an old-shape payload) and the configured network ids (covers
-// env-only config changes and local dev where no SHA exists).
+// payload shape. Salt the key with:
+//  - the deployment id (unique per deployment, INCLUDING env-only redeploys
+//    that keep the same git commit — an env change repointing a Hasura URL
+//    only takes effect via a redeploy, so this fully covers endpoint
+//    swaps; commit SHA is the fallback where the id isn't exposed), and
+//  - the configured network ids + their Hasura endpoints (covers local dev,
+//    where no deployment id exists but `.next/cache` persists across
+//    restarts with different env).
+// One fan-out per deploy is cheap insurance against a new deployment
+// reading a payload fetched by old code or from an old endpoint.
 const CACHE_KEY_PARTS = [
   "all-networks-ssr",
-  process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
-  NETWORK_IDS.filter(isConfiguredNetworkId).join("|"),
+  process.env.VERCEL_DEPLOYMENT_ID ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    "dev",
+  NETWORK_IDS.filter(isConfiguredNetworkId)
+    .map((id) => `${id}=${NETWORKS[id].hasuraUrl}`)
+    .join("|"),
 ];
 
 const cachedFetch = unstable_cache(

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -118,7 +118,7 @@ async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload
 // wrapper alone. The `fetchedAt` age gate in `fetchInitialNetworkData` is
 // what bounds served staleness and re-opens the degraded-error channel.
 const cachedFetch = unstable_cache(
-  fetchDehydratedInitialNetworkData,
+  fetchDehydratedInitialNetworkDataCoalesced,
   ["all-networks-ssr"],
   { revalidate: 30, tags: ["all-networks-ssr"] },
 );
@@ -130,19 +130,23 @@ const cachedFetch = unstable_cache(
 // Exported so tests derive their boundary fixtures from the real constant.
 export const MAX_SERVED_STALENESS_MS = 90_000;
 
-// Coalesce concurrent age-gate refetches within this isolate — a burst of
-// first-visitors-after-idle would otherwise each launch their own full
-// fan-out. This matches the coalescing scope of `unstable_cache`'s own
-// background revalidation (per-isolate via `pendingRevalidates`);
-// cross-instance duplication remains possible and is bounded by the
-// number of warm instances.
-let inFlightRefetch: Promise<CachedNetworkPayload> | null = null;
+// Coalesce EVERY invocation of the upstream fan-out within this isolate:
+// concurrent cold-miss fills, the background revalidation `unstable_cache`
+// schedules on a stale hit, and the over-age foreground refetch in
+// `fetchInitialNetworkData` all share one in-flight fan-out. Feeding this
+// coalesced function to `unstable_cache` (rather than only wrapping the
+// age-gate path) matters: on an over-age hit Next has ALREADY started its
+// background revalidation of this same callback, so a separately-coalesced
+// foreground copy would still pair with it and double the upstream work.
+// Cross-instance duplication remains possible and is bounded by the number
+// of warm instances.
+let inFlightFanout: Promise<CachedNetworkPayload> | null = null;
 
-function refetchInitialNetworkDataCoalesced(): Promise<CachedNetworkPayload> {
-  inFlightRefetch ??= fetchDehydratedInitialNetworkData().finally(() => {
-    inFlightRefetch = null;
+function fetchDehydratedInitialNetworkDataCoalesced(): Promise<CachedNetworkPayload> {
+  inFlightFanout ??= fetchDehydratedInitialNetworkData().finally(() => {
+    inFlightFanout = null;
   });
-  return inFlightRefetch;
+  return inFlightFanout;
 }
 
 /**
@@ -165,7 +169,10 @@ export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
     const cached = await cachedFetch();
     const payload =
       Date.now() - cached.fetchedAt > MAX_SERVED_STALENESS_MS
-        ? await refetchInitialNetworkDataCoalesced()
+        ? // Joins the background revalidation `unstable_cache` started for
+          // this same stale hit (shared in-flight promise) instead of
+          // launching a second fan-out.
+          await fetchDehydratedInitialNetworkDataCoalesced()
         : cached;
     return payload.networks.map(rehydrateNetworkData);
   } catch (err) {

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -1,0 +1,136 @@
+// Server-only cross-request cache for the SSR dashboard payload (perf-plan
+// P7). `fetchAllNetworks` re-ran its full multi-network Hasura fan-out
+// (1 + 13 queries per chain, several paginated) on every `/` and `/pools`
+// request because the CSP-nonce middleware + layout cookie read force dynamic
+// rendering — measured at 0.8–1.9s of server time squarely inside the LCP
+// path. This module makes that fan-out a cache read for every request within
+// the TTL.
+//
+// Not exported from the `@/lib/fetch-all-networks` barrel on purpose: that
+// barrel is imported by client hooks, and this module pulls `next/cache`.
+// Import it directly from Server Components only.
+
+import { unstable_cache } from "next/cache";
+import {
+  fetchAllNetworks,
+  isNetworkDataFullyHealthy,
+} from "@/lib/network-fetcher/fetch";
+import type { NetworkData, PoolLabel } from "@/lib/network-fetcher/types";
+
+/**
+ * `NetworkData` with every non-JSON field rewritten to a JSON round-trip-safe
+ * shape. `unstable_cache` JSON-serializes cached values, which silently turns
+ * `Map` into `{}` and `Set` into `{}` (lost oracle rates → blank TVL, lost
+ * strategy badges) — the exact hazard the perf plan flags for the naive P7
+ * fix. Every other `NetworkData` field is already plain JSON: Hasura BigInts
+ * ride as decimal strings and error channels are flattened to `{ message }`
+ * by `withSerializableErrors` inside `fetchAllNetworks`.
+ */
+type DehydratedNetworkData = Omit<
+  NetworkData,
+  "rates" | "poolLabels" | "olsPoolIds" | "cdpPoolIds" | "reservePoolIds"
+> & {
+  rates: [string, number][];
+  poolLabels: [string, PoolLabel][];
+  olsPoolIds: string[];
+  cdpPoolIds: string[];
+  reservePoolIds: string[];
+};
+
+export function dehydrateNetworkData(data: NetworkData): DehydratedNetworkData {
+  return {
+    ...data,
+    rates: [...data.rates.entries()],
+    poolLabels: [...data.poolLabels.entries()],
+    olsPoolIds: [...data.olsPoolIds],
+    cdpPoolIds: [...data.cdpPoolIds],
+    reservePoolIds: [...data.reservePoolIds],
+  };
+}
+
+export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
+  return {
+    ...data,
+    rates: new Map(data.rates),
+    poolLabels: new Map(data.poolLabels),
+    olsPoolIds: new Set(data.olsPoolIds),
+    cdpPoolIds: new Set(data.cdpPoolIds),
+    reservePoolIds: new Set(data.reservePoolIds),
+  };
+}
+
+/**
+ * Drops the raw `feeSnapshots` rows (~330KB of the ~1.04MB Flight payload)
+ * from the SSR payload. Nothing on `/` or `/pools` reads the raw rows — the
+ * aggregated `fees` summary is computed server-side in `assembleNetworkData`
+ * before this projection, `/revenue` uses its own slim `useProtocolFees` hook
+ * with a separate SWR key, and `seedIncrementalRowCacheFromNetworkData`
+ * intentionally never seeds fee history (it keeps full pagination so healed
+ * rows are re-fetched). `feeSnapshotsError` / `feeSnapshotsTruncated` are
+ * kept so `isNetworkDataFullyHealthy` and the `≈` truncation UX still see
+ * the fetch outcome.
+ */
+function stripFeeSnapshotRows(
+  data: DehydratedNetworkData,
+): DehydratedNetworkData {
+  return { ...data, feeSnapshots: [] };
+}
+
+/**
+ * Carries the dehydrated payload of a degraded fetch out of `unstable_cache`
+ * without caching it: thrown values propagate to the caller instead of being
+ * written to the cache, so a partial/error payload is never pinned for the
+ * TTL (it would otherwise trap every visitor on `N/A` tiles until expiry).
+ */
+class DegradedNetworkDataError extends Error {
+  constructor(readonly payload: DehydratedNetworkData[]) {
+    super("degraded network data payload — not cached");
+    this.name = "DegradedNetworkDataError";
+  }
+}
+
+async function fetchDehydratedInitialNetworkData(): Promise<
+  DehydratedNetworkData[]
+> {
+  const data = await fetchAllNetworks();
+  const dehydrated = data.map((networkData) =>
+    stripFeeSnapshotRows(dehydrateNetworkData(networkData)),
+  );
+  // Empty = no configured networks (misconfigured env) — treat as degraded
+  // rather than pinning an empty dashboard for the TTL.
+  if (data.length === 0 || !data.every(isNetworkDataFullyHealthy)) {
+    throw new DegradedNetworkDataError(dehydrated);
+  }
+  return dehydrated;
+}
+
+// 30s revalidate: half the pool-detail/OG 60s TTL because this payload IS the
+// page (KPI tiles + pools table), not a preview. Client-side freshness after
+// first paint is owned by the SWR poll (SNAPSHOT_REFRESH_MS); the healthy-
+// payload mount-revalidation skip in `useAllNetworksData` means SSR staleness
+// is user-visible until that first poll, so keep the TTL tight.
+const cachedFetch = unstable_cache(
+  fetchDehydratedInitialNetworkData,
+  ["all-networks-ssr"],
+  { revalidate: 30, tags: ["all-networks-ssr"] },
+);
+
+/**
+ * Cached drop-in for `fetchAllNetworks()` in the `/` and `/pools` Server
+ * Components. Healthy payloads are served from a 30s shared cache; degraded
+ * payloads (any per-chain or per-slice error) bypass the cache entirely so
+ * the next request retries upstream — mirroring the client hook, which
+ * revalidates degraded fallbacks on mount. Raw `feeSnapshots` rows are
+ * stripped (see `stripFeeSnapshotRows`); use `fetchAllNetworks` directly if a
+ * future server consumer needs them.
+ */
+export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
+  try {
+    return (await cachedFetch()).map(rehydrateNetworkData);
+  } catch (err) {
+    if (err instanceof DegradedNetworkDataError) {
+      return err.payload.map(rehydrateNetworkData);
+    }
+    throw err;
+  }
+}

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -158,12 +158,16 @@ const cachedFetch = unstable_cache(
   { revalidate: 30, tags: ["all-networks-ssr"] },
 );
 
-// 3× the 30s TTL: under steady traffic the serve-stale-while-revalidate
-// window keeps real staleness ≈ one TTL, so this bound only bites after idle
-// gaps (first visitor after a quiet stretch) or sustained degradation —
-// exactly the cases where a foreground refetch is worth the latency.
+// Aligned with SNAPSHOT_REFRESH_MS (the 5-min client poll cadence users
+// already accept between refreshes). Production traffic is sparse — ~96
+// homepage document requests/day, ~15-min average gaps — so a tight bound
+// would force the common isolated visitor into a foreground fan-out; instead
+// we serve up to 5-min-old data instantly and rely on the client-side
+// freshness gate in `useAllNetworksData` (payloads older than
+// SSR_FRESH_ENOUGH_MS revalidate immediately on mount), so stale numbers are
+// on screen for the ~1-2s the refetch takes, not until the next poll.
 // Exported so tests derive their boundary fixtures from the real constant.
-export const MAX_SERVED_STALENESS_MS = 90_000;
+export const MAX_SERVED_STALENESS_MS = 300_000;
 
 // Coalesce EVERY invocation of the upstream fan-out within this isolate:
 // concurrent cold-miss fills, the background revalidation `unstable_cache`
@@ -184,22 +188,34 @@ function fetchDehydratedInitialNetworkDataCoalesced(): Promise<CachedNetworkPayl
   return inFlightFanout;
 }
 
+/** SSR payload plus its fetch-completion timestamp. `fetchedAtMs` crosses to
+ *  the client so `useAllNetworksData` can gate its mount-revalidation skip on
+ *  actual payload freshness rather than trusting whatever the cache served. */
+export type InitialNetworkDataPayload = {
+  networks: NetworkData[];
+  fetchedAtMs: number;
+};
+
 /**
  * Cached drop-in for `fetchAllNetworks()` in the `/` and `/pools` Server
  * Components. Healthy payloads are served from a shared `unstable_cache`
- * entry (30s TTL, ~90s worst-case served staleness); degraded payloads (any
- * per-chain or per-slice error) are thrown out of the cache callback so they
- * are never written to the cache. That bypass alone only covers cold misses —
- * on a stale hit `unstable_cache` swallows the revalidation error — so the
- * `fetchedAt` age gate below discards cache results older than
- * `MAX_SERVED_STALENESS_MS` and refetches in the foreground, giving idle-gap
- * visitors fresh data and letting a sustained outage surface as the fresh
- * degraded payload (error channels intact → the client hook's mount
- * revalidation fires) instead of a pinned last-healthy one. Raw
+ * entry (30s TTL, up to `MAX_SERVED_STALENESS_MS` of served staleness);
+ * degraded payloads (any per-chain or per-slice error) are thrown out of the
+ * cache callback so they are never written to the cache. That bypass alone
+ * only covers cold misses — on a stale hit `unstable_cache` swallows the
+ * revalidation error — so the `fetchedAt` age gate below discards cache
+ * results older than `MAX_SERVED_STALENESS_MS` and refetches in the
+ * foreground, giving long-idle-gap visitors fresh data and letting a
+ * sustained outage surface as the fresh degraded payload (error channels
+ * intact → the client hook's mount revalidation fires) instead of a pinned
+ * last-healthy one. Within the staleness window, freshness is the CLIENT's
+ * job: the returned `fetchedAtMs` drives the hook's freshness gate, which
+ * revalidates on mount whenever the payload is older than its
+ * fresh-enough bound — instant paint, live data ~1-2s later. Raw
  * `feeSnapshots` rows are stripped (see `stripFeeSnapshotRows`); use
  * `fetchAllNetworks` directly if a future server consumer needs them.
  */
-export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
+export async function fetchInitialNetworkData(): Promise<InitialNetworkDataPayload> {
   try {
     const cached = await cachedFetch();
     const payload =
@@ -209,10 +225,18 @@ export async function fetchInitialNetworkData(): Promise<NetworkData[]> {
           // launching a second fan-out.
           await fetchDehydratedInitialNetworkDataCoalesced()
         : cached;
-    return payload.networks.map(rehydrateNetworkData);
+    return {
+      networks: payload.networks.map(rehydrateNetworkData),
+      fetchedAtMs: payload.fetchedAt,
+    };
   } catch (err) {
     if (err instanceof DegradedNetworkDataError) {
-      return err.payload.map(rehydrateNetworkData);
+      // Degraded payloads are fetched in-band (never cached), so they are
+      // fresh as of this request.
+      return {
+        networks: err.payload.map(rehydrateNetworkData),
+        fetchedAtMs: Date.now(),
+      };
     }
     throw err;
   }


### PR DESCRIPTION
## The Problem

- Every `/` and `/pools` request re-runs the full multi-network Hasura fan-out server-side (~0.9–1.9s measured on prod) because the CSP-nonce middleware forces dynamic rendering — the homepage document streams for up to ~2s and LCP sits at 1.4–1.95s, with the fan-out squarely inside the LCP path.
- The serialized SSR payload is 1.3MB decoded (143KB gzip), of which ~330KB is raw `feeSnapshots` rows that nothing on `/` or `/pools` reads.

## The Solution

- Serve the SSR payload from a cross-request `unstable_cache` (new `src/lib/network-fetcher/server-cache.ts`, perf-plan P7): 30s TTL with a `fetchedAt` age gate bounding worst-case served staleness at 90s. Healthy payloads are cached; degraded payloads (any per-chain/per-slice error) are thrown out of the cache callback so they are never written to the cache.
- Dehydrate→rehydrate the five Map/Set fields (`rates`, `poolLabels`, `olsPoolIds`, `cdpPoolIds`, `reservePoolIds`) around the cache's JSON round-trip — the exact silent-drop hazard the perf plan flagged for the naive P7 fix.
- Strip raw `feeSnapshots` rows from the initial payload (aggregated `fees` summary plus error/truncation flags are kept).

## Details

**Measured** (local prod build against the live Envio endpoint):

| Metric | before (prod today) | after |
| --- | --- | --- |
| Doc complete, warm | 0.9–1.9s (every request pays the fan-out) | 47–174ms (cache hit) |
| Doc complete, cold miss | same | 1.63s (first request per TTL window only) |
| Homepage LCP (lab) | 1.4–1.95s | 211ms |
| Doc size | 1.30MB decoded / 143KB gz | 1.10MB / 125KB gz |
| CLS | 0.00 | 0.00 |

`/pools` shares the same cache entry. Flight payload integrity verified byte-level: Map/Set fields re-encode as native Flight `$Q`/`$W` refs identical to prod, `fees` summary intact, `feeSnapshots: []`.

### Invariants

- Map/Set `NetworkData` fields survive the cache's JSON round-trip — unit-tested with an explicit `JSON.parse(JSON.stringify(...))` round-trip plus a full deep-equality schema-evolution net (a future unhandled Map/Set field fails the test instead of silently flattening to `{}`).
- Degraded or empty payloads are never written to the cache (tests assert the cache callback threw vs resolved).
- Served staleness is bounded: `unstable_cache` alone serves stale entries indefinitely on dynamic renders and swallows background-revalidation errors, so the cached value carries `fetchedAt` and results older than 90s are discarded with a foreground refetch through the same degraded-error path (stale-hit tests with fake timers).
- `feeSnapshotsError` / `feeSnapshotsTruncated` survive the row strip so `isNetworkDataFullyHealthy` and the `≈` truncation UX still see the fetch outcome.
- No consumer on `/` or `/pools` reads raw `feeSnapshots` rows: `/revenue` uses its own slim `useProtocolFees` hook with a separate SWR key, and `seedIncrementalRowCacheFromNetworkData` intentionally never seeds fee history (comment at `pagination.ts:295-297`).

### Degraded behavior

- Degraded fetch on a cache miss → served uncached (same UX as today; the client hook already revalidates degraded fallbacks on mount); the next request retries upstream.
- Upstream degrades after a healthy fill → within 90s the stale healthy entry serves (background revalidation errors are logged by Next); past 90s the age gate forces a foreground refetch, so a sustained outage surfaces as a fresh degraded payload (error channels intact → client mount revalidation fires) instead of a pinned last-healthy one.
- Cache miss → identical to today's uncached path (one request per TTL window pays the fan-out).
- Freshness trade-off: a healthy SSR payload can be up to 90s old at first paint in the worst case (idle-gap first visitor), ≈30s under steady traffic. The client poll cadence is unchanged; pool-detail SSR already accepts 60s.

### Validation

- `pnpm agent:quality-gate --run` green: codegen, lint, typecheck, test:coverage, knip, dep-cruiser, browser tests, react-doctor diff + score 100, size-limit.
- 15 tests across `server-cache.test.ts` + both page server tests (stale-hit path covered with fake timers).
- Browser-verified on a local prod build against the live Envio endpoint: all KPIs, strategy badges, oracle-priced TVL, charts, and the fee-summary tile render from the cached payload; zero console errors.
- `unstable_cache` stale/error semantics verified against the installed Next 16.2.6 source (background revalidation errors swallowed; miss errors propagate).

### Intentional non-goals

- Capping `snapshotsAllDaily` history (54% of the payload) — #1208.
- SSR-prefetch for `/volume` (perf-plan S4), pool-detail CLS fixes, Sentry Replay lazy-load — next PRs in this perf series.
- The pre-existing inert `export const revalidate = 60` on both pages is left untouched (documented no-op under forced dynamic rendering).

Refs `docs/notes/ui-dashboard-performance-plan.md` P7 (marked shipped in this PR, with an impact re-rating: fresh measurement showed the fan-out runs inside the streamed RSC content, so it was the homepage LCP lever, not just origin cost).

## Deferrals

- Unbounded `snapshotsAllDaily` payload growth + ~2MB Data Cache item ceiling → #1208
- Narrowed SSR payload type + stateful cache-mock (fresh-hit JSON fidelity) tests → #1209

## Ship Checklist

- [x] ship skill used
- [x] local review run (parallel specialist review + Codex; 1 blocker found and fixed: `fetchedAt` age gate)
- [x] validation run (`pnpm agent:quality-gate --run` + browser verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core dashboard SSR data path and cache/staleness/degraded-outage behavior; mitigated by explicit health checks, age gates, and broad unit tests.
> 
> **Overview**
> Adds **`fetchInitialNetworkData`** in `server-cache.ts` so `/` and `/pools` no longer run the full multi-network Hasura fan-out on every request. Healthy payloads are stored in **`unstable_cache`** (30s revalidate) with **dehydrate/rehydrate** for `Map`/`Set` fields, **raw `feeSnapshots` rows stripped** from the Flight payload, and **degraded or empty payloads never written** to the cache.
> 
> Server-side **`fetchedAt`** bounds how stale a cache hit may be (**`MAX_SERVED_STALENESS_MS`**); over-age hits **foreground-refetch** via a **coalesced** in-flight fan-out. Cache keys are salted by deploy id and configured Hasura URLs.
> 
> **`useAllNetworksData`** now takes **`initialNetworkDataFetchedAtMs`** and only skips mount revalidation when the SSR payload is healthy, the SWR cache is cold, and age is under **`SSR_FRESH_ENOUGH_MS`** (60s)—so older cached SSR numbers still paint instantly but **revalidate on mount** within ~1–2s instead of sitting until the next poll.
> 
> Home and pools server components, client wrappers, server tests, and **`server-cache.test.ts`** are updated; the perf plan marks **P7 shipped**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03df0649d32739ac969c8bcc24318b6fcd2a2b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->