### PR TITLE
perf(dashboard): bound SSR history payload

### DIFF
--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -192,8 +192,9 @@ chainId}]` — the server must reproduce the exact normalized id + `network.id`
   so `N/A` tiles are never pinned), and strips the unread raw `feeSnapshots` rows from
   the `/` + `/pools` Flight payload. **Payload projection shipped 2026-07-15:** the
   transport now carries the 30 UTC-day default v3 window plus one latest pre-window
-  anchor per pool for TVL forward-fill, and the exact 30 UTC-day Broker window. It omits
-  the redundant 1/7/30-day arrays. `useAllNetworksData` reconstructs those
+  anchor per pool for TVL forward-fill. Broker carries one additional UTC-day boundary
+  bucket because the rolling 30-day window starts exactly 30 midnights ago during UTC
+  hour zero. It omits the redundant 1/7/30-day arrays. `useAllNetworksData` reconstructs those
   arrays synchronously from the bounded canonical rows before consumers or
   incremental-cache seeding; selecting a chart's "All" range triggers the normal
   full-history SWR fetch, and capped seeds remain cache-incomplete until that pagination

--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -188,9 +188,19 @@ chainId}]` — the server must reproduce the exact normalized id + `network.id`
   for the Map/Set fields, caches healthy payloads only (degraded ones pass through
   uncached via an error carrier — cold misses only, since `unstable_cache` serves stale
   entries and swallows background-revalidation errors; a `fetchedAt` age gate bounds
-  served staleness at ~90s with a foreground refetch, covering the stale-serve path so
-  `N/A` tiles are never pinned), and strips
-  the unread raw `feeSnapshots` rows from the `/` + `/pools` Flight payload. Note the
+  served staleness at 5 minutes with a foreground refetch, covering the stale-serve path
+  so `N/A` tiles are never pinned), and strips the unread raw `feeSnapshots` rows from
+  the `/` + `/pools` Flight payload. **Payload projection shipped 2026-07-15:** the
+  transport now carries only the exact 30 UTC-day default v3 and Broker snapshot windows
+  and omits the redundant 1/7/30-day arrays. `useAllNetworksData` reconstructs those
+  arrays synchronously from the bounded canonical rows before consumers or
+  incremental-cache seeding; selecting a chart's "All" range triggers the normal
+  full-history SWR fetch, and capped seeds remain cache-incomplete until that pagination
+  succeeds. The cumulative LP-address arrays are replaced by the homepage's exact
+  cross-chain union count, while `/pools` receives neither Broker history nor LP data
+  because it consumes neither. This is the audited transport invariant: every
+  time/cumulative `InitialNetworkData` field is bounded, omitted, or aggregated; the
+  remaining collections are bounded by current configured entities. Note the
   impact re-rating vs. this plan's original scoring: a 2026-07-09 re-measure showed the
   homepage document _streaming_ until 0.9–1.9s (the fan-out runs inside the streamed
   RSC content, not TTFB), so this was in fact the homepage LCP lever, not just cost.

--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -191,8 +191,9 @@ chainId}]` — the server must reproduce the exact normalized id + `network.id`
   served staleness at 5 minutes with a foreground refetch, covering the stale-serve path
   so `N/A` tiles are never pinned), and strips the unread raw `feeSnapshots` rows from
   the `/` + `/pools` Flight payload. **Payload projection shipped 2026-07-15:** the
-  transport now carries only the exact 30 UTC-day default v3 and Broker snapshot windows
-  and omits the redundant 1/7/30-day arrays. `useAllNetworksData` reconstructs those
+  transport now carries the 30 UTC-day default v3 window plus one latest pre-window
+  anchor per pool for TVL forward-fill, and the exact 30 UTC-day Broker window. It omits
+  the redundant 1/7/30-day arrays. `useAllNetworksData` reconstructs those
   arrays synchronously from the bounded canonical rows before consumers or
   incremental-cache seeding; selecting a chart's "All" range triggers the normal
   full-history SWR fetch, and capped seeds remain cache-incomplete until that pagination

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -70,20 +70,6 @@
     "linePreview": " | function Card({ data }: { data: HomepageOgData | null }) { | // null → \"—\" (unavailable); 0 → \"$0.00\" (real empty state)."
   },
   {
-    "file": "src/app/page-client.tsx",
-    "ruleId": "complexity",
-    "message": "Arrow function has a complexity of 35. Maximum allowed is 15.",
-    "line": 177,
-    "linePreview": "// Aggregate KPIs across all chains for the summary tiles. | const aggregated = useMemo(() => { | let totalPools = 0;"
-  },
-  {
-    "file": "src/app/page-client.tsx",
-    "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 53 to the 18 allowed.",
-    "line": 177,
-    "linePreview": "// Aggregate KPIs across all chains for the summary tiles. | const aggregated = useMemo(() => { | let totalPools = 0;"
-  },
-  {
     "file": "src/app/pool/[poolId]/_components/ols-liquidity-events.tsx",
     "ruleId": "complexity",
     "message": "Function 'OlsLiquidityEvents' has a complexity of 35. Maximum allowed is 15.",
@@ -108,7 +94,7 @@
     "file": "src/app/pool/[poolId]/_components/pool-header.tsx",
     "ruleId": "complexity",
     "message": "Function 'PoolHeader' has a complexity of 28. Maximum allowed is 15.",
-    "line": 55,
+    "line": 60,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing composed header surface; this PR only threads SSR fallback props into its current queries. | export function PoolHeader({ | pool,"
   },
   {
@@ -150,14 +136,14 @@
     "file": "src/app/pools/_components/pools-page-client.tsx",
     "ruleId": "complexity",
     "message": "Function 'PoolsContent' has a complexity of 26. Maximum allowed is 15.",
-    "line": 60,
+    "line": 67,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing page component owns network data, table controls, and degraded-count messaging. | function PoolsContent({ | initialNetworkData,"
   },
   {
     "file": "src/app/pools/_components/pools-page-client.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 24 to the 18 allowed.",
-    "line": 60,
+    "line": 67,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing page component owns network data, table controls, and degraded-count messaging. | function PoolsContent({ | initialNetworkData,"
   },
   {

--- a/ui-dashboard/scripts/hasura-fixture-server.test.mjs
+++ b/ui-dashboard/scripts/hasura-fixture-server.test.mjs
@@ -45,6 +45,8 @@ describe("hasura fixture daily snapshot filters", () => {
       since: todayStart - 1,
     });
 
-    expect(rows).toHaveLength(6);
+    // Four rows per fixture pool (today, 1d, 2d, and the deliberate 365d
+    // full-history sentinel used by the bounded-SSR browser flow).
+    expect(rows).toHaveLength(8);
   });
 });

--- a/ui-dashboard/scripts/hasura-fixture-server.test.mjs
+++ b/ui-dashboard/scripts/hasura-fixture-server.test.mjs
@@ -4,6 +4,7 @@ import { handleGraphQL } from "../tests/browser/fixtures/hasura-fixture-server.m
 const DAY_SECONDS = 86_400;
 const QUERY =
   "query HomepageOgDailySnapshots { PoolDailySnapshot { timestamp } }";
+const POOL_ID = "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e";
 const FIXED_NOW_MS = Date.UTC(2026, 5, 16, 12, 0, 0);
 
 function dailyRows(variables) {
@@ -45,8 +46,27 @@ describe("hasura fixture daily snapshot filters", () => {
       since: todayStart - 1,
     });
 
-    // Four rows per fixture pool (today, 1d, 2d, and the deliberate 365d
-    // full-history sentinel used by the bounded-SSR browser flow).
-    expect(rows).toHaveLength(8);
+    // Five rows per fixture pool (today, 1d, 2d, plus deliberate 365d and
+    // 366d full-history sentinels used by the bounded-SSR browser flow).
+    expect(rows).toHaveLength(10);
   });
+
+  it.each(["PoolDailySnapshotsChart", "PoolOgDailySnapshots"])(
+    "keeps the old all-history sentinels out of %s",
+    (operation) => {
+      const todayStart =
+        Math.floor(FIXED_NOW_MS / 1000 / DAY_SECONDS) * DAY_SECONDS;
+      const rows = handleGraphQL({
+        query: `query ${operation} { PoolDailySnapshot { timestamp } }`,
+        variables: { poolId: POOL_ID },
+      }).PoolDailySnapshot;
+
+      expect(rows).toHaveLength(3);
+      expect(rows.map((row) => Number(row.timestamp))).toEqual([
+        todayStart,
+        todayStart - DAY_SECONDS,
+        todayStart - 2 * DAY_SECONDS,
+      ]);
+    },
+  );
 });

--- a/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
@@ -196,6 +196,7 @@ function networkData(snapshots: PoolDailyFeeSnapshot[]): NetworkData {
     snapshots7d: [],
     snapshots30d: [],
     snapshotsAllDaily: [],
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/src/app/(home)/page.tsx
+++ b/ui-dashboard/src/app/(home)/page.tsx
@@ -87,7 +87,8 @@ export default async function HomePage() {
   // Promise.allSettled internally so it won't throw). Guard anyway in case a
   // truly unexpected error bubbles up; an undefined initial payload just
   // reverts to the client-only code path. Snapshot history is projected to a
-  // bounded 30 UTC-day seed; the default charts fit inside it, while their
+  // bounded 30 UTC-day seed plus one pre-window TVL anchor per pool; the default
+  // charts fit inside it, while their
   // "All" controls request the normal full SWR payload before rendering.
   const initialPayload = await fetchInitialNetworkData("home").catch(
     () => undefined,

--- a/ui-dashboard/src/app/(home)/page.tsx
+++ b/ui-dashboard/src/app/(home)/page.tsx
@@ -86,13 +86,18 @@ export default async function HomePage() {
   // are never cached, and the underlying `fetchAllNetworks` uses
   // Promise.allSettled internally so it won't throw). Guard anyway in case a
   // truly unexpected error bubbles up; an undefined initial payload just
-  // reverts to the client-only code path.
-  const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  // reverts to the client-only code path. Snapshot history is projected to a
+  // bounded 30 UTC-day seed; the default charts fit inside it, while their
+  // "All" controls request the normal full SWR payload before rendering.
+  const initialPayload = await fetchInitialNetworkData("home").catch(
+    () => undefined,
+  );
   const initialIsWeekend = isWeekend();
   return (
     <GlobalPage
       initialNetworkData={initialPayload?.networks}
       initialNetworkDataFetchedAtMs={initialPayload?.fetchedAtMs}
+      initialUniqueLpCount={initialPayload?.uniqueLpCount}
       initialIsWeekend={initialIsWeekend}
     />
   );

--- a/ui-dashboard/src/app/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.server.test.tsx
@@ -4,6 +4,8 @@ import HomePage, { generateMetadata } from "../(home)/page";
 
 type GlobalPageProps = {
   initialNetworkData?: unknown;
+  initialNetworkDataFetchedAtMs?: number;
+  initialUniqueLpCount?: number | null;
   initialIsWeekend?: boolean;
 };
 
@@ -99,13 +101,16 @@ describe("HomePage server component", () => {
     mockFetchInitialNetworkData.mockResolvedValueOnce({
       networks: initialNetworkData,
       fetchedAtMs: 1_700_000_000_000,
+      uniqueLpCount: 123,
     });
 
     renderToStaticMarkup(await HomePage());
 
+    expect(mockFetchInitialNetworkData).toHaveBeenCalledWith("home");
     expect(mockGlobalPage).toHaveBeenCalledWith({
       initialNetworkData,
       initialNetworkDataFetchedAtMs: 1_700_000_000_000,
+      initialUniqueLpCount: 123,
       initialIsWeekend: true,
     });
   });
@@ -122,6 +127,7 @@ describe("HomePage server component", () => {
     expect(mockGlobalPage).toHaveBeenCalledWith({
       initialNetworkData: undefined,
       initialNetworkDataFetchedAtMs: undefined,
+      initialUniqueLpCount: undefined,
       initialIsWeekend: false,
     });
   });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -91,14 +91,21 @@ function render(
   networkData: NetworkData[],
   isLoading = false,
   initialIsWeekend = false,
+  initialUniqueLpCount?: number | null,
 ): string {
   (useAllNetworksData as ReturnType<typeof vi.fn>).mockReturnValue({
     networkData,
     isLoading,
     error: null,
+    isSnapshotHistoryCapped: false,
+    snapshotHistoryError: null,
+    requestFullSnapshotHistory: vi.fn(async () => undefined),
   });
   return renderToStaticMarkup(
-    <GlobalPage initialIsWeekend={initialIsWeekend} />,
+    <GlobalPage
+      initialIsWeekend={initialIsWeekend}
+      initialUniqueLpCount={initialUniqueLpCount}
+    />,
   );
 }
 
@@ -137,6 +144,40 @@ describe("GlobalPage — loading state", () => {
     const html = render([], true);
     // Should have multiple "…" placeholders
     expect(html.split("…").length - 1).toBeGreaterThanOrEqual(4);
+  });
+
+  it("keeps last-good KPIs, the recent charts, and the pool table visible during background revalidation", () => {
+    const pool = makeTvlPool({
+      swapCount: 17,
+      reserves0: "1000000000000000000",
+      reserves1: "1000000000000000000",
+    });
+    const html = render(
+      [
+        makeNetworkData({
+          network: TVL_NETWORK,
+          pools: [pool],
+          uniqueLpAddresses: ["0x1111111111111111111111111111111111111111"],
+          fees: {
+            totalFeesUSD: 1_000,
+            fees24hUSD: 10,
+            fees7dUSD: 70,
+            fees30dUSD: 300,
+            unpricedSymbols: [],
+            unpricedSymbols24h: [],
+            unresolvedCount: 0,
+            unresolvedCount24h: 0,
+          },
+        }),
+      ],
+      true,
+    );
+
+    expect(html).toContain('aria-label="Swap Fees: $1K"');
+    expect(html).toContain('data-testid="global-pools-table"');
+    expect(html).not.toContain("Total Value Locked chart is loading.");
+    expect(html).not.toContain("Volume chart is loading.");
+    expect(html).not.toContain("…");
   });
 
   // The "All Pools" degraded-path skeleton must reserve the same table
@@ -257,6 +298,29 @@ describe("GlobalPage — fees-only failure", () => {
 // LP query failure
 
 describe("GlobalPage — LP query failure", () => {
+  it("renders the exact server aggregate while cumulative LP addresses are omitted", () => {
+    const html = render(
+      [
+        makeNetworkData({
+          uniqueLpAddresses: null,
+          uniqueLpAddressesOmitted: true,
+        }),
+        makeNetworkData({
+          network: NETWORK_2,
+          uniqueLpAddresses: null,
+          uniqueLpAddressesOmitted: true,
+        }),
+      ],
+      false,
+      false,
+      13,
+    );
+
+    expect(html).toContain("LPs");
+    expect(html).toContain(">13<");
+    expect(html).toContain("Unique LP addresses across all chains");
+  });
+
   it("shows N/A when all LP queries fail", () => {
     const html = render([
       makeNetworkData({

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -98,7 +98,9 @@ function render(
     isLoading,
     error: null,
     isSnapshotHistoryCapped: false,
+    isPoolSnapshotHistoryCapped: false,
     snapshotHistoryError: null,
+    poolSnapshotHistoryError: null,
     requestFullSnapshotHistory: vi.fn(async () => undefined),
   });
   return renderToStaticMarkup(

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -53,13 +53,12 @@ export default function GlobalPage({
   initialIsWeekend?: boolean;
 }) {
   // First paint uses `initialNetworkData` via SWR's `fallbackData`; on
-  // back-navigation the populated SWR cache wins, which is the right call —
-  // cache may hold fresher data from another page's polling cycle (e.g.
-  // /pools also calls useAllNetworksData under the same key). If no other
-  // page has polled, the worst case is the cache matches the SSR payload
-  // anyway. The bounded snapshot seed stays sufficient for the default 30d
-  // charts; selecting "All" explicitly requests complete history without
-  // waiting for the next `refreshInterval` tick.
+  // back-navigation the populated homepage SWR cache wins, which is the right
+  // call because it may hold fresher data from this route's polling cycle.
+  // `/pools` has an isolated key because its Flight payload deliberately omits
+  // homepage-only Broker history. The bounded homepage seed stays sufficient
+  // for the default 30d charts; selecting "All" explicitly requests complete
+  // history without waiting for the next `refreshInterval` tick.
   return (
     <Suspense>
       <GlobalContent
@@ -135,7 +134,9 @@ function GlobalContent({
     networkData,
     isLoading,
     isSnapshotHistoryCapped,
+    isPoolSnapshotHistoryCapped,
     snapshotHistoryError,
+    poolSnapshotHistoryError,
     requestFullSnapshotHistory,
   } = useAllNetworksData(initialNetworkData, initialNetworkDataFetchedAtMs);
   // SWR reports `isLoading` while `fallbackData` is being revalidated, even
@@ -384,8 +385,8 @@ function GlobalContent({
             anySnapshotsAllDailyError ||
             anySnapshotsAllDailyTruncated
           }
-          snapshotHistoryCapped={isSnapshotHistoryCapped}
-          snapshotHistoryError={snapshotHistoryError}
+          snapshotHistoryCapped={isPoolSnapshotHistoryCapped}
+          snapshotHistoryError={poolSnapshotHistoryError}
           requestFullSnapshotHistory={requestFullSnapshotHistory}
           plotlyDeferMode="idle"
         />

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -42,10 +42,14 @@ const SECONDS_PER_DAY = 86_400;
 export default function GlobalPage({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialUniqueLpCount,
   initialIsWeekend = false,
 }: {
   initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  /** Exact server aggregate used while raw cumulative LP addresses are omitted
+   * from the bounded Flight payload. `null` is a real unavailable result. */
+  initialUniqueLpCount?: number | null | undefined;
   initialIsWeekend?: boolean;
 }) {
   // First paint uses `initialNetworkData` via SWR's `fallbackData`; on
@@ -53,12 +57,15 @@ export default function GlobalPage({
   // cache may hold fresher data from another page's polling cycle (e.g.
   // /pools also calls useAllNetworksData under the same key). If no other
   // page has polled, the worst case is the cache matches the SSR payload
-  // anyway, and the next `refreshInterval` tick will refresh either way.
+  // anyway. The bounded snapshot seed stays sufficient for the default 30d
+  // charts; selecting "All" explicitly requests complete history without
+  // waiting for the next `refreshInterval` tick.
   return (
     <Suspense>
       <GlobalContent
         initialNetworkData={initialNetworkData}
         initialNetworkDataFetchedAtMs={initialNetworkDataFetchedAtMs}
+        initialUniqueLpCount={initialUniqueLpCount}
         initialIsWeekend={initialIsWeekend}
       />
     </Suspense>
@@ -116,16 +123,27 @@ function perPoolTvlWindow(
 function GlobalContent({
   initialNetworkData,
   initialNetworkDataFetchedAtMs,
+  initialUniqueLpCount,
   initialIsWeekend,
 }: {
   initialNetworkData?: InitialNetworkData[] | undefined;
   initialNetworkDataFetchedAtMs?: number | undefined;
+  initialUniqueLpCount?: number | null | undefined;
   initialIsWeekend: boolean;
 }) {
-  const { networkData, isLoading } = useAllNetworksData(
-    initialNetworkData,
-    initialNetworkDataFetchedAtMs,
-  );
+  const {
+    networkData,
+    isLoading,
+    isSnapshotHistoryCapped,
+    snapshotHistoryError,
+    requestFullSnapshotHistory,
+  } = useAllNetworksData(initialNetworkData, initialNetworkDataFetchedAtMs);
+  // SWR reports `isLoading` while `fallbackData` is being revalidated, even
+  // though the last-good network payload is still renderable. That distinction
+  // matters for the on-demand full-history request: selecting a capped chart's
+  // "All" range must only load that chart, not blank every KPI and sibling
+  // chart while the shared SWR key refreshes in the background.
+  const isInitialLoading = showInitialSkeleton(isLoading, networkData.length);
 
   // Whether any network has a top-level, rates, snapshot, or pagination
   // failure. Used to show N/A / "partial data" in KPI tiles rather than
@@ -163,6 +181,9 @@ function GlobalContent({
   const anyLpError = networkData.some(
     (netData) => netData.lpError !== null && netData.error === null,
   );
+  const uniqueLpAddressesOmitted = networkData.some(
+    (netData) => netData.uniqueLpAddressesOmitted === true,
+  );
 
   // Per-pool entries, volume, WoW, and strategy badges — shared with pools page.
   // Trading-limit pressure still flows into Health through Pool fields.
@@ -180,6 +201,7 @@ function GlobalContent({
   } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   // Aggregate KPIs across all chains for the summary tiles.
+  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- This single pass intentionally keeps cross-network KPI numerators, denominators, and partial-data gates atomic.
   const aggregated = useMemo(() => {
     let totalPools = 0;
     let totalFpmmPools = 0;
@@ -285,8 +307,12 @@ function GlobalContent({
 
     // Show N/A when no chain contributed a successful LP result OR any
     // top-level chain error means we can't claim a complete global count.
-    const totalUniqueLps =
-      anyNetworkError || (!hasSuccessfulLpResult && anyLpError)
+    const totalUniqueLps = uniqueLpAddressesOmitted
+      ? // The server computed this exact cross-chain union before replacing
+        // the cumulative address arrays. `undefined` violates that projection
+        // invariant, so fail closed instead of displaying a false zero.
+        (initialUniqueLpCount ?? null)
+      : anyNetworkError || (!hasSuccessfulLpResult && anyLpError)
         ? null
         : uniqueLpSet.size;
 
@@ -320,6 +346,8 @@ function GlobalContent({
     anySnapshots7dError,
     anyFeesError,
     anyLpError,
+    uniqueLpAddressesOmitted,
+    initialUniqueLpCount,
   ]);
 
   const failedNetworks = networkData.filter((net) => net.error !== null);
@@ -349,18 +377,21 @@ function GlobalContent({
           totalTvl={aggregated.totalTvl}
           tvlPartial={aggregated.tvlPartial}
           change7d={aggregated.tvlChange7d}
-          isLoading={isLoading}
+          isLoading={isInitialLoading}
           hasError={anyNetworkError}
           hasSnapshotError={
             anySnapshots7dError ||
             anySnapshotsAllDailyError ||
             anySnapshotsAllDailyTruncated
           }
+          snapshotHistoryCapped={isSnapshotHistoryCapped}
+          snapshotHistoryError={snapshotHistoryError}
+          requestFullSnapshotHistory={requestFullSnapshotHistory}
           plotlyDeferMode="idle"
         />
         <VolumeOverTimeChart
           networkData={networkData}
-          isLoading={isLoading}
+          isLoading={isInitialLoading}
           hasError={anyNetworkError}
           hasSnapshotError={
             anySnapshotsAllDailyError || anySnapshotsAllDailyTruncated
@@ -370,6 +401,9 @@ function GlobalContent({
             anyBrokerSnapshotsAllDailyTruncated
           }
           fullVolumeSeries={aggregated.volumeSeries}
+          snapshotHistoryCapped={isSnapshotHistoryCapped}
+          snapshotHistoryError={snapshotHistoryError}
+          requestFullSnapshotHistory={requestFullSnapshotHistory}
           plotlyDeferMode="idle"
         />
       </div>
@@ -382,7 +416,7 @@ function GlobalContent({
             sub24h={aggregated.totalFees24h}
             sub7d={aggregated.totalFees7d}
             sub30d={aggregated.totalFees30d}
-            isLoading={isLoading}
+            isLoading={isInitialLoading}
             hasError={anyNetworkError || anyFeesError}
             format={formatUSD}
             totalPrefix={feesApprox ? "≈ " : ""}
@@ -399,7 +433,7 @@ function GlobalContent({
           />
 
           <LpTile
-            isLoading={isLoading}
+            isLoading={isInitialLoading}
             totalUniqueLps={aggregated.totalUniqueLps}
             anyNetworkError={anyNetworkError}
             anyLpError={anyLpError}
@@ -407,10 +441,10 @@ function GlobalContent({
           />
 
           <SwapsTile
-            isLoading={isLoading}
+            isLoading={isInitialLoading}
             totalSwapsAllTime={aggregated.totalSwapsAllTime}
           />
-          <TradersTile isLoading={isLoading} networkData={networkData} />
+          <TradersTile isLoading={isInitialLoading} networkData={networkData} />
         </div>
       </section>
 
@@ -429,7 +463,7 @@ function GlobalContent({
 
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">All Pools</h2>
-        {showInitialSkeleton(isLoading, networkData.length) ? (
+        {isInitialLoading ? (
           // Matches the real GlobalPoolsTable's 45px header / 58px row
           // rhythm (`PoolsTableSkeleton`, `@/components/pools-table-skeleton`)
           // — same shape `(home)/loading.tsx` and /pools's stand-ins

--- a/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.server.test.tsx
@@ -4,6 +4,7 @@ import PoolsPage from "../page";
 
 type PoolsPageProps = {
   initialNetworkData?: unknown;
+  initialNetworkDataFetchedAtMs?: number;
   initialIsWeekend?: boolean;
 };
 
@@ -44,6 +45,7 @@ describe("PoolsPage server component", () => {
 
     renderToStaticMarkup(await PoolsPage());
 
+    expect(mockFetchInitialNetworkData).toHaveBeenCalledWith("pools");
     expect(mockPoolsPageClient).toHaveBeenCalledWith({
       initialNetworkData,
       initialNetworkDataFetchedAtMs: 1_700_000_000_000,

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -233,7 +233,9 @@ const baseAllNetworksResult = {
   isLoading: false,
   error: null,
   isSnapshotHistoryCapped: false,
+  isPoolSnapshotHistoryCapped: false,
   snapshotHistoryError: null,
+  poolSnapshotHistoryError: null,
   requestFullSnapshotHistory: vi.fn(async () => undefined),
 };
 
@@ -272,6 +274,11 @@ describe("PoolsPage multichain rendering", () => {
     const html = renderToStaticMarkup(<PoolsPage initialIsWeekend={true} />);
 
     expect(html).toContain('data-testid="initial-is-weekend">true<');
+    expect(useAllNetworksData).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      "pools",
+    );
   });
 
   it("keeps pools visible and discloses a live-health refresh failure", () => {
@@ -502,7 +509,9 @@ describe("PoolsPage loading-state skeleton parity", () => {
       isLoading: true,
       error: null,
       isSnapshotHistoryCapped: false,
+      isPoolSnapshotHistoryCapped: false,
       snapshotHistoryError: null,
+      poolSnapshotHistoryError: null,
       requestFullSnapshotHistory: vi.fn(async () => undefined),
     });
     vi.mocked(useGQL).mockReturnValue(baseSwapsResult as SWRResponse);

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -198,6 +198,7 @@ function makeNetworkData(
     snapshots7d: [],
     snapshots30d: [],
     snapshotsAllDaily: [],
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,
@@ -231,6 +232,9 @@ const baseAllNetworksResult = {
   ],
   isLoading: false,
   error: null,
+  isSnapshotHistoryCapped: false,
+  snapshotHistoryError: null,
+  requestFullSnapshotHistory: vi.fn(async () => undefined),
 };
 
 const baseSwapsResult = {
@@ -497,6 +501,9 @@ describe("PoolsPage loading-state skeleton parity", () => {
       networkData: [],
       isLoading: true,
       error: null,
+      isSnapshotHistoryCapped: false,
+      snapshotHistoryError: null,
+      requestFullSnapshotHistory: vi.fn(async () => undefined),
     });
     vi.mocked(useGQL).mockReturnValue(baseSwapsResult as SWRResponse);
 

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -87,6 +87,7 @@ function PoolsContent({
   const { networkData, isLoading: poolsLoading } = useAllNetworksData(
     initialNetworkData,
     initialNetworkDataFetchedAtMs,
+    "pools",
   );
   const searchParams = useSearchParams();
   const { replace } = useRouter();

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -81,7 +81,9 @@ function PoolsContent({
   // hook's `fallbackData` branch turns off mount revalidation on a cold SWR
   // cache when the payload is fresh (< SSR_FRESH_ENOUGH_MS), so that first
   // paint fires zero client GraphQL requests; older SSR payloads paint
-  // instantly and revalidate immediately.
+  // instantly and revalidate immediately. The seed's bounded daily history
+  // is intentional: this route only consumes 24h/7d/30d windows, and a later
+  // normal poll replaces it with the complete client payload.
   const { networkData, isLoading: poolsLoading } = useAllNetworksData(
     initialNetworkData,
     initialNetworkDataFetchedAtMs,

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -8,12 +8,14 @@ import { isWeekend } from "@/lib/weekend";
 // then swaps in a ~27-row table when SWR resolves, pushing the swaps section
 // below it down by ~1 200 px — measured CLS 0.4896 on the lhci /pools run
 // (BACKLOG "Lighthouse CI Follow-Ups"). The payload is served from a
-// cross-request cache (30s TTL, ~90s worst-case staleness via the fetchedAt
+// cross-request cache (30s TTL, up to 5min served staleness via the fetchedAt
 // age gate in server-cache; healthy payloads only — degraded ones are never
 // cached, and the underlying `fetchAllNetworks` uses `Promise.allSettled`
 // internally so it degrades per-network on failure); the catch only fires on
 // truly unexpected errors, and an undefined initial payload falls back to
-// the existing client-only path.
+// the existing client-only path. Pool rows and recent KPI windows remain
+// complete in this seed; only chart history older than 30 UTC days is
+// projected out, so the route's Flight payload cannot grow forever.
 //
 // This route also now has its own `loading.tsx`, shaped like the real page
 // (KPI tiles + table placeholders). The 0.4896 CLS regression above came
@@ -29,7 +31,9 @@ export const metadata: Metadata = {
 };
 
 export default async function PoolsPage() {
-  const initialPayload = await fetchInitialNetworkData().catch(() => undefined);
+  const initialPayload = await fetchInitialNetworkData("pools").catch(
+    () => undefined,
+  );
   const initialIsWeekend = isWeekend();
   return (
     <PoolsPageClient

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table-url-state.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table-url-state.test.tsx
@@ -89,6 +89,7 @@ function networkData(snapshots: PoolDailyFeeSnapshot[]): NetworkData {
     snapshots7d: [],
     snapshots30d: [],
     snapshotsAllDaily: [],
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
@@ -131,6 +131,7 @@ function networkData(snapshots: PoolDailyFeeSnapshot[]): NetworkData {
     snapshots7d: [],
     snapshots30d: [],
     snapshotsAllDaily: [],
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
+++ b/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
@@ -113,6 +113,41 @@ describe("homepage snapshot history range handoff", () => {
     expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps TVL All available when only Broker history is capped", () => {
+    const requestFullSnapshotHistory = vi.fn(async () => undefined);
+    const networkData = historyData(false).map((data) => ({
+      ...data,
+      brokerSnapshotsAllDailyCapped: true,
+      brokerSnapshotsAllDailyTruncated: true,
+    }));
+    act(() => {
+      root.render(
+        <TvlOverTimeChart
+          networkData={networkData}
+          totalTvl={2}
+          tvlPartial={false}
+          change7d={null}
+          isLoading={false}
+          hasError={false}
+          hasSnapshotError={false}
+          snapshotHistoryCapped={false}
+          snapshotHistoryError={null}
+          requestFullSnapshotHistory={requestFullSnapshotHistory}
+        />,
+      );
+    });
+
+    act(() => {
+      rangeButton("TVL chart time range", "All").click();
+    });
+
+    expect(requestFullSnapshotHistory).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain(
+      "Total Value Locked chart is loading.",
+    );
+    expect(container.querySelector('[data-testid="plot"]')).not.toBeNull();
+  });
+
   it("shows an explicit error instead of plotting capped volume as All", () => {
     const networkData = historyData(true);
     const requestFullSnapshotHistory = vi.fn(async () => undefined);

--- a/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
+++ b/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
@@ -148,6 +148,36 @@ describe("homepage snapshot history range handoff", () => {
     expect(container.querySelector('[data-testid="plot"]')).not.toBeNull();
   });
 
+  it("uses Broker cap state when a Volume caller omits the combined override", () => {
+    const requestFullSnapshotHistory = vi.fn(async () => undefined);
+    const networkData = historyData(false).map((data) => ({
+      ...data,
+      brokerSnapshotsAllDailyCapped: true,
+    }));
+    act(() => {
+      root.render(
+        <VolumeOverTimeChart
+          networkData={networkData}
+          isLoading={false}
+          hasError={false}
+          hasSnapshotError={false}
+          hasBrokerSnapshotError={false}
+          fullVolumeSeries={buildDailyVolumeSeries(networkData)}
+          snapshotHistoryError={null}
+          requestFullSnapshotHistory={requestFullSnapshotHistory}
+        />,
+      );
+    });
+
+    act(() => {
+      rangeButton("Volume chart time range", "All").click();
+    });
+
+    expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Volume chart is loading.");
+    expect(container.querySelector('[data-testid="plot"]')).toBeNull();
+  });
+
   it("shows an explicit error instead of plotting capped volume as All", () => {
     const networkData = historyData(true);
     const requestFullSnapshotHistory = vi.fn(async () => undefined);

--- a/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
+++ b/ui-dashboard/src/components/__tests__/snapshot-history-range.test.tsx
@@ -1,0 +1,214 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
+import {
+  VolumeOverTimeChart,
+  buildDailyVolumeSeries,
+} from "@/components/volume-over-time-chart";
+import {
+  TVL_NETWORK,
+  makeNetworkData,
+  makeSnapshot,
+  makeTvlPool,
+} from "@/test-utils/network-fixtures";
+import type { NetworkData } from "@/hooks/use-all-networks-data";
+
+type CapturedTrace = { name?: string; x?: unknown[] };
+let capturedPlots: CapturedTrace[][] = [];
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot({ data }: { data?: CapturedTrace[] }) {
+      if (data) capturedPlots.push(data);
+      return React.createElement("div", { "data-testid": "plot" });
+    },
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  capturedPlots = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function historyData(capped: boolean): NetworkData[] {
+  const pool = makeTvlPool({ id: "pool-a" });
+  return [
+    makeNetworkData({
+      network: TVL_NETWORK,
+      pools: [pool],
+      snapshotsAllDaily: [makeSnapshot({ poolId: pool.id })],
+      snapshotsAllDailyCapped: capped,
+    }),
+  ];
+}
+
+function rangeButton(label: string, range: string): HTMLButtonElement {
+  const group = container.querySelector(`[aria-label="${label}"]`);
+  const button = Array.from(group?.querySelectorAll("button") ?? []).find(
+    (candidate) => candidate.textContent === range,
+  );
+  expect(button).toBeDefined();
+  return button as HTMLButtonElement;
+}
+
+describe("homepage snapshot history range handoff", () => {
+  it("requests full history and hides the capped TVL series until uncapped data arrives", () => {
+    const requestFullSnapshotHistory = vi.fn(async () => undefined);
+    const render = (networkData: NetworkData[], capped: boolean) => {
+      act(() => {
+        root.render(
+          <TvlOverTimeChart
+            networkData={networkData}
+            totalTvl={2}
+            tvlPartial={false}
+            change7d={null}
+            isLoading={false}
+            hasError={false}
+            hasSnapshotError={false}
+            snapshotHistoryCapped={capped}
+            snapshotHistoryError={null}
+            requestFullSnapshotHistory={requestFullSnapshotHistory}
+          />,
+        );
+      });
+    };
+    render(historyData(true), true);
+    expect(container.querySelector('[data-testid="plot"]')).not.toBeNull();
+
+    act(() => {
+      rangeButton("TVL chart time range", "All").click();
+    });
+
+    expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
+    expect(
+      rangeButton("TVL chart time range", "All").getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(container.textContent).toContain(
+      "Total Value Locked chart is loading.",
+    );
+    expect(container.querySelector('[data-testid="plot"]')).toBeNull();
+
+    render(historyData(false), false);
+
+    expect(container.textContent).not.toContain(
+      "Total Value Locked chart is loading.",
+    );
+    expect(container.querySelector('[data-testid="plot"]')).not.toBeNull();
+    expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an explicit error instead of plotting capped volume as All", () => {
+    const networkData = historyData(true);
+    const requestFullSnapshotHistory = vi.fn(async () => undefined);
+    const render = (snapshotHistoryError: Error | null) => {
+      act(() => {
+        root.render(
+          <VolumeOverTimeChart
+            networkData={networkData}
+            isLoading={false}
+            hasError={false}
+            hasSnapshotError={false}
+            hasBrokerSnapshotError={false}
+            fullVolumeSeries={buildDailyVolumeSeries(networkData)}
+            snapshotHistoryCapped
+            snapshotHistoryError={snapshotHistoryError}
+            requestFullSnapshotHistory={requestFullSnapshotHistory}
+          />,
+        );
+      });
+    };
+    render(null);
+
+    act(() => {
+      rangeButton("Volume chart time range", "All").click();
+    });
+    render(new Error("full history timeout"));
+
+    expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain(
+      "Unable to load full volume history",
+    );
+    expect(container.textContent).not.toContain("Volume chart is loading.");
+    expect(container.querySelector('[data-testid="plot"]')).toBeNull();
+  });
+
+  it("plots an older Broker sentinel after a Broker-only capped All request completes", () => {
+    const today = Math.floor(Date.now() / 1000 / 86_400) * 86_400;
+    const recentRow = {
+      id: "broker-recent",
+      timestamp: String(today - 86_400),
+      volumeUsdWei: "1000000000000000000",
+      swapCount: 1,
+    };
+    const olderRow = {
+      id: "broker-older-sentinel",
+      timestamp: String(today - 40 * 86_400),
+      volumeUsdWei: "42000000000000000000",
+      swapCount: 42,
+    };
+    const requestFullSnapshotHistory = vi.fn(async () => undefined);
+    const render = (networkData: NetworkData[], capped: boolean) => {
+      act(() => {
+        root.render(
+          <VolumeOverTimeChart
+            networkData={networkData}
+            isLoading={false}
+            hasError={false}
+            hasSnapshotError={false}
+            hasBrokerSnapshotError={false}
+            fullVolumeSeries={buildDailyVolumeSeries(networkData)}
+            snapshotHistoryCapped={capped}
+            snapshotHistoryError={null}
+            requestFullSnapshotHistory={requestFullSnapshotHistory}
+          />,
+        );
+      });
+    };
+    const bounded = [
+      makeNetworkData({
+        snapshotsAllDailyCapped: false,
+        brokerSnapshotsAllDaily: [recentRow],
+        brokerSnapshotsAllDailyCapped: true,
+      }),
+    ];
+    render(bounded, true);
+
+    act(() => {
+      rangeButton("Volume chart time range", "All").click();
+    });
+    expect(requestFullSnapshotHistory).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="plot"]')).toBeNull();
+
+    const complete = [
+      makeNetworkData({
+        snapshotsAllDailyCapped: false,
+        brokerSnapshotsAllDaily: [recentRow, olderRow],
+        brokerSnapshotsAllDailyCapped: false,
+      }),
+    ];
+    render(complete, false);
+
+    const olderIso = new Date(Number(olderRow.timestamp) * 1000).toISOString();
+    const v2Trace = capturedPlots
+      .flat()
+      .find((trace) => trace.name === "v2" && trace.x?.includes(olderIso));
+    expect(v2Trace).toBeDefined();
+    expect(container.querySelector('[data-testid="plot"]')).not.toBeNull();
+  });
+});

--- a/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
+++ b/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
@@ -138,8 +138,12 @@ describe("stacked TimeSeriesChartCard caller matrix", () => {
     ];
     const model = {
       showChart: true,
+      poolChartRange: "30d",
       poolChart: {
-        poolVolumeBreakdown: { totalSeries: chartSeries() },
+        poolVolumeBreakdown: {
+          totalSeries: chartSeries(),
+          windowTotalUsdWei: BigInt(30),
+        },
         chartBreakdown: poolBreakdown,
         topPoolsListEntries: [],
       },

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { chainColor } from "@/lib/chain-colors";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
@@ -17,9 +17,9 @@ import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
   SECONDS_PER_DAY,
   filterSeriesByRange,
-  type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
+import { useSnapshotHistoryRange } from "@/hooks/use-snapshot-history-range";
 
 type SeriesPoint = { timestamp: number; tvlUSD: number };
 
@@ -393,9 +393,16 @@ interface TvlOverTimeChartProps {
   isLoading: boolean;
   hasError: boolean;
   hasSnapshotError: boolean;
+  /** Whether the current Server Component seed intentionally omits old rows. */
+  snapshotHistoryCapped?: boolean;
+  /** Unexpected error from the on-demand full-history SWR revalidation. */
+  snapshotHistoryError?: Error | null;
+  /** Shared/coalesced request used when this chart first selects "All". */
+  requestFullSnapshotHistory?: () => Promise<void>;
   plotlyDeferMode?: PlotlyDeferMode;
 }
 
+// eslint-disable-next-line max-lines-per-function -- Chart owns range handoff plus TVL series/breakdown projection as one render contract.
 export function TvlOverTimeChart({
   networkData,
   totalTvl,
@@ -404,9 +411,25 @@ export function TvlOverTimeChart({
   isLoading,
   hasError,
   hasSnapshotError,
+  snapshotHistoryCapped,
+  snapshotHistoryError = null,
+  requestFullSnapshotHistory,
   plotlyDeferMode = "none",
 }: TvlOverTimeChartProps) {
-  const [range, setRange] = useState<RangeKey>("30d");
+  const historyIsCapped =
+    snapshotHistoryCapped ??
+    networkData.some((network) => network.snapshotsAllDailyCapped);
+  const {
+    range,
+    handleRangeChange,
+    allHistoryUnavailable,
+    allHistoryLoading,
+    allHistoryFailed,
+  } = useSnapshotHistoryRange({
+    historyIsCapped,
+    snapshotHistoryError,
+    requestFullSnapshotHistory,
+  });
 
   const { fullSeries, fullBreakdown } = useMemo<{
     fullSeries: TimeSeriesPoint[];
@@ -449,19 +472,23 @@ export function TvlOverTimeChart({
   // is fine: the headline shows current TVL (not a bar-sum), so no invariant
   // to preserve against a rolling-hour summary window.
   const visibleSeries = useMemo(
-    () => filterSeriesByRange(fullSeries, range),
-    [fullSeries, range],
+    () => (allHistoryUnavailable ? [] : filterSeriesByRange(fullSeries, range)),
+    [allHistoryUnavailable, fullSeries, range],
   );
   const visibleBreakdown = useMemo<BreakdownSeries[]>(
     () =>
-      fullBreakdown.map((b) => ({
-        ...b,
-        series: filterSeriesByRange(b.series, range),
-      })),
-    [fullBreakdown, range],
+      allHistoryUnavailable
+        ? []
+        : fullBreakdown.map((b) => ({
+            ...b,
+            series: filterSeriesByRange(b.series, range),
+          })),
+    [allHistoryUnavailable, fullBreakdown, range],
   );
 
-  const headline = isLoading
+  const chartIsLoading = isLoading || allHistoryLoading;
+  const chartHasSnapshotError = hasSnapshotError || allHistoryFailed;
+  const headline = chartIsLoading
     ? "…"
     : tvlPartial === null
       ? "—"
@@ -470,9 +497,11 @@ export function TvlOverTimeChart({
         : formatUSD(totalTvl);
   const emptyMessage = hasError
     ? "Unable to load TVL history"
-    : hasSnapshotError
-      ? "Historical data partial — some chains failed to load"
-      : "Not enough history yet";
+    : allHistoryFailed
+      ? "Unable to load full TVL history"
+      : hasSnapshotError
+        ? "Historical data partial — some chains failed to load"
+        : "Not enough history yet";
 
   return (
     <TimeSeriesChartCard
@@ -481,13 +510,13 @@ export function TvlOverTimeChart({
       series={visibleSeries}
       breakdown={visibleBreakdown}
       range={range}
-      onRangeChange={setRange}
+      onRangeChange={handleRangeChange}
       headline={headline}
       change={change7d}
       hoverDateFormat="%b %d, %Y"
-      isLoading={isLoading}
+      isLoading={chartIsLoading}
       hasError={hasError}
-      hasSnapshotError={hasSnapshotError}
+      hasSnapshotError={chartHasSnapshotError}
       emptyMessage={emptyMessage}
       plotlyDeferMode={plotlyDeferMode}
     />

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -595,7 +595,11 @@ export function VolumeOverTimeChart({
 }: VolumeOverTimeChartProps) {
   const historyIsCapped =
     snapshotHistoryCapped ??
-    networkData.some((network) => network.snapshotsAllDailyCapped);
+    networkData.some(
+      (network) =>
+        network.snapshotsAllDailyCapped ||
+        network.brokerSnapshotsAllDailyCapped === true,
+    );
   const {
     range,
     handleRangeChange,

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { formatUSD } from "@/lib/format";
 import {
   getSnapshotVolumeInUsd,
@@ -21,6 +21,7 @@ import {
   type TimeSeriesPoint,
 } from "@/lib/time-series";
 import { zeroFillSeries } from "@/lib/chart-gap-fill";
+import { useSnapshotHistoryRange } from "@/hooks/use-snapshot-history-range";
 
 type SeriesPoint = { timestamp: number; volumeUSD: number };
 
@@ -567,11 +568,18 @@ interface VolumeOverTimeChartProps {
    */
   hasBrokerSnapshotError: boolean;
   fullVolumeSeries: DailyVolumeSeriesResult;
+  /** Whether the current Server Component seed intentionally omits old rows. */
+  snapshotHistoryCapped?: boolean;
+  /** Unexpected error from the on-demand full-history SWR revalidation. */
+  snapshotHistoryError?: Error | null;
+  /** Shared/coalesced request used when this chart first selects "All". */
+  requestFullSnapshotHistory?: () => Promise<void>;
   plotlyDeferMode?: PlotlyDeferMode;
 }
 
 // The four loading/error flags are independent: volume can load while
 // snapshots or broker rollups degrade separately.
+/* eslint-disable max-lines-per-function -- Chart owns range handoff plus v2/v3 stacked-series projection as one render contract. */
 // react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function VolumeOverTimeChart({
   networkData,
@@ -580,9 +588,25 @@ export function VolumeOverTimeChart({
   hasSnapshotError,
   hasBrokerSnapshotError,
   fullVolumeSeries,
+  snapshotHistoryCapped,
+  snapshotHistoryError = null,
+  requestFullSnapshotHistory,
   plotlyDeferMode = "none",
 }: VolumeOverTimeChartProps) {
-  const [range, setRange] = useState<RangeKey>("30d");
+  const historyIsCapped =
+    snapshotHistoryCapped ??
+    networkData.some((network) => network.snapshotsAllDailyCapped);
+  const {
+    range,
+    handleRangeChange,
+    allHistoryUnavailable,
+    allHistoryLoading,
+    allHistoryFailed,
+  } = useSnapshotHistoryRange({
+    historyIsCapped,
+    snapshotHistoryError,
+    requestFullSnapshotHistory,
+  });
 
   // v3 WoW pill — v2 has a separate trajectory but is much smaller today, so
   // tracking the dominant-side delta keeps the headline meaningful. v2 WoW
@@ -602,9 +626,11 @@ export function VolumeOverTimeChart({
   const visibleV3Result = useMemo<DailyVolumeSeriesResult>(
     () =>
       range === "all"
-        ? fullVolumeSeries
+        ? allHistoryUnavailable
+          ? { series: [], byChain: [], volumePartial: false }
+          : fullVolumeSeries
         : buildDailyVolumeSeries(networkData, activeWindow),
-    [networkData, range, activeWindow, fullVolumeSeries],
+    [activeWindow, allHistoryUnavailable, fullVolumeSeries, networkData, range],
   );
   const visibleV3Points = visibleV3Result.series;
   const visibleVolumePartial = visibleV3Result.volumePartial;
@@ -613,8 +639,11 @@ export function VolumeOverTimeChart({
   // (already filtered to routedViaV3Router=false server-side). Empty until
   // the indexer's Broker handler is deployed and resyncs.
   const visibleV2Points = useMemo<SeriesPoint[]>(
-    () => buildBrokerDailyV2Series(networkData, activeWindow),
-    [networkData, activeWindow],
+    () =>
+      allHistoryUnavailable
+        ? []
+        : buildBrokerDailyV2Series(networkData, activeWindow),
+    [activeWindow, allHistoryUnavailable, networkData],
   );
 
   // Stack v3 (bottom) + v2 (top). Distinct, named legend entries; the chart
@@ -649,10 +678,12 @@ export function VolumeOverTimeChart({
     [visibleV3Points, visibleV2Points],
   );
 
+  const chartIsLoading = isLoading || allHistoryLoading;
+  const chartHasSnapshotError = hasSnapshotError || allHistoryFailed;
   const headline = computeHeadline({
-    isLoading,
+    isLoading: chartIsLoading,
     hasError,
-    hasSnapshotError,
+    hasSnapshotError: chartHasSnapshotError,
     hasBrokerSnapshotError,
     v3Partial: visibleVolumePartial,
     v3Points: visibleV3Points,
@@ -663,11 +694,9 @@ export function VolumeOverTimeChart({
 
   const change = weekOverWeekChangePct(fullV3Series);
 
-  const emptyMessage = volumeEmptyMessage(
-    hasError,
-    hasSnapshotError,
-    visibleVolumePartial,
-  );
+  const emptyMessage = allHistoryFailed
+    ? "Unable to load full volume history"
+    : volumeEmptyMessage(hasError, hasSnapshotError, visibleVolumePartial);
 
   return (
     <TimeSeriesChartCard
@@ -677,15 +706,16 @@ export function VolumeOverTimeChart({
       breakdown={visibleBreakdown}
       breakdownMode="stacked"
       range={range}
-      onRangeChange={setRange}
+      onRangeChange={handleRangeChange}
       headline={headline}
       change={change}
       changeLabel="v3 week-over-week"
-      isLoading={isLoading}
+      isLoading={chartIsLoading}
       hasError={hasError}
-      hasSnapshotError={hasSnapshotError || visibleVolumePartial === true}
+      hasSnapshotError={chartHasSnapshotError || visibleVolumePartial === true}
       emptyMessage={emptyMessage}
       plotlyDeferMode={plotlyDeferMode}
     />
   );
 }
+/* eslint-enable max-lines-per-function */

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
@@ -3,11 +3,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { InitialNetworkData, NetworkData } from "@/lib/fetch-all-networks";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+import {
+  SWR_KEY_ALL_NETWORKS_DATA,
+  SWR_KEY_POOLS_NETWORKS_DATA,
+} from "@/lib/swr-keys";
 
 const harness = vi.hoisted(() => ({
   fetchAllNetworks: vi.fn<() => Promise<NetworkData[]>>(),
   fetcher: undefined as (() => Promise<NetworkData[]>) | undefined,
   fetchers: [] as (() => Promise<NetworkData[]>)[],
+  cacheKeys: [] as string[],
   mutateRequest: undefined as Promise<NetworkData[]> | undefined,
   seedIncrementalRowCacheFromNetworkData: vi.fn(),
 }));
@@ -32,10 +37,11 @@ vi.mock("@/hooks/use-live-pool-health", () => ({
 
 vi.mock("swr", () => ({
   default: (
-    _key: string,
+    key: string,
     fetcher: () => Promise<NetworkData[]>,
     config: { fallbackData?: NetworkData[] },
   ) => {
+    harness.cacheKeys.push(key);
     harness.fetcher = fetcher;
     harness.fetchers.push(fetcher);
     return {
@@ -52,7 +58,10 @@ vi.mock("swr", () => ({
   useSWRConfig: () => ({ cache: { get: () => undefined } }),
 }));
 
-import { useAllNetworksData } from "../use-all-networks-data";
+import {
+  useAllNetworksData,
+  type AllNetworksDataCacheScope,
+} from "../use-all-networks-data";
 
 const NETWORK = {
   id: "celo-mainnet",
@@ -118,8 +127,14 @@ function networkData(
 
 let latestResult: ReturnType<typeof useAllNetworksData> | undefined;
 
-function Probe({ fallback }: { fallback: InitialNetworkData[] }) {
-  latestResult = useAllNetworksData(fallback, 0);
+function Probe({
+  fallback,
+  cacheScope = "home",
+}: {
+  fallback: InitialNetworkData[];
+  cacheScope?: AllNetworksDataCacheScope;
+}) {
+  latestResult = useAllNetworksData(fallback, 0, cacheScope);
   return null;
 }
 
@@ -128,8 +143,22 @@ describe("useAllNetworksData cold-cache reconciliation", () => {
     vi.clearAllMocks();
     harness.fetcher = undefined;
     harness.fetchers.length = 0;
+    harness.cacheKeys.length = 0;
     harness.mutateRequest = undefined;
     latestResult = undefined;
+  });
+
+  it("isolates the intentionally stripped /pools fallback under its own SWR key", () => {
+    const fallback = [networkData(ACTIVE_VP)];
+
+    renderToStaticMarkup(<Probe fallback={fallback} />);
+    renderToStaticMarkup(<Probe fallback={fallback} cacheScope="pools" />);
+
+    expect(harness.cacheKeys).toEqual([
+      SWR_KEY_ALL_NETWORKS_DATA,
+      SWR_KEY_POOLS_NETWORKS_DATA,
+    ]);
+    expect(SWR_KEY_POOLS_NETWORKS_DATA).not.toBe(SWR_KEY_ALL_NETWORKS_DATA);
   });
 
   it("retains the SSR VirtualPool extension on the first client refresh", async () => {
@@ -196,6 +225,30 @@ describe("useAllNetworksData cold-cache reconciliation", () => {
     expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
     resolveFetch([networkData(ACTIVE_VP, false) as NetworkData]);
     await Promise.all([first, second]);
+  });
+
+  it("starts an All request without Promise.finally support", () => {
+    const fallback = [networkData(ACTIVE_VP)];
+    harness.fetchAllNetworks.mockResolvedValueOnce([
+      networkData(ACTIVE_VP, false) as NetworkData,
+    ]);
+    renderToStaticMarkup(<Probe fallback={fallback} />);
+
+    const finallyDescriptor = Object.getOwnPropertyDescriptor(
+      Promise.prototype,
+      "finally",
+    )!;
+    Object.defineProperty(Promise.prototype, "finally", {
+      ...finallyDescriptor,
+      value: undefined,
+    });
+
+    try {
+      expect(() => latestResult!.requestFullSnapshotHistory()).not.toThrow();
+      expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(Promise.prototype, "finally", finallyDescriptor);
+    }
   });
 
   it("joins a user-triggered All request to mount revalidation at the fetch boundary", async () => {
@@ -284,7 +337,57 @@ describe("useAllNetworksData cold-cache reconciliation", () => {
     await latestResult!.requestFullSnapshotHistory();
 
     expect(latestResult!.isSnapshotHistoryCapped).toBe(true);
+    expect(latestResult!.isPoolSnapshotHistoryCapped).toBe(false);
+    expect(latestResult!.poolSnapshotHistoryError).toBeNull();
     expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates a Broker-only completion failure from the TVL error channel", () => {
+    const fallback = {
+      ...networkData(ACTIVE_VP, false),
+      brokerSnapshotsAllDailyCapped: true,
+      brokerSnapshotsAllDailyTruncated: true,
+    } satisfies InitialNetworkData;
+
+    renderToStaticMarkup(<Probe fallback={[fallback]} />);
+
+    expect(latestResult!.isSnapshotHistoryCapped).toBe(true);
+    expect(latestResult!.snapshotHistoryError?.message).toBe(
+      "Full Broker history pagination was truncated",
+    );
+    expect(latestResult!.isPoolSnapshotHistoryCapped).toBe(false);
+    expect(latestResult!.poolSnapshotHistoryError).toBeNull();
+  });
+
+  it("retains bounded Broker rows when completion fails before page one", async () => {
+    const recentBrokerRow = {
+      id: "broker-recent",
+      timestamp: String(TODAY_MIDNIGHT),
+      volumeUsdWei: "1000000000000000000",
+      swapCount: 1,
+    };
+    const fallback = {
+      ...networkData(ACTIVE_VP, false),
+      brokerSnapshotsAllDaily: [recentBrokerRow],
+      brokerSnapshotsAllDailyCapped: true,
+    } satisfies InitialNetworkData;
+    harness.fetchAllNetworks.mockResolvedValueOnce([
+      {
+        ...fallback,
+        brokerSnapshotsAllDaily: [],
+        brokerSnapshotsAllDailyCapped: true,
+        brokerSnapshotsAllDailyError: { message: "Broker unavailable" },
+      } as NetworkData,
+    ]);
+    renderToStaticMarkup(<Probe fallback={[fallback]} />);
+
+    const refreshed = await harness.fetcher!();
+
+    expect(refreshed[0]!.brokerSnapshotsAllDaily).toEqual([recentBrokerRow]);
+    expect(refreshed[0]!.brokerSnapshotsAllDailyCapped).toBe(true);
+    expect(refreshed[0]!.brokerSnapshotsAllDailyError?.message).toBe(
+      "Broker unavailable",
+    );
   });
 
   it("surfaces a failed completion while keeping the bounded history marked incomplete", () => {

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data-hook.test.tsx
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { InitialNetworkData, NetworkData } from "@/lib/fetch-all-networks";
 import type { Network } from "@/lib/networks";
-import type { Pool } from "@/lib/types";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
 
 const harness = vi.hoisted(() => ({
   fetchAllNetworks: vi.fn<() => Promise<NetworkData[]>>(),
   fetcher: undefined as (() => Promise<NetworkData[]>) | undefined,
+  fetchers: [] as (() => Promise<NetworkData[]>)[],
+  mutateRequest: undefined as Promise<NetworkData[]> | undefined,
+  seedIncrementalRowCacheFromNetworkData: vi.fn(),
 }));
 
 vi.mock("@/lib/fetch-all-networks", async (importOriginal) => {
@@ -15,7 +18,8 @@ vi.mock("@/lib/fetch-all-networks", async (importOriginal) => {
   return {
     ...actual,
     fetchAllNetworks: harness.fetchAllNetworks,
-    seedIncrementalRowCacheFromNetworkData: vi.fn(),
+    seedIncrementalRowCacheFromNetworkData:
+      harness.seedIncrementalRowCacheFromNetworkData,
   };
 });
 
@@ -33,10 +37,16 @@ vi.mock("swr", () => ({
     config: { fallbackData?: NetworkData[] },
   ) => {
     harness.fetcher = fetcher;
+    harness.fetchers.push(fetcher);
     return {
       data: config.fallbackData,
       error: undefined,
       isLoading: false,
+      mutate: () => {
+        const request = fetcher();
+        harness.mutateRequest = request;
+        return request;
+      },
     };
   },
   useSWRConfig: () => ({ cache: { get: () => undefined } }),
@@ -64,17 +74,52 @@ const ACTIVE_VP = {
   updatedAtTimestamp: "2000",
 } satisfies Pool;
 
-function networkData(pool: Pool): InitialNetworkData {
+const TODAY_MIDNIGHT = 1_700_006_400;
+const SECONDS_PER_DAY = 86_400;
+
+function dailySnapshot(daysAgo: number): PoolSnapshotWindow {
+  return {
+    poolId: ACTIVE_VP.id,
+    timestamp: String(TODAY_MIDNIGHT - daysAgo * SECONDS_PER_DAY),
+    reserves0: "1",
+    reserves1: "1",
+    swapCount: daysAgo + 1,
+    swapVolume0: "1",
+    swapVolume1: "1",
+  };
+}
+
+const DAILY_HISTORY = [0, 6, 7, 29, 30].map(dailySnapshot);
+
+function networkData(
+  pool: Pool,
+  snapshotsAllDailyCapped = true,
+): InitialNetworkData {
   return {
     network: NETWORK,
     pools: [pool],
+    snapshotWindows: {
+      w24h: { from: TODAY_MIDNIGHT - SECONDS_PER_DAY, to: TODAY_MIDNIGHT },
+      w7d: { from: TODAY_MIDNIGHT - 7 * SECONDS_PER_DAY, to: TODAY_MIDNIGHT },
+      w30d: {
+        from: TODAY_MIDNIGHT - 30 * SECONDS_PER_DAY,
+        to: TODAY_MIDNIGHT,
+      },
+    },
+    snapshots: [],
+    snapshots7d: [],
+    snapshots30d: [],
+    snapshotsAllDaily: DAILY_HISTORY,
+    snapshotsAllDailyCapped,
     feeSnapshots: [],
     liveHealthError: null,
   } as InitialNetworkData;
 }
 
+let latestResult: ReturnType<typeof useAllNetworksData> | undefined;
+
 function Probe({ fallback }: { fallback: InitialNetworkData[] }) {
-  useAllNetworksData(fallback, 0);
+  latestResult = useAllNetworksData(fallback, 0);
   return null;
 }
 
@@ -82,6 +127,9 @@ describe("useAllNetworksData cold-cache reconciliation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     harness.fetcher = undefined;
+    harness.fetchers.length = 0;
+    harness.mutateRequest = undefined;
+    latestResult = undefined;
   });
 
   it("retains the SSR VirtualPool extension on the first client refresh", async () => {
@@ -99,6 +147,158 @@ describe("useAllNetworksData cold-cache reconciliation", () => {
     expect(refreshed[0]?.pools[0]?.wrappedExchangeMinimumReports).toBe("2");
     expect(refreshed[0]?.liveHealthError?.message).toContain(
       "did not reconfirm 1 VirtualPool extension",
+    );
+  });
+
+  it("restores omitted daily windows before consumers and cache seeding", () => {
+    const fallback = [networkData(ACTIVE_VP)];
+
+    renderToStaticMarkup(<Probe fallback={fallback} />);
+
+    const restored = latestResult!.networkData[0]!;
+    expect(restored.snapshots.map((row) => row.timestamp)).toEqual([
+      String(TODAY_MIDNIGHT),
+    ]);
+    expect(restored.snapshots7d.map((row) => row.timestamp)).toEqual(
+      [0, 6].map((daysAgo) =>
+        String(TODAY_MIDNIGHT - daysAgo * SECONDS_PER_DAY),
+      ),
+    );
+    expect(restored.snapshots30d.map((row) => row.timestamp)).toEqual(
+      [0, 6, 7, 29].map((daysAgo) =>
+        String(TODAY_MIDNIGHT - daysAgo * SECONDS_PER_DAY),
+      ),
+    );
+    expect(harness.seedIncrementalRowCacheFromNetworkData).toHaveBeenCalledWith(
+      [restored],
+    );
+    // The transport object is immutable: it still carries the explicit empty
+    // tuples, proving restoration did not re-inflate the Flight prop itself.
+    expect(fallback[0]!.snapshots).toEqual([]);
+    expect(fallback[0]!.snapshots7d).toEqual([]);
+    expect(fallback[0]!.snapshots30d).toEqual([]);
+  });
+
+  it("coalesces repeated full-history requests while the capped seed refresh is in flight", async () => {
+    const fallback = [networkData(ACTIVE_VP)];
+    let resolveFetch!: (value: NetworkData[]) => void;
+    harness.fetchAllNetworks.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    renderToStaticMarkup(<Probe fallback={fallback} />);
+
+    const first = latestResult!.requestFullSnapshotHistory();
+    const second = latestResult!.requestFullSnapshotHistory();
+
+    expect(second).toBe(first);
+    expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+    resolveFetch([networkData(ACTIVE_VP, false) as NetworkData]);
+    await Promise.all([first, second]);
+  });
+
+  it("joins a user-triggered All request to mount revalidation at the fetch boundary", async () => {
+    const fallback = [networkData(ACTIVE_VP)];
+    let resolveFetch!: (value: NetworkData[]) => void;
+    harness.fetchAllNetworks.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    renderToStaticMarkup(<Probe fallback={fallback} />);
+
+    // Model SWR starting a mount revalidation before the chart asks for All.
+    const mountRequest = harness.fetcher!();
+    const allRequest = latestResult!.requestFullSnapshotHistory();
+
+    expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+    expect(harness.mutateRequest).toBe(mountRequest);
+
+    const completed = networkData(ACTIVE_VP, false) as NetworkData;
+    resolveFetch([completed]);
+    const [mountResult] = await Promise.all([mountRequest, allRequest]);
+
+    expect(mountResult).toEqual([completed]);
+  });
+
+  it("shares one raw fan-out across hook instances but reconciles each caller's fallback", async () => {
+    const firstFallback = [networkData(ACTIVE_VP)];
+    const secondFallback = [
+      networkData({
+        ...ACTIVE_VP,
+        wrappedExchangeMinimumReports: "3",
+      }),
+    ];
+    let resolveFetch!: (value: NetworkData[]) => void;
+    harness.fetchAllNetworks.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    renderToStaticMarkup(<Probe fallback={firstFallback} />);
+    const firstInstanceFetcher = harness.fetchers[0]!;
+    renderToStaticMarkup(<Probe fallback={secondFallback} />);
+
+    const firstMountRequest = firstInstanceFetcher();
+    const secondAllRequest = latestResult!.requestFullSnapshotHistory();
+
+    expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+    resolveFetch([
+      networkData({
+        ...ACTIVE_VP,
+        wrappedExchangeMinimumReports: undefined,
+      }) as NetworkData,
+    ]);
+    const [firstResult, secondResult] = await Promise.all([
+      firstMountRequest,
+      harness.mutateRequest!,
+      secondAllRequest,
+    ]);
+
+    expect(firstResult[0]?.pools[0]?.wrappedExchangeMinimumReports).toBe("2");
+    expect(secondResult[0]?.pools[0]?.wrappedExchangeMinimumReports).toBe("3");
+  });
+
+  it("does not refetch when the visible snapshot history is already complete", async () => {
+    renderToStaticMarkup(<Probe fallback={[networkData(ACTIVE_VP, false)]} />);
+
+    await latestResult!.requestFullSnapshotHistory();
+
+    expect(harness.fetchAllNetworks).not.toHaveBeenCalled();
+  });
+
+  it("treats bounded Broker rows as incomplete even when v3 history is complete", async () => {
+    const fallback = {
+      ...networkData(ACTIVE_VP, false),
+      brokerSnapshotsAllDailyCapped: true,
+    } satisfies InitialNetworkData;
+    harness.fetchAllNetworks.mockResolvedValueOnce([
+      {
+        ...fallback,
+        brokerSnapshotsAllDailyCapped: false,
+      } as NetworkData,
+    ]);
+    renderToStaticMarkup(<Probe fallback={[fallback]} />);
+
+    await latestResult!.requestFullSnapshotHistory();
+
+    expect(latestResult!.isSnapshotHistoryCapped).toBe(true);
+    expect(harness.fetchAllNetworks).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a failed completion while keeping the bounded history marked incomplete", () => {
+    const failedFallback = {
+      ...networkData(ACTIVE_VP),
+      snapshotsAllDailyError: { message: "full history timeout" },
+      snapshotsAllDailyTruncated: true,
+    } satisfies InitialNetworkData;
+
+    renderToStaticMarkup(<Probe fallback={[failedFallback]} />);
+
+    expect(latestResult!.isSnapshotHistoryCapped).toBe(true);
+    expect(latestResult!.snapshotHistoryError?.message).toBe(
+      "full history timeout",
     );
   });
 });

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -367,6 +367,16 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.fees).not.toBeNull();
     expect(result.uniqueLpAddresses).toHaveLength(5);
     expect(result.rates).toBeInstanceOf(Map);
+    expect(isNetworkDataFullyHealthy(result)).toBe(true);
+    // The SSR cap is an intentional transport projection, not upstream
+    // degradation. A fresh capped seed must remain eligible for the cold-cache
+    // mount skip; the explicit "All" interaction owns full-history recovery.
+    expect(
+      isNetworkDataFullyHealthy({
+        ...result,
+        snapshotsAllDailyCapped: true,
+      }),
+    ).toBe(true);
 
     // Verify the request shape per query type (call order can vary because
     // the fees/snapshots/LP triad fires via Promise.allSettled after Pool).
@@ -1015,6 +1025,7 @@ describe("fetchNetworkData — daily snapshot pagination", () => {
       variablesKey: "pool-tail",
       rows: cachedRows,
       refreshAfterTimestamp: todayMidnight - 86400,
+      complete: true,
     });
     const tailErr = new Error("incremental tail timeout");
 

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -10,7 +10,10 @@ import {
   type NetworkData,
 } from "@/lib/fetch-all-networks";
 import { SHARED_QUERY_SWR_CONFIG } from "@/lib/gql-retry";
-import { SWR_KEY_ALL_NETWORKS_DATA } from "@/lib/swr-keys";
+import {
+  SWR_KEY_ALL_NETWORKS_DATA,
+  SWR_KEY_POOLS_NETWORKS_DATA,
+} from "@/lib/swr-keys";
 import { useLivePoolHealth } from "@/hooks/use-live-pool-health";
 import { buildDailySnapshotSlices } from "@/lib/volume";
 
@@ -20,19 +23,30 @@ type AllNetworksResult = {
   error: Error | null;
   /** True while the visible data still carries the bounded SSR history. */
   isSnapshotHistoryCapped: boolean;
+  /** PoolDailySnapshot-only cap used by the TVL chart. */
+  isPoolSnapshotHistoryCapped: boolean;
   /** Unexpected failure from an on-demand full-history revalidation. */
   snapshotHistoryError: Error | null;
+  /** PoolDailySnapshot-only failure used by the TVL chart. */
+  poolSnapshotHistoryError: Error | null;
   /** Coalesced normal SWR revalidation used by the homepage "All" charts. */
   requestFullSnapshotHistory: () => Promise<void>;
 };
 
+export type AllNetworksDataCacheScope = "home" | "pools";
+
+const ALL_NETWORKS_DATA_KEYS = {
+  home: SWR_KEY_ALL_NETWORKS_DATA,
+  pools: SWR_KEY_POOLS_NETWORKS_DATA,
+} as const satisfies Record<AllNetworksDataCacheScope, string>;
+
 const EMPTY_NETWORK_DATA: NetworkData[] = [];
 
-// One browser-tab fetch boundary for the shared all-networks SWR key. Multiple
-// hook instances can coexist briefly during route transitions; SWR normally
-// dedupes them, but an imperative mutate in one instance can overlap a mount or
-// polling revalidation in another. Share only the raw fleet fan-out here, then
-// let each caller reconcile that result against its own last-good data.
+// One browser-tab fetch boundary across the route-scoped all-networks caches.
+// Multiple hook instances can coexist briefly during route transitions; SWR
+// dedupes within a key, while this boundary lets overlapping route fetches
+// share only the raw fleet fan-out. Each caller still reconciles that result
+// against its own last-good data before writing to its isolated cache.
 let allNetworksFetchInFlight: Promise<NetworkData[]> | null = null;
 
 function fetchAllNetworksAtBoundary(): Promise<NetworkData[]> {
@@ -51,7 +65,7 @@ function fetchAllNetworksAtBoundary(): Promise<NetworkData[]> {
   return request;
 }
 
-function cappedSnapshotHistoryFailure(
+function cappedPoolSnapshotHistoryFailure(
   networkData: readonly NetworkData[],
 ): Error | null {
   for (const network of networkData) {
@@ -63,6 +77,14 @@ function cappedSnapshotHistoryFailure(
         return new Error("Full snapshot history pagination was truncated");
       }
     }
+  }
+  return null;
+}
+
+function cappedBrokerSnapshotHistoryFailure(
+  networkData: readonly NetworkData[],
+): Error | null {
+  for (const network of networkData) {
     if (network.brokerSnapshotsAllDailyCapped === true) {
       if (network.brokerSnapshotsAllDailyError != null) {
         return new Error(network.brokerSnapshotsAllDailyError.message);
@@ -73,6 +95,46 @@ function cappedSnapshotHistoryFailure(
     }
   }
   return null;
+}
+
+type SnapshotHistoryStatus = Pick<
+  AllNetworksResult,
+  | "isSnapshotHistoryCapped"
+  | "isPoolSnapshotHistoryCapped"
+  | "snapshotHistoryError"
+  | "poolSnapshotHistoryError"
+>;
+
+function deriveSnapshotHistoryStatus(
+  networkData: readonly NetworkData[],
+  swrError: Error | null,
+): SnapshotHistoryStatus {
+  const isPoolSnapshotHistoryCapped = networkData.some(
+    (network) => network.snapshotsAllDailyCapped,
+  );
+  const isSnapshotHistoryCapped = networkData.some(
+    (network) =>
+      network.snapshotsAllDailyCapped ||
+      network.brokerSnapshotsAllDailyCapped === true,
+  );
+  const poolSnapshotHistoryNetworkError =
+    cappedPoolSnapshotHistoryFailure(networkData);
+  const snapshotHistoryNetworkError =
+    poolSnapshotHistoryNetworkError ??
+    cappedBrokerSnapshotHistoryFailure(networkData);
+
+  return {
+    isSnapshotHistoryCapped,
+    isPoolSnapshotHistoryCapped,
+    snapshotHistoryError:
+      isSnapshotHistoryCapped && swrError !== null
+        ? swrError
+        : snapshotHistoryNetworkError,
+    poolSnapshotHistoryError:
+      isPoolSnapshotHistoryCapped && swrError !== null
+        ? swrError
+        : poolSnapshotHistoryNetworkError,
+  };
 }
 
 function vpCursorRegressed(
@@ -185,6 +247,34 @@ export function retainConfirmedVpExtensions(
   });
 }
 
+/** Preserve the bounded Broker seed when a completion attempt fails before
+ * returning any rows. The fresh error/cap channels stay in place, so the
+ * volume chart discloses degradation while continuing to show recent
+ * last-confirmed v2 data instead of a misleading zero. */
+function retainConfirmedBrokerHistory(
+  current: NetworkData[],
+  previous: NetworkData[] | undefined,
+): NetworkData[] {
+  if (previous === undefined) return current;
+  const previousByNetwork = new Map(
+    previous.map((data) => [data.network.id, data] as const),
+  );
+  return current.map((data) => {
+    if (
+      data.brokerSnapshotsAllDailyCapped !== true ||
+      data.brokerSnapshotsAllDaily.length > 0
+    ) {
+      return data;
+    }
+    const prior = previousByNetwork.get(data.network.id);
+    if (!prior || prior.brokerSnapshotsAllDaily.length === 0) return data;
+    return {
+      ...data,
+      brokerSnapshotsAllDaily: prior.brokerSnapshotsAllDaily,
+    };
+  });
+}
+
 /**
  * SSR payloads younger than this skip mount revalidation entirely (first
  * paint fires 0 client GraphQL requests). Older ones still paint instantly
@@ -256,10 +346,11 @@ export {
  * - On a COLD cache (first visit within a session) with a healthy SSR
  *   payload, skip mount- and stale-revalidation so first paint fires 0
  *   client GraphQL requests.
- * - On a WARM cache (back-navigation; `/pools` and `/` share this key and
- *   its poll cycle may have already populated it), let SWR revalidate so
- *   stale cached entries get refreshed — otherwise the user can see
- *   cached data up to 5 min old until the next interval fires.
+ * - On a WARM route cache (back-navigation; its poll cycle may have already
+ *   populated it), let SWR revalidate so stale cached entries get refreshed —
+ *   otherwise the user can see cached data up to 5 min old until the next
+ *   interval fires. `/` and `/pools` use distinct keys because their bounded
+ *   server payloads intentionally have different shapes.
  * - On any SSR degradation (per-slice or per-chain error), let SWR
  *   revalidate on mount so partial `N/A` metrics recover immediately
  *   instead of being pinned until the next poll.
@@ -277,8 +368,10 @@ export function useAllNetworksData(
    *  (`fetchInitialNetworkData(route).fetchedAtMs`). Omitted/unknown counts as
    *  stale — revalidate-on-mount is the safe default. */
   fallbackFetchedAtMs?: number,
+  cacheScope: AllNetworksDataCacheScope = "home",
 ): AllNetworksResult {
   const { cache } = useSWRConfig();
+  const swrKey = ALL_NETWORKS_DATA_KEYS[cacheScope];
   const fullHistoryRequestRef = useRef<Promise<void> | null>(null);
   // SWR dedupes ordinary revalidations, but a user-triggered `mutate()` may
   // still invoke the fetcher while mount or polling revalidation is already in
@@ -297,7 +390,7 @@ export function useAllNetworksData(
   // default stale-check should fire to refresh cached data that could be
   // older than the SSR payload. The read is synchronous and idempotent —
   // `cache.get` doesn't mutate state.
-  const isCacheCold = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data === undefined;
+  const isCacheCold = cache.get(swrKey)?.data === undefined;
   const skipRevalidation = shouldSkipMountRevalidation({
     hasFallback: restoredFallbackData !== undefined,
     allHealthy,
@@ -317,11 +410,14 @@ export function useAllNetworksData(
     if (networkFetchRef.current !== null) return networkFetchRef.current;
 
     const request = fetchAllNetworksAtBoundary().then((current) => {
-      const cached = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data;
+      const cached = cache.get(swrKey)?.data;
       const previous = Array.isArray(cached)
         ? (cached as NetworkData[])
         : restoredFallbackData;
-      return retainConfirmedVpExtensions(current, previous);
+      return retainConfirmedBrokerHistory(
+        retainConfirmedVpExtensions(current, previous),
+        previous,
+      );
     });
     networkFetchRef.current = request;
     void request.then(
@@ -333,9 +429,9 @@ export function useAllNetworksData(
       },
     );
     return request;
-  }, [cache, restoredFallbackData]);
+  }, [cache, restoredFallbackData, swrKey]);
   const { data, error, isLoading, mutate } = useSWR<NetworkData[]>(
-    SWR_KEY_ALL_NETWORKS_DATA,
+    swrKey,
     fetcher,
     {
       ...SHARED_QUERY_SWR_CONFIG,
@@ -353,18 +449,13 @@ export function useAllNetworksData(
         : { revalidateOnMount: true }),
     },
   );
-  const isSnapshotHistoryCapped = (
-    data ??
-    restoredFallbackData ??
-    EMPTY_NETWORK_DATA
-  ).some(
-    (network) =>
-      network.snapshotsAllDailyCapped ||
-      network.brokerSnapshotsAllDailyCapped === true,
+  const visibleNetworkData = data ?? restoredFallbackData ?? EMPTY_NETWORK_DATA;
+  const swrError = error instanceof Error ? error : null;
+  const snapshotHistoryStatus = deriveSnapshotHistoryStatus(
+    visibleNetworkData,
+    swrError,
   );
-  const snapshotHistoryNetworkError = cappedSnapshotHistoryFailure(
-    data ?? restoredFallbackData ?? EMPTY_NETWORK_DATA,
-  );
+  const { isSnapshotHistoryCapped } = snapshotHistoryStatus;
   const requestFullSnapshotHistory = useCallback((): Promise<void> => {
     if (!isSnapshotHistoryCapped) return Promise.resolve();
     if (fullHistoryRequestRef.current !== null) {
@@ -375,29 +466,26 @@ export function useAllNetworksData(
     // from timestamp 0; other consumers keep the same SWR key and failure
     // semantics. Swallow the promise rejection here—the SWR `error` channel
     // below is what renders an honest unavailable state for the selected
-    // "All" range.
-    const request = mutate()
-      .then(
-        () => undefined,
-        () => undefined,
-      )
-      .finally(() => {
+    // "All" range. Use `.then(success, failure)` rather than `Promise.finally`
+    // because this client bundle targets ES2017 without a Promise polyfill.
+    const request = mutate().then(
+      () => {
         fullHistoryRequestRef.current = null;
-      });
+      },
+      () => {
+        fullHistoryRequestRef.current = null;
+      },
+    );
     fullHistoryRequestRef.current = request;
     return request;
   }, [isSnapshotHistoryCapped, mutate]);
-  const liveHealth = useLivePoolHealth(data ?? EMPTY_NETWORK_DATA);
+  const liveHealth = useLivePoolHealth(visibleNetworkData);
 
   return {
     networkData: liveHealth.networkData,
     isLoading,
-    error: error instanceof Error ? error : liveHealth.error,
-    isSnapshotHistoryCapped,
-    snapshotHistoryError:
-      isSnapshotHistoryCapped && error instanceof Error
-        ? error
-        : snapshotHistoryNetworkError,
+    error: swrError ?? liveHealth.error,
+    ...snapshotHistoryStatus,
     requestFullSnapshotHistory,
   };
 }

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import {
   fetchAllNetworks,
@@ -12,14 +12,68 @@ import {
 import { SHARED_QUERY_SWR_CONFIG } from "@/lib/gql-retry";
 import { SWR_KEY_ALL_NETWORKS_DATA } from "@/lib/swr-keys";
 import { useLivePoolHealth } from "@/hooks/use-live-pool-health";
+import { buildDailySnapshotSlices } from "@/lib/volume";
 
 type AllNetworksResult = {
   networkData: NetworkData[];
   isLoading: boolean;
   error: Error | null;
+  /** True while the visible data still carries the bounded SSR history. */
+  isSnapshotHistoryCapped: boolean;
+  /** Unexpected failure from an on-demand full-history revalidation. */
+  snapshotHistoryError: Error | null;
+  /** Coalesced normal SWR revalidation used by the homepage "All" charts. */
+  requestFullSnapshotHistory: () => Promise<void>;
 };
 
 const EMPTY_NETWORK_DATA: NetworkData[] = [];
+
+// One browser-tab fetch boundary for the shared all-networks SWR key. Multiple
+// hook instances can coexist briefly during route transitions; SWR normally
+// dedupes them, but an imperative mutate in one instance can overlap a mount or
+// polling revalidation in another. Share only the raw fleet fan-out here, then
+// let each caller reconcile that result against its own last-good data.
+let allNetworksFetchInFlight: Promise<NetworkData[]> | null = null;
+
+function fetchAllNetworksAtBoundary(): Promise<NetworkData[]> {
+  if (allNetworksFetchInFlight !== null) return allNetworksFetchInFlight;
+
+  const request = fetchAllNetworks();
+  allNetworksFetchInFlight = request;
+  void request.then(
+    () => {
+      if (allNetworksFetchInFlight === request) allNetworksFetchInFlight = null;
+    },
+    () => {
+      if (allNetworksFetchInFlight === request) allNetworksFetchInFlight = null;
+    },
+  );
+  return request;
+}
+
+function cappedSnapshotHistoryFailure(
+  networkData: readonly NetworkData[],
+): Error | null {
+  for (const network of networkData) {
+    if (network.snapshotsAllDailyCapped) {
+      if (network.snapshotsAllDailyError != null) {
+        return new Error(network.snapshotsAllDailyError.message);
+      }
+      if (network.snapshotsAllDailyTruncated) {
+        return new Error("Full snapshot history pagination was truncated");
+      }
+    }
+    if (network.brokerSnapshotsAllDailyCapped === true) {
+      if (network.brokerSnapshotsAllDailyError != null) {
+        return new Error(network.brokerSnapshotsAllDailyError.message);
+      }
+      if (network.brokerSnapshotsAllDailyTruncated) {
+        return new Error("Full Broker history pagination was truncated");
+      }
+    }
+  }
+  return null;
+}
 
 function vpCursorRegressed(
   current: string | undefined,
@@ -165,6 +219,20 @@ export function shouldSkipMountRevalidation({
   return hasFallback && allHealthy && isCacheCold && isFreshEnough;
 }
 
+/**
+ * Restore the 1/7/30-day arrays deliberately omitted from the Server
+ * Component transport. This runs synchronously before health evaluation,
+ * incremental-cache seeding, and SWR fallback installation, preserving the
+ * same initial HTML and consumer contract without serializing duplicate rows.
+ */
+function restoreInitialSnapshotSlices(data: InitialNetworkData): NetworkData {
+  const { snapshots, snapshots7d, snapshots30d } = buildDailySnapshotSlices(
+    data.snapshotsAllDaily,
+    data.snapshotWindows.w24h.to,
+  );
+  return { ...data, snapshots, snapshots7d, snapshots30d };
+}
+
 // Re-exports so long-established import sites keep working
 // (`import { NetworkData, fetchAllNetworks, warnedCapKeys, ... } from
 // "@/hooks/use-all-networks-data"`). New code should import directly from
@@ -206,13 +274,24 @@ export {
 export function useAllNetworksData(
   fallbackData?: InitialNetworkData[],
   /** Fetch-completion time of `fallbackData`
-   *  (`fetchInitialNetworkData().fetchedAtMs`). Omitted/unknown counts as
+   *  (`fetchInitialNetworkData(route).fetchedAtMs`). Omitted/unknown counts as
    *  stale — revalidate-on-mount is the safe default. */
   fallbackFetchedAtMs?: number,
 ): AllNetworksResult {
   const { cache } = useSWRConfig();
+  const fullHistoryRequestRef = useRef<Promise<void> | null>(null);
+  // SWR dedupes ordinary revalidations, but a user-triggered `mutate()` may
+  // still invoke the fetcher while mount or polling revalidation is already in
+  // flight. Coalesce at the actual fetch boundary so every trigger shares one
+  // fleet fan-out and receives the same reconciled result.
+  const networkFetchRef = useRef<Promise<NetworkData[]> | null>(null);
+  const restoredFallbackData = useMemo(
+    () => fallbackData?.map(restoreInitialSnapshotSlices),
+    [fallbackData],
+  );
   const allHealthy =
-    fallbackData !== undefined && fallbackData.every(isNetworkDataFullyHealthy);
+    restoredFallbackData !== undefined &&
+    restoredFallbackData.every(isNetworkDataFullyHealthy);
   // Reading cache at render time is intentional: when the cache is cold we
   // want fallbackData to win with zero revalidation; when warm, SWR's
   // default stale-check should fire to refresh cached data that could be
@@ -220,34 +299,49 @@ export function useAllNetworksData(
   // `cache.get` doesn't mutate state.
   const isCacheCold = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data === undefined;
   const skipRevalidation = shouldSkipMountRevalidation({
-    hasFallback: fallbackData !== undefined,
+    hasFallback: restoredFallbackData !== undefined,
     allHealthy,
     isCacheCold,
     fallbackFetchedAtMs,
     nowMs: Date.now(),
   });
 
-  // Seed before `useSWR`: degraded SSR payloads intentionally revalidate on
-  // mount, and that immediate fetch must still use the incremental snapshot
-  // path for any complete slices present in the fallback.
-  if (fallbackData !== undefined) {
-    seedIncrementalRowCacheFromNetworkData(fallbackData);
+  // Seed before `useSWR`: complete slices can take the incremental path, while
+  // a bounded SSR slice is retained as incomplete last-good data and forces
+  // from-zero pagination when mount recovery or an "All" interaction fetches.
+  if (restoredFallbackData !== undefined) {
+    seedIncrementalRowCacheFromNetworkData(restoredFallbackData);
   }
 
-  const fetcher = useCallback(async () => {
-    const current = await fetchAllNetworks();
-    const cached = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data;
-    const previous = Array.isArray(cached)
-      ? (cached as NetworkData[])
-      : fallbackData;
-    return retainConfirmedVpExtensions(current, previous);
-  }, [cache, fallbackData]);
-  const { data, error, isLoading } = useSWR<NetworkData[]>(
+  const fetcher = useCallback(() => {
+    if (networkFetchRef.current !== null) return networkFetchRef.current;
+
+    const request = fetchAllNetworksAtBoundary().then((current) => {
+      const cached = cache.get(SWR_KEY_ALL_NETWORKS_DATA)?.data;
+      const previous = Array.isArray(cached)
+        ? (cached as NetworkData[])
+        : restoredFallbackData;
+      return retainConfirmedVpExtensions(current, previous);
+    });
+    networkFetchRef.current = request;
+    void request.then(
+      () => {
+        if (networkFetchRef.current === request) networkFetchRef.current = null;
+      },
+      () => {
+        if (networkFetchRef.current === request) networkFetchRef.current = null;
+      },
+    );
+    return request;
+  }, [cache, restoredFallbackData]);
+  const { data, error, isLoading, mutate } = useSWR<NetworkData[]>(
     SWR_KEY_ALL_NETWORKS_DATA,
     fetcher,
     {
       ...SHARED_QUERY_SWR_CONFIG,
-      ...(fallbackData !== undefined && { fallbackData }),
+      ...(restoredFallbackData !== undefined && {
+        fallbackData: restoredFallbackData,
+      }),
       // When `fallbackData` is present, SWR's default for `revalidateOnMount`
       // flips to `false`. That's what we want in the skip case (cold cache +
       // healthy SSR → 0 client requests on first paint). In every other
@@ -259,12 +353,52 @@ export function useAllNetworksData(
         : { revalidateOnMount: true }),
     },
   );
+  const isSnapshotHistoryCapped = (
+    data ??
+    restoredFallbackData ??
+    EMPTY_NETWORK_DATA
+  ).some(
+    (network) =>
+      network.snapshotsAllDailyCapped ||
+      network.brokerSnapshotsAllDailyCapped === true,
+  );
+  const snapshotHistoryNetworkError = cappedSnapshotHistoryFailure(
+    data ?? restoredFallbackData ?? EMPTY_NETWORK_DATA,
+  );
+  const requestFullSnapshotHistory = useCallback((): Promise<void> => {
+    if (!isSnapshotHistoryCapped) return Promise.resolve();
+    if (fullHistoryRequestRef.current !== null) {
+      return fullHistoryRequestRef.current;
+    }
+    // `mutate()` runs this hook's normal `fetchAllNetworks` fetcher. Because
+    // capped SSR rows are seeded as incomplete, the snapshot paginator starts
+    // from timestamp 0; other consumers keep the same SWR key and failure
+    // semantics. Swallow the promise rejection here—the SWR `error` channel
+    // below is what renders an honest unavailable state for the selected
+    // "All" range.
+    const request = mutate()
+      .then(
+        () => undefined,
+        () => undefined,
+      )
+      .finally(() => {
+        fullHistoryRequestRef.current = null;
+      });
+    fullHistoryRequestRef.current = request;
+    return request;
+  }, [isSnapshotHistoryCapped, mutate]);
   const liveHealth = useLivePoolHealth(data ?? EMPTY_NETWORK_DATA);
 
   return {
     networkData: liveHealth.networkData,
     isLoading,
     error: error instanceof Error ? error : liveHealth.error,
+    isSnapshotHistoryCapped,
+    snapshotHistoryError:
+      isSnapshotHistoryCapped && error instanceof Error
+        ? error
+        : snapshotHistoryNetworkError,
+    requestFullSnapshotHistory,
   };
 }
 

--- a/ui-dashboard/src/hooks/use-snapshot-history-range.ts
+++ b/ui-dashboard/src/hooks/use-snapshot-history-range.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { RangeKey } from "@/lib/time-series";
+
+export function useSnapshotHistoryRange({
+  historyIsCapped,
+  snapshotHistoryError,
+  requestFullSnapshotHistory,
+}: {
+  historyIsCapped: boolean;
+  snapshotHistoryError: Error | null;
+  requestFullSnapshotHistory?: (() => Promise<void>) | undefined;
+}) {
+  const [range, setRange] = useState<RangeKey>("30d");
+  const handleRangeChange = useCallback(
+    (nextRange: RangeKey) => {
+      setRange(nextRange);
+      if (nextRange === "all" && historyIsCapped) {
+        void requestFullSnapshotHistory?.();
+      }
+    },
+    [historyIsCapped, requestFullSnapshotHistory],
+  );
+  const allHistoryUnavailable = range === "all" && historyIsCapped;
+
+  return {
+    range,
+    handleRangeChange,
+    allHistoryUnavailable,
+    allHistoryLoading: allHistoryUnavailable && snapshotHistoryError === null,
+    allHistoryFailed: allHistoryUnavailable && snapshotHistoryError !== null,
+  };
+}

--- a/ui-dashboard/src/lib/__tests__/fetch-incremental.test.ts
+++ b/ui-dashboard/src/lib/__tests__/fetch-incremental.test.ts
@@ -358,6 +358,7 @@ describe("incremental pool daily snapshot pagination", () => {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-a" }],
         snapshotsAllDaily: [cachedToday],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [],
@@ -383,6 +384,95 @@ describe("incremental pool daily snapshot pagination", () => {
     });
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0]!.swapVolume0).toBe("9");
+    expect(
+      incrementalRowCache.get("celo-mainnet:PoolDailySnapshot")?.complete,
+    ).toBe(true);
+  });
+
+  it("forces a full fetch for a capped SSR seed, then dedupes later incremental merges", async () => {
+    const ssrToday = poolSnapshotRow("pool-a", TODAY_MIDNIGHT_SECONDS, "1");
+    const fullToday = poolSnapshotRow("pool-a", TODAY_MIDNIGHT_SECONDS, "9");
+    const historical = poolSnapshotRow(
+      "pool-a",
+      TODAY_MIDNIGHT_SECONDS - 200 * 86_400,
+      "2",
+    );
+    const nextToday = poolSnapshotRow("pool-a", TODAY_MIDNIGHT_SECONDS, "11");
+    seedIncrementalRowCacheFromNetworkData([
+      {
+        network: NETWORKS["celo-mainnet"],
+        pools: [{ id: "pool-a" }],
+        snapshotsAllDaily: [ssrToday],
+        snapshotsAllDailyCapped: true,
+        snapshotsAllDailyError: null,
+        snapshotsAllDailyTruncated: false,
+      } as unknown as NetworkData,
+    ]);
+    expect(
+      incrementalRowCache.get("celo-mainnet:PoolDailySnapshot")?.complete,
+    ).toBe(false);
+    requestMock
+      .mockResolvedValueOnce({
+        PoolDailySnapshot: [fullToday, historical],
+      })
+      .mockResolvedValueOnce({ PoolDailySnapshot: [nextToday] });
+
+    const full = await fetchAllDailySnapshotPages(
+      makeClient(),
+      ["pool-a"],
+      "celo-mainnet",
+    );
+    // The second call intentionally depends on the first populating the
+    // incremental cache; parallelizing them would invalidate this regression.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
+    const incremental = await fetchAllDailySnapshotPages(
+      makeClient(),
+      ["pool-a"],
+      "celo-mainnet",
+    );
+
+    expect(variablesAt(0)).toMatchObject({ afterTimestamp: 0, offset: 0 });
+    expect(variablesAt(1)).toMatchObject({
+      afterTimestamp: YESTERDAY_MIDNIGHT_SECONDS,
+      offset: 0,
+    });
+    expect(full.rows).toEqual([fullToday, historical]);
+    expect(full.historyComplete).toBe(true);
+    expect(incremental.rows).toEqual([nextToday, historical]);
+    expect(incremental.historyComplete).toBe(true);
+    expect(
+      incrementalRowCache.get("celo-mainnet:PoolDailySnapshot")?.complete,
+    ).toBe(true);
+  });
+
+  it("preserves a capped SSR seed and its incomplete marker when the full fetch fails", async () => {
+    const ssrToday = poolSnapshotRow("pool-a", TODAY_MIDNIGHT_SECONDS, "1");
+    seedIncrementalRowCacheFromNetworkData([
+      {
+        network: NETWORKS["celo-mainnet"],
+        pools: [{ id: "pool-a" }],
+        snapshotsAllDaily: [ssrToday],
+        snapshotsAllDailyCapped: true,
+        snapshotsAllDailyError: null,
+        snapshotsAllDailyTruncated: false,
+      } as unknown as NetworkData,
+    ]);
+    requestMock.mockRejectedValueOnce(new Error("full history timeout"));
+
+    const result = await fetchAllDailySnapshotPages(
+      makeClient(),
+      ["pool-a"],
+      "celo-mainnet",
+    );
+
+    expect(variablesAt(0)).toMatchObject({ afterTimestamp: 0, offset: 0 });
+    expect(result.rows).toEqual([ssrToday]);
+    expect(result.truncated).toBe(true);
+    expect(result.error?.message).toBe("full history timeout");
+    expect(result.historyComplete).toBe(false);
+    expect(
+      incrementalRowCache.get("celo-mainnet:PoolDailySnapshot")?.complete,
+    ).toBe(false);
   });
 
   it("does not overwrite a warm cache with older SSR fallback rows", async () => {
@@ -393,12 +483,14 @@ describe("incremental pool daily snapshot pagination", () => {
       variablesKey: "pool-a",
       rows: [polledToday],
       refreshAfterTimestamp: YESTERDAY_MIDNIGHT_SECONDS,
+      complete: true,
     });
     seedIncrementalRowCacheFromNetworkData([
       {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-a" }],
         snapshotsAllDaily: [ssrToday],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [],
@@ -429,12 +521,14 @@ describe("incremental pool daily snapshot pagination", () => {
       variablesKey: "pool-a",
       rows: [polledToday],
       refreshAfterTimestamp: YESTERDAY_MIDNIGHT_SECONDS,
+      complete: true,
     });
     seedIncrementalRowCacheFromNetworkData([
       {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-b" }],
         snapshotsAllDaily: [ssrToday],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [],
@@ -473,12 +567,14 @@ describe("incremental pool daily snapshot pagination", () => {
       variablesKey: "pool-a",
       rows: [cachedToday],
       refreshAfterTimestamp: YESTERDAY_MIDNIGHT_SECONDS,
+      complete: true,
     });
     seedIncrementalRowCacheFromNetworkData([
       {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-a" }],
         snapshotsAllDaily: [ssrToday, ssrOld],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [],
@@ -509,12 +605,14 @@ describe("incremental pool daily snapshot pagination", () => {
       variablesKey: "pool-a",
       rows: [cachedStale],
       refreshAfterTimestamp: staleTimestamp,
+      complete: true,
     });
     seedIncrementalRowCacheFromNetworkData([
       {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-a" }],
         snapshotsAllDaily: [ssrToday],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [],
@@ -544,6 +642,7 @@ describe("incremental pool daily snapshot pagination", () => {
         network: NETWORKS["celo-mainnet"],
         pools: [{ id: "pool-a" }],
         snapshotsAllDaily: [poolSnapshotRow("pool-a", TODAY_MIDNIGHT_SECONDS)],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: null,
         snapshotsAllDailyTruncated: true,
         feeSnapshots: [],
@@ -554,6 +653,7 @@ describe("incremental pool daily snapshot pagination", () => {
         network: NETWORKS["monad-mainnet"],
         pools: [{ id: "pool-b" }],
         snapshotsAllDaily: [poolSnapshotRow("pool-b", TODAY_MIDNIGHT_SECONDS)],
+        snapshotsAllDailyCapped: false,
         snapshotsAllDailyError: new Error("snapshot failed"),
         snapshotsAllDailyTruncated: false,
         feeSnapshots: [feeRow("fee-b", TODAY_MIDNIGHT_SECONDS)],

--- a/ui-dashboard/src/lib/__tests__/revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/revenue.test.ts
@@ -56,6 +56,7 @@ function networkData(
     snapshots7d: [],
     snapshots30d: [],
     snapshotsAllDaily: [],
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/assemble.test.ts
@@ -193,6 +193,7 @@ describe("assembleNetworkData — pure composition", () => {
     expect(result.feeSnapshotsError).toBeNull();
     expect(result.snapshotsAllDailyError).toBeNull();
     expect(result.brokerSnapshotsAllDailyError).toBeNull();
+    expect(result.brokerSnapshotsAllDailyCapped).toBe(false);
     expect(result.lpError).toBeNull();
     expect(result.strategyError).toBeNull();
     expect(result.olsPoolIds).toEqual(new Set());
@@ -231,5 +232,42 @@ describe("assembleNetworkData — pure composition", () => {
     expect(result.snapshotsError).toBe(tailErr);
     expect(result.snapshots7dError).toBe(tailErr);
     expect(result.snapshots30dError).toBe(tailErr);
+  });
+
+  it("keeps Broker history capped when pagination returns partial rows", () => {
+    const result = assembleNetworkData({
+      ...baseArgs,
+      brokerSnapshotsAllDailyResult: fulfilled({
+        rows: [
+          {
+            id: "broker-partial",
+            timestamp: String(NOW),
+            volumeUsdWei: "1",
+            swapCount: 1,
+          },
+        ],
+        truncated: true,
+        error: new Error("page 2 failed"),
+      }),
+    });
+
+    expect(result.brokerSnapshotsAllDaily).toHaveLength(1);
+    expect(result.brokerSnapshotsAllDailyTruncated).toBe(true);
+    expect(result.brokerSnapshotsAllDailyCapped).toBe(true);
+    expect(result.brokerSnapshotsAllDailyError?.message).toBe("page 2 failed");
+  });
+
+  it("marks Broker history capped when its first page rejects", () => {
+    const result = assembleNetworkData({
+      ...baseArgs,
+      brokerSnapshotsAllDailyResult: rejected(new Error("Broker unavailable")),
+    });
+
+    expect(result.brokerSnapshotsAllDaily).toEqual([]);
+    expect(result.brokerSnapshotsAllDailyTruncated).toBe(false);
+    expect(result.brokerSnapshotsAllDailyCapped).toBe(true);
+    expect(result.brokerSnapshotsAllDailyError?.message).toBe(
+      "Broker unavailable",
+    );
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
@@ -176,6 +176,7 @@ describe("fetchNetworkData characterization — window error precedence", () => 
         makeDaily(todayMidnight - 60 * 86400, "pool-tail"),
       ],
       refreshAfterTimestamp: todayMidnight - 86400,
+      complete: true,
     });
     const tailErr = new Error("incremental tail timeout");
     installGraphQLMock({

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -12,6 +12,12 @@ import type {
   InitialNetworkData,
   NetworkData,
 } from "@/lib/network-fetcher/types";
+import type { PoolSnapshotWindow } from "@/lib/types";
+import { buildSnapshotWindows } from "@/lib/volume";
+import {
+  INITIAL_SNAPSHOT_HISTORY_DAYS,
+  SECONDS_PER_DAY,
+} from "@/lib/network-fetcher/constants";
 
 const {
   mockFetchAllNetworks,
@@ -144,6 +150,18 @@ function healthyNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
   });
 }
 
+function snapshotRow(poolId: string, timestamp: number): PoolSnapshotWindow {
+  return {
+    poolId,
+    timestamp: String(timestamp),
+    reserves0: "1000000000000000000000000",
+    reserves1: "1000000000000000000000000",
+    swapCount: 42,
+    swapVolume0: "25000000000000000000000",
+    swapVolume1: "25000000000000000000000",
+  };
+}
+
 function armStaleCacheEntry(value: unknown): void {
   cacheState.value = value;
   cacheState.stale = true;
@@ -168,6 +186,18 @@ describe("InitialNetworkData type contract", () => {
       Awaited<ReturnType<typeof fetchInitialNetworkData>>["networks"][number]
     >().toEqualTypeOf<InitialNetworkData>();
     expectTypeOf<InitialNetworkData["feeSnapshots"]>().toEqualTypeOf<[]>();
+    expectTypeOf<InitialNetworkData["snapshots"]>().toEqualTypeOf<[]>();
+    expectTypeOf<InitialNetworkData["snapshots7d"]>().toEqualTypeOf<[]>();
+    expectTypeOf<InitialNetworkData["snapshots30d"]>().toEqualTypeOf<[]>();
+    expectTypeOf<
+      InitialNetworkData["uniqueLpAddresses"]
+    >().toEqualTypeOf<null>();
+    expectTypeOf<
+      InitialNetworkData["uniqueLpAddressesOmitted"]
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      InitialNetworkData["snapshotsAllDailyCapped"]
+    >().toEqualTypeOf<boolean>();
     expectTypeOf<
       InitialNetworkData["feeSnapshots"][number]
     >().toEqualTypeOf<never>();
@@ -211,7 +241,7 @@ describe("cache key salting", () => {
     // across deployments within an environment.
     expect(capturedCacheKeyParts).toHaveLength(1);
     const parts = capturedCacheKeyParts[0]!;
-    expect(parts[0]).toBe("all-networks-ssr");
+    expect(parts[0]).toBe("all-networks-ssr-v2");
     // Deploy salt: VERCEL_GIT_COMMIT_SHA in prod, "dev" locally/in tests.
     expect(parts[1]).toBeTruthy();
     // Config salt: pipe-joined configured network ids (may be "" when no
@@ -225,7 +255,7 @@ describe("fetchInitialNetworkData", () => {
   it("returns the rehydrated healthy payload and marks it cacheable", async () => {
     mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
-    const result = await fetchInitialNetworkData();
+    const result = await fetchInitialNetworkData("home");
 
     expect(result.networks).toHaveLength(1);
     expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
@@ -237,11 +267,11 @@ describe("fetchInitialNetworkData", () => {
   it("serves a fresh JSON cache hit without refetching and restores Map/Set fields", async () => {
     mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
-    const first = await fetchInitialNetworkData();
+    const first = await fetchInitialNetworkData("home");
     // Intentional sequence: the first call must populate the fake cache before
     // the second proves a serialized fresh-hit read.
     // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
-    const second = await fetchInitialNetworkData();
+    const second = await fetchInitialNetworkData("home");
 
     expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
     expect(cacheCallbackOutcomes).toEqual(["resolved"]);
@@ -263,11 +293,220 @@ describe("fetchInitialNetworkData", () => {
       healthyNetworkData({ feeSnapshotsTruncated: true }),
     ]);
 
-    const [data] = (await fetchInitialNetworkData()).networks;
+    const [data] = (await fetchInitialNetworkData("home")).networks;
 
     expect(data!.feeSnapshots).toEqual([]);
     expect(data!.feeSnapshotsError).toBeNull();
     expect(data!.feeSnapshotsTruncated).toBe(true);
+  });
+
+  it("ships only the configured recent UTC-day buckets and marks the initial history capped", async () => {
+    const now = Date.UTC(2026, 6, 15, 12, 34, 56);
+    const today = Math.floor(now / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const fullHistory = Array.from(
+      { length: INITIAL_SNAPSHOT_HISTORY_DAYS + 5 },
+      (_, daysAgo) => snapshotRow("pool-a", today - daysAgo * SECONDS_PER_DAY),
+    );
+    const source = healthyNetworkData({
+      snapshotWindows: buildSnapshotWindows(now),
+      snapshotsAllDaily: fullHistory,
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockFetchAllNetworks.mockResolvedValueOnce([source]);
+
+    const [initial] = (await fetchInitialNetworkData("home")).networks;
+
+    expect(initial!.snapshotsAllDaily).toHaveLength(
+      INITIAL_SNAPSHOT_HISTORY_DAYS,
+    );
+    expect(initial!.snapshotsAllDaily[0]!.timestamp).toBe(String(today));
+    expect(initial!.snapshotsAllDaily.at(-1)!.timestamp).toBe(
+      String(today - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY),
+    );
+    expect(initial!.snapshotsAllDailyCapped).toBe(true);
+    expect(initial!.snapshots).toEqual([]);
+    expect(initial!.snapshots7d).toEqual([]);
+    expect(initial!.snapshots30d).toEqual([]);
+    expect(source.snapshotsAllDaily).toHaveLength(
+      INITIAL_SNAPSHOT_HISTORY_DAYS + 5,
+    );
+  });
+
+  it("caps homepage Broker history to the same recent UTC-day window", async () => {
+    const now = Date.UTC(2026, 6, 15, 12, 34, 56);
+    const today = Math.floor(now / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const brokerHistory = Array.from(
+      { length: INITIAL_SNAPSHOT_HISTORY_DAYS + 7 },
+      (_, daysAgo) => ({
+        id: `broker-${daysAgo}`,
+        timestamp: String(today - daysAgo * SECONDS_PER_DAY),
+        volumeUsdWei: "1000000000000000000",
+        swapCount: daysAgo,
+      }),
+    );
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockFetchAllNetworks.mockResolvedValueOnce([
+      healthyNetworkData({
+        snapshotWindows: buildSnapshotWindows(now),
+        brokerSnapshotsAllDaily: brokerHistory,
+      }),
+    ]);
+
+    const [initial] = (await fetchInitialNetworkData("home")).networks;
+
+    expect(initial!.brokerSnapshotsAllDaily).toHaveLength(
+      INITIAL_SNAPSHOT_HISTORY_DAYS,
+    );
+    expect(initial!.brokerSnapshotsAllDaily.at(-1)!.timestamp).toBe(
+      String(today - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY),
+    );
+    expect(initial!.brokerSnapshotsAllDailyCapped).toBe(true);
+  });
+
+  it("aggregates homepage LPs exactly and removes homepage-only data from /pools", async () => {
+    const secondNetwork = {
+      ...network,
+      id: "monad-mainnet",
+      label: "Monad",
+      chainId: 143,
+    } as Network;
+    mockFetchAllNetworks.mockResolvedValueOnce([
+      healthyNetworkData({
+        uniqueLpAddresses: ["0xAAA", "0xbbb"],
+        brokerSnapshotsAllDaily: [
+          {
+            id: "broker-1",
+            timestamp: "86400",
+            volumeUsdWei: "1",
+            swapCount: 1,
+          },
+        ],
+      }),
+      healthyNetworkData({
+        network: secondNetwork,
+        uniqueLpAddresses: ["0xaaa", "0xCCC"],
+      }),
+    ]);
+
+    const homepage = await fetchInitialNetworkData("home");
+    // Reads the same JSON-cached projection: route selection must not refetch.
+    // This must remain sequential so the assertion proves a completed cache hit.
+    // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
+    const pools = await fetchInitialNetworkData("pools");
+
+    expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
+    expect(homepage.uniqueLpCount).toBe(3);
+    expect(
+      homepage.networks.every((data) => data.uniqueLpAddresses === null),
+    ).toBe(true);
+    expect(
+      homepage.networks.every((data) => data.uniqueLpAddressesOmitted === true),
+    ).toBe(true);
+    expect(pools).not.toHaveProperty("uniqueLpCount");
+    expect(
+      pools.networks.every(
+        (data) =>
+          data.uniqueLpAddresses === null &&
+          data.brokerSnapshotsAllDaily.length === 0,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps every history-growing field in a representative payload below 500KB", async () => {
+    const now = Date.UTC(2026, 6, 15, 12);
+    const today = Math.floor(now / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const poolCountPerNetwork = 20;
+    const historyFor = (chainId: number) =>
+      Array.from({ length: poolCountPerNetwork * 730 }, (_, index) =>
+        snapshotRow(
+          `${chainId}-0x${String(index % poolCountPerNetwork).padStart(40, "0")}`,
+          today - Math.floor(index / poolCountPerNetwork) * SECONDS_PER_DAY,
+        ),
+      );
+    const poolsFor = (chainId: number) =>
+      Array.from({ length: poolCountPerNetwork }, (_, index) => ({
+        id: `${chainId}-0x${String(index).padStart(40, "0")}`,
+        chainId,
+        token0: null,
+        token1: null,
+        source: "FPMM" as const,
+        createdAtBlock: "0",
+        createdAtTimestamp: "0",
+        updatedAtBlock: "0",
+        updatedAtTimestamp: "0",
+      }));
+    const brokerHistory = Array.from({ length: 730 }, (_, daysAgo) => ({
+      id: `broker-${daysAgo}`,
+      timestamp: String(today - daysAgo * SECONDS_PER_DAY),
+      volumeUsdWei: "1000000000000000000",
+      swapCount: daysAgo,
+    }));
+    const uniqueLpAddresses = Array.from(
+      { length: 10_000 },
+      (_, index) => `0x${String(index).padStart(40, "0")}`,
+    );
+    const source = healthyNetworkData({
+      pools: poolsFor(network.chainId),
+      snapshotWindows: buildSnapshotWindows(now),
+      snapshotsAllDaily: historyFor(network.chainId),
+      brokerSnapshotsAllDaily: brokerHistory,
+      uniqueLpAddresses,
+    });
+    const secondNetwork = {
+      ...network,
+      id: "monad-mainnet",
+      label: "Monad",
+      chainId: 143,
+    } as Network;
+    const secondSource = healthyNetworkData({
+      network: secondNetwork,
+      pools: poolsFor(secondNetwork.chainId),
+      snapshotWindows: buildSnapshotWindows(now),
+      snapshotsAllDaily: historyFor(secondNetwork.chainId),
+      uniqueLpAddresses: Array.from(
+        { length: 10_000 },
+        (_, index) => `0x${String(index + 5_000).padStart(40, "0")}`,
+      ),
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockFetchAllNetworks.mockResolvedValueOnce([source, secondSource]);
+
+    const result = await fetchInitialNetworkData("home");
+    const fullBytes = Buffer.byteLength(
+      JSON.stringify([source, secondSource].map(dehydrateNetworkData)),
+    );
+    // Measure the explicit JSON-safe representation rather than stringifying
+    // rehydrated Maps/Sets (which would turn them into `{}` and undercount the
+    // Data Cache / Flight transport).
+    const projectedBytes = Buffer.byteLength(
+      JSON.stringify({
+        ...result,
+        networks: result.networks.map(dehydrateNetworkData),
+      }),
+    );
+
+    expect(fullBytes).toBeGreaterThan(500_000);
+    expect(projectedBytes).toBeLessThan(500_000);
+    expect(
+      result.networks.every(
+        (initial) =>
+          initial.snapshotsAllDaily.length ===
+          poolCountPerNetwork * INITIAL_SNAPSHOT_HISTORY_DAYS,
+      ),
+    ).toBe(true);
+    expect(result.networks[0]!.brokerSnapshotsAllDaily).toHaveLength(
+      INITIAL_SNAPSHOT_HISTORY_DAYS,
+    );
+    expect(
+      result.networks.every((initial) => initial.uniqueLpAddresses === null),
+    ).toBe(true);
+    expect(result.networks.flatMap((initial) => initial.pools)).toHaveLength(
+      40,
+    );
+    expect(result.uniqueLpCount).toBe(15_000);
   });
 
   it("still returns a degraded payload but never caches it", async () => {
@@ -275,7 +514,7 @@ describe("fetchInitialNetworkData", () => {
       healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
     ]);
 
-    const { networks, fetchedAtMs } = await fetchInitialNetworkData();
+    const { networks, fetchedAtMs } = await fetchInitialNetworkData("home");
 
     expect(networks[0]!.ratesError).toEqual({ message: "oracle query failed" });
     expect(networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
@@ -289,7 +528,7 @@ describe("fetchInitialNetworkData", () => {
   it("treats an empty payload as degraded instead of pinning it", async () => {
     mockFetchAllNetworks.mockResolvedValueOnce([]);
 
-    const result = await fetchInitialNetworkData();
+    const result = await fetchInitialNetworkData("home");
 
     expect(result.networks).toEqual([]);
     expect(cacheCallbackOutcomes).toEqual(["threw"]);
@@ -298,7 +537,7 @@ describe("fetchInitialNetworkData", () => {
   it("rethrows unexpected errors from the fetch", async () => {
     mockFetchAllNetworks.mockRejectedValueOnce(new Error("boom"));
 
-    await expect(fetchInitialNetworkData()).rejects.toThrow("boom");
+    await expect(fetchInitialNetworkData("home")).rejects.toThrow("boom");
   });
 
   // Stale-hit path: `unstable_cache` serves stale entries and swallows
@@ -317,6 +556,7 @@ describe("fetchInitialNetworkData", () => {
             healthyNetworkData({ feeSnapshots: [], ...overrides }),
           ),
         ],
+        uniqueLpCount: 0,
       };
     }
 
@@ -329,7 +569,7 @@ describe("fetchInitialNetworkData", () => {
       armStaleCacheEntry(staleEntry(MAX_SERVED_STALENESS_MS - 1_000));
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
-      const result = await fetchInitialNetworkData();
+      const result = await fetchInitialNetworkData("home");
       await Promise.all(cacheState.backgroundRevalidations);
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
@@ -347,7 +587,7 @@ describe("fetchInitialNetworkData", () => {
         healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
       ]);
 
-      const result = await fetchInitialNetworkData();
+      const result = await fetchInitialNetworkData("home");
       await Promise.all(cacheState.backgroundRevalidations);
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
@@ -367,7 +607,7 @@ describe("fetchInitialNetworkData", () => {
       );
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
-      const result = await fetchInitialNetworkData();
+      const result = await fetchInitialNetworkData("home");
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
       expect(result.networks[0]!.rates.get("42220:cUSD")).toBe(1.0004);
@@ -379,7 +619,7 @@ describe("fetchInitialNetworkData", () => {
         healthyNetworkData({ ratesError: { message: "oracle query failed" } }),
       ]);
 
-      const [data] = (await fetchInitialNetworkData()).networks;
+      const [data] = (await fetchInitialNetworkData("home")).networks;
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);
       // Error channel intact → client mount revalidation fires, instead of
@@ -396,8 +636,8 @@ describe("fetchInitialNetworkData", () => {
       mockFetchAllNetworks.mockResolvedValueOnce([healthyNetworkData()]);
 
       const [first, second] = await Promise.all([
-        fetchInitialNetworkData(),
-        fetchInitialNetworkData(),
+        fetchInitialNetworkData("home"),
+        fetchInitialNetworkData("home"),
       ]);
 
       expect(mockFetchAllNetworks).toHaveBeenCalledTimes(1);

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -199,6 +199,9 @@ describe("InitialNetworkData type contract", () => {
       InitialNetworkData["snapshotsAllDailyCapped"]
     >().toEqualTypeOf<boolean>();
     expectTypeOf<
+      InitialNetworkData["brokerSnapshotsAllDailyCapped"]
+    >().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<
       InitialNetworkData["feeSnapshots"][number]
     >().toEqualTypeOf<never>();
   });
@@ -318,11 +321,16 @@ describe("fetchInitialNetworkData", () => {
     const [initial] = (await fetchInitialNetworkData("home")).networks;
 
     expect(initial!.snapshotsAllDaily).toHaveLength(
-      INITIAL_SNAPSHOT_HISTORY_DAYS,
+      INITIAL_SNAPSHOT_HISTORY_DAYS + 1,
     );
     expect(initial!.snapshotsAllDaily[0]!.timestamp).toBe(String(today));
-    expect(initial!.snapshotsAllDaily.at(-1)!.timestamp).toBe(
+    expect(initial!.snapshotsAllDaily.at(-2)!.timestamp).toBe(
       String(today - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY),
+    );
+    // One latest pre-window anchor lets TVL forward-fill quiet pools from
+    // their last confirmed reserves without carrying unbounded history.
+    expect(initial!.snapshotsAllDaily.at(-1)!.timestamp).toBe(
+      String(today - INITIAL_SNAPSHOT_HISTORY_DAYS * SECONDS_PER_DAY),
     );
     expect(initial!.snapshotsAllDailyCapped).toBe(true);
     expect(initial!.snapshots).toEqual([]);
@@ -331,6 +339,37 @@ describe("fetchInitialNetworkData", () => {
     expect(source.snapshotsAllDaily).toHaveLength(
       INITIAL_SNAPSHOT_HISTORY_DAYS + 5,
     );
+  });
+
+  it("keeps exactly the latest pre-window TVL anchor for each pool", async () => {
+    const now = Date.UTC(2026, 6, 15, 12, 34, 56);
+    const today = Math.floor(now / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const cutoff =
+      today - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY;
+    const source = healthyNetworkData({
+      snapshotWindows: buildSnapshotWindows(now),
+      snapshotsAllDaily: [
+        snapshotRow("active", cutoff),
+        snapshotRow("active", cutoff - SECONDS_PER_DAY),
+        snapshotRow("active", cutoff - 2 * SECONDS_PER_DAY),
+        snapshotRow("quiet", cutoff - 3 * SECONDS_PER_DAY),
+        snapshotRow("quiet", cutoff - 9 * SECONDS_PER_DAY),
+      ],
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockFetchAllNetworks.mockResolvedValueOnce([source]);
+
+    const [initial] = (await fetchInitialNetworkData("home")).networks;
+
+    expect(
+      initial!.snapshotsAllDaily.map((row) => [row.poolId, row.timestamp]),
+    ).toEqual([
+      ["active", String(cutoff)],
+      ["active", String(cutoff - SECONDS_PER_DAY)],
+      ["quiet", String(cutoff - 3 * SECONDS_PER_DAY)],
+    ]);
+    expect(initial!.snapshotsAllDailyCapped).toBe(true);
   });
 
   it("caps homepage Broker history to the same recent UTC-day window", async () => {
@@ -412,6 +451,7 @@ describe("fetchInitialNetworkData", () => {
           data.brokerSnapshotsAllDaily.length === 0,
       ),
     ).toBe(true);
+    expect(pools.networks[0]!.brokerSnapshotsAllDailyCapped).toBe(true);
   });
 
   it("keeps every history-growing field in a representative payload below 500KB", async () => {
@@ -494,7 +534,7 @@ describe("fetchInitialNetworkData", () => {
       result.networks.every(
         (initial) =>
           initial.snapshotsAllDaily.length ===
-          poolCountPerNetwork * INITIAL_SNAPSHOT_HISTORY_DAYS,
+          poolCountPerNetwork * (INITIAL_SNAPSHOT_HISTORY_DAYS + 1),
       ),
     ).toBe(true);
     expect(result.networks[0]!.brokerSnapshotsAllDaily).toHaveLength(

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/server-cache.test.ts
@@ -372,8 +372,8 @@ describe("fetchInitialNetworkData", () => {
     expect(initial!.snapshotsAllDailyCapped).toBe(true);
   });
 
-  it("caps homepage Broker history to the same recent UTC-day window", async () => {
-    const now = Date.UTC(2026, 6, 15, 12, 34, 56);
+  it("keeps the Broker boundary day required during the first UTC hour", async () => {
+    const now = Date.UTC(2026, 6, 15, 0, 34, 56);
     const today = Math.floor(now / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
     const brokerHistory = Array.from(
       { length: INITIAL_SNAPSHOT_HISTORY_DAYS + 7 },
@@ -396,10 +396,13 @@ describe("fetchInitialNetworkData", () => {
     const [initial] = (await fetchInitialNetworkData("home")).networks;
 
     expect(initial!.brokerSnapshotsAllDaily).toHaveLength(
-      INITIAL_SNAPSHOT_HISTORY_DAYS,
+      INITIAL_SNAPSHOT_HISTORY_DAYS + 1,
     );
     expect(initial!.brokerSnapshotsAllDaily.at(-1)!.timestamp).toBe(
-      String(today - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY),
+      String(today - INITIAL_SNAPSHOT_HISTORY_DAYS * SECONDS_PER_DAY),
+    );
+    expect(initial!.brokerSnapshotsAllDaily.at(-1)!.timestamp).toBe(
+      String(buildSnapshotWindows(now).w30d.from),
     );
     expect(initial!.brokerSnapshotsAllDailyCapped).toBe(true);
   });
@@ -538,7 +541,7 @@ describe("fetchInitialNetworkData", () => {
       ),
     ).toBe(true);
     expect(result.networks[0]!.brokerSnapshotsAllDaily).toHaveLength(
-      INITIAL_SNAPSHOT_HISTORY_DAYS,
+      INITIAL_SNAPSHOT_HISTORY_DAYS + 1,
     );
     expect(
       result.networks.every((initial) => initial.uniqueLpAddresses === null),

--- a/ui-dashboard/src/lib/network-fetcher/assemble.ts
+++ b/ui-dashboard/src/lib/network-fetcher/assemble.ts
@@ -13,8 +13,7 @@ import {
 } from "@/lib/protocol-fees";
 import { buildOracleRateMap, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolDailyFeeSnapshot } from "@/lib/types";
-import { filterSnapshotsToWindow, type TimeRange } from "@/lib/volume";
-import { SECONDS_PER_DAY } from "./constants";
+import { buildDailySnapshotSlices, type TimeRange } from "@/lib/volume";
 import { toError } from "./errors";
 import { mutableDayCutoff } from "./pagination";
 import type {
@@ -177,7 +176,9 @@ function deriveOlsPoolIds(
 /**
  * Derives the snapshotsAllDaily/snapshots7d/snapshots30d/snapshots slices
  * plus their per-window errors. Window-specific arrays are derived in-memory
- * from `snapshotsAllDaily` — no separate requests, no server-side cap. If
+ * from `snapshotsAllDaily` — no separate requests. This fetch-layer payload
+ * is always uncapped; the Server Component transport projection applies its
+ * own recent-history cap later and marks that projection explicitly. If
  * pagination truncated (hit MAX_PAGES or mid-loop fetch failure) we keep the
  * most-recent rows we did fetch: 24h/7d/30d derive correctly from those and
  * "All" is flagged as partial.
@@ -188,6 +189,7 @@ function deriveSnapshotSlice(args: {
   snapshotTailNowMs: number;
 }): {
   snapshotsAllDaily: NetworkData["snapshotsAllDaily"];
+  snapshotsAllDailyCapped: boolean;
   snapshotsAllDailyTruncated: boolean;
   snapshotsAllDailyError: Error | null;
   snapshots: NetworkData["snapshots"];
@@ -211,30 +213,11 @@ function deriveSnapshotSlice(args: {
       ? toError(snapshotsAllDailyResult.reason)
       : (snapshotsAllDailyResult.value.error ?? null);
 
-  // PoolDailySnapshot rows are UTC-midnight-aligned incremental aggregates
-  // (one row per pool per UTC day). Anchoring on today's UTC midnight gives
-  // exactly 1/7/30 daily rows per KPI window without overcounting.
-  //
   // `nowSeconds` is the caller's snapshot of "now" (`windows.w24h.to`), so
-  // deriving todayMidnight from it keeps all three windows consistent with
-  // the same clock tick rather than calling Date.now() again.
-  const todayMidnight =
-    Math.floor(nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  const dw24h: TimeRange = {
-    from: todayMidnight,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-  const dw7d: TimeRange = {
-    from: todayMidnight - 6 * SECONDS_PER_DAY,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-  const dw30d: TimeRange = {
-    from: todayMidnight - 29 * SECONDS_PER_DAY,
-    to: todayMidnight + SECONDS_PER_DAY,
-  };
-
-  const snapshots7d = filterSnapshotsToWindow(snapshotsAllDaily, dw7d);
-  const snapshots30d = filterSnapshotsToWindow(snapshotsAllDaily, dw30d);
+  // the shared derivation keeps server assembly and client restoration on the
+  // same UTC-day boundaries without another Date.now() tick.
+  const { dailyWindows, snapshots, snapshots7d, snapshots30d } =
+    buildDailySnapshotSlices(snapshotsAllDaily, nowSeconds);
 
   // Per-window error detection. Pagination issues (error or truncation) only
   // affect a specific window if we didn't fetch far enough back to cover its
@@ -262,7 +245,7 @@ function deriveSnapshotSlice(args: {
 
   const { snapshotsError, snapshots7dError, snapshots30dError } =
     resolveWindowErrors({
-      windows: { w24h: dw24h, w7d: dw7d, w30d: dw30d },
+      windows: dailyWindows,
       oldestFetchedTs,
       paginationIssue,
       mutableTailIssue,
@@ -271,9 +254,12 @@ function deriveSnapshotSlice(args: {
 
   return {
     snapshotsAllDaily,
+    snapshotsAllDailyCapped:
+      snapshotsAllDailyResult.status === "fulfilled" &&
+      snapshotsAllDailyResult.value.historyComplete === false,
     snapshotsAllDailyTruncated,
     snapshotsAllDailyError,
-    snapshots: filterSnapshotsToWindow(snapshotsAllDaily, dw24h),
+    snapshots,
     snapshots7d,
     snapshots30d,
     snapshotsError,

--- a/ui-dashboard/src/lib/network-fetcher/assemble.ts
+++ b/ui-dashboard/src/lib/network-fetcher/assemble.ts
@@ -125,6 +125,7 @@ function deriveBrokerSlice(
   result: PromiseSettledResult<PaginatedPageResult<BrokerDailySnapshotRow>>,
 ): {
   brokerSnapshotsAllDaily: BrokerDailySnapshotRow[];
+  brokerSnapshotsAllDailyCapped: boolean;
   brokerSnapshotsAllDailyTruncated: boolean;
   brokerSnapshotsAllDailyError: Error | null;
 } {
@@ -133,6 +134,13 @@ function deriveBrokerSlice(
   return {
     brokerSnapshotsAllDaily:
       result.status === "fulfilled" ? result.value.rows : [],
+    // A rejected first page and either kind of partial pagination are all
+    // incomplete-history outcomes. Keep the cap explicit so the shared chart
+    // handoff cannot relabel missing Broker history as a complete "All" range.
+    brokerSnapshotsAllDailyCapped:
+      result.status === "rejected" ||
+      result.value.truncated ||
+      result.value.error !== null,
     brokerSnapshotsAllDailyTruncated:
       result.status === "fulfilled" && result.value.truncated,
     brokerSnapshotsAllDailyError:

--- a/ui-dashboard/src/lib/network-fetcher/constants.ts
+++ b/ui-dashboard/src/lib/network-fetcher/constants.ts
@@ -1,2 +1,10 @@
 export const SNAPSHOT_PAGE_SIZE = 1000;
 export const SECONDS_PER_DAY = 86_400;
+
+/**
+ * Number of UTC-day PoolDailySnapshot buckets carried across the Server →
+ * Client boundary for `/` and `/pools`. Thirty-day charts and KPI windows fit
+ * entirely inside this seed; the "All" range explicitly requests the normal
+ * full-history client payload before rendering.
+ */
+export const INITIAL_SNAPSHOT_HISTORY_DAYS = 30;

--- a/ui-dashboard/src/lib/network-fetcher/constants.ts
+++ b/ui-dashboard/src/lib/network-fetcher/constants.ts
@@ -5,7 +5,9 @@ export const SECONDS_PER_DAY = 86_400;
  * Number of recent UTC-day PoolDailySnapshot buckets carried across the
  * Server → Client boundary for `/` and `/pools`. Thirty-day charts and KPI
  * windows fit entirely inside this seed; the projection also keeps one older
- * anchor per pool so TVL can forward-fill quiet pools. The "All" range
- * explicitly requests the normal full-history client payload before rendering.
+ * anchor per pool so TVL can forward-fill quiet pools. Broker history keeps one
+ * extra UTC-day boundary bucket because its rolling 30-day window can begin
+ * exactly 30 midnights ago during UTC hour zero. The "All" range explicitly
+ * requests the normal full-history client payload before rendering.
  */
 export const INITIAL_SNAPSHOT_HISTORY_DAYS = 30;

--- a/ui-dashboard/src/lib/network-fetcher/constants.ts
+++ b/ui-dashboard/src/lib/network-fetcher/constants.ts
@@ -2,9 +2,10 @@ export const SNAPSHOT_PAGE_SIZE = 1000;
 export const SECONDS_PER_DAY = 86_400;
 
 /**
- * Number of UTC-day PoolDailySnapshot buckets carried across the Server →
- * Client boundary for `/` and `/pools`. Thirty-day charts and KPI windows fit
- * entirely inside this seed; the "All" range explicitly requests the normal
- * full-history client payload before rendering.
+ * Number of recent UTC-day PoolDailySnapshot buckets carried across the
+ * Server → Client boundary for `/` and `/pools`. Thirty-day charts and KPI
+ * windows fit entirely inside this seed; the projection also keeps one older
+ * anchor per pool so TVL can forward-fill quiet pools. The "All" range
+ * explicitly requests the normal full-history client payload before rendering.
  */
 export const INITIAL_SNAPSHOT_HISTORY_DAYS = 30;

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -92,6 +92,7 @@ export const blankNetworkData = (
   snapshots7d: [],
   snapshots30d: [],
   snapshotsAllDaily: [],
+  snapshotsAllDailyCapped: false,
   snapshotsAllDailyTruncated: false,
   brokerSnapshotsAllDaily: [],
   brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/src/lib/network-fetcher/fetch.ts
+++ b/ui-dashboard/src/lib/network-fetcher/fetch.ts
@@ -95,6 +95,7 @@ export const blankNetworkData = (
   snapshotsAllDailyCapped: false,
   snapshotsAllDailyTruncated: false,
   brokerSnapshotsAllDaily: [],
+  brokerSnapshotsAllDailyCapped: false,
   brokerSnapshotsAllDailyTruncated: false,
   olsPoolIds: new Set(),
   cdpPoolIds: new Set(),

--- a/ui-dashboard/src/lib/network-fetcher/pagination.ts
+++ b/ui-dashboard/src/lib/network-fetcher/pagination.ts
@@ -207,7 +207,13 @@ function capturePageCapExhaustion(args: {
 /** @internal Exported for test-scope `.clear()`. */
 export const incrementalRowCache = new Map<
   string,
-  { variablesKey: string; rows: unknown[]; refreshAfterTimestamp: number }
+  {
+    variablesKey: string;
+    rows: unknown[];
+    refreshAfterTimestamp: number;
+    /** False for a bounded SSR seed until a full pagination succeeds. */
+    complete: boolean;
+  }
 >();
 
 const poolIdsVariablesKey = (poolIds: readonly string[]) =>
@@ -219,6 +225,7 @@ type IncrementalSeedArgs = {
   rows: unknown[];
   dedupKey: (row: unknown) => string;
   timestampOf: (row: unknown) => number;
+  complete: boolean;
   nowMs?: number;
 };
 
@@ -228,6 +235,7 @@ function seedIncrementalRows({
   rows,
   dedupKey,
   timestampOf,
+  complete,
   nowMs = Date.now(),
 }: IncrementalSeedArgs): void {
   if (rows.length === 0) return;
@@ -250,9 +258,11 @@ function seedIncrementalRows({
       timestampOf,
       nowMs,
     );
+    const mergedComplete = existing.complete || complete;
     if (
       existing.rows.length === mergedRows.length &&
-      existing.refreshAfterTimestamp === mergedRefreshAfterTimestamp
+      existing.refreshAfterTimestamp === mergedRefreshAfterTimestamp &&
+      existing.complete === mergedComplete
     ) {
       return;
     }
@@ -260,6 +270,9 @@ function seedIncrementalRows({
       variablesKey,
       rows: mergedRows,
       refreshAfterTimestamp: mergedRefreshAfterTimestamp,
+      // Never downgrade a full client cache when an older capped Server
+      // Component fallback renders later (for example on back-navigation).
+      complete: mergedComplete,
     });
     return;
   }
@@ -268,6 +281,7 @@ function seedIncrementalRows({
     variablesKey,
     rows,
     refreshAfterTimestamp,
+    complete,
   });
 }
 
@@ -289,6 +303,7 @@ export function seedIncrementalRowCacheFromNetworkData(
           return `${snapshot.poolId}-${snapshot.timestamp}`;
         },
         timestampOf: (row) => Number((row as PoolSnapshotWindow).timestamp),
+        complete: !data.snapshotsAllDailyCapped,
       });
     }
 
@@ -336,6 +351,21 @@ function mergeRowsPreservingExisting<TRow>(
   );
 }
 
+function mergeRowsReplacingExisting<TRow>(
+  existingRows: readonly TRow[],
+  incomingRows: readonly TRow[],
+  dedupKey: (row: TRow) => string,
+  timestampOf: (row: TRow) => number,
+): TRow[] {
+  const merged = new Map<string, TRow>();
+  for (const row of existingRows) merged.set(dedupKey(row), row);
+  for (const row of incomingRows) merged.set(dedupKey(row), row);
+  return [...merged.values()].sort(
+    (a, b) =>
+      timestampOf(b) - timestampOf(a) || dedupKey(b).localeCompare(dedupKey(a)),
+  );
+}
+
 function shouldCacheCompleteRows<TRow>(
   result: PaginatedPageResult<TRow>,
 ): boolean {
@@ -347,6 +377,130 @@ function surfacedIncrementalError(
   surfaceIncrementalError: boolean,
 ): Error | null {
   return surfaceIncrementalError ? error : null;
+}
+
+type CompleteHistoryResult<TRow> = PaginatedPageResult<TRow> & {
+  historyComplete: boolean;
+};
+
+type IncrementalBranchArgs<TRow> = {
+  paginate: (afterTimestamp: number) => Promise<PaginatedPageResult<TRow>>;
+  cacheKey: string;
+  variablesKey: string;
+  cachedRows: TRow[];
+  dedupKey: (row: TRow) => string;
+  timestampOf: (row: TRow) => number;
+  nowMs: number;
+  surfaceIncrementalError: boolean;
+};
+
+function cacheCompleteRows<TRow>(
+  result: PaginatedPageResult<TRow>,
+  rows: TRow[],
+  args: Pick<
+    IncrementalBranchArgs<TRow>,
+    "cacheKey" | "variablesKey" | "timestampOf" | "nowMs"
+  >,
+): void {
+  if (!shouldCacheCompleteRows(result)) return;
+  incrementalRowCache.set(args.cacheKey, {
+    variablesKey: args.variablesKey,
+    rows,
+    refreshAfterTimestamp: refreshAfterTimestampForRows(
+      rows,
+      args.timestampOf,
+      args.nowMs,
+    ),
+    complete: true,
+  });
+}
+
+async function fetchFullHistoryFromSeed<TRow>(
+  args: IncrementalBranchArgs<TRow> & { hasMatchingCache: boolean },
+): Promise<CompleteHistoryResult<TRow>> {
+  let full: PaginatedPageResult<TRow>;
+  try {
+    full = await args.paginate(0);
+  } catch (err) {
+    if (!args.hasMatchingCache) throw err;
+    const error = err instanceof Error ? err : new Error(String(err));
+    return {
+      rows: args.cachedRows,
+      truncated: true,
+      error: surfacedIncrementalError(error, args.surfaceIncrementalError),
+      historyComplete: false,
+    };
+  }
+
+  const rows = args.hasMatchingCache
+    ? mergeRowsReplacingExisting(
+        args.cachedRows,
+        full.rows,
+        args.dedupKey,
+        args.timestampOf,
+      )
+    : full.rows;
+  if (
+    args.hasMatchingCache &&
+    full.rows.length === 0 &&
+    args.cachedRows.length > 0
+  ) {
+    const error = new Error(
+      "Full snapshot history returned no rows after a capped SSR seed",
+    );
+    return {
+      rows: args.cachedRows,
+      truncated: true,
+      error: surfacedIncrementalError(error, args.surfaceIncrementalError),
+      historyComplete: false,
+    };
+  }
+
+  cacheCompleteRows(full, rows, args);
+  return {
+    ...full,
+    rows,
+    historyComplete: !full.truncated && full.error === null,
+  };
+}
+
+async function fetchMutableHistoryTail<TRow>(
+  args: IncrementalBranchArgs<TRow> & { refreshAfterTimestamp: number },
+): Promise<CompleteHistoryResult<TRow>> {
+  let tail: PaginatedPageResult<TRow>;
+  try {
+    tail = await args.paginate(args.refreshAfterTimestamp);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return {
+      rows: args.cachedRows,
+      truncated: true,
+      error: surfacedIncrementalError(error, args.surfaceIncrementalError),
+      mutableTailError: error,
+      // The immutable history remains complete; only its mutable tail is
+      // stale. Keep "All" renderable with the existing partial-data signal.
+      historyComplete: true,
+    };
+  }
+
+  const rows = mergeRowsReplacingExisting(
+    args.cachedRows,
+    tail.rows,
+    args.dedupKey,
+    args.timestampOf,
+  );
+  cacheCompleteRows(tail, rows, args);
+  return {
+    rows,
+    truncated: tail.truncated,
+    error: surfacedIncrementalError(tail.error, args.surfaceIncrementalError),
+    mutableTailError:
+      tail.error ??
+      (tail.truncated
+        ? new Error("Snapshot incremental tail pagination truncated")
+        : null),
+    historyComplete: true,
+  };
 }
 
 async function fetchPaginatedRowsIncremental<TRow, TVars>(args: {
@@ -363,7 +517,7 @@ async function fetchPaginatedRowsIncremental<TRow, TVars>(args: {
   nowMs?: number;
   surfaceIncrementalError?: boolean;
   extra?: Record<string, unknown>;
-}): Promise<PaginatedPageResult<TRow>> {
+}): Promise<CompleteHistoryResult<TRow>> {
   const {
     client,
     query,
@@ -392,66 +546,34 @@ async function fetchPaginatedRowsIncremental<TRow, TVars>(args: {
       ...(extra !== undefined ? { extra } : {}),
     });
 
-  if (cached === undefined || cached.variablesKey !== variablesKey) {
-    const full = await paginate(0);
-    if (shouldCacheCompleteRows(full)) {
-      incrementalRowCache.set(cacheKey, {
-        variablesKey,
-        rows: full.rows,
-        refreshAfterTimestamp: refreshAfterTimestampForRows(
-          full.rows,
-          timestampOf,
-          nowMs,
-        ),
-      });
-    }
-    return full;
-  }
-
-  const cachedRows = cached.rows as TRow[];
-  let tail: PaginatedPageResult<TRow>;
-  try {
-    tail = await paginate(cached.refreshAfterTimestamp);
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    return {
-      rows: cachedRows,
-      truncated: true,
-      error: surfacedIncrementalError(error, surfaceIncrementalError),
-      mutableTailError: error,
-    };
-  }
-
-  const merged = new Map<string, TRow>();
-  for (const row of cachedRows) merged.set(dedupKey(row), row);
-  for (const row of tail.rows) merged.set(dedupKey(row), row);
-  const rows = [...merged.values()].sort(
-    (a, b) =>
-      timestampOf(b) - timestampOf(a) || dedupKey(b).localeCompare(dedupKey(a)),
-  );
-
-  if (shouldCacheCompleteRows(tail)) {
-    incrementalRowCache.set(cacheKey, {
-      variablesKey,
-      rows,
-      refreshAfterTimestamp: refreshAfterTimestampForRows(
-        rows,
-        timestampOf,
-        nowMs,
-      ),
-    });
-  }
-
-  return {
-    rows,
-    truncated: tail.truncated,
-    error: surfacedIncrementalError(tail.error, surfaceIncrementalError),
-    mutableTailError:
-      tail.error ??
-      (tail.truncated
-        ? new Error("Snapshot incremental tail pagination truncated")
-        : null),
+  const hasMatchingCache =
+    cached !== undefined && cached.variablesKey === variablesKey;
+  const cachedRows = hasMatchingCache ? (cached.rows as TRow[]) : [];
+  const branchArgs: IncrementalBranchArgs<TRow> = {
+    paginate,
+    cacheKey,
+    variablesKey,
+    cachedRows,
+    dedupKey,
+    timestampOf,
+    nowMs,
+    surfaceIncrementalError,
   };
+
+  // A bounded SSR seed is useful last-good recent data, but it is not proof
+  // of complete history. Force the same from-zero pagination as a cold
+  // client, then merge the result over the seed so mutable rows get the
+  // fresher client value. On failure, preserve the seed and surface the
+  // degraded channel instead of either losing recent data or silently
+  // presenting the cap as "All".
+  if (!hasMatchingCache || !cached.complete) {
+    return fetchFullHistoryFromSeed({ ...branchArgs, hasMatchingCache });
+  }
+
+  return fetchMutableHistoryTail({
+    ...branchArgs,
+    refreshAfterTimestamp: cached.refreshAfterTimestamp,
+  });
 }
 
 /**

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -98,8 +98,9 @@ export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
  *   TVL chart forward-fill quiet pools from their last confirmed reserves;
  *   the bounded rows still cover every default chart/KPI window without
  *   letting the Flight payload grow forever.
- * - Broker history receives the same UTC-day cap; it is only consumed by the
- *   homepage's default volume chart and the cap covers that exact 30-day UI.
+ * - Broker history keeps one additional UTC-day boundary bucket beyond the
+ *   pool window. The rolling 30-day chart starts at the prior midnight during
+ *   UTC hour zero, so that bucket is required until the next hourly boundary.
  * - cumulative LP addresses are replaced by a payload-level exact cross-chain
  *   count before serialization. The raw addresses never enter the Data Cache
  *   or Flight payload.
@@ -147,14 +148,16 @@ function projectInitialNetworkData(
   const todayMidnightUtc =
     Math.floor(data.snapshotWindows.w24h.to / SECONDS_PER_DAY) *
     SECONDS_PER_DAY;
-  const cutoff =
+  const poolCutoff =
     todayMidnightUtc - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY;
+  const brokerCutoff =
+    todayMidnightUtc - INITIAL_SNAPSHOT_HISTORY_DAYS * SECONDS_PER_DAY;
   const snapshotsAllDaily = projectPoolSnapshotHistory(
     data.snapshotsAllDaily,
-    cutoff,
+    poolCutoff,
   );
   const brokerSnapshotsAllDaily = data.brokerSnapshotsAllDaily.filter(
-    (snapshot) => Number(snapshot.timestamp) >= cutoff,
+    (snapshot) => Number(snapshot.timestamp) >= brokerCutoff,
   );
   return {
     ...data,

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -94,7 +94,9 @@ export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
  * - the 1/7/30-day arrays are dropped because the client-safe daily-slice
  *   helper reconstructs them synchronously from the canonical daily rows;
  * - `snapshotsAllDaily` keeps the latest `INITIAL_SNAPSHOT_HISTORY_DAYS`
- *   UTC-day buckets, which covers every default chart/KPI window without
+ *   UTC-day buckets plus one pre-window anchor per pool. The anchor lets the
+ *   TVL chart forward-fill quiet pools from their last confirmed reserves;
+ *   the bounded rows still cover every default chart/KPI window without
  *   letting the Flight payload grow forever.
  * - Broker history receives the same UTC-day cap; it is only consumed by the
  *   homepage's default volume chart and the cap covers that exact 30-day UI.
@@ -102,11 +104,39 @@ export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
  *   count before serialization. The raw addresses never enter the Data Cache
  *   or Flight payload.
  *
- * `snapshotsAllDailyCapped` is the explicit handoff contract: the client may
- * use the rows for recent windows and as last-good data, but it must force a
- * from-zero pagination before presenting "All". Error/truncation outcome
- * fields remain intact so health and degraded UI semantics do not change.
+ * The routes use isolated client SWR keys so `/pools` can omit homepage-only
+ * Broker history without overwriting the homepage seed. The cap fields are
+ * the explicit handoff contract: the client may use bounded rows for recent
+ * windows and as last-good data, but it must force a from-zero pagination
+ * before presenting "All". Error/truncation outcome fields remain intact so
+ * health and degraded UI semantics do not change.
  */
+function projectPoolSnapshotHistory(
+  rows: DehydratedNetworkData["snapshotsAllDaily"],
+  cutoff: number,
+): DehydratedNetworkData["snapshotsAllDaily"] {
+  const recentRows: DehydratedNetworkData["snapshotsAllDaily"] = [];
+  const anchorByPool = new Map<
+    string,
+    DehydratedNetworkData["snapshotsAllDaily"][number]
+  >();
+  for (const row of rows) {
+    const timestamp = Number(row.timestamp);
+    if (timestamp >= cutoff) {
+      recentRows.push(row);
+      continue;
+    }
+    const currentAnchor = anchorByPool.get(row.poolId);
+    if (
+      currentAnchor === undefined ||
+      timestamp > Number(currentAnchor.timestamp)
+    ) {
+      anchorByPool.set(row.poolId, row);
+    }
+  }
+  return [...recentRows, ...anchorByPool.values()];
+}
+
 function projectInitialNetworkData(
   data: DehydratedNetworkData,
 ): DehydratedInitialNetworkData {
@@ -119,8 +149,9 @@ function projectInitialNetworkData(
     SECONDS_PER_DAY;
   const cutoff =
     todayMidnightUtc - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY;
-  const snapshotsAllDaily = data.snapshotsAllDaily.filter(
-    (snapshot) => Number(snapshot.timestamp) >= cutoff,
+  const snapshotsAllDaily = projectPoolSnapshotHistory(
+    data.snapshotsAllDaily,
+    cutoff,
   );
   const brokerSnapshotsAllDaily = data.brokerSnapshotsAllDaily.filter(
     (snapshot) => Number(snapshot.timestamp) >= cutoff,
@@ -162,8 +193,8 @@ function rehydrateInitialNetworkData(
   // `/pools` consumes neither Broker volume history nor LP addresses. Keep the
   // same shared server cache entry, then remove the homepage-only bounded rows
   // at the final route projection so they never cross this route's Flight
-  // boundary. An omitted non-empty/capped Broker slice stays marked incomplete
-  // if this fallback is ever observed by the shared client hook.
+  // boundary. The route's isolated SWR key prevents this intentionally slim
+  // fallback from replacing the homepage seed.
   return {
     ...rehydrated,
     brokerSnapshotsAllDaily: [],

--- a/ui-dashboard/src/lib/network-fetcher/server-cache.ts
+++ b/ui-dashboard/src/lib/network-fetcher/server-cache.ts
@@ -20,6 +20,10 @@ import type {
   NetworkData,
   PoolLabel,
 } from "@/lib/network-fetcher/types";
+import {
+  INITIAL_SNAPSHOT_HISTORY_DAYS,
+  SECONDS_PER_DAY,
+} from "@/lib/network-fetcher/constants";
 import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 
 /**
@@ -44,9 +48,19 @@ type DehydratedNetworkData = Omit<
 
 type DehydratedInitialNetworkData = Omit<
   DehydratedNetworkData,
-  "feeSnapshots"
+  | "feeSnapshots"
+  | "snapshots"
+  | "snapshots7d"
+  | "snapshots30d"
+  | "uniqueLpAddresses"
+  | "uniqueLpAddressesOmitted"
 > & {
   feeSnapshots: [];
+  snapshots: [];
+  snapshots7d: [];
+  snapshots30d: [];
+  uniqueLpAddresses: null;
+  uniqueLpAddressesOmitted: true;
 };
 
 export function dehydrateNetworkData(data: NetworkData): DehydratedNetworkData {
@@ -72,26 +86,113 @@ export function rehydrateNetworkData(data: DehydratedNetworkData): NetworkData {
 }
 
 /**
- * Drops the raw `feeSnapshots` rows (~330KB of the ~1.04MB Flight payload)
- * from the SSR payload. Nothing on `/` or `/pools` reads the raw rows — the
- * aggregated `fees` summary is computed server-side in `assembleNetworkData`
- * before this projection, `/revenue` uses its own slim `useProtocolFees` hook
- * with a separate SWR key, and `seedIncrementalRowCacheFromNetworkData`
- * intentionally never seeds fee history (it keeps full pagination so healed
- * rows are re-fetched). `feeSnapshotsError` / `feeSnapshotsTruncated` are
- * kept so `isNetworkDataFullyHealthy` and the `≈` truncation UX still see
- * the fetch outcome.
+ * Projects the full network response into the bounded homepage Server
+ * Component payload (the `/pools` route applies one additional omission):
+ *
+ * - raw `feeSnapshots` rows are dropped because those routes only read the
+ *   already-aggregated `fees` summary; `/revenue` has its own SWR key;
+ * - the 1/7/30-day arrays are dropped because the client-safe daily-slice
+ *   helper reconstructs them synchronously from the canonical daily rows;
+ * - `snapshotsAllDaily` keeps the latest `INITIAL_SNAPSHOT_HISTORY_DAYS`
+ *   UTC-day buckets, which covers every default chart/KPI window without
+ *   letting the Flight payload grow forever.
+ * - Broker history receives the same UTC-day cap; it is only consumed by the
+ *   homepage's default volume chart and the cap covers that exact 30-day UI.
+ * - cumulative LP addresses are replaced by a payload-level exact cross-chain
+ *   count before serialization. The raw addresses never enter the Data Cache
+ *   or Flight payload.
+ *
+ * `snapshotsAllDailyCapped` is the explicit handoff contract: the client may
+ * use the rows for recent windows and as last-good data, but it must force a
+ * from-zero pagination before presenting "All". Error/truncation outcome
+ * fields remain intact so health and degraded UI semantics do not change.
  */
-function stripFeeSnapshotRows(
+function projectInitialNetworkData(
   data: DehydratedNetworkData,
 ): DehydratedInitialNetworkData {
-  return { ...data, feeSnapshots: [] };
+  // Anchor the cap to the exact clock snapshot used to derive the server's
+  // 1/7/30-day windows. Using fetch-completion time here creates a midnight
+  // race: a fan-out that starts before 00:00 and finishes after it could drop
+  // the oldest row still required by the already-computed 30-day window.
+  const todayMidnightUtc =
+    Math.floor(data.snapshotWindows.w24h.to / SECONDS_PER_DAY) *
+    SECONDS_PER_DAY;
+  const cutoff =
+    todayMidnightUtc - (INITIAL_SNAPSHOT_HISTORY_DAYS - 1) * SECONDS_PER_DAY;
+  const snapshotsAllDaily = data.snapshotsAllDaily.filter(
+    (snapshot) => Number(snapshot.timestamp) >= cutoff,
+  );
+  const brokerSnapshotsAllDaily = data.brokerSnapshotsAllDaily.filter(
+    (snapshot) => Number(snapshot.timestamp) >= cutoff,
+  );
+  return {
+    ...data,
+    feeSnapshots: [],
+    snapshots: [],
+    snapshots7d: [],
+    snapshots30d: [],
+    snapshotsAllDaily,
+    snapshotsAllDailyCapped:
+      data.snapshotsAllDailyCapped ||
+      snapshotsAllDaily.length < data.snapshotsAllDaily.length,
+    brokerSnapshotsAllDaily,
+    brokerSnapshotsAllDailyCapped:
+      data.brokerSnapshotsAllDailyCapped === true ||
+      brokerSnapshotsAllDaily.length < data.brokerSnapshotsAllDaily.length,
+    uniqueLpAddresses: null,
+    uniqueLpAddressesOmitted: true,
+  };
 }
 
 function rehydrateInitialNetworkData(
   data: DehydratedInitialNetworkData,
+  route: InitialNetworkDataRoute,
 ): InitialNetworkData {
-  return { ...rehydrateNetworkData(data), feeSnapshots: [] };
+  const rehydrated: InitialNetworkData = {
+    ...rehydrateNetworkData(data),
+    feeSnapshots: [],
+    snapshots: [],
+    snapshots7d: [],
+    snapshots30d: [],
+    uniqueLpAddresses: null,
+    uniqueLpAddressesOmitted: true,
+  };
+  if (route === "home") return rehydrated;
+
+  // `/pools` consumes neither Broker volume history nor LP addresses. Keep the
+  // same shared server cache entry, then remove the homepage-only bounded rows
+  // at the final route projection so they never cross this route's Flight
+  // boundary. An omitted non-empty/capped Broker slice stays marked incomplete
+  // if this fallback is ever observed by the shared client hook.
+  return {
+    ...rehydrated,
+    brokerSnapshotsAllDaily: [],
+    brokerSnapshotsAllDailyCapped:
+      rehydrated.brokerSnapshotsAllDaily.length > 0 ||
+      rehydrated.brokerSnapshotsAllDailyCapped === true,
+  };
+}
+
+/** Exact homepage LP KPI semantics, computed while the raw address sets are
+ * still available. Successful chains are unioned case-insensitively; a total
+ * network failure makes the protocol-wide result unknowable, while an LP-only
+ * failure still preserves the lower-bound count from successful chains (the
+ * retained per-network error/truncation flags drive the existing disclosure). */
+function aggregateUniqueLpCount(data: readonly NetworkData[]): number | null {
+  if (data.some((networkData) => networkData.error !== null)) return null;
+
+  const addresses = new Set<string>();
+  let hasSuccessfulResult = false;
+  let hasLpError = false;
+  for (const networkData of data) {
+    if (networkData.lpError !== null) hasLpError = true;
+    if (networkData.uniqueLpAddresses === null) continue;
+    hasSuccessfulResult = true;
+    for (const address of networkData.uniqueLpAddresses) {
+      addresses.add(address.toLowerCase());
+    }
+  }
+  return !hasSuccessfulResult && hasLpError ? null : addresses.size;
 }
 
 /**
@@ -101,9 +202,9 @@ function rehydrateInitialNetworkData(
  * TTL (it would otherwise trap every visitor on `N/A` tiles until expiry).
  */
 class DegradedNetworkDataError extends Error {
-  declare readonly payload: DehydratedInitialNetworkData[];
+  declare readonly payload: CachedNetworkPayload;
 
-  constructor(payload: DehydratedInitialNetworkData[]) {
+  constructor(payload: CachedNetworkPayload) {
     super("degraded network data payload — not cached");
     this.name = "DegradedNetworkDataError";
     // Non-enumerable: `unstable_cache`'s swallowed-error path console.errors
@@ -123,19 +224,29 @@ class DegradedNetworkDataError extends Error {
 interface CachedNetworkPayload {
   fetchedAt: number;
   networks: DehydratedInitialNetworkData[];
+  /** Exact aggregate replacing the cumulative per-network LP address arrays. */
+  uniqueLpCount: number | null;
 }
 
 async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload> {
   const data = await fetchAllNetworks();
+  // One completion timestamp records cache freshness. The history projection
+  // itself uses each payload's shared window clock (see above).
+  const fetchedAt = Date.now();
+  const uniqueLpCount = aggregateUniqueLpCount(data);
   const dehydrated = data.map((networkData) =>
-    stripFeeSnapshotRows(dehydrateNetworkData(networkData)),
+    projectInitialNetworkData(dehydrateNetworkData(networkData)),
   );
   // Empty = no configured networks (misconfigured env) — treat as degraded
   // rather than pinning an empty dashboard for the TTL.
   if (data.length === 0 || !data.every(isNetworkDataFullyHealthy)) {
-    throw new DegradedNetworkDataError(dehydrated);
+    throw new DegradedNetworkDataError({
+      fetchedAt,
+      networks: dehydrated,
+      uniqueLpCount,
+    });
   }
-  return { fetchedAt: Date.now(), networks: dehydrated };
+  return { fetchedAt, networks: dehydrated, uniqueLpCount };
 }
 
 // 30s revalidate — but NOT a staleness bound: on dynamic renders
@@ -160,7 +271,9 @@ async function fetchDehydratedInitialNetworkData(): Promise<CachedNetworkPayload
 // One fan-out per deploy is cheap insurance against a new deployment
 // reading a payload fetched by old code or from an old endpoint.
 const CACHE_KEY_PARTS = [
-  "all-networks-ssr",
+  // Explicit projection version also protects persistent local `.next/cache`
+  // entries where no Vercel deployment id is available.
+  "all-networks-ssr-v2",
   process.env.VERCEL_DEPLOYMENT_ID ??
     process.env.VERCEL_GIT_COMMIT_SHA ??
     "dev",
@@ -208,9 +321,14 @@ function fetchDehydratedInitialNetworkDataCoalesced(): Promise<CachedNetworkPayl
 /** SSR payload plus its fetch-completion timestamp. `fetchedAtMs` crosses to
  *  the client so `useAllNetworksData` can gate its mount-revalidation skip on
  *  actual payload freshness rather than trusting whatever the cache served. */
+export type InitialNetworkDataRoute = "home" | "pools";
+
 export type InitialNetworkDataPayload = {
   networks: InitialNetworkData[];
   fetchedAtMs: number;
+  /** Present only for the homepage route; exact replacement for omitted raw
+   * LP address arrays. `null` retains the existing unavailable semantics. */
+  uniqueLpCount?: number | null | undefined;
 };
 
 /**
@@ -228,11 +346,15 @@ export type InitialNetworkDataPayload = {
  * last-healthy one. Within the staleness window, freshness is the CLIENT's
  * job: the returned `fetchedAtMs` drives the hook's freshness gate, which
  * revalidates on mount whenever the payload is older than its
- * fresh-enough bound — instant paint, live data ~1-2s later. Raw
- * `feeSnapshots` rows are stripped (see `stripFeeSnapshotRows`); use
- * `fetchAllNetworks` directly if a future server consumer needs them.
+ * fresh-enough bound — instant paint, live data ~1-2s later. Raw fee rows,
+ * redundant window arrays, and history older than the bounded SSR window are
+ * projected out (see `projectInitialNetworkData`); use `fetchAllNetworks`
+ * directly if a future
+ * server consumer needs either full dataset.
  */
-export async function fetchInitialNetworkData(): Promise<InitialNetworkDataPayload> {
+export async function fetchInitialNetworkData(
+  route: InitialNetworkDataRoute,
+): Promise<InitialNetworkDataPayload> {
   try {
     const cached = await cachedFetch();
     const payload =
@@ -242,18 +364,26 @@ export async function fetchInitialNetworkData(): Promise<InitialNetworkDataPaylo
           // launching a second fan-out.
           await fetchDehydratedInitialNetworkDataCoalesced()
         : cached;
-    return {
-      networks: payload.networks.map(rehydrateInitialNetworkData),
+    const result: InitialNetworkDataPayload = {
+      networks: payload.networks.map((networkData) =>
+        rehydrateInitialNetworkData(networkData, route),
+      ),
       fetchedAtMs: payload.fetchedAt,
     };
+    if (route === "home") result.uniqueLpCount = payload.uniqueLpCount;
+    return result;
   } catch (err) {
     if (err instanceof DegradedNetworkDataError) {
       // Degraded payloads are fetched in-band (never cached), so they are
       // fresh as of this request.
-      return {
-        networks: err.payload.map(rehydrateInitialNetworkData),
-        fetchedAtMs: Date.now(),
+      const result: InitialNetworkDataPayload = {
+        networks: err.payload.networks.map((networkData) =>
+          rehydrateInitialNetworkData(networkData, route),
+        ),
+        fetchedAtMs: err.payload.fetchedAt,
       };
+      if (route === "home") result.uniqueLpCount = err.payload.uniqueLpCount;
+      return result;
     }
     throw err;
   }

--- a/ui-dashboard/src/lib/network-fetcher/types.ts
+++ b/ui-dashboard/src/lib/network-fetcher/types.ts
@@ -77,11 +77,11 @@ export type NetworkData = {
    */
   brokerSnapshotsAllDaily: BrokerDailySnapshotRow[];
   /**
-   * True while the visible Broker daily rows are known to be only a recent
-   * subset (or deliberately omitted by a route projection). Absence is the
-   * normal full-fetch value and is equivalent to false. Together with
-   * `snapshotsAllDailyCapped`, this prevents the volume chart from presenting
-   * a bounded Server Component seed as complete "All" history.
+   * True while the visible Broker daily rows are known to be incomplete: a
+   * recent Server Component subset, a failed first page, or partial/truncated
+   * pagination. Absence is equivalent to false for legacy fixtures. Together
+   * with `snapshotsAllDailyCapped`, this prevents the volume chart from
+   * presenting incomplete data as complete "All" history.
    */
   brokerSnapshotsAllDailyCapped?: boolean | undefined;
   /** True when the broker pagination loop hit its safety cap. */

--- a/ui-dashboard/src/lib/network-fetcher/types.ts
+++ b/ui-dashboard/src/lib/network-fetcher/types.ts
@@ -57,6 +57,17 @@ export type NetworkData = {
    * Envio tier quota (429).
    */
   snapshotsAllDaily: PoolSnapshotWindow[];
+  /**
+   * True while the visible `snapshotsAllDaily` rows are known to be only a
+   * recent subset. The normal source fetch sets false; the Server Component
+   * projection sets true, and a failed attempt to complete that bounded seed
+   * keeps it true. This is distinct from `snapshotsAllDailyTruncated`: the
+   * latter explains an upstream pagination safety outcome, while this flag is
+   * the consumer contract that prevents presenting a subset as "All".
+   * Incremental-cache seeding must keep the slice incomplete until a full
+   * pagination succeeds.
+   */
+  snapshotsAllDailyCapped: boolean;
   /** True when the daily pagination loop hit its safety cap. */
   snapshotsAllDailyTruncated: boolean;
   /**
@@ -65,6 +76,14 @@ export type NetworkData = {
    * double-counted against v3. Empty on chains without a Broker (Monad).
    */
   brokerSnapshotsAllDaily: BrokerDailySnapshotRow[];
+  /**
+   * True while the visible Broker daily rows are known to be only a recent
+   * subset (or deliberately omitted by a route projection). Absence is the
+   * normal full-fetch value and is equivalent to false. Together with
+   * `snapshotsAllDailyCapped`, this prevents the volume chart from presenting
+   * a bounded Server Component seed as complete "All" history.
+   */
+  brokerSnapshotsAllDailyCapped?: boolean | undefined;
   /** True when the broker pagination loop hit its safety cap. */
   brokerSnapshotsAllDailyTruncated: boolean;
   olsPoolIds: Set<string>;
@@ -108,6 +127,13 @@ export type NetworkData = {
    */
   poolLabels: Map<string, PoolLabel>;
   uniqueLpAddresses: string[] | null;
+  /**
+   * True only when the Server Component projection deliberately removed the
+   * cumulative address set. The homepage then reads the exact pre-aggregated
+   * cross-chain count from its payload; a normal client fetch omits this flag
+   * and restores address-level deduplication.
+   */
+  uniqueLpAddressesOmitted?: boolean | undefined;
   /** True when the LP address pagination loop hit its safety cap. */
   uniqueLpAddressesTruncated: boolean;
   rates: OracleRateMap;
@@ -144,13 +170,38 @@ export type NetworkData = {
  * Network data that is safe to seed into the `/` and `/pools` SSR fallback.
  *
  * The server computes the aggregated `fees` summary before serializing this
- * payload, then deliberately strips the raw fee-history rows. Keeping the
- * empty tuple in the public type makes that projection part of the contract:
- * client fallback consumers cannot accidentally treat the SSR seed as a
- * complete fee-history response.
+ * payload, then deliberately strips the raw fee-history rows and the three
+ * redundant 1/7/30-day snapshot arrays. Keeping empty tuples in the public
+ * type makes that projection part of the contract: the all-networks hook must
+ * synchronously derive the window arrays from `snapshotsAllDaily` before the
+ * fallback reaches consumers or incremental-cache seeding, while client
+ * fallback consumers cannot treat the SSR seed as complete fee history.
+ * `snapshotsAllDailyCapped` and `brokerSnapshotsAllDailyCapped` separately mark
+ * whether canonical daily histories were shortened for transport; unlike fee
+ * rows, that history is fetched on demand when a chart selects "All". The raw
+ * cumulative LP-address set is also stripped; `uniqueLpAddressesOmitted`
+ * routes the homepage to the payload-level exact aggregate instead.
+ *
+ * Growth audit invariant: every time/cumulative field in `NetworkData` is
+ * bounded or aggregated here (`snapshotsAllDaily`, Broker history,
+ * `feeSnapshots`, LP addresses). Remaining collections are bounded by the
+ * configured network's current pool/token/strategy entity set.
  */
-export type InitialNetworkData = Omit<NetworkData, "feeSnapshots"> & {
+export type InitialNetworkData = Omit<
+  NetworkData,
+  | "feeSnapshots"
+  | "snapshots"
+  | "snapshots7d"
+  | "snapshots30d"
+  | "uniqueLpAddresses"
+  | "uniqueLpAddressesOmitted"
+> & {
   feeSnapshots: [];
+  snapshots: [];
+  snapshots7d: [];
+  snapshots30d: [];
+  uniqueLpAddresses: null;
+  uniqueLpAddressesOmitted: true;
 };
 
 /**
@@ -240,4 +291,11 @@ export type PaginatedPageResult<T> = {
   mutableTailError?: Error | null;
 };
 
-export type SnapshotPageResult = PaginatedPageResult<PoolSnapshotWindow>;
+export type SnapshotPageResult = PaginatedPageResult<PoolSnapshotWindow> & {
+  /**
+   * False when rows came from a bounded seed whose from-zero completion has
+   * not succeeded. Optional for older hand-built fixtures; only explicit
+   * false marks the assembled client payload capped.
+   */
+  historyComplete?: boolean;
+};

--- a/ui-dashboard/src/lib/swr-keys.ts
+++ b/ui-dashboard/src/lib/swr-keys.ts
@@ -4,6 +4,7 @@
 // there means the SSR payload never hydrates into the client cache.
 
 export const SWR_KEY_ALL_NETWORKS_DATA = "all-networks-data";
+export const SWR_KEY_POOLS_NETWORKS_DATA = "pools-all-networks-data";
 export const SWR_KEY_LIVE_POOL_HEALTH = "live-pool-health-all-networks";
 export const SWR_KEY_ORACLE_RATES = "oracle-rates-all-networks";
 export const SWR_KEY_PROTOCOL_FEES = "protocol-fees-all-networks";

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -167,6 +167,50 @@ export function filterSnapshotsToWindow(
   });
 }
 
+/**
+ * Derive the UTC-day-aligned 1/7/30-day slices used by the homepage and pools
+ * table from the canonical daily history. The normal `snapshotWindows` are
+ * rolling hour windows; daily rollup rows are midnight buckets, so these
+ * bounds deliberately include today plus the preceding 6/29 UTC days.
+ *
+ * Kept in this client-safe module so the Server Component transport can omit
+ * the three redundant arrays and the client can reconstruct them
+ * synchronously, before the SSR fallback reaches SWR consumers or the
+ * incremental cache.
+ */
+export function buildDailySnapshotSlices(
+  snapshotsAllDaily: PoolSnapshotWindow[],
+  nowSeconds: number,
+): {
+  dailyWindows: SnapshotWindows;
+  snapshots: PoolSnapshotWindow[];
+  snapshots7d: PoolSnapshotWindow[];
+  snapshots30d: PoolSnapshotWindow[];
+} {
+  const todayMidnight =
+    Math.floor(nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const dailyWindows: SnapshotWindows = {
+    w24h: {
+      from: todayMidnight,
+      to: todayMidnight + SECONDS_PER_DAY,
+    },
+    w7d: {
+      from: todayMidnight - 6 * SECONDS_PER_DAY,
+      to: todayMidnight + SECONDS_PER_DAY,
+    },
+    w30d: {
+      from: todayMidnight - 29 * SECONDS_PER_DAY,
+      to: todayMidnight + SECONDS_PER_DAY,
+    },
+  };
+  return {
+    dailyWindows,
+    snapshots: filterSnapshotsToWindow(snapshotsAllDaily, dailyWindows.w24h),
+    snapshots7d: filterSnapshotsToWindow(snapshotsAllDaily, dailyWindows.w7d),
+    snapshots30d: filterSnapshotsToWindow(snapshotsAllDaily, dailyWindows.w30d),
+  };
+}
+
 export function buildPoolVolumeMapInWindow(
   snapshots: PoolSnapshotWindow[],
   pools: Pool[],

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -118,6 +118,7 @@ export function makeNetworkData(
     snapshots7d: [],
     snapshots30d,
     snapshotsAllDaily,
+    snapshotsAllDailyCapped: false,
     snapshotsAllDailyTruncated: false,
     brokerSnapshotsAllDaily: [],
     brokerSnapshotsAllDailyTruncated: false,

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -127,6 +127,24 @@ test.describe("dashboard browser flows", () => {
     expect(browserErrors).toEqual([]);
   });
 
+  test("keeps decoded homepage and pools documents below the Flight payload budget", async ({
+    request,
+  }) => {
+    const paths = ["/", "/pools"] as const;
+    const responses = await Promise.all(paths.map((path) => request.get(path)));
+    const bodies = await Promise.all(
+      responses.map((response) => response.body()),
+    );
+
+    responses.forEach((response) => expect(response.ok()).toBe(true));
+    bodies.forEach((body, index) => {
+      expect(
+        body.byteLength,
+        `${paths[index]} decoded document bytes`,
+      ).toBeLessThan(500_000);
+    });
+  });
+
   test("switches chain context through the pool list target", async ({
     page,
   }) => {
@@ -154,6 +172,148 @@ test.describe("dashboard browser flows", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  test("keeps the bounded /pools SSR seed without an eager full-history client fetch", async ({
+    page,
+  }) => {
+    let fullHistoryRequests = 0;
+    await page.route("**/graphql", async (route) => {
+      if (
+        (route.request().postData() ?? "").includes(
+          "query PoolDailySnapshotsAll",
+        )
+      ) {
+        fullHistoryRequests += 1;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/pools");
+    await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "USDC/USDm" }).first(),
+    ).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    expect(fullHistoryRequests).toBe(0);
+  });
+
+  test("loads full homepage snapshot history on demand before rendering All", async ({
+    page,
+  }) => {
+    let fullHistoryRequests = 0;
+    let releaseFullHistory!: () => void;
+    const fullHistoryGate = new Promise<void>((resolve) => {
+      releaseFullHistory = resolve;
+    });
+    await page.route("**/graphql", async (route) => {
+      if (
+        !(route.request().postData() ?? "").includes(
+          "query PoolDailySnapshotsAll",
+        )
+      ) {
+        await route.continue();
+        return;
+      }
+      fullHistoryRequests += 1;
+      await fullHistoryGate;
+      await route.continue();
+    });
+
+    await page.goto("/");
+    const rangeGroup = page.getByRole("group", {
+      name: "TVL chart time range",
+    });
+    await expect(rangeGroup).toBeVisible();
+    await expect(
+      rangeGroup.getByRole("button", { name: "1M" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(fullHistoryRequests).toBe(0);
+
+    await rangeGroup.getByRole("button", { name: "All" }).click();
+
+    await expect.poll(() => fullHistoryRequests).toBeGreaterThan(0);
+    await expect(
+      page.getByText("Total Value Locked chart is loading."),
+    ).toHaveCount(1);
+    await expect(
+      rangeGroup.getByRole("button", { name: "All" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    // The shared SWR key is revalidating, but its bounded SSR payload remains
+    // valid last-good data for every surface except the selected capped chart.
+    // Keep the loading state scoped to TVL "All" instead of blanking the 1M
+    // Volume chart, KPI tiles, or pool table while the request is held.
+    await expect(
+      page.getByRole("figure", { name: "Volume chart, 1M range" }),
+    ).toBeVisible();
+    await expect(page.getByText("Volume chart is loading.")).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: /^Swap Fees:/ }),
+    ).not.toHaveAttribute("aria-label", "Swap Fees: …");
+    await expect(
+      page
+        .getByText("LPs", { exact: true })
+        .locator("xpath=following-sibling::p[1]"),
+    ).not.toHaveText("…");
+    await expect(
+      page
+        .getByText("Swaps", { exact: true })
+        .locator("xpath=following-sibling::p[1]"),
+    ).not.toHaveText("…");
+    await expect(
+      page.getByRole("link", { name: "USDC/USDm" }).first(),
+    ).toBeVisible();
+
+    releaseFullHistory();
+
+    await expect(
+      page.getByText("Total Value Locked chart is loading."),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("figure", {
+        name: "Total Value Locked chart, All range",
+      }),
+    ).toBeVisible();
+
+    const completedRequestCount = fullHistoryRequests;
+    await rangeGroup.getByRole("button", { name: "1M" }).click();
+    await rangeGroup.getByRole("button", { name: "All" }).click();
+    await page.waitForTimeout(200);
+    expect(fullHistoryRequests).toBe(completedRequestCount);
+  });
+
+  test("shows an honest degraded state when full homepage history cannot load", async ({
+    page,
+  }) => {
+    let fullHistoryRequests = 0;
+    await page.route("**/graphql", async (route) => {
+      if (
+        (route.request().postData() ?? "").includes(
+          "query PoolDailySnapshotsAll",
+        )
+      ) {
+        fullHistoryRequests += 1;
+        await route.abort("timedout");
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/");
+    const rangeGroup = page.getByRole("group", {
+      name: "TVL chart time range",
+    });
+    await rangeGroup.getByRole("button", { name: "All" }).click();
+
+    await expect.poll(() => fullHistoryRequests).toBeGreaterThan(0);
+    const figure = page.getByRole("figure", {
+      name: "Total Value Locked chart, All range",
+    });
+    await expect(
+      figure.getByText("Unable to load full TVL history", { exact: true }),
+    ).toBeVisible();
+    await expect(figure.getByRole("img")).toHaveCount(0);
   });
 
   test("keeps a fresh live-health overlay ahead of an expiring fleet snapshot", async ({

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -325,14 +325,11 @@ function vpOracleFreshnessRows(rows) {
   }));
 }
 
-function dailySnapshotsFor(poolId) {
+function dailySnapshotsFor(poolId, daysAgoValues = [0, 1, 2]) {
   const pool = poolsById.get(poolId);
   if (!pool) return [];
   const todayStart = Math.floor(nowSeconds() / DAY_SECONDS) * DAY_SECONDS;
-  // The 365d row deliberately sits outside the 30d Server Component seed.
-  // Browser tests can therefore prove that selecting "All" performs the
-  // normal client-side full-history fetch instead of relabeling the seed.
-  return [0, 1, 2, 365].map((daysAgo) => ({
+  return daysAgoValues.map((daysAgo) => ({
     id: `${poolId}-${todayStart - daysAgo * DAY_SECONDS}`,
     poolId,
     timestamp: String(todayStart - daysAgo * DAY_SECONDS),
@@ -852,8 +849,16 @@ function operationName(query) {
 
 function rowsByPoolIds(poolIds) {
   const ids = new Set(poolIds ?? []);
+  // The 365d and 366d rows deliberately sit outside the 30d Server Component
+  // seed. Projection keeps the latest old row as the TVL forward-fill anchor
+  // and drops the older row, preserving the capped-history handoff. Keep both
+  // exclusive to the all-history operation so browser tests can prove that
+  // selecting "All" performs the client fetch without polluting pool-detail
+  // and OG chart fixtures (and their visual snapshots).
   return pools.flatMap((pool) =>
-    ids.size === 0 || ids.has(pool.id) ? dailySnapshotsFor(pool.id) : [],
+    ids.size === 0 || ids.has(pool.id)
+      ? dailySnapshotsFor(pool.id, [0, 1, 2, 365, 366])
+      : [],
   );
 }
 

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -329,7 +329,10 @@ function dailySnapshotsFor(poolId) {
   const pool = poolsById.get(poolId);
   if (!pool) return [];
   const todayStart = Math.floor(nowSeconds() / DAY_SECONDS) * DAY_SECONDS;
-  return [0, 1, 2].map((daysAgo) => ({
+  // The 365d row deliberately sits outside the 30d Server Component seed.
+  // Browser tests can therefore prove that selecting "All" performs the
+  // normal client-side full-history fetch instead of relabeling the seed.
+  return [0, 1, 2, 365].map((daysAgo) => ({
     id: `${poolId}-${todayStart - daysAgo * DAY_SECONDS}`,
     poolId,
     timestamp: String(todayStart - daysAgo * DAY_SECONDS),
@@ -347,7 +350,7 @@ function dailySnapshotsFor(poolId) {
           ? "25000000000000000000"
           : "50000000000000000000",
     rebalanceCount: 0,
-    cumulativeSwapCount: 3 - daysAgo,
+    cumulativeSwapCount: daysAgo >= 365 ? 1 : 3 - daysAgo,
     cumulativeVolume0: "125000000000000000000",
     cumulativeVolume1:
       pool.token1Decimals === 6 ? "125000000" : "125000000000000000000",


### PR DESCRIPTION
## The Problem

- The homepage and pools routes serialized full daily pool history into their Flight payloads, so both the client download and the Vercel cache entry grew every day.
- Simply truncating that seed would make the All chart silently incomplete and could poison the incremental history cache.
- The same payload also repeated derivable windows and raw LP-address data that the initial routes did not need.

## The Solution

Bound the v3 SSR seed to the 30 UTC days needed by the default charts plus one latest pre-window anchor per pool for TVL forward-fill; keep the homepage Broker seed to the rolling window plus the UTC boundary bucket needed during hour zero, and omit it entirely from `/pools`. Derived windows are reconstructed on the client, and the homepage receives an exact case-insensitive LP count instead of raw addresses. Selecting All performs one coalesced from-zero history fetch, preserves unrelated dashboard content while it loads, reports source-specific failures honestly, and upgrades the incremental cache to complete history without allowing a later capped seed to downgrade it.

## Implementation notes

- Retain one latest pre-window v3 snapshot per pool so quiet pools remain represented across the default TVL window.
- Retain one additional Broker UTC-day boundary bucket so the rolling 30-day volume window remains complete from 00:00 through 00:59 UTC.
- Isolate the intentionally Broker-free `/pools` fallback under its own SWR key so it cannot replace homepage history.
- Give TVL pool-only cap/error state while Volume uses combined pool-plus-Broker completion state.
- Keep rejected, partial, or truncated Broker completion capped and preserve bounded last-good Broker rows on first-page failure.
- Avoid `Promise.finally` in the ES2017 client bundle; clear coalescing refs with success/failure handlers.
- Strip redundant 1d/7d/30d snapshot arrays and rebuild them synchronously from the bounded daily seed.

## Verification

- Final `pnpm agent:quality-gate --run` and the independent pre-push gate both passed every mapped command.
- Focused review suite: 114/114 tests passed; full dashboard coverage, lint, typecheck, Knip, dependency health, Trunk, codegen, and size-limit passed.
- Playwright dashboard suite: 23/23 passed, including payload budgets, All-range loading/success/failure, no eager `/pools` history fetch, and unchanged pool-detail visual snapshots.
- React Doctor diff passed and the full score is 100/100.
- Direct Chrome DevTools on the exact final patch: `/pools` made only live-health and recent-swap calls; homepage made no history calls before All, then one pool/Broker/LP completion per network; Volume, KPIs, and the pool table stayed painted; selecting All again made no new history calls; no console errors.

## Payload evidence

- The exact-head 40-pool browser fixture remains below the 500 KB dehydrated-payload budget, versus an 8,603,330-byte unbounded baseline (more than 94% smaller).
- Direct browser verification keeps both `/` and `/pools` below the 500 KB streamed-document target.

Closes #1208

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared SSR→client data contract, chart “All” semantics, and incremental history caching on the homepage LCP path; mitigated by extensive unit/browser tests but regressions could show wrong history or stale KPIs.
> 
> **Overview**
> Shrinks the `/` and `/pools` Flight payloads by **projecting** cached `fetchAllNetworks` data instead of shipping unbounded history: only the **30 UTC-day** daily snapshot (and matching Broker slice on the homepage), empty redundant 1d/7d/30d arrays, no raw `feeSnapshots`, and no per-chain LP address lists. The homepage gets a precomputed **`uniqueLpCount`**; `/pools` drops Broker history and LP data entirely while sharing the same cache entry via route-aware `fetchInitialNetworkData("home" | "pools")`.
> 
> On the client, **`useAllNetworksData`** rebuilds window slices from the canonical daily rows, exposes **`snapshotsAllDailyCapped`** / Broker cap flags, and **`requestFullSnapshotHistory`** (coalesced SWR `mutate` + shared in-flight fan-out). TVL and volume charts use **`useSnapshotHistoryRange`** so **All** triggers a from-zero history fetch, shows a scoped loading state, and surfaces failures without blanking other KPIs during background revalidation. The incremental snapshot cache gains a **`complete`** bit so capped SSR seeds cannot be mistaken for full history or downgrade a warm complete cache.
> 
> Docs note **5-minute** max served staleness for the server cache; cache key bumps to **`all-networks-ssr-v2`**. Coverage adds payload budget browser tests, snapshot-range behavior, and incremental-cache regression cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a552820310b20a0d14bf03cc7789ace01b07421d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
