### PR TITLE
fix(docs): trust GitHub Actions OIDC host family

### DIFF
--- a/.github/workflows/documentation-garden.yml
+++ b/.github/workflows/documentation-garden.yml
@@ -50,8 +50,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' &&
-        (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
-          inputs.dry_run))
+        github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
@@ -69,22 +68,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
-      - name: Diagnose runner OIDC credential shape
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        run: |
-          node --input-type=module <<'NODE'
-          const rawUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL ?? "";
-          let parsedUrl = null;
-          try {
-            parsedUrl = new URL(rawUrl);
-          } catch {}
-          process.stdout.write(`${JSON.stringify({
-            hasUrl: Boolean(rawUrl),
-            hasToken: Boolean(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN),
-            protocol: parsedUrl?.protocol ?? null,
-            hostname: parsedUrl?.hostname ?? null,
-          })}\n`);
-          NODE
       - name: Plan and synchronize the garden issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/documentation-garden.yml
+++ b/.github/workflows/documentation-garden.yml
@@ -50,7 +50,8 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' &&
-        github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+        (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+          inputs.dry_run))
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 10
     permissions:
@@ -68,6 +69,22 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
+      - name: Diagnose runner OIDC credential shape
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        run: |
+          node --input-type=module <<'NODE'
+          const rawUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL ?? "";
+          let parsedUrl = null;
+          try {
+            parsedUrl = new URL(rawUrl);
+          } catch {}
+          process.stdout.write(`${JSON.stringify({
+            hasUrl: Boolean(rawUrl),
+            hasToken: Boolean(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN),
+            protocol: parsedUrl?.protocol ?? null,
+            hostname: parsedUrl?.hostname ?? null,
+          })}\n`);
+          NODE
       - name: Plan and synchronize the garden issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/docs-garden-issue.mjs
+++ b/scripts/docs-garden-issue.mjs
@@ -24,11 +24,10 @@ import {
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 const GARDEN_OIDC_AUDIENCE = "mento-docs-garden";
 const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
-const GITHUB_OIDC_REQUEST_HOST_PATTERN =
-  /^pipelines(?:ghub[a-z0-9]+)?\.actions\.githubusercontent\.com$/u;
+const GITHUB_OIDC_REQUEST_HOST_SUFFIX = ".actions.githubusercontent.com";
 
 function isGithubOidcRequestHost(hostname) {
-  return GITHUB_OIDC_REQUEST_HOST_PATTERN.test(hostname);
+  return hostname.endsWith(GITHUB_OIDC_REQUEST_HOST_SUFFIX);
 }
 
 function parseBoolean(value, name) {

--- a/scripts/docs-garden-issue.test.mjs
+++ b/scripts/docs-garden-issue.test.mjs
@@ -671,12 +671,42 @@ await test("OIDC authorization accepts a regional GitHub pipeline host", async (
   );
 });
 
+await test("OIDC authorization accepts a GitHub Actions managed-runner host", async () => {
+  const { claims, env, nowSeconds } = workflowOidcFixture();
+  const managedRunnerEnv = {
+    ...env,
+    ACTIONS_ID_TOKEN_REQUEST_URL:
+      "https://run-actions-3-azure-eastus.actions.githubusercontent.com/example/idtoken?api-version=2.0",
+  };
+  let requestedUrl;
+  await assertAuthorizedGardenWorkflow(
+    { repo: "owner/repo" },
+    {
+      env: managedRunnerEnv,
+      now: () => nowSeconds * 1000,
+      fetchImpl: async (url) => {
+        requestedUrl = String(url);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ value: oidcToken(claims) }),
+        };
+      },
+    },
+  );
+  assert.match(
+    requestedUrl,
+    /^https:\/\/run-actions-3-azure-eastus\.actions\.githubusercontent\.com\//,
+  );
+});
+
 await test("OIDC authorization rejects untrusted request URL variants", async () => {
   const { env } = workflowOidcFixture();
   const rejectedUrls = [
     "https://pipelinesghubeus13.actions.githubusercontent.com.evil.example/idtoken",
     "http://pipelines.actions.githubusercontent.com/idtoken",
-    "https://runner.actions.githubusercontent.com/idtoken",
+    "https://actions.githubusercontent.com/idtoken",
+    "https://run-actions-3-azure-eastus.actions.githubusercontent.example/idtoken",
   ];
 
   for (const requestUrl of rejectedUrls) {


### PR DESCRIPTION
## The Problem

- The live Documentation Garden still cannot create its first bounded issue because its OIDC guard rejects GitHub's current managed-runner request hostname.
- The generic credential error hid whether the URL, token, protocol, or hostname was responsible, which led the earlier permission recovery to target the wrong condition.

## The Solution

Accept HTTPS OIDC request hosts inside the exact GitHub-owned `.actions.githubusercontent.com` DNS boundary instead of maintaining a brittle list of `pipelines...` prefixes. Keep every workflow, ref, SHA, run, issuer, audience, and expiry claim check unchanged, and add regression coverage for the observed managed-runner host plus lookalike domains.

## Root-cause evidence

A branch-only, non-mutating dry run captured only safe credential-shape metadata from the same Blacksmith runner family:

```json
{"hasUrl":true,"hasToken":true,"protocol":"https:","hostname":"run-actions-3-azure-eastus.actions.githubusercontent.com"}
```

Evidence: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29906788478

That proves the OIDC grant and runner credentials are present. The current regex accepts only `pipelines...actions.githubusercontent.com`, so it rejects the real `run-actions-...` GitHub hostname before requesting the JWT. The temporary diagnostic and branch-only guard are fully removed from the net PR diff.

## Security invariants

- The request URL must still use HTTPS.
- The hostname must end at the DNS-label boundary `.actions.githubusercontent.com`; apex and lookalike/suffixed domains remain rejected.
- The JWT must still match the exact repository, Documentation Garden workflow, ref, workflow SHA, event, run ID, run attempt, issuer, audience, and validity window.
- No token, secret, permission, runner, workflow trigger, or mutation scope changes.

## Verification

- `pnpm docs:garden:test` — 30 passed
- `pnpm lint:scripts`
- `pnpm agent:quality-gate --run` — all five mapped commands passed, including Trunk, planner dry-run, and catalog drift check
- `pnpm agent:autoreview` — clean deterministic review
- Fresh-context semantic review — clean, confidence 0.99

## Architecture and context

- Architecture decision: No. This repairs the implementation of ADR 0040's existing runner-bound authorization contract.
- Context update: No. The operator workflow, command surface, permissions, and authorization policy are unchanged; the regression test owns the newly observed GitHub hostname form.

Refs #1425
