### PR TITLE
perf(dashboard): stop pool-row RSC prefetch flood

### DIFF
--- a/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
@@ -12,6 +12,7 @@ const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 const mockPreloadGQL = vi.fn();
+const mockLinkProps = vi.fn();
 let mockSearchParams = new URLSearchParams();
 
 vi.mock("@/lib/graphql", () => ({
@@ -37,15 +38,20 @@ vi.mock("next/link", () => ({
   default: ({
     href,
     children,
+    prefetch,
     ...props
   }: {
     href: string;
     children: ReactNode;
-  } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
+    prefetch?: boolean;
+  } & AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    mockLinkProps({ href, prefetch });
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 import { GlobalPoolsTable } from "@/components/global-pools-table";
@@ -92,6 +98,7 @@ beforeEach(() => {
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   mockSearchParams = new URLSearchParams();
   mockPreloadGQL.mockClear();
+  mockLinkProps.mockClear();
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -107,6 +114,23 @@ afterEach(() => {
 });
 
 describe("GlobalPoolsTable pool-detail prefetch", () => {
+  it("disables Next.js viewport prefetch for pool links", () => {
+    act(() => {
+      root.render(
+        <GlobalPoolsTable
+          entries={[
+            { pool: BASE_POOL, network: CELO_NETWORK, rates: new Map() },
+          ]}
+        />,
+      );
+    });
+
+    expect(mockLinkProps).toHaveBeenCalledWith({
+      href: `/pool/${POOL_ID}`,
+      prefetch: false,
+    });
+  });
+
   it("preloads the pool detail query only on pool link hover", () => {
     act(() => {
       root.render(

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -185,6 +185,7 @@ function NameCell({
         <ChainIcon network={network} />
         <Link
           href={buildPoolDetailHref(pool.id)}
+          prefetch={false}
           className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
           onFocus={onPrefetch}
           onMouseEnter={onPrefetch}


### PR DESCRIPTION
## The Problem

- Every visible pool row automatically prefetched its full Next.js route payload on page load, creating dozens of unnecessary RSC requests before the user expressed intent.

## The Solution

- Disable Next.js viewport prefetch on the pool-name links while preserving the existing hover/focus GraphQL warm-up and normal link navigation.

## Details

- Adds `prefetch={false}` only to the global pools table's pool-detail link.
- Keeps the existing `onMouseEnter` and `onFocus` `PoolDetailWithHealth` preload unchanged.
- Adds regression coverage for the explicit Next.js link setting.
- No query shape, layout, degraded-mode, or indexer behavior changes.

Closes #1250

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/components/__tests__/global-pools-table-prefetch.test.tsx` — 3 passed.
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — 256 files and 3,810 tests passed.
- `pnpm agent:quality-gate --run` — all mapped commands passed, including browser tests, lint, typecheck, coverage, Trunk, knip, dependency checks, React Doctor, and size limits.
- `CI=true pnpm agent:autoreview` — clean.
- Local production build at `http://127.0.0.1:3210/pools`: 52 rendered pool links and zero automatic `/pool/*?_rsc=` requests after five idle seconds; hover issued `PoolDetailWithHealth`; mouse click and focused-link Enter both navigated; console errors: 0.
- Lighthouse snapshot: accessibility 95, best practices 100, SEO 100, agentic browsing 100.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] browser verification complete
- [x] PR readiness probe planned

## Deferrals

- Recent Swaps and revenue pool-detail link prefetch follow-up: #1245.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UI performance tweak with no auth, data, or API changes; navigation and intentional preload behavior stay the same.
> 
> **Overview**
> Stops the global pools table from firing dozens of automatic Next.js **RSC route prefetches** on `/pools` load by setting **`prefetch={false}`** on pool-name links in `pool-row.tsx`.
> 
> **Hover/focus GraphQL warm-up** (`preloadGQL` with `PoolDetailWithHealth` via `onMouseEnter` / `onFocus`) and normal navigation are unchanged—only default viewport/link prefetch is turned off.
> 
> Adds a regression test that the mocked `next/link` receives `prefetch: false` for pool detail URLs, alongside the existing hover/focus preload tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d042bdbc23961ee657b011d724a2c4cb0c41697b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->