### PR TITLE
fix(alerts): clarify per-feed oracle pages

### DIFF
--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -47,7 +47,8 @@ ${local.monad_relayer_signer_branches}
 {{ end -}}
 {{ $titleURL := .GeneratorURL -}}
 {{ if eq .Labels.chain "celo" -}}{{ $titleURL = printf "https://data.chain.link/feeds/celo/mainnet/%s" $hyphen -}}{{ end -}}
-*<{{ $titleURL }}|Stale price for the {{ $slash }} rate feed on {{ $chain }}>*
+*<{{ $titleURL }}|{{ $slash }} oracle report expired on {{ $chain }}> — swaps using this feed may revert until a fresh report is relayed*
+- Next action: confirm the relayer is executing, then inspect errors for this feed
 - Check the latest transactions of the {{ if $relayer -}}<https://{{ .Labels.explorer }}/address/{{ $relayer }}|{{ $slash }} relayer on {{ $chain }}>{{- else -}}{{ $slash }} relayer on {{ $chain }}{{- end }}
 - Check if the <https://console.cloud.google.com/logs/query;query=resource.labels.service_name%3D%22relay-{{ .Labels.chain }}%22%20AND%20labels.rateFeed%3D%22{{ $enc }}%22?project=${local.oracle_relayer_mainnet_project_id}|relayer cloud function> is still being triggered regularly
 
@@ -58,7 +59,7 @@ ${local.monad_relayer_signer_branches}
 {{ $chain := .Labels.chain | title -}}
 {{ $titleURL := .GeneratorURL -}}
 {{ if eq .Labels.chain "celo" -}}{{ $titleURL = printf "https://data.chain.link/feeds/celo/mainnet/%s" $hyphen -}}{{ end -}}
-*<{{ $titleURL }}|{{ $slash }} price is fresh again on {{ $chain }}>*
+*<{{ $titleURL }}|{{ $slash }} oracle report is fresh again on {{ $chain }}> — swap availability has recovered*
 {{ end -}}
 {{ end }}
 EOT

--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -48,7 +48,8 @@ ${local.monad_relayer_signer_branches}
 {{ $titleURL := .GeneratorURL -}}
 {{ if eq .Labels.chain "celo" -}}{{ $titleURL = printf "https://data.chain.link/feeds/celo/mainnet/%s" $hyphen -}}{{ end -}}
 *<{{ $titleURL }}|{{ $slash }} oracle report expired on {{ $chain }}> — swaps using this feed may revert until a fresh report is relayed*
-- Next action: confirm the relayer is executing, then inspect errors for this feed
+Next action: confirm the relayer is executing, then inspect errors for this feed.
+- If this is an FX feed during the weekend market closure, snooze it and escalate the monitoring configuration; this alert should have been muted
 - Check the latest transactions of the {{ if $relayer -}}<https://{{ .Labels.explorer }}/address/{{ $relayer }}|{{ $slash }} relayer on {{ $chain }}>{{- else -}}{{ $slash }} relayer on {{ $chain }}{{- end }}
 - Check if the <https://console.cloud.google.com/logs/query;query=resource.labels.service_name%3D%22relay-{{ .Labels.chain }}%22%20AND%20labels.rateFeed%3D%22{{ $enc }}%22?project=${local.oracle_relayer_mainnet_project_id}|relayer cloud function> is still being triggered regularly
 

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -8,9 +8,12 @@ resource "grafana_message_template" "victorops_oracle_stale_price_alert_title" {
 {{ define "victorops.oracle_stale_price_alert_title" }}
 {{ if (len .Alerts.Firing) -}}
 P1 {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" $alert.Labels.rateFeed -}}{{ $alert.Labels.chain | title }} {{ $slash }} oracle report expired{{ end -}}
-{{ else if (len .Alerts.Resolved) -}}
+{{ end -}}
+{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end -}}
+{{ if (len .Alerts.Resolved) -}}
 RESOLVED {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" $alert.Labels.rateFeed -}}{{ $alert.Labels.chain | title }} {{ $slash }} oracle report fresh{{ end -}}
-{{ else -}}
+{{ end -}}
+{{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) -}}
 Oracle report status unknown
 {{ end -}}
 {{ end }}

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -6,9 +6,13 @@ resource "grafana_message_template" "victorops_oracle_stale_price_alert_title" {
   name     = "VictorOps - Stale Price Alert Title"
   template = <<-EOT
 {{ define "victorops.oracle_stale_price_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] {{ .CommonLabels.alertname }}
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.rateFeed }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.rateFeed }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
+{{ if (len .Alerts.Firing) -}}
+P1 {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end -}}{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" $alert.Labels.rateFeed -}}{{ $alert.Labels.chain | title }} {{ $slash }} oracle report expired{{ end -}}
+{{ else if (len .Alerts.Resolved) -}}
+RESOLVED {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end -}}{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" $alert.Labels.rateFeed -}}{{ $alert.Labels.chain | title }} {{ $slash }} oracle report fresh{{ end -}}
+{{ else -}}
+Oracle report status unknown
+{{ end -}}
 {{ end }}
 EOT
 }
@@ -19,14 +23,20 @@ resource "grafana_message_template" "victorops_oracle_stale_price_alert_message"
   template = <<-EOT
 {{ define "victorops.oracle_stale_price_alert_message" }}
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
-{{ range .Alerts.Firing }}
-FIRING: Stale price for {{ .Labels.rateFeed }} rate feed on {{ .Labels.chain | title }}
-1. Check the latest transactions of the {{ .Labels.rateFeed }} relayer on {{ .Labels.chain | title }}
-2. Check if the relayer cloud function is still being triggered regularly
-{{ end }}
-{{ range .Alerts.Resolved }}
-RESOLVED: Price is fresh again for {{ .Labels.rateFeed }} rate feed on {{ .Labels.chain }}
-{{ end }}
+{{ range .Alerts.Firing -}}
+{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
+{{ $enc := reReplaceAll "/" "%2F" $slash -}}
+PROBLEM: The {{ $slash }} on-chain oracle report on {{ .Labels.chain | title }} has expired. Swaps using this feed may revert until a fresh report is relayed.
+ACTION: Check whether relay-{{ .Labels.chain }} is executing and inspect the {{ $slash }} relayer errors. If this is an FX feed during the weekend market closure, the alert routing is misconfigured; snooze it and escalate the monitoring configuration.
+Logs: https://console.cloud.google.com/logs/query;query=resource.labels.service_name%3D%22relay-{{ .Labels.chain }}%22%20AND%20labels.rateFeed%3D%22{{ $enc }}%22?project=${local.oracle_relayer_mainnet_project_id}
+Alert: {{ .GeneratorURL }}
+Started: {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
+{{ end -}}
+{{ range .Alerts.Resolved -}}
+{{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
+RESOLVED: The {{ $slash }} oracle report on {{ .Labels.chain | title }} is fresh again.
+Resolved: {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+{{ end -}}
 {{ end }}
 EOT
 }

--- a/alerts/rules/message-templates-victorops.tf
+++ b/alerts/rules/message-templates-victorops.tf
@@ -22,7 +22,6 @@ resource "grafana_message_template" "victorops_oracle_stale_price_alert_message"
   name     = "VictorOps - Stale Price Alert Message"
   template = <<-EOT
 {{ define "victorops.oracle_stale_price_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing -}}
 {{ $slash := reReplaceAll "^([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $enc := reReplaceAll "/" "%2F" $slash -}}

--- a/alerts/rules/rules-oracle-relayers.tf
+++ b/alerts/rules/rules-oracle-relayers.tf
@@ -14,7 +14,7 @@ resource "grafana_rule_group" "oracle_relayers" {
       no_data_state  = "NoData"
 
       annotations = {
-        summary = "The {{ $labels.rateFeed }} rate feed is stale on {{ $labels.chain | title }}. Check for possible issues with the oracle relayer."
+        summary = "{{ $labels.rateFeed }} oracle report expired on {{ $labels.chain | title }}. Swaps using this feed may revert until a fresh report is relayed."
       }
 
       labels = {

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -344,6 +344,31 @@ test("trading-mode notification templates avoid single-alert duplicate headings"
   );
 });
 
+test("oracle expiry notifications lead with human impact and action", () => {
+  const victorops = readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "alerts/rules/message-templates-victorops.tf",
+    ),
+    "utf8",
+  );
+  assert(
+    victorops.includes("P1 {{ range") &&
+      victorops.includes("oracle report expired"),
+    "VictorOps title should identify the page, chain, feed, and failure",
+  );
+  assert(
+    victorops.includes("Swaps using this feed may revert") &&
+      victorops.includes("ACTION: Check whether relay-"),
+    "VictorOps message should state impact and the next action",
+  );
+  assert(
+    !victorops.includes("FIRING: Stale price for"),
+    "VictorOps message should not use the old ambiguous stale-price copy",
+  );
+});
+
 test("Slack trading-mode bodies suppress duplicate single-alert headings", () => {
   const source = readFileSync(
     path.resolve(__dirname, "..", "alerts/rules/message-templates-slack.tf"),

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -359,6 +359,12 @@ test("oracle expiry notifications lead with human impact and action", () => {
     "VictorOps title should identify the page, chain, feed, and failure",
   );
   assert(
+    victorops.includes(
+      "{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end -}}",
+    ),
+    "VictorOps title should surface both states in mixed notification batches",
+  );
+  assert(
     victorops.includes("Swaps using this feed may revert") &&
       victorops.includes("ACTION: Check whether relay-"),
     "VictorOps message should state impact and the next action",
@@ -381,6 +387,16 @@ test("oracle expiry notifications lead with human impact and action", () => {
   assert(
     !staleMessage.includes("No alerts are currently firing."),
     "resolve-only pages should start directly with the recovery message",
+  );
+  const slack = readFileSync(
+    path.resolve(__dirname, "..", "alerts/rules/message-templates-slack.tf"),
+    "utf8",
+  );
+  assert(
+    slack.includes(
+      "If this is an FX feed during the weekend market closure, snooze it and escalate the monitoring configuration",
+    ),
+    "Slack should carry the same weekend-FX routing guidance as VictorOps",
   );
 });
 

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -367,6 +367,21 @@ test("oracle expiry notifications lead with human impact and action", () => {
     !victorops.includes("FIRING: Stale price for"),
     "VictorOps message should not use the old ambiguous stale-price copy",
   );
+  const staleMessageStart = victorops.indexOf(
+    'resource "grafana_message_template" "victorops_oracle_stale_price_alert_message"',
+  );
+  const staleMessageEnd = victorops.indexOf(
+    'resource "grafana_message_template" "victorops_oracle_relayer_low_balance_alert_title"',
+  );
+  assert(
+    staleMessageStart >= 0 && staleMessageEnd > staleMessageStart,
+    "stale-price VictorOps message template not found",
+  );
+  const staleMessage = victorops.slice(staleMessageStart, staleMessageEnd);
+  assert(
+    !staleMessage.includes("No alerts are currently firing."),
+    "resolve-only pages should start directly with the recovery message",
+  );
 });
 
 test("Slack trading-mode bodies suppress duplicate single-alert headings", () => {


### PR DESCRIPTION
## The Problem

- Per-feed oracle expiry pages reach on-call with ambiguous "stale price" copy that does not explain impact or the next action.
- SMS titles omit the affected chain/feed and are difficult to understand when away from a laptop.

## The Solution

Keep the existing per-feed alerting and FX weekend muting, while rewriting Splunk On-Call and Slack notifications to lead with the chain, feed, expired-report state, swap impact, and concrete investigation links.

Adds a regression test that protects the human-readable impact/action contract.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm tf validate alerts-rules`
- `node --test scripts/alert-rules-lint.test.mjs`
- `pnpm agent:autoreview` equivalent Codex-native fresh-context review: clean

Live `pnpm alerts:rules:plan` was attempted but could not complete in the isolated worktree because Grafana, Slack, and Splunk input credentials are intentionally unavailable.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification and annotation text only; alert thresholds, routing, and muting behavior are unchanged.
> 
> **Overview**
> **Per-feed oracle expiry** notifications are rewritten so on-call sees **chain, feed, and “oracle report expired”** instead of vague “stale price” wording, with explicit **swap revert risk** and **what to do next**.
> 
> **Slack** firing/resolved lines now state impact (swaps may revert / availability recovered) and add a **next action** bullet before the existing relayer and GCP log links. **Splunk On-Call (VictorOps)** titles use **P1** / **RESOLVED** lines with chain and feed; messages use **PROBLEM** / **ACTION** blocks, filtered log URLs, and weekend FX routing guidance. The **Grafana rule summary** annotation matches the same impact language.
> 
> A **regression test** in `alert-rules-lint.test.mjs` locks in the VictorOps impact/action contract and bans the old stale-price copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7bbc4e02bcafd632ece4fec7c87a41ea779634. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->