### PR TITLE
docs: warn against concurrent dashboard gates

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -60,6 +60,15 @@ quality prerequisites: a browser setup failure still lets independent
 lint/typecheck/unit/knip feedback run. `--fail-fast` stays sequential so it
 still stops before starting the next mapped command.
 
+Do not launch dashboard browser tests, a dashboard dev server, or another
+quality-gate run concurrently with `pnpm agent:quality-gate --run` in the same
+worktree. Next processes share `ui-dashboard/.next`; competing writers can
+produce false `Another next dev server is already running` or
+`ChunkLoadError` failures. The gate also schedules coverage alongside other
+independent checks, so an extra ad hoc coverage run only adds load and can turn
+normally passing accessibility tests into timeout noise. Run focused tests
+before the gate, then let one gate invocation own the full mapped batch.
+
 For non-trivial behavioral, workflow, security, data-flow, or UI batches, run
 the structured closeout review after the mapped gate and before pushing:
 


### PR DESCRIPTION
## The Problem

- Running dashboard verification beside the repository quality gate in the same worktree can start competing Next processes against one shared `.next` directory.
- The resulting dev-server, chunk-loading, and timeout failures look like product regressions even though they are test-runner contention.

## The Solution

- Document that focused tests should run before the quality gate, then one gate invocation should own the full mapped browser, coverage, and quality batch.

## Details

- Calls out the observed `Another next dev server is already running` and `ChunkLoadError` failure modes.
- Explains why duplicating coverage beside the gate can create timeout noise.
- Documentation-only; no command or gate behavior changes.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`
- `git diff --check`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent runbook; no runtime, auth, or gate logic changes.
> 
> **Overview**
> Adds operator guidance to **agent-quality-gate-mechanics** so agents do not run dashboard browser tests, a dashboard dev server, or a second quality-gate invocation alongside `pnpm agent:quality-gate --run` in the same worktree.
> 
> The new text explains that shared `ui-dashboard/.next` writers can cause misleading **Another next dev server is already running** or **ChunkLoadError** failures, and that parallel ad hoc coverage runs can add load and produce accessibility test timeouts. The recommended workflow is to run focused tests first, then a single gate run for the full mapped batch. **Documentation only**—no gate script or command behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8842772be9ee773c1da9c835d5b8cc12f9db3a2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->