### PR TITLE
fix(rpc): replace retired Polygon Amoy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | `NEXT_PUBLIC_HASURA_URL_TESTNET`           | Optional shared Monad Testnet + Polygon Amoy Envio GraphQL endpoint                                        |
 | `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA`      | Optional Celo Sepolia Envio GraphQL endpoint                                                               |
 | `NEXT_PUBLIC_RPC_URL_POLYGON_MAINNET`      | Optional Polygon RPC override (default: `https://polygon.drpc.org`)                                        |
-| `NEXT_PUBLIC_RPC_URL_POLYGON_AMOY`         | Optional Polygon Amoy RPC override (default: `https://rpc-amoy.polygon.technology`)                        |
+| `NEXT_PUBLIC_RPC_URL_POLYGON_AMOY`         | Optional Polygon Amoy RPC override (default: `https://polygon-amoy.drpc.org`)                              |
 | `NEXT_PUBLIC_EXPLORER_URL_POLYGON_MAINNET` | Optional Polygon explorer-base override (default: `https://polygonscan.com`)                               |
 | `NEXT_PUBLIC_EXPLORER_URL_POLYGON_AMOY`    | Optional Polygon Amoy explorer-base override (default: `https://amoy.polygonscan.com`)                     |
 | `NEXT_PUBLIC_SHOW_TESTNET_NETWORKS`        | Set to `true` with the per-testnet endpoint URL to show hosted testnet networks                            |

--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -238,7 +238,7 @@ chains:
 
   - id: polygonTestnet
     label: polygon-testnet
-    httpRpcUrl: https://rpc-amoy.polygon.technology
+    httpRpcUrl: https://polygon-amoy.drpc.org
     contracts:
       # Same deterministic testnet deploy addresses as monadTestnet above.
       # Verified on-chain (chainId 80002): only the three Polygon rate feeds

--- a/aegis/src/config.real.spec.ts
+++ b/aegis/src/config.real.spec.ts
@@ -14,4 +14,13 @@ describe('production config.yaml', () => {
       expect(m.source.functionAbi.name).toBeTruthy();
     }
   });
+
+  it('uses the supported Polygon Amoy RPC endpoint', () => {
+    const config = loadConfig();
+    const polygonAmoy = config.chains.find(
+      (chain) => chain.id === 'polygonTestnet',
+    );
+
+    expect(polygonAmoy?.httpRpcUrl).toBe('https://polygon-amoy.drpc.org');
+  });
 });

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -20,7 +20,7 @@ ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 # ENVIO_RPC_URL_143="https://rpc2.monad.xyz"             # Monad Mainnet primary (default — deeper archive than QuickNode)
 # ENVIO_RPC_URL_10143="<monad-testnet-full-node-rpc>"    # Monad Testnet primary (default: HyperRPC — needs ENVIO_API_TOKEN)
 # ENVIO_RPC_URL_137="https://polygon.drpc.org"            # Polygon Mainnet primary (default)
-# ENVIO_RPC_URL_80002="https://rpc-amoy.polygon.technology" # Polygon Amoy primary + event sync (default)
+# ENVIO_RPC_URL_80002="https://polygon-amoy.drpc.org"       # Polygon Amoy primary + event sync (default)
 
 # --- Per-chain fallback RPC overrides (optional) ---
 # Used by readContractWithBlockFallback for BOTH archive-depth AND rate-limit

--- a/indexer-envio/config.multichain.testnet.yaml
+++ b/indexer-envio/config.multichain.testnet.yaml
@@ -428,7 +428,7 @@ chains:
     # Earliest canonical deployment receipt: SortedOracles at block 37555761.
     # The first replayable FPMM factory events land at block 42219919.
     rpc:
-      url: ${ENVIO_RPC_URL_80002:-https://rpc-amoy.polygon.technology}
+      url: ${ENVIO_RPC_URL_80002:-https://polygon-amoy.drpc.org}
     start_block: ${ENVIO_START_BLOCK_POLYGON_AMOY:-37555761}
     contracts:
       - name: Broker

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -177,7 +177,7 @@ const RPC_CONFIG_BY_CHAIN: Record<number, { default: string; envVar: string }> =
       envVar: "ENVIO_RPC_URL_137",
     }, // Polygon Mainnet
     80002: {
-      default: "https://rpc-amoy.polygon.technology",
+      default: "https://polygon-amoy.drpc.org",
       envVar: "ENVIO_RPC_URL_80002",
     }, // Polygon Amoy
     42220: { default: "https://forno.celo.org", envVar: "ENVIO_RPC_URL_42220" }, // Celo Mainnet

--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -16,7 +16,7 @@ NEXT_PUBLIC_HASURA_URL=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 # Optional Polygon endpoint overrides. The dashboard uses these public defaults
 # when unset.
 # NEXT_PUBLIC_RPC_URL_POLYGON_MAINNET=https://polygon.drpc.org
-# NEXT_PUBLIC_RPC_URL_POLYGON_AMOY=https://rpc-amoy.polygon.technology
+# NEXT_PUBLIC_RPC_URL_POLYGON_AMOY=https://polygon-amoy.drpc.org
 # NEXT_PUBLIC_EXPLORER_URL_POLYGON_MAINNET=https://polygonscan.com
 # NEXT_PUBLIC_EXPLORER_URL_POLYGON_AMOY=https://amoy.polygonscan.com
 

--- a/ui-dashboard/src/__tests__/csp.test.ts
+++ b/ui-dashboard/src/__tests__/csp.test.ts
@@ -41,7 +41,7 @@ describe("buildCspWithNonce", () => {
     expect(connectSrc).toContain("https://rpc2.monad.xyz");
     expect(connectSrc).toContain("https://testnet-rpc.monad.xyz");
     expect(connectSrc).toContain("https://polygon.drpc.org");
-    expect(connectSrc).toContain("https://rpc-amoy.polygon.technology");
+    expect(connectSrc).toContain("https://polygon-amoy.drpc.org");
     expect(connectSrc).toContain("wss://ws-us3.pusher.com");
   });
 

--- a/ui-dashboard/src/env.ts
+++ b/ui-dashboard/src/env.ts
@@ -34,7 +34,7 @@ const clientSchema = z.object({
   ),
   NEXT_PUBLIC_RPC_URL_POLYGON_AMOY: z.catch(
     z.url(),
-    "https://rpc-amoy.polygon.technology",
+    "https://polygon-amoy.drpc.org",
   ),
   NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA: z.catch(
     z.url(),

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -399,7 +399,7 @@ describe("NETWORKS — Polygon networks", () => {
       "https://polygonscan.com",
     );
     expect(NETWORKS["polygon-amoy"].rpcUrl).toBe(
-      "https://rpc-amoy.polygon.technology",
+      "https://polygon-amoy.drpc.org",
     );
     expect(NETWORKS["polygon-amoy"].explorerBaseUrl).toBe(
       "https://amoy.polygonscan.com",

--- a/ui-dashboard/src/lib/csp.ts
+++ b/ui-dashboard/src/lib/csp.ts
@@ -46,7 +46,7 @@ const CSP_CONNECT_SRC = [
   "https://rpc2.monad.xyz",
   "https://testnet-rpc.monad.xyz",
   "https://polygon.drpc.org",
-  "https://rpc-amoy.polygon.technology",
+  "https://polygon-amoy.drpc.org",
   ...configuredHasuraConnectSrc(),
 ].join(" ");
 


### PR DESCRIPTION
## The Problem

- Polygon retired `https://rpc-amoy.polygon.technology`, so every Aegis Amoy view call now fails with `ENOTFOUND`.
- The same retired hostname remains in the Envio testnet replay path and dashboard runtime/CSP defaults, leaving Amoy polling and browser RPC access broken across all consumers.

## The Solution

Replace the retired Amoy hostname with Polygon's documented public dRPC endpoint, `https://polygon-amoy.drpc.org`, everywhere it is used. Add a production-config regression assertion so Aegis cannot silently return to the retired endpoint, and update the dashboard CSP/config tests with the new origin.

Polygon's deprecation notice: https://forum.polygon.technology/t/deprecation-of-polygons-public-rpc-endpoints-mainnet-amoy/22014

Current Polygon PoS RPC directory: https://docs.polygon.technology/pos/reference/rpc-endpoints

## Invariants

- Polygon Amoy remains chain ID `80002`; only its RPC origin changes.
- Mainnet Polygon RPCs and production Envio chain configuration are unchanged.
- Dashboard `connect-src`, network defaults, environment examples, Envio defaults, and Aegis config all use the same Amoy origin.

## Degraded behavior

- Amoy remains a single-endpoint testnet path. If dRPC is unavailable, Aegis exposes its existing RPC error counters and the existing testnet warning alerts fire; no unverified archive-incomplete fallback is introduced.
- Testnet Envio callers can still override the default with `ENVIO_RPC_URL_80002`.

## Intentional non-goals

- No Polygon mainnet endpoint change.
- No multi-provider failover or paid RPC credential rollout.
- No production Envio redeploy: chain `80002` is only in the testnet config.

## Validation

- Replacement endpoint returned `eth_chainId = 80002` and historical contract code/calls around Amoy start block `37,555,761`.
- Aegis: 80 tests, lint, typecheck, build, and Forge tests.
- Envio: mainnet/testnet codegen, lint, typecheck, 1,078 tests (27 skipped), build, and coverage.
- Dashboard: 4,045 tests, browser suite, production build, size limit, React Doctor 100/100, lint, typecheck, and coverage.
- Browser smoke from the production build issued `eth_chainId` to `https://polygon-amoy.drpc.org`, received HTTP 200 / `0x13882`, and produced no console errors.
- Trunk, docs/context checks, dependency checks, and local autoreview passed.

## Rollout verification

- Merge triggers the existing Aegis App Engine and dashboard deployment paths.
- After Aegis deploys, verify `polygonTestnet` RPC error counters stop increasing and successful `polygon-testnet` gauges appear.
- Verify the dashboard production CSP contains the new dRPC origin and omits the retired hostname.

Architecture decision? No — this is a provider endpoint replacement within the existing single-endpoint testnet architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Testnet-only default RPC URL swap with no auth, schema, or mainnet changes; override env vars still apply.
> 
> **Overview**
> Polygon retired the public Amoy RPC host (`rpc-amoy.polygon.technology`), which broke Amoy `eth_call`/sync and browser wallet RPC. This PR switches the default Amoy origin to **`https://polygon-amoy.drpc.org`** everywhere that host was hardcoded or documented.
> 
> **Aegis** `polygonTestnet` chain config and a new **`config.real.spec.ts`** assertion lock the Amoy URL so production config cannot drift back to the retired endpoint. **Envio** testnet YAML default, **`RPC_CONFIG_BY_CHAIN`** for chain `80002`, and **`.env.example`** comments are aligned. **Dashboard** updates **`env.ts`** default, **`networks`** wiring, **CSP `connect-src`**, env examples, and related tests so client RPC calls are allowed and defaults match.
> 
> Chain ID `80002` and Polygon mainnet RPCs are unchanged; `ENVIO_RPC_URL_80002` still overrides the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad45fd905ef3cbc1f0aa3f6236e400d577bbd77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->