### PR TITLE
perf(tooling): Tier-1 local-dev speedups — eslint result cache + dev janitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gha-creds-*.json
 .turbo/
 dist/
 *.tsbuildinfo
+.eslintcache
 .DS_Store
 .vercel/
 .vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,9 @@ pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review check; retain the 
 The gate never deploys or applies Terraform. It refuses package-script or
 package-manager changes until their lifecycle risk is reviewed and explicitly
 acknowledged. Do not run a competing dashboard server/browser suite or second
-gate in the same worktree. Invocation details, parallelism, cache behavior, the
+gate in the same worktree. Run `--run` gates and `git push` in the background;
+a 600s foreground kill discards the freshness stamp.
+Invocation details, parallelism, cache behavior, the
 server-side full-repository fallback, and common traps live in
 [`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,16 +83,15 @@ pnpm agent:quality-gate
 pnpm agent:quality-gate --run
 pnpm agent:autoreview # non-trivial completed batches
 pnpm agent:autoreview:test -- --jobs 1  # autoreview runtime changes only
-pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review check; retain the printed manifest for the bound post-check
+pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review check; retain the printed manifest
 ```
 
 The gate never deploys or applies Terraform. It refuses package-script or
-package-manager changes until their lifecycle risk is reviewed and explicitly
-acknowledged. Do not run a competing dashboard server/browser suite or second
-gate in the same worktree. Run `--run` gates and `git push` in the background;
-a 600s foreground kill discards the freshness stamp.
-Invocation details, parallelism, cache behavior, the
-server-side full-repository fallback, and common traps live in
+package-manager changes until their lifecycle risk is explicitly acknowledged.
+Do not run a competing dashboard server/browser suite or second gate in the
+same worktree. Background `--run` gates and `git push`; a 600s foreground kill
+discards the freshness stamp. Invocation details, parallelism, caching, the
+server-side fallback, and common traps live in
 [`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 
 Autoreview keeps this repo's branch-local target (base-to-`HEAD` plus dirty

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -42,6 +42,11 @@ and timing lines. For deterministic autoreview-runtime closeout, pass
 coverage. Hosted-CI hermeticity remains the separate follow-up tracked in
 #1422.
 
+Agent sessions must run `--run` gate invocations and `git push` as background
+tasks: foreground commands are killed at 600s, and a killed run writes no
+freshness stamp, so the next invocation re-runs the full mapped command set
+instead of hitting `--skip-if-fresh`.
+
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:
 
@@ -502,7 +507,8 @@ concurrently (the heavy `test:coverage` suites and the gate self-test overlap
 instead of summing to the serial total), and it reuses a recent successful
 manual gate run when the fetched base commit, mapped command plan, gate
 implementation, changed paths, validated file content, and package-risk state
-are unchanged. Because it runs in parallel rather than `--fail-fast`, a red
+are unchanged and the recorded success is no older than the freshness TTL
+(two hours). Because it runs in parallel rather than `--fail-fast`, a red
 push runs the remaining in-flight members before failing (green pushes, the
 common case, get the full speedup). Package-script acknowledgement is folded out
 of the reuse key when there is no package-script risk, so a warm

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -146,4 +146,8 @@ pnpm alerts:rules:init / alerts:rules:plan
 # Apply happens via CI on merge to main for alerts-rules, alerts-delivery, and Aegis.
 # The production-infra gate enforces required-reviewer approval and allows
 # self-review for the sole-maintainer workflow.
+
+# Dev janitor
+bash scripts/dev-janitor.sh            # Dry-run: report stale trunk repo caches, pnpm store, git worktrees, /private/tmp trees
+bash scripts/dev-janitor.sh --apply    # Delete stale trunk repo caches, prune pnpm store, and run git worktree prune
 ```

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1512,6 +1512,9 @@ while IFS= read -r path; do
         scripts/agent-autoreview.sh|scripts/agent-autoreview.test.sh)
           add_command "pnpm agent:autoreview:test" "agent autoreview adapter changed"
           ;;
+        scripts/dev-janitor.sh|scripts/dev-janitor.test.sh)
+          add_command "bash scripts/dev-janitor.test.sh" "dev janitor script changed"
+          ;;
         scripts/deploy-bridge.sh)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Run deploy script changed"
           add_command "pnpm agent:context-check" "Cloud Run revision suffix guard changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3141,6 +3141,12 @@ assert_contains "- pnpm agent:autoreview:test (agent autoreview adapter changed)
 run_gate "scripts/agent-autoreview.test.sh"
 assert_contains "- pnpm agent:autoreview:test (agent autoreview adapter changed)"
 
+run_gate "scripts/dev-janitor.sh"
+assert_contains "- bash scripts/dev-janitor.test.sh (dev janitor script changed)"
+
+run_gate "scripts/dev-janitor.test.sh"
+assert_contains "- bash scripts/dev-janitor.test.sh (dev janitor script changed)"
+
 # Other root-script changes only need the standalone scripts ESLint.
 run_gate "scripts/code-health-history.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"

--- a/scripts/dev-janitor.sh
+++ b/scripts/dev-janitor.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev-janitor.sh [--apply]
+
+Reports (and, with --apply, cleans up) stale local dev-machine disk usage:
+trunk repo caches, the pnpm store, pruned git worktree metadata, and stale
+/private/tmp scratch trees. Defaults to dry-run.
+
+Options:
+  --apply   Execute the cleanup actions instead of only reporting them.
+  -h, --help  Show this help.
+
+Environment:
+  JANITOR_TRUNK_REPOS_DIR  Trunk repo cache directory to scan.
+                           Default: $HOME/.cache/trunk/repos
+  JANITOR_STALE_DAYS       Age in days before a trunk repo cache is stale.
+                           Default: 30
+  JANITOR_SKIP_SYSTEM      When set to 1, skip the pnpm store and git
+                           worktree sections (used by tests to avoid
+                           touching real system state).
+USAGE
+}
+
+apply=0
+case "${1:-}" in
+  "") ;;
+  --apply) apply=1 ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+trunk_repos_dir="${JANITOR_TRUNK_REPOS_DIR:-$HOME/.cache/trunk/repos}"
+stale_days="${JANITOR_STALE_DAYS:-30}"
+skip_system="${JANITOR_SKIP_SYSTEM:-0}"
+
+print_disk_free() {
+  df -g / | awk 'NR==2 {print "Free disk: " $4 " GiB"}'
+}
+
+echo "== dev-janitor =="
+if [[ $apply -eq 1 ]]; then
+  echo "Mode: APPLY (destructive actions will run)"
+else
+  echo "Mode: DRY-RUN (nothing will be deleted)"
+fi
+print_disk_free
+echo
+
+echo "-- Trunk repo caches (older than ${stale_days}d, ${trunk_repos_dir}) --"
+stale_repos=()
+if [[ -d "$trunk_repos_dir" ]]; then
+  while IFS= read -r -d '' dir; do
+    stale_repos+=("$dir")
+  done < <(find "$trunk_repos_dir" -maxdepth 1 -mindepth 1 -type d -mtime +"$stale_days" -print0)
+fi
+echo "Found ${#stale_repos[@]} stale trunk repo cache(s)"
+for dir in "${stale_repos[@]+"${stale_repos[@]}"}"; do
+  echo "  $dir"
+done
+if [[ $apply -eq 1 ]]; then
+  for dir in "${stale_repos[@]+"${stale_repos[@]}"}"; do
+    rm -rf "$dir"
+  done
+fi
+echo
+
+echo "-- pnpm store --"
+if [[ "$skip_system" == "1" ]]; then
+  echo "Skipped (JANITOR_SKIP_SYSTEM=1)"
+elif [[ $apply -eq 1 ]]; then
+  pnpm store prune
+else
+  echo "Would run: pnpm store prune"
+fi
+echo
+
+echo "-- Git worktrees --"
+if [[ "$skip_system" == "1" ]]; then
+  echo "Skipped (JANITOR_SKIP_SYSTEM=1)"
+else
+  if [[ $apply -eq 1 ]]; then
+    git worktree prune
+  else
+    echo "Would run: git worktree prune"
+  fi
+  echo "Current worktrees (never auto-deleted; they can hold uncommitted work):"
+  git worktree list
+fi
+echo
+
+echo "-- Stale /private/tmp trees (report only, never deleted) --"
+tmp_count=0
+if [[ -d /private/tmp ]]; then
+  tmp_count="$(find /private/tmp -maxdepth 1 -mindepth 1 -type d \( -iname '*monitoring*' -o -iname '*autoreview*' \) 2>/dev/null | wc -l | tr -d ' ')"
+fi
+echo "Found ${tmp_count} monitoring/autoreview /private/tmp dir(s)"
+echo
+
+if [[ $apply -eq 1 ]]; then
+  echo "== After cleanup =="
+  print_disk_free
+fi

--- a/scripts/dev-janitor.sh
+++ b/scripts/dev-janitor.sh
@@ -64,7 +64,18 @@ echo
 real_root="$(cd "$trunk_repos_dir" 2>/dev/null && pwd -P || true)"
 repo_root="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 real_home="$(cd "$HOME" && pwd -P)"
-if [[ -n "$real_root" && ( "$real_root" == "/" || "$real_root" == "$real_home" || "$real_root" == "$repo_root" ) ]]; then
+unsafe_root=0
+if [[ -n "$real_root" ]]; then
+  if [[ "$real_root" == "/" || "$real_root" == "$real_home" || "$real_root" == "$repo_root" ]]; then
+    unsafe_root=1
+  # Also refuse when the configured root is an *ancestor* of $HOME or the
+  # repo root, not just an exact match — otherwise --apply would delete
+  # depth-1 directories (potentially other users' homes) under it.
+  elif [[ "$real_home" == "$real_root"/* || "$repo_root" == "$real_root"/* ]]; then
+    unsafe_root=1
+  fi
+fi
+if [[ $unsafe_root -eq 1 ]]; then
   echo "refusing to operate on unsafe trunk cache root: $real_root" >&2
   exit 1
 fi

--- a/scripts/dev-janitor.sh
+++ b/scripts/dev-janitor.sh
@@ -6,8 +6,9 @@ usage() {
 Usage: scripts/dev-janitor.sh [--apply]
 
 Reports (and, with --apply, cleans up) stale local dev-machine disk usage:
-trunk repo caches, the pnpm store, pruned git worktree metadata, and stale
-/private/tmp scratch trees. Defaults to dry-run.
+trunk repo caches, the pnpm store, and pruned git worktree metadata. Stale
+/private/tmp scratch trees are reported only, never deleted. Defaults to
+dry-run.
 
 Options:
   --apply   Execute the cleanup actions instead of only reporting them.
@@ -113,7 +114,7 @@ echo
 echo "-- Stale /private/tmp trees (report only, never deleted) --"
 tmp_count=0
 if [[ -d /private/tmp ]]; then
-  tmp_count="$(find /private/tmp -maxdepth 1 -mindepth 1 -type d \( -iname '*monitoring*' -o -iname '*autoreview*' \) 2>/dev/null | wc -l | tr -d ' ')"
+  tmp_count="$( (find /private/tmp -maxdepth 1 -mindepth 1 -type d \( -iname '*monitoring*' -o -iname '*autoreview*' \) 2>/dev/null || true) | wc -l | tr -d ' ')"
 fi
 echo "Found ${tmp_count} monitoring/autoreview /private/tmp dir(s)"
 echo

--- a/scripts/dev-janitor.sh
+++ b/scripts/dev-janitor.sh
@@ -48,7 +48,7 @@ stale_days="${JANITOR_STALE_DAYS:-30}"
 skip_system="${JANITOR_SKIP_SYSTEM:-0}"
 
 print_disk_free() {
-  df -g / | awk 'NR==2 {print "Free disk: " $4 " GiB"}'
+  df -Pk / | awk 'NR==2 {printf "Free disk: %.1f GiB\n", $4/1024/1024}'
 }
 
 echo "== dev-janitor =="
@@ -59,6 +59,14 @@ else
 fi
 print_disk_free
 echo
+
+real_root="$(cd "$trunk_repos_dir" 2>/dev/null && pwd -P || true)"
+repo_root="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+real_home="$(cd "$HOME" && pwd -P)"
+if [[ -n "$real_root" && ( "$real_root" == "/" || "$real_root" == "$real_home" || "$real_root" == "$repo_root" ) ]]; then
+  echo "refusing to operate on unsafe trunk cache root: $real_root" >&2
+  exit 1
+fi
 
 echo "-- Trunk repo caches (older than ${stale_days}d, ${trunk_repos_dir}) --"
 stale_repos=()

--- a/scripts/dev-janitor.test.sh
+++ b/scripts/dev-janitor.test.sh
@@ -38,4 +38,24 @@ if scripts/dev-janitor.sh --bogus-flag > "$output_file" 2>&1; then
   fail "unknown flag exited 0, expected nonzero"
 fi
 
+# Re-create the fixture immediately before the apply run so this test stays
+# order-independent (a prior test may have already deleted old_dir).
+rm -rf "$old_dir" "$fresh_dir"
+mkdir -p "$old_dir" "$fresh_dir"
+touch -t 202501010000 "$old_dir"
+
+if ! JANITOR_TRUNK_REPOS_DIR="$trunk_repos_dir" JANITOR_STALE_DAYS=30 JANITOR_SKIP_SYSTEM=1 \
+  scripts/dev-janitor.sh --apply > "$output_file"; then
+  fail "apply exited nonzero, expected 0"
+fi
+
+[[ ! -d "$old_dir" ]] || fail "apply did not delete the stale trunk repo cache"
+[[ -d "$fresh_dir" ]] || fail "apply deleted the fresh trunk repo cache"
+
+if JANITOR_TRUNK_REPOS_DIR="/" JANITOR_SKIP_SYSTEM=1 scripts/dev-janitor.sh --apply > "$output_file" 2>&1; then
+  fail "apply against unsafe trunk cache root exited 0, expected nonzero"
+fi
+
+grep -q "refus" "$output_file" || fail "apply against unsafe trunk cache root did not explain the refusal"
+
 echo "dev-janitor.test.sh: all checks passed"

--- a/scripts/dev-janitor.test.sh
+++ b/scripts/dev-janitor.test.sh
@@ -58,4 +58,14 @@ fi
 
 grep -q "refus" "$output_file" || fail "apply against unsafe trunk cache root did not explain the refusal"
 
+# An ancestor of the repo root (not just an exact match) must also be
+# refused, or --apply would delete depth-1 directories under it.
+ancestor_of_repo_root="$(dirname "$repo_root")"
+if JANITOR_TRUNK_REPOS_DIR="$ancestor_of_repo_root" JANITOR_SKIP_SYSTEM=1 \
+  scripts/dev-janitor.sh --apply > "$output_file" 2>&1; then
+  fail "apply against an ancestor-of-repo-root cache dir exited 0, expected nonzero"
+fi
+
+grep -q "refus" "$output_file" || fail "apply against an ancestor-of-repo-root cache dir did not explain the refusal"
+
 echo "dev-janitor.test.sh: all checks passed"

--- a/scripts/dev-janitor.test.sh
+++ b/scripts/dev-janitor.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+fixture_dir="$(mktemp -d)"
+output_file="$(mktemp)"
+trap 'rm -rf "$fixture_dir"; rm -f "$output_file"' EXIT
+
+fail() {
+  echo "dev-janitor test failed: $*" >&2
+  echo >&2
+  echo "Last output:" >&2
+  sed 's/^/  /' "$output_file" >&2
+  exit 1
+}
+
+trunk_repos_dir="$fixture_dir/trunk-repos"
+mkdir -p "$trunk_repos_dir"
+old_dir="$trunk_repos_dir/old-repo"
+fresh_dir="$trunk_repos_dir/fresh-repo"
+mkdir -p "$old_dir" "$fresh_dir"
+touch -t 202501010000 "$old_dir"
+# fresh_dir keeps its just-created mtime (today).
+
+if ! JANITOR_TRUNK_REPOS_DIR="$trunk_repos_dir" JANITOR_STALE_DAYS=30 JANITOR_SKIP_SYSTEM=1 \
+  scripts/dev-janitor.sh > "$output_file"; then
+  fail "dry-run exited nonzero, expected 0"
+fi
+
+grep -q "old-repo" "$output_file" || fail "dry-run output did not name the old repo cache"
+grep -q "fresh-repo" "$output_file" && fail "dry-run output named the fresh repo cache as a candidate"
+[[ -d "$old_dir" ]] || fail "dry-run deleted the old repo cache"
+[[ -d "$fresh_dir" ]] || fail "dry-run deleted the fresh repo cache"
+
+if scripts/dev-janitor.sh --bogus-flag > "$output_file" 2>&1; then
+  fail "unknown flag exited 0, expected nonzero"
+fi
+
+echo "dev-janitor.test.sh: all checks passed"

--- a/scripts/eslint-baseline-diff.mjs
+++ b/scripts/eslint-baseline-diff.mjs
@@ -95,7 +95,18 @@ if (eslintInputPath) {
   // running eslint inside the script keeps the contract self-contained.
   const eslintRun = spawnSync(
     "pnpm",
-    ["exec", "eslint", ".", "--format", "json"],
+    [
+      "exec",
+      "eslint",
+      ".",
+      "--format",
+      "json",
+      "--cache",
+      "--cache-strategy",
+      "content",
+      "--cache-location",
+      ".eslintcache",
+    ],
     { cwd, encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
   );
   if (eslintRun.error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- A one-line ui-dashboard edit cost 2m43s–4m23s of local quality gate, and warm reruns were no faster — ESLint re-linted every file on every run (72–94s per package).
- Gate runs killed by the agent-session 600s foreground command cap silently forfeit the freshness stamp, and nothing documented that gate runs and pushes must execute in the background.
- Dev machines accumulate unbounded cache debt: 8.3 GB across 605 trunk repo caches (347 stale >30 days), a 24 GB pnpm store, and 200+ stale /private/tmp scratch trees.

## The Solution

- Turn on ESLint's result cache in the shared baseline-diff wrapper — warm lint drops from 72–94s to 3–5s, cutting the common-case gate run ~38% (2m43s → 1m41s measured).
- Add a conservative dev-janitor script (dry-run by default) that reclaims stale trunk repo caches, prunes the pnpm store, and prunes dead worktree metadata — its first real run reclaimed 347 cache dirs and 3–4 GiB.
- Document the background-execution rule for gate runs and pushes in AGENTS.md and the gate mechanics note.

## Details

- `eslint-baseline-diff.mjs` now passes `--cache --cache-strategy content --cache-location .eslintcache` (content strategy so worktree/mtime churn cannot stale it); `.eslintcache` is gitignored and therefore excluded from turbo `$TURBO_DEFAULT$` inputs. ESLint does not cache files with existing violations, so baselined files re-lint every run — expected; the speedup comes from the clean majority. Two direct eslint invocations (root `lint:scripts`, governance-watchdog `lint`) are split into #1428 because root package-script edits trip the gate's acknowledgement path.
- `dev-janitor.sh` `--apply` scope is strictly: trunk repo caches older than 30 days (env-overridable for tests), `pnpm store prune`, `git worktree prune`. Worktree directories and /private/tmp trees are report-only by design (they can hold uncommitted work). A guard refuses `/`, `$HOME`, and the repo root as the cache dir before any `rm`. The gate maps janitor changes to its fixture-based test (`JANITOR_SKIP_SYSTEM=1`; the `--apply` deletion path is covered against a mktemp fixture only).
- Review provenance: two independent local review passes (six-specialist review + codex CLI). All cross-validated findings applied in-branch: rm -rf root guard, portable `df` (Linux), `--apply` fixture coverage, pipefail-safe tmp scan, usage-text accuracy.
- Rebased onto main after #1419 landed: the originally planned TTL bump (900s → 43200s, issue #1406) was **dropped** in favor of main's deliberate two-hour ceiling ("so callers cannot extend validation reuse beyond two hours"); #1406 is released to grooming with the 2h-vs-12h question. The first commit's subject predates that rebase decision — the squashed PR title is the accurate one.
- Measured baseline and the full audit behind this tier: epic #1404.

## Validation

- `pnpm agent:quality-gate:test` — green post-rebase (3m50s, includes main's #1419 suite changes).
- `bash scripts/dev-janitor.test.sh` — green (dry-run, fixture `--apply`, unsafe-root guard, bad-flag cases).
- `pnpm --filter @mento-protocol/ui-dashboard lint` ×2 — 57.6s cold → 4.8s warm (~12×); before/after benchmark tables on #1404.
- Real `--apply` on the dev machine: 605 → 258 trunk repo caches, +3–4 GiB free, stale worktree metadata pruned.
- `pnpm agent:context-budget --strict` — green.
- Full gate `--run` green pre-rebase (5m45s, tooling-PR class); the pre-push hook re-ran the mapped set on this push.

## Deferrals

- #1428 — eslint cache flags for the two direct invocations (root `lint:scripts`, governance-watchdog `lint`), split out because root package.json script edits trip the gate's package-script acknowledgement path.

Closes #1405
Closes #1407
Closes #1408
Refs #1404, #1406

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — tooling flags plus a maintenance script; no new constraint on future work.
