### PR TITLE
fix(dashboard): bound stacked chart cross-fades

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -280,13 +280,6 @@
     "linePreview": " | export function TagInput({ | tags,"
   },
   {
-    "file": "src/components/time-series-chart-card-hooks.ts",
-    "ruleId": "complexity",
-    "message": "Arrow function has a complexity of 16. Maximum allowed is 15.",
-    "line": 200,
-    "linePreview": "event?: { clientX?: number; clientY?: number }; | }) => { | if (!enabled) return;"
-  },
-  {
     "file": "src/lib/address-book.ts",
     "ruleId": "complexity",
     "message": "Function 'countImportLabels' has a complexity of 29. Maximum allowed is 15.",

--- a/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
+++ b/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot() {
+      return <div data-testid="plot" />;
+    },
+}));
+
+import { StablesHeroChart } from "@/app/stables/_components/stables-hero-chart";
+import type { StableSupplyDailySnapshot } from "@/app/stables/_lib/types";
+import { AggregatorBreakdownSection } from "@/app/volume/_components/aggregator-breakdown-section";
+import { VolumeChartArea } from "@/app/volume/_components/volume-page-sections";
+import type { VolumePageModel, VolumeUrlState } from "@/app/volume/page-client";
+import type { BreakdownSeries } from "@/components/time-series-chart-card";
+
+const DAY = 86_400;
+
+function plotCount(container: HTMLElement): number {
+  return container.querySelectorAll("[data-testid=plot]").length;
+}
+
+function chartSeries(): Array<{ timestamp: number; value: number }> {
+  const today = Math.floor(Date.now() / 1_000 / DAY) * DAY;
+  return [
+    { timestamp: today - DAY, value: 10 },
+    { timestamp: today, value: 20 },
+  ];
+}
+
+function breakdown(id: string, color: string): BreakdownSeries {
+  return {
+    id,
+    name: id,
+    color,
+    series: chartSeries(),
+  };
+}
+
+describe("stacked TimeSeriesChartCard caller matrix", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the stables hero on one steady Plot", () => {
+    const today = Math.floor(Date.now() / 1_000 / DAY) * DAY;
+    const snapshot: StableSupplyDailySnapshot = {
+      id: `42220-0xstable-${today}`,
+      chainId: 42220,
+      tokenAddress: "0xstable",
+      tokenSymbol: "USDm",
+      source: "RESERVE",
+      tokenDecimals: 18,
+      timestamp: String(today),
+      totalSupply: "100000000000000000000",
+      dailyMintAmount: "0",
+      dailyBurnAmount: "0",
+    };
+
+    act(() => {
+      root.render(
+        <StablesHeroChart
+          snapshots={[snapshot]}
+          latestPerToken={[snapshot]}
+          custodySnapshots={[]}
+          latestCustodyPerToken={[]}
+          rates={new Map([["USDm", 1]])}
+          range="all"
+          onRangeChange={() => undefined}
+          isLoading={false}
+          hasError={false}
+        />,
+      );
+    });
+
+    expect(plotCount(container)).toBe(1);
+    expect(container.textContent).toContain("Mento stablecoin supply");
+  });
+
+  it("keeps the aggregator breakdown on one steady Plot", () => {
+    const series = chartSeries();
+    act(() => {
+      root.render(
+        <AggregatorBreakdownSection
+          venueLabel="v3"
+          rangeLabel="1M"
+          aggregators={[]}
+          isLoading={false}
+          hasError={false}
+          isCapHit={false}
+          chart={{
+            series,
+            breakdown: [
+              breakdown("Aggregator A", "#6366f1"),
+              breakdown("Aggregator B", "#10b981"),
+            ],
+            range: "30d",
+            onRangeChange: () => undefined,
+            ranges: [{ key: "30d", label: "1M" }],
+            headline: "$30",
+          }}
+        />,
+      );
+    });
+
+    expect(plotCount(container)).toBe(1);
+    expect(container.textContent).toContain("v3 volume by aggregator");
+  });
+
+  it("keeps the per-pool custom-legend section on its single-Plot path", () => {
+    const poolBreakdown = [
+      { ...breakdown("Pool A", "#6366f1"), legendIcon: null },
+      { ...breakdown("Pool B", "#10b981"), legendIcon: null },
+    ];
+    const model = {
+      showChart: true,
+      poolChart: {
+        poolVolumeBreakdown: { totalSeries: chartSeries() },
+        chartBreakdown: poolBreakdown,
+        topPoolsListEntries: [],
+      },
+      chartControls: {
+        chartRange: "30d",
+        onChartRangeChange: () => undefined,
+      },
+      headline: "$30",
+      status: {
+        poolChartIsLoading: false,
+        poolChartHasError: false,
+      },
+    } as unknown as VolumePageModel;
+    const urlState = { range: "30d" } as unknown as VolumeUrlState;
+
+    act(() => {
+      root.render(<VolumeChartArea urlState={urlState} model={model} />);
+    });
+
+    expect(plotCount(container)).toBe(1);
+    expect(container.textContent).toContain("Volume by pool");
+    expect(container.textContent).toContain("Pool A");
+    expect(container.textContent).toContain("Pool B");
+  });
+});

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card-cross-fade.test.tsx
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card-cross-fade.test.tsx
@@ -1,0 +1,321 @@
+/** @vitest-environment jsdom */
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockTrace = { visible?: string };
+
+type MockPlotProps = {
+  ariaHidden?: boolean;
+  data?: MockTrace[];
+  onLegendClick?: (event: { readonly curveNumber: number }) => boolean;
+  onHover?: (event: {
+    points?: unknown[];
+    event?: { clientX?: number; clientY?: number };
+  }) => void;
+};
+
+const plotMock = vi.hoisted(() => ({
+  MockPlot(props: MockPlotProps) {
+    const visibility = (props.data ?? [])
+      .map((trace) => trace.visible ?? "visible")
+      .join(",");
+    return (
+      <div
+        data-testid="plot"
+        data-active={String(props.ariaHidden !== true)}
+        data-visibility={visibility}
+      >
+        {(props.data ?? []).map((_trace, curveNumber) => (
+          <button
+            key={curveNumber}
+            type="button"
+            data-legend-curve={curveNumber}
+            onClick={() => props.onLegendClick?.({ curveNumber })}
+          >
+            toggle {curveNumber}
+          </button>
+        ))}
+        <button
+          type="button"
+          data-hover-first
+          onClick={() =>
+            props.onHover?.({
+              points: [
+                {
+                  x: "2026-01-01T00:00:00.000Z",
+                  curveNumber: 0,
+                  pointIndex: 0,
+                },
+              ],
+              event: { clientX: 10, clientY: 10 },
+            })
+          }
+        >
+          hover
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => plotMock.MockPlot,
+}));
+
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import type { BreakdownSeries } from "@/components/time-series-chart-card-overlays";
+
+const SERIES = [
+  { timestamp: 1_767_225_600, value: 30 },
+  { timestamp: 1_767_312_000, value: 45 },
+];
+
+const BREAKDOWN: BreakdownSeries[] = [
+  {
+    id: "series-a",
+    name: "Series A",
+    color: "#6366f1",
+    series: [
+      { timestamp: SERIES[0]!.timestamp, value: 10 },
+      { timestamp: SERIES[1]!.timestamp, value: 15 },
+    ],
+  },
+  {
+    id: "series-b",
+    name: "Series B",
+    color: "#10b981",
+    series: [
+      { timestamp: SERIES[0]!.timestamp, value: 20 },
+      { timestamp: SERIES[1]!.timestamp, value: 30 },
+    ],
+  },
+];
+
+function Card({ customSortedHover = false }: { customSortedHover?: boolean }) {
+  return (
+    <TimeSeriesChartCard
+      title="Stacked volume"
+      rangeAriaLabel="Stacked volume range"
+      series={SERIES}
+      breakdown={BREAKDOWN}
+      breakdownMode="stacked"
+      range="30d"
+      onRangeChange={() => undefined}
+      headline="$45"
+      change={null}
+      isLoading={false}
+      hasError={false}
+      hasSnapshotError={false}
+      emptyMessage="No volume"
+      customSortedHover={customSortedHover}
+    />
+  );
+}
+
+function plots(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>("[data-testid=plot]"),
+  );
+}
+
+function activePlot(container: HTMLElement): HTMLElement {
+  const plot = container.querySelector<HTMLElement>(
+    '[data-testid="plot"][data-active="true"]',
+  );
+  if (!plot) throw new Error("Expected one active Plot");
+  return plot;
+}
+
+function inactivePlot(container: HTMLElement): HTMLElement {
+  const plot = container.querySelector<HTMLElement>(
+    '[data-testid="plot"][data-active="false"]',
+  );
+  if (!plot) throw new Error("Expected one inactive Plot");
+  return plot;
+}
+
+function clickLegend(container: HTMLElement, curveNumber: number): void {
+  const button = activePlot(container).querySelector<HTMLButtonElement>(
+    `[data-legend-curve="${curveNumber}"]`,
+  );
+  if (!button) throw new Error(`Expected legend button ${curveNumber}`);
+  act(() => button.click());
+}
+
+function layerFor(plot: HTMLElement): HTMLDivElement {
+  const layer = plot.parentElement;
+  if (!(layer instanceof HTMLDivElement)) {
+    throw new Error("Expected Plot to be wrapped in a transition layer");
+  }
+  return layer;
+}
+
+describe("TimeSeriesChartCard bounded stacked cross-fade", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let reduceMotion: boolean;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    reduceMotion = false;
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: reduceMotion,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(16), 16),
+    );
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) =>
+      window.clearTimeout(handle),
+    );
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(<Card />));
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    container.remove();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("mounts one Plot steady, two through the 250ms handoff, then one final Plot", () => {
+    expect(plots(container)).toHaveLength(1);
+    expect(activePlot(container).dataset.visibility).toBe("visible,visible");
+
+    clickLegend(container, 0);
+    expect(plots(container)).toHaveLength(2);
+    expect(activePlot(container).dataset.visibility).toBe("visible,visible");
+    expect(inactivePlot(container).dataset.visibility).toBe(
+      "legendonly,visible",
+    );
+
+    act(() => vi.advanceTimersByTime(16));
+    expect(plots(container)).toHaveLength(2);
+    expect(activePlot(container).dataset.visibility).toBe("legendonly,visible");
+
+    const incomingLayer = layerFor(activePlot(container));
+    const outgoingLayer = layerFor(inactivePlot(container));
+    expect(incomingLayer.style.opacity).toBe("1");
+    expect(incomingLayer.style.visibility).toBe("visible");
+    expect(incomingLayer.style.zIndex).toBe("1");
+    expect(incomingLayer.style.pointerEvents).toBe("auto");
+    expect(outgoingLayer.style.opacity).toBe("0");
+    expect(outgoingLayer.style.zIndex).toBe("0");
+    expect(outgoingLayer.style.pointerEvents).toBe("none");
+    expect(outgoingLayer.style.transition).toContain("visibility 0s 250ms");
+
+    act(() => vi.advanceTimersByTime(249));
+    expect(plots(container)).toHaveLength(2);
+    act(() => vi.advanceTimersByTime(1));
+    expect(plots(container)).toHaveLength(1);
+    expect(activePlot(container).dataset.visibility).toBe("legendonly,visible");
+  });
+
+  it("replaces the secondary target across rapid toggles without stale promotion", () => {
+    let maximumPlots = plots(container).length;
+    const recordMaximum = () => {
+      maximumPlots = Math.max(maximumPlots, plots(container).length);
+    };
+
+    clickLegend(container, 0);
+    recordMaximum();
+    act(() => vi.advanceTimersByTime(16));
+    recordMaximum();
+
+    // First retarget asks for both traces hidden. Before that frame commits,
+    // retarget again to only Series B hidden; the abandoned target must never
+    // become active later.
+    clickLegend(container, 1);
+    recordMaximum();
+    clickLegend(container, 0);
+    recordMaximum();
+    act(() => vi.advanceTimersByTime(16));
+    recordMaximum();
+
+    expect(maximumPlots).toBe(2);
+    expect(activePlot(container).dataset.visibility).toBe("visible,legendonly");
+
+    // Cross the first transition's now-cancelled completion deadline. The
+    // latest transition remains intact until its own 250ms completes.
+    act(() => vi.advanceTimersByTime(234));
+    expect(plots(container)).toHaveLength(2);
+    expect(activePlot(container).dataset.visibility).toBe("visible,legendonly");
+    act(() => vi.advanceTimersByTime(16));
+
+    expect(plots(container)).toHaveLength(1);
+    expect(activePlot(container).dataset.visibility).toBe("visible,legendonly");
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(plots(container)).toHaveLength(1);
+  });
+
+  it("clears custom hover owned by the outgoing Plot before retargeting", () => {
+    act(() => root?.render(<Card customSortedHover />));
+    const hoverButton =
+      activePlot(container).querySelector<HTMLButtonElement>(
+        "[data-hover-first]",
+      );
+    if (!hoverButton) throw new Error("Expected hover trigger");
+
+    act(() => hoverButton.click());
+    expect(container.textContent).toContain("Series A");
+
+    clickLegend(container, 0);
+    expect(container.textContent).not.toContain("Series A");
+    expect(plots(container)).toHaveLength(2);
+  });
+
+  it("settles reduced-motion toggles immediately with one Plot", () => {
+    reduceMotion = true;
+
+    clickLegend(container, 0);
+
+    expect(plots(container)).toHaveLength(1);
+    expect(activePlot(container).dataset.visibility).toBe("legendonly,visible");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels the completion timer when the card unmounts mid-fade", () => {
+    clickLegend(container, 0);
+    act(() => vi.advanceTimersByTime(16));
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => root?.unmount());
+    root = null;
+
+    expect(vi.getTimerCount()).toBe(0);
+    act(() => vi.advanceTimersByTime(1_000));
+  });
+
+  it("cancels the preparation frame when the card unmounts before handoff", () => {
+    clickLegend(container, 0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => root?.unmount());
+    root = null;
+
+    expect(vi.getTimerCount()).toBe(0);
+    act(() => vi.advanceTimersByTime(1_000));
+  });
+});

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -487,6 +487,19 @@ describe("VolumeOverTimeChart render", () => {
     capturedPlotProps = {};
   });
 
+  it("mounts exactly one Plot for the steady v3/v2 stacked breakdown", () => {
+    const html = renderChart({
+      networkData: makeVolumeNetworkData([
+        {
+          timestamp: dayAlignedNow(),
+          swapVolume0: "1000000000000000000",
+        },
+      ]),
+    });
+
+    expect(html.match(/data-testid="plot"/g) ?? []).toHaveLength(1);
+  });
+
   it("renders the 'Volume' title without a time-range suffix", () => {
     const html = renderChart();
     expect(html).toContain("Volume");

--- a/ui-dashboard/src/components/time-series-chart-card-hooks.ts
+++ b/ui-dashboard/src/components/time-series-chart-card-hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { sortedCopy } from "@/lib/immutable-sort";
 import { escapePlotText } from "@/lib/plot";
 import type {
@@ -12,114 +12,270 @@ export type ChartLayout = Record<string, unknown> & {
   yaxis: Record<string, unknown>;
 };
 
-export type CrossFadeCombo = {
+export type CrossFadePlot = {
   key: string;
-  combo: Set<number>;
+  active: boolean;
   traces: Array<Record<string, unknown>>;
   layout: ChartLayout;
 };
 
+const CROSS_FADE_DURATION_MS = 250;
+
+type CrossFadePhase = "steady" | "preparing" | "fading";
+
+type CrossFadeState = {
+  desiredHiddenKeys: Set<string>;
+  activeHiddenKeys: Set<string>;
+  secondaryHiddenKeys: Set<string> | null;
+  phase: CrossFadePhase;
+  transitionId: number;
+};
+
+type CrossFadeAction =
+  | { type: "toggle"; seriesKey: string; reduceMotion: boolean }
+  | { type: "start"; transitionId: number }
+  | { type: "finish"; transitionId: number }
+  | { type: "reset" };
+
+function initialCrossFadeState(): CrossFadeState {
+  return {
+    desiredHiddenKeys: new Set(),
+    activeHiddenKeys: new Set(),
+    secondaryHiddenKeys: null,
+    phase: "steady",
+    transitionId: 0,
+  };
+}
+
+function crossFadeReducer(
+  state: CrossFadeState,
+  action: CrossFadeAction,
+): CrossFadeState {
+  if (action.type === "reset") return initialCrossFadeState();
+
+  if (action.type === "toggle") {
+    const desiredHiddenKeys = new Set(state.desiredHiddenKeys);
+    if (desiredHiddenKeys.has(action.seriesKey)) {
+      desiredHiddenKeys.delete(action.seriesKey);
+    } else {
+      desiredHiddenKeys.add(action.seriesKey);
+    }
+    const transitionId = state.transitionId + 1;
+
+    // A retarget back to the currently interactive layer needs no fade. The
+    // same immediate settle honors reduced motion without mounting a second
+    // Plot (or leaving a timer/listener behind).
+    if (
+      action.reduceMotion ||
+      setEquals(desiredHiddenKeys, state.activeHiddenKeys)
+    ) {
+      return {
+        desiredHiddenKeys,
+        activeHiddenKeys: desiredHiddenKeys,
+        secondaryHiddenKeys: null,
+        phase: "steady",
+        transitionId,
+      };
+    }
+
+    // Keep the currently interactive Plot mounted while the latest target is
+    // inserted at opacity 0. Replacing (rather than appending) the secondary
+    // slot is what keeps rapid retargets bounded at two Plot instances.
+    return {
+      desiredHiddenKeys,
+      activeHiddenKeys: state.activeHiddenKeys,
+      secondaryHiddenKeys: desiredHiddenKeys,
+      phase: "preparing",
+      transitionId,
+    };
+  }
+
+  if (
+    action.type === "start" &&
+    state.phase === "preparing" &&
+    action.transitionId === state.transitionId &&
+    state.secondaryHiddenKeys
+  ) {
+    return {
+      ...state,
+      activeHiddenKeys: state.secondaryHiddenKeys,
+      secondaryHiddenKeys: state.activeHiddenKeys,
+      phase: "fading",
+    };
+  }
+
+  if (
+    action.type === "finish" &&
+    state.phase === "fading" &&
+    action.transitionId === state.transitionId
+  ) {
+    return {
+      ...state,
+      secondaryHiddenKeys: null,
+      phase: "steady",
+    };
+  }
+
+  return state;
+}
+
+function buildCrossFadePlot({
+  hiddenKeys,
+  currentBreakdown,
+  baseLayout,
+  active,
+}: {
+  hiddenKeys: ReadonlySet<string>;
+  currentBreakdown: ReadonlyArray<BreakdownSeries>;
+  baseLayout: ChartLayout;
+  active: boolean;
+}): CrossFadePlot {
+  const combo = hiddenSeriesKeysToIndexes(currentBreakdown, hiddenKeys);
+  const dayBuckets = new Map<number, number>();
+  currentBreakdown.forEach((breakdownSeries, index) => {
+    if (combo.has(index)) return;
+    breakdownSeries.series.forEach((point) => {
+      dayBuckets.set(
+        point.timestamp,
+        (dayBuckets.get(point.timestamp) ?? 0) + point.value,
+      );
+    });
+  });
+  const visibleMax = Array.from(dayBuckets.values()).reduce(
+    (maximum, value) => Math.max(maximum, value),
+    0,
+  );
+  const yRange: [number, number] = [0, Math.max(visibleMax * 1.1, 1)];
+
+  const traces = currentBreakdown.map((breakdownSeries, index) => {
+    const safeName = escapePlotText(breakdownSeries.name);
+    return {
+      x: breakdownSeries.series.map((point) =>
+        new Date(point.timestamp * 1000).toISOString(),
+      ),
+      y: breakdownSeries.series.map((point) => point.value),
+      name: safeName,
+      type: "scatter" as const,
+      mode: "lines" as const,
+      ...(combo.has(index) ? { visible: "legendonly" as const } : {}),
+      stackgroup: "total",
+      line: { color: breakdownSeries.color, width: 1.2 },
+      fillcolor: breakdownSeries.color + "cc",
+      hovertemplate: `${safeName}: $%{y:,.0f}<extra></extra>`,
+    };
+  });
+
+  return {
+    key: [...combo].join(",") || "all",
+    active,
+    traces,
+    layout: {
+      ...baseLayout,
+      yaxis: {
+        ...baseLayout.yaxis,
+        range: yRange,
+        autorange: false as const,
+      },
+    },
+  };
+}
+
 /**
- * Pre-render every visibility combo (2^N total) of a stacked breakdown
- * chart. Each combo carries its own y-range so toggling traces produces
- * a CSS-eased grow/shrink — Plotly cannot interpolate stackgroup y-values
- * via `Plotly.react` + `layout.transition`. Only enabled when the parent
- * uses Plotly's native legend (custom-legend mode owns its own visibility
- * state) and breakdown count is small enough that 2^N plot instances
- * stay cheap (≤3 → 8 plots).
+ * Build only the current and transitioning visibility states of a stacked
+ * breakdown chart. Each state carries its own y-range so toggling traces
+ * produces a CSS-eased grow/shrink — Plotly cannot interpolate stackgroup
+ * y-values via `Plotly.react` + `layout.transition`.
  *
  * Returns:
- * - `hiddenIdx` — current trace-visibility state.
  * - `handleLegendClick` — Plotly legend handler that toggles visibility
  *   through React state instead of Plotly's internal toggle (returns
  *   `false` to suppress the native handler).
- * - `crossFadeData` — null when disabled; an array of pre-computed combo
- *   { traces, layout } when active. Caller renders one Plot per combo
- *   stacked absolutely, with `opacity` driven by which combo matches
- *   `hiddenIdx`.
+ * - `crossFadeData` — null when disabled; otherwise exactly one Plot in
+ *   steady state and at most two during the 250ms transition.
  */
 export function useCrossFade(params: {
   enabled: boolean;
-  breakdownCount: number;
   series: ReadonlyArray<{ timestamp: number; value: number }>;
   breakdown: ReadonlyArray<BreakdownSeries> | undefined;
   baseLayout: ChartLayout;
 }): {
-  hiddenIdx: Set<number>;
   handleLegendClick: (e: { readonly curveNumber: number }) => boolean;
-  crossFadeData: CrossFadeCombo[] | null;
+  crossFadeData: CrossFadePlot[] | null;
 } {
-  const { enabled, breakdownCount, series, breakdown, baseLayout } = params;
+  const { enabled, series, breakdown, baseLayout } = params;
   const currentBreakdown = useMemo(() => breakdown ?? [], [breakdown]);
-  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(() => new Set());
-  const hiddenIdx = useMemo(
-    () => hiddenSeriesKeysToIndexes(currentBreakdown, hiddenKeys),
-    [currentBreakdown, hiddenKeys],
+  const [fadeState, dispatchFade] = useReducer(
+    crossFadeReducer,
+    undefined,
+    initialCrossFadeState,
   );
 
-  const combos = useMemo(() => {
-    if (!enabled) return [];
-    const out: Array<Set<number>> = [];
-    for (let mask = 0; mask < 1 << breakdownCount; mask++) {
-      const set = new Set<number>();
-      for (let i = 0; i < breakdownCount; i++) if (mask & (1 << i)) set.add(i);
-      out.push(set);
-    }
-    return out;
-  }, [enabled, breakdownCount]);
+  // Reset and cancel transition work when the caller leaves the eligible
+  // cross-fade path (for example, a breakdown grows past the N<=3 gate).
+  useEffect(() => {
+    if (!enabled) dispatchFade({ type: "reset" });
+  }, [enabled]);
 
-  const crossFadeData = useMemo<CrossFadeCombo[] | null>(() => {
-    if (!enabled) return null;
-    return combos.map((combo) => {
-      const dayBuckets = new Map<number, number>();
-      currentBreakdown.forEach((b, i) => {
-        if (combo.has(i)) return;
-        b.series.forEach((p) => {
-          dayBuckets.set(
-            p.timestamp,
-            (dayBuckets.get(p.timestamp) ?? 0) + p.value,
-          );
-        });
-      });
-      const visibleMax = Array.from(dayBuckets.values()).reduce(
-        (a, b) => Math.max(a, b),
-        0,
-      );
-      const yRange: [number, number] = [0, Math.max(visibleMax * 1.1, 1)];
-
-      const comboTraces = currentBreakdown.map((b, i) => {
-        const safeName = escapePlotText(b.name);
-        return {
-          x: b.series.map((p) => new Date(p.timestamp * 1000).toISOString()),
-          y: b.series.map((p) => p.value),
-          name: safeName,
-          type: "scatter" as const,
-          mode: "lines" as const,
-          ...(combo.has(i) ? { visible: "legendonly" as const } : {}),
-          stackgroup: "total",
-          line: { color: b.color, width: 1.2 },
-          fillcolor: b.color + "cc",
-          hovertemplate: `${safeName}: $%{y:,.0f}<extra></extra>`,
-        };
-      });
-
-      const comboLayout: ChartLayout = {
-        ...baseLayout,
-        yaxis: {
-          ...baseLayout.yaxis,
-          range: yRange,
-          autorange: false as const,
-        },
-      };
-      void series; // referenced for memo dep correctness (timestamps drive bucket keys)
-      return {
-        key: [...combo].join(",") || "all",
-        combo,
-        traces: comboTraces,
-        layout: comboLayout,
-      };
+  // The target Plot must commit once at opacity 0 before becoming active;
+  // otherwise a newly mounted node starts at opacity 1 and cannot fade in.
+  useEffect(() => {
+    if (!enabled || fadeState.phase !== "preparing") return;
+    const transitionId = fadeState.transitionId;
+    const frame = requestAnimationFrame(() => {
+      dispatchFade({ type: "start", transitionId });
     });
-  }, [enabled, series, currentBreakdown, combos, baseLayout]);
+    return () => cancelAnimationFrame(frame);
+  }, [enabled, fadeState.phase, fadeState.transitionId]);
+
+  // Removing the outgoing Plot at the same duration as the CSS fade leaves
+  // one real Plot in steady state. Cleanup cancels stale completions on every
+  // rapid retarget and on unmount.
+  useEffect(() => {
+    if (!enabled || fadeState.phase !== "fading") return;
+    const transitionId = fadeState.transitionId;
+    const timer = window.setTimeout(() => {
+      dispatchFade({ type: "finish", transitionId });
+    }, CROSS_FADE_DURATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [enabled, fadeState.phase, fadeState.transitionId]);
+
+  const crossFadeData = useMemo<CrossFadePlot[] | null>(() => {
+    if (!enabled) return null;
+    // `series` drives `baseLayout` and is retained as an explicit memo input
+    // so timestamp/window changes cannot reuse a stale pair of Plot props.
+    void series;
+    const activePlot = buildCrossFadePlot({
+      hiddenKeys: fadeState.activeHiddenKeys,
+      currentBreakdown,
+      baseLayout,
+      active: true,
+    });
+    if (!fadeState.secondaryHiddenKeys) return [activePlot];
+
+    const secondaryPlot = buildCrossFadePlot({
+      hiddenKeys: fadeState.secondaryHiddenKeys,
+      currentBreakdown,
+      baseLayout,
+      active: false,
+    });
+    // A removed/reordered breakdown can collapse distinct stable-key sets to
+    // the same effective index combo. Never mount the duplicate Plot.
+    if (secondaryPlot.key === activePlot.key) return [activePlot];
+
+    // Keep keyed layers in a stable DOM order while `active` swaps between
+    // them. Moving a Plot node during its opacity transition can make Plotly
+    // recalculate its SVG even though z-index already owns the visual order.
+    return activePlot.key < secondaryPlot.key
+      ? [activePlot, secondaryPlot]
+      : [secondaryPlot, activePlot];
+  }, [
+    enabled,
+    series,
+    currentBreakdown,
+    baseLayout,
+    fadeState.activeHiddenKeys,
+    fadeState.secondaryHiddenKeys,
+  ]);
 
   // Returns false to suppress Plotly's native legend toggle so visibility
   // flows through React state (which drives the cross-fade).
@@ -130,18 +286,20 @@ export function useCrossFade(params: {
         ? breakdownVisibilityKey(clickedSeries)
         : null;
       if (seriesKey === null) return false;
-      setHiddenKeys((prev) => {
-        const next = new Set(prev);
-        if (next.has(seriesKey)) next.delete(seriesKey);
-        else next.add(seriesKey);
-        return next;
+      dispatchFade({
+        type: "toggle",
+        seriesKey,
+        reduceMotion:
+          typeof window !== "undefined" &&
+          typeof window.matchMedia === "function" &&
+          window.matchMedia("(prefers-reduced-motion: reduce)").matches,
       });
       return false;
     },
     [currentBreakdown],
   );
 
-  return { hiddenIdx, handleLegendClick, crossFadeData };
+  return { handleLegendClick, crossFadeData };
 }
 
 export function breakdownVisibilityKey(series: BreakdownSeries): string {
@@ -161,7 +319,7 @@ export function hiddenSeriesKeysToIndexes(
   return hiddenIdx;
 }
 
-export function setEquals<T>(a: Set<T>, b: Set<T>): boolean {
+function setEquals<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
   if (a.size !== b.size) return false;
   for (const x of a) if (!b.has(x)) return false;
   return true;
@@ -193,10 +351,13 @@ export function useSortedHover(params: {
   const { enabled, isStacked, breakdown, containerRef } = params;
   const [hover, setHover] = useState<SortedHoverState | null>(null);
 
+  // Payload normalization intentionally guards malformed Plotly event fields;
+  // keep the existing complexity waiver local instead of line-number baselined.
   const onHover = useCallback(
     (e: {
       points?: unknown[];
       event?: { clientX?: number; clientY?: number };
+      // eslint-disable-next-line complexity -- Plotly events are untrusted optional-field payloads.
     }) => {
       if (!enabled) return;
       const rawPoints = (e.points ?? []) as Array<{

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -20,7 +20,6 @@ import {
   type BreakdownSeries,
 } from "@/components/time-series-chart-card-overlays";
 import {
-  setEquals,
   useCrossFade,
   useSortedHover,
 } from "@/components/time-series-chart-card-hooks";
@@ -202,12 +201,10 @@ export function TimeSeriesChartCard({
     hasBreakdown && (breakdown ?? []).some((b) => b.legendIcon !== undefined);
 
   const breakdownCount = breakdown?.length ?? 0;
-  // Cross-fade between pre-rendered visibility states. Pre-rendering
-  // 2^N Plot instances stays fine perf-wise up to N=3 (8 plots, ~10KB
-  // SVG each) — past that, fall back to a single chart with native
-  // toggle. Cross-fade requires Plotly's native legend (we toggle
-  // visibility by clicking it); custom-legend mode owns its own
-  // visibility via React state and a different render path.
+  // Cross-fade between stacked visibility states. The shared state machine
+  // mounts one Plot in steady state and only the incoming + outgoing pair
+  // during the 250ms transition. The N<=3 eligibility gate remains unchanged;
+  // larger native legends fall back to Plotly's own single-chart toggle.
   const crossFadeEnabled =
     isStacked && !useCustomLegend && breakdownCount >= 1 && breakdownCount <= 3;
   // Custom-legend visibility state. Keyed by `BreakdownSeries.id` (a
@@ -441,18 +438,27 @@ export function TimeSeriesChartCard({
     yAxisReferenceValues,
   ]);
 
-  // Cross-fade in stacked mode: pre-render every visibility combo (2^N
-  // total) as its own Plot, CSS-fade between them on legend click. Only
-  // animation path that produces a clean grow/shrink for stacked-area
-  // charts (Plotly cannot interpolate stackgroup y-values via
-  // `Plotly.react` + `layout.transition`).
-  const { hiddenIdx, handleLegendClick, crossFadeData } = useCrossFade({
+  // Cross-fade in stacked mode: retain the current Plot while the requested
+  // visibility state mounts at opacity 0, then swap the interactive target
+  // and remove the outgoing Plot after 250ms. This is the only animation path
+  // that produces a clean grow/shrink for stacked-area charts (Plotly cannot
+  // interpolate stackgroup y-values via `Plotly.react`).
+  const { handleLegendClick, crossFadeData } = useCrossFade({
     enabled: crossFadeEnabled,
-    breakdownCount,
     series,
     breakdown,
     baseLayout: layout,
   });
+  const handleCrossFadeLegendClick = useCallback(
+    (event: { readonly curveNumber: number }) => {
+      // The /volume aggregator chart can combine cross-fade with the custom
+      // sorted tooltip. Clear hover owned by the outgoing Plot before the hit
+      // target swaps so its label cannot linger over the incoming state.
+      onPlotlyUnhover();
+      return handleLegendClick(event);
+    },
+    [handleLegendClick, onPlotlyUnhover],
+  );
 
   const deltaPill =
     change === null || isLoading || hasError ? null : (
@@ -621,8 +627,7 @@ export function TimeSeriesChartCard({
           <PlotSkeleton heightPx={chartHeightPx} />
         ) : crossFadeEnabled && crossFadeData ? (
           <div style={{ position: "relative", height: chartHeightPx }}>
-            {crossFadeData.map(({ key, combo, traces, layout }) => {
-              const active = setEquals(combo, hiddenIdx);
+            {crossFadeData.map(({ key, active, traces, layout }) => {
               return (
                 <div
                   key={key}
@@ -660,13 +665,10 @@ export function TimeSeriesChartCard({
                     config={CHART_CARD_PLOTLY_CONFIG}
                     style={{ width: "100%", height: chartHeightPx }}
                     useResizeHandler
-                    onLegendClick={handleLegendClick}
-                    // Forward Plotly hover events on the active overlay
-                    // so a future caller using both crossFade + custom-
-                    // sorted-hover gets the React tooltip wired up. No
-                    // current caller hits both (custom-sorted-hover
-                    // implies legendIcon → useCustomLegend → cross-fade
-                    // disabled), but cursor flagged the asymmetry.
+                    onLegendClick={handleCrossFadeLegendClick}
+                    // Forward hover events on both mounted layers. Only the
+                    // active layer is visible/topmost, and legend retargeting
+                    // clears custom hover before that hit target swaps.
                     onHover={onPlotlyHover}
                     onUnhover={onPlotlyUnhover}
                   />


### PR DESCRIPTION
## The Problem

- Stacked chart cross-fades pre-rendered every visibility combination, mounting up to eight Plotly charts even when only one was visible.
- Rapid legend toggles could retain unnecessary chart layers and stale hover targets.

## The Solution

- Replace the exponential pre-render set with a bounded state machine that mounts one Plot in steady state and only the incoming/outgoing pair during the 250 ms fade.
- Retarget rapid toggles without growing the layer count, preserve reduced-motion behavior, and transfer pointer and hover ownership to the active Plot.

## Verification

- pnpm agent:quality-gate --run
- CI=true pnpm agent:autoreview
- 46 focused cross-fade and caller tests
- Full dashboard coverage: 3,819 tests
- React Doctor score 100
- Direct Chrome: the home Volume chart moved from one to two Plot layers during a legend fade and returned to one after approximately 259 ms.
- Direct Chrome: home, stables, volume, and canonical pool routes rendered without console errors; the canonical pool chart mounted one visible Plot.

Closes #1246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared chart rendering and legend/hover timing across volume, stables, and aggregator views; behavior is heavily tested but UI animation edge cases could still affect chart interaction.
> 
> **Overview**
> Stacked **TimeSeriesChartCard** legend toggles no longer pre-mount up to **2^N** Plotly charts for every visibility combo. **`useCrossFade`** now drives a **250ms** handoff with a reducer: **one** Plot at rest, **two** only while fading, with **rapid retargets** replacing the secondary slot instead of growing layers.
> 
> **Reduced motion** and toggles that match the current visibility settle immediately on a single Plot. Legend clicks wired through **`handleCrossFadeLegendClick`** clear custom sorted hover before the active layer swaps so tooltips do not linger.
> 
> Coverage adds cross-fade timing/retarget/unmount tests, caller checks that stables/volume/aggregator paths stay on one steady Plot, and a volume chart single-Plot assertion. ESLint baseline drops a stale complexity entry in favor of a local waiver on hover parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef82c0c61e163703b6d5857885c5c504fd07ac32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->