### PR TITLE
perf(dashboard): SSR-prefetch the /volume hero and KPI first paint

### DIFF
--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
 import {
   BROKER_AGGREGATOR_DAILY_TOP,
   BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
@@ -59,17 +60,23 @@ vi.mock("../_lib/pool-chart-vm", () => ({
   }),
 }));
 
+const mockUseHeroRollup = vi.hoisted(() => vi.fn());
+const heroState = vi.hoisted(() => ({ isLoading: false, hasError: false }));
+
 vi.mock("../_lib/use-hero-rollup", () => ({
-  useHeroRollup: () => ({
-    isLoading: false,
-    hasError: false,
-    totalVolume: 0,
-    totalTraders: 0,
-    totalSwaps: 0,
-    concentration: 0,
-    staleChains: [],
-    degradedChains: [],
-  }),
+  useHeroRollup: (args: unknown) => {
+    mockUseHeroRollup(args);
+    return {
+      isLoading: heroState.isLoading,
+      hasError: heroState.hasError,
+      totalVolume: 0,
+      totalTraders: 0,
+      totalSwaps: 0,
+      concentration: 0,
+      staleChains: [],
+      degradedChains: [],
+    };
+  },
 }));
 
 vi.mock("@/components/time-series-chart-card", () => ({
@@ -123,6 +130,9 @@ function variablesFor(query: string) {
 describe("VolumeClient useGQL wiring", () => {
   beforeEach(() => {
     mockUseGQL.mockReset();
+    mockUseHeroRollup.mockClear();
+    heroState.isLoading = false;
+    heroState.hasError = false;
     mockUseGQL.mockReturnValue({
       data: undefined,
       error: null,
@@ -215,5 +225,43 @@ describe("VolumeClient useGQL wiring", () => {
       html.indexOf('data-testid="v3-section"'),
     );
     expect(html).not.toContain("Exploratory exclusions");
+  });
+
+  it("forwards server-prefetched initialData into useHeroRollup", () => {
+    const initialData: VolumeHeroInitialData = {
+      view: {
+        networkId: "celo-mainnet",
+        venue: "v3",
+        range: "7d",
+        includeProtocolActors: false,
+        todayMidnight: 1_780_012_800,
+      },
+      heroV3: { volumeWindowSnapshots: [] },
+      todayV3: { volumeTodayTraders: [] },
+    };
+    volumeState.venue = "v3";
+    volumeState.includeProtocolActors = false;
+    renderToStaticMarkup(
+      <VolumeClient canUseVolumeFilters={false} initialData={initialData} />,
+    );
+
+    expect(mockUseHeroRollup).toHaveBeenCalledWith(
+      expect.objectContaining({ initialData }),
+    );
+  });
+
+  it("gates the swaps subtitle while the hero is loading (no happy-path zero)", () => {
+    heroState.isLoading = true;
+    const html = renderVolume("v3");
+
+    expect(html).toContain("— swaps");
+    expect(html).not.toContain("0 swaps");
+  });
+
+  it("renders the swap count in the subtitle once the hero resolves", () => {
+    const html = renderVolume("v3");
+
+    expect(html).toContain("0 swaps");
+    expect(html).not.toContain("— swaps");
   });
 });

--- a/ui-dashboard/src/app/volume/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page.server.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
+import VolumePage from "../page";
+
+type VolumeClientProps = {
+  canUseVolumeFilters: boolean;
+  initialData?: VolumeHeroInitialData | undefined;
+};
+
+const { mockGetAuthSession, mockFetchVolumeHeroForSSR, mockVolumeClient } =
+  vi.hoisted(() => ({
+    mockGetAuthSession: vi.fn(),
+    mockFetchVolumeHeroForSSR: vi.fn(),
+    mockVolumeClient: vi.fn((props: VolumeClientProps) => {
+      void props;
+      return null;
+    }),
+  }));
+
+vi.mock("@/auth", () => ({
+  getAuthSession: mockGetAuthSession,
+}));
+
+vi.mock("@/lib/volume-ssr", () => ({
+  fetchVolumeHeroForSSR: mockFetchVolumeHeroForSSR,
+}));
+
+vi.mock("../page-client", () => ({
+  VolumeClient: (props: VolumeClientProps) => mockVolumeClient(props),
+}));
+
+// Fixed clock so the expected todayMidnight is deterministic (2026-07-09
+// 12:00 UTC → midnight = 2026-07-09 00:00 UTC).
+const NOW = new Date("2026-07-09T12:00:00Z");
+const TODAY_MIDNIGHT = Math.floor(NOW.getTime() / 1000 / 86_400) * 86_400;
+
+const INITIAL_DATA: VolumeHeroInitialData = {
+  view: {
+    networkId: "celo-mainnet",
+    venue: "v3",
+    range: "7d",
+    includeProtocolActors: true,
+    todayMidnight: TODAY_MIDNIGHT,
+  },
+  heroV3: { volumeWindowSnapshots: [] },
+  todayV3: { volumeTodayTraders: [] },
+};
+
+async function renderVolumePage(
+  searchParams?: Record<string, string | string[] | undefined>,
+) {
+  renderToStaticMarkup(
+    await VolumePage(
+      searchParams === undefined
+        ? {}
+        : { searchParams: Promise.resolve(searchParams) },
+    ),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  mockGetAuthSession.mockReset();
+  mockFetchVolumeHeroForSSR.mockReset();
+  mockVolumeClient.mockClear();
+  mockGetAuthSession.mockResolvedValue(null);
+  mockFetchVolumeHeroForSSR.mockResolvedValue(INITIAL_DATA);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("VolumePage server component", () => {
+  it("prefetches the locked all-actors default view for logged-out visitors", async () => {
+    await renderVolumePage({});
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v3",
+      "7d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+    expect(mockVolumeClient).toHaveBeenCalledWith({
+      canUseVolumeFilters: false,
+      initialData: INITIAL_DATA,
+    });
+  });
+
+  it("ignores ?actors= for logged-out visitors (session gates the filter)", async () => {
+    await renderVolumePage({ actors: "organic" });
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v3",
+      "7d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+  });
+
+  it("prefetches the organic default view for logged-in users", async () => {
+    mockGetAuthSession.mockResolvedValue({ user: {} });
+
+    await renderVolumePage({});
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v3",
+      "7d",
+      false,
+      TODAY_MIDNIGHT,
+    );
+    expect(mockVolumeClient).toHaveBeenCalledWith({
+      canUseVolumeFilters: true,
+      initialData: INITIAL_DATA,
+    });
+  });
+
+  it("parses venue/range/actors from searchParams with url-state semantics", async () => {
+    mockGetAuthSession.mockResolvedValue({ user: {} });
+
+    await renderVolumePage({ venue: "v2", range: "90d", actors: "all" });
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v2",
+      "90d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+  });
+
+  it("falls back to defaults for invalid venue/range values", async () => {
+    await renderVolumePage({ venue: "v9", range: "1y" });
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v3",
+      "7d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+  });
+
+  it("renders without searchParams (test harness / non-request renders)", async () => {
+    await renderVolumePage();
+
+    expect(mockFetchVolumeHeroForSSR).toHaveBeenCalledWith(
+      "v3",
+      "7d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+  });
+
+  it("degrades to the client-only path when the prefetch returns undefined", async () => {
+    mockFetchVolumeHeroForSSR.mockResolvedValue(undefined);
+
+    await renderVolumePage({});
+
+    expect(mockVolumeClient).toHaveBeenCalledWith({
+      canUseVolumeFilters: false,
+      initialData: undefined,
+    });
+  });
+});

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -195,7 +195,7 @@ export function VolumeKpiTiles({
       <Tile
         label="Unique traders"
         value={heroValue(hero, hero.totalTraders.toLocaleString())}
-        subtitle={`${hero.totalSwaps.toLocaleString()} swaps`}
+        subtitle={swapsSubtitle(hero)}
       />
       <Tile
         label={
@@ -221,6 +221,15 @@ function heroValue(hero: VolumePageModel["hero"], value: string): string {
   if (hero.isLoading) return "…";
   if (hero.hasError) return "—";
   return value;
+}
+
+// Loading-vs-zero rule (ui-dashboard AGENTS.md): the swaps subtitle must not
+// render a happy-path "0 swaps" under a "…" value while the hero queries are
+// still loading. Always return a string so the subtitle line — and the tile
+// height — stay stable.
+function swapsSubtitle(hero: VolumePageModel["hero"]): string {
+  if (hero.isLoading || hero.hasError) return "— swaps";
+  return `${hero.totalSwaps.toLocaleString()} swaps`;
 }
 
 function concentrationValue({

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
@@ -67,19 +67,38 @@ const NULL_RESPONSE: GQLResponse = {
 
 let gqlResponses: Map<string, GQLResponse> = new Map();
 let lastVariables: Map<string, Record<string, unknown> | undefined> = new Map();
+let lastOptions: Map<string, Record<string, unknown> | undefined> = new Map();
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (
     query: string | null,
     variables?: Record<string, unknown>,
+    options?: Record<string, unknown>,
   ): GQLResponse => {
     if (query === null) return NULL_RESPONSE;
     lastVariables.set(query, variables);
-    return gqlResponses.get(query) ?? { data: undefined, isLoading: true };
+    lastOptions.set(query, options);
+    const configured = gqlResponses.get(query);
+    if (configured) return configured;
+    // Mirror SWR's fallbackData contract closely enough for gating tests:
+    // fallback-seeded hooks report data with isLoading still true (SWR does
+    // not count fallbackData as "loaded data" during first revalidation).
+    const fallbackData = options?.fallbackData;
+    if (fallbackData !== undefined)
+      return { data: fallbackData, isLoading: true };
+    return { data: undefined, isLoading: true };
   },
 }));
 
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    networkId: "celo-mainnet",
+    network: { id: "celo-mainnet", chainId: 42220 },
+  }),
+}));
+
 import { useHeroRollup } from "../use-hero-rollup";
+import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -144,7 +163,13 @@ function yesterdayRow(
 
 type HookResult = ReturnType<typeof useHeroRollup>;
 
-function Probe({ resultRef }: { resultRef: { current: HookResult | null } }) {
+function Probe({
+  resultRef,
+  initialData,
+}: {
+  resultRef: { current: HookResult | null };
+  initialData?: VolumeHeroInitialData | undefined;
+}) {
   resultRef.current = useHeroRollup({
     venue: "v3",
     range: "7d",
@@ -152,6 +177,7 @@ function Probe({ resultRef }: { resultRef: { current: HookResult | null } }) {
     isProtocolActorIn: [false],
     utcDayKey: 0,
     kpiSource: [],
+    initialData,
   });
   return null;
 }
@@ -166,6 +192,7 @@ let root: Root;
 beforeEach(() => {
   gqlResponses = new Map();
   lastVariables = new Map();
+  lastOptions = new Map();
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -178,10 +205,12 @@ afterEach(() => {
   container.remove();
 });
 
-function render(): { current: HookResult | null } {
+function render(initialData?: VolumeHeroInitialData): {
+  current: HookResult | null;
+} {
   const ref: { current: HookResult | null } = { current: null };
   act(() => {
-    root.render(<Probe resultRef={ref} />);
+    root.render(<Probe resultRef={ref} initialData={initialData} />);
   });
   return ref;
 }
@@ -320,6 +349,82 @@ describe("useHeroRollup orchestration", () => {
     // hasError is driven by the PRIMARY queries (snapshot + today). The
     // firstDay error degrades JUST the catch-up — that's the design.
     expect(result!.hasError).toBe(false);
+  });
+
+  it("attaches SSR fallbackData to the hero trio when the prefetched view matches", () => {
+    const initialData: VolumeHeroInitialData = {
+      view: {
+        networkId: "celo-mainnet",
+        venue: "v3",
+        range: "7d",
+        includeProtocolActors: false,
+        todayMidnight: TODAY_MIDNIGHT,
+      },
+      heroV3: { volumeWindowSnapshots: [snapshot({ chainId: CELO })] },
+      todayV3: { volumeTodayTraders: [] },
+      firstDayV3: {
+        volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+      },
+    };
+
+    const ref = render(initialData);
+
+    expect(lastOptions.get(VOLUME_WINDOW_LATEST)?.fallbackData).toBe(
+      initialData.heroV3,
+    );
+    expect(lastOptions.get(VOLUME_TODAY_TRADERS)?.fallbackData).toBe(
+      initialData.todayV3,
+    );
+    expect(lastOptions.get(VOLUME_WINDOW_FIRSTDAY_LATEST)?.fallbackData).toBe(
+      initialData.firstDayV3,
+    );
+    // With the fallback seeded (SWR reports data present but isLoading true
+    // during the first revalidation), the hook's data-presence loading gate
+    // lets the tiles render populated numbers immediately.
+    expect(ref.current!.isLoading).toBe(false);
+    expect(ref.current!.totalVolume).toBeCloseTo(1000, 4);
+  });
+
+  it("drops the SSR fallback when the prefetched view descriptor mismatches", () => {
+    const initialData: VolumeHeroInitialData = {
+      view: {
+        networkId: "celo-mainnet",
+        venue: "v3",
+        range: "30d", // Probe renders range "7d" — must not seed 30d data
+        includeProtocolActors: false,
+        todayMidnight: TODAY_MIDNIGHT,
+      },
+      heroV3: { volumeWindowSnapshots: [snapshot({ chainId: CELO })] },
+      todayV3: { volumeTodayTraders: [] },
+    };
+
+    const ref = render(initialData);
+
+    expect(lastOptions.get(VOLUME_WINDOW_LATEST)?.fallbackData).toBeUndefined();
+    expect(lastOptions.get(VOLUME_TODAY_TRADERS)?.fallbackData).toBeUndefined();
+    expect(
+      lastOptions.get(VOLUME_WINDOW_FIRSTDAY_LATEST)?.fallbackData,
+    ).toBeUndefined();
+    expect(ref.current!.isLoading).toBe(true);
+  });
+
+  it("drops the SSR fallback across the UTC-midnight edge (server day N, client day N+1)", () => {
+    const initialData: VolumeHeroInitialData = {
+      view: {
+        networkId: "celo-mainnet",
+        venue: "v3",
+        range: "7d",
+        includeProtocolActors: false,
+        todayMidnight: TODAY_MIDNIGHT - SECONDS_PER_DAY,
+      },
+      heroV3: { volumeWindowSnapshots: [snapshot({ chainId: CELO })] },
+      todayV3: { volumeTodayTraders: [] },
+    };
+
+    render(initialData);
+
+    expect(lastOptions.get(VOLUME_WINDOW_LATEST)?.fallbackData).toBeUndefined();
+    expect(lastOptions.get(VOLUME_TODAY_TRADERS)?.fallbackData).toBeUndefined();
   });
 
   it("does NOT fire the yesterday query when no chain is degraded", () => {

--- a/ui-dashboard/src/app/volume/_lib/url-state.ts
+++ b/ui-dashboard/src/app/volume/_lib/url-state.ts
@@ -11,9 +11,21 @@ import {
 import { useSearchParams } from "next/navigation";
 import { rangeCutoffSeconds, type VolumeRangeKey } from "@/lib/volume";
 import { SECONDS_PER_DAY } from "@/lib/time-series";
+// Pure param parsing is shared with the /volume Server Component (SSR
+// prefetch must derive the identical first-render view) — see
+// lib/volume-url-params.ts. This module stays the client-side owner of
+// URL writes + state sync.
+import {
+  DEFAULT_ACTOR_FILTER,
+  DEFAULT_RANGE,
+  readActorFilterFromParams,
+  readRangeFromParams,
+  readVenueFromParams,
+  type ActorFilter,
+  type Venue,
+} from "@/lib/volume-url-params";
 
-export type Venue = "v3" | "v2";
-type ActorFilter = "organic" | "all";
+export type { Venue } from "@/lib/volume-url-params";
 type VolumeUrlSnapshot = {
   range: VolumeRangeKey;
   actorFilter: ActorFilter;
@@ -43,33 +55,6 @@ type VolumeUrlStateResult = {
   updateIncludeProtocolActors: (next: boolean) => void;
   updateVenue: (next: Venue) => void;
 };
-
-const VALID_RANGES = new Set<VolumeRangeKey>([
-  "24h",
-  "7d",
-  "30d",
-  "90d",
-  "all",
-]);
-const DEFAULT_RANGE: VolumeRangeKey = "7d";
-const VALID_VENUES = new Set<Venue>(["v3", "v2"]);
-const DEFAULT_ACTOR_FILTER: ActorFilter = "organic";
-
-function readRangeFromParams(params: URLSearchParams): VolumeRangeKey {
-  const raw = params.get("range");
-  return raw && VALID_RANGES.has(raw as VolumeRangeKey)
-    ? (raw as VolumeRangeKey)
-    : DEFAULT_RANGE;
-}
-
-function readActorFilterFromParams(params: URLSearchParams): ActorFilter {
-  return params.get("actors") === "all" ? "all" : DEFAULT_ACTOR_FILTER;
-}
-
-function readVenueFromParams(params: URLSearchParams): Venue {
-  const raw = params.get("venue");
-  return raw && VALID_VENUES.has(raw as Venue) ? (raw as Venue) : "v3";
-}
 
 function writeVolumeUrl(
   { range, actorFilter, venue }: VolumeUrlSnapshot,

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useNetwork } from "@/components/network-provider";
 import { useGQL } from "@/lib/graphql";
-import { isLoadingWithoutData } from "@/lib/swr-state";
+import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
 import {
   volumeHeroViewMatches,
   type VolumeHeroInitialData,
@@ -360,10 +360,16 @@ export function useHeroRollup({
         isLoadingWithoutData(todayV3Result.isLoading, todayV3Result.data)
       : isLoadingWithoutData(heroV2Result.isLoading, heroV2Result.data) ||
         isLoadingWithoutData(todayV2Result.isLoading, todayV2Result.data);
+  // Same data-presence rule for errors: after a failed background
+  // revalidation SWR keeps the previous (fallback or cached) responses, and
+  // flipping the tiles to "—" while populated numbers exist would hide good
+  // data behind a transient poll failure.
   const hasError =
     venue === "v3"
-      ? !!heroV3Result.error || !!todayV3Result.error
-      : !!heroV2Result.error || !!todayV2Result.error;
+      ? hasErrorWithoutData(heroV3Result.error, heroV3Result.data) ||
+        hasErrorWithoutData(todayV3Result.error, todayV3Result.data)
+      : hasErrorWithoutData(heroV2Result.error, heroV2Result.data) ||
+        hasErrorWithoutData(todayV2Result.error, todayV2Result.data);
 
   return {
     todayMidnight,

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -1,7 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
+import { useNetwork } from "@/components/network-provider";
 import { useGQL } from "@/lib/graphql";
+import { isLoadingWithoutData } from "@/lib/swr-state";
+import {
+  volumeHeroViewMatches,
+  type VolumeHeroInitialData,
+} from "@/lib/volume-hero-initial-data";
 import {
   BROKER_VOLUME_PARTIAL_OVERLAP_TRADERS,
   BROKER_VOLUME_TODAY_TRADERS,
@@ -74,6 +80,7 @@ export function useHeroRollup({
   isProtocolActorIn,
   utcDayKey,
   kpiSource,
+  initialData,
 }: {
   venue: Venue;
   range: VolumeRangeKey;
@@ -85,6 +92,12 @@ export function useHeroRollup({
    *  the resulting rows so the table query and the hero query can degrade
    *  independently. */
   kpiSource: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
+  /** Server-prefetched hero responses (perf-plan S4), forwarded to the
+   *  matching `useGQL` calls as `fallbackData` so the first render paints
+   *  populated tiles. Only attached when the prefetched view descriptor
+   *  matches this render's actual (network, venue, range, actor filter,
+   *  todayMidnight) — a mismatched fallback would seed the wrong SWR key. */
+  initialData?: VolumeHeroInitialData | undefined;
 }): {
   /** Memoised UTC midnight in seconds — flips at UTC day rollover via
    *  `utcDayKey`. Re-exposed so callers can pass it to other queries
@@ -100,21 +113,6 @@ export function useHeroRollup({
   isLoading: boolean;
   hasError: boolean;
 } {
-  // Pre-rolled hero snapshot (one row per chain for the active window).
-  // Bypasses Hasura's 1000-row cap on long windows. The snapshot covers
-  // [windowStart, yesterday]; today's partial is fetched separately and
-  // added client-side.
-  const heroV3Result = useGQL<HeroV3Data>(
-    venue === "v3" ? VOLUME_WINDOW_LATEST : null,
-    { windowKey: range },
-    { schema: VolumeWindowLatestSchema },
-  );
-  const heroV2Result = useGQL<HeroV2Data>(
-    venue === "v2" ? BROKER_VOLUME_WINDOW_LATEST : null,
-    { windowKey: range },
-    { schema: BrokerVolumeWindowLatestSchema },
-  );
-
   // Today's UTC midnight in seconds. The hero snapshot's upper bound is
   // yesterday, so today's TraderDailySnapshot rows fill in the gap.
   // Memoised on `utcDayKey` so it flips at midnight without retriggering
@@ -123,19 +121,58 @@ export function useHeroRollup({
     () => Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY,
     [utcDayKey],
   );
+
+  // View-parity gate for the SSR prefetch: only attach fallbackData when the
+  // prefetched descriptor matches this render's key ingredients exactly (the
+  // SWR key is [network.id, query, variables]). `networkId` is always
+  // DEFAULT_NETWORK on /volume today, but comparing keeps a future network
+  // switcher from seeding foreign-chain data. `todayMidnight` mismatches at
+  // the UTC-midnight edge (server prefetched day N, client hydrates day N+1)
+  // → no fallback, today's client-only loading path takes over. When both
+  // sides are on day N but real time crossed midnight before the first poll,
+  // the today-partial fallback is at most one day off for ≤30s (next poll
+  // corrects it) — self-healing, acceptable.
+  const { networkId } = useNetwork();
+  const fallback =
+    initialData &&
+    volumeHeroViewMatches(initialData.view, {
+      networkId,
+      venue,
+      range,
+      isProtocolActorIn,
+      todayMidnight,
+    })
+      ? initialData
+      : undefined;
+
+  // Pre-rolled hero snapshot (one row per chain for the active window).
+  // Bypasses Hasura's 1000-row cap on long windows. The snapshot covers
+  // [windowStart, yesterday]; today's partial is fetched separately and
+  // added client-side.
+  const heroV3Result = useGQL<HeroV3Data>(
+    venue === "v3" ? VOLUME_WINDOW_LATEST : null,
+    { windowKey: range },
+    { schema: VolumeWindowLatestSchema, fallbackData: fallback?.heroV3 },
+  );
+  const heroV2Result = useGQL<HeroV2Data>(
+    venue === "v2" ? BROKER_VOLUME_WINDOW_LATEST : null,
+    { windowKey: range },
+    { schema: BrokerVolumeWindowLatestSchema, fallbackData: fallback?.heroV2 },
+  );
+
   const todayV3Result = useGQL<{
     volumeTodayTraders: VolumeTodayTraderRow[];
   }>(
     venue === "v3" ? VOLUME_TODAY_TRADERS : null,
     { todayMidnight, isProtocolActorIn },
-    { schema: VolumeTodayTradersSchema },
+    { schema: VolumeTodayTradersSchema, fallbackData: fallback?.todayV3 },
   );
   const todayV2Result = useGQL<{
     brokerVolumeTodayTraders: VolumeTodayTraderRow[];
   }>(
     venue === "v2" ? BROKER_VOLUME_TODAY_TRADERS : null,
     { todayMidnight, isProtocolActorIn },
-    { schema: BrokerVolumeTodayTradersSchema },
+    { schema: BrokerVolumeTodayTradersSchema, fallbackData: fallback?.todayV2 },
   );
 
   const snapshotRows =
@@ -157,14 +194,20 @@ export function useHeroRollup({
   }>(
     venue === "v3" ? VOLUME_WINDOW_FIRSTDAY_LATEST : null,
     { windowKey: range },
-    { schema: VolumeWindowFirstDayLatestSchema },
+    {
+      schema: VolumeWindowFirstDayLatestSchema,
+      fallbackData: fallback?.firstDayV3,
+    },
   );
   const heroFirstDayV2Result = useGQL<{
     brokerVolumeWindowFirstDaySnapshots: VolumeWindowFirstDayRow[];
   }>(
     venue === "v2" ? BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST : null,
     { windowKey: range },
-    { schema: BrokerVolumeWindowFirstDayLatestSchema },
+    {
+      schema: BrokerVolumeWindowFirstDayLatestSchema,
+      fallbackData: fallback?.firstDayV2,
+    },
   );
   const firstDayRows =
     venue === "v3"
@@ -306,10 +349,17 @@ export function useHeroRollup({
   // Tiles + chart load when the hero snapshot AND its today-partial both
   // land. The trader table loads independently from the existing
   // TraderDailySnapshot query (which is fast — capped at 1000 by design).
+  // Gate on data presence, not bare `isLoading`: SWR does NOT count
+  // `fallbackData` as "loaded data", so with the SSR prefetch attached
+  // `isLoading` stays true through the first revalidation even though the
+  // tiles already have real numbers to show (same rule as PoolOverview in
+  // pool-detail-page-client.tsx).
   const isLoading =
     venue === "v3"
-      ? heroV3Result.isLoading || todayV3Result.isLoading
-      : heroV2Result.isLoading || todayV2Result.isLoading;
+      ? isLoadingWithoutData(heroV3Result.isLoading, heroV3Result.data) ||
+        isLoadingWithoutData(todayV3Result.isLoading, todayV3Result.data)
+      : isLoadingWithoutData(heroV2Result.isLoading, heroV2Result.data) ||
+        isLoadingWithoutData(todayV2Result.isLoading, todayV2Result.data);
   const hasError =
     venue === "v3"
       ? !!heroV3Result.error || !!todayV3Result.error

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -30,6 +30,7 @@ import {
   type AggregatorDailyRowBase,
 } from "@/lib/volume-aggregators";
 import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
+import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
 import { HeroDataQualityBanners } from "./_components/hero-data-quality-banners";
 import {
   VolumeChartArea,
@@ -59,25 +60,34 @@ const RANGES_WITH_CHART = new Set<VolumeRangeKey>(["30d", "90d", "all"]);
 
 export function VolumeClient({
   canUseVolumeFilters,
+  initialData,
 }: {
   canUseVolumeFilters: boolean;
+  /** Server-prefetched hero responses (perf-plan S4), forwarded to
+   *  `useHeroRollup` as per-query `fallbackData` so the headline and KPI
+   *  tiles paint populated on first render. `undefined` degrades to the
+   *  client-only loading path. */
+  initialData?: VolumeHeroInitialData | undefined;
 }) {
   const urlState = useVolumeUrlState({ canUseVolumeFilters });
-  const model = useVolumePageModel(urlState);
+  const model = useVolumePageModel(urlState, initialData);
   return <VolumePageView urlState={urlState} model={model} />;
 }
 
 export type VolumeUrlState = ReturnType<typeof useVolumeUrlState>;
 export type VolumePageModel = ReturnType<typeof useVolumePageModel>;
 
-function useVolumePageModel({
-  range,
-  includeProtocolActors,
-  venue,
-  cutoff,
-  utcDayKey,
-  updateRange,
-}: VolumeUrlState) {
+function useVolumePageModel(
+  {
+    range,
+    includeProtocolActors,
+    venue,
+    cutoff,
+    utcDayKey,
+    updateRange,
+  }: VolumeUrlState,
+  initialData?: VolumeHeroInitialData,
+) {
   const isProtocolActorIn = useMemo(
     () => (includeProtocolActors ? [false, true] : [false]),
     [includeProtocolActors],
@@ -122,6 +132,7 @@ function useVolumePageModel({
     isProtocolActorIn,
     utcDayKey,
     kpiSource,
+    initialData,
   });
   const chartControls = useVolumeChartControls(range, updateRange);
   const status = buildVolumeStatus({ venue, queries });

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -30,7 +30,10 @@ import {
   type AggregatorDailyRowBase,
 } from "@/lib/volume-aggregators";
 import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
-import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
+import {
+  protocolActorInForView,
+  type VolumeHeroInitialData,
+} from "@/lib/volume-hero-initial-data";
 import { HeroDataQualityBanners } from "./_components/hero-data-quality-banners";
 import {
   VolumeChartArea,
@@ -88,8 +91,11 @@ function useVolumePageModel(
   }: VolumeUrlState,
   initialData?: VolumeHeroInitialData,
 ) {
+  // Single source for the actor filter list — the SSR view-descriptor gate
+  // compares against protocolActorInForView(), so a hand-rolled list here
+  // that drifted would silently drop the server-prefetched fallback.
   const isProtocolActorIn = useMemo(
-    () => (includeProtocolActors ? [false, true] : [false]),
+    () => protocolActorInForView(includeProtocolActors),
     [includeProtocolActors],
   );
   const showChart = venue === "v3" && RANGES_WITH_CHART.has(range);

--- a/ui-dashboard/src/app/volume/page.tsx
+++ b/ui-dashboard/src/app/volume/page.tsx
@@ -1,5 +1,12 @@
 import { Suspense } from "react";
 import { getAuthSession } from "@/auth";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+import { fetchVolumeHeroForSSR } from "@/lib/volume-ssr";
+import {
+  readActorFilterFromParams,
+  readRangeFromParams,
+  readVenueFromParams,
+} from "@/lib/volume-url-params";
 import { VolumeClient } from "./page-client";
 
 export const metadata = {
@@ -8,12 +15,70 @@ export const metadata = {
     "Top traders on Mento by USD volume — sorted by 24h, 7d, 30d, or all-time, with per-pool flow breakdown.",
 };
 
-export default async function VolumePage() {
-  const session = await getAuthSession();
+type PageSearchParams = Record<string, string | string[] | undefined>;
+
+function toURLSearchParams(searchParams: PageSearchParams): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else if (value !== undefined) {
+      params.set(key, value);
+    }
+  }
+  return params;
+}
+
+// Same expression the client's `useHeroRollup` memoizes for the today-partial
+// query variables. UTC-midnight edge: if the server computes day N and the
+// client hydrates on day N+1, the view descriptors disagree and the client
+// simply drops the fallback (loading path). If both land on day N but the day
+// flips before the first poll, the today-partial fallback is one day off for
+// ≤30s until SWR revalidates — self-healing, acceptable.
+function currentUtcDayStartSeconds(nowMs = Date.now()): number {
+  return Math.floor(nowMs / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+}
+
+export default async function VolumePage({
+  searchParams,
+}: {
+  searchParams?: Promise<PageSearchParams>;
+} = {}) {
+  const [session, resolvedSearchParams] = await Promise.all([
+    getAuthSession(),
+    searchParams,
+  ]);
+  const canUseVolumeFilters = !!session;
+  const params = toURLSearchParams(resolvedSearchParams ?? {});
+
+  // Derive the first-render view exactly as `useVolumeUrlState` will on the
+  // client (shared parsing in lib/volume-url-params.ts). Logged-out visitors
+  // are locked to the all-actors view — `?actors=` only applies when the
+  // session grants the private volume filters.
+  const venue = readVenueFromParams(params);
+  const range = readRangeFromParams(params);
+  const includeProtocolActors = canUseVolumeFilters
+    ? readActorFilterFromParams(params) === "all"
+    : true;
+
+  // SSR-prefetch the unconditional hero queries (window snapshot + today
+  // partial + firstDay slice) so the headline and KPI tiles paint populated
+  // instead of "…" → numbers after the client waterfall (perf-plan S4).
+  // Degrades to undefined on any primary-query failure; the client hooks then
+  // load normally through their own loading states.
+  const initialData = await fetchVolumeHeroForSSR(
+    venue,
+    range,
+    includeProtocolActors,
+    currentUtcDayStartSeconds(),
+  );
 
   return (
     <Suspense>
-      <VolumeClient canUseVolumeFilters={!!session} />
+      <VolumeClient
+        canUseVolumeFilters={canUseVolumeFilters}
+        initialData={initialData}
+      />
     </Suspense>
   );
 }

--- a/ui-dashboard/src/lib/__tests__/volume-hero-initial-data.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume-hero-initial-data.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  protocolActorInForView,
+  volumeHeroViewMatches,
+  type VolumeHeroView,
+} from "../volume-hero-initial-data";
+
+const TODAY_MIDNIGHT = 1_780_000_000 - (1_780_000_000 % 86_400);
+
+const VIEW: VolumeHeroView = {
+  networkId: "celo-mainnet",
+  venue: "v3",
+  range: "7d",
+  includeProtocolActors: false,
+  todayMidnight: TODAY_MIDNIGHT,
+};
+
+const MATCHING_ACTUAL = {
+  networkId: "celo-mainnet",
+  venue: "v3",
+  range: "7d",
+  isProtocolActorIn: [false],
+  todayMidnight: TODAY_MIDNIGHT,
+} as const;
+
+describe("protocolActorInForView", () => {
+  it("derives the same isProtocolActorIn list as the client memo", () => {
+    expect(protocolActorInForView(false)).toEqual([false]);
+    expect(protocolActorInForView(true)).toEqual([false, true]);
+  });
+});
+
+describe("volumeHeroViewMatches", () => {
+  it("matches when every key ingredient is identical", () => {
+    expect(volumeHeroViewMatches(VIEW, MATCHING_ACTUAL)).toBe(true);
+  });
+
+  it("matches the all-actors view against [false, true]", () => {
+    expect(
+      volumeHeroViewMatches(
+        { ...VIEW, includeProtocolActors: true },
+        { ...MATCHING_ACTUAL, isProtocolActorIn: [false, true] },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a network mismatch", () => {
+    expect(
+      volumeHeroViewMatches(VIEW, {
+        ...MATCHING_ACTUAL,
+        networkId: "monad-mainnet",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a venue mismatch", () => {
+    expect(
+      volumeHeroViewMatches(VIEW, { ...MATCHING_ACTUAL, venue: "v2" }),
+    ).toBe(false);
+  });
+
+  it("rejects a range mismatch", () => {
+    expect(
+      volumeHeroViewMatches(VIEW, { ...MATCHING_ACTUAL, range: "30d" }),
+    ).toBe(false);
+  });
+
+  it("rejects an actor-filter mismatch in either direction", () => {
+    expect(
+      volumeHeroViewMatches(VIEW, {
+        ...MATCHING_ACTUAL,
+        isProtocolActorIn: [false, true],
+      }),
+    ).toBe(false);
+    expect(
+      volumeHeroViewMatches(
+        { ...VIEW, includeProtocolActors: true },
+        MATCHING_ACTUAL,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a UTC-day mismatch (midnight edge: server day N, client day N+1)", () => {
+    expect(
+      volumeHeroViewMatches(VIEW, {
+        ...MATCHING_ACTUAL,
+        todayMidnight: TODAY_MIDNIGHT + 86_400,
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
@@ -151,12 +151,19 @@ describe("fetchVolumeHeroForSSR", () => {
     expect(byDocument.get(VOLUME_WINDOW_FIRSTDAY_LATEST)?.variables).toEqual({
       windowKey: "7d",
     });
-    expect(timeoutSpy).toHaveBeenCalledTimes(1);
+    // Two budgets: the shared primary deadline plus the tighter independent
+    // budget for the optional firstDay slice, so a hung optional query can't
+    // hold TTFB to the full shared deadline on a cache miss.
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
     expect(timeoutSpy).toHaveBeenCalledWith(HASURA_TIMEOUT_MS);
-    const signals = requestMock.mock.calls.map(
-      ([request]) => (request as { signal: AbortSignal }).signal,
+    expect(timeoutSpy).toHaveBeenCalledWith(2_000);
+    const signalOf = (document: string) =>
+      (byDocument.get(document) as { signal: AbortSignal }).signal;
+    // Primaries share one deadline; firstDay rides its own.
+    expect(signalOf(VOLUME_WINDOW_LATEST)).toBe(signalOf(VOLUME_TODAY_TRADERS));
+    expect(signalOf(VOLUME_WINDOW_FIRSTDAY_LATEST)).not.toBe(
+      signalOf(VOLUME_WINDOW_LATEST),
     );
-    expect(new Set(signals).size).toBe(1);
   });
 
   it("prefetches the broker variants with [false, true] actors for the v2 all-actors view", async () => {

--- a/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BROKER_VOLUME_TODAY_TRADERS,
+  BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
+  BROKER_VOLUME_WINDOW_LATEST,
+  VOLUME_TODAY_TRADERS,
+  VOLUME_WINDOW_FIRSTDAY_LATEST,
+  VOLUME_WINDOW_LATEST,
+} from "@/lib/queries/volume";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
+
+const requestMock = vi.fn();
+const makeOgGraphQLClientMock = vi.fn((network: unknown) => {
+  void network;
+  return { request: requestMock };
+});
+
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+vi.mock("@/lib/og-graphql-client", () => ({
+  makeOgGraphQLClient: (network: unknown) => makeOgGraphQLClientMock(network),
+}));
+
+const networksState = vi.hoisted(() => ({
+  hasuraUrl: "https://example.com/v1/graphql",
+}));
+
+vi.mock("@/lib/networks", () => ({
+  DEFAULT_NETWORK: "celo-mainnet",
+  NETWORKS: {
+    "celo-mainnet": {
+      id: "celo-mainnet",
+      get hasuraUrl() {
+        return networksState.hasuraUrl;
+      },
+    },
+  },
+}));
+
+import { fetchVolumeHeroForSSR } from "../volume-ssr";
+
+const TODAY_MIDNIGHT = 1_780_012_800;
+
+const WINDOW_ROWS = {
+  volumeWindowSnapshots: [
+    {
+      id: "42220-7d-1779840000",
+      chainId: 42220,
+      windowKey: "7d",
+      snapshotDay: "1779840000",
+      windowStartDay: "1779321600",
+      totalVolumeUsdWei: "1000000000000000000000",
+      totalVolumeUsdWeiIncludingProtocolActors: "2000000000000000000000",
+      totalSwapCount: 50,
+      totalSwapCountIncludingProtocolActors: 80,
+      uniqueTraders: 10,
+      uniqueTradersIncludingProtocolActors: 12,
+    },
+  ],
+};
+const TODAY_ROWS = {
+  volumeTodayTraders: [
+    {
+      chainId: 42220,
+      trader: "0xabc",
+      volumeUsdWei: "42000000000000000000",
+      swapCount: 3,
+      isProtocolActor: false,
+    },
+  ],
+};
+const FIRSTDAY_ROWS = {
+  volumeWindowFirstDaySnapshots: [
+    {
+      chainId: 42220,
+      snapshotDay: "1779840000",
+      firstDayVolumeUsdWei: "100000000000000000000",
+      firstDayVolumeUsdWeiIncludingProtocolActors: "100000000000000000000",
+      firstDaySwapCount: 5,
+      firstDaySwapCountIncludingProtocolActors: 5,
+      firstDayExclusiveUniqueTraders: 1,
+      firstDayExclusiveUniqueTradersIncludingProtocolActors: 1,
+    },
+  ],
+};
+
+function respondByDocument(
+  responses: Record<string, unknown>,
+): (request: { document: string }) => unknown {
+  return ({ document }) => {
+    if (document in responses) {
+      const value = responses[document];
+      if (value instanceof Error) throw value;
+      return value;
+    }
+    throw new Error("unexpected query");
+  };
+}
+
+describe("fetchVolumeHeroForSSR", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    networksState.hasuraUrl = "https://example.com/v1/graphql";
+  });
+
+  it("prefetches the v3 hero trio with timeout-bound requests and a matching view descriptor", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    requestMock.mockImplementation(
+      respondByDocument({
+        [VOLUME_WINDOW_LATEST]: WINDOW_ROWS,
+        [VOLUME_TODAY_TRADERS]: TODAY_ROWS,
+        [VOLUME_WINDOW_FIRSTDAY_LATEST]: FIRSTDAY_ROWS,
+      }),
+    );
+
+    const result = await fetchVolumeHeroForSSR(
+      "v3",
+      "7d",
+      false,
+      TODAY_MIDNIGHT,
+    );
+
+    expect(result?.view).toEqual({
+      networkId: "celo-mainnet",
+      venue: "v3",
+      range: "7d",
+      includeProtocolActors: false,
+      todayMidnight: TODAY_MIDNIGHT,
+    });
+    expect(result?.heroV3).toEqual(WINDOW_ROWS);
+    expect(result?.todayV3).toEqual(TODAY_ROWS);
+    expect(result?.firstDayV3).toEqual(FIRSTDAY_ROWS);
+    expect(result?.heroV2).toBeUndefined();
+
+    expect(requestMock).toHaveBeenCalledTimes(3);
+    const byDocument = new Map(
+      requestMock.mock.calls.map(([request]) => [
+        (request as { document: string }).document,
+        request as { variables: unknown; signal: AbortSignal },
+      ]),
+    );
+    expect(byDocument.get(VOLUME_WINDOW_LATEST)?.variables).toEqual({
+      windowKey: "7d",
+    });
+    expect(byDocument.get(VOLUME_TODAY_TRADERS)?.variables).toEqual({
+      todayMidnight: TODAY_MIDNIGHT,
+      isProtocolActorIn: [false],
+    });
+    expect(byDocument.get(VOLUME_WINDOW_FIRSTDAY_LATEST)?.variables).toEqual({
+      windowKey: "7d",
+    });
+    expect(timeoutSpy).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenCalledWith(HASURA_TIMEOUT_MS);
+    const signals = requestMock.mock.calls.map(
+      ([request]) => (request as { signal: AbortSignal }).signal,
+    );
+    expect(new Set(signals).size).toBe(1);
+  });
+
+  it("prefetches the broker variants with [false, true] actors for the v2 all-actors view", async () => {
+    const brokerWindow = { brokerVolumeWindowSnapshots: [] };
+    const brokerToday = { brokerVolumeTodayTraders: [] };
+    const brokerFirstDay = { brokerVolumeWindowFirstDaySnapshots: [] };
+    requestMock.mockImplementation(
+      respondByDocument({
+        [BROKER_VOLUME_WINDOW_LATEST]: brokerWindow,
+        [BROKER_VOLUME_TODAY_TRADERS]: brokerToday,
+        [BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST]: brokerFirstDay,
+      }),
+    );
+
+    const result = await fetchVolumeHeroForSSR(
+      "v2",
+      "90d",
+      true,
+      TODAY_MIDNIGHT,
+    );
+
+    expect(result?.view).toEqual({
+      networkId: "celo-mainnet",
+      venue: "v2",
+      range: "90d",
+      includeProtocolActors: true,
+      todayMidnight: TODAY_MIDNIGHT,
+    });
+    expect(result?.heroV2).toEqual(brokerWindow);
+    expect(result?.todayV2).toEqual(brokerToday);
+    expect(result?.firstDayV2).toEqual(brokerFirstDay);
+    expect(result?.heroV3).toBeUndefined();
+    const todayCall = requestMock.mock.calls.find(
+      ([request]) =>
+        (request as { document: string }).document ===
+        BROKER_VOLUME_TODAY_TRADERS,
+    );
+    expect((todayCall?.[0] as { variables: unknown }).variables).toEqual({
+      todayMidnight: TODAY_MIDNIGHT,
+      isProtocolActorIn: [false, true],
+    });
+  });
+
+  it("returns undefined overall when the primary window query fails", async () => {
+    requestMock.mockImplementation(
+      respondByDocument({
+        [VOLUME_WINDOW_LATEST]: new Error("Hasura down"),
+        [VOLUME_TODAY_TRADERS]: TODAY_ROWS,
+        [VOLUME_WINDOW_FIRSTDAY_LATEST]: FIRSTDAY_ROWS,
+      }),
+    );
+
+    await expect(
+      fetchVolumeHeroForSSR("v3", "7d", false, TODAY_MIDNIGHT),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined overall when the today-partial query fails", async () => {
+    requestMock.mockImplementation(
+      respondByDocument({
+        [VOLUME_WINDOW_LATEST]: WINDOW_ROWS,
+        [VOLUME_TODAY_TRADERS]: new Error("timeout"),
+        [VOLUME_WINDOW_FIRSTDAY_LATEST]: FIRSTDAY_ROWS,
+      }),
+    );
+
+    await expect(
+      fetchVolumeHeroForSSR("v3", "7d", false, TODAY_MIDNIGHT),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the primary pair when only the firstDay catch-up slice fails", async () => {
+    requestMock.mockImplementation(
+      respondByDocument({
+        [VOLUME_WINDOW_LATEST]: WINDOW_ROWS,
+        [VOLUME_TODAY_TRADERS]: TODAY_ROWS,
+        [VOLUME_WINDOW_FIRSTDAY_LATEST]: new Error(
+          "field firstDayVolumeUsdWei not found",
+        ),
+      }),
+    );
+
+    const result = await fetchVolumeHeroForSSR(
+      "v3",
+      "7d",
+      false,
+      TODAY_MIDNIGHT,
+    );
+
+    expect(result?.heroV3).toEqual(WINDOW_ROWS);
+    expect(result?.todayV3).toEqual(TODAY_ROWS);
+    expect(result?.firstDayV3).toBeUndefined();
+  });
+
+  it("returns undefined when the default network has no Hasura URL", async () => {
+    networksState.hasuraUrl = "";
+
+    await expect(
+      fetchVolumeHeroForSSR("v3", "7d", false, TODAY_MIDNIGHT),
+    ).resolves.toBeUndefined();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui-dashboard/src/lib/volume-hero-initial-data.ts
+++ b/ui-dashboard/src/lib/volume-hero-initial-data.ts
@@ -1,0 +1,107 @@
+// Shared shape for the /volume SSR-prefetch handoff (server fetch →
+// `useHeroRollup` fallbackData) plus the view-parity gate. Mirrors
+// `lib/pool-detail-initial-data.ts`: types only + pure helpers, importable
+// from both the Server Component and the client hook.
+
+import type { IndexerNetworkId } from "@/lib/networks";
+import type {
+  VolumeRangeKey,
+  VolumeTodayTraderRow,
+  VolumeWindowFirstDayRow,
+  VolumeWindowRow,
+} from "@/lib/volume";
+import type { Venue } from "@/lib/volume-url-params";
+
+// Raw response shapes for the unconditional hero queries (see
+// lib/queries/volume.ts). Kept structurally identical to the inline types in
+// `use-hero-rollup.ts` so the prefetched payload plugs straight into each
+// `useGQL` call's `fallbackData`.
+export type VolumeWindowLatestResponse = {
+  volumeWindowSnapshots: VolumeWindowRow[];
+};
+export type BrokerVolumeWindowLatestResponse = {
+  brokerVolumeWindowSnapshots: VolumeWindowRow[];
+};
+export type VolumeTodayTradersResponse = {
+  volumeTodayTraders: VolumeTodayTraderRow[];
+};
+export type BrokerVolumeTodayTradersResponse = {
+  brokerVolumeTodayTraders: VolumeTodayTraderRow[];
+};
+export type VolumeWindowFirstDayLatestResponse = {
+  volumeWindowFirstDaySnapshots: VolumeWindowFirstDayRow[];
+};
+export type BrokerVolumeWindowFirstDayLatestResponse = {
+  brokerVolumeWindowFirstDaySnapshots: VolumeWindowFirstDayRow[];
+};
+
+/**
+ * Descriptor of the exact view the server prefetched. `useGQL` keys on
+ * `[network.id, query, variables]`, so the client must only attach the
+ * prefetched responses as `fallbackData` when every key ingredient of its
+ * OWN first render matches — a silently mismatched fallback (wrong venue,
+ * range, actor filter, network, or UTC day) is worse than no fallback.
+ */
+export type VolumeHeroView = {
+  networkId: IndexerNetworkId;
+  venue: Venue;
+  range: VolumeRangeKey;
+  includeProtocolActors: boolean;
+  /** UTC midnight (seconds) the today-partial query was scoped to. */
+  todayMidnight: number;
+};
+
+/**
+ * Server-prefetched raw responses for the /volume hero first paint. Only the
+ * fields for `view.venue` are populated; the primary pair (window + today) is
+ * always present (the fetch returns `undefined` overall when either fails),
+ * while the firstDay catch-up slice is optional (schema-lag resilient, same
+ * as pool-detail's extension queries).
+ */
+export type VolumeHeroInitialData = {
+  view: VolumeHeroView;
+  heroV3?: VolumeWindowLatestResponse | undefined;
+  todayV3?: VolumeTodayTradersResponse | undefined;
+  firstDayV3?: VolumeWindowFirstDayLatestResponse | undefined;
+  heroV2?: BrokerVolumeWindowLatestResponse | undefined;
+  todayV2?: BrokerVolumeTodayTradersResponse | undefined;
+  firstDayV2?: BrokerVolumeWindowFirstDayLatestResponse | undefined;
+};
+
+/**
+ * The `isProtocolActorIn` variable both sides derive from the actor toggle
+ * (`page-client.tsx` memoizes the identical expression). Centralised so the
+ * server prefetch and the view-parity gate can't drift from the client.
+ */
+export function protocolActorInForView(
+  includeProtocolActors: boolean,
+): boolean[] {
+  return includeProtocolActors ? [false, true] : [false];
+}
+
+/**
+ * True when the client's actual first-render inputs match the prefetched
+ * view descriptor — the gate for attaching `fallbackData`.
+ */
+export function volumeHeroViewMatches(
+  view: VolumeHeroView,
+  actual: {
+    networkId: IndexerNetworkId;
+    venue: Venue;
+    range: VolumeRangeKey;
+    isProtocolActorIn: ReadonlyArray<boolean>;
+    todayMidnight: number;
+  },
+): boolean {
+  const expectedActors = protocolActorInForView(view.includeProtocolActors);
+  const actorsMatch =
+    expectedActors.length === actual.isProtocolActorIn.length &&
+    expectedActors.every((v, i) => actual.isProtocolActorIn[i] === v);
+  return (
+    view.networkId === actual.networkId &&
+    view.venue === actual.venue &&
+    view.range === actual.range &&
+    view.todayMidnight === actual.todayMidnight &&
+    actorsMatch
+  );
+}

--- a/ui-dashboard/src/lib/volume-hero-initial-data.ts
+++ b/ui-dashboard/src/lib/volume-hero-initial-data.ts
@@ -52,21 +52,34 @@ export type VolumeHeroView = {
 };
 
 /**
- * Server-prefetched raw responses for the /volume hero first paint. Only the
- * fields for `view.venue` are populated; the primary pair (window + today) is
- * always present (the fetch returns `undefined` overall when either fails),
- * while the firstDay catch-up slice is optional (schema-lag resilient, same
- * as pool-detail's extension queries).
+ * Server-prefetched raw responses for the /volume hero first paint, as a
+ * per-venue discriminated union: the primary pair (window + today) is
+ * REQUIRED for the active venue (the fetch returns `undefined` overall when
+ * either fails — the compiler now enforces that invariant), the firstDay
+ * catch-up slice stays optional (schema-lag resilient, same as pool-detail's
+ * extension queries), and the other venue's fields are typed `undefined` so
+ * a v3 payload can never silently carry v2 data (or vice versa) while
+ * `fallback?.heroV2`-style access sites stay valid on both branches.
  */
-export type VolumeHeroInitialData = {
-  view: VolumeHeroView;
-  heroV3?: VolumeWindowLatestResponse | undefined;
-  todayV3?: VolumeTodayTradersResponse | undefined;
-  firstDayV3?: VolumeWindowFirstDayLatestResponse | undefined;
-  heroV2?: BrokerVolumeWindowLatestResponse | undefined;
-  todayV2?: BrokerVolumeTodayTradersResponse | undefined;
-  firstDayV2?: BrokerVolumeWindowFirstDayLatestResponse | undefined;
-};
+export type VolumeHeroInitialData =
+  | {
+      view: VolumeHeroView & { venue: "v3" };
+      heroV3: VolumeWindowLatestResponse;
+      todayV3: VolumeTodayTradersResponse;
+      firstDayV3?: VolumeWindowFirstDayLatestResponse | undefined;
+      heroV2?: undefined;
+      todayV2?: undefined;
+      firstDayV2?: undefined;
+    }
+  | {
+      view: VolumeHeroView & { venue: "v2" };
+      heroV2: BrokerVolumeWindowLatestResponse;
+      todayV2: BrokerVolumeTodayTradersResponse;
+      firstDayV2?: BrokerVolumeWindowFirstDayLatestResponse | undefined;
+      heroV3?: undefined;
+      todayV3?: undefined;
+      firstDayV3?: undefined;
+    };
 
 /**
  * The `isProtocolActorIn` variable both sides derive from the actor toggle

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -148,8 +148,16 @@ async function fetchVolumeHeroUncached(
 // fallback paints instantly, then the client's useGQL revalidates on mount.
 // The raw responses are plain JSON (no Map/Set/BigInt — Hasura numerics are
 // strings), so unstable_cache serialization is lossless here.
+//
+// The key is salted with the deployment SHA ("dev" locally) because Vercel's
+// Data Cache persists across deployments within an environment — without the
+// salt, a deploy that changes the response shape or view-descriptor contract
+// could serve an entry written by older code for up to the TTL (same hazard
+// the homepage cache in network-fetcher/server-cache.ts guards against; view
+// variables such as venue, range, and todayMidnight are already part of the
+// key via the wrapped function's arguments).
 export const fetchVolumeHeroForSSR = unstable_cache(
   fetchVolumeHeroUncached,
-  ["volume-hero-ssr"],
+  ["volume-hero-ssr", process.env.VERCEL_GIT_COMMIT_SHA ?? "dev"],
   { revalidate: 60, tags: ["volume-hero-ssr"] },
 );

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -7,6 +7,9 @@
 import { unstable_cache } from "next/cache";
 import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
+
+// Tighter budget for the OPTIONAL firstDay slice — see firstDaySignal below.
+const FIRST_DAY_TIMEOUT_MS = 2_000;
 import { DEFAULT_NETWORK, NETWORKS } from "@/lib/networks";
 import {
   BROKER_VOLUME_TODAY_TRADERS,
@@ -77,6 +80,12 @@ async function fetchVolumeHeroUncached(
 
   const client = makeOgGraphQLClient(network);
   const signal = AbortSignal.timeout(HASURA_TIMEOUT_MS);
+  // The optional firstDay catch-up slice gets a tighter independent budget:
+  // it shares a Promise.all with the primary pair, so on a cache miss a hung
+  // optional query would otherwise hold the route's TTFB to the full shared
+  // deadline even when both primaries answered quickly. Missing firstDay only
+  // degrades the catch-up (chains render as degraded), never the hero.
+  const firstDaySignal = AbortSignal.timeout(FIRST_DAY_TIMEOUT_MS);
   const isProtocolActorIn = protocolActorInForView(includeProtocolActors);
   const windowVariables = { windowKey: range };
   const todayVariables = { todayMidnight, isProtocolActorIn };
@@ -107,7 +116,7 @@ async function fetchVolumeHeroUncached(
         client,
         BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
         windowVariables,
-        signal,
+        firstDaySignal,
       ),
     ]);
     // The hero tiles gate their loading state on the PRIMARY pair (window +
@@ -137,7 +146,7 @@ async function fetchVolumeHeroUncached(
       client,
       VOLUME_WINDOW_FIRSTDAY_LATEST,
       windowVariables,
-      signal,
+      firstDaySignal,
     ),
   ]);
   // Same primary-pair rule as the v2 branch above.
@@ -149,15 +158,23 @@ async function fetchVolumeHeroUncached(
 // The raw responses are plain JSON (no Map/Set/BigInt — Hasura numerics are
 // strings), so unstable_cache serialization is lossless here.
 //
-// The key is salted with the deployment SHA ("dev" locally) because Vercel's
-// Data Cache persists across deployments within an environment — without the
-// salt, a deploy that changes the response shape or view-descriptor contract
-// could serve an entry written by older code for up to the TTL (same hazard
-// the homepage cache in network-fetcher/server-cache.ts guards against; view
-// variables such as venue, range, and todayMidnight are already part of the
-// key via the wrapped function's arguments).
+// The key is salted with the deployment id (unique per deployment, including
+// env-only redeploys; commit SHA as fallback, "dev" locally) plus the
+// endpoint it fetches from, because Vercel's Data Cache persists across
+// deployments within an environment — without the salt, a deploy that
+// changes the response shape, the view-descriptor contract, or repoints the
+// Hasura endpoint could serve an entry written by older code for up to the
+// TTL (same hazard the homepage cache in network-fetcher/server-cache.ts
+// guards against; view variables such as venue, range, and todayMidnight are
+// already part of the key via the wrapped function's arguments).
 export const fetchVolumeHeroForSSR = unstable_cache(
   fetchVolumeHeroUncached,
-  ["volume-hero-ssr", process.env.VERCEL_GIT_COMMIT_SHA ?? "dev"],
+  [
+    "volume-hero-ssr",
+    process.env.VERCEL_DEPLOYMENT_ID ??
+      process.env.VERCEL_GIT_COMMIT_SHA ??
+      "dev",
+    NETWORKS[DEFAULT_NETWORK].hasuraUrl,
+  ],
   { revalidate: 60, tags: ["volume-hero-ssr"] },
 );

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -7,9 +7,6 @@
 import { unstable_cache } from "next/cache";
 import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
-
-// Tighter budget for the OPTIONAL firstDay slice — see firstDaySignal below.
-const FIRST_DAY_TIMEOUT_MS = 2_000;
 import { DEFAULT_NETWORK, NETWORKS } from "@/lib/networks";
 import {
   BROKER_VOLUME_TODAY_TRADERS,
@@ -31,6 +28,9 @@ import {
   type VolumeWindowLatestResponse,
 } from "@/lib/volume-hero-initial-data";
 import type { Venue } from "@/lib/volume-url-params";
+
+// Tighter budget for the OPTIONAL firstDay slice — see firstDaySignal below.
+const FIRST_DAY_TIMEOUT_MS = 2_000;
 
 // SSR-prefetch of the /volume hero queries (perf-plan S4, mirroring the proven
 // pool-detail pattern). `/volume` is otherwise a pure client waterfall: the
@@ -90,15 +90,17 @@ async function fetchVolumeHeroUncached(
   const windowVariables = { windowKey: range };
   const todayVariables = { todayMidnight, isProtocolActorIn };
 
-  const view = {
+  // Built per-branch (not hoisted) so `venue` carries its narrowed literal
+  // type into the discriminated `VolumeHeroInitialData` union member.
+  const viewBase = {
     networkId: network.id,
-    venue,
     range,
     includeProtocolActors,
     todayMidnight,
   };
 
   if (venue === "v2") {
+    const view = { ...viewBase, venue };
     const [heroV2, todayV2, firstDayV2] = await Promise.all([
       requestOptional<BrokerVolumeWindowLatestResponse>(
         client,
@@ -129,6 +131,7 @@ async function fetchVolumeHeroUncached(
       : undefined;
   }
 
+  const view = { ...viewBase, venue };
   const [heroV3, todayV3, firstDayV3] = await Promise.all([
     requestOptional<VolumeWindowLatestResponse>(
       client,

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -167,6 +167,13 @@ async function fetchVolumeHeroUncached(
 // TTL (same hazard the homepage cache in network-fetcher/server-cache.ts
 // guards against; view variables such as venue, range, and todayMidnight are
 // already part of the key via the wrapped function's arguments).
+//
+// Known fail-open trade-off (deliberate, mirrors pool-detail-ssr): a fetch
+// failure returns `undefined`, and unstable_cache stores that for the full
+// TTL — one transient upstream blip disables the SSR enhancement for that
+// view for up to 60s. The client-only path is unaffected (the page still
+// loads normally), so the blast radius is losing the progressive-paint win,
+// not correctness.
 export const fetchVolumeHeroForSSR = unstable_cache(
   fetchVolumeHeroUncached,
   [

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -1,0 +1,155 @@
+// Server-only by convention (like lib/pool-detail-ssr.ts): imported exclusively
+// from the `/volume` Server Component, and it pulls in no client-only modules
+// (`useSWR`/`useNetwork`/`next-auth`). Deliberately NOT using `import
+// "server-only"` — that guard throws under the (non-RSC) vitest environment
+// that transitively imports this via page.tsx, exactly as pool-detail-ssr.ts
+// avoids it.
+import { unstable_cache } from "next/cache";
+import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
+import { DEFAULT_NETWORK, NETWORKS } from "@/lib/networks";
+import {
+  BROKER_VOLUME_TODAY_TRADERS,
+  BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
+  BROKER_VOLUME_WINDOW_LATEST,
+  VOLUME_TODAY_TRADERS,
+  VOLUME_WINDOW_FIRSTDAY_LATEST,
+  VOLUME_WINDOW_LATEST,
+} from "@/lib/queries/volume";
+import type { VolumeRangeKey } from "@/lib/volume";
+import {
+  protocolActorInForView,
+  type BrokerVolumeTodayTradersResponse,
+  type BrokerVolumeWindowFirstDayLatestResponse,
+  type BrokerVolumeWindowLatestResponse,
+  type VolumeHeroInitialData,
+  type VolumeTodayTradersResponse,
+  type VolumeWindowFirstDayLatestResponse,
+  type VolumeWindowLatestResponse,
+} from "@/lib/volume-hero-initial-data";
+import type { Venue } from "@/lib/volume-url-params";
+
+// SSR-prefetch of the /volume hero queries (perf-plan S4, mirroring the proven
+// pool-detail pattern). `/volume` is otherwise a pure client waterfall: the
+// hero headline, KPI tiles, and data-quality banners all wait for
+// HTML → JS → hydrate → client GraphQL. Fetching the same query variables
+// server-side and handing the raw responses to `useHeroRollup` as per-query
+// fallbackData lets the first render paint populated numbers.
+//
+// Only the UNCONDITIONAL first-render queries are prefetched (window snapshot,
+// today partial, firstDay slice). The conditional second-wave queries
+// (yesterday catch-up / partial-overlap) are gated on the merge result and
+// stay client-only.
+
+type VolumeSsrClient = ReturnType<typeof makeOgGraphQLClient>;
+
+async function requestOptional<T>(
+  client: VolumeSsrClient,
+  document: string,
+  variables: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<T | undefined> {
+  try {
+    return await client.request<T>({
+      document,
+      variables,
+      signal,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchVolumeHeroUncached(
+  venue: Venue,
+  range: VolumeRangeKey,
+  includeProtocolActors: boolean,
+  // Passed in (not computed here) so it is part of the unstable_cache key —
+  // the cache can never serve a stale UTC day past midnight — and so the view
+  // descriptor records exactly what was fetched.
+  todayMidnight: number,
+): Promise<VolumeHeroInitialData | undefined> {
+  // `/volume` isn't a pool route, so NetworkProvider always resolves
+  // DEFAULT_NETWORK on the client — prefetch against the same endpoint the
+  // client's SWR keys will use.
+  const network = NETWORKS[DEFAULT_NETWORK];
+  if (!network.hasuraUrl) return undefined;
+
+  const client = makeOgGraphQLClient(network);
+  const signal = AbortSignal.timeout(HASURA_TIMEOUT_MS);
+  const isProtocolActorIn = protocolActorInForView(includeProtocolActors);
+  const windowVariables = { windowKey: range };
+  const todayVariables = { todayMidnight, isProtocolActorIn };
+
+  const view = {
+    networkId: network.id,
+    venue,
+    range,
+    includeProtocolActors,
+    todayMidnight,
+  };
+
+  if (venue === "v2") {
+    const [heroV2, todayV2, firstDayV2] = await Promise.all([
+      requestOptional<BrokerVolumeWindowLatestResponse>(
+        client,
+        BROKER_VOLUME_WINDOW_LATEST,
+        windowVariables,
+        signal,
+      ),
+      requestOptional<BrokerVolumeTodayTradersResponse>(
+        client,
+        BROKER_VOLUME_TODAY_TRADERS,
+        todayVariables,
+        signal,
+      ),
+      requestOptional<BrokerVolumeWindowFirstDayLatestResponse>(
+        client,
+        BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
+        windowVariables,
+        signal,
+      ),
+    ]);
+    // The hero tiles gate their loading state on the PRIMARY pair (window +
+    // today). If either failed, degrade to no fallback at all: the client
+    // hooks fetch normally and today's loading path takes over. Never hand
+    // back a partial pair that could paint happy-path zeros. The firstDay
+    // catch-up slice stays optional (schema-lag resilient).
+    return heroV2 && todayV2
+      ? { view, heroV2, todayV2, firstDayV2 }
+      : undefined;
+  }
+
+  const [heroV3, todayV3, firstDayV3] = await Promise.all([
+    requestOptional<VolumeWindowLatestResponse>(
+      client,
+      VOLUME_WINDOW_LATEST,
+      windowVariables,
+      signal,
+    ),
+    requestOptional<VolumeTodayTradersResponse>(
+      client,
+      VOLUME_TODAY_TRADERS,
+      todayVariables,
+      signal,
+    ),
+    requestOptional<VolumeWindowFirstDayLatestResponse>(
+      client,
+      VOLUME_WINDOW_FIRSTDAY_LATEST,
+      windowVariables,
+      signal,
+    ),
+  ]);
+  // Same primary-pair rule as the v2 branch above.
+  return heroV3 && todayV3 ? { view, heroV3, todayV3, firstDayV3 } : undefined;
+}
+
+// 60s revalidate matches pool-detail-ssr and the client polling cadence: the
+// fallback paints instantly, then the client's useGQL revalidates on mount.
+// The raw responses are plain JSON (no Map/Set/BigInt — Hasura numerics are
+// strings), so unstable_cache serialization is lossless here.
+export const fetchVolumeHeroForSSR = unstable_cache(
+  fetchVolumeHeroUncached,
+  ["volume-hero-ssr"],
+  { revalidate: 60, tags: ["volume-hero-ssr"] },
+);

--- a/ui-dashboard/src/lib/volume-url-params.ts
+++ b/ui-dashboard/src/lib/volume-url-params.ts
@@ -1,0 +1,42 @@
+// Pure URL-param parsing for the /volume page (range / actor filter / venue).
+//
+// Extracted from `app/volume/_lib/url-state.ts` (which is client-marked) so the
+// `/volume` Server Component can derive the first-render view for SSR-prefetch
+// with the exact same parsing + defaults the client hook uses — a silently
+// diverging server-side re-implementation would attach `fallbackData` to the
+// wrong SWR key. Zero runtime dependencies: safe on both sides of the
+// server/client module boundary (see ui-dashboard/AGENTS.md).
+
+import type { VolumeRangeKey } from "@/lib/volume";
+
+export type Venue = "v3" | "v2";
+export type ActorFilter = "organic" | "all";
+
+const VALID_RANGES = new Set<VolumeRangeKey>([
+  "24h",
+  "7d",
+  "30d",
+  "90d",
+  "all",
+]);
+export const DEFAULT_RANGE: VolumeRangeKey = "7d";
+const VALID_VENUES = new Set<Venue>(["v3", "v2"]);
+export const DEFAULT_ACTOR_FILTER: ActorFilter = "organic";
+
+export function readRangeFromParams(params: URLSearchParams): VolumeRangeKey {
+  const raw = params.get("range");
+  return raw && VALID_RANGES.has(raw as VolumeRangeKey)
+    ? (raw as VolumeRangeKey)
+    : DEFAULT_RANGE;
+}
+
+export function readActorFilterFromParams(
+  params: URLSearchParams,
+): ActorFilter {
+  return params.get("actors") === "all" ? "all" : DEFAULT_ACTOR_FILTER;
+}
+
+export function readVenueFromParams(params: URLSearchParams): Venue {
+  const raw = params.get("venue");
+  return raw && VALID_VENUES.has(raw as Venue) ? (raw as Venue) : "v3";
+}


### PR DESCRIPTION
## The Problem

- `/volume` is the only top-traffic page with zero server data: the hero headline, KPI tiles, and data-quality banners all wait for HTML → JS → hydrate → client GraphQL (~620ms to data on fast desktop, much worse on mobile) while the user stares at "…" tiles.
- The homepage and `/pool/[poolId]` already paint populated numbers on first render via SSR-prefetched SWR `fallbackData`; `/volume` never got that treatment (perf-plan S4).

## The Solution

- Prefetch the three unconditional hero queries server-side (`VOLUME_WINDOW_LATEST`, `VOLUME_TODAY_TRADERS`, `VOLUME_WINDOW_FIRSTDAY_LATEST`, or the `BROKER_*` trio for `?venue=v2`) for the exact first-render view derived from `searchParams`, behind a 60s `unstable_cache`, and thread the raw responses into `useHeroRollup` as per-query `fallbackData`.
- View parsing is shared, not duplicated: the pure URL readers moved into `lib/volume-url-params.ts`, imported by both the Server Component and the client `url-state`.
- A view descriptor (`networkId`, `venue`, `range`, `includeProtocolActors`, `todayMidnight`) rides with the prefetch; the client attaches `fallbackData` only when the descriptor matches its actual render inputs — a mismatch (e.g. UTC-midnight crossing between server render and hydration) silently drops the fallback rather than seeding wrong data.
- Bonus loading-vs-zero fix: the Unique-traders tile subtitle no longer shows "0 swaps" under a "…" value ("— swaps" while loading/error, line always rendered so tile height is stable).

## Details

### Invariants

- **Key parity**: server fetch variables exactly match the client `useGQL` keys (venue/range quantization, `isProtocolActorIn` via the shared `protocolActorInForView()` — page-client now routes through the same helper so drift can't silently kill the gate, network id compared against `useNetwork()`).
- **Session gating**: logged-out visitors are locked server-side to the all-actors view exactly as `url-state` locks the client (`?actors=` ignored); logged-in defaults to organic.
- **Loading-vs-zero**: fallback is primary-pair-or-nothing — if either the window snapshot or today-partial fails server-side, the whole prefetch degrades to `undefined` (today's client-only path). A partial pair can never paint happy-path zeros. Hero loading gates on data presence (`isLoadingWithoutData`), mirroring `PoolOverview`.
- **todayMidnight is part of the cache key** (function argument), so a cached entry can never serve a stale UTC day past midnight.
- **Cache-key salt**: deployment id (covers env-only redeploys) + endpoint, mirroring the homepage cache in `network-fetcher/server-cache.ts`.

### Degraded behavior

- Any server prefetch failure → `undefined` initialData → the existing client waterfall; deliberate fail-open, and a failure result is cached for the 60s TTL (documented in code; blast radius is losing the progressive-paint win, not correctness — same trade-off pool-detail-ssr ships).
- The optional firstDay catch-up slice has its own 2s abort budget so a hung optional query can't hold TTFB to the full shared 5s deadline on a cache miss; missing firstDay only degrades the catch-up (chains render as degraded), never the hero.
- Cold-miss TTFB can serialize behind the primary pair up to the shared 5s bound — ratified as the same tradeoff `/pool/[poolId]`'s SSR prefetch ships; cache hits (the common case at 60s TTL) are unaffected.
- UTC-midnight hydration crossing: descriptor mismatch drops the fallback; worst case is one numbers→"…" flash, self-healing on the ≤30s poll.

### Validation

- `pnpm agent:quality-gate --run` fully green (browser tests, size-limit, react-doctor diff + score 100, coverage, knip, dep-cruiser).
- Full dashboard suite 3573 tests green; new coverage: server fetch (v3/v2 trios, variable shapes, primary-failure → undefined, firstDay-only failure kept, unconfigured network, split firstDay budget), page server test (session × searchParams, 7 cases), view-matcher gating (fallback attaches only on match, drops on range/UTC-day mismatch), page-client threading + both subtitle states.
- Browser-verified on a local prod build against the live Envio endpoint: hero dollar figures are present in the initial HTML (server-rendered), CLS 0.02, zero console errors.
- Specialist review fleet: approve, 0 blockers; key parity, session gating, degraded path, and ES2017 compliance independently verified. Codex findings (uncommitted salt, firstDay TTFB budget) fixed.

### Intentional non-goals

- Trader/aggregator tables and the pool chart stay client-fetched (own skeletons; conditional second-wave hero queries are gated on merge results and can't be precomputed).
- Zod validation of the SSR-prefetched responses (fallbackData bypasses `useGQL`'s schema gate) — deferred with #1215, consistent with the shipped pool-detail-ssr pattern.

## Deferrals

- Zod validation for SSR-prefetched fallback payloads (volume + pool-detail) → #1215

## Ship Checklist

- [x] ship skill used
- [x] local review run (specialist fleet + Codex; all confirmed findings fixed)
- [x] validation run (quality gate + browser verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-paint data path and SWR fallback gating; mismatches are designed to drop prefetch, but wrong parity could briefly show stale hero numbers until revalidation.
> 
> **Overview**
> Adds **server-side prefetch** of the `/volume` hero GraphQL trio (window snapshot, today partial, optional firstDay slice; v3 or broker v2) so headline and KPI tiles can paint with real numbers on first render instead of waiting on the client waterfall.
> 
> The **`/volume` Server Component** derives the first-render view from `searchParams` and session (logged-out users stay on all-actors; `?actors=` only applies when filters are allowed), calls **`fetchVolumeHeroForSSR`** behind a 60s **`unstable_cache`** (deployment + Hasura URL salt), and passes **`initialData`** into **`VolumeClient`**. URL parsing moves to shared **`lib/volume-url-params.ts`** so server and client agree on SWR keys.
> 
> **`useHeroRollup`** only wires prefetched payloads as per-query **`fallbackData`** when **`volumeHeroViewMatches`** (network, venue, range, actors, UTC `todayMidnight`); hero loading/error use **`isLoadingWithoutData` / `hasErrorWithoutData`** so SSR seed does not show perpetual "…" or wipe numbers on background revalidation failures. Primary-pair fetch failures return **`undefined`** overall; optional firstDay uses a shorter abort budget.
> 
> **UI polish:** the Unique traders tile shows **"— swaps"** while the hero is loading or errored instead of **"0 swaps"** under **"…"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11dde801e51502c57e3d722547c8a64c0629ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->