### PR TITLE
fix(dashboard): narrow SSR network cache payload

### DIFF
--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -9,8 +9,8 @@ import type { Network } from "@/lib/networks";
 import {
   showInitialSkeleton,
   useAllNetworksData,
-  type NetworkData,
 } from "@/hooks/use-all-networks-data";
+import type { InitialNetworkData, NetworkData } from "@/lib/fetch-all-networks";
 import { EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { PoolsTableSkeleton } from "@/components/pools-table-skeleton";
 import { GlobalPoolsTable } from "@/components/global-pools-table";
@@ -43,7 +43,7 @@ export default function GlobalPage({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
 }: {
-  initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   // First paint uses `initialNetworkData` via SWR's `fallbackData`; on
@@ -114,7 +114,7 @@ function GlobalContent({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
 }: {
-  initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   const { networkData, isLoading } = useAllNetworksData(

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -8,8 +8,8 @@ import { useGQL } from "@/lib/graphql";
 import {
   showInitialSkeleton,
   useAllNetworksData,
-  type NetworkData,
 } from "@/hooks/use-all-networks-data";
+import type { InitialNetworkData } from "@/lib/fetch-all-networks";
 import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
 import { DEFAULT_SWAPS_LIMIT } from "@/lib/constants";
 import { RECENT_SWAPS, POOL_SWAPS } from "@/lib/queries";
@@ -46,7 +46,7 @@ export function PoolsPageClient({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
 }: {
-  initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   return (
@@ -64,7 +64,7 @@ function PoolsContent({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
 }: {
-  initialNetworkData?: NetworkData[] | undefined;
+  initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
 }) {
   "use memo";

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { NetworkData } from "@/lib/fetch-all-networks";
+import type { InitialNetworkData, NetworkData } from "@/lib/fetch-all-networks";
 import type { Network } from "@/lib/networks";
 import type { Pool } from "@/lib/types";
 
@@ -64,15 +64,16 @@ const ACTIVE_VP = {
   updatedAtTimestamp: "2000",
 } satisfies Pool;
 
-function networkData(pool: Pool): NetworkData {
+function networkData(pool: Pool): InitialNetworkData {
   return {
     network: NETWORK,
     pools: [pool],
+    feeSnapshots: [],
     liveHealthError: null,
-  } as NetworkData;
+  } as InitialNetworkData;
 }
 
-function Probe({ fallback }: { fallback: NetworkData[] }) {
+function Probe({ fallback }: { fallback: InitialNetworkData[] }) {
   useAllNetworksData(fallback, 0);
   return null;
 }

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -6,6 +6,7 @@ import {
   fetchAllNetworks,
   isNetworkDataFullyHealthy,
   seedIncrementalRowCacheFromNetworkData,
+  type InitialNetworkData,
   type NetworkData,
 } from "@/lib/fetch-all-networks";
 import { SHARED_QUERY_SWR_CONFIG } from "@/lib/gql-retry";
@@ -203,7 +204,7 @@ export {
  * `SWRConfig` so they don't cascade to any other `useSWR` in the tree.
  */
 export function useAllNetworksData(
-  fallbackData?: NetworkData[],
+  fallbackData?: InitialNetworkData[],
   /** Fetch-completion time of `fallbackData`
    *  (`fetchInitialNetworkData().fetchedAtMs`). Omitted/unknown counts as
    *  stale — revalidate-on-mount is the safe default. */

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -1,22 +1,36 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import type { Network } from "@/lib/networks";
-import type { NetworkData } from "@/lib/network-fetcher/types";
+import type {
+  InitialNetworkData,
+  NetworkData,
+} from "@/lib/network-fetcher/types";
 
 const {
   mockFetchAllNetworks,
   cacheCallbackOutcomes,
-  staleCacheEntry,
+  cacheState,
   capturedCacheKeyParts,
 } = vi.hoisted(() => ({
   mockFetchAllNetworks: vi.fn(),
   /** Records whether each unstable_cache callback invocation resolved
    *  (cacheable) or threw (never written to the cache). */
   cacheCallbackOutcomes: [] as ("resolved" | "threw")[],
-  /** When armed, the unstable_cache mock returns this value WITHOUT
-   *  invoking the callback — mirroring Next's stale-hit path, where the
-   *  cached entry is served immediately and the background revalidation
-   *  (including any error it throws) is swallowed. */
-  staleCacheEntry: { value: undefined as unknown },
+  /** Stateful JSON store for the `unstable_cache` fake. Fresh hits return a
+   *  JSON-parsed copy without invoking the callback. Stale hits return the
+   *  same copy immediately while revalidating in the background. */
+  cacheState: {
+    value: undefined as unknown,
+    stale: false,
+    backgroundRevalidations: [] as Promise<void>[],
+  },
   /** Key parts passed to unstable_cache at module init — asserted so the
    *  deploy/config salt can't silently disappear. */
   capturedCacheKeyParts: [] as string[][],
@@ -24,19 +38,21 @@ const {
 
 // next/cache needs the Next.js incremental-cache runtime; outside it the repo
 // convention is an identity wrapper (see pool-detail-ssr.test.ts). This one
-// additionally records resolve/throw so tests can assert which payloads would
-// have been written to the shared cache, and can serve an armed stale entry
-// to simulate `unstable_cache`'s serve-stale-while-background-revalidate.
+// additionally uses a stateful JSON store so tests exercise the same
+// serialize-on-write / parse-on-hit boundary as Vercel's Data Cache. Armed
+// stale entries are served immediately while the callback revalidates in the
+// background; background errors are swallowed and leave the stale value in
+// place, matching `unstable_cache`'s stale-while-revalidate behavior.
 vi.mock("next/cache", () => ({
   unstable_cache: <TArgs extends unknown[], TResult>(
     fn: (...args: TArgs) => Promise<TResult>,
     keyParts?: string[],
   ) => {
     if (keyParts) capturedCacheKeyParts.push(keyParts);
-    return async (...args: TArgs): Promise<TResult> => {
-      if (staleCacheEntry.value !== undefined) {
-        return staleCacheEntry.value as TResult;
-      }
+
+    const jsonRoundTrip = <T>(value: T): T =>
+      JSON.parse(JSON.stringify(value)) as T;
+    const invoke = async (args: TArgs): Promise<TResult> => {
       try {
         const result = await fn(...args);
         cacheCallbackOutcomes.push("resolved");
@@ -45,6 +61,26 @@ vi.mock("next/cache", () => ({
         cacheCallbackOutcomes.push("threw");
         throw err;
       }
+    };
+
+    return async (...args: TArgs): Promise<TResult> => {
+      if (cacheState.value !== undefined) {
+        const cached = jsonRoundTrip(cacheState.value) as TResult;
+        if (cacheState.stale) {
+          const revalidation = invoke(args)
+            .then((result) => {
+              cacheState.value = jsonRoundTrip(result);
+              cacheState.stale = false;
+            })
+            .catch(() => undefined);
+          cacheState.backgroundRevalidations.push(revalidation);
+        }
+        return cached;
+      }
+
+      const result = await invoke(args);
+      cacheState.value = jsonRoundTrip(result);
+      return result;
     };
   },
 }));
@@ -108,14 +144,34 @@ function healthyNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
   });
 }
 
+function armStaleCacheEntry(value: unknown): void {
+  cacheState.value = value;
+  cacheState.stale = true;
+}
+
 beforeEach(() => {
   mockFetchAllNetworks.mockReset();
   cacheCallbackOutcomes.length = 0;
-  staleCacheEntry.value = undefined;
+  cacheState.value = undefined;
+  cacheState.stale = false;
+  cacheState.backgroundRevalidations.length = 0;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await Promise.all(cacheState.backgroundRevalidations);
   vi.useRealTimers();
+});
+
+describe("InitialNetworkData type contract", () => {
+  it("exposes feeSnapshots as an empty tuple with no readable row type", () => {
+    expectTypeOf<
+      Awaited<ReturnType<typeof fetchInitialNetworkData>>["networks"][number]
+    >().toEqualTypeOf<InitialNetworkData>();
+    expectTypeOf<InitialNetworkData["feeSnapshots"]>().toEqualTypeOf<[]>();
+    expectTypeOf<
+      InitialNetworkData["feeSnapshots"][number]
+    >().toEqualTypeOf<never>();
+  });
 });
 
 describe("dehydrate/rehydrate round-trip", () => {
@@ -176,6 +232,30 @@ describe("fetchInitialNetworkData", () => {
     expect(result.networks[0]!.olsPoolIds.has("0xols")).toBe(true);
     expect(result.fetchedAtMs).toBeGreaterThan(0);
     expect(cacheCallbackOutcomes).toEqual(["resolved"]);
+  });
+
+  it("serves a fresh JSON cache hit without refetching and restores Map/Set fields", async () => {
+    mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
+
+    const first = await fetchInitialNetworkData();
+    // Intentional sequence: the first call must populate the fake cache before
+    // the second proves a serialized fresh-hit read.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
+    const second = await fetchInitialNetworkData();
+
+    expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+    expect(cacheCallbackOutcomes).toEqual(["resolved"]);
+    expect(second).not.toBe(first);
+    expect(second.networks[0]!.rates).toEqual(
+      new Map([["42220:cUSD", 1.0004]]),
+    );
+    expect(second.networks[0]!.poolLabels.get("0xabc")).toMatchObject({
+      id: "0xabc",
+    });
+    expect(second.networks[0]!.olsPoolIds).toEqual(new Set(["0xols"]));
+    expect(second.networks[0]!.cdpPoolIds).toEqual(new Set(["0xcdp"]));
+    expect(second.networks[0]!.reservePoolIds).toEqual(new Set(["0xres"]));
+    expect(second.networks[0]!.feeSnapshots).toEqual([]);
   });
 
   it("strips raw feeSnapshots rows but keeps the fee outcome fields", async () => {
@@ -245,12 +325,15 @@ describe("fetchInitialNetworkData", () => {
       vi.setSystemTime(NOW);
     });
 
-    it("serves a cached payload younger than the staleness bound without refetching", async () => {
-      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS - 1_000);
+    it("serves a cached payload younger than the bound while refreshing in the background", async () => {
+      armStaleCacheEntry(staleEntry(MAX_SERVED_STALENESS_MS - 1_000));
+      mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
       const result = await fetchInitialNetworkData();
+      await Promise.all(cacheState.backgroundRevalidations);
 
-      expect(mockFetchAllNetworks).not.toHaveBeenCalled();
+      expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+      expect(cacheCallbackOutcomes).toEqual(["resolved"]);
       expect(result.networks).toHaveLength(1);
       expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
       // The served entry's real fetch time crosses to the client so the
@@ -258,12 +341,30 @@ describe("fetchInitialNetworkData", () => {
       expect(result.fetchedAtMs).toBe(NOW - (MAX_SERVED_STALENESS_MS - 1_000));
     });
 
+    it("keeps the stale value when background revalidation rejects a degraded payload", async () => {
+      armStaleCacheEntry(staleEntry(MAX_SERVED_STALENESS_MS - 1_000));
+      mockFetchAllNetworks.mockResolvedValueOnce([
+        healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
+      ]);
+
+      const result = await fetchInitialNetworkData();
+      await Promise.all(cacheState.backgroundRevalidations);
+
+      expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+      expect(cacheCallbackOutcomes).toEqual(["threw"]);
+      expect(cacheState.stale).toBe(true);
+      expect(result.networks[0]!.ratesError).toBeNull();
+      expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
+    });
+
     it("foreground-refetches a cached payload older than the staleness bound", async () => {
       // Distinguishable stale rate — the assertion below proves the fresh
       // payload wins, not the pinned cache entry.
-      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1, {
-        rates: new Map([["42220:cUSD", 999]]),
-      });
+      armStaleCacheEntry(
+        staleEntry(MAX_SERVED_STALENESS_MS + 1, {
+          rates: new Map([["42220:cUSD", 999]]),
+        }),
+      );
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
       const result = await fetchInitialNetworkData();
@@ -273,7 +374,7 @@ describe("fetchInitialNetworkData", () => {
     });
 
     it("surfaces a fresh degraded payload past the staleness bound instead of the stale healthy one", async () => {
-      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1);
+      armStaleCacheEntry(staleEntry(MAX_SERVED_STALENESS_MS + 1));
       mockFetchAllNetworks.mockResolvedValueOnce([
         healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
       ]);
@@ -287,9 +388,11 @@ describe("fetchInitialNetworkData", () => {
     });
 
     it("coalesces concurrent over-age refetches into one upstream fan-out", async () => {
-      staleCacheEntry.value = staleEntry(MAX_SERVED_STALENESS_MS + 1, {
-        rates: new Map([["42220:cUSD", 999]]),
-      });
+      armStaleCacheEntry(
+        staleEntry(MAX_SERVED_STALENESS_MS + 1, {
+          rates: new Map([["42220:cUSD", 999]]),
+        }),
+      );
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
       const [first, second] = await Promise.all([

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -15,7 +15,11 @@ import {
   fetchAllNetworks,
   isNetworkDataFullyHealthy,
 } from "@/lib/network-fetcher/fetch";
-import type { NetworkData, PoolLabel } from "@/lib/network-fetcher/types";
+import type {
+  InitialNetworkData,
+  NetworkData,
+  PoolLabel,
+} from "@/lib/network-fetcher/types";
 import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 
 /**
@@ -36,6 +40,13 @@ type DehydratedNetworkData = Omit<
   olsPoolIds: string[];
   cdpPoolIds: string[];
   reservePoolIds: string[];
+};
+
+type DehydratedInitialNetworkData = Omit<
+  DehydratedNetworkData,
+  "feeSnapshots"
+> & {
+  feeSnapshots: [];
 };
 
 export function dehydrateNetworkData(data: NetworkData): DehydratedNetworkData {
@@ -73,8 +84,14 @@ export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
  */
 function stripFeeSnapshotRows(
   data: DehydratedNetworkData,
-): DehydratedNetworkData {
+): DehydratedInitialNetworkData {
   return { ...data, feeSnapshots: [] };
+}
+
+function rehydrateInitialNetworkData(
+  data: DehydratedInitialNetworkData,
+): InitialNetworkData {
+  return { ...rehydrateNetworkData(data), feeSnapshots: [] };
 }
 
 /**
@@ -84,9 +101,9 @@ function stripFeeSnapshotRows(
  * TTL (it would otherwise trap every visitor on `N/A` tiles until expiry).
  */
 class DegradedNetworkDataError extends Error {
-  declare readonly payload: DehydratedNetworkData[];
+  declare readonly payload: DehydratedInitialNetworkData[];
 
-  constructor(payload: DehydratedNetworkData[]) {
+  constructor(payload: DehydratedInitialNetworkData[]) {
     super("degraded network data payload — not cached");
     this.name = "DegradedNetworkDataError";
     // Non-enumerable: `unstable_cache`'s swallowed-error path console.errors
@@ -105,7 +122,7 @@ class DegradedNetworkDataError extends Error {
  *  along so `fetchInitialNetworkData` can age-gate stale cache hits. */
 interface CachedNetworkPayload {
   fetchedAt: number;
-  networks: DehydratedNetworkData[];
+  networks: DehydratedInitialNetworkData[];
 }
 
 async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload> {
@@ -192,7 +209,7 @@ function fetchDehydratedInitialNetworkDataCoalesced(): Promise<CachedNetworkPayl
  *  the client so `useAllNetworksData` can gate its mount-revalidation skip on
  *  actual payload freshness rather than trusting whatever the cache served. */
 export type InitialNetworkDataPayload = {
-  networks: NetworkData[];
+  networks: InitialNetworkData[];
   fetchedAtMs: number;
 };
 
@@ -226,7 +243,7 @@ export async function fetchInitialNetworkData(): Promise<InitialNetworkDataPaylo
           await fetchDehydratedInitialNetworkDataCoalesced()
         : cached;
     return {
-      networks: payload.networks.map(rehydrateNetworkData),
+      networks: payload.networks.map(rehydrateInitialNetworkData),
       fetchedAtMs: payload.fetchedAt,
     };
   } catch (err) {
@@ -234,7 +251,7 @@ export async function fetchInitialNetworkData(): Promise<InitialNetworkDataPaylo
       // Degraded payloads are fetched in-band (never cached), so they are
       // fresh as of this request.
       return {
-        networks: err.payload.map(rehydrateNetworkData),
+        networks: err.payload.map(rehydrateInitialNetworkData),
         fetchedAtMs: Date.now(),
       };
     }

--- a/ui-dashboard/src/lib/network-fetcher/types.ts
+++ b/ui-dashboard/src/lib/network-fetcher/types.ts
@@ -141,6 +141,19 @@ export type NetworkData = {
 };
 
 /**
+ * Network data that is safe to seed into the `/` and `/pools` SSR fallback.
+ *
+ * The server computes the aggregated `fees` summary before serializing this
+ * payload, then deliberately strips the raw fee-history rows. Keeping the
+ * empty tuple in the public type makes that projection part of the contract:
+ * client fallback consumers cannot accidentally treat the SSR seed as a
+ * complete fee-history response.
+ */
+export type InitialNetworkData = Omit<NetworkData, "feeSnapshots"> & {
+  feeSnapshots: [];
+};
+
+/**
  * Legacy v2 volume row from `BrokerDailySnapshot`. Already filtered server-
  * side to `routedViaV3Router=false` — the rows in this array are pure v2
  * (Broker-direct or v2 MentoRouter), no router-driven sibling double-count.


### PR DESCRIPTION
## The Problem

- The cached SSR seed was typed as full `NetworkData[]` even though raw `feeSnapshots` rows are always stripped, allowing future consumers to mistake an empty seed for complete fee history.
- The cache test mock did not prove that a fresh `unstable_cache` hit survives the real JSON store/read boundary.

## The Solution

- Give the SSR seed a narrowed `InitialNetworkData` contract with `feeSnapshots: []`, preserve it through `/`, `/pools`, and `useAllNetworksData`, and exercise fresh and stale cache reads through a stateful JSON round-trip fake.

## Invariants

- `fetchInitialNetworkData()` can never expose raw fee-history rows; the aggregated `fees` summary and fee error/truncation metadata remain available.
- Only the SSR fallback is narrowed. Client revalidation still returns full `NetworkData[]`.
- A fresh cache hit must not refetch upstream and must restore all `Map`/`Set` fields after JSON serialization.

## Degraded behavior

- Degraded payloads remain uncached and retain their error channels so the client revalidates immediately.
- Stale entries still refresh in the background; a degraded background refresh is swallowed by `unstable_cache` semantics and leaves the last confirmed stale value until the server age gate forces a foreground refresh.
- Existing staleness bounds, over-age foreground refresh, and concurrent fan-out coalescing remain unchanged.

## Validation

- Focused Vitest coverage: 4 files, 21 tests passed.
- Dashboard typecheck passed.
- Dashboard coverage: 256 files, 3,812 tests passed.
- `pnpm agent:quality-gate --run` passed all mapped commands, including fixture Playwright, Trunk, lint, typecheck, coverage, Knip, dependency checks, React Doctor 100, and size limits.
- Local and fresh-context structured autoreviews completed with no actionable findings.
- Localhost Chrome acceptance:
  - `/` hard load rendered 27 pool links and the populated `$2.67M` KPI with zero pulse skeletons.
  - `/pools` navigation and hard reload rendered 52 pool links/rows with zero skeletons.
  - Pool sort changed to descending and survived reload; returning to `/` retained populated data.
  - Console errors: 0; no `feeSnapshots`, `Map`/`Set`, or cache-serialization errors.

Closes #1209

## Ship Checklist

- [x] Repo `ship` skill used
- [x] Full mapped local quality gate passed
- [x] Structured closeout review passed
- [x] Browser verification completed
- [x] Issue transition and PR readiness probes run after PR creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly TypeScript contracts and test harness changes; runtime SSR strip/rehydrate behavior was already in place and client fetches remain full `NetworkData`.
> 
> **Overview**
> Introduces **`InitialNetworkData`**, a narrowed SSR/fallback shape where **`feeSnapshots` is typed as `[]`**, so code cannot treat the server seed as full fee-history rows while aggregated **`fees`** and fee error/truncation metadata stay available.
> 
> **`fetchInitialNetworkData`**, **`/`** and **`/pools`** props, and **`useAllNetworksData` fallback** now use that type end-to-end; client revalidation via **`fetchAllNetworks`** still yields full **`NetworkData[]`**.
> 
> Server-cache tests replace the simple stale-entry stub with a **stateful `unstable_cache` fake** that JSON round-trips on read/write, plus coverage for **fresh cache hits** (no refetch, **`Map`/`Set` restored**) and **stale background revalidation** that keeps the last good payload when refresh returns degraded data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db1d5d70c083da4b518fbbd960028b34c53ceea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->