### PR TITLE
docs: add SSR-fallback staleness-envelope gate to stateful-data-ui checklist

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -140,6 +140,40 @@ For each non-happy path, decide the behavior explicitly.
       Verify by diffing skeleton-phase vs loaded-phase section rects; the
       browser recipe (GraphQL-delay init script + rect sampler) is embedded in
       issue #1218 and its sibling skeleton-parity issues (#1219–#1223).
+- [ ] **SSR-prefetch / `fallbackData` of safety-critical or clock-dependent
+      data ships the full staleness envelope.** Painting SSR-cached
+      operator-safety state (breaker/market-hours config, halt status) on first
+      paint trades a loading skeleton for "stale-or-wrong data shown as
+      current." Each of these is a distinct way that goes wrong — verify all
+      that apply:
+  - [ ] **Clock-dependent state renders neutral/unknown until the client clock
+        resolves** — never SSR-guess "open"/"OK". `useNow*()` returns null on the
+        server, so a default-to-open branch prints a false-good state through the
+        whole closure window until hydration.
+  - [ ] **Identity/feed-match guard** — a revalidated row that changed identity
+        (e.g. `referenceRateFeedID` after a self-heal / governance update) must
+        NOT pair with the previous identity's cached `fallbackData`; gate the
+        fallback on chain + feed still matching the current row.
+  - [ ] **`fetchedAt` age gate** carried inside the cached value (Next
+        `unstable_cache` stale-serve is UNBOUNDED — see
+        `recurring-review-patterns.md` and the `server-cache.ts` pattern).
+  - [ ] **Cache key salted by deploy id + endpoint**
+        (`VERCEL_DEPLOYMENT_ID ?? VERCEL_GIT_COMMIT_SHA ?? "dev"` + the resolved
+        Hasura URL) — the Data Cache survives deploys and endpoint switches.
+  - [ ] **Revalidation timeout** (`timeoutMs` below the poll interval) on EVERY
+        subscriber sharing the dedup key — without it a _stalled_ fetch never
+        sets `error`, so it shows stale-as-fresh forever with no notice and no
+        retry. The age gate is server-side and can't help post-hydration.
+  - [ ] **Explicit `unavailable` state for error-with-no-data** (fetch failed
+        AND no fallback), rendered BEFORE any `!data`/`!config` early return that
+        would otherwise make the panel silently vanish — distinct from the
+        stale-but-present "last confirmed state" affordance and from a correctly
+        absent (null) panel.
+  - [ ] **Width/geometry reserved for hydration-variable content** (countdowns,
+        "· N today" suffixes) so the neutral→resolved swap can't wrap/grow at
+        narrow breakpoints. Verify at the mobile two-column grid, not just
+        desktop. (Reference: PR #1257 built this whole envelope for the
+        pool-detail breaker/market-hours SSR prefetch.)
 
 The key question:
 


### PR DESCRIPTION
## The Problem

- PR #1257 (SSR-prefetch breaker/market-hours config) took a 7-round Codex convergence loop because SSR-prefetching safety-critical, clock-dependent data behind `fallbackData` opens a whole family of "stale-or-wrong data shown as current" edges that aren't obvious up front.
- Each edge (false-open pre-clock, unbounded cache age, cross-deploy provenance, revalidation stall, silent error-no-data, hydration width wrap) was a separate review finding — the design lesson wasn't captured anywhere a future PR would see it.

## The Solution

- Add one degraded-mode gate to the stateful-data-ui checklist that lists the full staleness envelope, so the next SSR-prefetch of safety-critical/clock-dependent data ships it up front instead of discovering it across review rounds.

## Details

The gate (in `docs/pr-checklists/stateful-data-ui.md` §4, next to the skeleton-parity gate) covers: neutral-until-clock for clock-dependent state, feed/identity match on `fallbackData`, `fetchedAt` age gate, deploy+endpoint cache-key salt, per-subscriber revalidation timeout (so a stall surfaces as error, not stale-as-fresh), an explicit `unavailable` state for error-with-no-data, and width reserves for hydration-variable content.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZspiZsVCpN1gTrbckdzAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a PR checklist; no application code or behavior is modified.
> 
> **Overview**
> Adds a **degraded-mode gate** in `docs/pr-checklists/stateful-data-ui.md` §4 for SSR-prefetch / SWR `fallbackData` when the UI shows **safety-critical or clock-dependent** operator state (e.g. breaker, market hours, halt status). The intent is to require the full **staleness envelope** up front instead of rediscovering it across review rounds (lessons from PR #1257).
> 
> The new checklist item and sub-bullets cover: neutral/unknown until client clock resolves (`useNow*()` on SSR), identity/feed match before reusing cached fallback, in-value `fetchedAt` age limits, deploy+endpoint cache-key salt, per-subscriber revalidation `timeoutMs` so stalls surface as errors, an explicit **unavailable** state when fetch fails with no fallback (before silent `!data` panel removal), and reserved width for hydration-variable text at narrow breakpoints.
> 
> **Docs-only** — no runtime or test changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40e2f146d91cffb90c5b123284fee7b70f9095c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->