### PR TITLE
fix(tooling): recognize canonical docs notes in review materiality

### DIFF
--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -10,6 +10,7 @@ import {
   DOCUMENT_STATUSES,
   parseDocumentationMetadata,
 } from "./docs-index-helpers.mjs";
+import { assessStaleness, daysSince } from "./check-agent-context-helpers.mjs";
 
 const TIER_ORDER = ["trivial", "standard", "full"];
 const DEFAULT_BASE = "origin/main";
@@ -342,38 +343,40 @@ function parseFrontmatterDocument(content) {
     : null;
 }
 
-function hasCanonicalNoteMetadata(filePath, readContextFile) {
+function readCanonicalNoteState(filePath, readContextFile) {
   if (!filePath.startsWith("docs/notes/") || !filePath.endsWith(".md")) {
-    return false;
+    return null;
   }
 
   try {
-    // The documentation catalog derives authority from this same metadata. Do
-    // not fall back to its generated label: the catalog does not promote a
-    // document, and it may be stale while the working tree is being edited.
+    // Canonical authority comes from the source marker itself. Catalog and
+    // freshness validation decide whether head context is complete, but must
+    // not downgrade review materiality for an authoritative base or head note.
     const content = readContextFile(filePath);
     const frontmatter = parseFrontmatterDocument(content);
     if (frontmatter?.canonical !== true && frontmatter?.canonical !== "true") {
-      return false;
+      return null;
     }
-    const metadata = parseDocumentationMetadata(filePath, content);
-    return (
-      metadata?.canonical === "true" &&
-      DOCUMENT_STATUSES.includes(metadata.status) &&
-      REQUIRED_CANONICAL_NOTE_METADATA.every((key) => metadata[key]?.trim()) &&
-      classifyDocumentation(filePath, metadata).errors.length === 0
-    );
+    return { metadata: parseDocumentationMetadata(filePath, content) };
   } catch {
-    // Deleted, unreadable, and malformed notes must not satisfy a required
-    // context update merely because their path sits under docs/notes/.
-    return false;
+    return null;
   }
 }
 
-function isCanonicalContextPath(filePath, readContextFile) {
-  if (hasCanonicalNoteMetadata(filePath, readContextFile)) return true;
-  if (!isConventionBasedCanonicalContextPath(filePath)) return false;
+function hasValidCanonicalNoteMetadata(filePath, state) {
+  const { metadata } = state;
+  const verifiedAge = daysSince(metadata?.last_verified);
+  return (
+    metadata?.canonical === "true" &&
+    DOCUMENT_STATUSES.includes(metadata.status) &&
+    REQUIRED_CANONICAL_NOTE_METADATA.every((key) => metadata[key]?.trim()) &&
+    classifyDocumentation(filePath, metadata).errors.length === 0 &&
+    verifiedAge !== null &&
+    assessStaleness(verifiedAge) === "ok"
+  );
+}
 
+function isReadableContextPath(filePath, readContextFile) {
   try {
     readContextFile(filePath);
     return true;
@@ -621,20 +624,27 @@ export function analyzeMateriality({
   readHeadContextFile = (filePath) => readFileSync(filePath, "utf8"),
 } = {}) {
   const changedPaths = uniqueSorted(paths ?? []);
-  const headCanonicalContextPaths = new Set(
-    changedPaths.filter((filePath) =>
-      isCanonicalContextPath(filePath, readHeadContextFile),
-    ),
-  );
-  const materialityCanonicalContextPaths = new Set([
-    ...headCanonicalContextPaths,
-    ...changedPaths.filter(isConventionBasedCanonicalContextPath),
-  ]);
+  const headCanonicalContextPaths = new Set();
+  const materialityCanonicalContextPaths = new Set();
   for (const filePath of changedPaths) {
-    if (
-      !materialityCanonicalContextPaths.has(filePath) &&
-      isCanonicalContextPath(filePath, readBaseContextFile)
-    ) {
+    if (isConventionBasedCanonicalContextPath(filePath)) {
+      materialityCanonicalContextPaths.add(filePath);
+      if (isReadableContextPath(filePath, readHeadContextFile)) {
+        headCanonicalContextPaths.add(filePath);
+      }
+      continue;
+    }
+
+    const headNote = readCanonicalNoteState(filePath, readHeadContextFile);
+    if (headNote) {
+      materialityCanonicalContextPaths.add(filePath);
+      if (hasValidCanonicalNoteMetadata(filePath, headNote)) {
+        headCanonicalContextPaths.add(filePath);
+      }
+      continue;
+    }
+
+    if (readCanonicalNoteState(filePath, readBaseContextFile)) {
       materialityCanonicalContextPaths.add(filePath);
     }
   }

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { load as parseYaml } from "js-yaml";
@@ -90,9 +91,24 @@ function runGit(args) {
   return execFileSync("git", args, { encoding: "utf8" });
 }
 
+function runGitQuiet(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
 function tryGit(args) {
   try {
     return runGit(args);
+  } catch {
+    return "";
+  }
+}
+
+function tryGitQuiet(args) {
+  try {
+    return runGitQuiet(args);
   } catch {
     return "";
   }
@@ -138,6 +154,15 @@ function resolveDiffComparison(base, head) {
   }
 }
 
+function resolveMetadataBase(base, head) {
+  const mergeBase = tryGitQuiet(["merge-base", base, head]).trim();
+  if (mergeBase) return mergeBase;
+
+  return (
+    tryGitQuiet(["rev-parse", "--verify", `${base}^{commit}`]).trim() || base
+  );
+}
+
 function uniqueSorted(values) {
   return [...new Set(values.filter(Boolean))].sort();
 }
@@ -164,6 +189,42 @@ function changedPathsFromGit(comparison) {
 function changedPathsFromFile(filePath) {
   const output = readFileSync(filePath, "utf8");
   return uniqueSorted(output.split("\n").map((line) => line.trim()));
+}
+
+function isSafeWorktreeRegularFile(filePath) {
+  if (!filePath || isAbsolute(filePath)) return false;
+
+  try {
+    const root = process.cwd();
+    const absolute = resolve(root, filePath);
+    const relativePath = relative(root, absolute);
+    if (
+      !relativePath ||
+      relativePath === ".." ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      return false;
+    }
+
+    let current = root;
+    let entry;
+    for (const segment of relativePath.split(sep)) {
+      current = join(current, segment);
+      entry = lstatSync(current);
+      if (entry.isSymbolicLink()) return false;
+    }
+    return entry?.isFile() === true;
+  } catch {
+    return false;
+  }
+}
+
+function readWorktreeTextFile(filePath) {
+  if (!isSafeWorktreeRegularFile(filePath)) {
+    throw new Error(`not a regular worktree file: ${filePath}`);
+  }
+  return readFileSync(filePath, "utf8");
 }
 
 function addNumstatOutput(stats, output) {
@@ -193,7 +254,7 @@ function addUntrackedStats(stats, paths) {
     if (stats.has(filePath)) continue;
     let additions;
     try {
-      additions = countTextLines(readFileSync(filePath, "utf8"));
+      additions = countTextLines(readWorktreeTextFile(filePath));
     } catch {
       additions = 0;
     }
@@ -224,19 +285,28 @@ function numstatFromGit(comparison) {
 }
 
 function readTextAtRef(ref, filePath) {
-  return runGit(["show", `${ref}:${filePath}`]);
+  return runGitQuiet(["show", `${ref}:${filePath}`]);
 }
 
 function readTextAtHead(ref, filePath) {
   return ref === "HEAD"
-    ? readFileSync(filePath, "utf8")
+    ? readWorktreeTextFile(filePath)
     : readTextAtRef(ref, filePath);
+}
+
+function isRegularFileAtHead(ref, filePath) {
+  if (ref === "HEAD") {
+    return isSafeWorktreeRegularFile(filePath);
+  }
+
+  const entry = runGitQuiet(["ls-tree", "-z", ref, "--", filePath]);
+  return entry.startsWith("100644 blob ") || entry.startsWith("100755 blob ");
 }
 
 function readJsonAtRef(ref, filePath) {
   if (ref === "HEAD") {
     try {
-      return JSON.parse(readFileSync(filePath, "utf8"));
+      return JSON.parse(readWorktreeTextFile(filePath));
     } catch {
       return null;
     }
@@ -343,10 +413,12 @@ function parseFrontmatterDocument(content) {
     : null;
 }
 
+function isCanonicalNotePath(filePath) {
+  return filePath.startsWith("docs/notes/") && filePath.endsWith(".md");
+}
+
 function readCanonicalNoteState(filePath, readContextFile) {
-  if (!filePath.startsWith("docs/notes/") || !filePath.endsWith(".md")) {
-    return null;
-  }
+  if (!isCanonicalNotePath(filePath)) return null;
 
   try {
     // Canonical authority comes from the source marker itself. Catalog and
@@ -380,6 +452,14 @@ function isReadableContextPath(filePath, readContextFile) {
   try {
     readContextFile(filePath);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRegularHeadContextPath(filePath, isHeadContextFile) {
+  try {
+    return isHeadContextFile(filePath) === true;
   } catch {
     return false;
   }
@@ -622,6 +702,7 @@ export function analyzeMateriality({
   scriptChanges = [],
   readBaseContextFile = (filePath) => readFileSync(filePath, "utf8"),
   readHeadContextFile = (filePath) => readFileSync(filePath, "utf8"),
+  isHeadContextFile = () => true,
 } = {}) {
   const changedPaths = uniqueSorted(paths ?? []);
   const headCanonicalContextPaths = new Set();
@@ -629,19 +710,34 @@ export function analyzeMateriality({
   for (const filePath of changedPaths) {
     if (isConventionBasedCanonicalContextPath(filePath)) {
       materialityCanonicalContextPaths.add(filePath);
-      if (isReadableContextPath(filePath, readHeadContextFile)) {
+      if (
+        isRegularHeadContextPath(filePath, isHeadContextFile) &&
+        isReadableContextPath(filePath, readHeadContextFile)
+      ) {
         headCanonicalContextPaths.add(filePath);
       }
       continue;
     }
 
-    const headNote = readCanonicalNoteState(filePath, readHeadContextFile);
+    if (!isCanonicalNotePath(filePath)) continue;
+
+    const regularHeadNote = isRegularHeadContextPath(
+      filePath,
+      isHeadContextFile,
+    );
+    const headNote = regularHeadNote
+      ? readCanonicalNoteState(filePath, readHeadContextFile)
+      : null;
     if (headNote) {
       materialityCanonicalContextPaths.add(filePath);
       if (hasValidCanonicalNoteMetadata(filePath, headNote)) {
         headCanonicalContextPaths.add(filePath);
       }
       continue;
+    }
+
+    if (!regularHeadNote) {
+      materialityCanonicalContextPaths.add(filePath);
     }
 
     if (readCanonicalNoteState(filePath, readBaseContextFile)) {
@@ -720,7 +816,9 @@ async function main() {
   const comparison = args.changedPathsFile
     ? null
     : resolveDiffComparison(args.base, args.head);
-  const effectiveBase = comparison?.effectiveBase ?? args.base;
+  const effectiveBase = args.changedPathsFile
+    ? resolveMetadataBase(args.base, args.head)
+    : comparison.effectiveBase;
   const paths = args.changedPathsFile
     ? changedPathsFromFile(args.changedPathsFile)
     : changedPathsFromGit(comparison);
@@ -734,6 +832,7 @@ async function main() {
     scriptChanges,
     readBaseContextFile: (filePath) => readTextAtRef(effectiveBase, filePath),
     readHeadContextFile: (filePath) => readTextAtHead(args.head, filePath),
+    isHeadContextFile: (filePath) => isRegularFileAtHead(args.head, filePath),
   });
 
   process.stdout.write(

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -14,6 +14,13 @@ const FULL_LINE_CHANGE_THRESHOLD = 800;
 const STANDARD_LINE_CHANGE_THRESHOLD = 200;
 const FULL_FILE_COUNT_THRESHOLD = 25;
 const STANDARD_FILE_COUNT_THRESHOLD = 8;
+const REQUIRED_CANONICAL_NOTE_METADATA = [
+  "title",
+  "status",
+  "owner",
+  "last_verified",
+];
+const VALID_CONTEXT_STATUSES = new Set(["active", "archived", "draft"]);
 
 function usage() {
   return `Usage: pnpm agent:review-materiality [options]
@@ -326,7 +333,11 @@ function hasCanonicalNoteMetadata(filePath, readContextFile) {
       return false;
     }
     const metadata = parseDocumentationMetadata(filePath, content);
-    return metadata?.canonical === "true";
+    return (
+      metadata?.canonical === "true" &&
+      VALID_CONTEXT_STATUSES.has(metadata.status) &&
+      REQUIRED_CANONICAL_NOTE_METADATA.every((key) => metadata[key]?.trim())
+    );
   } catch {
     // Deleted, unreadable, and malformed notes must not satisfy a required
     // context update merely because their path sits under docs/notes/.
@@ -598,7 +609,10 @@ export function analyzeMateriality({
   );
   const materialityCanonicalContextPaths = new Set(headCanonicalContextPaths);
   for (const filePath of changedPaths) {
-    if (isCanonicalContextPath(filePath, readBaseContextFile)) {
+    if (
+      !materialityCanonicalContextPaths.has(filePath) &&
+      isCanonicalContextPath(filePath, readBaseContextFile)
+    ) {
       materialityCanonicalContextPaths.add(filePath);
     }
   }

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -306,6 +306,23 @@ function isAgentRuntimeContextPath(filePath) {
   );
 }
 
+function isConventionBasedCanonicalContextPath(filePath) {
+  return (
+    filePath === "AGENTS.md" ||
+    filePath.endsWith("/AGENTS.md") ||
+    filePath === "CLAUDE.md" ||
+    filePath.endsWith("/CLAUDE.md") ||
+    filePath === "README.md" ||
+    filePath === "docs/context-standards.md" ||
+    filePath === "docs/deployment.md" ||
+    filePath.startsWith("docs/pr-checklists/") ||
+    filePath.startsWith(".agents/skills/") ||
+    filePath.startsWith(".agents/roles/") ||
+    filePath.startsWith(".claude/skills/") ||
+    isAgentRuntimeContextPath(filePath)
+  );
+}
+
 function parseFrontmatterDocument(content) {
   if (typeof content !== "string" || !content.startsWith("---\n")) {
     return null;
@@ -346,21 +363,15 @@ function hasCanonicalNoteMetadata(filePath, readContextFile) {
 }
 
 function isCanonicalContextPath(filePath, readContextFile) {
-  return (
-    filePath === "AGENTS.md" ||
-    filePath.endsWith("/AGENTS.md") ||
-    filePath === "CLAUDE.md" ||
-    filePath.endsWith("/CLAUDE.md") ||
-    filePath === "README.md" ||
-    filePath === "docs/context-standards.md" ||
-    filePath === "docs/deployment.md" ||
-    filePath.startsWith("docs/pr-checklists/") ||
-    filePath.startsWith(".agents/skills/") ||
-    filePath.startsWith(".agents/roles/") ||
-    filePath.startsWith(".claude/skills/") ||
-    hasCanonicalNoteMetadata(filePath, readContextFile) ||
-    isAgentRuntimeContextPath(filePath)
-  );
+  if (hasCanonicalNoteMetadata(filePath, readContextFile)) return true;
+  if (!isConventionBasedCanonicalContextPath(filePath)) return false;
+
+  try {
+    readContextFile(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isRepoToolingTestPath(filePath) {
@@ -607,7 +618,10 @@ export function analyzeMateriality({
       isCanonicalContextPath(filePath, readHeadContextFile),
     ),
   );
-  const materialityCanonicalContextPaths = new Set(headCanonicalContextPaths);
+  const materialityCanonicalContextPaths = new Set([
+    ...headCanonicalContextPaths,
+    ...changedPaths.filter(isConventionBasedCanonicalContextPath),
+  ]);
   for (const filePath of changedPaths) {
     if (
       !materialityCanonicalContextPaths.has(filePath) &&

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -5,7 +5,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { load as parseYaml } from "js-yaml";
 
-import { parseDocumentationMetadata } from "./docs-index-helpers.mjs";
+import {
+  classifyDocumentation,
+  DOCUMENT_STATUSES,
+  parseDocumentationMetadata,
+} from "./docs-index-helpers.mjs";
 
 const TIER_ORDER = ["trivial", "standard", "full"];
 const DEFAULT_BASE = "origin/main";
@@ -19,8 +23,11 @@ const REQUIRED_CANONICAL_NOTE_METADATA = [
   "status",
   "owner",
   "last_verified",
+  "doc_type",
+  "scope",
+  "review_interval_days",
+  "garden_lane",
 ];
-const VALID_CONTEXT_STATUSES = new Set(["active", "archived", "draft"]);
 
 function usage() {
   return `Usage: pnpm agent:review-materiality [options]
@@ -352,8 +359,9 @@ function hasCanonicalNoteMetadata(filePath, readContextFile) {
     const metadata = parseDocumentationMetadata(filePath, content);
     return (
       metadata?.canonical === "true" &&
-      VALID_CONTEXT_STATUSES.has(metadata.status) &&
-      REQUIRED_CANONICAL_NOTE_METADATA.every((key) => metadata[key]?.trim())
+      DOCUMENT_STATUSES.includes(metadata.status) &&
+      REQUIRED_CANONICAL_NOTE_METADATA.every((key) => metadata[key]?.trim()) &&
+      classifyDocumentation(filePath, metadata).errors.length === 0
     );
   } catch {
     // Deleted, unreadable, and malformed notes must not satisfy a required

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -91,12 +91,29 @@ function gitErrorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function diffOutput(diffArgs, base, head) {
+function diffSnapshot(effectiveBase, head) {
+  const output = (format) =>
+    runGit(["diff", format, "--no-renames", effectiveBase, head]);
+  return {
+    nameOnly: output("--name-only"),
+    numstat: output("--numstat"),
+  };
+}
+
+function resolveDiffComparison(base, head) {
   try {
-    return runGit(["diff", ...diffArgs, `${base}...${head}`]);
+    const effectiveBase = runGit(["merge-base", base, head]).trim();
+    if (!effectiveBase)
+      throw new Error(`no merge base for ${base} and ${head}`);
+    return { effectiveBase, head, ...diffSnapshot(effectiveBase, head) };
   } catch (tripleDotError) {
     try {
-      return runGit(["diff", ...diffArgs, base, head]);
+      const effectiveBase = runGit([
+        "rev-parse",
+        "--verify",
+        `${base}^{commit}`,
+      ]).trim();
+      return { effectiveBase, head, ...diffSnapshot(effectiveBase, head) };
     } catch (twoDotError) {
       throw new Error(
         `unable to read git diff for ${base}..${head}: ${gitErrorMessage(twoDotError) || gitErrorMessage(tripleDotError)}`,
@@ -110,10 +127,10 @@ function uniqueSorted(values) {
   return [...new Set(values.filter(Boolean))].sort();
 }
 
-function changedPathsFromGit(base, head) {
-  const outputs = [diffOutput(["--name-only", "--no-renames"], base, head)];
+function changedPathsFromGit(comparison) {
+  const outputs = [comparison.nameOnly];
 
-  if (head === "HEAD") {
+  if (comparison.head === "HEAD") {
     outputs.push(
       tryGit(["diff", "--name-only", "--no-renames"]),
       tryGit(["diff", "--cached", "--name-only", "--no-renames"]),
@@ -169,14 +186,11 @@ function addUntrackedStats(stats, paths) {
   }
 }
 
-function numstatFromGit(base, head) {
+function numstatFromGit(comparison) {
   const stats = new Map();
-  addNumstatOutput(
-    stats,
-    diffOutput(["--numstat", "--no-renames"], base, head),
-  );
+  addNumstatOutput(stats, comparison.numstat);
 
-  if (head === "HEAD") {
+  if (comparison.head === "HEAD") {
     addNumstatOutput(stats, tryGit(["diff", "--numstat", "--no-renames"]));
     addNumstatOutput(
       stats,
@@ -195,8 +209,13 @@ function numstatFromGit(base, head) {
 }
 
 function readTextAtRef(ref, filePath) {
-  if (ref === "HEAD") return readFileSync(filePath, "utf8");
   return runGit(["show", `${ref}:${filePath}`]);
+}
+
+function readTextAtHead(ref, filePath) {
+  return ref === "HEAD"
+    ? readFileSync(filePath, "utf8")
+    : readTextAtRef(ref, filePath);
 }
 
 function readJsonAtRef(ref, filePath) {
@@ -568,16 +587,23 @@ export function analyzeMateriality({
   paths,
   numstat = new Map(),
   scriptChanges = [],
-  readContextFile = (filePath) => readFileSync(filePath, "utf8"),
+  readBaseContextFile = (filePath) => readFileSync(filePath, "utf8"),
+  readHeadContextFile = (filePath) => readFileSync(filePath, "utf8"),
 } = {}) {
   const changedPaths = uniqueSorted(paths ?? []);
-  const canonicalContextPaths = new Set(
+  const headCanonicalContextPaths = new Set(
     changedPaths.filter((filePath) =>
-      isCanonicalContextPath(filePath, readContextFile),
+      isCanonicalContextPath(filePath, readHeadContextFile),
     ),
   );
+  const materialityCanonicalContextPaths = new Set(headCanonicalContextPaths);
+  for (const filePath of changedPaths) {
+    if (isCanonicalContextPath(filePath, readBaseContextFile)) {
+      materialityCanonicalContextPaths.add(filePath);
+    }
+  }
   const pathSignals = changedPaths.map((filePath) =>
-    classifyPath(filePath, canonicalContextPaths),
+    classifyPath(filePath, materialityCanonicalContextPaths),
   );
   const lineChanges = summarizeLineChanges(changedPaths, numstat);
   const sizeSignal = classifyBySize(changedPaths.length, lineChanges.total);
@@ -587,7 +613,7 @@ export function analyzeMateriality({
     "trivial",
   );
   const contextReasons = contextRequirementSignals(changedPaths, scriptChanges);
-  const contextUpdatesPresent = canonicalContextPaths.size > 0;
+  const contextUpdatesPresent = headCanonicalContextPaths.size > 0;
   const contextUpdateRequired = contextReasons.length > 0;
 
   return {
@@ -645,20 +671,23 @@ async function main() {
     return;
   }
 
+  const comparison = args.changedPathsFile
+    ? null
+    : resolveDiffComparison(args.base, args.head);
+  const effectiveBase = comparison?.effectiveBase ?? args.base;
   const paths = args.changedPathsFile
     ? changedPathsFromFile(args.changedPathsFile)
-    : changedPathsFromGit(args.base, args.head);
-  const numstat = args.changedPathsFile
-    ? new Map()
-    : numstatFromGit(args.base, args.head);
+    : changedPathsFromGit(comparison);
+  const numstat = comparison ? numstatFromGit(comparison) : new Map();
   const scriptChanges = paths.includes("package.json")
-    ? rootScriptChanges(args.base, args.head)
+    ? rootScriptChanges(effectiveBase, args.head)
     : [];
   const report = analyzeMateriality({
     paths,
     numstat,
     scriptChanges,
-    readContextFile: (filePath) => readTextAtRef(args.head, filePath),
+    readBaseContextFile: (filePath) => readTextAtRef(effectiveBase, filePath),
+    readHeadContextFile: (filePath) => readTextAtHead(args.head, filePath),
   });
 
   process.stdout.write(

--- a/scripts/review-materiality.mjs
+++ b/scripts/review-materiality.mjs
@@ -3,6 +3,9 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { load as parseYaml } from "js-yaml";
+
+import { parseDocumentationMetadata } from "./docs-index-helpers.mjs";
 
 const TIER_ORDER = ["trivial", "standard", "full"];
 const DEFAULT_BASE = "origin/main";
@@ -191,6 +194,11 @@ function numstatFromGit(base, head) {
   return stats;
 }
 
+function readTextAtRef(ref, filePath) {
+  if (ref === "HEAD") return readFileSync(filePath, "utf8");
+  return runGit(["show", `${ref}:${filePath}`]);
+}
+
 function readJsonAtRef(ref, filePath) {
   if (ref === "HEAD") {
     try {
@@ -272,7 +280,42 @@ function isAgentRuntimeContextPath(filePath) {
   );
 }
 
-function isCanonicalContextPath(filePath) {
+function parseFrontmatterDocument(content) {
+  if (typeof content !== "string" || !content.startsWith("---\n")) {
+    return null;
+  }
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  const document = parseYaml(content.slice(4, end));
+  return document && typeof document === "object" && !Array.isArray(document)
+    ? document
+    : null;
+}
+
+function hasCanonicalNoteMetadata(filePath, readContextFile) {
+  if (!filePath.startsWith("docs/notes/") || !filePath.endsWith(".md")) {
+    return false;
+  }
+
+  try {
+    // The documentation catalog derives authority from this same metadata. Do
+    // not fall back to its generated label: the catalog does not promote a
+    // document, and it may be stale while the working tree is being edited.
+    const content = readContextFile(filePath);
+    const frontmatter = parseFrontmatterDocument(content);
+    if (frontmatter?.canonical !== true && frontmatter?.canonical !== "true") {
+      return false;
+    }
+    const metadata = parseDocumentationMetadata(filePath, content);
+    return metadata?.canonical === "true";
+  } catch {
+    // Deleted, unreadable, and malformed notes must not satisfy a required
+    // context update merely because their path sits under docs/notes/.
+    return false;
+  }
+}
+
+function isCanonicalContextPath(filePath, readContextFile) {
   return (
     filePath === "AGENTS.md" ||
     filePath.endsWith("/AGENTS.md") ||
@@ -285,6 +328,7 @@ function isCanonicalContextPath(filePath) {
     filePath.startsWith(".agents/skills/") ||
     filePath.startsWith(".agents/roles/") ||
     filePath.startsWith(".claude/skills/") ||
+    hasCanonicalNoteMetadata(filePath, readContextFile) ||
     isAgentRuntimeContextPath(filePath)
   );
 }
@@ -296,8 +340,8 @@ function isRepoToolingTestPath(filePath) {
   );
 }
 
-function classifyPath(filePath) {
-  if (filePath.startsWith("docs/PLAN-") || filePath.startsWith("docs/notes/")) {
+function classifyPath(filePath, canonicalContextPaths) {
+  if (filePath.startsWith("docs/PLAN-")) {
     return signal(
       filePath,
       "trivial",
@@ -325,8 +369,16 @@ function classifyPath(filePath) {
     return signal(filePath, "full", "agent, build, or repository tooling");
   }
 
-  if (isCanonicalContextPath(filePath)) {
+  if (canonicalContextPaths.has(filePath)) {
     return signal(filePath, "full", "canonical agent or operator context");
+  }
+
+  if (filePath.startsWith("docs/notes/")) {
+    return signal(
+      filePath,
+      "trivial",
+      "non-canonical planning or note document",
+    );
   }
 
   if (
@@ -516,9 +568,17 @@ export function analyzeMateriality({
   paths,
   numstat = new Map(),
   scriptChanges = [],
+  readContextFile = (filePath) => readFileSync(filePath, "utf8"),
 } = {}) {
   const changedPaths = uniqueSorted(paths ?? []);
-  const pathSignals = changedPaths.map(classifyPath);
+  const canonicalContextPaths = new Set(
+    changedPaths.filter((filePath) =>
+      isCanonicalContextPath(filePath, readContextFile),
+    ),
+  );
+  const pathSignals = changedPaths.map((filePath) =>
+    classifyPath(filePath, canonicalContextPaths),
+  );
   const lineChanges = summarizeLineChanges(changedPaths, numstat);
   const sizeSignal = classifyBySize(changedPaths.length, lineChanges.total);
   const allSignals = sizeSignal ? [...pathSignals, sizeSignal] : pathSignals;
@@ -527,7 +587,7 @@ export function analyzeMateriality({
     "trivial",
   );
   const contextReasons = contextRequirementSignals(changedPaths, scriptChanges);
-  const contextUpdatesPresent = changedPaths.some(isCanonicalContextPath);
+  const contextUpdatesPresent = canonicalContextPaths.size > 0;
   const contextUpdateRequired = contextReasons.length > 0;
 
   return {
@@ -594,7 +654,12 @@ async function main() {
   const scriptChanges = paths.includes("package.json")
     ? rootScriptChanges(args.base, args.head)
     : [];
-  const report = analyzeMateriality({ paths, numstat, scriptChanges });
+  const report = analyzeMateriality({
+    paths,
+    numstat,
+    scriptChanges,
+    readContextFile: (filePath) => readTextAtRef(args.head, filePath),
+  });
 
   process.stdout.write(
     args.json ? `${JSON.stringify(report, null, 2)}\n` : renderHuman(report),

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -201,6 +201,132 @@ test("CLI rejects a workflow plus non-canonical note in human and JSON output", 
   }
 });
 
+test("CLI keeps a deleted canonical note full without counting context present", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-delete-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+  const workflow = join(dir, ".github", "workflows", "ci.yml");
+  const note = join(dir, "docs", "notes", "runbook.md");
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    mkdirSync(join(dir, "docs", "notes"), { recursive: true });
+    writeFileSync(workflow, "name: CI\n");
+    writeFileSync(note, contextNote("true"));
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-m", "base"]);
+
+    writeFileSync(workflow, "name: Updated CI\n");
+    rmSync(note);
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "HEAD", "--head", "HEAD", "--json"],
+      { cwd: dir, encoding: "utf8" },
+    );
+
+    assertEqual(result.status, 0);
+    const report = JSON.parse(result.stdout);
+    assertEqual(report.contextUpdateRequired, true);
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.tier,
+      "full",
+    );
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "canonical agent or operator context",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI uses merge-base canonical metadata across divergent histories", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-diverge-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+  const workflow = join(dir, ".github", "workflows", "ci.yml");
+  const note = join(dir, "docs", "notes", "runbook.md");
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    mkdirSync(join(dir, "docs", "notes"), { recursive: true });
+    writeFileSync(workflow, "name: CI\n");
+    writeFileSync(note, contextNote("true"));
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-m", "merge base"]);
+    const mergeBase = git(dir, ["rev-parse", "HEAD"]).trim();
+
+    git(dir, ["checkout", "-b", "feature"]);
+    writeFileSync(workflow, "name: Feature CI\n");
+    rmSync(note);
+    git(dir, ["add", "-A"]);
+    git(dir, ["commit", "-m", "feature deletes runbook"]);
+
+    git(dir, ["checkout", "-b", "named-base", mergeBase]);
+    writeFileSync(note, contextNote("false"));
+    git(dir, ["add", "docs/notes/runbook.md"]);
+    git(dir, ["commit", "-m", "base demotes runbook"]);
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "named-base", "--head", "feature", "--json"],
+      { cwd: dir, encoding: "utf8" },
+    );
+
+    assertEqual(result.status, 0);
+    const report = JSON.parse(result.stdout);
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.tier,
+      "full",
+    );
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "canonical agent or operator context",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("canonical base keeps demoted or malformed head notes full", () => {
+  for (const headContent of [
+    contextNote("false"),
+    "---\ncanonical: true\nnot valid metadata\n---\n",
+  ]) {
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+      readBaseContextFile: () => contextNote("true"),
+      readHeadContextFile: () => headContent,
+    });
+
+    assertEqual(report.tier, "full");
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.tier,
+      "full",
+    );
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "canonical agent or operator context",
+    );
+  }
+});
+
 test("malformed canonical note metadata fails closed", () => {
   for (const content of [
     "---\ncanonical: true\n# Missing delimiter\n",
@@ -210,7 +336,8 @@ test("malformed canonical note metadata fails closed", () => {
   ]) {
     const report = analyzeMateriality({
       paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
-      readContextFile: () => content,
+      readBaseContextFile: () => content,
+      readHeadContextFile: () => content,
     });
 
     assertEqual(report.contextUpdatesPresent, false);
@@ -226,13 +353,21 @@ test("malformed canonical note metadata fails closed", () => {
 test("unreadable canonical note metadata fails closed", () => {
   const report = analyzeMateriality({
     paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
-    readContextFile: () => {
+    readBaseContextFile: () => {
+      throw new Error("permission denied");
+    },
+    readHeadContextFile: () => {
       throw new Error("permission denied");
     },
   });
 
   assertEqual(report.contextUpdatesPresent, false);
   assertEqual(report.contextUpdateMissing, true);
+  assertEqual(
+    report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+      ?.reason,
+    "non-canonical planning or note document",
+  );
 });
 
 test("recognizes scoped Claude context files as canonical context", () => {

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -62,7 +62,7 @@ title: Fixture runbook
 status: active
 owner: eng
 canonical: ${canonical}
-last_verified: 2026-07-22
+last_verified: ${new Date().toISOString().slice(0, 10)}
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -376,7 +376,7 @@ test("incomplete canonical note metadata fails closed", () => {
     assertEqual(
       report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
         ?.reason,
-      "non-canonical planning or note document",
+      "canonical agent or operator context",
     );
   }
 });
@@ -402,7 +402,46 @@ test("invalid canonical note classification metadata fails closed", () => {
 
     assertEqual(report.contextUpdatesPresent, false);
     assertEqual(report.contextUpdateMissing, true);
+    assertEqual(report.tier, "full");
   }
+});
+
+test("invalid canonical note verification dates fail presence closed", () => {
+  for (const lastVerified of ["not-a-date", "2000-01-01", "2999-01-01"]) {
+    const content = contextNote("true").replace(
+      /^last_verified:.*$/m,
+      `last_verified: ${lastVerified}`,
+    );
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+      readBaseContextFile: () => content,
+      readHeadContextFile: () => content,
+    });
+
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(report.tier, "full");
+  }
+});
+
+test("incomplete canonical metadata at base retains full materiality", () => {
+  const baseContent = contextNote("true").replace(/^doc_type:.*\n/m, "");
+  const report = analyzeMateriality({
+    paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+    readBaseContextFile: () => baseContent,
+    readHeadContextFile: () => {
+      throw new Error("deleted at head");
+    },
+  });
+
+  assertEqual(report.contextUpdatesPresent, false);
+  assertEqual(report.contextUpdateMissing, true);
+  assertEqual(report.tier, "full");
+  assertEqual(
+    report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+      ?.reason,
+    "canonical agent or operator context",
+  );
 });
 
 test("head-canonical notes do not require a redundant base read", () => {

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -350,6 +350,44 @@ test("malformed canonical note metadata fails closed", () => {
   }
 });
 
+test("incomplete canonical note metadata fails closed", () => {
+  for (const key of ["title", "status", "owner", "last_verified"]) {
+    const content = contextNote("true").replace(
+      new RegExp(`^${key}:.*\\n`, "m"),
+      "",
+    );
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+      readBaseContextFile: () => content,
+      readHeadContextFile: () => content,
+    });
+
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "non-canonical planning or note document",
+    );
+  }
+});
+
+test("head-canonical notes do not require a redundant base read", () => {
+  let baseReads = 0;
+  const report = analyzeMateriality({
+    paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+    readBaseContextFile: () => {
+      baseReads += 1;
+      return contextNote("true");
+    },
+    readHeadContextFile: () => contextNote("true"),
+  });
+
+  assertEqual(baseReads, 0);
+  assertEqual(report.contextUpdatesPresent, true);
+  assertEqual(report.contextUpdateMissing, false);
+});
+
 test("unreadable canonical note metadata fails closed", () => {
   const report = analyzeMateriality({
     paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -185,6 +191,8 @@ test("CLI rejects a workflow plus non-canonical note in human and JSON output", 
     const json = runMaterialityCli(dir, pathsFile, true);
     assertEqual(human.status, 0);
     assertEqual(json.status, 0);
+    assertEqual(human.stderr, "");
+    assertEqual(json.stderr, "");
     assertIncludes(human.stdout, "Context update: required but not present");
 
     const report = JSON.parse(json.stdout);
@@ -199,6 +207,80 @@ test("CLI rejects a workflow plus non-canonical note in human and JSON output", 
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("CLI never follows untracked symlinked context during normal analysis", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-symlink-test-"));
+  const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
+  const workflow = join(dir, ".github", "workflows", "ci.yml");
+  const note = join(dir, "docs", "notes", "runbook.md");
+  const agents = join(dir, "AGENTS.md");
+  const fifo = join(dir, "context.fifo");
+
+  try {
+    git(dir, ["init"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test User"]);
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    mkdirSync(join(dir, "docs", "notes"), { recursive: true });
+    writeFileSync(workflow, "name: CI\n");
+    git(dir, ["add", ".github/workflows/ci.yml"]);
+    git(dir, ["commit", "-m", "base"]);
+    writeFileSync(workflow, "name: Updated CI\n");
+
+    const fifoResult = spawnSync("mkfifo", [fifo], { encoding: "utf8" });
+    assertEqual(fifoResult.status, 0);
+    symlinkSync(fifo, note);
+    symlinkSync(fifo, agents);
+
+    const result = spawnSync(
+      process.execPath,
+      [script, "--base", "HEAD", "--head", "HEAD", "--json"],
+      { cwd: dir, encoding: "utf8", timeout: 2_000 },
+    );
+    assert(!result.error, result.error?.message ?? "CLI timed out");
+    assertEqual(result.status, 0);
+    const report = JSON.parse(result.stdout);
+    assertEqual(report.contextUpdateRequired, true);
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "canonical agent or operator context",
+    );
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "AGENTS.md")?.reason,
+      "canonical agent or operator context",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("non-regular context paths are rejected before their targets are read", () => {
+  let headReads = 0;
+  const report = analyzeMateriality({
+    paths: [".github/workflows/ci.yml", "AGENTS.md", "docs/notes/runbook.md"],
+    readBaseContextFile: () => {
+      throw new Error("absent at base");
+    },
+    readHeadContextFile: () => {
+      headReads += 1;
+      return contextNote("true");
+    },
+    isHeadContextFile: () => false,
+  });
+
+  assertEqual(headReads, 0);
+  assertEqual(report.contextUpdatesPresent, false);
+  assertEqual(report.contextUpdateMissing, true);
+  assertEqual(report.tier, "full");
+  assertEqual(
+    report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+      ?.reason,
+    "canonical agent or operator context",
+  );
 });
 
 test("CLI keeps a deleted canonical note full without counting context present", () => {
@@ -251,6 +333,7 @@ test("CLI uses merge-base canonical metadata across divergent histories", () => 
   const script = new URL("./review-materiality.mjs", import.meta.url).pathname;
   const workflow = join(dir, ".github", "workflows", "ci.yml");
   const note = join(dir, "docs", "notes", "runbook.md");
+  const pathsFile = join(dir, "paths.txt");
 
   try {
     git(dir, ["init"]);
@@ -274,27 +357,41 @@ test("CLI uses merge-base canonical metadata across divergent histories", () => 
     writeFileSync(note, contextNote("false"));
     git(dir, ["add", "docs/notes/runbook.md"]);
     git(dir, ["commit", "-m", "base demotes runbook"]);
-
-    const result = spawnSync(
-      process.execPath,
-      [script, "--base", "named-base", "--head", "feature", "--json"],
-      { cwd: dir, encoding: "utf8" },
+    writeFileSync(
+      pathsFile,
+      ".github/workflows/ci.yml\ndocs/notes/runbook.md\n",
     );
 
-    assertEqual(result.status, 0);
-    const report = JSON.parse(result.stdout);
-    assertEqual(report.contextUpdatesPresent, false);
-    assertEqual(report.contextUpdateMissing, true);
-    assertEqual(
-      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
-        ?.tier,
-      "full",
-    );
-    assertEqual(
-      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
-        ?.reason,
-      "canonical agent or operator context",
-    );
+    for (const extraArgs of [[], ["--changed-paths-file", pathsFile]]) {
+      const result = spawnSync(
+        process.execPath,
+        [
+          script,
+          "--base",
+          "named-base",
+          "--head",
+          "feature",
+          ...extraArgs,
+          "--json",
+        ],
+        { cwd: dir, encoding: "utf8" },
+      );
+
+      assertEqual(result.status, 0);
+      const report = JSON.parse(result.stdout);
+      assertEqual(report.contextUpdatesPresent, false);
+      assertEqual(report.contextUpdateMissing, true);
+      assertEqual(
+        report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+          ?.tier,
+        "full",
+      );
+      assertEqual(
+        report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+          ?.reason,
+        "canonical agent or operator context",
+      );
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -56,6 +56,47 @@ function git(cwd, args) {
   return result.stdout;
 }
 
+function contextNote(canonical) {
+  return `---
+title: Fixture runbook
+status: active
+owner: eng
+canonical: ${canonical}
+last_verified: 2026-07-22
+doc_type: runbook
+scope: repo-wide
+review_interval_days: 90
+garden_lane: operator-runbooks
+---
+
+# Fixture runbook
+`;
+}
+
+function materialityCliFixture(noteContent) {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-context-test-"));
+  const pathsFile = join(dir, "paths.txt");
+  mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+  mkdirSync(join(dir, "docs", "notes"), { recursive: true });
+  writeFileSync(join(dir, ".github", "workflows", "ci.yml"), "name: CI\n");
+  writeFileSync(join(dir, "docs", "notes", "runbook.md"), noteContent);
+  writeFileSync(pathsFile, ".github/workflows/ci.yml\ndocs/notes/runbook.md\n");
+  return { dir, pathsFile };
+}
+
+function runMaterialityCli(cwd, pathsFile, json = false) {
+  return spawnSync(
+    process.execPath,
+    [
+      new URL("./review-materiality.mjs", import.meta.url).pathname,
+      "--changed-paths-file",
+      pathsFile,
+      ...(json ? ["--json"] : []),
+    ],
+    { cwd, encoding: "utf8" },
+  );
+}
+
 console.log("\nreview-materiality.mjs tests\n");
 
 test("classifies non-canonical plan-only edits as trivial", () => {
@@ -110,6 +151,88 @@ test("recognizes context updates when canonical docs are present", () => {
   assertEqual(report.contextUpdateRequired, true);
   assertEqual(report.contextUpdatesPresent, true);
   assertEqual(report.contextUpdateMissing, false);
+});
+
+test("CLI recognizes a workflow plus canonical note in human and JSON output", () => {
+  const { dir, pathsFile } = materialityCliFixture(contextNote("true"));
+
+  try {
+    const human = runMaterialityCli(dir, pathsFile);
+    const json = runMaterialityCli(dir, pathsFile, true);
+    assertEqual(human.status, 0);
+    assertEqual(json.status, 0);
+    assertIncludes(human.stdout, "Context update: required and present");
+
+    const report = JSON.parse(json.stdout);
+    assertEqual(report.contextUpdateRequired, true);
+    assertEqual(report.contextUpdatesPresent, true);
+    assertEqual(report.contextUpdateMissing, false);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "canonical agent or operator context",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI rejects a workflow plus non-canonical note in human and JSON output", () => {
+  const { dir, pathsFile } = materialityCliFixture(contextNote("false"));
+
+  try {
+    const human = runMaterialityCli(dir, pathsFile);
+    const json = runMaterialityCli(dir, pathsFile, true);
+    assertEqual(human.status, 0);
+    assertEqual(json.status, 0);
+    assertIncludes(human.stdout, "Context update: required but not present");
+
+    const report = JSON.parse(json.stdout);
+    assertEqual(report.contextUpdateRequired, true);
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "non-canonical planning or note document",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("malformed canonical note metadata fails closed", () => {
+  for (const content of [
+    "---\ncanonical: true\n# Missing delimiter\n",
+    "---\ncanonical: true\nnot valid metadata\n---\n",
+    '---\ncanonical: "true\n---\n',
+    "---\ncanonical: false\ncanonical: true\n---\n",
+  ]) {
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+      readContextFile: () => content,
+    });
+
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "docs/notes/runbook.md")
+        ?.reason,
+      "non-canonical planning or note document",
+    );
+  }
+});
+
+test("unreadable canonical note metadata fails closed", () => {
+  const report = analyzeMateriality({
+    paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+    readContextFile: () => {
+      throw new Error("permission denied");
+    },
+  });
+
+  assertEqual(report.contextUpdatesPresent, false);
+  assertEqual(report.contextUpdateMissing, true);
 });
 
 test("recognizes scoped Claude context files as canonical context", () => {

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -351,7 +351,16 @@ test("malformed canonical note metadata fails closed", () => {
 });
 
 test("incomplete canonical note metadata fails closed", () => {
-  for (const key of ["title", "status", "owner", "last_verified"]) {
+  for (const key of [
+    "title",
+    "status",
+    "owner",
+    "last_verified",
+    "doc_type",
+    "scope",
+    "review_interval_days",
+    "garden_lane",
+  ]) {
     const content = contextNote("true").replace(
       new RegExp(`^${key}:.*\\n`, "m"),
       "",
@@ -369,6 +378,30 @@ test("incomplete canonical note metadata fails closed", () => {
         ?.reason,
       "non-canonical planning or note document",
     );
+  }
+});
+
+test("invalid canonical note classification metadata fails closed", () => {
+  for (const content of [
+    contextNote("true").replace("status: active", "status: unknown"),
+    contextNote("true").replace("doc_type: runbook", "doc_type: unknown"),
+    contextNote("true").replace(
+      "garden_lane: operator-runbooks",
+      "garden_lane: unknown",
+    ),
+    contextNote("true").replace(
+      "review_interval_days: 90",
+      "review_interval_days: 0",
+    ),
+  ]) {
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],
+      readBaseContextFile: () => content,
+      readHeadContextFile: () => content,
+    });
+
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
   }
 });
 

--- a/scripts/review-materiality.test.mjs
+++ b/scripts/review-materiality.test.mjs
@@ -388,6 +388,77 @@ test("head-canonical notes do not require a redundant base read", () => {
   assertEqual(report.contextUpdateMissing, false);
 });
 
+test("deleted convention-based context stays full without counting present", () => {
+  for (const filePath of [
+    "AGENTS.md",
+    "scripts/AGENTS.md",
+    "CLAUDE.md",
+    "scripts/CLAUDE.md",
+    "README.md",
+    "docs/context-standards.md",
+    "docs/deployment.md",
+    "docs/pr-checklists/example.md",
+    ".agents/skills/example/SKILL.md",
+    ".agents/roles/example.md",
+    ".claude/skills/example/SKILL.md",
+    ".codex/hooks.json",
+    ".claude/settings.json",
+  ]) {
+    const report = analyzeMateriality({
+      paths: [".github/workflows/ci.yml", filePath],
+      readBaseContextFile: () => "base context",
+      readHeadContextFile: () => {
+        throw new Error("deleted at head");
+      },
+    });
+
+    assertEqual(report.tier, "full");
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+  }
+});
+
+test("renaming convention-based context out of canonical paths is not present", () => {
+  const oldPath = "docs/pr-checklists/old-checklist.md";
+  const newPath = "docs/notes/old-checklist.md";
+  const report = analyzeMateriality({
+    paths: [".github/workflows/ci.yml", oldPath, newPath],
+    readBaseContextFile: (filePath) => {
+      if (filePath === oldPath) return "base context";
+      throw new Error("absent at base");
+    },
+    readHeadContextFile: (filePath) => {
+      if (filePath === newPath) return contextNote("false");
+      throw new Error("absent at head");
+    },
+  });
+
+  assertEqual(report.tier, "full");
+  assertEqual(report.contextUpdatesPresent, false);
+  assertEqual(report.contextUpdateMissing, true);
+});
+
+test("file-list mode keeps deleted convention-based context full", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-materiality-file-list-test-"));
+  const pathsFile = join(dir, "paths.txt");
+  writeFileSync(pathsFile, ".github/workflows/ci.yml\nAGENTS.md\n");
+
+  try {
+    const result = runMaterialityCli(dir, pathsFile, true);
+    assertEqual(result.status, 0);
+    const report = JSON.parse(result.stdout);
+    assertEqual(report.tier, "full");
+    assertEqual(report.contextUpdatesPresent, false);
+    assertEqual(report.contextUpdateMissing, true);
+    assertEqual(
+      report.pathSignals.find((item) => item.path === "AGENTS.md")?.reason,
+      "canonical agent or operator context",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("unreadable canonical note metadata fails closed", () => {
   const report = analyzeMateriality({
     paths: [".github/workflows/ci.yml", "docs/notes/runbook.md"],


### PR DESCRIPTION
## The Problem

- `pnpm agent:review-materiality` treated every `docs/notes/*.md` file as non-canonical, even when its validated metadata made it the current operator runbook.
- Deleting, demoting, or changing a canonical note on a diverged branch could also downgrade the change to trivial review depth.
- Worktree context probes could follow symlinked or non-regular paths before deciding whether the context update was valid.

## The Solution

- Derive note authority from canonical metadata at the diff's effective base and final head, validate final-head presence strictly, and reject unsafe worktree paths before reading them.

## Details

- Canonical notes now classify as full operator context and satisfy `contextUpdatesPresent` only when canonical in the resulting head/worktree.
- Deleted, demoted, malformed, or unreadable canonical notes fail closed and retain full materiality without pretending the context update is present.
- Normal diff paths, numstat, root-script comparison, and metadata reads share the same resolved merge base; file-list mode keeps supplied paths authoritative while resolving base metadata when Git is available.
- Final and ancestor symlinks, path escapes, FIFOs, and other non-regular worktree paths are rejected before untracked statistics, context, or root-package reads; expected absent-base note probes stay quiet.
- The canonical context and quality-gate docs already describe this authority model accurately, so no documentation text changed.
- Architecture decision: not needed; this fixes the existing context-authority contract.

## Validation

- `CI=true pnpm agent:review-materiality:test` — 37 tests passed.
- `CI=true pnpm agent:quality-gate --run`
- `git diff --check`
- Fresh-context semantic autoreview and deterministic local autoreview: clean; the file-size refactor is tracked in #1454.

## Deferrals

- #1454 — split the canonical-context and snapshot-reading logic into a focused helper module.

Closes #1435.
Closes #1448.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
