### PR TITLE
fix(alerts): codify Slack workspace label

### DIFF
--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -24,6 +24,9 @@ resource "google_monitoring_notification_channel" "alerts_infra_slack" {
 
   labels = {
     channel_name = local.alerts_infra_slack_channel_name
+    # GCP populates the Slack workspace label after channel creation. Model
+    # that stable provider value so refresh-only plans do not remove it.
+    team = "Mento Labs"
   }
 
   sensitive_labels {


### PR DESCRIPTION
## The Problem

- The Alerts Delivery Terraform stack reports the same daily drift on its managed Slack notification channel.
- GCP adds the Slack workspace `team` label after channel creation, while the configuration currently models only the channel name and therefore plans to remove the live label.

## The Solution

- Declare the stable `team = "Mento Labs"` provider value alongside `channel_name` so refresh-only plans converge without mutating the working notification channel.
- Document why the otherwise-surprising label belongs in configuration.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm tf validate alerts-delivery`
- `pnpm agent:review-materiality`
- `pnpm agent:autoreview`
- `git diff --check`

## Operational verification

The live channel already contains this value, so the authoritative full plan on `main` should report no Alerts Delivery changes and skip apply. Keep #1227 open until that main-branch plan (or the next scheduled drift run) confirms a clean stack; production approval is required only if an unexpected non-zero apply appears.

Refs #1227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only label alignment on an existing channel; live value already matches and plans should show no apply.
> 
> **Overview**
> Stops recurring **Terraform drift** on the alerts-infra **Slack notification channel** by modeling the workspace label GCP sets after create.
> 
> The `google_monitoring_notification_channel.alerts_infra_slack` `labels` block now includes **`team = "Mento Labs"`** next to `channel_name`, with a short comment that this matches the provider-populated value so refresh-only plans no longer try to strip it. No runtime alert routing or channel behavior changes—configuration only aligns with live GCP state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78544840cac010b1b4a3c701bd4ba65835481e58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->