### PR TITLE
fix(dashboard): skeleton parity for pool detail header, banner, and tab panels

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -105,13 +105,6 @@
     "linePreview": " | export function OlsStatusPanel({ | olsPool,"
   },
   {
-    "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'PoolTabPanel' has too many lines (122). Maximum allowed is 100.",
-    "line": 505,
-    "linePreview": " | function PoolTabPanel({ | tab,"
-  },
-  {
     "file": "src/app/pool/[poolId]/_components/pool-header.tsx",
     "ruleId": "complexity",
     "message": "Function 'PoolHeader' has a complexity of 28. Maximum allowed is 15.",
@@ -220,21 +213,21 @@
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "complexity",
     "message": "Function 'BreachHistoryPanelInner' has a complexity of 30. Maximum allowed is 15.",
-    "line": 203,
+    "line": 204,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'BreachHistoryPanelInner' has too many lines (195). Maximum allowed is 100.",
-    "line": 203,
+    "line": 204,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 29 to the 18 allowed.",
-    "line": 203,
+    "line": 204,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -86,30 +86,9 @@
   {
     "file": "src/app/pool/[poolId]/_components/ols-liquidity-events.tsx",
     "ruleId": "complexity",
-    "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 96,
-    "linePreview": "if (!searchQuery) return events; | return events.filter((e) => { | const givenSym = tokenSymbol(network, e.tokenGivenToPool);"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_components/ols-liquidity-events.tsx",
-    "ruleId": "complexity",
     "message": "Function 'OlsLiquidityEvents' has a complexity of 35. Maximum allowed is 15.",
-    "line": 31,
-    "linePreview": "*/ | export function OlsLiquidityEvents({ | poolId,"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_components/ols-liquidity-events.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'OlsLiquidityEvents' has too many lines (144). Maximum allowed is 100.",
-    "line": 31,
-    "linePreview": "*/ | export function OlsLiquidityEvents({ | poolId,"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_components/ols-liquidity-table.tsx",
-    "ruleId": "complexity",
-    "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 43,
-    "linePreview": "<tbody> | {events.map((e) => { | const givenSym = tokenSymbol(network, e.tokenGivenToPool);"
+    "line": 37,
+    "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing component keeps count/page fetching, search filtering, and table/pagination rendering together; this PR only threads a `limit` prop throu"
   },
   {
     "file": "src/app/pool/[poolId]/_components/ols-status-panel.tsx",
@@ -129,50 +108,36 @@
     "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'PoolTabPanel' has too many lines (122). Maximum allowed is 100.",
-    "line": 504,
+    "line": 505,
     "linePreview": " | function PoolTabPanel({ | tab,"
   },
   {
     "file": "src/app/pool/[poolId]/_components/pool-header.tsx",
     "ruleId": "complexity",
     "message": "Function 'PoolHeader' has a complexity of 28. Maximum allowed is 15.",
-    "line": 54,
+    "line": 55,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing composed header surface; this PR only threads SSR fallback props into its current queries. | export function PoolHeader({ | pool,"
   },
   {
     "file": "src/app/pool/[poolId]/_tabs/lps-tab.tsx",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 200,
+    "line": 206,
     "linePreview": "<tbody> | {pagedPositions.map((position) => { | const fmtTok = ("
   },
   {
     "file": "src/app/pool/[poolId]/_tabs/lps-tab.tsx",
     "ruleId": "complexity",
     "message": "Function 'LpsTab' has a complexity of 32. Maximum allowed is 15.",
-    "line": 42,
+    "line": 47,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing tab keeps LP pagination, totals, and degraded-count copy in one route-owned surface. | export function LpsTab({ | poolId,"
   },
   {
     "file": "src/app/pool/[poolId]/_tabs/reserves-tab.tsx",
     "ruleId": "complexity",
-    "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 126,
-    "linePreview": "<tbody> | {filteredRows.map((r) => { | const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_tabs/reserves-tab.tsx",
-    "ruleId": "complexity",
     "message": "Function 'ReservesTab' has a complexity of 20. Maximum allowed is 15.",
-    "line": 24,
-    "linePreview": " | export function ReservesTab({ | poolId,"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_tabs/reserves-tab.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'ReservesTab' has too many lines (152). Maximum allowed is 100.",
-    "line": 24,
-    "linePreview": " | export function ReservesTab({ | poolId,"
+    "line": 42,
+    "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing tab keeps reserve fetching, search filtering, chart, and table rendering together; this PR only swaps the loading skeleton to the shared "
   },
   {
     "file": "src/app/pool/[poolId]/opengraph-image.tsx",
@@ -255,21 +220,21 @@
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "complexity",
     "message": "Function 'BreachHistoryPanelInner' has a complexity of 30. Maximum allowed is 15.",
-    "line": 202,
+    "line": 203,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'BreachHistoryPanelInner' has too many lines (195). Maximum allowed is 100.",
-    "line": 202,
+    "line": 203,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {
     "file": "src/components/breach-history-panel.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 29 to the 18 allowed.",
-    "line": 202,
+    "line": 203,
     "linePreview": " | function BreachHistoryPanelInner({ | pool,"
   },
   {
@@ -283,15 +248,15 @@
     "file": "src/components/global-pools-table/sort.ts",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 58. Maximum allowed is 15.",
-    "line": 82,
-    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const aKey = globalPoolKey(a);"
+    "line": 84,
+    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const [aKey, bKey] = [globalPoolKey(a), globalPoolKey(b)];"
   },
   {
     "file": "src/components/global-pools-table/sort.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 65 to the 18 allowed.",
-    "line": 82,
-    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const aKey = globalPoolKey(a);"
+    "line": 84,
+    "linePreview": "): GlobalPoolEntry[] { | return sortedCopy(entries, (a, b) => { | const [aKey, bKey] = [globalPoolKey(a), globalPoolKey(b)];"
   },
   {
     "file": "src/components/pool-header/deviation-cell.tsx",
@@ -304,7 +269,7 @@
     "file": "src/components/pool-header/uptime-value.tsx",
     "ruleId": "complexity",
     "message": "Function 'UptimeValue' has a complexity of 29. Maximum allowed is 15.",
-    "line": 60,
+    "line": 79,
     "linePreview": " | export function UptimeValue({ pool }: { pool: Pool }) { | const isVirtual = isVirtualPool(pool);"
   },
   {

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts
@@ -359,6 +359,7 @@ describe("OlsLiquidityTable", () => {
         network: mockNetwork,
         isLoading: false,
         error: null,
+        limit: 25,
       }),
     );
     expect(html).toContain("EXPAND");
@@ -372,6 +373,7 @@ describe("OlsLiquidityTable", () => {
         network: mockNetwork,
         isLoading: false,
         error: null,
+        limit: 25,
       }),
     );
     expect(html).toContain("CONTRACT");
@@ -385,12 +387,13 @@ describe("OlsLiquidityTable", () => {
         network: mockNetwork,
         isLoading: false,
         error: null,
+        limit: 25,
       }),
     );
     expect(html).toContain("No OLS liquidity events for this pool");
   });
 
-  it("renders loading skeleton when isLoading=true", () => {
+  it("renders a row-shaped table skeleton matching `limit` when isLoading=true", () => {
     const html = renderToStaticMarkup(
       React.createElement(OlsLiquidityTable, {
         events: [],
@@ -398,9 +401,14 @@ describe("OlsLiquidityTable", () => {
         network: mockNetwork,
         isLoading: true,
         error: null,
+        limit: 25,
       }),
     );
-    expect(html).toContain("skeleton");
+    // TableSkeleton isn't mocked in this suite (it's the real shared
+    // primitive), so assert on its actual live-region markup instead of a
+    // test-id — loading-branch structure must match the loaded branch's
+    // table shape, not just render without crashing.
+    expect(html).toContain('aria-label="Loading table"');
   });
 
   it("renders error state when error is set", () => {
@@ -411,6 +419,7 @@ describe("OlsLiquidityTable", () => {
         network: mockNetwork,
         isLoading: false,
         error: new Error("query failed"),
+        limit: 25,
       }),
     );
     expect(html).toContain("query failed");

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -254,6 +254,31 @@ describe("Pool detail LPs tab", () => {
     );
   });
 
+  it("renders a header-card-shaped skeleton (not 4 flat bars) while the pool is still loading", () => {
+    // No SSR fallback and PoolDetailWithHealth still in flight — the
+    // degraded loading branch must mirror the route skeleton's header-card
+    // geometry (title row + 5-col stat grid), not a generic bar stack
+    // (issue #1222).
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (!query) return gqlResult(undefined);
+      if (query.includes("PoolDetailWithHealth")) {
+        return loadingGqlResult();
+      }
+      if (query.includes("TradingLimits"))
+        return gqlResult({ TradingLimit: [] });
+      if (query.includes("PoolDeployment")) {
+        return gqlResult({ FactoryDeployment: [] });
+      }
+      return gqlResult(undefined);
+    });
+
+    const html = renderPoolDetailPage();
+    expect(html).toContain('aria-label="Loading pool"');
+    const dlOpenTag = html.match(/<div[^>]*lg:grid-cols-5[^>]*>/)?.[0] ?? "";
+    expect(dlOpenTag).not.toBe("");
+    expect(html).not.toContain("Pool 0xpool not found.");
+  });
+
   it("keeps last-confirmed pool data visible and discloses a refresh failure", () => {
     const initialData: PoolDetailInitialData = {
       pool: {

--- a/ui-dashboard/src/app/pool/[poolId]/_components/header-card-skeleton.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/header-card-skeleton.tsx
@@ -1,0 +1,45 @@
+// Mirrors PoolHeader's card shape: p-5 card, title row (text-xl ≈ h-7) + 5-col
+// stat grid. Shared by the route's `loading.tsx` (SSR/Suspense fallback) and
+// `PoolOverview`'s degraded fallback (`pool-detail-page-client.tsx`, used when
+// the SSR prefetch missed and the client hasn't resolved a pool yet) so the two
+// loading branches can't drift apart — issue #1222's audit found the previous
+// 4-flat-bar `<Skeleton rows={4} />` degraded fallback was much smaller than
+// the route skeleton's header-card shape.
+const SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+export function HeaderCardSkeleton({
+  presentational,
+}: {
+  // When true, strips role/aria-live so a parent page-level live region
+  // (e.g. the route `loading.tsx` Suspense fallback, which announces via its
+  // trailing TableSkeleton) doesn't get a second nested live region.
+  presentational?: boolean;
+}) {
+  return (
+    <div
+      className="rounded-lg border border-slate-800 bg-slate-900/60 p-5"
+      {...(presentational
+        ? {}
+        : {
+            role: "status" as const,
+            "aria-live": "polite" as const,
+            "aria-label": "Loading pool",
+          })}
+    >
+      <div className="mb-3 flex flex-wrap items-center gap-3">
+        <div className={`h-7 w-40 ${SHIMMER}`} />
+        <div className={`h-5 w-24 ${SHIMMER}`} />
+        <div className={`h-5 w-16 ${SHIMMER}`} />
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`header-skel-stat-${i}`}>
+            <div className={`h-4 w-20 ${SHIMMER}`} />
+            <div className={`mt-1 h-5 w-24 ${SHIMMER}`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-events.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-events.tsx
@@ -22,13 +22,18 @@ import { buildOrderBy } from "@/lib/table-sort";
 import { tokenSymbol } from "@/lib/tokens";
 import type { OlsLiquidityEvent, Pool } from "@/lib/types";
 import React, { useMemo } from "react";
-import { addressSearchTerms, matchesRowSearch } from "../_lib/helpers";
+import {
+  addressSearchTerms,
+  matchesRowSearch,
+  tokenDecimalsFor,
+} from "../_lib/helpers";
 import { OlsLiquidityTable } from "./ols-liquidity-table";
 
 /**
  * Fetches OLS liquidity events scoped to the active OLS contract address,
  * preventing event mixing when a pool has been re-registered to a new OLS contract.
  */
+// eslint-disable-next-line max-lines-per-function -- Existing component keeps count/page fetching, search filtering, and table/pagination rendering together; this PR only threads a `limit` prop through to the table's loading skeleton.
 export function OlsLiquidityEvents({
   poolId,
   olsAddress,
@@ -94,14 +99,8 @@ export function OlsLiquidityEvents({
     return events.filter((e) => {
       const givenSym = tokenSymbol(network, e.tokenGivenToPool);
       const takenSym = tokenSymbol(network, e.tokenTakenFromPool);
-      const givenDec =
-        pool?.token0?.toLowerCase() === e.tokenGivenToPool.toLowerCase()
-          ? (pool?.token0Decimals ?? 18)
-          : (pool?.token1Decimals ?? 18);
-      const takenDec =
-        pool?.token0?.toLowerCase() === e.tokenTakenFromPool.toLowerCase()
-          ? (pool?.token0Decimals ?? 18)
-          : (pool?.token1Decimals ?? 18);
+      const givenDec = tokenDecimalsFor(pool, e.tokenGivenToPool);
+      const takenDec = tokenDecimalsFor(pool, e.tokenTakenFromPool);
       return matchesRowSearch(searchQuery, [
         e.txHash,
         e.direction === 0 ? "expand" : "contract",
@@ -114,6 +113,7 @@ export function OlsLiquidityEvents({
     });
   }, [events, searchQuery, pool, network, getName, getTags]);
   const showMetadata = !hasErrorWithoutData(error, data);
+  const tableProps = { pool, network, limit };
   return (
     <>
       {events.length > 0 && (
@@ -126,9 +126,8 @@ export function OlsLiquidityEvents({
       )}
       {!showMetadata ? (
         <OlsLiquidityTable
+          {...tableProps}
           events={[]}
-          pool={pool}
-          network={network}
           isLoading={false}
           error={error}
         />
@@ -136,9 +135,8 @@ export function OlsLiquidityEvents({
         <EmptyBox message="No OLS events match your search." />
       ) : (
         <OlsLiquidityTable
+          {...tableProps}
           events={filteredEvents}
-          pool={pool}
-          network={network}
           isLoading={isLoading}
           error={null}
         />

--- a/ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-table.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-table.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import type { useNetwork } from "@/components/network-provider";
 import { SenderCell } from "@/components/sender-cell";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TxHashCell } from "@/components/tx-hash-cell";
 import { formatTimestamp, formatWei, relativeTime } from "@/lib/format";
 import { tokenSymbol } from "@/lib/tokens";
 import type { OlsLiquidityEvent, Pool } from "@/lib/types";
+import { tokenDecimalsFor } from "../_lib/helpers";
 
 export function OlsLiquidityTable({
   events,
@@ -15,15 +17,17 @@ export function OlsLiquidityTable({
   network,
   isLoading,
   error,
+  limit,
 }: {
   events: OlsLiquidityEvent[];
   pool: Pool | null;
   network: ReturnType<typeof useNetwork>["network"];
   isLoading: boolean;
   error: Error | null;
+  limit: number;
 }) {
   if (error) return <ErrorBox message={error.message} />;
-  if (isLoading) return <Skeleton rows={5} />;
+  if (isLoading) return <TableSkeleton variant="rows" rows={limit} />;
   if (events.length === 0)
     return <EmptyBox message="No OLS liquidity events for this pool." />;
 
@@ -43,14 +47,8 @@ export function OlsLiquidityTable({
         {events.map((e) => {
           const givenSym = tokenSymbol(network, e.tokenGivenToPool);
           const takenSym = tokenSymbol(network, e.tokenTakenFromPool);
-          const givenDec =
-            pool?.token0?.toLowerCase() === e.tokenGivenToPool.toLowerCase()
-              ? (pool?.token0Decimals ?? 18)
-              : (pool?.token1Decimals ?? 18);
-          const takenDec =
-            pool?.token0?.toLowerCase() === e.tokenTakenFromPool.toLowerCase()
-              ? (pool?.token0Decimals ?? 18)
-              : (pool?.token1Decimals ?? 18);
+          const givenDec = tokenDecimalsFor(pool, e.tokenGivenToPool);
+          const takenDec = tokenDecimalsFor(pool, e.tokenTakenFromPool);
           return (
             <Row key={e.id}>
               <Td small muted title={formatTimestamp(e.blockTimestamp)}>

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
@@ -2,7 +2,7 @@
 
 import { AddressLink } from "@/components/address-link";
 import { BreachHistoryPanel } from "@/components/breach-history-panel";
-import { ErrorBox, Skeleton } from "@/components/feedback";
+import { ErrorBox } from "@/components/feedback";
 import { HealthPanel } from "@/components/health-panel";
 import { LimitPanel } from "@/components/limit-panel";
 import { useNetwork } from "@/components/network-provider";
@@ -39,6 +39,7 @@ import {
   useMemo,
   useSyncExternalStore,
 } from "react";
+import { HeaderCardSkeleton } from "./header-card-skeleton";
 import { PoolHeader } from "./pool-header";
 import { PoolTablist } from "./pool-tablist";
 import {
@@ -409,7 +410,7 @@ function PoolOverview({
   // (the degraded path where the SSR prefetch missed).
   if (!pool)
     return isLoadingWithoutData(poolLoading, pool) ? (
-      <Skeleton rows={4} />
+      <HeaderCardSkeleton />
     ) : (
       <ErrorBox message={`Pool ${normalizedPoolId} not found.`} />
     );

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
@@ -159,7 +159,11 @@ function usePoolDetailData(
       network.chainId,
       initialData,
     );
-  const { data: limitsData, error: limitsError } = useGQL<{
+  const {
+    data: limitsData,
+    error: limitsError,
+    isLoading: limitsLoading,
+  } = useGQL<{
     TradingLimit: TradingLimit[];
   }>(TRADING_LIMITS, { poolId: normalizedPoolId });
   const { data: deployData } = useGQL<{
@@ -179,6 +183,7 @@ function usePoolDetailData(
     thresholdsError,
     tradingLimits: limitsData?.TradingLimit ?? [],
     tradingLimitsError: limitsError !== undefined,
+    tradingLimitsLoading: isLoadingWithoutData(limitsLoading, limitsData),
     deployTxHash: deployData?.FactoryDeployment?.[0]?.txHash,
     olsData,
     olsLoading,
@@ -324,6 +329,7 @@ function PoolDetail({ initialSearch, initialData }: PoolDetailProps) {
             setTabSearch={setTabSearch}
             tradingLimits={detail.tradingLimits}
             tradingLimitsError={detail.tradingLimitsError}
+            tradingLimitsLoading={detail.tradingLimitsLoading}
             fpmmPool={detail.fpmmPool}
             network={network}
             thresholdsLoading={detail.thresholdsLoading}
@@ -511,6 +517,7 @@ function PoolTabPanel({
   setTabSearch,
   tradingLimits,
   tradingLimitsError,
+  tradingLimitsLoading,
   fpmmPool,
   network,
   thresholdsLoading,
@@ -524,6 +531,7 @@ function PoolTabPanel({
   setTabSearch: (tab: Tab, value: string) => void;
   tradingLimits: TradingLimit[];
   tradingLimitsError: boolean;
+  tradingLimitsLoading: boolean;
   fpmmPool: boolean;
   network: ReturnType<typeof useNetwork>["network"];
   thresholdsLoading: boolean;
@@ -542,86 +550,137 @@ function PoolTabPanel({
         thresholdsLoading={thresholdsLoading}
         thresholdsError={thresholdsError}
       >
-        {tab === "swaps" && (
-          <SwapsTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("swaps", value)}
-          />
-        )}
-        {tab === "reserves" && (
-          <ReservesTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("reserves", value)}
-          />
-        )}
-        {tab === "rebalances" && (
-          <RebalancesTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("rebalances", value)}
-          />
-        )}
-        {tab === "liquidity" && (
-          <LiquidityTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("liquidity", value)}
-          />
-        )}
-        {tab === "oracle" && (
-          <OracleTab
-            poolId={normalizedPoolId}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("oracle", value)}
-          />
-        )}
-        {tab === "providers" && (
-          <LpsTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("providers", value)}
-          />
-        )}
-        {tab === "limits" && pool && (
-          <LimitPanel
-            pool={pool}
-            tradingLimits={tradingLimits}
-            hasError={tradingLimitsError}
-          />
-        )}
-        {tab === "breaches" && fpmmPool && pool && (
-          <BreachHistoryPanel
-            pool={pool}
-            network={network}
-            limit={limit}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("breaches", value)}
-          />
-        )}
-        {tab === "ols" && (
-          <OlsTab
-            poolId={normalizedPoolId}
-            limit={limit}
-            pool={pool}
-            search={activeSearch}
-            onSearchChange={(value) => setTabSearch("ols", value)}
-          />
-        )}
+        <ActiveTabContent
+          tab={tab}
+          normalizedPoolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          activeSearch={activeSearch}
+          setTabSearch={setTabSearch}
+          tradingLimits={tradingLimits}
+          tradingLimitsError={tradingLimitsError}
+          tradingLimitsLoading={tradingLimitsLoading}
+          fpmmPool={fpmmPool}
+          network={network}
+        />
       </TokenAmountTrustGate>
     </div>
+  );
+}
+
+type ActiveTabContentProps = {
+  tab: Tab;
+  normalizedPoolId: string;
+  limit: number;
+  pool: Pool | null;
+  activeSearch: string;
+  setTabSearch: (tab: Tab, value: string) => void;
+  tradingLimits: TradingLimit[];
+  tradingLimitsError: boolean;
+  tradingLimitsLoading: boolean;
+  fpmmPool: boolean;
+  network: ReturnType<typeof useNetwork>["network"];
+};
+
+// Split out of `PoolTabPanel` so the per-tab switch (one branch per entry in
+// `TABS`) doesn't push the wrapper function over the repo's
+// max-lines-per-function budget.
+function ActiveTabContent(props: ActiveTabContentProps) {
+  const {
+    tab,
+    normalizedPoolId,
+    limit,
+    pool,
+    activeSearch,
+    setTabSearch,
+    tradingLimits,
+    tradingLimitsError,
+    tradingLimitsLoading,
+    fpmmPool,
+    network,
+  } = props;
+  return (
+    <>
+      {tab === "swaps" && (
+        <SwapsTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("swaps", value)}
+        />
+      )}
+      {tab === "reserves" && (
+        <ReservesTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("reserves", value)}
+        />
+      )}
+      {tab === "rebalances" && (
+        <RebalancesTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("rebalances", value)}
+        />
+      )}
+      {tab === "liquidity" && (
+        <LiquidityTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("liquidity", value)}
+        />
+      )}
+      {tab === "oracle" && (
+        <OracleTab
+          poolId={normalizedPoolId}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("oracle", value)}
+        />
+      )}
+      {tab === "providers" && (
+        <LpsTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("providers", value)}
+        />
+      )}
+      {tab === "limits" && pool && (
+        <LimitPanel
+          pool={pool}
+          tradingLimits={tradingLimits}
+          hasError={tradingLimitsError}
+          isLoading={tradingLimitsLoading}
+        />
+      )}
+      {tab === "breaches" && fpmmPool && pool && (
+        <BreachHistoryPanel
+          pool={pool}
+          network={network}
+          limit={limit}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("breaches", value)}
+        />
+      )}
+      {tab === "ols" && (
+        <OlsTab
+          poolId={normalizedPoolId}
+          limit={limit}
+          pool={pool}
+          search={activeSearch}
+          onSearchChange={(value) => setTabSearch("ols", value)}
+        />
+      )}
+    </>
   );
 }
 

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-header.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-header.tsx
@@ -254,6 +254,11 @@ export function PoolHeader({
       {isVirtual ? (
         <>
           <div className="my-5 h-px bg-slate-800" />
+          {/* V2ExchangePanel/PoolLifecyclePanel keep a fixed local loading
+              skeleton that doesn't match their real loaded height for
+              VirtualPools (issue #1222's header-height-stability criterion
+              was fixed for FPMM pools' BreakerPanel/MarketHoursPill only).
+              Tracked as a follow-up in issue #1238. */}
           <V2ExchangePanel
             pool={pool}
             network={network}

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/helpers.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/helpers.ts
@@ -36,6 +36,20 @@ export function getDebtTokenSideLabel(
   return "unknown";
 }
 
+/** Decimals for whichever pool side `tokenAddress` matches, defaulting to
+ *  18 for the unmatched/unknown side. Shared by `ols-liquidity-events.tsx`
+ *  (search-filter pass) and `ols-liquidity-table.tsx` (row renderer), which
+ *  both need the same token0/token1 side resolution for an OLS event's
+ *  given/taken token. */
+export function tokenDecimalsFor(
+  pool: Pool | null,
+  tokenAddress: string,
+): number {
+  return pool?.token0?.toLowerCase() === tokenAddress.toLowerCase()
+    ? (pool?.token0Decimals ?? 18)
+    : (pool?.token1Decimals ?? 18);
+}
+
 /**
  * Defensive selector for the current OLS row shown in the pool detail view.
  *

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx
@@ -151,3 +151,30 @@ describe("ReservesTab ordering contract", () => {
     expect(tx10).toBeGreaterThan(tx20);
   });
 });
+
+describe("ReservesTab loading skeleton", () => {
+  it("reserves `limit` table rows at the real header/row heights instead of 5 flat bars", () => {
+    mockUseGQL.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+    });
+
+    const html = renderToStaticMarkup(
+      <ReservesTab
+        poolId="42220-0xpool"
+        limit={10}
+        pool={POOL}
+        search=""
+        onSearchChange={() => {}}
+      />,
+    );
+
+    // TableSkeleton isn't mocked here (it's the real shared primitive) —
+    // assert on its live region and measured row rhythm so the loading
+    // branch's row count actually tracks the tab's real page size.
+    expect(html).toContain('aria-label="Loading table"');
+    const rowMatches = html.match(/height:44px/g) ?? [];
+    expect(rowMatches).toHaveLength(10);
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/liquidity-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/liquidity-tab.tsx
@@ -2,11 +2,12 @@
 
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge } from "@/components/badges";
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { LiquidityChart } from "@/components/liquidity-chart";
 import { useNetwork } from "@/components/network-provider";
 import { Pagination } from "@/components/pagination";
 import { SenderCell } from "@/components/sender-cell";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import { TagsCell } from "@/components/tags-cell";
@@ -129,7 +130,8 @@ export function LiquidityTab({
 
   if (hasErrorWithoutData(error, data))
     return <ErrorBox message={error.message} />;
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={5} />;
+  if (isLoadingWithoutData(isLoading, data))
+    return <TableSkeleton variant="rows" rows={limit} />;
 
   return (
     <>

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
@@ -349,10 +349,19 @@ function getFpmmPoolState(pool: Pool | null): boolean | null {
 
 const LP_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
 
+// Typical-pool row count for the table portion of the skeleton — reserving
+// the full page-size `limit` (up to MAX_TAB_LIMIT) overshoots the common
+// case badly (issue #1222 measured a low-position pool at 602px loaded vs.
+// ~1550px for a 25-row reservation). A first-screenful-sized reservation
+// tracks the common case; pools with many more LPs still get a stable
+// (if imperfect) skeleton→content transition since only the row COUNT is
+// approximate, not the row shape.
+const LPS_SKELETON_ROW_COUNT = 4;
+
 // Mirrors the LPs tab's real loaded layout — LpConcentrationChart (reserving
 // PIE_PLOT_HEIGHT_PX, the same constant the real chart's own chunk-loading
-// fallback uses) + the search input + the positions table sized to the
-// tab's real page size (`limit`). Issue #1222 measured the previous flat
+// fallback uses) + the search input + the positions table sized to a
+// typical first-screenful row count. Issue #1222 measured the previous flat
 // `<Skeleton rows={5} />` (232px) against 602px of real LPs-tab content.
 function LpsTabSkeleton({ limit }: { limit: number }) {
   return (
@@ -365,7 +374,10 @@ function LpsTabSkeleton({ limit }: { limit: number }) {
         />
       </div>
       <div className={`mb-4 h-9 w-full max-w-sm ${LP_SKELETON_SHIMMER}`} />
-      <TableSkeleton variant="rows" rows={limit} />
+      <TableSkeleton
+        variant="rows"
+        rows={Math.min(limit, LPS_SKELETON_ROW_COUNT)}
+      />
     </>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx
@@ -2,10 +2,14 @@
 
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
-import { LpConcentrationChart } from "@/components/lp-concentration-chart";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
+import {
+  LpConcentrationChart,
+  PIE_PLOT_HEIGHT_PX,
+} from "@/components/lp-concentration-chart";
 import { useNetwork } from "@/components/network-provider";
 import { Pagination } from "@/components/pagination";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import { formatTimestamp, parseWei, relativeTime } from "@/lib/format";
@@ -121,7 +125,7 @@ export function LpsTab({
     return <ErrorBox message={indexedError.message} />;
   }
   if (isLoadingWithoutData(indexedLoading, indexedData))
-    return <Skeleton rows={5} />;
+    return <LpsTabSkeleton limit={limit} />;
   if (positions.length === 0)
     return <EmptyBox message="No active LP positions for this pool." />;
 
@@ -341,4 +345,27 @@ function filterLpPositions(
 
 function getFpmmPoolState(pool: Pool | null): boolean | null {
   return pool ? isFpmm(pool) : null;
+}
+
+const LP_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+// Mirrors the LPs tab's real loaded layout — LpConcentrationChart (reserving
+// PIE_PLOT_HEIGHT_PX, the same constant the real chart's own chunk-loading
+// fallback uses) + the search input + the positions table sized to the
+// tab's real page size (`limit`). Issue #1222 measured the previous flat
+// `<Skeleton rows={5} />` (232px) against 602px of real LPs-tab content.
+function LpsTabSkeleton({ limit }: { limit: number }) {
+  return (
+    <>
+      <div className="mb-4 overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4">
+        <div className={`mb-3 h-4 w-28 ${LP_SKELETON_SHIMMER}`} />
+        <div
+          className={`w-full max-w-[360px] ${LP_SKELETON_SHIMMER}`}
+          style={{ height: PIE_PLOT_HEIGHT_PX }}
+        />
+      </div>
+      <div className={`mb-4 h-9 w-full max-w-sm ${LP_SKELETON_SHIMMER}`} />
+      <TableSkeleton variant="rows" rows={limit} />
+    </>
+  );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/ols-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/ols-tab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ErrorBox, Skeleton } from "@/components/feedback";
+import { ErrorBox } from "@/components/feedback";
 import { useNetwork } from "@/components/network-provider";
+import { TableSkeleton } from "@/components/skeletons";
 import { useGQL } from "@/lib/graphql";
 import { OLS_POOL } from "@/lib/queries";
 import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
@@ -41,7 +42,8 @@ export function OlsTab({
 
   if (hasErrorWithoutData(olsErr, olsData))
     return <ErrorBox message={olsErr.message} />;
-  if (isLoadingWithoutData(olsLoading, olsData)) return <Skeleton rows={3} />;
+  if (isLoadingWithoutData(olsLoading, olsData))
+    return <OlsTabSkeleton limit={limit} />;
 
   return (
     <div className="space-y-6">
@@ -55,6 +57,45 @@ export function OlsTab({
         search={search}
         onSearchChange={onSearchChange}
       />
+    </div>
+  );
+}
+
+const OLS_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+// Approximates OlsStatusPanel's shape (title+badge row, then 3 labelled
+// stat-grid sections) stacked above the liquidity-events table, sized to
+// `limit`. The OLS_POOL query resolves whether this pool is registered at
+// all, so — unlike the other tabs — the loaded outcome can be much smaller
+// (the "not registered" message) than this skeleton; that's an accepted
+// asymmetry, matching the checklist's "loading vs empty are distinct" rule.
+function OlsTabSkeleton({ limit }: { limit: number }) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-5 rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className={`h-5 w-48 ${OLS_SKELETON_SHIMMER}`} />
+          <div className={`h-5 w-16 rounded-full ${OLS_SKELETON_SHIMMER}`} />
+        </div>
+        {Array.from({ length: 3 }, (_, section) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`ols-skel-section-${section}`}
+            className="grid grid-cols-2 gap-4 border-t border-slate-800 pt-4 sm:grid-cols-3"
+          >
+            {Array.from({ length: 3 }, (_, stat) => (
+              <div
+                // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+                key={`ols-skel-stat-${section}-${stat}`}
+              >
+                <div className={`h-3 w-16 ${OLS_SKELETON_SHIMMER}`} />
+                <div className={`mt-1.5 h-4 w-20 ${OLS_SKELETON_SHIMMER}`} />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <TableSkeleton variant="rows" rows={limit} />
     </div>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/oracle-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/oracle-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { useNetwork } from "@/components/network-provider";
 import type { Network } from "@/lib/networks";
 import { OracleChart, lookAheadTarget } from "@/components/oracle-chart";
@@ -10,6 +10,7 @@ import {
   shouldSkipLookAhead,
 } from "@/components/oracle-daily";
 import { Pagination } from "@/components/pagination";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import {
@@ -345,7 +346,8 @@ export function OracleTab(props: OracleTabProps) {
 
   if (hasErrorWithoutData(error, data))
     return <ErrorBox message={error.message} />;
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={5} />;
+  if (isLoadingWithoutData(isLoading, data))
+    return <TableSkeleton variant="rows" rows={DEFAULT_PAGE_SIZE} />;
   if (rows.length === 0)
     return (
       <EmptyBox message="No oracle snapshots yet. Oracle data is captured on pool activity (swaps, rebalances)." />

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
@@ -2,10 +2,11 @@
 
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { EffectivenessChart } from "@/components/effectiveness-chart";
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { Tooltip } from "@/components/tooltip";
 import { Pagination } from "@/components/pagination";
 import { SenderCell } from "@/components/sender-cell";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import { TagsCell } from "@/components/tags-cell";
@@ -309,7 +310,8 @@ export function RebalancesTab({
 
   if (hasErrorWithoutData(error, data))
     return <ErrorBox message={error.message} />;
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={5} />;
+  if (isLoadingWithoutData(isLoading, data))
+    return <TableSkeleton variant="rows" rows={limit} />;
   if (rows.length === 0)
     return <EmptyBox message="No rebalance events for this pool." />;
 

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { useNetwork } from "@/components/network-provider";
 import { ReserveChart } from "@/components/reserve-chart";
+import { TableSkeleton } from "@/components/skeletons";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
 import { TxHashCell } from "@/components/tx-hash-cell";
@@ -22,6 +23,22 @@ import type { Pool, ReserveUpdate } from "@/lib/types";
 import { useMemo } from "react";
 import { matchesRowSearch } from "../_lib/helpers";
 
+// Shared by the search-filter pass and the table row renderer — both need
+// the same USD split for a reserve row.
+function reserveUsdSplit(
+  r: ReserveUpdate,
+  pool: Pool | null,
+  feedVal: number | null,
+  usdmIsToken0: boolean,
+): { usd0: number; usd1: number; total: number } {
+  const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);
+  const raw1 = parseWei(r.reserve1, pool?.token1Decimals ?? 18);
+  const usd0 = feedVal && !usdmIsToken0 ? raw0 * feedVal : raw0;
+  const usd1 = feedVal && usdmIsToken0 ? raw1 * feedVal : raw1;
+  return { usd0, usd1, total: usd0 + usd1 };
+}
+
+// eslint-disable-next-line max-lines-per-function -- Existing tab keeps reserve fetching, search filtering, chart, and table rendering together; this PR only swaps the loading skeleton to the shared row-count-matched primitive.
 export function ReservesTab({
   poolId,
   limit,
@@ -61,11 +78,7 @@ export function ReservesTab({
   const filteredRows = useMemo(() => {
     if (!query) return rows;
     return rows.filter((r) => {
-      const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);
-      const raw1 = parseWei(r.reserve1, pool?.token1Decimals ?? 18);
-      const usd0 = feedVal && !usdmIsToken0 ? raw0 * feedVal : raw0;
-      const usd1 = feedVal && usdmIsToken0 ? raw1 * feedVal : raw1;
-      const total = usd0 + usd1;
+      const { total } = reserveUsdSplit(r, pool, feedVal, usdmIsToken0);
 
       return matchesRowSearch(query, [
         r.txHash,
@@ -86,7 +99,8 @@ export function ReservesTab({
 
   if (hasErrorWithoutData(error, data))
     return <ErrorBox message={error.message} />;
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={5} />;
+  if (isLoadingWithoutData(isLoading, data))
+    return <TableSkeleton variant="rows" rows={limit} />;
   if (rows.length === 0)
     return <EmptyBox message="No reserve updates for this pool." />;
   return (
@@ -124,11 +138,12 @@ export function ReservesTab({
           </thead>
           <tbody>
             {filteredRows.map((r) => {
-              const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);
-              const raw1 = parseWei(r.reserve1, pool?.token1Decimals ?? 18);
-              const usd0 = feedVal && !usdmIsToken0 ? raw0 * feedVal : raw0;
-              const usd1 = feedVal && usdmIsToken0 ? raw1 * feedVal : raw1;
-              const total = usd0 + usd1;
+              const { usd0, usd1, total } = reserveUsdSplit(
+                r,
+                pool,
+                feedVal,
+                usdmIsToken0,
+              );
 
               return (
                 <Row key={r.id}>

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useAddressLabels } from "@/components/address-labels-provider";
-import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { useNetwork } from "@/components/network-provider";
 import { Pagination } from "@/components/pagination";
 import { SenderCell } from "@/components/sender-cell";
+import { TableSkeleton } from "@/components/skeletons";
 import { SnapshotChart } from "@/components/snapshot-chart";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
@@ -137,7 +138,8 @@ export function SwapsTab({
 
   if (hasErrorWithoutData(error, data))
     return <ErrorBox message={error.message} />;
-  if (isLoadingWithoutData(isLoading, data)) return <Skeleton rows={5} />;
+  if (isLoadingWithoutData(isLoading, data))
+    return <TableSkeleton variant="rows" rows={limit} />;
 
   return (
     <>

--- a/ui-dashboard/src/app/pool/[poolId]/loading.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/loading.tsx
@@ -1,5 +1,6 @@
 import { TableSkeleton } from "@/components/skeletons";
 import { ROW_CHART_HEIGHT_PX } from "@/lib/plot";
+import { HeaderCardSkeleton } from "./_components/header-card-skeleton";
 
 // Matches the real pool detail layout: breadcrumb + header card + health bar
 // + charts row + 7 tabs (see TABS in page.tsx) + a 6-column default table.
@@ -45,23 +46,11 @@ export default function PoolDetailLoading() {
         <div className="h-4 w-96 animate-pulse rounded bg-slate-800/50" />
       </div>
       {/* Header card — mirrors PoolHeader: p-5 card, title row (text-xl ≈
-          h-7) + 5-col stat grid. */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
-        <div className="mb-3 flex flex-wrap items-center gap-3">
-          <div className={`h-7 w-40 ${SHIMMER}`} />
-          <div className={`h-5 w-24 ${SHIMMER}`} />
-          <div className={`h-5 w-16 ${SHIMMER}`} />
-        </div>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
-          {Array.from({ length: 5 }, (_, i) => (
-            // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-            <div key={`skel-stat-${i}`}>
-              <div className={`h-4 w-20 ${SHIMMER}`} />
-              <div className={`mt-1 h-5 w-24 ${SHIMMER}`} />
-            </div>
-          ))}
-        </div>
-      </div>
+          h-7) + 5-col stat grid. Shared with PoolOverview's degraded
+          fallback via HeaderCardSkeleton so the two loading branches can't
+          drift apart. `presentational` because the page-level live region
+          lives on the trailing TableSkeleton below. */}
+      <HeaderCardSkeleton presentational />
       {/* Health panel — exception-only in the real page (often renders
           nothing); a slim bar splits the difference with the full panel. */}
       <div className="h-12 animate-pulse rounded-lg border border-slate-800 bg-slate-900/30" />

--- a/ui-dashboard/src/app/pool/[poolId]/loading.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/loading.tsx
@@ -49,7 +49,16 @@ export default function PoolDetailLoading() {
           h-7) + 5-col stat grid. Shared with PoolOverview's degraded
           fallback via HeaderCardSkeleton so the two loading branches can't
           drift apart. `presentational` because the page-level live region
-          lives on the trailing TableSkeleton below. */}
+          lives on the trailing TableSkeleton below.
+
+          Known residual: on FPMM pools with a rateFeedID, PoolHeader's own
+          BreakerPanel has no SSR fallback data, so its `isLoading` state is
+          true on first content paint and it renders a ~90px skeleton
+          section (divider + 5-stat grid) that this route skeleton can't
+          reserve without becoming pool-type-aware (this component doesn't
+          know the pool yet). That can still shift the loading.tsx→content
+          boundary for those pools until #1237 (SSR-prefetch
+          POOL_BREAKER_CONFIG) lands. */}
       <HeaderCardSkeleton presentational />
       {/* Health panel — exception-only in the real page (often renders
           nothing); a slim bar splits the difference with the full panel. */}

--- a/ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx
@@ -515,7 +515,11 @@ describe("Initial render", () => {
     expect(html).toContain("Liquidity event");
   });
 
-  it("shows the 'Loading…' placeholder while page is loading and rows are empty", () => {
+  it("shows a table-shaped skeleton (not a text sliver) while page is loading and rows are empty", () => {
+    // Issue #1222 criterion #3: switching into (or first-loading) the
+    // breaches tab must not collapse the panel to a sliver and re-expand
+    // once the page query resolves — the skeleton must be sized to the
+    // real table's row count (`limit`), not a bare loading string.
     setupGQL({
       count: { data: undefined, isLoading: true },
       page: { data: undefined, isLoading: true },
@@ -530,7 +534,10 @@ describe("Initial render", () => {
         onSearchChange={() => {}}
       />,
     );
-    expect(html).toContain("Loading…");
+    expect(html).not.toContain("py-6 text-center text-sm text-slate-500");
+    const rowCount = (html.match(/animate-pulse bg-slate-800\/30/g) ?? [])
+      .length;
+    expect(rowCount).toBe(25);
   });
 
   it("shows the schema-lag banner when page query errors with 'field not found'", () => {

--- a/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
@@ -165,6 +165,34 @@ describe("BreakerPanel", () => {
     expect(html).toBe("");
   });
 
+  it("renders a 5-stat skeleton (not nothing) while the query is still loading", () => {
+    // POOL_BREAKER_CONFIG has no SSR fallback, so on first client render this
+    // is the common state for FX pools — must not render `null` (issue
+    // #1222: a null→content swap here measured as +119px on PoolHeader).
+    mockUseGQL.mockReturnValue({ data: undefined, isLoading: true });
+    const html = renderToStaticMarkup(<BreakerPanel pool={fxPool()} />);
+    expect(html).not.toBe("");
+    // Same grid shape as the loaded `<dl>` — 5 stat cells behind the
+    // hairline divider that always precedes the real content.
+    expect(html).toContain("my-5 h-px bg-slate-800");
+    const dlOpenTag = html.match(/<dl[^>]*>/)?.[0] ?? "";
+    expect(dlOpenTag).toContain("lg:grid-cols-5");
+    // Each stat cell's label bar carries this exact class pair — 5 stat
+    // cells behind the divider, matching the real panel's 5 `<dl>` children
+    // (Breaker, Reference vs Actual, Threshold/Cooldown, live-Δ, Last trip).
+    const statCellCount = (html.match(/h-3 w-24/g) ?? []).length;
+    expect(statCellCount).toBe(5);
+  });
+
+  it("renders nothing once the query resolves and finds no trip-able breaker (not stuck on the skeleton)", () => {
+    mockUseGQL.mockReturnValue({
+      data: { BreakerConfig: [], BreakerTripEvent: noTrips },
+      isLoading: false,
+    });
+    const html = renderToStaticMarkup(<BreakerPanel pool={fxPool()} />);
+    expect(html).toBe("");
+  });
+
   it("renders nothing when the feed has no trip-able BreakerConfig (only MARKET_HOURS)", () => {
     mockUseGQL.mockReturnValue({
       data: {

--- a/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
@@ -182,6 +182,11 @@ describe("BreakerPanel", () => {
     // (Breaker, Reference vs Actual, Threshold/Cooldown, live-Δ, Last trip).
     const statCellCount = (html.match(/h-3 w-24/g) ?? []).length;
     expect(statCellCount).toBe(5);
+    // Each cell reserves the loaded row's measured 78px height (three text
+    // lines: label, value, sub-line) so the header card doesn't grow once
+    // BreakerConfig resolves.
+    const cellHeightCount = (html.match(/h-\[78px\]/g) ?? []).length;
+    expect(cellHeightCount).toBe(5);
   });
 
   it("renders nothing once the query resolves and finds no trip-able breaker (not stuck on the skeleton)", () => {

--- a/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
+++ b/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
@@ -96,6 +96,27 @@ describe("MarketHoursPill", () => {
     expect(html).toBe("");
   });
 
+  it("renders a same-height shimmer placeholder (not nothing) while the query is loading", () => {
+    // POOL_BREAKER_CONFIG has no SSR fallback, so on first client render this
+    // is the common state for FX pools — a null→pill swap here can push the
+    // title row onto a second line (issue #1222).
+    mockUseGQL.mockReturnValue({ data: undefined, isLoading: true });
+    const html = renderToStaticMarkup(<MarketHoursPill pool={fxPool()} />);
+    expect(html).not.toBe("");
+    expect(html).toContain("h-5");
+    expect(html).not.toContain("Market Open");
+    expect(html).not.toContain("Market Closed");
+  });
+
+  it("renders nothing once the query resolves and no MARKET_HOURS config exists (not stuck on the placeholder)", () => {
+    mockUseGQL.mockReturnValue({
+      data: { BreakerConfig: [], BreakerTripEvent: [] },
+      isLoading: false,
+    });
+    const html = renderToStaticMarkup(<MarketHoursPill pool={fxPool()} />);
+    expect(html).toBe("");
+  });
+
   it("renders nothing when the MARKET_HOURS BreakerConfig is disabled", () => {
     // Governance can disable the market-hours breaker for a feed via
     // BreakerStatusUpdated(..., false). The pill must hide in that case so

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -19,6 +19,7 @@ import { BreachHistoryChart } from "@/components/breach-history-chart";
 import { TableSearch } from "@/components/table-search";
 import { Pagination } from "@/components/pagination";
 import { EmptyBox, ErrorBox } from "@/components/feedback";
+import { TableSkeleton } from "@/components/skeletons";
 import { buildOrderBy, type SortDir } from "@/lib/table-sort";
 import {
   buildSearchBlob,
@@ -378,7 +379,11 @@ function BreachHistoryPanelInner({
         </div>
 
         {isLoading && rows.length === 0 ? (
-          <p className="py-6 text-center text-sm text-slate-500">Loading…</p>
+          // Sized to the tab's real page-size row count so switching into
+          // (or first-loading) the breaches tab doesn't collapse the panel
+          // to a text sliver and re-expand once the page query resolves
+          // (issue #1222 criterion #3).
+          <TableSkeleton variant="rows" rows={limit} />
         ) : rows.length === 0 && countConfirmed && rawTotal === 0 ? (
           <EmptyBox
             message={

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -74,6 +74,20 @@ function breakerConfigQuery(
   return !isVirtual && rateFeedID ? POOL_BREAKER_CONFIG : null;
 }
 
+// POOL_BREAKER_CONFIG has no SSR fallback, so on every first client render
+// the panel either renders nothing (no trip-able breaker) or
+// nothing-then-a-5-stat-row (issue #1222's measured +119px header jump).
+// True only while the query is genuinely in flight, so BreakerPanel can
+// render a matching-shape shimmer instead of null for that interval.
+function isBreakerConfigQueryPending(
+  isVirtual: boolean,
+  rateFeedID: string,
+  data: unknown,
+  isLoading: boolean,
+): boolean {
+  return !isVirtual && !!rateFeedID && data === undefined && isLoading;
+}
+
 /** Effective cooldown in seconds. Per-feed override else breaker default. */
 function effectiveCooldown(cfg: BreakerConfig): bigint {
   const override = BigInt(cfg.cooldownTime);
@@ -470,15 +484,24 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
   const isVirtual = isVirtualPool(pool);
   const rateFeedID = pool.referenceRateFeedID ?? "";
 
-  const { data } = useGQL<Response>(breakerConfigQuery(isVirtual, rateFeedID), {
-    chainId: pool.chainId,
-    rateFeedID,
-  });
+  const { data, isLoading } = useGQL<Response>(
+    breakerConfigQuery(isVirtual, rateFeedID),
+    {
+      chainId: pool.chainId,
+      rateFeedID,
+    },
+  );
 
   const configs = data?.BreakerConfig ?? [];
   const trips = data?.BreakerTripEvent ?? [];
   const cfg = pickTrippableConfig(configs);
   const tripped = cfg?.status === "TRIPPED";
+  const queryPending = isBreakerConfigQueryPending(
+    isVirtual,
+    rateFeedID,
+    data,
+    isLoading,
+  );
   // The 1-second ticker only matters during cooldown (it drives the
   // countdown text + the reset-path "elapsed" check). Healthy state shows
   // static text — skip the interval to avoid recurring re-renders for nothing.
@@ -498,6 +521,7 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
     return () => clearInterval(id);
   }, [tickerActive]);
 
+  if (queryPending) return <BreakerPanelSkeleton />;
   if (isVirtual || !rateFeedID || !cfg) return null;
   // No trip-able breaker (e.g. feed not registered with BreakerBox) → no panel.
 
@@ -567,6 +591,31 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
           presentation={presentation}
         />
       )}
+    </>
+  );
+}
+
+const BREAKER_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+// Mirrors the real panel's shape once a trip-able breaker resolves: a
+// hairline divider (`my-5 h-px`) plus the 5-stat `<dl>` grid (Breaker,
+// Reference vs Actual, Threshold/Cooldown, live-Δ bar, Last trip) — each
+// stat is a label line over a two-line value block, matching `dt` + `dd
+// flex flex-col gap-0.5` in the real metric components above.
+function BreakerPanelSkeleton() {
+  return (
+    <>
+      <div className="my-5 h-px bg-slate-800" />
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`breaker-skel-stat-${i}`}>
+            <div className={`h-3 w-24 ${BREAKER_SKELETON_SHIMMER}`} />
+            <div className={`mt-1.5 h-4 w-20 ${BREAKER_SKELETON_SHIMMER}`} />
+            <div className={`mt-1 h-3 w-16 ${BREAKER_SKELETON_SHIMMER}`} />
+          </div>
+        ))}
+      </dl>
     </>
   );
 }

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -522,6 +522,13 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
   }, [tickerActive]);
 
   if (queryPending) return <BreakerPanelSkeleton />;
+  // Accepted tradeoff: for the (less common) pool that resolves to no
+  // trip-able breaker, this is now skeleton→null instead of main's stable
+  // null→null — trading a rare small collapse for eliminating the far more
+  // common null→content jump this component exists to fix. The full fix
+  // (SSR-prefetch POOL_BREAKER_CONFIG so the resolved shape is known on
+  // first paint, mirroring PoolHeader's initialV2Exchange/
+  // initialExchangeVolume pattern) is tracked in issue #1237.
   if (isVirtual || !rateFeedID || !cfg) return null;
   // No trip-able breaker (e.g. feed not registered with BreakerBox) → no panel.
 

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -609,6 +609,12 @@ const BREAKER_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
 // Reference vs Actual, Threshold/Cooldown, live-Δ bar, Last trip) — each
 // stat is a label line over a two-line value block, matching `dt` + `dd
 // flex flex-col gap-0.5` in the real metric components above.
+//
+// Cell height: loaded breaker cells render three lines (label, value,
+// sub-line — e.g. "Breaker ⓘ" / "MedianDelta" / "trading mode 0") measuring
+// 78px in production, taller than a tight 3-line stack. Pin each placeholder
+// cell to that height so the breaker `<dl>` doesn't grow once BreakerConfig
+// resolves.
 function BreakerPanelSkeleton() {
   return (
     <>
@@ -616,10 +622,13 @@ function BreakerPanelSkeleton() {
       <dl className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
         {Array.from({ length: 5 }, (_, i) => (
           // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`breaker-skel-stat-${i}`}>
+          <div
+            key={`breaker-skel-stat-${i}`}
+            className="flex h-[78px] flex-col justify-between"
+          >
             <div className={`h-3 w-24 ${BREAKER_SKELETON_SHIMMER}`} />
-            <div className={`mt-1.5 h-4 w-20 ${BREAKER_SKELETON_SHIMMER}`} />
-            <div className={`mt-1 h-3 w-16 ${BREAKER_SKELETON_SHIMMER}`} />
+            <div className={`h-4 w-20 ${BREAKER_SKELETON_SHIMMER}`} />
+            <div className={`h-3 w-16 ${BREAKER_SKELETON_SHIMMER}`} />
           </div>
         ))}
       </dl>

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -69,12 +69,19 @@ interface LimitPanelProps {
   pool: Pool;
   tradingLimits: TradingLimit[];
   hasError?: boolean;
+  /** True while the trading-limits query is genuinely in flight and hasn't
+   * resolved data yet. Distinguishes "still loading" from "confirmed no
+   * limits configured" so the panel doesn't briefly show the empty-state
+   * copy for a pool that does have configured limits (issue #1222
+   * criterion #3: no sliver→expand on first load or tab switch). */
+  isLoading?: boolean;
 }
 
 export function LimitPanel({
   pool,
   tradingLimits,
   hasError = false,
+  isLoading = false,
 }: LimitPanelProps) {
   const { network } = useNetwork();
   const isVirtual = isVirtualPool(pool);
@@ -95,6 +102,8 @@ export function LimitPanel({
         <p className="text-sm text-red-400">
           Unable to load trading limits — try again later.
         </p>
+      ) : isLoading && tradingLimits.length === 0 ? (
+        <LimitPanelSkeleton />
       ) : tradingLimits.length === 0 ? (
         <p className="text-sm text-slate-400">
           No trading limit data available yet.
@@ -129,6 +138,43 @@ export function LimitPanel({
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+const LIMIT_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+
+// Mirrors the loaded shape for the common two-token case (a pool's token0 +
+// token1, each with an L0 + L1 PressureBar) so the panel doesn't briefly
+// render the "No trading limit data available yet." copy — which reads as a
+// confirmed empty state — while a pool that does have configured limits is
+// still loading (issue #1222 criterion #3).
+function LimitPanelSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: 2 }, (_, tokenIdx) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <div
+          key={`limit-skel-token-${tokenIdx}`}
+          className="flex flex-col gap-3"
+        >
+          <div className={`h-3 w-16 ${LIMIT_SKELETON_SHIMMER}`} />
+          {Array.from({ length: 2 }, (_, barIdx) => (
+            <div
+              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+              key={`limit-skel-bar-${tokenIdx}-${barIdx}`}
+              className="flex flex-col gap-1"
+            >
+              <div className="flex items-center justify-between">
+                <div className={`h-4 w-28 ${LIMIT_SKELETON_SHIMMER}`} />
+                <div className={`h-4 w-10 ${LIMIT_SKELETON_SHIMMER}`} />
+              </div>
+              <div className={`h-2 w-full ${LIMIT_SKELETON_SHIMMER}`} />
+              <div className={`h-3 w-40 ${LIMIT_SKELETON_SHIMMER}`} />
+            </div>
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -7,8 +7,11 @@ import { USDM_SYMBOLS } from "@/lib/tokens";
 import type { Pool } from "@/lib/types";
 
 /** Height of the pie's plot box — shared by the layout, the <Plot> style,
- *  and the chunk-loading fallback so the skeleton→chart swap is shift-free. */
-const PIE_PLOT_HEIGHT_PX = 280;
+ *  and the chunk-loading fallback so the skeleton→chart swap is shift-free.
+ *  Also exported for `lps-tab.tsx`'s SWR-loading skeleton, which reserves
+ *  this same plot height so the tab's loading→loaded swap doesn't jump
+ *  (issue #1222). */
+export const PIE_PLOT_HEIGHT_PX = 280;
 
 // Reserve the exact plot box while the Plotly chunk loads. Without a
 // fallback the card renders heading/legend/stats immediately and the pie

--- a/ui-dashboard/src/components/market-hours-pill.tsx
+++ b/ui-dashboard/src/components/market-hours-pill.tsx
@@ -84,9 +84,10 @@ function isBreakerClosure(config: BreakerConfig | undefined): boolean {
 export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   const isVirtual = isVirtualPool(pool);
   const rateFeedID = pool.referenceRateFeedID ?? "";
+  const queried = !isVirtual && !!rateFeedID;
 
-  const { data } = useGQL<Response>(
-    !isVirtual && rateFeedID ? POOL_BREAKER_CONFIG : null,
+  const { data, isLoading } = useGQL<Response>(
+    queried ? POOL_BREAKER_CONFIG : null,
     { chainId: pool.chainId, rateFeedID },
   );
 
@@ -98,6 +99,13 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   // countdown that no longer reflects the on-chain trading gate.
   const marketHoursConfig = findEnabledMarketHoursConfig(data?.BreakerConfig);
   const enabled = !isVirtual && !!marketHoursConfig;
+  // POOL_BREAKER_CONFIG has no SSR fallback, so on every first client render
+  // this pill either renders nothing (not FX) or nothing-then-pill (FX) —
+  // the latter is a late-mounting title-row element that can push the
+  // header card's flex-wrap onto a second line (issue #1222). A shimmer
+  // placeholder while the query is genuinely in flight turns that
+  // null→content jump into placeholder→content instead.
+  const queryPending = queried && data === undefined && isLoading;
 
   const [now, setNow] = useState(() => new Date());
 
@@ -116,6 +124,7 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
     return () => clearInterval(id);
   }, [enabled]);
 
+  if (queryPending) return <MarketHoursPillSkeleton />;
   if (!enabled) return null;
 
   const breakerClosed = isBreakerClosure(marketHoursConfig);
@@ -185,5 +194,17 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
       <span className="font-mono text-slate-300">{scheduleString()}</span>
       <span className="sr-only"> — {tooltip}</span>
     </span>
+  );
+}
+
+// Same box height as the real pill (text-xs line height + py-0.5 ≈ h-5).
+// Width approximates the widest real variant ("Market Open · <schedule>")
+// so a pool that does turn out FX-gated doesn't visibly widen the title row.
+function MarketHoursPillSkeleton() {
+  return (
+    <span
+      className="inline-flex h-5 w-40 animate-pulse items-center rounded bg-slate-800/50"
+      aria-hidden="true"
+    />
   );
 }

--- a/ui-dashboard/src/components/market-hours-pill.tsx
+++ b/ui-dashboard/src/components/market-hours-pill.tsx
@@ -125,6 +125,13 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   }, [enabled]);
 
   if (queryPending) return <MarketHoursPillSkeleton />;
+  // Accepted tradeoff: for the majority non-FX pool, this is now
+  // skeleton→null instead of main's stable null→null. At the title row's
+  // typical width this is horizontal-only (no wrap, no CLS) — a
+  // phantom-pill-then-vanish flash rather than a layout shift — but a
+  // narrow viewport could still push the flex-wrap title row onto a second
+  // line and back. The full fix (SSR-prefetch POOL_BREAKER_CONFIG so
+  // FX-eligibility is known on first paint) is tracked in issue #1237.
   if (!enabled) return null;
 
   const breakerClosed = isBreakerClosure(marketHoursConfig);


### PR DESCRIPTION
## The Problem

- The pool-detail header card grew 221→340px after data arrived (late-mounting stat rows and the breaker panel), pushing the charts row down 119px on every load.
- The uptime/health alert banner mounted late and shoved the whole page down (breadcrumb y jumped 77→110 in the production audit); tab switches collapsed the panel to a sliver before re-expanding.
- CLS ≈ 0 hides these whole-subtree swaps, so the fixes are verified against measured section rects, not Lighthouse scores.

## The Solution

- The header card's loading state now reserves every stat row at its loaded geometry — including three-line breaker cells — so the card is 340px from first client render to fully loaded.
- The route-level fallback and the in-page skeletons share the same shapes, the tab bar is pinned at its real height, and each tab gets a table-shaped skeleton at its real first-page row count.
- `PoolOverview`'s degraded fallback mirrors the header-card shape instead of four flat bars.

## Details

- Skeleton geometry is pinned by unit tests (five 78px breaker cells, tab-bar height, per-tab row counts) and matches the issue's production-audit measurements.
- The alert-banner path was measured on a degraded-uptime pool (GBPm/USDm, which renders the degraded-uptime affordance): nothing pushes the breadcrumb or header after first paint.
- Known residual mechanisms are deferred with issues (see Deferrals): the loading→null collapse for pools that resolve to no trip-able breaker, and virtual-pool header panels.

## Validation

Browser-measured on a production build with live production data, 1440×900, GraphQL-delay init script + rect sampler:

- Degraded-uptime FX pool (`143-0xd0e9…e081`, GBPm/USDm): cold-load CLS **0.008** (bar < 0.02; was 0.043). Loading → loaded: breadcrumb y **77 → 77**, header card **340 → 340 (was 221→340)**, charts row top **485 → 485** (height 355→354), tab bar 39→39.
- Healthy Celo pool (`42220-0x3aa7…f696`): cold-load CLS **0.014**; header card 356 stable from first paint; charts top 501 stable; no breaker-panel collapse observed.
- Default (LPs) tab panel: 624px reserved — +3.6% vs loaded on the Celo pool (602px). On LP-heavy pools the loaded panel is taller (1618px on GBPm/USDm): the growth is LP-count-driven, happens in a single reveal fully below the fold, and the panel never collapses to a sliver on tab switches. A static reserve cannot match both pools; the reserve tracks the typical case per the issue's audit.
- Local checks: trunk fmt/check, ui-dashboard typecheck, test:coverage (3688 tests), react-doctor 100/100, `pnpm agent:quality-gate --run` all pass.

## Deferrals

- Pools whose rate feed resolves to no trip-able breaker trade a rare skeleton→null collapse for eliminating the common null→content jump; the durable fix is SSR-prefetching `POOL_BREAKER_CONFIG`: #1237
- Virtual-pool header panels (V2ExchangePanel/PoolLifecyclePanel) keep fixed local skeletons smaller than their loaded content: #1238

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state and skeleton changes with expanded tests; no auth, data writes, or API contract changes. Minor accepted flash (skeleton→null) for pools without trip-able breakers until #1237.
> 
> **Overview**
> Addresses **layout shift on pool detail** (#1222) by replacing generic flat-bar loaders with geometry-matched placeholders so loading and loaded states reserve similar height.
> 
> **Header:** New shared `HeaderCardSkeleton` (title row + 5-col stat grid) is used in route `loading.tsx` and `PoolOverview` when the pool query has no data yet, replacing four flat bars. **`BreakerPanel`** and **`MarketHoursPill`** show shaped shimmers while `POOL_BREAKER_CONFIG` is in flight instead of rendering nothing and growing the header later.
> 
> **Tabs:** Pool detail tabs swap `<Skeleton rows={5} />` for **`TableSkeleton`** sized to the tab **`limit`** (or page size). **`LpsTab`** and **`OlsTab`** add composite skeletons (chart/status + table). **`LimitPanel`** gets a loading skeleton and **`tradingLimitsLoading`** from the page client. **`BreachHistoryPanel`** uses a full table skeleton instead of a “Loading…” line.
> 
> **Refactors:** `tokenDecimalsFor` / `reserveUsdSplit` dedupe logic; tab routing split into **`ActiveTabContent`**; tests assert skeleton markup and dimensions. Follow-ups noted for virtual-pool header panels (#1238) and SSR-prefetching breaker config (#1237).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa4b630f615403fd2f798676a12f37b14fc4042. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->