### PR TITLE
feat(terraform): model Sentry-triage secrets + kill switch in platform stack

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1,0 +1,63 @@
+---
+title: Sentry Triage/Autofix Pipeline
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-15
+scope: ci/process
+---
+
+# Sentry Triage/Autofix Pipeline
+
+Operational reference for the staged Sentry triage/autofix pipeline defined in
+[`docs/adr/0036-sentry-triage-pipeline.md`](../adr/0036-sentry-triage-pipeline.md).
+The queue and verdict contracts are added by the sibling Phase-1 PRs; this
+section covers the human token-provisioning and activation runbook.
+
+## Operator runbook (Phase-1 activation)
+
+Phase 1 provisions two read-limited credentials and one kill-switch variable
+entirely through the platform Terraform stack (`terraform/`, ADR 0030
+IaC-before-CLI): `github_actions_secret.sentry_triage_token`,
+`github_actions_secret.claude_code_oauth_token`, and
+`github_actions_variable.sentry_triage_enabled`. The two secret mirrors are
+`count`-gated on their tfvar being non-empty, so the Terraform code can merge
+and apply before the tokens exist. The pipeline stays inert until both tokens
+are set **and** `SENTRY_TRIAGE_ENABLED` is `"true"`.
+
+All token values live only in the platform stack's gitignored, operator-held
+`terraform/terraform.tfvars` (the same file that supplies `lifi_api_key` and the
+other `count`-gated platform secrets) — never committed, never set through
+`gh secret set` or the GitHub UI.
+
+1. **Mint the read-only Sentry token.** In Sentry (org `mento-labs`), create an
+   internal integration named `sentry-triage-reader` with READ-ONLY scopes:
+   _Issue & Event: Read_, _Project: Read_, _Organization: Read_. Add no write
+   scopes — Phase 2 mints a separate write-scoped token only if and when
+   auto-archive is approved (ADR 0036 trust boundary). Copy the generated token.
+2. **Mint the Claude OAuth token.** Locally, on the Max plan, run
+   `claude setup-token`. It mints a one-year, inference-only OAuth token used by
+   `anthropics/claude-code-action@v1`.
+3. **Set both values in the platform tfvars.** In your local, gitignored
+   `terraform/terraform.tfvars`, set `sentry_triage_token` and
+   `claude_code_oauth_token` (see `terraform/terraform.tfvars.example` for the
+   keys and placeholder comments). This is the exact same value source the
+   `count`-gated integration-probe secrets already use.
+4. **Plan and apply the platform stack (human-approved local apply).** Run
+   `pnpm infra:plan` and confirm the two new `github_actions_secret` resources
+   appear (they are absent while the tfvars are empty). After human sign-off,
+   run `pnpm tf apply platform` from a clean `main` checkout. The platform stack
+   is manual-plan / manual-apply (`terraform.stacks.json` →
+   `apply: "manual"`, `applyPolicy: "human-review-required"`); it is **not** a
+   CI `production-infra` apply like the alerts/aegis/governance-watchdog stacks.
+   The apply mirrors the two values into the repo Actions secrets
+   `SENTRY_TRIAGE_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`. `SENTRY_TRIAGE_ENABLED`
+   is provisioned by the same apply in its default `"false"` (off) position.
+5. **Flip the kill switch to activate.** Once both Phase-1 workflow PRs
+   (`sentry-triage-ingest`, `sentry-triage-agent`) are merged and the two tokens
+   are applied, set `sentry_triage_enabled = "true"` in `terraform.tfvars` and
+   re-apply the platform stack (still IaC, not the GitHub UI). The scheduled
+   workflows activate on their next run.
+
+To pause the pipeline at any time, set `sentry_triage_enabled = "false"` and
+re-apply; the secrets can stay in place.

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -35,17 +35,31 @@ other `count`-gated platform secrets) — never committed, never set through
    _Issue & Event: Read_, _Project: Read_, _Organization: Read_. Add no write
    scopes — Phase 2 mints a separate write-scoped token only if and when
    auto-archive is approved (ADR 0036 trust boundary). Copy the generated token.
-2. **Mint the Claude OAuth token.** Locally, on the Max plan, run
-   `claude setup-token`. It mints a one-year, inference-only OAuth token used by
-   `anthropics/claude-code-action@v1`.
+2. **Mint the Claude OAuth token — this rotates a shared live secret.**
+   `CLAUDE_CODE_OAUTH_TOKEN` already exists as a live repo secret consumed by
+   both `.github/workflows/claude.yml` jobs (the on-demand Claude assistant and
+   the auto-review job), and GitHub cannot read secret values back, so the
+   Terraform adoption necessarily writes a new value over the live one. Locally,
+   on the Max plan, run `claude setup-token` to mint a fresh one-year,
+   inference-only OAuth token. The first apply (step 4) overwrites the live
+   secret with this fresh token — a rotation, not an outage: `claude.yml` and
+   the triage workflows then share the new value. Do not put a placeholder or
+   stale token here; a bad value breaks the existing Claude PR automation on its
+   next run.
 3. **Set both values in the platform tfvars.** In your local, gitignored
    `terraform/terraform.tfvars`, set `sentry_triage_token` and
    `claude_code_oauth_token` (see `terraform/terraform.tfvars.example` for the
    keys and placeholder comments). This is the exact same value source the
-   `count`-gated integration-probe secrets already use.
+   `count`-gated integration-probe secrets already use. Once
+   `claude_code_oauth_token` has been applied, never empty it again: the count
+   gate would plan a destroy of the shared live secret, which the resource's
+   `prevent_destroy` lifecycle guard rejects at plan time (deliberately loud —
+   rotate by replacing the value, not by clearing it).
 4. **Plan and apply the platform stack (human-approved local apply).** Run
    `pnpm infra:plan` and confirm the two new `github_actions_secret` resources
-   appear (they are absent while the tfvars are empty). After human sign-off,
+   appear (they are absent while the tfvars are empty); the
+   `CLAUDE_CODE_OAUTH_TOKEN` "create" is an upsert that overwrites the existing
+   live secret (see step 2). After human sign-off,
    run `pnpm tf apply platform` from a clean `main` checkout. The platform stack
    is manual-plan / manual-apply (`terraform.stacks.json` →
    `apply: "manual"`, `applyPolicy: "human-review-required"`); it is **not** a
@@ -53,6 +67,9 @@ other `count`-gated platform secrets) — never committed, never set through
    The apply mirrors the two values into the repo Actions secrets
    `SENTRY_TRIAGE_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`. `SENTRY_TRIAGE_ENABLED`
    is provisioned by the same apply in its default `"false"` (off) position.
+   After the apply, sanity-check the rotation by triggering any PR's Claude
+   auto-review (or an on-demand mention) and confirming `claude.yml` still
+   authenticates.
 5. **Flip the kill switch to activate.** Once both Phase-1 workflow PRs
    (`sentry-triage-ingest`, `sentry-triage-agent`) are merged and the two tokens
    are applied, set `sentry_triage_enabled = "true"` in `terraform.tfvars` and

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -155,7 +155,10 @@ Sentry triage/autofix pipeline (ADR 0036), provisioned by issue #1276:
   trust boundary). `count`-gated.
 - `CLAUDE_CODE_OAUTH_TOKEN` — Claude Max OAuth token from `claude setup-token`
   (`claude_code_oauth_token` tfvar), for `anthropics/claude-code-action@v1`.
-  `count`-gated.
+  `count`-gated. Adopts the pre-existing live secret shared with
+  `.github/workflows/claude.yml`: the first apply overwrites (rotates) the live
+  value, and the resource carries `prevent_destroy` so emptying the tfvar fails
+  the plan loudly instead of silently breaking the Claude PR automation.
 - `SENTRY_TRIAGE_ENABLED` — kill-switch **variable** (`sentry_triage_enabled`
   tfvar), default `"false"`. The scheduled workflows stay inert until it is
   `"true"`.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -137,6 +137,32 @@ queued `main` run reaches a terminal state. Later queued jobs can pass the
 issue fixed from the first successful apply alone. Verify the live resource and
 run `terraform-drift.yml` before closing the drift issue.
 
+## Platform GitHub Actions secrets and variables
+
+The platform stack mirrors repo-level GitHub Actions secrets and variables on
+`monitoring-monorepo` (`terraform/github-secrets.tf`,
+`terraform/github-variables.tf`). Their values come from the platform stack's
+gitignored, operator-held `terraform/terraform.tfvars` (never committed) or from
+other platform resources; each secret-mirroring resource is `count`-gated on its
+value being set, so plan/apply succeed while a value is unset. The platform
+stack is manual-plan / manual-apply (`pnpm infra:plan`, then a human-approved
+`pnpm tf apply platform`), not a CI `production-infra` apply.
+
+Sentry triage/autofix pipeline (ADR 0036), provisioned by issue #1276:
+
+- `SENTRY_TRIAGE_TOKEN` — READ-ONLY Sentry internal-integration token
+  (`sentry_triage_token` tfvar). Read scopes only; no write scopes (Phase-1
+  trust boundary). `count`-gated.
+- `CLAUDE_CODE_OAUTH_TOKEN` — Claude Max OAuth token from `claude setup-token`
+  (`claude_code_oauth_token` tfvar), for `anthropics/claude-code-action@v1`.
+  `count`-gated.
+- `SENTRY_TRIAGE_ENABLED` — kill-switch **variable** (`sentry_triage_enabled`
+  tfvar), default `"false"`. The scheduled workflows stay inert until it is
+  `"true"`.
+
+The human token-provisioning and activation steps are in the operator runbook in
+[`docs/notes/sentry-triage-pipeline.md`](notes/sentry-triage-pipeline.md).
+
 ## GitHub Environment Setup
 
 Pre-merge requirement for the production-environment split in issue #762:

--- a/terraform/github-secrets.tf
+++ b/terraform/github-secrets.tf
@@ -146,6 +146,10 @@ resource "github_actions_secret" "integration_probe_squid_integrator_id" {
 #   - CLAUDE_CODE_OAUTH_TOKEN: the Max-subscription OAuth token minted by
 #     `claude setup-token`, used by `anthropics/claude-code-action@v1` in agent
 #     mode. Inference-only; it carries no repo write capability of its own.
+#     NOT a triage-only secret: it already exists live and is consumed by both
+#     `.github/workflows/claude.yml` jobs (on-demand assistant + auto-review),
+#     so the resource below ADOPTS a shared production credential — see its
+#     lifecycle note.
 #
 # Both are `count`-gated on their tfvar being non-empty, exactly like the
 # integration-probe aggregator keys above: plan and apply succeed while the
@@ -155,6 +159,11 @@ resource "github_actions_secret" "integration_probe_squid_integrator_id" {
 # `github-variables.tf`). Human provisioning runbook:
 # `docs/notes/sentry-triage-pipeline.md`.
 
+# SENTRY_TRIAGE_TOKEN is brand-new: no live secret of this name exists and no
+# workflow consumes it until the sibling Phase-1 PRs land, so plain count
+# gating is enough — destroying it while unused breaks nothing, which is why
+# it carries no `prevent_destroy` (asymmetric with
+# `claude_code_oauth_token` below, which guards a shared live credential).
 resource "github_actions_secret" "sentry_triage_token" {
   # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
   # `vercel_automation_bypass`; see the comment above for the threat model.
@@ -173,4 +182,27 @@ resource "github_actions_secret" "claude_code_oauth_token" {
   repository  = "monitoring-monorepo"
   secret_name = "CLAUDE_CODE_OAUTH_TOKEN"
   value       = var.claude_code_oauth_token
+
+  # This adopts an EXISTING live secret shared with `.github/workflows/
+  # claude.yml` (the on-demand Claude assistant and the auto-review job both
+  # read `secrets.CLAUDE_CODE_OAUTH_TOKEN`). Two hazards follow:
+  #
+  #   1. Adoption overwrite: GitHub secret writes are upserts, so the first
+  #      apply with the tfvar set OVERWRITES the live value. The runbook
+  #      (docs/notes/sentry-triage-pipeline.md) therefore requires putting a
+  #      current working token — in practice a freshly minted
+  #      `claude setup-token` value, since GitHub can't read secrets back —
+  #      into tfvars, which rotates the token for claude.yml too.
+  #   2. Destroy-on-empty: emptying the tfvar later would flip count 1→0 and
+  #      destroy the live secret, silently breaking claude.yml.
+  #      `prevent_destroy` turns that into a loud plan-time error instead.
+  #      (Limitation: deleting this whole resource block removes the guard
+  #      with it — Terraform then destroys the secret on the next apply.)
+  #
+  # While the tfvar is unset the resource has no state instance, so
+  # `prevent_destroy` has nothing to act on and plans stay green — the count
+  # gate and the guard compose cleanly.
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/terraform/github-secrets.tf
+++ b/terraform/github-secrets.tf
@@ -126,3 +126,51 @@ resource "github_actions_secret" "integration_probe_squid_integrator_id" {
   secret_name = "SQUID_INTEGRATOR_ID"
   value       = var.squid_integrator_id
 }
+
+# Sentry triage/autofix pipeline secrets
+# ───────────────────────────────────────
+#
+# The staged Sentry triage/autofix pipeline (ADR 0036) runs entirely inside
+# this repo's GitHub Actions. Two scheduled workflows —
+# `.github/workflows/sentry-triage-ingest.yml` and
+# `.github/workflows/sentry-triage-agent.yml`, added by sibling Phase-1 PRs —
+# consume these two repo-level secrets:
+#
+#   - SENTRY_TRIAGE_TOKEN: a READ-ONLY Sentry internal-integration token
+#     (scopes: Issue & Event Read, Project Read, Organization Read — NO write
+#     scopes). Phase-1 triage is read-only by design; the investigating agent
+#     treats Sentry payloads as untrusted input and holds no write credential
+#     beyond commenting on its queue issue (ADR 0036 trust boundary). A
+#     separate write-scoped token is minted only if/when Phase-2 auto-archive
+#     is approved — do NOT widen this token's scopes here.
+#   - CLAUDE_CODE_OAUTH_TOKEN: the Max-subscription OAuth token minted by
+#     `claude setup-token`, used by `anthropics/claude-code-action@v1` in agent
+#     mode. Inference-only; it carries no repo write capability of its own.
+#
+# Both are `count`-gated on their tfvar being non-empty, exactly like the
+# integration-probe aggregator keys above: plan and apply succeed while the
+# values are unset, so this stack can merge and apply before the operator
+# provisions the tokens. The pipeline stays inert until the tokens exist AND
+# `github_actions_variable.sentry_triage_enabled` is flipped to "true" (see
+# `github-variables.tf`). Human provisioning runbook:
+# `docs/notes/sentry-triage-pipeline.md`.
+
+resource "github_actions_secret" "sentry_triage_token" {
+  # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
+  # `vercel_automation_bypass`; see the comment above for the threat model.
+  count = var.sentry_triage_token == "" ? 0 : 1
+
+  repository  = "monitoring-monorepo"
+  secret_name = "SENTRY_TRIAGE_TOKEN"
+  value       = var.sentry_triage_token
+}
+
+resource "github_actions_secret" "claude_code_oauth_token" {
+  # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
+  # `vercel_automation_bypass`; see the comment above for the threat model.
+  count = var.claude_code_oauth_token == "" ? 0 : 1
+
+  repository  = "monitoring-monorepo"
+  secret_name = "CLAUDE_CODE_OAUTH_TOKEN"
+  value       = var.claude_code_oauth_token
+}

--- a/terraform/github-variables.tf
+++ b/terraform/github-variables.tf
@@ -26,3 +26,25 @@ resource "github_actions_variable" "terraform_apply_slack_channel" {
   variable_name = "TERRAFORM_APPLY_SLACK_CHANNEL"
   value         = var.terraform_apply_slack_channel
 }
+
+# Sentry triage/autofix kill switch
+# ───────────────────────────────────
+#
+# `SENTRY_TRIAGE_ENABLED` is the ADR 0036 / ADR 0030 kill switch for the
+# scheduled Sentry triage/autofix workflows. Those workflows read this repo
+# variable and no-op unless it equals "true", so the pipeline stays inert after
+# its secrets are provisioned until an operator deliberately activates it.
+#
+# Unlike the `count`-gated secret mirrors in `github-secrets.tf`, this resource
+# is unconditional so the kill switch always exists for the workflows to read;
+# `var.sentry_triage_enabled` defaults to "false", so the first apply provisions
+# the switch in its off position. Activation is a follow-up tfvar change to
+# "true" plus a re-apply (still IaC, not the GitHub UI), done only after both
+# Phase-1 workflow PRs are merged and the two tokens are provisioned. Runbook:
+# `docs/notes/sentry-triage-pipeline.md`.
+
+resource "github_actions_variable" "sentry_triage_enabled" {
+  repository    = "monitoring-monorepo"
+  variable_name = "SENTRY_TRIAGE_ENABLED"
+  value         = var.sentry_triage_enabled
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -74,6 +74,25 @@ upstash_api_key = "..."
 # `count`-gated so `terraform apply` succeeds without it.
 # squid_integrator_id = "..."
 
+# ── Sentry triage/autofix (ADR 0036) ──────────────────────────────────────────
+# READ-ONLY Sentry internal-integration token for the triage pipeline.
+# Scopes: Issue & Event Read, Project Read, Organization Read — NO write scopes.
+# Leave empty until provisioned; the GitHub Actions secret resource is
+# `count`-gated so `terraform apply` succeeds without it. See the human runbook
+# in docs/notes/sentry-triage-pipeline.md for how to mint it.
+# sentry_triage_token = "xxx-read-only-sentry-token-xxx"
+
+# Claude Max OAuth token from `claude setup-token` for claude-code-action.
+# Leave empty until provisioned; the GitHub Actions secret resource is
+# `count`-gated so `terraform apply` succeeds without it.
+# claude_code_oauth_token = "xxx-claude-oauth-token-xxx"
+
+# Kill switch for the scheduled Sentry triage workflows (string "true"/"false",
+# default "false"). Flip to "true" only after both Phase-1 workflow PRs are
+# merged AND the two tokens above are provisioned. Still IaC — set it here and
+# re-apply, never via the GitHub UI.
+# sentry_triage_enabled = "false"
+
 # ── Arkham Intelligence ───────────────────────────────────────────────────────
 # API key for manual /api/arkham/enrich counterparty tagging.
 # Apply for access at https://intel.arkm.com/api — gated, no self-serve signup.

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -85,6 +85,11 @@ upstash_api_key = "..."
 # Claude Max OAuth token from `claude setup-token` for claude-code-action.
 # Leave empty until provisioned; the GitHub Actions secret resource is
 # `count`-gated so `terraform apply` succeeds without it.
+# CAUTION: the CLAUDE_CODE_OAUTH_TOKEN repo secret already exists live and is
+# shared with .github/workflows/claude.yml — setting this value overwrites
+# (rotates) it on apply, so it must be a fresh working `claude setup-token`
+# value, and once applied it must never be emptied (the resource has
+# `prevent_destroy`). See the runbook in docs/notes/sentry-triage-pipeline.md.
 # claude_code_oauth_token = "xxx-claude-oauth-token-xxx"
 
 # Kill switch for the scheduled Sentry triage workflows (string "true"/"false",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -170,6 +170,51 @@ variable "squid_integrator_id" {
   default     = ""
 }
 
+# ── Sentry triage/autofix (ADR 0036) ──────────────────────────────────────────
+
+variable "sentry_triage_token" {
+  description = <<-EOT
+    READ-ONLY Sentry internal-integration token for the scheduled Sentry
+    triage/autofix pipeline (ADR 0036). Scopes: Issue & Event Read, Project
+    Read, Organization Read — NO write scopes. Mirrors into the repo-level
+    Actions secret `SENTRY_TRIAGE_TOKEN`. Leave empty until provisioned; the
+    secret resource is `count`-gated so `terraform apply` succeeds without it.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "claude_code_oauth_token" {
+  description = <<-EOT
+    Claude Max-subscription OAuth token (`claude setup-token`) used by
+    `anthropics/claude-code-action@v1` in the Sentry triage/autofix pipeline
+    (ADR 0036). Mirrors into the repo-level Actions secret
+    `CLAUDE_CODE_OAUTH_TOKEN`. Leave empty until provisioned; the secret
+    resource is `count`-gated so `terraform apply` succeeds without it.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "sentry_triage_enabled" {
+  description = <<-EOT
+    Kill switch for the scheduled Sentry triage/autofix workflows (ADR 0036,
+    ADR 0030). Mirrors into the repo-level Actions variable
+    `SENTRY_TRIAGE_ENABLED`; the workflows no-op unless it equals "true".
+    Defaults to "false" so the pipeline stays inert until deliberately
+    activated by a follow-up tfvar change plus a re-apply.
+  EOT
+  type        = string
+  default     = "false"
+
+  validation {
+    condition     = contains(["true", "false"], var.sentry_triage_enabled)
+    error_message = "sentry_triage_enabled must be the string \"true\" or \"false\"."
+  }
+}
+
 # ── Auth (Google OAuth / NextAuth) ─────────────────────────────────────────
 
 variable "auth_google_id" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -190,8 +190,12 @@ variable "claude_code_oauth_token" {
     Claude Max-subscription OAuth token (`claude setup-token`) used by
     `anthropics/claude-code-action@v1` in the Sentry triage/autofix pipeline
     (ADR 0036). Mirrors into the repo-level Actions secret
-    `CLAUDE_CODE_OAUTH_TOKEN`. Leave empty until provisioned; the secret
-    resource is `count`-gated so `terraform apply` succeeds without it.
+    `CLAUDE_CODE_OAUTH_TOKEN`, which ALREADY exists live and is shared with
+    `.github/workflows/claude.yml` — setting this value overwrites (rotates)
+    the live secret, and once applied it must not be emptied (the resource
+    has `prevent_destroy`; see github-secrets.tf and the runbook in
+    docs/notes/sentry-triage-pipeline.md). Leave empty until provisioned; the
+    secret resource is `count`-gated so `terraform apply` succeeds without it.
   EOT
   type        = string
   sensitive   = true


### PR DESCRIPTION
## The Problem

- The Phase-1 Sentry triage/autofix pipeline (ADR 0036) needs two GitHub Actions secrets and a kill-switch variable, but there's no IaC for them — provisioning by hand via `gh secret set` violates the IaC-before-CLI rule (ADR 0030) and drifts silently.
- The scheduled triage workflows (added by sibling Phase-1 PRs) must be able to merge and stay completely inert until an operator deliberately provisions credentials and activates them.
- There's no written procedure for producing the token values with correct (read-only) scopes, so the trust boundary could be widened by accident.

## The Solution

- Model both secrets and the kill switch in the platform stack, mirroring the existing `vercel_automation_bypass` / integration-probe pattern: `count`-gated `github_actions_secret` resources for `SENTRY_TRIAGE_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`, plus an unconditional `github_actions_variable` `SENTRY_TRIAGE_ENABLED` defaulting to `"false"`.
- Because the secret mirrors are `count`-gated on their tfvar being non-empty, this merges and applies green with the values unset — the pipeline is dormant until both tokens exist and the kill switch is flipped to `"true"`.
- Document where the values live and add an operator runbook so the tokens are minted with read-only scopes only.

## Details

- `terraform/github-secrets.tf` — `SENTRY_TRIAGE_TOKEN` (read-only Sentry internal-integration token) and `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max OAuth token), `count`-gated + `checkov:skip=CKV_GIT_4` with the same state-backed-plaintext justification as the sibling mirrors.
- **Shared-secret adoption (`CLAUDE_CODE_OAUTH_TOKEN`)**: this secret already exists live and is consumed by both `.github/workflows/claude.yml` jobs. The resource therefore carries `lifecycle { prevent_destroy = true }` so a later emptied tfvar (count 1→0) fails the plan loudly instead of destroying the shared live secret, and the runbook requires a fresh working `claude setup-token` value in tfvars because the first apply overwrites (rotates) the live value. `SENTRY_TRIAGE_TOKEN` is brand-new with no consumers, so it stays a plain count-gated mirror (asymmetry documented inline).
- `terraform/github-variables.tf` — `SENTRY_TRIAGE_ENABLED` kill switch, unconditional so the workflows always have a value to read; default `"false"`.
- `terraform/variables.tf` — `sentry_triage_token` + `claude_code_oauth_token` (`sensitive = true`, empty default → count gate) and `sentry_triage_enabled` (string with a `"true"`/`"false"` validation block).
- `terraform/terraform.tfvars.example`, `docs/terraform.md` (platform Actions secrets/variables subsection), and `docs/notes/sentry-triage-pipeline.md` (operator runbook).
- Read-only by design: the Sentry token carries no write scopes (ADR 0036 trust boundary); a write-scoped token is a separate Phase-2 concern only if auto-archive is approved.

### Merge-order dependency

ADR 0036 (`docs/adr/0036-sentry-triage-pipeline.md`) lands in **PR #1283** in this same Phase-1 batch. That PR should merge **before or together with** this one so the ADR references in this PR's Terraform comments and docs resolve; until then the links are intentionally forward-referencing, not broken by accident.

### Human steps required before this has any effect (operator-only)

This PR is **inert until values are provided and applied** — merging it changes no live behavior. Full runbook in `docs/notes/sentry-triage-pipeline.md`:

1. In Sentry (org `mento-labs`), create an internal integration `sentry-triage-reader` with READ-ONLY scopes (Issue & Event: Read, Project: Read, Organization: Read) — no write scopes — and copy its token.
2. Locally on the Max plan, run `claude setup-token` to mint a fresh inference-only OAuth token. Note: applying it rotates the live `CLAUDE_CODE_OAUTH_TOKEN` secret shared with `.github/workflows/claude.yml` (GitHub can't read the current value back), so it must be a working token.
3. Add both values to the platform stack's gitignored, operator-held `terraform/terraform.tfvars` (the same value source `lifi_api_key` and the other `count`-gated platform secrets already use).
4. Provision via the platform stack's **human-approved local apply** — `pnpm infra:plan`, then `pnpm tf apply platform` from a clean `main` checkout after sign-off. The platform stack is manual-plan / manual-apply (`terraform.stacks.json` → `apply: "manual"`, `applyPolicy: "human-review-required"`); it is **not** a CI `production-infra` apply like the alerts/aegis/governance-watchdog stacks. Afterwards, confirm `claude.yml` still authenticates (trigger any PR's auto-review).
5. Once both Phase-1 workflow PRs are merged, flip `sentry_triage_enabled = "true"` in `terraform.tfvars` and re-apply (still IaC, never the GitHub UI).

### Validation

- `terraform fmt -check -recursive`, `init`, and `validate` all clean.
- `pnpm agent:quality-gate --run` passes (fmt / init / validate / trunk check / context-check).
- No secret material, real-looking placeholder, or token-shaped string in the diff — tfvars.example uses obviously-fake `xxx-...-xxx` placeholders. PR plans stay secretless (per `docs/notes/terraform-secret-strategy-2026-07.md`).
- Verified `.github/workflows/claude.yml` consumes `secrets.CLAUDE_CODE_OAUTH_TOKEN` (2 jobs) and that the live repo secret exists (`gh secret list`), which drove the `prevent_destroy` + rotation-runbook design above.

Closes #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiUreX7DKuRKiHQT6HkY4z
