### PR TITLE
perf(dashboard): stabilize remaining Plotly config identities

### DIFF
--- a/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/__tests__/intel-wealth-chart.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IntelWealthRecord } from "@/lib/intel-wealth";
 
 let mockSwrData: IntelWealthRecord | null = null;
+const capturedPlotConfigs: Array<Record<string, unknown>> = [];
 
 vi.mock("next-auth/react", () => ({
   useSession: () => ({ status: "authenticated" }),
@@ -24,10 +25,13 @@ vi.mock("next/dynamic", () => ({
     function MockPlot({
       ariaLabel,
       textAlternative,
+      config,
     }: {
       ariaLabel: string;
       textAlternative: string;
+      config: Record<string, unknown>;
     }) {
+      capturedPlotConfigs.push(config);
       return (
         <div data-testid="plot" aria-label={ariaLabel}>
           {textAlternative}
@@ -77,8 +81,15 @@ function render() {
   });
 }
 
+function rerender() {
+  act(() => {
+    root?.render(<IntelWealthChart address={ADDRESS} />);
+  });
+}
+
 beforeEach(() => {
   mockSwrData = makeRecord();
+  capturedPlotConfigs.length = 0;
 });
 
 afterEach(() => {
@@ -120,5 +131,28 @@ describe("IntelWealthChart accessibility", () => {
     expect(container?.querySelector(".sr-only")?.textContent).toBe(
       "Wealth trajectory chart with 1 portfolio snapshot. Snapshot: Now $250.00.",
     );
+  });
+
+  it("keeps the Plotly config reference stable across an SWR data update", () => {
+    render();
+    const initialConfig = capturedPlotConfigs.at(-1);
+
+    mockSwrData = {
+      ...makeRecord(),
+      fetchedAt: "2026-07-02T12:00:00.000Z",
+      portfolio: {
+        ...makeRecord().portfolio,
+        "0d_ago": {
+          ts: 1_765_086_400,
+          data: { tokens: [{ symbol: "CELO", usd: 300 }] },
+        },
+      },
+    };
+    rerender();
+    const refreshedConfig = capturedPlotConfigs.at(-1);
+
+    expect(capturedPlotConfigs).toHaveLength(2);
+    expect(initialConfig).toMatchObject({ scrollZoom: false });
+    expect(refreshedConfig).toBe(initialConfig);
   });
 });

--- a/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/intel-wealth-chart.tsx
@@ -13,6 +13,13 @@ const Plot = dynamic(() => import("@/lib/react-plotly-basic"), {
   loading: () => <div className="h-40 animate-pulse rounded bg-slate-800/30" />,
 });
 
+// react-plotly.js ref-compares config and redraws when its identity changes.
+// Keep this chart-local override stable across SWR/session re-renders.
+const WEALTH_PLOTLY_CONFIG = {
+  ...PLOTLY_CONFIG,
+  scrollZoom: false,
+} as const;
+
 /**
  * Walk an unknown portfolio response and sum the `usd` field of every
  * per-token leaf. A "per-token leaf" is an object that has BOTH a `usd`
@@ -204,7 +211,7 @@ export function IntelWealthChart({ address }: { address: string }) {
             textAlternative={chartTextAlternative}
             data={[sparkTrace(points)]}
             layout={SPARK_LAYOUT}
-            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            config={WEALTH_PLOTLY_CONFIG}
             style={{ width: "100%", height: 160 }}
             useResizeHandler
           />

--- a/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/fee-over-time-chart.test.ts
@@ -1,11 +1,28 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 import {
+  TotalRevenueChart,
   buildRevenueChartFigure,
   revenueChartEmptyMessage,
   revenueChartSummary,
   revenueWeekOverWeekChangePct,
 } from "@/components/fee-over-time-chart";
 import type { CanonicalRevenueDailyPoint } from "@/lib/canonical-revenue";
+
+const capturedPlotConfigs: Array<Record<string, unknown>> = [];
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot({ config }: { config: Record<string, unknown> }) {
+      capturedPlotConfigs.push(config);
+      return React.createElement("div", { "data-testid": "plot" });
+    },
+}));
+
+vi.mock("@/components/use-deferred-mount", () => ({
+  useDeferredMount: () => true,
+}));
 
 const DAY = 86_400;
 const START = Date.UTC(2026, 5, 1) / 1000;
@@ -138,5 +155,23 @@ describe("buildRevenueChartFigure", () => {
       rangemode: "tozero",
     });
     expect("range" in figure.layout.yaxis).toBe(false);
+  });
+});
+
+describe("TotalRevenueChart Plotly config", () => {
+  it("keeps scroll zoom disabled with a stable config reference", () => {
+    const props = {
+      series: [revenuePoint(0, 10)],
+      isLoading: false,
+      partialReasons: [],
+    };
+
+    capturedPlotConfigs.length = 0;
+    renderToStaticMarkup(React.createElement(TotalRevenueChart, props));
+    renderToStaticMarkup(React.createElement(TotalRevenueChart, props));
+
+    expect(capturedPlotConfigs).toHaveLength(2);
+    expect(capturedPlotConfigs[0]).toMatchObject({ scrollZoom: false });
+    expect(capturedPlotConfigs[1]).toBe(capturedPlotConfigs[0]);
   });
 });

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -23,6 +23,13 @@ const Plot = dynamic(() => import("@/lib/react-plotly-basic"), {
   loading: PlotSkeleton,
 });
 
+// Stable identity lets react-plotly.js skip redraws when an unrelated parent
+// re-render leaves this chart's data and layout unchanged.
+const REVENUE_PLOTLY_CONFIG = {
+  ...PLOTLY_CONFIG,
+  scrollZoom: false,
+} as const;
+
 type TotalRevenueChartProps = {
   series: CanonicalRevenueDailyPoint[];
   isLoading: boolean;
@@ -349,7 +356,7 @@ function RevenueChartBody({
             textAlternative={summary}
             data={figure.traces}
             layout={figure.layout}
-            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            config={REVENUE_PLOTLY_CONFIG}
             style={{ width: "100%", height: 220 }}
             useResizeHandler
           />


### PR DESCRIPTION
## The Problem

- The wealth and total-revenue charts created a new Plotly `config` object on every React render, even when its values were unchanged.
- `react-plotly.js` compares config by reference, so those fresh objects forced avoidable `Plotly.react()` redraws during SWR/session updates and revenue-range interaction.

## The Solution

- Hoist each chart's `PLOTLY_CONFIG` override to a module-level constant. Both charts now pass a stable reference while preserving scroll zoom as disabled and keeping their existing visual and interaction behavior.

## Details

### Invariants

- The wealth and revenue Plotly config references remain stable across React renders.
- Both chart-local configs still spread the shared `PLOTLY_CONFIG` values and override only `scrollZoom: false`.
- The shared base config, chart data, layouts, range filtering, deferred mounting, and accessibility text are unchanged.

### Degraded behavior

- Existing loading, empty-data, unauthenticated, and deferred-mount states are unchanged; this optimization only affects redraw decisions after a Plot is mounted.
- If Intel wealth data is unavailable, the existing chart suppression behavior remains intact.

### Non-goals

- No changes to other Plotly call sites, `PLOTLY_CONFIG` base values, chart data/layout identity, revenue calculations, authentication, or Upstash behavior.

Closes #1253

## Validation

- `grep -R 'config={{ ...PLOTLY_CONFIG' ui-dashboard/src` — zero matches.
- Focused Vitest suite — 2 files and 12 tests passed. The wealth test rerenders after a mocked SWR data update and proves config reference identity; the revenue test proves stable identity and `scrollZoom: false` across renders.
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` — passed.
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — 256 files and 3,811 tests passed; coverage floors remained green.
- `pnpm dashboard:react-doctor:diff` — 100/100, zero diagnostics.
- `pnpm agent:quality-gate --run` — all mapped commands passed, including codegen/generated-output cleanliness, Trunk, lint, typecheck, coverage, Knip, dependency checks, browser fixtures, React Doctor, and size limits.
- `CI=true pnpm agent:autoreview` — clean; no accepted/actionable findings from the deterministic sandbox reviewer.
- The first pre-push coverage run hit an unrelated 5-second timeout in `scripts/intel-marathon/inspect-entities.test.mjs`; the test passed alone in 158ms and the unmodified full gate passed on the normal retry.

### Browser acceptance

- Authenticated simulated session on `/address-book/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`: a client-intercepted three-snapshot wealth fixture rendered the complete Wealth trajectory Plot. Plotly `_context.scrollZoom` was `false`; wheel input left both x/y ranges unchanged; the clean intercepted run had zero console errors.
  - The fixture/interception was needed only because local Upstash is intentionally unconfigured. It exercised the real authenticated component and Plotly runtime without changing application code or claiming production-backed Intel data.
- Authenticated `/revenue` with live data: `All → 1M → 1W` redrew 134 → 30 → 7 points with the correct summaries. `_context.scrollZoom` was `false`, wheel input left ranges unchanged, and the final clean run had zero console errors.
- Lighthouse snapshot: accessibility 94; best practices, SEO, and agentic scores 100.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] authenticated browser acceptance completed
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance tweak with no auth, data, or API changes; risk is limited to Plotly redraw behavior, covered by new tests.
> 
> **Overview**
> **Wealth** and **total revenue** charts no longer pass a fresh `config={{ ...PLOTLY_CONFIG, scrollZoom: false }}` on every render. Each chart now uses a module-level constant (`WEALTH_PLOTLY_CONFIG` / `REVENUE_PLOTLY_CONFIG`) so `react-plotly.js` can skip redundant `Plotly.react()` redraws when only parent/SWR state changes.
> 
> Behavior is unchanged: both still spread shared `PLOTLY_CONFIG` and keep **`scrollZoom: false`**. Tests capture the mocked Plot config and assert **reference stability** across re-renders (including a simulated SWR refresh on the wealth chart).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46a364d729ab1172602d6a70b4c534dbc7a7758. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->