### PR TITLE
fix(deps): align aegis js-yaml manifest pin with the override floor

### DIFF
--- a/aegis/package.json
+++ b/aegis/package.json
@@ -70,7 +70,7 @@
     "@willsoto/nestjs-prometheus": "6.0.2",
     "abitype": "1.1.2",
     "cron": "4.3.4",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "prom-client": "15.1.3",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",


### PR DESCRIPTION
## The Problem

- `aegis/package.json` still declares `js-yaml: 4.2.0` exact while the workspace override floor forces 4.3.0 — the pin is stale, and if the override is ever pruned, a fresh install silently downgrades aegis back to the vulnerable version.

## The Solution

- Bump the manifest pin to 4.3.0 so it matches the resolved version. Lockfile needs no change: pnpm records the overridden specifier, so this is a one-line manifest alignment. (Residual carried over from the superseded PR #1380; everything else in that PR landed via #1381.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiUreX7DKuRKiHQT6HkY4z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version pin bump with no application or lockfile changes; security-relevant only in that it documents the patched floor.
> 
> **Overview**
> Updates the **aegis** direct dependency on `js-yaml` from **4.2.0** to **4.3.0** so the manifest matches the workspace override minimum and what installs already resolve.
> 
> This is manifest-only alignment (no lockfile or runtime code changes); it avoids a future install path where a removed override could pull **4.2.0** back in for aegis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a298ef4f51331c6502c41fec93bdd2419dc45af3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->