### PR TITLE
fix(dashboard): validate SSR GraphQL fallbacks

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -3,6 +3,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { ReactNode } from "react";
 import type { PoolDetailInitialData } from "@/lib/pool-detail-initial-data";
 import type { PoolBreakerConfigResponse } from "@/lib/queries/config";
+import {
+  BrokerExchangeDailySnapshots24hSchema,
+  PoolBreakerConfigSchema,
+  PoolV2ExchangeSchema,
+} from "@/lib/queries/pool-detail-schemas";
 import type { Pool } from "@/lib/types";
 
 const mockUseGQL = vi.fn();
@@ -654,12 +659,14 @@ describe("Pool detail LPs tab", () => {
 
     expect(findUseGqlCall("PoolV2Exchange")?.[3]).toMatchObject({
       fallbackData: initialData.v2Exchange,
+      schema: PoolV2ExchangeSchema,
     });
     expect(
       findUseGqlCall("BrokerExchangeDailySnapshots24h")?.[3],
     ).toMatchObject({
       timeoutMs: 5000,
       fallbackData: initialData.brokerExchange24h,
+      schema: BrokerExchangeDailySnapshots24hSchema,
     });
     expect(html).toContain("ConstantSum");
     expect(html).not.toContain("v2 exchange config unavailable");
@@ -709,6 +716,7 @@ describe("Pool detail LPs tab", () => {
     for (const call of breakerCalls) {
       expect(call[3]).toMatchObject({
         fallbackData: initialData.breakerConfig,
+        schema: PoolBreakerConfigSchema,
       });
     }
     // Resolved shape paints on first render (no `h-[78px]` shimmer cell): the

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/use-gql-shape.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/use-gql-shape.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import React, { type ReactNode } from "react";
 import type { Pool } from "@/lib/types";
 import { BREAKER_CONFIG_TIMEOUT_MS } from "@/lib/hasura-timeout";
+import { PoolBreakerConfigSchema } from "@/lib/queries/pool-detail-schemas";
 
 // Characterization test for the upcoming pool-page extraction refactor.
 //
@@ -277,14 +278,19 @@ describe("useGQL call shape across pool detail tabs", () => {
 
     renderToStaticMarkup(React.createElement(PoolDetailPage));
 
-    const breakerCall = mockUseGQL.mock.calls.find(
+    const breakerCalls = mockUseGQL.mock.calls.filter(
       ([query]) =>
         typeof query === "string" && query.includes("query PoolBreakerConfig"),
     );
-    expect(breakerCall).toBeDefined();
+    // This harness stubs the header siblings, so OracleTab is the one mounted
+    // subscriber here. The page test covers BreakerPanel + MarketHoursPill.
+    expect(breakerCalls).toHaveLength(1);
     // arg[2] stays refreshMs (undefined → 30s poll); the timeout rides in arg[3].
-    expect(breakerCall?.[3]).toMatchObject({
-      timeoutMs: BREAKER_CONFIG_TIMEOUT_MS,
-    });
+    for (const breakerCall of breakerCalls) {
+      expect(breakerCall[3]).toMatchObject({
+        timeoutMs: BREAKER_CONFIG_TIMEOUT_MS,
+        schema: PoolBreakerConfigSchema,
+      });
+    }
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-header.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-header.tsx
@@ -35,6 +35,10 @@ import {
   type PoolBreakerConfigResponse,
   type PoolV2ExchangeResponse,
 } from "@/lib/queries";
+import {
+  BrokerExchangeDailySnapshots24hSchema,
+  PoolV2ExchangeSchema,
+} from "@/lib/queries/pool-detail-schemas";
 import { SECONDS_PER_DAY } from "@/lib/time-series";
 import { explorerAddressUrl, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
 import {
@@ -83,7 +87,7 @@ export function PoolHeader({
     isVirtual ? POOL_V2_EXCHANGE : null,
     { poolId: pool.id, chainId: pool.chainId },
     undefined,
-    { fallbackData: initialV2Exchange },
+    { fallbackData: initialV2Exchange, schema: PoolV2ExchangeSchema },
   );
   const v2Config = v2Data?.BiPoolExchange?.[0] ?? null;
   const v2LoadingWithoutData = isLoadingWithoutData(v2Data, v2Loading);
@@ -100,9 +104,7 @@ export function PoolHeader({
     data: exchangeVolumeData,
     isLoading: exchangeVolumeLoading,
     error: exchangeVolumeError,
-  } = useGQL<{
-    BrokerExchangeDailySnapshot: BrokerExchangeDailySnapshotRow[];
-  }>(
+  } = useGQL<BrokerExchangeDailySnapshots24hResponse>(
     isVirtual && exchangeIdForVolume && exchangeProviderForVolume
       ? BROKER_EXCHANGE_DAILY_SNAPSHOTS_24H
       : null,
@@ -113,7 +115,11 @@ export function PoolHeader({
       since: volumeSince,
     },
     SNAPSHOT_REFRESH_MS,
-    { timeoutMs: HASURA_TIMEOUT_MS, fallbackData: initialExchangeVolume },
+    {
+      timeoutMs: HASURA_TIMEOUT_MS,
+      fallbackData: initialExchangeVolume,
+      schema: BrokerExchangeDailySnapshots24hSchema,
+    },
   );
   const exchangeVolumeRows =
     exchangeVolumeData?.BrokerExchangeDailySnapshot ?? [];

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/use-observed-pool-detail.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/use-observed-pool-detail.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import type { PoolDetailInitialData } from "@/lib/pool-detail-initial-data";
 import type { PoolDetailResponse } from "@/lib/queries";
+import { PoolDetailWithHealthSchema } from "@/lib/queries/pool-detail-schemas";
 import type { Pool } from "@/lib/types";
 
 (
@@ -16,6 +17,7 @@ const gqlMock = vi.hoisted(() => ({
   error: undefined as Error | undefined,
   isLoading: false,
   onSuccess: undefined as ((response: PoolDetailResponse) => void) | undefined,
+  schema: undefined as unknown,
 }));
 
 vi.mock("@/lib/graphql", () => ({
@@ -23,9 +25,13 @@ vi.mock("@/lib/graphql", () => ({
     _query: string,
     _variables: Record<string, unknown>,
     _refreshInterval: undefined,
-    options: { onSuccess?: (response: PoolDetailResponse) => void },
+    options: {
+      onSuccess?: (response: PoolDetailResponse) => void;
+      schema?: unknown;
+    },
   ) => {
     gqlMock.onSuccess = options.onSuccess;
+    gqlMock.schema = options.schema;
     return {
       data: gqlMock.data,
       error: gqlMock.error,
@@ -78,6 +84,7 @@ beforeEach(() => {
   gqlMock.error = undefined;
   gqlMock.isLoading = false;
   gqlMock.onSuccess = undefined;
+  gqlMock.schema = undefined;
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -91,6 +98,14 @@ afterEach(() => {
 });
 
 describe("useObservedPoolDetail", () => {
+  it("uses the same base-response schema as the SSR prefetch", () => {
+    const pool = makePool("42220-0xpool-a", 42220, 2_000);
+
+    act(() => root.render(<Probe pool={pool} fallback={initialData(pool)} />));
+
+    expect(gqlMock.schema).toBe(PoolDetailWithHealthSchema);
+  });
+
   it("retains the SSR pool and reports degradation after a successful omission", () => {
     const pool = makePool("42220-0xpool-a", 42220, 2_000);
     gqlMock.data = { Pool: [] };

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/use-observed-pool-detail.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/use-observed-pool-detail.ts
@@ -7,6 +7,7 @@ import {
   POOL_DETAIL_WITH_HEALTH,
   type PoolDetailResponse,
 } from "@/lib/queries";
+import { PoolDetailWithHealthSchema } from "@/lib/queries/pool-detail-schemas";
 import type { Pool } from "@/lib/types";
 import { useCallback, useMemo, useRef, useState } from "react";
 
@@ -48,6 +49,7 @@ export function useObservedPoolDetail(
     {
       fallbackData: initialData?.pool,
       onSuccess: recordFreshnessCheck,
+      schema: PoolDetailWithHealthSchema,
       timeoutMs: HASURA_TIMEOUT_MS,
     },
   );

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/use-pool-with-thresholds.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/use-pool-with-thresholds.test.tsx
@@ -16,14 +16,20 @@ type GqlResult = {
 };
 
 const responses = vi.hoisted(() => new Map<string, GqlResult>());
+const useGqlCalls = vi.hoisted(() => [] as unknown[][]);
 
 vi.mock("@/lib/graphql", () => ({
-  useGQL: (query: string): GqlResult =>
-    responses.get(query) ?? {
-      data: undefined,
-      error: undefined,
-      isLoading: false,
-    },
+  useGQL: (...args: unknown[]): GqlResult => {
+    useGqlCalls.push(args);
+    const query = args[0] as string;
+    return (
+      responses.get(query) ?? {
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+      }
+    );
+  },
 }));
 
 import {
@@ -32,6 +38,12 @@ import {
   POOL_VP_LIFECYCLE_DEPRECATION_EXT,
   POOL_VP_ORACLE_FRESHNESS_EXT,
 } from "@/lib/queries";
+import {
+  PoolThresholdsKnownExtSchema,
+  PoolVpDeprecationExtSchema,
+  PoolVpLifecycleDeprecationExtSchema,
+  PoolVpOracleFreshnessExtSchema,
+} from "@/lib/queries/pool-detail-schemas";
 import {
   usePoolWithThresholds,
   type PoolWithThresholdsResult,
@@ -67,6 +79,7 @@ function result(data: unknown): GqlResult {
 
 beforeEach(() => {
   responses.clear();
+  useGqlCalls.length = 0;
   responses.set(
     POOL_THRESHOLDS_KNOWN_EXT,
     result({
@@ -109,6 +122,27 @@ afterEach(() => {
 });
 
 describe("usePoolWithThresholds missing-row retention", () => {
+  it("uses the shared SSR schemas for every split extension query", () => {
+    act(() => root.render(<Probe />));
+
+    const schemaFor = (query: string) =>
+      (
+        useGqlCalls.find(([document]) => document === query)?.[3] as
+          | { schema?: unknown }
+          | undefined
+      )?.schema;
+    expect(schemaFor(POOL_THRESHOLDS_KNOWN_EXT)).toBe(
+      PoolThresholdsKnownExtSchema,
+    );
+    expect(schemaFor(POOL_VP_ORACLE_FRESHNESS_EXT)).toBe(
+      PoolVpOracleFreshnessExtSchema,
+    );
+    expect(schemaFor(POOL_VP_DEPRECATION_EXT)).toBe(PoolVpDeprecationExtSchema);
+    expect(schemaFor(POOL_VP_LIFECYCLE_DEPRECATION_EXT)).toBe(
+      PoolVpLifecycleDeprecationExtSchema,
+    );
+  });
+
   it("retains breaker inputs and degrades when a successful response omits the pool", () => {
     act(() => root.render(<Probe />));
     expect(observed?.pool?.breakerTripped).toBe(true);

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/use-pool-with-thresholds.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/use-pool-with-thresholds.ts
@@ -28,6 +28,12 @@ import {
   type PoolVpOracleFreshnessExtResponse,
   type PoolVpOracleFreshnessExtRow,
 } from "@/lib/queries";
+import {
+  PoolThresholdsKnownExtSchema,
+  PoolVpDeprecationExtSchema,
+  PoolVpLifecycleDeprecationExtSchema,
+  PoolVpOracleFreshnessExtSchema,
+} from "@/lib/queries/pool-detail-schemas";
 import { isVirtualPool, type Pool } from "@/lib/types";
 
 function mergePoolExtensions(
@@ -253,7 +259,11 @@ function useThresholdExtension(args: {
     POOL_THRESHOLDS_KNOWN_EXT,
     { id: args.poolId, chainId: args.chainId },
     undefined,
-    { timeoutMs: 5000, fallbackData: args.initialData?.thresholds },
+    {
+      timeoutMs: 5000,
+      fallbackData: args.initialData?.thresholds,
+      schema: PoolThresholdsKnownExtSchema,
+    },
   );
   const current = firstPoolRow(data);
   const row = usePoolScopedRowFallback(
@@ -296,6 +306,7 @@ function useVpFreshnessExtension(args: {
       timeoutMs: 5000,
       fallbackData: args.initialData?.vpOracleFreshness,
       onSuccess: recordObservation,
+      schema: PoolVpOracleFreshnessExtSchema,
     },
   );
   const rawCurrent = firstPoolRow(data);
@@ -325,7 +336,11 @@ function useVpDeprecationExtensions(args: {
     POOL_VP_DEPRECATION_EXT,
     { id: args.poolId, chainId: args.chainId },
     undefined,
-    { timeoutMs: 5000, fallbackData: args.initialData?.vpDeprecation },
+    {
+      timeoutMs: 5000,
+      fallbackData: args.initialData?.vpDeprecation,
+      schema: PoolVpDeprecationExtSchema,
+    },
   );
   const currentExchange = firstBiPoolExchangeRow(exchange.data);
   const exchangeRow = usePoolScopedRowFallback(
@@ -346,6 +361,7 @@ function useVpDeprecationExtensions(args: {
     {
       timeoutMs: 5000,
       fallbackData: args.initialData?.vpLifecycleDeprecation,
+      schema: PoolVpLifecycleDeprecationExtSchema,
     },
   );
   const currentLifecycle = firstVirtualPoolLifecycleRow(lifecycle.data);

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/oracle-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/oracle-tab.tsx
@@ -32,19 +32,16 @@ import {
   ORACLE_SNAPSHOTS_CHART,
   ORACLE_SNAPSHOTS_COUNT_PAGE,
   POOL_BREAKER_CONFIG,
+  type PoolBreakerConfigResponse,
 } from "@/lib/queries";
+import { PoolBreakerConfigSchema } from "@/lib/queries/pool-detail-schemas";
 import { BREAKER_CONFIG_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import { hasErrorWithoutData, isLoadingWithoutData } from "@/lib/swr-state";
 import { effectiveBreakerThreshold, pickTrippableConfig } from "@/lib/breaker";
 import { normalizeSearch } from "@/lib/table-search";
 import { buildOrderBy } from "@/lib/table-sort";
 import { tokenSymbol } from "@/lib/tokens";
-import {
-  type BreakerConfig,
-  isVirtualPool,
-  type OracleSnapshot,
-  type Pool,
-} from "@/lib/types";
+import { isVirtualPool, type OracleSnapshot, type Pool } from "@/lib/types";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { matchesRowSearch } from "../_lib/helpers";
 import type { OracleSortCol } from "../_lib/types";
@@ -259,12 +256,7 @@ export function OracleTab(props: OracleTabProps) {
     data: breakerData,
     isLoading: isBreakerLoading,
     error: breakerError,
-  } = useGQL<{
-    // POOL_BREAKER_CONFIG also returns BreakerTripEvent[], but this consumer
-    // only reads BreakerConfig — typing the unread selection out keeps the
-    // local shape honest. <BreakerPanel /> consumes the trip events.
-    BreakerConfig: BreakerConfig[];
-  }>(
+  } = useGQL<PoolBreakerConfigResponse>(
     rateFeedID && chainId ? POOL_BREAKER_CONFIG : null,
     rateFeedID && chainId ? { chainId, rateFeedID } : undefined,
     // Bound the shared POOL_BREAKER_CONFIG fetch (arg[2] stays `undefined` →
@@ -272,7 +264,10 @@ export function OracleTab(props: OracleTabProps) {
     // Every subscriber of this SWR key must set it, or SWR could run this
     // consumer's unbounded fetcher and defeat the sibling timeouts.
     undefined,
-    { timeoutMs: BREAKER_CONFIG_TIMEOUT_MS },
+    {
+      timeoutMs: BREAKER_CONFIG_TIMEOUT_MS,
+      schema: PoolBreakerConfigSchema,
+    },
   );
   const breakerConfig = useMemo(() => {
     const configs = breakerData?.BreakerConfig ?? [];

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/lib/queries";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
+import { BrokerExchangeDailySnapshots24hSchema } from "@/lib/queries/pool-detail-schemas";
 
 const redirectMock = vi.fn();
 const useGQLMock = vi.fn();
@@ -1078,7 +1079,10 @@ describe("Pool detail tab search", () => {
         since: Date.UTC(2026, 4, 11) / 1000,
       },
       SNAPSHOT_REFRESH_MS,
-      { timeoutMs: HASURA_TIMEOUT_MS },
+      {
+        timeoutMs: HASURA_TIMEOUT_MS,
+        schema: BrokerExchangeDailySnapshots24hSchema,
+      },
     );
   });
 

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from "react";
 import { useGQL } from "@/lib/graphql";
 import { useNetwork } from "@/components/network-provider";
 import { type PoolBreakerConfigResponse } from "@/lib/queries";
+import { PoolBreakerConfigSchema } from "@/lib/queries/pool-detail-schemas";
 import { BREAKER_CONFIG_TIMEOUT_MS } from "@/lib/hasura-timeout";
-import type { BreakerConfig, BreakerTripEvent, Pool } from "@/lib/types";
+import type { BreakerConfig, Pool } from "@/lib/types";
 import { isVirtualPool } from "@/lib/types";
 import { pickTrippableConfig } from "@/lib/breaker";
 import { Tooltip } from "@/components/tooltip";
@@ -36,11 +37,6 @@ type Props = {
    *  the panel knows on first paint whether the pool has a trip-able breaker —
    *  no skeleton→null collapse for pools that resolve to none (issue #1237). */
   initialBreakerConfig?: PoolBreakerConfigResponse | undefined;
-};
-
-type Response = {
-  BreakerConfig: BreakerConfig[];
-  BreakerTripEvent: BreakerTripEvent[];
 };
 
 function BreakerIdentityMetric({
@@ -370,7 +366,7 @@ export function BreakerPanel({
   const isVirtual = isVirtualPool(pool);
   const rateFeedID = pool.referenceRateFeedID ?? "";
 
-  const { data, isLoading, error } = useGQL<Response>(
+  const { data, isLoading, error } = useGQL<PoolBreakerConfigResponse>(
     breakerConfigQuery(isVirtual, rateFeedID),
     {
       chainId: pool.chainId,
@@ -383,6 +379,7 @@ export function BreakerPanel({
     // subscriber (SWR dedup owns one fetcher).
     {
       fallbackData: initialBreakerConfig,
+      schema: PoolBreakerConfigSchema,
       timeoutMs: BREAKER_CONFIG_TIMEOUT_MS,
     },
   );

--- a/ui-dashboard/src/components/market-hours-pill.tsx
+++ b/ui-dashboard/src/components/market-hours-pill.tsx
@@ -13,6 +13,7 @@ import {
   POOL_BREAKER_CONFIG,
   type PoolBreakerConfigResponse,
 } from "@/lib/queries";
+import { PoolBreakerConfigSchema } from "@/lib/queries/pool-detail-schemas";
 import { BREAKER_CONFIG_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import type { BreakerConfig, Pool } from "@/lib/types";
 import { isVirtualPool } from "@/lib/types";
@@ -61,10 +62,6 @@ type Props = {
    *  the pill knows on first paint whether the pool is FX-gated — no
    *  shimmer→null flash for non-FX pools (issue #1237). */
   initialBreakerConfig?: PoolBreakerConfigResponse | undefined;
-};
-
-type Response = {
-  BreakerConfig: BreakerConfig[];
 };
 
 function findEnabledMarketHoursConfig(
@@ -257,7 +254,7 @@ export function MarketHoursPill({
   const rateFeedID = pool.referenceRateFeedID ?? "";
   const queried = !isVirtual && !!rateFeedID;
 
-  const { data, isLoading, error } = useGQL<Response>(
+  const { data, isLoading, error } = useGQL<PoolBreakerConfigResponse>(
     queried ? POOL_BREAKER_CONFIG : null,
     { chainId: pool.chainId, rateFeedID },
     undefined,
@@ -266,6 +263,7 @@ export function MarketHoursPill({
     // BREAKER_CONFIG_TIMEOUT_MS. Must match every sibling subscriber.
     {
       fallbackData: initialBreakerConfig,
+      schema: PoolBreakerConfigSchema,
       timeoutMs: BREAKER_CONFIG_TIMEOUT_MS,
     },
   );

--- a/ui-dashboard/src/lib/__tests__/pool-detail-ssr.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-detail-ssr.test.ts
@@ -137,6 +137,54 @@ const BREAKER_CONFIG_RESPONSE = {
   BreakerTripEvent: [],
 };
 
+const THRESHOLDS_RESPONSE = {
+  Pool: [
+    {
+      id: VIRTUAL_POOL.id,
+      rebalanceThresholdsKnown: true,
+      tokenDecimalsKnown: true,
+    },
+  ],
+};
+const VP_FRESHNESS_RESPONSE = {
+  Pool: [{ id: VIRTUAL_POOL.id, medianLive: true }],
+};
+const VP_DEPRECATION_RESPONSE = {
+  BiPoolExchange: [{ id: "v2", minimumReports: "1" }],
+};
+const VP_LIFECYCLE_RESPONSE = { VirtualPoolLifecycle: [] };
+const BROKER_24H_RESPONSE = {
+  BrokerExchangeDailySnapshot: [
+    {
+      id: "42220-v2-volume-1778457600",
+      timestamp: "1778457600",
+      volumeUsdWei: "42000000000000000000",
+      swapCount: 3,
+    },
+  ],
+};
+
+function validVirtualResponses(): Record<string, unknown> {
+  return {
+    [POOL_DETAIL_WITH_HEALTH]: { Pool: [VIRTUAL_POOL] },
+    [POOL_THRESHOLDS_KNOWN_EXT]: THRESHOLDS_RESPONSE,
+    [POOL_VP_ORACLE_FRESHNESS_EXT]: VP_FRESHNESS_RESPONSE,
+    [POOL_VP_DEPRECATION_EXT]: VP_DEPRECATION_RESPONSE,
+    [POOL_VP_LIFECYCLE_DEPRECATION_EXT]: VP_LIFECYCLE_RESPONSE,
+    [POOL_V2_EXCHANGE]: V2_EXCHANGE_RESPONSE,
+    [BROKER_EXCHANGE_DAILY_SNAPSHOTS_24H]: BROKER_24H_RESPONSE,
+  };
+}
+
+function respondByDocument(responses: Record<string, unknown>) {
+  return ({ document }: { document: string }) => {
+    if (!(document in responses)) throw new Error("unexpected query");
+    const response = responses[document];
+    if (response instanceof Error) throw response;
+    return response;
+  };
+}
+
 describe("fetchPoolDetailForSSR", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -427,5 +475,125 @@ describe("fetchPoolDetailForSSR", () => {
     ).toBeGreaterThan(0);
     expect(result?.v2Exchange).toEqual(V2_EXCHANGE_RESPONSE);
     expect(result?.brokerExchange24h?.BrokerExchangeDailySnapshot).toEqual([]);
+  });
+
+  it("drops the entire fallback when the primary pool payload is malformed before row access or freshness decoration", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    requestMock.mockResolvedValue({
+      Pool: [{ ...VIRTUAL_POOL, chainId: "42220" }],
+    });
+
+    try {
+      await expect(
+        fetchPoolDetailForSSR(42220, VIRTUAL_POOL.id),
+      ).resolves.toBeUndefined();
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it.each([
+    [POOL_THRESHOLDS_KNOWN_EXT, "thresholds"],
+    [POOL_VP_ORACLE_FRESHNESS_EXT, "vpOracleFreshness"],
+    [POOL_VP_DEPRECATION_EXT, "vpDeprecation"],
+    [POOL_VP_LIFECYCLE_DEPRECATION_EXT, "vpLifecycleDeprecation"],
+  ] as const)(
+    "drops only malformed optional response %s while retaining unrelated fallbacks",
+    async (malformedDocument, droppedKey) => {
+      const responses = validVirtualResponses();
+      responses[malformedDocument] = { unexpected: "wrong-shape" };
+      requestMock.mockImplementation(respondByDocument(responses));
+
+      const result = await fetchPoolDetailForSSR(42220, VIRTUAL_POOL.id);
+
+      expect(result?.pool.Pool[0]).toMatchObject(VIRTUAL_POOL);
+      expect(result?.[droppedKey]).toBeUndefined();
+      const independentKeys = [
+        "thresholds",
+        "vpOracleFreshness",
+        "vpDeprecation",
+        "vpLifecycleDeprecation",
+      ] as const;
+      for (const key of independentKeys) {
+        if (key !== droppedKey) expect(result?.[key]).toBeDefined();
+      }
+      expect(result?.v2Exchange).toEqual(V2_EXCHANGE_RESPONSE);
+      expect(result?.brokerExchange24h).toEqual(BROKER_24H_RESPONSE);
+      if (droppedKey === "vpOracleFreshness") {
+        expect(result?.vpOracleFreshness).toBeUndefined();
+      } else {
+        expect(
+          result?.vpOracleFreshness?.Pool[0]?.vpOracleFreshnessCheckedAt,
+        ).toBeGreaterThan(0);
+      }
+    },
+  );
+
+  it("drops a malformed v2 exchange and its unaddressable dependent volume request without losing independent pool extensions", async () => {
+    const responses = validVirtualResponses();
+    responses[POOL_V2_EXCHANGE] = { BiPoolExchange: [{ id: 123 }] };
+    requestMock.mockImplementation(respondByDocument(responses));
+
+    const result = await fetchPoolDetailForSSR(42220, VIRTUAL_POOL.id);
+
+    expect(result?.pool.Pool[0]).toMatchObject(VIRTUAL_POOL);
+    expect(result?.thresholds).toEqual(THRESHOLDS_RESPONSE);
+    expect(result?.vpOracleFreshness?.Pool[0]?.medianLive).toBe(true);
+    expect(result?.vpDeprecation).toEqual(VP_DEPRECATION_RESPONSE);
+    expect(result?.vpLifecycleDeprecation).toEqual(VP_LIFECYCLE_RESPONSE);
+    expect(result?.v2Exchange).toBeUndefined();
+    expect(result?.brokerExchange24h).toBeUndefined();
+    expect(
+      requestMock.mock.calls.some(
+        ([request]) =>
+          (request as { document: string }).document ===
+          BROKER_EXCHANGE_DAILY_SNAPSHOTS_24H,
+      ),
+    ).toBe(false);
+  });
+
+  it("drops only a malformed broker 24h payload while retaining the valid v2 exchange and pool extensions", async () => {
+    const responses = validVirtualResponses();
+    responses[BROKER_EXCHANGE_DAILY_SNAPSHOTS_24H] = {
+      BrokerExchangeDailySnapshot: [{ swapCount: "3" }],
+    };
+    requestMock.mockImplementation(respondByDocument(responses));
+
+    const result = await fetchPoolDetailForSSR(42220, VIRTUAL_POOL.id);
+
+    expect(result?.pool.Pool[0]).toMatchObject(VIRTUAL_POOL);
+    expect(result?.thresholds).toEqual(THRESHOLDS_RESPONSE);
+    expect(result?.v2Exchange).toEqual(V2_EXCHANGE_RESPONSE);
+    expect(result?.brokerExchange24h).toBeUndefined();
+  });
+
+  it("drops only a malformed breaker-config payload for an FPMM pool", async () => {
+    const responses: Record<string, unknown> = {
+      [POOL_DETAIL_WITH_HEALTH]: { Pool: [FPMM_POOL] },
+      [POOL_THRESHOLDS_KNOWN_EXT]: {
+        Pool: [{ id: FPMM_POOL.id, tokenDecimalsKnown: true }],
+      },
+      [POOL_VP_ORACLE_FRESHNESS_EXT]: {
+        Pool: [{ id: FPMM_POOL.id, medianLive: true }],
+      },
+      [POOL_VP_DEPRECATION_EXT]: { BiPoolExchange: [] },
+      [POOL_VP_LIFECYCLE_DEPRECATION_EXT]: { VirtualPoolLifecycle: [] },
+      [POOL_BREAKER_CONFIG]: {
+        BreakerConfig: [{ status: "NOT_A_STATUS" }],
+        BreakerTripEvent: [],
+      },
+    };
+    requestMock.mockImplementation(respondByDocument(responses));
+
+    const result = await fetchPoolDetailForSSR(42220, FPMM_POOL.id);
+
+    expect(result?.pool.Pool[0]).toMatchObject(FPMM_POOL);
+    expect(result?.thresholds?.Pool[0]?.tokenDecimalsKnown).toBe(true);
+    expect(result?.vpOracleFreshness?.Pool[0]?.medianLive).toBe(true);
+    expect(result?.breakerConfig).toBeUndefined();
   });
 });

--- a/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume-ssr.test.ts
@@ -85,6 +85,27 @@ const FIRSTDAY_ROWS = {
     },
   ],
 };
+const BROKER_WINDOW_ROWS = {
+  brokerVolumeWindowSnapshots: WINDOW_ROWS.volumeWindowSnapshots,
+};
+const BROKER_TODAY_ROWS = {
+  brokerVolumeTodayTraders: TODAY_ROWS.volumeTodayTraders,
+};
+const BROKER_FIRSTDAY_ROWS = {
+  brokerVolumeWindowFirstDaySnapshots:
+    FIRSTDAY_ROWS.volumeWindowFirstDaySnapshots,
+};
+
+function validHeroResponses(): Record<string, unknown> {
+  return {
+    [VOLUME_WINDOW_LATEST]: WINDOW_ROWS,
+    [VOLUME_TODAY_TRADERS]: TODAY_ROWS,
+    [VOLUME_WINDOW_FIRSTDAY_LATEST]: FIRSTDAY_ROWS,
+    [BROKER_VOLUME_WINDOW_LATEST]: BROKER_WINDOW_ROWS,
+    [BROKER_VOLUME_TODAY_TRADERS]: BROKER_TODAY_ROWS,
+    [BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST]: BROKER_FIRSTDAY_ROWS,
+  };
+}
 
 function respondByDocument(
   responses: Record<string, unknown>,
@@ -167,14 +188,11 @@ describe("fetchVolumeHeroForSSR", () => {
   });
 
   it("prefetches the broker variants with [false, true] actors for the v2 all-actors view", async () => {
-    const brokerWindow = { brokerVolumeWindowSnapshots: [] };
-    const brokerToday = { brokerVolumeTodayTraders: [] };
-    const brokerFirstDay = { brokerVolumeWindowFirstDaySnapshots: [] };
     requestMock.mockImplementation(
       respondByDocument({
-        [BROKER_VOLUME_WINDOW_LATEST]: brokerWindow,
-        [BROKER_VOLUME_TODAY_TRADERS]: brokerToday,
-        [BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST]: brokerFirstDay,
+        [BROKER_VOLUME_WINDOW_LATEST]: BROKER_WINDOW_ROWS,
+        [BROKER_VOLUME_TODAY_TRADERS]: BROKER_TODAY_ROWS,
+        [BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST]: BROKER_FIRSTDAY_ROWS,
       }),
     );
 
@@ -192,9 +210,9 @@ describe("fetchVolumeHeroForSSR", () => {
       includeProtocolActors: true,
       todayMidnight: TODAY_MIDNIGHT,
     });
-    expect(result?.heroV2).toEqual(brokerWindow);
-    expect(result?.todayV2).toEqual(brokerToday);
-    expect(result?.firstDayV2).toEqual(brokerFirstDay);
+    expect(result?.heroV2).toEqual(BROKER_WINDOW_ROWS);
+    expect(result?.todayV2).toEqual(BROKER_TODAY_ROWS);
+    expect(result?.firstDayV2).toEqual(BROKER_FIRSTDAY_ROWS);
     expect(result?.heroV3).toBeUndefined();
     const todayCall = requestMock.mock.calls.find(
       ([request]) =>
@@ -257,6 +275,61 @@ describe("fetchVolumeHeroForSSR", () => {
     expect(result?.todayV3).toEqual(TODAY_ROWS);
     expect(result?.firstDayV3).toBeUndefined();
   });
+
+  it.each([
+    ["v3 window", "v3", VOLUME_WINDOW_LATEST],
+    ["v3 today", "v3", VOLUME_TODAY_TRADERS],
+    ["v2 window", "v2", BROKER_VOLUME_WINDOW_LATEST],
+    ["v2 today", "v2", BROKER_VOLUME_TODAY_TRADERS],
+  ] as const)(
+    "drops the all-or-nothing primary pair when the %s payload is malformed",
+    async (_name, venue, malformedDocument) => {
+      const responses = validHeroResponses();
+      responses[malformedDocument] = { payload: "must-not-cross-or-log" };
+      requestMock.mockImplementation(respondByDocument(responses));
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      try {
+        await expect(
+          fetchVolumeHeroForSSR(venue, "7d", false, TODAY_MIDNIGHT),
+        ).resolves.toBeUndefined();
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    ["v3", VOLUME_WINDOW_FIRSTDAY_LATEST],
+    ["v2", BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST],
+  ] as const)(
+    "drops only the malformed %s firstDay extension and keeps valid primaries",
+    async (venue, malformedDocument) => {
+      const responses = validHeroResponses();
+      responses[malformedDocument] = { payload: "wrong-shape" };
+      requestMock.mockImplementation(respondByDocument(responses));
+
+      const result = await fetchVolumeHeroForSSR(
+        venue,
+        "7d",
+        false,
+        TODAY_MIDNIGHT,
+      );
+
+      if (venue === "v3") {
+        expect(result?.heroV3).toEqual(WINDOW_ROWS);
+        expect(result?.todayV3).toEqual(TODAY_ROWS);
+        expect(result?.firstDayV3).toBeUndefined();
+      } else {
+        expect(result?.heroV2).toEqual(BROKER_WINDOW_ROWS);
+        expect(result?.todayV2).toEqual(BROKER_TODAY_ROWS);
+        expect(result?.firstDayV2).toBeUndefined();
+      }
+    },
+  );
 
   it("returns undefined when the default network has no Hasura URL", async () => {
     networksState.hasuraUrl = "";

--- a/ui-dashboard/src/lib/pool-detail-ssr.ts
+++ b/ui-dashboard/src/lib/pool-detail-ssr.ts
@@ -4,6 +4,7 @@
 // — that guard throws under the (non-RSC) vitest environment that transitively
 // imports this via page.tsx, exactly as pool-og.ts avoids it.
 import { unstable_cache } from "next/cache";
+import type { ZodType } from "zod";
 import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import type { PoolDetailInitialData } from "@/lib/pool-detail-initial-data";
@@ -30,6 +31,16 @@ import {
   type PoolVpOracleFreshnessExtResponse,
 } from "@/lib/queries/pool-detail";
 import {
+  BrokerExchangeDailySnapshots24hSchema,
+  PoolBreakerConfigSchema,
+  PoolDetailWithHealthSchema,
+  PoolThresholdsKnownExtSchema,
+  PoolV2ExchangeSchema,
+  PoolVpDeprecationExtSchema,
+  PoolVpLifecycleDeprecationExtSchema,
+  PoolVpOracleFreshnessExtSchema,
+} from "@/lib/queries/pool-detail-schemas";
+import {
   NETWORKS,
   NETWORK_IDS,
   configuredNetworkIdForChainId,
@@ -46,7 +57,8 @@ import { isVirtualPool, type Pool } from "@/lib/types";
 // extension-backed tiles paint immediately, eliminating that shift.
 //
 // Distinct from lib/pool-og.ts: that fetch merges extensions and returns a
-// transformed PoolOgData shape for OG images; this returns the raw responses.
+// transformed PoolOgData shape for OG images; this returns the shared
+// schema-parsed response shapes used by the client hooks.
 function currentUtcDayStartSeconds(nowMs = Date.now()): number {
   return Math.floor(nowMs / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
 }
@@ -58,13 +70,16 @@ async function requestOptional<T>(
   document: string,
   variables: Record<string, unknown>,
   signal: AbortSignal,
+  schema: ZodType<T>,
 ): Promise<T | undefined> {
   try {
-    return await client.request<T>({
+    const raw = await client.request<unknown>({
       document,
       variables,
       signal,
     });
+    const result = schema.safeParse(raw);
+    return result.success ? result.data : undefined;
   } catch {
     return undefined;
   }
@@ -82,6 +97,7 @@ async function fetchVirtualPoolHeaderInitialData(
     POOL_V2_EXCHANGE,
     { poolId: pool.id, chainId },
     signal,
+    PoolV2ExchangeSchema,
   );
   const v2Config = v2Exchange?.BiPoolExchange?.[0];
   const exchangeId = (pool.wrappedExchangeId ?? v2Config?.exchangeId ?? "")
@@ -102,6 +118,7 @@ async function fetchVirtualPoolHeaderInitialData(
         since: currentUtcDayStartSeconds(),
       },
       signal,
+      BrokerExchangeDailySnapshots24hSchema,
     );
   return { v2Exchange, brokerExchange24h };
 }
@@ -127,6 +144,7 @@ async function fetchPoolBreakerConfig(
     POOL_BREAKER_CONFIG,
     { chainId, rateFeedID },
     signal,
+    PoolBreakerConfigSchema,
   );
 }
 
@@ -148,6 +166,7 @@ async function fetchPoolDetailUncached(
     POOL_DETAIL_WITH_HEALTH,
     { id, chainId },
     signal,
+    PoolDetailWithHealthSchema,
   );
   const oracleFreshnessCheckedAt = Date.now() / 1000;
   const pool = rawPool
@@ -179,12 +198,14 @@ async function fetchPoolDetailUncached(
       POOL_THRESHOLDS_KNOWN_EXT,
       { id, chainId },
       signal,
+      PoolThresholdsKnownExtSchema,
     ),
     requestOptional<PoolVpOracleFreshnessExtResponse>(
       client,
       POOL_VP_ORACLE_FRESHNESS_EXT,
       { id, chainId },
       signal,
+      PoolVpOracleFreshnessExtSchema,
     ).then((response) => {
       if (!response) return undefined;
       const vpOracleFreshnessCheckedAt = Date.now() / 1000;
@@ -201,12 +222,14 @@ async function fetchPoolDetailUncached(
       POOL_VP_DEPRECATION_EXT,
       { id, chainId },
       signal,
+      PoolVpDeprecationExtSchema,
     ),
     requestOptional<PoolVpLifecycleDeprecationExtResponse>(
       client,
       POOL_VP_LIFECYCLE_DEPRECATION_EXT,
       { id, chainId },
       signal,
+      PoolVpLifecycleDeprecationExtSchema,
     ),
     fetchVirtualPoolHeaderInitialData(client, chainId, poolRow, signal),
     fetchPoolBreakerConfig(client, chainId, poolRow, signal),
@@ -256,8 +279,8 @@ const CACHE_KEY_PARTS = [
 
 // 60s revalidate matches the OG cache and the client polling cadence: the fallback
 // paints instantly, then the client's useGQL revalidates on mount for fresh data.
-// The raw response is plain JSON (no Map/Set), so unstable_cache serialization is
-// lossless here.
+// The parsed response is plain JSON (no Map/Set), so unstable_cache
+// serialization is lossless here.
 const fetchPoolDetailCached = unstable_cache(
   fetchPoolDetailUncached,
   CACHE_KEY_PARTS,

--- a/ui-dashboard/src/lib/queries/pool-detail-schemas.ts
+++ b/ui-dashboard/src/lib/queries/pool-detail-schemas.ts
@@ -1,17 +1,16 @@
 /**
- * Zod response schemas for high-risk pool-detail queries.
+ * Zod response schemas for pool-detail queries.
  *
- * These are the three most drift-prone query shapes (they're explicitly
- * isolated because Hasura rejects new fields during deploy+resync windows).
- * When passed to useGQL's `schema` option, a parse failure surfaces as a
- * typed `GraphQLSchemaError` via SWR's error path instead of silently
- * rendering `undefined`.
+ * The SSR prefetch and matching client `useGQL` subscriber pass the same
+ * schema object for every prefetched selection. Server parse failures degrade
+ * to an absent fallback; client parse failures surface as a typed
+ * `GraphQLSchemaError` through SWR's error path.
  *
  * Rules for these schemas:
  * - All Hasura scalar fields are strings (even numeric ones) unless
  *   explicitly typed otherwise (e.g. `id: z.string()`).
  * - Fields that the indexer may not have written yet are `.optional()`.
- * - The outer shape is always `{ Pool: z.array(...) }` for entity queries.
+ * - The outer object keys mirror the query's selected/aliased entity names.
  * - Keep in sync with the corresponding query and TypeScript type in types.ts.
  */
 
@@ -130,4 +129,167 @@ const PoolDetailRowSchema = z.object({
 
 export const PoolDetailWithHealthSchema = z.object({
   Pool: z.array(PoolDetailRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_THRESHOLDS_KNOWN_EXT
+// ---------------------------------------------------------------------------
+
+const PoolThresholdsKnownExtRowSchema = z.object({
+  id: z.string(),
+  rebalanceThresholdAbove: z.number().optional(),
+  rebalanceThresholdBelow: z.number().optional(),
+  rebalanceThresholdsKnown: z.boolean().optional(),
+  tokenDecimalsKnown: z.boolean().optional(),
+  degenerateReserves: z.boolean().optional(),
+  breakerTripped: z.boolean().optional(),
+});
+
+export const PoolThresholdsKnownExtSchema = z.object({
+  Pool: z.array(PoolThresholdsKnownExtRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_VP_ORACLE_FRESHNESS_EXT
+// ---------------------------------------------------------------------------
+
+const PoolVpOracleFreshnessExtRowSchema = z.object({
+  id: z.string(),
+  oracleTimestamp: z.string().optional(),
+  oracleNumReporters: z.number().optional(),
+  tokenDecimalsKnown: z.boolean().optional(),
+  lastOracleReportAt: z.string().optional(),
+  medianLive: z.boolean().optional(),
+  oracleFreshnessWindow: z.string().optional(),
+});
+
+export const PoolVpOracleFreshnessExtSchema = z.object({
+  Pool: z.array(PoolVpOracleFreshnessExtRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_VP_DEPRECATION_EXT
+// ---------------------------------------------------------------------------
+
+const PoolVpDeprecationExtRowSchema = z.object({
+  id: z.string(),
+  isDeprecated: z.boolean().optional(),
+  minimumReports: z.string().optional(),
+});
+
+export const PoolVpDeprecationExtSchema = z.object({
+  BiPoolExchange: z.array(PoolVpDeprecationExtRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_VP_LIFECYCLE_DEPRECATION_EXT
+// ---------------------------------------------------------------------------
+
+const PoolVpLifecycleDeprecationExtRowSchema = z.object({
+  id: z.string(),
+  poolId: z.string().optional(),
+});
+
+export const PoolVpLifecycleDeprecationExtSchema = z.object({
+  VirtualPoolLifecycle: z.array(PoolVpLifecycleDeprecationExtRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_V2_EXCHANGE
+// ---------------------------------------------------------------------------
+
+const PoolV2ExchangeRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  exchangeId: z.string(),
+  exchangeProvider: z.string(),
+  asset0: z.string(),
+  asset1: z.string(),
+  pricingModule: z.string(),
+  pricingModuleName: z.string().nullable(),
+  spread: z.string(),
+  referenceRateFeedID: z.string(),
+  referenceRateResetFrequency: z.string(),
+  minimumReports: z.string(),
+  stablePoolResetSize: z.string(),
+  bucket0: z.string(),
+  bucket1: z.string(),
+  lastBucketUpdate: z.string(),
+  isDeprecated: z.boolean(),
+  wrappedByPoolId: z.string().nullable(),
+});
+
+export const PoolV2ExchangeSchema = z.object({
+  BiPoolExchange: z.array(PoolV2ExchangeRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// BROKER_EXCHANGE_DAILY_SNAPSHOTS_24H
+// ---------------------------------------------------------------------------
+
+const BrokerExchangeDailySnapshot24hRowSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  volumeUsdWei: z.string(),
+  swapCount: z.number(),
+});
+
+export const BrokerExchangeDailySnapshots24hSchema = z.object({
+  BrokerExchangeDailySnapshot: z.array(BrokerExchangeDailySnapshot24hRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_BREAKER_CONFIG
+// ---------------------------------------------------------------------------
+
+const BreakerKindSchema = z.enum([
+  "MEDIAN_DELTA",
+  "VALUE_DELTA",
+  "MARKET_HOURS",
+]);
+
+const BreakerConfigRowSchema = z.object({
+  id: z.string(),
+  enabled: z.boolean(),
+  cooldownTime: z.string(),
+  rateChangeThreshold: z.string(),
+  smoothingFactor: z.string().nullable(),
+  medianRatesEMA: z.string().nullable(),
+  referenceValue: z.string().nullable(),
+  lastMedianRate: z.string().nullable(),
+  lastUpdatedAt: z.string().nullable(),
+  status: z.enum(["OK", "TRIPPED"]),
+  tradingMode: z.number(),
+  lastStatusUpdatedAt: z.string(),
+  cooldownEndsAt: z.string(),
+  lastTripAt: z.string().nullable(),
+  lastTripTxHash: z.string().nullable(),
+  lastResetAt: z.string().nullable(),
+  tripCountLifetime: z.number(),
+  breaker: z.object({
+    id: z.string(),
+    address: z.string(),
+    kind: BreakerKindSchema,
+    activatesTradingMode: z.number(),
+    defaultCooldownTime: z.string(),
+    defaultRateChangeThreshold: z.string(),
+  }),
+});
+
+const BreakerTripEventRowSchema = z.object({
+  id: z.string(),
+  blockTimestamp: z.string(),
+  txHash: z.string(),
+  medianRateAtTrip: z.string(),
+  referenceAtTrip: z.string().nullable(),
+  thresholdAtTrip: z.string(),
+  breaker: z.object({
+    address: z.string(),
+    kind: BreakerKindSchema,
+  }),
+});
+
+export const PoolBreakerConfigSchema = z.object({
+  BreakerConfig: z.array(BreakerConfigRowSchema),
+  BreakerTripEvent: z.array(BreakerTripEventRowSchema),
 });

--- a/ui-dashboard/src/lib/volume-hero-initial-data.ts
+++ b/ui-dashboard/src/lib/volume-hero-initial-data.ts
@@ -12,7 +12,7 @@ import type {
 } from "@/lib/volume";
 import type { Venue } from "@/lib/volume-url-params";
 
-// Raw response shapes for the unconditional hero queries (see
+// Schema-validated response shapes for the unconditional hero queries (see
 // lib/queries/volume.ts). Kept structurally identical to the inline types in
 // `use-hero-rollup.ts` so the prefetched payload plugs straight into each
 // `useGQL` call's `fallbackData`.
@@ -52,7 +52,8 @@ export type VolumeHeroView = {
 };
 
 /**
- * Server-prefetched raw responses for the /volume hero first paint, as a
+ * Schema-validated server-prefetched responses for the /volume hero first
+ * paint, as a
  * per-venue discriminated union: the primary pair (window + today) is
  * REQUIRED for the active venue (the fetch returns `undefined` overall when
  * either fails — the compiler now enforces that invariant), the firstDay

--- a/ui-dashboard/src/lib/volume-hero-initial-data.ts
+++ b/ui-dashboard/src/lib/volume-hero-initial-data.ts
@@ -53,10 +53,10 @@ export type VolumeHeroView = {
 
 /**
  * Schema-validated server-prefetched responses for the /volume hero first
- * paint, as a
- * per-venue discriminated union: the primary pair (window + today) is
- * REQUIRED for the active venue (the fetch returns `undefined` overall when
- * either fails — the compiler now enforces that invariant), the firstDay
+ * paint, modeled as a per-venue discriminated union. The primary pair
+ * (window + today) is REQUIRED for the active venue; the fetch returns
+ * `undefined` overall when either fails, and the compiler enforces that
+ * invariant. The firstDay
  * catch-up slice stays optional (schema-lag resilient, same as pool-detail's
  * extension queries), and the other venue's fields are typed `undefined` so
  * a v3 payload can never silently carry v2 data (or vice versa) while

--- a/ui-dashboard/src/lib/volume-ssr.ts
+++ b/ui-dashboard/src/lib/volume-ssr.ts
@@ -5,6 +5,7 @@
 // that transitively imports this via page.tsx, exactly as pool-detail-ssr.ts
 // avoids it.
 import { unstable_cache } from "next/cache";
+import type { ZodType } from "zod";
 import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 import { DEFAULT_NETWORK, NETWORKS } from "@/lib/networks";
@@ -16,6 +17,14 @@ import {
   VOLUME_WINDOW_FIRSTDAY_LATEST,
   VOLUME_WINDOW_LATEST,
 } from "@/lib/queries/volume";
+import {
+  BrokerVolumeTodayTradersSchema,
+  BrokerVolumeWindowFirstDayLatestSchema,
+  BrokerVolumeWindowLatestSchema,
+  VolumeTodayTradersSchema,
+  VolumeWindowFirstDayLatestSchema,
+  VolumeWindowLatestSchema,
+} from "@/lib/queries/volume-schemas";
 import type { VolumeRangeKey } from "@/lib/volume";
 import {
   protocolActorInForView,
@@ -36,8 +45,8 @@ const FIRST_DAY_TIMEOUT_MS = 2_000;
 // pool-detail pattern). `/volume` is otherwise a pure client waterfall: the
 // hero headline, KPI tiles, and data-quality banners all wait for
 // HTML → JS → hydrate → client GraphQL. Fetching the same query variables
-// server-side and handing the raw responses to `useHeroRollup` as per-query
-// fallbackData lets the first render paint populated numbers.
+// server-side and handing the schema-validated responses to `useHeroRollup` as
+// per-query fallbackData lets the first render paint populated numbers.
 //
 // Only the UNCONDITIONAL first-render queries are prefetched (window snapshot,
 // today partial, firstDay slice). The conditional second-wave queries
@@ -51,13 +60,16 @@ async function requestOptional<T>(
   document: string,
   variables: Record<string, unknown>,
   signal: AbortSignal,
+  schema: ZodType<T>,
 ): Promise<T | undefined> {
   try {
-    return await client.request<T>({
+    const raw = await client.request<unknown>({
       document,
       variables,
       signal,
     });
+    const result = schema.safeParse(raw);
+    return result.success ? result.data : undefined;
   } catch {
     return undefined;
   }
@@ -107,18 +119,21 @@ async function fetchVolumeHeroUncached(
         BROKER_VOLUME_WINDOW_LATEST,
         windowVariables,
         signal,
+        BrokerVolumeWindowLatestSchema,
       ),
       requestOptional<BrokerVolumeTodayTradersResponse>(
         client,
         BROKER_VOLUME_TODAY_TRADERS,
         todayVariables,
         signal,
+        BrokerVolumeTodayTradersSchema,
       ),
       requestOptional<BrokerVolumeWindowFirstDayLatestResponse>(
         client,
         BROKER_VOLUME_WINDOW_FIRSTDAY_LATEST,
         windowVariables,
         firstDaySignal,
+        BrokerVolumeWindowFirstDayLatestSchema,
       ),
     ]);
     // The hero tiles gate their loading state on the PRIMARY pair (window +
@@ -138,18 +153,21 @@ async function fetchVolumeHeroUncached(
       VOLUME_WINDOW_LATEST,
       windowVariables,
       signal,
+      VolumeWindowLatestSchema,
     ),
     requestOptional<VolumeTodayTradersResponse>(
       client,
       VOLUME_TODAY_TRADERS,
       todayVariables,
       signal,
+      VolumeTodayTradersSchema,
     ),
     requestOptional<VolumeWindowFirstDayLatestResponse>(
       client,
       VOLUME_WINDOW_FIRSTDAY_LATEST,
       windowVariables,
       firstDaySignal,
+      VolumeWindowFirstDayLatestSchema,
     ),
   ]);
   // Same primary-pair rule as the v2 branch above.
@@ -158,7 +176,7 @@ async function fetchVolumeHeroUncached(
 
 // 60s revalidate matches pool-detail-ssr and the client polling cadence: the
 // fallback paints instantly, then the client's useGQL revalidates on mount.
-// The raw responses are plain JSON (no Map/Set/BigInt — Hasura numerics are
+// The parsed responses are plain JSON (no Map/Set/BigInt — Hasura numerics are
 // strings), so unstable_cache serialization is lossless here.
 //
 // The key is salted with the deployment id (unique per deployment, including


### PR DESCRIPTION
## The Problem

- Volume and pool-detail SSR fallbacks trusted unvalidated GraphQL responses even though matching client subscriptions already used runtime schemas.
- A malformed optional response could cross the server/client boundary or make an entire fallback fail instead of degrading only that extension.

## The Solution

- Validate every prefetched volume and pool-detail response with the exact shared Zod schema used by its client useGQL subscriber.
- Drop malformed optional extensions independently and return no overall fallback when a required base response is malformed, preserving the existing fail-open client revalidation path.

## Verification

- pnpm agent:quality-gate --run
- CI=true pnpm agent:autoreview
- Focused SSR/schema tests: 137 tests
- Full dashboard coverage: 3,825 tests
- React Doctor score 100
- Independent semantic review: no actionable findings
- Direct Chrome: /volume completed without its loading boundary and without console errors.
- Direct Chrome: canonical Celo pool rendered its validated header, oracle, reserve, TVL, and volume data with no loading boundary or console errors.

## Stateful data/UI checklist

- Invariant: a server fallback and its matching client subscriber accept the same response shape through the same schema object.
- Degraded behavior: malformed optional extensions disappear independently; malformed required base data yields undefined so the existing client fetch remains authoritative.
- Non-goals: change queries, polling cadence, cache keys, timeouts, or user-facing error policy.

Closes #1215

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-paint SSR fallbacks for pool detail and volume hero data; wrong schema strictness could strip valid fallbacks, but behavior intentionally fails open to client revalidation without changing queries or cache keys.
> 
> **Overview**
> **Pool-detail and volume SSR prefetches now run every GraphQL response through the same Zod schemas their matching `useGQL` subscribers use**, so server and client agree on shape instead of trusting raw Hasura JSON.
> 
> `pool-detail-ssr.ts` and `volume-ssr.ts` **`safeParse` each optional fetch**: a bad **required** base payload drops the whole fallback (`undefined`); a bad **optional** extension is omitted on its own (e.g. malformed thresholds but valid v2 exchange). Malformed v2 exchange also skips the dependent 24h volume request.
> 
> **New schemas** in `pool-detail-schemas.ts` cover thresholds, VP extensions, v2 exchange, broker 24h snapshots, and breaker config; volume SSR uses existing `volume-schemas`. **Client hooks and header/breaker/oracle components** pass those schema objects into `useGQL` alongside existing `fallbackData` and timeouts. **Tests** assert schema wiring and SSR degradation for wrong-shaped responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb796d114f4ffcd3d7fdf381f2ed2f6b2caeb60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->