### PR TITLE
perf(tooling): scoped local tests, narrower gate escalation, persisted durations

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -42,6 +42,13 @@ and timing lines. For deterministic autoreview-runtime closeout, pass
 coverage. Hosted-CI hermeticity remains the separate follow-up tracked in
 #1422.
 
+`--run` appends one JSON line per mapped command (plus one `__run_total__`
+summary line per invocation) to `.tmp/agent-quality-gate/durations.jsonl`, a
+gitignored scratch file, for local wall-clock tracking. Budget targets: the
+common-case mapped set should finish in 3 minutes or less; the full workspace
+suite in 8 minutes or less. Treat a durations regression against these targets
+like any other perf regression (Refs #1415).
+
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:
 
@@ -120,6 +127,64 @@ source-fingerprinting tests such as autoreview from observing synthetic drift.
 A browser setup failure still lets independent lint/typecheck/unit/knip
 feedback run. `--fail-fast` stays sequential so it still stops before starting
 the next mapped command.
+
+Two manifest-class changes are narrowed away from the full workspace suite
+instead of escalating unconditionally (Refs #1414). Every ambiguity fails toward
+the full suite:
+
+| Change                                               | Escalation                                                                                                                                                        |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm-lock.yaml`, importer sections only             | `pnpm install --frozen-lockfile` + `pnpm skew:check` + `pnpm lockfile:lint` + each changed importer's package quality bundle (`.` root importer → full suite).    |
+| Root `package.json`, `devDependencies`/metadata only | `pnpm install --frozen-lockfile` + `pnpm skew:check` + `pnpm lockfile:lint` + the `@mento-protocol/config` bundle as canary (it typechecks downstream consumers). |
+
+Lockfile scoping applies only when `pnpm-lock.yaml` is the sole
+workspace-manifest-class change and `scripts/lockfile-scope.mjs` (js-yaml
+structural diff) reports that only importer sections changed; a parse/`git show`
+failure, a co-changed manifest, any non-importer top-level section
+(`settings`, `catalogs`, `overrides`, `patchedDependencies`,
+`packageExtensionsChecksum`, `packages`, `snapshots`, …), or an importer that
+maps to no known package bundle falls back to the full suite. The dev-metadata
+class covers a root `package.json` whose changed JSON pointers are all under
+`/devDependencies` or `/name`, `/description`, `/license`, `/keywords`,
+`/author`, `/repository`, `/bugs`, `/homepage`; any `/dependencies`, `/pnpm`,
+`/packageManager`, `/engines`, `/scripts`, or unknown-key change keeps today's
+full-suite and package-script refusal behavior. Both classes still set the
+package-script risk flag, so `--run` continues to refuse until
+`--allow-package-script-changes`, and `package.json` still gets a full-repo
+Trunk scan.
+
+### Scoped local test runs (Refs #1413)
+
+A per-package quality bundle normally runs `pnpm --filter <pkg> test:coverage`
+(the package's full suite plus its coverage floor). Locally, when a package's
+changed paths are a small set of production source files, the gate narrows that
+one command to `pnpm --filter <pkg> exec vitest related --run <files>` so an
+agent only pays for the tests reaching its edit. The reason string carries
+`(scoped-tests)` so the substitution is visible in dry-run output. This is a
+local-signal optimization only: CI still runs the full `test:coverage` coverage
+floors, so scoping never changes what gets enforced — it only trims the local
+feedback loop.
+
+The rewrite fires for a package only when **all** of these hold:
+
+- the run has 15 or fewer total changed paths;
+- every changed path inside that package directory is production source — not
+  `*.test.*`/`*.spec.*`, `__tests__/**`, `test/**`/`tests/**`, `vitest.config.*`,
+  `vitest.hermetic-setup.ts`, `tsconfig*`, `package.json`, `*.graphql`,
+  `__generated__/**` or other generated types, or `fixtures/**`;
+- the package is not `@mento-protocol/config` (shared-config's downstream blast
+  radius is the point, so it keeps full suites);
+- the run is not a full-workspace escalation (those keep full `test:coverage`
+  everywhere);
+- no test-infra file changed anywhere in the diff
+  (`scripts/envio-schema-stubs.graphql`, any vitest setup file).
+
+Anything outside those bounds keeps the full `test:coverage`. `vitest related`
+takes the file list relative to the package root and exits 0 when a changed file
+has no related tests. Two escape hatches force the full local suite everywhere:
+the `--full-local-tests` flag and the `AGENT_GATE_FULL_TESTS=1` environment
+variable. Aegis (`test:cov` + `forge test`) is out of scope and always runs its
+full suite.
 
 QuickNode webhook state parsing has a dedicated fail-closed regression suite.
 Changes to its shared parser, repair tool, shell test, or the listener
@@ -532,7 +597,9 @@ task orchestrator.
 Per-package coverage floors run as direct package commands such as
 `pnpm --filter <pkg> test:coverage` (or Aegis `test:cov`) so they always
 exercise the current local coverage threshold rather than a stale cached test
-result.
+result. A small production-source-only diff narrows the local `test:coverage`
+command to `vitest related` per the scoped-test rules above; the full coverage
+floor still runs in CI.
 Dashboard build/browser/React Doctor cache keys explicitly include
 `shared-config`, package-manager, workflow, wrapper-script, and relevant env
 inputs; CI still runs browser tests normally and remains the Linux snapshot

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -175,10 +175,14 @@ feedback loop.
 The rewrite fires for a package only when **all** of these hold:
 
 - the run has 15 or fewer total changed paths;
-- every changed path inside that package directory is production source — not
-  `*.test.*`/`*.spec.*`, `__tests__/**`, `test/**`/`tests/**`, `vitest.config.*`,
-  `vitest.hermetic-setup.ts`, `tsconfig*`, `package.json`, `*.graphql`,
-  `__generated__/**` or other generated types, or `fixtures/**`;
+- every changed path inside that package directory is production source: a
+  recognized TS/JS module extension (`.ts`, `.tsx`, `.mts`, `.cts`, `.js`,
+  `.jsx`, `.mjs`, `.cjs`) that is not `*.test.*`/`*.spec.*`, `__tests__/**`,
+  `test/**`/`tests/**`, `vitest.config.*`, `vitest.hermetic-setup.ts`,
+  `tsconfig*`, `package.json`, `*.graphql`, `__generated__/**` or other
+  generated types, or `fixtures/**`. Non-module files (JSON/YAML/CSS/assets)
+  disqualify scoping because tests may read them via `fs` rather than the
+  import graph `vitest related` follows;
 - the package is not `@mento-protocol/config` (shared-config's downstream blast
   radius is the point, so it keeps full suites);
 - the run is not a full-workspace escalation (those keep full `test:coverage`

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -187,7 +187,10 @@ The rewrite fires for a package only when **all** of these hold:
   radius is the point, so it keeps full suites);
 - the run is not a full-workspace escalation (those keep full `test:coverage`
   everywhere);
-- no test-infra file changed anywhere in the diff
+- no test-infra file and no `shared-config/**` path changed anywhere in the
+  diff (shared-config edits can regress any consumer through the dependency
+  graph, which `vitest related` on the consumer's own changed files cannot
+  see)
   (`scripts/envio-schema-stubs.graphql`, any vitest setup file).
 
 Anything outside those bounds keeps the full `test:coverage`. `vitest related`

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -736,12 +736,17 @@ scoped_is_non_source_path() {
 }
 
 # True iff any changed path anywhere is a test-infra file whose edit can change
-# which tests run for unrelated source. Such a change disables scoping globally.
+# which tests run for unrelated source, or a shared-config path whose edit can
+# regress any consumer through the dependency graph (`vitest related` only
+# follows imports from the changed files themselves, so a consumer's scoped
+# run would miss shared-config-induced regressions). Either disables scoping
+# globally.
 scoped_test_infra_changed() {
   local path
   while IFS= read -r path; do
     case "$path" in
       scripts/envio-schema-stubs.graphql) return 0 ;;
+      shared-config/*) return 0 ;;
       vitest.hermetic-setup.ts | */vitest.hermetic-setup.ts) return 0 ;;
       vitest.config.* | */vitest.config.* | vitest.*.config.* | */vitest.*.config.*) return 0 ;;
       */test/setup/* | */tests/setup/*) return 0 ;;

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -726,7 +726,12 @@ scoped_is_non_source_path() {
     *.graphql) return 0 ;;
     __generated__/* | */__generated__/* | generated/* | */generated/* | *.gen.ts) return 0 ;;
     fixtures/* | */fixtures/* | __fixtures__/* | */__fixtures__/*) return 0 ;;
-    *) return 1 ;;
+    # Only recognized TS/JS module extensions count as production source.
+    # Anything else (YAML/JSON/CSS/assets) may be read by tests via fs rather
+    # than the import graph `vitest related` follows, so it disqualifies
+    # scoping (fail toward full).
+    *.ts | *.tsx | *.mts | *.cts | *.js | *.jsx | *.mjs | *.cjs) return 1 ;;
+    *) return 0 ;;
   esac
 }
 
@@ -2644,6 +2649,7 @@ run_mapped_entries_sequential() {
         echo
         echo "Stopping after first failed mapped command (--fail-fast)." >&2
         print_command_summary
+        log_duration_line "fail" "$(($(date +%s) - gate_start_ts))" "__run_total__" "run" || true
         exit 1
       fi
     fi

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gate_start_ts="$(date +%s)"
+
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh] [--parallel <n>]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh] [--parallel <n>] [--full-local-tests]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -29,6 +31,10 @@ Options:
                  n concurrent jobs. Default: auto, capped at 4. Fail-fast mode
                  stays sequential so it still stops before starting the next
                  mapped command.
+  --full-local-tests
+                 Force full per-package `test:coverage` locally instead of the
+                 scoped `vitest related` optimization. CI always runs the full
+                 coverage floors regardless of this flag.
   -h, --help     Show this help.
 
 Environment:
@@ -41,6 +47,8 @@ Environment:
                       Same behavior as --fail-fast when set to 1 or true.
   AGENT_QUALITY_PARALLELISM
                       Same behavior as --parallel. Use auto for the default.
+  AGENT_GATE_FULL_TESTS
+                      Same behavior as --full-local-tests when set to 1 or true.
 USAGE
 }
 
@@ -52,6 +60,7 @@ allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
 fail_fast="${AGENT_QUALITY_FAIL_FAST:-false}"
 skip_if_fresh="${AGENT_QUALITY_SKIP_IF_FRESH:-false}"
 quality_parallelism="${AGENT_QUALITY_PARALLELISM:-auto}"
+full_local_tests="${AGENT_GATE_FULL_TESTS:-false}"
 if [[ -z "$allow_package_script_changes" ]]; then
   allow_package_script_changes="$(git config --bool --get agent.qualityGate.allowPackageScriptChanges 2>/dev/null || true)"
 fi
@@ -106,6 +115,10 @@ while [[ $# -gt 0 ]]; do
       skip_if_fresh="true"
       shift
       ;;
+    --full-local-tests)
+      full_local_tests="true"
+      shift
+      ;;
     --parallel|--jobs)
       quality_parallelism="${2:-}"
       if [[ -z "$quality_parallelism" ]]; then
@@ -151,6 +164,11 @@ if [[ ! "$quality_parallelism" =~ ^[0-9]+$ || "$quality_parallelism" -lt 1 ]]; t
   exit 2
 fi
 
+# Resolve this script's own directory before the cd below so node helpers it
+# invokes (e.g. lockfile-scope.mjs) resolve from the real checkout even when the
+# gate runs against a temp fixture repo whose working directory is elsewhere.
+script_source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
@@ -162,6 +180,7 @@ cd "$repo_root"
 # the system default (which sandboxed shells often cannot write to).
 scratch_dir="$repo_root/.tmp/agent-quality-gate"
 mkdir -p "$scratch_dir"
+durations_file="$scratch_dir/durations.jsonl"
 success_stamp_file="$scratch_dir/last-success.stamp"
 # An exact-signature success may cover the manual-run-to-pre-push interval even
 # for the slowest mapped suites. Keep this fixed rather than environment-
@@ -238,6 +257,10 @@ quality_commands=()
 checklists=()
 surfaces=()
 package_script_risk_changed=false
+# Set true whenever a full-workspace suite is routed. Scoped-test rewriting
+# (GitHub issue #1413) is suppressed in that case so escalations keep the full
+# per-package `test:coverage` floors everywhere.
+saw_workspace_escalation=false
 
 has_command() {
   local command="$1"
@@ -465,6 +488,8 @@ classify_root_package_json_changes() {
   local saw_tooling_script=false
   local saw_non_tooling_script=false
   local saw_non_script=false
+  local saw_dev_metadata=false
+  local saw_non_dev_metadata=false
 
   while IFS= read -r change; do
     [[ -n "$change" ]] || continue
@@ -483,8 +508,16 @@ classify_root_package_json_changes() {
       /scripts/*)
         saw_non_tooling_script=true
         ;;
+      # Dev-metadata pointers (GitHub issue #1414): devDependencies plus the
+      # descriptive top-level keys. A manifest whose only non-script changes are
+      # these is safe to scope to the config canary rather than the full suite.
+      /devDependencies | /devDependencies/* | /name | /description | /license | /keywords | /keywords/* | /author | /author/* | /repository | /repository/* | /bugs | /bugs/* | /homepage)
+        saw_non_script=true
+        saw_dev_metadata=true
+        ;;
       *)
         saw_non_script=true
+        saw_non_dev_metadata=true
         ;;
     esac
   done < <(json_change_paths "package.json")
@@ -495,6 +528,8 @@ classify_root_package_json_changes() {
     echo "root-tooling-scripts"
   elif [[ "$saw_tooling_script" == true || "$saw_non_tooling_script" == true ]]; then
     echo "package-scripts"
+  elif [[ "$saw_dev_metadata" == true && "$saw_non_dev_metadata" != true ]]; then
+    echo "workspace-dev-metadata"
   else
     echo "workspace"
   fi
@@ -606,6 +641,7 @@ add_indexer_mutation_baseline() {
 
 add_workspace_quality_commands() {
   local reason="$1"
+  saw_workspace_escalation=true
   add_command "pnpm skew:check" "$reason"
   add_all_indexer_codegen "$reason"
   # Use the lightweight dashboard quality (typecheck/lint/test/knip) for
@@ -631,6 +667,268 @@ add_workspace_quality_commands() {
   add_package_quality_commands "@mento-protocol/config" "$reason"
   add_package_quality_commands "@mento-protocol/governance-watchdog" "$reason"
   add_aegis_quality_commands "$reason"
+}
+
+# ── Scoped local test runs (GitHub issue #1413) ─────────────────────────────
+# A per-package quality bundle normally runs `pnpm --filter <pkg> test:coverage`
+# (the full suite + coverage floor). Locally, when a package's changed paths are
+# a small set of production source files, narrow that one command to
+# `pnpm --filter <pkg> exec vitest related --run <files>` so agents only pay for
+# the tests touching their edit. CI is untouched — it always runs the full
+# coverage floors — so this is a local-signal optimization, not a floor change.
+# Every ambiguity fails toward the full suite.
+
+# Package name → repo-relative importer directory. Unmapped packages have no
+# directory, so scoping never fires for them (→ full suite).
+scoped_package_dir_for() {
+  case "$1" in
+    @mento-protocol/ui-dashboard) echo "ui-dashboard" ;;
+    @mento-protocol/indexer-envio) echo "indexer-envio" ;;
+    @mento-protocol/metrics-bridge) echo "metrics-bridge" ;;
+    @mento-protocol/integration-probes) echo "integration-probes" ;;
+    @mento-protocol/governance-watchdog) echo "governance-watchdog" ;;
+    @mento-protocol/alerts-onchain-event-handler) echo "alerts/infra/onchain-event-handler" ;;
+    @mento-protocol/alerts-oncall-announcer) echo "alerts/infra/oncall-announcer" ;;
+    *) return 1 ;;
+  esac
+}
+
+# True iff a package-relative path is NOT production source. Tests, specs, test
+# directories, vitest/tsconfig config, package manifests, GraphQL schemas,
+# generated types, and fixtures all disqualify a package from scoping so its
+# full suite still runs. Ambiguous paths are treated as non-source (fail toward
+# full).
+scoped_is_non_source_path() {
+  local path="$1"
+  case "$path" in
+    *.test.* | *.spec.*) return 0 ;;
+    __tests__/* | */__tests__/*) return 0 ;;
+    test/* | tests/* | */test/* | */tests/*) return 0 ;;
+    vitest.config.* | */vitest.config.* | vitest.*.config.* | */vitest.*.config.*) return 0 ;;
+    vitest.hermetic-setup.ts | */vitest.hermetic-setup.ts) return 0 ;;
+    tsconfig* | */tsconfig*) return 0 ;;
+    package.json | */package.json) return 0 ;;
+    *.graphql) return 0 ;;
+    __generated__/* | */__generated__/* | generated/* | */generated/* | *.gen.ts) return 0 ;;
+    fixtures/* | */fixtures/* | __fixtures__/* | */__fixtures__/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True iff any changed path anywhere is a test-infra file whose edit can change
+# which tests run for unrelated source. Such a change disables scoping globally.
+scoped_test_infra_changed() {
+  local path
+  while IFS= read -r path; do
+    case "$path" in
+      scripts/envio-schema-stubs.graphql) return 0 ;;
+      vitest.hermetic-setup.ts | */vitest.hermetic-setup.ts) return 0 ;;
+      vitest.config.* | */vitest.config.* | vitest.*.config.* | */vitest.*.config.*) return 0 ;;
+      */test/setup/* | */tests/setup/*) return 0 ;;
+    esac
+  done < "$changed_paths_file"
+  return 1
+}
+
+# Print the package-relative production-source paths changed inside a package
+# directory, one per line. Returns non-zero (no output) when the package is
+# unscopable: no changed paths inside it, or any non-source path inside it.
+scoped_source_files_for_package() {
+  local package_name="$1"
+  local package_dir
+  package_dir="$(scoped_package_dir_for "$package_name")" || return 1
+
+  local path rel
+  local saw_source=false
+  local files=()
+  while IFS= read -r path; do
+    case "$path" in
+      "$package_dir"/*)
+        rel="${path#"$package_dir"/}"
+        if scoped_is_non_source_path "$rel"; then
+          return 1
+        fi
+        files+=("$rel")
+        saw_source=true
+        ;;
+    esac
+  done < "$changed_paths_file"
+
+  [[ "$saw_source" == true ]] || return 1
+  printf '%s\n' "${files[@]}"
+}
+
+# True iff scoping is globally permitted for this run.
+scoped_tests_enabled() {
+  [[ "$full_local_tests" == "1" || "$full_local_tests" == "true" ]] && return 1
+  [[ "$saw_workspace_escalation" == true ]] && return 1
+  local changed_count
+  changed_count="$(wc -l < "$changed_paths_file" | tr -d '[:space:]')"
+  [[ "$changed_count" =~ ^[0-9]+$ && "$changed_count" -le 15 ]] || return 1
+  scoped_test_infra_changed && return 1
+  return 0
+}
+
+# Rewrite eligible `pnpm --filter <pkg> test:coverage` quality commands to the
+# scoped `vitest related --run` form. Runs once, after the full dispatch, so the
+# escalation flag and the complete changed-path set are final.
+apply_scoped_test_commands() {
+  scoped_tests_enabled || return 0
+
+  local i entry command reason package_name package_dir files scoped_files rel
+  for i in "${!quality_commands[@]}"; do
+    entry="${quality_commands[$i]}"
+    command="${entry%%|*}"
+    reason="${entry#*|}"
+
+    [[ "$command" =~ ^pnpm\ --filter\ (@mento-protocol/[a-z-]+)\ test:coverage$ ]] || continue
+    package_name="${BASH_REMATCH[1]}"
+
+    # shared-config's blast radius is the point — keep its full suite (issue #1413).
+    [[ "$package_name" == "@mento-protocol/config" ]] && continue
+
+    files="$(scoped_source_files_for_package "$package_name")" || continue
+
+    scoped_files=""
+    while IFS= read -r rel; do
+      [[ -n "$rel" ]] || continue
+      scoped_files+=" $(quote_path "$rel")"
+    done <<< "$files"
+    [[ -n "$scoped_files" ]] || continue
+
+    quality_commands[i]="pnpm --filter ${package_name} exec vitest related --run${scoped_files}|${reason} (scoped-tests)"
+  done
+}
+
+# ── Lockfile-importer scoping (GitHub issue #1414) ──────────────────────────
+# A pnpm-lock.yaml change normally escalates to the full workspace suite. When
+# the lockfile is the ONLY workspace-manifest-class change and it structurally
+# touches only importer sections, narrow the suite to the affected packages.
+# Every ambiguity (co-changed manifests, non-importer sections, an unmapped or
+# root importer, parse/git failure) fails toward the full suite.
+
+# True iff pnpm-lock.yaml changed and no other workspace-manifest-class path did.
+lockfile_only_manifest_change() {
+  local path
+  local saw_lock=false
+  while IFS= read -r path; do
+    case "$path" in
+      pnpm-lock.yaml)
+        saw_lock=true
+        ;;
+      package.json | */package.json | pnpm-workspace.yaml | patches/* | .npmrc | */.npmrc | pnpmfile.cjs | .pnpmfile.cjs | .node-version)
+        return 1
+        ;;
+    esac
+  done < "$changed_paths_file"
+  [[ "$saw_lock" == true ]]
+}
+
+# Print the changed importer keys (one per line) on stdout when the lockfile
+# change is scopable; return non-zero to signal fail-toward-full.
+lockfile_scoped_importers() {
+  local base_file
+  local head_file
+  base_file="$(make_tmpfile)"
+  head_file="$(make_tmpfile)"
+
+  if ! git show "${base_ref}:pnpm-lock.yaml" > "$base_file" 2>/dev/null; then
+    rm -f "$base_file" "$head_file"
+    return 1
+  fi
+
+  if [[ "$head_ref" == "HEAD" && -f "pnpm-lock.yaml" ]]; then
+    cp "pnpm-lock.yaml" "$head_file"
+  elif ! git show "${head_ref}:pnpm-lock.yaml" > "$head_file" 2>/dev/null; then
+    rm -f "$base_file" "$head_file"
+    return 1
+  fi
+
+  local rc=0
+  node "$script_source_dir/lockfile-scope.mjs" "$base_file" "$head_file" < /dev/null || rc=$?
+  rm -f "$base_file" "$head_file"
+  return "$rc"
+}
+
+# Known importer dir → package quality bundle. `.` (root) and any unknown
+# importer are absent, so is_mappable/map both reject them (→ full suite).
+lockfile_importer_is_mappable() {
+  case "$1" in
+    aegis | ui-dashboard | indexer-envio | metrics-bridge | integration-probes | shared-config | governance-watchdog | alerts/infra/onchain-event-handler | alerts/infra/oncall-announcer)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+map_lockfile_importer_to_bundle() {
+  local importer="$1"
+  local reason="$2"
+  case "$importer" in
+    aegis)
+      add_aegis_quality_commands "$reason"
+      ;;
+    ui-dashboard)
+      add_dashboard_quality_commands "$reason"
+      ;;
+    indexer-envio)
+      add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
+      ;;
+    metrics-bridge)
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "$reason"
+      ;;
+    integration-probes)
+      add_package_quality_commands "@mento-protocol/integration-probes" "$reason"
+      ;;
+    shared-config)
+      add_package_quality_commands "@mento-protocol/config" "$reason"
+      ;;
+    governance-watchdog)
+      add_package_quality_commands "@mento-protocol/governance-watchdog" "$reason"
+      ;;
+    alerts/infra/onchain-event-handler)
+      add_package_quality_commands "@mento-protocol/alerts-onchain-event-handler" "$reason"
+      ;;
+    alerts/infra/oncall-announcer)
+      add_alerts_oncall_quality_commands "$reason"
+      ;;
+  esac
+}
+
+# Route a pnpm-lock.yaml change: scoped when eligible and every changed importer
+# maps to a package bundle, otherwise the full workspace suite.
+route_lockfile_change() {
+  add_surface "workspace"
+  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+
+  local importers
+  if lockfile_only_manifest_change && importers="$(lockfile_scoped_importers)"; then
+    local importer
+    local mappable=true
+    while IFS= read -r importer; do
+      [[ -n "$importer" ]] || continue
+      lockfile_importer_is_mappable "$importer" || {
+        mappable=false
+        break
+      }
+    done <<< "$importers"
+
+    if [[ "$mappable" == true ]]; then
+      add_command "pnpm skew:check" "lockfile change scoped to importers"
+      add_command "pnpm lockfile:lint" "lockfile change scoped to importers"
+      while IFS= read -r importer; do
+        [[ -n "$importer" ]] || continue
+        map_lockfile_importer_to_bundle "$importer" "lockfile importer ${importer} changed"
+      done <<< "$importers"
+      return
+    fi
+  fi
+
+  # Fail toward the full workspace suite.
+  add_workspace_quality_commands "workspace dependency/config changed"
+  add_adr_reminder "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)"
 }
 
 add_root_tooling_package_script_checks() {
@@ -1628,6 +1926,9 @@ while IFS= read -r path; do
         scripts/lockfile-lint.mjs|scripts/lockfile-lint.test.mjs)
           add_command "pnpm lockfile:lint:test" "lockfile lint helper changed"
           ;;
+        scripts/lockfile-scope.mjs|scripts/lockfile-scope.test.mjs)
+          add_command "node scripts/lockfile-scope.test.mjs" "lockfile scope helper changed"
+          ;;
         scripts/pnpm-audit-high-gate.mjs|scripts/pnpm-audit-high-gate.test.mjs)
           add_command "node scripts/pnpm-audit-high-gate.test.mjs" "pnpm audit high gate changed"
           ;;
@@ -1734,6 +2035,17 @@ while IFS= read -r path; do
           ;;
         package-scripts)
           ;;
+        workspace-dev-metadata)
+          # devDependencies / descriptive metadata only (GitHub issue #1414):
+          # reinstall + skew/lockfile lint, plus the @mento-protocol/config
+          # bundle as canary (it typechecks three downstream consumers). Trunk
+          # still full-scans package.json via trunk_requires_full_scan.
+          add_surface "workspace"
+          add_preflight_command "pnpm install --frozen-lockfile" "workspace dev metadata changed"
+          add_command "pnpm skew:check" "workspace dev metadata changed"
+          add_command "pnpm lockfile:lint" "workspace dev metadata changed"
+          add_package_quality_commands "@mento-protocol/config" "workspace dev metadata changed (config typechecks downstream consumers as canary)"
+          ;;
         *)
           add_surface "workspace"
           add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
@@ -1742,7 +2054,10 @@ while IFS= read -r path; do
           ;;
       esac
       ;;
-    pnpm-lock.yaml|pnpm-workspace.yaml)
+    pnpm-lock.yaml)
+      route_lockfile_change
+      ;;
+    pnpm-workspace.yaml)
       add_surface "workspace"
       add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
       add_workspace_quality_commands "workspace dependency/config changed"
@@ -1778,6 +2093,7 @@ done < "$changed_paths_file"
 add_trunk_check_command
 sort_codegen_commands
 compact_turbo_quality_commands
+apply_scoped_test_commands
 
 hash_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -2068,11 +2384,27 @@ print_autoreview_test_timings() {
   ' "$output_file"
 }
 
+log_duration_line() {
+  # Best-effort append; a logging failure must never fail the gate itself.
+  local status="$1"
+  local elapsed="$2"
+  local command="$3"
+  local line_mode="$4"
+  local ts
+  local escaped_command
+
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)" || return 0
+  escaped_command="$(node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' -- "$command" 2>/dev/null)" || return 0
+  printf '{"ts":"%s","command":%s,"status":"%s","seconds":%s,"mode":"%s"}\n' \
+    "$ts" "$escaped_command" "$status" "$elapsed" "$line_mode" >> "$durations_file" 2>/dev/null || true
+}
+
 record_command_summary() {
   local status="$1"
   local elapsed="$2"
   local command="$3"
   command_summaries+=("${status}|${elapsed}|${command}")
+  log_duration_line "$status" "$elapsed" "$command" "$mode" || true
 }
 
 print_command_summary() {
@@ -2468,11 +2800,16 @@ run_quality_phase
 
 print_command_summary
 
+gate_total_elapsed=$(( $(date +%s) - gate_start_ts ))
+
 if [[ "$failures" -gt 0 ]]; then
+  log_duration_line "fail" "$gate_total_elapsed" "__run_total__" "run" || true
   echo
   echo "${failures} mapped command(s) failed." >&2
   exit 1
 fi
+
+log_duration_line "ok" "$gate_total_elapsed" "__run_total__" "run" || true
 
 echo
 echo "All mapped commands passed."

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -920,9 +920,15 @@ map_lockfile_importer_to_bundle() {
     ui-dashboard)
       mark_lockfile_scoped_package "@mento-protocol/ui-dashboard"
       add_dashboard_quality_commands "$reason"
+      # Dependency resolution changes can regress bundle size; the workspace
+      # route ran size-limit for lockfile edits, so the scoped route must too.
+      add_ui_size_limit "$reason"
       ;;
     indexer-envio)
       mark_lockfile_scoped_package "@mento-protocol/indexer-envio"
+      # A changed Envio resolution can break the testnet/bridge-only codegen
+      # even when mainnet codegen passes; keep the workspace route's coverage.
+      add_all_indexer_codegen "$reason"
       add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
       ;;
     metrics-bridge)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -261,6 +261,21 @@ package_script_risk_changed=false
 # (GitHub issue #1413) is suppressed in that case so escalations keep the full
 # per-package `test:coverage` floors everywhere.
 saw_workspace_escalation=false
+# Space-padded set of package names whose test:coverage must not be narrowed
+# by apply_scoped_test_commands, because pnpm-lock.yaml also bumped their
+# importer section this run (issue #1414). The lockfile-triggered coverage
+# floor exists specifically to catch a dependency bump's effect on the whole
+# package, so an unrelated small source edit in the same package must not
+# narrow it down to just that edit's related tests.
+lockfile_scoped_packages=""
+
+mark_lockfile_scoped_package() {
+  lockfile_scoped_packages+=" $1 "
+}
+
+is_lockfile_scoped_package() {
+  [[ "$lockfile_scoped_packages" == *" $1 "* ]]
+}
 
 has_command() {
   local command="$1"
@@ -730,9 +745,26 @@ scoped_test_infra_changed() {
   return 1
 }
 
+# True iff the repo-relative path exists in the head state: the working tree
+# when head_ref is HEAD (the common case, so local uncommitted edits count),
+# otherwise the given ref via git. A deleted file, or the old side of a
+# --no-renames rename, reports false.
+scoped_path_exists_at_head() {
+  local path="$1"
+  if [[ "$head_ref" == "HEAD" ]]; then
+    [[ -e "$path" ]]
+  else
+    git cat-file -e "${head_ref}:${path}" 2>/dev/null
+  fi
+}
+
 # Print the package-relative production-source paths changed inside a package
 # directory, one per line. Returns non-zero (no output) when the package is
-# unscopable: no changed paths inside it, or any non-source path inside it.
+# unscopable: no changed paths inside it, any non-source path inside it, or a
+# changed path that no longer exists at head (a deletion, or the old side of a
+# rename — `vitest related --run` silently finds zero tests for a missing
+# path instead of erroring, which would otherwise skip the coverage floor
+# entirely instead of failing toward the full suite).
 scoped_source_files_for_package() {
   local package_name="$1"
   local package_dir
@@ -746,6 +778,9 @@ scoped_source_files_for_package() {
       "$package_dir"/*)
         rel="${path#"$package_dir"/}"
         if scoped_is_non_source_path "$rel"; then
+          return 1
+        fi
+        if ! scoped_path_exists_at_head "$path"; then
           return 1
         fi
         files+=("$rel")
@@ -786,6 +821,12 @@ apply_scoped_test_commands() {
 
     # shared-config's blast radius is the point — keep its full suite (issue #1413).
     [[ "$package_name" == "@mento-protocol/config" ]] && continue
+
+    # A lockfile importer bump for this package (issue #1414) means the
+    # coverage floor is standing in for the dependency-bump regression check;
+    # an unrelated small source edit in the same package must not narrow it
+    # down to just that edit's related tests.
+    is_lockfile_scoped_package "$package_name" && continue
 
     files="$(scoped_source_files_for_package "$package_name")" || continue
 
@@ -868,30 +909,39 @@ map_lockfile_importer_to_bundle() {
   local reason="$2"
   case "$importer" in
     aegis)
+      mark_lockfile_scoped_package "@mento-protocol/aegis"
       add_aegis_quality_commands "$reason"
       ;;
     ui-dashboard)
+      mark_lockfile_scoped_package "@mento-protocol/ui-dashboard"
       add_dashboard_quality_commands "$reason"
       ;;
     indexer-envio)
+      mark_lockfile_scoped_package "@mento-protocol/indexer-envio"
       add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
       ;;
     metrics-bridge)
+      mark_lockfile_scoped_package "@mento-protocol/metrics-bridge"
       add_package_quality_commands "@mento-protocol/metrics-bridge" "$reason"
       ;;
     integration-probes)
+      mark_lockfile_scoped_package "@mento-protocol/integration-probes"
       add_package_quality_commands "@mento-protocol/integration-probes" "$reason"
       ;;
     shared-config)
+      mark_lockfile_scoped_package "@mento-protocol/config"
       add_package_quality_commands "@mento-protocol/config" "$reason"
       ;;
     governance-watchdog)
+      mark_lockfile_scoped_package "@mento-protocol/governance-watchdog"
       add_package_quality_commands "@mento-protocol/governance-watchdog" "$reason"
       ;;
     alerts/infra/onchain-event-handler)
+      mark_lockfile_scoped_package "@mento-protocol/alerts-onchain-event-handler"
       add_package_quality_commands "@mento-protocol/alerts-onchain-event-handler" "$reason"
       ;;
     alerts/infra/oncall-announcer)
+      mark_lockfile_scoped_package "@mento-protocol/alerts-oncall-announcer"
       add_alerts_oncall_quality_commands "$reason"
       ;;
   esac

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1304,6 +1304,51 @@ assert_not_contains "cd aegis && forge test"
 assert_not_contains "@mento-protocol/integration-probes test:coverage"
 assert_not_contains "workspace dependency/config changed (coverage floor)"
 
+# An importer version bump PLUS an unrelated small source edit in that same
+# package must still run the package's FULL test:coverage — the
+# lockfile-triggered coverage floor stands in for the dependency-bump
+# regression check (issue #1414), so scoped-tests (issue #1413) must not
+# narrow it down to just the unrelated edit's related tests.
+lockfile_and_source_repo="$(mktemp -d)"
+(
+  cd "$lockfile_and_source_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf '{ "name": "fixture" }\n' > package.json
+  printf '%s' "$lockfile_scope_base_yaml" > pnpm-lock.yaml
+  mkdir -p metrics-bridge/src
+  echo "export const x = 1;" > metrics-bridge/src/existing.ts
+  git add package.json pnpm-lock.yaml metrics-bridge/src/existing.ts
+  git commit -qm init
+  cat > pnpm-lock.yaml <<'YAML'
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+overrides: {}
+importers:
+  .:
+    dependencies: {}
+  metrics-bridge:
+    dependencies:
+      viem:
+        specifier: ^2.1.0
+        version: 2.1.0
+  integration-probes:
+    dependencies:
+      undici:
+        specifier: ^6.0.0
+        version: 6.0.0
+packages:
+  viem@2.0.0: {}
+YAML
+  echo "export const x = 2;" > metrics-bridge/src/existing.ts
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$lockfile_and_source_repo"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test:coverage (metrics-bridge changed (coverage floor))"
+assert_not_contains "exec vitest related --run"
+
 # Two importers changed → both bundles.
 run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
 settings:
@@ -1863,9 +1908,20 @@ assert_contains "- pnpm dashboard:size-limit (shared-config exports feed the das
 # full coverage floors, so this only trims the local signal.
 
 # Two production-source files in one package → both listed (sorted) + scoped.
-run_gate "ui-dashboard/src/lib/aardvark.ts" "ui-dashboard/src/lib/zebra.ts"
-assert_raw_contains "- pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/lib/aardvark.ts src/lib/zebra.ts (ui-dashboard changed (coverage floor) (scoped-tests))"
+# Real, existing files: scoping now requires each changed path to exist at
+# head (see the deletion test below), so placeholder paths would no longer
+# qualify.
+run_gate "ui-dashboard/src/lib/address-book.ts" "ui-dashboard/src/lib/arkham.ts"
+assert_raw_contains "- pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/lib/address-book.ts src/lib/arkham.ts (ui-dashboard changed (coverage floor) (scoped-tests))"
 assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+
+# A deleted production-source file (or the old side of a --no-renames rename)
+# keeps the full suite: `vitest related --run <missing path>` silently finds
+# zero tests instead of erroring, which would otherwise skip the coverage
+# floor entirely rather than failing toward it.
+run_gate "ui-dashboard/src/lib/this-file-does-not-exist.ts"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
 
 # A test-file-only edit keeps the full suite (test files are not scopable source).
 run_gate "ui-dashboard/src/lib/__tests__/scope-probe.test.ts"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1609,6 +1609,14 @@ assert_occurrences 1 "- pnpm --filter @mento-protocol/ui-dashboard test:browser 
 assert_occurrences 1 "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
 assert_not_contains_mapped "- pnpm dashboard:build"
 
+# A shared-config change alongside a small consumer edit must disable scoping
+# globally: `vitest related` only follows imports from the changed files, so a
+# scoped consumer run would miss shared-config-induced regressions in tests
+# that import @mento-protocol/config through OTHER consumer source.
+run_gate "shared-config/src/chains.ts" "ui-dashboard/src/lib/gql-retry.ts"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "vitest related --run src/lib/gql-retry.ts"
+
 run_gate "ui-dashboard/react-doctor.config.json"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1304,6 +1304,35 @@ assert_not_contains "cd aegis && forge test"
 assert_not_contains "@mento-protocol/integration-probes test:coverage"
 assert_not_contains "workspace dependency/config changed (coverage floor)"
 
+# Scoped dashboard/indexer importer bumps keep the workspace route's extra
+# coverage: size-limit (dependency-driven bundle regressions) and the full
+# indexer codegen matrix (testnet/bridge-only resolutions can break even when
+# mainnet codegen passes).
+run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
+settings:
+  autoInstallPeers: true
+overrides: {}
+importers:
+  .:
+    dependencies: {}
+  ui-dashboard:
+    dependencies:
+      viem:
+        specifier: ^2.1.0
+        version: 2.1.0
+  indexer-envio:
+    dependencies:
+      viem:
+        specifier: ^2.1.0
+        version: 2.1.0
+packages:
+  viem@2.0.0: {}
+'
+assert_contains "turbo run size-limit --filter=@mento-protocol/ui-dashboard"
+assert_contains "- pnpm indexer:testnet:codegen (lockfile importer indexer-envio changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage (lockfile importer indexer-envio changed (coverage floor))"
+assert_not_contains "workspace dependency/config changed (coverage floor)"
+
 # An importer version bump PLUS an unrelated small source edit in that same
 # package must still run the package's FULL test:coverage — the
 # lockfile-triggered coverage floor stands in for the dependency-bump

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1097,6 +1097,271 @@ assert_contains "- bash scripts/agent-quality-gate.test.sh (root package script 
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (root package script changed)"
 assert_not_contains_mapped "- pnpm --filter @mento-protocol/ui-dashboard test:browser (root package script changed)"
 
+# ── Root package.json workspace-dev-metadata classification (issue #1414) ────
+
+# devDependencies-only change → config canary set, not the full workspace suite.
+dev_metadata_devdeps_repo="$(mktemp -d)"
+(
+  cd "$dev_metadata_devdeps_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  cat > package.json <<'JSON'
+{
+  "name": "fixture",
+  "devDependencies": {
+    "typescript": "5.4.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -qm init
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.devDependencies.typescript = "5.5.0";
+fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$dev_metadata_devdeps_repo"
+# The preflight install is deduped to the first-arm reason ("workspace package
+# manifest changed"); the scoped skew/lockfile-lint/canary lines below carry the
+# dev-metadata reason and distinguish this class from the full suite.
+assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
+assert_contains "- pnpm skew:check (workspace dev metadata changed)"
+assert_contains "- pnpm lockfile:lint (workspace dev metadata changed)"
+assert_contains "- pnpm --filter @mento-protocol/config test:coverage (workspace dev metadata changed"
+assert_not_contains "cd aegis && forge test"
+assert_not_contains "@mento-protocol/indexer-envio test:coverage"
+assert_not_contains "workspace dependency/config changed"
+
+# Metadata-only change (description) → same config canary set.
+dev_metadata_only_repo="$(mktemp -d)"
+(
+  cd "$dev_metadata_only_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  cat > package.json <<'JSON'
+{
+  "name": "fixture",
+  "description": "before"
+}
+JSON
+  git add package.json
+  git commit -qm init
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.description = "after";
+fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$dev_metadata_only_repo"
+assert_contains "- pnpm --filter @mento-protocol/config test:coverage (workspace dev metadata changed"
+assert_not_contains "cd aegis && forge test"
+assert_not_contains "workspace dependency/config changed"
+
+# devDependencies + a dependencies change → full suite (not dev-metadata).
+dev_metadata_mixed_repo="$(mktemp -d)"
+(
+  cd "$dev_metadata_mixed_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  cat > package.json <<'JSON'
+{
+  "name": "fixture",
+  "dependencies": {
+    "left-pad": "1.3.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -qm init
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.devDependencies.typescript = "5.5.0";
+pkg.dependencies["left-pad"] = "1.2.0";
+fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$dev_metadata_mixed_repo"
+assert_contains "- cd aegis && forge test (workspace dependency/config changed)"
+assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
+assert_not_contains "workspace dev metadata changed"
+
+# devDependencies + a script change → package-scripts refusal path, unchanged.
+dev_metadata_scripts_repo="$(mktemp -d)"
+(
+  cd "$dev_metadata_scripts_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  cat > package.json <<'JSON'
+{
+  "name": "fixture",
+  "scripts": {
+    "agent:quality-gate": "./scripts/agent-quality-gate.sh"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -qm init
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.devDependencies.typescript = "5.5.0";
+pkg.scripts.build = "tsc";
+fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$dev_metadata_scripts_repo"
+assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package script changed)"
+assert_not_contains "workspace dev metadata changed"
+
+# ── Lockfile-importer scoping (issue #1414) ─────────────────────────────────
+
+# Reusable lockfile fixture body: writes a base pnpm-lock.yaml, commits, then
+# overwrites the working copy with $1 before running the gate against HEAD.
+lockfile_scope_base_yaml='lockfileVersion: '"'"'9.0'"'"'
+settings:
+  autoInstallPeers: true
+overrides: {}
+importers:
+  .:
+    dependencies: {}
+  metrics-bridge:
+    dependencies:
+      viem:
+        specifier: ^2.0.0
+        version: 2.0.0
+  integration-probes:
+    dependencies:
+      undici:
+        specifier: ^6.0.0
+        version: 6.0.0
+packages:
+  viem@2.0.0: {}
+'
+
+run_lockfile_scope_gate() {
+  local head_yaml="$1"
+  local repo
+  repo="$(mktemp -d)"
+  (
+    cd "$repo"
+    git init -q
+    git config user.email test@example.invalid
+    git config user.name "Quality Gate Test"
+    printf '{ "name": "fixture" }\n' > package.json
+    printf '%s' "$lockfile_scope_base_yaml" > pnpm-lock.yaml
+    git add package.json pnpm-lock.yaml
+    git commit -qm init
+    printf '%s' "$head_yaml" > pnpm-lock.yaml
+    "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+  )
+  rm -rf "$repo"
+}
+
+# Single importer version bump → that package's bundle + scoped skew/lockfile
+# lint, and NOT the full workspace suite.
+run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
+settings:
+  autoInstallPeers: true
+overrides: {}
+importers:
+  .:
+    dependencies: {}
+  metrics-bridge:
+    dependencies:
+      viem:
+        specifier: ^2.1.0
+        version: 2.1.0
+  integration-probes:
+    dependencies:
+      undici:
+        specifier: ^6.0.0
+        version: 6.0.0
+packages:
+  viem@2.0.0: {}
+'
+assert_contains "- pnpm skew:check (lockfile change scoped to importers)"
+assert_contains "- pnpm lockfile:lint (lockfile change scoped to importers)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test:coverage (lockfile importer metrics-bridge changed (coverage floor))"
+assert_not_contains "cd aegis && forge test"
+assert_not_contains "@mento-protocol/integration-probes test:coverage"
+assert_not_contains "workspace dependency/config changed (coverage floor)"
+
+# Two importers changed → both bundles.
+run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
+settings:
+  autoInstallPeers: true
+overrides: {}
+importers:
+  .:
+    dependencies: {}
+  metrics-bridge:
+    dependencies:
+      viem:
+        specifier: ^2.1.0
+        version: 2.1.0
+  integration-probes:
+    dependencies:
+      undici:
+        specifier: ^6.1.0
+        version: 6.1.0
+packages:
+  viem@2.0.0: {}
+'
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test:coverage (lockfile importer metrics-bridge changed (coverage floor))"
+assert_contains "- pnpm --filter @mento-protocol/integration-probes test:coverage (lockfile importer integration-probes changed (coverage floor))"
+assert_not_contains "cd aegis && forge test"
+
+# Overrides section change → full workspace suite (fail toward full).
+run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
+settings:
+  autoInstallPeers: true
+overrides:
+  cross-spawn: '"'"'>=7.0.5'"'"'
+importers:
+  .:
+    dependencies: {}
+  metrics-bridge:
+    dependencies:
+      viem:
+        specifier: ^2.0.0
+        version: 2.0.0
+  integration-probes:
+    dependencies:
+      undici:
+        specifier: ^6.0.0
+        version: 6.0.0
+packages:
+  viem@2.0.0: {}
+'
+assert_contains "- cd aegis && forge test (workspace dependency/config changed)"
+assert_not_contains "lockfile change scoped to importers"
+
+# Corrupt (unparsable) lockfile head → full workspace suite (fail toward full).
+run_lockfile_scope_gate 'lockfileVersion: '"'"'9.0'"'"'
+importers:
+  metrics-bridge: [unterminated
+'
+assert_contains "- cd aegis && forge test (workspace dependency/config changed)"
+assert_not_contains "lockfile change scoped to importers"
+
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 assert_occurrences 1 "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
@@ -1118,7 +1383,10 @@ assert_order \
 
 run_gate "indexer-envio/src/bridge.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
-assert_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage (indexer-envio changed (coverage floor))"
+# Single production-source edit → scoped `vitest related` (issue #1413); the
+# full test:coverage floor still runs in CI.
+assert_raw_contains "- pnpm --filter @mento-protocol/indexer-envio exec vitest related --run src/bridge.ts (indexer-envio changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage"
 assert_not_contains "indexer:bridge-only:codegen"
 assert_not_contains "indexer:testnet:codegen"
 # Mainnet codegen now runs as a preflight for every indexer quality command
@@ -1208,12 +1476,16 @@ assert_order \
 
 run_gate "indexer-envio/config/aggregators.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer config data flow changed)"
-assert_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage (indexer-envio changed (coverage floor))"
+# JSON config is production source (not in the scoping exclusion list), so a
+# lone config edit scopes to `vitest related` (issue #1413).
+assert_raw_contains "- pnpm --filter @mento-protocol/indexer-envio exec vitest related --run config/aggregators.json (indexer-envio changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage"
 
 run_gate "metrics-bridge/src/graphql.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
-assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test:coverage (metrics-bridge changed (coverage floor))"
+assert_raw_contains "- pnpm --filter @mento-protocol/metrics-bridge exec vitest related --run src/graphql.ts (metrics-bridge changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/metrics-bridge test:coverage"
 
 run_gate "metrics-bridge/src/poller.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
@@ -1253,7 +1525,8 @@ run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
-assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage (ui-dashboard changed (coverage floor))"
+assert_raw_contains "- pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/lib/gql-retry.ts (ui-dashboard changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
 assert_contains "- pnpm dashboard:size-limit (ui-dashboard bundle inputs changed)"
@@ -1459,12 +1732,14 @@ assert_contains "- docs/pr-checklists/terraform-cloudrun.md (alerts/infra Cloud 
 run_gate "alerts/infra/onchain-event-handler/src/slack.ts"
 assert_contains "- pnpm exec turbo run lint --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (alerts onchain-event-handler changed)"
 assert_contains "- pnpm exec turbo run typecheck --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (alerts onchain-event-handler changed)"
-assert_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage (alerts onchain-event-handler changed (coverage floor))"
+assert_raw_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler exec vitest related --run src/slack.ts (alerts onchain-event-handler changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage"
 
 run_gate "alerts/infra/onchain-event-handler/src/safe-abi.json"
 assert_contains "- pnpm exec turbo run lint --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (Safe ABI changed (handler imports it))"
 assert_contains "- pnpm exec turbo run typecheck --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (Safe ABI changed (handler imports it))"
-assert_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage (Safe ABI changed (handler imports it) (coverage floor))"
+assert_raw_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler exec vitest related --run src/safe-abi.json (Safe ABI changed (handler imports it) (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate node scripts/terraform-fmt-check.mjs alerts/infra (Safe ABI changed (listener filter uses it at plan time))"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chdir=alerts/infra init -backend=false -input=false (Safe ABI changed (listener filter uses it at plan time))"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chdir=alerts/infra validate -no-color (Safe ABI changed (listener filter uses it at plan time))"
@@ -1576,8 +1851,70 @@ assert_not_contains_mapped "- pnpm --filter @mento-protocol/ui-dashboard test:br
 run_gate "shared-config/src/thresholds.ts"
 assert_contains "- node scripts/check-deviation-threshold-drift.mjs (shared deviation threshold source changed)"
 assert_raw_contains "- pnpm --filter @mento-protocol/indexer-envio exec vitest run deviationThresholdSharedConfigSync (shared deviation threshold source changed)"
+# shared-config's downstream blast radius is the point — it keeps the full suite
+# and never scopes to `vitest related` (issue #1413, condition c).
 assert_contains "- pnpm --filter @mento-protocol/config test:coverage (shared-config changed (coverage floor))"
+assert_not_contains "exec vitest related --run"
 assert_contains "- pnpm dashboard:size-limit (shared-config exports feed the dashboard bundle)"
+
+# ── Scoped local test runs (GitHub issue #1413) ─────────────────────────────
+# A small production-source-only edit narrows a package's full `test:coverage`
+# floor to `pnpm exec vitest related --run <files>` locally. CI always runs the
+# full coverage floors, so this only trims the local signal.
+
+# Two production-source files in one package → both listed (sorted) + scoped.
+run_gate "ui-dashboard/src/lib/aardvark.ts" "ui-dashboard/src/lib/zebra.ts"
+assert_raw_contains "- pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/lib/aardvark.ts src/lib/zebra.ts (ui-dashboard changed (coverage floor) (scoped-tests))"
+assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+
+# A test-file-only edit keeps the full suite (test files are not scopable source).
+run_gate "ui-dashboard/src/lib/__tests__/scope-probe.test.ts"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
+
+# A source edit co-changed with a test file in the same package keeps the full
+# suite — any non-source path inside the package disqualifies scoping (b).
+run_gate "ui-dashboard/src/lib/scope-probe.ts" "ui-dashboard/src/lib/scope-probe.test.ts"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
+
+# 16+ changed paths → too broad to scope; full suite (a).
+scope_probe_paths=()
+for scope_probe_i in $(seq 1 16); do
+  scope_probe_paths+=("ui-dashboard/src/lib/scope-probe-$scope_probe_i.ts")
+done
+run_gate "${scope_probe_paths[@]}"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
+
+# A test-infra change anywhere disables scoping globally (e).
+run_gate "ui-dashboard/src/lib/scope-probe.ts" "scripts/envio-schema-stubs.graphql"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
+
+# Escape hatch: --full-local-tests forces the full suite for a lone source edit.
+: > "$paths_file"
+printf 'ui-dashboard/src/lib/scope-probe.ts\n' > "$paths_file"
+AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  --full-local-tests \
+  > "$output_file"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
+
+# Escape hatch: AGENT_GATE_FULL_TESTS=1 forces the full suite too.
+: > "$paths_file"
+printf 'ui-dashboard/src/lib/scope-probe.ts\n' > "$paths_file"
+AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  AGENT_GATE_FULL_TESTS=1 \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:coverage"
+assert_not_contains "exec vitest related --run"
 
 assert_hermetic_setup_routes() {
   local path="$1"
@@ -1784,6 +2121,17 @@ STUB
   printf 'changed\n' >> fixture.txt
   "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
 )
+quiet_success_durations_file="$quiet_success_repo/.tmp/agent-quality-gate/durations.jsonl"
+[[ -f "$quiet_success_durations_file" ]] ||
+  fail "expected durations file to exist: $quiet_success_durations_file"
+quiet_success_last_duration_line="$(tail -n1 "$quiet_success_durations_file")"
+node -e '
+  const parsed = JSON.parse(process.argv[1]);
+  if (parsed.command !== "__run_total__") {
+    process.exit(1);
+  }
+' -- "$quiet_success_last_duration_line" ||
+  fail "expected last durations.jsonl line to be __run_total__, got: $quiet_success_last_duration_line"
 rm -rf "$quiet_success_repo"
 assert_contains "+ ./tools/trunk check fixture.txt"
 assert_contains "Command elapsed-time summary:"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1521,10 +1521,11 @@ assert_order \
 
 run_gate "indexer-envio/config/aggregators.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer config data flow changed)"
-# JSON config is production source (not in the scoping exclusion list), so a
-# lone config edit scopes to `vitest related` (issue #1413).
-assert_raw_contains "- pnpm --filter @mento-protocol/indexer-envio exec vitest related --run config/aggregators.json (indexer-envio changed (coverage floor) (scoped-tests))"
-assert_not_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage"
+# Non-module files (JSON/YAML/assets) may be read by tests via fs rather than
+# the import graph `vitest related` follows, so they disqualify scoping and
+# the full coverage floor runs (fail toward full).
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio test:coverage"
+assert_not_contains "vitest related --run config/aggregators.json"
 
 run_gate "metrics-bridge/src/graphql.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
@@ -1783,8 +1784,11 @@ assert_not_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handle
 run_gate "alerts/infra/onchain-event-handler/src/safe-abi.json"
 assert_contains "- pnpm exec turbo run lint --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (Safe ABI changed (handler imports it))"
 assert_contains "- pnpm exec turbo run typecheck --filter=@mento-protocol/alerts-onchain-event-handler --cache=local:rw (Safe ABI changed (handler imports it))"
-assert_raw_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler exec vitest related --run src/safe-abi.json (Safe ABI changed (handler imports it) (coverage floor) (scoped-tests))"
-assert_not_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage"
+# Even though this JSON is genuinely imported, non-module files may be fs-read
+# elsewhere and the gate cannot tell statically — they disqualify scoping, so
+# the full coverage floor runs (fail toward full).
+assert_contains "- pnpm --filter @mento-protocol/alerts-onchain-event-handler test:coverage"
+assert_not_contains "vitest related --run src/safe-abi.json"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate node scripts/terraform-fmt-check.mjs alerts/infra (Safe ABI changed (listener filter uses it at plan time))"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chdir=alerts/infra init -backend=false -input=false (Safe ABI changed (listener filter uses it at plan time))"
 assert_contains "- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chdir=alerts/infra validate -no-color (Safe ABI changed (listener filter uses it at plan time))"

--- a/scripts/lockfile-scope.mjs
+++ b/scripts/lockfile-scope.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Structural classifier for pnpm-lock.yaml changes, used by
+ * scripts/agent-quality-gate.sh to narrow the escalation a lockfile edit
+ * triggers (GitHub issue #1414).
+ *
+ * Contract (fail toward the full suite):
+ *   - Parses base and head lockfile YAML with js-yaml.
+ *   - If ANY non-`importers` top-level section differs (settings, catalogs,
+ *     overrides, patchedDependencies, packageExtensionsChecksum, packages,
+ *     snapshots, lockfileVersion, …), the change is not scopable → "full".
+ *   - Otherwise reports the importer keys whose section changed, so the gate
+ *     can map each to its package quality bundle.
+ *
+ * CLI: `node scripts/lockfile-scope.mjs <base-lockfile> <head-lockfile>`
+ *   - exit 0 and print each changed importer key on its own line when the
+ *     change is scopable (an empty list means no semantic importer change).
+ *   - exit 1 on any fail-toward-full condition, including read/parse errors.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import jsYaml from "js-yaml";
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Order-insensitive deep equality for parsed YAML documents.
+ *
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean}
+ */
+function deepEqual(a, b) {
+  if (Object.is(a, b)) return true;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (isRecord(a) && isRecord(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const key of keys) {
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @param {unknown} base parsed base lockfile document
+ * @param {unknown} head parsed head lockfile document
+ * @returns {{ scope: "full" } | { scope: "importers", importers: string[] }}
+ */
+export function classifyLockfileChange(base, head) {
+  if (!isRecord(base) || !isRecord(head)) return { scope: "full" };
+
+  const topLevelKeys = new Set([...Object.keys(base), ...Object.keys(head)]);
+  for (const key of topLevelKeys) {
+    if (key === "importers") continue;
+    if (!deepEqual(base[key], head[key])) return { scope: "full" };
+  }
+
+  const baseImporters = isRecord(base.importers) ? base.importers : {};
+  const headImporters = isRecord(head.importers) ? head.importers : {};
+  const importerKeys = new Set([
+    ...Object.keys(baseImporters),
+    ...Object.keys(headImporters),
+  ]);
+
+  const changed = [];
+  for (const key of [...importerKeys].sort()) {
+    if (!deepEqual(baseImporters[key], headImporters[key])) changed.push(key);
+  }
+
+  return { scope: "importers", importers: changed };
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {number} process exit code
+ */
+function main(argv) {
+  const [basePath, headPath] = argv;
+  if (!basePath || !headPath) {
+    process.stderr.write(
+      "usage: lockfile-scope.mjs <base-lockfile> <head-lockfile>\n",
+    );
+    return 1;
+  }
+
+  let base;
+  let head;
+  try {
+    base = jsYaml.load(readFileSync(basePath, "utf8"));
+    head = jsYaml.load(readFileSync(headPath, "utf8"));
+  } catch {
+    return 1;
+  }
+
+  const result = classifyLockfileChange(base, head);
+  if (result.scope === "full") return 1;
+
+  for (const importer of result.importers) {
+    process.stdout.write(`${importer}\n`);
+  }
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/lockfile-scope.test.mjs
+++ b/scripts/lockfile-scope.test.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for scripts/lockfile-scope.mjs.
+ *
+ * Exercises the pure `classifyLockfileChange` classifier plus the CLI
+ * exit-code contract the agent quality gate depends on.
+ *
+ * Run: node scripts/lockfile-scope.test.mjs
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { classifyLockfileChange } from "./lockfile-scope.mjs";
+
+let passed = 0;
+let failed = 0;
+
+/**
+ * @param {string} name
+ * @param {() => void} fn
+ */
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok ${name}`);
+    passed += 1;
+  } catch (/** @type {unknown} */ err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`not ok ${name}`);
+    console.error(`  ${message}`);
+    failed += 1;
+  }
+}
+
+/**
+ * @param {boolean} condition
+ * @param {string} message
+ */
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+/**
+ * Minimal lockfile document with a couple importer sections and the
+ * derivative top-level sections a real pnpm-lock.yaml carries.
+ *
+ * @param {Record<string, unknown>} overrides
+ * @returns {Record<string, unknown>}
+ */
+function lockfile(overrides = {}) {
+  return {
+    lockfileVersion: "9.0",
+    settings: { autoInstallPeers: true, excludeLinksFromLockfile: false },
+    overrides: {},
+    importers: {
+      ".": { dependencies: {} },
+      "ui-dashboard": {
+        dependencies: { react: { specifier: "^18.0.0", version: "18.0.0" } },
+      },
+      "indexer-envio": {
+        dependencies: { viem: { specifier: "^2.0.0", version: "2.0.0" } },
+      },
+    },
+    packages: { "react@18.0.0": {} },
+    snapshots: { "react@18.0.0": {} },
+    ...overrides,
+  };
+}
+
+test("no change → scopable with empty importer list", () => {
+  const result = classifyLockfileChange(lockfile(), lockfile());
+  assert(result.scope === "importers", `scope: ${result.scope}`);
+  assert(result.importers.length === 0, `importers: ${result.importers}`);
+});
+
+test("single importer changed → that importer only", () => {
+  const head = lockfile();
+  head.importers["ui-dashboard"].dependencies.react.version = "18.2.0";
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "importers", `scope: ${result.scope}`);
+  assert(
+    JSON.stringify(result.importers) === JSON.stringify(["ui-dashboard"]),
+    `importers: ${JSON.stringify(result.importers)}`,
+  );
+});
+
+test("two importers changed → both, sorted", () => {
+  const head = lockfile();
+  head.importers["ui-dashboard"].dependencies.react.version = "18.2.0";
+  head.importers["indexer-envio"].dependencies.viem.version = "2.1.0";
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "importers", `scope: ${result.scope}`);
+  assert(
+    JSON.stringify(result.importers) ===
+      JSON.stringify(["indexer-envio", "ui-dashboard"]),
+    `importers: ${JSON.stringify(result.importers)}`,
+  );
+});
+
+test("added importer section is reported", () => {
+  const head = lockfile();
+  head.importers["metrics-bridge"] = { dependencies: {} };
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "importers", `scope: ${result.scope}`);
+  assert(
+    JSON.stringify(result.importers) === JSON.stringify(["metrics-bridge"]),
+    `importers: ${JSON.stringify(result.importers)}`,
+  );
+});
+
+test("overrides change → full", () => {
+  const head = lockfile({ overrides: { "cross-spawn": ">=7.0.5" } });
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "full", `scope: ${result.scope}`);
+});
+
+test("settings change → full", () => {
+  const head = lockfile({
+    settings: { autoInstallPeers: false, excludeLinksFromLockfile: false },
+  });
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "full", `scope: ${result.scope}`);
+});
+
+test("packages/snapshots (transitive) change → full", () => {
+  const head = lockfile();
+  head.packages["left-pad@1.3.0"] = {};
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "full", `scope: ${result.scope}`);
+});
+
+test("lockfileVersion change → full", () => {
+  const head = lockfile({ lockfileVersion: "9.1" });
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "full", `scope: ${result.scope}`);
+});
+
+test("patchedDependencies change → full", () => {
+  const head = lockfile({
+    patchedDependencies: { "foo@1.0.0": { hash: "abc", path: "patches/foo" } },
+  });
+  const result = classifyLockfileChange(lockfile(), head);
+  assert(result.scope === "full", `scope: ${result.scope}`);
+});
+
+test("non-record input → full", () => {
+  assert(
+    classifyLockfileChange(null, lockfile()).scope === "full",
+    "base null",
+  );
+  assert(
+    classifyLockfileChange(lockfile(), "x").scope === "full",
+    "head string",
+  );
+});
+
+// ── CLI exit-code contract ─────────────────────────────────────────────────
+
+const SCRIPT = new URL("./lockfile-scope.mjs", import.meta.url).pathname;
+
+/**
+ * @param {string} baseYaml
+ * @param {string} headYaml
+ * @returns {{ status: number | null, stdout: string }}
+ */
+function runCli(baseYaml, headYaml) {
+  const dir = mkdtempSync(join(tmpdir(), "lockfile-scope-"));
+  try {
+    const basePath = join(dir, "base.yaml");
+    const headPath = join(dir, "head.yaml");
+    writeFileSync(basePath, baseYaml);
+    writeFileSync(headPath, headYaml);
+    const result = spawnSync("node", [SCRIPT, basePath, headPath], {
+      encoding: "utf8",
+    });
+    return { status: result.status, stdout: result.stdout };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("CLI: importer-only change exits 0 and prints importer", () => {
+  const base =
+    "importers:\n  ui-dashboard:\n    dependencies:\n      react: 18.0.0\n";
+  const head =
+    "importers:\n  ui-dashboard:\n    dependencies:\n      react: 18.2.0\n";
+  const { status, stdout } = runCli(base, head);
+  assert(status === 0, `status: ${status}`);
+  assert(stdout.trim() === "ui-dashboard", `stdout: ${JSON.stringify(stdout)}`);
+});
+
+test("CLI: overrides change exits 1", () => {
+  const base = "overrides: {}\nimporters:\n  ui-dashboard: {}\n";
+  const head =
+    "overrides:\n  cross-spawn: '>=7.0.5'\nimporters:\n  ui-dashboard: {}\n";
+  const { status } = runCli(base, head);
+  assert(status === 1, `status: ${status}`);
+});
+
+test("CLI: unparsable input exits 1 (fail toward full)", () => {
+  const { status } = runCli(
+    "importers:\n  a: [unterminated\n",
+    "importers: {}\n",
+  );
+  assert(status === 1, `status: ${status}`);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Any root `package.json` or `pnpm-lock.yaml` change — including a devDependency floor bump — escalates the local gate to all 36 commands (**measured 7m23s wall / 21m CPU**), and dependency PRs are among the most frequent PR types here.
- Full per-package coverage suites re-run on every gate invocation regardless of what changed; `indexer-envio test:coverage` alone is **3m07s and runs solo as the tail** of every full-suite run.
- The gate measures per-command durations but throws them away — regressions in gate wall-time are invisible.

## The Solution

- **Scoped local tests (#1413):** when a diff is ≤15 changed paths of pure production source, each eligible package's `test:coverage` becomes `vitest related --run <files>` locally. CI coverage floors are untouched — this narrows the local pre-push signal, not enforcement.
- **Narrower escalation (#1414):** lockfile-only diffs are structurally classified per pnpm importer and map to just the affected packages' bundles; devDependencies/metadata-only root `package.json` changes map to a shared-config canary set. **Every ambiguity fails toward the full suite.**
- **Durations persisted (#1415, gate half):** every mapped command appends `{ts, command, status, seconds, mode}` to `.tmp/agent-quality-gate/durations.jsonl`, plus a `__run_total__` line per run, with documented budget targets (common case ≤3 min, full suite ≤8 min).

## Details

- **Fail-toward-full is the design invariant.** `scripts/lockfile-scope.mjs` (js-yaml structural diff) exits non-zero on any non-`importers` top-level change (settings/catalogs/overrides/patchedDependencies/packages/snapshots/version), parse or read error, or non-record input; the gate additionally requires the lockfile to be the *only* workspace-manifest-class change, every changed importer to map to a known package bundle, and falls back to `add_workspace_quality_commands` otherwise. Root `package.json` classification: scripts changes keep the refusal path byte-identical; devDeps+anything-else → full suite; the dev-metadata pointer allowlist is explicit in the case arm.
- **Scoping guards (#1413):** disabled by `--full-local-tests` or `AGENT_GATE_FULL_TESTS=1`, any full-workspace escalation, >15 changed paths, any test-infra change (vitest configs/setup files, envio schema stubs), and per-package by any non-source path (tests, specs, tsconfig, package.json, `*.graphql`, generated types, fixtures). `@mento-protocol/config` is excluded — its downstream blast radius is the point. Aegis (`test:cov` + forge) untouched.
- Rewriting happens once, after the full dispatch and command compaction, so the escalation flag and complete changed-path set are final; scoped commands carry a `(scoped-tests)` reason visible in dry-run output.
- Duration logging is best-effort everywhere (`|| true`): a broken node, unwritable disk, or hostile command string (JSON-escaped via `JSON.stringify`) can never fail the gate.
- Verification provenance: table-driven self-test fixtures for every classification row including the fall-back-to-full cases; 13 unit tests + 3 CLI-contract tests for the classifier; an independent adversarial review (attack list: pre/post pairing collapse, classification bypass combos, threshold off-by-one, refusal-path integrity, JSON injection, `set -euo pipefail` edges) returned zero confirmed defects.
- Merged with main post-#1432 (janitor mapping + eslint cache coexist in the same files); self-test re-run green after the merge.

## Validation

- `bash scripts/agent-quality-gate.test.sh` — green post-merge.
- `node scripts/lockfile-scope.test.mjs` — 13/13 green; `pnpm lint:scripts` — green.
- Live demo: single ui-dashboard source edit maps `pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/components/address-link.tsx` (scoped-tests reason in dry-run); corrupt-lockfile and overrides-change fixtures route to the full suite.
- Expected impact from the #1404 baseline: deps-floor PRs 7m23s → ~2–3 min; common-case gate loses the 25–58s always-on coverage tail (indexer edits: −3m07s).

## Deferrals

- None

Closes #1413
Closes #1414
Refs #1415, #1404

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — the gate's existing escalation design gains narrower, fail-closed classifications; no new constraint on future work.
