### PR TITLE
fix(dashboard): skeleton parity for /volume below-the-fold sections

### DIFF
--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -148,6 +148,24 @@ describe("route-level loading UIs", () => {
     expect(grid!.children).toHaveLength(3);
   });
 
+  it("VolumeLoading only fixes flow-insight panel height at the xl breakpoint where the grid goes 3-column", () => {
+    render(<VolumeLoading />);
+
+    // The grid stacks to a single column below `xl` (mirroring
+    // V3FlowInsights' `grid-cols-1 xl:grid-cols-3`) — below `xl` each panel
+    // is a full-width row on its own, not a column sharing a row's height
+    // with the taller corridor/outlier panels. A desktop-measured 500px
+    // fixed height would triple-reserve ~1500px on narrow viewports (the
+    // real cohort panel is much shorter), so the panels must use a
+    // breakpoint-scoped class rather than an unconditional inline style.
+    const grid = container.querySelector(".xl\\:grid-cols-3");
+    expect(grid).not.toBeNull();
+    Array.from(grid!.children).forEach((panel) => {
+      expect((panel as HTMLElement).style.height).toBe("");
+      expect(panel.className).toContain("xl:h-[500px]");
+    });
+  });
+
   it("VolumeLoading reserves a single full-width top-traders table, not a two-column layout", () => {
     render(<VolumeLoading />);
 

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -168,12 +168,23 @@ describe("route-level loading UIs", () => {
     expect(tableSkeletonRoots).toHaveLength(2);
   });
 
-  it("VolumeLoading reserves a 230px chart card ahead of the aggregator table skeleton", () => {
+  it("VolumeLoading reserves the full aggregator chart card chrome (title/headline/range pills), not a bare 230px box, ahead of the table skeleton", () => {
     render(<VolumeLoading />);
 
-    const chartPlaceholder = [
+    const plotPlaceholders = [
       ...container.querySelectorAll<HTMLElement>("[class*='h-[230px]']"),
     ];
-    expect(chartPlaceholder).toHaveLength(1);
+    expect(plotPlaceholders).toHaveLength(1);
+    const [plot] = plotPlaceholders;
+
+    // The 230px plot must sit inside the same full card chrome as the hero
+    // chart card above it — p-5/sm:p-6 rounded card wrapping a title line,
+    // a 3xl/4xl headline, and a 4-pill range group — not stand alone as the
+    // entire "card".
+    const card = plot!.closest("section.rounded-lg");
+    expect(card).not.toBeNull();
+    expect(card!.querySelector(".text-3xl")).not.toBeNull();
+    const rangePills = card!.querySelectorAll(".h-6.w-9");
+    expect(rangePills).toHaveLength(4);
   });
 });

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -186,5 +186,25 @@ describe("route-level loading UIs", () => {
     expect(card!.querySelector(".text-3xl")).not.toBeNull();
     const rangePills = card!.querySelectorAll(".h-6.w-9");
     expect(rangePills).toHaveLength(4);
+
+    // AggregatorBreakdownSection passes yAxisTopPadding={0} to this card,
+    // which triggers TimeSeriesChartCard's dense-layout bottom-padding
+    // override — mirrored here so the card doesn't shrink on client mount.
+    expect(card!.className).toContain("pb-2");
+    expect(card!.className).toContain("sm:pb-3");
+  });
+
+  it("VolumeLoading reserves a second line under the aggregator heading for its static description paragraph", () => {
+    render(<VolumeLoading />);
+
+    // AggregatorBreakdownSection always renders a title plus a
+    // `mt-1 text-xs` description paragraph underneath it — a single 16px
+    // heading bar undershoots that block by ~25px on client mount.
+    const heading = container.querySelector<HTMLElement>(".h-4.w-64");
+    expect(heading).not.toBeNull();
+    const descriptionLine = heading!.nextElementSibling as HTMLElement | null;
+    expect(descriptionLine).not.toBeNull();
+    expect(descriptionLine!.className).toContain("mt-1");
+    expect(descriptionLine!.className).toContain("h-3");
   });
 });

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -148,22 +148,47 @@ describe("route-level loading UIs", () => {
     expect(grid!.children).toHaveLength(3);
   });
 
-  it("VolumeLoading only fixes flow-insight panel height at the xl breakpoint where the grid goes 3-column", () => {
+  it("VolumeLoading renders the client's own flow-insight loading composition (no hand-mirrored heights)", () => {
     render(<VolumeLoading />);
 
-    // The grid stacks to a single column below `xl` (mirroring
-    // V3FlowInsights' `grid-cols-1 xl:grid-cols-3`) — below `xl` each panel
-    // is a full-width row on its own, not a column sharing a row's height
-    // with the taller corridor/outlier panels. A desktop-measured 500px
-    // fixed height would triple-reserve ~1500px on narrow viewports (the
-    // real cohort panel is much shorter), so the panels must use a
-    // breakpoint-scoped class rather than an unconditional inline style.
+    // The fallback imports InsightPanel + CohortPanelSkeleton +
+    // InsightTableSkeleton from v3-flow-insight-skeletons.tsx — the same
+    // components V3FlowInsights' panels render while loading — instead of
+    // hand-mirroring measured heights. That keeps the fallback→client
+    // handoff structurally identical at every breakpoint: a fixed desktop
+    // height over-reserved when the grid stacks below xl, and no
+    // reservation under-reserved against the client's intrinsic-height
+    // table skeletons (both flagged by codex on this PR).
     const grid = container.querySelector(".xl\\:grid-cols-3");
     expect(grid).not.toBeNull();
-    Array.from(grid!.children).forEach((panel) => {
-      expect((panel as HTMLElement).style.height).toBe("");
-      expect(panel.className).toContain("xl:h-[500px]");
+    const panels = Array.from(grid!.children) as HTMLElement[];
+    expect(panels).toHaveLength(3);
+    panels.forEach((panel) => {
+      // No fixed heights — parity comes from shared structure.
+      expect(panel.style.height).toBe("");
+      expect(panel.className).not.toContain("h-[500px]");
+      // Real InsightPanel chrome (h3 title), not a shimmer bar.
+      expect(panel.querySelector("h3")).not.toBeNull();
     });
+
+    const [cohort, corridor, outlier] = panels;
+    // Cohort: 3-stat mini grid + 3 leader rows (CohortPanelSkeleton).
+    const cohortStatGrid = cohort!.querySelector(".grid-cols-3");
+    expect(cohortStatGrid).not.toBeNull();
+    expect(cohortStatGrid!.children).toHaveLength(3);
+    // Corridor/outlier: InsightTableSkeleton with the query cap's 10 rows
+    // and the real tables' column counts (4-col corridor, 3-col outlier).
+    for (const [panel, cols] of [
+      [corridor!, 4],
+      [outlier!, 3],
+    ] as const) {
+      const header = panel.querySelector(".flex.gap-3.border-b");
+      expect(header).not.toBeNull();
+      expect(header!.children).toHaveLength(cols);
+      const body = panel.querySelector(".divide-y");
+      expect(body).not.toBeNull();
+      expect(body!.children).toHaveLength(10);
+    }
   });
 
   it("VolumeLoading reserves a single full-width top-traders table, not a two-column layout", () => {

--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -139,4 +139,41 @@ describe("route-level loading UIs", () => {
     // wrapper — reserving it shifted the KPI tiles down ~20px on swap.
     expect(container.querySelector(".flex.h-5.items-center")).toBeNull();
   });
+
+  it("VolumeLoading reserves a 3-panel flow-insights grid mirroring V3FlowInsights", () => {
+    render(<VolumeLoading />);
+
+    const grid = container.querySelector(".xl\\:grid-cols-3");
+    expect(grid).not.toBeNull();
+    expect(grid!.children).toHaveLength(3);
+  });
+
+  it("VolumeLoading reserves a single full-width top-traders table, not a two-column layout", () => {
+    render(<VolumeLoading />);
+
+    // Table-shaped skeletons (header 36px bar + 44px measured rows) reserve
+    // exactly two: the top-traders table and the aggregator table. Neither
+    // reserves a side column — `TopPoolsList` only renders alongside the
+    // per-pool chart for the 30d/90d/all ranges, which this route's default
+    // 7d fallback never reaches. `TableSkeleton` is rendered `presentational`
+    // here (a single outer live region already wraps the whole page), which
+    // strips its own `aria-label` — so table-skeleton roots are located
+    // structurally via the 36px header bar instead.
+    const tableSkeletonRoots = Array.from(
+      container.querySelectorAll<HTMLElement>("div"),
+    ).filter(
+      (el) =>
+        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
+    );
+    expect(tableSkeletonRoots).toHaveLength(2);
+  });
+
+  it("VolumeLoading reserves a 230px chart card ahead of the aggregator table skeleton", () => {
+    render(<VolumeLoading />);
+
+    const chartPlaceholder = [
+      ...container.querySelectorAll<HTMLElement>("[class*='h-[230px]']"),
+    ];
+    expect(chartPlaceholder).toHaveLength(1);
+  });
 });

--- a/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
@@ -173,6 +173,31 @@ describe("AggregatorBreakdownSection", () => {
     ]);
   });
 
+  it("reserves a table-shaped skeleton (header + measured row rhythm) while loading, matching the loaded table's <thead> structure", () => {
+    handle = renderSection({ isLoading: true });
+    const status = handle.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading table"]',
+    );
+    expect(status).not.toBeNull();
+    const [header, body] = Array.from(status!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
+    expect(header.style.height).toBe("36px");
+    expect(body.children.length).toBeGreaterThan(0);
+    Array.from(body.children).forEach((row) => {
+      expect((row as HTMLElement).style.height).toBe("44px");
+    });
+    teardown(handle);
+
+    handle = renderSection({
+      isLoading: false,
+      aggregators: [row({ aggregator: "squid" })],
+    });
+    expect(handle.container.querySelector("thead")).not.toBeNull();
+    expect(handle.container.querySelector("tbody")).not.toBeNull();
+  });
+
   it("sorts rows through the v3 aggregator URL params", () => {
     handle = renderSection({
       aggregators: [

--- a/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
@@ -174,19 +174,14 @@ describe("AggregatorBreakdownSection", () => {
   });
 
   it("reserves a table-shaped skeleton (header + measured row rhythm) while loading, matching the loaded table's <thead> structure", () => {
+    // Without `hasExternalLoadingAnnouncer`, the skeleton announces itself
+    // (role="status") — the standalone-loading case where no other element
+    // on the page covers the loading state.
     handle = renderSection({ isLoading: true });
-    // The aggregator table's skeleton is `presentational` (no `role`/
-    // `aria-label` — the top-traders table in `volume-table.tsx` owns the
-    // page's single live-region announcement, see that file's comment), so
-    // it's located structurally via its 36px header bar instead of ARIA
-    // attributes.
-    const status = Array.from(
-      handle.container.querySelectorAll<HTMLElement>("div"),
-    ).find(
-      (el) =>
-        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
+    const status = handle.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading table"]',
     );
-    expect(status).not.toBeUndefined();
+    expect(status).not.toBeNull();
     const [header, body] = Array.from(status!.children) as [
       HTMLElement,
       HTMLElement,
@@ -204,6 +199,25 @@ describe("AggregatorBreakdownSection", () => {
     });
     expect(handle.container.querySelector("thead")).not.toBeNull();
     expect(handle.container.querySelector("tbody")).not.toBeNull();
+  });
+
+  it("silences the loading skeleton only while another announcer is active (hasExternalLoadingAnnouncer)", () => {
+    // Combined loading: the venue's trader table is announcing, so this
+    // section's skeleton must go presentational — no role/aria-live at all.
+    handle = renderSection({
+      isLoading: true,
+      hasExternalLoadingAnnouncer: true,
+    });
+    expect(handle.container.querySelector('[role="status"]')).toBeNull();
+    expect(handle.container.querySelector("[aria-live]")).toBeNull();
+    // The skeleton itself still renders (36px header bar).
+    const skeleton = Array.from(
+      handle.container.querySelectorAll<HTMLElement>("div"),
+    ).find(
+      (el) =>
+        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
+    );
+    expect(skeleton).not.toBeUndefined();
   });
 
   it("sorts rows through the v3 aggregator URL params", () => {

--- a/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/aggregator-breakdown-section.test.tsx
@@ -175,10 +175,18 @@ describe("AggregatorBreakdownSection", () => {
 
   it("reserves a table-shaped skeleton (header + measured row rhythm) while loading, matching the loaded table's <thead> structure", () => {
     handle = renderSection({ isLoading: true });
-    const status = handle.container.querySelector<HTMLElement>(
-      '[role="status"][aria-label="Loading table"]',
+    // The aggregator table's skeleton is `presentational` (no `role`/
+    // `aria-label` — the top-traders table in `volume-table.tsx` owns the
+    // page's single live-region announcement, see that file's comment), so
+    // it's located structurally via its 36px header bar instead of ARIA
+    // attributes.
+    const status = Array.from(
+      handle.container.querySelectorAll<HTMLElement>("div"),
+    ).find(
+      (el) =>
+        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
     );
-    expect(status).not.toBeNull();
+    expect(status).not.toBeUndefined();
     const [header, body] = Array.from(status!.children) as [
       HTMLElement,
       HTMLElement,

--- a/ui-dashboard/src/app/volume/_components/__tests__/top-pools-list.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/top-pools-list.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
 import { TopPoolsList, type TopPoolsListEntry } from "../top-pools-list";
 
 let container: HTMLDivElement;
@@ -47,9 +48,14 @@ describe("TopPoolsList", () => {
       '[role="status"][aria-label="Loading pool ranking"]',
     );
     expect(status).not.toBeNull();
-    expect(status!.tagName).toBe("OL");
-    expect(status!.className).toContain("space-y-1.5");
-    const skeletonRows = Array.from(status!.children).filter(
+    // `role="status"` lives on a wrapping `<div>`, not the `<ol>` itself —
+    // an `<ol>` may only contain `<li>` elements, so the sr-only
+    // announcement text can't be a direct child of the list.
+    expect(status!.tagName).toBe("DIV");
+    const list = status!.querySelector("ol");
+    expect(list).not.toBeNull();
+    expect(list!.className).toContain("space-y-1.5");
+    const skeletonRows = Array.from(list!.children).filter(
       (child) => child.tagName === "LI",
     );
     expect(skeletonRows).toHaveLength(10);
@@ -72,6 +78,19 @@ describe("TopPoolsList", () => {
       (child) => child.tagName === "LI",
     );
     expect(loadedRows).toHaveLength(2);
+  });
+
+  it("keeps the loading <ol> valid (no direct non-<li> children) and passes axe", async () => {
+    render(
+      <TopPoolsList entries={[]} isLoading hasError={false} windowLabel="1M" />,
+    );
+    const list = container.querySelector("ol");
+    expect(list).not.toBeNull();
+    Array.from(list!.children).forEach((child) => {
+      expect(child.tagName).toBe("LI");
+    });
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
   });
 
   it("renders distinct error and empty states instead of the list skeleton", () => {

--- a/ui-dashboard/src/app/volume/_components/__tests__/top-pools-list.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/top-pools-list.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { TopPoolsList, type TopPoolsListEntry } from "../top-pools-list";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+function entry(overrides: Partial<TopPoolsListEntry> = {}): TopPoolsListEntry {
+  return {
+    poolId: "42220-0xpool",
+    name: "USDC/USDm",
+    totalUsd: 1_000,
+    share: 0.42,
+    color: "#6366f1",
+    ...overrides,
+  };
+}
+
+describe("TopPoolsList", () => {
+  it("renders a compact 10-row list placeholder while loading, matching the loaded <ol> row rhythm", () => {
+    render(
+      <TopPoolsList entries={[]} isLoading hasError={false} windowLabel="1M" />,
+    );
+    const status = container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading pool ranking"]',
+    );
+    expect(status).not.toBeNull();
+    expect(status!.tagName).toBe("OL");
+    expect(status!.className).toContain("space-y-1.5");
+    const skeletonRows = Array.from(status!.children).filter(
+      (child) => child.tagName === "LI",
+    );
+    expect(skeletonRows).toHaveLength(10);
+
+    render(
+      <TopPoolsList
+        entries={[
+          entry({}),
+          entry({ poolId: "42220-0xpool2", name: "cUSD/USDT", color: null }),
+        ]}
+        isLoading={false}
+        hasError={false}
+        windowLabel="1M"
+      />,
+    );
+    const loadedList = container.querySelector("ol");
+    expect(loadedList).not.toBeNull();
+    expect(loadedList!.className).toContain("space-y-1.5");
+    const loadedRows = Array.from(loadedList!.children).filter(
+      (child) => child.tagName === "LI",
+    );
+    expect(loadedRows).toHaveLength(2);
+  });
+
+  it("renders distinct error and empty states instead of the list skeleton", () => {
+    render(
+      <TopPoolsList entries={[]} isLoading={false} hasError windowLabel="1M" />,
+    );
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Couldn't load pool ranking.",
+    );
+    expect(container.querySelector("ol")).toBeNull();
+
+    render(
+      <TopPoolsList
+        entries={[]}
+        isLoading={false}
+        hasError={false}
+        windowLabel="1M"
+      />,
+    );
+    expect(container.textContent).toContain("No pool volume in this window.");
+    expect(container.querySelector("ol")).toBeNull();
+  });
+});

--- a/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
@@ -165,8 +165,14 @@ describe("CorridorPanel loading state", () => {
       '[role="status"][aria-label="Loading corridor map"]',
     );
     expect(status).not.toBeNull();
-    const [header] = Array.from(status!.children) as [HTMLElement];
+    const [header, body] = Array.from(status!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
     expect(header.children).toHaveLength(4);
+    // Row count matches INSIGHT_ROW_LIMIT (the corridor query's row cap) so
+    // the skeleton doesn't undershoot the common capped-query case.
+    expect(body.children).toHaveLength(10);
     teardown(handle);
 
     handle = renderInto(
@@ -220,8 +226,14 @@ describe("OutlierPanel loading state", () => {
       '[role="status"][aria-label="Loading outlier swaps"]',
     );
     expect(status).not.toBeNull();
-    const [header] = Array.from(status!.children) as [HTMLElement];
+    const [header, body] = Array.from(status!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
     expect(header.children).toHaveLength(3);
+    // Row count matches INSIGHT_ROW_LIMIT (the outlier query's row cap) so
+    // the skeleton doesn't undershoot the common capped-query case.
+    expect(body.children).toHaveLength(10);
     teardown(handle);
 
     handle = renderInto(

--- a/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
@@ -1,0 +1,251 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LpFriendliness } from "@/lib/volume-insights";
+import {
+  CohortPanel,
+  CorridorPanel,
+  OutlierPanel,
+} from "../v3-flow-insight-panels";
+
+vi.mock("@/components/address-link", () => ({
+  AddressLink: ({ address }: { address: string }) => (
+    <span data-testid="address-link">{address}</span>
+  ),
+}));
+
+vi.mock("@/components/chain-icon", () => ({
+  ChainIcon: () => <span data-testid="chain-icon" />,
+}));
+
+type Handle = {
+  container: HTMLElement;
+  root: Root;
+};
+
+function renderInto(element: React.ReactElement): Handle {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return { container, root };
+}
+
+function teardown(handle: Handle): void {
+  act(() => {
+    handle.root.unmount();
+  });
+  handle.container.remove();
+}
+
+const LP: LpFriendliness = {
+  score: 0.5,
+  ratio: 1,
+  feeRateBps: 30,
+  imbalance: 0,
+  pressureUsdWei: BigInt(0),
+  band: "balanced",
+};
+
+describe("CohortPanel loading state", () => {
+  let handle: Handle | null = null;
+
+  afterEach(() => {
+    if (handle) {
+      teardown(handle);
+      handle = null;
+    }
+  });
+
+  it("reserves the 3-stat mini grid + 3 leader rows + caption line, matching the loaded structure", () => {
+    handle = renderInto(
+      <CohortPanel
+        range="7d"
+        summary={null}
+        isLoading
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const status = handle.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading cohort comparison"]',
+    );
+    expect(status).not.toBeNull();
+    const statGrid = status!.querySelector(".grid-cols-3");
+    expect(statGrid).not.toBeNull();
+    expect(statGrid!.children).toHaveLength(3);
+    const leaderRows = status!.querySelectorAll(
+      ".flex.items-center.justify-between.gap-3",
+    );
+    expect(leaderRows).toHaveLength(3);
+    teardown(handle);
+
+    handle = renderInto(
+      <CohortPanel
+        range="7d"
+        summary={{
+          newCount: 4,
+          returningCount: 5,
+          dormantCount: 6,
+          topNewTrader: null,
+          topReturningTrader: null,
+          topDormantTrader: null,
+          currentCount: 20,
+          previousCount: 10,
+        }}
+        isLoading={false}
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const loadedGrid = handle.container.querySelector(".grid-cols-3");
+    expect(loadedGrid).not.toBeNull();
+    expect(loadedGrid!.children).toHaveLength(3);
+    const loadedLeaderRows = handle.container.querySelectorAll(
+      ".flex.items-center.justify-between.gap-3",
+    );
+    expect(loadedLeaderRows).toHaveLength(3);
+  });
+
+  it("does not reserve the mini-stat grid on the error or unbounded-range branches", () => {
+    handle = renderInto(
+      <CohortPanel
+        range="all"
+        summary={null}
+        isLoading={false}
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    expect(handle.container.querySelector(".grid-cols-3")).toBeNull();
+    teardown(handle);
+
+    handle = renderInto(
+      <CohortPanel
+        range="7d"
+        summary={null}
+        isLoading={false}
+        hasError
+        isPartial={false}
+      />,
+    );
+    expect(handle.container.querySelector(".grid-cols-3")).toBeNull();
+    expect(handle.container.querySelector('[role="alert"]')).not.toBeNull();
+  });
+});
+
+describe("CorridorPanel loading state", () => {
+  let handle: Handle | null = null;
+
+  afterEach(() => {
+    if (handle) {
+      teardown(handle);
+      handle = null;
+    }
+  });
+
+  it("renders a dense 4-column table skeleton while loading, matching the real table's column count", () => {
+    handle = renderInto(
+      <CorridorPanel
+        rows={[]}
+        pools={new Map()}
+        isLoading
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const status = handle.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading corridor map"]',
+    );
+    expect(status).not.toBeNull();
+    const [header] = Array.from(status!.children) as [HTMLElement];
+    expect(header.children).toHaveLength(4);
+    teardown(handle);
+
+    handle = renderInto(
+      <CorridorPanel
+        rows={[
+          {
+            key: "row-1",
+            chainId: 42220,
+            poolId: "42220-0xpool",
+            direction: 0,
+            traderCount: 1,
+            swapCount: 1,
+            volumeUsdWei: BigInt(0),
+            netPressureUsdWei: BigInt(0),
+            feesPaidUsdWei: BigInt(0),
+            lpFriendliness: LP,
+          },
+        ]}
+        pools={new Map()}
+        isLoading={false}
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const headerCells = handle.container.querySelectorAll("thead th");
+    expect(headerCells).toHaveLength(4);
+  });
+});
+
+describe("OutlierPanel loading state", () => {
+  let handle: Handle | null = null;
+
+  afterEach(() => {
+    if (handle) {
+      teardown(handle);
+      handle = null;
+    }
+  });
+
+  it("renders a dense 3-column table skeleton while loading, matching the real table's column count", () => {
+    handle = renderInto(
+      <OutlierPanel
+        rows={[]}
+        pools={new Map()}
+        isLoading
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const status = handle.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading outlier swaps"]',
+    );
+    expect(status).not.toBeNull();
+    const [header] = Array.from(status!.children) as [HTMLElement];
+    expect(header.children).toHaveLength(3);
+    teardown(handle);
+
+    handle = renderInto(
+      <OutlierPanel
+        rows={[
+          {
+            id: "swap-1",
+            chainId: 42220,
+            poolId: "42220-0xpool",
+            caller: "0xtrader",
+            txTo: "0xrouter",
+            recipient: "0xtrader",
+            volumeUsdWei: (BigInt(10) * BigInt(10) ** BigInt(18)).toString(),
+            txHash: `0x${"a".repeat(64)}`,
+            blockTimestamp: "1700000000",
+          },
+        ]}
+        pools={new Map()}
+        isLoading={false}
+        hasError={false}
+        isPartial={false}
+      />,
+    );
+    const headerCells = handle.container.querySelectorAll("thead th");
+    expect(headerCells).toHaveLength(3);
+  });
+});

--- a/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/v3-flow-insight-panels.test.tsx
@@ -165,7 +165,8 @@ describe("CorridorPanel loading state", () => {
       '[role="status"][aria-label="Loading corridor map"]',
     );
     expect(status).not.toBeNull();
-    const [header, body] = Array.from(status!.children) as [
+    const [header, body, caption] = Array.from(status!.children) as [
+      HTMLElement,
       HTMLElement,
       HTMLElement,
     ];
@@ -173,6 +174,15 @@ describe("CorridorPanel loading state", () => {
     // Row count matches INSIGHT_ROW_LIMIT (the corridor query's row cap) so
     // the skeleton doesn't undershoot the common capped-query case.
     expect(body.children).toHaveLength(10);
+    // Reserves a 2-line trailing-caption placeholder (mt-2 + 2x h-3 +
+    // space-y-1) matching the real "Top-query subset…" caption the loaded
+    // panel renders when isPartial && rows.length > 0 — unreserved, this
+    // undershot the loaded panel by ~46px in a live 1440x900 measurement.
+    expect(caption.className).toContain("mt-2");
+    expect(caption.children).toHaveLength(2);
+    for (const line of Array.from(caption.children)) {
+      expect((line as HTMLElement).className).toContain("h-3");
+    }
     teardown(handle);
 
     handle = renderInto(
@@ -226,7 +236,8 @@ describe("OutlierPanel loading state", () => {
       '[role="status"][aria-label="Loading outlier swaps"]',
     );
     expect(status).not.toBeNull();
-    const [header, body] = Array.from(status!.children) as [
+    const [header, body, caption] = Array.from(status!.children) as [
+      HTMLElement,
       HTMLElement,
       HTMLElement,
     ];
@@ -234,6 +245,15 @@ describe("OutlierPanel loading state", () => {
     // Row count matches INSIGHT_ROW_LIMIT (the outlier query's row cap) so
     // the skeleton doesn't undershoot the common capped-query case.
     expect(body.children).toHaveLength(10);
+    // Reserves a 2-line trailing-caption placeholder (mt-2 + 2x h-3 +
+    // space-y-1) matching the real "Top-query subset…" caption the loaded
+    // panel renders when isPartial && rows.length > 0 — unreserved, this
+    // undershot the loaded panel by ~46px in a live 1440x900 measurement.
+    expect(caption.className).toContain("mt-2");
+    expect(caption.children).toHaveLength(2);
+    for (const line of Array.from(caption.children)) {
+      expect((line as HTMLElement).className).toContain("h-3");
+    }
     teardown(handle);
 
     handle = renderInto(

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
@@ -1,0 +1,95 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/time-series-chart-card", () => ({
+  TimeSeriesChartCard: () => <div data-testid="chart" />,
+}));
+
+import { VolumeTable } from "../volume-table";
+import { AggregatorBreakdownSection } from "../aggregator-breakdown-section";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+describe("/volume client-side loading — single live region invariant", () => {
+  // The top-traders table (volume-table.tsx) and the aggregator breakdown
+  // table (aggregator-breakdown-section.tsx) are backed by independent SWR
+  // queries in V3VolumeSection/V2VolumeSection and commonly load
+  // simultaneously on first mount. Each renders a `TableSkeleton`, which is
+  // a polite live region by default — without exactly one of them opting
+  // out via `presentational`, screen readers get two competing "Loading
+  // table" announcements at once.
+  it("renders exactly one aria-live=polite region when both tables load simultaneously", () => {
+    render(
+      <>
+        <VolumeTable
+          cutoff={0}
+          traders={[]}
+          pools={new Map()}
+          emptyMessage="No traders."
+          isLoading
+          hasError={false}
+        />
+        <AggregatorBreakdownSection
+          venueLabel="v3"
+          rangeLabel="7d"
+          aggregators={[]}
+          isLoading
+          hasError={false}
+          isCapHit={false}
+        />
+      </>,
+    );
+
+    // Both table skeletons still render (a 36px header bar identifies each
+    // `TableSkeleton` root) — the fix silences one of them, it doesn't
+    // remove it.
+    const headerBars = Array.from(
+      container.querySelectorAll<HTMLElement>("div"),
+    ).filter(
+      (el) =>
+        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
+    );
+    expect(headerBars).toHaveLength(2);
+
+    // Exactly one live region — the presentational aggregator skeleton
+    // strips `role`/`aria-live`/`aria-label` entirely, so the surviving
+    // `role="status"` element and the surviving `aria-live="polite"`
+    // element must be the same node (the top-traders table).
+    const statusRegions = container.querySelectorAll('[role="status"]');
+    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
+    expect(statusRegions).toHaveLength(1);
+    expect(liveRegions).toHaveLength(1);
+    expect(statusRegions[0]).toBe(liveRegions[0]);
+    expect(liveRegions[0]?.getAttribute("aria-label")).toBe("Loading table");
+  });
+});

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
@@ -15,8 +15,14 @@ vi.mock("@/components/time-series-chart-card", () => ({
   TimeSeriesChartCard: () => <div data-testid="chart" />,
 }));
 
-import { VolumeTable } from "../volume-table";
-import { AggregatorBreakdownSection } from "../aggregator-breakdown-section";
+// V3FlowInsights runs its own SWR queries (and its panel skeletons are
+// role="status" without explicit aria-live) — out of scope for the
+// table-skeleton live-region invariant under test here.
+vi.mock("../v3-flow-insights", () => ({
+  V3FlowInsights: () => null,
+}));
+
+import { V3VolumeSection } from "../v3-volume-section";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -34,57 +40,84 @@ afterEach(() => {
   container.remove();
 });
 
-function render(element: React.ReactElement) {
+function renderSection({
+  tableIsLoading,
+  aggregatorIsLoading,
+}: {
+  tableIsLoading: boolean;
+  aggregatorIsLoading: boolean;
+}) {
   act(() => {
-    root.render(element);
+    root.render(
+      <V3VolumeSection
+        rangeLabel="7d"
+        range="7d"
+        cutoff={0}
+        filteredTraderRows={[]}
+        traders={[]}
+        pools={new Map()}
+        protocolActorFilter={[false]}
+        canUseVolumeFilters={false}
+        tableState={{
+          isLoading: tableIsLoading,
+          hasError: false,
+          isCapHit: false,
+        }}
+        aggregators={[]}
+        aggregatorState={{
+          isLoading: aggregatorIsLoading,
+          hasError: false,
+          isCapHit: false,
+        }}
+      />,
+    );
   });
 }
 
+function tableSkeletonRoots(): HTMLElement[] {
+  // A 36px header bar identifies each `TableSkeleton variant="rows"` root,
+  // presentational or not.
+  return Array.from(container.querySelectorAll<HTMLElement>("div")).filter(
+    (el) =>
+      (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
+  );
+}
+
+// The top-traders table (volume-table.tsx) and the aggregator breakdown
+// table (aggregator-breakdown-section.tsx) are backed by independent SWR
+// queries and commonly load simultaneously on first mount. Each renders a
+// `TableSkeleton`, which is a polite live region by default. The venue
+// section wires the trader table's loading state into the aggregator
+// section's `hasExternalLoadingAnnouncer` so the page has exactly one
+// announcer in every combination — never two competing live regions during
+// combined loading, and never zero while something is still loading.
 describe("/volume client-side loading — single live region invariant", () => {
-  // The top-traders table (volume-table.tsx) and the aggregator breakdown
-  // table (aggregator-breakdown-section.tsx) are backed by independent SWR
-  // queries in V3VolumeSection/V2VolumeSection and commonly load
-  // simultaneously on first mount. Each renders a `TableSkeleton`, which is
-  // a polite live region by default — without exactly one of them opting
-  // out via `presentational`, screen readers get two competing "Loading
-  // table" announcements at once.
   it("renders exactly one aria-live=polite region when both tables load simultaneously", () => {
-    render(
-      <>
-        <VolumeTable
-          cutoff={0}
-          traders={[]}
-          pools={new Map()}
-          emptyMessage="No traders."
-          isLoading
-          hasError={false}
-        />
-        <AggregatorBreakdownSection
-          venueLabel="v3"
-          rangeLabel="7d"
-          aggregators={[]}
-          isLoading
-          hasError={false}
-          isCapHit={false}
-        />
-      </>,
-    );
+    renderSection({ tableIsLoading: true, aggregatorIsLoading: true });
 
-    // Both table skeletons still render (a 36px header bar identifies each
-    // `TableSkeleton` root) — the fix silences one of them, it doesn't
+    // Both table skeletons render — the wiring silences one, it doesn't
     // remove it.
-    const headerBars = Array.from(
-      container.querySelectorAll<HTMLElement>("div"),
-    ).filter(
-      (el) =>
-        (el.firstElementChild as HTMLElement | null)?.style.height === "36px",
-    );
-    expect(headerBars).toHaveLength(2);
+    expect(tableSkeletonRoots()).toHaveLength(2);
 
-    // Exactly one live region — the presentational aggregator skeleton
+    // Exactly one live region: the presentational aggregator skeleton
     // strips `role`/`aria-live`/`aria-label` entirely, so the surviving
     // `role="status"` element and the surviving `aria-live="polite"`
     // element must be the same node (the top-traders table).
+    const statusRegions = container.querySelectorAll('[role="status"]');
+    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
+    expect(statusRegions).toHaveLength(1);
+    expect(liveRegions).toHaveLength(1);
+    expect(statusRegions[0]).toBe(liveRegions[0]);
+    expect(liveRegions[0]?.getAttribute("aria-label")).toBe("Loading table");
+  });
+
+  it("keeps a standalone-loading aggregator table announced once the trader table settles", () => {
+    renderSection({ tableIsLoading: false, aggregatorIsLoading: true });
+
+    // Only the aggregator skeleton remains (the trader table settled into
+    // its empty state) — it must announce itself now that nothing else on
+    // the page covers the loading state (codex review, PR 1242).
+    expect(tableSkeletonRoots()).toHaveLength(1);
     const statusRegions = container.querySelectorAll('[role="status"]');
     const liveRegions = container.querySelectorAll('[aria-live="polite"]');
     expect(statusRegions).toHaveLength(1);

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
@@ -256,7 +256,7 @@ describe("VolumeTable", () => {
       HTMLElement,
     ];
     expect(header.style.height).toBe("36px");
-    expect(body.children).toHaveLength(10);
+    expect(body.children).toHaveLength(18);
     Array.from(body.children).forEach((row) => {
       expect((row as HTMLElement).style.height).toBe("44px");
     });

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-table.test.tsx
@@ -245,6 +245,33 @@ describe("VolumeTable", () => {
     );
   });
 
+  it("reserves a table-shaped skeleton (header + measured row rhythm) while loading, matching the loaded table's <thead> structure", () => {
+    renderVolumeTable(handle!, { isLoading: true });
+    const status = handle!.container.querySelector<HTMLElement>(
+      '[role="status"][aria-label="Loading table"]',
+    );
+    expect(status).not.toBeNull();
+    const [header, body] = Array.from(status!.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
+    expect(header.style.height).toBe("36px");
+    expect(body.children).toHaveLength(10);
+    Array.from(body.children).forEach((row) => {
+      expect((row as HTMLElement).style.height).toBe("44px");
+    });
+
+    renderVolumeTable(handle!, {
+      isLoading: false,
+      traders: [trader({ trader: "0xaaa" })],
+    });
+    // The loaded branch is a real <table> with a <thead> — the same
+    // "header row + body rows" shape the skeleton reserves, not a
+    // generic bar stack.
+    expect(handle!.container.querySelector("thead")).not.toBeNull();
+    expect(handle!.container.querySelector("tbody")).not.toBeNull();
+  });
+
   it("sorts traders through volume URL params", () => {
     renderVolumeTable(handle!, {
       traders: [

--- a/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
@@ -42,6 +42,12 @@ export type AggregatorChartProps = {
   headline: string;
 };
 
+// The four flags are independent: loading/error/cap-hit describe this
+// section's own query, while hasExternalLoadingAnnouncer coordinates the
+// page-level live-region ownership with the sibling trader table — merging
+// them into a variant enum would couple unrelated states. Same waiver
+// rationale as VolumeOverTimeChart's independent degradation flags.
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function AggregatorBreakdownSection({
   venueLabel,
   rangeLabel,
@@ -50,6 +56,7 @@ export function AggregatorBreakdownSection({
   hasError,
   isCapHit,
   chart,
+  hasExternalLoadingAnnouncer = false,
 }: {
   venueLabel: "v3" | "v2";
   rangeLabel: string;
@@ -58,6 +65,15 @@ export function AggregatorBreakdownSection({
   hasError: boolean;
   isCapHit: boolean;
   chart?: AggregatorChartProps | undefined;
+  /** True while another element on the page is already announcing a loading
+   *  state — the venue's trader table renders a `role="status"` loading
+   *  skeleton while its own query is in flight. When true, this section's
+   *  table skeleton goes `presentational` so the page keeps exactly one
+   *  polite live region during combined loading. When the aggregator query
+   *  is the only one still loading (trader table settled or errored into a
+   *  `role="alert"`), callers must pass false so assistive tech still hears
+   *  this section's loading state (codex review, PR 1242). */
+  hasExternalLoadingAnnouncer?: boolean | undefined;
 }) {
   return (
     <section className="space-y-3">
@@ -119,6 +135,7 @@ export function AggregatorBreakdownSection({
         venueLabel={venueLabel}
         isLoading={isLoading}
         hasError={hasError}
+        hasExternalLoadingAnnouncer={hasExternalLoadingAnnouncer}
       />
     </section>
   );
@@ -130,11 +147,13 @@ function AggregatorTable({
   venueLabel,
   isLoading,
   hasError,
+  hasExternalLoadingAnnouncer,
 }: {
   aggregators: readonly AggregatorWindowRow[];
   venueLabel: "v3" | "v2";
   isLoading: boolean;
   hasError: boolean;
+  hasExternalLoadingAnnouncer: boolean;
 }) {
   const { sortKey, sortDir, handleSort } = useTableSort<AggSortKey>({
     defaultKey: "volume",
@@ -174,17 +193,19 @@ function AggregatorTable({
     );
   }
   if (isLoading) {
-    // `presentational`: this component is shared by both venue sections and
-    // always renders alongside another independently-loading table (the top
-    // traders table in `volume-table.tsx`), which owns the page's single
-    // `aria-live="polite"` announcement during combined client-side
-    // loading. Without `presentational` here, both `TableSkeleton`s would
-    // announce simultaneously — two competing live regions.
+    // Contextually presentational: while the venue's trader table is also
+    // loading, it owns the page's single `aria-live="polite"` announcement
+    // and this skeleton must stay silent (two `TableSkeleton`s announcing
+    // simultaneously = competing live regions). But when this aggregator
+    // query is the only one still loading — trader table settled or errored
+    // — this skeleton is the only remaining loading indicator and must
+    // announce itself (codex review, PR 1242). The venue sections compute
+    // `hasExternalLoadingAnnouncer` from their trader table's state.
     return (
       <TableSkeleton
         variant="rows"
         rows={AGGREGATOR_TABLE_SKELETON_ROWS}
-        presentational
+        presentational={hasExternalLoadingAnnouncer}
       />
     );
   }

--- a/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
@@ -8,7 +8,8 @@ import { Table, Row, Td, Th } from "@/components/table";
 import { SortableTh } from "@/components/sortable-th";
 import { ChainIcon } from "@/components/chain-icon";
 import { AddressLink } from "@/components/address-link";
-import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
+import { EmptyBox, ErrorBox } from "@/components/feedback";
+import { TableSkeleton } from "@/components/skeletons";
 import {
   TimeSeriesChartCard,
   type BreakdownSeries,
@@ -26,6 +27,15 @@ import type { TimeSeriesPoint, RangeKey } from "@/lib/time-series";
 import { TableSectionTitle } from "./table-section-title";
 
 const PAGE_LIMIT = 50;
+
+// Row count for the loading-phase table skeleton. Aggregator/entry-point
+// breakdowns typically resolve to a much smaller distinct-row count than
+// `PAGE_LIMIT` (50) — reserving the full cap would over-shoot the real
+// table's height on every load. 6 matches the production skeleton-parity
+// audit's measured aggregator-section delta (issue #1221). `volume/loading.tsx`'s
+// route-level fallback mirrors this same row count for its own aggregator
+// placeholder — keep both in sync if this changes.
+const AGGREGATOR_TABLE_SKELETON_ROWS = 6;
 
 const AGG_SORT_KEYS = ["volume", "swaps", "traders"] as const;
 type AggSortKey = (typeof AGG_SORT_KEYS)[number];
@@ -171,7 +181,11 @@ function AggregatorTable({
       />
     );
   }
-  if (isLoading) return <Skeleton rows={4} />;
+  if (isLoading) {
+    return (
+      <TableSkeleton variant="rows" rows={AGGREGATOR_TABLE_SKELETON_ROWS} />
+    );
+  }
   if (sorted.length === 0) {
     return (
       <EmptyBox

--- a/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/aggregator-breakdown-section.tsx
@@ -24,18 +24,10 @@ import {
 } from "@/lib/volume";
 import type { AggregatorWindowRow } from "@/lib/volume-aggregators";
 import type { TimeSeriesPoint, RangeKey } from "@/lib/time-series";
+import { AGGREGATOR_TABLE_SKELETON_ROWS } from "../_lib/skeleton-rows";
 import { TableSectionTitle } from "./table-section-title";
 
 const PAGE_LIMIT = 50;
-
-// Row count for the loading-phase table skeleton. Aggregator/entry-point
-// breakdowns typically resolve to a much smaller distinct-row count than
-// `PAGE_LIMIT` (50) — reserving the full cap would over-shoot the real
-// table's height on every load. 6 matches the production skeleton-parity
-// audit's measured aggregator-section delta (issue #1221). `volume/loading.tsx`'s
-// route-level fallback mirrors this same row count for its own aggregator
-// placeholder — keep both in sync if this changes.
-const AGGREGATOR_TABLE_SKELETON_ROWS = 6;
 
 const AGG_SORT_KEYS = ["volume", "swaps", "traders"] as const;
 type AggSortKey = (typeof AGG_SORT_KEYS)[number];
@@ -182,8 +174,18 @@ function AggregatorTable({
     );
   }
   if (isLoading) {
+    // `presentational`: this component is shared by both venue sections and
+    // always renders alongside another independently-loading table (the top
+    // traders table in `volume-table.tsx`), which owns the page's single
+    // `aria-live="polite"` announcement during combined client-side
+    // loading. Without `presentational` here, both `TableSkeleton`s would
+    // announce simultaneously — two competing live regions.
     return (
-      <TableSkeleton variant="rows" rows={AGGREGATOR_TABLE_SKELETON_ROWS} />
+      <TableSkeleton
+        variant="rows"
+        rows={AGGREGATOR_TABLE_SKELETON_ROWS}
+        presentational
+      />
     );
   }
   if (sorted.length === 0) {

--- a/ui-dashboard/src/app/volume/_components/top-pools-list.tsx
+++ b/ui-dashboard/src/app/volume/_components/top-pools-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Skeleton, ErrorBox, EmptyBox } from "@/components/feedback";
+import { ErrorBox, EmptyBox } from "@/components/feedback";
 import { formatUSD } from "@/lib/format";
 
 export type TopPoolsListEntry = {
@@ -64,7 +64,7 @@ export function TopPoolsList({
       {hasError ? (
         <ErrorBox message="Couldn't load pool ranking." />
       ) : isLoading ? (
-        <Skeleton rows={10} />
+        <TopPoolsListSkeleton />
       ) : entries.length === 0 ? (
         <EmptyBox message="No pool volume in this window." />
       ) : (
@@ -99,5 +99,30 @@ export function TopPoolsList({
         </ol>
       )}
     </section>
+  );
+}
+
+// Real rows are dense (~26px incl. the `space-y-1.5` gap) — matched here
+// with a fixed-height `li` per row instead of the old generic `h-10`
+// (40px) bar stack, which reserved ~2x the real list's height and produced
+// the "350px-wide bars materializing at the right edge during load" jump
+// measured in the production skeleton-parity audit (issue #1221).
+const TOP_POOLS_SKELETON_ROWS = 10;
+
+function TopPoolsListSkeleton() {
+  return (
+    <ol className="space-y-1.5" role="status" aria-label="Loading pool ranking">
+      {Array.from({ length: TOP_POOLS_SKELETON_ROWS }, (_, i) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <li key={`top-pools-skel-${i}`} className="flex h-5 items-center gap-2">
+          <span className="h-2.5 w-5 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
+          <span className="h-2 w-2 flex-shrink-0 animate-pulse rounded-sm bg-slate-800/50" />
+          <span className="h-2.5 flex-1 animate-pulse rounded bg-slate-800/50" />
+          <span className="ml-auto h-2.5 w-12 flex-shrink-0 animate-pulse rounded bg-slate-800/50" />
+          <span className="h-2.5 w-8 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
+        </li>
+      ))}
+      <span className="sr-only">Loading…</span>
+    </ol>
   );
 }

--- a/ui-dashboard/src/app/volume/_components/top-pools-list.tsx
+++ b/ui-dashboard/src/app/volume/_components/top-pools-list.tsx
@@ -109,20 +109,31 @@ export function TopPoolsList({
 // measured in the production skeleton-parity audit (issue #1221).
 const TOP_POOLS_SKELETON_ROWS = 10;
 
+// `role="status"` + the sr-only announcement text live on a wrapping `<div>`
+// rather than on the `<ol>` itself — an `<ol>` may only contain `<li>` (or
+// script-supporting) elements, so a direct `sr-only` `<span>` child would be
+// invalid HTML. Matches the `CohortPanelSkeleton`/`InsightTableSkeleton`
+// pattern in `v3-flow-insight-panels.tsx`, which wrap their content in a
+// `<div>` for the same reason.
 function TopPoolsListSkeleton() {
   return (
-    <ol className="space-y-1.5" role="status" aria-label="Loading pool ranking">
-      {Array.from({ length: TOP_POOLS_SKELETON_ROWS }, (_, i) => (
-        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-        <li key={`top-pools-skel-${i}`} className="flex h-5 items-center gap-2">
-          <span className="h-2.5 w-5 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
-          <span className="h-2 w-2 flex-shrink-0 animate-pulse rounded-sm bg-slate-800/50" />
-          <span className="h-2.5 flex-1 animate-pulse rounded bg-slate-800/50" />
-          <span className="ml-auto h-2.5 w-12 flex-shrink-0 animate-pulse rounded bg-slate-800/50" />
-          <span className="h-2.5 w-8 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
-        </li>
-      ))}
+    <div role="status" aria-label="Loading pool ranking">
+      <ol className="space-y-1.5">
+        {Array.from({ length: TOP_POOLS_SKELETON_ROWS }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <li
+            key={`top-pools-skel-${i}`}
+            className="flex h-5 items-center gap-2"
+          >
+            <span className="h-2.5 w-5 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
+            <span className="h-2 w-2 flex-shrink-0 animate-pulse rounded-sm bg-slate-800/50" />
+            <span className="h-2.5 flex-1 animate-pulse rounded bg-slate-800/50" />
+            <span className="ml-auto h-2.5 w-12 flex-shrink-0 animate-pulse rounded bg-slate-800/50" />
+            <span className="h-2.5 w-8 flex-shrink-0 animate-pulse rounded bg-slate-800/40" />
+          </li>
+        ))}
+      </ol>
       <span className="sr-only">Loading…</span>
-    </ol>
+    </div>
   );
 }

--- a/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
@@ -85,6 +85,13 @@ export function V2VolumeSection({
         isLoading={v2AggIsLoading}
         hasError={v2AggHasError}
         isCapHit={isV2AggregatorCapHit}
+        // While the v2 trader table above is loading it renders a
+        // role="status" skeleton that announces for the page, so the
+        // aggregator skeleton stays presentational; once the trader table
+        // settles (or errors into a role="alert" — V2VolumeTraderTable
+        // checks error before loading), the aggregator skeleton must
+        // announce its own still-loading state.
+        hasExternalLoadingAnnouncer={tableIsLoading && !tableHasError}
       />
     </>
   );

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -259,10 +259,10 @@ function CohortPanelSkeleton() {
 // both tables are usually query-capped (`isPartial`), which also renders a
 // trailing warning line below the table. `INSIGHT_PANEL_SKELETON_ROWS`
 // mirrors the cap so the skeleton doesn't undershoot the loaded table on the
-// (common) capped path. The row rhythm (`py-3.5` + `h-3`, ~40px) intentionally
-// runs a few px above the measured real row height (~36-37px) to absorb that
-// conditional warning line without needing a separate reserved element for
-// it — real rows are denser than the shared `TableSkeleton`'s 36px/44px
+// (common) capped path. The row rhythm (`py-3` + `h-3`, 36px) matches the
+// measured real row height (~36-37px) so an uncapped result (fewer than 10
+// rows, no trailing warning line) doesn't overshoot the loaded panel either —
+// real rows are denser than the shared `TableSkeleton`'s 36px/44px
 // main-table geometry, so this stays a local skeleton rather than reusing
 // that primitive.
 const INSIGHT_PANEL_SKELETON_ROWS = 10;
@@ -288,7 +288,7 @@ function InsightTableSkeleton({
       <div className="divide-y divide-slate-800/40">
         {Array.from({ length: INSIGHT_PANEL_SKELETON_ROWS }, (_, rowIdx) => (
           // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-3.5">
+          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-3">
             {Array.from({ length: cols }, (_, colIdx) => (
               // react-doctor-disable-next-line react-doctor/no-array-index-as-key
               <div

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { AddressLink } from "@/components/address-link";
 import { ChainIcon } from "@/components/chain-icon";
 import { formatUSD, relativeTime } from "@/lib/format";
@@ -17,6 +16,14 @@ import { networkForChainId } from "@/lib/networks";
 import { explorerTxUrl, poolName } from "@/lib/tokens";
 import type { PoolMeta } from "../_lib/types";
 import { LpFriendlinessBadge } from "./lp-friendliness-badge";
+// Panel chrome + loading skeletons live in their own module so the route
+// fallback (`../loading.tsx`) can render this exact loading composition —
+// geometry derivations documented in v3-flow-insight-skeletons.tsx.
+import {
+  CohortPanelSkeleton,
+  InsightPanel,
+  InsightTableSkeleton,
+} from "./v3-flow-insight-skeletons";
 
 export function CohortPanel({
   range,
@@ -196,133 +203,6 @@ export function OutlierPanel({
         </div>
       )}
     </InsightPanel>
-  );
-}
-
-function InsightPanel({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
-      <h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
-        {title}
-      </h3>
-      {children}
-    </div>
-  );
-}
-
-// Mirrors CohortPanel's loaded shape (3-stat mini grid + 3 leader rows +
-// caption line) so the section doesn't grow when the query resolves — the
-// old `<Skeleton rows={4} />` (4 generic 40px bars) undershot the real
-// content by roughly half.
-function CohortPanelSkeleton() {
-  return (
-    <div
-      className="space-y-4"
-      role="status"
-      aria-label="Loading cohort comparison"
-    >
-      <div className="grid grid-cols-3 gap-2">
-        {Array.from({ length: 3 }, (_, i) => (
-          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`cohort-skel-stat-${i}`} className="min-w-0">
-            <div className="h-[11px] w-10 animate-pulse rounded bg-slate-800/50" />
-            <div className="mt-1 h-[18px] w-8 animate-pulse rounded bg-slate-800/50" />
-          </div>
-        ))}
-      </div>
-      <div className="space-y-2 text-xs">
-        {Array.from({ length: 3 }, (_, i) => (
-          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div
-            key={`cohort-skel-leader-${i}`}
-            className="flex items-center justify-between gap-3"
-          >
-            <div className="h-3 w-16 animate-pulse rounded bg-slate-800/40" />
-            <div className="h-3 w-28 animate-pulse rounded bg-slate-800/40" />
-          </div>
-        ))}
-      </div>
-      <div className="h-[11px] w-40 animate-pulse rounded bg-slate-800/40" />
-      <span className="sr-only">Loading…</span>
-    </div>
-  );
-}
-
-// Corridor/outlier queries cap at 10 rows (`INSIGHT_ROW_LIMIT` in
-// `v3-flow-insights.tsx`), and that cap is the common case in production —
-// both tables are usually query-capped (`isPartial`), which also renders a
-// trailing "Top-query subset…" caption below the table. `INSIGHT_PANEL_SKELETON_ROWS`
-// mirrors the cap so the skeleton doesn't undershoot the loaded table on the
-// (common) capped path. The row rhythm (`py-3` + `h-3`, 36px) matches the
-// measured real row height (~36-37px) so an uncapped result (fewer than 10
-// rows, no trailing warning line) doesn't overshoot the loaded panel either —
-// real rows are denser than the shared `TableSkeleton`'s 36px/44px
-// main-table geometry, so this stays a local skeleton rather than reusing
-// that primitive.
-//
-// A live measurement (2026-07-13, 1440x900, production build/data) with the
-// row rhythm above already in place still showed the flow-insights section
-// growing 496px -> 542px (+46px) between the SWR-loading and loaded phases,
-// isolating the remaining gap to that trailing caption paragraph
-// (`pt-2 text-[11px]`), which this skeleton didn't reserve at all. Its
-// column (~421px wide inside the xl:grid-cols-3 layout, minus the panel's
-// p-4 padding) is narrow relative to the longer outlier caption text
-// ("Top-query subset; eligible outliers beyond the fetch cap may be
-// absent.", ~68 chars), so it can wrap to 2 lines. The reserved placeholder
-// below always renders 2 lines (`mt-2` + 2x `h-3` + `space-y-1` =
-// 8 + 12 + 4 + 12 = 36px): 496 + 36 = 532, a 10px gap against the measured
-// 542px loaded height (within the ±24px parity bar), with margin on both
-// sides for measurement noise.
-const INSIGHT_PANEL_SKELETON_ROWS = 10;
-
-function InsightTableSkeleton({
-  cols,
-  label,
-}: {
-  cols: number;
-  label: string;
-}) {
-  return (
-    <div role="status" aria-label={label}>
-      <div className="flex gap-3 border-b border-slate-800 py-2.5">
-        {Array.from({ length: cols }, (_, i) => (
-          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div
-            key={`insight-skel-th-${i}`}
-            className="h-3 flex-1 animate-pulse rounded bg-slate-800/50"
-          />
-        ))}
-      </div>
-      <div className="divide-y divide-slate-800/40">
-        {Array.from({ length: INSIGHT_PANEL_SKELETON_ROWS }, (_, rowIdx) => (
-          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-3">
-            {Array.from({ length: cols }, (_, colIdx) => (
-              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-              <div
-                key={`insight-skel-cell-${rowIdx}-${colIdx}`}
-                className="h-3 flex-1 animate-pulse rounded bg-slate-800/40"
-              />
-            ))}
-          </div>
-        ))}
-      </div>
-      {/* Reserves the trailing "Top-query subset…" caption both panels
-          render when isPartial && rows.length > 0 — the common capped case
-          (see INSIGHT_PANEL_SKELETON_ROWS above), reserved unconditionally
-          since this skeleton has no isPartial input of its own. */}
-      <div className="mt-2 space-y-1">
-        <div className="h-3 w-full animate-pulse rounded bg-slate-800/40" />
-        <div className="h-3 w-2/3 animate-pulse rounded bg-slate-800/40" />
-      </div>
-      <span className="sr-only">Loading…</span>
-    </div>
   );
 }
 

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -254,13 +254,18 @@ function CohortPanelSkeleton() {
   );
 }
 
-// Corridor/outlier row rhythm is `py-2` + `text-xs` (~28px including the
-// header) — much denser than the shared `TableSkeleton`'s measured 36px/44px
+// Corridor/outlier queries cap at 10 rows (`INSIGHT_ROW_LIMIT` in
+// `v3-flow-insights.tsx`), and that cap is the common case in production —
+// both tables are usually query-capped (`isPartial`), which also renders a
+// trailing warning line below the table. `INSIGHT_PANEL_SKELETON_ROWS`
+// mirrors the cap so the skeleton doesn't undershoot the loaded table on the
+// (common) capped path. The row rhythm (`py-3.5` + `h-3`, ~40px) intentionally
+// runs a few px above the measured real row height (~36-37px) to absorb that
+// conditional warning line without needing a separate reserved element for
+// it — real rows are denser than the shared `TableSkeleton`'s 36px/44px
 // main-table geometry, so this stays a local skeleton rather than reusing
-// that primitive. `INSIGHT_PANEL_SKELETON_ROWS` approximates the panel's
-// typical row count (queries cap at 10 — `INSIGHT_ROW_LIMIT` in
-// `v3-flow-insights.tsx` — but real windows usually resolve fewer).
-const INSIGHT_PANEL_SKELETON_ROWS = 6;
+// that primitive.
+const INSIGHT_PANEL_SKELETON_ROWS = 10;
 
 function InsightTableSkeleton({
   cols,
@@ -271,7 +276,7 @@ function InsightTableSkeleton({
 }) {
   return (
     <div role="status" aria-label={label}>
-      <div className="flex gap-3 border-b border-slate-800 py-2">
+      <div className="flex gap-3 border-b border-slate-800 py-2.5">
         {Array.from({ length: cols }, (_, i) => (
           // react-doctor-disable-next-line react-doctor/no-array-index-as-key
           <div
@@ -283,7 +288,7 @@ function InsightTableSkeleton({
       <div className="divide-y divide-slate-800/40">
         {Array.from({ length: INSIGHT_PANEL_SKELETON_ROWS }, (_, rowIdx) => (
           // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-2">
+          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-3.5">
             {Array.from({ length: cols }, (_, colIdx) => (
               // react-doctor-disable-next-line react-doctor/no-array-index-as-key
               <div

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -257,7 +257,7 @@ function CohortPanelSkeleton() {
 // Corridor/outlier queries cap at 10 rows (`INSIGHT_ROW_LIMIT` in
 // `v3-flow-insights.tsx`), and that cap is the common case in production —
 // both tables are usually query-capped (`isPartial`), which also renders a
-// trailing warning line below the table. `INSIGHT_PANEL_SKELETON_ROWS`
+// trailing "Top-query subset…" caption below the table. `INSIGHT_PANEL_SKELETON_ROWS`
 // mirrors the cap so the skeleton doesn't undershoot the loaded table on the
 // (common) capped path. The row rhythm (`py-3` + `h-3`, 36px) matches the
 // measured real row height (~36-37px) so an uncapped result (fewer than 10
@@ -265,6 +265,20 @@ function CohortPanelSkeleton() {
 // real rows are denser than the shared `TableSkeleton`'s 36px/44px
 // main-table geometry, so this stays a local skeleton rather than reusing
 // that primitive.
+//
+// A live measurement (2026-07-13, 1440x900, production build/data) with the
+// row rhythm above already in place still showed the flow-insights section
+// growing 496px -> 542px (+46px) between the SWR-loading and loaded phases,
+// isolating the remaining gap to that trailing caption paragraph
+// (`pt-2 text-[11px]`), which this skeleton didn't reserve at all. Its
+// column (~421px wide inside the xl:grid-cols-3 layout, minus the panel's
+// p-4 padding) is narrow relative to the longer outlier caption text
+// ("Top-query subset; eligible outliers beyond the fetch cap may be
+// absent.", ~68 chars), so it can wrap to 2 lines. The reserved placeholder
+// below always renders 2 lines (`mt-2` + 2x `h-3` + `space-y-1` =
+// 8 + 12 + 4 + 12 = 36px): 496 + 36 = 532, a 10px gap against the measured
+// 542px loaded height (within the ±24px parity bar), with margin on both
+// sides for measurement noise.
 const INSIGHT_PANEL_SKELETON_ROWS = 10;
 
 function InsightTableSkeleton({
@@ -298,6 +312,14 @@ function InsightTableSkeleton({
             ))}
           </div>
         ))}
+      </div>
+      {/* Reserves the trailing "Top-query subset…" caption both panels
+          render when isPartial && rows.length > 0 — the common capped case
+          (see INSIGHT_PANEL_SKELETON_ROWS above), reserved unconditionally
+          since this skeleton has no isPartial input of its own. */}
+      <div className="mt-2 space-y-1">
+        <div className="h-3 w-full animate-pulse rounded bg-slate-800/40" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-slate-800/40" />
       </div>
       <span className="sr-only">Loading…</span>
     </div>

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-panels.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { AddressLink } from "@/components/address-link";
 import { ChainIcon } from "@/components/chain-icon";
-import { Skeleton } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
   weiToUsd,
@@ -42,7 +41,7 @@ export function CohortPanel({
           message="Couldn't load cohort comparison."
         />
       ) : isLoading || !summary ? (
-        <Skeleton rows={4} />
+        <CohortPanelSkeleton />
       ) : (
         <div className="space-y-4">
           <div className="grid grid-cols-3 gap-2">
@@ -87,7 +86,7 @@ export function CorridorPanel({
       {hasError ? (
         <PanelMessage variant="error" message="Couldn't load corridor flows." />
       ) : isLoading ? (
-        <Skeleton rows={4} />
+        <InsightTableSkeleton cols={4} label="Loading corridor map" />
       ) : isPartial && rows.length === 0 ? (
         <PanelMessage
           variant="warn"
@@ -149,7 +148,7 @@ export function OutlierPanel({
       {hasError ? (
         <PanelMessage variant="error" message="Couldn't load outlier swaps." />
       ) : isLoading ? (
-        <Skeleton rows={4} />
+        <InsightTableSkeleton cols={3} label="Loading outlier swaps" />
       ) : isPartial && rows.length === 0 ? (
         <PanelMessage
           variant="warn"
@@ -213,6 +212,89 @@ function InsightPanel({
         {title}
       </h3>
       {children}
+    </div>
+  );
+}
+
+// Mirrors CohortPanel's loaded shape (3-stat mini grid + 3 leader rows +
+// caption line) so the section doesn't grow when the query resolves — the
+// old `<Skeleton rows={4} />` (4 generic 40px bars) undershot the real
+// content by roughly half.
+function CohortPanelSkeleton() {
+  return (
+    <div
+      className="space-y-4"
+      role="status"
+      aria-label="Loading cohort comparison"
+    >
+      <div className="grid grid-cols-3 gap-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`cohort-skel-stat-${i}`} className="min-w-0">
+            <div className="h-[11px] w-10 animate-pulse rounded bg-slate-800/50" />
+            <div className="mt-1 h-[18px] w-8 animate-pulse rounded bg-slate-800/50" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2 text-xs">
+        {Array.from({ length: 3 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`cohort-skel-leader-${i}`}
+            className="flex items-center justify-between gap-3"
+          >
+            <div className="h-3 w-16 animate-pulse rounded bg-slate-800/40" />
+            <div className="h-3 w-28 animate-pulse rounded bg-slate-800/40" />
+          </div>
+        ))}
+      </div>
+      <div className="h-[11px] w-40 animate-pulse rounded bg-slate-800/40" />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
+// Corridor/outlier row rhythm is `py-2` + `text-xs` (~28px including the
+// header) — much denser than the shared `TableSkeleton`'s measured 36px/44px
+// main-table geometry, so this stays a local skeleton rather than reusing
+// that primitive. `INSIGHT_PANEL_SKELETON_ROWS` approximates the panel's
+// typical row count (queries cap at 10 — `INSIGHT_ROW_LIMIT` in
+// `v3-flow-insights.tsx` — but real windows usually resolve fewer).
+const INSIGHT_PANEL_SKELETON_ROWS = 6;
+
+function InsightTableSkeleton({
+  cols,
+  label,
+}: {
+  cols: number;
+  label: string;
+}) {
+  return (
+    <div role="status" aria-label={label}>
+      <div className="flex gap-3 border-b border-slate-800 py-2">
+        {Array.from({ length: cols }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`insight-skel-th-${i}`}
+            className="h-3 flex-1 animate-pulse rounded bg-slate-800/50"
+          />
+        ))}
+      </div>
+      <div className="divide-y divide-slate-800/40">
+        {Array.from({ length: INSIGHT_PANEL_SKELETON_ROWS }, (_, rowIdx) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-2">
+            {Array.from({ length: cols }, (_, colIdx) => (
+              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+              <div
+                key={`insight-skel-cell-${rowIdx}-${colIdx}`}
+                className="h-3 flex-1 animate-pulse rounded bg-slate-800/40"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+      <span className="sr-only">Loading…</span>
     </div>
   );
 }

--- a/ui-dashboard/src/app/volume/_components/v3-flow-insight-skeletons.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-flow-insight-skeletons.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared chrome + loading skeletons for the flow-insight panels.
+ *
+ * Lives in its own module (rather than inside `v3-flow-insight-panels.tsx`)
+ * so the Server Component route fallback (`../loading.tsx`) can render the
+ * exact same loading composition the client's `V3FlowInsights` panels
+ * render, without dragging the loaded-panel dependencies (`AddressLink`,
+ * `ChainIcon`, token/network libs) into the fallback's server bundle —
+ * same split rationale as `../_lib/skeleton-rows.ts`. Sharing the
+ * components (instead of hand-mirroring measured heights in the fallback)
+ * keeps the fallback→client handoff structurally identical at every
+ * breakpoint, including below `xl` where the panel grid stacks and each
+ * panel reserves its real intrinsic height (codex review, PR 1242).
+ *
+ * The skeletons announce themselves (`role="status"`) by default — the
+ * client renders them standalone. The route fallback passes
+ * `presentational` because its root already wraps the whole page in a
+ * single polite live region (same convention as `TableSkeleton` in
+ * `@/components/skeletons`).
+ */
+
+type InsightSkeletonAriaProps = {
+  presentational?: boolean | undefined;
+};
+
+function statusRegion(
+  label: string,
+  presentational: boolean | undefined,
+): Record<string, string> {
+  if (presentational) return {};
+  return { role: "status", "aria-label": label };
+}
+
+export function InsightPanel({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+      <h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+// Mirrors CohortPanel's loaded shape (3-stat mini grid + 3 leader rows +
+// caption line) so the section doesn't grow when the query resolves — the
+// old `<Skeleton rows={4} />` (4 generic 40px bars) undershot the real
+// content by roughly half.
+export function CohortPanelSkeleton({
+  presentational,
+}: InsightSkeletonAriaProps) {
+  return (
+    <div
+      className="space-y-4"
+      {...statusRegion("Loading cohort comparison", presentational)}
+    >
+      <div className="grid grid-cols-3 gap-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`cohort-skel-stat-${i}`} className="min-w-0">
+            <div className="h-[11px] w-10 animate-pulse rounded bg-slate-800/50" />
+            <div className="mt-1 h-[18px] w-8 animate-pulse rounded bg-slate-800/50" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2 text-xs">
+        {Array.from({ length: 3 }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`cohort-skel-leader-${i}`}
+            className="flex items-center justify-between gap-3"
+          >
+            <div className="h-3 w-16 animate-pulse rounded bg-slate-800/40" />
+            <div className="h-3 w-28 animate-pulse rounded bg-slate-800/40" />
+          </div>
+        ))}
+      </div>
+      <div className="h-[11px] w-40 animate-pulse rounded bg-slate-800/40" />
+      {!presentational && <span className="sr-only">Loading…</span>}
+    </div>
+  );
+}
+
+// Corridor/outlier queries cap at 10 rows (`INSIGHT_ROW_LIMIT` in
+// `v3-flow-insights.tsx`), and that cap is the common case in production —
+// both tables are usually query-capped (`isPartial`), which also renders a
+// trailing "Top-query subset…" caption below the table. `INSIGHT_PANEL_SKELETON_ROWS`
+// mirrors the cap so the skeleton doesn't undershoot the loaded table on the
+// (common) capped path. The row rhythm (`py-3` + `h-3`, 36px) matches the
+// measured real row height (~36-37px) so an uncapped result (fewer than 10
+// rows, no trailing warning line) doesn't overshoot the loaded panel either —
+// real rows are denser than the shared `TableSkeleton`'s 36px/44px
+// main-table geometry, so this stays a local skeleton rather than reusing
+// that primitive.
+//
+// A live measurement (2026-07-13, 1440x900, production build/data) with the
+// row rhythm above already in place still showed the flow-insights section
+// growing 496px -> 542px (+46px) between the SWR-loading and loaded phases,
+// isolating the remaining gap to that trailing caption paragraph
+// (`pt-2 text-[11px]`), which this skeleton didn't reserve at all. Its
+// column (~421px wide inside the xl:grid-cols-3 layout, minus the panel's
+// p-4 padding) is narrow relative to the longer outlier caption text
+// ("Top-query subset; eligible outliers beyond the fetch cap may be
+// absent.", ~68 chars), so it can wrap to 2 lines. The reserved placeholder
+// below always renders 2 lines (`mt-2` + 2x `h-3` + `space-y-1` =
+// 8 + 12 + 4 + 12 = 36px): 496 + 36 = 532, a 10px gap against the measured
+// 542px loaded height (within the ±24px parity bar), with margin on both
+// sides for measurement noise.
+const INSIGHT_PANEL_SKELETON_ROWS = 10;
+
+export function InsightTableSkeleton({
+  cols,
+  label,
+  presentational,
+}: {
+  cols: number;
+  label: string;
+} & InsightSkeletonAriaProps) {
+  return (
+    <div {...statusRegion(label, presentational)}>
+      <div className="flex gap-3 border-b border-slate-800 py-2.5">
+        {Array.from({ length: cols }, (_, i) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div
+            key={`insight-skel-th-${i}`}
+            className="h-3 flex-1 animate-pulse rounded bg-slate-800/50"
+          />
+        ))}
+      </div>
+      <div className="divide-y divide-slate-800/40">
+        {Array.from({ length: INSIGHT_PANEL_SKELETON_ROWS }, (_, rowIdx) => (
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <div key={`insight-skel-row-${rowIdx}`} className="flex gap-3 py-3">
+            {Array.from({ length: cols }, (_, colIdx) => (
+              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+              <div
+                key={`insight-skel-cell-${rowIdx}-${colIdx}`}
+                className="h-3 flex-1 animate-pulse rounded bg-slate-800/40"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+      {/* Reserves the trailing "Top-query subset…" caption both panels
+          render when isPartial && rows.length > 0 — the common capped case
+          (see INSIGHT_PANEL_SKELETON_ROWS above), reserved unconditionally
+          since this skeleton has no isPartial input of its own. */}
+      <div className="mt-2 space-y-1">
+        <div className="h-3 w-full animate-pulse rounded bg-slate-800/40" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-slate-800/40" />
+      </div>
+      {!presentational && <span className="sr-only">Loading…</span>}
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
@@ -94,6 +94,14 @@ export function V3VolumeSection({
         hasError={aggregatorState.hasError}
         isCapHit={aggregatorState.isCapHit}
         chart={chart}
+        // While the top-traders VolumeTable above is loading it renders the
+        // page's single polite live region, so the aggregator skeleton stays
+        // presentational; once the trader table settles (or errors into a
+        // role="alert" — VolumeTable checks error before loading), the
+        // aggregator skeleton must announce its own still-loading state.
+        hasExternalLoadingAnnouncer={
+          tableState.isLoading && !tableState.hasError
+        }
       />
     </>
   );

--- a/ui-dashboard/src/app/volume/_components/volume-table.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-table.tsx
@@ -104,14 +104,16 @@ export function VolumeTable({
     // `TOP_TRADERS_TABLE_SKELETON_ROWS` in `../_lib/skeleton-rows.ts` for the
     // row-count derivation.
     //
-    // This is the sole `aria-live="polite"` announcer for the /volume
-    // client-side loading state: both this table and the aggregator
-    // breakdown table below it (`aggregator-breakdown-section.tsx`) load
-    // from independent SWR queries and can be loading simultaneously.
-    // `TableSkeleton` renders `role="status" aria-live="polite"` by default,
-    // so if both stayed non-presentational, two live regions would announce
-    // at once. The aggregator table's skeleton passes `presentational` to
-    // stay silent — keep this one as the single owner if either changes.
+    // While this skeleton renders it is the page's `aria-live="polite"`
+    // announcer: both this table and the aggregator breakdown table below
+    // it (`aggregator-breakdown-section.tsx`) load from independent SWR
+    // queries and can be loading simultaneously. `TableSkeleton` renders
+    // `role="status" aria-live="polite"` by default, so if both stayed
+    // non-presentational, two live regions would announce at once. The
+    // venue sections feed this table's loading state into the aggregator
+    // section's `hasExternalLoadingAnnouncer` prop, which silences the
+    // aggregator skeleton only while this one is announcing — once this
+    // table settles, a still-loading aggregator skeleton announces itself.
     return (
       <TableSkeleton variant="rows" rows={TOP_TRADERS_TABLE_SKELETON_ROWS} />
     );

--- a/ui-dashboard/src/app/volume/_components/volume-table.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-table.tsx
@@ -7,6 +7,7 @@ import { SortableTh } from "@/components/sortable-th";
 import { ChainIcon } from "@/components/chain-icon";
 import { AddressLink } from "@/components/address-link";
 import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
+import { TableSkeleton } from "@/components/skeletons";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateTraderPoolsByWindow,
@@ -97,7 +98,13 @@ export function VolumeTable({
   }
 
   if (isLoading) {
-    return <Skeleton rows={10} />;
+    // Table-shaped (header + measured row rhythm), not a generic bar stack —
+    // the real table always renders a <thead>. Row count is a fixed
+    // approximation of the first page, not `PAGE_LIMIT`: a client-fetched
+    // table can't know the real row count before the query resolves, and
+    // over-reserving to the 20-row cap would itself introduce a jump on
+    // windows with fewer traders.
+    return <TableSkeleton variant="rows" rows={10} />;
   }
 
   if (sorted.length === 0) {

--- a/ui-dashboard/src/app/volume/_components/volume-table.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-table.tsx
@@ -34,6 +34,23 @@ const VALID_KEYS = new Set<SortKey>(SORT_KEYS);
 
 const PAGE_LIMIT = 20;
 
+// Row count for the loading-phase table skeleton. The default (7d, v3) view
+// consistently fills to `PAGE_LIMIT` in production (verified via a live
+// monitoring.mento.org measurement, 2026-07-13: 20 rows, thead 45px, each
+// row 40px -> 845px real table height). `TableSkeleton`'s generic per-row
+// geometry (36px header + 44px/row, calibrated off other tables) doesn't
+// match this table's real rhythm exactly, so reserving all 20 rows
+// overshoots (36 + 20*44 = 916px, +71px vs the 845px measurement). 18 rows
+// (36 + 18*44 = 828px) lands within 24px of the measured full-page case —
+// the closest achievable parity without editing the shared skeleton
+// primitive's fixed row height. Windows with fewer than ~18 active traders
+// will still shrink on load; that's an accepted tradeoff for a
+// client-fetched table that can't know the real count before the query
+// resolves. `volume/loading.tsx`'s route-level fallback mirrors this same
+// row count for its own top-traders placeholder — keep both in sync if this
+// changes.
+const TOP_TRADERS_TABLE_SKELETON_ROWS = 18;
+
 export function VolumeTable({
   cutoff,
   traders,
@@ -99,12 +116,11 @@ export function VolumeTable({
 
   if (isLoading) {
     // Table-shaped (header + measured row rhythm), not a generic bar stack —
-    // the real table always renders a <thead>. Row count is a fixed
-    // approximation of the first page, not `PAGE_LIMIT`: a client-fetched
-    // table can't know the real row count before the query resolves, and
-    // over-reserving to the 20-row cap would itself introduce a jump on
-    // windows with fewer traders.
-    return <TableSkeleton variant="rows" rows={10} />;
+    // the real table always renders a <thead>. See
+    // `TOP_TRADERS_TABLE_SKELETON_ROWS` above for the row-count derivation.
+    return (
+      <TableSkeleton variant="rows" rows={TOP_TRADERS_TABLE_SKELETON_ROWS} />
+    );
   }
 
   if (sorted.length === 0) {

--- a/ui-dashboard/src/app/volume/_components/volume-table.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-table.tsx
@@ -24,6 +24,7 @@ import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
 import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/volume";
 import { TraderPoolDailyForTraderSchema } from "@/lib/queries/volume-schemas";
+import { TOP_TRADERS_TABLE_SKELETON_ROWS } from "../_lib/skeleton-rows";
 import { FlowBadge } from "./flow-badge";
 import { LpFriendlinessBadge } from "./lp-friendliness-badge";
 import { ProtocolActorChip } from "./protocol-actor-chip";
@@ -33,23 +34,6 @@ type SortKey = (typeof SORT_KEYS)[number];
 const VALID_KEYS = new Set<SortKey>(SORT_KEYS);
 
 const PAGE_LIMIT = 20;
-
-// Row count for the loading-phase table skeleton. The default (7d, v3) view
-// consistently fills to `PAGE_LIMIT` in production (verified via a live
-// monitoring.mento.org measurement, 2026-07-13: 20 rows, thead 45px, each
-// row 40px -> 845px real table height). `TableSkeleton`'s generic per-row
-// geometry (36px header + 44px/row, calibrated off other tables) doesn't
-// match this table's real rhythm exactly, so reserving all 20 rows
-// overshoots (36 + 20*44 = 916px, +71px vs the 845px measurement). 18 rows
-// (36 + 18*44 = 828px) lands within 24px of the measured full-page case —
-// the closest achievable parity without editing the shared skeleton
-// primitive's fixed row height. Windows with fewer than ~18 active traders
-// will still shrink on load; that's an accepted tradeoff for a
-// client-fetched table that can't know the real count before the query
-// resolves. `volume/loading.tsx`'s route-level fallback mirrors this same
-// row count for its own top-traders placeholder — keep both in sync if this
-// changes.
-const TOP_TRADERS_TABLE_SKELETON_ROWS = 18;
 
 export function VolumeTable({
   cutoff,
@@ -117,7 +101,17 @@ export function VolumeTable({
   if (isLoading) {
     // Table-shaped (header + measured row rhythm), not a generic bar stack —
     // the real table always renders a <thead>. See
-    // `TOP_TRADERS_TABLE_SKELETON_ROWS` above for the row-count derivation.
+    // `TOP_TRADERS_TABLE_SKELETON_ROWS` in `../_lib/skeleton-rows.ts` for the
+    // row-count derivation.
+    //
+    // This is the sole `aria-live="polite"` announcer for the /volume
+    // client-side loading state: both this table and the aggregator
+    // breakdown table below it (`aggregator-breakdown-section.tsx`) load
+    // from independent SWR queries and can be loading simultaneously.
+    // `TableSkeleton` renders `role="status" aria-live="polite"` by default,
+    // so if both stayed non-presentational, two live regions would announce
+    // at once. The aggregator table's skeleton passes `presentational` to
+    // stay silent — keep this one as the single owner if either changes.
     return (
       <TableSkeleton variant="rows" rows={TOP_TRADERS_TABLE_SKELETON_ROWS} />
     );

--- a/ui-dashboard/src/app/volume/_lib/skeleton-rows.ts
+++ b/ui-dashboard/src/app/volume/_lib/skeleton-rows.ts
@@ -1,0 +1,37 @@
+/**
+ * Row counts for the `/volume` table skeletons — shared between the
+ * client-side tables (`../_components/volume-table.tsx`,
+ * `../_components/aggregator-breakdown-section.tsx`) and the route-level
+ * `../loading.tsx` fallback.
+ *
+ * Zero-dependency module (no imports) so the Server Component route
+ * fallback can import these directly: `volume-table.tsx` /
+ * `aggregator-breakdown-section.tsx` are `"use client"` (SWR-backed), and
+ * per this package's "Server vs client module boundaries" rule, shared
+ * constants needed on both sides live in a standalone module rather than
+ * being duplicated as bare numbers kept in sync by a comment (see
+ * `src/lib/hasura-timeout.ts` for the established pattern).
+ */
+
+// The default (7d, v3) top-traders view consistently fills to `PAGE_LIMIT`
+// (20, in volume-table.tsx) in production (verified via a live
+// monitoring.mento.org measurement, 2026-07-13: 20 rows, thead 45px, each
+// row 40px -> 845px real table height). `TableSkeleton`'s generic per-row
+// geometry (36px header + 44px/row, calibrated off other tables) doesn't
+// match this table's real rhythm exactly, so reserving all 20 rows
+// overshoots (36 + 20*44 = 916px, +71px vs the 845px measurement). 18 rows
+// (36 + 18*44 = 828px) lands within 24px of the measured full-page case —
+// the closest achievable parity without editing the shared skeleton
+// primitive's fixed row height. Windows with fewer than ~18 active traders
+// will still shrink on load; that's an accepted tradeoff for a
+// client-fetched table that can't know the real count before the query
+// resolves.
+export const TOP_TRADERS_TABLE_SKELETON_ROWS = 18;
+
+// Aggregator/entry-point breakdowns typically resolve to a much smaller
+// distinct-row count than `PAGE_LIMIT` (50, in
+// aggregator-breakdown-section.tsx) — reserving the full cap would
+// over-shoot the real table's height on every load. 6 matches the
+// production skeleton-parity audit's measured aggregator-section delta
+// (issue #1221).
+export const AGGREGATOR_TABLE_SKELETON_ROWS = 6;

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -88,12 +88,13 @@ export default function VolumeLoading() {
           venue/range, so each panel reserves a generic sized block rather
           than replicating the panels' internal row shapes — that detail
           lives in v3-flow-insight-panels.tsx's own client loading branch.
-          The height (464) matches that client skeleton's own corridor/
-          outlier panel height (10-row InsightTableSkeleton + InsightPanel
-          chrome: p-4 + h3 title + header row + 10 rows at py-3, recomputed
-          from v3-flow-insight-panels.tsx's geometry) so the route->mount
-          swap doesn't shrink before the client skeleton takes over — keep
-          both in sync if either changes. */}
+          The height (500) matches that client skeleton's own corridor/
+          outlier panel height (10-row InsightTableSkeleton + a reserved
+          2-line trailing-caption placeholder + InsightPanel chrome: p-4 +
+          h3 title + header row + 10 rows at py-3 + the caption placeholder,
+          recomputed from v3-flow-insight-panels.tsx's geometry) so the
+          route->mount swap doesn't shrink before the client skeleton takes
+          over — keep both in sync if either changes. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
@@ -102,7 +103,7 @@ export default function VolumeLoading() {
             <div
               key={`vol-insight-panel-${i}`}
               className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
-              style={{ height: 464 }}
+              style={{ height: 500 }}
             >
               <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
               <div className="space-y-2">

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -18,6 +18,7 @@ import { TableSkeleton } from "@/components/skeletons";
 // column: `TopPoolsList` only renders alongside the per-pool chart for the
 // 30d/90d/all ranges (`RANGES_WITH_CHART` in `page-client.tsx`), which the
 // default 7d view never reaches.
+// eslint-disable-next-line max-lines-per-function -- Route-level skeleton mirrors five below-the-fold sections 1:1 with their real components for CLS parity (issue #1221); splitting the JSX would fragment that direct mapping.
 export default function VolumeLoading() {
   return (
     <div
@@ -86,7 +87,11 @@ export default function VolumeLoading() {
           (Cohort / Corridor / Outlier). This route-level fallback can't know
           venue/range, so each panel reserves a generic sized block rather
           than replicating the panels' internal row shapes — that detail
-          lives in v3-flow-insight-panels.tsx's own client loading branch. */}
+          lives in v3-flow-insight-panels.tsx's own client loading branch.
+          The height (493) matches that client skeleton's own corridor/
+          outlier panel height (10-row InsightTableSkeleton + InsightPanel
+          chrome) so the route->mount swap doesn't shrink before the client
+          skeleton takes over — keep both in sync if either changes. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
@@ -95,7 +100,7 @@ export default function VolumeLoading() {
             <div
               key={`vol-insight-panel-${i}`}
               className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
-              style={{ height: 480 }}
+              style={{ height: 493 }}
             >
               <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
               <div className="space-y-2">
@@ -117,13 +122,41 @@ export default function VolumeLoading() {
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <TableSkeleton rows={10} variant="rows" presentational />
       </div>
-      {/* Aggregator breakdown: heading + 230px chart card + table skeleton,
-          mirroring AggregatorBreakdownSection. Row count matches
+      {/* Aggregator breakdown: heading + the aggregator chart card + table
+          skeleton, mirroring AggregatorBreakdownSection. The chart card
+          reserves the same full chrome as the hero card above (p-5/sm:p-6 +
+          title + 3xl/4xl headline + range pills + mt-4 plot), just at the
+          aggregator chart's 230px plot height instead of the hero's 200px —
+          a bare 230px box under-reserved the title/headline/range-pill rows
+          that AggregatorBreakdownSection's TimeSeriesChartCard also renders
+          on every load. No delta row here either: like the hero chart, this
+          card always passes reserveDeltaRow={false}. Row count matches
           AGGREGATOR_TABLE_SKELETON_ROWS in aggregator-breakdown-section.tsx —
           keep both in sync if that changes. */}
       <div className="space-y-3">
         <div className="h-4 w-64 animate-pulse rounded bg-slate-800/50" />
-        <div className="h-[230px] animate-pulse rounded-lg border border-slate-800 bg-slate-900/30" />
+        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-sm">
+                <span className="inline-block h-[1em] w-40 animate-pulse rounded bg-slate-800/50 align-middle" />
+              </p>
+              <p className="mt-1 text-3xl font-semibold sm:text-4xl">
+                <span className="inline-block h-[1em] w-36 animate-pulse rounded bg-slate-800/60 align-middle" />
+              </p>
+            </div>
+            <div className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5">
+              {Array.from({ length: 4 }, (_, i) => (
+                // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+                <span
+                  key={`vol-agg-range-${i}`}
+                  className="h-6 w-9 animate-pulse rounded bg-slate-800/40"
+                />
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 h-[230px] animate-pulse rounded bg-slate-800/30" />
+        </section>
         <TableSkeleton rows={6} variant="rows" presentational />
       </div>
       <span className="sr-only">Loading…</span>

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -1,5 +1,10 @@
 import { TableSkeleton } from "@/components/skeletons";
 import {
+  CohortPanelSkeleton,
+  InsightPanel,
+  InsightTableSkeleton,
+} from "./_components/v3-flow-insight-skeletons";
+import {
   AGGREGATOR_TABLE_SKELETON_ROWS,
   TOP_TRADERS_TABLE_SKELETON_ROWS,
 } from "./_lib/skeleton-rows";
@@ -87,52 +92,40 @@ export default function VolumeLoading() {
           </div>
         ))}
       </div>
-      {/* Flow insights: heading + 3-panel grid mirroring V3FlowInsights
-          (Cohort / Corridor / Outlier). This route-level fallback can't know
-          venue/range, so each panel reserves a generic sized block rather
-          than replicating the panels' internal row shapes — that detail
-          lives in v3-flow-insight-panels.tsx's own client loading branch.
-          The 500px height matches that client skeleton's own corridor/
-          outlier panel height (10-row InsightTableSkeleton + a reserved
-          2-line trailing-caption placeholder + InsightPanel chrome: p-4 +
-          h3 title + header row + 10 rows at py-3 + the caption placeholder,
-          recomputed from v3-flow-insight-panels.tsx's geometry) so the
-          route->mount swap doesn't shrink before the client skeleton takes
-          over — keep both in sync if either changes.
-
-          That 500px figure is only true at the `xl:grid-cols-3` layout,
-          where the grid row's height is governed by the tallest panel
-          (corridor/outlier, which really do run ~500px) — the compact
-          cohort panel borrows that same row height "for free" via CSS Grid.
-          Below `xl` the grid stacks to `grid-cols-1`, so each panel gets its
-          own full-width row instead of sharing one — asserting 500px on all
-          three there would reserve ~1500px (vs. cohort's real, much shorter
-          content), reintroducing the below-the-fold jump this fallback
-          exists to prevent for narrower viewports. `xl:h-[500px]` below
-          scopes the fixed height to that breakpoint; under `xl` each panel
-          sizes to its natural content (the 8-row bar stack), which is a
-          closer approximation of the real per-panel geometry when stacked. */}
+      {/* Flow insights: heading + the exact loading composition
+          V3FlowInsights' panels render while their queries are in flight —
+          InsightPanel chrome + CohortPanelSkeleton / InsightTableSkeleton,
+          shared via v3-flow-insight-skeletons.tsx. Sharing the components
+          (instead of hand-mirroring measured heights here) keeps the
+          fallback→client handoff structurally identical at every
+          breakpoint: at xl the grid row is governed by the tallest
+          (corridor/outlier) panels exactly as on the client, and below xl,
+          where the grid stacks to one column, each panel reserves its real
+          intrinsic height — a fixed desktop height over-reserved when
+          stacked, and no reservation under-reserved (codex reviews, PR
+          1242). Panel titles are the panels' own static strings; the
+          skeletons render `presentational` because this fallback's root
+          already provides the single page-level live region. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
-          {Array.from({ length: 3 }, (_, i) => (
-            // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-            <div
-              key={`vol-insight-panel-${i}`}
-              className="rounded-lg border border-slate-800 bg-slate-900/50 p-4 xl:h-[500px]"
-            >
-              <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
-              <div className="space-y-2">
-                {Array.from({ length: 8 }, (_, r) => (
-                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-                  <div
-                    key={`vol-insight-row-${i}-${r}`}
-                    className="h-5 animate-pulse rounded bg-slate-800/30"
-                  />
-                ))}
-              </div>
-            </div>
-          ))}
+          <InsightPanel title="Cohort + dormancy">
+            <CohortPanelSkeleton presentational />
+          </InsightPanel>
+          <InsightPanel title="Corridor map">
+            <InsightTableSkeleton
+              cols={4}
+              label="Loading corridor map"
+              presentational
+            />
+          </InsightPanel>
+          <InsightPanel title="Outlier swaps">
+            <InsightTableSkeleton
+              cols={3}
+              label="Loading outlier swaps"
+              presentational
+            />
+          </InsightPanel>
         </div>
       </div>
       {/* Top traders: heading + main table skeleton (header + measured row

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -88,10 +88,12 @@ export default function VolumeLoading() {
           venue/range, so each panel reserves a generic sized block rather
           than replicating the panels' internal row shapes — that detail
           lives in v3-flow-insight-panels.tsx's own client loading branch.
-          The height (493) matches that client skeleton's own corridor/
+          The height (504) matches that client skeleton's own corridor/
           outlier panel height (10-row InsightTableSkeleton + InsightPanel
-          chrome) so the route->mount swap doesn't shrink before the client
-          skeleton takes over — keep both in sync if either changes. */}
+          chrome: p-4 + h3 title + header row + 10 rows, recomputed from
+          v3-flow-insight-panels.tsx's geometry) so the route->mount swap
+          doesn't shrink before the client skeleton takes over — keep both
+          in sync if either changes. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
@@ -100,7 +102,7 @@ export default function VolumeLoading() {
             <div
               key={`vol-insight-panel-${i}`}
               className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
-              style={{ height: 493 }}
+              style={{ height: 504 }}
             >
               <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
               <div className="space-y-2">
@@ -117,10 +119,12 @@ export default function VolumeLoading() {
         </div>
       </div>
       {/* Top traders: heading + main table skeleton (header + measured row
-          rhythm), mirroring V3VolumeSection's "Top traders" table. */}
+          rhythm), mirroring V3VolumeSection's "Top traders" table. Row count
+          matches TOP_TRADERS_TABLE_SKELETON_ROWS in volume-table.tsx — keep
+          both in sync if that changes. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
-        <TableSkeleton rows={10} variant="rows" presentational />
+        <TableSkeleton rows={18} variant="rows" presentational />
       </div>
       {/* Aggregator breakdown: heading + the aggregator chart card + table
           skeleton, mirroring AggregatorBreakdownSection. The chart card
@@ -130,12 +134,24 @@ export default function VolumeLoading() {
           a bare 230px box under-reserved the title/headline/range-pill rows
           that AggregatorBreakdownSection's TimeSeriesChartCard also renders
           on every load. No delta row here either: like the hero chart, this
-          card always passes reserveDeltaRow={false}. Row count matches
+          card always passes reserveDeltaRow={false}. Unlike the hero card,
+          this one passes yAxisTopPadding={0} to its real TimeSeriesChartCard,
+          which triggers that component's dense-layout `pb-2 sm:pb-3` bottom
+          padding override — mirrored here too, so the card doesn't shrink a
+          few px on client mount. Row count matches
           AGGREGATOR_TABLE_SKELETON_ROWS in aggregator-breakdown-section.tsx —
-          keep both in sync if that changes. */}
+          keep both in sync if that changes. The heading also reserves a
+          second line for the static "Canonical name from aggregators.json…"
+          description paragraph AggregatorBreakdownSection always renders
+          under its title (measured live, 2026-07-13: title 20px + description
+          17px = 41px vs a single 16px bar) — without it the table shifts down
+          on client mount even before SWR resolves. */}
       <div className="space-y-3">
-        <div className="h-4 w-64 animate-pulse rounded bg-slate-800/50" />
-        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+        <div>
+          <div className="h-4 w-64 animate-pulse rounded bg-slate-800/50" />
+          <div className="mt-1 h-3 w-full max-w-2xl animate-pulse rounded bg-slate-800/40" />
+        </div>
+        <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6 pb-2 sm:pb-3">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
               <p className="text-sm">

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -1,4 +1,8 @@
 import { TableSkeleton } from "@/components/skeletons";
+import {
+  AGGREGATOR_TABLE_SKELETON_ROWS,
+  TOP_TRADERS_TABLE_SKELETON_ROWS,
+} from "./_lib/skeleton-rows";
 
 // Route-level fallback for /volume, rendered during the server session-await —
 // BEFORE the client reads URL-state (venue/range) or the auth session. It
@@ -88,13 +92,26 @@ export default function VolumeLoading() {
           venue/range, so each panel reserves a generic sized block rather
           than replicating the panels' internal row shapes — that detail
           lives in v3-flow-insight-panels.tsx's own client loading branch.
-          The height (500) matches that client skeleton's own corridor/
+          The 500px height matches that client skeleton's own corridor/
           outlier panel height (10-row InsightTableSkeleton + a reserved
           2-line trailing-caption placeholder + InsightPanel chrome: p-4 +
           h3 title + header row + 10 rows at py-3 + the caption placeholder,
           recomputed from v3-flow-insight-panels.tsx's geometry) so the
           route->mount swap doesn't shrink before the client skeleton takes
-          over — keep both in sync if either changes. */}
+          over — keep both in sync if either changes.
+
+          That 500px figure is only true at the `xl:grid-cols-3` layout,
+          where the grid row's height is governed by the tallest panel
+          (corridor/outlier, which really do run ~500px) — the compact
+          cohort panel borrows that same row height "for free" via CSS Grid.
+          Below `xl` the grid stacks to `grid-cols-1`, so each panel gets its
+          own full-width row instead of sharing one — asserting 500px on all
+          three there would reserve ~1500px (vs. cohort's real, much shorter
+          content), reintroducing the below-the-fold jump this fallback
+          exists to prevent for narrower viewports. `xl:h-[500px]` below
+          scopes the fixed height to that breakpoint; under `xl` each panel
+          sizes to its natural content (the 8-row bar stack), which is a
+          closer approximation of the real per-panel geometry when stacked. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
@@ -102,8 +119,7 @@ export default function VolumeLoading() {
             // react-doctor-disable-next-line react-doctor/no-array-index-as-key
             <div
               key={`vol-insight-panel-${i}`}
-              className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
-              style={{ height: 500 }}
+              className="rounded-lg border border-slate-800 bg-slate-900/50 p-4 xl:h-[500px]"
             >
               <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
               <div className="space-y-2">
@@ -121,11 +137,15 @@ export default function VolumeLoading() {
       </div>
       {/* Top traders: heading + main table skeleton (header + measured row
           rhythm), mirroring V3VolumeSection's "Top traders" table. Row count
-          matches TOP_TRADERS_TABLE_SKELETON_ROWS in volume-table.tsx — keep
-          both in sync if that changes. */}
+          is TOP_TRADERS_TABLE_SKELETON_ROWS, shared with volume-table.tsx via
+          `./_lib/skeleton-rows.ts` so the two can't drift apart. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
-        <TableSkeleton rows={18} variant="rows" presentational />
+        <TableSkeleton
+          rows={TOP_TRADERS_TABLE_SKELETON_ROWS}
+          variant="rows"
+          presentational
+        />
       </div>
       {/* Aggregator breakdown: heading + the aggregator chart card + table
           skeleton, mirroring AggregatorBreakdownSection. The chart card
@@ -139,10 +159,11 @@ export default function VolumeLoading() {
           this one passes yAxisTopPadding={0} to its real TimeSeriesChartCard,
           which triggers that component's dense-layout `pb-2 sm:pb-3` bottom
           padding override — mirrored here too, so the card doesn't shrink a
-          few px on client mount. Row count matches
-          AGGREGATOR_TABLE_SKELETON_ROWS in aggregator-breakdown-section.tsx —
-          keep both in sync if that changes. The heading also reserves a
-          second line for the static "Canonical name from aggregators.json…"
+          few px on client mount. Row count is AGGREGATOR_TABLE_SKELETON_ROWS,
+          shared with aggregator-breakdown-section.tsx via
+          `./_lib/skeleton-rows.ts` so the two can't drift apart. The heading
+          also reserves a second line for the static "Canonical name from
+          aggregators.json…"
           description paragraph AggregatorBreakdownSection always renders
           under its title (measured live, 2026-07-13: title 20px + description
           17px = 41px vs a single 16px bar) — without it the table shifts down
@@ -174,7 +195,11 @@ export default function VolumeLoading() {
           </div>
           <div className="mt-4 h-[230px] animate-pulse rounded bg-slate-800/30" />
         </section>
-        <TableSkeleton rows={6} variant="rows" presentational />
+        <TableSkeleton
+          rows={AGGREGATOR_TABLE_SKELETON_ROWS}
+          variant="rows"
+          presentational
+        />
       </div>
       <span className="sr-only">Loading…</span>
     </div>

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -88,12 +88,12 @@ export default function VolumeLoading() {
           venue/range, so each panel reserves a generic sized block rather
           than replicating the panels' internal row shapes — that detail
           lives in v3-flow-insight-panels.tsx's own client loading branch.
-          The height (504) matches that client skeleton's own corridor/
+          The height (464) matches that client skeleton's own corridor/
           outlier panel height (10-row InsightTableSkeleton + InsightPanel
-          chrome: p-4 + h3 title + header row + 10 rows, recomputed from
-          v3-flow-insight-panels.tsx's geometry) so the route->mount swap
-          doesn't shrink before the client skeleton takes over — keep both
-          in sync if either changes. */}
+          chrome: p-4 + h3 title + header row + 10 rows at py-3, recomputed
+          from v3-flow-insight-panels.tsx's geometry) so the route->mount
+          swap doesn't shrink before the client skeleton takes over — keep
+          both in sync if either changes. */}
       <div className="space-y-3">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
@@ -102,7 +102,7 @@ export default function VolumeLoading() {
             <div
               key={`vol-insight-panel-${i}`}
               className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
-              style={{ height: 504 }}
+              style={{ height: 464 }}
             >
               <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
               <div className="space-y-2">

--- a/ui-dashboard/src/app/volume/loading.tsx
+++ b/ui-dashboard/src/app/volume/loading.tsx
@@ -6,8 +6,18 @@ import { TableSkeleton } from "@/components/skeletons";
 // venue insight/aggregator sections are venue-specific). It reserves the
 // always-present, fixed-size blocks of VolumePageView for the common (7d, v3)
 // case so the skeleton→content swap doesn't shift: header (title + toggle
-// controls) → 200px chart card → 3 KPI tiles → venue table. A single live region
-// wraps the presentational child skeletons.
+// controls) → 200px chart card → 3 KPI tiles → flow insights → top traders →
+// aggregator breakdown. A single live region wraps the presentational child
+// skeletons.
+//
+// The below-the-fold three sections mirror V3VolumeSection's default (7d,
+// v3) layout — the venue this route falls back to. Non-default deep links
+// (24h, v2) still mismatch somewhat here; that's an accepted tradeoff (this
+// file can't read search params before the client mounts). Notably, the top
+// traders table is reserved as a single full-width table with no side
+// column: `TopPoolsList` only renders alongside the per-pool chart for the
+// 30d/90d/all ranges (`RANGES_WITH_CHART` in `page-client.tsx`), which the
+// default 7d view never reaches.
 export default function VolumeLoading() {
   return (
     <div
@@ -72,7 +82,50 @@ export default function VolumeLoading() {
           </div>
         ))}
       </div>
-      <TableSkeleton rows={10} presentational />
+      {/* Flow insights: heading + 3-panel grid mirroring V3FlowInsights
+          (Cohort / Corridor / Outlier). This route-level fallback can't know
+          venue/range, so each panel reserves a generic sized block rather
+          than replicating the panels' internal row shapes — that detail
+          lives in v3-flow-insight-panels.tsx's own client loading branch. */}
+      <div className="space-y-3">
+        <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+          {Array.from({ length: 3 }, (_, i) => (
+            // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+            <div
+              key={`vol-insight-panel-${i}`}
+              className="rounded-lg border border-slate-800 bg-slate-900/50 p-4"
+              style={{ height: 480 }}
+            >
+              <div className="mb-3 h-3 w-32 animate-pulse rounded bg-slate-800/50" />
+              <div className="space-y-2">
+                {Array.from({ length: 8 }, (_, r) => (
+                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+                  <div
+                    key={`vol-insight-row-${i}-${r}`}
+                    className="h-5 animate-pulse rounded bg-slate-800/30"
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Top traders: heading + main table skeleton (header + measured row
+          rhythm), mirroring V3VolumeSection's "Top traders" table. */}
+      <div className="space-y-3">
+        <div className="h-4 w-40 animate-pulse rounded bg-slate-800/50" />
+        <TableSkeleton rows={10} variant="rows" presentational />
+      </div>
+      {/* Aggregator breakdown: heading + 230px chart card + table skeleton,
+          mirroring AggregatorBreakdownSection. Row count matches
+          AGGREGATOR_TABLE_SKELETON_ROWS in aggregator-breakdown-section.tsx —
+          keep both in sync if that changes. */}
+      <div className="space-y-3">
+        <div className="h-4 w-64 animate-pulse rounded bg-slate-800/50" />
+        <div className="h-[230px] animate-pulse rounded-lg border border-slate-800 bg-slate-900/30" />
+        <TableSkeleton rows={6} variant="rows" presentational />
+      </div>
       <span className="sr-only">Loading…</span>
     </div>
   );


### PR DESCRIPTION
## The Problem

- The `/volume` below-the-fold sections grew substantially after data arrived (production audit: flow insights 278→542, top traders 504→879, aggregator 621→731), so scrolling during load felt like the page assembling itself.
- Their loading states were short generic bar stacks that shared no geometry with the loaded tables and panels.
- CLS ≈ 0 hides these whole-subtree swaps, so parity is verified against measured section rects.

## The Solution

- Flow-insight panels, the top-traders table, and the aggregator breakdown now render loading states shaped like their loaded content: real headers mounted, table-shaped skeletons at the real page-size row counts and measured row rhythms, and the usually-present top-query caption line reserved.
- The route-level `/volume` fallback mirrors the same shapes so the fallback→client handoff is seamless.

## Details

- Skeleton geometry is pinned by unit tests (row counts, row rhythm, caption placeholder) and derived from live measurements rather than CSS guesses.
- Intentional tradeoff: when a panel's query errors or resolves empty, it collapses to its compact message state rather than holding a ~500px reserved block. Reserving full height for rare transient failures would leave a large dead box on screen; compact, visibly-degraded error states are the repo's documented preference. The loading→loaded path (the common case) is jump-free.

## Validation

Browser-measured on a production build with live production data, 1440×900, GraphQL-delay init script + rect sampler:

- Cold-load CLS on `/volume`: **0.0005** (bar < 0.02).
- Section parity, loading → loaded: header 60→60, hero chart 331→330 (−1px), KPI strip 112→112, flow insights **532→542 (−10px)**, top traders **862→879 (+17px)**, aggregator **715→731 (+16px)** — every section within the issue's ±24px bar.
- Local checks: trunk fmt/check, ui-dashboard typecheck, test:coverage (3694 tests), react-doctor 100/100, `pnpm agent:quality-gate --run` all pass.

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state and test changes; no auth, data, or API behavior changes. Intentional collapse on error/empty remains.
> 
> **Overview**
> Replaces generic bar-stack loading placeholders on `/volume` with **layout-matched skeletons** so below-the-fold sections no longer jump when data arrives (issue #1221).
> 
> **Client components:** Flow-insight panels get structured placeholders (`CohortPanelSkeleton`, `InsightTableSkeleton` with 10 rows and a 2-line caption). Top traders and aggregator tables use `TableSkeleton` with **tuned row counts** (18 and 6). `TopPoolsList` uses a compact 10-row `<ol>` skeleton instead of oversized bars.
> 
> **Route fallback:** `volume/loading.tsx` now reserves flow-insights (3-panel grid), top-traders table, and full aggregator chrome (chart card + description line + table), aligned with the default 7d/v3 layout.
> 
> **Tests:** New/expanded tests lock skeleton geometry (grids, row rhythm, caption placeholders) against loaded UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82235e8dbd01f1f13362fd32f1a3d6966165d74e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->