### PR TITLE
Harden Terraform Cloud Run checklist

### DIFF
--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -51,6 +51,11 @@ trimmed build context:
 - [ ] `.gcloudignore` does not exclude those same inputs. Keep it aligned with
       the Dockerfile and any workspace packages the build needs before install
       (for example `shared-config/` for metrics-bridge).
+- [ ] Terraform `archive_file` sources exclude local-only outputs produced by
+      commands run in the source root (especially `coverage/`), and
+      `.gcloudignore` mirrors those exclusions. Run the representative local
+      commands before the final plan and confirm transient files do not replace
+      the source object or Cloud Function.
 - [ ] Deploy workflow `paths:` filters include those inputs so patch-only or
       build-context-only changes actually redeploy (`patches/**`, lockfiles,
       package manifests, `cloudbuild.yaml`, Dockerfile, and any workspace deps the
@@ -68,12 +73,17 @@ This bit me on PRs #197 and #200 — both P1 blockers.
 - [ ] CI/CD deployer SAs need `roles/iam.serviceAccountTokenCreator` on the runtime SA they impersonate. Without it, Workload Identity Federation (`google-github-actions/auth`) fails at `getAccessToken` time before any Terraform/gcloud command runs
 - [ ] Any new `google_project_iam_member` should be reviewed against the API enablement and SA bindings already present, not added as an isolated grant
 
-## 6. Variable validation
+## 6. Variable and Terraform-version validation
 
 For variables that gate critical behavior:
 
 - [ ] Add a `validation` block for non-empty strings (image refs, project IDs, region). An empty string forwarded to a required field fails the apply with a cryptic error and blocks unrelated infra changes
 - [ ] If a previous schema accepted an empty value as "disable this resource", normalize it back to a safe default (or fail loudly with a migration message) — silent breakage of previously-valid `terraform.tfvars` is a hostile change
+- [ ] When adopting a Terraform CLI feature, check its minimum version and
+      raise the owning root's `required_version` to match. Provider write-only
+      resource arguments such as `*_wo` require Terraform 1.11 or newer; CI
+      using a newer binary does not prove every version allowed by the root can
+      plan the configuration.
 
 ## 7. Build-artifact retention
 


### PR DESCRIPTION
## The Problem

- The Cloud Run checklist did not catch transient test output changing a Cloud Function source archive and forcing an unrelated replacement.
- It also did not require the owning Terraform root to raise its minimum version when adopting newer language features such as provider write-only arguments.

## The Solution

- Add focused checklist gates for archive hygiene and Terraform CLI feature compatibility.

## Details

- Require archive_file sources and .gcloudignore to exclude local-only outputs such as coverage directories.
- Require representative local commands to run before the final plan so transient source-hash drift is visible.
- Require the owning root required_version to match adopted Terraform features, explicitly noting that write-only resource arguments need Terraform 1.11 or newer.
- Docs-only change; no runtime or infrastructure mutation.

## Validation

- pnpm agent:quality-gate --run
- pnpm agent:autoreview
- pnpm agent:review-materiality
- pnpm agent:prewarm --base origin/main
- git diff --check
- Fresh-context semantic review: clean

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, Terraform, or deploy behavior changes.
> 
> **Overview**
> **Docs-only** update to `docs/pr-checklists/terraform-cloudrun.md` so infra reviews catch two gaps that already caused pain elsewhere.
> 
> **Cloud Build / source context (§4):** New items require `archive_file` sources and `.gcloudignore` to exclude local-only outputs (especially `coverage/`), run representative local commands before the final plan, and confirm transient files do not change the source hash and force an unrelated Cloud Function replacement.
> 
> **Validation (§6, renamed):** Section title becomes “Variable and Terraform-version validation.” A new bullet requires raising the owning root’s `required_version` when adopting Terraform CLI features—explicitly calling out that provider write-only args (`*_wo`) need **Terraform 1.11+**, and that CI on a newer binary does not cover older versions still allowed by the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da8333967376f5a598d62cb4526813a2c81e8ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->