### PR TITLE
feat(tooling): post per-run Sentry triage verdict digest to Slack #engineering

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -249,3 +249,96 @@ jobs:
             --remove-label 'sentry:needs-triage' \
             --add-label "${label}"
           echo "Applied ${label} to issue #${QUEUE_ISSUE_NUMBER}."
+
+  # ---------------------------------------------------------------------------
+  # digest: post ONE deterministic Slack digest per run — what was triaged,
+  # with what verdicts, with links — so verdict review needs zero GitHub
+  # polling (ADR 0036's failure mode is "unauditable automation going dark").
+  #
+  #   - if: always() + a non-zero select count. `always()` makes the digest
+  #     post even when some `triage` matrix jobs failed (partial visibility is
+  #     the point — the failed-triage bucket lists issues still labeled
+  #     sentry:needs-triage). The count gate keeps it SILENT on empty batches
+  #     and kill-switch no-ops (select emits count '0'/'' then), so a run where
+  #     nothing happened stays quiet.
+  #   - permissions: issues:read + contents:read ONLY — the digest reads issue
+  #     labels/comments and posts to Slack; it holds no write credential.
+  #   - This is a pure CONSUMER of the verdict contract: no LLM, no label
+  #     writes, no Sentry, no contract changes.
+  #   - A digest-job failure fails the whole run, which the main-failure
+  #     notifier (notify-slack-on-main-failure.yml, where this workflow is
+  #     registered) surfaces to #ci-failures — so a broken digest can't go dark.
+  # ---------------------------------------------------------------------------
+  digest:
+    needs: [select, triage]
+    if: ${{ always() && needs.select.outputs.count != '' && needs.select.outputs.count != '0' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      # SHA-pinned (not tags) so tag retargeting / a compromised release cannot
+      # silently run new code. Bump via Dependabot (.github/dependabot.yml).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Build digest payload
+        env:
+          # Read-only: the digest job's GITHUB_TOKEN is issues:read + contents:read.
+          GH_TOKEN: ${{ github.token }}
+          # The exact batch this run selected (JSON int array from the select
+          # job). Passed via env — never interpolated into the shell command.
+          # No Slack token in this step: it only reads issues and emits JSON.
+          SENTRY_TRIAGE_ISSUES: ${{ needs.select.outputs.issues }}
+        run: |
+          set -euo pipefail
+          # The digest channel is DELIBERATELY hardcoded here (not a secret or
+          # repo variable): #engineering is the standing triage-review channel,
+          # and changing it is a one-line PR. The bot's chat:write.public scope
+          # lets it post to this public channel uninvited (same mechanism as
+          # notify-slack-on-main-failure.yml). The script prints ONLY the Slack
+          # payload JSON to stdout; diagnostics go to stderr.
+          node scripts/sentry-triage-digest.mjs \
+            --channel '#engineering' \
+            > "${RUNNER_TEMP}/digest-payload.json"
+
+      - name: Post digest to #engineering
+        env:
+          # SLACK_BOT_TOKEN reaches ONLY this posting step's env — never the
+          # collector step, never echoed, never placed in a URL. Reuses the
+          # existing Terraform-managed bot token (no new secret).
+          SLACK_BOT_TOKEN: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Defense in depth: the job is already gated on a non-zero batch, but
+          # if the collector produced no payload (empty-batch guard), there is
+          # nothing to post — exit cleanly without touching Slack.
+          if [ ! -s "${RUNNER_TEMP}/digest-payload.json" ]; then
+            echo "::notice::No digest payload produced; nothing to post."
+            exit 0
+          fi
+
+          # POST the pre-built payload verbatim (--data @file); the summary text
+          # was already Slack-escaped by the collector. Mirrors the main-failure
+          # notifier's curl + ok-check pattern.
+          RESPONSE=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data @"${RUNNER_TEMP}/digest-payload.json")
+
+          # Slack returns 200 OK with {"ok": false, "error": "..."} on logical
+          # errors; fail loudly so a silently-broken digest turns the run red
+          # (the main-failure notifier then fires).
+          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+            echo "::error::Slack digest post failed: $(echo "$RESPONSE" | jq -r '.error // "unknown"')"
+            echo "Full response: $RESPONSE"
+            exit 1
+          fi
+          echo "Posted Sentry triage digest to #engineering."

--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -304,8 +304,12 @@ jobs:
           # lets it post to this public channel uninvited (same mechanism as
           # notify-slack-on-main-failure.yml). The script prints ONLY the Slack
           # payload JSON to stdout; diagnostics go to stderr.
+          # --repo: same source of truth as the select/triage jobs
+          # (GITHUB_REPOSITORY), so the digest reads the run's own repository
+          # instead of assuming the script's default (matters on forks/renames).
           node scripts/sentry-triage-digest.mjs \
             --channel '#engineering' \
+            --repo "${GITHUB_REPOSITORY}" \
             > "${RUNNER_TEMP}/digest-payload.json"
 
       - name: Post digest to #engineering

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -82,9 +82,11 @@ pnpm issue:release --issue 901                 # Release a mistaken claim back t
 pnpm issue:board sync                          # Re-project labels and close merged in-pr board items
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 
-# Sentry triage pipeline (Stage A — deterministic ingest, ADR 0036)
+# Sentry triage pipeline (Stage A — deterministic ingest; Stage B — read-only triage + digest; ADR 0036)
 pnpm sentry:ingest --dry-run                   # Print queue-issue mutations without applying (needs local SENTRY_TRIAGE_TOKEN)
 pnpm sentry:ingest:test                        # Offline tests for the ingest helper (docs/notes/sentry-triage-pipeline.md)
+pnpm sentry:digest:test                        # Offline tests for the per-run Slack verdict-digest collector
+SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#engineering'  # Print the Slack digest payload for a batch (needs gh auth; does not post)
 
 # Public config package
 pnpm --filter @mento-protocol/config build     # Build the public protocol metadata package

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -258,6 +258,41 @@ A missing verdict comment on a `sentry:needs-triage` issue after a scheduled run
 means the triage agent did not run or did not finish — treat it as a signal,
 not as "no issues found".
 
+### Observability (run record + per-run Slack digest)
+
+ADR 0036's dominant failure mode is _unauditable automation going dark_, so the
+pipeline surfaces itself two ways, and a break in either turns a run red:
+
+- **Run record (Stage A).** Every ingest run updates the rolling
+  `<!-- sentry-triage-ingest:run-record:v1 -->` comment on tracker issue
+  [#1282](https://github.com/mento-protocol/monitoring-monorepo/issues/1282)
+  with counts (see the Stage A "Run record" section). A missing update is a
+  dead-man-switch signal.
+- **Per-run Slack digest (Stage B).** After every triage run that processed at
+  least one queue issue, the `digest` job in `sentry-triage-agent.yml` posts a
+  deterministic digest to Slack `#engineering` so verdict review needs zero
+  GitHub polling. It is a pure CONSUMER of the verdict contract — no LLM, no
+  label writes, no Sentry — driven by the collector `scripts/sentry-triage-digest.mjs`:
+  for each batch issue it reads the current labels and the latest
+  `<!-- sentry-triage-verdict:v1 -->` comment and renders one line per issue
+  (`<SHORT-ID> (<project>) — <verdict> (<confidence>): <summary>`, linked to the
+  queue issue), with counts by verdict plus a `failed triage` bucket for batch
+  issues still carrying `sentry:needs-triage` (their triage matrix job died —
+  kept visible, never hidden). The job runs `if: always()` gated on a non-zero
+  select count, so it posts even when some triage matrix jobs failed (partial
+  visibility) but stays silent on empty batches and kill-switch no-ops.
+
+  Security: verdict summaries are agent-authored from untrusted Sentry data, so
+  every free-form value embedded in the payload is neutralized and Slack-escaped
+  with the same `& < >` escape the main-failure notifier uses
+  (`.github/workflows/notify-slack-on-main-failure.yml`) — the escape that
+  makes Slack mention/link syntax (`<!channel>`, `<@U…>`) inert. The bot token
+  (`secrets.TF_VAR_SLACK_BOT_TOKEN`, `chat:write.public`, reused — no new
+  secret) reaches only the posting step; the channel is hardcoded in the
+  workflow (changing it is a one-line PR). A digest-job failure fails the run,
+  which `notify-slack-on-main-failure.yml` (where this workflow is registered)
+  surfaces to `#ci-failures`.
+
 ### What Phase 2 does with verdicts (forward-looking)
 
 Phase 1 is read-only by design: verdicts and labels only, no fixes and no Sentry
@@ -362,4 +397,7 @@ skipped.
 ```bash
 pnpm sentry:ingest --dry-run   # needs a local SENTRY_TRIAGE_TOKEN; prints mutations without applying them
 pnpm sentry:ingest:test        # node --test scripts/sentry-triage-ingest.test.mjs
+pnpm sentry:digest:test        # node --test scripts/sentry-triage-digest.test.mjs (offline)
+# Print the Slack digest payload for a batch without posting (needs gh auth):
+SENTRY_TRIAGE_ISSUES='[123,456]' pnpm sentry:digest --channel '#engineering'
 ```

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "issue:release": "node scripts/agent-issue-board.mjs release",
     "sentry:ingest": "node scripts/sentry-triage-ingest.mjs",
     "sentry:ingest:test": "node scripts/sentry-triage-ingest.test.mjs",
+    "sentry:digest": "node scripts/sentry-triage-digest.mjs",
+    "sentry:digest:test": "node scripts/sentry-triage-digest.test.mjs",
     "pr:feedback-state": "node scripts/pr-feedback-state.mjs",
     "pr:feedback-state:test": "node scripts/pr-feedback-state.test.mjs",
     "pr:ready-state": "node scripts/pr-ready-state.mjs",

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -468,7 +468,7 @@ classify_root_package_json_changes() {
         echo "workspace"
         return
         ;;
-      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
+      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/sentry:digest|/scripts/sentry:digest:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
         saw_tooling_script=true
         ;;
       /scripts)
@@ -631,6 +631,7 @@ add_root_tooling_package_script_checks() {
   add_command "node scripts/review-materiality.test.mjs" "$reason"
   add_command "node scripts/agent-issue-board.test.mjs" "$reason"
   add_command "pnpm sentry:ingest:test" "$reason"
+  add_command "pnpm sentry:digest:test" "$reason"
   add_command "node scripts/pr-feedback-state.test.mjs" "$reason"
   add_command "node scripts/pr-ready-state.test.mjs" "$reason"
   add_command "node scripts/tf-stacks.test.mjs" "$reason"
@@ -1493,6 +1494,9 @@ while IFS= read -r path; do
           ;;
         scripts/sentry-triage-ingest.mjs|scripts/sentry-triage-ingest.test.mjs)
           add_command "pnpm sentry:ingest:test" "Sentry triage ingest helper changed"
+          ;;
+        scripts/sentry-triage-digest.mjs|scripts/sentry-triage-digest.test.mjs)
+          add_command "pnpm sentry:digest:test" "Sentry triage digest helper changed"
           ;;
         scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2470,6 +2470,12 @@ assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
 run_gate "scripts/lockfile-lint.test.mjs"
 assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
 
+run_gate "scripts/sentry-triage-digest.mjs"
+assert_contains "- pnpm sentry:digest:test (Sentry triage digest helper changed)"
+
+run_gate "scripts/sentry-triage-digest.test.mjs"
+assert_contains "- pnpm sentry:digest:test (Sentry triage digest helper changed)"
+
 run_gate "scripts/sanitize-terraform-output.sh"
 assert_contains "- pnpm sanitize:test (Terraform output sanitizer changed)"
 

--- a/scripts/check-agent-quality-gate-package-scripts.sh
+++ b/scripts/check-agent-quality-gate-package-scripts.sh
@@ -24,6 +24,8 @@ const expectedScripts = {
   "issue:release": "node scripts/agent-issue-board.mjs release",
   "sentry:ingest": "node scripts/sentry-triage-ingest.mjs",
   "sentry:ingest:test": "node scripts/sentry-triage-ingest.test.mjs",
+  "sentry:digest": "node scripts/sentry-triage-digest.mjs",
+  "sentry:digest:test": "node scripts/sentry-triage-digest.test.mjs",
   "pr:feedback-state": "node scripts/pr-feedback-state.mjs",
   "pr:feedback-state:test": "node scripts/pr-feedback-state.test.mjs",
   "pr:ready-state": "node scripts/pr-ready-state.mjs",

--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+/**
+ * Observability leg of the Sentry triage pipeline (ADR 0036,
+ * docs/adr/0036-sentry-triage-pipeline.md): a deterministic, no-LLM collector
+ * that turns one triage-agent run's batch into a single Slack digest payload —
+ * what was triaged, with what verdicts, with links — so verdict review needs
+ * zero GitHub polling. ADR 0036's dominant failure mode is "unauditable
+ * automation going dark"; this digest is the per-run heartbeat that makes a
+ * run's output visible where the team already looks.
+ *
+ * This script is a PURE CONSUMER of the verdict contract in
+ * docs/notes/sentry-triage-pipeline.md — it reads each batch issue's current
+ * labels and its latest `<!-- sentry-triage-verdict:v1 -->` comment and never
+ * changes the contract, the labels, or Sentry. It builds the Slack payload
+ * (including escaping); the workflow's posting step is the only place the
+ * Slack token lives and the only thing that POSTs.
+ *
+ * Security posture: verdict summaries are agent-authored from untrusted Sentry
+ * data — treated exactly like the queue-issue body text in Stage A. Every
+ * free-form value embedded in the payload (summary, plus the short-id/project
+ * lifted from the queue title) is neutralized and Slack-escaped before it
+ * reaches a payload field, using the SAME `& < >` escape the main-failure
+ * notifier uses (.github/workflows/notify-slack-on-main-failure.yml). That
+ * escape is what neutralizes Slack mention/link control syntax (`<!channel>`,
+ * `<@U123>`, `<url|text>`): the closed-set fields (verdict, confidence) are
+ * validated against their enums so only known-safe tokens ever render.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
+
+export const VERDICT_MARKER = "<!-- sentry-triage-verdict:v1 -->";
+export const NEEDS_TRIAGE_LABEL = "sentry:needs-triage";
+
+// Verdict LABEL -> verdict VALUE. This is the inverse of the ingest's
+// value->label map; note the deliberate asymmetry the verdict contract calls
+// out: label `sentry:verdict-upstream` <-> value `upstream-transient`.
+export const LABEL_TO_VERDICT = {
+  "sentry:verdict-code-fix": "code-fix",
+  "sentry:verdict-config-fix": "config-fix",
+  "sentry:verdict-upstream": "upstream-transient",
+  "sentry:verdict-needs-human": "needs-human",
+};
+
+export const VALID_VERDICTS = [
+  "code-fix",
+  "config-fix",
+  "upstream-transient",
+  "needs-human",
+];
+export const VALID_CONFIDENCE = ["high", "medium", "low"];
+
+// The `failed` bucket is not a verdict — it is batch issues still carrying
+// `sentry:needs-triage` (their triage job died before a verdict landed). It
+// must stay visible, never hidden.
+export const FAILED_BUCKET = "failed";
+
+// Counts header order — matches the verdict contract's parenthetical
+// (`code-fix / config-fix / upstream-transient / needs-human`) plus the
+// failed-triage bucket.
+export const COUNTS_ORDER = [
+  "code-fix",
+  "config-fix",
+  "upstream-transient",
+  "needs-human",
+  FAILED_BUCKET,
+];
+
+// Per-issue line order — `code-fix`/`config-fix` first, then `needs-human`,
+// then `upstream-transient` (verdict contract), with failed-triage lines last.
+export const LINE_ORDER = [
+  "code-fix",
+  "config-fix",
+  "needs-human",
+  "upstream-transient",
+  FAILED_BUCKET,
+];
+
+const BUCKET_LABELS = {
+  "code-fix": "code-fix",
+  "config-fix": "config-fix",
+  "upstream-transient": "upstream-transient",
+  "needs-human": "needs-human",
+  [FAILED_BUCKET]: "failed triage",
+};
+
+// Hard bound on the one free-form field we embed. "Truncate hard" mirrors the
+// Stage A queue-body defense; also keeps every Slack section well under the
+// 3000-char block limit (batch is capped at 6 issues upstream).
+const MAX_SUMMARY_LEN = 300;
+
+// ---------------------------------------------------------------------------
+// Untrusted-text neutralization + Slack escaping.
+// ---------------------------------------------------------------------------
+
+/**
+ * Slack mrkdwn escape — identical to the main-failure notifier's
+ * `gsub("&";"&amp;") | gsub("<";"&lt;") | gsub(">";"&gt;")`. Order matters:
+ * `&` first, or the later substitutions corrupt their own output. Escaping
+ * `<`/`>` is what makes Slack mention/link control syntax inert.
+ */
+export function escapeSlackText(text) {
+  return String(text ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** Collapse control chars/newlines/tabs to single spaces so an untrusted
+ * summary stays on one line. Same intent as the ingest's sanitizeFreeText. */
+export function sanitizeSummary(text) {
+  return (
+    String(text ?? "")
+      // eslint-disable-next-line no-control-regex -- stripping control chars from untrusted agent text is the whole point here
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+      .replace(/[\r\n\t]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+/** Sanitize -> hard-truncate -> Slack-escape, in that order (escape last so
+ * the byte bound applies to the human-visible text, not the entity soup). */
+export function formatSummaryForSlack(text) {
+  const clean = sanitizeSummary(text);
+  const bounded =
+    clean.length > MAX_SUMMARY_LEN
+      ? `${clean.slice(0, MAX_SUMMARY_LEN).trimEnd()}…`
+      : clean;
+  return escapeSlackText(bounded);
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsing: queue title, verdict comment.
+// ---------------------------------------------------------------------------
+
+// Queue contract v2 title: `[sentry] <SHORT-ID> (<project>, <level>)`.
+const QUEUE_TITLE_PATTERN = /^\[sentry\]\s+(\S+)\s+\(([^,()]+),/;
+
+export function parseQueueTitle(title) {
+  const match = QUEUE_TITLE_PATTERN.exec(String(title ?? ""));
+  if (!match) return { shortId: null, project: null };
+  return { shortId: match[1], project: match[2].trim() };
+}
+
+/** Extract the fenced ```yaml block from a verdict comment body. Falls back to
+ * the whole body if no fence is found (defensive — still line-parseable). */
+export function extractVerdictYamlBlock(commentBody) {
+  const match = /```ya?ml[ \t]*\r?\n([\s\S]*?)\r?\n```/.exec(
+    String(commentBody ?? ""),
+  );
+  return match ? match[1] : "";
+}
+
+function stripYamlQuotes(value) {
+  const v = String(value ?? "").trim();
+  if (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'")))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/**
+ * Line-oriented, tolerant parse of the verdict yaml (matches the workflow's
+ * deterministic label step, which sed-extracts the same fields). `verdict`
+ * and `confidence` are read as their leading enum token so a trailing
+ * `# ...` inline comment is ignored; `summary` keeps its full line value
+ * (it may legitimately contain `#`) minus one layer of surrounding quotes.
+ * Returns validated enums or null; summary is returned raw for later
+ * sanitize+escape.
+ */
+export function parseVerdictComment(commentBody) {
+  const block = extractVerdictYamlBlock(commentBody);
+  const source = block || String(commentBody ?? "");
+  const verdictMatch = /^verdict:[ \t]*([a-z-]+)/m.exec(source);
+  const confidenceMatch = /^confidence:[ \t]*([a-z]+)/m.exec(source);
+  const summaryMatch = /^summary:[ \t]*(.*)$/m.exec(source);
+
+  const verdict = verdictMatch ? verdictMatch[1] : null;
+  const confidence = confidenceMatch ? confidenceMatch[1] : null;
+  const summary = summaryMatch ? stripYamlQuotes(summaryMatch[1]) : "";
+
+  return {
+    verdict: VALID_VERDICTS.includes(verdict) ? verdict : null,
+    confidence: VALID_CONFIDENCE.includes(confidence) ? confidence : null,
+    summary,
+  };
+}
+
+/** Latest verdict-marker comment on the issue. `gh issue view --json comments`
+ * returns comments oldest-first, so the last match is the newest. */
+export function findLatestVerdictComment(comments) {
+  const marked = (comments ?? []).filter(
+    (comment) =>
+      typeof comment?.body === "string" &&
+      comment.body.startsWith(VERDICT_MARKER),
+  );
+  return marked.length ? marked[marked.length - 1].body : null;
+}
+
+// ---------------------------------------------------------------------------
+// Classification: one collected issue -> one digest entry.
+// ---------------------------------------------------------------------------
+
+/**
+ * The bucket is decided from LABELS (deterministic, validated by the workflow
+ * label step), not from the agent's free-text comment:
+ *   - still carrying `sentry:needs-triage`  -> failed (triage did not finish);
+ *   - carries a `sentry:verdict-*` label    -> that verdict;
+ *   - neither (shouldn't happen for a batch issue) -> failed, so it stays
+ *     visible rather than silently dropped.
+ * The comment supplies only the human-readable confidence + summary.
+ */
+export function classifyIssue(issue) {
+  const labelNames = (issue?.labels ?? []).map((label) =>
+    typeof label === "string" ? label : label?.name,
+  );
+  const { shortId, project } = parseQueueTitle(issue?.title);
+  const verdictCommentBody = findLatestVerdictComment(issue?.comments);
+  const parsed = verdictCommentBody
+    ? parseVerdictComment(verdictCommentBody)
+    : { verdict: null, confidence: null, summary: "" };
+
+  const stillNeedsTriage = labelNames.includes(NEEDS_TRIAGE_LABEL);
+  const verdictLabel = labelNames.find((name) =>
+    Object.hasOwn(LABEL_TO_VERDICT, name),
+  );
+  const verdictFromLabel = verdictLabel ? LABEL_TO_VERDICT[verdictLabel] : null;
+
+  let bucket;
+  if (stillNeedsTriage) bucket = FAILED_BUCKET;
+  else if (verdictFromLabel) bucket = verdictFromLabel;
+  else bucket = FAILED_BUCKET;
+
+  return {
+    number: issue?.number,
+    shortId: shortId ?? `#${issue?.number}`,
+    project: project ?? "unknown",
+    url: typeof issue?.url === "string" ? issue.url : "",
+    bucket,
+    verdict: bucket === FAILED_BUCKET ? null : bucket,
+    confidence: parsed.confidence,
+    summary: parsed.summary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Slack payload assembly.
+// ---------------------------------------------------------------------------
+
+function formatUtcTimestamp(date) {
+  // 2026-07-17T14:20:33.123Z -> "2026-07-17 14:20 UTC"
+  const iso = new Date(date).toISOString();
+  return `${iso.slice(0, 16).replace("T", " ")} UTC`;
+}
+
+function isHttpsUrl(value) {
+  try {
+    return new URL(String(value)).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function renderIssueLine(entry) {
+  const idText = escapeSlackText(entry.shortId);
+  // Only render a real Slack link for a trusted https URL (the issue URL comes
+  // from `gh issue view --json url`); otherwise show the escaped id as text.
+  const linked = isHttpsUrl(entry.url) ? `<${entry.url}|${idText}>` : idText;
+  const project = escapeSlackText(entry.project);
+
+  if (entry.bucket === FAILED_BUCKET) {
+    return `• ${linked} (${project}) — triage incomplete (still \`${NEEDS_TRIAGE_LABEL}\`)`;
+  }
+
+  const confidence = entry.confidence ?? "unknown";
+  const summary = entry.summary
+    ? formatSummaryForSlack(entry.summary)
+    : "_(no summary)_";
+  return `• ${linked} (${project}) — ${entry.verdict} (${confidence}): ${summary}`;
+}
+
+/**
+ * Build the deterministic Slack `chat.postMessage` payload for one batch.
+ * `channel` is passed in (hardcoded by the workflow); `now` is injectable for
+ * tests. Pure — no I/O, no escaping omissions: every free-form value is routed
+ * through the escape/format helpers here.
+ */
+export function buildDigest(issues, { channel, now = new Date() } = {}) {
+  const entries = (issues ?? []).map(classifyIssue);
+
+  const counts = Object.fromEntries(COUNTS_ORDER.map((key) => [key, 0]));
+  for (const entry of entries) {
+    counts[entry.bucket] = (counts[entry.bucket] ?? 0) + 1;
+  }
+
+  const total = entries.length;
+  const headerText = `*Sentry triage — ${total} issue(s) triaged*\n${formatUtcTimestamp(now)}`;
+  const countsText = COUNTS_ORDER.map(
+    (key) => `${BUCKET_LABELS[key]}: ${counts[key] ?? 0}`,
+  ).join(" · ");
+
+  const ordered = [];
+  for (const key of LINE_ORDER) {
+    for (const entry of entries) {
+      if (entry.bucket === key) ordered.push(entry);
+    }
+  }
+  const linesText = ordered.map(renderIssueLine).join("\n");
+
+  const blocks = [
+    { type: "section", text: { type: "mrkdwn", text: headerText } },
+    { type: "section", text: { type: "mrkdwn", text: countsText } },
+  ];
+  if (linesText) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: linesText } });
+  }
+
+  return {
+    channel,
+    // Plain-text fallback for notifications/screen readers (no untrusted text).
+    text: `Sentry triage — ${total} issue(s) triaged`,
+    blocks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub collection (via `gh`, mirroring the ingest script's runGh). Read-only
+// — `gh issue view` needs only `issues: read`.
+// ---------------------------------------------------------------------------
+
+function runGh(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      reject(new Error(`gh ${args.join(" ")} failed: ${err.message}`));
+    });
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(
+          new Error(
+            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+async function fetchIssue(repo, number, run) {
+  const stdout = await run([
+    "issue",
+    "view",
+    String(number),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,url,labels,comments",
+  ]);
+  const data = JSON.parse(stdout);
+  return {
+    number: data.number,
+    title: data.title ?? "",
+    url: data.url ?? "",
+    labels: (data.labels ?? []).map((label) => label?.name),
+    comments: data.comments ?? [],
+  };
+}
+
+/** Fetch each batch issue's title/url/labels/comments. `run` is injectable for
+ * tests. ≤6 issues per run (upstream batch cap), so a serial loop is fine. */
+export async function collectIssues(repo, numbers, deps = {}) {
+  const run = deps.runGh ?? runGh;
+  const issues = [];
+  for (const number of numbers ?? []) {
+    issues.push(await fetchIssue(repo, number, run));
+  }
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/** Parse the batch from a JSON array of positive integers (the select job's
+ * `issues` output). Empty/absent -> [] (the empty-batch guard). Fails loud on
+ * anything that isn't a JSON array of positive integers. */
+export function parseIssueNumbers(raw) {
+  if (raw == null || String(raw).trim() === "") return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(String(raw));
+  } catch {
+    throw new Error(
+      `--issues must be a JSON array of issue numbers, got: ${raw}`,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("--issues must be a JSON array of issue numbers");
+  }
+  return parsed.map((value) => {
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+    }
+    return value;
+  });
+}
+
+function usage() {
+  return `Usage: pnpm sentry:digest --channel <slack-channel> [options]
+
+Collects the current triage batch's verdicts and prints a deterministic Slack
+chat.postMessage payload (JSON) to stdout. The workflow's posting step is the
+only thing that holds the Slack token and POSTs.
+
+Options:
+  --channel <name>     Slack channel to post to (e.g. '#engineering'). Required.
+                       Env fallback: SENTRY_TRIAGE_CHANNEL.
+  --issues <json>      JSON array of queue-issue numbers (the select job's
+                       output). Env fallback: SENTRY_TRIAGE_ISSUES.
+  --repo <owner/name>  Repository the queue issues live in (default: ${DEFAULT_REPO}).
+  -h, --help           Show this help.
+`;
+}
+
+export function parseArgs(argv, env = process.env) {
+  const options = {
+    repo: DEFAULT_REPO,
+    channel: env.SENTRY_TRIAGE_CHANNEL ?? null,
+    help: false,
+  };
+  let issuesRaw = env.SENTRY_TRIAGE_ISSUES ?? null;
+
+  const args = [...argv];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const readValue = () => {
+      const value = args[++i];
+      if (value == null) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+    switch (arg) {
+      case "--repo":
+        options.repo = readValue();
+        break;
+      case "--channel":
+        options.channel = readValue();
+        break;
+      case "--issues":
+        issuesRaw = readValue();
+        break;
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+    }
+  }
+
+  options.issues = parseIssueNumbers(issuesRaw);
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!options.channel || !String(options.channel).trim()) {
+    throw new Error("--channel is required (or set SENTRY_TRIAGE_CHANNEL)");
+  }
+
+  // Empty-batch guard: nothing to report. Emit nothing on stdout so the
+  // posting step has no payload to POST (defense in depth — the digest job is
+  // already gated on a non-zero select count).
+  if (options.issues.length === 0) {
+    process.stderr.write(
+      "::notice::No issues in the triage batch; nothing to post.\n",
+    );
+    return;
+  }
+
+  const issues = await collectIssues(options.repo, options.issues);
+  const payload = buildDigest(issues, {
+    channel: options.channel,
+    now: new Date(),
+  });
+  // ONLY the payload goes to stdout (the workflow redirects it to a file for
+  // the posting step); all diagnostics go to stderr.
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -286,6 +286,43 @@ function renderIssueLine(entry) {
   return `• ${linked} (${project}) — ${entry.verdict} (${confidence}): ${summary}`;
 }
 
+// Slack caps a text object at 3000 chars; escape expansion (`<` -> `&lt;`,
+// `&` -> `&amp;`) means six worst-case 300-char summaries would blow far past
+// it in one section, and chat.postMessage would reject the whole payload with
+// `invalid_blocks`. Budget per section, with headroom under the hard cap.
+export const MAX_SECTION_TEXT_LEN = 2800;
+
+function mrkdwnSection(text) {
+  // verbatim: true disables Slack's automatic parsing of this text object
+  // (defense in depth on top of escapeSlackText): raw `@everyone` / `#channel`
+  // strings in user-controlled text can otherwise be auto-linkified into live
+  // mentions by layout-block parsing. The explicit `<url|label>` links we emit
+  // are mrkdwn markup, not auto-parsing, and still render.
+  return { type: "section", text: { type: "mrkdwn", text, verbatim: true } };
+}
+
+/** Greedily pack already-escaped lines into newline-joined chunks that each
+ * stay within `maxLen` (a single oversized line gets its own chunk — with the
+ * 300-char summary bound a rendered line stays well under the Slack cap). */
+export function chunkLines(lines, maxLen = MAX_SECTION_TEXT_LEN) {
+  const chunks = [];
+  let current = [];
+  let currentLen = 0;
+  for (const line of lines) {
+    const extra = line.length + (current.length > 0 ? 1 : 0); // +1 for "\n"
+    if (current.length > 0 && currentLen + extra > maxLen) {
+      chunks.push(current.join("\n"));
+      current = [line];
+      currentLen = line.length;
+    } else {
+      current.push(line);
+      currentLen += extra;
+    }
+  }
+  if (current.length > 0) chunks.push(current.join("\n"));
+  return chunks;
+}
+
 /**
  * Build the deterministic Slack `chat.postMessage` payload for one batch.
  * `channel` is passed in (hardcoded by the workflow); `now` is injectable for
@@ -312,15 +349,17 @@ export function buildDigest(issues, { channel, now = new Date() } = {}) {
       if (entry.bucket === key) ordered.push(entry);
     }
   }
-  const linesText = ordered.map(renderIssueLine).join("\n");
+  const lines = ordered.map(renderIssueLine);
 
   const blocks = [
-    { type: "section", text: { type: "mrkdwn", text: headerText } },
-    { type: "section", text: { type: "mrkdwn", text: countsText } },
+    mrkdwnSection(headerText),
+    mrkdwnSection(countsText),
+    // Issue lines are split across as many sections as the per-section budget
+    // needs (order preserved) so escape-expanded summaries can never push a
+    // single text object past Slack's 3000-char cap. Batch cap is 6, so this
+    // stays far below Slack's 50-blocks-per-message limit.
+    ...chunkLines(lines).map(mrkdwnSection),
   ];
-  if (linesText) {
-    blocks.push({ type: "section", text: { type: "mrkdwn", text: linesText } });
-  }
 
   return {
     channel,

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import {
   buildDigest,
+  chunkLines,
   classifyIssue,
   collectIssues,
   escapeSlackText,
@@ -8,6 +9,7 @@ import {
   findLatestVerdictComment,
   formatSummaryForSlack,
   LABEL_TO_VERDICT,
+  MAX_SECTION_TEXT_LEN,
   NEEDS_TRIAGE_LABEL,
   parseArgs,
   parseIssueNumbers,
@@ -324,6 +326,24 @@ await test("buildDigest produces a valid chat.postMessage payload shape", () => 
   JSON.parse(JSON.stringify(payload));
 });
 
+await test("every mrkdwn text object sets verbatim: true (no Slack auto-parsing)", () => {
+  const payload = buildDigest(
+    [
+      issueFixture({
+        number: 1,
+        labels: ["sentry:verdict-code-fix"],
+        comments: [{ body: verdictComment({ summary: "@everyone #general" }) }],
+      }),
+      issueFixture({ number: 2, labels: [NEEDS_TRIAGE_LABEL] }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  assert(payload.blocks.length >= 3, "expected header/counts/lines blocks");
+  for (const block of payload.blocks) {
+    assertEqual(block.text.verbatim, true);
+  }
+});
+
 await test("buildDigest renders the counts line in contract order incl. failed triage", () => {
   const payload = buildDigest(
     [
@@ -473,6 +493,51 @@ await test("buildDigest tolerates an empty batch (defensive; job is gated upstre
 });
 
 // ---------------------------------------------------------------------------
+// Slack 3000-char text-object cap (escape expansion must never overflow one
+// section)
+// ---------------------------------------------------------------------------
+
+await test("chunkLines packs greedily and respects the per-chunk budget", () => {
+  assertDeepEqual(chunkLines([], 10), []);
+  assertDeepEqual(chunkLines(["aa", "bb", "cc"], 5), ["aa\nbb", "cc"]);
+  // Exact fit including the joining newline: "aa\nbb" is 5 chars.
+  assertDeepEqual(chunkLines(["aa", "bb"], 5), ["aa\nbb"]);
+  assertDeepEqual(chunkLines(["aa", "bb"], 4), ["aa", "bb"]);
+  // A single line longer than the budget still lands in its own chunk.
+  assertDeepEqual(chunkLines(["xxxxxxxxxx", "y"], 5), ["xxxxxxxxxx", "y"]);
+});
+
+await test("buildDigest splits a worst-case 6-issue batch across sections under the Slack cap", () => {
+  // Six 300-char all-`<` summaries escape-expand to 1200 chars each — the
+  // exact invalid_blocks scenario: one section would be ~7.9k chars.
+  const issues = Array.from({ length: 6 }, (_, i) =>
+    issueFixture({
+      number: 100 + i,
+      shortId: `WC-${i}`,
+      labels: ["sentry:verdict-code-fix"],
+      comments: [{ body: verdictComment({ summary: "<".repeat(300) }) }],
+    }),
+  );
+  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+
+  const lineBlocks = payload.blocks.slice(2);
+  assert(lineBlocks.length >= 2, "expected the lines split across sections");
+  for (const block of payload.blocks) {
+    assert(
+      block.text.text.length <= MAX_SECTION_TEXT_LEN,
+      `expected every section under the ${MAX_SECTION_TEXT_LEN}-char budget, got ${block.text.text.length}`,
+    );
+  }
+  // No line lost and order preserved across the chunk boundaries.
+  const allLines = lineBlocks.flatMap((block) => block.text.text.split("\n"));
+  assertEqual(allLines.length, 6);
+  assertDeepEqual(
+    allLines.map((line) => /\|(\S+)>/.exec(line)?.[1]),
+    ["WC-0", "WC-1", "WC-2", "WC-3", "WC-4", "WC-5"],
+  );
+});
+
+// ---------------------------------------------------------------------------
 // CLI arg parsing
 // ---------------------------------------------------------------------------
 
@@ -525,10 +590,39 @@ await test("collectIssues fetches each issue via the injected gh runner", async 
   assertEqual(calls[0][0], "issue");
   assertEqual(calls[0][1], "view");
   assert(calls[0].includes("number,title,url,labels,comments"), "json fields");
+  // The caller's repo (the workflow passes --repo "$GITHUB_REPOSITORY")
+  // propagates into every gh call — never the script's baked-in default.
+  const repoFlagIndex = calls[0].indexOf("--repo");
+  assert(repoFlagIndex !== -1, "expected --repo flag in gh args");
+  assertEqual(calls[0][repoFlagIndex + 1], "o/r");
+  assertEqual(calls[1][calls[1].indexOf("--repo") + 1], "o/r");
 
   // End-to-end: collected issues feed straight into a valid payload.
   const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
   assertEqual(payload.text, "Sentry triage — 2 issue(s) triaged");
+});
+
+await test("collectIssues propagates a single fetch failure (fail loud, no silent drop)", async () => {
+  // One bad `gh issue view` must fail the whole digest (and so the job/run),
+  // never silently omit that issue from the posted digest.
+  const runGh = async (args) => {
+    if (args[2] === "22") throw new Error("gh issue view failed: HTTP 502");
+    return JSON.stringify({
+      number: Number(args[2]),
+      title: `[sentry] X-${args[2]} (app-mento-org, error)`,
+      url: `https://github.com/o/r/issues/${args[2]}`,
+      labels: [],
+      comments: [],
+    });
+  };
+  let threw = null;
+  try {
+    await collectIssues("o/r", [11, 22, 33], { runGh });
+  } catch (err) {
+    threw = err;
+  }
+  assert(threw, "expected a single fetch failure to reject collectIssues");
+  assert(/HTTP 502/.test(threw.message), "expected the gh error to propagate");
 });
 
 if (failed > 0) {

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+import {
+  buildDigest,
+  classifyIssue,
+  collectIssues,
+  escapeSlackText,
+  extractVerdictYamlBlock,
+  findLatestVerdictComment,
+  formatSummaryForSlack,
+  LABEL_TO_VERDICT,
+  NEEDS_TRIAGE_LABEL,
+  parseArgs,
+  parseIssueNumbers,
+  parseQueueTitle,
+  parseVerdictComment,
+  sanitizeSummary,
+  VERDICT_MARKER,
+} from "./sentry-triage-digest.mjs";
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    process.stdout.write(`ok ${name}\n`);
+    passed += 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`not ok ${name}\n  ${message}\n`);
+    failed += 1;
+  }
+}
+
+function assertEqual(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertDeepEqual(actual, expected) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`expected ${expectedJson}, got ${actualJson}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertThrows(fn, pattern) {
+  try {
+    fn();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!pattern.test(message)) {
+      throw new Error(`expected ${message} to match ${pattern}`, {
+        cause: err,
+      });
+    }
+    return;
+  }
+  throw new Error("expected function to throw");
+}
+
+// Build a verdict comment body the way the triage agent would.
+function verdictComment({
+  verdict = "code-fix",
+  confidence = "medium",
+  summary = "A short summary",
+} = {}) {
+  return [
+    VERDICT_MARKER,
+    "",
+    "```yaml",
+    `verdict: ${verdict} # code-fix | config-fix | upstream-transient | needs-human`,
+    `confidence: ${confidence} # high | medium | low`,
+    "affected_repo: mento-protocol/monitoring-monorepo",
+    `summary: ${summary}`,
+    "root_cause: |",
+    "  Some abstract root cause.",
+    "proposed_action: |",
+    "  Some abstract action.",
+    "duplicate_of: []",
+    "```",
+    "",
+    "Prose diagnosis goes here.",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Slack escaping (reused notifier pattern)
+// ---------------------------------------------------------------------------
+
+await test("escapeSlackText escapes & < > with & first", () => {
+  assertEqual(escapeSlackText("a & b"), "a &amp; b");
+  assertEqual(escapeSlackText("<b>&</b>"), "&lt;b&gt;&amp;&lt;/b&gt;");
+});
+
+await test("escapeSlackText neutralizes Slack mention/link control syntax", () => {
+  // <!channel>, <@U123>, <url|text> all require < and >, which we escape.
+  const injected = "<!channel> ping <@U999999> click <https://evil|here>";
+  const escaped = escapeSlackText(injected);
+  assert(!escaped.includes("<"), "expected all < escaped");
+  assert(!escaped.includes(">"), "expected all > escaped");
+  assert(
+    escaped.includes("&lt;!channel&gt;"),
+    "expected channel mention inert",
+  );
+});
+
+await test("sanitizeSummary collapses newlines/control chars to single spaces", () => {
+  assertEqual(
+    sanitizeSummary("line one\nline two\tthree   four"),
+    "line one line two three four",
+  );
+});
+
+await test("formatSummaryForSlack sanitizes, hard-bounds, then escapes", () => {
+  // A hostile multi-line summary with mention syntax and a fence-breakout try.
+  const hostile =
+    "<!channel> please\n```\nrm -rf\n``` " + "z".repeat(400) + " <@U1>";
+  const out = formatSummaryForSlack(hostile);
+  assert(!out.includes("\n"), "expected single line");
+  assert(!out.includes("<"), "expected < escaped");
+  assert(!out.includes(">"), "expected > escaped");
+  assert(out.endsWith("…"), "expected hard-truncation ellipsis");
+  assert(out.length <= 320, "expected bounded length (<=300 + entities)");
+});
+
+// ---------------------------------------------------------------------------
+// Queue-title parsing (short id + project)
+// ---------------------------------------------------------------------------
+
+await test("parseQueueTitle extracts short id and project from a v2 title", () => {
+  assertDeepEqual(
+    parseQueueTitle(
+      "[sentry] GOVERNANCE-MENTO-ORG-51 (governance-mento-org, error)",
+    ),
+    { shortId: "GOVERNANCE-MENTO-ORG-51", project: "governance-mento-org" },
+  );
+});
+
+await test("parseQueueTitle returns nulls for a non-queue title", () => {
+  assertDeepEqual(parseQueueTitle("random issue title"), {
+    shortId: null,
+    project: null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict-comment parsing (marker + yaml)
+// ---------------------------------------------------------------------------
+
+await test("extractVerdictYamlBlock pulls the fenced yaml block only", () => {
+  const block = extractVerdictYamlBlock(verdictComment());
+  assert(block.includes("verdict: code-fix"), "expected verdict line in block");
+  assert(!block.includes("Prose diagnosis"), "expected prose excluded");
+});
+
+await test("parseVerdictComment reads verdict/confidence/summary, ignoring inline comments", () => {
+  const parsed = parseVerdictComment(
+    verdictComment({
+      verdict: "config-fix",
+      confidence: "high",
+      summary: "CSP allowlist missing a domain",
+    }),
+  );
+  assertDeepEqual(parsed, {
+    verdict: "config-fix",
+    confidence: "high",
+    summary: "CSP allowlist missing a domain",
+  });
+});
+
+await test("parseVerdictComment strips one layer of surrounding quotes from summary", () => {
+  const parsed = parseVerdictComment(
+    verdictComment({ summary: '"quoted summary with # hash kept"' }),
+  );
+  assertEqual(parsed.summary, "quoted summary with # hash kept");
+});
+
+await test("parseVerdictComment rejects out-of-enum verdict/confidence to null", () => {
+  const parsed = parseVerdictComment(
+    verdictComment({ verdict: "totally-bogus", confidence: "certain" }),
+  );
+  assertEqual(parsed.verdict, null);
+  assertEqual(parsed.confidence, null);
+});
+
+await test("findLatestVerdictComment returns the newest marker-bearing comment", () => {
+  const comments = [
+    { body: "not a verdict" },
+    { body: verdictComment({ summary: "older" }) },
+    { body: "another chatter comment" },
+    { body: verdictComment({ summary: "newest" }) },
+  ];
+  const latest = findLatestVerdictComment(comments);
+  assert(latest.includes("summary: newest"), "expected newest verdict comment");
+});
+
+await test("findLatestVerdictComment returns null when no marker comment exists", () => {
+  assertEqual(
+    findLatestVerdictComment([{ body: "hi" }, { body: "bye" }]),
+    null,
+  );
+  assertEqual(findLatestVerdictComment([]), null);
+});
+
+// ---------------------------------------------------------------------------
+// Classification (label-driven bucket + failed-triage bucket)
+// ---------------------------------------------------------------------------
+
+function issueFixture({
+  number = 100,
+  shortId = "X-1",
+  project = "app-mento-org",
+  labels = [],
+  comments = [],
+} = {}) {
+  return {
+    number,
+    title: `[sentry] ${shortId} (${project}, error)`,
+    url: `https://github.com/mento-protocol/monitoring-monorepo/issues/${number}`,
+    labels: labels.map((name) => ({ name })),
+    comments,
+  };
+}
+
+await test("classifyIssue buckets by the verdict label, not the comment text", () => {
+  const entry = classifyIssue(
+    issueFixture({
+      labels: ["sentry-triage", "sentry:verdict-config-fix"],
+      // Comment says code-fix, but the deterministic LABEL wins.
+      comments: [
+        { body: verdictComment({ verdict: "code-fix", summary: "sum" }) },
+      ],
+    }),
+  );
+  assertEqual(entry.bucket, "config-fix");
+  assertEqual(entry.verdict, "config-fix");
+  assertEqual(entry.confidence, "medium");
+  assertEqual(entry.summary, "sum");
+});
+
+await test("classifyIssue maps the upstream label to the upstream-transient verdict", () => {
+  const entry = classifyIssue(
+    issueFixture({ labels: ["sentry-triage", "sentry:verdict-upstream"] }),
+  );
+  assertEqual(entry.bucket, "upstream-transient");
+});
+
+await test("classifyIssue puts still-needs-triage issues in the failed bucket", () => {
+  const entry = classifyIssue(
+    issueFixture({ labels: ["sentry-triage", NEEDS_TRIAGE_LABEL] }),
+  );
+  assertEqual(entry.bucket, "failed");
+  assertEqual(entry.verdict, null);
+});
+
+await test("classifyIssue treats an unlabeled batch issue as failed (visible, not dropped)", () => {
+  const entry = classifyIssue(issueFixture({ labels: ["sentry-triage"] }));
+  assertEqual(entry.bucket, "failed");
+});
+
+await test("classifyIssue falls back to #number when the title does not parse", () => {
+  const entry = classifyIssue({
+    number: 42,
+    title: "not a queue title",
+    url: "",
+    labels: [{ name: "sentry:verdict-needs-human" }],
+    comments: [],
+  });
+  assertEqual(entry.shortId, "#42");
+  assertEqual(entry.project, "unknown");
+  assertEqual(entry.bucket, "needs-human");
+});
+
+// LABEL_TO_VERDICT preserves the contract's upstream asymmetry.
+await test("LABEL_TO_VERDICT encodes the upstream label/value asymmetry", () => {
+  assertEqual(
+    LABEL_TO_VERDICT["sentry:verdict-upstream"],
+    "upstream-transient",
+  );
+  assertEqual(LABEL_TO_VERDICT["sentry:verdict-code-fix"], "code-fix");
+});
+
+// ---------------------------------------------------------------------------
+// Digest payload assembly (shape, counts, ordering, escaping)
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-07-17T14:20:33.000Z");
+
+await test("buildDigest produces a valid chat.postMessage payload shape", () => {
+  const payload = buildDigest(
+    [
+      issueFixture({
+        number: 1,
+        shortId: "A-1",
+        labels: ["sentry:verdict-code-fix"],
+        comments: [{ body: verdictComment({ summary: "null deref" }) }],
+      }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  assertEqual(payload.channel, "#engineering");
+  assertEqual(payload.text, "Sentry triage — 1 issue(s) triaged");
+  assert(Array.isArray(payload.blocks), "expected blocks array");
+  assertEqual(payload.blocks[0].type, "section");
+  assertEqual(payload.blocks[0].text.type, "mrkdwn");
+  assert(
+    payload.blocks[0].text.text.includes("Sentry triage — 1 issue(s) triaged"),
+    "expected header text",
+  );
+  assert(
+    payload.blocks[0].text.text.includes("2026-07-17 14:20 UTC"),
+    "expected UTC timestamp",
+  );
+  // Payload must be JSON-serializable (the workflow curls it verbatim).
+  JSON.parse(JSON.stringify(payload));
+});
+
+await test("buildDigest renders the counts line in contract order incl. failed triage", () => {
+  const payload = buildDigest(
+    [
+      issueFixture({ number: 1, labels: ["sentry:verdict-code-fix"] }),
+      issueFixture({ number: 2, labels: ["sentry:verdict-code-fix"] }),
+      issueFixture({ number: 3, labels: ["sentry:verdict-config-fix"] }),
+      issueFixture({ number: 4, labels: ["sentry:verdict-needs-human"] }),
+      issueFixture({ number: 5, labels: [NEEDS_TRIAGE_LABEL] }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  const countsText = payload.blocks[1].text.text;
+  assertEqual(
+    countsText,
+    "code-fix: 2 · config-fix: 1 · upstream-transient: 0 · needs-human: 1 · failed triage: 1",
+  );
+});
+
+await test("buildDigest orders issue lines: code/config, needs-human, upstream, failed last", () => {
+  const payload = buildDigest(
+    [
+      issueFixture({
+        number: 1,
+        shortId: "UP-1",
+        labels: ["sentry:verdict-upstream"],
+        comments: [{ body: verdictComment({ verdict: "upstream-transient" }) }],
+      }),
+      issueFixture({
+        number: 2,
+        shortId: "FAIL-1",
+        labels: [NEEDS_TRIAGE_LABEL],
+      }),
+      issueFixture({
+        number: 3,
+        shortId: "NH-1",
+        labels: ["sentry:verdict-needs-human"],
+        comments: [{ body: verdictComment({ verdict: "needs-human" }) }],
+      }),
+      issueFixture({
+        number: 4,
+        shortId: "CF-1",
+        labels: ["sentry:verdict-code-fix"],
+        comments: [{ body: verdictComment({ verdict: "code-fix" }) }],
+      }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  const lines = payload.blocks[2].text.text.split("\n");
+  const order = lines.map((line) => /\|(\S+)>/.exec(line)?.[1]);
+  assertDeepEqual(order, ["CF-1", "NH-1", "UP-1", "FAIL-1"]);
+});
+
+await test("buildDigest renders a linked, escaped per-issue line for a verdict", () => {
+  const payload = buildDigest(
+    [
+      issueFixture({
+        number: 7,
+        shortId: "APP-7",
+        project: "app-mento-org",
+        labels: ["sentry:verdict-code-fix"],
+        comments: [
+          {
+            body: verdictComment({
+              verdict: "code-fix",
+              confidence: "high",
+              summary: "unhandled <null> & missing guard",
+            }),
+          },
+        ],
+      }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  const line = payload.blocks[2].text.text;
+  assert(
+    line.includes(
+      "<https://github.com/mento-protocol/monitoring-monorepo/issues/7|APP-7>",
+    ),
+    "expected linked short id",
+  );
+  assert(line.includes("(app-mento-org)"), "expected project");
+  assert(line.includes("code-fix (high):"), "expected verdict + confidence");
+  // The summary's < > & must be escaped, not raw.
+  assert(
+    line.includes("unhandled &lt;null&gt; &amp; missing guard"),
+    "expected escaped summary",
+  );
+  assert(!/unhandled <null>/.test(line), "expected no raw angle brackets");
+});
+
+await test("buildDigest renders a distinct failed-triage line with no verdict", () => {
+  const payload = buildDigest(
+    [issueFixture({ number: 9, shortId: "F-9", labels: [NEEDS_TRIAGE_LABEL] })],
+    { channel: "#engineering", now: NOW },
+  );
+  const line = payload.blocks[2].text.text;
+  assert(line.includes("triage incomplete"), "expected failed-triage phrasing");
+  assert(
+    line.includes(NEEDS_TRIAGE_LABEL),
+    "expected needs-triage label named",
+  );
+});
+
+await test("buildDigest shows a placeholder when a verdict issue has no parseable summary", () => {
+  const payload = buildDigest(
+    [issueFixture({ number: 3, labels: ["sentry:verdict-code-fix"] })],
+    { channel: "#engineering", now: NOW },
+  );
+  assert(
+    payload.blocks[2].text.text.includes("_(no summary)_"),
+    "expected no-summary placeholder",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Empty-batch guard + issue-number parsing
+// ---------------------------------------------------------------------------
+
+await test("parseIssueNumbers returns [] for empty/absent input (empty-batch guard)", () => {
+  assertDeepEqual(parseIssueNumbers(undefined), []);
+  assertDeepEqual(parseIssueNumbers(null), []);
+  assertDeepEqual(parseIssueNumbers(""), []);
+  assertDeepEqual(parseIssueNumbers("   "), []);
+  assertDeepEqual(parseIssueNumbers("[]"), []);
+});
+
+await test("parseIssueNumbers parses a JSON array of positive integers", () => {
+  assertDeepEqual(parseIssueNumbers("[123, 456]"), [123, 456]);
+});
+
+await test("parseIssueNumbers fails loud on non-arrays and bad members", () => {
+  assertThrows(() => parseIssueNumbers("not json"), /JSON array/);
+  assertThrows(() => parseIssueNumbers('{"a":1}'), /JSON array/);
+  assertThrows(() => parseIssueNumbers("[0]"), /Invalid issue number/);
+  assertThrows(() => parseIssueNumbers("[-1]"), /Invalid issue number/);
+  assertThrows(() => parseIssueNumbers('["7"]'), /Invalid issue number/);
+  assertThrows(() => parseIssueNumbers("[1.5]"), /Invalid issue number/);
+});
+
+await test("buildDigest tolerates an empty batch (defensive; job is gated upstream)", () => {
+  const payload = buildDigest([], { channel: "#engineering", now: NOW });
+  assertEqual(payload.text, "Sentry triage — 0 issue(s) triaged");
+  assertEqual(
+    payload.blocks[1].text.text,
+    "code-fix: 0 · config-fix: 0 · upstream-transient: 0 · needs-human: 0 · failed triage: 0",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+
+await test("parseArgs reads channel/issues from flags", () => {
+  const options = parseArgs(
+    ["--channel", "#engineering", "--issues", "[1,2]"],
+    {},
+  );
+  assertEqual(options.channel, "#engineering");
+  assertDeepEqual(options.issues, [1, 2]);
+  assertEqual(options.repo, "mento-protocol/monitoring-monorepo");
+});
+
+await test("parseArgs falls back to env, flag wins", () => {
+  const options = parseArgs(["--channel", "#flag"], {
+    SENTRY_TRIAGE_CHANNEL: "#env",
+    SENTRY_TRIAGE_ISSUES: "[9]",
+  });
+  assertEqual(options.channel, "#flag");
+  assertDeepEqual(options.issues, [9]);
+});
+
+await test("parseArgs rejects unknown options", () => {
+  assertThrows(() => parseArgs(["--nope"], {}), /Unknown option/);
+});
+
+// ---------------------------------------------------------------------------
+// Collection layer (injected gh runner)
+// ---------------------------------------------------------------------------
+
+await test("collectIssues fetches each issue via the injected gh runner", async () => {
+  const calls = [];
+  const runGh = async (args) => {
+    calls.push(args);
+    const number = args[2];
+    return JSON.stringify({
+      number: Number(number),
+      title: `[sentry] X-${number} (app-mento-org, error)`,
+      url: `https://github.com/o/r/issues/${number}`,
+      labels: [{ name: "sentry:verdict-code-fix" }],
+      comments: [{ body: verdictComment({ summary: `sum ${number}` }) }],
+    });
+  };
+
+  const issues = await collectIssues("o/r", [11, 22], { runGh });
+  assertEqual(issues.length, 2);
+  assertEqual(issues[0].number, 11);
+  assertDeepEqual(issues[0].labels, ["sentry:verdict-code-fix"]);
+  // Each call is a read-only `gh issue view ... --json ...`.
+  assertEqual(calls[0][0], "issue");
+  assertEqual(calls[0][1], "view");
+  assert(calls[0].includes("number,title,url,labels,comments"), "json fields");
+
+  // End-to-end: collected issues feed straight into a valid payload.
+  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+  assertEqual(payload.text, "Sentry triage — 2 issue(s) triaged");
+});
+
+if (failed > 0) {
+  process.stderr.write(`${failed} failed, ${passed} passed\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`${passed} passed\n`);
+}


### PR DESCRIPTION
## The Problem

- After a Sentry triage-agent run, the only way to see what was triaged and with
  what verdicts is to poll GitHub issues — nobody does, so verdict review lags.
- ADR 0036's stated failure mode for this automation is "unauditable automation
  going dark": a run that silently stops mattering is the real risk, not a wrong
  verdict.
- When a triage matrix job dies mid-run, the issue stays labeled
  `sentry:needs-triage` with no signal that its triage never completed.

## The Solution

- Add a final `digest` job to `sentry-triage-agent.yml` that, after every run
  that processed at least one queue issue, posts one deterministic digest to
  Slack `#engineering`: counts by verdict plus one linked line per issue.
- A new no-LLM collector `scripts/sentry-triage-digest.mjs` reads each batch
  issue's labels + latest verdict comment and builds the Slack payload; a
  `failed triage` bucket lists issues still carrying `sentry:needs-triage` so a
  dead triage job is visible, not hidden.
- Reuses the existing Slack bot token and the main-failure notifier's exact
  `& < >` escaping — no new secret, and untrusted agent summaries can't inject
  Slack mentions/links.

## Details

The digest is a pure **consumer** of the verdict contract in
`docs/notes/sentry-triage-pipeline.md` — no LLM, no label writes, no Sentry
calls, and it does not change the contract.

- **Job gating.** `digest` runs `if: always() && needs.select.outputs.count != ''
  && needs.select.outputs.count != '0'`. `always()` makes it post even when some
  `triage` matrix jobs failed (partial visibility is the point); the count gate
  keeps it silent on empty batches and kill-switch no-ops (select emits count
  `'0'`/`''` then).
- **Classification is label-driven** (deterministic): still carrying
  `sentry:needs-triage` → `failed triage`; else the `sentry:verdict-*` label maps
  to the verdict bucket (preserving the contract's `upstream` label/value
  asymmetry). The verdict comment supplies only the human-readable confidence +
  summary. `verdict`/`confidence` are validated against their enums; anything
  off-enum degrades safely (`unknown`, `_(no summary)_`).
- **Payload assembly in the script, posting in the workflow.** The collector
  prints only the Slack `chat.postMessage` JSON to stdout (diagnostics to
  stderr); the workflow's posting step curls it verbatim (`--data @file`) and
  fails loudly on `{"ok": false}`, mirroring `notify-slack-on-main-failure.yml`.
- **Ordering.** Counts line: `code-fix / config-fix / upstream-transient /
  needs-human / failed triage`. Per-issue lines: `code-fix`/`config-fix`, then
  `needs-human`, then `upstream-transient`, then failed-triage last.
- **Failure surfacing.** A digest-job failure fails the run; the workflow is
  already registered in `notify-slack-on-main-failure.yml`, so a broken digest
  surfaces to `#ci-failures` — it can't go dark.
- **Channel.** `#engineering` is hardcoded in the workflow with a comment;
  changing it is a one-line PR (no new secret/variable).

Tests: `scripts/sentry-triage-digest.test.mjs` (32 cases, `node --test`, offline,
same hand-rolled harness as the ingest tests) covers verdict-comment parsing
(marker + yaml, inline-comment tolerance, quote stripping), the failed-triage
bucket, counts/line ordering, escaping (mention-injection neutralized),
empty-batch guard, the Slack payload shape, and the injected-`gh` collection
layer. Docs: `docs/notes/sentry-triage-pipeline.md` gains an Observability
section; `docs/notes/quick-commands.md` gains the digest rows.

### Security self-checks

- **(a) Slack token isolation — PASS.** `SLACK_BOT_TOKEN`
  (`secrets.TF_VAR_SLACK_BOT_TOKEN`) is set only in the posting step's `env:`;
  the collector step has `GH_TOKEN` only. Token is never echoed and never placed
  in a URL (Bearer header only).
- **(b) Untrusted-text escaping — PASS.** Every free-form value embedded
  (verdict `summary`, plus short-id/project lifted from the queue title) is
  sanitized, hard-bounded, and Slack-escaped with the notifier's `& < >` pattern
  before payload assembly. Closed-set fields (`verdict`, `confidence`) are
  enum-validated, so only known-safe tokens render. `root_cause`/`proposed_action`
  and any raw Sentry text are never embedded.
- **(c) Least privilege — PASS.** The `digest` job's `permissions` are exactly
  `contents: read` + `issues: read`. select/triage permissions are unchanged.
- **(d) SHA-pinned actions — PASS.** `actions/checkout@9c091bb…` (v7.0.0) and
  `actions/setup-node@48b55a0…` (v6.4.0) reuse the exact pins already in this
  repo; `check-github-action-pins.mjs` passes.
- **(e) Fires correctly — PASS.** Count gate blocks kill-switch/no-op runs
  (count `'0'`/`''`); `always()` + count gate still fires on partial triage
  failure, and the `failed triage` bucket lists issues still labeled
  `sentry:needs-triage`.

### Notes for reviewers

- The `digest` job has no `github.ref == 'refs/heads/main'` guard — matching the
  existing `select`/`triage` jobs. Branch-dispatch hardening for the whole agent
  workflow is tracked in #1289 (GitHub-Environment protection); scoping a guard
  to only `digest` would not close it while select/triage still run.

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only GitHub permissions for digest collection; Slack token isolated to the posting step with escaping for agent-authored summaries. Main risk is operational (wrong channel or noisy partial digests), not auth or data mutation.
> 
> **Overview**
> Adds **Stage B observability** so triage runs are reviewable without polling GitHub: after any run that selected a non-empty batch, a new **`digest` job** in `sentry-triage-agent.yml` builds and posts one Slack message to **`#engineering`**.
> 
> The collector **`scripts/sentry-triage-digest.mjs`** is read-only (no LLM, no label/Sentry writes): it loads each batch issue via `gh`, **classifies from labels** (verdict labels vs still `sentry:needs-triage` → **failed triage**), pulls confidence/summary from the latest verdict comment, sanitizes and Slack-escapes untrusted text, and prints a `chat.postMessage` JSON payload; a separate workflow step posts with the existing **`TF_VAR_SLACK_BOT_TOKEN`**. The job uses **`if: always()`** with a non-zero select count so partial triage failures still get a digest; empty/kill-switch runs stay silent. Digest failures fail the run (surfaced via the existing main-failure notifier).
> 
> Also adds **`pnpm sentry:digest`** / **`sentry:digest:test`**, offline tests, and docs updates in `sentry-triage-pipeline.md` and `quick-commands.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab871d7dd95efbfb8405578f5cf093d96934032d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->