### PR TITLE
fix(dashboard): reserve BreakdownTile sub-row footprint in the error state

### DIFF
--- a/ui-dashboard/src/components/__tests__/breakdown-tile.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breakdown-tile.test.tsx
@@ -48,10 +48,12 @@ function getSubRows(): HTMLElement[] {
   return Array.from(row.children) as HTMLElement[];
 }
 
-// The empty-state branch (loaded, no error, `total === null`) grid-stacks
-// an invisible spacer mirroring the row shapes with the visible message —
-// distinct markup from `getSubRows()`'s `mt-1.5 flex flex-wrap` sub-rows
-// div, so it needs its own query.
+// The empty-state branch (loaded, no error, `total === null`) and the
+// error branch (`hasError`) both render an invisible spacer mirroring the
+// row shapes via this same markup — distinct from `getSubRows()`'s
+// `mt-1.5 flex flex-wrap` sub-rows div, so it needs its own query. Only the
+// empty-state branch pairs it with a visible message (see
+// `getEmptyStateMessage`); the error branch renders the spacer alone.
 function getEmptyStateSpacerRows(): HTMLElement[] {
   const spacer = container.querySelector(".invisible.flex.flex-wrap");
   if (!spacer) return [];
@@ -110,10 +112,12 @@ describe("BreakdownTile loading parity", () => {
     expect(container.textContent).toContain("$30000");
   });
 
-  it("still omits the breakdown rows and the empty state on error once loaded (unchanged behavior)", () => {
+  it("reserves the same 3-row footprint on error as it does once loaded, instead of collapsing", () => {
     render(<BreakdownTile {...BASE_PROPS} isLoading={false} hasError />);
     expect(getSubRows()).toHaveLength(0);
-    expect(getEmptyStateSpacerRows()).toHaveLength(0);
+    expect(getEmptyStateSpacerRows()).toHaveLength(3);
+    // The error message renders on the subtitle line (BreakdownTile), not
+    // duplicated inside the sub-row block.
     expect(getEmptyStateMessage()).toBeNull();
   });
 });
@@ -176,9 +180,35 @@ describe("BreakdownTile empty-state parity (loaded, no error, total === null)", 
     );
   });
 
-  it("does not render the empty state while loading or on error", () => {
+  it("does not render the empty-state message while loading", () => {
     render(<BreakdownTile {...EMPTY_PROPS} isLoading />);
     expect(getEmptyStateSpacerRows()).toHaveLength(0);
+    expect(getEmptyStateMessage()).toBeNull();
+  });
+
+  it("reserves the spacer but omits the empty-state message on error (error takes precedence over the empty state)", () => {
+    render(<BreakdownTile {...EMPTY_PROPS} hasError />);
+    // Same invisible-row technique as the plain empty state, but without
+    // its message — hasError renders its own reserved-height spacer (see
+    // the "BreakdownTile error-state parity" suite below) rather than the
+    // `total === null` empty-state message.
+    expect(getEmptyStateSpacerRows()).toHaveLength(3);
+    expect(getEmptyStateMessage()).toBeNull();
+  });
+});
+
+// hasError takes precedence over both the loaded-with-total and the
+// total === null empty-state branches once loading finishes: a
+// loading-to-error or loaded-to-error transition must not shrink the tile
+// by the sub-row block's height. Reserves the same footprint via the same
+// invisible-row technique as the total === null empty state, but with no
+// visible message here — the "Some chains failed to load" text already
+// renders on the subtitle line, not inside the sub-row block.
+describe("BreakdownTile error-state parity (loaded, hasError)", () => {
+  it("reserves the same sub-row footprint as the loaded-with-total state instead of collapsing to nothing", () => {
+    render(<BreakdownTile {...BASE_PROPS} isLoading={false} />);
+    const loadedRows = getSubRows();
+    expect(loadedRows).toHaveLength(3);
 
     act(() => {
       root.unmount();
@@ -187,8 +217,44 @@ describe("BreakdownTile empty-state parity (loaded, no error, total === null)", 
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    render(<BreakdownTile {...EMPTY_PROPS} hasError />);
-    expect(getEmptyStateSpacerRows()).toHaveLength(0);
+    render(<BreakdownTile {...BASE_PROPS} isLoading={false} hasError />);
+    expect(getSubRows()).toHaveLength(0);
+    const errorSpacerRows = getEmptyStateSpacerRows();
+    expect(errorSpacerRows).toHaveLength(loadedRows.length);
+  });
+
+  it("sizes the error-state spacer slots identically to the loading/empty-state placeholders (w-14/h-3, same labels)", () => {
+    render(<BreakdownTile {...BASE_PROPS} isLoading={false} hasError />);
+    const spacerRows = getEmptyStateSpacerRows();
+    expect(spacerRows.map((r) => r.textContent?.trim())).toEqual([
+      "24h",
+      "7d",
+      "30d",
+    ]);
+    spacerRows.forEach((row) => {
+      const box = row.querySelector("span:last-child");
+      expect(box).not.toBeNull();
+      expect(box!.className).toContain("w-14");
+      expect(box!.className).toContain("h-3");
+    });
+  });
+
+  it("hides the spacer from assistive tech and does not duplicate the error message inside the sub-row block", () => {
+    render(<BreakdownTile {...BASE_PROPS} isLoading={false} hasError />);
+    const spacer = container.querySelector(".invisible.flex.flex-wrap");
+    expect(spacer).not.toBeNull();
+    expect(spacer!.getAttribute("aria-hidden")).toBe("true");
+    expect(container.querySelector(".animate-pulse")).toBeNull();
     expect(getEmptyStateMessage()).toBeNull();
+
+    // The error message renders once, on the subtitle line.
+    expect(container.textContent).toContain("Some chains failed to load");
+  });
+
+  it("reserves the same footprint regardless of whether a total resolved before the error", () => {
+    render(
+      <BreakdownTile {...BASE_PROPS} isLoading={false} hasError total={null} />,
+    );
+    expect(getEmptyStateSpacerRows()).toHaveLength(3);
   });
 });

--- a/ui-dashboard/src/components/breakdown-tile.tsx
+++ b/ui-dashboard/src/components/breakdown-tile.tsx
@@ -96,7 +96,7 @@ export function BreakdownTile({
 const SUB_WINDOW_LABELS = ["24h", "7d", "30d"] as const;
 
 /**
- * The 24h/7d/30d row under the headline value. Three mutually exclusive
+ * The 24h/7d/30d row under the headline value. Four mutually exclusive
  * states, all reserving the same footprint so the tile never resizes as
  * data resolves:
  *  - loading: shimmer placeholders (was 114 -> 164px on /stables before
@@ -110,8 +110,12 @@ const SUB_WINDOW_LABELS = ["24h", "7d", "30d"] as const;
  *    invisible copy of the row shapes, so the block's height is driven by
  *    the same flex-wrap it would take on while loading — at any tile
  *    width — without showing fake skeleton/placeholder rows.
- *  - error, or loaded with no total and an error: renders nothing
- *    (unchanged from before this file reserved rows at all).
+ *  - hasError (whether or not a total resolved): renders an invisible copy
+ *    of the row shapes, same technique as the empty state, with no visible
+ *    message here — the "Some chains failed to load" text already renders
+ *    on the subtitle line (see `BreakdownTile`). Reserves the same
+ *    footprint so a loading-to-error or loaded-to-error transition doesn't
+ *    shrink the tile.
  */
 function BreakdownSubRows({
   isLoading,
@@ -184,5 +188,22 @@ function BreakdownSubRows({
     );
   }
 
-  return null;
+  // hasError, whether or not a total resolved. Reserve the same footprint
+  // as the branches above via an invisible copy of the row shapes; the
+  // visible error message renders on the subtitle line instead.
+  return (
+    <div className="mt-1.5 text-sm">
+      <div
+        aria-hidden="true"
+        className="invisible flex flex-wrap gap-x-3 gap-y-0.5 font-mono"
+      >
+        {SUB_WINDOW_LABELS.map((l) => (
+          <span key={l}>
+            <span>{l}</span>{" "}
+            <span className="inline-block h-3 w-14 align-middle" />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## The Problem

- `BreakdownTile`'s 24h/7d/30d sub-row block reserves an identical footprint across loading, loaded-with-total, and loaded-empty states, but not for the loaded-with-error state — the error branch fell through to `return null`.
- A loading-to-error (or loaded-to-error) transition shrinks the tile by the sub-row block's height (~24-52px depending on wrap), reintroducing the same class of layout jump the shared skeleton-primitives work (#1218 / PR #1232) was meant to eliminate.
- Every `BreakdownTile` consumer (`/stables` KPI strip, homepage tiles, mover tiles, etc.) is affected any time chain data fails to load.

## The Solution

`BreakdownSubRows` now reserves the same footprint for the error state using the existing invisible-row technique already used for the `total === null` empty state: an `aria-hidden` copy of the row shapes (same `w-14`/`h-3` slots, same `24h`/`7d`/`30d` labels) sized to hold the block's height without showing fake data. No visible message renders inside the block — the "Some chains failed to load" text already renders on the tile's subtitle line, so nothing is duplicated.

## Details

- `hasError` now short-circuits before the `total === null` empty-state check, so it takes precedence regardless of whether a total resolved.
- Reuses the same `w-14`/`h-3` placeholder sizing already tuned (in prior work) to track a representative formatted value's width, so flex-wrap line count stays consistent across loading, loaded, empty, and error states.
- Added `BreakdownTile error-state parity` test suite pinning: (1) the error branch renders the same sub-row count as the loaded-with-total branch instead of collapsing to zero, (2) the error spacer slots use the same `w-14`/`h-3` sizing and labels as the loading/empty-state placeholders, and (3) the spacer is `aria-hidden` and does not duplicate the error message inside the sub-row block.
- Only `ui-dashboard/src/components/breakdown-tile.tsx` and its test file changed; no other `BreakdownTile` consumers needed changes.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage`
- `pnpm dashboard:react-doctor:diff`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` — one finding (spacer slot width may not exactly track every possible formatted-value width at every breakpoint, so wrap-line parity isn't pixel-guaranteed for all value lengths). This reuses the same `w-14`/`h-3` invisible-row technique already shipped and tested for the `total === null` empty-state branch, so it isn't a regression introduced by this diff; noting for awareness rather than blocking on it.
- The session lead runs the browser parity measurement (loading → error, loaded → error transitions across breakpoints) before merge.

Closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout stability in one shared dashboard component; no API, auth, or data-path changes.
> 
> **Overview**
> **`BreakdownSubRows`** no longer returns nothing when **`hasError`** is set after load. It now renders the same **`aria-hidden`** invisible **24h / 7d / 30d** spacer row used for the empty state, so loading→error and loaded→error transitions do not collapse the tile height.
> 
> **`hasError`** still wins over the **`total === null`** empty-state branch; the subtitle line keeps **"Some chains failed to load"** and nothing is duplicated in the sub-row block.
> 
> Tests were split and extended to assert the error spacer matches loaded row count, **`w-14`/`h-3`** sizing, and accessibility behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fd9903449a9d30d5e3547c561d12a792b95a40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->