### PR TITLE
fix(tooling): handle reviewer stdin EPIPE

### DIFF
--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -2465,7 +2465,7 @@ function runCommandWithInput(
       if (stdinWriteError) {
         rejectOnce(
           new Error(
-            `${command} exited successfully after closing stdin before the complete review prompt was written`,
+            `${command} exited successfully after closing stdin before the complete review prompt was written: ${stderr || stdout}`,
           ),
         );
         return;

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -2362,6 +2362,7 @@ function runCommandWithInput(
     let timedOut = false;
     let killTimer = null;
     let settled = false;
+    let stdinWriteError = null;
     const configuredHeartbeat = Number.parseInt(
       process.env.AUTOREVIEW_HEARTBEAT_SECONDS || "60",
       10,
@@ -2438,6 +2439,15 @@ function runCommandWithInput(
     child.on("error", (error) => {
       rejectOnce(error);
     });
+    const handleStdinError = (error) => {
+      if (settled) return;
+      if (error?.code === "EPIPE") {
+        stdinWriteError = error;
+        return;
+      }
+      forceAbort(error);
+    };
+    child.stdin.on("error", handleStdinError);
     child.on("close", (code, signal) => {
       signalReviewerProcessGroup(child, "SIGKILL");
       if (timedOut) {
@@ -2452,9 +2462,21 @@ function runCommandWithInput(
         );
         return;
       }
+      if (stdinWriteError) {
+        rejectOnce(
+          new Error(
+            `${command} exited successfully after closing stdin before the complete review prompt was written`,
+          ),
+        );
+        return;
+      }
       resolveOnce({ stdout, stderr });
     });
-    child.stdin.end(prompt);
+    try {
+      child.stdin.end(prompt);
+    } catch (error) {
+      handleStdinError(error);
+    }
   });
 }
 

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -2578,7 +2578,11 @@ const exitCode = Number.parseInt(
 );
 
 fs.closeSync(0);
-if (exitCode !== 0) process.stderr.write("reviewer rejected startup\n");
+process.stderr.write(
+  exitCode === 0
+    ? "reviewer closed stdin early\n"
+    : "reviewer rejected startup\n",
+);
 setTimeout(() => process.exit(exitCode), 25);
 CODEX
   chmod +x "$fake_bin/codex"
@@ -2596,6 +2600,7 @@ CODEX
     "$review_repo" "$fake_bin" --mode local --engine codex
   expect_stderr_contains \
     "exited successfully after closing stdin before the complete review prompt was written"
+  expect_stderr_contains "reviewer closed stdin early"
 }
 
 run_symlinked_node_codex_regression() {

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -1169,6 +1169,7 @@ run_helper_with_path_in_repo() {
     GOOGLE_APPLICATION_CREDENTIALS \
     SSL_CERT_DIR \
     SSL_CERT_FILE \
+    AUTOREVIEW_FAKE_STDIN_EXIT_CODE \
     AUTOREVIEW_FAKE_CREDENTIAL_PROCESS_MARKER \
     AUTOREVIEW_FAKE_MUTATE_AWS_CONFIG_SOURCE; do
     value="${!key-}"
@@ -2555,6 +2556,46 @@ CODEX
       expect_file_contains "$engine_capture.stderr" "failed (7)"
     fi
   done
+}
+
+run_stdin_epipe_regression() {
+  local review_repo="$tmp_dir/stdin-epipe"
+  local fake_bin="$tmp_dir/stdin-epipe-bin"
+
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  "$node_bin" -e \
+    'require("node:fs").writeFileSync(process.argv[1], "x".repeat(180 * 1024))' \
+    "$review_repo/large-review.txt"
+  mkdir "$fake_bin"
+  cat >"$fake_bin/codex" <<'CODEX'
+#!/usr/bin/env node
+const fs = require("node:fs");
+const exitCode = Number.parseInt(
+  process.env.AUTOREVIEW_FAKE_STDIN_EXIT_CODE || "7",
+  10,
+);
+
+fs.closeSync(0);
+if (exitCode !== 0) process.stderr.write("reviewer rejected startup\n");
+setTimeout(() => process.exit(exitCode), 25);
+CODEX
+  chmod +x "$fake_bin/codex"
+
+  AUTOREVIEW_FAKE_STDIN_EXIT_CODE=7 run_helper_with_path_in_repo_expect_failure \
+    "$review_repo" "$fake_bin" --mode local --engine codex
+  expect_stderr_contains "failed (7): reviewer rejected startup"
+  if grep -Fq -- "write EPIPE" "$stderr"; then
+    printf 'reviewer stdin EPIPE escaped the controlled failure path\nstderr:\n%s\n' \
+      "$(cat "$stderr")" >&2
+    exit 1
+  fi
+
+  AUTOREVIEW_FAKE_STDIN_EXIT_CODE=0 run_helper_with_path_in_repo_expect_failure \
+    "$review_repo" "$fake_bin" --mode local --engine codex
+  expect_stderr_contains \
+    "exited successfully after closing stdin before the complete review prompt was written"
 }
 
 run_symlinked_node_codex_regression() {
@@ -4711,6 +4752,7 @@ case "$test_focus" in
     run_claude_no_tools_regression
     run_codex_isolation_regression
     run_engine_signal_cleanup_regression
+    run_stdin_epipe_regression
     printf 'focused autoreview engine-isolation tests passed\n'
     exit 0
     ;;
@@ -4771,6 +4813,7 @@ if [[ "$test_focus" == "all" ]]; then
   run_claude_no_tools_regression
   run_codex_isolation_regression
   run_engine_signal_cleanup_regression
+  run_stdin_epipe_regression
   run_symlinked_node_codex_regression
   run_repo_controlled_node_regression
   run_pr_base_detection_regression


### PR DESCRIPTION
## The Problem

- Autoreview can crash with an uncaught `EPIPE` when a semantic reviewer exits before consuming the full prompt.
- That crash hides the reviewer's actionable exit code and stderr.

## The Solution

- Listen for child-stdin errors before writing; retain `EPIPE` until child close so nonzero reviewer failures stay authoritative, force-abort other stdin errors, and fail closed if an incomplete prompt is followed by exit 0.
- Add deterministic 180 KiB regressions for both exit 7 and exit 0 while preserving the existing timeout and process-group cleanup coverage.

## Validation

- `pnpm agent:quality-gate --run` via the pre-push hook: all mapped commands passed; full autoreview suite 9m59s.
- `AUTOREVIEW_TEST_FOCUS=engine-isolation bash scripts/agent-autoreview.test.sh`
- Trusted `origin/main` autoreview helper: clean.
- Fresh-context semantic closeout review: ALL_CLEAR.

Closes #1395