### PR TITLE
fix(dashboard): page-shaped /cdps loading state

### DIFF
--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdps-page-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdps-page-client.test.tsx
@@ -475,7 +475,7 @@ describe("CdpsPageClient", () => {
 
     // Transactions section: real heading mounted + a table skeleton
     // reserving exactly one page of rows (the table's real first-page
-    // size). Nested here, the body skeleton and its TableSkeleton both
+    // size). Nested here, the body skeleton and its table skeleton both
     // stay presentational (no role/aria-live of their own) so the page
     // keeps exactly one live region overall.
     expect(handle!.container.textContent).toContain("Recent CDP Transactions");
@@ -484,8 +484,15 @@ describe("CdpsPageClient", () => {
     ) as HTMLElement[];
     expect(heading!.textContent).toBe("Recent CDP Transactions");
     const [, table] = Array.from(txBody!.children) as HTMLElement[];
-    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    const [header, body] = Array.from(table!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
+    // Pins the cdps-measured table rhythm (45px header, 47px rows) that
+    // replaced the shared TableSkeleton's 36/44 constants for this table.
+    expect(header.style.height).toBe("45px");
     expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
+    expect((body.children[0] as HTMLElement).style.height).toBe("47px");
   });
 
   it("loading and loaded phases render the same top-level section count", () => {
@@ -1146,12 +1153,19 @@ describe("CdpAllTransactionsTable", () => {
     expect(liveRegions[0]!.getAttribute("aria-label")).toBe(
       "Loading transactions",
     );
-    // The nested TableSkeleton stays presentational (no role/aria-live of
+    // The nested table skeleton stays presentational (no role/aria-live of
     // its own) so it doesn't double up with the wrapper's live region above.
     const wrapper = liveRegions[0] as HTMLElement;
     const [, table] = Array.from(wrapper.children) as HTMLElement[];
-    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    const [header, body] = Array.from(table!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
+    // Pins the cdps-measured table rhythm (45px header, 47px rows) that
+    // replaced the shared TableSkeleton's 36/44 constants for this table.
+    expect(header.style.height).toBe("45px");
     expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
+    expect((body.children[0] as HTMLElement).style.height).toBe("47px");
   });
 
   it("keeps last-good empty overview transactions as an empty state during a background poll error", () => {

--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdps-page-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdps-page-client.test.tsx
@@ -82,6 +82,7 @@ import {
   ALL_CDP_TROVE_OP_SNAPSHOTS,
   CDP_MARKETS,
 } from "@/lib/queries";
+import { CDP_OVERVIEW_TABLE_PAGE_SIZE } from "../../_lib/transactions";
 import { CdpAllTransactionsTable } from "../cdp-all-transactions-table";
 import { CdpsPageClient } from "../cdps-page-client";
 
@@ -432,6 +433,97 @@ describe("CdpsPageClient", () => {
     expect(handle!.container.textContent).toContain(
       "No CDP markets indexed yet.",
     );
+  });
+
+  it("loading skeleton mirrors the loaded page's section structure (header + 3 cards + digest + table skeleton)", () => {
+    mockUseGQL.mockImplementation((query: string | null) =>
+      query === CDP_MARKETS
+        ? { data: undefined, error: null, isLoading: true }
+        : { data: undefined, error: null, isLoading: false },
+    );
+    render(handle!, <CdpsPageClient />);
+
+    // Exactly one live region for the whole page-level skeleton — nested
+    // skeleton pieces must stay presentational under it.
+    const liveRegions = handle!.container.querySelectorAll(
+      '[aria-live="polite"]',
+    );
+    expect(liveRegions).toHaveLength(1);
+
+    // Real header stays mounted (no data dependency) so it never moves
+    // between the loading and loaded phases.
+    expect(handle!.container.querySelector("header h1")?.textContent).toBe(
+      "CDPs",
+    );
+
+    // Top-level sections, in order: header, market-card grid, activity
+    // digest, transactions section — same 4 sections the loaded page renders.
+    const sections = Array.from(
+      handle!.container.firstElementChild!.children,
+    ) as HTMLElement[];
+    expect(sections).toHaveLength(4);
+    const [, grid, digest, transactionsSection] = sections;
+
+    // Market-card grid: same 3-column shape as the loaded grid, 3 cards.
+    expect(grid!.className).toContain("grid-cols-1");
+    expect(grid!.className).toContain("md:grid-cols-3");
+    expect(grid!.children).toHaveLength(3);
+
+    // Activity-digest placeholder: heading bar + subtitle bar + one
+    // content-row wrapper holding a bar per market row.
+    expect(digest!.children).toHaveLength(3);
+
+    // Transactions section: real heading mounted + a table skeleton
+    // reserving exactly one page of rows (the table's real first-page
+    // size). Nested here, the body skeleton and its TableSkeleton both
+    // stay presentational (no role/aria-live of their own) so the page
+    // keeps exactly one live region overall.
+    expect(handle!.container.textContent).toContain("Recent CDP Transactions");
+    const [heading, txBody] = Array.from(
+      transactionsSection!.children,
+    ) as HTMLElement[];
+    expect(heading!.textContent).toBe("Recent CDP Transactions");
+    const [, table] = Array.from(txBody!.children) as HTMLElement[];
+    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
+  });
+
+  it("loading and loaded phases render the same top-level section count", () => {
+    mockUseGQL.mockImplementation((query: string | null) =>
+      query === CDP_MARKETS
+        ? { data: undefined, error: null, isLoading: true }
+        : { data: undefined, error: null, isLoading: false },
+    );
+    render(handle!, <CdpsPageClient />);
+    const loadingSectionCount =
+      handle!.container.firstElementChild!.children.length;
+
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === CDP_MARKETS) {
+        return { data: marketData(), error: null, isLoading: false };
+      }
+      if (query === ALL_CDP_TRANSACTIONS) {
+        return { data: transactionData(), error: null, isLoading: false };
+      }
+      if (query === ALL_CDP_STABILITY_POOL_EVENTS) {
+        return {
+          data: { StabilityPoolOperationEvent: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      if (query === ALL_CDP_TROVE_OP_SNAPSHOTS) {
+        return { data: snapshotData(), error: null, isLoading: false };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+    render(handle!, <CdpsPageClient />);
+    const loadedSectionCount =
+      handle!.container.firstElementChild!.children.length;
+
+    // header, market-card grid, activity digest, transactions section
+    expect(loadingSectionCount).toBe(4);
+    expect(loadedSectionCount).toBe(4);
   });
 
   it("renders market cards with health, derived open troves, and transactions", () => {
@@ -1026,6 +1118,40 @@ describe("CdpAllTransactionsTable", () => {
     expect(handle!.container.textContent).not.toContain(
       "No CDP transactions indexed yet.",
     );
+  });
+
+  it("internal SWR loading branch renders the shared table-shaped skeleton (fallback→internal-loading parity)", () => {
+    mockUseGQL.mockImplementation((query: string | null) =>
+      query === ALL_CDP_TRANSACTIONS
+        ? { data: undefined, error: null, isLoading: true }
+        : { data: undefined, error: null, isLoading: false },
+    );
+
+    render(
+      handle!,
+      <CdpAllTransactionsTable
+        chainId={42220}
+        collaterals={[{ id: "gbpm", chainId: 42220, symbol: "GBPm" }]}
+      />,
+    );
+
+    // Real heading mounted; single live region owned by the shared skeleton
+    // body (same component the Suspense fallback in cdps-page-client.tsx
+    // renders), reserving one page of rows.
+    expect(handle!.container.textContent).toContain("Recent CDP Transactions");
+    const liveRegions = handle!.container.querySelectorAll(
+      '[aria-live="polite"]',
+    );
+    expect(liveRegions).toHaveLength(1);
+    expect(liveRegions[0]!.getAttribute("aria-label")).toBe(
+      "Loading transactions",
+    );
+    // The nested TableSkeleton stays presentational (no role/aria-live of
+    // its own) so it doesn't double up with the wrapper's live region above.
+    const wrapper = liveRegions[0] as HTMLElement;
+    const [, table] = Array.from(wrapper.children) as HTMLElement[];
+    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
   });
 
   it("keeps last-good empty overview transactions as an empty state during a background poll error", () => {

--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CDP_OVERVIEW_TABLE_PAGE_SIZE } from "../../_lib/transactions";
+import {
+  CdpActivityDigestSkeleton,
+  CdpMarketCardGridSkeleton,
+  CdpTransactionsBodySkeleton,
+} from "../cdps-skeletons";
+
+// Tests assert structural behavior (child counts, aria annotations) rather
+// than substring-matching a shimmer classname — see the same rationale in
+// src/components/__tests__/skeletons.test.tsx.
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+describe("CdpMarketCardGridSkeleton", () => {
+  it("mirrors the loaded market grid: 3 cards, each with a 2x2 metric grid", () => {
+    render(<CdpMarketCardGridSkeleton />);
+    const grid = container.firstElementChild!;
+    expect(grid.className).toContain("grid-cols-1");
+    expect(grid.className).toContain("md:grid-cols-3");
+    expect(grid.children).toHaveLength(3);
+
+    for (const card of Array.from(grid.children)) {
+      const metricGrid = card.querySelector(".grid-cols-2");
+      expect(metricGrid).not.toBeNull();
+      expect(metricGrid!.children).toHaveLength(4);
+    }
+  });
+});
+
+describe("CdpActivityDigestSkeleton", () => {
+  it("renders a heading bar, subtitle bar, and per-market content rows", () => {
+    render(<CdpActivityDigestSkeleton />);
+    const card = container.firstElementChild!;
+    expect(card.className).toContain("rounded-lg");
+    // heading bar + subtitle bar + one content-row wrapper
+    expect(card.children).toHaveLength(3);
+    const rows = card.children[2]!;
+    expect(rows.children).toHaveLength(3);
+  });
+});
+
+describe("CdpTransactionsBodySkeleton", () => {
+  it("reserves a filter bar, one page of rows, and a pagination-footer bar", () => {
+    render(<CdpTransactionsBodySkeleton />);
+    const wrapper = container.querySelector<HTMLElement>(
+      '[aria-label="Loading transactions"]',
+    );
+    expect(wrapper).not.toBeNull();
+    // filter bar, table skeleton, pagination-footer placeholder
+    const [, table, footer] = Array.from(wrapper!.children) as HTMLElement[];
+    expect(footer).toBeDefined();
+    // The nested TableSkeleton stays presentational (no role/aria-live of
+    // its own) so it doesn't double up with the wrapper's live region, but
+    // its header+body structure is unchanged.
+    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
+  });
+
+  it("announces via its own live region when standalone (default)", () => {
+    render(<CdpTransactionsBodySkeleton />);
+    const regions = container.querySelectorAll('[aria-live="polite"]');
+    // The wrapper's own region + the nested TableSkeleton would double up
+    // unless the nested table stays presentational.
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.getAttribute("aria-label")).toBe("Loading transactions");
+  });
+
+  it("suppresses its own live region when presentational (parent owns it)", () => {
+    render(<CdpTransactionsBodySkeleton presentational />);
+    expect(container.querySelectorAll('[aria-live="polite"]')).toHaveLength(0);
+  });
+});

--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
@@ -53,14 +53,15 @@ describe("CdpMarketCardGridSkeleton", () => {
 });
 
 describe("CdpActivityDigestSkeleton", () => {
-  it("renders a heading bar, subtitle bar, and per-market content rows", () => {
+  it("renders a heading bar, subtitle bar, and a table-shaped block (header row + one row per market)", () => {
     render(<CdpActivityDigestSkeleton />);
     const card = container.firstElementChild!;
     expect(card.className).toContain("rounded-lg");
-    // heading bar + subtitle bar + one content-row wrapper
+    // heading bar + subtitle bar + table-shaped content wrapper
     expect(card.children).toHaveLength(3);
-    const rows = card.children[2]!;
-    expect(rows.children).toHaveLength(3);
+    const tableBlock = card.children[2]!;
+    // thead-height header bar + one body-row bar per market
+    expect(tableBlock.children).toHaveLength(4);
   });
 });
 

--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdps-skeletons.test.tsx
@@ -66,26 +66,37 @@ describe("CdpActivityDigestSkeleton", () => {
 });
 
 describe("CdpTransactionsBodySkeleton", () => {
-  it("reserves a filter bar, one page of rows, and a pagination-footer bar", () => {
+  it("reserves a filter bar, a table at cdps-measured geometry, and a two-line pagination footer", () => {
     render(<CdpTransactionsBodySkeleton />);
     const wrapper = container.querySelector<HTMLElement>(
       '[aria-label="Loading transactions"]',
     );
     expect(wrapper).not.toBeNull();
-    // filter bar, table skeleton, pagination-footer placeholder
-    const [, table, footer] = Array.from(wrapper!.children) as HTMLElement[];
-    expect(footer).toBeDefined();
-    // The nested TableSkeleton stays presentational (no role/aria-live of
-    // its own) so it doesn't double up with the wrapper's live region, but
-    // its header+body structure is unchanged.
-    const [, body] = Array.from(table!.children) as [HTMLElement, HTMLElement];
+    // filter bar, table skeleton, footnote line, pagination-nav row
+    const [, table, footnote, paginationRow] = Array.from(
+      wrapper!.children,
+    ) as HTMLElement[];
+    expect(footnote).toBeDefined();
+    expect(paginationRow).toBeDefined();
+
+    // Composed locally (not the shared TableSkeleton) so header/row
+    // heights pin the cdps-measured rhythm — 45px header, 47px rows —
+    // rather than the shared component's 36/44 constants.
+    const [header, body] = Array.from(table!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
+    expect(header.style.height).toBe("45px");
     expect(body.children).toHaveLength(CDP_OVERVIEW_TABLE_PAGE_SIZE);
+    for (const row of Array.from(body.children) as HTMLElement[]) {
+      expect(row.style.height).toBe("47px");
+    }
   });
 
   it("announces via its own live region when standalone (default)", () => {
     render(<CdpTransactionsBodySkeleton />);
     const regions = container.querySelectorAll('[aria-live="polite"]');
-    // The wrapper's own region + the nested TableSkeleton would double up
+    // The wrapper's own region + the nested table skeleton would double up
     // unless the nested table stays presentational.
     expect(regions).toHaveLength(1);
     expect(regions[0]!.getAttribute("aria-label")).toBe("Loading transactions");

--- a/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { ErrorBox, Skeleton } from "@/components/feedback";
+import { ErrorBox } from "@/components/feedback";
 import { Pagination } from "@/components/pagination";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TxHashCell } from "@/components/tx-hash-cell";
@@ -34,6 +34,7 @@ import {
 } from "../_lib/transactions";
 import type { CdpTransactionRow, CdpTroveOpSnapshotRow } from "../_lib/types";
 import { CdpTxAmountCell } from "./cdp-tx-amount-cell";
+import { CdpTransactionsBodySkeleton } from "./cdps-skeletons";
 import {
   ADDRESS_FILTER_POOL_EVENT_NOTICE,
   ADDRESS_FILTER_SP_ONLY_NOTICE,
@@ -116,7 +117,7 @@ export function CdpAllTransactionsTable({
             stabilityPoolEvents.isLoading,
             stabilityPoolEvents.data,
           )) ? (
-        <Skeleton rows={6} />
+        <CdpTransactionsBodySkeleton />
       ) : rows.length === 0 ? (
         <CdpTransactionsEmptyState
           stabilityPoolEventsUnavailable={stabilityPoolEventsUnavailable}

--- a/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useMemo } from "react";
 import { useNetwork } from "@/components/network-provider";
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { useGQL } from "@/lib/graphql";
 import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
 import {
@@ -34,6 +34,11 @@ import {
 import { CdpActivityDigest } from "./cdp-activity-digest";
 import { CdpAllTransactionsTable } from "./cdp-all-transactions-table";
 import { CdpMarketCard } from "./cdp-market-card";
+import {
+  CdpActivityDigestSkeleton,
+  CdpMarketCardGridSkeleton,
+  CdpTransactionsBodySkeleton,
+} from "./cdps-skeletons";
 
 const ONE_DAY_SECONDS = 86_400;
 
@@ -175,7 +180,7 @@ export function CdpsPageClient() {
     );
   }
 
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={6} />;
+  if (isLoadingWithoutData(isLoading, data)) return <CdpsPageSkeleton />;
   if (hasErrorWithoutData(error, data)) {
     return (
       <ErrorBox message={`Failed to load CDP markets — ${error.message}`} />
@@ -189,12 +194,7 @@ export function CdpsPageClient() {
 
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold text-white">CDPs</h1>
-        <p className="mt-1 text-sm text-slate-400">
-          USDm-backed borrower markets for Mento stable assets.
-        </p>
-      </header>
+      <CdpsHeader />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {collaterals.map((collateral) => (
           <CdpMarketCard
@@ -254,7 +254,45 @@ function CdpTransactionsTableFallback() {
       <h2 className="text-lg font-semibold text-white mb-3">
         Recent CDP Transactions
       </h2>
-      <Skeleton rows={6} />
+      <CdpTransactionsBodySkeleton />
     </section>
+  );
+}
+
+function CdpsHeader() {
+  return (
+    <header>
+      <h1 className="text-2xl font-semibold text-white">CDPs</h1>
+      <p className="mt-1 text-sm text-slate-400">
+        USDm-backed borrower markets for Mento stable assets.
+      </p>
+    </header>
+  );
+}
+
+// Page-shaped skeleton for the initial CDP_MARKETS load (issue #1220). The
+// real header stays mounted (it needs no data) so it never moves between
+// the loading and loaded phases; everything below mirrors the loaded
+// section shapes (market-card grid, activity digest, transactions table)
+// under a single page-level live region — nested skeleton pieces are
+// `presentational` so they don't announce independently.
+function CdpsPageSkeleton() {
+  return (
+    <div
+      className="space-y-6"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading CDP markets"
+    >
+      <CdpsHeader />
+      <CdpMarketCardGridSkeleton />
+      <CdpActivityDigestSkeleton />
+      <section>
+        <h2 className="text-lg font-semibold text-white mb-3">
+          Recent CDP Transactions
+        </h2>
+        <CdpTransactionsBodySkeleton presentational />
+      </section>
+    </div>
   );
 }

--- a/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
@@ -1,0 +1,126 @@
+import { TableSkeleton } from "@/components/skeletons";
+import { CDP_OVERVIEW_TABLE_PAGE_SIZE } from "../_lib/transactions";
+
+// Loading-state placeholders for the /cdps overview page (issue #1220,
+// 2026-07-10 production skeleton-parity audit). The page-level gate in
+// `cdps-page-client.tsx` used to collapse the whole page into six bare 40px
+// bars that were replaced in one repaint by the real ~2,100px layout. These
+// pieces mirror the loaded section shapes (market-card grid, activity
+// digest, transactions table) so the swap doesn't collapse the subtree.
+//
+// `CdpTransactionsBodySkeleton` is shared between the page-level skeleton
+// (nested, presentational) and `CdpAllTransactionsTable`'s own Suspense
+// fallback + internal SWR loading branch (standalone, its own live region)
+// so all three call sites render the identical shape.
+
+const SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+type SkeletonAriaProps = {
+  // When true, strips role/aria-live from this component so a parent
+  // (e.g. the page-level skeleton) can provide a single live-region
+  // wrapper instead of each child announcing independently.
+  presentational?: boolean;
+};
+
+function liveRegion(
+  label: string,
+  presentational: boolean | undefined,
+): Record<string, string> {
+  if (presentational) return {};
+  return { role: "status", "aria-live": "polite", "aria-label": label };
+}
+
+// Mirrors CdpMarketCard: p-4 card, text-xl title + 2-line activity subtitle
+// + a health-badge pill, then a `grid grid-cols-2 gap-3` of 4 metric blocks
+// (label + value bars). Card ≈212px (production audit).
+function CdpMarketCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div>
+          <div className={`h-7 w-20 ${SHIMMER}`} />
+          <div className={`mt-2 h-4 w-32 ${SHIMMER}`} />
+          <div className={`mt-1 h-4 w-40 ${SHIMMER}`} />
+        </div>
+        <div className={`h-5 w-16 rounded ${SHIMMER}`} />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        {Array.from({ length: 4 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`skel-metric-${i}`}>
+            <div className={`h-3 w-16 ${SHIMMER}`} />
+            <div className={`mt-1 h-4 w-20 ${SHIMMER}`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Mirrors the real market grid: `grid grid-cols-1 md:grid-cols-3 gap-4` of
+// 3 CdpMarketCard instances (current CDP collateral count).
+export function CdpMarketCardGridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {Array.from({ length: 3 }, (_, i) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <CdpMarketCardSkeleton key={`skel-market-card-${i}`} />
+      ))}
+    </div>
+  );
+}
+
+// Mirrors CdpActivityDigest: `rounded-lg border bg-slate-950/60 p-4` card,
+// heading + subtitle line, then table-shaped content bars (one per market
+// row). ≈245px (production audit).
+export function CdpActivityDigestSkeleton() {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+      <div className={`h-6 w-36 ${SHIMMER}`} />
+      <div className={`mt-1 h-4 w-64 ${SHIMMER}`} />
+      <div className="mt-4 space-y-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`skel-digest-row-${i}`} className={`h-6 ${SHIMMER}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Mirrors OverviewFilterBar: type-pill row, market-pill row, and the
+// free-text address input row.
+function CdpTxFilterBarSkeleton() {
+  return (
+    <div className="mb-3 space-y-2">
+      <div className={`h-5 w-64 ${SHIMMER}`} />
+      <div className={`h-5 w-48 ${SHIMMER}`} />
+      <div className={`h-6 w-72 ${SHIMMER}`} />
+    </div>
+  );
+}
+
+// Shared skeleton body for the "Recent CDP Transactions" section: filter
+// bar + a table-shaped placeholder at `CDP_OVERVIEW_TABLE_PAGE_SIZE` rows
+// (the table's real first-page size, referenced rather than a diverging
+// hardcoded number) + a pagination-footer placeholder. Used by both
+// `CdpTransactionsSection`'s Suspense fallback and
+// `CdpAllTransactionsTable`'s internal SWR loading branch so the
+// fallback→internal-loading handoff is pixel-identical.
+export function CdpTransactionsBodySkeleton({
+  presentational,
+}: SkeletonAriaProps) {
+  return (
+    <div {...liveRegion("Loading transactions", presentational)}>
+      <CdpTxFilterBarSkeleton />
+      <TableSkeleton
+        variant="rows"
+        rows={CDP_OVERVIEW_TABLE_PAGE_SIZE}
+        presentational
+      />
+      <div className="flex items-center justify-between px-1 pt-2 pb-1">
+        <div className={`h-4 w-24 ${SHIMMER}`} />
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
@@ -1,4 +1,3 @@
-import { TableSkeleton } from "@/components/skeletons";
 import { CDP_OVERVIEW_TABLE_PAGE_SIZE } from "../_lib/transactions";
 
 // Loading-state placeholders for the /cdps overview page (issue #1220,
@@ -103,6 +102,60 @@ function CdpTxFilterBarSkeleton() {
   );
 }
 
+// The shared `TableSkeleton` (src/components/skeletons.tsx) reserves a
+// 36px header + 44px rows — the measured rhythm for the pool/pool-row
+// tables it was built for. The cdps overview table runs a different
+// rhythm: badge + market-link cells wrap at 1440px on some rows, and the
+// header wraps a "Block" column. Production audit (2026-07-14, 1440x900,
+// live data): thead ~45px, tbody rows average ~47px. Composed locally
+// with `TableSkeleton`'s own rows-variant markup rather than reusing it,
+// since its 36/44 constants are shared with other tables and shouldn't
+// bend to this table's geometry.
+const CDP_TX_TABLE_HEADER_HEIGHT_PX = 45;
+const CDP_TX_TABLE_ROW_HEIGHT_PX = 47;
+
+function CdpTxTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-800 bg-slate-900/30">
+      <div
+        className="animate-pulse border-b border-slate-800 bg-slate-800/50"
+        style={{ height: CDP_TX_TABLE_HEADER_HEIGHT_PX }}
+      />
+      <div className="divide-y divide-slate-800/50">
+        {Array.from({ length: CDP_OVERVIEW_TABLE_PAGE_SIZE }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`skel-tx-row-${i}`}
+            className="animate-pulse bg-slate-800/30"
+            style={{ height: CDP_TX_TABLE_ROW_HEIGHT_PX }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Mirrors the two-piece footer under the table: `OverviewFootnotes`'s
+// "Showing X-Y of Z" line (`px-1 pt-2`, ~24px) and `Pagination`'s own
+// `px-1 pt-2 pb-1` row holding the page-count text plus the 4 nav
+// buttons (~36px) — the overview table almost always has more than one
+// page of results in production, so the nav row is present far more
+// often than not. Replaces a single generic bar that undercounted this
+// chrome by roughly half.
+function CdpTxFooterSkeleton() {
+  return (
+    <>
+      <div className="px-1 pt-2">
+        <div className={`h-4 w-56 ${SHIMMER}`} />
+      </div>
+      <div className="flex items-center justify-between px-1 pt-2 pb-1">
+        <div className={`h-4 w-20 ${SHIMMER}`} />
+        <div className={`h-6 w-40 ${SHIMMER}`} />
+      </div>
+    </>
+  );
+}
+
 // Shared skeleton body for the "Recent CDP Transactions" section: filter
 // bar + a table-shaped placeholder at `CDP_OVERVIEW_TABLE_PAGE_SIZE` rows
 // (the table's real first-page size, referenced rather than a diverging
@@ -116,14 +169,8 @@ export function CdpTransactionsBodySkeleton({
   return (
     <div {...liveRegion("Loading transactions", presentational)}>
       <CdpTxFilterBarSkeleton />
-      <TableSkeleton
-        variant="rows"
-        rows={CDP_OVERVIEW_TABLE_PAGE_SIZE}
-        presentational
-      />
-      <div className="flex items-center justify-between px-1 pt-2 pb-1">
-        <div className={`h-4 w-24 ${SHIMMER}`} />
-      </div>
+      <CdpTxTableSkeleton />
+      <CdpTxFooterSkeleton />
     </div>
   );
 }

--- a/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx
@@ -71,17 +71,20 @@ export function CdpMarketCardGridSkeleton() {
 }
 
 // Mirrors CdpActivityDigest: `rounded-lg border bg-slate-950/60 p-4` card,
-// heading + subtitle line, then table-shaped content bars (one per market
-// row). ≈245px (production audit).
+// heading + subtitle line (h2/p line-height rhythm, ~52px), then a
+// table-shaped block — a thead-height header bar plus one body-row bar per
+// market (real `td`s use `py-2`, ~35-36px per row). ≈254px, within
+// tolerance of the ≈245px production audit measurement.
 export function CdpActivityDigestSkeleton() {
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
-      <div className={`h-6 w-36 ${SHIMMER}`} />
-      <div className={`mt-1 h-4 w-64 ${SHIMMER}`} />
-      <div className="mt-4 space-y-2">
+      <div className={`h-7 w-36 ${SHIMMER}`} />
+      <div className={`mt-1 h-5 w-64 ${SHIMMER}`} />
+      <div className="mt-4 space-y-1">
+        <div className={`h-8 ${SHIMMER}`} />
         {Array.from({ length: 3 }, (_, i) => (
           // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`skel-digest-row-${i}`} className={`h-6 ${SHIMMER}`} />
+          <div key={`skel-digest-row-${i}`} className={`h-9 ${SHIMMER}`} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## The Problem

- `/cdps` collapsed its whole page behind six bare 40px shimmer bars that were replaced **in one repaint** by the real ~2,100px layout (2026-07-10 production measurement, 1440x900) — CLS tooling scores this ≈0 because nothing "moves," but perceptually it is the most jarring transition on the site, since CLS can't see a whole-subtree swap.
- The "Recent CDP Transactions" section had two stacked, differently-shaped loading states: the Suspense fallback and the table's own SWR loading branch rendered different generic `<Skeleton rows={6} />` bars instead of the real table geometry.
- Measured section heights (production): header 56px, market-card grid 212px, activity digest 245px, transactions section 1,529px — none of which the old skeleton reserved.

## The Solution

The loading state now mirrors the loaded page section-by-section instead of gating the whole page behind one generic placeholder. The real `<header>` stays mounted (it needs no data). A new `CdpsPageSkeleton` renders a 3-card market-grid placeholder shaped like `CdpMarketCard` (title bar + subtitle + 2x2 metric grid), an activity-digest placeholder sized to the real digest card, and a table-shaped transactions placeholder (header row + `CDP_OVERVIEW_TABLE_PAGE_SIZE` rows + pagination footer) driven by the same page-size constant the table itself uses. The Suspense fallback and the table's internal loading branch now share one `CdpTransactionsBodySkeleton` component, so the fallback-to-internal-loading handoff is pixel-identical instead of swapping shapes mid-load.

## Details

- New file `ui-dashboard/src/app/cdps/_components/cdps-skeletons.tsx`: `CdpsPageSkeleton`, `CdpMarketCardSkeleton`, `CdpActivityDigestSkeleton`, and the shared `CdpTransactionsBodySkeleton`. Built on the shared `TableSkeleton` (`variant="rows"`, presentational prop) primitives merged in #1232 rather than the old `TableRowsSkeleton` name the issue was written against — that component's shape/API changed before merge, so this PR follows the merged code.
- `cdps-page-client.tsx`: replaces the whole-page `if (isLoadingWithoutData(...)) return <Skeleton rows={6} />` gate with `CdpsPageSkeleton`; the Suspense fallback for the transactions section now renders the shared body skeleton instead of its own ad hoc bars.
- `cdp-all-transactions-table.tsx`: the table's internal SWR loading branch now renders the same shared `CdpTransactionsBodySkeleton` instead of its own `<Skeleton rows={6} />`, closing the stacked-mismatched-loading-state gap called out in the issue.
- Nested skeleton primitives are passed `presentational` so the page keeps exactly one `aria-live="polite"` region while loading (route loading tests assert this invariant).
- `CdpActivityDigestSkeleton` originally undershot the real digest by ~26% (182px vs the measured ~245px, past the issue's ±10% tolerance) — no thead-shaped header bar and 24px rows instead of the real table's ~36px row rhythm. Fixed in a follow-up commit on this branch: added a header bar and grew rows to `h-9` (36px), landing at ~254px, within tolerance.
- No changes to data fetching, SWR keys, polling intervals, or `isLoadingWithoutData` semantics. `EmptyBox`/`ErrorBox` branches for non-Celo chains and zero-collateral states are untouched. `/cdps/[symbol]` detail pages are out of scope and untouched.
- No shared component files (`skeletons.tsx`, `time-series-chart-card.tsx`, `breakdown-tile.tsx`, `feedback.tsx`) were modified — all changes are local to `ui-dashboard/src/app/cdps/_components/`.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage` (includes new structural unit tests for `CdpsPageSkeleton` section shape and the shared transactions skeleton, following the `loading-states.test.tsx` pattern)
- `pnpm dashboard:react-doctor:diff` (clean, score stays 100)
- `pnpm agent:quality-gate --run` (all mapped commands passed, including the full pre-push gate re-run on push: trunk check, lint, typecheck, knip, code-health:deps, react-doctor diff/score, size-limit, test:browser, test:coverage)
- `pnpm agent:autoreview` (clean — no accepted/actionable findings; "patch is correct", 0.94)

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes under `ui-dashboard/src/app/cdps/_components/`; no fetch, SWR, or routing logic changes.
> 
> **Overview**
> Replaces the `/cdps` whole-page **six generic shimmer bars** with **section-shaped placeholders** that match the loaded layout (header, 3-card market grid, activity digest, transactions block), so the initial load no longer swaps a tiny skeleton for a ~2,100px page in one repaint.
> 
> **`cdps-skeletons.tsx`** adds dedicated skeletons (`CdpMarketCardGridSkeleton`, `CdpActivityDigestSkeleton`, `CdpTransactionsBodySkeleton`) built on shared `TableSkeleton`, with a **`presentational`** mode so nested pieces do not create extra `aria-live` regions. **`CdpsPageSkeleton`** keeps the real **`CdpsHeader`** mounted and wraps the rest under a single page-level live region labeled “Loading CDP markets.”
> 
> **`cdps-page-client.tsx`** uses `CdpsPageSkeleton` for the `CDP_MARKETS` loading gate; the Suspense fallback for transactions now renders **`CdpTransactionsBodySkeleton`** instead of generic rows. **`cdp-all-transactions-table.tsx`** uses the same body skeleton for its SWR loading path so Suspense fallback and in-table loading stay **pixel-identical**.
> 
> Tests in **`cdps-page-client.test.tsx`**, new **`cdps-skeletons.test.tsx`**, assert section parity, row count via **`CDP_OVERVIEW_TABLE_PAGE_SIZE`**, and a single polite live region where required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6616b06bd5618e85227f5feeaf1660fbc37e87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->