### PR TITLE
docs: clarify volume auth-state verification

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -72,6 +72,13 @@ surface behaves differently by session. Examples: nav links, address-label edit
 affordances, `/address-book`, `/entities`, `/integrations`, and `/volume`
 Organic/All controls.
 
+For `/volume`, the Organic/All protocol-actor controls are authenticated-only.
+Logged-out sessions intentionally hide the toggle and force all-volume queries,
+so a protocol actor appearing in a logged-out browser is not proof that organic
+filtering failed. To verify organic filtering, use a simulated authenticated
+session or query the production/local GraphQL path with
+`isProtocolActorIn: [false]`.
+
 Use a fixed localhost port so the user can inspect the exact URL you verified:
 
 ```bash


### PR DESCRIPTION
## The Problem

- The `/volume` page can mislead verification in logged-out browser sessions because the Organic/All protocol-actor controls are private.
- A protocol actor appearing in logged-out production is expected all-volume behavior, not proof that organic filtering failed.

## The Solution

- Document that logged-out `/volume` sessions force all-volume queries, and that organic filtering should be verified with a simulated authenticated session or GraphQL `isProtocolActorIn: [false]`.

## Details

- Adds the note next to the existing dashboard auth-state verification workflow.
- No rendered UI or runtime code changed.

## Validation

- `pnpm agent:quality-gate --run` (passed after rerun; first coverage attempt hit a Vitest worker cleanup error after all tests passed)
- `CI=true pnpm agent:review-materiality` (full due canonical operator context)
- `CI=true pnpm agent:autoreview` (clean; local deterministic engine)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime, API, or auth logic modifications.
> 
> **Overview**
> Adds agent-facing guidance in `ui-dashboard/AGENTS.md` so reviewers do not misread **logged-out** `/volume` behavior as a broken organic filter.
> 
> The new text states that **Organic/All** protocol-actor controls are **authenticated-only**, that logged-out sessions hide the toggle and query **all-volume**, and that seeing a protocol actor while logged out is **not** evidence organic filtering failed. It also points to the correct verification paths: a **simulated authenticated session** or GraphQL with `isProtocolActorIn: [false]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606c4a2c2d46753adc05d7a783f52c9c3f56dc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->