### PR TITLE
docs(dashboard): clarify Lighthouse retry contract

### DIFF
--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -163,13 +163,17 @@ ratchet is now fully in place.
   fixture, verifies the exact SSR breaker and Volume values through deliberately
   delayed client breaker revalidation in Playwright, and collects three
   canonical `?lhci=fixture` runs with median LCP blocking above the same 1 700 ms
-  ceiling. The runner requires one completed delayed breaker request per browser
-  audit and inspects `assertion-results.json` to prove the blocking assertion
-  actually ran across all three numeric values. Fixture mode isolates app
-  render/hydration cost; it deliberately excludes Vercel edge/network variance,
-  production analytics/Sentry, and live-indexer latency. Exact query markers
-  make the live warning and fixture error patterns non-overlapping, while all
-  non-LCP assertions remain mechanically identical and blocking.
+  ceiling. The browser smoke requires exactly one delayed breaker completion.
+  Lighthouse collection permits additional valid retries or prefetches but
+  requires at least four cumulative completions afterward. The generated
+  diagnostics must contain exactly three Lighthouse runs, each independently
+  proving a GraphQL duration above 1 700 ms and completion after LCP, while
+  `assertion-results.json` proves the blocking assertion actually ran across
+  all three numeric values. Fixture mode isolates app render/hydration cost; it
+  deliberately excludes Vercel edge/network variance, production
+  analytics/Sentry, and live-indexer latency. Exact query markers make the live
+  warning and fixture error patterns non-overlapping, while all non-LCP
+  assertions remain mechanically identical and blocking.
 
   `ui-dashboard/scripts/measure-inp.mjs` separately drives `/pools` filter,
   `/volume` time-window and sort, and canonical pool TVL-range interactions;

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -215,8 +215,12 @@ the canonical pool-detail LCP contract. It builds against the local
 all-time Volume headline remain visible while client revalidation is
 deliberately delayed, rejects fixture GraphQL/request/browser errors, and
 collects three exact `?lhci=fixture` Lighthouse runs with the blocking 1,700 ms
-median ceiling. The runner proves one delayed breaker completion per audit and
-requires a real blocking LHCI assertion result across all three values.
+median ceiling. The browser smoke requires exactly one delayed breaker
+completion. Lighthouse collection permits additional valid retries or
+prefetches but requires at least four cumulative completions afterward. The
+generated diagnostics must contain exactly three Lighthouse runs, each
+independently proving GraphQL duration above 1,700 ms and completion after LCP,
+plus a real blocking LHCI assertion result across all three values.
 Artifacts and per-run phase/network diagnostics are written under
 `reports/lighthouse-pool/`. This secretless fixture lane also runs for workflow
 self-changes, fork PRs, and Dependabot PRs. It isolates app render/hydration


### PR DESCRIPTION
## The Problem

- The dashboard instructions still described the Lighthouse fixture as proving one delayed breaker request per audit.
- The implemented runner permits valid retries and prefetches, then proves delay timing independently from each Lighthouse report.

## The Solution

- Document the runner's actual fail-closed contract: exactly one delayed browser-smoke completion, at least four cumulative completions after collection, and exactly three diagnostic runs that each prove delayed GraphQL completion after LCP.

## Details

- Aligns `ui-dashboard/AGENTS.md` and the recurring-review checklist with the implementation merged in #1295.
- Keeps the unchanged 1,700 ms blocking threshold and the separate LHCI assertion-result proof explicit.
- No runtime behavior changes.

## Validation

- `pnpm agent:quality-gate --run`
- `CI=true pnpm agent:review-materiality` (`full`, canonical context)
- `CI=true pnpm agent:autoreview` (clean)
- Independent semantic comparison against the fixture runner and diagnostics-contract modules (clean after wording corrections)
- Pre-push mapped quality gate (passed)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime, CI script, or threshold changes.
> 
> **Overview**
> Updates **documentation only** so the canonical pool-detail Lighthouse fixture gate matches the runner behavior from #1295.
> 
> **`ui-dashboard/AGENTS.md`** and **`docs/pr-checklists/recurring-review-patterns.md`** no longer say the fixture proves a single delayed breaker GraphQL completion per Lighthouse audit. They now state: browser smoke needs **exactly one** delayed breaker completion; collection may include extra valid retries/prefetches but must reach **at least four** cumulative completions afterward; generated diagnostics must have **exactly three** Lighthouse runs, each showing GraphQL duration above **1,700 ms** and completion **after LCP**, with **`assertion-results.json`** still proving the blocking LCP assertion across all three values. The **1,700 ms** median ceiling and non-LCP assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bada2c34e7990c4241a22a27d4589a5bc0feee3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->