### PR TITLE
perf(tooling): split and time autoreview suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       terraform: ${{ steps.filter.outputs.terraform }}
       codeHealth: ${{ steps.filter.outputs.codeHealth }}
       rootScripts: ${{ steps.filter.outputs.rootScripts }}
+      autoreviewSuite: ${{ steps.filter.outputs.autoreviewSuite }}
       versionSkew: ${{ steps.filter.outputs.versionSkew }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -263,6 +264,22 @@ jobs:
               - .claude/settings.json
               - .codex/config.toml
               - .codex/hooks.json
+            # The adversarial autoreview suite is intentionally isolated from
+            # the broader root-scripts job: it is expensive, path-specific,
+            # and runs sequentially in CI for deterministic fixture/process
+            # cleanup. The local quality gate may orchestrate the same complete
+            # family set in parallel.
+            autoreviewSuite:
+              - scripts/agent-autoreview.sh
+              - scripts/agent-autoreview.mjs
+              - scripts/agent-autoreview-core.mjs
+              - scripts/agent-autoreview-core.test.mjs
+              - scripts/agent-autoreview-target-guard.test.mjs
+              - scripts/agent-autoreview.test.sh
+              - package.json
+              - .node-version
+              - .github/workflows/ci.yml
+              - .github/actions/pnpm-install/**
             # Dependency manifest and pnpm catalog/lifecycle policy drift.
             # This runs independently of package quality jobs so a manifest-only
             # PR cannot satisfy the required `ci` sentinel while bypassing the
@@ -952,6 +969,26 @@ jobs:
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
         if: always()
 
+  autoreview-suite:
+    name: Autoreview adversarial suite
+    needs: changes
+    if: needs.changes.outputs.autoreviewSuite == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm-install
+      - name: Full sequential autoreview regression suite
+        run: pnpm agent:autoreview:test -- --jobs 1
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
+        if: always()
+
   version-skew:
     name: Version skew
     needs: changes
@@ -1018,6 +1055,7 @@ jobs:
         terraform,
         deps,
         scripts,
+        autoreview-suite,
         version-skew,
       ]
     if: always()
@@ -1030,6 +1068,6 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,version-skew
+          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,autoreview-suite,version-skew
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,7 +985,19 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-install
       - name: Full sequential autoreview regression suite
-        run: pnpm agent:autoreview:test -- --jobs 1
+        shell: bash
+        run: |
+          set -euo pipefail
+          # setup-node lives below a runner toolcache whose writable ancestry is
+          # intentionally rejected by the nested semantic helper. Stage the same
+          # native binary under private runner-owned ancestry instead of relaxing
+          # runtime trust; #1397 owns the separate root/container fallback.
+          trusted_node_dir="$(/usr/bin/mktemp -d "${HOME}/.autoreview-node.XXXXXX")"
+          trap '/bin/rm -rf -- "${trusted_node_dir}"' EXIT
+          /bin/chmod 0700 "$trusted_node_dir"
+          node_source="$(node -p 'process.execPath')"
+          /usr/bin/install -m 0500 "$node_source" "$trusted_node_dir/node"
+          PATH="$trusted_node_dir:$PATH" pnpm agent:autoreview:test -- --jobs 1
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
         if: always()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       terraform: ${{ steps.filter.outputs.terraform }}
       codeHealth: ${{ steps.filter.outputs.codeHealth }}
       rootScripts: ${{ steps.filter.outputs.rootScripts }}
-      autoreviewSuite: ${{ steps.filter.outputs.autoreviewSuite }}
       versionSkew: ${{ steps.filter.outputs.versionSkew }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -264,22 +263,6 @@ jobs:
               - .claude/settings.json
               - .codex/config.toml
               - .codex/hooks.json
-            # The adversarial autoreview suite is intentionally isolated from
-            # the broader root-scripts job: it is expensive, path-specific,
-            # and runs sequentially in CI for deterministic fixture/process
-            # cleanup. The local quality gate may orchestrate the same complete
-            # family set in parallel.
-            autoreviewSuite:
-              - scripts/agent-autoreview.sh
-              - scripts/agent-autoreview.mjs
-              - scripts/agent-autoreview-core.mjs
-              - scripts/agent-autoreview-core.test.mjs
-              - scripts/agent-autoreview-target-guard.test.mjs
-              - scripts/agent-autoreview.test.sh
-              - package.json
-              - .node-version
-              - .github/workflows/ci.yml
-              - .github/actions/pnpm-install/**
             # Dependency manifest and pnpm catalog/lifecycle policy drift.
             # This runs independently of package quality jobs so a manifest-only
             # PR cannot satisfy the required `ci` sentinel while bypassing the
@@ -969,38 +952,6 @@ jobs:
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
         if: always()
 
-  autoreview-suite:
-    name: Autoreview adversarial suite
-    needs: changes
-    if: needs.changes.outputs.autoreviewSuite == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - uses: ./.github/actions/pnpm-install
-      - name: Full sequential autoreview regression suite
-        shell: bash
-        run: |
-          set -euo pipefail
-          # setup-node lives below a runner toolcache whose writable ancestry is
-          # intentionally rejected by the nested semantic helper. Stage the same
-          # native binary under private runner-owned ancestry instead of relaxing
-          # runtime trust; #1397 owns the separate root/container fallback.
-          trusted_node_dir="$(/usr/bin/mktemp -d "${HOME}/.autoreview-node.XXXXXX")"
-          trap '/bin/rm -rf -- "${trusted_node_dir}"' EXIT
-          /bin/chmod 0700 "$trusted_node_dir"
-          node_source="$(node -p 'process.execPath')"
-          /usr/bin/install -m 0500 "$node_source" "$trusted_node_dir/node"
-          PATH="$trusted_node_dir:$PATH" pnpm agent:autoreview:test -- --jobs 1
-      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
-        if: always()
-
   version-skew:
     name: Version skew
     needs: changes
@@ -1067,7 +1018,6 @@ jobs:
         terraform,
         deps,
         scripts,
-        autoreview-suite,
         version-skew,
       ]
     if: always()
@@ -1080,6 +1030,6 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,autoreview-suite,version-skew
+          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,version-skew
       - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ local-only checks:
 pnpm agent:quality-gate
 pnpm agent:quality-gate --run
 pnpm agent:autoreview # non-trivial completed batches
+pnpm agent:autoreview:test -- --jobs 1  # autoreview runtime changes only
 pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review check; retain the printed manifest for the bound post-check
 ```
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -25,10 +25,21 @@ Before opening or updating an agent-authored PR:
 pnpm agent:quality-gate          # inspect mapped commands and checklists
 pnpm agent:quality-gate --run    # execute the safe local mapped commands
 pnpm agent:autoreview            # required for a non-trivial completed batch
+pnpm agent:autoreview:test -- --jobs 1  # sequential full regression closeout for autoreview runtime changes
 ```
 
 The gate is local-only and never deploys or runs Terraform apply. Do not assume
 the pre-push hook is installed; run the gate explicitly.
+
+`pnpm agent:autoreview` performs source review and never runs tests.
+`pnpm agent:autoreview:test` is the canonical command boundary for the complete
+autoreview regression harness. It defaults to at most three independent family
+workers and emits bounded family-start/heartbeat progress plus per-family
+completion timings, so a long adversarial case does not look hung. The mapped
+local quality gate invokes this package command and preserves those progress
+and timing lines. For deterministic autoreview-runtime closeout, or to
+reproduce the required path-filtered GitHub-hosted CI job, pass `-- --jobs 1`;
+this changes scheduling only and keeps the same full family coverage.
 
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:
@@ -74,7 +85,7 @@ edit limited to root tooling scripts such as `scripts.agent:quality-gate`,
 `scripts.agent:prewarm:test`, `scripts.agent:review-materiality`,
 `scripts.agent:review-materiality:test`, `scripts.agent:context-check`,
 `scripts.agent:context-budget`, `scripts.agent:context-budget:test`,
-`scripts.agent:autoreview`, `scripts.issue:board`,
+`scripts.agent:autoreview`, `scripts.agent:autoreview:test`, `scripts.issue:board`,
 `scripts.issue:board:test`, `scripts.issue:claim`, `scripts.issue:review`,
 `scripts.issue:release`, `scripts.sentry:ingest`,
 `scripts.sentry:ingest:test`, `scripts.docs:index`, `scripts.docs:index:test`,
@@ -468,6 +479,12 @@ review the script/lifecycle diff first, then set
 `agent.qualityGate.allowPackageScriptChanges=true` in local git config (seen by
 both the manual warm run and the hook) so a just-passed acknowledged manual gate
 can satisfy the `--skip-if-fresh` check.
+
+An exact-signature success stamp is reusable for at most two hours. The
+signature binds the fetched base object, mapped plan, gate implementation,
+changed paths and validated content, plus package-risk state; any bound-input
+change reruns the mapped commands immediately, and an unchanged stamp older
+than two hours expires instead of masking drift.
 
 Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
 local dashboard browser tests, and dashboard React Doctor checks run through

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -39,7 +39,11 @@ completion timings, so a long adversarial case does not look hung. The mapped
 local quality gate invokes this package command and preserves those progress
 and timing lines. For deterministic autoreview-runtime closeout, or to
 reproduce the required path-filtered GitHub-hosted CI job, pass `-- --jobs 1`;
-this changes scheduling only and keeps the same full family coverage.
+this changes scheduling only and keeps the same full family coverage. The CI
+job stages setup-node's resolved native executable at mode `0500` under private
+runner-owned home-directory ancestry before invoking the suite. That keeps the
+production runtime-trust policy intact; root/container runtime discovery
+remains the separate follow-up tracked in #1397.
 
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -37,13 +37,10 @@ autoreview regression harness. It defaults to at most three independent family
 workers and emits bounded family-start/heartbeat progress plus per-family
 completion timings, so a long adversarial case does not look hung. The mapped
 local quality gate invokes this package command and preserves those progress
-and timing lines. For deterministic autoreview-runtime closeout, or to
-reproduce the required path-filtered GitHub-hosted CI job, pass `-- --jobs 1`;
-this changes scheduling only and keeps the same full family coverage. The CI
-job stages setup-node's resolved native executable at mode `0500` under private
-runner-owned home-directory ancestry before invoking the suite. That keeps the
-production runtime-trust policy intact; root/container runtime discovery
-remains the separate follow-up tracked in #1397.
+and timing lines. For deterministic autoreview-runtime closeout, pass
+`-- --jobs 1`; this changes scheduling only and keeps the same full family
+coverage. Hosted-CI hermeticity remains the separate follow-up tracked in
+#1422.
 
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -49,7 +49,7 @@ pnpm code-health                   # Run knip + deps together (everything except
 pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
 pnpm agent:autoreview              # Isolated closeout review; multi-pass uses --prepare-bundle-dir DIR + one fresh-context reviewer; quality gate owns tests
 pnpm agent:autoreview:test         # Full autoreview regression families; defaults to up to 3 workers with progress + timings
-pnpm agent:autoreview:test -- --jobs 1  # Sequential full closeout and CI reproduction for autoreview runtime changes
+pnpm agent:autoreview:test -- --jobs 1  # Sequential full closeout for autoreview runtime changes
 pnpm agent:autoreview --verify-bundle-dir DIR  # Pre-review rehash; retain the printed manifest digest
 pnpm agent:autoreview --verify-bundle-dir DIR --expected-bundle-manifest DIGEST  # Bound post-review rehash
 pnpm docs:index --write            # Regenerate docs/README.md from tracked + non-ignored untracked Markdown

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -48,6 +48,8 @@ pnpm code-health:schema-diff       # GraphQL schema breaking-change diff vs orig
 pnpm code-health                   # Run knip + deps together (everything except history + duplication)
 pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
 pnpm agent:autoreview              # Isolated closeout review; multi-pass uses --prepare-bundle-dir DIR + one fresh-context reviewer; quality gate owns tests
+pnpm agent:autoreview:test         # Full autoreview regression families; defaults to up to 3 workers with progress + timings
+pnpm agent:autoreview:test -- --jobs 1  # Sequential full closeout and CI reproduction for autoreview runtime changes
 pnpm agent:autoreview --verify-bundle-dir DIR  # Pre-review rehash; retain the printed manifest digest
 pnpm agent:autoreview --verify-bundle-dir DIR --expected-bundle-manifest DIGEST  # Bound post-review rehash
 pnpm docs:index --write            # Regenerate docs/README.md from tracked + non-ignored untracked Markdown

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "adr:check": "node scripts/check-adr-reminder.mjs",
     "adr:check:test": "node scripts/check-adr-reminder.test.mjs",
     "agent:autoreview": "./scripts/agent-autoreview.sh",
+    "agent:autoreview:test": "AUTOREVIEW_TEST_FOCUS=suite bash scripts/agent-autoreview.test.sh",
     "issue:board": "node scripts/agent-issue-board.mjs",
     "issue:board:test": "node scripts/agent-issue-board.test.mjs",
     "issue:claim": "node scripts/agent-issue-board.mjs claim",

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -7,6 +7,364 @@ set -euo pipefail
 umask 077
 unset SSL_CERT_DIR
 
+suite_tmp_dir=""
+suite_child_pids=()
+suite_registry_in_progress=0
+suite_pending_exit=0
+
+handle_suite_signal() {
+  local exit_code="$1"
+  if [[ "$suite_registry_in_progress" -eq 1 ]]; then
+    suite_pending_exit="$exit_code"
+    return 0
+  fi
+  trap - HUP INT TERM
+  exit "$exit_code"
+}
+
+finish_suite_registry_update() {
+  suite_registry_in_progress=0
+  if [[ "$suite_pending_exit" -ne 0 ]]; then
+    local exit_code="$suite_pending_exit"
+    suite_pending_exit=0
+    handle_suite_signal "$exit_code"
+  fi
+}
+
+unregister_suite_child_pid() {
+  local completed_pid="$1"
+  local registered_pid
+  local remaining_pids=()
+  for registered_pid in "${suite_child_pids[@]:-}"; do
+    [[ -n "$registered_pid" ]] || continue
+    if [[ "$registered_pid" != "$completed_pid" ]]; then
+      remaining_pids+=("$registered_pid")
+    fi
+  done
+  suite_child_pids=()
+  if [[ "${#remaining_pids[@]}" -gt 0 ]]; then
+    suite_child_pids=("${remaining_pids[@]}")
+  fi
+}
+
+reap_and_unregister_suite_wrapper() {
+  local pid="$1"
+  suite_registry_in_progress=1
+  while kill -0 "$pid" 2>/dev/null; do
+    wait "$pid" 2>/dev/null || true
+  done
+  wait "$pid" 2>/dev/null || true
+  unregister_suite_child_pid "$pid"
+  finish_suite_registry_update
+}
+
+cleanup_suite_runner() {
+  local pid
+  local group_file
+  local group_pid
+  for pid in "${suite_child_pids[@]:-}"; do
+    [[ -n "$pid" ]] || continue
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  for pid in "${suite_child_pids[@]:-}"; do
+    [[ -n "$pid" ]] || continue
+    wait "$pid" 2>/dev/null || true
+  done
+  if [[ -n "$suite_tmp_dir" && -d "$suite_tmp_dir" ]]; then
+    for group_file in "$suite_tmp_dir"/*.group; do
+      [[ -f "$group_file" ]] || continue
+      group_pid="$(cat "$group_file" 2>/dev/null || true)"
+      [[ "$group_pid" =~ ^[0-9]+$ ]] || continue
+      terminate_suite_process_group "$group_pid"
+    done
+  fi
+  if [[ -n "$suite_tmp_dir" && -d "$suite_tmp_dir" ]]; then
+    rm -rf -- "$suite_tmp_dir"
+  fi
+}
+
+terminate_suite_process_group() {
+  local group_pid="$1"
+  local grace_tenths="${2:-70}"
+  local attempt
+
+  [[ -n "$group_pid" ]] || return 0
+  if ! kill -0 -- "-$group_pid" 2>/dev/null; then
+    wait "$group_pid" 2>/dev/null || true
+    return 0
+  fi
+  kill -TERM -- "-$group_pid" 2>/dev/null || true
+  for ((attempt = 0; attempt < grace_tenths; attempt++)); do
+    if ! kill -0 -- "-$group_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  if kill -0 -- "-$group_pid" 2>/dev/null; then
+    kill -KILL -- "-$group_pid" 2>/dev/null || true
+  fi
+  wait "$group_pid" 2>/dev/null || true
+}
+
+run_autoreview_test_suite() {
+  local jobs=3
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --)
+        shift
+        ;;
+      --jobs)
+        if [[ $# -lt 2 ]]; then
+          printf '%s\n' '--jobs requires a value from 1 through 3' >&2
+          return 2
+        fi
+        jobs="$2"
+        shift 2
+        ;;
+      --jobs=*)
+        jobs="${1#*=}"
+        shift
+        ;;
+      *)
+        printf 'unknown autoreview test-suite argument: %s\n' "$1" >&2
+        return 2
+        ;;
+    esac
+  done
+  if [[ ! "$jobs" =~ ^[1-3]$ ]]; then
+    printf 'autoreview test-suite --jobs must be from 1 through 3: %s\n' \
+      "$jobs" >&2
+    return 2
+  fi
+
+  local suite_script
+  suite_script="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/$(basename -- "${BASH_SOURCE[0]}")"
+  local suite_tmp_parent="$trusted_fixture_parent"
+  suite_tmp_dir="$(/usr/bin/mktemp -d "$suite_tmp_parent/agent-autoreview-suite.XXXXXX")"
+  suite_tmp_dir="$(cd "$suite_tmp_dir" && pwd -P)"
+  trap cleanup_suite_runner EXIT
+  trap 'handle_suite_signal 129' HUP
+  trap 'handle_suite_signal 130' INT
+  trap 'handle_suite_signal 143' TERM
+
+  local suite_started_at
+  suite_started_at="$(date +%s)"
+  local next_progress_at=$((suite_started_at + 20))
+
+  launch_suite_family() {
+    local family="$1"
+    local log_file="$suite_tmp_dir/$family.log"
+    local status_file="$suite_tmp_dir/$family.status"
+    local started_file="$suite_tmp_dir/$family.started"
+    local group_file="$suite_tmp_dir/$family.group"
+    date +%s >"$started_file"
+    suite_registry_in_progress=1
+    (
+      local family_pid=""
+      local family_status=125
+      local family_launch_in_progress=0
+      local family_pending_exit=0
+      # Invoked indirectly by the EXIT trap below.
+      # shellcheck disable=SC2329
+      publish_family_status() {
+        printf '%s\n' "$family_status" >"$status_file.tmp"
+        mv -- "$status_file.tmp" "$status_file"
+      }
+      forward_family_signal() {
+        local exit_code="$1"
+        if [[ "$family_launch_in_progress" -eq 1 ]]; then
+          family_pending_exit="$exit_code"
+          return 0
+        fi
+        trap - HUP INT TERM
+        if [[ -n "$family_pid" ]]; then
+          terminate_suite_process_group "$family_pid"
+          rm -f -- "$group_file"
+        fi
+        family_status="$exit_code"
+        exit "$family_status"
+      }
+      trap publish_family_status EXIT
+      trap 'forward_family_signal 129' HUP
+      trap 'forward_family_signal 130' INT
+      trap 'forward_family_signal 143' TERM
+      set +e
+      family_launch_in_progress=1
+      set -m
+      AUTOREVIEW_TEST_FOCUS="$family" /bin/bash "$suite_script" \
+        >"$log_file" 2>&1 &
+      family_pid=$!
+      set +m
+      printf '%s\n' "$family_pid" >"$group_file.tmp"
+      mv -- "$group_file.tmp" "$group_file"
+      family_launch_in_progress=0
+      if [[ "$family_pending_exit" -ne 0 ]]; then
+        local pending_exit="$family_pending_exit"
+        family_pending_exit=0
+        forward_family_signal "$pending_exit"
+      fi
+      wait "$family_pid"
+      family_status=$?
+      terminate_suite_process_group "$family_pid"
+      rm -f -- "$group_file"
+      set -e
+      exit "$family_status"
+    ) &
+    local wrapper_pid
+    wrapper_pid=$!
+    if [[ -n "${AUTOREVIEW_TEST_SUITE_REGISTRATION_MARKER:-}" ]]; then
+      printf 'registration\n' >"$AUTOREVIEW_TEST_SUITE_REGISTRATION_MARKER"
+      sleep 2 || true
+    fi
+    suite_child_pids+=("$wrapper_pid")
+    finish_suite_registry_update
+    printf 'AUTOREVIEW_TEST_PROGRESS family=%s elapsed=%ss\n' \
+      "$family" "$(( $(date +%s) - suite_started_at ))"
+  }
+
+  run_suite_family_group() {
+    local group_jobs="$1"
+    shift
+    local families=("$@")
+    local next_family=0
+    local active_families=()
+    local active_pids=()
+    local family
+    local pid
+    local index
+    local status_file
+    local now
+
+    while [[ "$next_family" -lt "${#families[@]}" || "${#active_families[@]}" -gt 0 ]]; do
+      while [[ "$next_family" -lt "${#families[@]}" && "${#active_families[@]}" -lt "$group_jobs" ]]; do
+        family="${families[$next_family]}"
+        launch_suite_family "$family"
+        active_families+=("$family")
+        active_pids+=("${suite_child_pids[${#suite_child_pids[@]}-1]}")
+        next_family=$((next_family + 1))
+      done
+
+      local remaining_families=()
+      local remaining_pids=()
+      for ((index = 0; index < ${#active_families[@]}; index++)); do
+        family="${active_families[$index]}"
+        pid="${active_pids[$index]}"
+        status_file="$suite_tmp_dir/$family.status"
+        if [[ -f "$status_file" ]]; then
+          reap_and_unregister_suite_wrapper "$pid"
+          if [[ -f "$suite_tmp_dir/$family.group" ]]; then
+            local completed_group_pid
+            completed_group_pid="$(cat "$suite_tmp_dir/$family.group")"
+            if [[ "$completed_group_pid" =~ ^[0-9]+$ ]]; then
+              terminate_suite_process_group "$completed_group_pid"
+            fi
+            rm -f -- "$suite_tmp_dir/$family.group"
+          fi
+          local family_started
+          family_started="$(cat "$suite_tmp_dir/$family.started")"
+          printf '%s\n' "$(( $(date +%s) - family_started ))" \
+            >"$suite_tmp_dir/$family.elapsed"
+        elif ! kill -0 "$pid" 2>/dev/null; then
+          local wrapper_status=0
+          suite_registry_in_progress=1
+          set +e
+          wait "$pid" 2>/dev/null
+          wrapper_status=$?
+          set -e
+          unregister_suite_child_pid "$pid"
+          finish_suite_registry_update
+          if [[ "$wrapper_status" -eq 0 ]]; then
+            wrapper_status=125
+          fi
+          if [[ -f "$suite_tmp_dir/$family.group" ]]; then
+            local orphaned_group_pid
+            orphaned_group_pid="$(cat "$suite_tmp_dir/$family.group")"
+            if [[ "$orphaned_group_pid" =~ ^[0-9]+$ ]]; then
+              terminate_suite_process_group "$orphaned_group_pid"
+            fi
+            rm -f -- "$suite_tmp_dir/$family.group"
+          fi
+          printf '%s\n' "$wrapper_status" >"$status_file.tmp"
+          mv -- "$status_file.tmp" "$status_file"
+          local failed_family_started
+          failed_family_started="$(cat "$suite_tmp_dir/$family.started")"
+          printf '%s\n' "$(( $(date +%s) - failed_family_started ))" \
+            >"$suite_tmp_dir/$family.elapsed"
+        else
+          remaining_families+=("$family")
+          remaining_pids+=("$pid")
+        fi
+      done
+      active_families=()
+      active_pids=()
+      if [[ "${#remaining_families[@]}" -gt 0 ]]; then
+        active_families=("${remaining_families[@]}")
+        active_pids=("${remaining_pids[@]}")
+      fi
+
+      now="$(date +%s)"
+      if [[ "${#active_families[@]}" -gt 0 && "$now" -ge "$next_progress_at" ]]; then
+        local active_csv
+        active_csv="$(IFS=,; printf '%s' "${active_families[*]}")"
+        printf 'AUTOREVIEW_TEST_PROGRESS family=%s elapsed=%ss\n' \
+          "$active_csv" "$((now - suite_started_at))"
+        next_progress_at=$((now + 20))
+      fi
+      if [[ "${#active_families[@]}" -gt 0 ]]; then
+        sleep 1
+      fi
+    done
+  }
+
+  if [[ "${AUTOREVIEW_TEST_SUITE_SIGNAL_FIXTURE:-}" == "1" ]]; then
+    run_suite_family_group 1 suite-wrapper-fixture
+    if [[ "$(cat "$suite_tmp_dir/suite-wrapper-fixture.status")" != "0" ]]; then
+      cat "$suite_tmp_dir/suite-wrapper-fixture.log" >&2
+    fi
+    printf 'suite wrapper signal fixture exited without cancellation\n' >&2
+    return 1
+  fi
+
+  # Engine lifecycle and signal assertions are timing-sensitive, so this family
+  # remains exclusive even when the rest of the suite uses bounded parallelism.
+  run_suite_family_group 1 engine-isolation
+  run_suite_family_group "$jobs" \
+    target-selection runtime-trust bundle-integrity adapter
+
+  local failed=0
+  local family
+  local status
+  local elapsed
+  for family in \
+    engine-isolation target-selection runtime-trust bundle-integrity adapter; do
+    status="$(cat "$suite_tmp_dir/$family.status")"
+    elapsed="$(cat "$suite_tmp_dir/$family.elapsed")"
+    if [[ "$status" == "0" ]]; then
+      printf 'AUTOREVIEW_TEST_TIMING family=%s status=ok elapsed=%ss\n' \
+        "$family" "$elapsed"
+    else
+      failed=1
+      printf 'AUTOREVIEW_TEST_TIMING family=%s status=failed elapsed=%ss\n' \
+        "$family" "$elapsed"
+    fi
+  done
+
+  if [[ "$failed" -ne 0 ]]; then
+    for family in \
+      engine-isolation target-selection runtime-trust bundle-integrity adapter; do
+      status="$(cat "$suite_tmp_dir/$family.status")"
+      if [[ "$status" != "0" ]]; then
+        printf '\n===== autoreview family failed: %s =====\n' "$family" >&2
+        cat "$suite_tmp_dir/$family.log" >&2
+      fi
+    done
+    return 1
+  fi
+
+  printf 'autoreview test suite passed in %ss with jobs=%s\n' \
+    "$(( $(date +%s) - suite_started_at ))" "$jobs"
+}
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 original_path="$PATH"
@@ -48,11 +406,57 @@ if [[ -z "$trusted_fixture_parent" ]]; then
   printf 'autoreview adversarial tests require a writable fixture parent with non-shared-writable ancestry\n' >&2
   exit 1
 fi
+if [[ "${AUTOREVIEW_TEST_FOCUS:-all}" == "suite-wrapper-fixture" ]]; then
+  fixture_state="${AUTOREVIEW_TEST_SUITE_FIXTURE_STATE:-}"
+  if [[ -z "$fixture_state" || ! -d "$fixture_state" ]]; then
+    printf 'suite wrapper fixture requires an existing state directory\n' >&2
+    exit 2
+  fi
+  printf 'entered\n' >"$fixture_state/entered"
+  fixture_script="$fixture_state/family-worker.mjs"
+  cat >"$fixture_script" <<'NODE'
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const stateDir = process.argv[2];
+const reviewer = spawn(
+  process.execPath,
+  [
+    "-e",
+    'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000);',
+  ],
+  { detached: true, stdio: "ignore" },
+);
+writeFileSync(`${stateDir}/worker.pid`, `${process.pid}\n`);
+writeFileSync(`${stateDir}/reviewer.pid`, `${reviewer.pid}\n`);
+writeFileSync(`${stateDir}/ready`, "ready\n");
+let terminating = false;
+process.on("SIGTERM", () => {
+  if (terminating) return;
+  terminating = true;
+  setTimeout(() => {
+    try {
+      process.kill(-reviewer.pid, "SIGKILL");
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+    writeFileSync(`${stateDir}/cleaned`, "cleaned\n");
+    process.exit(143);
+  }, 500);
+});
+setInterval(() => {}, 1000);
+NODE
+  "$node_bin" "$fixture_script" "$fixture_state" \
+    >"$fixture_state/worker.stdout" 2>"$fixture_state/worker.stderr"
+  exit $?
+fi
+if [[ "${AUTOREVIEW_TEST_FOCUS:-all}" == "suite" ]]; then
+  run_autoreview_test_suite "$@"
+  exit $?
+fi
 tmp_dir="$(/usr/bin/mktemp -d "$trusted_fixture_parent/agent-autoreview-test.XXXXXX")"
 tmp_dir="$(cd "$tmp_dir" && pwd -P)"
-repo_untracked="$repo_root/.agent-autoreview-test-untracked.$$.$RANDOM.txt"
-repo_node_test_dir="$repo_root/.agent-autoreview-node-test.$$.$RANDOM"
-trap 'rm -rf "$tmp_dir" "$repo_untracked" "$repo_node_test_dir"' EXIT
+trap 'rm -rf "$tmp_dir"' EXIT
 node_exec_path="$("$node_bin" -p 'process.execPath')"
 trusted_test_node_dir="$tmp_dir/trusted-test-node"
 mkdir "$trusted_test_node_dir"
@@ -290,20 +694,27 @@ if [[ ! -x /usr/bin/cc ]]; then
 fi
 /usr/bin/cc -O2 -Wall -Wextra -o "$terminal_manifest_node" "$terminal_manifest_node_source"
 
-TMPDIR="$tmp_dir" "$node_bin" "$repo_root/scripts/agent-autoreview-core.test.mjs"
-AUTOREVIEW_TEST_TRUSTED_FIXTURE_PARENT="$tmp_dir" \
+run_core_target_node_tests() {
   TMPDIR="$tmp_dir" \
-  "$node_bin" "$repo_root/scripts/agent-autoreview-target-guard.test.mjs"
-adapter_help="$("$node_bin" "$repo_root/scripts/agent-autoreview.mjs" --help)"
-if [[
-  "$adapter_help" != *"--verify-bundle-dir <dir>"* ||
-    "$adapter_help" != *"--expected-bundle-manifest <sha>"* ||
-    "$adapter_help" != *"--serialize-untracked-file <path>"* ||
-    "$adapter_help" != *"a repo adapter should use --prepare-bundle-dir"*
-]]; then
-  printf 'autoreview help omitted prepared-bundle replacement options\n' >&2
-  exit 1
-fi
+    "$node_bin" "$repo_root/scripts/agent-autoreview-core.test.mjs"
+  AUTOREVIEW_TEST_TRUSTED_FIXTURE_PARENT="$tmp_dir" \
+    TMPDIR="$tmp_dir" \
+    "$node_bin" "$repo_root/scripts/agent-autoreview-target-guard.test.mjs"
+}
+
+run_adapter_help_contract() {
+  local adapter_help
+  adapter_help="$("$node_bin" "$repo_root/scripts/agent-autoreview.mjs" --help)"
+  if [[
+    "$adapter_help" != *"--verify-bundle-dir <dir>"* ||
+      "$adapter_help" != *"--expected-bundle-manifest <sha>"* ||
+      "$adapter_help" != *"--serialize-untracked-file <path>"* ||
+      "$adapter_help" != *"a repo adapter should use --prepare-bundle-dir"*
+  ]]; then
+    printf 'autoreview help omitted prepared-bundle replacement options\n' >&2
+    exit 1
+  fi
+}
 
 helper="$tmp_dir/autoreview-helper"
 trusted_direct_helper_dir="$tmp_dir/trusted-direct-helper"
@@ -2603,6 +3014,159 @@ CODEX
   expect_stderr_contains "reviewer closed stdin early"
 }
 
+run_suite_process_group_cleanup_regression() {
+  local fixture="$tmp_dir/suite-process-group-fixture.mjs"
+  local fixture_state="$tmp_dir/suite-process-group-state"
+  local leader_pid
+  local descendant_pid
+  local launched=0
+  local exited
+  mkdir "$fixture_state"
+  cat >"$fixture" <<'NODE'
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const [role, stateDir] = process.argv.slice(2);
+process.on("SIGTERM", () => {});
+writeFileSync(`${stateDir}/${role}.pid`, `${process.pid}\n`);
+if (role === "leader") {
+  spawn(process.execPath, [import.meta.filename, "child", stateDir], {
+    stdio: "ignore",
+  });
+} else if (role === "child") {
+  spawn(process.execPath, [import.meta.filename, "grandchild", stateDir], {
+    stdio: "ignore",
+  });
+}
+setInterval(() => {}, 1000);
+NODE
+
+  set -m
+  "$node_bin" "$fixture" leader "$fixture_state" &
+  leader_pid=$!
+  set +m
+  for _ in {1..200}; do
+    if [[
+      -s "$fixture_state/leader.pid" &&
+        -s "$fixture_state/child.pid" &&
+        -s "$fixture_state/grandchild.pid"
+    ]]; then
+      launched=1
+      break
+    fi
+    if ! kill -0 "$leader_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  if [[ "$launched" -ne 1 ]]; then
+    kill -KILL -- "-$leader_pid" 2>/dev/null || true
+    wait "$leader_pid" 2>/dev/null || true
+    printf 'suite process-group cleanup fixture did not launch\n' >&2
+    exit 1
+  fi
+
+  terminate_suite_process_group "$leader_pid" 2
+  for role in leader child grandchild; do
+    descendant_pid="$(cat "$fixture_state/$role.pid")"
+    exited=0
+    for _ in {1..100}; do
+      if ! kill -0 "$descendant_pid" 2>/dev/null; then
+        exited=1
+        break
+      fi
+      sleep 0.05
+    done
+    if [[ "$exited" -ne 1 ]]; then
+      kill -KILL "$descendant_pid" 2>/dev/null || true
+      printf 'suite process-group descendant survived cleanup: %s (%s)\n' \
+        "$role" "$descendant_pid" >&2
+      exit 1
+    fi
+  done
+}
+
+run_suite_wrapper_signal_regression() {
+  local fixture_state="$tmp_dir/suite-wrapper-signal-state"
+  local registration_marker="$fixture_state/registration-window"
+  local nested_stdout="$fixture_state/suite.stdout"
+  local nested_stderr="$fixture_state/suite.stderr"
+  local suite_pid
+  local suite_status
+  local descendant_pid
+  local exited
+  local launched=0
+  mkdir "$fixture_state"
+
+  AUTOREVIEW_TEST_FOCUS=suite \
+    AUTOREVIEW_TEST_SUITE_SIGNAL_FIXTURE=1 \
+    AUTOREVIEW_TEST_SUITE_FIXTURE_STATE="$fixture_state" \
+    AUTOREVIEW_TEST_SUITE_REGISTRATION_MARKER="$registration_marker" \
+    /bin/bash "${BASH_SOURCE[0]}" --jobs 1 \
+      >"$nested_stdout" 2>"$nested_stderr" &
+  suite_pid=$!
+  for _ in {1..200}; do
+    if [[ -s "$registration_marker" && -s "$fixture_state/ready" ]]; then
+      launched=1
+      break
+    fi
+    if ! kill -0 "$suite_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  if [[ "$launched" -ne 1 ]]; then
+    kill -TERM "$suite_pid" 2>/dev/null || true
+    wait "$suite_pid" 2>/dev/null || true
+    printf 'nested suite did not reach its wrapper registration window\n' >&2
+    cat "$nested_stdout" >&2
+    cat "$nested_stderr" >&2
+    if [[ -f "$fixture_state/worker.stderr" ]]; then
+      cat "$fixture_state/worker.stderr" >&2
+    fi
+    for role in entered worker reviewer ready; do
+      if [[ -f "$fixture_state/$role.pid" ]]; then
+        printf '%s pid: %s\n' "$role" "$(cat "$fixture_state/$role.pid")" >&2
+      elif [[ -f "$fixture_state/$role" ]]; then
+        printf '%s marker present\n' "$role" >&2
+      fi
+    done
+    exit 1
+  fi
+
+  kill -TERM "$suite_pid"
+  set +e
+  wait "$suite_pid"
+  suite_status=$?
+  set -e
+  if [[ "$suite_status" -eq 0 ]]; then
+    printf 'nested suite exited successfully after cancellation\n' >&2
+    exit 1
+  fi
+  if [[ ! -f "$fixture_state/cleaned" ]]; then
+    printf 'nested suite killed its worker before detached-reviewer cleanup\n' >&2
+    cat "$nested_stderr" >&2
+    exit 1
+  fi
+  for role in worker reviewer; do
+    descendant_pid="$(cat "$fixture_state/$role.pid")"
+    exited=0
+    for _ in {1..100}; do
+      if ! kill -0 "$descendant_pid" 2>/dev/null; then
+        exited=1
+        break
+      fi
+      sleep 0.05
+    done
+    if [[ "$exited" -ne 1 ]]; then
+      kill -KILL "$descendant_pid" 2>/dev/null || true
+      printf 'nested suite cancellation orphaned %s process: %s\n' \
+        "$role" "$descendant_pid" >&2
+      exit 1
+    fi
+  done
+}
+
 run_symlinked_node_codex_regression() {
   local review_repo="$tmp_dir/symlinked-node-codex"
   local fake_bin="$tmp_dir/symlinked-node-codex-bin"
@@ -2643,6 +3207,7 @@ run_repo_controlled_node_regression() {
   local review_repo="$tmp_dir/repo-controlled-node"
   local fake_bin="$tmp_dir/repo-controlled-node-bin"
   local marker="$tmp_dir/repo-controlled-node-ran"
+  local repo_node_test_dir="$adapter_runtime/.agent-autoreview-node-test"
   init_review_repo "$review_repo"
   printf 'base\n' >"$review_repo/README.md"
   commit_review_repo "$review_repo" init
@@ -4259,7 +4824,10 @@ CLAUDE
   chmod +x "$fake_bin/claude"
 
   AUTOREVIEW_HEARTBEAT_SECONDS=1 run_helper_with_path_in_repo "$review_repo" "$fake_bin" --mode local --engine claude --no-tools
-  expect_stderr_contains "review still running: claude elapsed=1s pid="
+  if ! grep -Eq '^review still running: claude elapsed=[0-9]+s pid=[1-9][0-9]*$' "$stderr"; then
+    printf 'expected a well-formed Claude heartbeat\nstderr:\n%s\n' "$(cat "$stderr")" >&2
+    exit 1
+  fi
   expect_stdout_contains "autoreview clean"
 }
 
@@ -4737,73 +5305,20 @@ run_untrusted_cleanup_retention_regression() {
   rm -rf -- "$cleanup_race_staging"
 }
 
-run_default_adapter
-expect_stdout_contains "engine: local"
-expect_empty_stderr
+run_engine_isolation_family() {
+  run_requested_codex_missing_regression
+  run_claude_no_tools_regression
+  run_codex_isolation_regression
+  run_engine_signal_cleanup_regression
+  run_stdin_epipe_regression
+  run_suite_process_group_cleanup_regression
+  run_suite_wrapper_signal_regression
+  run_claude_multi_pass_regression
+  run_heartbeat_regression
+}
 
-run_default_adapter_in_clean_main
-expect_stdout_contains "autoreview target: none"
-expect_stdout_contains "branch: main"
-expect_stdout_contains "engine: local"
-expect_empty_stderr
-
-run_default_adapter_with_inline_engine
-expect_stdout_contains "engine: local"
-expect_empty_stderr
-
-test_focus="${AUTOREVIEW_TEST_FOCUS:-all}"
-case "$test_focus" in
-  engine-isolation)
-    run_claude_no_tools_regression
-    run_codex_isolation_regression
-    run_engine_signal_cleanup_regression
-    run_stdin_epipe_regression
-    printf 'focused autoreview engine-isolation tests passed\n'
-    exit 0
-    ;;
-  signal-cleanup)
-    run_engine_signal_cleanup_regression
-    printf 'focused autoreview signal-cleanup tests passed\n'
-    exit 0
-    ;;
-  review-target-trust)
-    run_review_target_metadata_regression
-    run_trusted_helper_runtime_regression
-    run_same_checkout_explicit_helper_fail_closed_regression
-    run_same_checkout_protected_runtime_regression
-    run_nested_wrapper_fail_closed_regression
-    run_external_wrapper_source_trust_regression
-    printf 'focused autoreview target/trust tests passed\n'
-    exit 0
-    ;;
-  prepared-bundle-safety)
-    run_frozen_checklist_provenance_regression
-    run_prepared_unsupported_path_regressions
-    run_sensitive_input_regressions
-    printf 'focused autoreview prepared-bundle safety tests passed\n'
-    exit 0
-    ;;
-  cleanup-race)
-    run_untrusted_cleanup_retention_regression
-    printf 'focused autoreview cleanup-race tests passed\n'
-    exit 0
-    ;;
-  adapter | all) ;;
-  *)
-    printf 'unknown AUTOREVIEW_TEST_FOCUS: %s\n' "$AUTOREVIEW_TEST_FOCUS" >&2
-    exit 2
-    ;;
-esac
-
-if [[ "$test_focus" == "adapter" || "$test_focus" == "all" ]]; then
-  run_same_checkout_explicit_helper_fail_closed_regression
-  run_same_checkout_protected_runtime_regression
-  run_nested_wrapper_fail_closed_regression
-  run_external_wrapper_source_trust_regression
-fi
-
-if [[ "$test_focus" == "all" ]]; then
-  run_parallel_tests_removed_regression
+run_target_selection_family() {
+  run_core_target_node_tests
   run_review_target_metadata_regression
   run_branch_diff_check_regression
   run_local_deleted_reference_regression
@@ -4814,13 +5329,6 @@ if [[ "$test_focus" == "all" ]]; then
   run_branch_local_diff_check_fixed_regression
   run_branch_local_deleted_reference_regression
   run_branch_local_deleted_reference_fixed_regression
-  run_requested_codex_missing_regression
-  run_claude_no_tools_regression
-  run_codex_isolation_regression
-  run_engine_signal_cleanup_regression
-  run_stdin_epipe_regression
-  run_symlinked_node_codex_regression
-  run_repo_controlled_node_regression
   run_pr_base_detection_regression
   run_target_selection_drift_regression
   run_dry_run_unresolved_ref_regression
@@ -4830,25 +5338,85 @@ if [[ "$test_focus" == "all" ]]; then
   run_mode_source_drift_regression
   run_branch_identity_source_drift_regression
   run_explicit_snapshot_scope_regression
+  run_git_replace_ref_regression
+}
+
+run_runtime_trust_family() {
+  run_same_checkout_explicit_helper_fail_closed_regression
+  run_same_checkout_protected_runtime_regression
+  run_nested_wrapper_fail_closed_regression
+  run_external_wrapper_source_trust_regression
+  run_symlinked_node_codex_regression
+  run_repo_controlled_node_regression
+  run_trusted_helper_runtime_regression
+  run_hostile_git_path_regression
+  run_unsafe_script_fallback_regressions
+  run_privileged_shebang_startup_regression
+  run_hostile_volta_environment_regression
+}
+
+run_bundle_integrity_family() {
   run_frozen_checklist_provenance_regression
   run_prepared_unsupported_path_regressions
   run_frozen_checklist_symlink_regression
-  run_git_replace_ref_regression
-  run_trusted_helper_runtime_regression
   run_prepared_untracked_symlink_regression
   run_feedback_runtime_aggregate_regression
   run_large_untracked_bound_regression
   run_aggregate_untracked_bound_regression
   run_bundle_output_deferred_regression
-  run_claude_multi_pass_regression
-  run_heartbeat_regression
-  run_hostile_git_path_regression
-  run_unsafe_script_fallback_regressions
-  run_privileged_shebang_startup_regression
-  run_hostile_volta_environment_regression
   run_sensitive_input_regressions
   run_attested_untracked_serializer_regression
-fi
+  run_untrusted_cleanup_retention_regression
+}
+
+verify_canonical_family_partition() {
+  local definitions="$tmp_dir/canonical-regression-definitions"
+  local assignments="$tmp_dir/canonical-regression-assignments"
+  local duplicate_assignments="$tmp_dir/canonical-regression-duplicates"
+  local source_file="${BASH_SOURCE[0]}"
+
+  sed -nE \
+    's/^(run_[a-zA-Z0-9_]+_regressions?)\(\) \{$/\1/p' \
+    "$source_file" | LC_ALL=C sort >"$definitions"
+  awk '
+    /^run_(engine_isolation|target_selection|runtime_trust|bundle_integrity|adapter)_family\(\) \{/ {
+      in_family = 1
+      next
+    }
+    /^test_focus=/ { in_family = 0 }
+    in_family && $1 ~ /^run_[a-zA-Z0-9_]+_regressions?$/ { print $1 }
+  ' "$source_file" >"$assignments"
+  LC_ALL=C sort "$assignments" | uniq -d >"$duplicate_assignments"
+  if [[ -s "$duplicate_assignments" ]]; then
+    printf 'autoreview regressions assigned to multiple canonical families:\n' >&2
+    cat "$duplicate_assignments" >&2
+    exit 1
+  fi
+  LC_ALL=C sort "$assignments" -o "$assignments"
+  if ! cmp -s "$definitions" "$assignments"; then
+    printf 'canonical autoreview family partition differs from regression definitions:\n' >&2
+    diff -u "$definitions" "$assignments" >&2 || true
+    exit 1
+  fi
+}
+
+run_adapter_family() {
+  run_adapter_help_contract
+  run_parallel_tests_removed_regression
+
+  run_default_adapter
+  expect_stdout_contains "engine: local"
+  expect_empty_stderr
+
+  run_default_adapter_in_clean_main
+  expect_stdout_contains "autoreview target: none"
+  expect_stdout_contains "branch: main"
+  expect_stdout_contains "engine: local"
+  expect_empty_stderr
+
+  run_default_adapter_with_inline_engine
+  expect_stdout_contains "engine: local"
+  expect_empty_stderr
 
 run_adapter CODEX_SANDBOX=seatbelt --dry-run
 expect_args $'--engine\nlocal\n--dry-run'
@@ -5403,8 +5971,6 @@ if [[ "$(/usr/bin/uname -s)" == "Darwin" ]]; then
     exit 1
   fi
 fi
-
-run_untrusted_cleanup_retention_regression
 
 staging_swap_bundle="$tmp_dir/context-bundle-staging-swap"
 run_adapter_expect_failure \
@@ -5989,12 +6555,27 @@ if [[ -e "$failed_pr_lookup_bundle" ]]; then
   exit 1
 fi
 
-run_adapter_expect_failure --prepare-bundle-dir "$repo_root/.autoreview-bundle" --mode branch --base HEAD
+in_repo_bundle_review_repo="$tmp_dir/in-repo-bundle-review-repo"
+init_review_repo "$in_repo_bundle_review_repo"
+printf 'base\n' >"$in_repo_bundle_review_repo/README.md"
+commit_review_repo "$in_repo_bundle_review_repo" init
+(
+  cd "$in_repo_bundle_review_repo"
+  run_adapter_expect_failure \
+    --prepare-bundle-dir "$in_repo_bundle_review_repo/.autoreview-bundle" \
+    --mode branch \
+    --base HEAD
+)
 expect_stderr_contains "must be outside the repo worktree"
 
-nested_in_repo_parent="$repo_root/.autoreview-test-parent"
-rm -rf "$nested_in_repo_parent"
-run_adapter_expect_failure --prepare-bundle-dir "$nested_in_repo_parent/review" --mode branch --base HEAD
+nested_in_repo_parent="$in_repo_bundle_review_repo/.autoreview-test-parent"
+(
+  cd "$in_repo_bundle_review_repo"
+  run_adapter_expect_failure \
+    --prepare-bundle-dir "$nested_in_repo_parent/review" \
+    --mode branch \
+    --base HEAD
+)
 expect_stderr_contains "must be outside the repo worktree"
 if [[ -e "$nested_in_repo_parent" ]]; then
   printf 'expected rejected in-repo bundle parent not to be created: %s\n' "$nested_in_repo_parent" >&2
@@ -6084,10 +6665,77 @@ subdir_bundle="$tmp_dir/context-bundle-subdir"
 (cd "$repo_root/scripts" && run_adapter --prepare-bundle-dir "$subdir_bundle" --mode branch --base HEAD)
 expect_file_contains "$capture.cwd" "$repo_root"
 
+untracked_review_repo="$tmp_dir/untracked-review-repo"
+init_review_repo "$untracked_review_repo"
+printf 'base\n' >"$untracked_review_repo/README.md"
+commit_review_repo "$untracked_review_repo" init
+repo_untracked="$untracked_review_repo/untracked-review-body.txt"
 printf 'untracked review body\n' >"$repo_untracked"
 untracked_bundle="$tmp_dir/context-bundle-untracked"
 canonical_untracked_bundle="$(cd "$(dirname "$untracked_bundle")" && pwd -P)/$(basename "$untracked_bundle")"
-run_adapter --prepare-bundle-dir "$untracked_bundle" --mode local
+(
+  cd "$untracked_review_repo"
+  run_adapter --prepare-bundle-dir "$untracked_bundle" --mode local
+)
 expect_file_contains "$canonical_untracked_bundle/patches/untracked.diff" "untracked review body"
 
 printf 'agent-autoreview adapter tests passed\n'
+}
+
+test_focus="${AUTOREVIEW_TEST_FOCUS:-all}"
+verify_canonical_family_partition
+case "$test_focus" in
+  engine-isolation)
+    run_engine_isolation_family
+    ;;
+  target-selection)
+    run_target_selection_family
+    ;;
+  runtime-trust)
+    run_runtime_trust_family
+    ;;
+  bundle-integrity)
+    run_bundle_integrity_family
+    ;;
+  adapter)
+    run_adapter_family
+    ;;
+  all)
+    run_engine_isolation_family
+    run_target_selection_family
+    run_runtime_trust_family
+    run_bundle_integrity_family
+    run_adapter_family
+    ;;
+  signal-cleanup)
+    run_engine_signal_cleanup_regression
+    ;;
+  suite-process-cleanup)
+    run_suite_process_group_cleanup_regression
+    ;;
+  suite-wrapper-signal)
+    run_suite_wrapper_signal_regression
+    ;;
+  review-target-trust)
+    run_review_target_metadata_regression
+    run_trusted_helper_runtime_regression
+    run_same_checkout_explicit_helper_fail_closed_regression
+    run_same_checkout_protected_runtime_regression
+    run_nested_wrapper_fail_closed_regression
+    run_external_wrapper_source_trust_regression
+    ;;
+  prepared-bundle-safety)
+    run_frozen_checklist_provenance_regression
+    run_prepared_unsupported_path_regressions
+    run_sensitive_input_regressions
+    ;;
+  cleanup-race)
+    run_untrusted_cleanup_retention_regression
+    ;;
+  *)
+    printf 'unknown AUTOREVIEW_TEST_FOCUS: %s\n' "$test_focus" >&2
+    exit 2
+    ;;
+esac
+
+printf 'focused autoreview %s tests passed\n' "$test_focus"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -163,7 +163,10 @@ cd "$repo_root"
 scratch_dir="$repo_root/.tmp/agent-quality-gate"
 mkdir -p "$scratch_dir"
 success_stamp_file="$scratch_dir/last-success.stamp"
-success_stamp_ttl_seconds=900
+# An exact-signature success may cover the manual-run-to-pre-push interval even
+# for the slowest mapped suites. Keep this fixed rather than environment-
+# configurable so callers cannot extend validation reuse beyond two hours.
+success_stamp_ttl_seconds=$((2 * 60 * 60))
 # Avoid overriding a usable TMPDIR: Terraform providers use go-plugin grpc on
 # a socket in TMPDIR, and repo-local paths can be blocked by agent seatbelts.
 # Trunk hooks can strip TMPDIR entirely, so prefer the system temp directory
@@ -257,6 +260,9 @@ command_dedupe_key() {
   case "$command" in
     "pnpm agent:quality-gate:test"|"bash scripts/agent-quality-gate.test.sh")
       echo "agent-quality-gate.test"
+      ;;
+    "pnpm agent:autoreview:test"|"bash scripts/agent-autoreview.test.sh")
+      echo "agent-autoreview.test"
       ;;
     *)
       echo "$command"
@@ -468,7 +474,7 @@ classify_root_package_json_changes() {
         echo "workspace"
         return
         ;;
-      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:context-budget|/scripts/agent:context-budget:test|/scripts/docs:index|/scripts/docs:index:test|/scripts/docs:audit|/scripts/docs:audit:test|/scripts/docs:garden|/scripts/docs:garden:test|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/sentry:digest|/scripts/sentry:digest:test|/scripts/sentry:autofix:select|/scripts/sentry:autofix:select:test|/scripts/sentry:autofix:finalize:test|/scripts/sentry:archive|/scripts/sentry:archive:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
+      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:context-budget|/scripts/agent:context-budget:test|/scripts/docs:index|/scripts/docs:index:test|/scripts/docs:audit|/scripts/docs:audit:test|/scripts/docs:garden|/scripts/docs:garden:test|/scripts/agent:autoreview|/scripts/agent:autoreview:test|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/sentry:digest|/scripts/sentry:digest:test|/scripts/sentry:autofix:select|/scripts/sentry:autofix:select:test|/scripts/sentry:autofix:finalize:test|/scripts/sentry:archive|/scripts/sentry:archive:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
         saw_tooling_script=true
         ;;
       /scripts)
@@ -1487,7 +1493,7 @@ while IFS= read -r path; do
           add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
           ;;
         scripts/agent-autoreview.sh|scripts/agent-autoreview.test.sh)
-          add_command "bash scripts/agent-autoreview.test.sh" "agent autoreview adapter changed"
+          add_command "pnpm agent:autoreview:test" "agent autoreview adapter changed"
           ;;
         scripts/deploy-bridge.sh)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Run deploy script changed"
@@ -1506,7 +1512,7 @@ while IFS= read -r path; do
       add_command "pnpm lint:scripts" "root build script changed"
       case "$path" in
         scripts/agent-autoreview.mjs|scripts/agent-autoreview-core.mjs|scripts/agent-autoreview-core.test.mjs|scripts/agent-autoreview-target-guard.test.mjs)
-          add_command "bash scripts/agent-autoreview.test.sh" "agent autoreview helper changed"
+          add_command "pnpm agent:autoreview:test" "agent autoreview helper changed"
           ;;
         scripts/check-agent-context.mjs|scripts/check-agent-context-helpers.mjs|scripts/check-agent-context.test.mjs)
           add_command "pnpm agent:context-check" "agent context checker changed"
@@ -1999,6 +2005,46 @@ filter_expected_output() {
   done
 }
 
+is_autoreview_test_command() {
+  local command="$1"
+  case "$command" in
+    *"pnpm agent:autoreview:test"*|*"bash scripts/agent-autoreview.test.sh"*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+latest_autoreview_test_progress() {
+  local output_file="$1"
+  awk '
+    length($0) <= 512 &&
+      $0 ~ /^AUTOREVIEW_TEST_PROGRESS family=[[:alnum:]_,-]+ elapsed=[0-9]+s$/ {
+      latest = $0
+    }
+    END {
+      if (latest != "") {
+        print latest
+      }
+    }
+  ' "$output_file"
+}
+
+print_autoreview_test_timings() {
+  local output_file="$1"
+  # A canonical run currently has only a handful of families. Cap accepted
+  # protocol lines defensively so a noisy child cannot flood otherwise-quiet
+  # successful gate output while preserving each accepted marker verbatim.
+  awk '
+    count < 32 && length($0) <= 512 &&
+      $0 ~ /^AUTOREVIEW_TEST_TIMING family=[[:alnum:]_-]+ status=(ok|failed) elapsed=[0-9]+s$/ {
+      print
+      count++
+    }
+  ' "$output_file"
+}
+
 record_command_summary() {
   local status="$1"
   local elapsed="$2"
@@ -2028,9 +2074,37 @@ print_command_summary() {
   done
 }
 
+monitor_sequential_autoreview_progress() {
+  local command="$1"
+  local output_file="$2"
+  local start_ts="$3"
+  local done_file="$4"
+  local parent_pid="$5"
+  local last_heartbeat_ts="$start_ts"
+  local heartbeat_interval=20
+  local now_ts
+
+  while [[ ! -e "$done_file" ]] && kill -0 "$parent_pid" 2>/dev/null; do
+    sleep 1
+    if [[ -e "$done_file" ]] || ! kill -0 "$parent_pid" 2>/dev/null; then
+      break
+    fi
+    now_ts="$(date +%s)"
+    if [[ $((now_ts - last_heartbeat_ts)) -ge "$heartbeat_interval" ]]; then
+      printf '⏳ still running after %s:\n' "$(format_duration $((now_ts - start_ts)))"
+      printf '    · %s\n' "$command"
+      latest_autoreview_test_progress "$output_file"
+      last_heartbeat_ts="$now_ts"
+    fi
+  done
+}
+
 run_mapped_command() {
   local command="$1"
   local output_file
+  local gate_pid="$$"
+  local monitor_done_file=""
+  local monitor_pid=""
   local start_ts
   local end_ts
   local elapsed
@@ -2040,15 +2114,31 @@ run_mapped_command() {
   start_ts="$(date +%s)"
   echo
   echo "+ ${command}"
+  if is_autoreview_test_command "$command"; then
+    monitor_done_file="${output_file}.done"
+    tmpfiles+=("$monitor_done_file")
+    rm -f "$monitor_done_file"
+    monitor_sequential_autoreview_progress \
+      "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
+    monitor_pid="$!"
+  fi
   set +e
   bash -c "$command" > "$output_file" 2>&1
   exit_code=$?
   set -e
+  if [[ -n "$monitor_pid" ]]; then
+    : > "$monitor_done_file"
+    wait "$monitor_pid" 2>/dev/null || true
+    rm -f "$monitor_done_file"
+  fi
   end_ts="$(date +%s)"
   elapsed=$((end_ts - start_ts))
 
   if [[ "$exit_code" -eq 0 ]]; then
     record_command_summary "ok" "$elapsed" "$command"
+    if is_autoreview_test_command "$command"; then
+      print_autoreview_test_timings "$output_file"
+    fi
     echo "✓ ${command} ($(format_duration "$elapsed"))"
     rm -f "$output_file"
     return 0
@@ -2253,6 +2343,9 @@ run_mapped_entries_parallel() {
 
       if [[ "$status" -eq 0 ]]; then
         record_command_summary "ok" "$elapsed" "$command"
+        if is_autoreview_test_command "$command"; then
+          print_autoreview_test_timings "$output_file"
+        fi
         echo "✓ ${command} ($(format_duration "$elapsed"))"
       else
         failures=$((failures + 1))
@@ -2278,8 +2371,12 @@ run_mapped_entries_parallel() {
       if [[ $((now_ts - last_heartbeat_ts)) -ge "$heartbeat_interval" ]]; then
         printf '⏳ still running after %s (%d/%d done):\n' \
           "$(format_duration $((now_ts - phase_start_ts)))" "$completed" "$total"
-        for hb_cmd in "${active_commands[@]}"; do
+        for i in "${!active_commands[@]}"; do
+          hb_cmd="${active_commands[$i]}"
           printf '    · %s\n' "$hb_cmd"
+          if is_autoreview_test_command "$hb_cmd"; then
+            latest_autoreview_test_progress "${active_output_files[$i]}"
+          fi
         done
         last_heartbeat_ts="$now_ts"
       fi

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1832,6 +1832,192 @@ assert_contains "+ pnpm agent:prewarm:test"
 assert_contains "All mapped commands passed."
 assert_not_contains "parallel marker was not created"
 
+autoreview_progress_repo="$(mktemp -d)"
+(
+  cd "$autoreview_progress_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p bin scripts tools
+  cat > scripts/agent-autoreview.test.sh <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+/bin/sleep 0.1
+printf '%s\n' \
+  'AUTOREVIEW_TEST_PROGRESS family=target-selection elapsed=1s' \
+  'AUTOREVIEW_TEST_PROGRESS family=adapter elapsed=2s'
+echo 'successful autoreview noise that should stay quiet'
+/bin/sleep 2
+printf '%s\n' \
+  'AUTOREVIEW_TEST_TIMING family=target-selection status=ok elapsed=3s' \
+  'AUTOREVIEW_TEST_TIMING family=adapter status=ok elapsed=4s'
+STUB
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == agent:autoreview:test* ]]; then
+  /bin/bash scripts/agent-autoreview.test.sh
+fi
+STUB
+  # Advance the gate's clock by 30 seconds per read so the 20-second heartbeat
+  # can be exercised without adding 20 real seconds to this regression suite.
+  cat > bin/date <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" != "+%s" ]]; then
+  exec /bin/date "$@"
+fi
+lock_dir="${DATE_COUNTER_FILE:?}.lock"
+while ! mkdir "$lock_dir" 2>/dev/null; do
+  /bin/sleep 0.01
+done
+trap 'rmdir "$lock_dir"' EXIT
+value=0
+if [[ -f "$DATE_COUNTER_FILE" ]]; then
+  value="$(cat "$DATE_COUNTER_FILE")"
+else
+  value="$(/bin/date +%s)"
+fi
+value=$((value + 30))
+printf '%s\n' "$value" > "$DATE_COUNTER_FILE"
+printf '%s\n' "$value"
+STUB
+  chmod +x bin/date bin/pnpm scripts/agent-autoreview.test.sh tools/trunk
+  git add .
+  git commit -qm init
+  printf 'scripts/agent-autoreview.test.sh\n' > changed-paths.txt
+  DATE_COUNTER_FILE="$autoreview_progress_repo/date-counter" \
+    PATH="$autoreview_progress_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 4 \
+      > "$output_file" 2>&1
+)
+assert_contains "AUTOREVIEW_TEST_PROGRESS family=adapter elapsed=2s"
+assert_not_contains "AUTOREVIEW_TEST_PROGRESS family=target-selection elapsed=1s"
+assert_contains "AUTOREVIEW_TEST_TIMING family=target-selection status=ok elapsed=3s"
+assert_contains "AUTOREVIEW_TEST_TIMING family=adapter status=ok elapsed=4s"
+assert_not_contains "successful autoreview noise that should stay quiet"
+
+for sequential_mode in parallel-one fail-fast; do
+  sequential_args=(--fail-fast)
+  if [[ "$sequential_mode" == parallel-one ]]; then
+    sequential_args=(--parallel 1)
+  fi
+  (
+    cd "$autoreview_progress_repo"
+    DATE_COUNTER_FILE="$autoreview_progress_repo/date-counter" \
+      PATH="$autoreview_progress_repo/bin:$PATH" \
+      "$repo_root/scripts/agent-quality-gate.sh" \
+        --changed-paths-file changed-paths.txt \
+        --base HEAD \
+        --run \
+        "${sequential_args[@]}" \
+        > "$output_file" 2>&1
+  )
+  assert_contains "AUTOREVIEW_TEST_PROGRESS family=adapter elapsed=2s"
+  assert_contains "AUTOREVIEW_TEST_TIMING family=adapter status=ok elapsed=4s"
+  assert_not_contains "successful autoreview noise that should stay quiet"
+done
+
+(
+  cd "$autoreview_progress_repo"
+  cat > scripts/agent-autoreview.test.sh <<'STUB'
+#!/usr/bin/env bash
+echo 'AUTOREVIEW_TEST_PROGRESS family=runtime-trust elapsed=5s'
+echo 'AUTOREVIEW_TEST_TIMING family=runtime-trust status=failed elapsed=6s'
+echo 'complete autoreview failure diagnostic'
+exit 7
+STUB
+  chmod +x scripts/agent-autoreview.test.sh
+  set +e
+  DATE_COUNTER_FILE="$autoreview_progress_repo/date-counter" \
+    PATH="$autoreview_progress_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 4 \
+      > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]] ||
+    fail "gate did not fail when the autoreview test command failed"
+)
+assert_contains "AUTOREVIEW_TEST_PROGRESS family=runtime-trust elapsed=5s"
+assert_contains "AUTOREVIEW_TEST_TIMING family=runtime-trust status=failed elapsed=6s"
+assert_contains "complete autoreview failure diagnostic"
+
+(
+  cd "$autoreview_progress_repo"
+  cat > scripts/agent-autoreview.test.sh <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" > "${AUTOREVIEW_TEST_PID_FILE:?}"
+echo 'AUTOREVIEW_TEST_PROGRESS family=adapter elapsed=7s'
+sleep 30
+STUB
+  chmod +x scripts/agent-autoreview.test.sh
+  autoreview_pid_file="$autoreview_progress_repo/autoreview-child-pid"
+  gate_output_fifo="$autoreview_progress_repo/gate-output.fifo"
+  rm -f "$autoreview_pid_file" "$gate_output_fifo"
+  mkfifo "$gate_output_fifo"
+  cat "$gate_output_fifo" > "$output_file" &
+  output_reader_pid=$!
+  AUTOREVIEW_TEST_PID_FILE="$autoreview_pid_file" \
+    DATE_COUNTER_FILE="$autoreview_progress_repo/date-counter" \
+    PATH="$autoreview_progress_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --parallel 1 \
+      > "$gate_output_fifo" 2>&1 &
+  gate_pid=$!
+  launched=0
+  for _ in {1..200}; do
+    if [[ -s "$autoreview_pid_file" ]]; then
+      launched=1
+      break
+    fi
+    if ! kill -0 "$gate_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  if [[ "$launched" -ne 1 ]]; then
+    kill -KILL "$gate_pid" 2>/dev/null || true
+    wait "$gate_pid" 2>/dev/null || true
+    kill -KILL "$output_reader_pid" 2>/dev/null || true
+    wait "$output_reader_pid" 2>/dev/null || true
+    fail "sequential autoreview cancellation fixture did not launch"
+  fi
+
+  kill -KILL "$gate_pid"
+  wait "$gate_pid" 2>/dev/null || true
+  kill -KILL "$(cat "$autoreview_pid_file")" 2>/dev/null || true
+  reader_exited=0
+  for _ in {1..100}; do
+    if ! kill -0 "$output_reader_pid" 2>/dev/null; then
+      reader_exited=1
+      break
+    fi
+    sleep 0.05
+  done
+  if [[ "$reader_exited" -ne 1 ]]; then
+    kill -KILL "$output_reader_pid" 2>/dev/null || true
+    wait "$output_reader_pid" 2>/dev/null || true
+    fail "sequential autoreview progress monitor survived its killed gate parent"
+  fi
+  wait "$output_reader_pid" 2>/dev/null || true
+  rm -f "$gate_output_fifo"
+)
+rm -rf "$autoreview_progress_repo"
+
 serialized_repo_mutation_repo="$(mktemp -d)"
 (
   cd "$serialized_repo_mutation_repo"
@@ -1858,12 +2044,17 @@ STUB
 #!/usr/bin/env bash
 exit 0
 STUB
-  cat > bin/pnpm <<'STUB'
+cat > bin/pnpm <<'STUB'
 #!/usr/bin/env bash
-if [[ "$*" == "agent:quality-gate:test" ]]; then
-  sleep 0.2
-  : > "${SERIAL_MUTATION_MARKER:?}"
-fi
+case "$*" in
+  "agent:quality-gate:test")
+    sleep 0.2
+    : > "${SERIAL_MUTATION_MARKER:?}"
+    ;;
+  agent:autoreview:test*)
+    /bin/bash scripts/agent-autoreview.test.sh
+    ;;
+esac
 STUB
   chmod +x bin/pnpm scripts/agent-autoreview.sh scripts/agent-autoreview.test.sh scripts/agent-quality-gate.sh tools/trunk
   git add .
@@ -1883,7 +2074,7 @@ STUB
 )
 rm -rf "$serialized_repo_mutation_repo"
 assert_contains "+ pnpm agent:quality-gate:test"
-assert_contains "+ bash scripts/agent-autoreview.test.sh"
+assert_contains "+ pnpm agent:autoreview:test"
 assert_contains "All mapped commands passed."
 assert_not_contains "autoreview test overlapped the repo-mutating quality-gate self-test"
 
@@ -2100,13 +2291,31 @@ STUB
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --allow-package-script-changes > "$output_file" 2>&1
   git add fixture.txt
   git commit -qm "commit validated content"
+  stamp_file="$fresh_stamp_repo/.tmp/agent-quality-gate/last-success.stamp"
+  stamp_value="$(sed -n '2s/^stamp=//p' "$stamp_file")"
+  printf 'created_at=%s\nstamp=%s\n' \
+    "$(( $(date +%s) - 60 * 60 ))" \
+    "$stamp_value" \
+    > "$stamp_file"
   COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --skip-if-fresh >> "$output_file" 2>&1
   [[ "$(cat "$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
-    fail "fresh gate stamp did not skip flag-less run after allow-flag warm"
+    fail "one-hour-old exact gate stamp did not skip flag-less run after allow-flag warm"
+  grep -Fq -- "Previous successful agent quality gate run is still fresh; skipping mapped commands." "$output_file" ||
+    fail "one-hour-old exact gate stamp did not report a freshness skip"
+
+  printf 'created_at=%s\nstamp=%s\n' \
+    "$(( $(date +%s) - 2 * 60 * 60 - 1 ))" \
+    "$stamp_value" \
+    > "$stamp_file"
+  : > "$output_file"
+  COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --skip-if-fresh >> "$output_file" 2>&1
+  [[ "$(cat "$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "2" ]] ||
+    fail "gate reused an exact success stamp older than the hard two-hour cap"
 )
 rm -rf "$fresh_stamp_repo"
-assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
+assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
 # Workflow changes add the ADR reminder command, whose execution argument uses
 # a randomized changed-paths scratch file. That volatile path must be
@@ -2199,9 +2408,26 @@ STUB
       >> "$output_file" 2>&1
   [[ "$(cat "$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
     fail "fresh gate stamp did not skip duplicate package-risk run"
+  grep -Fq -- "Previous successful agent quality gate run is still fresh; skipping mapped commands." "$output_file" ||
+    fail "acknowledged duplicate package-risk run did not reuse its exact stamp"
+
+  : > "$output_file"
+  if COUNTER_FILE="$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    PATH="$package_risk_fresh_stamp_repo/bin:$PATH" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths.txt \
+      --base HEAD \
+      --run \
+      --skip-if-fresh \
+      > "$output_file" 2>&1; then
+    fail "unacknowledged package-risk run reused an acknowledged success stamp"
+  fi
+  [[ "$(cat "$package_risk_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
+    fail "unacknowledged package-risk run executed mapped commands"
 )
 rm -rf "$package_risk_fresh_stamp_repo"
-assert_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
+assert_contains "Refusing to run because package manifests, patches, or lockfile changed."
+assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
 # A failed ORDERED prerequisite phase (here the preflight `pnpm install`) must
 # stop the run before the parallel quality pool executes. Prerequisite phases
@@ -2282,6 +2508,79 @@ STUB
     fail "fresh gate stamp was reused after worktree content changed"
 )
 rm -rf "$stale_stamp_repo"
+assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
+
+# Extending the reuse window must not weaken any exact-signature binding. Use
+# equal-tree base commits to isolate the base OID, then change the validation
+# path/command plan and the fixture's gate implementation independently. Every
+# change must execute the mapped command again instead of reusing the stamp.
+signature_stamp_repo="$(mktemp -d)"
+(
+  cd "$signature_stamp_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p scripts tools
+  printf 'fixture\n' > fixture.txt
+  printf 'second fixture\n' > second.txt
+  printf '# fixture gate implementation\n' > scripts/agent-quality-gate.sh
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+counter_file="${COUNTER_FILE:?}"
+count=0
+if [[ -f "$counter_file" ]]; then
+  count="$(cat "$counter_file")"
+fi
+printf '%s\n' "$((count + 1))" > "$counter_file"
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  base_one="$(git rev-parse --verify HEAD)"
+  git commit --allow-empty -qm "equal-tree alternate base"
+  base_two="$(git rev-parse --verify HEAD)"
+  printf 'changed\n' >> fixture.txt
+  printf 'fixture.txt\n' > changed-paths-one.txt
+  printf 'fixture.txt\nsecond.txt\n' > changed-paths-two.txt
+
+  COUNTER_FILE="$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths-one.txt \
+      --base "$base_one" \
+      --run \
+      > "$output_file" 2>&1
+  COUNTER_FILE="$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths-one.txt \
+      --base "$base_two" \
+      --run \
+      --skip-if-fresh \
+      > "$output_file" 2>&1
+  [[ "$(cat "$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "2" ]] ||
+    fail "fresh gate stamp was reused after the base OID changed"
+
+  COUNTER_FILE="$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths-two.txt \
+      --base "$base_two" \
+      --run \
+      --skip-if-fresh \
+      > "$output_file" 2>&1
+  [[ "$(cat "$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "3" ]] ||
+    fail "fresh gate stamp was reused after the validation path/command plan changed"
+
+  printf '# changed fixture gate implementation\n' >> scripts/agent-quality-gate.sh
+  COUNTER_FILE="$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths-two.txt \
+      --base "$base_two" \
+      --run \
+      --skip-if-fresh \
+      > "$output_file" 2>&1
+  [[ "$(cat "$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "4" ]] ||
+    fail "fresh gate stamp was reused after the gate implementation changed"
+)
+rm -rf "$signature_stamp_repo"
 assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
 sha256sum_repo="$(mktemp -d)"
@@ -2724,19 +3023,19 @@ assert_contains "- node scripts/check-pr-description.test.mjs (PR description va
 
 run_gate "scripts/agent-autoreview.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview helper changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview helper changed)"
 
 run_gate "scripts/agent-autoreview-core.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview helper changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview helper changed)"
 
 run_gate "scripts/agent-autoreview-core.test.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview helper changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview helper changed)"
 
 run_gate "scripts/agent-autoreview-target-guard.test.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview helper changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview helper changed)"
 
 run_gate "scripts/check-agent-context.mjs"
 assert_contains "- pnpm agent:context-check (agent context checker changed)"
@@ -2804,10 +3103,10 @@ run_gate "scripts/verify-github-environment-protection.test.mjs"
 assert_contains "- node scripts/verify-github-environment-protection.test.mjs (GitHub environment protection checker changed)"
 
 run_gate "scripts/agent-autoreview.sh"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview adapter changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview adapter changed)"
 
 run_gate "scripts/agent-autoreview.test.sh"
-assert_contains "- bash scripts/agent-autoreview.test.sh (agent autoreview adapter changed)"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview adapter changed)"
 
 # Other root-script changes only need the standalone scripts ESLint.
 run_gate "scripts/code-health-history.mjs"

--- a/scripts/check-agent-quality-gate-package-scripts.sh
+++ b/scripts/check-agent-quality-gate-package-scripts.sh
@@ -25,6 +25,7 @@ const expectedScripts = {
   "adr:check": "node scripts/check-adr-reminder.mjs",
   "adr:check:test": "node scripts/check-adr-reminder.test.mjs",
   "agent:autoreview": "./scripts/agent-autoreview.sh",
+  "agent:autoreview:test": "AUTOREVIEW_TEST_FOCUS=suite bash scripts/agent-autoreview.test.sh",
   "issue:board": "node scripts/agent-issue-board.mjs",
   "issue:board:test": "node scripts/agent-issue-board.test.mjs",
   "issue:claim": "node scripts/agent-issue-board.mjs claim",


### PR DESCRIPTION
## The Problem

- Autoreview's adversarial regression suite could keep the mapped quality gate silent for many minutes and made a healthy run look hung.
- The monolithic suite could not expose which family owned the time or safely overlap independent fixtures.
- A successful full gate expired too quickly to cover the normal review-to-push interval, causing unchanged work to rerun.

## The Solution

- Partition the complete autoreview harness into five exact-once families, run independent families with at most three workers, and retain a deterministic sequential closeout mode.
- Emit bounded family progress and timing markers through both parallel and sequential quality-gate paths, with process-group cleanup on cancellation.
- Reuse an exact-signature successful gate for up to two hours and retain the full sequential autoreview suite as an explicit closeout command; hosted-CI enablement is tracked separately.

## What changed

- Keeps engine isolation exclusive, then schedules target selection, runtime trust, bundle integrity, and adapter families with private fixtures/logs and a hard maximum of three workers.
- Preserves every canonical regression exactly once and adds signal-registration, detached-child, wrapper-cancellation, and same-group cleanup coverage.
- Makes `pnpm agent:autoreview:test` the canonical command; `-- --jobs 1` changes scheduling only and is reserved for deterministic autoreview-runtime closeout.
- Relays validated `AUTOREVIEW_TEST_PROGRESS` and `AUTOREVIEW_TEST_TIMING` records without exposing successful command noise; failures still print complete diagnostics.
- Extends the exact-content success stamp from 15 minutes to a fixed two-hour ceiling. Base OID, changed paths and bytes, command plan, package risk, and gate implementation still invalidate it.
- Updates operator/agent documentation around the canonical full-suite command and records hosted-CI hermeticity as a separate follow-up.

## Timing evidence

### Autoreview suite

| Run | Wall time | Notes |
| --- | ---: | --- |
| Prior stable branch-first baseline | 9m56s | Monolithic suite |
| Prior immediate warm baseline | 5m52s | Monolithic suite |
| New default (`jobs=3`) | 3m30s | All families, complete coverage |
| New sequential (`jobs=1`) | 5m11s | Same families and coverage |
| Final reduced mapped-gate run | 3m25s | Default scheduling under the final 32-command gate |

The final reduced 32-command mapped gate finished in about five minutes on this workstation. An immediate exact-signature repeat exited in 4s and skipped every mapped command.

<details>
<summary>Per-command first-run and warm timings</summary>

"First" is the first complete keep-going branch run after dependency hydration; it inherited any existing machine-wide caches. "Warm" is the final all-green run on the frozen PR diff. The first Trunk result exposed the trap-callback annotation fixed before the warm run; every other first-run command passed.

| Mapped command | First | Warm |
| --- | ---: | ---: |
| `pnpm install --frozen-lockfile` | 1s | 2s |
| `pnpm dashboard:codegen` | 1s | 1s |
| `pnpm --filter indexer-envio indexer:bridge-only:codegen` | 2s | 1s |
| `pnpm indexer:testnet:codegen` | 1s | 2s |
| `pnpm indexer:codegen` | 1s | 1s |
| post-codegen `pnpm install --frozen-lockfile` | 0s | 0s |
| generated dashboard type guard | 0s | 0s |
| root Terraform fmt check | 1s | 1s |
| root Terraform init | 1s | 1s |
| root Terraform validate | 1s | 1s |
| alert-rules Terraform fmt check | 0s | 1s |
| alert-rules Terraform init | 1s | 0s |
| alert-rules Terraform validate | 0s | 0s |
| alert-infra Terraform fmt check | 1s | 1s |
| alert-infra Terraform init | 1s | 1s |
| alert-infra Terraform validate | 2s | 2s |
| Aegis Terraform fmt check | 0s | 0s |
| Aegis Terraform init | 0s | 0s |
| Aegis Terraform validate | 1s | 0s |
| dashboard size-limit | 30s | 27s |
| agent quality-gate self-test | 1m33s | 1m39s |
| GitHub Action pin check | 0s | 0s |
| ADR reminder | 0s | 0s |
| version skew check | 0s | 0s |
| workspace lint | 1m00s | 1s |
| workspace typecheck | 31s | 1s |
| dashboard coverage | 58s | 50s |
| workspace knip | 8s | 2s |
| dependency-cruiser checks | 13s | 16s |
| React Doctor score | 8s | 1s |
| indexer coverage | 1m48s | 1m51s |
| metrics-bridge coverage | 4s | 6s |
| integration-probes coverage | 2s | 4s |
| shared-config coverage | 3s | 4s |
| governance-watchdog coverage | 3s | 4s |
| Aegis build | 13s | 8s |
| Aegis coverage | 18s | 11s |
| Aegis Forge tests | 2s | 2s |
| Terraform registry tests | 5s | 5s |
| full Trunk check | 1m11s (failed) | 48s |
| docs index check | 1s | 0s |
| strict context budget | 1s | 0s |
| context standards check | 1s | 0s |
| package-script validator | 1s | 0s |
| agent prewarm tests | 0s | 0s |
| review-materiality tests | 1s | 1s |
| issue-board tests | 0s | 0s |
| Sentry ingest tests | 0s | 1s |
| Sentry digest tests | 0s | 1s |
| Sentry project tests | 0s | 1s |
| Sentry autofix-selection tests | 0s | 1s |
| Sentry autofix-finalize tests | 1s | 1s |
| Sentry archive tests | 1s | 1s |
| PR feedback-state tests | 0s | 0s |
| PR ready-state tests | 0s | 1s |
| Terraform fmt helper tests | 1s | 1s |
| Terraform stack tests | 3s | 4s |
| lockfile lint tests | 3s | 2s |
| version-skew helper tests | 1s | 0s |
| override-prune tests | 1s | 1s |
| ADR-reminder tests | 0s | 0s |
| docs-index tests | 1s | 1s |
| docs-audit tests | 0s | 0s |
| docs-garden issue tests | 0s | 0s |
| context-budget tests | 1s | 1s |
| autoreview harness shell syntax | 0s | 0s |
| autoreview full suite | 3m45s | 3m31s |
| quality-gate shell syntax | 0s | 0s |
| quality-gate test shell syntax | 0s | 0s |
| package-script validator shell syntax | 0s | 0s |

</details>

## Verification

- `pnpm agent:autoreview:test` — passed in 3m30s with `jobs=3`
- `pnpm agent:autoreview:test -- --jobs 1` — passed in 5m11s with identical family coverage
- `pnpm agent:quality-gate --run --allow-package-script-changes` — all mapped commands passed
- `pnpm agent:quality-gate --run --allow-package-script-changes --skip-if-fresh` — exact-signature skip confirmed in 6s
- `bash scripts/agent-quality-gate.test.sh` — passed, including parallel/sequential progress and killed-parent FIFO cleanup
- focused and full Trunk checks — passed
- immutable `origin/main` local autoreview — clean
- fresh-context frozen-diff semantic reviews — clean

Reviewed `docs/pr-checklists/code-health.md`. The final diff changes existing tooling and does not create a new architectural boundary, so no ADR is required.

## Deferrals

- Newly published high-severity `sharp` advisory: #1420
- Autoreview cleanup can misclassify zombie descendants as live: #1421
- Hosted CI exposes non-hermetic ambient-tool assumptions in the suite: #1422

Closes #1401




