### PR TITLE
fix(dashboard): keep volume data visible during range changes

### DIFF
--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { VolumeHeroInitialData } from "@/lib/volume-hero-initial-data";
 import {
+  AGGREGATOR_DAILY_TOP,
   BROKER_AGGREGATOR_DAILY_TOP,
   BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS,
   BROKER_TRADER_DAILY_TOP,
@@ -13,7 +14,17 @@ const mockUseGQL = vi.hoisted(() => vi.fn());
 const volumeState = vi.hoisted(() => ({
   venue: "v3" as "v3" | "v2",
   includeProtocolActors: false,
+  range: "7d" as "24h" | "7d" | "30d" | "90d" | "all",
 }));
+const poolVolumeState = vi.hoisted(() => ({
+  rows: [] as Array<Record<string, unknown>>,
+  isLoading: false,
+  error: null as Error | null,
+  partial: false,
+}));
+const mockTimeSeriesChartCard = vi.hoisted(() => vi.fn());
+const mockV2VolumeSection = vi.hoisted(() => vi.fn());
+const mockV3VolumeSection = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (...args: unknown[]) => mockUseGQL(...args),
@@ -30,7 +41,7 @@ vi.mock("../_lib/url-state", () => ({
       : true;
     return {
       canUseVolumeFilters,
-      range: "7d",
+      range: volumeState.range,
       actorFilter: includeProtocolActors ? "all" : "organic",
       includeProtocolActors,
       venue: volumeState.venue,
@@ -44,12 +55,7 @@ vi.mock("../_lib/url-state", () => ({
 }));
 
 vi.mock("../_lib/use-pool-volume-snapshots", () => ({
-  usePoolVolumeSnapshots: () => ({
-    rows: [],
-    isLoading: false,
-    error: null,
-    partial: false,
-  }),
+  usePoolVolumeSnapshots: () => poolVolumeState,
 }));
 
 vi.mock("../_lib/pool-chart-vm", () => ({
@@ -80,9 +86,10 @@ vi.mock("../_lib/use-hero-rollup", () => ({
 }));
 
 vi.mock("@/components/time-series-chart-card", () => ({
-  TimeSeriesChartCard: ({ title }: { title: string }) => (
-    <div data-testid="chart">{title}</div>
-  ),
+  TimeSeriesChartCard: (props: { title: string }) => {
+    mockTimeSeriesChartCard(props);
+    return <div data-testid="chart">{props.title}</div>;
+  },
 }));
 
 vi.mock("../_components/hero-data-quality-banners", () => ({
@@ -94,11 +101,17 @@ vi.mock("../_components/top-pools-list", () => ({
 }));
 
 vi.mock("../_components/v2-volume-section", () => ({
-  V2VolumeSection: () => <div data-testid="v2-section" />,
+  V2VolumeSection: (props: unknown) => {
+    mockV2VolumeSection(props);
+    return <div data-testid="v2-section" />;
+  },
 }));
 
 vi.mock("../_components/v3-volume-section", () => ({
-  V3VolumeSection: () => <div data-testid="v3-section" />,
+  V3VolumeSection: (props: unknown) => {
+    mockV3VolumeSection(props);
+    return <div data-testid="v3-section" />;
+  },
 }));
 
 import { VolumeClient } from "../page-client";
@@ -131,8 +144,16 @@ describe("VolumeClient useGQL wiring", () => {
   beforeEach(() => {
     mockUseGQL.mockReset();
     mockUseHeroRollup.mockClear();
+    mockTimeSeriesChartCard.mockClear();
+    mockV2VolumeSection.mockClear();
+    mockV3VolumeSection.mockClear();
     heroState.isLoading = false;
     heroState.hasError = false;
+    volumeState.range = "7d";
+    poolVolumeState.rows = [];
+    poolVolumeState.isLoading = false;
+    poolVolumeState.error = null;
+    poolVolumeState.partial = false;
     mockUseGQL.mockReturnValue({
       data: undefined,
       error: null,
@@ -143,10 +164,18 @@ describe("VolumeClient useGQL wiring", () => {
   it("uses 8s timeouts for v3 volume polling queries", () => {
     renderVolume("v3");
 
-    expect(optionsFor(TRADER_DAILY_TOP)).toMatchObject({ timeoutMs: 8_000 });
+    expect(optionsFor(TRADER_DAILY_TOP)).toMatchObject({
+      timeoutMs: 8_000,
+      keepPreviousData: true,
+    });
+    expect(optionsFor(AGGREGATOR_DAILY_TOP)).toMatchObject({
+      timeoutMs: 8_000,
+      keepPreviousData: true,
+    });
     expect(optionsFor(POOLS_FOR_VOLUME)).toMatchObject({
       timeoutMs: 8_000,
     });
+    expect(optionsFor(POOLS_FOR_VOLUME)?.keepPreviousData).toBeUndefined();
   });
 
   it("uses 8s timeouts for v2 broker volume polling queries", () => {
@@ -154,10 +183,80 @@ describe("VolumeClient useGQL wiring", () => {
 
     expect(optionsFor(BROKER_TRADER_DAILY_TOP)).toMatchObject({
       timeoutMs: 8_000,
+      keepPreviousData: true,
     });
     expect(optionsFor(BROKER_AGGREGATOR_DAILY_TOP)).toMatchObject({
       timeoutMs: 8_000,
+      keepPreviousData: true,
     });
+  });
+
+  it("keeps v3 chart, trader, and aggregator skeletons off while retained data revalidates", () => {
+    volumeState.range = "30d";
+    poolVolumeState.rows = [{ id: "prior-window-row" }];
+    poolVolumeState.isLoading = true;
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === TRADER_DAILY_TOP) {
+        return {
+          data: { TraderDailySnapshot: [] },
+          error: null,
+          isLoading: true,
+        };
+      }
+      if (query === POOLS_FOR_VOLUME) {
+        return { data: { Pool: [] }, error: null, isLoading: true };
+      }
+      if (query === AGGREGATOR_DAILY_TOP) {
+        return {
+          data: { AggregatorDailySnapshot: [] },
+          error: null,
+          isLoading: true,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    renderVolume("v3");
+
+    const chartCall = mockTimeSeriesChartCard.mock.calls.find(
+      ([props]) => props.title === "Volume by pool",
+    );
+    expect(chartCall?.[0]).toMatchObject({ isLoading: false });
+    expect(mockV3VolumeSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableState: expect.objectContaining({ isLoading: false }),
+        aggregatorState: expect.objectContaining({ isLoading: false }),
+      }),
+    );
+  });
+
+  it("keeps v2 trader and aggregator skeletons off while retained data revalidates", () => {
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === BROKER_TRADER_DAILY_TOP) {
+        return {
+          data: { BrokerTraderDailySnapshot: [] },
+          error: null,
+          isLoading: true,
+        };
+      }
+      if (query === BROKER_AGGREGATOR_DAILY_TOP) {
+        return {
+          data: { BrokerAggregatorDailySnapshot: [] },
+          error: null,
+          isLoading: true,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    renderVolume("v2");
+
+    expect(mockV2VolumeSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableIsLoading: false,
+        v2AggIsLoading: false,
+      }),
+    );
   });
 
   it("switches the v2 aggregator query ordering with the actor filter", () => {
@@ -167,6 +266,7 @@ describe("VolumeClient useGQL wiring", () => {
       optionsFor(BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS),
     ).toMatchObject({
       timeoutMs: 8_000,
+      keepPreviousData: true,
     });
   });
 
@@ -187,6 +287,7 @@ describe("VolumeClient useGQL wiring", () => {
       optionsFor(BROKER_AGGREGATOR_DAILY_TOP_INCLUDING_PROTOCOL_ACTORS),
     ).toMatchObject({
       timeoutMs: 8_000,
+      keepPreviousData: true,
     });
   });
 

--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -29,6 +29,12 @@ const mockTimeSeriesChartCard = vi.hoisted(() => vi.fn());
 const mockV2VolumeSection = vi.hoisted(() => vi.fn());
 const mockV3VolumeSection = vi.hoisted(() => vi.fn());
 const mockUsePoolChartViewModel = vi.hoisted(() => vi.fn());
+const resolvedIdentityOverrides = vi.hoisted(() => ({
+  v3Trader: undefined as string | undefined,
+  v3Aggregator: undefined as string | undefined,
+  v2Trader: undefined as string | undefined,
+  v2Aggregator: undefined as string | undefined,
+}));
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (...args: unknown[]) => mockUseGQL(...args),
@@ -48,12 +54,27 @@ vi.mock("../_lib/use-resolved-query-identity", async (importOriginal) => {
     useVersionedVolumeQueryData: (
       result: { data: unknown; error: unknown; isLoading: boolean },
       currentIdentity: string,
-    ) => ({
-      data: result.data,
-      dataIdentity: result.data === undefined ? undefined : currentIdentity,
-      isLoading: result.isLoading && result.data === undefined,
-      hasError: result.error != null && result.data === undefined,
-    }),
+    ) => {
+      const data = result.data as Record<string, unknown> | undefined;
+      const identityOverride = data?.TraderDailySnapshot
+        ? resolvedIdentityOverrides.v3Trader
+        : data?.AggregatorDailySnapshot
+          ? resolvedIdentityOverrides.v3Aggregator
+          : data?.BrokerTraderDailySnapshot
+            ? resolvedIdentityOverrides.v2Trader
+            : data?.BrokerAggregatorDailySnapshot
+              ? resolvedIdentityOverrides.v2Aggregator
+              : undefined;
+      return {
+        data: result.data,
+        dataIdentity:
+          result.data === undefined
+            ? undefined
+            : (identityOverride ?? currentIdentity),
+        isLoading: result.isLoading && result.data === undefined,
+        hasError: result.error != null && result.data === undefined,
+      };
+    },
   };
 });
 
@@ -101,7 +122,14 @@ vi.mock("../_lib/pool-chart-vm", () => ({
 }));
 
 const mockUseHeroRollup = vi.hoisted(() => vi.fn());
-const heroState = vi.hoisted(() => ({ isLoading: false, hasError: false }));
+const heroState = vi.hoisted(() => ({
+  isLoading: false,
+  hasError: false,
+  totalVolume: 0,
+  concentration: 0,
+  displayIdentity: undefined as string | undefined,
+  isKpiSourceCapHit: false,
+}));
 
 vi.mock("../_lib/use-hero-rollup", () => ({
   useHeroRollup: (args: unknown) => {
@@ -109,13 +137,15 @@ vi.mock("../_lib/use-hero-rollup", () => ({
     return {
       isLoading: heroState.isLoading,
       hasError: heroState.hasError,
-      totalVolume: 0,
+      totalVolume: heroState.totalVolume,
       totalTraders: 0,
       totalSwaps: 0,
-      concentration: 0,
+      concentration: heroState.concentration,
       staleChains: [],
       degradedChains: [],
       displayRange: volumeState.range,
+      displayIdentity: heroState.displayIdentity,
+      isKpiSourceCapHit: heroState.isKpiSourceCapHit,
     };
   },
 }));
@@ -183,8 +213,16 @@ describe("VolumeClient useGQL wiring", () => {
     mockV2VolumeSection.mockClear();
     mockV3VolumeSection.mockClear();
     mockUsePoolChartViewModel.mockClear();
+    resolvedIdentityOverrides.v3Trader = undefined;
+    resolvedIdentityOverrides.v3Aggregator = undefined;
+    resolvedIdentityOverrides.v2Trader = undefined;
+    resolvedIdentityOverrides.v2Aggregator = undefined;
     heroState.isLoading = false;
     heroState.hasError = false;
+    heroState.totalVolume = 0;
+    heroState.concentration = 0;
+    heroState.displayIdentity = undefined;
+    heroState.isKpiSourceCapHit = false;
     volumeState.range = "7d";
     poolVolumeState.rows = [];
     poolVolumeState.isLoading = false;
@@ -372,6 +410,48 @@ describe("VolumeClient useGQL wiring", () => {
     );
   });
 
+  it("labels v2 trader and aggregator rows with their independent resolved ranges", () => {
+    volumeState.range = "90d";
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === BROKER_TRADER_DAILY_TOP) {
+        return {
+          data: { BrokerTraderDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      if (query === BROKER_AGGREGATOR_DAILY_TOP) {
+        return {
+          data: { BrokerAggregatorDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+    resolvedIdentityOverrides.v2Trader = "90d|100|organic";
+    resolvedIdentityOverrides.v2Aggregator = "30d|200|organic";
+
+    renderVolume("v2");
+    expect(mockV2VolumeSection).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rangeLabel: "3M",
+        aggregatorRangeLabel: "1M",
+      }),
+    );
+
+    mockV2VolumeSection.mockClear();
+    resolvedIdentityOverrides.v2Trader = "30d|200|organic";
+    resolvedIdentityOverrides.v2Aggregator = "90d|100|organic";
+    renderVolume("v2");
+    expect(mockV2VolumeSection).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rangeLabel: "1M",
+        aggregatorRangeLabel: "3M",
+      }),
+    );
+  });
+
   it("switches the v2 aggregator query ordering with the actor filter", () => {
     renderVolume("v2", true);
 
@@ -430,6 +510,81 @@ describe("VolumeClient useGQL wiring", () => {
     );
   });
 
+  it("withholds the daily-chart headline until the full trader and hero identities match", () => {
+    volumeState.range = "90d";
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === BROKER_TRADER_DAILY_TOP) {
+        return {
+          data: { BrokerTraderDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+    resolvedIdentityOverrides.v2Trader = "90d|200|organic";
+    heroState.totalVolume = 123;
+    heroState.displayIdentity = "90d|100|organic";
+
+    renderVolume("v2");
+    let chartCall = mockTimeSeriesChartCard.mock.calls.find(
+      ([props]) => props.title === "Daily v2 traded volume",
+    );
+    expect(chartCall?.[0]).toMatchObject({ headline: "" });
+
+    mockTimeSeriesChartCard.mockClear();
+    heroState.displayIdentity = "90d|200|organic";
+    renderVolume("v2");
+    chartCall = mockTimeSeriesChartCard.mock.calls.find(
+      ([props]) => props.title === "Daily v2 traded volume",
+    );
+    expect(chartCall?.[0].headline).not.toBe("");
+  });
+
+  it("keeps the displayed concentration cap state separate from the current table cap", () => {
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === TRADER_DAILY_TOP) {
+        return {
+          data: { TraderDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+    heroState.displayIdentity = "7d|100|organic";
+    heroState.isKpiSourceCapHit = true;
+
+    const html = renderVolume("v3");
+
+    expect(html).toContain("Top-10 concentration (≈)");
+    expect(mockV3VolumeSection).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tableState: expect.objectContaining({ isCapHit: false }),
+      }),
+    );
+  });
+
+  it("withholds concentration while no coherent hero and trader identity exists", () => {
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === TRADER_DAILY_TOP) {
+        return {
+          data: { TraderDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+    heroState.concentration = 42;
+    heroState.displayIdentity = undefined;
+
+    const html = renderVolume("v3");
+
+    expect(html).not.toContain("42.0%");
+    expect(html).toContain(">…</p>");
+  });
+
   it("keeps analysis sections directly below top-line volume", () => {
     const html = renderVolume("v3");
 
@@ -461,6 +616,27 @@ describe("VolumeClient useGQL wiring", () => {
 
     expect(mockUseHeroRollup).toHaveBeenCalledWith(
       expect.objectContaining({ initialData }),
+    );
+  });
+
+  it("passes the trader range, cutoff, and actor scope into the hero KPI identity", () => {
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === TRADER_DAILY_TOP) {
+        return {
+          data: { TraderDailySnapshot: [] },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    renderVolume("v3");
+
+    expect(mockUseHeroRollup).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        kpiSourceIdentity: "7d|1700000000|organic",
+      }),
     );
   });
 

--- a/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/volume/__tests__/page-client.test.tsx
@@ -21,14 +21,41 @@ const poolVolumeState = vi.hoisted(() => ({
   isLoading: false,
   error: null as Error | null,
   partial: false,
+  dataAfterTimestamp: undefined as number | undefined,
+  dataRange: undefined as typeof volumeState.range | undefined,
+  hasData: false,
 }));
 const mockTimeSeriesChartCard = vi.hoisted(() => vi.fn());
 const mockV2VolumeSection = vi.hoisted(() => vi.fn());
 const mockV3VolumeSection = vi.hoisted(() => vi.fn());
+const mockUsePoolChartViewModel = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (...args: unknown[]) => mockUseGQL(...args),
 }));
+
+vi.mock("../_lib/use-resolved-query-identity", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../_lib/use-resolved-query-identity")
+    >();
+  return {
+    ...actual,
+    // Static-markup wiring tests have no persistent component instance. The
+    // real range/filter transition state machine is covered in the hook's
+    // jsdom orchestration tests; here we model already-versioned current-key
+    // data so the page-level loading/error plumbing stays focused.
+    useVersionedVolumeQueryData: (
+      result: { data: unknown; error: unknown; isLoading: boolean },
+      currentIdentity: string,
+    ) => ({
+      data: result.data,
+      dataIdentity: result.data === undefined ? undefined : currentIdentity,
+      isLoading: result.isLoading && result.data === undefined,
+      hasError: result.error != null && result.data === undefined,
+    }),
+  };
+});
 
 vi.mock("../_lib/url-state", () => ({
   useVolumeUrlState: ({
@@ -59,11 +86,18 @@ vi.mock("../_lib/use-pool-volume-snapshots", () => ({
 }));
 
 vi.mock("../_lib/pool-chart-vm", () => ({
-  usePoolChartViewModel: () => ({
-    poolVolumeBreakdown: { totalSeries: [], breakdown: [] },
-    chartBreakdown: [],
-    topPoolsListEntries: [],
-  }),
+  usePoolChartViewModel: (args: unknown) => {
+    mockUsePoolChartViewModel(args);
+    return {
+      poolVolumeBreakdown: {
+        totalSeries: [],
+        breakdown: [],
+        windowTotalUsdWei: BigInt(0),
+      },
+      chartBreakdown: [],
+      topPoolsListEntries: [],
+    };
+  },
 }));
 
 const mockUseHeroRollup = vi.hoisted(() => vi.fn());
@@ -81,6 +115,7 @@ vi.mock("../_lib/use-hero-rollup", () => ({
       concentration: 0,
       staleChains: [],
       degradedChains: [],
+      displayRange: volumeState.range,
     };
   },
 }));
@@ -147,6 +182,7 @@ describe("VolumeClient useGQL wiring", () => {
     mockTimeSeriesChartCard.mockClear();
     mockV2VolumeSection.mockClear();
     mockV3VolumeSection.mockClear();
+    mockUsePoolChartViewModel.mockClear();
     heroState.isLoading = false;
     heroState.hasError = false;
     volumeState.range = "7d";
@@ -154,6 +190,9 @@ describe("VolumeClient useGQL wiring", () => {
     poolVolumeState.isLoading = false;
     poolVolumeState.error = null;
     poolVolumeState.partial = false;
+    poolVolumeState.dataAfterTimestamp = undefined;
+    poolVolumeState.dataRange = undefined;
+    poolVolumeState.hasData = false;
     mockUseGQL.mockReturnValue({
       data: undefined,
       error: null,
@@ -192,9 +231,12 @@ describe("VolumeClient useGQL wiring", () => {
   });
 
   it("keeps v3 chart, trader, and aggregator skeletons off while retained data revalidates", () => {
-    volumeState.range = "30d";
+    volumeState.range = "90d";
     poolVolumeState.rows = [{ id: "prior-window-row" }];
     poolVolumeState.isLoading = true;
+    poolVolumeState.dataAfterTimestamp = 1_690_000_000;
+    poolVolumeState.dataRange = "30d";
+    poolVolumeState.hasData = true;
     mockUseGQL.mockImplementation((query: string | null) => {
       if (query === TRADER_DAILY_TOP) {
         return {
@@ -222,6 +264,9 @@ describe("VolumeClient useGQL wiring", () => {
       ([props]) => props.title === "Volume by pool",
     );
     expect(chartCall?.[0]).toMatchObject({ isLoading: false });
+    expect(mockUsePoolChartViewModel).toHaveBeenCalledWith(
+      expect.objectContaining({ cutoff: 1_690_000_000 }),
+    );
     expect(mockV3VolumeSection).toHaveBeenCalledWith(
       expect.objectContaining({
         tableState: expect.objectContaining({ isLoading: false }),
@@ -256,6 +301,74 @@ describe("VolumeClient useGQL wiring", () => {
         tableIsLoading: false,
         v2AggIsLoading: false,
       }),
+    );
+  });
+
+  it("keeps retained v3 table, aggregator, and pool data visible after replacement errors", () => {
+    volumeState.range = "30d";
+    poolVolumeState.rows = [{ id: "retained-pool-row" }];
+    poolVolumeState.error = new Error("new pool window failed");
+    poolVolumeState.dataAfterTimestamp = 1_690_000_000;
+    poolVolumeState.dataRange = "30d";
+    poolVolumeState.hasData = true;
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === TRADER_DAILY_TOP) {
+        return {
+          data: { TraderDailySnapshot: [] },
+          error: new Error("new trader window failed"),
+          isLoading: false,
+        };
+      }
+      if (query === POOLS_FOR_VOLUME) {
+        return { data: { Pool: [] }, error: null, isLoading: false };
+      }
+      if (query === AGGREGATOR_DAILY_TOP) {
+        return {
+          data: { AggregatorDailySnapshot: [] },
+          error: new Error("new aggregator window failed"),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    renderVolume("v3");
+
+    const chartCall = mockTimeSeriesChartCard.mock.calls.find(
+      ([props]) => props.title === "Volume by pool",
+    );
+    expect(chartCall?.[0]).toMatchObject({ hasError: false });
+    expect(mockV3VolumeSection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableState: expect.objectContaining({ hasError: false }),
+        aggregatorState: expect.objectContaining({ hasError: false }),
+      }),
+    );
+  });
+
+  it("keeps retained v2 trader and aggregator data visible after replacement errors", () => {
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (query === BROKER_TRADER_DAILY_TOP) {
+        return {
+          data: { BrokerTraderDailySnapshot: [] },
+          error: new Error("new trader window failed"),
+          isLoading: false,
+        };
+      }
+      if (query === BROKER_AGGREGATOR_DAILY_TOP) {
+        return {
+          data: { BrokerAggregatorDailySnapshot: [] },
+          error: new Error("new aggregator window failed"),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: null, isLoading: false };
+    });
+
+    renderVolume("v2");
+
+    expect(mockV2VolumeSection).toHaveBeenCalledWith(
+      expect.objectContaining({ tableHasError: false, v2AggHasError: false }),
     );
   });
 

--- a/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
+++ b/ui-dashboard/src/app/volume/_components/__tests__/volume-live-region.test.tsx
@@ -51,6 +51,7 @@ function renderSection({
     root.render(
       <V3VolumeSection
         rangeLabel="7d"
+        aggregatorRangeLabel="7d"
         range="7d"
         cutoff={0}
         filteredTraderRows={[]}

--- a/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v2-volume-section.tsx
@@ -29,6 +29,7 @@ import { TableSectionTitle } from "./table-section-title";
  */
 export function V2VolumeSection({
   rangeLabel,
+  aggregatorRangeLabel,
   cutoff,
   canUseVolumeFilters,
   v2Aggregated,
@@ -43,6 +44,8 @@ export function V2VolumeSection({
    *  "all-time" — already mapped from `VolumeRangeKey` by the
    *  parent. Used only in section titles. */
   rangeLabel: string;
+  /** Range label resolved independently by the aggregator query. */
+  aggregatorRangeLabel: string;
   /** Same UTC-day cutoff used by the trader query; bounds the Via marker query. */
   cutoff: number;
   canUseVolumeFilters: boolean;
@@ -80,7 +83,7 @@ export function V2VolumeSection({
       </section>
       <AggregatorBreakdownSection
         venueLabel="v2"
-        rangeLabel={rangeLabel}
+        rangeLabel={aggregatorRangeLabel}
         aggregators={v2AggregatorAggregated}
         isLoading={v2AggIsLoading}
         hasError={v2AggHasError}

--- a/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
+++ b/ui-dashboard/src/app/volume/_components/v3-volume-section.tsx
@@ -29,6 +29,7 @@ type V3AggregatorState = {
 
 export function V3VolumeSection({
   rangeLabel,
+  aggregatorRangeLabel,
   range,
   cutoff,
   filteredTraderRows,
@@ -42,6 +43,7 @@ export function V3VolumeSection({
   chart,
 }: {
   rangeLabel: string;
+  aggregatorRangeLabel: string;
   range: VolumeRangeKey;
   cutoff: number;
   filteredTraderRows: readonly TraderDailyRow[];
@@ -88,7 +90,7 @@ export function V3VolumeSection({
       </section>
       <AggregatorBreakdownSection
         venueLabel="v3"
-        rangeLabel={rangeLabel}
+        rangeLabel={aggregatorRangeLabel}
         aggregators={aggregators}
         isLoading={aggregatorState.isLoading}
         hasError={aggregatorState.hasError}

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -2,10 +2,16 @@ import { Tile } from "@/components/feedback";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { Tooltip } from "@/components/tooltip";
 import { formatUSD } from "@/lib/format";
-import { VOLUME_RANGES, rangeDays, type VolumeRangeKey } from "@/lib/volume";
+import {
+  VOLUME_RANGES,
+  rangeDays,
+  weiToUsd,
+  type VolumeRangeKey,
+} from "@/lib/volume";
 import {
   VOLUME_CHART_RANGES,
   VOLUME_FALLBACK_CHART_RANGES,
+  type RangeKey,
 } from "@/lib/time-series";
 import type { VolumePageModel, VolumeUrlState } from "../page-client";
 import { TopPoolsList } from "./top-pools-list";
@@ -255,19 +261,12 @@ export function VolumeChartArea({
   urlState: VolumeUrlState;
   model: VolumePageModel;
 }) {
-  if (model.showChart)
-    return <PoolChartArea urlState={urlState} model={model} />;
+  if (model.showChart) return <PoolChartArea model={model} />;
   if (urlState.range === "24h") return null;
   return <DailyVolumeChart urlState={urlState} model={model} />;
 }
 
-function PoolChartArea({
-  urlState,
-  model,
-}: {
-  urlState: VolumeUrlState;
-  model: VolumePageModel;
-}) {
+function PoolChartArea({ model }: { model: VolumePageModel }) {
   const { poolVolumeBreakdown, chartBreakdown, topPoolsListEntries } =
     model.poolChart;
   return (
@@ -279,10 +278,10 @@ function PoolChartArea({
           series={poolVolumeBreakdown.totalSeries}
           breakdown={chartBreakdown}
           breakdownMode="stacked"
-          range={model.chartControls.chartRange}
+          range={chartRangeForVolumeRange(model.poolChartRange)}
           onRangeChange={model.chartControls.onChartRangeChange}
           ranges={VOLUME_CHART_RANGES}
-          headline={model.headline}
+          headline={formatUSD(weiToUsd(poolVolumeBreakdown.windowTotalUsdWei))}
           change={null}
           isLoading={model.status.poolChartIsLoading}
           hasError={model.status.poolChartHasError}
@@ -302,7 +301,7 @@ function PoolChartArea({
           entries={topPoolsListEntries}
           isLoading={model.status.poolChartIsLoading}
           hasError={model.status.poolChartHasError}
-          windowLabel={rangeLabel(urlState.range)}
+          windowLabel={rangeLabel(model.poolChartRange)}
         />
       </div>
     </div>
@@ -325,7 +324,7 @@ function DailyVolumeChart({
       series={
         venue === "v3" ? aggregates.dailyVolume : aggregates.v2DailyVolume
       }
-      range={chartControls.chartRange}
+      range={chartRangeForVolumeRange(model.tableRange)}
       onRangeChange={chartControls.onChartRangeChange}
       ranges={VOLUME_FALLBACK_CHART_RANGES}
       headline={model.headline}
@@ -354,14 +353,13 @@ export function VolumeVenueSection({
   urlState: VolumeUrlState;
   model: VolumePageModel;
 }) {
-  const { range, cutoff } = urlState;
   const { aggregates, status } = model;
   if (urlState.venue === "v2") {
     return (
       <>
         <V2VolumeSection
-          rangeLabel={rangeLabel(range)}
-          cutoff={cutoff}
+          rangeLabel={rangeLabel(model.tableRange)}
+          cutoff={model.tableCutoff}
           canUseVolumeFilters={urlState.canUseVolumeFilters}
           v2Aggregated={aggregates.v2Aggregated}
           v2AggregatorAggregated={aggregates.v2AggregatorAggregated}
@@ -377,9 +375,10 @@ export function VolumeVenueSection({
   return (
     <>
       <V3VolumeSection
-        rangeLabel={rangeLabel(range)}
-        range={range}
-        cutoff={cutoff}
+        rangeLabel={rangeLabel(model.tableRange)}
+        aggregatorRangeLabel={rangeLabel(model.aggregatorRange)}
+        range={model.tableRange}
+        cutoff={model.tableCutoff}
         filteredTraderRows={aggregates.filteredTraderRows}
         traders={aggregates.aggregated}
         pools={model.poolMeta}
@@ -407,7 +406,7 @@ function v3SourceChart(urlState: VolumeUrlState, model: VolumePageModel) {
   return {
     series: model.aggregatorChart.v3AggregatorChart.totalSeries,
     breakdown: model.aggregatorChart.v3AggregatorChart.breakdown,
-    range: model.chartControls.chartRange,
+    range: chartRangeForVolumeRange(model.aggregatorRange),
     onRangeChange: model.chartControls.onChartRangeChange,
     ranges: VOLUME_FALLBACK_CHART_RANGES,
     headline: formatUSD(model.aggregatorChart.v3AggregatorChartTotal),
@@ -419,6 +418,10 @@ function rangeSubtitle(range: VolumeRangeKey): string {
   if (range === "24h") return "Today (UTC)";
   const days = rangeDays(range);
   return `Last ${days} days`;
+}
+
+function chartRangeForVolumeRange(range: VolumeRangeKey): RangeKey {
+  return range === "30d" || range === "90d" || range === "all" ? range : "7d";
 }
 
 function rangeLabel(range: VolumeRangeKey): string {

--- a/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
+++ b/ui-dashboard/src/app/volume/_components/volume-page-sections.tsx
@@ -181,13 +181,11 @@ function SegmentButton({
 export function VolumeKpiTiles({
   hero,
   range,
-  isTableCapHit,
   tableIsLoading,
   tableHasError,
 }: {
   hero: VolumePageModel["hero"];
   range: VolumeRangeKey;
-  isTableCapHit: boolean;
   tableIsLoading: boolean;
   tableHasError: boolean;
 }) {
@@ -205,16 +203,17 @@ export function VolumeKpiTiles({
       />
       <Tile
         label={
-          isTableCapHit ? "Top-10 concentration (≈)" : "Top-10 concentration"
+          hero.isKpiSourceCapHit
+            ? "Top-10 concentration (≈)"
+            : "Top-10 concentration"
         }
         value={concentrationValue({
           hero,
-          isTableCapHit,
           tableIsLoading,
           tableHasError,
         })}
         subtitle={
-          isTableCapHit
+          hero.isKpiSourceCapHit
             ? "Lower bound — long-tail trader-days outside top-1000 by single-day volume can bias this low"
             : "Share of window volume"
         }
@@ -240,18 +239,17 @@ function swapsSubtitle(hero: VolumePageModel["hero"]): string {
 
 function concentrationValue({
   hero,
-  isTableCapHit,
   tableIsLoading,
   tableHasError,
 }: {
   hero: VolumePageModel["hero"];
-  isTableCapHit: boolean;
   tableIsLoading: boolean;
   tableHasError: boolean;
 }): string {
   if (hero.isLoading || tableIsLoading) return "…";
   if (hero.hasError || tableHasError) return "—";
-  return `${isTableCapHit ? "≈ " : ""}${hero.concentration.toFixed(1)}%`;
+  if (hero.displayIdentity === undefined) return "…";
+  return `${hero.isKpiSourceCapHit ? "≈ " : ""}${hero.concentration.toFixed(1)}%`;
 }
 
 export function VolumeChartArea({
@@ -359,6 +357,7 @@ export function VolumeVenueSection({
       <>
         <V2VolumeSection
           rangeLabel={rangeLabel(model.tableRange)}
+          aggregatorRangeLabel={rangeLabel(model.aggregatorRange)}
           cutoff={model.tableCutoff}
           canUseVolumeFilters={urlState.canUseVolumeFilters}
           v2Aggregated={aggregates.v2Aggregated}

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
@@ -166,17 +166,25 @@ function yesterdayRow(
 // ---------------------------------------------------------------------------
 
 type HookResult = ReturnType<typeof useHeroRollup>;
+const EMPTY_KPI_SOURCE: ReadonlyArray<{
+  chainId: number;
+  volumeUsdWei: bigint;
+}> = [];
 
 function Probe({
   resultRef,
   initialData,
   venue = "v3",
   range = "7d",
+  kpiSource = EMPTY_KPI_SOURCE,
+  kpiSourceRange,
 }: {
   resultRef: { current: HookResult | null };
   initialData?: VolumeHeroInitialData | undefined;
   venue?: "v3" | "v2" | undefined;
   range?: VolumeRangeKey | undefined;
+  kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
+  kpiSourceRange?: VolumeRangeKey | undefined;
 }) {
   resultRef.current = useHeroRollup({
     venue,
@@ -184,7 +192,10 @@ function Probe({
     includeProtocolActors: false,
     isProtocolActorIn: [false],
     utcDayKey: 0,
-    kpiSource: [],
+    kpiSource,
+    kpiSourceRange,
+    kpiSourceIncludesProtocolActors:
+      kpiSourceRange === undefined ? undefined : false,
     initialData,
   });
   return null;
@@ -215,7 +226,12 @@ afterEach(() => {
 
 function render(
   initialData?: VolumeHeroInitialData,
-  options: { venue?: "v3" | "v2"; range?: VolumeRangeKey } = {},
+  options: {
+    venue?: "v3" | "v2";
+    range?: VolumeRangeKey;
+    kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
+    kpiSourceRange?: VolumeRangeKey;
+  } = {},
 ): { current: HookResult | null } {
   const ref: { current: HookResult | null } = { current: null };
   act(() => {
@@ -228,7 +244,12 @@ function render(
 
 function rerender(
   ref: { current: HookResult | null },
-  options: { venue?: "v3" | "v2"; range?: VolumeRangeKey } = {},
+  options: {
+    venue?: "v3" | "v2";
+    range?: VolumeRangeKey;
+    kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
+    kpiSourceRange?: VolumeRangeKey;
+  } = {},
 ) {
   act(() => {
     root.render(<Probe resultRef={ref} {...options} />);
@@ -390,6 +411,117 @@ describe("useHeroRollup orchestration", () => {
     ).toBeUndefined();
     expect(ref.current?.isLoading).toBe(false);
     expect(ref.current?.totalVolume).toBeGreaterThan(0);
+  });
+
+  it("publishes only range-coherent hero slices and concentration inputs", () => {
+    const yesterdayMidnight = TODAY_MIDNIGHT - SECONDS_PER_DAY;
+    const priorPrimary = {
+      volumeWindowSnapshots: [
+        snapshot({
+          chainId: CELO,
+          windowKey: "7d",
+          snapshotDay: String(yesterdayMidnight),
+          windowStartDay: String(yesterdayMidnight - 6 * SECONDS_PER_DAY),
+          totalVolumeUsdWei: "1000000000000000000000",
+        }),
+      ],
+    };
+    const priorFirstDay = {
+      volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+    };
+    const todayData = { volumeTodayTraders: [] };
+    const priorKpi = [
+      { chainId: CELO, volumeUsdWei: BigInt("500000000000000000000") },
+    ];
+
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: priorPrimary,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: priorFirstDay,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_TODAY_TRADERS, {
+      data: todayData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const ref = render(undefined, {
+      range: "7d",
+      kpiSource: priorKpi,
+      kpiSourceRange: "7d",
+    });
+    expect(ref.current?.displayRange).toBe("7d");
+    expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(50, 4);
+
+    const nextPrimary = {
+      volumeWindowSnapshots: [
+        snapshot({
+          chainId: CELO,
+          windowKey: "30d",
+          snapshotDay: String(yesterdayMidnight),
+          windowStartDay: String(yesterdayMidnight - 29 * SECONDS_PER_DAY),
+          totalVolumeUsdWei: "3000000000000000000000",
+        }),
+      ],
+    };
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: nextPrimary,
+      isLoading: false,
+      error: undefined,
+    });
+    // The primary response won the race. SWR still exposes the prior
+    // first-day slice and trader numerator for their replacement keys.
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: priorFirstDay,
+      isLoading: true,
+      error: undefined,
+    });
+    rerender(ref, {
+      range: "30d",
+      kpiSource: priorKpi,
+      kpiSourceRange: "7d",
+    });
+
+    // Keep the prior complete snapshot; never combine the new denominator
+    // with an old first-day subtraction or numerator.
+    expect(ref.current?.displayRange).toBe("7d");
+    expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(50, 4);
+
+    const nextFirstDay = {
+      volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+    };
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: nextFirstDay,
+      isLoading: false,
+      error: undefined,
+    });
+    // Even after the hero pair is current, the old trader numerator keeps
+    // the whole display on its previous coherent version.
+    rerender(ref, {
+      range: "30d",
+      kpiSource: priorKpi,
+      kpiSourceRange: "7d",
+    });
+    expect(ref.current?.displayRange).toBe("7d");
+    expect(ref.current?.concentration).toBeCloseTo(50, 4);
+
+    rerender(ref, {
+      range: "30d",
+      kpiSource: [
+        { chainId: CELO, volumeUsdWei: BigInt("600000000000000000000") },
+      ],
+      kpiSourceRange: "30d",
+    });
+    expect(ref.current?.displayRange).toBe("30d");
+    expect(ref.current?.totalVolume).toBeCloseTo(3000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(20, 4);
   });
 
   it("opts both v2 range-keyed hero queries into previous-data retention", () => {

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
@@ -44,12 +44,17 @@ import {
   VOLUME_WINDOW_LATEST,
   VOLUME_YESTERDAY_TRADERS,
 } from "@/lib/queries/volume";
-import type {
-  VolumeTodayTraderRow,
-  VolumeRangeKey,
-  VolumeWindowFirstDayRow,
-  VolumeWindowRow,
+import {
+  rangeCutoffSeconds,
+  type VolumeRangeKey,
+  type VolumeTodayTraderRow,
+  type VolumeWindowFirstDayRow,
+  type VolumeWindowRow,
 } from "@/lib/volume";
+import {
+  volumeQueryIdentity,
+  type VolumeQueryIdentity,
+} from "../use-resolved-query-identity";
 
 // ---------------------------------------------------------------------------
 // useGQL mock — programmable per-query response. Each test configures
@@ -171,31 +176,45 @@ const EMPTY_KPI_SOURCE: ReadonlyArray<{
   volumeUsdWei: bigint;
 }> = [];
 
+function kpiIdentity(
+  range: VolumeRangeKey,
+  cutoff = rangeCutoffSeconds(range),
+): VolumeQueryIdentity {
+  return volumeQueryIdentity({
+    range,
+    cutoff,
+    includeProtocolActors: false,
+  });
+}
+
 function Probe({
   resultRef,
   initialData,
   venue = "v3",
   range = "7d",
+  utcDayKey = 0,
   kpiSource = EMPTY_KPI_SOURCE,
-  kpiSourceRange,
+  kpiSourceIdentity,
+  kpiSourceIsCapHit = false,
 }: {
   resultRef: { current: HookResult | null };
   initialData?: VolumeHeroInitialData | undefined;
   venue?: "v3" | "v2" | undefined;
   range?: VolumeRangeKey | undefined;
+  utcDayKey?: number | undefined;
   kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
-  kpiSourceRange?: VolumeRangeKey | undefined;
+  kpiSourceIdentity?: VolumeQueryIdentity | undefined;
+  kpiSourceIsCapHit?: boolean | undefined;
 }) {
   resultRef.current = useHeroRollup({
     venue,
     range,
     includeProtocolActors: false,
     isProtocolActorIn: [false],
-    utcDayKey: 0,
+    utcDayKey,
     kpiSource,
-    kpiSourceRange,
-    kpiSourceIncludesProtocolActors:
-      kpiSourceRange === undefined ? undefined : false,
+    kpiSourceIdentity,
+    kpiSourceIsCapHit,
     initialData,
   });
   return null;
@@ -222,6 +241,7 @@ afterEach(() => {
     root.unmount();
   });
   container.remove();
+  vi.useRealTimers();
 });
 
 function render(
@@ -229,8 +249,10 @@ function render(
   options: {
     venue?: "v3" | "v2";
     range?: VolumeRangeKey;
+    utcDayKey?: number;
     kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
-    kpiSourceRange?: VolumeRangeKey;
+    kpiSourceIdentity?: VolumeQueryIdentity;
+    kpiSourceIsCapHit?: boolean;
   } = {},
 ): { current: HookResult | null } {
   const ref: { current: HookResult | null } = { current: null };
@@ -247,8 +269,10 @@ function rerender(
   options: {
     venue?: "v3" | "v2";
     range?: VolumeRangeKey;
+    utcDayKey?: number;
     kpiSource?: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
-    kpiSourceRange?: VolumeRangeKey;
+    kpiSourceIdentity?: VolumeQueryIdentity;
+    kpiSourceIsCapHit?: boolean;
   } = {},
 ) {
   act(() => {
@@ -453,11 +477,13 @@ describe("useHeroRollup orchestration", () => {
     const ref = render(undefined, {
       range: "7d",
       kpiSource: priorKpi,
-      kpiSourceRange: "7d",
+      kpiSourceIdentity: kpiIdentity("7d"),
+      kpiSourceIsCapHit: true,
     });
     expect(ref.current?.displayRange).toBe("7d");
     expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
     expect(ref.current?.concentration).toBeCloseTo(50, 4);
+    expect(ref.current?.isKpiSourceCapHit).toBe(true);
 
     const nextPrimary = {
       volumeWindowSnapshots: [
@@ -485,7 +511,7 @@ describe("useHeroRollup orchestration", () => {
     rerender(ref, {
       range: "30d",
       kpiSource: priorKpi,
-      kpiSourceRange: "7d",
+      kpiSourceIdentity: kpiIdentity("7d"),
     });
 
     // Keep the prior complete snapshot; never combine the new denominator
@@ -493,6 +519,7 @@ describe("useHeroRollup orchestration", () => {
     expect(ref.current?.displayRange).toBe("7d");
     expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
     expect(ref.current?.concentration).toBeCloseTo(50, 4);
+    expect(ref.current?.isKpiSourceCapHit).toBe(true);
 
     const nextFirstDay = {
       volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
@@ -507,21 +534,325 @@ describe("useHeroRollup orchestration", () => {
     rerender(ref, {
       range: "30d",
       kpiSource: priorKpi,
-      kpiSourceRange: "7d",
+      kpiSourceIdentity: kpiIdentity("7d"),
     });
     expect(ref.current?.displayRange).toBe("7d");
     expect(ref.current?.concentration).toBeCloseTo(50, 4);
+    expect(ref.current?.isKpiSourceCapHit).toBe(true);
 
     rerender(ref, {
       range: "30d",
       kpiSource: [
         { chainId: CELO, volumeUsdWei: BigInt("600000000000000000000") },
       ],
-      kpiSourceRange: "30d",
+      kpiSourceIdentity: kpiIdentity("30d"),
     });
     expect(ref.current?.displayRange).toBe("30d");
     expect(ref.current?.totalVolume).toBeCloseTo(3000, 4);
     expect(ref.current?.concentration).toBeCloseTo(20, 4);
+    expect(ref.current?.isKpiSourceCapHit).toBe(false);
+  });
+
+  it("withholds concentration identity after a venue round trip until the active hero catches up", () => {
+    const yesterdayMidnight = TODAY_MIDNIGHT - SECONDS_PER_DAY;
+    const v2Primary7d = {
+      brokerVolumeWindowSnapshots: [
+        snapshot({
+          chainId: CELO,
+          windowKey: "7d",
+          snapshotDay: String(yesterdayMidnight),
+          windowStartDay: String(yesterdayMidnight - 6 * SECONDS_PER_DAY),
+          totalVolumeUsdWei: "1000000000000000000000",
+        }),
+      ],
+    };
+    const v2FirstDay7d = {
+      brokerVolumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+    };
+    gqlResponses.set(BROKER_VOLUME_WINDOW_LATEST, {
+      data: v2Primary7d,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: v2FirstDay7d,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_TODAY_TRADERS, {
+      data: { brokerVolumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+
+    const ref = render(undefined, {
+      venue: "v2",
+      range: "7d",
+      kpiSource: [
+        { chainId: CELO, volumeUsdWei: BigInt("500000000000000000000") },
+      ],
+      kpiSourceIdentity: kpiIdentity("7d"),
+      kpiSourceIsCapHit: true,
+    });
+    expect(ref.current?.displayIdentity).toBe(kpiIdentity("7d"));
+    expect(ref.current?.isKpiSourceCapHit).toBe(true);
+
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: {
+        volumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "30d",
+            snapshotDay: String(yesterdayMidnight),
+            windowStartDay: String(yesterdayMidnight - 29 * SECONDS_PER_DAY),
+            totalVolumeUsdWei: "3000000000000000000000",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: {
+        volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_TODAY_TRADERS, {
+      data: { volumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+    rerender(ref, {
+      venue: "v3",
+      range: "30d",
+      kpiSource: [
+        { chainId: CELO, volumeUsdWei: BigInt("600000000000000000000") },
+      ],
+      kpiSourceIdentity: kpiIdentity("30d"),
+    });
+    expect(ref.current?.displayIdentity).toBe(kpiIdentity("30d"));
+
+    // Switching back reactivates v2's retained 7d hero pair while the v2
+    // trader query has already resolved for 30d. The last coherent display
+    // belongs to v3, so no same-venue prior can hide this intermediate state.
+    gqlResponses.set(BROKER_VOLUME_WINDOW_LATEST, {
+      data: v2Primary7d,
+      isLoading: true,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: v2FirstDay7d,
+      isLoading: true,
+      error: undefined,
+    });
+    rerender(ref, {
+      venue: "v2",
+      range: "30d",
+      kpiSource: [
+        { chainId: CELO, volumeUsdWei: BigInt("900000000000000000000") },
+      ],
+      kpiSourceIdentity: kpiIdentity("30d"),
+      kpiSourceIsCapHit: true,
+    });
+    expect(ref.current?.displayRange).toBe("7d");
+    expect(ref.current?.displayIdentity).toBeUndefined();
+    expect(ref.current?.isKpiSourceCapHit).toBe(false);
+
+    gqlResponses.set(BROKER_VOLUME_WINDOW_LATEST, {
+      data: {
+        brokerVolumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "30d",
+            snapshotDay: String(yesterdayMidnight),
+            windowStartDay: String(yesterdayMidnight - 29 * SECONDS_PER_DAY),
+            totalVolumeUsdWei: "3000000000000000000000",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: {
+        brokerVolumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    rerender(ref, {
+      venue: "v2",
+      range: "30d",
+      kpiSource: [
+        { chainId: CELO, volumeUsdWei: BigInt("900000000000000000000") },
+      ],
+      kpiSourceIdentity: kpiIdentity("30d"),
+      kpiSourceIsCapHit: true,
+    });
+    expect(ref.current?.displayRange).toBe("30d");
+    expect(ref.current?.displayIdentity).toBe(kpiIdentity("30d"));
+    expect(ref.current?.isKpiSourceCapHit).toBe(true);
+  });
+
+  it("keeps the prior coherent display across UTC midnight until the KPI cutoff catches up", () => {
+    vi.useFakeTimers();
+    const dayN = Date.UTC(2026, 6, 14) / 1000;
+    vi.setSystemTime((dayN + 12 * 60 * 60) * 1000);
+    const oldCutoff = rangeCutoffSeconds("7d", dayN);
+    const priorKpi = [
+      { chainId: CELO, volumeUsdWei: BigInt("500000000000000000000") },
+    ];
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: {
+        volumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "7d",
+            snapshotDay: String(dayN - SECONDS_PER_DAY),
+            windowStartDay: String(dayN - 7 * SECONDS_PER_DAY),
+            totalVolumeUsdWei: "1000000000000000000000",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: { volumeWindowFirstDaySnapshots: [] },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_TODAY_TRADERS, {
+      data: { volumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+
+    const ref = render(undefined, {
+      range: "7d",
+      utcDayKey: dayN,
+      kpiSource: priorKpi,
+      kpiSourceIdentity: kpiIdentity("7d", oldCutoff),
+    });
+    expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(50, 4);
+
+    const dayNPlusOne = dayN + SECONDS_PER_DAY;
+    vi.setSystemTime((dayNPlusOne + 12 * 60 * 60) * 1000);
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: {
+        volumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "7d",
+            snapshotDay: String(dayN),
+            windowStartDay: String(dayN - 6 * SECONDS_PER_DAY),
+            totalVolumeUsdWei: "2000000000000000000000",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    rerender(ref, {
+      range: "7d",
+      utcDayKey: dayNPlusOne,
+      kpiSource: priorKpi,
+      kpiSourceIdentity: kpiIdentity("7d", oldCutoff),
+    });
+
+    // The denominator advanced to day N+1, but the numerator still belongs
+    // to day N. Keep the complete day-N display instead of mixing them.
+    expect(ref.current?.totalVolume).toBeCloseTo(1000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(50, 4);
+
+    const freshKpi = [
+      { chainId: CELO, volumeUsdWei: BigInt("600000000000000000000") },
+    ];
+    rerender(ref, {
+      range: "7d",
+      utcDayKey: dayNPlusOne,
+      kpiSource: freshKpi,
+      kpiSourceIdentity: kpiIdentity(
+        "7d",
+        rangeCutoffSeconds("7d", dayNPlusOne),
+      ),
+    });
+    expect(ref.current?.totalVolume).toBeCloseTo(2000, 4);
+    expect(ref.current?.concentration).toBeCloseTo(30, 4);
+  });
+
+  it("publishes a degraded current primary when retained first-day replacement fails", () => {
+    const yesterdayMidnight = TODAY_MIDNIGHT - SECONDS_PER_DAY;
+    const priorFirstDay = {
+      volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+    };
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: {
+        volumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "7d",
+            snapshotDay: String(yesterdayMidnight),
+            windowStartDay: String(yesterdayMidnight - 6 * SECONDS_PER_DAY),
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: priorFirstDay,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_TODAY_TRADERS, {
+      data: { volumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+
+    const ref = render(undefined, {
+      range: "7d",
+      kpiSource: [],
+      kpiSourceIdentity: kpiIdentity("7d"),
+    });
+    expect(ref.current?.displayRange).toBe("7d");
+
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: {
+        volumeWindowSnapshots: [
+          snapshot({
+            chainId: CELO,
+            windowKey: "30d",
+            totalVolumeUsdWei: "3000000000000000000000",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: priorFirstDay,
+      isLoading: false,
+      error: new Error("30d first-day replacement failed"),
+    });
+    gqlResponses.set(VOLUME_YESTERDAY_TRADERS, {
+      data: { volumeYesterdayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+    rerender(ref, {
+      range: "30d",
+      kpiSource: [],
+      kpiSourceIdentity: kpiIdentity("30d"),
+    });
+
+    expect(ref.current?.displayRange).toBe("30d");
+    expect(ref.current?.totalVolume).toBeCloseTo(3000, 4);
+    expect(ref.current?.degradedChains).toEqual([CELO]);
   });
 
   it("opts both v2 range-keyed hero queries into previous-data retention", () => {

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-hero-rollup.test.tsx
@@ -35,6 +35,9 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
+  BROKER_VOLUME_TODAY_TRADERS,
+  BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
+  BROKER_VOLUME_WINDOW_LATEST,
   VOLUME_PARTIAL_OVERLAP_TRADERS,
   VOLUME_TODAY_TRADERS,
   VOLUME_WINDOW_FIRSTDAY_LATEST,
@@ -43,6 +46,7 @@ import {
 } from "@/lib/queries/volume";
 import type {
   VolumeTodayTraderRow,
+  VolumeRangeKey,
   VolumeWindowFirstDayRow,
   VolumeWindowRow,
 } from "@/lib/volume";
@@ -166,13 +170,17 @@ type HookResult = ReturnType<typeof useHeroRollup>;
 function Probe({
   resultRef,
   initialData,
+  venue = "v3",
+  range = "7d",
 }: {
   resultRef: { current: HookResult | null };
   initialData?: VolumeHeroInitialData | undefined;
+  venue?: "v3" | "v2" | undefined;
+  range?: VolumeRangeKey | undefined;
 }) {
   resultRef.current = useHeroRollup({
-    venue: "v3",
-    range: "7d",
+    venue,
+    range,
     includeProtocolActors: false,
     isProtocolActorIn: [false],
     utcDayKey: 0,
@@ -205,14 +213,26 @@ afterEach(() => {
   container.remove();
 });
 
-function render(initialData?: VolumeHeroInitialData): {
-  current: HookResult | null;
-} {
+function render(
+  initialData?: VolumeHeroInitialData,
+  options: { venue?: "v3" | "v2"; range?: VolumeRangeKey } = {},
+): { current: HookResult | null } {
   const ref: { current: HookResult | null } = { current: null };
   act(() => {
-    root.render(<Probe resultRef={ref} initialData={initialData} />);
+    root.render(
+      <Probe resultRef={ref} initialData={initialData} {...options} />,
+    );
   });
   return ref;
+}
+
+function rerender(
+  ref: { current: HookResult | null },
+  options: { venue?: "v3" | "v2"; range?: VolumeRangeKey } = {},
+) {
+  act(() => {
+    root.render(<Probe resultRef={ref} {...options} />);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +328,98 @@ describe("useHeroRollup orchestration", () => {
     expect(result!.totalTraders).toBe(11);
     const overlapVars = lastVariables.get(VOLUME_PARTIAL_OVERLAP_TRADERS);
     expect(overlapVars?.limit).toBe(4);
+    expect(
+      lastOptions.get(VOLUME_YESTERDAY_TRADERS)?.keepPreviousData,
+    ).toBeUndefined();
+    expect(
+      lastOptions.get(VOLUME_PARTIAL_OVERLAP_TRADERS)?.keepPreviousData,
+    ).toBeUndefined();
+  });
+
+  it("keeps retained hero data rendered across a range-key change", () => {
+    const yesterdayMidnight = TODAY_MIDNIGHT - SECONDS_PER_DAY;
+    const priorSnapshot = snapshot({
+      chainId: CELO,
+      snapshotDay: String(yesterdayMidnight),
+      windowStartDay: String(yesterdayMidnight - 5 * SECONDS_PER_DAY),
+    });
+    const primaryData = { volumeWindowSnapshots: [priorSnapshot] };
+    const firstDayData = {
+      volumeWindowFirstDaySnapshots: [firstDaySlice({ chainId: CELO })],
+    };
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: primaryData,
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_TODAY_TRADERS, {
+      data: { volumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: firstDayData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const ref = render(undefined, { range: "7d" });
+    expect(ref.current?.isLoading).toBe(false);
+
+    // Mirror SWR's key-transition state with keepPreviousData: the old
+    // response remains present while the new key reports isLoading=true.
+    gqlResponses.set(VOLUME_WINDOW_LATEST, {
+      data: primaryData,
+      isLoading: true,
+      error: undefined,
+    });
+    gqlResponses.set(VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: firstDayData,
+      isLoading: true,
+      error: undefined,
+    });
+    rerender(ref, { range: "30d" });
+
+    expect(lastVariables.get(VOLUME_WINDOW_LATEST)?.windowKey).toBe("30d");
+    expect(lastOptions.get(VOLUME_WINDOW_LATEST)?.keepPreviousData).toBe(true);
+    expect(
+      lastOptions.get(VOLUME_WINDOW_FIRSTDAY_LATEST)?.keepPreviousData,
+    ).toBe(true);
+    expect(
+      lastOptions.get(VOLUME_TODAY_TRADERS)?.keepPreviousData,
+    ).toBeUndefined();
+    expect(ref.current?.isLoading).toBe(false);
+    expect(ref.current?.totalVolume).toBeGreaterThan(0);
+  });
+
+  it("opts both v2 range-keyed hero queries into previous-data retention", () => {
+    gqlResponses.set(BROKER_VOLUME_WINDOW_LATEST, {
+      data: { brokerVolumeWindowSnapshots: [] },
+      isLoading: true,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_TODAY_TRADERS, {
+      data: { brokerVolumeTodayTraders: [] },
+      isLoading: false,
+      error: undefined,
+    });
+    gqlResponses.set(BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST, {
+      data: { brokerVolumeWindowFirstDaySnapshots: [] },
+      isLoading: true,
+      error: undefined,
+    });
+
+    render(undefined, { venue: "v2", range: "90d" });
+
+    expect(lastOptions.get(BROKER_VOLUME_WINDOW_LATEST)?.keepPreviousData).toBe(
+      true,
+    );
+    expect(
+      lastOptions.get(BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST)?.keepPreviousData,
+    ).toBe(true);
+    expect(
+      lastOptions.get(BROKER_VOLUME_TODAY_TRADERS)?.keepPreviousData,
+    ).toBeUndefined();
   });
 
   it("phase 3: firstDay query errors out → chain stays degraded, tiles stay rendered with conservative totals", () => {

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots-hook.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots-hook.test.tsx
@@ -1,0 +1,135 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SWRConfig, type Cache } from "swr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolDailyVolumeRow } from "@/lib/volume-pool";
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock("graphql-request", () => ({
+  GraphQLClient: vi.fn(function GraphQLClientMock() {
+    return { request: requestMock };
+  }),
+}));
+
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    network: {
+      id: "celo-mainnet",
+      label: "Celo",
+      hasuraUrl: "https://hasura.example/v1/graphql",
+    },
+  }),
+}));
+
+import { usePoolVolumeSnapshots } from "../use-pool-volume-snapshots";
+
+type HookResult = ReturnType<typeof usePoolVolumeSnapshots>;
+type ResultRef = { current: HookResult | null };
+
+function row(id: string, timestamp: string): PoolDailyVolumeRow {
+  return {
+    id,
+    chainId: 42220,
+    poolId: `42220-0x${id.padStart(40, "0")}`,
+    timestamp,
+    swapCount: 1,
+    swapCountIncludingProtocolActors: 1,
+    volumeUsdWei: "1000000000000000000",
+    volumeUsdWeiIncludingProtocolActors: "1000000000000000000",
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function Probe({
+  afterTimestamp,
+  resultRef,
+}: {
+  afterTimestamp: number;
+  resultRef: ResultRef;
+}) {
+  resultRef.current = usePoolVolumeSnapshots({
+    enabled: true,
+    afterTimestamp,
+  });
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let cache: Cache;
+let resultRef: ResultRef;
+
+function render(afterTimestamp: number) {
+  act(() => {
+    root.render(
+      <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
+        <Probe afterTimestamp={afterTimestamp} resultRef={resultRef} />
+      </SWRConfig>,
+    );
+  });
+}
+
+beforeEach(() => {
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  requestMock.mockReset();
+  cache = new Map();
+  resultRef = { current: null };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("usePoolVolumeSnapshots", () => {
+  it("retains rows and keeps the chart skeleton off across a cutoff-key change", async () => {
+    const first = deferred<{ PoolDailyVolumeSnapshot: PoolDailyVolumeRow[] }>();
+    const second = deferred<{
+      PoolDailyVolumeSnapshot: PoolDailyVolumeRow[];
+    }>();
+    requestMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render(100);
+    await act(async () => {
+      first.resolve({ PoolDailyVolumeSnapshot: [row("1", "100")] });
+      await first.promise;
+    });
+    expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["1"]);
+    expect(resultRef.current?.isLoading).toBe(false);
+
+    render(200);
+
+    expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["1"]);
+    expect(resultRef.current?.isLoading).toBe(true);
+    expect(
+      resultRef.current!.isLoading && resultRef.current!.rows.length === 0,
+    ).toBe(false);
+
+    await act(async () => {
+      second.resolve({ PoolDailyVolumeSnapshot: [row("2", "200")] });
+      await second.promise;
+    });
+    expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["2"]);
+    expect(resultRef.current?.isLoading).toBe(false);
+  });
+});

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots-hook.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots-hook.test.tsx
@@ -54,14 +54,17 @@ function deferred<T>() {
 
 function Probe({
   afterTimestamp,
+  range,
   resultRef,
 }: {
   afterTimestamp: number;
+  range: "30d" | "90d";
   resultRef: ResultRef;
 }) {
   resultRef.current = usePoolVolumeSnapshots({
     enabled: true,
     afterTimestamp,
+    range,
   });
   return null;
 }
@@ -71,11 +74,15 @@ let root: Root;
 let cache: Cache;
 let resultRef: ResultRef;
 
-function render(afterTimestamp: number) {
+function render(afterTimestamp: number, range: "30d" | "90d") {
   act(() => {
     root.render(
       <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
-        <Probe afterTimestamp={afterTimestamp} resultRef={resultRef} />
+        <Probe
+          afterTimestamp={afterTimestamp}
+          range={range}
+          resultRef={resultRef}
+        />
       </SWRConfig>,
     );
   });
@@ -109,18 +116,22 @@ describe("usePoolVolumeSnapshots", () => {
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
 
-    render(100);
+    render(100, "30d");
     await act(async () => {
       first.resolve({ PoolDailyVolumeSnapshot: [row("1", "100")] });
       await first.promise;
     });
     expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["1"]);
     expect(resultRef.current?.isLoading).toBe(false);
+    expect(resultRef.current?.dataAfterTimestamp).toBe(100);
+    expect(resultRef.current?.dataRange).toBe("30d");
 
-    render(200);
+    render(200, "90d");
 
     expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["1"]);
     expect(resultRef.current?.isLoading).toBe(true);
+    expect(resultRef.current?.dataAfterTimestamp).toBe(100);
+    expect(resultRef.current?.dataRange).toBe("30d");
     expect(
       resultRef.current!.isLoading && resultRef.current!.rows.length === 0,
     ).toBe(false);
@@ -131,5 +142,7 @@ describe("usePoolVolumeSnapshots", () => {
     });
     expect(resultRef.current?.rows.map(({ id }) => id)).toEqual(["2"]);
     expect(resultRef.current?.isLoading).toBe(false);
+    expect(resultRef.current?.dataAfterTimestamp).toBe(200);
+    expect(resultRef.current?.dataRange).toBe("90d");
   });
 });

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots.test.ts
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-pool-volume-snapshots.test.ts
@@ -50,6 +50,7 @@ describe("fetchPoolVolumeSnapshots", () => {
     const result = await fetchPoolVolumeSnapshots("https://hasura.test", 123);
 
     expect(result.partial).toBe(false);
+    expect(result.afterTimestamp).toBe(123);
     expect(result.rows).toHaveLength(1001);
     expect(requestMock).toHaveBeenCalledTimes(2);
     expect(requestMock.mock.calls[0]![0].variables).toMatchObject({

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
@@ -1,0 +1,266 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cutoffFromQueryIdentity,
+  dataMatchesCurrentActor,
+  rangeFromQueryIdentity,
+  useResolvedQueryIdentity,
+  useVersionedVolumeQueryData,
+  volumeQueryIdentity,
+  type VolumeQueryIdentity,
+} from "../use-resolved-query-identity";
+
+type ResultState = {
+  data: unknown;
+  error: unknown;
+  isLoading: boolean;
+};
+
+function Probe({
+  result,
+  identity,
+  fallbackMatchesCurrent = false,
+  resultRef,
+}: {
+  result: ResultState;
+  identity: string;
+  fallbackMatchesCurrent?: boolean;
+  resultRef: { current: string | undefined };
+}) {
+  resultRef.current = useResolvedQueryIdentity(
+    result,
+    identity,
+    fallbackMatchesCurrent,
+  );
+  return null;
+}
+
+type VersionedResult = ReturnType<
+  typeof useVersionedVolumeQueryData<{ rows: string[] }>
+>;
+
+function VersionedProbe({
+  result,
+  identity,
+  resultRef,
+}: {
+  result: ResultState & { data: { rows: string[] } | undefined };
+  identity: VolumeQueryIdentity;
+  resultRef: { current: VersionedResult | null };
+}) {
+  resultRef.current = useVersionedVolumeQueryData(result, identity);
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useResolvedQueryIdentity", () => {
+  it("keeps retained data paired with its last successful key through loading and error", () => {
+    const resultRef: { current: string | undefined } = { current: undefined };
+    const priorData = { rows: ["prior"] };
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{ data: priorData, error: null, isLoading: false }}
+          identity="30d|organic"
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toBe("30d|organic");
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{ data: priorData, error: null, isLoading: true }}
+          identity="90d|organic"
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toBe("30d|organic");
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{
+            data: priorData,
+            error: new Error("replacement failed"),
+            isLoading: false,
+          }}
+          identity="90d|organic"
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toBe("30d|organic");
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{ data: { rows: ["next"] }, error: null, isLoading: false }}
+          identity="90d|organic"
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toBe("90d|organic");
+  });
+
+  it("recognises descriptor-validated SSR fallback as current-key data", () => {
+    const resultRef: { current: string | undefined } = { current: undefined };
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{ data: { rows: [] }, error: null, isLoading: true }}
+          identity="7d|organic"
+          fallbackMatchesCurrent
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    expect(resultRef.current).toBe("7d|organic");
+  });
+
+  it("retains ranges but rejects retained data across actor-filter identities", () => {
+    const retainedOrganic = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+    const widerOrganic = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: false,
+    });
+    const widerAll = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: true,
+    });
+
+    expect(dataMatchesCurrentActor(retainedOrganic, widerOrganic)).toBe(true);
+    expect(rangeFromQueryIdentity(retainedOrganic)).toBe("30d");
+    expect(cutoffFromQueryIdentity(retainedOrganic)).toBe(100);
+    expect(dataMatchesCurrentActor(retainedOrganic, widerAll)).toBe(false);
+  });
+
+  it("keeps range-retained rows through replacement errors but hides them on actor changes", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const retainedData = { rows: ["prior complete window"] };
+    const priorOrganic = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+    const widerOrganic = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: false,
+    });
+    const widerAll = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: true,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedData, error: null, isLoading: false }}
+          identity={priorOrganic}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedData, error: null, isLoading: true }}
+          identity={widerOrganic}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: retainedData,
+      dataIdentity: priorOrganic,
+      isLoading: false,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: retainedData,
+            error: new Error("new range failed"),
+            isLoading: false,
+          }}
+          identity={widerOrganic}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: retainedData,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedData, error: null, isLoading: true }}
+          identity={widerAll}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      isLoading: true,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: retainedData,
+            error: new Error("actor-filter request failed"),
+            isLoading: false,
+          }}
+          identity={widerAll}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      isLoading: false,
+      hasError: true,
+    });
+  });
+});

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
@@ -23,18 +23,19 @@ function Probe({
   result,
   identity,
   fallbackMatchesCurrent = false,
+  enabled = true,
   resultRef,
 }: {
   result: ResultState;
   identity: string;
   fallbackMatchesCurrent?: boolean;
+  enabled?: boolean;
   resultRef: { current: string | undefined };
 }) {
-  resultRef.current = useResolvedQueryIdentity(
-    result,
-    identity,
+  resultRef.current = useResolvedQueryIdentity(result, identity, {
+    enabled,
     fallbackMatchesCurrent,
-  );
+  });
   return null;
 }
 
@@ -45,13 +46,17 @@ type VersionedResult = ReturnType<
 function VersionedProbe({
   result,
   identity,
+  enabled = true,
   resultRef,
 }: {
   result: ResultState & { data: { rows: string[] } | undefined };
   identity: VolumeQueryIdentity;
+  enabled?: boolean;
   resultRef: { current: VersionedResult | null };
 }) {
-  resultRef.current = useVersionedVolumeQueryData(result, identity);
+  resultRef.current = useVersionedVolumeQueryData(result, identity, {
+    enabled,
+  });
   return null;
 }
 
@@ -141,6 +146,24 @@ describe("useResolvedQueryIdentity", () => {
     });
 
     expect(resultRef.current).toBe("7d|organic");
+  });
+
+  it("does not stamp descriptor fallback while its query is disabled", () => {
+    const resultRef: { current: string | undefined } = { current: undefined };
+
+    act(() => {
+      root.render(
+        <Probe
+          result={{ data: { rows: [] }, error: null, isLoading: true }}
+          identity="90d|organic"
+          fallbackMatchesCurrent
+          enabled={false}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    expect(resultRef.current).toBeUndefined();
   });
 
   it("retains ranges but rejects retained data across actor-filter identities", () => {
@@ -261,6 +284,177 @@ describe("useResolvedQueryIdentity", () => {
       data: undefined,
       isLoading: false,
       hasError: true,
+    });
+  });
+
+  it("does not restamp retained v2 data while its venue query is disabled", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const staleV2Data = { rows: ["v2 organic 30d"] };
+    const v2Organic30d = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+    const v2All90d = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: true,
+    });
+
+    // Resolve v2 Organic/30d, then switch to v3. The disabled v2 SWR hook
+    // still exposes its last response with `isLoading: false`.
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: staleV2Data, error: null, isLoading: false }}
+          identity={v2Organic30d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: staleV2Data,
+      dataIdentity: v2Organic30d,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: staleV2Data, error: null, isLoading: false }}
+          identity={v2Organic30d}
+          enabled={false}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    // Change both range and actor scope while v2 remains disabled. Its old
+    // response must keep the identity it actually resolved under.
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: staleV2Data, error: null, isLoading: false }}
+          identity={v2All90d}
+          enabled={false}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      dataIdentity: v2Organic30d,
+      isLoading: false,
+      hasError: false,
+    });
+
+    // Switching back to v2 starts the new key. The retained Organic/30d rows
+    // stay withheld instead of being mislabeled as All/90d.
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: staleV2Data, error: null, isLoading: true }}
+          identity={v2All90d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      dataIdentity: v2Organic30d,
+      isLoading: true,
+      hasError: false,
+    });
+
+    const freshV2Data = { rows: ["v2 all 90d"] };
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: freshV2Data, error: null, isLoading: false }}
+          identity={v2All90d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: freshV2Data,
+      dataIdentity: v2All90d,
+      isLoading: false,
+      hasError: false,
+    });
+  });
+
+  it("keeps the prior range identity across a same-actor disabled venue transition", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const retainedV2Data = { rows: ["v2 organic 30d"] };
+    const v2Organic30d = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+    const v2Organic90d = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedV2Data, error: null, isLoading: false }}
+          identity={v2Organic30d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedV2Data, error: null, isLoading: false }}
+          identity={v2Organic90d}
+          enabled={false}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      dataIdentity: v2Organic30d,
+      isLoading: false,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: retainedV2Data, error: null, isLoading: true }}
+          identity={v2Organic90d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: retainedV2Data,
+      dataIdentity: v2Organic30d,
+      isLoading: false,
+      hasError: false,
+    });
+
+    const freshV2Data = { rows: ["v2 organic 90d"] };
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: freshV2Data, error: null, isLoading: false }}
+          identity={v2Organic90d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: freshV2Data,
+      dataIdentity: v2Organic90d,
+      isLoading: false,
+      hasError: false,
     });
   });
 });

--- a/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
+++ b/ui-dashboard/src/app/volume/_lib/__tests__/use-resolved-query-identity.test.tsx
@@ -131,6 +131,56 @@ describe("useResolvedQueryIdentity", () => {
     expect(resultRef.current).toBe("90d|organic");
   });
 
+  it("adopts distinct current-key cache data when its revalidation errors", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const priorData = { rows: ["same payload"] };
+    const cachedCurrentData = { rows: ["same payload"] };
+    const priorIdentity = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+    const currentIdentity = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: priorData, error: null, isLoading: false }}
+          identity={priorIdentity}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    // SWR serves B's own cached object while B's background revalidation
+    // fails. It is structurally equal to A on purpose: provenance is the
+    // exact reference, not row equality.
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: cachedCurrentData,
+            error: new Error("current cache revalidation failed"),
+            isLoading: false,
+          }}
+          identity={currentIdentity}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    expect(resultRef.current).toMatchObject({
+      data: cachedCurrentData,
+      dataIdentity: currentIdentity,
+      isLoading: false,
+      hasError: false,
+    });
+  });
+
   it("recognises descriptor-validated SSR fallback as current-key data", () => {
     const resultRef: { current: string | undefined } = { current: undefined };
 
@@ -164,6 +214,84 @@ describe("useResolvedQueryIdentity", () => {
     });
 
     expect(resultRef.current).toBeUndefined();
+  });
+
+  it("seeds current identity from cached data with a remount-time error", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const cachedData = { rows: ["cached current window"] };
+    const currentIdentity = volumeQueryIdentity({
+      range: "30d",
+      cutoff: 100,
+      includeProtocolActors: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: cachedData,
+            error: new Error("background revalidation failed"),
+            isLoading: false,
+          }}
+          identity={currentIdentity}
+          resultRef={resultRef}
+        />,
+      );
+    });
+
+    expect(resultRef.current).toMatchObject({
+      data: cachedData,
+      dataIdentity: currentIdentity,
+      isLoading: false,
+      hasError: false,
+    });
+  });
+
+  it("seeds cached error data when a tracker is first enabled after mounting disabled", () => {
+    const resultRef: { current: VersionedResult | null } = { current: null };
+    const cachedData = { rows: ["cached v2 window"] };
+    const currentIdentity = volumeQueryIdentity({
+      range: "90d",
+      cutoff: 50,
+      includeProtocolActors: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{ data: cachedData, error: null, isLoading: false }}
+          identity={currentIdentity}
+          enabled={false}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: undefined,
+      dataIdentity: undefined,
+      isLoading: false,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: cachedData,
+            error: new Error("cached key revalidation failed"),
+            isLoading: false,
+          }}
+          identity={currentIdentity}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: cachedData,
+      dataIdentity: currentIdentity,
+      isLoading: false,
+      hasError: false,
+    });
   });
 
   it("retains ranges but rejects retained data across actor-filter identities", () => {
@@ -249,6 +377,7 @@ describe("useResolvedQueryIdentity", () => {
     });
     expect(resultRef.current).toMatchObject({
       data: retainedData,
+      dataIdentity: priorOrganic,
       hasError: false,
     });
 
@@ -428,6 +557,26 @@ describe("useResolvedQueryIdentity", () => {
       root.render(
         <VersionedProbe
           result={{ data: retainedV2Data, error: null, isLoading: true }}
+          identity={v2Organic90d}
+          resultRef={resultRef}
+        />,
+      );
+    });
+    expect(resultRef.current).toMatchObject({
+      data: retainedV2Data,
+      dataIdentity: v2Organic30d,
+      isLoading: false,
+      hasError: false,
+    });
+
+    act(() => {
+      root.render(
+        <VersionedProbe
+          result={{
+            data: retainedV2Data,
+            error: new Error("new v2 key failed"),
+            isLoading: false,
+          }}
           identity={v2Organic90d}
           resultRef={resultRef}
         />,

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -152,12 +152,20 @@ export function useHeroRollup({
   const heroV3Result = useGQL<HeroV3Data>(
     venue === "v3" ? VOLUME_WINDOW_LATEST : null,
     { windowKey: range },
-    { schema: VolumeWindowLatestSchema, fallbackData: fallback?.heroV3 },
+    {
+      schema: VolumeWindowLatestSchema,
+      fallbackData: fallback?.heroV3,
+      keepPreviousData: true,
+    },
   );
   const heroV2Result = useGQL<HeroV2Data>(
     venue === "v2" ? BROKER_VOLUME_WINDOW_LATEST : null,
     { windowKey: range },
-    { schema: BrokerVolumeWindowLatestSchema, fallbackData: fallback?.heroV2 },
+    {
+      schema: BrokerVolumeWindowLatestSchema,
+      fallbackData: fallback?.heroV2,
+      keepPreviousData: true,
+    },
   );
 
   const todayV3Result = useGQL<{
@@ -197,6 +205,7 @@ export function useHeroRollup({
     {
       schema: VolumeWindowFirstDayLatestSchema,
       fallbackData: fallback?.firstDayV3,
+      keepPreviousData: true,
     },
   );
   const heroFirstDayV2Result = useGQL<{
@@ -207,6 +216,7 @@ export function useHeroRollup({
     {
       schema: BrokerVolumeWindowFirstDayLatestSchema,
       fallbackData: fallback?.firstDayV2,
+      keepPreviousData: true,
     },
   );
   const firstDayRows =

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useNetwork } from "@/components/network-provider";
 import { useGQL } from "@/lib/graphql";
 import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
@@ -45,6 +45,7 @@ import {
 } from "@/lib/volume";
 import { SECONDS_PER_DAY } from "@/lib/time-series";
 import type { Venue } from "./url-state";
+import { useResolvedQueryIdentity } from "./use-resolved-query-identity";
 
 type HeroV3Data = { volumeWindowSnapshots: VolumeWindowRow[] };
 type HeroV2Data = { brokerVolumeWindowSnapshots: VolumeWindowRow[] };
@@ -80,6 +81,8 @@ export function useHeroRollup({
   isProtocolActorIn,
   utcDayKey,
   kpiSource,
+  kpiSourceRange,
+  kpiSourceIncludesProtocolActors,
   initialData,
 }: {
   venue: Venue;
@@ -92,6 +95,11 @@ export function useHeroRollup({
    *  the resulting rows so the table query and the hero query can degrade
    *  independently. */
   kpiSource: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
+  /** Identity of `kpiSource`. A retained trader response keeps its resolved
+   * range/filter identity so concentration never divides an old numerator by
+   * a new hero denominator. */
+  kpiSourceRange?: VolumeRangeKey | undefined;
+  kpiSourceIncludesProtocolActors?: boolean | undefined;
   /** Server-prefetched hero responses (perf-plan S4), forwarded to the
    *  matching `useGQL` calls as `fallbackData` so the first render paints
    *  populated tiles. Only attached when the prefetched view descriptor
@@ -110,6 +118,10 @@ export function useHeroRollup({
   concentration: number;
   staleChains: number[];
   degradedChains: number[];
+  /** Range that produced the returned display snapshot. During a transition
+   * this can intentionally lag `range` while the next coherent snapshot is
+   * still assembling. */
+  displayRange: VolumeRangeKey;
   isLoading: boolean;
   hasError: boolean;
 } {
@@ -167,6 +179,16 @@ export function useHeroRollup({
       keepPreviousData: true,
     },
   );
+  const heroV3DataRange = useResolvedQueryIdentity(
+    heroV3Result,
+    range,
+    fallback?.heroV3 !== undefined,
+  );
+  const heroV2DataRange = useResolvedQueryIdentity(
+    heroV2Result,
+    range,
+    fallback?.heroV2 !== undefined,
+  );
 
   const todayV3Result = useGQL<{
     volumeTodayTraders: VolumeTodayTraderRow[];
@@ -219,10 +241,32 @@ export function useHeroRollup({
       keepPreviousData: true,
     },
   );
-  const firstDayRows =
+  const heroFirstDayV3DataRange = useResolvedQueryIdentity(
+    heroFirstDayV3Result,
+    range,
+    fallback?.firstDayV3 !== undefined,
+  );
+  const heroFirstDayV2DataRange = useResolvedQueryIdentity(
+    heroFirstDayV2Result,
+    range,
+    fallback?.firstDayV2 !== undefined,
+  );
+  const snapshotDataRange = venue === "v3" ? heroV3DataRange : heroV2DataRange;
+  const firstDayDataRange =
+    venue === "v3" ? heroFirstDayV3DataRange : heroFirstDayV2DataRange;
+  const activeFirstDayResult =
+    venue === "v3" ? heroFirstDayV3Result : heroFirstDayV2Result;
+  const rawFirstDayRows =
     venue === "v3"
       ? heroFirstDayV3Result.data?.volumeWindowFirstDaySnapshots
       : heroFirstDayV2Result.data?.brokerVolumeWindowFirstDaySnapshots;
+  // A first-day slice is valid only for the same resolved window as its
+  // primary snapshot. During staggered key replacement, keep it out of the
+  // merge rather than subtracting an old-window slice from a new total.
+  const firstDayRows =
+    snapshotDataRange !== undefined && firstDayDataRange === snapshotDataRange
+      ? rawFirstDayRows
+      : undefined;
 
   // First-pass merge — without `yesterdayRows`. Used solely to discover
   // which chains are in the DEGRADED state (snapshotDay = today - 2 days),
@@ -317,7 +361,7 @@ export function useHeroRollup({
           ? partialOverlapV3Result.data?.volumePartialOverlapTraders
           : partialOverlapV2Result.data?.brokerVolumePartialOverlapTraders;
 
-  const heroTotals = useMemo(
+  const candidateHeroTotals = useMemo(
     () =>
       mergeHeroSnapshot({
         snapshotRows,
@@ -338,22 +382,71 @@ export function useHeroRollup({
       todayMidnight,
     ],
   );
-  const totalVolume = useMemo(
-    () => weiToUsd(heroTotals.totalVolumeUsdWei),
-    [heroTotals.totalVolumeUsdWei],
-  );
-
-  // Stale-chain mask is applied to numerator AND denominator in
-  // `top10Concentration` — denominator already excludes them via
-  // `mergeHeroSnapshot` — see that helper's JSDoc in `lib/volume.ts`.
-  const concentration = useMemo(
+  const candidateConcentration = useMemo(
     () =>
       top10Concentration({
         rowsByVolumeDesc: kpiSource,
-        totalVolumeUsdWei: heroTotals.totalVolumeUsdWei,
-        staleChains: heroTotals.staleChains,
+        totalVolumeUsdWei: candidateHeroTotals.totalVolumeUsdWei,
+        staleChains: candidateHeroTotals.staleChains,
       }),
-    [kpiSource, heroTotals.totalVolumeUsdWei, heroTotals.staleChains],
+    [
+      kpiSource,
+      candidateHeroTotals.totalVolumeUsdWei,
+      candidateHeroTotals.staleChains,
+    ],
+  );
+
+  type HeroDisplaySnapshot = {
+    venue: Venue;
+    includeProtocolActors: boolean;
+    range: VolumeRangeKey;
+    totals: typeof candidateHeroTotals;
+    concentration: number;
+  };
+  const lastCoherentDisplay = useRef<HeroDisplaySnapshot | undefined>(
+    undefined,
+  );
+  const firstDayMatchesPrimary =
+    snapshotDataRange !== undefined && firstDayDataRange === snapshotDataRange;
+  const firstDayTerminallyUnavailable =
+    snapshotDataRange === range &&
+    rawFirstDayRows === undefined &&
+    !activeFirstDayResult.isLoading;
+  const kpiMatchesPrimary =
+    kpiSourceRange === snapshotDataRange &&
+    kpiSourceIncludesProtocolActors === includeProtocolActors;
+  const kpiSourceIsPending =
+    kpiSourceRange === undefined ||
+    kpiSourceIncludesProtocolActors === undefined;
+  const canPublishCoherentDisplay =
+    snapshotDataRange !== undefined &&
+    (firstDayMatchesPrimary || firstDayTerminallyUnavailable) &&
+    (kpiMatchesPrimary || kpiSourceIsPending);
+  const candidateDisplay: HeroDisplaySnapshot = {
+    venue,
+    includeProtocolActors,
+    range: snapshotDataRange ?? range,
+    totals: candidateHeroTotals,
+    concentration: candidateConcentration,
+  };
+  const priorDisplay = lastCoherentDisplay.current;
+  const canReusePriorDisplay =
+    priorDisplay !== undefined &&
+    priorDisplay.venue === venue &&
+    priorDisplay.includeProtocolActors === includeProtocolActors;
+  const display =
+    canPublishCoherentDisplay || !canReusePriorDisplay
+      ? candidateDisplay
+      : priorDisplay;
+
+  useEffect(() => {
+    if (!canPublishCoherentDisplay) return;
+    lastCoherentDisplay.current = candidateDisplay;
+  }, [canPublishCoherentDisplay, candidateDisplay]);
+
+  const totalVolume = useMemo(
+    () => weiToUsd(display.totals.totalVolumeUsdWei),
+    [display.totals.totalVolumeUsdWei],
   );
 
   // Tiles + chart load when the hero snapshot AND its today-partial both
@@ -384,11 +477,12 @@ export function useHeroRollup({
   return {
     todayMidnight,
     totalVolume,
-    totalTraders: heroTotals.uniqueTraders,
-    totalSwaps: heroTotals.totalSwapCount,
-    concentration,
-    staleChains: heroTotals.staleChains,
-    degradedChains: heroTotals.degradedChains,
+    totalTraders: display.totals.uniqueTraders,
+    totalSwaps: display.totals.totalSwapCount,
+    concentration: display.concentration,
+    staleChains: display.totals.staleChains,
+    degradedChains: display.totals.degradedChains,
+    displayRange: display.range,
     isLoading,
     hasError,
   };

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -35,6 +35,7 @@ import {
 import {
   buildHeroPartialOverlapQueryInput,
   mergeHeroSnapshot,
+  rangeCutoffSeconds,
   top10Concentration,
   weiToUsd,
   type VolumeRangeKey,
@@ -45,7 +46,13 @@ import {
 } from "@/lib/volume";
 import { SECONDS_PER_DAY } from "@/lib/time-series";
 import type { Venue } from "./url-state";
-import { useResolvedQueryIdentity } from "./use-resolved-query-identity";
+import {
+  actorViewFromQueryIdentity,
+  cutoffFromQueryIdentity,
+  rangeFromQueryIdentity,
+  useResolvedQueryIdentity,
+  type VolumeQueryIdentity,
+} from "./use-resolved-query-identity";
 
 type HeroV3Data = { volumeWindowSnapshots: VolumeWindowRow[] };
 type HeroV2Data = { brokerVolumeWindowSnapshots: VolumeWindowRow[] };
@@ -81,8 +88,8 @@ export function useHeroRollup({
   isProtocolActorIn,
   utcDayKey,
   kpiSource,
-  kpiSourceRange,
-  kpiSourceIncludesProtocolActors,
+  kpiSourceIdentity,
+  kpiSourceIsCapHit,
   initialData,
 }: {
   venue: Venue;
@@ -95,11 +102,12 @@ export function useHeroRollup({
    *  the resulting rows so the table query and the hero query can degrade
    *  independently. */
   kpiSource: ReadonlyArray<{ chainId: number; volumeUsdWei: bigint }>;
-  /** Identity of `kpiSource`. A retained trader response keeps its resolved
-   * range/filter identity so concentration never divides an old numerator by
-   * a new hero denominator. */
-  kpiSourceRange?: VolumeRangeKey | undefined;
-  kpiSourceIncludesProtocolActors?: boolean | undefined;
+  /** Full identity of `kpiSource`. A retained trader response keeps its
+   * resolved range/cutoff/filter identity so concentration never divides an
+   * old numerator by a new hero denominator, including across UTC midnight. */
+  kpiSourceIdentity?: VolumeQueryIdentity | undefined;
+  /** Cap state paired with `kpiSource`; retained displays keep this version. */
+  kpiSourceIsCapHit: boolean;
   /** Server-prefetched hero responses (perf-plan S4), forwarded to the
    *  matching `useGQL` calls as `fallbackData` so the first render paints
    *  populated tiles. Only attached when the prefetched view descriptor
@@ -122,6 +130,11 @@ export function useHeroRollup({
    * this can intentionally lag `range` while the next coherent snapshot is
    * still assembling. */
   displayRange: VolumeRangeKey;
+  /** Trader identity paired with the displayed concentration. Undefined while
+   * the hero slices and trader numerator do not form one coherent version. */
+  displayIdentity: VolumeQueryIdentity | undefined;
+  /** Whether the displayed concentration is a lower-bound approximation. */
+  isKpiSourceCapHit: boolean;
   isLoading: boolean;
   hasError: boolean;
 } {
@@ -406,6 +419,8 @@ export function useHeroRollup({
     range: VolumeRangeKey;
     totals: typeof candidateHeroTotals;
     concentration: number;
+    kpiSourceIdentity: VolumeQueryIdentity | undefined;
+    isKpiSourceCapHit: boolean;
   };
   const lastCoherentDisplay = useRef<HeroDisplaySnapshot | undefined>(
     undefined,
@@ -414,24 +429,32 @@ export function useHeroRollup({
     snapshotDataRange !== undefined && firstDayDataRange === snapshotDataRange;
   const firstDayTerminallyUnavailable =
     snapshotDataRange === range &&
-    rawFirstDayRows === undefined &&
+    firstDayRows === undefined &&
     !activeFirstDayResult.isLoading;
+  const kpiSourceRange = rangeFromQueryIdentity(kpiSourceIdentity);
   const kpiMatchesPrimary =
     kpiSourceRange === snapshotDataRange &&
-    kpiSourceIncludesProtocolActors === includeProtocolActors;
-  const kpiSourceIsPending =
-    kpiSourceRange === undefined ||
-    kpiSourceIncludesProtocolActors === undefined;
+    snapshotDataRange !== undefined &&
+    cutoffFromQueryIdentity(kpiSourceIdentity) ===
+      rangeCutoffSeconds(snapshotDataRange, todayMidnight) &&
+    actorViewFromQueryIdentity(kpiSourceIdentity) === includeProtocolActors;
+  const kpiSourceIsPending = kpiSourceIdentity === undefined;
   const canPublishCoherentDisplay =
     snapshotDataRange !== undefined &&
     (firstDayMatchesPrimary || firstDayTerminallyUnavailable) &&
     (kpiMatchesPrimary || kpiSourceIsPending);
+  const canPublishCoherentConcentration =
+    canPublishCoherentDisplay && kpiMatchesPrimary;
   const candidateDisplay: HeroDisplaySnapshot = {
     venue,
     includeProtocolActors,
     range: snapshotDataRange ?? range,
     totals: candidateHeroTotals,
     concentration: candidateConcentration,
+    kpiSourceIdentity: canPublishCoherentConcentration
+      ? kpiSourceIdentity
+      : undefined,
+    isKpiSourceCapHit: canPublishCoherentConcentration && kpiSourceIsCapHit,
   };
   const priorDisplay = lastCoherentDisplay.current;
   const canReusePriorDisplay =
@@ -487,6 +510,8 @@ export function useHeroRollup({
     staleChains: display.totals.staleChains,
     degradedChains: display.totals.degradedChains,
     displayRange: display.range,
+    displayIdentity: display.kpiSourceIdentity,
+    isKpiSourceCapHit: display.isKpiSourceCapHit,
     isLoading,
     hasError,
   };

--- a/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-hero-rollup.ts
@@ -179,16 +179,14 @@ export function useHeroRollup({
       keepPreviousData: true,
     },
   );
-  const heroV3DataRange = useResolvedQueryIdentity(
-    heroV3Result,
-    range,
-    fallback?.heroV3 !== undefined,
-  );
-  const heroV2DataRange = useResolvedQueryIdentity(
-    heroV2Result,
-    range,
-    fallback?.heroV2 !== undefined,
-  );
+  const heroV3DataRange = useResolvedQueryIdentity(heroV3Result, range, {
+    enabled: venue === "v3",
+    fallbackMatchesCurrent: fallback?.heroV3 !== undefined,
+  });
+  const heroV2DataRange = useResolvedQueryIdentity(heroV2Result, range, {
+    enabled: venue === "v2",
+    fallbackMatchesCurrent: fallback?.heroV2 !== undefined,
+  });
 
   const todayV3Result = useGQL<{
     volumeTodayTraders: VolumeTodayTraderRow[];
@@ -244,12 +242,18 @@ export function useHeroRollup({
   const heroFirstDayV3DataRange = useResolvedQueryIdentity(
     heroFirstDayV3Result,
     range,
-    fallback?.firstDayV3 !== undefined,
+    {
+      enabled: venue === "v3",
+      fallbackMatchesCurrent: fallback?.firstDayV3 !== undefined,
+    },
   );
   const heroFirstDayV2DataRange = useResolvedQueryIdentity(
     heroFirstDayV2Result,
     range,
-    fallback?.firstDayV2 !== undefined,
+    {
+      enabled: venue === "v2",
+      fallbackMatchesCurrent: fallback?.firstDayV2 !== undefined,
+    },
   );
   const snapshotDataRange = venue === "v3" ? heroV3DataRange : heroV2DataRange;
   const firstDayDataRange =

--- a/ui-dashboard/src/app/volume/_lib/use-pool-volume-snapshots.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-pool-volume-snapshots.ts
@@ -116,6 +116,7 @@ export function usePoolVolumeSnapshots({
       revalidateOnReconnect: false,
       refreshWhenHidden: false,
       onErrorRetry: rateLimitAwareRetry,
+      keepPreviousData: true,
     },
   );
 

--- a/ui-dashboard/src/app/volume/_lib/use-pool-volume-snapshots.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-pool-volume-snapshots.ts
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { useNetwork } from "@/components/network-provider";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
 import { POOL_DAILY_VOLUME } from "@/lib/queries/volume";
+import type { VolumeRangeKey } from "@/lib/volume";
 import type { PoolDailyVolumeRow } from "@/lib/volume-pool";
 
 const PAGE_SIZE = 1000;
@@ -22,15 +23,21 @@ type PoolVolumePage = {
 type PoolVolumeResult = {
   rows: PoolDailyVolumeRow[];
   partial: boolean;
+  afterTimestamp: number;
+};
+
+type PoolVolumeCacheResult = PoolVolumeResult & {
+  range: VolumeRangeKey;
 };
 
 function finishAfterDeadline(
   rows: readonly PoolDailyVolumeRow[],
+  afterTimestamp: number,
 ): PoolVolumeResult {
   if (rows.length === 0) {
     throw new Error("Pool volume snapshot pagination exceeded its budget");
   }
-  return { rows: [...rows], partial: true };
+  return { rows: [...rows], partial: true, afterTimestamp };
 }
 
 export async function fetchPoolVolumeSnapshots(
@@ -49,7 +56,7 @@ export async function fetchPoolVolumeSnapshots(
   for (let page = 0; page <= MAX_PAGES; page += 1) {
     const remainingMs = deadlineMs - Date.now();
     if (remainingMs <= 0) {
-      return finishAfterDeadline(rows);
+      return finishAfterDeadline(rows, afterTimestamp);
     }
 
     let batch: PoolDailyVolumeRow[];
@@ -67,11 +74,11 @@ export async function fetchPoolVolumeSnapshots(
       batch = result.PoolDailyVolumeSnapshot ?? [];
     } catch (err) {
       if (rows.length === 0) throw err;
-      return { rows, partial: true };
+      return { rows, partial: true, afterTimestamp };
     }
 
     if (page === MAX_PAGES) {
-      return { rows, partial: batch.length > 0 };
+      return { rows, partial: batch.length > 0, afterTimestamp };
     }
 
     for (const row of batch) {
@@ -79,7 +86,8 @@ export async function fetchPoolVolumeSnapshots(
       seen.add(row.id);
       rows.push(row);
     }
-    if (batch.length < PAGE_SIZE) return { rows, partial: false };
+    if (batch.length < PAGE_SIZE)
+      return { rows, partial: false, afterTimestamp };
   }
 
   throw new Error("unreachable pool-volume pagination state");
@@ -88,14 +96,22 @@ export async function fetchPoolVolumeSnapshots(
 export function usePoolVolumeSnapshots({
   enabled,
   afterTimestamp,
+  range,
 }: {
   enabled: boolean;
   afterTimestamp: number;
+  range: VolumeRangeKey;
 }): {
   rows: PoolDailyVolumeRow[];
   isLoading: boolean;
   error: unknown;
   partial: boolean;
+  /** Cutoff that produced `rows`. During `keepPreviousData` revalidation this
+   * remains the prior cutoff, so consumers never clip/zero-fill old rows as if
+   * they covered the newly requested window. */
+  dataAfterTimestamp: number | undefined;
+  dataRange: VolumeRangeKey | undefined;
+  hasData: boolean;
 } {
   const { network } = useNetwork();
   const missingUrlError =
@@ -105,11 +121,20 @@ export function usePoolVolumeSnapshots({
             `Get the GraphQL endpoint from the Envio dashboard and set it in .env.local.`,
         )
       : null;
-  const { data, error, isLoading } = useSWR<PoolVolumeResult>(
+  const { data, error, isLoading } = useSWR<PoolVolumeCacheResult>(
     enabled && network.hasuraUrl
-      ? ["volume-pool-snapshots", network.id, network.hasuraUrl, afterTimestamp]
+      ? [
+          "volume-pool-snapshots",
+          network.id,
+          network.hasuraUrl,
+          range,
+          afterTimestamp,
+        ]
       : null,
-    () => fetchPoolVolumeSnapshots(network.hasuraUrl, afterTimestamp),
+    async () => ({
+      ...(await fetchPoolVolumeSnapshots(network.hasuraUrl, afterTimestamp)),
+      range,
+    }),
     {
       refreshInterval: REFRESH_MS,
       revalidateOnFocus: false,
@@ -125,5 +150,8 @@ export function usePoolVolumeSnapshots({
     isLoading: missingUrlError ? false : isLoading,
     error: missingUrlError ?? error,
     partial: data?.partial ?? false,
+    dataAfterTimestamp: data?.afterTimestamp,
+    dataRange: data?.range,
+    hasData: data !== undefined,
   };
 }

--- a/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { VolumeRangeKey } from "@/lib/volume";
+import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
+
+type ActorView = "all" | "organic";
+export type VolumeQueryIdentity = `${VolumeRangeKey}|${number}|${ActorView}`;
+
+export function volumeQueryIdentity({
+  range,
+  cutoff,
+  includeProtocolActors,
+}: {
+  range: VolumeRangeKey;
+  cutoff: number;
+  includeProtocolActors: boolean;
+}): VolumeQueryIdentity {
+  return `${range}|${cutoff}|${includeProtocolActors ? "all" : "organic"}`;
+}
+
+export function rangeFromQueryIdentity(
+  identity: VolumeQueryIdentity | undefined,
+): VolumeRangeKey | undefined {
+  return identity?.split("|", 1)[0] as VolumeRangeKey | undefined;
+}
+
+export function cutoffFromQueryIdentity(
+  identity: VolumeQueryIdentity | undefined,
+): number | undefined {
+  const cutoff = identity?.split("|")[1];
+  return cutoff === undefined ? undefined : Number(cutoff);
+}
+
+export function actorViewFromQueryIdentity(
+  identity: VolumeQueryIdentity | undefined,
+): boolean | undefined {
+  const actorView = identity?.split("|")[2] as ActorView | undefined;
+  return actorView === undefined ? undefined : actorView === "all";
+}
+
+export function dataMatchesCurrentActor(
+  identity: VolumeQueryIdentity | undefined,
+  currentIdentity: VolumeQueryIdentity,
+): boolean {
+  return (
+    actorViewFromQueryIdentity(identity) ===
+    actorViewFromQueryIdentity(currentIdentity)
+  );
+}
+
+type QueryResultState = {
+  data: unknown;
+  error: unknown;
+  isLoading: boolean;
+};
+
+/**
+ * Tracks which query identity produced SWR's currently exposed data.
+ *
+ * With `keepPreviousData`, a key change exposes the prior response while the
+ * replacement request is loading (and keeps exposing it if that request
+ * fails). Consumers must therefore pair the data with the last successfully
+ * resolved key, rather than with the render's newly requested key.
+ *
+ * `fallbackMatchesCurrent` covers SSR `fallbackData`: SWR reports it as
+ * loading during the first revalidation, but the server descriptor has
+ * already proved that it belongs to the current key.
+ */
+export function useResolvedQueryIdentity<
+  TIdentity extends string | number | boolean,
+>(
+  result: QueryResultState,
+  currentIdentity: TIdentity,
+  fallbackMatchesCurrent = false,
+): TIdentity | undefined {
+  const isCurrentResponse =
+    result.data !== undefined && result.error == null && !result.isLoading;
+  const lastResolvedIdentity = useRef<TIdentity | undefined>(
+    isCurrentResponse || (result.data !== undefined && fallbackMatchesCurrent)
+      ? currentIdentity
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (!isCurrentResponse) return;
+    lastResolvedIdentity.current = currentIdentity;
+  }, [currentIdentity, isCurrentResponse]);
+
+  if (result.data === undefined) return undefined;
+  if (isCurrentResponse || fallbackMatchesCurrent) return currentIdentity;
+  return lastResolvedIdentity.current;
+}
+
+/** Range-retained query state with actor-sensitive data exposure. */
+export function useVersionedVolumeQueryData<T>(
+  result: QueryResultState & { data: T | undefined },
+  currentIdentity: VolumeQueryIdentity,
+): {
+  data: T | undefined;
+  dataIdentity: VolumeQueryIdentity | undefined;
+  isLoading: boolean;
+  hasError: boolean;
+} {
+  const dataIdentity = useResolvedQueryIdentity(result, currentIdentity);
+  const data = dataMatchesCurrentActor(dataIdentity, currentIdentity)
+    ? result.data
+    : undefined;
+  return {
+    data,
+    dataIdentity,
+    isLoading: isLoadingWithoutData(result.isLoading, data),
+    hasError: hasErrorWithoutData(result.error, data),
+  };
+}

--- a/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
@@ -62,6 +62,43 @@ type ResolvedQueryIdentityOptions = {
   fallbackMatchesCurrent?: boolean;
 };
 
+function classifyCurrentResponse(
+  result: QueryResultState,
+  { enabled, fallbackMatchesCurrent = false }: ResolvedQueryIdentityOptions,
+): {
+  isCurrentResponse: boolean;
+  isCurrentFallback: boolean;
+  isSeedableResponse: boolean;
+} {
+  const hasCurrentKeyData = enabled && result.data !== undefined;
+  return {
+    isCurrentResponse:
+      hasCurrentKeyData && result.error == null && !result.isLoading,
+    isCurrentFallback: hasCurrentKeyData && fallbackMatchesCurrent,
+    isSeedableResponse: hasCurrentKeyData && !result.isLoading,
+  };
+}
+
+type ResolvedData<TIdentity> = {
+  identity: TIdentity;
+  data: unknown;
+};
+
+function canAdoptSeedableResponse<TIdentity>(
+  isSeedableResponse: boolean,
+  currentIdentity: TIdentity,
+  currentData: unknown,
+  lastResolved: ResolvedData<TIdentity> | undefined,
+): boolean {
+  if (!isSeedableResponse) return false;
+  if (lastResolved === undefined) return true;
+  if (lastResolved.identity === currentIdentity) return true;
+  // SWR 2.4's keepPreviousData path exposes laggyDataRef.current by exact
+  // reference. A distinct non-loading value therefore came from the current
+  // key's cache, even when its background revalidation also returned an error.
+  return lastResolved.data !== currentData;
+}
+
 /**
  * Tracks which query identity produced SWR's currently exposed data.
  *
@@ -84,27 +121,37 @@ export function useResolvedQueryIdentity<
 >(
   result: QueryResultState,
   currentIdentity: TIdentity,
-  { enabled, fallbackMatchesCurrent = false }: ResolvedQueryIdentityOptions,
+  options: ResolvedQueryIdentityOptions,
 ): TIdentity | undefined {
-  const isCurrentResponse =
-    enabled &&
-    result.data !== undefined &&
-    result.error == null &&
-    !result.isLoading;
-  const isCurrentFallback =
-    enabled && result.data !== undefined && fallbackMatchesCurrent;
-  const lastResolvedIdentity = useRef<TIdentity | undefined>(
-    isCurrentResponse || isCurrentFallback ? currentIdentity : undefined,
+  const { isCurrentResponse, isCurrentFallback, isSeedableResponse } =
+    classifyCurrentResponse(result, options);
+  // Cached data with a background-revalidation error still belongs to the
+  // current SWR key when a tracker first mounts or becomes enabled. Keep this
+  // broader seed separate from `isCurrentResponse`: an error after a key
+  // change may be retained data from the previous key and must not update an
+  // already-established identity.
+  const lastResolved = useRef<ResolvedData<TIdentity> | undefined>(
+    isSeedableResponse || isCurrentFallback
+      ? { identity: currentIdentity, data: result.data }
+      : undefined,
   );
+  const canAdoptCurrentData = canAdoptSeedableResponse(
+    isSeedableResponse,
+    currentIdentity,
+    result.data,
+    lastResolved.current,
+  );
+  const resolvesCurrentIdentity =
+    isCurrentResponse || isCurrentFallback || canAdoptCurrentData;
 
   useEffect(() => {
-    if (!isCurrentResponse) return;
-    lastResolvedIdentity.current = currentIdentity;
-  }, [currentIdentity, isCurrentResponse]);
+    if (!resolvesCurrentIdentity || result.data === undefined) return;
+    lastResolved.current = { identity: currentIdentity, data: result.data };
+  }, [currentIdentity, resolvesCurrentIdentity, result.data]);
 
   if (result.data === undefined) return undefined;
-  if (isCurrentResponse || isCurrentFallback) return currentIdentity;
-  return lastResolvedIdentity.current;
+  if (resolvesCurrentIdentity) return currentIdentity;
+  return lastResolved.current?.identity;
 }
 
 /** Range-retained query state with actor-sensitive data exposure. */

--- a/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
+++ b/ui-dashboard/src/app/volume/_lib/use-resolved-query-identity.ts
@@ -55,6 +55,13 @@ type QueryResultState = {
   isLoading: boolean;
 };
 
+type ResolvedQueryIdentityOptions = {
+  /** Whether the query's SWR key is currently non-null. */
+  enabled: boolean;
+  /** Whether descriptor validation proved SSR fallback belongs to this key. */
+  fallbackMatchesCurrent?: boolean;
+};
+
 /**
  * Tracks which query identity produced SWR's currently exposed data.
  *
@@ -66,20 +73,28 @@ type QueryResultState = {
  * `fallbackMatchesCurrent` covers SSR `fallbackData`: SWR reports it as
  * loading during the first revalidation, but the server descriptor has
  * already proved that it belongs to the current key.
+ *
+ * `enabled` must match whether the query's SWR key is non-null. A disabled
+ * SWR hook can expose its last data with `isLoading: false`; that data must
+ * not be restamped as belonging to identities selected while the query was
+ * disabled.
  */
 export function useResolvedQueryIdentity<
   TIdentity extends string | number | boolean,
 >(
   result: QueryResultState,
   currentIdentity: TIdentity,
-  fallbackMatchesCurrent = false,
+  { enabled, fallbackMatchesCurrent = false }: ResolvedQueryIdentityOptions,
 ): TIdentity | undefined {
   const isCurrentResponse =
-    result.data !== undefined && result.error == null && !result.isLoading;
+    enabled &&
+    result.data !== undefined &&
+    result.error == null &&
+    !result.isLoading;
+  const isCurrentFallback =
+    enabled && result.data !== undefined && fallbackMatchesCurrent;
   const lastResolvedIdentity = useRef<TIdentity | undefined>(
-    isCurrentResponse || (result.data !== undefined && fallbackMatchesCurrent)
-      ? currentIdentity
-      : undefined,
+    isCurrentResponse || isCurrentFallback ? currentIdentity : undefined,
   );
 
   useEffect(() => {
@@ -88,7 +103,7 @@ export function useResolvedQueryIdentity<
   }, [currentIdentity, isCurrentResponse]);
 
   if (result.data === undefined) return undefined;
-  if (isCurrentResponse || fallbackMatchesCurrent) return currentIdentity;
+  if (isCurrentResponse || isCurrentFallback) return currentIdentity;
   return lastResolvedIdentity.current;
 }
 
@@ -96,20 +111,24 @@ export function useResolvedQueryIdentity<
 export function useVersionedVolumeQueryData<T>(
   result: QueryResultState & { data: T | undefined },
   currentIdentity: VolumeQueryIdentity,
+  { enabled }: Pick<ResolvedQueryIdentityOptions, "enabled">,
 ): {
   data: T | undefined;
   dataIdentity: VolumeQueryIdentity | undefined;
   isLoading: boolean;
   hasError: boolean;
 } {
-  const dataIdentity = useResolvedQueryIdentity(result, currentIdentity);
-  const data = dataMatchesCurrentActor(dataIdentity, currentIdentity)
-    ? result.data
-    : undefined;
+  const dataIdentity = useResolvedQueryIdentity(result, currentIdentity, {
+    enabled,
+  });
+  const data =
+    enabled && dataMatchesCurrentActor(dataIdentity, currentIdentity)
+      ? result.data
+      : undefined;
   return {
     data,
     dataIdentity,
-    isLoading: isLoadingWithoutData(result.isLoading, data),
-    hasError: hasErrorWithoutData(result.error, data),
+    isLoading: enabled && isLoadingWithoutData(result.isLoading, data),
+    hasError: enabled && hasErrorWithoutData(result.error, data),
   };
 }

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -29,6 +29,7 @@ import {
   type AggregatorDailyRow,
   type AggregatorDailyRowBase,
 } from "@/lib/volume-aggregators";
+import { isLoadingWithoutData } from "@/lib/swr-state";
 import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
 import {
   protocolActorInForView,
@@ -183,7 +184,11 @@ function useVolumeQueries({
       isProtocolActorIn,
       limit: ENVIO_MAX_ROWS,
     },
-    { timeoutMs: 8_000, schema: TraderDailyTopSchema },
+    {
+      timeoutMs: 8_000,
+      schema: TraderDailyTopSchema,
+      keepPreviousData: true,
+    },
   );
   const poolsResult = useGQL<{ Pool: PoolRow[] }>(
     venue === "v3" ? POOLS_FOR_VOLUME : null,
@@ -198,7 +203,11 @@ function useVolumeQueries({
   const v3AggregatorsResult = useGQL<V3AggregatorsData>(
     venue === "v3" ? aggregatorDailyTopQuery(includeProtocolActors) : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
-    { timeoutMs: 8_000, schema: AggregatorDailyTopSchema },
+    {
+      timeoutMs: 8_000,
+      schema: AggregatorDailyTopSchema,
+      keepPreviousData: true,
+    },
   );
 
   const v2TradersResult = useGQL<{
@@ -206,7 +215,11 @@ function useVolumeQueries({
   }>(
     venue === "v2" ? BROKER_TRADER_DAILY_TOP : null,
     { afterTimestamp: cutoff, isProtocolActorIn, limit: ENVIO_MAX_ROWS },
-    { timeoutMs: 8_000, schema: BrokerTraderDailyTopSchema },
+    {
+      timeoutMs: 8_000,
+      schema: BrokerTraderDailyTopSchema,
+      keepPreviousData: true,
+    },
   );
   const v2AggregatorsResult = useGQL<{
     BrokerAggregatorDailySnapshot: BrokerAggregatorDailyRow[];
@@ -215,7 +228,11 @@ function useVolumeQueries({
       ? brokerAggregatorDailyTopQuery(includeProtocolActors)
       : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
-    { timeoutMs: 8_000, schema: BrokerAggregatorDailyTopSchema },
+    {
+      timeoutMs: 8_000,
+      schema: BrokerAggregatorDailyTopSchema,
+      keepPreviousData: true,
+    },
   );
   return {
     tradersResult,
@@ -322,14 +339,21 @@ function buildVolumeStatus({
   // failure must NOT blank the chart or trader table (and vice versa).
   // Per docs/pr-checklists/swr-polling-hasura.md: new schema fields ship
   // in isolated queries that degrade independently.
-  const v2AggIsLoading = v2AggregatorsResult.isLoading;
+  const v2AggIsLoading = isLoadingWithoutData(
+    v2AggregatorsResult.isLoading,
+    v2AggregatorsResult.data,
+  );
   const v2AggHasError = !!v2AggregatorsResult.error;
-  const v3AggIsLoading = v3AggregatorsResult.isLoading;
+  const v3AggIsLoading = isLoadingWithoutData(
+    v3AggregatorsResult.isLoading,
+    v3AggregatorsResult.data,
+  );
   const v3AggHasError = !!v3AggregatorsResult.error;
   // The pool chart now reads PoolDailyVolumeSnapshot, not the top-trader
   // query. Keep its degraded mode isolated so a capped/failing trader table
   // does not blank the pre-rolled pool breakdown.
-  const poolChartIsLoading = poolVolumeResult.isLoading;
+  const poolChartIsLoading =
+    poolVolumeResult.isLoading && poolVolumeResult.rows.length === 0;
   const poolChartHasError =
     !!poolVolumeResult.error || poolVolumeResult.partial;
   // Independent Hasura cap signals.
@@ -371,8 +395,18 @@ function volumeTableIsLoading({
   queries: VolumeQueries;
 }): boolean {
   return venue === "v3"
-    ? queries.tradersResult.isLoading || queries.poolsResult.isLoading
-    : queries.v2TradersResult.isLoading;
+    ? isLoadingWithoutData(
+        queries.tradersResult.isLoading,
+        queries.tradersResult.data,
+      ) ||
+        isLoadingWithoutData(
+          queries.poolsResult.isLoading,
+          queries.poolsResult.data,
+        )
+    : isLoadingWithoutData(
+        queries.v2TradersResult.isLoading,
+        queries.v2TradersResult.data,
+      );
 }
 
 function volumeTableHasError({

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -48,7 +48,6 @@ import { useVolumeAggregates } from "./_lib/use-volume-aggregates";
 import { useVolumeUrlState } from "./_lib/url-state";
 import { usePoolVolumeSnapshots } from "./_lib/use-pool-volume-snapshots";
 import {
-  actorViewFromQueryIdentity,
   cutoffFromQueryIdentity,
   rangeFromQueryIdentity,
   useVersionedVolumeQueryData,
@@ -116,6 +115,8 @@ function useVolumePageModel(
     isProtocolActorIn,
     showChart,
   });
+  const traderDataIdentity = activeTraderDataIdentity(queries);
+  const aggregatorDataIdentity = activeAggregatorDataIdentity(queries);
   const rows = readVolumeRows(queries);
   const aggregates = useVolumeAggregates({
     includeProtocolActors,
@@ -143,6 +144,7 @@ function useVolumePageModel(
     venue === "v3"
       ? aggregates.unfilteredAggregated
       : aggregates.unfilteredV2Aggregated;
+  const kpiSourceIsCapHit = volumeTableCapHit({ venue, queries });
   const hero = useHeroRollup({
     venue,
     range,
@@ -150,16 +152,19 @@ function useVolumePageModel(
     isProtocolActorIn,
     utcDayKey,
     kpiSource,
-    kpiSourceRange: rangeFromQueryIdentity(activeTraderDataIdentity(queries)),
-    kpiSourceIncludesProtocolActors: actorViewFromQueryIdentity(
-      activeTraderDataIdentity(queries),
-    ),
+    kpiSourceIdentity: traderDataIdentity,
+    kpiSourceIsCapHit,
     initialData,
   });
   const chartControls = useVolumeChartControls(range, updateRange);
   const status = buildVolumeStatus({ venue, queries });
   const headline =
-    hero.isLoading || hero.hasError ? "" : formatUSD(hero.totalVolume);
+    hero.isLoading ||
+    hero.hasError ||
+    traderDataIdentity === undefined ||
+    hero.displayIdentity !== traderDataIdentity
+      ? ""
+      : formatUSD(hero.totalVolume);
 
   return {
     venue,
@@ -174,13 +179,9 @@ function useVolumePageModel(
     chartControls,
     status,
     headline,
-    tableCutoff:
-      cutoffFromQueryIdentity(activeTraderDataIdentity(queries)) ?? cutoff,
-    tableRange:
-      rangeFromQueryIdentity(activeTraderDataIdentity(queries)) ?? range,
-    aggregatorRange:
-      rangeFromQueryIdentity(queries.v3AggregatorsDataState.dataIdentity) ??
-      range,
+    tableCutoff: cutoffFromQueryIdentity(traderDataIdentity) ?? cutoff,
+    tableRange: rangeFromQueryIdentity(traderDataIdentity) ?? range,
+    aggregatorRange: rangeFromQueryIdentity(aggregatorDataIdentity) ?? range,
     poolChartRange: queries.poolVolumeResult.dataRange ?? range,
   };
 }
@@ -310,6 +311,18 @@ function activeTraderDataIdentity(
     : queries.v2TradersDataState.data === undefined
       ? undefined
       : queries.v2TradersDataState.dataIdentity;
+}
+
+function activeAggregatorDataIdentity(
+  queries: VolumeQueries,
+): VolumeQueryIdentity | undefined {
+  return queries.venue === "v3"
+    ? queries.v3AggregatorsDataState.data === undefined
+      ? undefined
+      : queries.v3AggregatorsDataState.dataIdentity
+    : queries.v2AggregatorsDataState.data === undefined
+      ? undefined
+      : queries.v2AggregatorsDataState.dataIdentity;
 }
 
 function readVolumeRows({
@@ -550,7 +563,6 @@ function VolumePageView({
       <VolumeKpiTiles
         hero={hero}
         range={hero.displayRange}
-        isTableCapHit={status.isTableCapHit}
         tableIsLoading={status.tableIsLoading}
         tableHasError={status.tableHasError}
       />

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -270,18 +270,22 @@ function useVolumeQueries({
   const tradersDataState = useVersionedVolumeQueryData(
     tradersResult,
     currentDataIdentity,
+    { enabled: venue === "v3" },
   );
   const v3AggregatorsDataState = useVersionedVolumeQueryData(
     v3AggregatorsResult,
     currentDataIdentity,
+    { enabled: venue === "v3" },
   );
   const v2TradersDataState = useVersionedVolumeQueryData(
     v2TradersResult,
     currentDataIdentity,
+    { enabled: venue === "v2" },
   );
   const v2AggregatorsDataState = useVersionedVolumeQueryData(
     v2AggregatorsResult,
     currentDataIdentity,
+    { enabled: venue === "v2" },
   );
   return {
     venue,

--- a/ui-dashboard/src/app/volume/page-client.tsx
+++ b/ui-dashboard/src/app/volume/page-client.tsx
@@ -29,7 +29,7 @@ import {
   type AggregatorDailyRow,
   type AggregatorDailyRowBase,
 } from "@/lib/volume-aggregators";
-import { isLoadingWithoutData } from "@/lib/swr-state";
+import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
 import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
 import {
   protocolActorInForView,
@@ -47,6 +47,14 @@ import { useHeroRollup } from "./_lib/use-hero-rollup";
 import { useVolumeAggregates } from "./_lib/use-volume-aggregates";
 import { useVolumeUrlState } from "./_lib/url-state";
 import { usePoolVolumeSnapshots } from "./_lib/use-pool-volume-snapshots";
+import {
+  actorViewFromQueryIdentity,
+  cutoffFromQueryIdentity,
+  rangeFromQueryIdentity,
+  useVersionedVolumeQueryData,
+  volumeQueryIdentity,
+  type VolumeQueryIdentity,
+} from "./_lib/use-resolved-query-identity";
 
 type V3AggregatorsData = { AggregatorDailySnapshot: AggregatorDailyRow[] };
 
@@ -102,6 +110,7 @@ function useVolumePageModel(
   const showChart = venue === "v3" && RANGES_WITH_CHART.has(range);
   const queries = useVolumeQueries({
     venue,
+    range,
     cutoff,
     includeProtocolActors,
     isProtocolActorIn,
@@ -120,11 +129,13 @@ function useVolumePageModel(
     includeProtocolActors: includeProtocolActors,
     poolVolumeRows: rows.poolVolumeRows,
     poolMeta,
-    cutoff,
+    cutoff: queries.poolVolumeResult.dataAfterTimestamp ?? cutoff,
     utcDayKey,
   });
   const aggregatorChart = useV3AggregatorChart({
-    cutoff,
+    cutoff:
+      cutoffFromQueryIdentity(queries.v3AggregatorsDataState.dataIdentity) ??
+      cutoff,
     utcDayKey,
     rows: aggregates.filteredV3AggregatorRows,
   });
@@ -139,6 +150,10 @@ function useVolumePageModel(
     isProtocolActorIn,
     utcDayKey,
     kpiSource,
+    kpiSourceRange: rangeFromQueryIdentity(activeTraderDataIdentity(queries)),
+    kpiSourceIncludesProtocolActors: actorViewFromQueryIdentity(
+      activeTraderDataIdentity(queries),
+    ),
     initialData,
   });
   const chartControls = useVolumeChartControls(range, updateRange);
@@ -147,6 +162,7 @@ function useVolumePageModel(
     hero.isLoading || hero.hasError ? "" : formatUSD(hero.totalVolume);
 
   return {
+    venue,
     isProtocolActorIn,
     showChart,
     rows,
@@ -158,22 +174,38 @@ function useVolumePageModel(
     chartControls,
     status,
     headline,
+    tableCutoff:
+      cutoffFromQueryIdentity(activeTraderDataIdentity(queries)) ?? cutoff,
+    tableRange:
+      rangeFromQueryIdentity(activeTraderDataIdentity(queries)) ?? range,
+    aggregatorRange:
+      rangeFromQueryIdentity(queries.v3AggregatorsDataState.dataIdentity) ??
+      range,
+    poolChartRange: queries.poolVolumeResult.dataRange ?? range,
   };
 }
 
+// eslint-disable-next-line max-lines-per-function -- Keep the four parallel retained-query identity policies beside their query definitions so actor/range drift cannot reappear through split wiring.
 function useVolumeQueries({
   venue,
+  range,
   cutoff,
   includeProtocolActors,
   isProtocolActorIn,
   showChart,
 }: {
   venue: VolumeUrlState["venue"];
+  range: VolumeRangeKey;
   cutoff: number;
   includeProtocolActors: boolean;
   isProtocolActorIn: ReadonlyArray<boolean>;
   showChart: boolean;
 }) {
+  const currentDataIdentity = volumeQueryIdentity({
+    range,
+    cutoff,
+    includeProtocolActors,
+  });
   // Each venue's queries are gated to its tab so we don't burn Envio quota
   // on the side the user isn't looking at — same trick as `expanded ? Q : null`
   // in VolumeTable.TraderRow.
@@ -199,6 +231,7 @@ function useVolumeQueries({
   const poolVolumeResult = usePoolVolumeSnapshots({
     enabled: showChart,
     afterTimestamp: cutoff,
+    range,
   });
   const v3AggregatorsResult = useGQL<V3AggregatorsData>(
     venue === "v3" ? aggregatorDailyTopQuery(includeProtocolActors) : null,
@@ -234,34 +267,63 @@ function useVolumeQueries({
       keepPreviousData: true,
     },
   );
-  return {
+  const tradersDataState = useVersionedVolumeQueryData(
     tradersResult,
+    currentDataIdentity,
+  );
+  const v3AggregatorsDataState = useVersionedVolumeQueryData(
+    v3AggregatorsResult,
+    currentDataIdentity,
+  );
+  const v2TradersDataState = useVersionedVolumeQueryData(
+    v2TradersResult,
+    currentDataIdentity,
+  );
+  const v2AggregatorsDataState = useVersionedVolumeQueryData(
+    v2AggregatorsResult,
+    currentDataIdentity,
+  );
+  return {
+    venue,
     poolsResult,
     poolVolumeResult,
-    v3AggregatorsResult,
-    v2TradersResult,
-    v2AggregatorsResult,
+    tradersDataState,
+    v3AggregatorsDataState,
+    v2TradersDataState,
+    v2AggregatorsDataState,
   };
 }
 
 type VolumeQueries = ReturnType<typeof useVolumeQueries>;
 
+function activeTraderDataIdentity(
+  queries: VolumeQueries,
+): VolumeQueryIdentity | undefined {
+  return queries.venue === "v3"
+    ? queries.tradersDataState.data === undefined
+      ? undefined
+      : queries.tradersDataState.dataIdentity
+    : queries.v2TradersDataState.data === undefined
+      ? undefined
+      : queries.v2TradersDataState.dataIdentity;
+}
+
 function readVolumeRows({
-  tradersResult,
   poolsResult,
   poolVolumeResult,
-  v3AggregatorsResult,
-  v2TradersResult,
-  v2AggregatorsResult,
+  tradersDataState,
+  v3AggregatorsDataState,
+  v2TradersDataState,
+  v2AggregatorsDataState,
 }: VolumeQueries) {
-  const traderRows = tradersResult.data?.TraderDailySnapshot ?? [];
+  const traderRows = tradersDataState.data?.TraderDailySnapshot ?? [];
   const poolRows = poolsResult.data?.Pool ?? [];
   const poolVolumeRows = poolVolumeResult.rows;
   const v3AggregatorRows =
-    v3AggregatorsResult.data?.AggregatorDailySnapshot ?? [];
-  const v2TraderRows = v2TradersResult.data?.BrokerTraderDailySnapshot ?? [];
+    v3AggregatorsDataState.data?.AggregatorDailySnapshot ?? [];
+  const v2TraderRows = v2TradersDataState.data?.BrokerTraderDailySnapshot ?? [];
   const v2AggregatorRows =
-    v2AggregatorsResult.data?.BrokerAggregatorDailySnapshot ?? [];
+    v2AggregatorsDataState.data?.BrokerAggregatorDailySnapshot ?? [];
   return {
     traderRows,
     poolRows,
@@ -323,7 +385,7 @@ function buildVolumeStatus({
   venue: VolumeUrlState["venue"];
   queries: VolumeQueries;
 }) {
-  const { poolVolumeResult, v3AggregatorsResult, v2AggregatorsResult } =
+  const { poolVolumeResult, v3AggregatorsDataState, v2AggregatorsDataState } =
     queries;
   // Page chrome / KPIs / chart / trader table all read from the
   // trader-side query for the active venue. The v2 aggregator query is
@@ -339,23 +401,20 @@ function buildVolumeStatus({
   // failure must NOT blank the chart or trader table (and vice versa).
   // Per docs/pr-checklists/swr-polling-hasura.md: new schema fields ship
   // in isolated queries that degrade independently.
-  const v2AggIsLoading = isLoadingWithoutData(
-    v2AggregatorsResult.isLoading,
-    v2AggregatorsResult.data,
-  );
-  const v2AggHasError = !!v2AggregatorsResult.error;
-  const v3AggIsLoading = isLoadingWithoutData(
-    v3AggregatorsResult.isLoading,
-    v3AggregatorsResult.data,
-  );
-  const v3AggHasError = !!v3AggregatorsResult.error;
+  const v2AggIsLoading = v2AggregatorsDataState.isLoading;
+  const v2AggHasError = v2AggregatorsDataState.hasError;
+  const v3AggIsLoading = v3AggregatorsDataState.isLoading;
+  const v3AggHasError = v3AggregatorsDataState.hasError;
   // The pool chart now reads PoolDailyVolumeSnapshot, not the top-trader
   // query. Keep its degraded mode isolated so a capped/failing trader table
   // does not blank the pre-rolled pool breakdown.
   const poolChartIsLoading =
-    poolVolumeResult.isLoading && poolVolumeResult.rows.length === 0;
+    poolVolumeResult.isLoading && !poolVolumeResult.hasData;
   const poolChartHasError =
-    !!poolVolumeResult.error || poolVolumeResult.partial;
+    hasErrorWithoutData(
+      poolVolumeResult.error,
+      poolVolumeResult.hasData ? poolVolumeResult.rows : undefined,
+    ) || poolVolumeResult.partial;
   // Independent Hasura cap signals.
   //
   // Hero tiles (total volume / unique traders / total swaps) are EXACT
@@ -395,18 +454,12 @@ function volumeTableIsLoading({
   queries: VolumeQueries;
 }): boolean {
   return venue === "v3"
-    ? isLoadingWithoutData(
-        queries.tradersResult.isLoading,
-        queries.tradersResult.data,
-      ) ||
+    ? queries.tradersDataState.isLoading ||
         isLoadingWithoutData(
           queries.poolsResult.isLoading,
           queries.poolsResult.data,
         )
-    : isLoadingWithoutData(
-        queries.v2TradersResult.isLoading,
-        queries.v2TradersResult.data,
-      );
+    : queries.v2TradersDataState.isLoading;
 }
 
 function volumeTableHasError({
@@ -417,8 +470,8 @@ function volumeTableHasError({
   queries: VolumeQueries;
 }): boolean {
   return venue === "v3"
-    ? !!queries.tradersResult.error
-    : !!queries.v2TradersResult.error;
+    ? queries.tradersDataState.hasError
+    : queries.v2TradersDataState.hasError;
 }
 
 function volumeTableCapHit({
@@ -430,14 +483,14 @@ function volumeTableCapHit({
 }): boolean {
   if (venue === "v3") {
     return (
-      !!queries.tradersResult.data &&
-      (queries.tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
+      !!queries.tradersDataState.data &&
+      (queries.tradersDataState.data.TraderDailySnapshot?.length ?? 0) ===
         ENVIO_MAX_ROWS
     );
   }
   return (
-    !!queries.v2TradersResult.data &&
-    (queries.v2TradersResult.data.BrokerTraderDailySnapshot?.length ?? 0) ===
+    !!queries.v2TradersDataState.data &&
+    (queries.v2TradersDataState.data.BrokerTraderDailySnapshot?.length ?? 0) ===
       ENVIO_MAX_ROWS
   );
 }
@@ -451,9 +504,9 @@ function v2AggregatorCapHit({
 }): boolean {
   return (
     venue === "v2" &&
-    !!queries.v2AggregatorsResult.data &&
-    (queries.v2AggregatorsResult.data.BrokerAggregatorDailySnapshot?.length ??
-      0) === ENVIO_MAX_ROWS
+    !!queries.v2AggregatorsDataState.data &&
+    (queries.v2AggregatorsDataState.data.BrokerAggregatorDailySnapshot
+      ?.length ?? 0) === ENVIO_MAX_ROWS
   );
 }
 
@@ -466,9 +519,9 @@ function v3AggregatorCapHit({
 }): boolean {
   return (
     venue === "v3" &&
-    !!queries.v3AggregatorsResult.data &&
-    (queries.v3AggregatorsResult.data.AggregatorDailySnapshot?.length ?? 0) ===
-      ENVIO_MAX_ROWS
+    !!queries.v3AggregatorsDataState.data &&
+    (queries.v3AggregatorsDataState.data.AggregatorDailySnapshot?.length ??
+      0) === ENVIO_MAX_ROWS
   );
 }
 
@@ -492,7 +545,7 @@ function VolumePageView({
       <VolumeChartArea urlState={urlState} model={model} />
       <VolumeKpiTiles
         hero={hero}
-        range={urlState.range}
+        range={hero.displayRange}
         isTableCapHit={status.isTableCapHit}
         tableIsLoading={status.tableIsLoading}
         tableHasError={status.tableHasError}

--- a/ui-dashboard/src/lib/__tests__/graphql-keep-previous-data.test.tsx
+++ b/ui-dashboard/src/lib/__tests__/graphql-keep-previous-data.test.tsx
@@ -1,0 +1,165 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SWRConfig, type Cache, type SWRResponse } from "swr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock("graphql-request", () => ({
+  GraphQLClient: vi.fn(function GraphQLClientMock() {
+    return { request: requestMock };
+  }),
+}));
+
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    networkId: "celo-mainnet",
+    network: {
+      id: "celo-mainnet",
+      label: "Celo",
+      chainId: 42220,
+      hasuraUrl: "https://hasura.example/v1/graphql",
+    },
+  }),
+}));
+
+import { useGQL } from "@/lib/graphql";
+
+type Payload = { value: string };
+type ResultRef = { current: SWRResponse<Payload> | null };
+
+const QUERY = "query Window($range: String!) { value(range: $range) }";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function Probe({
+  range,
+  resultRef,
+  keepPreviousData,
+}: {
+  range: string;
+  resultRef: ResultRef;
+  keepPreviousData?: boolean | undefined;
+}) {
+  resultRef.current = useGQL<Payload>(
+    QUERY,
+    { range },
+    {
+      refreshInterval: 0,
+      ...(keepPreviousData !== undefined && { keepPreviousData }),
+    },
+  );
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let cache: Cache;
+let resultRef: ResultRef;
+
+function render(range: string, keepPreviousData?: boolean) {
+  act(() => {
+    root.render(
+      <SWRConfig
+        value={{
+          provider: () => cache,
+          dedupingInterval: 0,
+        }}
+      >
+        <Probe
+          range={range}
+          resultRef={resultRef}
+          keepPreviousData={keepPreviousData}
+        />
+      </SWRConfig>,
+    );
+  });
+}
+
+beforeEach(() => {
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  requestMock.mockReset();
+  cache = new Map();
+  resultRef = { current: null };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useGQL keepPreviousData", () => {
+  it("retains the prior key's data while the next key is loading", async () => {
+    const first = deferred<Payload>();
+    const second = deferred<Payload>();
+    requestMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render("7d", true);
+    await act(async () => {
+      first.resolve({ value: "7d data" });
+      await first.promise;
+      await vi.waitFor(() => {
+        expect(resultRef.current?.data).toEqual({ value: "7d data" });
+      });
+    });
+    expect(resultRef.current?.data).toEqual({ value: "7d data" });
+    expect(resultRef.current?.isLoading).toBe(false);
+
+    render("30d", true);
+
+    expect(resultRef.current?.data).toEqual({ value: "7d data" });
+    expect(resultRef.current?.isLoading).toBe(true);
+    expect(requestMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      second.resolve({ value: "30d data" });
+      await second.promise;
+      await vi.waitFor(() => {
+        expect(resultRef.current?.data).toEqual({ value: "30d data" });
+      });
+    });
+    expect(resultRef.current?.data).toEqual({ value: "30d data" });
+    expect(resultRef.current?.isLoading).toBe(false);
+  });
+
+  it("preserves SWR's default empty transition when the option is omitted", async () => {
+    const first = deferred<Payload>();
+    const second = deferred<Payload>();
+    requestMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render("7d");
+    await act(async () => {
+      first.resolve({ value: "7d data" });
+      await first.promise;
+      await vi.waitFor(() => {
+        expect(resultRef.current?.data).toEqual({ value: "7d data" });
+      });
+    });
+    expect(resultRef.current?.data).toEqual({ value: "7d data" });
+
+    render("30d");
+
+    expect(resultRef.current?.data).toBeUndefined();
+    expect(resultRef.current?.isLoading).toBe(true);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -685,6 +685,13 @@ describe("rangeCutoffSeconds", () => {
     expect(rangeCutoffSeconds("all")).toBe(0);
   });
 
+  it("can anchor the cutoff to an explicit UTC epoch", () => {
+    const nextDayMidnight = TODAY_MIDNIGHT_UTC + SECONDS_PER_DAY;
+    expect(rangeCutoffSeconds("30d", nextDayMidnight + 12 * 60 * 60)).toBe(
+      nextDayMidnight - 29 * SECONDS_PER_DAY,
+    );
+  });
+
   it("cutoff is independent of intra-day clock drift", () => {
     // Two probes at 09:00 UTC and 23:59 UTC of the same UTC day must
     // produce identical cutoffs — the `Date.now() / 86400` floor masks

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -140,6 +140,9 @@ export type UseGQLOptions<T> = {
    *  real content instead of a skeleton (kills the layout shift) while the normal
    *  poll revalidates in the background. */
   fallbackData?: T | undefined;
+  /** Retain the prior cache key's data while a new key loads. Opt-in because
+   *  most callers poll a fixed key and should keep SWR's default semantics. */
+  keepPreviousData?: boolean | undefined;
   /** Runs after each successful network response, including unchanged data.
    *  Used by freshness-sensitive consumers to record when a cached row was
    *  actually re-observed rather than aging it continuously in the browser. */
@@ -195,6 +198,7 @@ export function useGQL<T>(
     revalidateOnFocus = false,
     revalidateOnReconnect = false,
     fallbackData,
+    keepPreviousData,
     onSuccess,
   } = opts;
 
@@ -214,6 +218,7 @@ export function useGQL<T>(
     onErrorRetry: rateLimitAwareRetry,
     ...(onSuccess !== undefined && { onSuccess }),
     ...(fallbackData !== undefined && { fallbackData }),
+    ...(keepPreviousData !== undefined && { keepPreviousData }),
   });
 
   if (!network.hasuraUrl) {

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -307,11 +307,14 @@ export function rangeDays(range: VolumeRangeKey): number | null {
  * midnight" (≤ 24h of data, sometimes only a few hours). Aligning to the
  * UTC boundary makes the window deterministic against bucket size.
  */
-export function rangeCutoffSeconds(range: VolumeRangeKey): number {
+export function rangeCutoffSeconds(
+  range: VolumeRangeKey,
+  nowSeconds = Date.now() / 1000,
+): number {
   const days = rangeDays(range);
   if (days === null) return 0;
   const todayMidnightUtc =
-    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    Math.floor(nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
   return todayMidnightUtc - (days - 1) * SECONDS_PER_DAY;
 }
 


### PR DESCRIPTION
## The Problem

- Changing the range, venue, or actor filter on `/volume` replaced already-rendered KPIs, charts, and tables with loading skeletons while the next Hasura window loaded.
- Retaining SWR data alone was unsafe: stale rows could be relabeled as a new range, mixed across actor scopes, or combined with numerator/denominator data from different query versions.

## The Solution

- Keep the last coherent volume window visible during compatible range transitions, while carrying the resolved range, cutoff, actor, and query-enabled identity with every retained result. Publish a replacement only when the dependent hero, pool, trader, and aggregator data is internally consistent.

## Details

### Invariants

- `UseGQLOptions.keepPreviousData` remains opt-in; existing callers retain SWR's default behavior.
- Retained responses carry their resolved query identity, so old rows keep their original range labels and cutoff, including across UTC midnight.
- Cached current-key data with a failed background revalidation adopts the current identity, while SWR's exact-reference laggy data remains paired with the previous identity.
- Disabled venue queries cannot stamp identities selected while their SWR key is null, expose inactive data/status, or validate SSR fallback for the inactive venue.
- Actor-scoped rows are withheld when the active Organic/All filter differs; filterable raw pool rows are recomputed locally.
- Hero totals, first-day slices, Top-10 concentration, approximation state, and daily-chart headlines publish only when their full range/cutoff/filter identities match. Otherwise the prior coherent display remains visible or the dependent value is withheld.
- Trader and aggregator headings use their own resolved identities independently for both v2 and v3.
- Errors blank a section only when there is no usable retained data for that section.

### Degraded behavior

- During a compatible range transition, the previous coherent window remains visible with its original labels until the replacement resolves.
- A cold load, incompatible actor transition, or return to a venue whose inactive query identity changed shows the existing loading/error state rather than leaking stale rows.
- Fixed-key pool/today queries and conditional yesterday/partial-overlap catch-up queries retain their existing semantics.

### Non-goals

- No global `useGQL` default, separate updating spinner, pool-detail behavior change, GraphQL/schema change, or indexer change.

Closes #1244

## Validation

- Exact commit: `8adc400e885a1e59e1bec3d9f41b516e8e1578b8`.
- `CI=true pnpm agent:quality-gate --run` — passed, including dashboard codegen, generated-output check, targeted Trunk, lint, typecheck, full coverage, Knip, dependency checks, Playwright browser fixtures, React Doctor diff/score, and size limits. The pre-push hook repeated the mapped gate successfully.
- Focused identity/hero/page/cutoff regression suite — 4 files and 138 tests passed.
- `CI=true pnpm agent:autoreview` — clean; an independent fresh-context semantic review also reported no remaining actionable findings (0.94 confidence).
- Chrome acceptance on the exact commit:
  - Authenticated v2 Organic `7d` baseline rendered `$2.61M`, `Last 7 days`, both v2 headings at `7d`, and `≈ 89.9%`. Going offline and selecting `3M` retained those exact 7-day values, labels, rows, and headline without relabeling.
  - Offline v3 `3M` exposed placeholders instead of leaking v2 hero or concentration values. A v2 → v3 → v2 round trip preserved the coherent v2 7-day version.
  - Offline Organic → All withheld mismatched rows and headline and kept concentration unavailable.
  - Recovery aligned v2 All `3M` (`$76.6M`, both headings `3M`, `≈ 90.6%`), v2 Organic `3M` (`$46.75M`, both headings `3M`, `≈ 85.3%`), and then v3 Organic `3M` (`$10.7M`, both headings `3M`, `≈ 79.4%`). The v3 transition used placeholders until its own coherent version landed.
  - All GraphQL requests recovered with HTTP 200. The authenticated local run had only the documented missing-local-Upstash `/api/address-labels` 500.
  - Public v2 `3M` aligned `$76.6M`, both table headings and chart at `3M`, hid authenticated actor controls, and logged zero console errors.
  - Lighthouse on the exact commit: accessibility 94, SEO 100, agentic 100; the remaining best-practices noise was development-only.

## Ship Checklist

- [x] ship skill used
- [x] local quality gate and closeout review passed
- [x] authenticated and public browser acceptance completed on the exact commit
- [ ] current-head CI and review readiness confirmed
