### PR TITLE
docs(adr): renumber dashboard GraphQL/Zod-Mini ADR to 0037 (number collision)

### DIFF
--- a/docs/adr/0037-dashboard-graphql-zod-mini.md
+++ b/docs/adr/0037-dashboard-graphql-zod-mini.md
@@ -8,7 +8,7 @@ scope: ui-dashboard
 date: 2026-07
 ---
 
-# ADR 0036 — Dashboard native GraphQL transport and client-side Zod Mini
+# ADR 0037 — Dashboard native GraphQL transport and client-side Zod Mini
 
 **Status:** Accepted (Jul 2026), in force.
 **Scope:** ui-dashboard

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,7 +101,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0023](0023-es2017-no-polyfill.md)                   | Ship ES2017 with no polyfill; ban immutable-array methods via lint + `sortedCopy` |
 | [0024](0024-plotly-basic-dist-bundle-budgets.md)     | Plotly.js `basic-dist` + enforced bundle-size budgets                             |
 | [0025](0025-fixture-browser-tests-react-doctor.md)   | Fixture-driven browser tests + visual snapshots + a react-doctor score gate       |
-| [0036](0036-dashboard-graphql-zod-mini.md)           | Native GraphQL transport + Zod Mini for browser-reachable validation              |
+| [0037](0037-dashboard-graphql-zod-mini.md)           | Native GraphQL transport + Zod Mini for browser-reachable validation              |
 
 ### aegis
 


### PR DESCRIPTION
## The Problem

- Two PRs merged in parallel yesterday both claimed ADR number 0036: #1283 (Sentry triage pipeline) and #1285 (dashboard GraphQL transport + Zod Mini), leaving two `docs/adr/0036-*.md` files and a duplicate index number.

## The Solution

- Renumber the dashboard GraphQL/Zod-Mini ADR to 0037 (file rename + heading + index row). It is the cheaper rename: the Sentry ADR is referenced by number from ~12 files across terraform/, workflows, and docs; the zod-mini ADR only from its own file and the index.

**Architecture decision?** No — mechanical renumbering, no decision content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiUreX7DKuRKiHQT6HkY4z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only renumbering with no runtime, infra, or decision-content changes.
> 
> **Overview**
> Resolves a duplicate ADR number after parallel merges both claimed **0036** (Sentry triage vs dashboard GraphQL/Zod Mini).
> 
> The dashboard GraphQL transport + Zod Mini record is renumbered to **ADR 0037**: filename `0037-dashboard-graphql-zod-mini.md`, title heading, and the **ui-dashboard** row in `docs/adr/README.md`. **Decision text is unchanged**—only identifiers and index links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9f055ebd890a987f2a5fd1f4cf01a0793d85b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->