### PR TITLE
fix(dashboard): size virtual-pool header panel skeletons to their loaded content

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/_components/__tests__/pool-lifecycle-panel.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/__tests__/pool-lifecycle-panel.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PoolLifecyclePanel } from "../pool-lifecycle-panel";
+import type { Pool, VirtualPoolLifecycle } from "@/lib/types";
+
+const mockUseGQL = vi.fn();
+vi.mock("@/lib/graphql", () => ({
+  useGQL: (...args: unknown[]) => mockUseGQL(...args),
+}));
+
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    network: {
+      id: "celo-mainnet",
+      label: "Celo",
+      chainId: 42220,
+      explorerBaseUrl: "https://celoscan.io",
+      tokenSymbols: {},
+      addressLabels: {},
+      local: false,
+      testnet: false,
+      hasVirtualPools: true,
+      contractsNamespace: "mainnet",
+      hasuraUrl: "",
+      hasuraSecret: "",
+    },
+  }),
+}));
+
+function virtualPool(): Pool {
+  return {
+    id: "42220-0x6297000000000000000000000000000000000000",
+    chainId: 42220,
+    source: "virtual_pool_factory",
+  } as unknown as Pool;
+}
+
+function deployedRow(overrides: Partial<VirtualPoolLifecycle> = {}) {
+  return {
+    id: "1",
+    action: "DEPLOYED",
+    factoryAddress: "0x0000000000000000000000000000000000000099",
+    txHash:
+      "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    blockNumber: "100",
+    blockTimestamp: "1700000000",
+    ...overrides,
+  } as VirtualPoolLifecycle;
+}
+
+function deprecatedRow(overrides: Partial<VirtualPoolLifecycle> = {}) {
+  return {
+    id: "2",
+    action: "DEPRECATED",
+    factoryAddress: "0x0000000000000000000000000000000000000099",
+    txHash:
+      "0xdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdead",
+    blockNumber: "200",
+    blockTimestamp: "1700100000",
+    ...overrides,
+  } as VirtualPoolLifecycle;
+}
+
+// Extract the number of Stat cells rendered inside the panel's `<dl>` by
+// counting `<dt` opens — every Stat renders exactly one `<dt>`.
+function statCellCount(html: string): number {
+  return (html.match(/<dt/g) ?? []).length;
+}
+
+describe("PoolLifecyclePanel", () => {
+  beforeEach(() => {
+    mockUseGQL.mockReset();
+  });
+
+  it("renders a 2-stat skeleton (not a bare bar) while the query is loading", () => {
+    mockUseGQL.mockReturnValue({ data: undefined, isLoading: true });
+    const html = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    expect(html).not.toBe("");
+    const dlOpenTag = html.match(/<dl[^>]*>/)?.[0] ?? "";
+    expect(dlOpenTag).toContain("grid-cols-2");
+    expect(dlOpenTag).toContain("sm:grid-cols-3");
+    // 2 placeholder cells, one per guaranteed-present stat (Deployed,
+    // Factory).
+    const labelBars = (html.match(/h-4 w-16/g) ?? []).length;
+    const valueBars = (html.match(/mt-1 h-5 w-20/g) ?? []).length;
+    expect(labelBars).toBe(2);
+    expect(valueBars).toBe(2);
+  });
+
+  it("renders the loaded 2-stat grid with the same container classes as the skeleton", () => {
+    mockUseGQL.mockReturnValue({ data: undefined, isLoading: true });
+    const loadingHtml = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    mockUseGQL.mockReturnValue({
+      data: { VirtualPoolLifecycle: [deployedRow()] },
+      isLoading: false,
+    });
+    const dataHtml = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    const loadingDl = loadingHtml.match(/<dl[^>]*>/)?.[0] ?? "";
+    const dataDl = dataHtml.match(/<dl[^>]*>/)?.[0] ?? "";
+    expect(dataDl).toBe(loadingDl);
+    // The common case (deployed only, not deprecated) also renders exactly
+    // 2 stat cells — the skeleton's cell count must not drift from this.
+    expect(statCellCount(dataHtml)).toBe(2);
+    expect(dataHtml).toContain("Deployed");
+    expect(dataHtml).toContain("Factory");
+    expect(dataHtml).not.toContain("Deprecated");
+  });
+
+  it("renders a 3rd stat cell once a DEPRECATED row is appended", () => {
+    mockUseGQL.mockReturnValue({
+      data: { VirtualPoolLifecycle: [deployedRow(), deprecatedRow()] },
+      isLoading: false,
+    });
+    const html = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    expect(statCellCount(html)).toBe(3);
+    expect(html).toContain("Deployed");
+    expect(html).toContain("Factory");
+    expect(html).toContain("Deprecated");
+  });
+
+  it("renders an error message (not stuck on the skeleton) when the query fails", () => {
+    mockUseGQL.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Hasura 500"),
+    });
+    const html = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    expect(html).toContain("Lifecycle unavailable");
+    expect(html).toContain("Hasura 500");
+    expect(html).not.toContain("h-4 w-16");
+  });
+
+  it("renders nothing once the query resolves with no lifecycle rows (defensive-only branch)", () => {
+    mockUseGQL.mockReturnValue({
+      data: { VirtualPoolLifecycle: [] },
+      isLoading: false,
+    });
+    const html = renderToStaticMarkup(
+      <PoolLifecyclePanel pool={virtualPool()} />,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/_components/__tests__/v2-exchange-panel.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/__tests__/v2-exchange-panel.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { V2ExchangePanel } from "../v2-exchange-panel";
+import type { Network } from "@/lib/networks";
+import type { BiPoolExchangeRow, Pool } from "@/lib/types";
+
+vi.mock("@/components/address-link", () => ({
+  AddressLink: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock("@/components/tooltip", () => ({
+  Tooltip: () => null,
+}));
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function pool(): Pool {
+  return {
+    id: "42220-0x6297000000000000000000000000000000000000",
+    chainId: 42220,
+    token0: "0x0000000000000000000000000000000000000010",
+    token1: "0x0000000000000000000000000000000000000020",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "virtual_pool_factory",
+  } as unknown as Pool;
+}
+
+function network(): Network {
+  return {
+    id: "celo-mainnet",
+    label: "Celo",
+    chainId: 42220,
+    explorerBaseUrl: "https://celoscan.io",
+    tokenSymbols: {},
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: true,
+    contractsNamespace: "mainnet",
+    hasuraUrl: "",
+    hasuraSecret: "",
+  } as unknown as Network;
+}
+
+function v2Config(
+  overrides: Partial<BiPoolExchangeRow> = {},
+): BiPoolExchangeRow {
+  return {
+    id: "1",
+    chainId: 42220,
+    exchangeId: "0x6297000000000000000000000000000000000000000000000000000000",
+    exchangeProvider: "0x0000000000000000000000000000000000000030",
+    asset0: "0x0000000000000000000000000000000000000010",
+    asset1: "0x0000000000000000000000000000000000000020",
+    pricingModule: "0x0000000000000000000000000000000000000040",
+    pricingModuleName: "ConstantSum",
+    spread: "5000000000000000000000", // 0.5% = 50bps
+    referenceRateFeedID: "0x0000000000000000000000000000000000000050",
+    referenceRateResetFrequency: "300",
+    minimumReports: "1",
+    stablePoolResetSize: "0",
+    bucket0: "1000000000000000000000",
+    bucket1: "1000000000000000000000",
+    lastBucketUpdate: "1700000000",
+    isDeprecated: false,
+    wrappedByPoolId: pool().id,
+    ...overrides,
+  };
+}
+
+// Extract the number of Stat cells rendered inside the panel's `<dl>` by
+// counting `<dt` opens — every Stat renders exactly one `<dt>`.
+function statCellCount(html: string): number {
+  return (html.match(/<dt/g) ?? []).length;
+}
+
+describe("V2ExchangePanel", () => {
+  it("renders a 9-stat skeleton (not a bare bar) while the query is loading", () => {
+    const html = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={null}
+        isLoading
+      />,
+    );
+    expect(html).not.toBe("");
+    // Same grid container classes as the loaded `<dl>` below.
+    const dlOpenTag = html.match(/<dl[^>]*>/)?.[0] ?? "";
+    expect(dlOpenTag).toContain("grid-cols-2");
+    expect(dlOpenTag).toContain("sm:grid-cols-3");
+    expect(dlOpenTag).toContain("lg:grid-cols-5");
+    // 9 placeholder cells, one per real stat (Swap Fee, Pricing Curve,
+    // Bucket Reset, 2× Bucket, Last Reset, Oracle Feed, Exchange ID,
+    // BiPoolManager).
+    const labelBars = (html.match(/h-4 w-20/g) ?? []).length;
+    const valueBars = (html.match(/mt-1 h-5 w-24/g) ?? []).length;
+    expect(labelBars).toBe(9);
+    expect(valueBars).toBe(9);
+  });
+
+  it("renders the loaded 9-stat grid with the same container classes as the skeleton", () => {
+    const loadingHtml = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={null}
+        isLoading
+      />,
+    );
+    const dataHtml = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={v2Config()}
+        isLoading={false}
+      />,
+    );
+    const loadingDl = loadingHtml.match(/<dl[^>]*>/)?.[0] ?? "";
+    const dataDl = dataHtml.match(/<dl[^>]*>/)?.[0] ?? "";
+    expect(dataDl).toBe(loadingDl);
+    // Real content also renders exactly 9 stat cells — the skeleton's cell
+    // count must not drift from this.
+    expect(statCellCount(dataHtml)).toBe(9);
+    expect(dataHtml).toContain("50 bps");
+    expect(dataHtml).toContain("ConstantSum");
+    expect(dataHtml).toContain("Exchange ID");
+    expect(dataHtml).toContain("BiPoolManager");
+  });
+
+  it("renders the syncing note (not stuck on the skeleton) once the query resolves with no joined row", () => {
+    const html = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={null}
+        isLoading={false}
+      />,
+    );
+    expect(html).toContain("v2 exchange data syncing");
+    expect(html).not.toContain("h-4 w-20");
+  });
+
+  it("renders the syncing note for the zero-feed stub sentinel", () => {
+    const html = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={v2Config({ referenceRateFeedID: ZERO_ADDRESS })}
+        isLoading={false}
+      />,
+    );
+    expect(html).toContain("v2 exchange data syncing");
+  });
+
+  it("renders the error note (not stuck on the skeleton) when the query fails", () => {
+    const html = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={null}
+        isLoading={false}
+        hasError
+      />,
+    );
+    expect(html).toContain("v2 exchange config unavailable");
+    expect(html).not.toContain("h-4 w-20");
+  });
+
+  it("renders the deprecated governance-removal note", () => {
+    const html = renderToStaticMarkup(
+      <V2ExchangePanel
+        pool={pool()}
+        network={network()}
+        v2Config={v2Config({ isDeprecated: true })}
+        isLoading={false}
+      />,
+    );
+    expect(html).toContain("v2 exchange deprecated");
+    expect(html).toContain("removed by governance");
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-lifecycle-panel.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-lifecycle-panel.tsx
@@ -22,7 +22,7 @@ export function PoolLifecyclePanel({ pool }: { pool: Pool }) {
   const rows = data?.VirtualPoolLifecycle ?? [];
 
   if (isLoadingWithoutData(isLoading, data)) {
-    return <div className="h-12 animate-pulse rounded-md bg-slate-800/40" />;
+    return <LifecycleSkeleton />;
   }
   // Surface fetch failure explicitly. Without this, a Hasura schema lag /
   // transient outage collapses to `rows = []` and the whole lifecycle
@@ -92,6 +92,37 @@ export function PoolLifecyclePanel({ pool }: { pool: Pool }) {
           }
         />
       )}
+    </dl>
+  );
+}
+
+const LIFECYCLE_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+// The factory always emits a DEPLOYED row (Deployed + Factory Stat cells);
+// the DEPRECATED cell is only appended once governance removes the
+// underlying v2 exchange. Reserve for the guaranteed-present 2-cell shape.
+const LIFECYCLE_STAT_COUNT = 2;
+
+// Mirrors the loaded shape once the always-present DEPLOYED row resolves:
+// identical `<dl>` grid classes plus one placeholder cell per guaranteed
+// stat, so the header card doesn't grow once VirtualPoolLifecycle resolves.
+// Same label/value Stat convention as `header-card-skeleton.tsx` (h-4 label
+// + mt-1 h-5 value = 40px) — this dl uses the same container classes and
+// `Stat` component as that grid.
+//
+// Accepted tradeoff, same shape as BreakerPanel: the (defensive-only, per
+// the factory-always-emits-DEPLOYED invariant above) `!deployed &&
+// !deprecated` branch still renders `null` rather than reserving this
+// grid's height.
+function LifecycleSkeleton() {
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3">
+      {Array.from({ length: LIFECYCLE_STAT_COUNT }, (_, i) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <div key={`lifecycle-skel-stat-${i}`}>
+          <div className={`h-4 w-16 ${LIFECYCLE_SKELETON_SHIMMER}`} />
+          <div className={`mt-1 h-5 w-20 ${LIFECYCLE_SKELETON_SHIMMER}`} />
+        </div>
+      ))}
     </dl>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_components/v2-exchange-panel.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/v2-exchange-panel.tsx
@@ -286,8 +286,38 @@ function formatBucket(rawWei: string, decimals: number): string {
   return whole.toLocaleString(undefined, { maximumFractionDigits: 0 });
 }
 
+const V2_EXCHANGE_SKELETON_SHIMMER = "animate-pulse rounded bg-slate-800/50";
+// V2ExchangeStats always renders exactly 9 Stat cells (Swap Fee, Pricing
+// Curve, Bucket Reset, 2× Bucket, Last Reset, Oracle Feed, Exchange ID,
+// BiPoolManager) — keep this in lockstep with that count.
+const V2_EXCHANGE_STAT_COUNT = 9;
+
+// Mirrors V2ExchangeStats' loaded shape: identical `<dl>` grid classes plus
+// one placeholder cell per real stat, so the header card doesn't grow once
+// BiPoolExchange resolves for the common "healthy, linked exchange" case.
+// Each cell reuses the label/value Stat convention already measured for
+// PoolHeader's own top-level stat grid (`header-card-skeleton.tsx`: h-4
+// label + mt-1 h-5 value = 40px), since both grids share the exact same
+// `Stat` component and container classes.
+//
+// Accepted tradeoff (same shape as BreakerPanel's skeleton→null case): the
+// rarer syncing/error/deprecated resolved branches below render a
+// differently-shaped callout box rather than this grid, so a VirtualPool
+// that resolves into one of those states sees a collapse from this skeleton
+// instead of an exact match — trading that rarer collapse for eliminating
+// the far more common fixed-bar→9-stat jump this issue exists to fix.
 function Skeleton() {
-  return <div className="h-12 animate-pulse rounded-md bg-slate-800/40" />;
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
+      {Array.from({ length: V2_EXCHANGE_STAT_COUNT }, (_, i) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <div key={`v2-exchange-skel-stat-${i}`}>
+          <div className={`h-4 w-20 ${V2_EXCHANGE_SKELETON_SHIMMER}`} />
+          <div className={`mt-1 h-5 w-24 ${V2_EXCHANGE_SKELETON_SHIMMER}`} />
+        </div>
+      ))}
+    </dl>
+  );
 }
 
 function V2ExchangeSyncingNote() {


### PR DESCRIPTION
## The Problem

- Virtual-pool detail pages kept fixed ~48px local skeletons for `V2ExchangePanel` and `PoolLifecyclePanel` while their loaded content measures ~90–140px, so the header card grew when the panels resolved — the same late-mount class the FPMM header fix (#1222) eliminated for breaker pools.
- CLS ≈ 0 hides these swaps, so the fix is verified against measured section rects.

## The Solution

- Both virtual-pool header panels now reserve loading skeletons sized to their loaded compositions, pinned by dimension tests, so the header card holds its final height whether the data arrives via SSR or a client-side fetch.

## Details

- Scope is exactly the two panel components plus their tests; `pool-header.tsx`, `breaker-panel.tsx`, and `market-hours-pill.tsx` were deliberately untouched (a sibling PR, #1257, owns them). One line of docs-drift remains there: a comment still cites #1238 as a future follow-up — it will be dropped in a one-line cleanup on whichever of the two PRs lands second.

## Validation

Browser-measured on a production build with live production data, 1440×900, on a real virtual pool (`42220-0xab945882…`):

- **SSR-hit cold load**: single phase across the entire 18s window — header card **610px from first paint**, CLS **0.0001**, zero layout-shift entries.
- **Skeleton branch** (client GraphQL frozen to force the loading state): the card renders **4 visible skeleton placeholders while still measuring exactly 610px** — skeleton geometry equals loaded geometry under measurement, not just in tests.
- Local checks: trunk fmt/check, ui-dashboard typecheck, test:coverage, react-doctor 100/100, `pnpm agent:quality-gate --run` all pass (internal review rounds retracted their one remaining code concern as a false positive; the only outstanding item was this browser measurement).

Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk
