### PR TITLE
fix(dashboard): add windowTotalUsdWei to stacked-chart caller fixture

### DIFF
--- a/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
+++ b/ui-dashboard/src/components/__tests__/stacked-chart-callers.test.tsx
@@ -139,7 +139,10 @@ describe("stacked TimeSeriesChartCard caller matrix", () => {
     const model = {
       showChart: true,
       poolChart: {
-        poolVolumeBreakdown: { totalSeries: chartSeries() },
+        poolVolumeBreakdown: {
+          totalSeries: chartSeries(),
+          windowTotalUsdWei: BigInt(0),
+        },
         chartBreakdown: poolBreakdown,
         topPoolsListEntries: [],
       },


### PR DESCRIPTION
## The Problem

- A latent unit-test breakage sits on `main`: `stacked-chart-callers.test.tsx` → "keeps the per-pool custom-legend section on its single-Plot path" throws `TypeError: Cannot read properties of undefined (reading 'toString')` in `weiToUsd`.
- It stays hidden until Turbo's `ui-dashboard` test cache misses, at which point it fails **required** CI — blocking in-flight PRs (e.g. #1287, #1286) that recompute the dashboard test suite.

## The Solution

- The test's `poolChart.poolVolumeBreakdown` fixture omitted `windowTotalUsdWei`, the field `PoolChartArea` reads for its headline (`formatUSD(weiToUsd(...))`); this PR adds it so the fixture matches the current component contract.
- Test-only fix — production never reaches `weiToUsd(undefined)` here: `aggregatePoolDailyVolume` always returns `windowTotalUsdWei: bigint` (`BigInt(0)` on the empty path, the summed total otherwise), and the sibling `page-client.test.tsx` fixture already uses `windowTotalUsdWei: BigInt(0)`.

## Details

Root cause is a logical (semantic) merge conflict between two independently-green PRs:

- **#1263** (`2fe9b2b7`) changed `PoolChartArea`'s headline from `model.headline` to `formatUSD(weiToUsd(poolVolumeBreakdown.windowTotalUsdWei))`.
- **#1269** (`29e4faeb`) then added `stacked-chart-callers.test.tsx` with a fixture that omits `windowTotalUsdWei`, so the combined code on `main` throws when the fixture-backed component renders.

Repro (fails on `main` at `2b224a71`, passes with this fix):

```
pnpm --filter @mento-protocol/ui-dashboard exec vitest run \
  src/components/__tests__/stacked-chart-callers.test.tsx
```

## Validation

- Targeted test: 3 passed.
- Full suite: `pnpm --filter @mento-protocol/ui-dashboard test:coverage` → 264 files / 3906 tests passed.
- `pnpm dashboard:react-doctor:diff` → 100/100, no issues.
- `pnpm agent:quality-gate --run` → green; the single `test:browser` blip was the known ~1/15 Playwright flake (re-ran clean, 19 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test fixture field addition; no runtime or production code touched.
> 
> **Overview**
> Fixes a **latent CI failure** in `stacked-chart-callers.test.tsx`: the per-pool `VolumeChartArea` test fixture’s `poolVolumeBreakdown` now includes **`windowTotalUsdWei: BigInt(0)`**, matching what `PoolChartArea` uses for the chart headline (`formatUSD(weiToUsd(...))`) after that field replaced `model.headline`.
> 
> **Test-only** — no production behavior changes; real data paths already supply `windowTotalUsdWei` from aggregation (same pattern as `page-client.test.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7997ae9e971886e8bf232fb6802381adafd5d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->