### PR TITLE
perf(dashboard): preload plotly and pool details

### DIFF
--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { DataFreshnessBanner } from "@/components/data-freshness-banner";
 import { ResourceHints } from "@/components/resource-hints";
 import { SessionErrorGuard } from "@/components/session-error-guard";
 import { SwrProvider } from "@/components/swr-provider";
+import { PlotlyIdlePreloader } from "@/components/plotly-idle-preloader";
 import { Analytics } from "@vercel/analytics/next";
 import { serverEnv, clientEnv } from "@/env";
 import "./globals.css";
@@ -62,6 +63,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
+        <PlotlyIdlePreloader />
         <ResourceHints />
         <SessionProvider session={session}>
           <SessionErrorGuard />

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -8,6 +8,7 @@ import type { SWRResponse } from "swr";
 import { NETWORKS, type Network } from "@/lib/networks";
 import type { GlobalPoolEntry } from "@/components/global-pools-table";
 import { POOLS_TABLE_SKELETON_ROWS } from "@/components/pools-table-skeleton";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 import type { SwapEvent } from "@/lib/types";
 
@@ -361,6 +362,7 @@ describe("PoolsPage multichain rendering", () => {
       celoNet,
       POOL_DETAIL_WITH_HEALTH,
       { id: celoPool.id, chainId: celoNet.chainId },
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
 
     mockPreloadGQL.mockClear();
@@ -371,6 +373,7 @@ describe("PoolsPage multichain rendering", () => {
       celoNet,
       POOL_DETAIL_WITH_HEALTH,
       { id: celoPool.id, chainId: celoNet.chainId },
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
 
     act(() => root.unmount());
@@ -422,6 +425,7 @@ describe("PoolsPage multichain rendering", () => {
       NETWORKS["celo-mainnet"],
       POOL_DETAIL_WITH_HEALTH,
       { id: celoPool.id, chainId: 42220 },
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
     expect(entryNetwork.hasuraUrl).not.toBe(NETWORKS["celo-mainnet"].hasuraUrl);
 

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -1,12 +1,24 @@
+/** @vitest-environment jsdom */
+
+import { act, type AnchorHTMLAttributes, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { SWRResponse } from "swr";
 import type { Network } from "@/lib/networks";
 import type { GlobalPoolEntry } from "@/components/global-pools-table";
 import { POOLS_TABLE_SKELETON_ROWS } from "@/components/pools-table-skeleton";
+import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
+import type { SwapEvent } from "@/lib/types";
 
 const mockReplace = vi.fn();
+const mockPreloadGQL = vi.fn();
 let mockSearchParams = new URLSearchParams();
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
@@ -36,6 +48,22 @@ vi.mock("@/components/network-provider", () => ({
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: vi.fn(),
+  preloadGQL: (...args: unknown[]) => mockPreloadGQL(...args),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 // Keep the real `showInitialSkeleton` (a pure helper) and mock only the hook —
@@ -84,6 +112,10 @@ vi.mock("@/components/global-pools-table", () => ({
   ),
   globalPoolKey: ({ network, pool }: GlobalPoolEntry) =>
     `${network.id}:${pool.id}`,
+}));
+
+vi.mock("@/components/sender-cell", () => ({
+  SenderCell: ({ address }: { address: string }) => <td>{address}</td>,
 }));
 
 import { useGQL } from "@/lib/graphql";
@@ -194,6 +226,21 @@ const baseSwapsResult = {
   isLoading: false,
 };
 
+const recentSwap: SwapEvent = {
+  id: "42220-swap-1",
+  chainId: 42220,
+  poolId: celoPool.id,
+  sender: "0x0000000000000000000000000000000000000003",
+  recipient: "0x0000000000000000000000000000000000000004",
+  amount0In: "1000000000000000000",
+  amount1In: "0",
+  amount0Out: "0",
+  amount1Out: "1000000000000000000",
+  txHash: `0x${"1".repeat(64)}`,
+  blockNumber: "123",
+  blockTimestamp: "1700000000",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockSearchParams = new URLSearchParams();
@@ -274,6 +321,52 @@ describe("PoolsPage multichain rendering", () => {
     renderToStaticMarkup(<PoolsPage />);
 
     expect(poolSwapsSeen).toEqual([{ poolId: celoPool.id, limit: 25 }]);
+  });
+
+  it("preloads the exact pool-detail key on Recent Swaps hover and focus", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: { SwapEvent: [recentSwap] },
+      error: null,
+      isLoading: false,
+    } as SWRResponse);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<PoolsPage />);
+    });
+    const link = container.querySelector<HTMLAnchorElement>(
+      `a[href="/pool/${celoPool.id}"]`,
+    );
+    expect(link).not.toBeNull();
+
+    act(() => {
+      link?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      celoNet,
+      POOL_DETAIL_WITH_HEALTH,
+      { id: celoPool.id, chainId: celoNet.chainId },
+    );
+
+    mockPreloadGQL.mockClear();
+    act(() => {
+      link?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      celoNet,
+      POOL_DETAIL_WITH_HEALTH,
+      { id: celoPool.id, chainId: celoNet.chainId },
+    );
+
+    act(() => root.unmount());
+    container.remove();
   });
 });
 

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -5,7 +5,7 @@ import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { SWRResponse } from "swr";
-import type { Network } from "@/lib/networks";
+import { NETWORKS, type Network } from "@/lib/networks";
 import type { GlobalPoolEntry } from "@/components/global-pools-table";
 import { POOLS_TABLE_SKELETON_ROWS } from "@/components/pools-table-skeleton";
 import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
@@ -13,6 +13,7 @@ import type { SwapEvent } from "@/lib/types";
 
 const mockReplace = vi.fn();
 const mockPreloadGQL = vi.fn();
+const mockConfiguredNetworkIdForChainId = vi.fn();
 let mockSearchParams = new URLSearchParams();
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -49,6 +50,12 @@ vi.mock("@/components/network-provider", () => ({
 vi.mock("@/lib/graphql", () => ({
   useGQL: vi.fn(),
   preloadGQL: (...args: unknown[]) => mockPreloadGQL(...args),
+}));
+
+vi.mock("@/lib/networks", async () => ({
+  ...(await vi.importActual<typeof import("@/lib/networks")>("@/lib/networks")),
+  configuredNetworkIdForChainId: (chainId: number) =>
+    mockConfiguredNetworkIdForChainId(chainId),
 }));
 
 vi.mock("next/link", () => ({
@@ -243,6 +250,7 @@ const recentSwap: SwapEvent = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockConfiguredNetworkIdForChainId.mockReturnValue(null);
   mockSearchParams = new URLSearchParams();
   vi.mocked(useAllNetworksData).mockReturnValue(baseAllNetworksResult);
 });
@@ -364,6 +372,58 @@ describe("PoolsPage multichain rendering", () => {
       POOL_DETAIL_WITH_HEALTH,
       { id: celoPool.id, chainId: celoNet.chainId },
     );
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("preloads through the configured pool route while retaining entry network metadata", () => {
+    const entryNetwork = makeNetwork(
+      "celo-mainnet-local",
+      42220,
+      "Celo local fallback",
+    );
+    entryNetwork.tokenSymbols = {
+      [celoPool.token0]: "LOCAL0",
+      [celoPool.token1]: "LOCAL1",
+    };
+    vi.mocked(useAllNetworksData).mockReturnValue({
+      ...baseAllNetworksResult,
+      networkData: [makeNetworkData(entryNetwork, celoPool)],
+    });
+    vi.mocked(useGQL).mockReturnValue({
+      data: { SwapEvent: [recentSwap] },
+      error: null,
+      isLoading: false,
+    } as SWRResponse);
+    mockConfiguredNetworkIdForChainId.mockReturnValue("celo-mainnet");
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<PoolsPage />);
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      `a[href="/pool/${celoPool.id}"]`,
+    );
+    expect(link?.textContent).toBe("LOCAL0/LOCAL1");
+
+    act(() => {
+      link?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      NETWORKS["celo-mainnet"],
+      POOL_DETAIL_WITH_HEALTH,
+      { id: celoPool.id, chainId: 42220 },
+    );
+    expect(entryNetwork.hasuraUrl).not.toBe(NETWORKS["celo-mainnet"].hasuraUrl);
 
     act(() => root.unmount());
     container.remove();

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { buildPoolDetailHref, buildPoolsFilterUrl } from "@/lib/routing";
 import { useGQL } from "@/lib/graphql";
+import { preloadPoolDetail } from "@/lib/pool-detail-preload";
 import {
   showInitialSkeleton,
   useAllNetworksData,
@@ -423,6 +424,8 @@ function SwapTable({
                     href={buildPoolDetailHref(s.poolId)}
                     className="text-sm font-medium text-indigo-400 hover:text-indigo-300"
                     title={s.poolId}
+                    onFocus={() => preloadPoolDetail(network, s.poolId)}
+                    onMouseEnter={() => preloadPoolDetail(network, s.poolId)}
                   >
                     {poolNames[s.poolId] ?? truncateAddress(s.poolId)}
                   </Link>

--- a/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table-prefetch.test.tsx
@@ -6,6 +6,7 @@ import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Network } from "@/lib/networks";
 import type { Pool } from "@/lib/types";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -146,6 +147,7 @@ describe("GlobalPoolsTable pool-detail prefetch", () => {
       expect.objectContaining({ id: "celo-mainnet", chainId: 42220 }),
       POOL_DETAIL_WITH_HEALTH,
       { id: POOL_ID, chainId: 42220 },
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
   });
 
@@ -170,6 +172,7 @@ describe("GlobalPoolsTable pool-detail prefetch", () => {
       expect.objectContaining({ id: "celo-mainnet", chainId: 42220 }),
       POOL_DETAIL_WITH_HEALTH,
       { id: POOL_ID, chainId: 42220 },
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
   });
 });

--- a/ui-dashboard/src/components/__tests__/plotly-idle-preloader.test.tsx
+++ b/ui-dashboard/src/components/__tests__/plotly-idle-preloader.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPlotlyIdlePreloadScheduler,
+  PlotlyIdlePreloader,
+} from "@/components/plotly-idle-preloader";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+let container: HTMLDivElement;
+let root: Root | null;
+let previousActEnvironment: boolean | undefined;
+
+beforeEach(() => {
+  previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = null;
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container.remove();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT =
+    previousActEnvironment ?? false;
+});
+
+describe("PlotlyIdlePreloader", () => {
+  it("does no SSR work and invokes the idle import once across remounts", () => {
+    let idleCallback: (() => void) | null = null;
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallback = callback;
+      return 1;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+
+    const loadPlotly = vi.fn(() => Promise.resolve());
+    const schedule = createPlotlyIdlePreloadScheduler(loadPlotly);
+
+    expect(
+      renderToStaticMarkup(<PlotlyIdlePreloader schedule={schedule} />),
+    ).toBe("");
+    expect(requestIdleCallback).not.toHaveBeenCalled();
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <StrictMode>
+          <PlotlyIdlePreloader schedule={schedule} />
+        </StrictMode>,
+      );
+    });
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 1_500,
+    });
+
+    act(() => root?.unmount());
+    root = createRoot(container);
+    act(() => {
+      root?.render(<PlotlyIdlePreloader schedule={schedule} />);
+    });
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    act(() => idleCallback?.());
+    expect(loadPlotly).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the 1500ms timeout fallback when requestIdleCallback is absent", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestIdleCallback", undefined);
+    const loadPlotly = vi.fn(() => Promise.resolve());
+    const schedule = createPlotlyIdlePreloadScheduler(loadPlotly);
+
+    schedule();
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(loadPlotly).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(loadPlotly).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a rejected chunk import", async () => {
+    const idleCallbackRef: { current: (() => void) | null } = {
+      current: null,
+    };
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: () => void) => {
+        idleCallbackRef.current = callback;
+        return 1;
+      }),
+    );
+    const loadPlotly = vi.fn(() =>
+      Promise.reject(new Error("plotly chunk unavailable")),
+    );
+    const onUnhandledRejection = vi.fn();
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    const schedule = createPlotlyIdlePreloadScheduler(loadPlotly);
+
+    schedule();
+    idleCallbackRef.current?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadPlotly).toHaveBeenCalledTimes(1);
+    expect(onUnhandledRejection).not.toHaveBeenCalled();
+    window.removeEventListener("unhandledrejection", onUnhandledRejection);
+  });
+});

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
@@ -48,16 +48,20 @@ vi.mock("next/link", () => ({
   default: ({
     href,
     children,
-    className,
+    ...props
   }: {
     href: string;
     children: React.ReactNode;
-    className?: string;
-  }) => (
-    <a href={href} className={className}>
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>
       {children}
     </a>
   ),
+}));
+
+const mockPreloadGQL = vi.fn();
+vi.mock("@/lib/graphql", () => ({
+  preloadGQL: (...args: unknown[]) => mockPreloadGQL(...args),
 }));
 
 // ChainIcon pulls in Next Image; stub it out.
@@ -66,6 +70,7 @@ vi.mock("@/components/chain-icon", () => ({
 }));
 
 import { RevenueByPoolTable } from "@/components/revenue-by-pool-table";
+import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -570,6 +575,57 @@ describe("RevenueByPoolTable — sort transitions", () => {
     names = poolNamesInOrder(handle.container);
     expect(names[0]).toContain("0xaaaa");
     expect(names[1]).toContain("0xbbbb");
+  });
+});
+
+describe("RevenueByPoolTable — pool-detail prefetch", () => {
+  let handle: InteractiveHandle | null = null;
+
+  beforeEach(() => {
+    mockPreloadGQL.mockClear();
+    window.history.replaceState(null, "", "/revenue");
+    handle = renderInteractive([networkData([feeSnapshot()])]);
+  });
+
+  afterEach(() => {
+    if (handle) teardown(handle);
+    handle = null;
+  });
+
+  it("preloads the exact namespaced pool key on hover and focus", () => {
+    const link = handle?.container.querySelector<HTMLAnchorElement>(
+      `a[href="/pool/${CHAIN}-${POOL_ADDR}"]`,
+    );
+    expect(link).not.toBeNull();
+    const expectedNetwork = networkData([]).network;
+    const expectedVariables = {
+      id: `${CHAIN}-${POOL_ADDR}`,
+      chainId: CHAIN,
+    };
+
+    act(() => {
+      link?.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      expectedNetwork,
+      POOL_DETAIL_WITH_HEALTH,
+      expectedVariables,
+    );
+
+    mockPreloadGQL.mockClear();
+    act(() => {
+      link?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+    expect(mockPreloadGQL).toHaveBeenCalledWith(
+      expectedNetwork,
+      POOL_DETAIL_WITH_HEALTH,
+      expectedVariables,
+    );
   });
 });
 

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
@@ -70,6 +70,7 @@ vi.mock("@/components/chain-icon", () => ({
 }));
 
 import { RevenueByPoolTable } from "@/components/revenue-by-pool-table";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import { POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 
 // ---------------------------------------------------------------------------
@@ -615,6 +616,7 @@ describe("RevenueByPoolTable — pool-detail prefetch", () => {
       expectedNetwork,
       POOL_DETAIL_WITH_HEALTH,
       expectedVariables,
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
 
     mockPreloadGQL.mockClear();
@@ -625,6 +627,7 @@ describe("RevenueByPoolTable — pool-detail prefetch", () => {
       expectedNetwork,
       POOL_DETAIL_WITH_HEALTH,
       expectedVariables,
+      { timeoutMs: HASURA_TIMEOUT_MS },
     );
   });
 });

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -3,11 +3,7 @@ import type { ReactNode } from "react";
 import { formatUSD } from "@/lib/format";
 import { poolName } from "@/lib/tokens";
 import { type Pool } from "@/lib/types";
-import {
-  configuredNetworkIdForChainId,
-  NETWORKS,
-  type Network,
-} from "@/lib/networks";
+import { type Network } from "@/lib/networks";
 import { preloadPoolDetail } from "@/lib/pool-detail-preload";
 import { Row } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
@@ -106,7 +102,7 @@ export function PoolRow({
       <NameCell
         pool={pool}
         network={network}
-        onPrefetch={() => prefetchPoolDetail(entry)}
+        onPrefetch={() => preloadPoolDetail(network, pool.id)}
       />
       {showVirtualPoolSource && <SourceCell pool={pool} />}
       <HealthCell status={effectiveStatus} details={healthDetails} />
@@ -142,12 +138,6 @@ export function PoolRow({
       <StrategyCell strategies={strategies} />
     </Row>
   );
-}
-
-function prefetchPoolDetail(entry: GlobalPoolEntry): void {
-  const networkId = configuredNetworkIdForChainId(entry.pool.chainId);
-  const network = networkId ? NETWORKS[networkId] : entry.network;
-  preloadPoolDetail(network, entry.pool.id);
 }
 
 function Cell({

--- a/ui-dashboard/src/components/global-pools-table/pool-row.tsx
+++ b/ui-dashboard/src/components/global-pools-table/pool-row.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { formatUSD, normalizePoolIdForChain } from "@/lib/format";
-import { preloadGQL } from "@/lib/graphql";
+import { formatUSD } from "@/lib/format";
 import { poolName } from "@/lib/tokens";
 import { type Pool } from "@/lib/types";
 import {
@@ -9,10 +8,7 @@ import {
   NETWORKS,
   type Network,
 } from "@/lib/networks";
-import {
-  POOL_DETAIL_WITH_HEALTH,
-  type PoolDetailResponse,
-} from "@/lib/queries";
+import { preloadPoolDetail } from "@/lib/pool-detail-preload";
 import { Row } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
 import { ChainIcon } from "@/components/chain-icon";
@@ -151,11 +147,7 @@ export function PoolRow({
 function prefetchPoolDetail(entry: GlobalPoolEntry): void {
   const networkId = configuredNetworkIdForChainId(entry.pool.chainId);
   const network = networkId ? NETWORKS[networkId] : entry.network;
-  const id = normalizePoolIdForChain(entry.pool.id, network.chainId);
-  preloadGQL<PoolDetailResponse>(network, POOL_DETAIL_WITH_HEALTH, {
-    id,
-    chainId: network.chainId,
-  });
+  preloadPoolDetail(network, entry.pool.id);
 }
 
 function Cell({

--- a/ui-dashboard/src/components/plotly-idle-preloader.tsx
+++ b/ui-dashboard/src/components/plotly-idle-preloader.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+type PlotlyModuleLoader = () => Promise<unknown>;
+type PlotlyPreloadScheduler = () => void;
+
+export function createPlotlyIdlePreloadScheduler(
+  loadPlotly: PlotlyModuleLoader,
+): PlotlyPreloadScheduler {
+  let scheduled = false;
+
+  return () => {
+    if (scheduled) return;
+    scheduled = true;
+
+    const load = () => {
+      void loadPlotly().catch(() => {
+        // Chunk failed to load (offline, blocked) — charts still load on demand.
+      });
+    };
+
+    // Match the route-independent Sentry Replay preload: busy tabs get a
+    // bounded 1.5s wait, and older Safari gets the same post-hydration delay.
+    if (typeof window.requestIdleCallback === "function") {
+      window.requestIdleCallback(load, { timeout: 1_500 });
+    } else {
+      window.setTimeout(load, 1_500);
+    }
+  };
+}
+
+const schedulePlotlyIdlePreload = createPlotlyIdlePreloadScheduler(
+  () => import("@/lib/react-plotly-basic"),
+);
+
+export function PlotlyIdlePreloader({
+  schedule = schedulePlotlyIdlePreload,
+}: {
+  schedule?: PlotlyPreloadScheduler;
+}) {
+  // The singleton scheduler owns the page-load lifecycle. Deliberately do not
+  // cancel it during effect cleanup: React Strict Mode remounts effects in
+  // development, and the guarded first schedule must still get to fire once.
+  useEffect(() => {
+    schedule();
+  }, [schedule]);
+
+  return null;
+}

--- a/ui-dashboard/src/components/revenue-by-pool-table.tsx
+++ b/ui-dashboard/src/components/revenue-by-pool-table.tsx
@@ -14,6 +14,7 @@ import { buildPoolDetailHref } from "@/lib/routing";
 import type { NetworkData, PoolLabel } from "@/lib/fetch-all-networks";
 import type { Network } from "@/lib/networks";
 import { stripChainIdFromPoolId } from "@/lib/pool-id";
+import { preloadPoolDetail } from "@/lib/pool-detail-preload";
 import type { SortDir } from "@/lib/table-sort";
 import { useTableSort } from "@/lib/use-table-sort";
 
@@ -269,6 +270,7 @@ function FeeCell({ row, column }: { row: PoolFeeRow; column: FeeColumn }) {
 function RevenueTableRow({ row }: { row: PoolFeeRow }) {
   const display = rowDisplayName(row);
   const href = buildPoolDetailHref(row.poolId);
+  const prefetch = () => preloadPoolDetail(row.network, row.poolId);
   return (
     <Row>
       <td className="px-2 sm:px-4 py-2 sm:py-3">
@@ -277,6 +279,8 @@ function RevenueTableRow({ row }: { row: PoolFeeRow }) {
           <Link
             href={href}
             className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
+            onFocus={prefetch}
+            onMouseEnter={prefetch}
           >
             {display}
           </Link>

--- a/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
+++ b/ui-dashboard/src/lib/__tests__/graphql-preload.test.ts
@@ -2,6 +2,7 @@
 
 import { cache, serialize, SWRGlobalState } from "swr/_internal";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import type { Network } from "@/lib/networks";
 
 const { requestMock } = vi.hoisted(() => ({
@@ -62,22 +63,62 @@ describe("preloadGQL", () => {
 
   afterEach(() => {
     clearSWRPreloads();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
-  it("expires speculative SWR preloads that are not consumed", async () => {
+  it("keeps timeout options out of the SWR key and preserves TTL eviction", async () => {
+    const signal = new AbortController().signal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(signal);
     requestMock.mockResolvedValue({ pool_by_pk: { id: VARIABLES.id } });
 
-    preloadGQL(NETWORK, QUERY, VARIABLES, { ttlMs: 1_000 });
+    preloadGQL(NETWORK, QUERY, VARIABLES, {
+      ttlMs: 1_000,
+      timeoutMs: HASURA_TIMEOUT_MS,
+    });
 
     const key = serializedPreloadKey();
+    expect(Object.keys(swrPreloads())).toEqual([key]);
     expect(swrPreloads()[key]).toBeDefined();
+    expect(timeoutSpy).toHaveBeenCalledWith(HASURA_TIMEOUT_MS);
+    expect(requestMock).toHaveBeenCalledWith({
+      document: QUERY,
+      variables: VARIABLES,
+      signal,
+    });
 
     await vi.advanceTimersByTimeAsync(999);
     expect(swrPreloads()[key]).toBeDefined();
 
     await vi.advanceTimersByTimeAsync(1);
     expect(swrPreloads()[key]).toBeUndefined();
+  });
+
+  it("aborts and clears a stalled speculative request at its timeout", async () => {
+    vi.useRealTimers();
+    let requestSignal: AbortSignal | undefined;
+    requestMock.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          requestSignal = signal;
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    preloadGQL(NETWORK, QUERY, VARIABLES, {
+      ttlMs: 1_000,
+      timeoutMs: 10,
+    });
+
+    const key = serializedPreloadKey();
+    expect(swrPreloads()[key]).toBeDefined();
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal?.aborted).toBe(false);
+
+    await vi.waitFor(() => expect(requestSignal?.aborted).toBe(true));
+    await vi.waitFor(() => expect(swrPreloads()[key]).toBeUndefined());
   });
 
   it("refreshes expiry when duplicate speculative preloads reuse the same request", async () => {

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -75,14 +75,18 @@ export function preloadGQL<T>(
   network: Network,
   query: string,
   variables?: Record<string, unknown>,
-  options: { ttlMs?: number } = {},
+  options: { ttlMs?: number; timeoutMs?: number } = {},
 ): void {
   const key = gqlKey(network, query, variables);
   if (!key) return;
   const [serializedKey] = serialize(key);
   if (!serializedKey) return;
 
-  const req = preload(key, () => requestGQL<T>(network, query, variables));
+  const req = preload(key, () =>
+    requestGQL<T>(network, query, variables, {
+      timeoutMs: options.timeoutMs,
+    }),
+  );
   if (req === undefined) return;
 
   const ttlMs = options.ttlMs ?? SPECULATIVE_PRELOAD_TTL_MS;

--- a/ui-dashboard/src/lib/pool-detail-preload.ts
+++ b/ui-dashboard/src/lib/pool-detail-preload.ts
@@ -1,0 +1,15 @@
+import { preloadGQL } from "@/lib/graphql";
+import { normalizePoolIdForChain } from "@/lib/format";
+import type { Network } from "@/lib/networks";
+import {
+  POOL_DETAIL_WITH_HEALTH,
+  type PoolDetailResponse,
+} from "@/lib/queries";
+
+export function preloadPoolDetail(network: Network, id: string): void {
+  const normalizedId = normalizePoolIdForChain(id, network.chainId);
+  preloadGQL<PoolDetailResponse>(network, POOL_DETAIL_WITH_HEALTH, {
+    id: normalizedId,
+    chainId: network.chainId,
+  });
+}

--- a/ui-dashboard/src/lib/pool-detail-preload.ts
+++ b/ui-dashboard/src/lib/pool-detail-preload.ts
@@ -1,15 +1,26 @@
 import { preloadGQL } from "@/lib/graphql";
 import { normalizePoolIdForChain } from "@/lib/format";
-import type { Network } from "@/lib/networks";
+import {
+  configuredNetworkIdForChainId,
+  NETWORKS,
+  type Network,
+} from "@/lib/networks";
 import {
   POOL_DETAIL_WITH_HEALTH,
   type PoolDetailResponse,
 } from "@/lib/queries";
 
 export function preloadPoolDetail(network: Network, id: string): void {
-  const normalizedId = normalizePoolIdForChain(id, network.chainId);
-  preloadGQL<PoolDetailResponse>(network, POOL_DETAIL_WITH_HEALTH, {
+  // Pool routes resolve their NetworkProvider from the pool's chain ID. Mirror
+  // that configured-only resolution here so the speculative SWR key and the
+  // request endpoint are the ones the destination consumes after navigation.
+  // The caller's network remains the fallback for an otherwise unroutable
+  // chain and can still be used independently for row display metadata.
+  const routeNetworkId = configuredNetworkIdForChainId(network.chainId);
+  const routeNetwork = routeNetworkId ? NETWORKS[routeNetworkId] : network;
+  const normalizedId = normalizePoolIdForChain(id, routeNetwork.chainId);
+  preloadGQL<PoolDetailResponse>(routeNetwork, POOL_DETAIL_WITH_HEALTH, {
     id: normalizedId,
-    chainId: network.chainId,
+    chainId: routeNetwork.chainId,
   });
 }

--- a/ui-dashboard/src/lib/pool-detail-preload.ts
+++ b/ui-dashboard/src/lib/pool-detail-preload.ts
@@ -1,5 +1,6 @@
 import { preloadGQL } from "@/lib/graphql";
 import { normalizePoolIdForChain } from "@/lib/format";
+import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import {
   configuredNetworkIdForChainId,
   NETWORKS,
@@ -19,8 +20,13 @@ export function preloadPoolDetail(network: Network, id: string): void {
   const routeNetworkId = configuredNetworkIdForChainId(network.chainId);
   const routeNetwork = routeNetworkId ? NETWORKS[routeNetworkId] : network;
   const normalizedId = normalizePoolIdForChain(id, routeNetwork.chainId);
-  preloadGQL<PoolDetailResponse>(routeNetwork, POOL_DETAIL_WITH_HEALTH, {
-    id: normalizedId,
-    chainId: routeNetwork.chainId,
-  });
+  preloadGQL<PoolDetailResponse>(
+    routeNetwork,
+    POOL_DETAIL_WITH_HEALTH,
+    {
+      id: normalizedId,
+      chainId: routeNetwork.chainId,
+    },
+    { timeoutMs: HASURA_TIMEOUT_MS },
+  );
 }


### PR DESCRIPTION
## The Problem

- Plotly stayed cold on direct visits to chart-heavy routes, delaying the first chart render.
- Recent Swaps and revenue pool links did not warm the exact pool-detail query before navigation.

## The Solution

- Schedule one caught idle Plotly import after hydration so direct route visits can prepare the chart runtime without mounting charts.
- Reuse one normalized pool-detail preload helper for global pools, Recent Swaps, and revenue links on hover or keyboard focus.

## Verification

- pnpm agent:quality-gate --run
- CI=true pnpm agent:autoreview
- pnpm dashboard:build
- pnpm dashboard:size-limit
- Direct Chrome: the idle Plotly request started before any offscreen chart mounted on /stables.
- Direct Chrome: Recent Swaps hover and revenue keyboard focus emitted the exact PoolDetailWithHealth id and chainId variables.
- Direct Chrome: canonical pool detail recorded LCP 235 ms, CLS 0.00, and no console errors.

Closes #1245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only prefetching with safe fallbacks; no auth, payments, or data-write paths touched.
> 
> **Overview**
> Adds **client-side warm-up** so chart routes and pool navigation feel faster without changing what pages render.
> 
> A **`PlotlyIdlePreloader`** in the root layout schedules a **single** post-hydration idle import of `@/lib/react-plotly-basic` (1.5s `requestIdleCallback` timeout or `setTimeout` fallback). Failed chunk loads are caught so charts still load on demand.
> 
> Pool detail navigation now shares **`preloadPoolDetail`**, which normalizes the pool id and calls `preloadGQL` for **`POOL_DETAIL_WITH_HEALTH`**. **Hover and keyboard focus** on pool links trigger prefetch in the global pools table, Recent Swaps on `/pools`, and the revenue-by-pool table (global pools refactored off inline `preloadGQL`).
> 
> Tests cover the Plotly scheduler (SSR no-op, once-per-page scheduling, rejection handling) and assert the correct preload variables on hover/focus for pools and revenue links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5454fbcce5d0adbcfb12aee88ec7663ed2a8e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->