### PR TITLE
fix(docs): restore documentation garden gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,42 +93,17 @@ gate in the same worktree. Invocation details, parallelism, cache behavior, the
 server-side full-repository fallback, and common traps live in
 [`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 
-Autoreview keeps this repo's branch-local target (base-to-`HEAD` plus dirty
-tracked and untracked work), deterministic Mento checks, and repo-selected
-checklist/feedback context. It reviews that complete target without truncation,
-but direct semantic engines fail closed when the target needs more than one
-prompt. Prepared bundles retain a bounded, lossless pass index that one
-fresh-context reviewer must inspect completely. Their completion marker binds
-the evidence manifest; run `--verify-bundle-dir` immediately before review,
-retain its printed digest outside the bundle, then pass that digest to the
-post-review check with `--expected-bundle-manifest`. On macOS, write-granting
-ACLs on bundle-parent ancestors or entries fail preparation or verification.
-Automatic feedback capture
-pins the canonical GitHub repository. The owning-checkout default semantic
-helper, feedback-state modules, and checklist policy come from one pinned
-`origin/main` object rather than a PR-selected base, mutable worktree, or
-branch-controlled package scripts; wrapper-owned Node launches discard
-`NODE_OPTIONS`, `NODE_PATH`, and loader/startup injection variables. Direct
-executables require trusted ownership and non-shared-writable ancestry; on
-Darwin, Homebrew-style paths are accepted only through sealed private native
-Mach-O snapshots with system-only library closure, while scripts and unsafe
-library closure fail closed. Runtime-changing PRs must keep the owning-checkout
-refusal intact and use the compatible last-reviewed pre-change wrapper from the
-reviewed checkout; the exact command sequence is in
-`docs/notes/agent-quality-gate-mechanics.md`.
-Checklist edits remain diff evidence. Direct and prepared capture enforce a
-cumulative byte budget before review input accumulates in memory or staging
-sidecars.
-Semantic engines run in an isolated empty workspace with restricted project
-configuration and environment; reviewer web search is disabled by default and
-requires explicit `--web-search`. Review inputs fail closed on sensitive
-content, including wallet recovery phrases.
-Inside an active Codex sandbox, the adapter may choose its local deterministic
-engine only when no engine was explicitly selected; an explicitly selected
-unavailable semantic engine fails closed. Autoreview does not run tests;
-`pnpm agent:quality-gate --run` owns test execution.
-Autoreview is source review, not runtime or behavior proof, so all mapped gate,
-browser, generated-artifact, and runtime verification still applies.
+Autoreview covers the complete branch-local target without truncation. One
+fresh-context reviewer must inspect every prepared-bundle pass, with manifest
+verification before and after review. Capture, bundle-integrity,
+sensitive-input, and runtime-trust failures are fail-closed; so is an explicitly
+selected unavailable semantic engine. Runtime-changing PRs use the compatible
+last-reviewed owning-checkout wrapper. Autoreview reviews source only: it runs
+no tests and proves no behavior, so mapped gate, browser, generated-artifact,
+and runtime checks still apply. Exact target, bundle, isolation, trust,
+engine-selection, and command contracts live in
+[`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md)
+and [`docs/notes/codex-agent-skills.md`](docs/notes/codex-agent-skills.md).
 
 ## PR description standard
 

--- a/scripts/docs-garden-issue.mjs
+++ b/scripts/docs-garden-issue.mjs
@@ -24,7 +24,12 @@ import {
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 const GARDEN_OIDC_AUDIENCE = "mento-docs-garden";
 const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
-const GITHUB_OIDC_REQUEST_HOST = "pipelines.actions.githubusercontent.com";
+const GITHUB_OIDC_REQUEST_HOST_PATTERN =
+  /^pipelines(?:ghub[a-z0-9]+)?\.actions\.githubusercontent\.com$/u;
+
+function isGithubOidcRequestHost(hostname) {
+  return GITHUB_OIDC_REQUEST_HOST_PATTERN.test(hostname);
+}
 
 function parseBoolean(value, name) {
   if (value == null || String(value).trim() === "") return false;
@@ -195,7 +200,7 @@ export async function assertAuthorizedGardenWorkflow(
   }
   if (
     requestUrl.protocol !== "https:" ||
-    requestUrl.hostname !== GITHUB_OIDC_REQUEST_HOST ||
+    !isGithubOidcRequestHost(requestUrl.hostname) ||
     !requestToken
   ) {
     throw new Error("GitHub Actions OIDC runner credentials are unavailable");

--- a/scripts/docs-garden-issue.test.mjs
+++ b/scripts/docs-garden-issue.test.mjs
@@ -640,6 +640,64 @@ await test("OIDC authorization binds creation to the exact workflow run", async 
   assert.equal(request.init.headers.authorization, "bearer runner-bound-token");
 });
 
+await test("OIDC authorization accepts a regional GitHub pipeline host", async () => {
+  const { claims, env, nowSeconds } = workflowOidcFixture();
+  const regionalEnv = {
+    ...env,
+    ACTIONS_ID_TOKEN_REQUEST_URL:
+      "https://pipelinesghubeus13.actions.githubusercontent.com/example/idtoken?api-version=2.0",
+  };
+  let requestedUrl;
+  await assertAuthorizedGardenWorkflow(
+    { repo: "owner/repo" },
+    {
+      env: regionalEnv,
+      now: () => nowSeconds * 1000,
+      fetchImpl: async (url) => {
+        requestedUrl = String(url);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ value: oidcToken(claims) }),
+        };
+      },
+    },
+  );
+  assert.match(
+    requestedUrl,
+    /^https:\/\/pipelinesghubeus13\.actions\.githubusercontent\.com\//,
+  );
+});
+
+await test("OIDC authorization rejects untrusted request URL variants", async () => {
+  const { env } = workflowOidcFixture();
+  const rejectedUrls = [
+    "https://pipelinesghubeus13.actions.githubusercontent.com.evil.example/idtoken",
+    "http://pipelines.actions.githubusercontent.com/idtoken",
+    "https://runner.actions.githubusercontent.com/idtoken",
+  ];
+
+  for (const requestUrl of rejectedUrls) {
+    let fetched = false;
+    await assert.rejects(
+      assertAuthorizedGardenWorkflow(
+        { repo: "owner/repo" },
+        {
+          env: {
+            ...env,
+            ACTIONS_ID_TOKEN_REQUEST_URL: requestUrl,
+          },
+          fetchImpl: async () => {
+            fetched = true;
+          },
+        },
+      ),
+      /runner credentials are unavailable/,
+    );
+    assert.equal(fetched, false);
+  }
+});
+
 await test("OIDC authorization rejects env spoofing and claim drift", async () => {
   const { claims, env, nowSeconds } = workflowOidcFixture();
   let fetched = false;

--- a/scripts/docs-navigation-eval.test.mjs
+++ b/scripts/docs-navigation-eval.test.mjs
@@ -42,14 +42,16 @@ import {
 } from "./docs-navigation-eval.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
-const repoBaseCommit = execFileSync(
-  "git",
-  ["rev-parse", "refs/remotes/origin/main^{commit}"],
-  {
-    cwd: repoRoot,
-    encoding: "utf8",
-  },
-).trim();
+const committedBaseline = JSON.parse(
+  readFileSync(
+    new URL(
+      "../docs/evals/documentation-navigation-baseline.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+const repoBaseCommit = committedBaseline.run.repository_base_commit;
 const scriptPath = fileURLToPath(
   new URL("./docs-navigation-eval.mjs", import.meta.url),
 );


### PR DESCRIPTION
## The Problem

- The first live Documentation Garden dispatch failed before creating its bounded issue because the OIDC guard accepted only GitHub's unsharded pipeline hostname.
- PR #1403's final merge incorporated concurrent documentation growth and left `main` above the navigation evaluation's 250,000-byte route-union cap; its synthetic passing-result helper also read mutable `origin/main`, so a recovery branch could not prove its own correction.

## The Solution

- Accept the narrowly anchored canonical and region-sharded GitHub pipeline hostname family while retaining HTTPS, runner-token, redirect, workflow/ref/run, and JWT-claim checks.
- Move duplicated autoreview implementation detail out of the default-loaded root router, preserving its mandatory boundaries and routing exact mechanics to the canonical notes; anchor synthetic navigation results to the immutable committed baseline while keeping current-worktree feasibility as a separate fixture check.

## Evidence

- Successful no-mutation garden preview: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29901359699
- Failed live garden run that exposed the literal-host assumption: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29901421088
- Current `main` navigation floor before this PR: 250,446 / 250,000 bytes
- Recovered current-worktree floor: 248,759 / 250,000 bytes, with the fixture digest and committed baseline unchanged
- Root instruction budget: 12,229 bytes (99.5%) to 10,542 bytes (85.8%)
- Live packet creation remains intentionally deferred until this fix is merged onto `main`; #1425 stays open for that post-merge proof.

## Verification

- `node scripts/docs-garden-issue.test.mjs` — 29 passed
- `pnpm docs:navigation-eval:test` — 32 passed
- `pnpm docs:navigation-eval -- --check-fixtures` — 1,241 bytes aggregate headroom
- `pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json` — passed unchanged
- `pnpm agent:context-budget --strict` — root router at 85.8%
- `pnpm docs:index --check` — passed
- `pnpm agent:quality-gate --run` — all 11 mapped commands passed
- Fresh-context semantic autoreview — clean, confidence 0.96
- Deterministic local autoreview — clean

Architecture decision: No — these repairs stay within ADR 0040's runner-bound garden authorization and the existing immutable navigation-baseline contract.

Context update: Yes — root `AGENTS.md` now preserves the mandatory autoreview boundaries as a compact router and points exact implementation mechanics to `docs/notes/agent-quality-gate-mechanics.md` and `docs/notes/codex-agent-skills.md`.

Refs #1425
Closes #1427
