### PR TITLE
docs: add skeleton-parity gate to stateful-data-ui checklist

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -133,6 +133,13 @@ For each non-happy path, decide the behavior explicitly.
 - [ ] total dataset is much larger than the current happy-path sample
 - [ ] search term matches data outside the currently fetched window
 - [ ] empty state vs loading state vs partial-data state are distinct
+- [ ] skeleton parity: any new or changed loading branch matches the loaded
+      content's dimensions and section structure (a text line or generic bar
+      stack standing in for a card grid or table is a regression). CLS ≈ 0 does
+      NOT prove no jump — whole-subtree swaps are invisible to layout-shift.
+      Verify by diffing skeleton-phase vs loaded-phase section rects; the
+      browser recipe (GraphQL-delay init script + rect sampler) is embedded in
+      issue #1218 and its sibling skeleton-parity issues (#1219–#1223).
 
 The key question:
 


### PR DESCRIPTION
## The Problem

- The stateful-data-ui checklist covers loading/empty/partial states but has no gate for skeleton↔content dimension parity, which is how the 2026-07-10 audit found jumps of up to +1,321px on /stables and a full-page 280px→2,114px swap on /cdps.
- CLS ≈ 0 falsely suggests "no jumping" for whole-subtree skeleton swaps, so reviewers relying on Lighthouse miss the worst perceived transitions.

## The Solution

- Add one degraded-mode checklist gate: any new or changed loading branch must match the loaded content's dimensions and section structure, verified by diffing skeleton-phase vs loaded-phase rects (recipe embedded in issue #1218 and siblings #1219–#1223), with an explicit note that CLS cannot prove the absence of a jump.

Docs-only change; no code paths affected.

Refs #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only checklist change; no runtime or build behavior is modified.
> 
> **Overview**
> Extends **§4 Degraded-mode** in `docs/pr-checklists/stateful-data-ui.md` with a new reviewer gate: **skeleton parity** for any new or changed loading UI.
> 
> Reviewers must confirm loading branches mirror the loaded page’s **section structure and dimensions** (generic bars or one-line placeholders for card grids/tables count as regressions). The item explicitly states that **CLS ≈ 0 is not sufficient** when skeleton and content are swapped as whole subtrees, and points to **rect diffing** (skeleton vs loaded phase) using the browser recipe in issues **#1218** and **#1219–#1223**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08c6f988236d7cc8bb8483fb2bd22481fe50b25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->