### PR TITLE
fix(ci): grant garden OIDC permission at job scope

### DIFF
--- a/.github/workflows/documentation-garden.yml
+++ b/.github/workflows/documentation-garden.yml
@@ -38,12 +38,7 @@ on:
         default: true
         type: boolean
 
-permissions:
-  contents: read
-  # Issues are the only mutable resource. OIDC supplies runner-bound identity
-  # proof and does not grant write access to a GitHub or cloud resource.
-  id-token: write
-  issues: write
+permissions: read-all
 
 concurrency:
   group: documentation-garden
@@ -58,6 +53,12 @@ jobs:
         github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Issues are the only mutable resource. OIDC supplies runner-bound
+      # identity proof and does not grant write access to GitHub or cloud.
+      id-token: write
+      issues: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/scripts/docs-garden-issue.test.mjs
+++ b/scripts/docs-garden-issue.test.mjs
@@ -3,6 +3,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+import jsYaml from "js-yaml";
+
 import {
   buildDocsGardenIssueSpec,
   DOCS_GARDEN_MARKER,
@@ -745,7 +747,13 @@ await test("scheduled workflow fetches the history required by packet evidence",
     workflow,
     /actions\/checkout@[a-f0-9]+[^\n]*\n\s+with:\n(?:\s+#[^\n]*\n)*\s+#[^\n]*\n\s+fetch-depth: 0/,
   );
-  assert.match(workflow, /id-token: write/);
+  const parsedWorkflow = jsYaml.load(workflow);
+  assert.equal(parsedWorkflow.permissions, "read-all");
+  assert.deepEqual(parsedWorkflow.jobs?.["schedule-issue"]?.permissions, {
+    contents: "read",
+    "id-token": "write",
+    issues: "write",
+  });
   assert.match(
     workflow,
     /github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)/,


### PR DESCRIPTION
## The Problem

- The first post-#1426 live Documentation Garden run still failed before issue creation because the Blacksmith job's effective permissions omitted `IDToken: write` even though it was declared at workflow scope.
- Without the runner-issued OIDC token, the fail-closed mutation guard correctly refuses to create the bounded packet.

## The Solution

- Keep the repository's Checkov-safe `permissions: read-all` workflow default, then override the garden job with exactly `contents: read`, `id-token: write`, and `issues: write` so the runner receives the required identity capability without broader write access.
- Strengthen the workflow regression test to require that exact job-indented permission block, preventing a move back to ineffective workflow-only placement.

## Evidence

- Failed live run after the regional-host fix: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29903969403
- Its debug rerun reported effective permissions `Contents: read`, `Issues: write`, and implicit `Metadata: read`; `IDToken: write` was absent.
- Successful Blacksmith OIDC jobs in this repository use job-scoped permissions; example: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29901007252
- Live packet creation remains deferred until this focused fix merges; #1425 stays open for the required post-merge creation and retention proof.

## Verification

- `pnpm docs:garden:test` — 29 passed
- `node scripts/check-github-action-pins.mjs` — passed
- `node scripts/check-notifier-coverage.mjs` — passed
- `pnpm agent:quality-gate --run` — all 8 mapped commands passed
- `pnpm agent:review-materiality` — full review required; CI checklist and sibling workflow patterns audited
- `pnpm agent:prewarm --base origin/main` — no Turbo-backed commands mapped
- Fresh-context semantic autoreview — clean, confidence 0.99; earlier review findings replaced text matching with an exact parsed permission-object assertion
- Deterministic local autoreview — clean

Architecture decision: No — this preserves ADR 0040's existing least-privilege, runner-bound authorization design and repairs where GitHub applies the declared capability.

Context update: No — the documented operator workflow and authorization contract are unchanged; the structural test now owns the job-scope implementation invariant.

Refs #1425
