### PR TITLE
perf(dashboard): lazy-load Sentry Session Replay off the critical bundle

### DIFF
--- a/ui-dashboard/.size-limit.cjs
+++ b/ui-dashboard/.size-limit.cjs
@@ -15,11 +15,12 @@
 // 3. Set budget to current_bytes × 1.10 (10% headroom).
 // 4. Update the comments below with the new baseline + date.
 //
-// BASELINE (measured 2026-07-06 with Next.js 16.2.6 + Turbopack):
-//   All client JS chunks (brotli):     1,094,742 bytes (1.04 MB)
-//   Plotly chunk (brotli):               291,466 bytes
-//   Markdown editor chunk (brotli):       44,130 bytes
-//   All CSS (brotli):                     10,987 bytes (10.7 KB)
+// BASELINE (measured 2026-07-09 with Next.js 16.2.6 + Turbopack):
+//   All client JS chunks (brotli):     1,134,004 bytes (1.08 MB)
+//   Plotly chunk (brotli):               289,067 bytes
+//   Markdown editor chunk (brotli):       44,080 bytes
+//   Sentry replay chunk (brotli):         34,824 bytes
+//   All CSS (brotli):                     11,276 bytes (11.0 KB)
 
 const fs = process.getBuiltinModule("node:fs");
 const path = process.getBuiltinModule("node:path");
@@ -192,11 +193,14 @@ const config = [
     // traces are used) cut the client JS from 1,702,785 → 1,085,606 bytes brotli
     // (−36%). See docs/notes/ui-dashboard-performance-plan.md (P1).
     //
-    // Baseline: 1,094,742 bytes  Budget: 1190 KB. (Was 1,085,606 after the P1
+    // Baseline: 1,134,004 bytes  Budget: 1190 KB. (Was 1,085,606 after the P1
     // plotly swap; lazy-splitting the markdown editor in P4 moved ~44 KB brotli off
     // the data-page critical path but added ~9 KB of async chunk-boundary overhead
-    // to this all-chunks total — the per-chunk budgets below track the real wins.)
-    // Keep this tight so a regression back to the full plotly.js build fails CI.
+    // to this all-chunks total; lazy-loading Sentry Session Replay (2026-07-09)
+    // moved ~29 KB brotli off every page's root chunks for ~6 KB of async
+    // chunk-boundary overhead here — the per-chunk budgets below track the real
+    // wins.) Keep this tight so a regression back to the full plotly.js build
+    // fails CI.
     name: "All client JS chunks",
     path: manifestPathsOrFallback(
       ".js",
@@ -229,6 +233,21 @@ const config = [
     name: "Markdown editor chunk (react-markdown)",
     path: chunkContaining("react-markdown", "markdown"),
     limit: "49 kB",
+  },
+  {
+    // Sentry Session Replay chunk, pinned by the rrweb "rr_width" attribute the
+    // recorder emits. Guards the replay lazy-load: replayIntegration() is added
+    // after Sentry.init via a dynamic import of @/lib/sentry-replay (see
+    // src/instrumentation-client.ts), so the rrweb recorder lives in its own
+    // ~35 KB brotli idle-loaded async chunk instead of every page's root chunks.
+    // If a static import (or a barrel-wide dynamic import) re-merges it into a
+    // shared chunk, the matched chunk's size jumps well past this budget and
+    // fails CI.
+    //
+    // Baseline: 34,824 bytes  Budget: ×1.10 = 38,306 bytes → 39 KB
+    name: "Sentry replay chunk (rr_width)",
+    path: chunkContaining("rr_width", "sentry-replay"),
+    limit: "39 kB",
   },
   {
     // Manifest-referenced CSS emitted under .next/static/ (single Tailwind v4 bundle).

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -24,10 +24,14 @@ function lazyLoadReplayIntegration(): void {
     import("@/lib/sentry-replay")
       .then(({ replayIntegration }) => {
         const client = Sentry.getClient();
-        // Client can be undefined if init failed; skip double-registration
-        // (e.g. dev fast-refresh re-running this module).
-        if (!client || client.getIntegrationByName("Replay")) return;
-        client.addIntegration(replayIntegration());
+        if (!client) return; // init failed — nothing to attach to
+        // Skip double-registration (e.g. dev fast-refresh re-running this
+        // module). The guard reads the name off the constructed integration
+        // instead of hardcoding "Replay" so an SDK rename can't silently
+        // break it into double-registering.
+        const integration = replayIntegration();
+        if (client.getIntegrationByName(integration.name)) return;
+        client.addIntegration(integration);
       })
       .catch(() => {
         // Chunk failed to load (offline, blocked) — run without replay.

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -7,7 +7,8 @@ import {
 import { clientEnv } from "./env";
 
 // Session Replay is registered lazily (see below) so the rrweb recorder
-// (~55 KB brotli) stays out of the critical client bundle. A dynamic
+// (~35 KB brotli, measured in .size-limit.cjs's replay-chunk budget) stays
+// out of the critical client bundle. A dynamic
 // import keeps the replay chunk on our own origin (script-src 'self');
 // Sentry.lazyLoadIntegration() would instead fetch it from
 // browser.sentry-cdn.com, which our CSP blocks. @/lib/sentry-replay
@@ -34,8 +35,12 @@ function lazyLoadReplayIntegration(): void {
   };
 
   // requestIdleCallback is missing from older Safari; ES2017-safe fallback.
+  // The timeout bounds how late replay can attach on busy/backgrounded tabs
+  // — without it a tab that never goes idle would never start recording,
+  // degrading replaysOnErrorSampleRate well beyond the documented
+  // very-early-errors trade-off.
   if (typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(load);
+    window.requestIdleCallback(load, { timeout: 1_500 });
   } else {
     window.setTimeout(load, 0);
   }

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -38,11 +38,13 @@ function lazyLoadReplayIntegration(): void {
   // The timeout bounds how late replay can attach on busy/backgrounded tabs
   // — without it a tab that never goes idle would never start recording,
   // degrading replaysOnErrorSampleRate well beyond the documented
-  // very-early-errors trade-off.
+  // very-early-errors trade-off. The Safari fallback uses the same 1.5s
+  // delay (not 0) so the recorder import can't land mid-hydration and eat
+  // into LCP on the one engine without idle callbacks.
   if (typeof window.requestIdleCallback === "function") {
     window.requestIdleCallback(load, { timeout: 1_500 });
   } else {
-    window.setTimeout(load, 0);
+    window.setTimeout(load, 1_500);
   }
 }
 

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -6,6 +6,41 @@ import {
 } from "../sentry.shared";
 import { clientEnv } from "./env";
 
+// Session Replay is registered lazily (see below) so the rrweb recorder
+// (~55 KB brotli) stays out of the critical client bundle. A dynamic
+// import keeps the replay chunk on our own origin (script-src 'self');
+// Sentry.lazyLoadIntegration() would instead fetch it from
+// browser.sentry-cdn.com, which our CSP blocks. @/lib/sentry-replay
+// re-exports only replayIntegration so the async chunk tree-shakes down
+// to the recorder instead of retaining the whole "@sentry/nextjs" barrel.
+//
+// Trade-off: errors thrown before the idle-time chunk finishes loading
+// lose the pre-error replay buffer, so replaysOnErrorSampleRate degrades
+// slightly for very-early errors. Session-sample recording starts when the
+// integration attaches, moments after load.
+function lazyLoadReplayIntegration(): void {
+  const load = () => {
+    import("@/lib/sentry-replay")
+      .then(({ replayIntegration }) => {
+        const client = Sentry.getClient();
+        // Client can be undefined if init failed; skip double-registration
+        // (e.g. dev fast-refresh re-running this module).
+        if (!client || client.getIntegrationByName("Replay")) return;
+        client.addIntegration(replayIntegration());
+      })
+      .catch(() => {
+        // Chunk failed to load (offline, blocked) — run without replay.
+      });
+  };
+
+  // requestIdleCallback is missing from older Safari; ES2017-safe fallback.
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(load);
+  } else {
+    window.setTimeout(load, 0);
+  }
+}
+
 if (shouldEnableSentry(clientEnv.NEXT_PUBLIC_VERCEL_ENV)) {
   Sentry.init({
     dsn: clientEnv.NEXT_PUBLIC_SENTRY_DSN,
@@ -13,13 +48,17 @@ if (shouldEnableSentry(clientEnv.NEXT_PUBLIC_VERCEL_ENV)) {
     // NEXT_PUBLIC_VERCEL_ENV is the build-time-inlined mirror of VERCEL_ENV
     // used by the server config; see resolveTracesSampleRate in sentry.shared.
     tracesSampleRate: resolveTracesSampleRate(clientEnv.NEXT_PUBLIC_VERCEL_ENV),
+    // Replay sample rates stay here even though replayIntegration() is added
+    // lazily — the SDK reads them from the client options when the
+    // integration attaches.
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     sendDefaultPii: false,
     beforeSend: filterAndStripSentryEvent,
     beforeSendTransaction: filterAndStripSentryEvent,
-    integrations: [Sentry.replayIntegration()],
   });
+
+  lazyLoadReplayIntegration();
 }
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/ui-dashboard/src/lib/sentry-replay.ts
+++ b/ui-dashboard/src/lib/sentry-replay.ts
@@ -1,0 +1,7 @@
+// Re-export ONLY replayIntegration so the lazy replay chunk stays minimal.
+// instrumentation-client.ts dynamic-imports this module instead of the whole
+// "@sentry/nextjs" barrel: a dynamic namespace import retains every export of
+// the target module, which pulled ~30 KB brotli of already-shipped SDK core
+// into the async chunk. A single named re-export lets Turbopack tree-shake
+// the async chunk down to the replay integration (rrweb recorder) itself.
+export { replayIntegration } from "@sentry/nextjs";


### PR DESCRIPTION
## The Problem

- `instrumentation-client.ts` statically registers `Sentry.replayIntegration()`, shipping the rrweb session-replay recorder in the critical client JS of **every page** — measured at ~29KB brotli (10.7%) of the root client bundle — even though only 10% of sessions record.
- The page's LCP is ~99% render-delay (download/parse/execute), so every critical-path KB is paid on every load.

## The Solution

- Remove `replayIntegration()` from the eager `Sentry.init`; attach it post-init via a `requestIdleCallback`-scheduled (1.5s timeout bound, `setTimeout` fallback for older Safari) dynamic import, guarded against a missing client, double registration, and chunk-load failure.
- The import targets a new single-export module `@/lib/sentry-replay` rather than `Sentry.lazyLoadIntegration()` (which fetches from `browser.sentry-cdn.com` — blocked by our CSP `script-src 'self'`) or a dynamic import of the full `@sentry/nextjs` barrel (which retained every export: +62KB in the async chunk).
- `.size-limit.cjs`: refreshed dated baselines and added a marker-pinned budget for the new replay chunk (34,824B / 39KB budget), following the existing Plotly/markdown guard pattern.

## Details

**Measured (brotli, prod build, Next 16.2.6 + Turbopack):**

| Budget | before | after |
| --- | --- | --- |
| Root client JS (every page) | 270,320 B | **241,362 B (−28,958, −10.7%)** |
| Replay chunk (idle-loaded) | — | 34,824 B (new budget: 39 kB) |
| All client JS (aggregate) | 1,128,138 B | 1,134,004 B (+5,866 chunk-boundary overhead) |
| Plotly / markdown / CSS | unchanged | unchanged |

rrweb verified present in root chunks before and absent after (content-matched).

- **Runtime-verified** on a local prod build with `VERCEL_ENV=preview` + a placeholder DSN: Sentry client initializes, the replay chunk loads at idle (~1.3–2.1s, off the critical path), `getIntegrationByName("Replay")` resolves, and the `replaysSessionSampleRate`/`replaysOnErrorSampleRate` options survive in the client options (the SDK reads them when the integration attaches).
- `withSentryConfig` `bundleSizeOptimizations` intentionally NOT added: verified in the @sentry/nextjs 10.49.0 source that the `__RRWEB_*`/`__SENTRY_DEBUG__` defines are wired only in the webpack config path — inert under Turbopack — and they'd now only shrink the idle-loaded chunk anyway.
- CSP: no change needed — `worker-src 'self' blob:` already covers the replay compression worker, and the lazy chunk is same-origin.
- Documented trade-off: errors thrown before the idle chunk attaches lose the pre-error replay buffer (bounded by the 1.5s idle timeout).

## Validation

- `pnpm agent:quality-gate --run` fully green (browser tests, size-limit with the new budgets, react-doctor diff + score 100, coverage, knip, dep-cruiser).
- Codex review: no blockers; both confirmed notes (unbounded idle delay, stale size comment) fixed in the follow-up commit. Its judgment-call note — the shared `chunkContaining` helper fails open if a marker stops matching — is the pre-existing, deliberately documented design of that helper (aggregate budget as backstop), unchanged by this PR.
- Browser console clean; Sentry tunnel requests unaffected.

## Ship Checklist

- [x] ship skill used
- [x] local review run (Codex; both confirmed findings fixed)
- [x] validation run (quality gate + runtime browser verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundle-splitting and deferred observability only; replay may miss pre-buffer for errors in the first ~1.5s after load, with no auth or data-handling changes.
> 
> **Overview**
> Moves **Sentry Session Replay** off every page’s critical client JS by dropping eager `replayIntegration()` from `Sentry.init` and attaching it after load via an idle-scheduled dynamic import of `@/lib/sentry-replay` (~29 KB brotli removed from root chunks; rrweb lives in a separate async chunk).
> 
> The new `sentry-replay` module re-exports only `replayIntegration` so the async chunk tree-shakes instead of pulling the full `@sentry/nextjs` barrel; same-origin import avoids CDN-based lazy load blocked by CSP. Loading uses `requestIdleCallback` with a **1.5s** timeout (and `setTimeout` on older Safari), with guards for missing client, double registration, and chunk failures. Replay sample rates remain on `Sentry.init` for when the integration attaches.
> 
> **`.size-limit.cjs`** refreshes baselines and adds a marker-pinned budget for the new replay chunk so CI catches regressions that merge rrweb back into shared bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d13ffb950d93df64a9787f82a54c8d3c1bee07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->