### PR TITLE
fix(dashboard): SSR the FX weekend banner

### DIFF
--- a/ui-dashboard/knip.json
+++ b/ui-dashboard/knip.json
@@ -5,7 +5,8 @@
     "scripts/intel-marathon/*.mjs",
     "vitest.mutation.config.ts",
     "tests/**/*.test.{ts,tsx}",
-    "tests/browser/fixtures/hasura-fixture-server.mjs"
+    "tests/browser/fixtures/hasura-fixture-server.mjs",
+    "tests/browser/fixtures/fixed-weekend-server-clock.mjs"
   ],
   "project": [
     "src/**/*.{ts,tsx}",

--- a/ui-dashboard/playwright.config.ts
+++ b/ui-dashboard/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 import { unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const nextPort = Number(process.env.PLAYWRIGHT_NEXT_PORT ?? 3210);
 const fixturePort = Number(process.env.PLAYWRIGHT_FIXTURE_PORT ?? 3211);
@@ -11,6 +13,15 @@ const nextCommand =
   process.env.PLAYWRIGHT_NEXT_COMMAND?.replaceAll("{port}", String(nextPort)) ??
   `pnpm dev --hostname 127.0.0.1 --port ${nextPort}`;
 const nextTimeout = Number(process.env.PLAYWRIGHT_NEXT_TIMEOUT_MS ?? 120_000);
+const fixedWeekendServerClock = pathToFileURL(
+  resolve("tests/browser/fixtures/fixed-weekend-server-clock.mjs"),
+).href;
+const nextServerNodeOptions = [
+  process.env.NODE_OPTIONS,
+  `--import=${fixedWeekendServerClock}`,
+]
+  .filter(Boolean)
+  .join(" ");
 
 /**
  * Probe the active Claude Code bash sandbox by attempting a write to /tmp,
@@ -88,6 +99,7 @@ export default defineConfig({
     {
       command: nextCommand,
       env: {
+        NODE_OPTIONS: nextServerNodeOptions,
         NEXT_PUBLIC_HASURA_URL: `${fixtureUrl}/graphql`,
         NEXT_PUBLIC_BROWSER_TEST_FIXTURES: "true",
         NEXT_TELEMETRY_DISABLED: "1",

--- a/ui-dashboard/src/app/(home)/page.tsx
+++ b/ui-dashboard/src/app/(home)/page.tsx
@@ -3,6 +3,7 @@ import GlobalPage from "../page-client";
 import { fetchHomepageOgData } from "@/lib/homepage-og";
 import { fetchInitialNetworkData } from "@/lib/network-fetcher/server-cache";
 import { formatUSD } from "@/lib/format";
+import { isWeekend } from "@/lib/weekend";
 
 // Dynamic OG metadata — scoped to the homepage so other routes (/pool/...,
 // /address-book, etc.) don't inherit the cross-chain I/O when the cache is
@@ -87,10 +88,12 @@ export default async function HomePage() {
   // truly unexpected error bubbles up; an undefined initial payload just
   // reverts to the client-only code path.
   const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  const initialIsWeekend = isWeekend();
   return (
     <GlobalPage
       initialNetworkData={initialPayload?.networks}
       initialNetworkDataFetchedAtMs={initialPayload?.fetchedAtMs}
+      initialIsWeekend={initialIsWeekend}
     />
   );
 }

--- a/ui-dashboard/src/app/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.server.test.tsx
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import HomePage, { generateMetadata } from "../(home)/page";
 
-type GlobalPageProps = { initialNetworkData?: unknown };
+type GlobalPageProps = {
+  initialNetworkData?: unknown;
+  initialIsWeekend?: boolean;
+};
 
 const { mockFetchInitialNetworkData, mockFetchHomepageOgData, mockGlobalPage } =
   vi.hoisted(() => ({
@@ -48,6 +51,10 @@ beforeEach(() => {
   mockGlobalPage.mockClear();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("HomePage route metadata", () => {
   it("returns fallback metadata when homepage OG data is unavailable", async () => {
     mockFetchHomepageOgData.mockResolvedValueOnce(null);
@@ -86,6 +93,8 @@ describe("HomePage route metadata", () => {
 
 describe("HomePage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
     mockFetchInitialNetworkData.mockResolvedValueOnce({
       networks: initialNetworkData,
@@ -97,10 +106,13 @@ describe("HomePage server component", () => {
     expect(mockGlobalPage).toHaveBeenCalledWith({
       initialNetworkData,
       initialNetworkDataFetchedAtMs: 1_700_000_000_000,
+      initialIsWeekend: true,
     });
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"));
     mockFetchInitialNetworkData.mockRejectedValueOnce(
       new Error("network fanout"),
     );
@@ -110,6 +122,7 @@ describe("HomePage server component", () => {
     expect(mockGlobalPage).toHaveBeenCalledWith({
       initialNetworkData: undefined,
       initialNetworkDataFetchedAtMs: undefined,
+      initialIsWeekend: false,
     });
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/lib/graphql", () => ({
 // GlobalPoolsTable has complex deps — stub it, but capture props for assertions
 interface CapturedTableProps {
   entries: { pool: { id: string }; network: { id: string } }[];
+  initialIsWeekend?: boolean;
   volume24hByKey?: Map<string, number | null>;
   tvlChangeWoWByKey?: Map<string, number | null>;
 }
@@ -82,13 +83,19 @@ function makePool(id: string): Pool {
   };
 }
 
-function render(networkData: NetworkData[], isLoading = false): string {
+function render(
+  networkData: NetworkData[],
+  isLoading = false,
+  initialIsWeekend = false,
+): string {
   (useAllNetworksData as ReturnType<typeof vi.fn>).mockReturnValue({
     networkData,
     isLoading,
     error: null,
   });
-  return renderToStaticMarkup(<GlobalPage />);
+  return renderToStaticMarkup(
+    <GlobalPage initialIsWeekend={initialIsWeekend} />,
+  );
 }
 
 beforeEach(() => {
@@ -149,6 +156,12 @@ describe("GlobalPage — loading state", () => {
 // All networks succeed
 
 describe("GlobalPage — all networks succeed", () => {
+  it("threads the server weekend snapshot into GlobalPoolsTable", () => {
+    render([makeNetworkData({ pools: [makeTvlPool()] })], false, true);
+
+    expect(capturedProps?.initialIsWeekend).toBe(true);
+  });
+
   it("renders the summary tiles without error state on all-success", () => {
     const html = render([
       makeNetworkData({ pools: [], fees: null }),

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -42,9 +42,11 @@ const SECONDS_PER_DAY = 86_400;
 export default function GlobalPage({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialIsWeekend = false,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  initialIsWeekend?: boolean;
 }) {
   // First paint uses `initialNetworkData` via SWR's `fallbackData`; on
   // back-navigation the populated SWR cache wins, which is the right call —
@@ -57,6 +59,7 @@ export default function GlobalPage({
       <GlobalContent
         initialNetworkData={initialNetworkData}
         initialNetworkDataFetchedAtMs={initialNetworkDataFetchedAtMs}
+        initialIsWeekend={initialIsWeekend}
       />
     </Suspense>
   );
@@ -113,9 +116,11 @@ function perPoolTvlWindow(
 function GlobalContent({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialIsWeekend,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  initialIsWeekend: boolean;
 }) {
   const { networkData, isLoading } = useAllNetworksData(
     initialNetworkData,
@@ -435,6 +440,7 @@ function GlobalContent({
         ) : (
           <GlobalPoolsTable
             entries={globalEntries}
+            initialIsWeekend={initialIsWeekend}
             volume24hByKey={volume24hByKey}
             volume7dByKey={volume7dByKey}
             tvlChangeWoWByKey={tvlChangeWoWByKey}

--- a/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import PoolsPage from "../page";
 
-type PoolsPageProps = { initialNetworkData?: unknown };
+type PoolsPageProps = {
+  initialNetworkData?: unknown;
+  initialIsWeekend?: boolean;
+};
 
 const { mockFetchInitialNetworkData, mockPoolsPageClient } = vi.hoisted(() => ({
   mockFetchInitialNetworkData: vi.fn(),
@@ -25,8 +28,14 @@ beforeEach(() => {
   mockPoolsPageClient.mockClear();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("PoolsPage server component", () => {
   it("passes resolved initial network data into the client page", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
     const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
     mockFetchInitialNetworkData.mockResolvedValueOnce({
       networks: initialNetworkData,
@@ -38,10 +47,13 @@ describe("PoolsPage server component", () => {
     expect(mockPoolsPageClient).toHaveBeenCalledWith({
       initialNetworkData,
       initialNetworkDataFetchedAtMs: 1_700_000_000_000,
+      initialIsWeekend: true,
     });
   });
 
   it("falls back to client-side fetching when initial network data rejects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"));
     mockFetchInitialNetworkData.mockRejectedValueOnce(
       new Error("network fanout"),
     );
@@ -51,6 +63,7 @@ describe("PoolsPage server component", () => {
     expect(mockPoolsPageClient).toHaveBeenCalledWith({
       initialNetworkData: undefined,
       initialNetworkDataFetchedAtMs: undefined,
+      initialIsWeekend: false,
     });
   });
 });

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -50,12 +50,14 @@ vi.mock("@/hooks/use-all-networks-data", async () => ({
 vi.mock("@/components/global-pools-table", () => ({
   GlobalPoolsTable: ({
     entries,
+    initialIsWeekend,
     olsPoolKeys,
     volume24hByKey,
     volume7dByKey,
     tvlChangeWoWByKey,
   }: {
     entries: GlobalPoolEntry[];
+    initialIsWeekend?: boolean;
     olsPoolKeys?: Set<string>;
     volume24hByKey?: Map<string, number | null | undefined>;
     volume7dByKey?: Map<string, number | null | undefined>;
@@ -63,6 +65,9 @@ vi.mock("@/components/global-pools-table", () => ({
   }) => (
     <div data-testid="global-pools-table">
       <span data-testid="entries-count">{entries.length}</span>
+      <span data-testid="initial-is-weekend">
+        {String(initialIsWeekend ?? false)}
+      </span>
       <span data-testid="chains">
         {[...new Set(entries.map((e) => e.network.id))].join(",")}
       </span>
@@ -201,6 +206,14 @@ beforeEach(() => {
 });
 
 describe("PoolsPage multichain rendering", () => {
+  it("threads the server weekend snapshot into GlobalPoolsTable", () => {
+    vi.mocked(useGQL).mockReturnValue(baseSwapsResult as SWRResponse);
+
+    const html = renderToStaticMarkup(<PoolsPage initialIsWeekend={true} />);
+
+    expect(html).toContain('data-testid="initial-is-weekend">true<');
+  });
+
   it("keeps pools visible and discloses a live-health refresh failure", () => {
     vi.mocked(useAllNetworksData).mockReturnValue({
       ...baseAllNetworksResult,

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -45,15 +45,18 @@ import { SwapsTableSkeleton } from "./pools-skeletons";
 export function PoolsPageClient({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialIsWeekend = false,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  initialIsWeekend?: boolean;
 }) {
   return (
     <Suspense>
       <PoolsContent
         initialNetworkData={initialNetworkData}
         initialNetworkDataFetchedAtMs={initialNetworkDataFetchedAtMs}
+        initialIsWeekend={initialIsWeekend}
       />
     </Suspense>
   );
@@ -63,9 +66,11 @@ export function PoolsPageClient({
 function PoolsContent({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialIsWeekend,
 }: {
   initialNetworkData?: NetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  initialIsWeekend: boolean;
 }) {
   "use memo";
 
@@ -239,6 +244,7 @@ function PoolsContent({
         ) : (
           <GlobalPoolsTable
             entries={entries}
+            initialIsWeekend={initialIsWeekend}
             volume24hByKey={volume24hByKey}
             volume7dByKey={volume7dByKey}
             tvlChangeWoWByKey={tvlChangeWoWByKey}

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { PoolsPageClient } from "./_components/pools-page-client";
 import { fetchInitialNetworkData } from "@/lib/network-fetcher/server-cache";
+import { isWeekend } from "@/lib/weekend";
 
 // SSR the initial cross-chain pool list so first paint already contains the
 // full pools table. Without this, the client renders a 3-row `<Skeleton />`
@@ -29,10 +30,12 @@ export const metadata: Metadata = {
 
 export default async function PoolsPage() {
   const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  const initialIsWeekend = isWeekend();
   return (
     <PoolsPageClient
       initialNetworkData={initialPayload?.networks}
       initialNetworkDataFetchedAtMs={initialPayload?.fetchedAtMs}
+      initialIsWeekend={initialIsWeekend}
     />
   );
 }

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -131,6 +131,24 @@ describe("globalPoolKey", () => {
 
 // GlobalPoolsTable rendering
 
+describe("GlobalPoolsTable — FX weekend SSR banner", () => {
+  it("includes the banner in weekend server markup", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry()]} initialIsWeekend={true} />,
+    );
+
+    expect(html).toContain("FX markets are closed this weekend.");
+  });
+
+  it("omits the banner from weekday server markup", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry()]} initialIsWeekend={false} />,
+    );
+
+    expect(html).not.toContain("FX markets are closed this weekend.");
+  });
+});
+
 describe("GlobalPoolsTable — column structure", () => {
   it("renders a branded chain icon before the pool name", () => {
     const html = renderToStaticMarkup(

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -29,6 +29,7 @@ function hasAnyVirtualPools(entries: GlobalPoolEntry[]): boolean {
 
 interface GlobalPoolsTableProps {
   entries: GlobalPoolEntry[];
+  initialIsWeekend?: boolean;
   volume24hByKey?: Map<string, number | null | undefined>;
   volume24hLoading?: boolean;
   volume24hError?: boolean;
@@ -43,6 +44,7 @@ interface GlobalPoolsTableProps {
 
 export function GlobalPoolsTable({
   entries,
+  initialIsWeekend = false,
   volume24hByKey,
   volume24hLoading = false,
   volume24hError = false,
@@ -108,15 +110,10 @@ export function GlobalPoolsTable({
   );
 
   const showVirtualPoolSource = hasAnyVirtualPools(entries);
-  // SSR-safe: only show the weekend banner after mount. The server's
-  // wall-clock day can differ from the viewer's (and a cached SSR payload can
-  // outlive the weekend), so gating on isWeekend() during render would emit
-  // server HTML the client discards as a hydration mismatch. See useIsWeekend.
-  const showWeekendBanner = useIsWeekend();
 
   return (
     <>
-      {showWeekendBanner && <WeekendBanner />}
+      <WeekendBanner initialIsWeekend={initialIsWeekend} />
       <Table>
         <PoolTableHeader
           sortKey={sortKey}
@@ -151,7 +148,11 @@ export function GlobalPoolsTable({
   );
 }
 
-function WeekendBanner() {
+function WeekendBanner({ initialIsWeekend }: { initialIsWeekend: boolean }) {
+  // Reuse the route's serialized snapshot through hydration, then go live.
+  const showWeekendBanner = useIsWeekend(initialIsWeekend);
+  if (!showWeekendBanner) return null;
+
   return (
     <div className="mb-4 flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/60 px-4 py-3 text-sm text-slate-300">
       <span className="text-base leading-5 flex-shrink-0" aria-hidden="true">

--- a/ui-dashboard/src/hooks/__tests__/use-is-weekend.test.tsx
+++ b/ui-dashboard/src/hooks/__tests__/use-is-weekend.test.tsx
@@ -1,19 +1,29 @@
 /** @vitest-environment jsdom */
 
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderToStaticMarkup, renderToString } from "react-dom/server";
 import { act, createElement, type ReactNode } from "react";
-import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isWeekend } from "@/lib/weekend";
 import { useIsWeekend } from "../use-is-weekend";
 
 vi.mock("@/lib/weekend", () => ({ isWeekend: vi.fn() }));
 const mockIsWeekend = vi.mocked(isWeekend);
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousActEnvironment: boolean | undefined;
 
-async function renderOnClient(): Promise<boolean | undefined> {
+function Probe({ initialIsWeekend = false }: { initialIsWeekend?: boolean }) {
+  return createElement("span", null, String(useIsWeekend(initialIsWeekend)));
+}
+
+async function renderOnClient(
+  initialIsWeekend = false,
+): Promise<boolean | undefined> {
   let captured: boolean | undefined;
   function Probe(): null {
-    captured = useIsWeekend();
+    captured = useIsWeekend(initialIsWeekend);
     return null;
   }
   const container = document.createElement("div");
@@ -28,20 +38,75 @@ async function renderOnClient(): Promise<boolean | undefined> {
 }
 
 describe("useIsWeekend", () => {
-  afterEach(() => vi.clearAllMocks());
-
-  it("renders false on the server even when it IS the weekend (SSR-safe)", () => {
-    // getServerSnapshot is () => false, so the server HTML and the client's
-    // hydration render agree — weekend-dependent UI can't cause a hydration
-    // mismatch regardless of the server's day or a stale cached payload.
-    mockIsWeekend.mockReturnValue(true);
-    function SsrProbe(): ReactNode {
-      return createElement("span", null, String(useIsWeekend()));
-    }
-    expect(renderToStaticMarkup(createElement(SsrProbe))).toBe(
-      "<span>false</span>",
-    );
+  beforeEach(() => {
+    previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    mockIsWeekend.mockReset();
+    mockIsWeekend.mockReturnValue(false);
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT =
+      previousActEnvironment ?? false;
+    document.body.replaceChildren();
+  });
+
+  it.each([
+    [true, "<span>true</span>"],
+    [false, "<span>false</span>"],
+  ])("renders the seeded %s snapshot on the server", (initial, expected) => {
+    expect(
+      renderToStaticMarkup(createElement(Probe, { initialIsWeekend: initial })),
+    ).toBe(expected);
+    expect(mockIsWeekend).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { initial: true, live: false },
+    { initial: false, live: true },
+  ])(
+    "hydrates the exact $initial server snapshot before switching to live $live",
+    async ({ initial, live }) => {
+      const serverHtml = renderToString(
+        createElement(Probe, { initialIsWeekend: initial }),
+      );
+      const container = document.createElement("div");
+      container.innerHTML = serverHtml;
+      document.body.appendChild(container);
+      expect(container.textContent).toBe(String(initial));
+
+      mockIsWeekend.mockReturnValue(live);
+      const clientSnapshots: boolean[] = [];
+      function HydrationProbe(): ReactNode {
+        const snapshot = useIsWeekend(initial);
+        clientSnapshots.push(snapshot);
+        return createElement("span", null, String(snapshot));
+      }
+
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      let root: Root | null = null;
+      try {
+        await act(async () => {
+          root = hydrateRoot(container, createElement(HydrationProbe));
+          await Promise.resolve();
+        });
+
+        expect(consoleError).not.toHaveBeenCalled();
+        expect(clientSnapshots[0]).toBe(initial);
+        expect(container.textContent).toBe(String(live));
+      } finally {
+        consoleError.mockRestore();
+        if (root) {
+          act(() => {
+            (root as Root).unmount();
+          });
+        }
+      }
+    },
+  );
 
   it("returns the real isWeekend() value on the client", async () => {
     mockIsWeekend.mockReturnValue(true);
@@ -51,5 +116,35 @@ describe("useIsWeekend", () => {
   it("returns false on the client on a weekday", async () => {
     mockIsWeekend.mockReturnValue(false);
     expect(await renderOnClient()).toBe(false);
+  });
+
+  it("self-corrects in both directions on the existing hourly interval", async () => {
+    vi.useFakeTimers();
+    let liveIsWeekend = false;
+    mockIsWeekend.mockImplementation(() => liveIsWeekend);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(Probe));
+      });
+      expect(container.textContent).toBe("false");
+
+      liveIsWeekend = true;
+      act(() => {
+        vi.advanceTimersByTime(60 * 60 * 1000);
+      });
+      expect(container.textContent).toBe("true");
+
+      liveIsWeekend = false;
+      act(() => {
+        vi.advanceTimersByTime(60 * 60 * 1000);
+      });
+      expect(container.textContent).toBe("false");
+    } finally {
+      act(() => root.unmount());
+    }
   });
 });

--- a/ui-dashboard/src/hooks/use-is-weekend.ts
+++ b/ui-dashboard/src/hooks/use-is-weekend.ts
@@ -18,19 +18,18 @@ const subscribe = (notify: () => void): (() => void) => {
 /**
  * SSR-safe FX-weekend flag.
  *
- * Returns `false` on the server render and the client's hydration render (the
- * `getServerSnapshot`), then the real `isWeekend()` value on the client after
- * commit (`getSnapshot`). This keeps the server HTML and the first client
- * render in agreement, so weekend-dependent UI (e.g. the FX "markets closed"
- * banner) can never trigger a hydration mismatch — the server's wall-clock day
- * can differ from the viewer's, and a statically-cached SSR payload can outlive
- * the weekend entirely. `useSyncExternalStore` is the idiomatic way to read a
- * client-only value with a server fallback (no setState-in-effect dance).
+ * Returns `initialIsWeekend` on the server render and the client's hydration
+ * render (the `getServerSnapshot`), then the real `isWeekend()` value on the
+ * client after commit (`getSnapshot`). The default stays `false` for consumers
+ * that do not receive a server-computed clock snapshot. A seeded consumer must
+ * pass the exact same serialized value on the server and client so hydration
+ * never recomputes wall-clock state independently. `useSyncExternalStore` then
+ * switches to the live clock after mount and keeps the hourly correction.
  */
-export function useIsWeekend(): boolean {
+export function useIsWeekend(initialIsWeekend = false): boolean {
   return useSyncExternalStore(
     subscribe,
     () => isWeekend(),
-    () => false,
+    () => initialIsWeekend,
   );
 }

--- a/ui-dashboard/src/hooks/use-is-weekend.ts
+++ b/ui-dashboard/src/hooks/use-is-weekend.ts
@@ -24,7 +24,11 @@ const subscribe = (notify: () => void): (() => void) => {
  * that do not receive a server-computed clock snapshot. A seeded consumer must
  * pass the exact same serialized value on the server and client so hydration
  * never recomputes wall-clock state independently. `useSyncExternalStore` then
- * switches to the live clock after mount and keeps the hourly correction.
+ * synchronously compares against the live clock immediately after hydration
+ * and corrects any ISR-stale seed before keeping the hourly subscription.
+ * This seeded path is intentionally limited to the informational weekend
+ * banner; operator-safety state with async inputs must still render neutral
+ * until those inputs resolve.
  */
 export function useIsWeekend(initialIsWeekend = false): boolean {
   return useSyncExternalStore(

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
 const CELO_POOL_ID = "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e";
 const MONAD_POOL_ID = "143-0xb0a0264ce6847f101b76ba36a4a3083ba489f501";
@@ -27,6 +27,8 @@ function trackUnexpectedBrowserErrors(page: Page): string[] {
 // and the rebalance-blocked prose never renders. Wed 2026-04-15 12:00
 // UTC is mid-window for FX trading hours on every supported chain.
 const WEEKDAY_FIXTURE_INSTANT = new Date("2026-04-15T12:00:00Z");
+const WEEKEND_FIXTURE_INSTANT = new Date("2026-04-18T12:00:00Z");
+const FIXED_WEEKEND_SERVER_CLOCK_HEADER = "x-playwright-fixed-weekend-clock";
 const FIXTURE_NOW_SECONDS = Math.floor(
   WEEKDAY_FIXTURE_INSTANT.getTime() / 1000,
 );
@@ -664,22 +666,58 @@ test.describe("dashboard browser flows", () => {
     await expect(rows).toHaveCount(1);
   });
 
-  test("shows the FX weekend banner after mount without a hydration mismatch", async ({
+  test("SSR-renders the FX weekend banner on both pool surfaces and hydrates without a mismatch", async ({
     page,
+    request,
   }) => {
-    // Pin the CLIENT clock to a Saturday so the weekend banner should show.
-    // SSR renders with the server's own wall-clock day (often a weekday), so
-    // gating the banner on a render-time isWeekend() would diverge from the
-    // client and trip a hydration mismatch — caught by the afterEach
-    // console-error assertion. useIsWeekend defers the banner to after mount, so
-    // SSR and the hydration pass agree and the banner fades in client-side.
-    await page.clock.setFixedTime(new Date("2026-04-18T12:00:00Z")); // Saturday
-    await page.goto("/pools");
+    const fixedClockHeaders = {
+      [FIXED_WEEKEND_SERVER_CLOCK_HEADER]: "true",
+    };
+    const routeDocumentWithFixedClock = async (route: Route) => {
+      const request = route.request();
+      if (request.resourceType() !== "document") {
+        await route.continue();
+        return;
+      }
+      await route.continue({
+        headers: { ...request.headers(), ...fixedClockHeaders },
+      });
+    };
+    try {
+      // The Playwright-managed Next process scopes its matching Saturday
+      // `new Date()` clock to this fixture header. Raw API responses never
+      // execute page JavaScript, proving the banner is in SSR HTML rather than
+      // inserted by the mounted client hook.
+      await Promise.all(
+        ["/", "/pools"].map(async (route) => {
+          const response = await request.get(route, {
+            headers: fixedClockHeaders,
+          });
+          expect(response.ok()).toBe(true);
+          expect(await response.text()).toContain(
+            "FX markets are closed this weekend.",
+          );
+        }),
+      );
 
-    await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
-    await expect(
-      page.getByText(/FX markets are closed this weekend/),
-    ).toBeVisible();
+      // Scope the header to document requests. Sending it to the fixture
+      // GraphQL origin would trigger an unnecessary CORS preflight.
+      await page.route("**/*", routeDocumentWithFixedClock);
+      await page.clock.setFixedTime(WEEKEND_FIXTURE_INSTANT);
+      const expectHydratedWeekendBanner = async (route: string) => {
+        await page.goto(route);
+        await expect(
+          page.getByText(/FX markets are closed this weekend/),
+        ).toBeVisible();
+      };
+      await expectHydratedWeekendBanner("/");
+      await expectHydratedWeekendBanner("/pools");
+    } finally {
+      if (!page.isClosed()) {
+        await page.unroute("**/*", routeDocumentWithFixedClock);
+      }
+    }
+    // The suite's afterEach rejects every page/console hydration error.
   });
 
   test("shows rebalance-blocked prose without the raw Solidity error code", async ({

--- a/ui-dashboard/tests/browser/fixtures/fixed-weekend-server-clock.mjs
+++ b/ui-dashboard/tests/browser/fixtures/fixed-weekend-server-clock.mjs
@@ -1,0 +1,46 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { Server } from "node:http";
+
+// Loaded only into the Playwright-managed Next.js process. A request opts in
+// with this fixture-only header; AsyncLocalStorage keeps concurrent requests
+// isolated, so unmarked routes always retain the real server clock.
+const FIXED_CLOCK_HEADER = "x-playwright-fixed-weekend-clock";
+const fixedClockScope = new AsyncLocalStorage();
+const originalServerEmit = Server.prototype.emit;
+
+Server.prototype.emit = function emitWithFixedClockScope(event, ...args) {
+  if (event !== "request") return originalServerEmit.call(this, event, ...args);
+  const [request] = args;
+  const useFixedClock = request?.headers?.[FIXED_CLOCK_HEADER] === "true";
+  return fixedClockScope.run(useFixedClock, () =>
+    originalServerEmit.call(this, event, ...args),
+  );
+};
+
+// `isWeekend()` reads a zero-argument `new Date()`, so pin only that path to
+// Saturday for marked requests while leaving Date.now() real. SSR cache ages
+// and data windows keep the same clock they use outside this focused fixture.
+const RealDate = globalThis.Date;
+const realNow = RealDate.now.bind(RealDate);
+const fixtureOriginMs = RealDate.parse("2026-04-18T12:00:00Z");
+
+function FixedWeekendServerDate(...args) {
+  const useFixedClock = fixedClockScope.getStore() === true;
+  if (!new.target) {
+    return useFixedClock
+      ? new RealDate(fixtureOriginMs).toString()
+      : RealDate();
+  }
+  return Reflect.construct(
+    RealDate,
+    args.length === 0 && useFixedClock ? [fixtureOriginMs] : args,
+    new.target,
+  );
+}
+
+Object.setPrototypeOf(FixedWeekendServerDate, RealDate);
+FixedWeekendServerDate.prototype = RealDate.prototype;
+FixedWeekendServerDate.now = realNow;
+FixedWeekendServerDate.parse = RealDate.parse;
+FixedWeekendServerDate.UTC = RealDate.UTC;
+globalThis.Date = FixedWeekendServerDate;


### PR DESCRIPTION
## The Problem

- The FX weekend banner was decided only after hydration, so server HTML could omit it and then shift when the client mounted.
- Independent server and client clock reads could disagree at a weekend boundary.

## The Solution

- Compute one weekend boolean in each server route and serialize it through the existing page-client/table path.
- Seed the client hook from that server value for SSR and hydration, then switch to the live clock after mount and preserve the existing hourly correction.

## Verification

- pnpm agent:quality-gate --run
- CI=true pnpm agent:autoreview
- Focused Vitest: 130 tests
- Full dashboard coverage: 3,817 tests
- Full Playwright browser suite: 19 tests
- React Doctor score 100
- Direct Chrome Saturday proof on / and /pools: raw SSR HTML contained the banner once, hydrated DOM kept it visible, and console stayed error-free.
- Direct Chrome Wednesday proof on / and /pools: raw SSR HTML and hydrated DOM omitted the banner, with no console errors.

## Stateful data/UI checklist

- Invariant: one route-derived weekend boolean crosses the server/client boundary and getServerSnapshot consumes that same serialized value.
- Degraded behavior: cached route output may briefly retain the prior boundary state, but hydration remains exact and the live client snapshot corrects after mount and hourly thereafter.
- Non-goals: change FX window semantics, seed unrelated health/deviation consumers, or alter route cache policy.

Closes #1254

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only weekend banner plumbing and test fixtures; no auth, payments, or data-model changes. Brief staleness if cached SSR crosses the FX window boundary is documented and corrected client-side after mount.
> 
> **Overview**
> **SSR-renders the FX weekend banner** on `/` and `/pools` by computing `isWeekend()` on each server route and threading `initialIsWeekend` through the page clients into `GlobalPoolsTable`.
> 
> `useIsWeekend` now seeds `useSyncExternalStore`'s server snapshot from that prop (default `false` elsewhere) so server HTML, hydration, and the post-mount live clock stay aligned; the banner no longer appears only after client mount.
> 
> Playwright loads `fixed-weekend-server-clock.mjs` into the Next dev server so document requests with a fixture header get a pinned Saturday `new Date()` for SSR assertions, alongside expanded Vitest coverage for routing, SSR markup, and hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f451fcaaa5942bd52a1ca38b4427f0a78ccdd7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->