### PR TITLE
perf(dashboard): reduce homepage trader polling

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -58,6 +58,10 @@ import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { useGQL } from "@/lib/graphql";
 import * as volumeModule from "@/lib/volume";
 import { buildSnapshotWindows } from "@/lib/volume";
+import {
+  VOLUME_TODAY_TRADERS,
+  VOLUME_WINDOW_TRADERS_LATEST,
+} from "@/lib/queries/volume";
 // Import from page-client (not page.tsx): page.tsx is now an async Server
 // Component that awaits fetchAllNetworks() and hands the result through
 // SWRConfig's fallback. renderToStaticMarkup can't execute async components,
@@ -847,6 +851,24 @@ describe("GlobalPage — Volume chart wiring", () => {
 // snapshot can't satisfy it because naïve summing double-counts.
 
 describe("GlobalPage — Traders tile", () => {
+  it("polls both trader queries every 15 minutes", () => {
+    render([makeNetworkData({ pools: [], fees: null })]);
+
+    const optionsFor = (query: string) =>
+      vi
+        .mocked(useGQL)
+        .mock.calls.find(([calledQuery]) => calledQuery === query)?.[2];
+
+    expect(optionsFor(VOLUME_WINDOW_TRADERS_LATEST)).toMatchObject({
+      refreshInterval: 15 * 60_000,
+      timeoutMs: 30_000,
+    });
+    expect(optionsFor(VOLUME_TODAY_TRADERS)).toMatchObject({
+      refreshInterval: 15 * 60_000,
+      timeoutMs: 30_000,
+    });
+  });
+
   it("counts cross-chain overlapping addresses once (Set-deduplicates)", () => {
     // Two chains each contribute 3 traders with 2 overlaps (case-insensitive).
     // Expected unique count = |{A, B, C, D}| = 4. `snapshotDay` set to

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -550,7 +550,7 @@ function TradersTile({
     { todayMidnight, isProtocolActorIn: [false] },
     {
       schema: VolumeTodayTradersSchema,
-      refreshInterval: 5 * 60_000,
+      refreshInterval: 15 * 60_000,
       timeoutMs: 30_000,
     },
   );
@@ -687,12 +687,12 @@ function useVolumeWindowTradersSnapshot() {
       schema: VolumeWindowTradersLatestSchema,
       // The "all" window snapshot only rolls over at the per-chain
       // UTC-midnight heartbeat, so the default 30s polling cadence is wildly
-      // over-cadenced for this tile. 5min keeps a fresh-after-rollover read
+      // over-cadenced for this tile. 15min keeps a fresh-after-rollover read
       // without burning quota for a multi-KB address list on every poll.
-      refreshInterval: 5 * 60_000,
+      refreshInterval: 15 * 60_000,
       // Required by docs/pr-checklists/swr-polling-hasura.md §1 — without a
       // request-level timeout, a wedged TCP connection would hold the poll
-      // open for the full 5min interval.
+      // open for the full 15min interval.
       timeoutMs: 30_000,
     },
   );


### PR DESCRIPTION
## The Problem

- The homepage's two all-time trader queries poll every five minutes even though the closed-day snapshot changes only at UTC midnight and today's partial does not need near-real-time precision.
- Each poll transfers large address lists and spends hosted Hasura quota without materially improving the operator-facing Traders tile.

## The Solution

- Poll both trader queries every 15 minutes while preserving their 30-second request timeout and all existing loading, error, stale-chain, and UTC-rollover behavior.
- Add a regression test that identifies each query and locks both intervals and timeouts.

## Invariants

- Both halves of the Traders count use the same 15-minute cadence.
- The request timeout remains well below the polling interval, as required by the SWR/Hasura checklist.
- Cross-chain deduplication, partial-data badges, and midnight query-key rollover are unchanged.

## Degraded behavior

Existing behavior is preserved: unresolved queries render a loading sentinel, snapshot failure renders `N/A`, and partial today/chain coverage remains visibly approximate.

## Intentional non-goals

- No query-shape, count semantics, SWR wrapper, or other homepage polling cadence changes.

Closes #1252

## Verification

- `pnpm --filter @mento-protocol/ui-dashboard test --run src/app/__tests__/page.test.tsx` (50 tests)
- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:autoreview`
- Chrome DevTools at `http://127.0.0.1:3214/`: Traders rendered `723`, zero loading sentinels, four live GraphQL requests returned 200, and zero console errors
- Lighthouse snapshot: accessibility 94, best practices 100, agentic browsing 100

## Ship Checklist

- [x] Definition of Done and relevant SWR/stateful-data checklists reviewed
- [x] Targeted regression and full mapped quality gates pass
- [x] Browser behavior and console verified
- [x] Structured closeout review is clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Polling cadence only; query shape, trader count logic, and error/loading UX are unchanged.
> 
> **Overview**
> Lowers Hasura load for the homepage **Traders** tile by slowing SWR polling on the two GraphQL queries that feed it (`VOLUME_WINDOW_TRADERS_LATEST` and `VOLUME_TODAY_TRADERS`) from **5 minutes** to **15 minutes**, while keeping the **30s** request timeout unchanged.
> 
> Adds a regression test that asserts both queries use the same `refreshInterval` and `timeoutMs` when `useGQL` is invoked from `page-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541be6d9a65b6579978cb7c070ffd77a222be8d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->