### PR TITLE
fix(dashboard): stop the stables truncation notice from shifting the supply-changes table

### DIFF
--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -239,10 +239,63 @@ describe("StablesPageClient — smoke", () => {
       }),
     ];
     const html = renderToStaticMarkup(<StablesPageClient />);
-    const noticeIndex = html.indexOf("Showing the most recent");
+    const noticeIndex = html.indexOf("Showing the most recent 1,000");
     expect(noticeIndex).toBeGreaterThan(-1);
+    // Folded into the supply-changes card's header (issue #1239) so it
+    // never displaces the card's position — it renders just after the
+    // "Supply changes" heading, not as a standalone block before it.
     expect(html.indexOf("Per-token supply detail")).toBeLessThan(noticeIndex);
-    expect(noticeIndex).toBeLessThan(html.indexOf("Supply changes"));
+    expect(html.indexOf("Supply changes")).toBeLessThan(noticeIndex);
+  });
+
+  it("does not render the snapshot-limit notice, and does not insert a sibling before the supply-changes card, when the cap is not hit", () => {
+    mockSnapshots.data = [
+      snapshot({
+        timestamp: "1716336000",
+        totalSupply: "1000000000000000000",
+      }),
+    ];
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+
+    // Uncapped: no notice anywhere, and the changes card is the last of the
+    // page's five top-level sections (header, KPI strip, hero chart,
+    // sparkline grid, changes card) — no phantom sibling reserved for it.
+    mockSnapshots.capped = false;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+    const rootContainer = div.querySelector<HTMLDivElement>(".space-y-8");
+    expect(rootContainer).toBeTruthy();
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const childCountUncapped = rootContainer!.children.length;
+    const lastChildUncapped = rootContainer!.lastElementChild;
+    expect(lastChildUncapped?.textContent).toContain("Supply changes");
+
+    // Capped: the notice appears, but folded into the card's own header —
+    // the card stays the same last child at the same sibling index, so its
+    // top position relative to the sparkline grid above it is unchanged.
+    mockSnapshots.capped = true;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+    expect(div.textContent).toContain("Showing the most recent 1,000");
+    expect(rootContainer!.children.length).toBe(childCountUncapped);
+    expect(rootContainer!.lastElementChild?.textContent).toContain(
+      "Supply changes",
+    );
+    // The notice text lives inside the same card element that was already
+    // the last child, not in a new sibling ahead of it.
+    expect(rootContainer!.lastElementChild?.textContent).toContain(
+      "Showing the most recent 1,000",
+    );
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
   });
 
   it("degrades custody query errors to raw supply instead of failing the page", () => {

--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -294,28 +294,42 @@ describe("StablesPageClient — smoke", () => {
     const lastChildUncapped = rootContainer!.lastElementChild;
     expect(lastChildUncapped?.textContent).toContain("Supply changes");
 
-    // Capped: the notice appears, but folded into the card's own header —
-    // the card stays the same last child at the same sibling index, so its
-    // top position relative to the sparkline grid above it is unchanged.
-    mockSnapshots.capped = true;
-    act(() => {
-      localRoot.render(<StablesPageClient />);
-    });
-    expect(div.textContent).toContain("Showing the most recent 1,000");
-    expect(rootContainer!.children.length).toBe(childCountUncapped);
-    expect(rootContainer!.lastElementChild?.textContent).toContain(
-      "Supply changes",
-    );
-    // The notice text lives inside the same card element that was already
-    // the last child, not in a new sibling ahead of it.
-    expect(rootContainer!.lastElementChild?.textContent).toContain(
-      "Showing the most recent 1,000",
-    );
-
     act(() => {
       localRoot.unmount();
     });
     div.remove();
+
+    // Capped (on a FRESH mount — post-settle in-place flips are frozen out,
+    // see the "freezes the truncation notice" test below): the notice
+    // appears, but folded into the card's own header — the card stays the
+    // same last child at the same sibling index, so its top position
+    // relative to the sparkline grid above it is unchanged.
+    mockSnapshots.capped = true;
+    const cappedMountDiv = document.createElement("div");
+    document.body.appendChild(cappedMountDiv);
+    const cappedMountRoot = createRoot(cappedMountDiv);
+    act(() => {
+      cappedMountRoot.render(<StablesPageClient />);
+    });
+    const cappedContainer =
+      cappedMountDiv.querySelector<HTMLDivElement>(".space-y-8");
+    expect(cappedMountDiv.textContent).toContain(
+      "Showing the most recent 1,000",
+    );
+    expect(cappedContainer!.children.length).toBe(childCountUncapped);
+    expect(cappedContainer!.lastElementChild?.textContent).toContain(
+      "Supply changes",
+    );
+    // The notice text lives inside the same card element that was already
+    // the last child, not in a new sibling ahead of it.
+    expect(cappedContainer!.lastElementChild?.textContent).toContain(
+      "Showing the most recent 1,000",
+    );
+
+    act(() => {
+      cappedMountRoot.unmount();
+    });
+    cappedMountDiv.remove();
   });
 
   it("degrades custody query errors to raw supply instead of failing the page", () => {
@@ -479,6 +493,156 @@ describe("StablesPageClient — smoke", () => {
       localRoot.unmount();
     });
     div.remove();
+  });
+
+  it("short-circuits the cap wait when one snapshot source already resolved capped, instead of waiting on the other", () => {
+    // The notice is driven by an OR of the supply-snapshots and
+    // custody-snapshots caps. Once the supply query resolves capped=true the
+    // outcome is irrevocably "capped" — the header is already in its final
+    // notice-shown shape — so a slow (or wedged) custody query must not keep
+    // otherwise-ready rows hidden behind the skeleton.
+    mockChanges.data = [changeEvent()];
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = false;
+    mockSnapshots.capped = true;
+    mockCustodySnapshots.isLoading = true; // still in flight — must not matter
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(
+      div.querySelector('[role="status"][aria-label="Loading table"]'),
+    ).toBeNull();
+    expect(div.textContent).toContain("Showing the most recent 1,000");
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
+
+    // Control: the same custody-still-loading state WITHOUT a decided cap
+    // (supply resolved uncapped) must still hold the skeleton — an
+    // all-sources-uncapped conclusion needs every query settled.
+    mockSnapshots.capped = false;
+    const controlDiv = document.createElement("div");
+    document.body.appendChild(controlDiv);
+    const controlRoot = createRoot(controlDiv);
+    act(() => {
+      controlRoot.render(<StablesPageClient />);
+    });
+
+    expect(controlDiv.querySelectorAll("tbody tr")).toHaveLength(0);
+    expect(
+      controlDiv.querySelector('[role="status"][aria-label="Loading table"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      controlRoot.unmount();
+    });
+    controlDiv.remove();
+  });
+
+  it("freezes the truncation notice at its settle-time state so a post-settle cap flip cannot move the visible rows", () => {
+    // Once the reveal latch fires it stops watching the cap flag — so a
+    // later SWR poll crossing the 1,000-row cap would insert the notice
+    // above already-visible rows, the original displacement re-entering
+    // through the polling path. The latch therefore stores the cap outcome
+    // itself and the header renders the frozen value: a post-settle flip in
+    // either direction leaves the header untouched (the fresh cap state
+    // surfaces on the next mount instead).
+    mockChanges.data = [changeEvent()];
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = false;
+    mockSnapshots.capped = false;
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    // Settled uncapped: rows visible, no notice.
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const row = div.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    const settledPosition = precedingElementCount(row!);
+
+    // Post-settle flip to capped (a later poll returns the 1,000th row):
+    // the notice must NOT appear, and the rows must not move.
+    mockSnapshots.capped = true;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const rowAfterFlip = div.querySelector("tbody tr");
+    expect(rowAfterFlip).not.toBeNull();
+    expect(precedingElementCount(rowAfterFlip!)).toBe(settledPosition);
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
+
+    // Mirror case: settled CAPPED, then a poll dips back under the cap —
+    // the notice must stay (frozen), so rows don't move UP either.
+    mockSnapshots.capped = true;
+    const cappedDiv = document.createElement("div");
+    document.body.appendChild(cappedDiv);
+    const cappedRoot = createRoot(cappedDiv);
+    act(() => {
+      cappedRoot.render(<StablesPageClient />);
+    });
+
+    expect(cappedDiv.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(cappedDiv.textContent).toContain("Showing the most recent 1,000");
+    const cappedRow = cappedDiv.querySelector("tbody tr");
+    expect(cappedRow).not.toBeNull();
+    const cappedPosition = precedingElementCount(cappedRow!);
+
+    mockSnapshots.capped = false;
+    act(() => {
+      cappedRoot.render(<StablesPageClient />);
+    });
+
+    expect(cappedDiv.textContent).toContain("Showing the most recent 1,000");
+    const cappedRowAfterFlip = cappedDiv.querySelector("tbody tr");
+    expect(cappedRowAfterFlip).not.toBeNull();
+    expect(precedingElementCount(cappedRowAfterFlip!)).toBe(cappedPosition);
+
+    act(() => {
+      cappedRoot.unmount();
+    });
+    cappedDiv.remove();
+  });
+
+  it("surfaces the supply-changes error immediately even while the snapshot-cap outcome is still loading", () => {
+    // Without error precedence, a failed changes query plus a slow
+    // snapshot/custody request keeps `showChangesSkeleton` true (the table
+    // branches on isLoading before hasError), so the user would see an
+    // indefinite loading table instead of the error affordance.
+    mockChanges.error = new Error("changes query failed");
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = true; // cap outcome unknown — must not matter
+
+    const html = renderToStaticMarkup(<StablesPageClient />);
+
+    expect(html).toContain("Failed to load supply changes.");
+    expect(html).not.toContain('aria-label="Loading table"');
   });
 
   it("keeps the supply-changes skeleton up while a follow-up raw page is still pending, even with first-page rows in hand", () => {

--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -628,6 +628,110 @@ describe("StablesPageClient — smoke", () => {
     cappedDiv.remove();
   });
 
+  it("upgrades a degraded uncapped settle to capped when the errored custody leg recovers past the cap", () => {
+    // The custody leg errored empty at settle time, so it was excluded from
+    // the cap OR and the latch settled uncapped on DEGRADED inputs. That
+    // conclusion is error-derived, not trustworthy: if a later poll recovers
+    // custody with a full (capped) page, keeping the frozen `false` would
+    // show truncated custody history with no warning until remount — silent
+    // degradation, which outranks the one-off layout shift of a late notice
+    // in this rare error-recovery path. The upgrade is strictly one-way.
+    mockChanges.data = [changeEvent()];
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = false;
+    mockSnapshots.capped = false;
+    mockCustodySnapshots.error = new Error("custody table unavailable");
+    mockCustodySnapshots.data = [];
+    mockCustodySnapshots.isLoading = false;
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    // Degraded settle: rows visible, no notice (cap outcome resolved
+    // uncapped because the errored custody leg was excluded).
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+
+    // Custody recovers with a capped page: the notice must upgrade in.
+    mockCustodySnapshots.error = null;
+    mockCustodySnapshots.capped = true;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).toContain("Showing the most recent 1,000");
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
+  });
+
+  it("re-freezes a degraded uncapped settle once custody recovers uncapped, keeping later cap crossings frozen", () => {
+    // Same degraded settle as above, but custody recovers with an UNCAPPED
+    // page: nothing changes visually, and the degraded escape hatch closes —
+    // the uncapped conclusion is now confirmed on healthy inputs, so a later
+    // ordinary cap crossing must stay frozen out exactly like a healthy
+    // settle (no notice insertion above visible rows).
+    mockChanges.data = [changeEvent()];
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = false;
+    mockSnapshots.capped = false;
+    mockCustodySnapshots.error = new Error("custody table unavailable");
+    mockCustodySnapshots.data = [];
+    mockCustodySnapshots.isLoading = false;
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const row = div.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    const settledPosition = precedingElementCount(row!);
+
+    // Custody recovers uncapped: no notice, rows don't move.
+    mockCustodySnapshots.error = null;
+    mockCustodySnapshots.capped = false;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const rowAfterRecovery = div.querySelector("tbody tr");
+    expect(rowAfterRecovery).not.toBeNull();
+    expect(precedingElementCount(rowAfterRecovery!)).toBe(settledPosition);
+
+    // Later ordinary cap crossing: frozen out, exactly like a healthy settle.
+    mockSnapshots.capped = true;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+    const rowAfterCross = div.querySelector("tbody tr");
+    expect(rowAfterCross).not.toBeNull();
+    expect(precedingElementCount(rowAfterCross!)).toBe(settledPosition);
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
+  });
+
   it("surfaces the supply-changes error immediately even while the snapshot-cap outcome is still loading", () => {
     // Without error precedence, a failed changes query plus a slow
     // snapshot/custody request keeps `showChangesSkeleton` true (the table

--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -164,6 +164,26 @@ function changeEvent(
   };
 }
 
+// JSDOM does not compute real layout, so `getBoundingClientRect().top` is
+// always 0 — no direct stand-in for "did this element move down the page".
+// Counts every earlier-in-document-order element across all ancestor levels
+// instead: under this page's normal top-to-bottom flow (no floats/absolute
+// positioning), an element gaining or losing preceding elements is exactly
+// an element gaining or losing vertical position above it.
+function precedingElementCount(el: Element): number {
+  let count = 0;
+  let node: Node | null = el;
+  while (node?.parentNode) {
+    let sibling = node.previousSibling;
+    while (sibling) {
+      if (sibling.nodeType === Node.ELEMENT_NODE) count++;
+      sibling = sibling.previousSibling;
+    }
+    node = node.parentNode;
+  }
+  return count;
+}
+
 describe("StablesPageClient — smoke", () => {
   beforeEach(() => {
     mockRates.merged = new Map<string, number>([["EURm", 1.1]]);
@@ -385,6 +405,75 @@ describe("StablesPageClient — smoke", () => {
     expect(
       div.querySelector('[role="status"][aria-label="Loading table"]'),
     ).toBeNull();
+
+    act(() => {
+      localRoot.unmount();
+    });
+    div.remove();
+  });
+
+  it("does not settle early when supply-change rows resolve before the snapshot-cap outcome is known, so the row's position never moves (Codex review on #1256)", () => {
+    // Staggered resolution: the supply-changes rows are ready first (changes
+    // query settled, no pending page, rates in) while the daily-snapshots
+    // query that decides `snapshotLimitCapped` is still in flight. The
+    // notice is folded into this card's OWN header (issue #1239), so if the
+    // reveal gate ignored the still-loading snapshots query, the row would
+    // appear now under an uncapped header, and the LATER cap resolution
+    // would grow the header and shove the already-visible row down inside
+    // the card — the exact displacement #1239 eliminated at the page level,
+    // reintroduced one level down.
+    mockChanges.data = [changeEvent()];
+    mockChanges.isLoading = false;
+    mockChanges.hasPendingPage = false;
+    mockRates.isLoading = false;
+    mockSnapshots.isLoading = true; // cap outcome not yet known
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const localRoot = createRoot(div);
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    // Step 1 — rows are ready but the cap outcome isn't: the skeleton must
+    // still hold instead of revealing the row under a header that might grow.
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(0);
+    expect(
+      div.querySelector('[role="status"][aria-label="Loading table"]'),
+    ).not.toBeNull();
+    expect(div.textContent).not.toContain("Showing the most recent 1,000");
+
+    // Step 2 — the daily-snapshots query resolves as capped. The cap outcome
+    // is now known, so the single reveal fires: the row and the header
+    // notice must both appear together in this SAME render.
+    mockSnapshots.isLoading = false;
+    mockSnapshots.capped = true;
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(
+      div.querySelector('[role="status"][aria-label="Loading table"]'),
+    ).toBeNull();
+    expect(div.textContent).toContain("Showing the most recent 1,000");
+    const row = div.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    const positionAtReveal = precedingElementCount(row!);
+
+    // Step 3 — a further render with the same settled props (e.g. a SWR
+    // background revalidation returning identical data) must not move the
+    // row again: the header/notice are already final, so nothing above the
+    // row can grow or shrink a second time.
+    act(() => {
+      localRoot.render(<StablesPageClient />);
+    });
+
+    expect(div.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(div.textContent).toContain("Showing the most recent 1,000");
+    const rowAfterRerender = div.querySelector("tbody tr");
+    expect(rowAfterRerender).not.toBeNull();
+    expect(precedingElementCount(rowAfterRerender!)).toBe(positionAtReveal);
 
     act(() => {
       localRoot.unmount();

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
@@ -40,6 +40,7 @@ function renderThresholdInput({
         hasSettled={true}
         capped={false}
         unpricedEventsCount={0}
+        snapshotLimitCapped={false}
       />,
     );
   });
@@ -109,6 +110,7 @@ describe("StablesChangesTable", () => {
         hasSettled={true}
         capped={true}
         unpricedEventsCount={0}
+        snapshotLimitCapped={false}
       />,
     );
 
@@ -148,6 +150,7 @@ describe("StablesChangesTable", () => {
         hasSettled={true}
         capped={false}
         unpricedEventsCount={1}
+        snapshotLimitCapped={false}
       />,
     );
 
@@ -207,6 +210,7 @@ describe("StablesChangesTable", () => {
           hasSettled={true}
           capped={false}
           unpricedEventsCount={0}
+          snapshotLimitCapped={false}
         />,
       );
     });
@@ -252,6 +256,7 @@ describe("StablesChangesTable", () => {
           hasSettled={true}
           capped={false}
           unpricedEventsCount={0}
+          snapshotLimitCapped={false}
         />,
       );
     };
@@ -292,6 +297,7 @@ describe("StablesChangesTable", () => {
       isLoading: boolean;
       hasError: boolean;
       hasSettled?: boolean;
+      snapshotLimitCapped?: boolean;
     }): HTMLDivElement {
       const div = document.createElement("div");
       document.body.appendChild(div);
@@ -308,6 +314,7 @@ describe("StablesChangesTable", () => {
             hasSettled={props.hasSettled ?? false}
             capped={false}
             unpricedEventsCount={0}
+            snapshotLimitCapped={props.snapshotLimitCapped ?? false}
           />,
         );
       });
@@ -419,6 +426,136 @@ describe("StablesChangesTable", () => {
         ),
       ).not.toBeNull();
       expect(div.textContent).toContain("Supply changes");
+    });
+
+    describe("snapshot-limit notice (issue #1239)", () => {
+      // The daily-snapshots truncation notice ("Showing the most recent 1,000
+      // snapshot rows...") is folded into this card's own header row instead
+      // of rendering as a standalone paragraph above the card, so it never
+      // displaces the card's position when it turns on/off. It must appear
+      // identically across every content branch — loading, error, empty, and
+      // loaded — since it is driven by `snapshotLimitCapped`, not by the
+      // events/loading state of this table's own query.
+      function headerNoticeElement(div: HTMLDivElement): HTMLElement | null {
+        return (
+          ([...div.querySelectorAll("p")].find((p) =>
+            p.textContent?.startsWith("Showing the most recent 1,000"),
+          ) as HTMLElement | undefined) ?? null
+        );
+      }
+
+      it.each([
+        ["loading", { events: [], isLoading: true, hasError: false }],
+        ["error", { events: [], isLoading: false, hasError: true }],
+        [
+          "empty",
+          { events: [], isLoading: false, hasError: false, hasSettled: true },
+        ],
+        [
+          "loaded with data",
+          {
+            events: [changeEvent(0)],
+            isLoading: false,
+            hasError: false,
+            hasSettled: true,
+          },
+        ],
+      ] as const)(
+        "renders the header notice in the %s branch when snapshotLimitCapped is true",
+        (_label, branchProps) => {
+          const div = renderBranch({
+            ...branchProps,
+            snapshotLimitCapped: true,
+          });
+
+          expect(div.textContent).toContain("Supply changes");
+          const notice = headerNoticeElement(div);
+          expect(notice).not.toBeNull();
+          expect(notice!.textContent).toContain(
+            "Use the 1W or 1M range for a complete view.",
+          );
+
+          div.remove();
+        },
+      );
+
+      it.each([
+        ["loading", { events: [], isLoading: true, hasError: false }],
+        ["error", { events: [], isLoading: false, hasError: true }],
+        [
+          "empty",
+          { events: [], isLoading: false, hasError: false, hasSettled: true },
+        ],
+        [
+          "loaded with data",
+          {
+            events: [changeEvent(0)],
+            isLoading: false,
+            hasError: false,
+            hasSettled: true,
+          },
+        ],
+      ] as const)(
+        "omits the header notice in the %s branch when snapshotLimitCapped is false",
+        (_label, branchProps) => {
+          const div = renderBranch({
+            ...branchProps,
+            snapshotLimitCapped: false,
+          });
+
+          expect(headerNoticeElement(div)).toBeNull();
+
+          div.remove();
+        },
+      );
+
+      it("keeps the card's header the same element regardless of the body branch, so toggling the notice never moves the card", () => {
+        // Render each branch twice — once uncapped, once capped — and assert
+        // the "Supply changes" heading is always the FIRST element inside the
+        // card, i.e. the notice is appended after it rather than being a
+        // sibling block rendered above the card that would push the whole
+        // card down.
+        const branches = [
+          { events: [], isLoading: true, hasError: false },
+          { events: [], isLoading: false, hasError: true },
+          {
+            events: [],
+            isLoading: false,
+            hasError: false,
+            hasSettled: true,
+          },
+        ] as const;
+
+        for (const branch of branches) {
+          const uncapped = renderBranch({
+            ...branch,
+            snapshotLimitCapped: false,
+          });
+          const capped = renderBranch({ ...branch, snapshotLimitCapped: true });
+
+          const uncappedFirstHeading =
+            uncapped.querySelector("section h2")?.textContent;
+          const cappedFirstHeading =
+            capped.querySelector("section h2")?.textContent;
+          expect(uncappedFirstHeading).toBe("Supply changes");
+          expect(cappedFirstHeading).toBe("Supply changes");
+
+          // The heading is always the FIRST element of its wrapping div — the
+          // notice (when present) is appended after it, never inserted as a
+          // leading sibling that would push the heading itself down.
+          const uncappedWrapperFirstTag =
+            uncapped.querySelector("section h2")?.parentElement
+              ?.firstElementChild?.tagName;
+          const cappedWrapperFirstTag =
+            capped.querySelector("section h2")?.parentElement?.firstElementChild
+              ?.tagName;
+          expect(uncappedWrapperFirstTag).toBe("H2");
+          expect(cappedWrapperFirstTag).toBe("H2");
+
+          uncapped.remove();
+          capped.remove();
+        }
+      });
     });
   });
 });

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -61,6 +61,12 @@ type Props = {
   hasSettled: boolean;
   capped: boolean;
   unpricedEventsCount: number;
+  // Truncation flag for the daily-snapshots query that feeds the chart above
+  // (independent of `capped`, which flags the supply-changes list itself).
+  // Folded into this card's header row — rather than rendered as a standalone
+  // paragraph between the sparkline grid and this card — so the notice never
+  // displaces the card's position when it turns on/off (issue #1239).
+  snapshotLimitCapped: boolean;
 };
 
 /**
@@ -82,6 +88,7 @@ export function StablesChangesTable({
   hasSettled,
   capped,
   unpricedEventsCount,
+  snapshotLimitCapped,
 }: Props): React.JSX.Element {
   const thresholdLabel = formatSupplyChangeUsdThreshold(minimumUsdValue);
   const hasRows = !isLoading && !hasError && events.length > 0;
@@ -95,6 +102,7 @@ export function StablesChangesTable({
         capped={hasRows || showEmptyState ? capped : false}
         eventCount={hasRows ? events.length : 0}
         unpricedEventsCount={hasRows ? unpricedEventsCount : 0}
+        snapshotLimitCapped={snapshotLimitCapped}
         onMinimumUsdValueChange={onMinimumUsdValueChange}
         onMinimumUsdValueReset={onMinimumUsdValueReset}
       />
@@ -237,6 +245,7 @@ function ChangesHeader({
   capped,
   eventCount,
   unpricedEventsCount,
+  snapshotLimitCapped,
   onMinimumUsdValueChange,
   onMinimumUsdValueReset,
 }: {
@@ -245,12 +254,21 @@ function ChangesHeader({
   capped: boolean;
   eventCount: number;
   unpricedEventsCount: number;
+  snapshotLimitCapped: boolean;
   onMinimumUsdValueChange: (next: number) => void;
   onMinimumUsdValueReset: () => void;
 }): React.JSX.Element {
   return (
     <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-      <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
+      <div>
+        <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
+        {snapshotLimitCapped ? (
+          <p className="mt-1 text-xs text-amber-400" role="status">
+            Showing the most recent 1,000 snapshot rows — older history may be
+            truncated. Use the 1W or 1M range for a complete view.
+          </p>
+        ) : null}
+      </div>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between lg:justify-end">
         <SupplyChangeThresholdInput
           value={minimumUsdValue}

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -25,14 +25,24 @@ export function StablesPageClient(): React.JSX.Element {
   );
 }
 
-// Whether the daily-snapshots truncation-cap outcome (`chartCapped` above)
-// is still unresolved. Kept as a standalone function so its two boolean
+// Whether the daily-snapshots truncation-cap outcome (`chartCapped` below)
+// is still unresolved. Kept as a standalone function so its boolean
 // operators don't count against `StablesContent`'s own complexity budget.
+//
+// `chartCapped` is an OR of the two per-source cap flags, so the moment any
+// source reports capped the outcome is irrevocably "capped" — the header is
+// already in its final notice-shown shape and there is nothing left to wait
+// for, even if the other query is slow or wedged. Short-circuit so the
+// changes card doesn't delay otherwise-ready rows behind an unrelated
+// request. Only an all-sources-uncapped conclusion needs every query
+// settled.
 function isSnapshotCapOutcomeLoading(
+  alreadyCapped: boolean,
   snapshotsLoading: boolean,
   custodySnapshotsLoading: boolean,
   custodySnapshotsUnavailable: boolean,
 ): boolean {
+  if (alreadyCapped) return false;
   return (
     snapshotsLoading ||
     (!custodySnapshotsUnavailable && custodySnapshotsLoading)
@@ -89,6 +99,7 @@ function StablesContent(): React.JSX.Element {
   // inlined like `chartCapped` above) to keep `StablesContent`'s own
   // cyclomatic complexity under the lint ceiling.
   const snapshotLimitCappedLoading = isSnapshotCapOutcomeLoading(
+    chartCapped,
     snapshotsLoading,
     custodySnapshotsLoading,
     custodySnapshotsUnavailable,
@@ -197,9 +208,28 @@ function StablesChangesSection({
   // #1239 eliminated at the page level, just reintroduced inside the card
   // (Codex review on #1256). Holding the reveal until the cap outcome is
   // known guarantees the header is already in its final shape by the time
-  // rows first appear, so revealing rows never coincides with a header size
-  // change.
-  const [hasSettledOnce, setHasSettledOnce] = useState(false);
+  // rows first appear.
+  //
+  // The latch stores the cap outcome itself (null = not settled yet), and
+  // the header renders the FROZEN value after settle. A post-settle flip
+  // (e.g. a later SWR poll returns the 1,000th snapshot row) would otherwise
+  // insert the notice above already-visible rows — the #1239 displacement
+  // re-entering through the polling path. Reserving a permanent slot instead
+  // would violate #1239's "no reserved gap on uncapped days" criterion, and
+  // resetting the latch would drop visible rows back to a skeleton, so the
+  // notice is pinned to its settle-time state; a mid-session cap crossing is
+  // a once-per-dataset event (snapshot count only grows ~daily and stays
+  // capped once past the limit) and surfaces on the next mount.
+  //
+  // A changes-query error always wins over the pre-settle hold: without
+  // that, a failed changes query + a slow cap/rates query would show an
+  // indefinite skeleton instead of the error affordance (the table branches
+  // on isLoading before hasError).
+  const [settledSnapshotLimitCapped, setSettledSnapshotLimitCapped] = useState<
+    boolean | null
+  >(null);
+  const hasSettledOnce = settledSnapshotLimitCapped !== null;
+  const changesHasError = changesError != null;
   if (
     !hasSettledOnce &&
     !changesLoading &&
@@ -207,12 +237,13 @@ function StablesChangesSection({
     !ratesLoading &&
     !snapshotLimitCappedLoading
   ) {
-    setHasSettledOnce(true);
+    setSettledSnapshotLimitCapped(snapshotLimitCapped);
   }
   const showChangesSkeleton =
-    changesLoading ||
-    (!hasSettledOnce &&
-      (changesHasPendingPage || ratesLoading || snapshotLimitCappedLoading));
+    !changesHasError &&
+    (changesLoading ||
+      (!hasSettledOnce &&
+        (changesHasPendingPage || ratesLoading || snapshotLimitCappedLoading)));
 
   return (
     <StablesChangesTable
@@ -221,11 +252,11 @@ function StablesChangesSection({
       onMinimumUsdValueChange={updateMinimumSupplyChangeUsd}
       onMinimumUsdValueReset={resetMinimumSupplyChangeUsd}
       isLoading={showChangesSkeleton}
-      hasError={changesError != null}
+      hasError={changesHasError}
       hasSettled={hasSettledOnce}
       capped={changesCapped}
       unpricedEventsCount={changesUnpricedEventsCount}
-      snapshotLimitCapped={snapshotLimitCapped}
+      snapshotLimitCapped={settledSnapshotLimitCapped ?? snapshotLimitCapped}
     />
   );
 }

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -25,6 +25,20 @@ export function StablesPageClient(): React.JSX.Element {
   );
 }
 
+// Whether the daily-snapshots truncation-cap outcome (`chartCapped` above)
+// is still unresolved. Kept as a standalone function so its two boolean
+// operators don't count against `StablesContent`'s own complexity budget.
+function isSnapshotCapOutcomeLoading(
+  snapshotsLoading: boolean,
+  custodySnapshotsLoading: boolean,
+  custodySnapshotsUnavailable: boolean,
+): boolean {
+  return (
+    snapshotsLoading ||
+    (!custodySnapshotsUnavailable && custodySnapshotsLoading)
+  );
+}
+
 function StablesContent(): React.JSX.Element {
   const { range, updateRange } = useStablesRangeUrlState();
 
@@ -63,6 +77,22 @@ function StablesContent(): React.JSX.Element {
     : custodySnapshots;
   const chartCapped =
     snapshotsCapped || (!custodySnapshotsUnavailable && custodySnapshotsCapped);
+  // Whether `chartCapped` (fed into the changes card as `snapshotLimitCapped`)
+  // still might change — mirrors chartCapped's own guard so the two flip
+  // together. Passed down so the changes card's settle latch can hold its
+  // reveal until this resolves too (see StablesChangesSection below): the
+  // card's header folds the truncation notice into its own height (issue
+  // #1239), so if real rows revealed before this was known, a late cap
+  // resolution would grow the header and shove the already-visible rows down
+  // — the exact displacement #1239 exists to eliminate, just moved inside the
+  // card (Codex review on #1256). Extracted to its own function (rather than
+  // inlined like `chartCapped` above) to keep `StablesContent`'s own
+  // cyclomatic complexity under the lint ceiling.
+  const snapshotLimitCappedLoading = isSnapshotCapOutcomeLoading(
+    snapshotsLoading,
+    custodySnapshotsLoading,
+    custodySnapshotsUnavailable,
+  );
   const isLoading =
     ratesLoading ||
     latestLoading ||
@@ -111,6 +141,7 @@ function StablesContent(): React.JSX.Element {
         rates={rates}
         ratesLoading={ratesLoading}
         snapshotLimitCapped={chartCapped}
+        snapshotLimitCappedLoading={snapshotLimitCappedLoading}
       />
     </div>
   );
@@ -120,10 +151,12 @@ function StablesChangesSection({
   rates,
   ratesLoading,
   snapshotLimitCapped,
+  snapshotLimitCappedLoading,
 }: {
   rates: OracleRateMap;
   ratesLoading: boolean;
   snapshotLimitCapped: boolean;
+  snapshotLimitCappedLoading: boolean;
 }): React.JSX.Element {
   const {
     minimumUsdValue: minimumSupplyChangeUsd,
@@ -154,18 +187,32 @@ function StablesChangesSection({
   // skeleton there would drop already-visible rows and flash blank. Latch
   // "settled once" (React's render-phase state update, not an effect) and stop
   // gating on `hasPendingPage`/`ratesLoading` after it.
+  //
+  // Also gates on `snapshotLimitCappedLoading`: this card folds the daily
+  // snapshots' truncation notice into its own header (issue #1239), so the
+  // header's height depends on a query this section doesn't otherwise wait
+  // on. Without this, real rows could reveal before that query resolves, and
+  // a later cap-outcome flip would grow the header and shove the
+  // already-visible rows down inside the card — the same displacement
+  // #1239 eliminated at the page level, just reintroduced inside the card
+  // (Codex review on #1256). Holding the reveal until the cap outcome is
+  // known guarantees the header is already in its final shape by the time
+  // rows first appear, so revealing rows never coincides with a header size
+  // change.
   const [hasSettledOnce, setHasSettledOnce] = useState(false);
   if (
     !hasSettledOnce &&
     !changesLoading &&
     !changesHasPendingPage &&
-    !ratesLoading
+    !ratesLoading &&
+    !snapshotLimitCappedLoading
   ) {
     setHasSettledOnce(true);
   }
   const showChangesSkeleton =
     changesLoading ||
-    (!hasSettledOnce && (changesHasPendingPage || ratesLoading));
+    (!hasSettledOnce &&
+      (changesHasPendingPage || ratesLoading || snapshotLimitCappedLoading));
 
   return (
     <StablesChangesTable

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -107,33 +107,23 @@ function StablesContent(): React.JSX.Element {
         hasError={hasError}
       />
 
-      <StablesSnapshotLimitNotice visible={chartCapped} />
-
-      <StablesChangesSection rates={rates} ratesLoading={ratesLoading} />
+      <StablesChangesSection
+        rates={rates}
+        ratesLoading={ratesLoading}
+        snapshotLimitCapped={chartCapped}
+      />
     </div>
-  );
-}
-
-function StablesSnapshotLimitNotice({
-  visible,
-}: {
-  visible: boolean;
-}): React.JSX.Element | null {
-  if (!visible) return null;
-  return (
-    <p className="text-xs text-amber-400" role="status">
-      Showing the most recent 1,000 snapshot rows — older history may be
-      truncated. Use the 1W or 1M range for a complete view.
-    </p>
   );
 }
 
 function StablesChangesSection({
   rates,
   ratesLoading,
+  snapshotLimitCapped,
 }: {
   rates: OracleRateMap;
   ratesLoading: boolean;
+  snapshotLimitCapped: boolean;
 }): React.JSX.Element {
   const {
     minimumUsdValue: minimumSupplyChangeUsd,
@@ -188,6 +178,7 @@ function StablesChangesSection({
       hasSettled={hasSettledOnce}
       capped={changesCapped}
       unpricedEventsCount={changesUnpricedEventsCount}
+      snapshotLimitCapped={snapshotLimitCapped}
     />
   );
 }

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -104,6 +104,12 @@ function StablesContent(): React.JSX.Element {
     custodySnapshotsLoading,
     custodySnapshotsUnavailable,
   );
+  // Whether the cap inputs currently include an errored snapshot leg. An
+  // uncapped conclusion reached in this state (e.g. custody errored empty
+  // and was excluded from the cap OR above) is not trustworthy enough to
+  // freeze permanently — see `reconcileDegradedCapSettle`.
+  const snapshotLimitCappedDegraded =
+    snapshotsError != null || custodySnapshotsError != null;
   const isLoading =
     ratesLoading ||
     latestLoading ||
@@ -153,9 +159,43 @@ function StablesContent(): React.JSX.Element {
         ratesLoading={ratesLoading}
         snapshotLimitCapped={chartCapped}
         snapshotLimitCappedLoading={snapshotLimitCappedLoading}
+        snapshotLimitCappedDegraded={snapshotLimitCappedDegraded}
       />
     </div>
   );
+}
+
+// The changes card's settled cap outcome: the frozen notice value plus
+// whether it was reached on degraded inputs (an errored snapshot leg at
+// settle time). `null` = not settled yet.
+type CapSettleState = { capped: boolean; degraded: boolean };
+
+// Post-settle reconciliation for a cap conclusion that was reached on
+// degraded inputs (an errored snapshot leg at settle time — e.g. custody
+// errored empty and was excluded from the cap OR). Returns the next settle
+// state, or null when nothing needs to change. The settle-time freeze
+// stays authoritative for healthy settles, but an uncapped conclusion
+// derived from an error is not trustworthy: if the errored leg later
+// recovers with enough rows to cross the cap, keeping the frozen `false`
+// would show truncated history with no warning until remount — silent
+// degradation, which docs/pr-checklists/stateful-data-ui.md disallows and
+// which outranks the one-off layout shift of a late notice in this rare
+// error-recovery path. The upgrade is strictly one-way: the downgrade
+// direction (removing a shown notice) stays forbidden. The re-freeze arm
+// closes the escape hatch once the uncapped conclusion is confirmed on
+// healthy, settled inputs — the conclusion a normal settle would have
+// produced — so the ordinary daily cap crossing stays frozen even in
+// sessions that started with a transient snapshot error.
+function reconcileDegradedCapSettle(
+  settle: CapSettleState | null,
+  liveCapped: boolean,
+  liveDegraded: boolean,
+  liveLoading: boolean,
+): CapSettleState | null {
+  if (settle === null || !settle.degraded || settle.capped) return null;
+  if (liveCapped) return { capped: true, degraded: false };
+  if (!liveDegraded && !liveLoading) return { capped: false, degraded: false };
+  return null;
 }
 
 function StablesChangesSection({
@@ -163,11 +203,13 @@ function StablesChangesSection({
   ratesLoading,
   snapshotLimitCapped,
   snapshotLimitCappedLoading,
+  snapshotLimitCappedDegraded,
 }: {
   rates: OracleRateMap;
   ratesLoading: boolean;
   snapshotLimitCapped: boolean;
   snapshotLimitCappedLoading: boolean;
+  snapshotLimitCappedDegraded: boolean;
 }): React.JSX.Element {
   const {
     minimumUsdValue: minimumSupplyChangeUsd,
@@ -219,16 +261,17 @@ function StablesChangesSection({
   // resetting the latch would drop visible rows back to a skeleton, so the
   // notice is pinned to its settle-time state; a mid-session cap crossing is
   // a once-per-dataset event (snapshot count only grows ~daily and stays
-  // capped once past the limit) and surfaces on the next mount.
+  // capped once past the limit) and surfaces on the next mount. The one
+  // exception: an uncapped conclusion reached on DEGRADED inputs (an errored
+  // snapshot leg at settle time) may later upgrade one-way to capped — see
+  // `reconcileDegradedCapSettle` above.
   //
   // A changes-query error always wins over the pre-settle hold: without
   // that, a failed changes query + a slow cap/rates query would show an
   // indefinite skeleton instead of the error affordance (the table branches
   // on isLoading before hasError).
-  const [settledSnapshotLimitCapped, setSettledSnapshotLimitCapped] = useState<
-    boolean | null
-  >(null);
-  const hasSettledOnce = settledSnapshotLimitCapped !== null;
+  const [capSettle, setCapSettle] = useState<CapSettleState | null>(null);
+  const hasSettledOnce = capSettle !== null;
   const changesHasError = changesError != null;
   if (
     !hasSettledOnce &&
@@ -237,7 +280,19 @@ function StablesChangesSection({
     !ratesLoading &&
     !snapshotLimitCappedLoading
   ) {
-    setSettledSnapshotLimitCapped(snapshotLimitCapped);
+    setCapSettle({
+      capped: snapshotLimitCapped,
+      degraded: snapshotLimitCappedDegraded,
+    });
+  }
+  const reconciledCapSettle = reconcileDegradedCapSettle(
+    capSettle,
+    snapshotLimitCapped,
+    snapshotLimitCappedDegraded,
+    snapshotLimitCappedLoading,
+  );
+  if (reconciledCapSettle !== null) {
+    setCapSettle(reconciledCapSettle);
   }
   const showChangesSkeleton =
     !changesHasError &&
@@ -256,7 +311,7 @@ function StablesChangesSection({
       hasSettled={hasSettledOnce}
       capped={changesCapped}
       unpricedEventsCount={changesUnpricedEventsCount}
-      snapshotLimitCapped={settledSnapshotLimitCapped ?? snapshotLimitCapped}
+      snapshotLimitCapped={capSettle ? capSettle.capped : snapshotLimitCapped}
     />
   );
 }


### PR DESCRIPTION
## The Problem

- On `/stables`, the snapshot-truncation notice ("Showing the most recent 1,000 snapshot rows…") only renders once the daily-snapshots query resolves as capped, and it rendered as a standalone paragraph between the sparkline grid and the supply-changes table.
- Measured on a production build with live data at 1440×900: that paragraph inserted ~49px of extra space (16px text plus section gap), shifting the supply-changes table down whenever the 1,000-row cap was hit.
- Because the flag is data-conditional, the loading phase has no way to know in advance whether to reserve that space, so a layout-only fix was needed.

## The Solution

Instead of rendering the notice as a sibling block above the supply-changes card, fold it into the card's own header row — a row that already renders unconditionally across every loading/error/empty/loaded branch. The card is now always the same sibling at the same position on the page; when the notice appears it grows inside the card's existing header instead of pushing the card down, and when the cap isn't hit there's no notice and no reserved gap.

## Details

- Chose the "fold the notice into the table card header row" mechanism (of the three offered in the issue) because the header row is the one piece of the card's DOM that is already present identically across all four content branches (loading, error, empty, loaded) — reserving a slot or deriving the flag early would have required either a fixed-height placeholder (phantom gap on uncapped days) or plumbing an SSR-derivable flag that doesn't exist without #1208.
- `StablesChangesTable` gains a `snapshotLimitCapped` prop (independent of the existing `capped` prop, which flags the supply-changes list itself, not the snapshots feed) and passes it through to `ChangesHeader`, which renders the notice under the "Supply changes" heading when set.
- `stables-page-client.tsx` drops the standalone `StablesSnapshotLimitNotice` component/render call and instead threads `chartCapped` down through `StablesChangesSection` into the table as `snapshotLimitCapped`.
- No changes to the snapshot query row cap itself (out of scope per issue #1208).

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — includes new tests asserting the header notice renders identically (or is omitted identically) across loading/error/empty/loaded branches, and that the supply-changes card stays the same last child / same sibling position whether or not the cap is hit.
- `pnpm agent:autoreview` — clean, no actionable findings (0.93 confidence).
- The browser parity measurement (production build, GraphQL-delay + rect-sampler recipe from #1219, at 1440×900) is run by the session lead before merge to confirm the supply-changes table's top position no longer shifts when the notice appears.

Closes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and copy relocation on the stables dashboard with no API or data-layer changes; risk is limited to notice visibility and minor in-card header height growth when capped.
> 
> **Overview**
> Fixes layout shift on `/stables` when the daily-snapshots query hits the 1,000-row cap by **moving** the amber truncation message out of a standalone block between the sparkline grid and the supply-changes card.
> 
> **`stables-page-client.tsx`** removes `StablesSnapshotLimitNotice` and passes `chartCapped` into `StablesChangesSection` as `snapshotLimitCapped`, then into `StablesChangesTable`. **`StablesChangesTable`** adds a `snapshotLimitCapped` prop (separate from list `capped`) and **`ChangesHeader`** shows the same copy under the “Supply changes” heading when true, so the card stays the same page sibling and only the header grows.
> 
> Tests in **`page-client.test.tsx`** and **`stables-changes-table.test.tsx`** assert notice placement, stable top-level child count when toggling the cap, and identical notice behavior across loading/error/empty/loaded branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bd4502374555a0d219cc27a8bb93d8e89e50fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->