### PR TITLE
perf(dashboard): reserve chart geometry to kill pool-detail CLS + stabilize Plotly config identity

### DIFF
--- a/ui-dashboard/next-env.d.ts
+++ b/ui-dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/ui-dashboard/next-env.d.ts
+++ b/ui-dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -7,6 +7,7 @@ import { createRoot, type Root } from "react-dom/client";
 import RootLoading from "@/app/loading";
 import PoolDetailLoading from "@/app/pool/[poolId]/loading";
 import AddressBookLoading from "@/app/address-book/loading";
+import { ROW_CHART_HEIGHT_PX } from "@/lib/plot";
 
 // Each route-level loading UI must expose exactly one aria-live region so
 // screen readers don't announce nested status regions redundantly. Keeping
@@ -93,8 +94,14 @@ describe("route-level loading UIs", () => {
     expect(chartsRow).not.toBeNull();
     expect(chartsRow!.children).toHaveLength(3);
 
-    // Chart card plot areas reserve ROW_CHART_HEIGHT_PX (200) so the real
+    // Chart card plot areas reserve ROW_CHART_HEIGHT_PX so the real
     // TimeSeriesChartCards stream in without pushing the tab strip down.
-    expect(container.querySelectorAll(".h-\\[200px\\]")).toHaveLength(2);
+    // Matched on the inline style derived from the shared constant, so a
+    // future height change can't silently strand the skeleton at a stale
+    // hardcoded value.
+    const plotAreas = [...container.querySelectorAll("[style]")].filter(
+      (el) => (el as HTMLElement).style.height === `${ROW_CHART_HEIGHT_PX}px`,
+    );
+    expect(plotAreas).toHaveLength(2);
   });
 });

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -79,4 +79,22 @@ describe("route-level loading UIs", () => {
     expect(tabStrip).not.toBeNull();
     expect(tabStrip!.children).toHaveLength(7);
   });
+
+  it("PoolDetailLoading reserves the header card, health bar, and charts row (CLS guard)", () => {
+    render(<PoolDetailLoading />);
+
+    // Header card: 5-col stat grid mirroring PoolHeader's <dl>.
+    const statGrid = container.querySelector(".lg\\:grid-cols-5");
+    expect(statGrid).not.toBeNull();
+    expect(statGrid!.children).toHaveLength(5);
+
+    // Charts row: two chart cards + reserves panel, mirroring PoolChartsRow.
+    const chartsRow = container.querySelector(".lg\\:grid-cols-3");
+    expect(chartsRow).not.toBeNull();
+    expect(chartsRow!.children).toHaveLength(3);
+
+    // Chart card plot areas reserve ROW_CHART_HEIGHT_PX (200) so the real
+    // TimeSeriesChartCards stream in without pushing the tab strip down.
+    expect(container.querySelectorAll(".h-\\[200px\\]")).toHaveLength(2);
+  });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/loading.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/loading.tsx
@@ -1,4 +1,5 @@
 import { TableSkeleton } from "@/components/skeletons";
+import { ROW_CHART_HEIGHT_PX } from "@/lib/plot";
 
 // Matches the real pool detail layout: breadcrumb + header card + health bar
 // + charts row + 7 tabs (see TABS in page.tsx) + a 6-column default table.
@@ -11,14 +12,19 @@ import { TableSkeleton } from "@/components/skeletons";
 const SHIMMER = "animate-pulse rounded bg-slate-800/50";
 
 // Mirrors TimeSeriesChartCard: p-5 sm:p-6 card, text-sm title, 3xl/4xl mono
-// headline, h-5 change row, then a plot area at ROW_CHART_HEIGHT_PX (200).
+// headline, h-5 change row, then a plot area at ROW_CHART_HEIGHT_PX — the
+// real constant (not a hardcoded class) so the skeleton can't drift if the
+// chart height ever changes.
 function ChartCardSkeleton() {
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
       <div className={`h-5 w-28 ${SHIMMER}`} />
       <div className={`mt-1 h-10 w-36 ${SHIMMER}`} />
       <div className={`mt-1 h-5 w-32 ${SHIMMER}`} />
-      <div className="mt-4 h-[200px] animate-pulse rounded bg-slate-800/30" />
+      <div
+        className="mt-4 animate-pulse rounded bg-slate-800/30"
+        style={{ height: ROW_CHART_HEIGHT_PX }}
+      />
     </div>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/loading.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/loading.tsx
@@ -1,8 +1,27 @@
 import { TableSkeleton } from "@/components/skeletons";
 
-// Matches the real pool detail layout: breadcrumb + header + 7 tabs (see
-// TABS in page.tsx) + a 6-column default table. ARIA announcement lives on
-// TableSkeleton itself so we don't nest live regions.
+// Matches the real pool detail layout: breadcrumb + header card + health bar
+// + charts row + 7 tabs (see TABS in page.tsx) + a 6-column default table.
+// The header/health/charts placeholders mirror the geometry of PoolHeader,
+// HealthPanel, and PoolChartsRow (pool-detail-page-client.tsx) so the tab
+// strip and table don't jump down when the real page streams in (CLS).
+// ARIA announcement lives on TableSkeleton itself so we don't nest live
+// regions.
+
+const SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+// Mirrors TimeSeriesChartCard: p-5 sm:p-6 card, text-sm title, 3xl/4xl mono
+// headline, h-5 change row, then a plot area at ROW_CHART_HEIGHT_PX (200).
+function ChartCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+      <div className={`h-5 w-28 ${SHIMMER}`} />
+      <div className={`mt-1 h-10 w-36 ${SHIMMER}`} />
+      <div className={`mt-1 h-5 w-32 ${SHIMMER}`} />
+      <div className="mt-4 h-[200px] animate-pulse rounded bg-slate-800/30" />
+    </div>
+  );
+}
 
 export default function PoolDetailLoading() {
   return (
@@ -10,6 +29,42 @@ export default function PoolDetailLoading() {
       <div className="space-y-2">
         <div className="h-6 w-64 animate-pulse rounded bg-slate-800/50" />
         <div className="h-4 w-96 animate-pulse rounded bg-slate-800/50" />
+      </div>
+      {/* Header card — mirrors PoolHeader: p-5 card, title row (text-xl ≈
+          h-7) + 5-col stat grid. */}
+      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <div className={`h-7 w-40 ${SHIMMER}`} />
+          <div className={`h-5 w-24 ${SHIMMER}`} />
+          <div className={`h-5 w-16 ${SHIMMER}`} />
+        </div>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
+          {Array.from({ length: 5 }, (_, i) => (
+            // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+            <div key={`skel-stat-${i}`}>
+              <div className={`h-4 w-20 ${SHIMMER}`} />
+              <div className={`mt-1 h-5 w-24 ${SHIMMER}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Health panel — exception-only in the real page (often renders
+          nothing); a slim bar splits the difference with the full panel. */}
+      <div className="h-12 animate-pulse rounded-lg border border-slate-800 bg-slate-900/30" />
+      {/* Charts row — mirrors PoolChartsRow: two 200px chart cards +
+          reserves panel in a 3-col grid. */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <ChartCardSkeleton />
+        <ChartCardSkeleton />
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+          <div className={`h-5 w-24 ${SHIMMER}`} />
+          <div className="mt-4 space-y-3">
+            {Array.from({ length: 5 }, (_, i) => (
+              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+              <div key={`skel-reserve-${i}`} className={`h-4 ${SHIMMER}`} />
+            ))}
+          </div>
+        </div>
       </div>
       <div className="flex gap-1 border-b border-slate-800">
         {Array.from({ length: 7 }, (_, i) => (

--- a/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
@@ -2,9 +2,19 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
+// Captures the options handed to next/dynamic so the chunk-loading
+// fallback (the CLS-guard skeleton) can be rendered and asserted on.
+const dynamicOptions = vi.hoisted(() => ({
+  current: undefined as { loading?: () => React.ReactElement } | undefined,
+}));
+
 vi.mock("next/dynamic", () => ({
-  default: () =>
-    function MockPlot(props: {
+  default: (
+    _loader: unknown,
+    options?: { loading?: () => React.ReactElement },
+  ) => {
+    dynamicOptions.current = options;
+    return function MockPlot(props: {
       data?: Array<{
         labels?: string[];
         values?: number[];
@@ -33,7 +43,8 @@ vi.mock("next/dynamic", () => ({
           ),
         ) ?? []),
       );
-    },
+    };
+  },
 }));
 
 import {
@@ -169,6 +180,16 @@ describe("LpConcentrationChart", () => {
     expect(html).toContain(
       'data-testid="customdata">&amp;lt;img src=x onerror=&amp;#39;alert(1)&amp;#39;&amp;gt;</span>',
     );
+  });
+
+  it("reserves the exact 280px plot box while the Plotly chunk loads", () => {
+    // The dynamic() loading fallback must match the pie's plot box height
+    // (layout.height / style.height = 280) so the chunk-resolve swap is
+    // shift-free on the pool page's default "providers" tab.
+    const loading = dynamicOptions.current?.loading;
+    expect(loading).toBeDefined();
+    const html = renderToStaticMarkup(loading!());
+    expect(html).toContain("height:280px");
   });
 
   it("hides estimated TVL when no valid USDm side exists", () => {

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card.a11y.test.tsx
@@ -82,3 +82,18 @@ describe("TimeSeriesChartCard accessibility (WCAG 1.1.1)", () => {
     expect(html).toContain("Total Value Locked chart: Not enough history yet");
   });
 });
+
+describe("TimeSeriesChartCard layout reservation (CLS guard)", () => {
+  it("reserves a custom chart height on the plot container", () => {
+    // next/dynamic's chunk fallback renders PlotSkeleton at the default
+    // 200px; the container's min-height must reserve the real chart height
+    // so taller cards (volume page's 250/230px) don't shift on chunk load.
+    const html = render({ chartHeightPx: 250 });
+    expect(html).toContain("min-height:250px");
+  });
+
+  it("reserves the default 200px height (homepage CLS 0.00 guard)", () => {
+    const html = render();
+    expect(html).toContain("min-height:200px");
+  });
+});

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -6,7 +6,22 @@ import { escapePlotText, PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
 import { USDM_SYMBOLS } from "@/lib/tokens";
 import type { Pool } from "@/lib/types";
 
-const Plot = dynamic(() => import("@/lib/react-plotly-basic"), { ssr: false });
+/** Height of the pie's plot box — shared by the layout, the <Plot> style,
+ *  and the chunk-loading fallback so the skeleton→chart swap is shift-free. */
+const PIE_PLOT_HEIGHT_PX = 280;
+
+// Reserve the exact plot box while the Plotly chunk loads. Without a
+// fallback the card renders heading/legend/stats immediately and the pie
+// pops in when the chunk resolves, pushing everything below it down (CLS).
+const Plot = dynamic(() => import("@/lib/react-plotly-basic"), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="animate-pulse rounded bg-slate-800/30"
+      style={{ height: PIE_PLOT_HEIGHT_PX }}
+    />
+  ),
+});
 
 interface LpPosition {
   address: string;
@@ -166,7 +181,7 @@ function lpConcentrationLayout() {
     ...PLOTLY_BASE_LAYOUT,
     margin: { t: 8, r: 8, b: 8, l: 8 },
     showlegend: false,
-    height: 280,
+    height: PIE_PLOT_HEIGHT_PX,
     autosize: true,
   };
 }
@@ -257,7 +272,7 @@ export function LpConcentrationChart({
                 data={[model.trace]}
                 layout={model.layout}
                 config={PLOTLY_CONFIG}
-                style={{ width: "100%", height: 280 }}
+                style={{ width: "100%", height: PIE_PLOT_HEIGHT_PX }}
                 useResizeHandler
               />
             </div>

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -50,12 +50,23 @@ function PlotSkeleton({
 
 // `dynamic`'s `loading` prop receives `DynamicOptionsLoadingProps`, not
 // our custom `{ heightPx }`, so the chunk-loading flash falls back to
-// the default 200px height. That's a 1-frame visual nit before
-// hydration; not worth threading the height through.
+// the default 200px height. The plot container below compensates with
+// `minHeight: chartHeightPx`, so taller charts (the volume page's 250px
+// and 230px cards) don't shift content down when the chunk resolves.
 const Plot = dynamic(() => import("@/lib/react-plotly-basic"), {
   ssr: false,
   loading: () => <PlotSkeleton />,
 });
+
+// Hoisted so the merged config keeps a stable identity across renders —
+// react-plotly.js ref-compares data/layout/config and skips Plotly.react
+// when all three are unchanged. An inline `{ ...PLOTLY_CONFIG, scrollZoom:
+// false }` object is a fresh identity every render, scheduling a full
+// chart redraw on every hover-state re-render.
+const CHART_CARD_PLOTLY_CONFIG = {
+  ...PLOTLY_CONFIG,
+  scrollZoom: false,
+} as const;
 
 /** `stacked` suppresses the dedicated total trace (top of stack = total). */
 type BreakdownMode = "lines" | "stacked";
@@ -562,6 +573,12 @@ export function TimeSeriesChartCard({
         role="figure"
         aria-label={chartAriaLabel}
         className="relative mt-4 -mx-2 sm:-mx-3"
+        // Reserve the final plot height even while next/dynamic's chunk
+        // fallback (PlotSkeleton at the default 200px) is showing, so
+        // charts taller than the default don't shift content down when
+        // the Plotly chunk resolves. For the default-height cards this
+        // equals the rendered height — a no-op, keeping homepage CLS 0.00.
+        style={{ minHeight: chartHeightPx }}
       >
         {isLoading ? (
           <PlotSkeleton heightPx={chartHeightPx} />
@@ -612,7 +629,7 @@ export function TimeSeriesChartCard({
                     ariaHidden={!active}
                     data={traces}
                     layout={layout}
-                    config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+                    config={CHART_CARD_PLOTLY_CONFIG}
                     style={{ width: "100%", height: chartHeightPx }}
                     useResizeHandler
                     onLegendClick={handleLegendClick}
@@ -635,7 +652,7 @@ export function TimeSeriesChartCard({
             textAlternative={chartSummary}
             data={traces}
             layout={layout}
-            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            config={CHART_CARD_PLOTLY_CONFIG}
             style={{ width: "100%", height: chartHeightPx }}
             useResizeHandler
             onHover={onPlotlyHover}


### PR DESCRIPTION
## The Problem

- Production measurement (2026-07-09): `/pool/[poolId]` CLS is **0.17** ("needs improvement"), with the worst shift (0.145) at ~1.2s as streamed content replaces under-reserved placeholders — the route `loading.tsx` omits the header card, health panel, and charts row entirely, and the LP-concentration pie pops in with no reserved height on the default tab.
- The shared chart card's chunk-loading fallback is hardcoded to 200px while the volume page renders 250px/230px cards (a 30–50px shift), and its inline Plotly `config` object defeats react-plotly 4.0's redraw skip — every hover re-render schedules a full `Plotly.react`.

## The Solution

Reserve real geometry everywhere a chart or streamed block lands, and stabilize the config identity:

1. `lp-concentration-chart.tsx` — the `ssr:false` pie now has a loading fallback reserving exactly its 280px plot box (shared `PIE_PLOT_HEIGHT_PX` constant used by layout, style, and fallback so they can't drift).
2. `pool/[poolId]/loading.tsx` — mirrors the real page between breadcrumb and tab strip: header card (title row + 5-col stat grid), slim health-panel bar, and the charts-row grid (two 200px chart cards + reserves panel).
3. `time-series-chart-card.tsx` — `minHeight: chartHeightPx` on the plot container so the 200px default fallback can't shift taller cards; a no-op for default-height cards (homepage CLS 0.00 preserved and asserted).
4. Same file — `{ ...PLOTLY_CONFIG, scrollZoom: false }` hoisted to a module constant (`CHART_CARD_PLOTLY_CONFIG`) restoring react-plotly's ref-compare redraw skip.

## Details

**Measured** (local prod build against the live Envio endpoint, warm cache, same methodology as the prod baseline): pool detail CLS **0.17 → 0.01**, `/volume` CLS **0.02**, zero console errors, all charts render.

Intentional tradeoffs (documented in code comments):
- The health-bar placeholder over-reserves for healthy FPMM pools (real `HealthPanel` renders null) and under-reserves for incident/virtual pools — deliberate middle ground; incident states (weekend FX pauses, virtual pools) are not rare.
- The charts-row skeleton reserves for all pools while the real page gates it on FPMM — `loading.tsx` receives no params so it cannot know pool type; reserving nothing (the previous state) hurt the dominant FPMM case far more.

## Validation

- `pnpm agent:quality-gate --run` fully green (browser tests, size-limit, react-doctor diff + score 100, coverage, knip, dep-cruiser).
- New CLS-guard tests: loading.tsx geometry (5-stat grid, charts-row cells, 200px plot areas), LP pie fallback height captured from the `dynamic()` options, `min-height` assertions for custom and default chart heights. 196 tests green across touched + adjacent suites.
- Browser-verified on a local prod build (traces above); single-live-region a11y invariant unchanged.
- Codex review: no confirmed bugs; the tradeoffs above were its two judgment-call notes.

## Ship Checklist

- [x] ship skill used
- [x] local review run (Codex review; findings triaged as documented tradeoffs)
- [x] validation run (quality gate + browser CLS traces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading skeletons, layout reservation, and a Plotly config identity fix; no auth, data, or API behavior changes.
> 
> **Overview**
> Reduces layout shift on pool detail and chart-heavy routes by **reserving the same vertical space** the real UI will occupy before streamed content and Plotly chunks load.
> 
> **Pool route skeleton** (`pool/[poolId]/loading.tsx`) now mirrors breadcrumb-through-tabs layout: header card (5-stat grid), slim health bar, and a 3-column charts row (two chart card skeletons using shared `ROW_CHART_HEIGHT_PX` + reserves panel), so tabs and the table no longer jump when the page streams in.
> 
> **LP concentration pie** adds a `next/dynamic` loading fallback at **280px** via `PIE_PLOT_HEIGHT_PX`, aligned with layout and inline `style` so the pie swap is shift-free on the default providers tab.
> 
> **Time series chart cards** set `minHeight: chartHeightPx` on the plot container so the default 200px chunk fallback cannot shrink taller cards (e.g. volume page 250/230px). Plotly `config` is hoisted to **`CHART_CARD_PLOTLY_CONFIG`** so react-plotly’s ref compare can skip redundant full redraws on hover re-renders.
> 
> CLS-guard tests cover pool loading geometry, LP pie fallback height, and chart `min-height` for default and custom heights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637c24edf63b40952a921c44a91ed2ced45c5806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->