### PR TITLE
fix(indexer): keep Envio effects phase-local

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -204,6 +204,13 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
+- **Never bridge Envio's preload and processing passes with module-local mutable
+  state.** Hosted workers and process restarts do not share a module-scoped
+  `Set` or `Map`. Derive conditional-effect eligibility from the entity/event
+  inputs in each pass (or use a phase-stable event-only condition), invoke the
+  identical effect key before the preload return, and let a rare newly-visible
+  entity take the safe serialized exact-block path. A missing warmed result must
+  fail closed; it must not be reconstructed from a later event.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -210,7 +210,12 @@ Notes:
   inputs in each pass (or use a phase-stable event-only condition), invoke the
   identical effect key before the preload return, and let a rare newly-visible
   entity take the safe serialized exact-block path. A missing warmed result must
-  fail closed; it must not be reconstructed from a later event.
+  fail closed; it must not be reconstructed from a later event. Moving the
+  collection into an imported handler helper does not make it safe: the
+  blocking invariant follows TypeScript-resolved imported/transitive handler
+  calls, callbacks, aliases, and collection arguments and rejects reachable
+  module-level `Set`/`Map` mutations. Deterministic read-only lookup collections
+  are allowed outside the preload-aware handler module.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -32,7 +32,8 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
   ordered processing pass for writes. Before changing a handler or RPC effect,
   read `indexer-envio/AGENTS.md` and
   `docs/pr-checklists/indexer-handler-invariants.md`; that checklist owns effect
-  ordering, preload markers, exemption syntax, helper declarations, and tests.
+  ordering, phase-state and preload markers, exemption syntax, helper
+  declarations, and tests.
 - Prefer the installed CLI help over stale docs when they disagree. In this baseline, `envio metrics`, `envio metrics runtime`, `envio tools search-docs`, and `envio tools fetch-docs` exist; `envio benchmark-summary` does not.
 
 ## Mento repo quick reference
@@ -204,18 +205,6 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
-- **Never bridge Envio's preload and processing passes with module-local mutable
-  state.** Hosted workers and process restarts do not share a module-scoped
-  `Set` or `Map`. Derive conditional-effect eligibility from the entity/event
-  inputs in each pass (or use a phase-stable event-only condition), invoke the
-  identical effect key before the preload return, and let a rare newly-visible
-  entity take the safe serialized exact-block path. A missing warmed result must
-  fail closed; it must not be reconstructed from a later event. Moving the
-  collection into an imported handler helper does not make it safe: the
-  blocking invariant follows TypeScript-resolved imported/transitive handler
-  calls, callbacks, aliases, and collection arguments and rejects reachable
-  module-level `Set`/`Map` mutations. Deterministic read-only lookup collections
-  are allowed outside the preload-aware handler module.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -204,6 +204,13 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
+- **Never bridge Envio's preload and processing passes with module-local mutable
+  state.** Hosted workers and process restarts do not share a module-scoped
+  `Set` or `Map`. Derive conditional-effect eligibility from the entity/event
+  inputs in each pass (or use a phase-stable event-only condition), invoke the
+  identical effect key before the preload return, and let a rare newly-visible
+  entity take the safe serialized exact-block path. A missing warmed result must
+  fail closed; it must not be reconstructed from a later event.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -210,7 +210,12 @@ Notes:
   inputs in each pass (or use a phase-stable event-only condition), invoke the
   identical effect key before the preload return, and let a rare newly-visible
   entity take the safe serialized exact-block path. A missing warmed result must
-  fail closed; it must not be reconstructed from a later event.
+  fail closed; it must not be reconstructed from a later event. Moving the
+  collection into an imported handler helper does not make it safe: the
+  blocking invariant follows TypeScript-resolved imported/transitive handler
+  calls, callbacks, aliases, and collection arguments and rejects reachable
+  module-level `Set`/`Map` mutations. Deterministic read-only lookup collections
+  are allowed outside the preload-aware handler module.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -32,7 +32,8 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
   ordered processing pass for writes. Before changing a handler or RPC effect,
   read `indexer-envio/AGENTS.md` and
   `docs/pr-checklists/indexer-handler-invariants.md`; that checklist owns effect
-  ordering, preload markers, exemption syntax, helper declarations, and tests.
+  ordering, phase-state and preload markers, exemption syntax, helper
+  declarations, and tests.
 - Prefer the installed CLI help over stale docs when they disagree. In this baseline, `envio metrics`, `envio metrics runtime`, `envio tools search-docs`, and `envio tools fetch-docs` exist; `envio benchmark-summary` does not.
 
 ## Mento repo quick reference
@@ -204,18 +205,6 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
-- **Never bridge Envio's preload and processing passes with module-local mutable
-  state.** Hosted workers and process restarts do not share a module-scoped
-  `Set` or `Map`. Derive conditional-effect eligibility from the entity/event
-  inputs in each pass (or use a phase-stable event-only condition), invoke the
-  identical effect key before the preload return, and let a rare newly-visible
-  entity take the safe serialized exact-block path. A missing warmed result must
-  fail closed; it must not be reconstructed from a later event. Moving the
-  collection into an imported handler helper does not make it safe: the
-  blocking invariant follows TypeScript-resolved imported/transitive handler
-  calls, callbacks, aliases, and collection arguments and rejects reachable
-  module-level `Set`/`Map` mutations. Deterministic read-only lookup collections
-  are allowed outside the preload-aware handler module.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/pr-checklists/ci-workflow-gates.md`](pr-checklists/ci-workflow-gates.md) | CI Workflow Gates Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-17 |
 | [`docs/pr-checklists/code-health.md`](pr-checklists/code-health.md) | Code Health Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-17 |
 | [`docs/pr-checklists/dynamic-route-metadata.md`](pr-checklists/dynamic-route-metadata.md) | Dynamic Route Metadata and Private Data Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-17 |
-| [`docs/pr-checklists/indexer-handler-invariants.md`](pr-checklists/indexer-handler-invariants.md) | Indexer Handler Invariants | canonical / active | checklist / indexer-envio | eng | 90d; verified 2026-07-21 |
+| [`docs/pr-checklists/indexer-handler-invariants.md`](pr-checklists/indexer-handler-invariants.md) | Indexer Handler Invariants | canonical / active | checklist / indexer-envio | eng | 90d; verified 2026-07-22 |
 | [`docs/pr-checklists/keyboard-a11y-controlled-widgets.md`](pr-checklists/keyboard-a11y-controlled-widgets.md) | Keyboard Accessibility on Controlled Widgets Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-17 |
 | [`docs/pr-checklists/mutation-testing.md`](pr-checklists/mutation-testing.md) | Mutation Testing Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-17 |
 | [`docs/pr-checklists/recurring-review-patterns.md`](pr-checklists/recurring-review-patterns.md) | Recurring PR Review Patterns | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-21 |

--- a/docs/notes/polygon-monitoring.md
+++ b/docs/notes/polygon-monitoring.md
@@ -102,6 +102,12 @@ The promotion verifier additionally reads the versioned
 which prevents a pre-fix replay from passing solely because a later event made
 the final pool row look current.
 
+Version 2 also records the hosted-worker boundary discovered during the first
+fail-closed replay: preload and processing must independently derive whether an
+effect is needed. Module-local collections cannot bridge those passes because
+Envio may place them in different workers or restart the process. The v1
+candidate therefore remains incompatible even if it later appears caught up.
+
 ## Alert conditions
 
 The ordinary v3 FPMM rule groups apply to Polygon automatically because the

--- a/docs/pr-checklists/indexer-handler-invariants.md
+++ b/docs/pr-checklists/indexer-handler-invariants.md
@@ -50,12 +50,22 @@ propagation, also apply [`stateful-data-ui.md`](stateful-data-ui.md).
   ordered-state exemption. Do not substitute a later event's value for exact
   event/block state.
 - Do not hide phase-bridging state in an imported handler helper. The blocking
-  code-quality invariant follows TypeScript-resolved calls from preload-aware
-  handlers through imported and transitive handler helpers, including callbacks,
-  aliases, and collection arguments. A reachable mutation of a module-level
-  native `Set` or `Map` (`add`, `set`, `delete`, or `clear`) fails; deterministic
-  read-only lookup collections remain valid outside the preload-aware handler
-  module.
+  code-quality invariant starts at registered `indexer.onEvent`, `onBlock`, and
+  `contractRegister` callbacks and follows TypeScript-resolved imported calls,
+  transitive calls,
+  callbacks, aliases, destructuring, and arguments. Every top-level handler
+  binding is a potential module-state root regardless of initializer. The
+  invariant rejects direct assignment, update, deletion, object/record write,
+  and native collection/array mutator forms reached through those
+  symbol-propagated paths. Returned module-state aliases and custom receiver
+  methods that mutate through `this` still require manual review until
+  [#1462](https://github.com/mento-protocol/monitoring-monorepo/issues/1462) is
+  resolved. Deterministic read-only lookup state and module-initialization
+  builders remain valid. A necessary processing-only write requires an adjacent
+  `// phase-state-exempt: <reason>; ... #<issue>.` at each mutation call site;
+  never exempt an entire binding. A bounded or rebuildable optimization cache
+  whose loss can only repeat authoritative/idempotent work may instead use
+  `// phase-state-cache: <why loss cannot change entity output>.` at each write.
 - The blocking code-quality invariant rejects a direct effect that exists only
   after a positive preload return (including exact `maybePreloadPool(...)` and
   `maybePreloadBreaker(...)` wrappers)

--- a/docs/pr-checklists/indexer-handler-invariants.md
+++ b/docs/pr-checklists/indexer-handler-invariants.md
@@ -49,6 +49,13 @@ propagation, also apply [`stateful-data-ui.md`](stateful-data-ui.md).
   handler requires that event's state; otherwise fail closed with a documented
   ordered-state exemption. Do not substitute a later event's value for exact
   event/block state.
+- Do not hide phase-bridging state in an imported handler helper. The blocking
+  code-quality invariant follows TypeScript-resolved calls from preload-aware
+  handlers through imported and transitive handler helpers, including callbacks,
+  aliases, and collection arguments. A reachable mutation of a module-level
+  native `Set` or `Map` (`add`, `set`, `delete`, or `clear`) fails; deterministic
+  read-only lookup collections remain valid outside the preload-aware handler
+  module.
 - The blocking code-quality invariant rejects a direct effect that exists only
   after a positive preload return (including exact `maybePreloadPool(...)` and
   `maybePreloadBreaker(...)` wrappers)

--- a/docs/pr-checklists/indexer-handler-invariants.md
+++ b/docs/pr-checklists/indexer-handler-invariants.md
@@ -3,7 +3,7 @@ title: Indexer Handler Invariants
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 doc_type: checklist
 scope: indexer-envio
 review_interval_days: 90
@@ -40,10 +40,15 @@ propagation, also apply [`stateful-data-ui.md`](stateful-data-ui.md).
 - Start event-derived effects before any entity-dependent early return. A
   concurrent preload pass can see an empty lookup while ordered processing for
   the same event sees a row created by an earlier event in the batch.
-- For state-dependent retry effects, carry an event-scoped in-memory marker
-  only when preload actually scheduled the key. Processing must stay
-  fail-closed and defer newly visible rows until the next event rather than
-  issuing an un-preloaded call.
+- For effects whose eligibility depends on entity state, derive the condition
+  independently in preload and processing; never carry eligibility across the
+  phase boundary in a module-scoped `Set`, `Map`, or other mutable marker.
+  Hosted Envio may run the passes in different workers or after a restart. Use
+  the identical event-only effect key in both passes. If ordered processing
+  newly exposes a row, take a bounded safe serialized exact-block path when the
+  handler requires that event's state; otherwise fail closed with a documented
+  ordered-state exemption. Do not substitute a later event's value for exact
+  event/block state.
 - The blocking code-quality invariant rejects a direct effect that exists only
   after a positive preload return (including exact `maybePreloadPool(...)` and
   `maybePreloadBreaker(...)` wrappers)

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -104,7 +104,8 @@ tests, apply
 [`../docs/pr-checklists/indexer-handler-invariants.md`](../docs/pr-checklists/indexer-handler-invariants.md).
 It owns the collision-resistant ID rule, entity rollups, trading-time units,
 bounded caches, median freshness, partial-heal retry coordination, downstream
-predicate/query audit, Vitest RPC mocks, and env parsing.
+predicate/query audit, phase-local preload state (including imported
+handler-helper call graphs), Vitest RPC mocks, and env parsing.
 
 Also apply the shared recurring-review rules for file-size limits, multichain
 enumeration, Hasura row caps, and effect-layer boundaries:

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -289,6 +289,11 @@ lacks the required version is never promotion-compatible even if later rows
 look healthy. Bump a marker only in the same change as the new replay invariant
 and its handler-level regression tests.
 
+Replay-integrity v2 additionally requires effect eligibility to be derived in
+both Envio passes. Never carry preload decisions in a module-scoped `Set` or
+`Map`: hosted preload and processing workers, and restarted processes, do not
+share that memory. The code-health invariant rejects that pattern in handlers.
+
 The `mento` project on Envio Cloud watches this branch. Envio registers
 deployments under the short commit hash, and the registration can lag the Git
 push by several minutes. Use the explicit commit form above while babysitting a

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -290,9 +290,20 @@ look healthy. Bump a marker only in the same change as the new replay invariant
 and its handler-level regression tests.
 
 Replay-integrity v2 additionally requires effect eligibility to be derived in
-both Envio passes. Never carry preload decisions in a module-scoped `Set` or
-`Map`: hosted preload and processing workers, and restarted processes, do not
-share that memory. The code-health invariant rejects that pattern in handlers.
+both Envio passes. Never carry preload decisions in any module-scoped mutable
+marker: hosted preload and processing workers, and restarted processes, do not
+share that memory. The code-health invariant follows every `onEvent`, `onBlock`,
+and `contractRegister` callback plus imported helpers. It rejects direct and
+symbol-propagated assignment, update, deletion, object/record write, and native
+collection/array mutator forms for top-level bindings, including primitive,
+object, array, native-collection, and factory-result state. Returned
+module-state aliases and custom receiver methods that mutate through `this`
+remain a manual-review requirement tracked in
+[#1462](https://github.com/mento-protocol/monitoring-monorepo/issues/1462).
+Narrow processing-only exceptions require an adjacent `phase-state-exempt`
+reason and tracking issue at each mutation. Rebuildable optimization caches
+whose loss can only repeat authoritative/idempotent work use an adjacent
+`phase-state-cache` reason at each write.
 
 The `mento` project on Envio Cloud watches this branch. Envio registers
 deployments under the short commit hash, and the registration can lag the Git

--- a/indexer-envio/config/replay-integrity.json
+++ b/indexer-envio/config/replay-integrity.json
@@ -1,3 +1,3 @@
 {
-  "polygonExactMedianTimestamp": 1
+  "polygonExactMedianTimestamp": 2
 }

--- a/indexer-envio/src/breakers.ts
+++ b/indexer-envio/src/breakers.ts
@@ -242,6 +242,7 @@ export async function bootstrapFeedBreakerConfigs(
     // Empty list is itself authoritative (no breakers registered for this
     // BreakerBox at this block) — safe to cache so we don't refetch.
     markBootstrapAttempted(cacheKey);
+    // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
     _bootstrapBackoffUntilTs.delete(cacheKey);
     return true;
   }
@@ -276,6 +277,7 @@ export async function bootstrapFeedBreakerConfigs(
 
   if (allSucceeded) {
     markBootstrapAttempted(cacheKey);
+    // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
     _bootstrapBackoffUntilTs.delete(cacheKey);
   } else {
     setBootstrapBackoff(cacheKey, blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS);
@@ -292,8 +294,12 @@ function setBootstrapBackoff(cacheKey: string, untilTs: bigint): void {
     !_bootstrapBackoffUntilTs.has(cacheKey)
   ) {
     const oldest = _bootstrapBackoffUntilTs.keys().next().value;
-    if (oldest !== undefined) _bootstrapBackoffUntilTs.delete(oldest);
+    if (oldest !== undefined) {
+      // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
+      _bootstrapBackoffUntilTs.delete(oldest);
+    }
   }
+  // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
   _bootstrapBackoffUntilTs.set(cacheKey, untilTs);
 }
 
@@ -308,10 +314,13 @@ function markBootstrapAttempted(cacheKey: string): void {
   ) {
     const oldest = _bootstrapAttempted.values().next().value;
     if (oldest !== undefined) {
+      // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
       _bootstrapAttempted.delete(oldest);
+      // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
       _bootstrapBackoffUntilTs.delete(oldest);
     }
   }
+  // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
   _bootstrapAttempted.add(cacheKey);
 }
 
@@ -967,7 +976,10 @@ export async function loadFeedDependencies(args: {
     setBootstrapBackoff(cacheKey, blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS);
     // A forced refresh that fails must not stay "attempted", or a later oracle
     // event won't retry the changed set.
-    if (args.force) _bootstrapAttempted.delete(cacheKey);
+    if (args.force) {
+      // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
+      _bootstrapAttempted.delete(cacheKey);
+    }
     return false;
   }
   await reconcileDependencyEdges(context, chainId, rateFeedID, deps);
@@ -992,6 +1004,7 @@ export async function loadFeedDependencies(args: {
   }
   if (allHydrated) {
     markBootstrapAttempted(cacheKey);
+    // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
     _bootstrapBackoffUntilTs.delete(cacheKey);
   } else {
     // A dependency's config bootstrap failed transiently — do NOT mark the
@@ -1000,7 +1013,10 @@ export async function loadFeedDependencies(args: {
     // already reconciled so the re-sync below still runs (best-effort, self-
     // corrects once the dependency hydrates).
     setBootstrapBackoff(cacheKey, blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS);
-    if (args.force) _bootstrapAttempted.delete(cacheKey);
+    if (args.force) {
+      // phase-state-cache: bounded rebuildable bootstrap cache; loss only repeats authoritative RPC hydration.
+      _bootstrapAttempted.delete(cacheKey);
+    }
   }
   return true;
 }

--- a/indexer-envio/src/contractAddresses.ts
+++ b/indexer-envio/src/contractAddresses.ts
@@ -146,6 +146,7 @@ export function lookupPricingModuleName(
         }
       }
     }
+    // phase-state-cache: rebuildable deployment lookup; loss only repeats deterministic manifest indexing.
     _pricingModuleIndex.set(chainId, index);
   }
   return index.get(address.toLowerCase()) ?? null;
@@ -207,6 +208,7 @@ export function lookupLiquidityStrategyKind(
         index.set(key, kind);
       }
     }
+    // phase-state-cache: rebuildable deployment lookup; loss only repeats deterministic manifest indexing.
     _liquidityStrategyKindIndex.set(chainId, index);
   }
   return index.get(address.toLowerCase()) ?? null;

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -31,18 +31,9 @@ import { buildSwapAddressFields } from "../swap.js";
 import { selfHealWrappedExchangeId } from "../pool.js";
 import { feeTokenMetaEffect } from "../rpc/effects.js";
 
-// Per-chain cache of the v3 Router address. JSON lookup once per chain is
-// cheap, but a Map is cheaper still and Broker.Swap fires per swap event.
-// `null` is cached too — chains without a registered Router (testnets that
-// haven't been wired) skip the lookup permanently.
-const routerByChain = new Map<number, string | null>();
 function v3RouterAddress(chainId: number): string | null {
-  const cached = routerByChain.get(chainId);
-  if (cached !== undefined) return cached;
   const addr = getContractAddress(chainId, "Routerv300");
-  const value = addr ? addr.toLowerCase() : null;
-  routerByChain.set(chainId, value);
-  return value;
+  return addr ? addr.toLowerCase() : null;
 }
 
 function contractAddress(chainId: number, name: string): string | null {

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -196,6 +196,7 @@ indexer.onEvent(
             });
           }
         }
+        // phase-state-cache: rebuildable backfill cache; loss only repeats idempotent entity reconciliation.
         backfilledTokens.add(backfillKey);
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);

--- a/indexer-envio/src/handlers/fpmm/state-sync.ts
+++ b/indexer-envio/src/handlers/fpmm/state-sync.ts
@@ -681,6 +681,7 @@ function txReserveScratchKey(
 function pruneOldTxPreRebalanceReserves(blockNumber: bigint): void {
   for (const [key, snapshot] of txPreRebalanceReserves) {
     if (snapshot.blockNumber < blockNumber) {
+      // phase-state-exempt: bounded ordered same-tx reserve scratch; remove with #1394.
       txPreRebalanceReserves.delete(key);
     }
   }
@@ -716,6 +717,7 @@ function captureTxPreRebalanceReserves(args: {
   pruneOldTxPreRebalanceReserves(args.blockNumber);
   const key = txReserveScratchKey(args.chainId, args.poolId, args.txHash);
   if (txPreRebalanceReserves.has(key)) return;
+  // phase-state-exempt: bounded ordered same-tx reserve scratch; remove with #1394.
   txPreRebalanceReserves.set(key, {
     ...args.reserves,
     blockNumber: args.blockNumber,
@@ -732,6 +734,7 @@ function consumeTxPreRebalanceReserves(args: {
   const key = txReserveScratchKey(args.chainId, args.poolId, args.txHash);
   const snapshot = txPreRebalanceReserves.get(key);
   if (!snapshot) return null;
+  // phase-state-exempt: bounded ordered same-tx reserve scratch; remove with #1394.
   txPreRebalanceReserves.delete(key);
   return snapshot.blockNumber === args.blockNumber
     ? { reserve0: snapshot.reserve0, reserve1: snapshot.reserve1 }

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -123,46 +123,14 @@ class OracleReportedPreWriteFailure extends Error {
   }
 }
 
-// Envio's preload and processing passes can observe different entity state
-// within one batch. Record only event keys whose preload pass actually warmed
-// each conditional effect, so processing never turns a newly-visible pool into
-// a serialized archive call. A newly-visible pool stays fail-closed and is
-// retried by preload on its next oracle event.
-const preloadedMedianTimestampEvents = new Set<string>();
-const preloadedReportExpiryEvents = new Set<string>();
-
-function shouldRequestMedianTimestamp(
-  context: EvmOnEventContext,
-  preloadEventKey: string,
-  hasPools: boolean,
-): boolean {
-  if (!context.isPreload) {
-    return preloadedMedianTimestampEvents.delete(preloadEventKey);
-  }
-
-  if (hasPools) preloadedMedianTimestampEvents.add(preloadEventKey);
-  else preloadedMedianTimestampEvents.delete(preloadEventKey);
-  return hasPools;
-}
-
 async function shouldRequestReportExpiry(
   context: EvmOnEventContext,
-  preloadEventKey: string,
   poolIds: readonly string[],
 ): Promise<boolean> {
-  if (!context.isPreload) {
-    return preloadedReportExpiryEvents.delete(preloadEventKey);
-  }
-
   const pools = await Promise.all(
     poolIds.map((poolId) => context.Pool.get(poolId)),
   );
-  const needsExpiry = pools.some(
-    (pool) => pool !== undefined && pool.oracleExpiry <= 0n,
-  );
-  if (needsExpiry) preloadedReportExpiryEvents.add(preloadEventKey);
-  else preloadedReportExpiryEvents.delete(preloadEventKey);
-  return needsExpiry;
+  return pools.some((pool) => pool !== undefined && pool.oracleExpiry <= 0n);
 }
 
 /** Process one pool's OracleReported update: self-heal, advance the oracle
@@ -420,11 +388,11 @@ indexer.onEvent(
       getPoolsByFeed(context, event.chainId, rateFeedID),
       getBreakerConfigsByFeed(context, event.chainId, rateFeedID),
     ]);
-    const requestMedianTimestamp = shouldRequestMedianTimestamp(
-      context,
-      preloadEventKey,
-      poolIds.length > 0,
-    );
+    // Derive effect conditions from entity state in each pass. Do not bridge
+    // preload and processing with module-local memory: hosted Envio can run
+    // those passes in different workers (and restarts always clear it), which
+    // makes a warmed exact-block result look absent during processing.
+    const requestMedianTimestamp = poolIds.length > 0;
     const medianTimestampPromise = requestMedianTimestamp
       ? context.effect(medianTimestampEffect, {
           chainId: event.chainId,
@@ -434,7 +402,6 @@ indexer.onEvent(
       : undefined;
     const requestReportExpiry = await shouldRequestReportExpiry(
       context,
-      preloadEventKey,
       poolIds,
     );
     const reportExpiryPromise = requestReportExpiry
@@ -568,12 +535,6 @@ indexer.onEvent(
     const rateFeedID = asAddress(event.params.token);
     const oraclePrice = event.params.value;
     const blockNumber = asBigInt(event.block.number);
-    const preloadEventKey = eventId(
-      event.chainId,
-      event.block.number,
-      event.logIndex,
-    );
-
     // Two parallel concerns share this event: pool-side oracle/breach state
     // (existing) and breaker-side EMA / lastMedianRate mirror (new). Look up
     // both up front so neither's emptiness suppresses the other, and so a
@@ -582,11 +543,9 @@ indexer.onEvent(
       getPoolsByFeed(context, event.chainId, rateFeedID),
       getBreakerConfigsByFeed(context, event.chainId, rateFeedID),
     ]);
-    const requestMedianTimestamp = shouldRequestMedianTimestamp(
-      context,
-      preloadEventKey,
-      poolIds.length > 0,
-    );
+    // See OracleReported: the preload/processing decision must not depend on
+    // module-local state that disappears across hosted workers or restarts.
+    const requestMedianTimestamp = poolIds.length > 0;
     const medianTimestampPromise = requestMedianTimestamp
       ? context.effect(medianTimestampEffect, {
           chainId: event.chainId,
@@ -596,7 +555,6 @@ indexer.onEvent(
       : undefined;
     const requestReportExpiry = await shouldRequestReportExpiry(
       context,
-      preloadEventKey,
       poolIds,
     );
     const reportExpiryPromise = requestReportExpiry

--- a/indexer-envio/src/handlers/stables/classifyKind.ts
+++ b/indexer-envio/src/handlers/stables/classifyKind.ts
@@ -25,19 +25,12 @@ export type StableSupplyChangeKind =
   | "OTHER_MINT"
   | "OTHER_BURN";
 
-// Per-chain Broker address. Resolved lazily via getContractAddress so the
-// classifier degrades to OTHER_* on chains where Broker isn't deployed
-// (e.g. Monad), rather than throwing at module load. Map is bounded by the
-// number of indexed chains (currently 5 across mainnet + testnet), so the
-// unbounded-Map rule in CLAUDE.md doesn't apply meaningfully.
-const _brokerCache = new Map<number, string | null>();
+// Resolve on demand so the classifier degrades to OTHER_* on chains where
+// Broker isn't deployed (e.g. Monad), rather than throwing at module load.
+// getContractAddress is a static registry lookup, so caching it here only
+// creates worker-local mutable state without avoiding meaningful work.
 const getBrokerAddress = (chainId: number): string | null => {
-  if (_brokerCache.has(chainId)) {
-    return _brokerCache.get(chainId) ?? null;
-  }
-  const lowered = getContractAddress(chainId, "Broker")?.toLowerCase() ?? null;
-  _brokerCache.set(chainId, lowered);
-  return lowered;
+  return getContractAddress(chainId, "Broker")?.toLowerCase() ?? null;
 };
 
 /**
@@ -61,9 +54,4 @@ export function classifyStableSupplyChangeKind(
     return isMint ? "BRIDGE_MINT" : "BRIDGE_BURN";
   }
   return isMint ? "OTHER_MINT" : "OTHER_BURN";
-}
-
-/** @internal Test-only: reset the broker-address cache between tests. */
-export function _resetBrokerAddressCacheForTest(): void {
-  _brokerCache.clear();
 }

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -28,6 +28,110 @@ function sourceFiles(dir: string): string[] {
   });
 }
 
+function topLevelSetOrMapDeclarations(
+  sourceFile: ts.SourceFile,
+): Map<string, "Set" | "Map"> {
+  const declarations = new Map<string, "Set" | "Map">();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer;
+      if (!initializer || !ts.isNewExpression(initializer)) continue;
+      const constructor = initializer.expression;
+      const collectionKind = ts.isIdentifier(constructor)
+        ? constructor.text
+        : ts.isPropertyAccessExpression(constructor)
+          ? constructor.name.text
+          : null;
+      if (collectionKind !== "Set" && collectionKind !== "Map") continue;
+      if (!ts.isIdentifier(declaration.name)) continue;
+
+      declarations.set(declaration.name.text, collectionKind);
+    }
+  }
+
+  return declarations;
+}
+
+function moduleLocalPhaseCollectionMutations(
+  sourceText: string,
+  fileName: string,
+): string[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const moduleCollections = topLevelSetOrMapDeclarations(sourceFile);
+  if (moduleCollections.size === 0) return [];
+
+  const offenders = new Set<string>();
+  const collectionMutators = new Set(["add", "set", "delete", "clear"]);
+  const visitFunction = (fn: ts.Node): void => {
+    let preloadAware = false;
+    const findPreload = (node: ts.Node): void => {
+      if (node !== fn && isFunctionLikeNode(node)) return;
+      if (
+        ts.isPropertyAccessExpression(node) &&
+        node.name.text === "isPreload"
+      ) {
+        preloadAware = true;
+        return;
+      }
+      ts.forEachChild(node, findPreload);
+    };
+    findPreload(fn);
+    if (!preloadAware) return;
+
+    const findMutation = (node: ts.Node): void => {
+      if (node !== fn && isFunctionLikeNode(node)) return;
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        moduleCollections.has(node.expression.expression.text) &&
+        collectionMutators.has(node.expression.name.text)
+      ) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+          node.expression.getStart(sourceFile),
+        );
+        offenders.add(
+          `${fileName}:${line + 1}:${character + 1} ${node.expression.getText(sourceFile)}`,
+        );
+      }
+      ts.forEachChild(node, findMutation);
+    };
+    findMutation(fn);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (isFunctionLikeNode(node)) visitFunction(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return [...offenders];
+}
+
+function moduleLocalSetOrMapDeclarations(
+  sourceText: string,
+  fileName: string,
+): string[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  return [...topLevelSetOrMapDeclarations(sourceFile)].map(
+    ([name, collectionKind]) => `${fileName} ${name} (${collectionKind})`,
+  );
+}
+
 function findUnsafeMultiFieldGetWhereCalls(): string[] {
   const offenders: string[] = [];
   for (const file of sourceFiles(srcRoot)) {
@@ -1210,19 +1314,46 @@ describe("indexer code quality invariants", () => {
     assert.deepEqual(offenders, []);
   });
 
-  it("does not bridge preload and processing with module-local collections", () => {
-    const moduleLocalPreloadCollection =
-      /(?:preload|preloaded)[A-Za-z0-9_]*\s*=\s*new\s+(?:Set|Map)\b/i;
-    const offenders = sourceFiles(path.join(srcRoot, "handlers"))
-      .filter((file) =>
-        moduleLocalPreloadCollection.test(readFileSync(file, "utf8")),
-      )
-      .map((file) => path.relative(packageRoot, file));
+  it("does not mutate module-local collections in preload-aware handlers", () => {
+    const offenders = sourceFiles(path.join(srcRoot, "handlers")).flatMap(
+      (file) =>
+        moduleLocalPhaseCollectionMutations(
+          readFileSync(file, "utf8"),
+          path.relative(packageRoot, file),
+        ),
+    );
 
     assert.deepEqual(
       offenders,
       [],
       "Hosted Envio may run preload and processing in different workers; derive effect conditions in each pass instead of bridging them with module-local Set/Map state",
+    );
+  });
+
+  it("detects renamed module-local phase mutations without flagging locals", () => {
+    assert.deepEqual(
+      moduleLocalPhaseCollectionMutations(
+        `
+          const renamed: Set<string> = new Set();
+          const cache = new globalThis.Map<string, boolean>();
+          function handler(context: { isPreload: boolean }) {
+            if (context.isPreload) renamed.add("event");
+            cache.set("event", true);
+            const preloadedIds = new Set<string>();
+            preloadedIds.add("local");
+            return preloadedIds;
+          }
+        `,
+        "fixture.ts",
+      ).map((offender) => offender.replace(/:\d+:\d+/, "")),
+      ["fixture.ts renamed.add", "fixture.ts cache.set"],
+    );
+    assert.deepEqual(
+      moduleLocalSetOrMapDeclarations(
+        `const renamed: Set<string> = new Set();`,
+        "fixture.ts",
+      ),
+      ["fixture.ts renamed (Set)"],
     );
   });
 

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -28,29 +28,127 @@ function sourceFiles(dir: string): string[] {
   });
 }
 
-function topLevelSetOrMapDeclarations(
+type TopLevelCollectionDeclaration = {
+  kind: "Set" | "Map";
+  name: string;
+  propertyPath: string[];
+  rootSymbolNode: ts.Identifier;
+};
+
+function newCollectionKind(
+  initializer: ts.Expression,
+): "Set" | "Map" | undefined {
+  if (!ts.isNewExpression(initializer)) return undefined;
+  const constructor = initializer.expression;
+  const collectionKind = ts.isIdentifier(constructor)
+    ? constructor.text
+    : ts.isPropertyAccessExpression(constructor)
+      ? constructor.name.text
+      : undefined;
+  return collectionKind === "Set" || collectionKind === "Map"
+    ? collectionKind
+    : undefined;
+}
+
+function nestedCollectionDeclarations(
+  initializer: ts.Expression,
+  name: string,
+  rootSymbolNode: ts.Identifier,
+  propertyPath: string[],
+): TopLevelCollectionDeclaration[] {
+  const collectionKind = newCollectionKind(initializer);
+  if (collectionKind) {
+    return [{ kind: collectionKind, name, propertyPath, rootSymbolNode }];
+  }
+  if (
+    ts.isAsExpression(initializer) ||
+    ts.isParenthesizedExpression(initializer) ||
+    ts.isSatisfiesExpression(initializer) ||
+    ts.isTypeAssertionExpression(initializer)
+  ) {
+    return nestedCollectionDeclarations(
+      initializer.expression,
+      name,
+      rootSymbolNode,
+      propertyPath,
+    );
+  }
+  if (!ts.isObjectLiteralExpression(initializer)) return [];
+
+  return initializer.properties.flatMap((property) => {
+    if (
+      !ts.isPropertyAssignment(property) ||
+      !(
+        ts.isIdentifier(property.name) ||
+        ts.isStringLiteral(property.name) ||
+        ts.isNumericLiteral(property.name)
+      )
+    ) {
+      return [];
+    }
+    return nestedCollectionDeclarations(
+      property.initializer,
+      `${name}.${property.name.text}`,
+      rootSymbolNode,
+      [...propertyPath, property.name.text],
+    );
+  });
+}
+
+function topLevelSetOrMapDeclarationNodes(
   sourceFile: ts.SourceFile,
-): Map<string, "Set" | "Map"> {
-  const declarations = new Map<string, "Set" | "Map">();
+): TopLevelCollectionDeclaration[] {
+  const declarations: TopLevelCollectionDeclaration[] = [];
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) continue;
     for (const declaration of statement.declarationList.declarations) {
-      const initializer = declaration.initializer;
-      if (!initializer || !ts.isNewExpression(initializer)) continue;
-      const constructor = initializer.expression;
-      const collectionKind = ts.isIdentifier(constructor)
-        ? constructor.text
-        : ts.isPropertyAccessExpression(constructor)
-          ? constructor.name.text
-          : null;
-      if (collectionKind !== "Set" && collectionKind !== "Map") continue;
-      if (!ts.isIdentifier(declaration.name)) continue;
-
-      declarations.set(declaration.name.text, collectionKind);
+      if (!declaration.initializer || !ts.isIdentifier(declaration.name)) {
+        continue;
+      }
+      declarations.push(
+        ...nestedCollectionDeclarations(
+          declaration.initializer,
+          declaration.name.text,
+          declaration.name,
+          [],
+        ),
+      );
     }
   }
 
   return declarations;
+}
+
+function topLevelSetOrMapDeclarations(
+  sourceFile: ts.SourceFile,
+): Map<string, "Set" | "Map"> {
+  return new Map(
+    topLevelSetOrMapDeclarationNodes(sourceFile).map(({ kind, name }) => [
+      name,
+      kind,
+    ]),
+  );
+}
+
+function isPreloadAccess(node: ts.Node): boolean {
+  if (ts.isPropertyAccessExpression(node) && node.name.text === "isPreload") {
+    return true;
+  }
+  if (
+    ts.isElementAccessExpression(node) &&
+    node.argumentExpression &&
+    (ts.isStringLiteral(node.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(node.argumentExpression)) &&
+    node.argumentExpression.text === "isPreload"
+  ) {
+    return true;
+  }
+  if (!ts.isBindingElement(node)) return false;
+  const bindingName = node.propertyName ?? node.name;
+  return (
+    (ts.isIdentifier(bindingName) || ts.isStringLiteral(bindingName)) &&
+    bindingName.text === "isPreload"
+  );
 }
 
 function moduleLocalCollectionsInPreloadAwareModule(
@@ -69,7 +167,7 @@ function moduleLocalCollectionsInPreloadAwareModule(
 
   let preloadAwareModule = false;
   const findPreload = (node: ts.Node): void => {
-    if (ts.isPropertyAccessExpression(node) && node.name.text === "isPreload") {
+    if (isPreloadAccess(node)) {
       preloadAwareModule = true;
       return;
     }
@@ -516,6 +614,417 @@ function buildEffectfulProgramAnalysis(): EffectfulProgramAnalysis {
 }
 
 const effectfulProgramAnalysis = buildEffectfulProgramAnalysis();
+
+type ModuleCollectionInfo = {
+  kind: "Set" | "Map";
+  name: string;
+  sourceFile: ts.SourceFile;
+};
+
+// Follow real TypeScript symbols so imported helpers, callbacks, aliases, and
+// collection parameters cannot hide worker-local mutations. Read-only lookup
+// collections are intentionally allowed.
+function findModuleCollectionMutationsReachableFromPreload(
+  program: ts.Program,
+  includesSourceFile: (sourceFile: ts.SourceFile) => boolean,
+  displayRoot: string,
+): string[] {
+  const checker = program.getTypeChecker();
+  const sourceFileList = program
+    .getSourceFiles()
+    .filter(
+      (sourceFile) =>
+        !sourceFile.isDeclarationFile && includesSourceFile(sourceFile),
+    );
+  type SymbolAccess = { path: string[]; root: ts.Symbol };
+  type PathBinding = {
+    collections: Set<ModuleCollectionInfo>;
+    path: string[];
+  };
+  type CollectionPathBindings = Map<ts.Symbol, Map<string, PathBinding>>;
+  const collectionPathBindings: CollectionPathBindings = new Map();
+  const pathKey = (propertyPath: readonly string[]): string =>
+    JSON.stringify(propertyPath);
+  const mergePathBinding = (
+    symbol: ts.Symbol,
+    propertyPath: readonly string[],
+    collections: ReadonlySet<ModuleCollectionInfo>,
+  ): boolean => {
+    const byPath = collectionPathBindings.get(symbol) ?? new Map();
+    const key = pathKey(propertyPath);
+    const existing = byPath.get(key) ?? {
+      collections: new Set<ModuleCollectionInfo>(),
+      path: [...propertyPath],
+    };
+    const initialSize = existing.collections.size;
+    for (const collection of collections) {
+      existing.collections.add(collection);
+    }
+    if (existing.collections.size === initialSize) return false;
+    byPath.set(key, existing);
+    collectionPathBindings.set(symbol, byPath);
+    return true;
+  };
+  const expressionAccess = (
+    expression: ts.Expression,
+  ): SymbolAccess | undefined => {
+    if (
+      ts.isAsExpression(expression) ||
+      ts.isNonNullExpression(expression) ||
+      ts.isParenthesizedExpression(expression) ||
+      ts.isSatisfiesExpression(expression) ||
+      ts.isTypeAssertionExpression(expression)
+    ) {
+      return expressionAccess(expression.expression);
+    }
+    if (ts.isIdentifier(expression)) {
+      const root = canonicalSymbol(
+        checker,
+        checker.getSymbolAtLocation(expression),
+      );
+      return root ? { path: [], root } : undefined;
+    }
+    if (ts.isPropertyAccessExpression(expression)) {
+      const parent = expressionAccess(expression.expression);
+      return parent
+        ? { path: [...parent.path, expression.name.text], root: parent.root }
+        : undefined;
+    }
+    if (
+      ts.isElementAccessExpression(expression) &&
+      expression.argumentExpression &&
+      (ts.isStringLiteral(expression.argumentExpression) ||
+        ts.isNoSubstitutionTemplateLiteral(expression.argumentExpression) ||
+        ts.isNumericLiteral(expression.argumentExpression))
+    ) {
+      const parent = expressionAccess(expression.expression);
+      return parent
+        ? {
+            path: [...parent.path, expression.argumentExpression.text],
+            root: parent.root,
+          }
+        : undefined;
+    }
+    return undefined;
+  };
+  const copyAccessBindings = (
+    alias: ts.Symbol,
+    target: SymbolAccess,
+  ): boolean => {
+    let changed = false;
+    for (const binding of collectionPathBindings.get(target.root)?.values() ??
+      []) {
+      if (
+        target.path.length > binding.path.length ||
+        target.path.some((segment, index) => binding.path[index] !== segment)
+      ) {
+        continue;
+      }
+      if (
+        mergePathBinding(
+          alias,
+          binding.path.slice(target.path.length),
+          binding.collections,
+        )
+      ) {
+        changed = true;
+      }
+    }
+    return changed;
+  };
+  const aliasEdges: Array<{
+    alias: ts.Symbol;
+    target: SymbolAccess;
+  }> = [];
+  for (const sourceFile of sourceFileList) {
+    for (const {
+      kind,
+      name,
+      propertyPath,
+      rootSymbolNode,
+    } of topLevelSetOrMapDeclarationNodes(sourceFile)) {
+      const collection = { kind, name, sourceFile };
+      const root = canonicalSymbol(
+        checker,
+        checker.getSymbolAtLocation(rootSymbolNode),
+      );
+      if (root) mergePathBinding(root, propertyPath, new Set([collection]));
+    }
+    const collectAliases = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer
+      ) {
+        const alias = canonicalSymbol(
+          checker,
+          checker.getSymbolAtLocation(node.name),
+        );
+        const target = expressionAccess(node.initializer);
+        if (alias && target) aliasEdges.push({ alias, target });
+      }
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isObjectBindingPattern(node.name) &&
+        node.initializer
+      ) {
+        const initializerAccess = expressionAccess(node.initializer);
+        for (const element of node.name.elements) {
+          const propertyName = element.propertyName ?? element.name;
+          if (
+            !ts.isIdentifier(element.name) ||
+            !(
+              ts.isIdentifier(propertyName) ||
+              ts.isStringLiteral(propertyName) ||
+              ts.isNumericLiteral(propertyName)
+            )
+          ) {
+            continue;
+          }
+          const alias = canonicalSymbol(
+            checker,
+            checker.getSymbolAtLocation(element.name),
+          );
+          if (alias && initializerAccess) {
+            aliasEdges.push({
+              alias,
+              target: {
+                path: [...initializerAccess.path, propertyName.text],
+                root: initializerAccess.root,
+              },
+            });
+          }
+        }
+      }
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(node.left)
+      ) {
+        const alias = canonicalSymbol(
+          checker,
+          checker.getSymbolAtLocation(node.left),
+        );
+        const target = expressionAccess(node.right);
+        if (alias && target) aliasEdges.push({ alias, target });
+      }
+      ts.forEachChild(node, collectAliases);
+    };
+    collectAliases(sourceFile);
+  }
+
+  const functions = new Set<ts.FunctionLikeDeclaration>();
+  const functionsBySymbol = new Map<
+    ts.Symbol,
+    Set<ts.FunctionLikeDeclaration>
+  >();
+  for (const sourceFile of sourceFileList) {
+    const visit = (node: ts.Node): void => {
+      if (isFunctionLikeNode(node)) {
+        const fn = node as ts.FunctionLikeDeclaration;
+        functions.add(fn);
+        const symbol = functionSymbol(fn, checker);
+        if (symbol) {
+          const declarations = functionsBySymbol.get(symbol) ?? new Set();
+          declarations.add(fn);
+          functionsBySymbol.set(symbol, declarations);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  const edges = new Map<
+    ts.FunctionLikeDeclaration,
+    Set<ts.FunctionLikeDeclaration>
+  >();
+  const callSitesByFunction = new Map<
+    ts.FunctionLikeDeclaration,
+    Array<{
+      call: ts.CallExpression;
+      invokedTargets: Set<ts.FunctionLikeDeclaration>;
+    }>
+  >();
+  const preloadFunctions = new Set<ts.FunctionLikeDeclaration>();
+  for (const fn of functions) {
+    const targets = new Set<ts.FunctionLikeDeclaration>();
+    const callSites: Array<{
+      call: ts.CallExpression;
+      invokedTargets: Set<ts.FunctionLikeDeclaration>;
+    }> = [];
+    let preloadAware = false;
+    const visit = (node: ts.Node): void => {
+      if (node !== fn && isFunctionLikeNode(node)) return;
+      if (isPreloadAccess(node)) {
+        preloadAware = true;
+      }
+      if (ts.isCallExpression(node)) {
+        const invokedTargets = new Set<ts.FunctionLikeDeclaration>();
+        for (const calledSymbol of callExpressionSymbols(node, checker)) {
+          for (const target of functionsBySymbol.get(calledSymbol) ?? []) {
+            targets.add(target);
+            invokedTargets.add(target);
+          }
+        }
+        for (const argument of node.arguments) {
+          if (isFunctionLikeNode(argument)) {
+            const target = argument as ts.FunctionLikeDeclaration;
+            targets.add(target);
+          }
+          const argumentSymbol = expressionSymbol(argument, checker);
+          if (!argumentSymbol) continue;
+          for (const target of functionsBySymbol.get(argumentSymbol) ?? []) {
+            targets.add(target);
+          }
+        }
+        callSites.push({ call: node, invokedTargets });
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(fn);
+    edges.set(fn, targets);
+    callSitesByFunction.set(fn, callSites);
+    if (preloadAware) preloadFunctions.add(fn);
+  }
+
+  const reachableFunctions = new Set(preloadFunctions);
+  const pendingFunctions = [...preloadFunctions];
+  while (pendingFunctions.length > 0) {
+    const fn = pendingFunctions.pop();
+    if (!fn) continue;
+    for (const target of edges.get(fn) ?? []) {
+      if (reachableFunctions.has(target)) continue;
+      reachableFunctions.add(target);
+      pendingFunctions.push(target);
+    }
+  }
+
+  let bindingsChanged = true;
+  while (bindingsChanged) {
+    bindingsChanged = false;
+    for (const { alias, target } of aliasEdges) {
+      if (copyAccessBindings(alias, target)) bindingsChanged = true;
+    }
+    for (const fn of reachableFunctions) {
+      for (const { call, invokedTargets } of callSitesByFunction.get(fn) ??
+        []) {
+        for (const target of invokedTargets) {
+          for (
+            let argumentIndex = 0;
+            argumentIndex < call.arguments.length;
+            argumentIndex += 1
+          ) {
+            const argument = call.arguments[argumentIndex];
+            const parameter = target.parameters[argumentIndex];
+            if (!argument || !parameter) continue;
+            const argumentAccess = expressionAccess(argument);
+            if (!argumentAccess) continue;
+            if (ts.isIdentifier(parameter.name)) {
+              const parameterSymbol = canonicalSymbol(
+                checker,
+                checker.getSymbolAtLocation(parameter.name),
+              );
+              if (
+                parameterSymbol &&
+                copyAccessBindings(parameterSymbol, argumentAccess)
+              ) {
+                bindingsChanged = true;
+              }
+              continue;
+            }
+            if (ts.isObjectBindingPattern(parameter.name)) {
+              for (const element of parameter.name.elements) {
+                const propertyName = element.propertyName ?? element.name;
+                if (
+                  !ts.isIdentifier(element.name) ||
+                  !(
+                    ts.isIdentifier(propertyName) ||
+                    ts.isStringLiteral(propertyName) ||
+                    ts.isNumericLiteral(propertyName)
+                  )
+                ) {
+                  continue;
+                }
+                const bindingSymbol = canonicalSymbol(
+                  checker,
+                  checker.getSymbolAtLocation(element.name),
+                );
+                if (
+                  bindingSymbol &&
+                  copyAccessBindings(bindingSymbol, {
+                    path: [...argumentAccess.path, propertyName.text],
+                    root: argumentAccess.root,
+                  })
+                ) {
+                  bindingsChanged = true;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const mutatedCollectionsByFunction = new Map<
+    ts.FunctionLikeDeclaration,
+    Set<ModuleCollectionInfo>
+  >();
+  for (const fn of functions) {
+    const mutatedCollections = new Set<ModuleCollectionInfo>();
+    const visit = (node: ts.Node): void => {
+      if (node !== fn && isFunctionLikeNode(node)) return;
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ["add", "clear", "delete", "set"].includes(node.expression.name.text)
+      ) {
+        const receiverAccess = expressionAccess(node.expression.expression);
+        const binding =
+          receiverAccess &&
+          collectionPathBindings
+            .get(receiverAccess.root)
+            ?.get(pathKey(receiverAccess.path));
+        if (binding) {
+          for (const collection of binding.collections) {
+            mutatedCollections.add(collection);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(fn);
+    mutatedCollectionsByFunction.set(fn, mutatedCollections);
+  }
+
+  const reachableCollections = new Set<ModuleCollectionInfo>();
+  for (const fn of reachableFunctions) {
+    for (const collection of mutatedCollectionsByFunction.get(fn) ?? []) {
+      reachableCollections.add(collection);
+    }
+  }
+  return [...reachableCollections]
+    .map(
+      ({ kind, name, sourceFile }) =>
+        `${path.relative(displayRoot, sourceFile.fileName)} ${name} (${kind})`,
+    )
+    .sort();
+}
+
+function findHandlerCollectionMutationsReachableFromPreload(): string[] {
+  const handlersRoot = path.join(srcRoot, "handlers");
+  // RPC/effect modules own intentional process-local client and test caches;
+  // this guard targets phase-bridging state hidden in the handler module graph.
+  return findModuleCollectionMutationsReachableFromPreload(
+    effectfulProgramAnalysis.program,
+    (sourceFile) =>
+      path
+        .resolve(sourceFile.fileName)
+        .startsWith(`${handlersRoot}${path.sep}`),
+    packageRoot,
+  );
+}
 
 function isDirectContextEffectCall(node: ts.Node): node is ts.CallExpression {
   return (
@@ -1140,14 +1649,17 @@ function hiddenEffectNames(sourceText: string): string[] {
   ).map((offender) => offender.slice(offender.lastIndexOf(" ") + 1));
 }
 
-function hiddenEffectNamesInProgram(
+type ProgramFixture = {
+  fixtureFiles: Map<string, string>;
+  fixtureRoot: string;
+  program: ts.Program;
+};
+
+function createProgramFixture(
   files: Readonly<Record<string, string>>,
-  entryFile: string,
-  preloadWrapperExports: ReadonlyArray<
-    readonly [file: string, exportName: string]
-  > = [],
-): string[] {
-  const fixtureRoot = path.join(packageRoot, "__preload-effect-fixtures__");
+  fixtureDirectory: string,
+): ProgramFixture {
+  const fixtureRoot = path.join(packageRoot, fixtureDirectory);
   const fixtureFiles = new Map(
     Object.entries(files).map(([file, sourceText]) => [
       path.resolve(fixtureRoot, file),
@@ -1218,6 +1730,20 @@ function hiddenEffectNamesInProgram(
         .join("\n"),
     );
   }
+  return { fixtureFiles, fixtureRoot, program };
+}
+
+function hiddenEffectNamesInProgram(
+  files: Readonly<Record<string, string>>,
+  entryFile: string,
+  preloadWrapperExports: ReadonlyArray<
+    readonly [file: string, exportName: string]
+  > = [],
+): string[] {
+  const { fixtureFiles, fixtureRoot, program } = createProgramFixture(
+    files,
+    "__preload-effect-fixtures__",
+  );
   const checker = program.getTypeChecker();
   const preloadWrapperSymbols = new Set<ts.Symbol>();
   for (const [file, exportName] of preloadWrapperExports) {
@@ -1255,6 +1781,20 @@ function hiddenEffectNamesInProgram(
   ).map((offender) => offender.slice(offender.lastIndexOf(" ") + 1));
 }
 
+function phaseCollectionNamesInProgram(
+  files: Readonly<Record<string, string>>,
+): string[] {
+  const { fixtureFiles, fixtureRoot, program } = createProgramFixture(
+    files,
+    "__preload-phase-collection-fixtures__",
+  );
+  return findModuleCollectionMutationsReachableFromPreload(
+    program,
+    (sourceFile) => fixtureFiles.has(path.resolve(sourceFile.fileName)),
+    fixtureRoot,
+  );
+}
+
 describe("indexer code quality invariants", () => {
   it("does not hardcode mainnet-only chain iteration in source", () => {
     const mainnetPairPattern = /\[\s*(?:42220\s*,\s*143|143\s*,\s*42220)\s*\]/;
@@ -1281,21 +1821,32 @@ describe("indexer code quality invariants", () => {
     );
   });
 
+  it("keeps preload-aware handlers from mutating imported handler collections", () => {
+    assert.deepEqual(
+      findHandlerCollectionMutationsReachableFromPreload(),
+      [],
+      "Hosted Envio workers do not share module state; preload-aware handlers must not mutate module-local Set/Map state through imported handler helpers",
+    );
+  });
+
   it("detects helper-hidden phase collections without flagging locals", () => {
     assert.deepEqual(
       moduleLocalCollectionsInPreloadAwareModule(
         `
           const renamed: Set<string> = new Set();
           const cache = new globalThis.Map<string, boolean>();
+          const phase = { queued: new Set<string>() };
           function remember() {
             const alias = renamed;
             alias.add("event");
+            phase.queued.add("event");
           }
           function consume() {
             renamed.delete("event");
           }
           function handler(context: { isPreload: boolean }) {
-            if (context.isPreload) remember();
+            const { isPreload } = context;
+            if (isPreload) remember();
             consume();
             cache.set("event", true);
             const preloadedIds = new Set<string>();
@@ -1305,7 +1856,11 @@ describe("indexer code quality invariants", () => {
         `,
         "fixture.ts",
       ),
-      ["fixture.ts renamed (Set)", "fixture.ts cache (Map)"],
+      [
+        "fixture.ts renamed (Set)",
+        "fixture.ts cache (Map)",
+        "fixture.ts phase.queued (Set)",
+      ],
     );
     assert.deepEqual(
       moduleLocalCollectionsInPreloadAwareModule(
@@ -1319,6 +1874,130 @@ describe("indexer code quality invariants", () => {
         "fixture.ts",
       ),
       [],
+    );
+  });
+
+  it("follows imported helper calls to phase collections across files", () => {
+    assert.deepEqual(
+      phaseCollectionNamesInProgram({
+        "entry.ts": `
+          import { consume, remember } from "./helpers.js";
+          export function handler(context: { isPreload: boolean }) {
+            const { isPreload } = context;
+            if (isPreload) {
+              remember("event");
+              return;
+            }
+            consume("event");
+            const local = new Set<string>();
+            local.add("safe");
+          }
+        `,
+        "helpers.ts": `
+          import {
+            deleteState,
+            writeAssignedState,
+            writeCallbackState,
+            writeDirectState,
+            writeNestedState,
+            writeParameterizedState,
+            mutateLocalNestedState,
+            prepareSharedAlias,
+            mutateSharedAlias,
+          } from "./phase-state.js";
+          const unrelatedStaticLookup = new Set(["safe"]);
+          export function remember(id: string) {
+            writeDirectState(id);
+            writeNestedState(id);
+            writeParameterizedState(id);
+            writeCallbackState(id);
+            writeAssignedState(id);
+            mutateLocalNestedState(id);
+            prepareSharedAlias();
+            unrelated();
+          }
+          export function consume(id: string) {
+            deleteState(id);
+            mutateSharedAlias();
+          }
+          export function unrelated() {
+            return unrelatedStaticLookup.has("safe");
+          }
+        `,
+        "phase-state.ts": `
+          interface NestedState {
+            remembered: Set<string>;
+          }
+          const directState = new Set<string>();
+          const nestedState: NestedState = { remembered: new Set<string>() };
+          const moduleLookup: NestedState = { remembered: new Set<string>() };
+          const parameterState = new Set<string>();
+          const callbackState = new Map<string, boolean>();
+          const assignmentState = new Set<string>();
+          const sharedAliasState = new Set<string>();
+          const unrelatedPathState = new Set<string>();
+          let sharedAlias: Set<string> | undefined;
+          function mutate(target: Set<string>, id: string) {
+            target.add(id);
+          }
+          export function writeDirectState(id: string) {
+            directState.add(id);
+          }
+          export function writeNestedState(id: string) {
+            const { remembered } = nestedState;
+            remembered.add(id);
+          }
+          export function mutateLocalNestedState(id: string) {
+            const local: NestedState = { remembered: new Set<string>() };
+            local.remembered.add(id);
+            moduleLookup.remembered.has(id);
+          }
+          export function writeParameterizedState(id: string) {
+            mutate(parameterState, id);
+          }
+          export function writeCallbackState(id: string) {
+            [id].forEach((item) => callbackState.set(item, true));
+          }
+          export function writeAssignedState(id: string) {
+            let alias: Set<string>;
+            alias = assignmentState;
+            alias.add(id);
+          }
+          export function deleteState(id: string) {
+            directState.delete(id);
+          }
+          export function prepareSharedAlias() {
+            sharedAlias = sharedAliasState;
+          }
+          export function mutateSharedAlias() {
+            sharedAlias?.delete("event");
+          }
+          export function mutateOnlyOutsideThePreloadGraph() {
+            mutate(unrelatedPathState, "unrelated");
+          }
+        `,
+        "bracket-entry.ts": `
+          import { writeBracketState } from "./bracket-state.js";
+          export function bracketHandler(context: { isPreload: boolean }) {
+            if (context["isPreload"]) writeBracketState("event");
+          }
+        `,
+        "bracket-state.ts": `
+          const bracketState = new Set<string>();
+          export function writeBracketState(id: string) {
+            bracketState.add(id);
+          }
+        `,
+      }),
+      [
+        "bracket-state.ts bracketState (Set)",
+        "phase-state.ts assignmentState (Set)",
+        "phase-state.ts callbackState (Map)",
+        "phase-state.ts directState (Set)",
+        "phase-state.ts nestedState.remembered (Set)",
+        "phase-state.ts parameterState (Set)",
+        "phase-state.ts sharedAliasState (Set)",
+      ],
     );
   });
 

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -643,6 +643,7 @@ function findModuleCollectionMutationsReachableFromPreload(
   };
   type CollectionPathBindings = Map<ts.Symbol, Map<string, PathBinding>>;
   const collectionPathBindings: CollectionPathBindings = new Map();
+  const moduleScopedBindingSymbols = new Set<ts.Symbol>();
   const pathKey = (propertyPath: readonly string[]): string =>
     JSON.stringify(propertyPath);
   const mergePathBinding = (
@@ -737,6 +738,27 @@ function findModuleCollectionMutationsReachableFromPreload(
     target: SymbolAccess;
   }> = [];
   for (const sourceFile of sourceFileList) {
+    const collectModuleBindingSymbols = (name: ts.BindingName): void => {
+      if (ts.isIdentifier(name)) {
+        const symbol = canonicalSymbol(
+          checker,
+          checker.getSymbolAtLocation(name),
+        );
+        if (symbol) moduleScopedBindingSymbols.add(symbol);
+        return;
+      }
+      for (const element of name.elements) {
+        if (!ts.isOmittedExpression(element)) {
+          collectModuleBindingSymbols(element.name);
+        }
+      }
+    };
+    for (const statement of sourceFile.statements) {
+      if (!ts.isVariableStatement(statement)) continue;
+      for (const declaration of statement.declarationList.declarations) {
+        collectModuleBindingSymbols(declaration.name);
+      }
+    }
     for (const {
       kind,
       name,
@@ -748,7 +770,10 @@ function findModuleCollectionMutationsReachableFromPreload(
         checker,
         checker.getSymbolAtLocation(rootSymbolNode),
       );
-      if (root) mergePathBinding(root, propertyPath, new Set([collection]));
+      if (root) {
+        const collections = new Set([collection]);
+        mergePathBinding(root, propertyPath, collections);
+      }
     }
     const collectAliases = (node: ts.Node): void => {
       if (
@@ -971,10 +996,43 @@ function findModuleCollectionMutationsReachableFromPreload(
     ts.FunctionLikeDeclaration,
     Set<ModuleCollectionInfo>
   >();
+  const isAssignmentOperator = (kind: ts.SyntaxKind): boolean =>
+    kind >= ts.SyntaxKind.FirstAssignment &&
+    kind <= ts.SyntaxKind.LastAssignment;
   for (const fn of functions) {
     const mutatedCollections = new Set<ModuleCollectionInfo>();
     const visit = (node: ts.Node): void => {
       if (node !== fn && isFunctionLikeNode(node)) return;
+      if (
+        ts.isBinaryExpression(node) &&
+        isAssignmentOperator(node.operatorToken.kind) &&
+        (ts.isIdentifier(node.left) ||
+          ts.isPropertyAccessExpression(node.left) ||
+          ts.isElementAccessExpression(node.left))
+      ) {
+        const assignedAccess = expressionAccess(node.left);
+        const mayReplaceModuleState =
+          assignedAccess &&
+          (!ts.isIdentifier(node.left) ||
+            moduleScopedBindingSymbols.has(assignedAccess.root));
+        if (assignedAccess && mayReplaceModuleState) {
+          for (const binding of collectionPathBindings
+            .get(assignedAccess.root)
+            ?.values() ?? []) {
+            if (
+              assignedAccess.path.length > binding.path.length ||
+              assignedAccess.path.some(
+                (segment, index) => binding.path[index] !== segment,
+              )
+            ) {
+              continue;
+            }
+            for (const collection of binding.collections) {
+              mutatedCollections.add(collection);
+            }
+          }
+        }
+      }
       if (
         ts.isCallExpression(node) &&
         ts.isPropertyAccessExpression(node.expression) &&
@@ -1903,7 +1961,11 @@ describe("indexer code quality invariants", () => {
             writeParameterizedState,
             mutateLocalNestedState,
             prepareSharedAlias,
+            replaceAliasState,
+            replaceContainerState,
             mutateSharedAlias,
+            replaceNestedState,
+            replaceState,
           } from "./phase-state.js";
           const unrelatedStaticLookup = new Set(["safe"]);
           export function remember(id: string) {
@@ -1914,6 +1976,10 @@ describe("indexer code quality invariants", () => {
             writeAssignedState(id);
             mutateLocalNestedState(id);
             prepareSharedAlias();
+            replaceAliasState(id);
+            replaceContainerState(id);
+            replaceNestedState(id);
+            replaceState(id);
             unrelated();
           }
           export function consume(id: string) {
@@ -1934,8 +2000,13 @@ describe("indexer code quality invariants", () => {
           const parameterState = new Set<string>();
           const callbackState = new Map<string, boolean>();
           const assignmentState = new Set<string>();
+          const aliasStateSeed = new Set<string>();
+          const reassignedNestedState = { remembered: new Set<string>() };
           const sharedAliasState = new Set<string>();
           const unrelatedPathState = new Set<string>();
+          let aliasState = aliasStateSeed;
+          let replacedContainerState = { remembered: new Set<string>() };
+          let reassignedState = new Set<string>();
           let sharedAlias: Set<string> | undefined;
           function mutate(target: Set<string>, id: string) {
             target.add(id);
@@ -1949,8 +2020,12 @@ describe("indexer code quality invariants", () => {
           }
           export function mutateLocalNestedState(id: string) {
             const local: NestedState = { remembered: new Set<string>() };
+            let localAlias = moduleLookup.remembered;
+            localAlias.has(id);
+            localAlias = new Set([id]);
             local.remembered.add(id);
             moduleLookup.remembered.has(id);
+            localAlias.has(id);
           }
           export function writeParameterizedState(id: string) {
             mutate(parameterState, id);
@@ -1972,6 +2047,18 @@ describe("indexer code quality invariants", () => {
           export function mutateSharedAlias() {
             sharedAlias?.delete("event");
           }
+          export function replaceAliasState(id: string) {
+            aliasState = new Set([id]);
+          }
+          export function replaceContainerState(id: string) {
+            replacedContainerState = { remembered: new Set([id]) };
+          }
+          export function replaceNestedState(id: string) {
+            reassignedNestedState.remembered = new Set([id]);
+          }
+          export function replaceState(id: string) {
+            reassignedState = new Set([id]);
+          }
           export function mutateOnlyOutsideThePreloadGraph() {
             mutate(unrelatedPathState, "unrelated");
           }
@@ -1991,11 +2078,15 @@ describe("indexer code quality invariants", () => {
       }),
       [
         "bracket-state.ts bracketState (Set)",
+        "phase-state.ts aliasStateSeed (Set)",
         "phase-state.ts assignmentState (Set)",
         "phase-state.ts callbackState (Map)",
         "phase-state.ts directState (Set)",
         "phase-state.ts nestedState.remembered (Set)",
         "phase-state.ts parameterState (Set)",
+        "phase-state.ts reassignedNestedState.remembered (Set)",
+        "phase-state.ts reassignedState (Set)",
+        "phase-state.ts replacedContainerState.remembered (Set)",
         "phase-state.ts sharedAliasState (Set)",
       ],
     );

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -53,7 +53,7 @@ function topLevelSetOrMapDeclarations(
   return declarations;
 }
 
-function moduleLocalPhaseCollectionMutations(
+function moduleLocalCollectionsInPreloadAwareModule(
   sourceText: string,
   fileName: string,
 ): string[] {
@@ -67,67 +67,18 @@ function moduleLocalPhaseCollectionMutations(
   const moduleCollections = topLevelSetOrMapDeclarations(sourceFile);
   if (moduleCollections.size === 0) return [];
 
-  const offenders = new Set<string>();
-  const collectionMutators = new Set(["add", "set", "delete", "clear"]);
-  const visitFunction = (fn: ts.Node): void => {
-    let preloadAware = false;
-    const findPreload = (node: ts.Node): void => {
-      if (node !== fn && isFunctionLikeNode(node)) return;
-      if (
-        ts.isPropertyAccessExpression(node) &&
-        node.name.text === "isPreload"
-      ) {
-        preloadAware = true;
-        return;
-      }
-      ts.forEachChild(node, findPreload);
-    };
-    findPreload(fn);
-    if (!preloadAware) return;
-
-    const findMutation = (node: ts.Node): void => {
-      if (node !== fn && isFunctionLikeNode(node)) return;
-      if (
-        ts.isCallExpression(node) &&
-        ts.isPropertyAccessExpression(node.expression) &&
-        ts.isIdentifier(node.expression.expression) &&
-        moduleCollections.has(node.expression.expression.text) &&
-        collectionMutators.has(node.expression.name.text)
-      ) {
-        const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-          node.expression.getStart(sourceFile),
-        );
-        offenders.add(
-          `${fileName}:${line + 1}:${character + 1} ${node.expression.getText(sourceFile)}`,
-        );
-      }
-      ts.forEachChild(node, findMutation);
-    };
-    findMutation(fn);
+  let preloadAwareModule = false;
+  const findPreload = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) && node.name.text === "isPreload") {
+      preloadAwareModule = true;
+      return;
+    }
+    ts.forEachChild(node, findPreload);
   };
+  findPreload(sourceFile);
+  if (!preloadAwareModule) return [];
 
-  const visit = (node: ts.Node): void => {
-    if (isFunctionLikeNode(node)) visitFunction(node);
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-
-  return [...offenders];
-}
-
-function moduleLocalSetOrMapDeclarations(
-  sourceText: string,
-  fileName: string,
-): string[] {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-
-  return [...topLevelSetOrMapDeclarations(sourceFile)].map(
+  return [...moduleCollections].map(
     ([name, collectionKind]) => `${fileName} ${name} (${collectionKind})`,
   );
 }
@@ -1314,10 +1265,10 @@ describe("indexer code quality invariants", () => {
     assert.deepEqual(offenders, []);
   });
 
-  it("does not mutate module-local collections in preload-aware handlers", () => {
+  it("keeps preload-aware handler modules free of module-local collections", () => {
     const offenders = sourceFiles(path.join(srcRoot, "handlers")).flatMap(
       (file) =>
-        moduleLocalPhaseCollectionMutations(
+        moduleLocalCollectionsInPreloadAwareModule(
           readFileSync(file, "utf8"),
           path.relative(packageRoot, file),
         ),
@@ -1326,18 +1277,26 @@ describe("indexer code quality invariants", () => {
     assert.deepEqual(
       offenders,
       [],
-      "Hosted Envio may run preload and processing in different workers; derive effect conditions in each pass instead of bridging them with module-local Set/Map state",
+      "Hosted Envio may run preload and processing in different workers; preload-aware handler modules must not declare module-local Set/Map state",
     );
   });
 
-  it("detects renamed module-local phase mutations without flagging locals", () => {
+  it("detects helper-hidden phase collections without flagging locals", () => {
     assert.deepEqual(
-      moduleLocalPhaseCollectionMutations(
+      moduleLocalCollectionsInPreloadAwareModule(
         `
           const renamed: Set<string> = new Set();
           const cache = new globalThis.Map<string, boolean>();
+          function remember() {
+            const alias = renamed;
+            alias.add("event");
+          }
+          function consume() {
+            renamed.delete("event");
+          }
           function handler(context: { isPreload: boolean }) {
-            if (context.isPreload) renamed.add("event");
+            if (context.isPreload) remember();
+            consume();
             cache.set("event", true);
             const preloadedIds = new Set<string>();
             preloadedIds.add("local");
@@ -1345,15 +1304,21 @@ describe("indexer code quality invariants", () => {
           }
         `,
         "fixture.ts",
-      ).map((offender) => offender.replace(/:\d+:\d+/, "")),
-      ["fixture.ts renamed.add", "fixture.ts cache.set"],
+      ),
+      ["fixture.ts renamed (Set)", "fixture.ts cache (Map)"],
     );
     assert.deepEqual(
-      moduleLocalSetOrMapDeclarations(
-        `const renamed: Set<string> = new Set();`,
+      moduleLocalCollectionsInPreloadAwareModule(
+        `
+          function handler(context: { isPreload: boolean }) {
+            if (context.isPreload) return;
+            const warmed = new Set<string>();
+            warmed.add("local");
+          }
+        `,
         "fixture.ts",
       ),
-      ["fixture.ts renamed (Set)"],
+      [],
     );
   });
 

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -1210,6 +1210,22 @@ describe("indexer code quality invariants", () => {
     assert.deepEqual(offenders, []);
   });
 
+  it("does not bridge preload and processing with module-local collections", () => {
+    const moduleLocalPreloadCollection =
+      /(?:preload|preloaded)[A-Za-z0-9_]*\s*=\s*new\s+(?:Set|Map)\b/i;
+    const offenders = sourceFiles(path.join(srcRoot, "handlers"))
+      .filter((file) =>
+        moduleLocalPreloadCollection.test(readFileSync(file, "utf8")),
+      )
+      .map((file) => path.relative(packageRoot, file));
+
+    assert.deepEqual(
+      offenders,
+      [],
+      "Hosted Envio may run preload and processing in different workers; derive effect conditions in each pass instead of bridging them with module-local Set/Map state",
+    );
+  });
+
   it("keeps multi-field Envio getWhere calls chain-scoped or pool-scoped", () => {
     assert.deepEqual(findUnsafeMultiFieldGetWhereCalls(), []);
   });

--- a/indexer-envio/test/code-quality-invariants.test.ts
+++ b/indexer-envio/test/code-quality-invariants.test.ts
@@ -615,19 +615,23 @@ function buildEffectfulProgramAnalysis(): EffectfulProgramAnalysis {
 
 const effectfulProgramAnalysis = buildEffectfulProgramAnalysis();
 
-type ModuleCollectionInfo = {
-  kind: "Set" | "Map";
+type ModuleStateInfo = {
+  kind: "Set" | "Map" | "state";
   name: string;
+  owner: ts.Symbol;
   sourceFile: ts.SourceFile;
 };
 
 // Follow real TypeScript symbols so imported helpers, callbacks, aliases, and
-// collection parameters cannot hide worker-local mutations. Read-only lookup
-// collections are intentionally allowed.
-function findModuleCollectionMutationsReachableFromPreload(
+// parameters cannot hide worker-local mutations. Read-only module bindings are
+// intentionally allowed.
+function findModuleStateMutationsReachableFromRegisteredHandlers(
   program: ts.Program,
   includesSourceFile: (sourceFile: ts.SourceFile) => boolean,
   displayRoot: string,
+  includesStateSourceFile: (
+    sourceFile: ts.SourceFile,
+  ) => boolean = includesSourceFile,
 ): string[] {
   const checker = program.getTypeChecker();
   const sourceFileList = program
@@ -638,34 +642,40 @@ function findModuleCollectionMutationsReachableFromPreload(
     );
   type SymbolAccess = { path: string[]; root: ts.Symbol };
   type PathBinding = {
-    collections: Set<ModuleCollectionInfo>;
+    states: Set<ModuleStateInfo>;
     path: string[];
   };
-  type CollectionPathBindings = Map<ts.Symbol, Map<string, PathBinding>>;
-  const collectionPathBindings: CollectionPathBindings = new Map();
+  type StatePathBindings = Map<ts.Symbol, Map<string, PathBinding>>;
+  const statePathBindings: StatePathBindings = new Map();
   const moduleScopedBindingSymbols = new Set<ts.Symbol>();
   const pathKey = (propertyPath: readonly string[]): string =>
     JSON.stringify(propertyPath);
   const mergePathBinding = (
     symbol: ts.Symbol,
     propertyPath: readonly string[],
-    collections: ReadonlySet<ModuleCollectionInfo>,
+    states: ReadonlySet<ModuleStateInfo>,
   ): boolean => {
-    const byPath = collectionPathBindings.get(symbol) ?? new Map();
+    const byPath = statePathBindings.get(symbol) ?? new Map();
     const key = pathKey(propertyPath);
     const existing = byPath.get(key) ?? {
-      collections: new Set<ModuleCollectionInfo>(),
+      states: new Set<ModuleStateInfo>(),
       path: [...propertyPath],
     };
-    const initialSize = existing.collections.size;
-    for (const collection of collections) {
-      existing.collections.add(collection);
+    const initialSize = existing.states.size;
+    for (const state of states) {
+      existing.states.add(state);
     }
-    if (existing.collections.size === initialSize) return false;
+    if (existing.states.size === initialSize) return false;
     byPath.set(key, existing);
-    collectionPathBindings.set(symbol, byPath);
+    statePathBindings.set(symbol, byPath);
     return true;
   };
+  const isPathPrefix = (
+    prefix: readonly string[],
+    candidate: readonly string[],
+  ): boolean =>
+    prefix.length <= candidate.length &&
+    prefix.every((segment, index) => candidate[index] === segment);
   const expressionAccess = (
     expression: ts.Expression,
   ): SymbolAccess | undefined => {
@@ -691,17 +701,19 @@ function findModuleCollectionMutationsReachableFromPreload(
         ? { path: [...parent.path, expression.name.text], root: parent.root }
         : undefined;
     }
-    if (
-      ts.isElementAccessExpression(expression) &&
-      expression.argumentExpression &&
-      (ts.isStringLiteral(expression.argumentExpression) ||
-        ts.isNoSubstitutionTemplateLiteral(expression.argumentExpression) ||
-        ts.isNumericLiteral(expression.argumentExpression))
-    ) {
+    if (ts.isElementAccessExpression(expression)) {
       const parent = expressionAccess(expression.expression);
+      const argument = expression.argumentExpression;
+      const property =
+        argument &&
+        (ts.isStringLiteral(argument) ||
+          ts.isNoSubstitutionTemplateLiteral(argument) ||
+          ts.isNumericLiteral(argument))
+          ? argument.text
+          : "<computed>";
       return parent
         ? {
-            path: [...parent.path, expression.argumentExpression.text],
+            path: [...parent.path, property],
             root: parent.root,
           }
         : undefined;
@@ -713,19 +725,15 @@ function findModuleCollectionMutationsReachableFromPreload(
     target: SymbolAccess,
   ): boolean => {
     let changed = false;
-    for (const binding of collectionPathBindings.get(target.root)?.values() ??
-      []) {
-      if (
-        target.path.length > binding.path.length ||
-        target.path.some((segment, index) => binding.path[index] !== segment)
-      ) {
-        continue;
-      }
+    for (const binding of statePathBindings.get(target.root)?.values() ?? []) {
+      const targetContainsBinding = isPathPrefix(target.path, binding.path);
+      const bindingContainsTarget = isPathPrefix(binding.path, target.path);
+      if (!targetContainsBinding && !bindingContainsTarget) continue;
       if (
         mergePathBinding(
           alias,
-          binding.path.slice(target.path.length),
-          binding.collections,
+          targetContainsBinding ? binding.path.slice(target.path.length) : [],
+          binding.states,
         )
       ) {
         changed = true;
@@ -738,41 +746,47 @@ function findModuleCollectionMutationsReachableFromPreload(
     target: SymbolAccess;
   }> = [];
   for (const sourceFile of sourceFileList) {
-    const collectModuleBindingSymbols = (name: ts.BindingName): void => {
+    const collectModuleBindingState = (
+      name: ts.BindingName,
+      kind: ModuleStateInfo["kind"],
+    ): void => {
       if (ts.isIdentifier(name)) {
         const symbol = canonicalSymbol(
           checker,
           checker.getSymbolAtLocation(name),
         );
-        if (symbol) moduleScopedBindingSymbols.add(symbol);
+        if (symbol) {
+          moduleScopedBindingSymbols.add(symbol);
+          mergePathBinding(
+            symbol,
+            [],
+            new Set([
+              {
+                kind,
+                name: name.text,
+                owner: symbol,
+                sourceFile,
+              },
+            ]),
+          );
+        }
         return;
       }
       for (const element of name.elements) {
         if (!ts.isOmittedExpression(element)) {
-          collectModuleBindingSymbols(element.name);
+          collectModuleBindingState(element.name, "state");
         }
       }
     };
-    for (const statement of sourceFile.statements) {
-      if (!ts.isVariableStatement(statement)) continue;
-      for (const declaration of statement.declarationList.declarations) {
-        collectModuleBindingSymbols(declaration.name);
-      }
-    }
-    for (const {
-      kind,
-      name,
-      propertyPath,
-      rootSymbolNode,
-    } of topLevelSetOrMapDeclarationNodes(sourceFile)) {
-      const collection = { kind, name, sourceFile };
-      const root = canonicalSymbol(
-        checker,
-        checker.getSymbolAtLocation(rootSymbolNode),
-      );
-      if (root) {
-        const collections = new Set([collection]);
-        mergePathBinding(root, propertyPath, collections);
+    if (includesStateSourceFile(sourceFile)) {
+      for (const statement of sourceFile.statements) {
+        if (!ts.isVariableStatement(statement)) continue;
+        for (const declaration of statement.declarationList.declarations) {
+          const kind = declaration.initializer
+            ? (newCollectionKind(declaration.initializer) ?? "state")
+            : "state";
+          collectModuleBindingState(declaration.name, kind);
+        }
       }
     }
     const collectAliases = (node: ts.Node): void => {
@@ -871,19 +885,14 @@ function findModuleCollectionMutationsReachableFromPreload(
       invokedTargets: Set<ts.FunctionLikeDeclaration>;
     }>
   >();
-  const preloadFunctions = new Set<ts.FunctionLikeDeclaration>();
   for (const fn of functions) {
     const targets = new Set<ts.FunctionLikeDeclaration>();
     const callSites: Array<{
       call: ts.CallExpression;
       invokedTargets: Set<ts.FunctionLikeDeclaration>;
     }> = [];
-    let preloadAware = false;
     const visit = (node: ts.Node): void => {
       if (node !== fn && isFunctionLikeNode(node)) return;
-      if (isPreloadAccess(node)) {
-        preloadAware = true;
-      }
       if (ts.isCallExpression(node)) {
         const invokedTargets = new Set<ts.FunctionLikeDeclaration>();
         for (const calledSymbol of callExpressionSymbols(node, checker)) {
@@ -910,11 +919,49 @@ function findModuleCollectionMutationsReachableFromPreload(
     visit(fn);
     edges.set(fn, targets);
     callSitesByFunction.set(fn, callSites);
-    if (preloadAware) preloadFunctions.add(fn);
   }
 
-  const reachableFunctions = new Set(preloadFunctions);
-  const pendingFunctions = [...preloadFunctions];
+  const registeredHandlerFunctions = new Set<ts.FunctionLikeDeclaration>();
+  for (const sourceFile of sourceFileList) {
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ["contractRegister", "onBlock", "onEvent"].includes(
+          node.expression.name.text,
+        )
+      ) {
+        const indexerSymbol = checker.getSymbolAtLocation(
+          node.expression.expression,
+        );
+        const callback = node.arguments[1];
+        if (indexerSymbol?.name === "indexer" && callback) {
+          if (isFunctionLikeNode(callback)) {
+            registeredHandlerFunctions.add(
+              callback as ts.FunctionLikeDeclaration,
+            );
+          } else {
+            const callbackSymbol = expressionSymbol(callback, checker);
+            if (callbackSymbol) {
+              for (const fn of functionsBySymbol.get(callbackSymbol) ?? []) {
+                registeredHandlerFunctions.add(fn);
+              }
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  if (registeredHandlerFunctions.size === 0) {
+    throw new Error(
+      "Module-state analysis found no registered indexer callbacks",
+    );
+  }
+
+  const reachableFunctions = new Set(registeredHandlerFunctions);
+  const pendingFunctions = [...registeredHandlerFunctions];
   while (pendingFunctions.length > 0) {
     const fn = pendingFunctions.pop();
     if (!fn) continue;
@@ -988,19 +1035,122 @@ function findModuleCollectionMutationsReachableFromPreload(
             }
           }
         }
+        const receiverAccess = ts.isPropertyAccessExpression(call.expression)
+          ? expressionAccess(call.expression.expression)
+          : undefined;
+        if (receiverAccess) {
+          for (const argument of call.arguments) {
+            const callbackTargets = new Set<ts.FunctionLikeDeclaration>();
+            if (isFunctionLikeNode(argument)) {
+              callbackTargets.add(argument as ts.FunctionLikeDeclaration);
+            }
+            const callbackSymbol = expressionSymbol(argument, checker);
+            if (callbackSymbol) {
+              for (const target of functionsBySymbol.get(callbackSymbol) ??
+                []) {
+                callbackTargets.add(target);
+              }
+            }
+            for (const callbackTarget of callbackTargets) {
+              const valueParameter = callbackTarget.parameters[0];
+              if (!valueParameter || !ts.isIdentifier(valueParameter.name)) {
+                continue;
+              }
+              const valueSymbol = canonicalSymbol(
+                checker,
+                checker.getSymbolAtLocation(valueParameter.name),
+              );
+              if (
+                valueSymbol &&
+                copyAccessBindings(valueSymbol, receiverAccess)
+              ) {
+                bindingsChanged = true;
+              }
+            }
+          }
+        }
       }
     }
   }
 
-  const mutatedCollectionsByFunction = new Map<
+  const statesForAccess = (
+    access: SymbolAccess,
+    includeDescendants: boolean,
+  ): Set<ModuleStateInfo> => {
+    const states = new Set<ModuleStateInfo>();
+    for (const binding of statePathBindings.get(access.root)?.values() ?? []) {
+      if (
+        !isPathPrefix(binding.path, access.path) &&
+        !(includeDescendants && isPathPrefix(access.path, binding.path))
+      ) {
+        continue;
+      }
+      for (const state of binding.states) states.add(state);
+    }
+    const directlyOwned = new Set(
+      [...states].filter((state) => state.owner === access.root),
+    );
+    return directlyOwned.size > 0 ? directlyOwned : states;
+  };
+  const mutatedStatesByFunction = new Map<
     ts.FunctionLikeDeclaration,
-    Set<ModuleCollectionInfo>
+    Set<ModuleStateInfo>
   >();
   const isAssignmentOperator = (kind: ts.SyntaxKind): boolean =>
     kind >= ts.SyntaxKind.FirstAssignment &&
     kind <= ts.SyntaxKind.LastAssignment;
+  const mutatingMethodNames = new Set([
+    "add",
+    "clear",
+    "copyWithin",
+    "delete",
+    "fill",
+    "pop",
+    "push",
+    "reverse",
+    "set",
+    "shift",
+    "sort",
+    "splice",
+    "unshift",
+  ]);
+  const objectMutationMethods = new Set([
+    "assign",
+    "defineProperties",
+    "defineProperty",
+    "setPrototypeOf",
+  ]);
+  const reflectMutationMethods = new Set([
+    "defineProperty",
+    "deleteProperty",
+    "set",
+    "setPrototypeOf",
+  ]);
+  const hasPhaseStateAllowance = (node: ts.Node): boolean => {
+    const sourceFile = node.getSourceFile();
+    const leadingTrivia = sourceFile.text.slice(
+      node.getFullStart(),
+      node.getStart(sourceFile),
+    );
+    return (
+      /phase-state-exempt:[ \t]*[^#\r\n]*[A-Za-z][^#\r\n]*#\d+/.test(
+        leadingTrivia,
+      ) ||
+      /phase-state-cache:[ \t]*[^\r\n]*[A-Za-z][^\r\n]*/.test(leadingTrivia)
+    );
+  };
   for (const fn of functions) {
-    const mutatedCollections = new Set<ModuleCollectionInfo>();
+    const mutatedStates = new Set<ModuleStateInfo>();
+    const recordMutation = (
+      access: SymbolAccess | undefined,
+      includeDescendants: boolean,
+      mutationNode: ts.Node,
+    ): void => {
+      if (!access || hasPhaseStateAllowance(mutationNode)) return;
+      for (const state of statesForAccess(access, includeDescendants)) {
+        mutatedStates.add(state);
+      }
+    };
     const visit = (node: ts.Node): void => {
       if (node !== fn && isFunctionLikeNode(node)) return;
       if (
@@ -1016,53 +1166,61 @@ function findModuleCollectionMutationsReachableFromPreload(
           (!ts.isIdentifier(node.left) ||
             moduleScopedBindingSymbols.has(assignedAccess.root));
         if (assignedAccess && mayReplaceModuleState) {
-          for (const binding of collectionPathBindings
-            .get(assignedAccess.root)
-            ?.values() ?? []) {
-            if (
-              assignedAccess.path.length > binding.path.length ||
-              assignedAccess.path.some(
-                (segment, index) => binding.path[index] !== segment,
-              )
-            ) {
-              continue;
-            }
-            for (const collection of binding.collections) {
-              mutatedCollections.add(collection);
-            }
-          }
+          recordMutation(assignedAccess, true, node);
         }
+      }
+      if (
+        (ts.isPrefixUnaryExpression(node) ||
+          ts.isPostfixUnaryExpression(node)) &&
+        (node.operator === ts.SyntaxKind.PlusPlusToken ||
+          node.operator === ts.SyntaxKind.MinusMinusToken)
+      ) {
+        const operand = node.operand;
+        const access = expressionAccess(operand);
+        if (
+          access &&
+          (!ts.isIdentifier(operand) ||
+            moduleScopedBindingSymbols.has(access.root))
+        ) {
+          recordMutation(access, true, node);
+        }
+      }
+      if (ts.isDeleteExpression(node)) {
+        recordMutation(expressionAccess(node.expression), false, node);
       }
       if (
         ts.isCallExpression(node) &&
         ts.isPropertyAccessExpression(node.expression) &&
-        ["add", "clear", "delete", "set"].includes(node.expression.name.text)
+        mutatingMethodNames.has(node.expression.name.text)
       ) {
         const receiverAccess = expressionAccess(node.expression.expression);
-        const binding =
-          receiverAccess &&
-          collectionPathBindings
-            .get(receiverAccess.root)
-            ?.get(pathKey(receiverAccess.path));
-        if (binding) {
-          for (const collection of binding.collections) {
-            mutatedCollections.add(collection);
-          }
-        }
+        recordMutation(receiverAccess, false, node);
+      }
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        ((node.expression.expression.text === "Object" &&
+          objectMutationMethods.has(node.expression.name.text)) ||
+          (node.expression.expression.text === "Reflect" &&
+            reflectMutationMethods.has(node.expression.name.text)))
+      ) {
+        const target = node.arguments[0];
+        if (target) recordMutation(expressionAccess(target), false, node);
       }
       ts.forEachChild(node, visit);
     };
     visit(fn);
-    mutatedCollectionsByFunction.set(fn, mutatedCollections);
+    mutatedStatesByFunction.set(fn, mutatedStates);
   }
 
-  const reachableCollections = new Set<ModuleCollectionInfo>();
+  const reachableStates = new Set<ModuleStateInfo>();
   for (const fn of reachableFunctions) {
-    for (const collection of mutatedCollectionsByFunction.get(fn) ?? []) {
-      reachableCollections.add(collection);
+    for (const state of mutatedStatesByFunction.get(fn) ?? []) {
+      reachableStates.add(state);
     }
   }
-  return [...reachableCollections]
+  return [...reachableStates]
     .map(
       ({ kind, name, sourceFile }) =>
         `${path.relative(displayRoot, sourceFile.fileName)} ${name} (${kind})`,
@@ -1070,16 +1228,14 @@ function findModuleCollectionMutationsReachableFromPreload(
     .sort();
 }
 
-function findHandlerCollectionMutationsReachableFromPreload(): string[] {
-  const handlersRoot = path.join(srcRoot, "handlers");
-  // RPC/effect modules own intentional process-local client and test caches;
-  // this guard targets phase-bridging state hidden in the handler module graph.
-  return findModuleCollectionMutationsReachableFromPreload(
+function includesIndexerSourceFile(sourceFile: ts.SourceFile): boolean {
+  return path.resolve(sourceFile.fileName).startsWith(`${srcRoot}${path.sep}`);
+}
+
+function findHandlerModuleStateMutationsReachableFromHandlers(): string[] {
+  return findModuleStateMutationsReachableFromRegisteredHandlers(
     effectfulProgramAnalysis.program,
-    (sourceFile) =>
-      path
-        .resolve(sourceFile.fileName)
-        .startsWith(`${handlersRoot}${path.sep}`),
+    includesIndexerSourceFile,
     packageRoot,
   );
 }
@@ -1839,14 +1995,14 @@ function hiddenEffectNamesInProgram(
   ).map((offender) => offender.slice(offender.lastIndexOf(" ") + 1));
 }
 
-function phaseCollectionNamesInProgram(
+function phaseStateNamesInProgram(
   files: Readonly<Record<string, string>>,
 ): string[] {
   const { fixtureFiles, fixtureRoot, program } = createProgramFixture(
     files,
-    "__preload-phase-collection-fixtures__",
+    "__preload-phase-state-fixtures__",
   );
-  return findModuleCollectionMutationsReachableFromPreload(
+  return findModuleStateMutationsReachableFromRegisteredHandlers(
     program,
     (sourceFile) => fixtureFiles.has(path.resolve(sourceFile.fileName)),
     fixtureRoot,
@@ -1879,12 +2035,23 @@ describe("indexer code quality invariants", () => {
     );
   });
 
-  it("keeps preload-aware handlers from mutating imported handler collections", () => {
+  it("keeps registered handlers from mutating module-scoped handler state", () => {
     assert.deepEqual(
-      findHandlerCollectionMutationsReachableFromPreload(),
+      findHandlerModuleStateMutationsReachableFromHandlers(),
       [],
-      "Hosted Envio workers do not share module state; preload-aware handlers must not mutate module-local Set/Map state through imported handler helpers",
+      "Hosted Envio workers and restarts do not share module state; registered handlers must not mutate module-scoped state through imported handler helpers",
     );
+  });
+
+  it("includes non-handler source modules in phase-state analysis", () => {
+    const sourceFile = effectfulProgramAnalysis.program.getSourceFile(
+      path.join(srcRoot, "contractAddresses.ts"),
+    );
+    assert.ok(
+      sourceFile,
+      "expected contractAddresses.ts in the indexer program",
+    );
+    assert.equal(includesIndexerSourceFile(sourceFile), true);
   });
 
   it("detects helper-hidden phase collections without flagging locals", () => {
@@ -1935,14 +2102,17 @@ describe("indexer code quality invariants", () => {
     );
   });
 
-  it("follows imported helper calls to phase collections across files", () => {
+  it("follows imported helper calls to module phase state across files", () => {
     assert.deepEqual(
-      phaseCollectionNamesInProgram({
+      phaseStateNamesInProgram({
         "entry.ts": `
           import { consume, remember } from "./helpers.js";
+          const indexer = { onEvent: (..._args: unknown[]) => undefined };
+          function isPreloadPhase(context: { isPreload: boolean }) {
+            return context.isPreload;
+          }
           export function handler(context: { isPreload: boolean }) {
-            const { isPreload } = context;
-            if (isPreload) {
+            if (isPreloadPhase(context)) {
               remember("event");
               return;
             }
@@ -1950,6 +2120,7 @@ describe("indexer code quality invariants", () => {
             const local = new Set<string>();
             local.add("safe");
           }
+          indexer.onEvent({}, handler);
         `,
         "helpers.ts": `
           import {
@@ -1966,8 +2137,22 @@ describe("indexer code quality invariants", () => {
             mutateSharedAlias,
             replaceNestedState,
             replaceState,
+            writeArrayState,
+            writeAssignedRecordState,
+            writeCacheState,
+            writeCallbackObjectState,
+            writeComputedRecordState,
+            writeDeletedRecordState,
+            writeExemptState,
+            writeFactoryArrayState,
+            writeFactorySetState,
+            writeInvalidCacheState,
+            writeInvalidExemptState,
+            writePrimitiveState,
           } from "./phase-state.js";
           const unrelatedStaticLookup = new Set(["safe"]);
+          const unrelatedStaticArray = ["safe"];
+          const unrelatedStaticRecord: Record<string, boolean> = { safe: true };
           export function remember(id: string) {
             writeDirectState(id);
             writeNestedState(id);
@@ -1980,6 +2165,18 @@ describe("indexer code quality invariants", () => {
             replaceContainerState(id);
             replaceNestedState(id);
             replaceState(id);
+            writeArrayState(id);
+            writeAssignedRecordState(id);
+            writeCacheState(id);
+            writeCallbackObjectState();
+            writeComputedRecordState(id);
+            writeDeletedRecordState(id);
+            writeExemptState(id);
+            writeFactoryArrayState(id);
+            writeFactorySetState(id);
+            writeInvalidCacheState(id);
+            writeInvalidExemptState(id);
+            writePrimitiveState(id);
             unrelated();
           }
           export function consume(id: string) {
@@ -1987,7 +2184,11 @@ describe("indexer code quality invariants", () => {
             mutateSharedAlias();
           }
           export function unrelated() {
-            return unrelatedStaticLookup.has("safe");
+            return (
+              unrelatedStaticLookup.has("safe") &&
+              unrelatedStaticArray.includes("safe") &&
+              unrelatedStaticRecord.safe
+            );
           }
         `,
         "phase-state.ts": `
@@ -2001,13 +2202,31 @@ describe("indexer code quality invariants", () => {
           const callbackState = new Map<string, boolean>();
           const assignmentState = new Set<string>();
           const aliasStateSeed = new Set<string>();
+          const arrayState: string[] = [];
+          const assignedRecordState: Record<string, boolean> = {};
+          const cacheState = new Set<string>();
+          const callbackObjectState = [{ done: false }];
+          const computedRecordState: Record<string, boolean> = {};
+          const deletedRecordState: Record<string, boolean> = {};
+          const exemptState = new Set<string>();
+          const factoryArrayState = makeArrayState();
+          const factorySetState = makeSetState();
+          const invalidCacheState = new Set<string>();
+          const invalidExemptState = new Set<string>();
           const reassignedNestedState = { remembered: new Set<string>() };
           const sharedAliasState = new Set<string>();
           const unrelatedPathState = new Set<string>();
           let aliasState = aliasStateSeed;
+          let primitiveState: string | undefined;
           let replacedContainerState = { remembered: new Set<string>() };
           let reassignedState = new Set<string>();
           let sharedAlias: Set<string> | undefined;
+          function makeArrayState() {
+            return [] as string[];
+          }
+          function makeSetState() {
+            return new Set<string>();
+          }
           function mutate(target: Set<string>, id: string) {
             target.add(id);
           }
@@ -2059,15 +2278,59 @@ describe("indexer code quality invariants", () => {
           export function replaceState(id: string) {
             reassignedState = new Set([id]);
           }
+          export function writeArrayState(id: string) {
+            arrayState.push(id);
+          }
+          export function writeAssignedRecordState(id: string) {
+            Object.assign(assignedRecordState, { [id]: true });
+          }
+          export function writeCacheState(id: string) {
+            // phase-state-cache: bounded rebuildable fixture cache; loss only repeats work.
+            cacheState.add(id);
+          }
+          export function writeCallbackObjectState() {
+            callbackObjectState.forEach((item) => {
+              item.done = true;
+            });
+          }
+          export function writeComputedRecordState(id: string) {
+            computedRecordState[id] = true;
+          }
+          export function writeDeletedRecordState(id: string) {
+            delete deletedRecordState[id];
+          }
+          export function writeExemptState(id: string) {
+            // phase-state-exempt: ordered fixture state; remove with #123.
+            exemptState.add(id);
+          }
+          export function writeFactoryArrayState(id: string) {
+            factoryArrayState.splice(0, 0, id);
+          }
+          export function writeFactorySetState(id: string) {
+            factorySetState.add(id);
+          }
+          export function writeInvalidCacheState(id: string) {
+            // phase-state-cache:
+            invalidCacheState.add(id);
+          }
+          export function writeInvalidExemptState(id: string) {
+            // phase-state-exempt: missing tracking issue.
+            invalidExemptState.add(id);
+          }
+          export function writePrimitiveState(id: string) {
+            primitiveState = id;
+          }
           export function mutateOnlyOutsideThePreloadGraph() {
             mutate(unrelatedPathState, "unrelated");
           }
         `,
         "bracket-entry.ts": `
           import { writeBracketState } from "./bracket-state.js";
+          const indexer = { onEvent: (..._args: unknown[]) => undefined };
           export function bracketHandler(context: { isPreload: boolean }) {
             if (context["isPreload"]) writeBracketState("event");
           }
+          indexer.onEvent({}, bracketHandler);
         `,
         "bracket-state.ts": `
           const bracketState = new Set<string>();
@@ -2078,17 +2341,49 @@ describe("indexer code quality invariants", () => {
       }),
       [
         "bracket-state.ts bracketState (Set)",
-        "phase-state.ts aliasStateSeed (Set)",
+        "phase-state.ts aliasState (state)",
+        "phase-state.ts arrayState (state)",
+        "phase-state.ts assignedRecordState (state)",
         "phase-state.ts assignmentState (Set)",
+        "phase-state.ts callbackObjectState (state)",
         "phase-state.ts callbackState (Map)",
+        "phase-state.ts computedRecordState (state)",
+        "phase-state.ts deletedRecordState (state)",
         "phase-state.ts directState (Set)",
-        "phase-state.ts nestedState.remembered (Set)",
+        "phase-state.ts factoryArrayState (state)",
+        "phase-state.ts factorySetState (state)",
+        "phase-state.ts invalidCacheState (Set)",
+        "phase-state.ts invalidExemptState (Set)",
+        "phase-state.ts nestedState (state)",
         "phase-state.ts parameterState (Set)",
-        "phase-state.ts reassignedNestedState.remembered (Set)",
+        "phase-state.ts primitiveState (state)",
+        "phase-state.ts reassignedNestedState (state)",
         "phase-state.ts reassignedState (Set)",
-        "phase-state.ts replacedContainerState.remembered (Set)",
-        "phase-state.ts sharedAliasState (Set)",
+        "phase-state.ts replacedContainerState (state)",
+        "phase-state.ts sharedAlias (state)",
       ],
+    );
+  });
+
+  it("follows module state outside the registered handler directory", () => {
+    assert.deepEqual(
+      phaseStateNamesInProgram({
+        "handlers/entry.ts": `
+          import { writeImportedState } from "../outside-helper.js";
+          const indexer = { onEvent: (..._args: unknown[]) => undefined };
+          function handler() {
+            writeImportedState("event");
+          }
+          indexer.onEvent({}, handler);
+        `,
+        "outside-helper.ts": `
+          let warmedId: string | undefined;
+          export function writeImportedState(id: string) {
+            warmedId = id;
+          }
+        `,
+      }),
+      ["outside-helper.ts warmedId (state)"],
     );
   });
 

--- a/indexer-envio/test/stables.test.ts
+++ b/indexer-envio/test/stables.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { beforeEach, describe, it } from "vitest";
+import { describe, it } from "vitest";
 import {
   LOCK_AND_MINT_NTT_STABLES,
   LOCK_AND_MINT_NTT_STABLE_ADDRESSES,
@@ -12,10 +12,7 @@ import {
   makeStableSupplyDailySnapshotId,
   makeStableTokenCustodyDailySnapshotId,
 } from "../src/handlers/stables/config.ts";
-import {
-  _resetBrokerAddressCacheForTest,
-  classifyStableSupplyChangeKind,
-} from "../src/handlers/stables/classifyKind.ts";
+import { classifyStableSupplyChangeKind } from "../src/handlers/stables/classifyKind.ts";
 import { flushStableDailySnapshot } from "../src/handlers/stables/dailyFlush.ts";
 import { makeStableTokenSupply } from "../src/handlers/stables/bootstrap.ts";
 import {
@@ -255,10 +252,6 @@ describe("stables — YAML drift gate", () => {
 });
 
 describe("classifyStableSupplyChangeKind", () => {
-  beforeEach(() => {
-    _resetBrokerAddressCacheForTest();
-  });
-
   it("Broker tx.to maps to RESERVE_MINT / RESERVE_BURN on Celo", () => {
     // Broker address from @mento-protocol/contracts mainnet Celo.
     const broker = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";

--- a/scripts/deploy-indexer-verify.mjs
+++ b/scripts/deploy-indexer-verify.mjs
@@ -8,7 +8,7 @@ const ENVIO_ORG = "mento-protocol";
 const ENVIO_INDEXER = "mento";
 const GRAPHQL_TIMEOUT_MS = 20_000;
 const REPLAY_INTEGRITY_PATH = "indexer-envio/config/replay-integrity.json";
-const REQUIRED_POLYGON_EXACT_MEDIAN_VERSION = 1;
+const REQUIRED_POLYGON_EXACT_MEDIAN_VERSION = 2;
 
 const PROBE_TABLES = [
   "Pool",

--- a/scripts/deploy-indexer-verify.test.mjs
+++ b/scripts/deploy-indexer-verify.test.mjs
@@ -20,7 +20,7 @@ import {
 
 const NOW_SECONDS = 2_000_000_000;
 const VALID_REPLAY_INTEGRITY = {
-  value: { polygonExactMedianTimestamp: 1 },
+  value: { polygonExactMedianTimestamp: 2 },
   readError: "",
 };
 
@@ -127,6 +127,13 @@ assert.equal(
 assert.equal(resolveProdDeployment(indexerJson)?.commit_hash, "abc1234");
 
 assert.equal(summarizeReplayIntegrity(VALID_REPLAY_INTEGRITY).ok, true);
+assert.match(
+  summarizeReplayIntegrity({
+    value: { polygonExactMedianTimestamp: 1 },
+    readError: "",
+  }).failures.join("\n"),
+  /predates Polygon exact-median replay integrity v2/,
+);
 assert.match(
   summarizeReplayIntegrity({
     value: null,


### PR DESCRIPTION
## The Problem

- The first Polygon replay hotfix candidate stopped safely because hosted Envio preload and processing ran in separate workers, losing module-local effect-warming state.
- Exact median timestamp effects were then skipped during processing, so the fail-closed guard halted Polygon and Celo replay.

## The Solution

- Derive conditional effect requests independently in each Envio phase while preserving identical event-only effect keys.
- Bump replay-integrity compatibility to v2 so the failed v1 candidate can never pass promotion verification.
- Encode the hosted-worker invariant in tests, both Envio skill mirrors, and operator documentation.

## Validation

- `pnpm agent:quality-gate --run`
- `./tools/trunk fmt --all`
- `node scripts/review-materiality.mjs`
- Deterministic autoreview: clean
- Fresh-context semantic review: clean (0.94 confidence)

## Deferrals

- #1462 tracks returned module-state aliases and custom receiver methods that mutate through `this`, two bounded analyzer forms outside the exact representations raised in this hotfix review.
