### PR TITLE
fix(indexer): fail closed on Polygon oracle replay

### DIFF
--- a/.agents/skills/deploy-indexer/SKILL.md
+++ b/.agents/skills/deploy-indexer/SKILL.md
@@ -179,10 +179,10 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 pnpm deploy:indexer:perf <TARGET_COMMIT>
 ```
 
-Treat a successful caught-up exit as `READY_TO_PROMOTE`. If the command exits
-non-zero, the deployment never registers within 5-10 min, or full sync is not
-reached within 90 minutes, stop and surface the failure. **Never promote a
-non-synced deployment.**
+Treat a successful caught-up exit as `SYNCED_PENDING_DATA_VERIFY`, not
+`READY_TO_PROMOTE`. If the command exits non-zero, the deployment never
+registers within 5-10 min, or full sync is not reached within 90 minutes, stop
+and surface the failure. **Never promote a non-synced deployment.**
 
 If the target is already in `prod_status=prod`, treat it as `ALREADY_PROMOTED`
 and continue through the DNS wait + verify path for idempotency.
@@ -193,7 +193,7 @@ synced commit and the paste-ready promote command for the user to run later
 removals/renames until a compatibility or cutover plan is confirmed):
 
 ```text
-Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and ready.
+Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and pending deployment verification.
 For additive fields/entities, promote after the PR lands and before the matching dashboard deployment serves traffic:
   pnpm deploy:indexer:verify <TARGET_COMMIT>
   pnpm deploy:indexer:promote <TARGET_COMMIT> -y
@@ -228,11 +228,25 @@ Run the narrow deployment verifier before promoting:
 pnpm deploy:indexer:verify <TARGET_COMMIT>
 ```
 
-This batches the Envio deployment status, metrics, endpoint resolution, and
-core GraphQL row probe into one pre-promotion gate. Do not promote if this
+This batches the Envio deployment status, metrics, endpoint resolution, core
+GraphQL rows, and Polygon replay semantics into one pre-promotion gate. The
+Polygon checks require the canonical three FPMMs, exact feed/expiry mappings,
+positive historical oracle anchors and snapshot cursors, valid health
+counters, and a current one-year EURm/EUROP oracle. Do not promote if this
 command exits non-zero. `--allow-syncing` is for diagnostics only here: it can
-waive an in-progress chain status during investigation, but it does not waive
-empty GraphQL probe tables and is not a promotion approval.
+waive an in-progress chain status during investigation, but it never waives
+empty rows or semantic failures and is not a promotion approval.
+
+The verifier reads `indexer-envio/config/replay-integrity.json` from the exact
+deployed commit. Missing or outdated marker versions are a hard failure: later
+healthy-looking rows cannot make a candidate replayed by pre-invariant code
+promotion-compatible.
+
+Any `sortedOracles.exactMedianTimestampUnavailable` failure for a tracked pool
+means the event was deliberately rejected and will retry. If an older candidate
+instead reached head after `[RPC_FAILURE] chainId=137 fn=medianTimestamp`,
+classify it as `TAINTED`; never promote it, and deploy a fresh commit for a
+clean replay.
 
 ## Phase 4 — Promote
 
@@ -344,7 +358,7 @@ user to verify manually.
 - **Push to envio fails** → stop; never force-push.
 - **Build doesn't register in 30 min** → stop; suggest `pnpm deploy:indexer:logs --build`.
 - **Sync stalls past 90 min** → stop; report last status. Don't promote.
-- **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, and GraphQL row probe pass.
+- **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, core rows, and semantic replay checks pass. A tainted historical replay requires a fresh deployment, not another promotion attempt.
 - **Promote fails** → stop; the previous deployment is still serving. Surface the error.
 - **DNS wait interrupted** (user cancels) → stop; do not skip to verify.
 - **Verify UI finds errors** → surface them with file/line, ask the user whether to roll back. Don't auto-rollback — promote-to-prior is destructive.

--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -87,7 +87,11 @@ Per-chain fields that matter:
 | `has_processed_to_end_block`              | Only `true` when config has a concrete `end_block`; ignore for live indexers where `end_block: 0` |
 | `num_events_processed`                    | Cumulative; useful for progress feel but not completion                                           |
 
-**"Ready to promote"** = `timestamp_caught_up_to_head_or_endblock` is non-empty on **every** chain in the response. `latest_processed_block === block_height` is a close proxy but can flicker because `block_height` keeps advancing.
+**"Caught up"** = `timestamp_caught_up_to_head_or_endblock` is non-empty on
+**every** chain in the response. This is `SYNCED_PENDING_DATA_VERIFY`, not
+`READY_TO_PROMOTE`: the commit-scoped deployment verifier must still pass.
+`latest_processed_block === block_height` is a close proxy but can flicker
+because `block_height` keeps advancing.
 
 Add `--watch-till-synced` to block until all chains hit 100%. Useful in CI or a foreground terminal; for agentic monitoring, poll with `-o json` and parse.
 
@@ -186,6 +190,12 @@ Notes:
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).
 - **Celo Sepolia / Monad Testnet may fall back to RPC** instead of HyperSync. Slower but works; set `ENVIO_API_TOKEN` for HyperRPC access on testnets.
 - **HyperRPC does NOT support `eth_call`** — only event sync (HyperSync) + a subset of chain-info methods (`eth_blockNumber` etc.). Contract reads in handlers (`client.readContract`, `getBreakers()`, `getReserves()`, etc.) MUST use a full-node RPC (`forno.celo.org` for Celo, `rpc2.monad.xyz` / quiknode for Monad). The constraint is hard-documented in `indexer-envio/src/rpc/client.ts` near `RPC_CONFIG_BY_CHAIN`. Don't suggest "switch to HyperRPC for archive depth" as a perf lever — it won't run the call shape we need at all.
+- **dRPC public JSON-RPC batches are capped at three calls.** The repo applies
+  `{ batchSize: 3 }` to exact `drpc.org` hosts; do not replace it with viem's
+  default 1,000-call batch. Tracked SortedOracles events also fail closed when
+  their exact-block median timestamp remains unavailable after transient retry
+  and fallback. A caught-up deployment with those historical reads missing is
+  tainted and requires a clean replay.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 
 ## Monitoring playbook (agentic)
@@ -194,9 +204,9 @@ When asked to "monitor the latest deployment until ready to promote":
 
 1. `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — required to surface `deployments[]` + `prod_status`. Filter for the newest entry where `prod_status !== "prod"`. (`pnpm deploy:indexer:info <commit>` is the wrapper for inspecting a specific known commit, not for the "find newest pending" step.) If no pending deployment exists, count `deployments[]` first: three live entries means Envio has no room for a new deployment and you must delete, or ask the user to delete, an obsolete non-prod deployment before retrying. If fewer than three deployments exist, cross-check `git rev-parse origin/envio` — if the branch HEAD commit has no deployment record, the build is still pending (or failed → check `--build` logs).
 2. Poll `deployment status <commit> -o json` every 5–15 min (Envio builds finish fast, syncs take minutes–hours).
-3. Ready-to-promote condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`.
-4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, and the GraphQL row probe before promotion.
-5. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
+3. Caught-up condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`; classify this as `SYNCED_PENDING_DATA_VERIFY`.
+4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, core rows, and Polygon replay semantics before promotion. Polygon semantic failures are never waived by `--allow-syncing`.
+5. Only a passing verifier transitions the candidate to `READY_TO_PROMOTE`. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
 
 ## Useful links
 

--- a/.claude/skills/deploy-indexer/SKILL.md
+++ b/.claude/skills/deploy-indexer/SKILL.md
@@ -179,10 +179,10 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 pnpm deploy:indexer:perf <TARGET_COMMIT>
 ```
 
-Treat a successful caught-up exit as `READY_TO_PROMOTE`. If the command exits
-non-zero, the deployment never registers within 5-10 min, or full sync is not
-reached within 90 minutes, stop and surface the failure. **Never promote a
-non-synced deployment.**
+Treat a successful caught-up exit as `SYNCED_PENDING_DATA_VERIFY`, not
+`READY_TO_PROMOTE`. If the command exits non-zero, the deployment never
+registers within 5-10 min, or full sync is not reached within 90 minutes, stop
+and surface the failure. **Never promote a non-synced deployment.**
 
 If the target is already in `prod_status=prod`, treat it as `ALREADY_PROMOTED`
 and continue through the DNS wait + verify path for idempotency.
@@ -193,7 +193,7 @@ synced commit and the paste-ready promote command for the user to run later
 removals/renames until a compatibility or cutover plan is confirmed):
 
 ```text
-Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and ready.
+Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and pending deployment verification.
 For additive fields/entities, promote after the PR lands and before the matching dashboard deployment serves traffic:
   pnpm deploy:indexer:verify <TARGET_COMMIT>
   pnpm deploy:indexer:promote <TARGET_COMMIT> -y
@@ -228,11 +228,25 @@ Run the narrow deployment verifier before promoting:
 pnpm deploy:indexer:verify <TARGET_COMMIT>
 ```
 
-This batches the Envio deployment status, metrics, endpoint resolution, and
-core GraphQL row probe into one pre-promotion gate. Do not promote if this
+This batches the Envio deployment status, metrics, endpoint resolution, core
+GraphQL rows, and Polygon replay semantics into one pre-promotion gate. The
+Polygon checks require the canonical three FPMMs, exact feed/expiry mappings,
+positive historical oracle anchors and snapshot cursors, valid health
+counters, and a current one-year EURm/EUROP oracle. Do not promote if this
 command exits non-zero. `--allow-syncing` is for diagnostics only here: it can
-waive an in-progress chain status during investigation, but it does not waive
-empty GraphQL probe tables and is not a promotion approval.
+waive an in-progress chain status during investigation, but it never waives
+empty rows or semantic failures and is not a promotion approval.
+
+The verifier reads `indexer-envio/config/replay-integrity.json` from the exact
+deployed commit. Missing or outdated marker versions are a hard failure: later
+healthy-looking rows cannot make a candidate replayed by pre-invariant code
+promotion-compatible.
+
+Any `sortedOracles.exactMedianTimestampUnavailable` failure for a tracked pool
+means the event was deliberately rejected and will retry. If an older candidate
+instead reached head after `[RPC_FAILURE] chainId=137 fn=medianTimestamp`,
+classify it as `TAINTED`; never promote it, and deploy a fresh commit for a
+clean replay.
 
 ## Phase 4 — Promote
 
@@ -344,7 +358,7 @@ user to verify manually.
 - **Push to envio fails** → stop; never force-push.
 - **Build doesn't register in 30 min** → stop; suggest `pnpm deploy:indexer:logs --build`.
 - **Sync stalls past 90 min** → stop; report last status. Don't promote.
-- **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, and GraphQL row probe pass.
+- **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, core rows, and semantic replay checks pass. A tainted historical replay requires a fresh deployment, not another promotion attempt.
 - **Promote fails** → stop; the previous deployment is still serving. Surface the error.
 - **DNS wait interrupted** (user cancels) → stop; do not skip to verify.
 - **Verify UI finds errors** → surface them with file/line, ask the user whether to roll back. Don't auto-rollback — promote-to-prior is destructive.

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -87,7 +87,11 @@ Per-chain fields that matter:
 | `has_processed_to_end_block`              | Only `true` when config has a concrete `end_block`; ignore for live indexers where `end_block: 0` |
 | `num_events_processed`                    | Cumulative; useful for progress feel but not completion                                           |
 
-**"Ready to promote"** = `timestamp_caught_up_to_head_or_endblock` is non-empty on **every** chain in the response. `latest_processed_block === block_height` is a close proxy but can flicker because `block_height` keeps advancing.
+**"Caught up"** = `timestamp_caught_up_to_head_or_endblock` is non-empty on
+**every** chain in the response. This is `SYNCED_PENDING_DATA_VERIFY`, not
+`READY_TO_PROMOTE`: the commit-scoped deployment verifier must still pass.
+`latest_processed_block === block_height` is a close proxy but can flicker
+because `block_height` keeps advancing.
 
 Add `--watch-till-synced` to block until all chains hit 100%. Useful in CI or a foreground terminal; for agentic monitoring, poll with `-o json` and parse.
 
@@ -186,6 +190,12 @@ Notes:
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).
 - **Celo Sepolia / Monad Testnet may fall back to RPC** instead of HyperSync. Slower but works; set `ENVIO_API_TOKEN` for HyperRPC access on testnets.
 - **HyperRPC does NOT support `eth_call`** — only event sync (HyperSync) + a subset of chain-info methods (`eth_blockNumber` etc.). Contract reads in handlers (`client.readContract`, `getBreakers()`, `getReserves()`, etc.) MUST use a full-node RPC (`forno.celo.org` for Celo, `rpc2.monad.xyz` / quiknode for Monad). The constraint is hard-documented in `indexer-envio/src/rpc/client.ts` near `RPC_CONFIG_BY_CHAIN`. Don't suggest "switch to HyperRPC for archive depth" as a perf lever — it won't run the call shape we need at all.
+- **dRPC public JSON-RPC batches are capped at three calls.** The repo applies
+  `{ batchSize: 3 }` to exact `drpc.org` hosts; do not replace it with viem's
+  default 1,000-call batch. Tracked SortedOracles events also fail closed when
+  their exact-block median timestamp remains unavailable after transient retry
+  and fallback. A caught-up deployment with those historical reads missing is
+  tainted and requires a clean replay.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 
 ## Monitoring playbook (agentic)
@@ -194,9 +204,9 @@ When asked to "monitor the latest deployment until ready to promote":
 
 1. `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — required to surface `deployments[]` + `prod_status`. Filter for the newest entry where `prod_status !== "prod"`. (`pnpm deploy:indexer:info <commit>` is the wrapper for inspecting a specific known commit, not for the "find newest pending" step.) If no pending deployment exists, count `deployments[]` first: three live entries means Envio has no room for a new deployment and you must delete, or ask the user to delete, an obsolete non-prod deployment before retrying. If fewer than three deployments exist, cross-check `git rev-parse origin/envio` — if the branch HEAD commit has no deployment record, the build is still pending (or failed → check `--build` logs).
 2. Poll `deployment status <commit> -o json` every 5–15 min (Envio builds finish fast, syncs take minutes–hours).
-3. Ready-to-promote condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`.
-4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, and the GraphQL row probe before promotion.
-5. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
+3. Caught-up condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`; classify this as `SYNCED_PENDING_DATA_VERIFY`.
+4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, core rows, and Polygon replay semantics before promotion. Polygon semantic failures are never waived by `--allow-syncing`.
+5. Only a passing verifier transitions the candidate to `READY_TO_PROMOTE`. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
 
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ pnpm deploy:indexer:verify "$COMMIT"
 pnpm deploy:indexer:promote "$COMMIT"
 ```
 
+The status watcher only proves a deployment caught up. Promotion additionally
+requires `deploy:indexer:verify` to pass core-row and Polygon replay semantics;
+`--allow-syncing` never waives those data-integrity checks.
+
 If a promotion turns out bad, roll back with
 `pnpm deploy:indexer:rollback <last-good-sha>` - see
 [docs/deployment.md](./docs/deployment.md#rollback-a-bad-promotion).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,8 +93,8 @@ pnpm deploy:indexer --yes
 1. Wait for the deployed commit to register and catch up to the chain head (`pnpm deploy:indexer:status "$COMMIT" --watch --compact` for low-noise agent output, `pnpm deploy:indexer:status "$COMMIT" --watch` for the full terminal table, or [envio.dev/app](https://envio.dev/app)).
 2. Inspect build and runtime errors with explicit commit-scoped logs (`pnpm deploy:indexer:logs "$COMMIT" --build` and `pnpm deploy:indexer:logs "$COMMIT" --level error,warn --since 2h`).
 3. Capture a combined status/metrics/log snapshot for comparison (`pnpm deploy:indexer:perf "$COMMIT"`).
-4. Verify sync, metrics, endpoint resolution, and core GraphQL rows (`pnpm deploy:indexer:verify "$COMMIT"`).
-5. Promote the same caught-up commit (`pnpm deploy:indexer:promote "$COMMIT"`) so the static production endpoint serves it.
+4. Verify sync, metrics, endpoint resolution, core rows, and fail-closed Polygon replay semantics (`pnpm deploy:indexer:verify "$COMMIT"`). The verifier reads `indexer-envio/config/replay-integrity.json` from that exact commit, so a pre-invariant replay cannot pass merely because later rows look healthy. A caught-up status alone is only `SYNCED_PENDING_DATA_VERIFY`.
+5. Promote the same caught-up, semantically verified commit (`pnpm deploy:indexer:promote "$COMMIT"`) so the static production endpoint serves it.
 6. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
 7. Verify monitoring.mento.org loads data.
 

--- a/docs/notes/polygon-monitoring.md
+++ b/docs/notes/polygon-monitoring.md
@@ -76,8 +76,9 @@ exporter and degraded-mode contract.
 FPMM freshness follows `OracleAdapter` exactly: a rate remains valid until the
 SortedOracles median report timestamp plus that feed's configured expiry. Pool
 events and RPC reconciliation timestamps are diagnostic observations; they do
-not renew the feed TTL. This distinction matters for sparse Polygon FX feeds,
-including the one-year expiries used by the EURm pools.
+not renew the feed TTL. This distinction matters for the sparse Polygon
+EUROP/EUR feed, whose configured expiry is one year. The USDC/USD and EUR/USD
+feeds remain at 150 seconds.
 
 The indexer reads the median timestamp at the event block, stores it in
 `Pool.lastOracleReportAt`, and uses the prior report timestamp and prior expiry
@@ -90,8 +91,16 @@ Deploying a change to these semantics requires a full Envio resync before
 promotion. Existing rows and cumulative health counters were derived with the
 older bounded-carry approximation and cannot be repaired safely in place.
 Verify a candidate only after replay has populated positive
-`lastOracleReportAt` values for all FPMMs and the EURm Polygon pools stay healthy
-inside their configured one-year window.
+`lastOracleReportAt` values for all FPMMs and EURm/EUROP stays healthy inside
+its configured one-year window. Tracked `OracleReported` and `MedianUpdated`
+events now reject a missing exact-block median timestamp, and dRPC batches are
+capped at three calls. A historical `[RPC_FAILURE] chainId=137
+fn=medianTimestamp` on an older candidate makes that replay tainted even if its
+hosted status later reaches head; deploy a fresh commit and replay cleanly.
+The promotion verifier additionally reads the versioned
+`indexer-envio/config/replay-integrity.json` marker from the deployed commit,
+which prevents a pre-fix replay from passing solely because a later event made
+the final pool row look current.
 
 ## Alert conditions
 
@@ -127,11 +136,13 @@ Roll out in this order:
 
 1. From the reviewed PR head, deploy the multichain Envio candidate to the
    `envio` branch without promoting it.
-2. Wait for every chain to reach the hosted head. At the candidate endpoint,
+2. Wait for every chain to reach the hosted head; classify that state as
+   `SYNCED_PENDING_DATA_VERIFY`. At the candidate endpoint,
    verify the three Polygon pools, two NTT tokens, bridge handlers, and exactly
    four active Polygon strategy rows: USDC/USDm Reserve, EURm/USDm Open, plus
    EURm/EUROP Reserve and Open. Then run the repository's commit-scoped
-   deployment verifier.
+   deployment verifier. Only a passing semantic verifier makes the candidate
+   ready to promote; `--allow-syncing` never waives Polygon integrity failures.
 3. Merge the PR. This starts the metrics-bridge and Aegis production-service
    deploys and the protected Terraform workflows in parallel. Keep the
    `alerts-rules` `production-infra` approval pending.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -33,7 +33,7 @@ pnpm deploy:indexer:logs <commit> --level error,warn --since 2h  # Runtime issue
 pnpm deploy:indexer:metrics <commit>  # Per-chain hosted indexing progress
 pnpm deploy:indexer:info <commit>     # Hosted deployment info/cache state
 pnpm deploy:indexer:perf <commit>     # Combined status/metrics/log snapshot for perf comparisons
-pnpm deploy:indexer:verify <commit>   # Batch status, metrics, endpoint, and GraphQL row probe
+pnpm deploy:indexer:verify <commit>   # Gate promotion on sync, core rows, and Polygon replay semantics
 pnpm deploy:indexer:promote <commit>  # Promote a synced deployment to prod
 pnpm deploy:indexer:rollback <last-good-sha>  # Roll prod back: re-promote if still registered, else rebuild + resync
 

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -21,13 +21,14 @@ ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 # ENVIO_RPC_URL_10143="<monad-testnet-full-node-rpc>"    # Monad Testnet primary (default: HyperRPC — needs ENVIO_API_TOKEN)
 # ENVIO_RPC_URL_137="https://polygon.drpc.org"            # Polygon Mainnet primary (default)
 # ENVIO_RPC_URL_80002="https://polygon-amoy.drpc.org"       # Polygon Amoy primary + event sync (default)
+# Public dRPC hosts are automatically capped at 3 calls per JSON-RPC batch.
 
 # --- Per-chain fallback RPC overrides (optional) ---
-# Used by readContractWithBlockFallback for BOTH archive-depth AND rate-limit
-# failover. The fallback URL must therefore cover the full sync window — if
-# the primary rate-limits on a deep historical block and the fallback can't
-# serve it (shallow archive), the helper returns null and the caller skips
-# the entity update for that event. The next event re-tries.
+# Used by readContractWithBlockFallback for archive-depth, rate-limit, and HTTP
+# 5xx failover. The fallback URL must therefore cover the full sync window. A
+# tracked SortedOracles event rejects and retries when its exact historical
+# median timestamp remains unavailable; it must never skip the event and rely
+# on a later event to reconstruct snapshots or health counters.
 #
 # Caveat for the swap pattern: making a deep-archive RPC the primary and a
 # shallow-archive RPC the fallback means rate-limit failover can leak into

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -90,6 +90,7 @@ Deploy branch: `envio` → triggers hosted reindex on push.
 ```bash
 cp indexer-envio/.env.example indexer-envio/.env
 # Mainnet defaults (forno, rpc2.monad.xyz, polygon.drpc.org) work out of the box.
+# dRPC transports are capped at three calls per JSON-RPC batch for replay safety.
 # For testnet, set ENVIO_API_TOKEN or override ENVIO_RPC_URL_10143.
 # For a custom Celo Sepolia provider, set ENVIO_RPC_URL_CELO_SEPOLIA for event
 # sync and ENVIO_RPC_URL_11142220 for handler eth_call reads.
@@ -111,6 +112,10 @@ GraphQL endpoint: `http://localhost:8080/v1/graphql`
   cover the full replay/archive window as well as rate-limit failover. Celo
   Sepolia event sync uses `ENVIO_RPC_URL_CELO_SEPOLIA`; handler contract reads
   use `ENVIO_RPC_URL_11142220`, so a full provider override sets both.
+- Polygon dRPC transports retain batching with a three-call cap. Transient
+  rate-limit and HTTP 5xx errors retry and use a same-block fallback when one is
+  configured. Tracked OracleReported and MedianUpdated events reject a missing
+  exact-block median timestamp so a later event cannot hide replay corruption.
 - Hasura must use port 8080. Envio's startup liveness URL is hard-coded to that
   port, so a different `HASURA_EXTERNAL_PORT` stalls startup. All configs also
   share Docker project `generated`; run only one local indexer at a time.
@@ -136,7 +141,7 @@ pnpm deploy:indexer:logs <commit> --level error,warn --since 2h  # Show runtime 
 pnpm deploy:indexer:metrics <commit>         # Show per-chain indexing progress
 pnpm deploy:indexer:info <commit>            # Show deployment info/cache state
 pnpm deploy:indexer:perf <commit>            # Combined status/metrics/log snapshot for perf comparisons
-pnpm deploy:indexer:verify <commit>          # Batch status, metrics, endpoint, and GraphQL row probe
+pnpm deploy:indexer:verify <commit>          # Gate promotion on sync, core rows, and Polygon replay semantics
 pnpm deploy:indexer:promote <commit>         # Promote a synced deployment to prod
 ```
 
@@ -273,6 +278,16 @@ pnpm deploy:indexer:perf "$COMMIT"
 pnpm deploy:indexer:verify "$COMMIT"
 pnpm deploy:indexer:promote "$COMMIT"
 ```
+
+A caught-up watcher exit is `SYNCED_PENDING_DATA_VERIFY`, not promotion
+readiness. The verifier must pass the canonical Polygon FPMM feed/expiry,
+oracle-anchor, snapshot-cursor, and health-counter checks before promotion.
+It also reads `config/replay-integrity.json` from the deployed commit. That
+versioned marker is the commit-scoped proof that the candidate was replayed by
+code enforcing the exact-median fail-closed invariant; a candidate whose commit
+lacks the required version is never promotion-compatible even if later rows
+look healthy. Bump a marker only in the same change as the new replay invariant
+and its handler-level regression tests.
 
 The `mento` project on Envio Cloud watches this branch. Envio registers
 deployments under the short commit hash, and the registration can lag the Git

--- a/indexer-envio/config/replay-integrity.json
+++ b/indexer-envio/config/replay-integrity.json
@@ -1,0 +1,3 @@
+{
+  "polygonExactMedianTimestamp": 1
+}

--- a/indexer-envio/knip.json
+++ b/indexer-envio/knip.json
@@ -5,6 +5,8 @@
     "src/EventHandlersBridgeOnly.ts",
     "src/indexer.ts",
     "vitest.mutation.config.ts",
+    "vitest.fail-closed.config.ts",
+    "test/fixtures/failClosedSortedOracles.case.ts",
     "scripts/*.mjs"
   ],
   "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.mjs", "*.config.*"],

--- a/indexer-envio/src/handlers/exact-median-timestamp.ts
+++ b/indexer-envio/src/handlers/exact-median-timestamp.ts
@@ -1,0 +1,33 @@
+import type { Logger } from "envio";
+
+type SortedOraclesMedianEvent = "OracleReported" | "MedianUpdated";
+
+/**
+ * Historical oracle events cannot be reconstructed from a later state-sync.
+ * Reject a tracked event when its exact-block median timestamp read failed so
+ * Envio retries the event instead of committing incomplete snapshots and
+ * health counters.
+ */
+export function requireExactMedianTimestamp({
+  timestamp,
+  eventName,
+  chainId,
+  rateFeedID,
+  blockNumber,
+  log,
+}: {
+  timestamp: bigint | null;
+  eventName: SortedOraclesMedianEvent;
+  chainId: number;
+  rateFeedID: string;
+  blockNumber: bigint;
+  log: Logger;
+}): bigint {
+  if (timestamp !== null) return timestamp;
+
+  const message =
+    `sortedOracles.exactMedianTimestampUnavailable event=${eventName} ` +
+    `chainId=${chainId} feed=${rateFeedID} block=${blockNumber}`;
+  log.error(message);
+  throw new Error(message);
+}

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -48,6 +48,7 @@ import {
   syncHaltOnColdStart,
 } from "../breakers.js";
 import { ensureRateFeed, preloadRateFeed } from "./rateFeed.js";
+import { requireExactMedianTimestamp } from "./exact-median-timestamp.js";
 
 function priceDifferenceForOracleSample(
   pool: Pool,
@@ -469,9 +470,17 @@ indexer.onEvent(
     if (poolIds.length === 0) return;
 
     const blockTimestamp = asBigInt(event.block.timestamp);
-    const medianTimestamp = medianTimestampPromise
+    let medianTimestamp = medianTimestampPromise
       ? await medianTimestampPromise
       : null;
+    medianTimestamp = requireExactMedianTimestamp({
+      timestamp: medianTimestamp,
+      eventName: "OracleReported",
+      chainId: event.chainId,
+      rateFeedID,
+      blockNumber,
+      log: context.log,
+    });
     const reportExpiry = reportExpiryPromise ? await reportExpiryPromise : null;
 
     await ensureRateFeed({
@@ -622,9 +631,19 @@ indexer.onEvent(
     if (poolIds.length === 0 && breakerConfigs.length === 0) return;
 
     const blockTimestamp = asBigInt(event.block.timestamp);
-    const medianTimestamp = medianTimestampPromise
+    let medianTimestamp = medianTimestampPromise
       ? await medianTimestampPromise
       : null;
+    if (poolIds.length > 0) {
+      medianTimestamp = requireExactMedianTimestamp({
+        timestamp: medianTimestamp,
+        eventName: "MedianUpdated",
+        chainId: event.chainId,
+        rateFeedID,
+        blockNumber,
+        log: context.log,
+      });
+    }
     const reportExpiry = reportExpiryPromise ? await reportExpiryPromise : null;
 
     await ensureRateFeed({

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -1,16 +1,17 @@
 // `readContractWithBlockFallback` — the shared retry/fallback primitive every
 // fetcher in rpc.ts wraps `client.readContract` in. Two transient-failure
-// modes are handled here so individual fetchers don't have to: rate-limit
+// modes are handled here so individual fetchers don't have to: transient RPC
 // retries (with secondary-RPC fallback) and "block not yet on this node"
 // retries (with a same-block secondary attempt before `latest` fallback).
 
 import type { createPublicClient, ReadContractParameters } from "viem";
 import {
-  RATE_LIMIT_RETRY_DELAYS_MS,
+  RPC_TRANSIENT_RETRY_DELAYS_MS,
   _resetRpcFailureCounts,
   describeKnownRevert,
   fallbackLikelyHasBlock,
   isRateLimitError,
+  isRetryableRpcError,
   logRpcFailure,
   recordFallbackArchiveMiss,
   sanitizeErrorMessage,
@@ -140,6 +141,7 @@ export const _testHooks = {
     new Promise((resolve) => setTimeout(resolve, ms)),
   nowFn: (): number => Date.now(),
   isRateLimitError: (err: unknown): boolean => isRateLimitError(err),
+  isRetryableRpcError: (err: unknown): boolean => isRetryableRpcError(err),
   logRpcFailure: (
     chainId: number,
     fn: string,
@@ -173,8 +175,8 @@ type RecoveryDeps = {
 /**
  * Wrapper around `client.readContract` that handles two transient failure modes:
  *
- * 1. **Rate limits** — retries with backoff, then falls back to a secondary
- *    (public) RPC client if available.
+ * 1. **Transient RPC failures** — retries rate limits and HTTP 5xx responses
+ *    with backoff, then falls back to a secondary RPC client if available.
  * 2. **Block not available** — retries the original block with backoff, then
  *    tries the secondary RPC at the same block before falling back to "latest".
  *
@@ -216,8 +218,8 @@ export async function readContractWithBlockFallback(
       log,
     };
     let currentError: unknown = initialErr;
-    if (isRateLimitError(currentError)) {
-      const outcome = await attemptRateLimitRecovery(deps, currentError);
+    if (isRetryableRpcError(currentError)) {
+      const outcome = await attemptTransientRecovery(deps, currentError);
       if (outcome.kind === "result") return outcome.value;
       // fallthrough: archive-depth surfaced from a retry — try archive branch
       currentError = outcome.error;
@@ -265,30 +267,30 @@ function isBlockNotAvailableErr(
   );
 }
 
-/** Rate-limit retry can finish in three states: a recovered result, a non-rate-limit
- *  archive-depth error that should re-enter the archive-depth branch, or a thrown
- *  error (handled by caller). */
-type RateLimitOutcome =
+/** Transient retry can finish in three states: a recovered result, an
+ * archive-depth error that should re-enter the archive-depth branch, or a
+ * thrown error (handled by the caller). */
+type TransientOutcome =
   | { kind: "result"; value: BlockFallbackResult }
   | { kind: "fallthrough"; error: unknown };
 
-/** Retry the original call against the primary until rate-limit clears. If a
- *  retry surfaces an archive-depth error (primary recovered from 429 but lacks
+/** Retry the original call against the primary until the transient failure
+ *  clears. If a retry surfaces an archive-depth error (primary recovered but lacks
  *  archive depth for the requested block), return `fallthrough` so the
  *  dispatcher consults the archive-depth secondary path. BLOCK_NOT_AVAILABLE
  *  errors surfaced from a retry are thrown instead — silently swapping in
- *  `latest` after a 429-then-block-miss would corrupt historical entity state
+ *  `latest` after a transient-then-block-miss would corrupt historical state
  *  for callers that destructure `result` without checking `usedLatestFallback`. */
-async function retryThroughRateLimit(
+async function retryThroughTransientError(
   deps: RecoveryDeps,
   initialError: unknown,
-): Promise<RateLimitOutcome | { kind: "exhausted"; error: unknown }> {
+): Promise<TransientOutcome | { kind: "exhausted"; error: unknown }> {
   const { callWithBlock, fn, target, log } = deps;
   let surfacedError: unknown = initialError;
-  for (let i = 0; i < RATE_LIMIT_RETRY_DELAYS_MS.length; i++) {
-    const delay = RATE_LIMIT_RETRY_DELAYS_MS[i] ?? 0;
+  for (let i = 0; i < RPC_TRANSIENT_RETRY_DELAYS_MS.length; i++) {
+    const delay = RPC_TRANSIENT_RETRY_DELAYS_MS[i] ?? 0;
     log.debug(
-      `[RPC_RATE_LIMIT_RETRY] fn=${fn} target=${target} retry=${i + 1}/${RATE_LIMIT_RETRY_DELAYS_MS.length} delay=${delay}ms`,
+      `[RPC_TRANSIENT_RETRY] fn=${fn} target=${target} retry=${i + 1}/${RPC_TRANSIENT_RETRY_DELAYS_MS.length} delay=${delay}ms`,
     );
     await _testHooks.delayFn(delay);
     try {
@@ -298,7 +300,7 @@ async function retryThroughRateLimit(
         value: { result, usedFallback: false, usedLatestFallback: false },
       };
     } catch (retryErr) {
-      if (isRateLimitError(retryErr)) {
+      if (isRetryableRpcError(retryErr)) {
         surfacedError = retryErr;
         continue;
       }
@@ -314,31 +316,31 @@ async function retryThroughRateLimit(
   return { kind: "exhausted", error: surfacedError };
 }
 
-/** Rate-limit dispatcher: drive retries, then attempt the secondary RPC at the
+/** Transient-failure dispatcher: drive retries, then attempt the secondary at the
  *  same block when the fallback's known horizon covers it. Returns a result if
  *  one of those succeeded, or `fallthrough` so the dispatcher reconsiders the
  *  current error against the archive-depth branch. */
-async function attemptRateLimitRecovery(
+async function attemptTransientRecovery(
   deps: RecoveryDeps,
   initialError: unknown,
-): Promise<RateLimitOutcome> {
+): Promise<TransientOutcome> {
   const { chainId, makeCall, fallbackClient, blockNumber, fn, target, log } =
     deps;
-  const retried = await retryThroughRateLimit(deps, initialError);
+  const retried = await retryThroughTransientError(deps, initialError);
   if (retried.kind === "result" || retried.kind === "fallthrough") {
     return retried;
   }
-  // Retries exhausted with rate-limit still in place — try the secondary IF
+  // Retries exhausted with a transient failure still in place — try the secondary IF
   // its archive horizon covers the requested block. A call to a fallback we
   // know lacks the block would just surface a confusing archive-miss error
-  // masking the rate-limit cause, and waste a round trip.
+  // masking the original transient failure, and waste a round trip.
   if (
     fallbackClient &&
     fallbackLikelyHasBlock(chainId, blockNumber) &&
     fallbackCooldownAllows(deps)
   ) {
     log.warn(
-      `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
+      `[RPC_TRANSIENT_FALLBACK] fn=${fn} target=${target} — primary unavailable after retries, using fallback RPC`,
     );
     try {
       const result = await makeCall(fallbackClient, blockNumber);

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -1,9 +1,9 @@
 // RPC client management, structured failure logging, and rate-limit
 // detection. Extracted from rpc.ts in PR-S6; pinned by rpcClient.test.ts +
 // hyperRpcToken.test.ts. The internal helpers (`isRateLimitError`,
-// `logRpcFailure`, `_resetRpcFailureCounts`, `RATE_LIMIT_RETRY_DELAYS_MS`)
-// are imported by rpc.ts for use by its remaining fetchers and the
-// `_testHooks` proxy.
+// `isRetryableRpcError`, `logRpcFailure`, `_resetRpcFailureCounts`,
+// `RPC_TRANSIENT_RETRY_DELAYS_MS`) are imported by rpc.ts for use by its
+// remaining fetchers and the `_testHooks` proxy.
 
 import { createPublicClient, http } from "viem";
 
@@ -196,26 +196,39 @@ const RPC_CONFIG_BY_CHAIN: Record<number, { default: string; envVar: string }> =
     }, // Monad Testnet (no public full-node RPC known)
   };
 
-/** True when viem's JSON-RPC batching is safe for this RPC URL.
+export type RpcBatchConfig = boolean | { batchSize: number };
+
+/** Return the viem JSON-RPC batching policy for an RPC URL.
  *
  * Monad's tokenized monadinfra primary currently serves historical
  * `eth_call`s correctly when the request body is a single JSON-RPC object,
  * but returns "Block requested not found" when the exact same call is wrapped
  * in a JSON-RPC batch array. `latest` batch calls still work, which makes the
  * failure look like an archive-depth miss during backfills. Disable batching
- * only for that host so historical reads stay on the primary and don't spill
+ * for that exact host so historical reads stay on the primary and don't spill
  * into archive fallback unnecessarily.
+ *
+ * dRPC's public endpoints allow at most three calls in one JSON-RPC batch.
+ * Viem otherwise defaults to batches of up to 1,000 calls, which can turn an
+ * Envio replay burst into HTTP 500 responses. Keep batching enabled for dRPC,
+ * but cap every `drpc.org` host (including Polygon mainnet and Amoy) at the
+ * provider's documented limit.
  */
-export function rpcBatchEnabledForUrl(url: string): boolean {
+export function rpcBatchConfigForUrl(url: string): RpcBatchConfig {
   try {
-    return new URL(url).hostname !== "rpc-mainnet.monadinfra.com";
+    const hostname = new URL(url).hostname;
+    if (hostname === "rpc-mainnet.monadinfra.com") return false;
+    if (hostname === "drpc.org" || hostname.endsWith(".drpc.org")) {
+      return { batchSize: 3 };
+    }
+    return true;
   } catch {
     return true;
   }
 }
 
 function rpcTransport(url: string): ReturnType<typeof http> {
-  return http(url, { batch: rpcBatchEnabledForUrl(url) });
+  return http(url, { batch: rpcBatchConfigForUrl(url) });
 }
 
 /**
@@ -443,7 +456,7 @@ export function fallbackLikelyHasBlock(
 }
 
 // ---------------------------------------------------------------------------
-// Rate limit detection & retry
+// Transient provider failure detection & retry
 // ---------------------------------------------------------------------------
 
 /** Matches common rate-limit error messages from RPC providers.
@@ -454,7 +467,7 @@ export function fallbackLikelyHasBlock(
  * - Generic / RFC 6585: `429`, `too many requests`, `throttled`
  *
  * Add new provider phrasings here when they show up in `[RPC_FAILURE]`
- * lines that should have been retried + faled-over instead. Without a
+ * lines that should have been retried + failed over instead. Without a
  * match, the rate-limit retry/fallback path in `block-fallback.ts` is
  * skipped and the error escapes to the caller (visible as a viem stack
  * trace dump in the logs). */
@@ -467,5 +480,17 @@ export function isRateLimitError(err: unknown): boolean {
   return RATE_LIMIT_RE.test(err.message);
 }
 
-/** Delays for rate-limit retries before falling back. */
-export const RATE_LIMIT_RETRY_DELAYS_MS = [200, 500, 1000];
+/** Matches provider/network HTTP failures that are normally safe to retry.
+ * Keep the numeric alternatives anchored to HTTP/status wording so an
+ * unrelated block number such as 500 is never treated as transient. */
+const TRANSIENT_SERVER_ERROR_RE =
+  /(?:\b(?:http(?:\s+status)?|status(?:\s+code)?)\s*[:=]?\s*(?:500|502|503|504)\b)|(?:\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway timeout\b)/i;
+
+/** Returns true for rate limiting and retryable HTTP 5xx provider failures. */
+export function isRetryableRpcError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return isRateLimitError(err) || TRANSIENT_SERVER_ERROR_RE.test(err.message);
+}
+
+/** Delays for transient RPC retries before falling back. */
+export const RPC_TRANSIENT_RETRY_DELAYS_MS = [200, 500, 1000];

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -674,7 +674,10 @@ export const medianTimestampEffect = createEffect(
       blockNumber: S.bigint,
     },
     output: S.nullable(S.bigint),
-    rateLimit: { calls: 200, per: "second" },
+    // dRPC's stressed public-tier floor is 40 eth_call/s. This exact-block
+    // read fans out during Polygon replays, so stay within that floor instead
+    // of creating a retry/fallback storm after transport-level batching.
+    rateLimit: { calls: 40, per: "second" },
     cache: false,
   },
   async ({ input, context }) =>

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -407,6 +407,92 @@ describe("readContractWithBlockFallback", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Transient HTTP failures
+  // -------------------------------------------------------------------------
+
+  it("retries a viem HTTP 500 at the same historical block and recovers", async () => {
+    const calls: MockReadContractArgs[] = [];
+    const captured = captureLogs();
+    const client = mockClient(async (args) => {
+      calls.push({ ...args });
+      if (calls.length === 1) {
+        throw new Error(
+          "HTTP request failed.\nStatus: 500\nURL: https://polygon.drpc.org",
+        );
+      }
+      return "recovered";
+    });
+
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      baseArgs,
+      90_450_421n,
+      null,
+      captured.logger,
+    );
+
+    assert.equal(res.result, "recovered");
+    assert.equal(res.usedFallback, false);
+    assert.equal(res.usedLatestFallback, false);
+    assert.equal(calls.length, 2);
+    assert.ok(calls.every((call) => call.blockNumber === 90_450_421n));
+    assert.match(captured.debug.join("\n"), /RPC_TRANSIENT_RETRY/);
+  });
+
+  it("uses the secondary at the same block after persistent HTTP 5xx", async () => {
+    const primaryCalls: MockReadContractArgs[] = [];
+    const fallbackCalls: MockReadContractArgs[] = [];
+    const primary = mockClient(async (args) => {
+      primaryCalls.push({ ...args });
+      throw new Error("HTTP request failed. Status: 503 Service Unavailable");
+    });
+    const fallback = mockClient(async (args) => {
+      fallbackCalls.push({ ...args });
+      return "secondary-block-result";
+    });
+
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      primary,
+      baseArgs,
+      90_450_421n,
+      fallback,
+    );
+
+    assert.equal(res.result, "secondary-block-result");
+    assert.equal(res.usedFallback, true);
+    assert.equal(res.usedLatestFallback, false);
+    assert.equal(primaryCalls.length, 4);
+    assert.equal(fallbackCalls.length, 1);
+    assert.equal(fallbackCalls[0].blockNumber, 90_450_421n);
+  });
+
+  it("fails closed after persistent HTTP 5xx without a secondary", async () => {
+    const calls: MockReadContractArgs[] = [];
+    const client = mockClient(async (args) => {
+      calls.push({ ...args });
+      throw new Error("HTTP request failed. Status: 504 Gateway Timeout");
+    });
+
+    await assert.rejects(
+      readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        client,
+        baseArgs,
+        90_450_421n,
+        null,
+      ),
+      /Status: 504/,
+    );
+    assert.equal(calls.length, 4);
+    assert.ok(
+      calls.every((call) => call.blockNumber === 90_450_421n),
+      "transient recovery must never replace a historical read with latest",
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // Archive-depth fallback (primary's archive doesn't reach this block, but
   // a deeper-archive secondary does). Distinct from rate-limit fallback
   // because the secondary is consulted on the archive-depth error pattern,

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -12,6 +12,8 @@ import {
   _setMockBreakerList,
   _clearBreakerMocks,
   _clearBootstrapCaches,
+  _clearMockMedianTimestamps,
+  _setMockMedianTimestamp,
 } from "../src/EventHandlers.ts";
 import {
   makeBreakerConfigId,
@@ -48,6 +50,7 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
   beforeEach(() => {
     _clearBreakerMocks();
     _clearBootstrapCaches();
+    _setMockMedianTimestamp(CHAIN_ID, FEED, 1_700_001_950n);
     // RPC self-heal payload for fetchBreakerKind / Defaults / FeedState.
     _setMockBreakerList(CHAIN_ID, [MD_BREAKER]);
     _setMockBreakerKind(CHAIN_ID, MD_BREAKER, "MEDIAN_DELTA");
@@ -70,6 +73,7 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
 
   afterEach(() => {
     _clearBreakerMocks();
+    _clearMockMedianTimestamps();
   });
 
   it("BreakerStatusUpdated bootstraps Breaker + BreakerConfig from RPC mocks", async () => {

--- a/indexer-envio/test/breakerScenarios.test.ts
+++ b/indexer-envio/test/breakerScenarios.test.ts
@@ -13,6 +13,8 @@ import {
   _setMockBreakerList,
   _clearBreakerMocks,
   _clearBootstrapCaches,
+  _clearMockMedianTimestamps,
+  _setMockMedianTimestamp,
 } from "../src/EventHandlers.ts";
 import { makeBreakerConfigId, makeBreakerId } from "../src/breakers.ts";
 import { makePoolId } from "../src/helpers.ts";
@@ -54,6 +56,7 @@ describe("Issue #1052 scenario gap-closing", () => {
   beforeEach(() => {
     _clearBreakerMocks();
     _clearBootstrapCaches();
+    _setMockMedianTimestamp(CHAIN_ID, FEED, 1_700_001_950n);
     _setMockBreakerList(CHAIN_ID, [MD_BREAKER]);
     _setMockBreakerKind(CHAIN_ID, MD_BREAKER, "MEDIAN_DELTA");
     _setMockBreakerDefaults(CHAIN_ID, MD_BREAKER, {
@@ -75,6 +78,7 @@ describe("Issue #1052 scenario gap-closing", () => {
 
   afterEach(() => {
     _clearBreakerMocks();
+    _clearMockMedianTimestamps();
   });
 
   // ---------------------------------------------------------------------

--- a/indexer-envio/test/exactMedianTimestamp.test.ts
+++ b/indexer-envio/test/exactMedianTimestamp.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import type { Logger } from "envio";
+import { requireExactMedianTimestamp } from "../src/handlers/exact-median-timestamp.js";
+
+const INDEXER_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const VITEST_CLI = fileURLToPath(
+  new URL("../node_modules/vitest/vitest.mjs", import.meta.url),
+);
+
+function captureLogger(): { logger: Logger; errors: string[] } {
+  const errors: string[] = [];
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string) => errors.push(message),
+  } as Logger;
+  return { logger, errors };
+}
+
+describe("requireExactMedianTimestamp", () => {
+  it("returns exact contract responses including zero", () => {
+    const { logger, errors } = captureLogger();
+    assert.equal(
+      requireExactMedianTimestamp({
+        timestamp: 0n,
+        eventName: "MedianUpdated",
+        chainId: 137,
+        rateFeedID: "0xfeed",
+        blockNumber: 90_450_421n,
+        log: logger,
+      }),
+      0n,
+    );
+    assert.deepEqual(errors, []);
+  });
+
+  for (const eventName of ["OracleReported", "MedianUpdated"] as const) {
+    it(`throws and logs when ${eventName} has no exact timestamp`, () => {
+      const { logger, errors } = captureLogger();
+      assert.throws(
+        () =>
+          requireExactMedianTimestamp({
+            timestamp: null,
+            eventName,
+            chainId: 137,
+            rateFeedID: "0xfeed",
+            blockNumber: 90_450_421n,
+            log: logger,
+          }),
+        new RegExp(
+          `sortedOracles\\.exactMedianTimestampUnavailable event=${eventName} chainId=137 feed=0xfeed block=90450421`,
+        ),
+      );
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /exactMedianTimestampUnavailable/);
+    });
+  }
+
+  for (const eventName of ["OracleReported", "MedianUpdated"] as const) {
+    it(`rejects tracked ${eventName} before committing writes`, () => {
+      const result = spawnSync(
+        process.execPath,
+        [VITEST_CLI, "run", "--config", "vitest.fail-closed.config.ts"],
+        {
+          cwd: INDEXER_ROOT,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            SORTED_ORACLES_FAILURE_EVENT: eventName,
+          },
+        },
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.equal(result.status, 0, output);
+    });
+  }
+});

--- a/indexer-envio/test/fixtures/failClosedSortedOracles.case.ts
+++ b/indexer-envio/test/fixtures/failClosedSortedOracles.case.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import type { Pool } from "envio";
+import {
+  type EntityCollection,
+  indexerTestHelpers,
+  type MockDbWith,
+  type WritableEntity,
+} from "../helpers/indexerTestHarness.js";
+import {
+  _clearMockMedianTimestamps,
+  _setMockMedianTimestamp,
+} from "../../src/EventHandlers.ts";
+import { makePoolId } from "../../src/helpers.js";
+import { registerMockRateFeedDependenciesHttp } from "../../src/rpc/http-test-mock-bridge.js";
+import { makePool } from "../helpers/makePool.js";
+
+type MockDb = MockDbWith<{
+  OracleSnapshot: WritableEntity & EntityCollection;
+  Pool: WritableEntity<Pool>;
+}>;
+
+const TestHelpers = indexerTestHelpers<MockDb>();
+const { MockDb, SortedOracles } = TestHelpers;
+const CHAIN_ID = 42220;
+const FEED = "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a";
+const SORTED_ORACLES = "0xefb84935239dacdecf7c5ba76d8de40b077b7b33";
+const EVENT_NAME = process.env.SORTED_ORACLES_FAILURE_EVENT;
+
+if (EVENT_NAME !== "OracleReported" && EVENT_NAME !== "MedianUpdated") {
+  throw new Error(`Unsupported SORTED_ORACLES_FAILURE_EVENT=${EVENT_NAME}`);
+}
+
+it(`fails closed before writes for tracked ${EVENT_NAME}`, async () => {
+  registerMockRateFeedDependenciesHttp(CHAIN_ID, FEED, []);
+  _setMockMedianTimestamp(CHAIN_ID, FEED, null);
+
+  const poolId = makePoolId(
+    CHAIN_ID,
+    "0x0000000000000000000000000000000000008562",
+  );
+  const initialPool = makePool({
+    id: poolId,
+    referenceRateFeedID: FEED,
+    reserves0: 10n ** 21n,
+    reserves1: 10n ** 21n,
+    invertRateFeedKnown: true,
+    tokenDecimalsKnown: true,
+    oracleExpiry: 300n,
+    lastMedianPrice: 10n ** 24n,
+  });
+  let mockDb = MockDb.createMockDb();
+  mockDb = mockDb.entities.Pool.set(initialPool);
+
+  const mockEventData = {
+    chainId: CHAIN_ID,
+    logIndex: 9,
+    srcAddress: SORTED_ORACLES,
+    block: { number: 60_664_503, timestamp: 1_700_002_200 },
+  };
+  const event =
+    EVENT_NAME === "OracleReported"
+      ? SortedOracles.OracleReported.createMockEvent({
+          token: FEED,
+          reporter: "0x00000000000000000000000000000000000000aa",
+          value: 10n ** 24n,
+          timestamp: 1_700_002_150n,
+          mockEventData,
+        })
+      : SortedOracles.MedianUpdated.createMockEvent({
+          token: FEED,
+          value: 10n ** 24n,
+          mockEventData,
+        });
+
+  try {
+    await assert.rejects(
+      () =>
+        SortedOracles[EVENT_NAME].processEvent({
+          event,
+          mockDb,
+        }),
+      /Worker exited with code 1/,
+    );
+    assert.deepEqual(mockDb.entities.Pool.get(poolId), initialPool);
+    assert.deepEqual(mockDb.entities.OracleSnapshot.getAll(), []);
+    assert.equal(initialPool.healthTotalSeconds, 0n);
+    assert.equal(initialPool.healthBinarySeconds, 0n);
+    assert.equal(initialPool.lastOracleSnapshotTimestamp, 0n);
+  } finally {
+    _clearMockMedianTimestamps();
+  }
+});

--- a/indexer-envio/test/oracleReportedMedianParity.test.ts
+++ b/indexer-envio/test/oracleReportedMedianParity.test.ts
@@ -87,7 +87,7 @@ describe("SortedOracles.OracleReported median parity", () => {
     existingPriceDifference?: bigint;
     value: bigint;
     blockTimestamp?: number;
-    medianTimestamp?: bigint;
+    medianTimestamp?: bigint | null;
   }) {
     registerMockRateFeedDependenciesHttp(CHAIN_ID, FEED, []);
     _setMockMedianTimestamp(CHAIN_ID, FEED, medianTimestamp);

--- a/indexer-envio/test/rateFeedHandlers.test.ts
+++ b/indexer-envio/test/rateFeedHandlers.test.ts
@@ -11,8 +11,10 @@ import { makeRateFeedId } from "../src/oracleReporters.js";
 import {
   _clearMockRateFeedOracles,
   _clearMockNumReporters,
+  _clearMockMedianTimestamps,
   _setMockRateFeedOracles,
   _setMockNumReporters,
+  _setMockMedianTimestamp,
 } from "../src/EventHandlers.ts";
 import { UNKNOWN_ORACLE_REPORTERS } from "../src/constants.js";
 import { syncRateFeedFromRpc } from "../src/handlers/rateFeed.js";
@@ -35,9 +37,15 @@ const UNKNOWN_REPORTER = "0x0000000000000000000000000000000000000001";
 const SORTED_ORACLES = "0xefb84935239dacdecf7c5ba76d8de40b077b7b33";
 
 describe("RateFeed handlers", () => {
+  beforeEach(() => {
+    _setMockMedianTimestamp(CELO, CELO_GBP_FEED, 1_700_000_000n);
+    _setMockMedianTimestamp(MONAD, MONAD_GBP_FEED, 1_700_000_000n);
+  });
+
   afterEach(() => {
     _clearMockRateFeedOracles();
     _clearMockNumReporters();
+    _clearMockMedianTimestamps();
   });
 
   it("writes chain-scoped RateFeed rows from OracleAdded", async () => {

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "assert";
 import { getRpcClient, _clearRpcClients, _testHooks } from "../src/rpc.js";
 import {
   getFallbackRpcClient,
-  rpcBatchEnabledForUrl,
+  rpcBatchConfigForUrl,
 } from "../src/rpc/client.js";
 
 // ---------------------------------------------------------------------------
@@ -149,25 +149,38 @@ describe("getRpcClient", () => {
 });
 
 // ---------------------------------------------------------------------------
-// rpcBatchEnabledForUrl
+// rpcBatchConfigForUrl
 // ---------------------------------------------------------------------------
 
-describe("rpcBatchEnabledForUrl", () => {
+describe("rpcBatchConfigForUrl", () => {
   it("disables batching for the Monad monadinfra primary", () => {
     assert.equal(
-      rpcBatchEnabledForUrl(
+      rpcBatchConfigForUrl(
         "https://rpc-mainnet.monadinfra.com/rpc/token-value",
       ),
       false,
     );
   });
 
+  it("caps Polygon mainnet and Amoy dRPC batches at three calls", () => {
+    assert.deepEqual(rpcBatchConfigForUrl("https://polygon.drpc.org"), {
+      batchSize: 3,
+    });
+    assert.deepEqual(rpcBatchConfigForUrl("https://polygon-amoy.drpc.org"), {
+      batchSize: 3,
+    });
+  });
+
+  it("does not apply the dRPC policy to spoofed suffix hosts", () => {
+    assert.equal(rpcBatchConfigForUrl("https://drpc.org.example.com"), true);
+  });
+
   it("keeps batching enabled for rpc2.monad.xyz fallback", () => {
-    assert.equal(rpcBatchEnabledForUrl("https://rpc2.monad.xyz"), true);
+    assert.equal(rpcBatchConfigForUrl("https://rpc2.monad.xyz"), true);
   });
 
   it("keeps batching enabled for malformed URLs rather than failing client setup", () => {
-    assert.equal(rpcBatchEnabledForUrl("not a url"), true);
+    assert.equal(rpcBatchConfigForUrl("not a url"), true);
   });
 });
 
@@ -206,6 +219,37 @@ describe("isRateLimitError", () => {
     assert.equal(_testHooks.isRateLimitError(null), false);
     assert.equal(_testHooks.isRateLimitError(undefined), false);
     assert.equal(_testHooks.isRateLimitError({ message: "rate limit" }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRetryableRpcError
+// ---------------------------------------------------------------------------
+
+describe("isRetryableRpcError", () => {
+  const cases: Array<[string, boolean]> = [
+    ["HTTP request failed.\nStatus: 500\nURL: https://polygon.drpc.org", true],
+    ["HTTP status 502 Bad Gateway", true],
+    ["Status code: 503 Service Unavailable", true],
+    ["504 Gateway Timeout", true],
+    ["Internal Server Error", true],
+    ["429 Too Many Requests", true],
+    ["Status: 400 Bad Request", false],
+    ["Status: 404 Not Found", false],
+    ["execution reverted at block 500", false],
+    ["block 503 is not available", false],
+    ["execution reverted", false],
+  ];
+
+  for (const [msg, expected] of cases) {
+    it(`returns ${expected} for "${msg.split("\n")[0]}"`, () => {
+      assert.equal(_testHooks.isRetryableRpcError(new Error(msg)), expected);
+    });
+  }
+
+  it("returns false for non-Error values", () => {
+    assert.equal(_testHooks.isRetryableRpcError("Status: 500"), false);
+    assert.equal(_testHooks.isRetryableRpcError(null), false);
   });
 });
 

--- a/indexer-envio/vitest.fail-closed.config.ts
+++ b/indexer-envio/vitest.fail-closed.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60_000,
+    include: ["test/fixtures/failClosedSortedOracles.case.ts"],
+    setupFiles: [
+      "./vitest.hermetic-setup.ts",
+      "./test/setup/publish-test-rpc.ts",
+    ],
+    env: {
+      ENVIO_START_BLOCK_CELO: "0",
+      ENVIO_START_BLOCK_MONAD: "0",
+      ENVIO_START_BLOCK_CELO_SEPOLIA: "0",
+      ENVIO_START_BLOCK_MONAD_TESTNET: "0",
+    },
+  },
+});

--- a/scripts/deploy-indexer-verify.mjs
+++ b/scripts/deploy-indexer-verify.mjs
@@ -2,10 +2,13 @@
 
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import { summarizePolygonPools } from "./lib/polygon-deployment-semantics.mjs";
 
 const ENVIO_ORG = "mento-protocol";
 const ENVIO_INDEXER = "mento";
 const GRAPHQL_TIMEOUT_MS = 20_000;
+const REPLAY_INTEGRITY_PATH = "indexer-envio/config/replay-integrity.json";
+const REQUIRED_POLYGON_EXACT_MEDIAN_VERSION = 1;
 
 const PROBE_TABLES = [
   "Pool",
@@ -17,6 +20,23 @@ const PROBE_TABLES = [
 
 export const PROBE_QUERY = `query VerifyIndexerRows {
   Pool(limit: 1) { id chainId source }
+  PolygonPool: Pool(
+    where: { chainId: { _eq: 137 }, source: { _eq: "fpmm_factory" } }
+    order_by: { id: asc }
+  ) {
+    id
+    source
+    referenceRateFeedID
+    lastOracleReportAt
+    oracleExpiry
+    oracleOk
+    medianLive
+    healthStatus
+    hasHealthData
+    lastOracleSnapshotTimestamp
+    healthTotalSeconds
+    healthBinarySeconds
+  }
   SusdsYieldSummary(limit: 1) { id lastMovementTxHash lastUpdatedBlock }
   SusdsYieldMovement(limit: 1, order_by: { blockNumber: asc }) { id kind txHash blockNumber }
   StethYieldSummary(limit: 1) { id lastMovementTxHash lastUpdatedBlock }
@@ -173,6 +193,51 @@ function verifyGitTarget(target) {
   return result.status === 0 ? result.stdout.trim() : "";
 }
 
+function replayIntegrityFromCommit(commit) {
+  const result = spawnSync(
+    "git",
+    ["show", `${commit}:${REPLAY_INTEGRITY_PATH}`],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  if (result.status !== 0) {
+    return {
+      value: null,
+      readError: `could not read ${REPLAY_INTEGRITY_PATH} from deployment commit ${commit}`,
+    };
+  }
+  try {
+    return { value: JSON.parse(result.stdout), readError: "" };
+  } catch (error) {
+    return {
+      value: null,
+      readError: `${REPLAY_INTEGRITY_PATH} is invalid JSON at deployment commit ${commit}: ${error.message}`,
+    };
+  }
+}
+
+export function summarizeReplayIntegrity(input) {
+  const observedVersion = Number(
+    input?.value?.polygonExactMedianTimestamp ?? 0,
+  );
+  const failures = [];
+  if (input?.readError) failures.push(input.readError);
+  if (
+    !Number.isSafeInteger(observedVersion) ||
+    observedVersion < REQUIRED_POLYGON_EXACT_MEDIAN_VERSION
+  ) {
+    failures.push(
+      `deployment predates Polygon exact-median replay integrity v${REQUIRED_POLYGON_EXACT_MEDIAN_VERSION}`,
+    );
+  }
+  return {
+    ok: failures.length === 0,
+    markerPath: REPLAY_INTEGRITY_PATH,
+    requiredVersion: REQUIRED_POLYGON_EXACT_MEDIAN_VERSION,
+    observedVersion,
+    failures,
+  };
+}
+
 function deploymentsFromIndexer(indexerJson) {
   return [...(indexerJson.data?.deployments ?? [])].sort((a, b) =>
     String(b.created_time ?? "").localeCompare(String(a.created_time ?? "")),
@@ -310,9 +375,16 @@ export function buildSummary({
   statusJson,
   metricsJson,
   graphqlJson,
+  nowSeconds,
+  replayIntegrityInput,
 }) {
   const sync = summarizeStatus(statusJson);
   const probe = summarizeProbe(graphqlJson);
+  const replayIntegrity = summarizeReplayIntegrity(replayIntegrityInput);
+  const polygon = summarizePolygonPools(
+    graphqlJson.data?.PolygonPool,
+    nowSeconds,
+  );
   const failures = [];
 
   if (!args.allowSyncing && !sync.allSynced) {
@@ -330,6 +402,8 @@ export function buildSummary({
       );
     }
   }
+  failures.push(...replayIntegrity.failures);
+  failures.push(...polygon.failures);
 
   return {
     ok: failures.length === 0,
@@ -343,6 +417,8 @@ export function buildSummary({
     sync,
     metrics: metricSummary(metricsJson),
     probe,
+    replayIntegrity,
+    polygon,
     failures,
   };
 }
@@ -385,6 +461,17 @@ export function renderText(summary) {
   for (const [table, count] of Object.entries(summary.probe.rowCounts)) {
     lines.push(`  ${table}: ${count}`);
   }
+  lines.push("");
+  lines.push("Replay integrity contract:");
+  lines.push(
+    `  Polygon exact median: v${summary.replayIntegrity.observedVersion}/v${summary.replayIntegrity.requiredVersion}`,
+  );
+  lines.push("");
+  lines.push("Polygon replay semantics:");
+  lines.push(
+    `  FPMMs: ${summary.polygon.actualCount}/${summary.polygon.expectedCount}`,
+  );
+  lines.push(`  semantic integrity: ${summary.polygon.ok ? "yes" : "no"}`);
 
   if (summary.failures.length > 0) {
     lines.push("");
@@ -405,12 +492,12 @@ function printUsage() {
   pnpm deploy:indexer:verify <commit> --prod [--json]
 
 Checks a registered Envio deployment by fetching status, metrics, a GraphQL
-endpoint, and a small row probe for core Pool and reserve-yield tables.
+endpoint, core rows, and fail-closed Polygon replay semantics.
 
 Options:
   --prod           Probe the static production endpoint and require <commit> to be prod.
   --allow-syncing  Do not fail solely because one or more chains are still syncing.
-                   Empty GraphQL probe tables remain a failure.
+                   Empty rows and Polygon semantic failures remain failures.
   --json, -j       Print machine-readable summary JSON.
 `);
 }
@@ -470,6 +557,9 @@ async function main() {
     deployment.commit_hash,
     ENVIO_ORG,
   ]);
+  const replayIntegrityInput = replayIntegrityFromCommit(
+    deployment.commit_hash,
+  );
   const graphqlJson = await queryGraphql(endpoint);
   const summary = buildSummary({
     args,
@@ -479,6 +569,7 @@ async function main() {
     statusJson,
     metricsJson,
     graphqlJson,
+    replayIntegrityInput,
   });
 
   if (args.json) {

--- a/scripts/deploy-indexer-verify.test.mjs
+++ b/scripts/deploy-indexer-verify.test.mjs
@@ -10,8 +10,36 @@ import {
   resolveDeployment,
   resolveProdDeployment,
   summarizeProbe,
+  summarizeReplayIntegrity,
   summarizeStatus,
 } from "./deploy-indexer-verify.mjs";
+import {
+  POLYGON_FPMM_EXPECTATIONS,
+  summarizePolygonPools,
+} from "./lib/polygon-deployment-semantics.mjs";
+
+const NOW_SECONDS = 2_000_000_000;
+const VALID_REPLAY_INTEGRITY = {
+  value: { polygonExactMedianTimestamp: 1 },
+  readError: "",
+};
+
+function validPolygonPools() {
+  return POLYGON_FPMM_EXPECTATIONS.map((expected, index) => ({
+    id: expected.id,
+    source: "fpmm_factory",
+    referenceRateFeedID: expected.referenceRateFeedID,
+    lastOracleReportAt: String(NOW_SECONDS - 1_000 - index),
+    oracleExpiry: expected.oracleExpiry.toString(),
+    oracleOk: true,
+    medianLive: true,
+    healthStatus: "OK",
+    hasHealthData: true,
+    lastOracleSnapshotTimestamp: String(NOW_SECONDS - 500 - index),
+    healthTotalSeconds: "1000",
+    healthBinarySeconds: "900",
+  }));
+}
 
 const indexerJson = {
   data: {
@@ -98,6 +126,22 @@ assert.equal(
 );
 assert.equal(resolveProdDeployment(indexerJson)?.commit_hash, "abc1234");
 
+assert.equal(summarizeReplayIntegrity(VALID_REPLAY_INTEGRITY).ok, true);
+assert.match(
+  summarizeReplayIntegrity({
+    value: null,
+    readError: "marker missing from old commit",
+  }).failures.join("\n"),
+  /marker missing[\s\S]*predates Polygon exact-median replay integrity/,
+);
+assert.equal(
+  summarizeReplayIntegrity({
+    value: { polygonExactMedianTimestamp: "not-a-version" },
+    readError: "",
+  }).ok,
+  false,
+);
+
 assert.deepEqual(
   summarizeStatus({
     data: [
@@ -144,6 +188,56 @@ assert.deepEqual(
       },
     ],
   },
+);
+
+assert.equal(summarizePolygonPools(validPolygonPools(), NOW_SECONDS).ok, true);
+
+const missingPolygonPool = validPolygonPools().slice(1);
+assert.match(
+  summarizePolygonPools(missingPolygonPool, NOW_SECONDS).failures.join("\n"),
+  /missing Polygon FPMMs/,
+);
+
+const zeroCursors = validPolygonPools();
+zeroCursors[0].lastOracleReportAt = "0";
+zeroCursors[0].lastOracleSnapshotTimestamp = "0";
+assert.match(
+  summarizePolygonPools(zeroCursors, NOW_SECONDS).failures.join("\n"),
+  /no positive exact oracle anchor[\s\S]*no positive oracle snapshot cursor/,
+);
+
+const wrongFeedAndExpiry = validPolygonPools();
+wrongFeedAndExpiry[1].referenceRateFeedID =
+  "0x0000000000000000000000000000000000000001";
+wrongFeedAndExpiry[1].oracleExpiry = "31536000";
+assert.match(
+  summarizePolygonPools(wrongFeedAndExpiry, NOW_SECONDS).failures.join("\n"),
+  /feed is[\s\S]*expiry is/,
+);
+
+const expiredOneYearPool = validPolygonPools();
+expiredOneYearPool[2].lastOracleReportAt = String(NOW_SECONDS - 31_536_001);
+assert.match(
+  summarizePolygonPools(expiredOneYearPool, NOW_SECONDS).failures.join("\n"),
+  /one-year oracle anchor is expired/,
+);
+
+const invalidHealthCounters = validPolygonPools();
+invalidHealthCounters[0].healthTotalSeconds = "10";
+invalidHealthCounters[0].healthBinarySeconds = "11";
+assert.match(
+  summarizePolygonPools(invalidHealthCounters, NOW_SECONDS).failures.join("\n"),
+  /health binary seconds exceed total seconds/,
+);
+
+const unexpectedPolygonPool = validPolygonPools();
+unexpectedPolygonPool.push({
+  ...unexpectedPolygonPool[0],
+  id: "137-0x0000000000000000000000000000000000000001",
+});
+assert.match(
+  summarizePolygonPools(unexpectedPolygonPool, NOW_SECONDS).failures.join("\n"),
+  /unexpected Polygon FPMMs/,
 );
 
 assert.deepEqual(
@@ -215,15 +309,58 @@ const summary = buildSummary({
   graphqlJson: {
     data: {
       Pool: [{ id: "pool" }],
+      PolygonPool: validPolygonPools(),
       SusdsYieldSummary: [{ id: "susds" }],
       SusdsYieldMovement: [{ id: "susds-move" }],
       StethYieldSummary: [{ id: "steth" }],
       StethYieldMovement: [{ id: "steth-move" }],
     },
   },
+  nowSeconds: NOW_SECONDS,
+  replayIntegrityInput: VALID_REPLAY_INTEGRITY,
 });
 
 assert.equal(summary.ok, true);
 assert.match(renderText(summary), /Result: verified/);
+
+const semanticFailureWhileSyncing = buildSummary({
+  args: { allowSyncing: true },
+  deployment: indexerJson.data.deployments[1],
+  endpoint: indexerJson.data.deployments[1].gql_endpoint,
+  endpointMode: "deployment",
+  statusJson: {
+    data: [
+      {
+        chain_id: 137,
+        block_height: 100,
+        latest_processed_block: 50,
+        num_events_processed: 1,
+        timestamp_caught_up_to_head_or_endblock: "",
+      },
+    ],
+  },
+  metricsJson: { data: [] },
+  graphqlJson: {
+    data: {
+      Pool: [{ id: "non-polygon-core-row" }],
+      PolygonPool: missingPolygonPool,
+      SusdsYieldSummary: [{ id: "susds" }],
+      SusdsYieldMovement: [{ id: "susds-move" }],
+      StethYieldSummary: [{ id: "steth" }],
+      StethYieldMovement: [{ id: "steth-move" }],
+    },
+  },
+  nowSeconds: NOW_SECONDS,
+  replayIntegrityInput: VALID_REPLAY_INTEGRITY,
+});
+assert.equal(semanticFailureWhileSyncing.ok, false);
+assert.match(
+  semanticFailureWhileSyncing.failures.join("\n"),
+  /missing Polygon FPMMs/,
+);
+assert.doesNotMatch(
+  semanticFailureWhileSyncing.failures.join("\n"),
+  /not caught up/,
+);
 
 console.log("deploy-indexer-verify tests passed.");

--- a/scripts/lib/polygon-deployment-semantics.mjs
+++ b/scripts/lib/polygon-deployment-semantics.mjs
@@ -1,0 +1,157 @@
+// Promotion contract for the live Polygon deployment. Feed addresses come
+// from each FPMM and expiries from SortedOracles; update these expectations in
+// the same PR as any governance/deployment change that alters either mapping.
+export const POLYGON_FPMM_EXPECTATIONS = [
+  {
+    id: "137-0x463c0d1f04bcd99a1efcf94ac2a75bc19ea4a7e5",
+    label: "USDC/USDm",
+    referenceRateFeedID: "0x81a313ff894bfc6093d33b5514e34d7faa41b7ef",
+    oracleExpiry: 150n,
+    requireCurrent: false,
+  },
+  {
+    id: "137-0x93e15a22fda39fefccce82d387a09ccf030ead61",
+    label: "EURm/USDm",
+    referenceRateFeedID: "0xec57482aa55e3ad026c315a0e4a692b776c318ca",
+    oracleExpiry: 150n,
+    requireCurrent: false,
+  },
+  {
+    id: "137-0xcd8c6811d975981f57e7fb32e59f0bee66af3201",
+    label: "EURm/EUROP",
+    referenceRateFeedID: "0xc22418a83dfc262b10a1f57e25309db83e7ea79e",
+    oracleExpiry: 31_536_000n,
+    requireCurrent: true,
+  },
+];
+
+function parseBigInt(value) {
+  if (
+    !["bigint", "number", "string"].includes(typeof value) ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return null;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizedId(value) {
+  return String(value ?? "").toLowerCase();
+}
+
+/**
+ * Verify that a caught-up deployment contains a complete, internally
+ * consistent Polygon replay. `--allow-syncing` never bypasses these checks:
+ * partial rows are not safe to promote even when the hosted status is green.
+ */
+export function summarizePolygonPools(rows, nowSeconds = Date.now() / 1000) {
+  const inputRows = Array.isArray(rows) ? rows : [];
+  const failures = [];
+  const expectedIds = POLYGON_FPMM_EXPECTATIONS.map(({ id }) => id).sort();
+  const actualIds = inputRows.map(({ id }) => normalizedId(id)).sort();
+  const duplicateIds = actualIds.filter(
+    (id, index) => index > 0 && id === actualIds[index - 1],
+  );
+
+  const missingIds = expectedIds.filter((id) => !actualIds.includes(id));
+  const unexpectedIds = actualIds.filter((id) => !expectedIds.includes(id));
+  if (missingIds.length > 0) {
+    failures.push(`missing Polygon FPMMs: ${missingIds.join(", ")}`);
+  }
+  if (unexpectedIds.length > 0) {
+    failures.push(`unexpected Polygon FPMMs: ${unexpectedIds.join(", ")}`);
+  }
+  if (duplicateIds.length > 0) {
+    failures.push(`duplicate Polygon FPMMs: ${duplicateIds.join(", ")}`);
+  }
+
+  const rowsById = new Map(inputRows.map((row) => [normalizedId(row.id), row]));
+  const now = BigInt(Math.floor(nowSeconds));
+
+  for (const expected of POLYGON_FPMM_EXPECTATIONS) {
+    const row = rowsById.get(expected.id);
+    if (!row) continue;
+    const prefix = `${expected.label} (${expected.id})`;
+
+    if (row.source !== "fpmm_factory") {
+      failures.push(`${prefix} source is ${String(row.source)}`);
+    }
+    if (
+      normalizedId(row.referenceRateFeedID) !== expected.referenceRateFeedID
+    ) {
+      failures.push(
+        `${prefix} feed is ${normalizedId(row.referenceRateFeedID) || "missing"}; expected ${expected.referenceRateFeedID}`,
+      );
+    }
+
+    const lastOracleReportAt = parseBigInt(row.lastOracleReportAt);
+    const oracleExpiry = parseBigInt(row.oracleExpiry);
+    const lastOracleSnapshotTimestamp = parseBigInt(
+      row.lastOracleSnapshotTimestamp,
+    );
+    const healthTotalSeconds = parseBigInt(row.healthTotalSeconds);
+    const healthBinarySeconds = parseBigInt(row.healthBinarySeconds);
+
+    if (lastOracleReportAt === null || lastOracleReportAt <= 0n) {
+      failures.push(`${prefix} has no positive exact oracle anchor`);
+    }
+    if (oracleExpiry === null) {
+      failures.push(`${prefix} has an invalid oracle expiry`);
+    } else if (oracleExpiry !== expected.oracleExpiry) {
+      failures.push(
+        `${prefix} expiry is ${oracleExpiry}; expected ${expected.oracleExpiry}`,
+      );
+    }
+    if (
+      lastOracleSnapshotTimestamp === null ||
+      lastOracleSnapshotTimestamp <= 0n
+    ) {
+      failures.push(`${prefix} has no positive oracle snapshot cursor`);
+    }
+    if (row.hasHealthData !== true) {
+      failures.push(`${prefix} hasHealthData is not true`);
+    }
+    if (
+      healthTotalSeconds === null ||
+      healthBinarySeconds === null ||
+      healthTotalSeconds < 0n ||
+      healthBinarySeconds < 0n
+    ) {
+      failures.push(`${prefix} has invalid health counters`);
+    } else if (healthBinarySeconds > healthTotalSeconds) {
+      failures.push(`${prefix} health binary seconds exceed total seconds`);
+    }
+
+    if (expected.requireCurrent) {
+      if (
+        lastOracleReportAt !== null &&
+        lastOracleReportAt > 0n &&
+        oracleExpiry !== null &&
+        lastOracleReportAt + oracleExpiry < now
+      ) {
+        failures.push(`${prefix} one-year oracle anchor is expired`);
+      }
+      if (row.oracleOk !== true) {
+        failures.push(`${prefix} oracleOk is not true`);
+      }
+      if (row.medianLive !== true) {
+        failures.push(`${prefix} medianLive is not true`);
+      }
+      if (row.healthStatus === "CRITICAL" || row.healthStatus === "N/A") {
+        failures.push(`${prefix} health status is ${String(row.healthStatus)}`);
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    expectedCount: expectedIds.length,
+    actualCount: inputRows.length,
+    poolIds: actualIds,
+    failures,
+  };
+}


### PR DESCRIPTION
## The Problem

- Polygon dRPC accepts at most three calls per JSON-RPC batch, but the indexer used viem's much larger default during replay, producing HTTP 500 failures for historical median-timestamp reads.
- A failed exact-block read could previously let a tracked oracle event commit incomplete snapshots and health counters; later healthy rows could hide that corrupted history.
- The deployment workflow treated a caught-up candidate as promotion-ready without proving that the canonical Polygon pools were replayed with the expected feeds, expiries, cursors, and health state.

## The Solution

- Bound dRPC batches to the provider limit, retry transient server failures, and use any configured secondary at the same historical block.
- Reject tracked oracle events before any entity writes when the exact median timestamp is unavailable, so Envio retries instead of silently skipping history.
- Require both a commit-scoped replay-integrity version and strict Polygon pool semantics before a caught-up deployment can be promoted.

## Details

- Applies a three-call batch cap to exact `drpc.org` hosts while preserving the existing no-batch Monad host policy and rejecting spoofed hostname suffixes.
- Retries rate limits and HTTP 500/502/503/504 responses, then attempts a configured fallback at the same requested block; transient recovery never substitutes `latest` for a historical oracle read.
- Lowers the exact median-timestamp effect rate to 40 calls per second and fails both tracked `OracleReported` and `MedianUpdated` handlers before writes on a missing result.
- Adds `indexer-envio/config/replay-integrity.json` version 1. The deployment verifier reads the marker from the deployed commit, so a pre-fix replay cannot pass merely because later rows look healthy.
- Gates promotion on exactly three Polygon FPMMs and their on-chain feed/expiry mappings: USDC/USDm at 150 seconds, EURm/USDm at 150 seconds, and EURm/EUROP at one year. It also requires positive oracle/snapshot cursors, valid health counters, and a current healthy EURm/EUROP row.
- Changes the operator state machine from caught up equals ready to `SYNCED_PENDING_DATA_VERIFY`; `--allow-syncing` never waives semantic or replay-integrity failures.

## Operational rollout

- Never promote the existing `db12736` candidate: its historical Polygon replay contains 2,540 median-timestamp RPC failures.
- After merge, deploy this commit as a fresh candidate, remove only the corrupt non-production candidate once the new deployment registers, and wait for a clean replay.
- Promote only after the commit-scoped verifier, target logs, sync status, and Polygon semantic checks all pass; then verify the production endpoint and dashboard after the DNS wait.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including main/testnet codegen, typecheck, lint, Trunk, Knip, dependency boundaries, mutation tests, full indexer coverage, reserve-yield tests, docs/context checks, and verifier tests.
- The mandatory pre-push quality gate passed again on rebased commit `81f69f9c`.
- Focused RPC and oracle-handler regression suite passed, including isolated fail-closed processing for both real SortedOracles handlers.
- `node scripts/deploy-indexer-verify.test.mjs` passed after rebasing onto current main.
- Fresh-context semantic autoreview found zero findings; deterministic autoreview was also clean.
- A live probe against current production reproduced the incident: EURm/EUROP has no positive exact oracle anchor, `oracleOk=false`, and `healthStatus=CRITICAL`, which the new semantic gate rejects.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] No work or reviewer finding is knowingly deferred from this PR.
- [x] This does not create a new architecture decision; it hardens the existing exact-block RPC and deployment-verification boundaries.
