### PR TITLE
perf(tooling): instrument autoreview stages, hash bundles once, bound gh lookups

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -168,10 +168,13 @@ that directory; `AGENT_AUTOREVIEW_STAGE_SUMMARY` (any non-empty value) also
 echoes a filterable `agent:autoreview: stage-timing ...` line per stage to
 stderr — off by default so it never violates the reviewer-cleanliness stderr
 contract. Logging failure never aborts or fails a run. Automatic `gh`-based PR
-lookups (base-branch detection, `--feedback-pr auto` resolution, feedback
-capture) are bounded by `AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS` (default 60s)
-so a hung `gh` process cannot stall autoreview indefinitely; a lookup that
-exceeds the deadline fails closed like any other lookup error. The wrapper's
+lookups for base-branch detection and `--feedback-pr auto` resolution are
+bounded by `AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS` (default 60s); the separate
+multi-call PR feedback capture is bounded by its own
+`AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS` (default 120s, higher because it
+runs several GitHub calls in one pass). Either way a hung `gh` process cannot
+stall autoreview indefinitely; a lookup that exceeds its deadline fails closed
+like any other lookup error. The wrapper's
 own `gh`/subprocess deadlines (`run_with_deadline`) run the command in its own
 process group and escalate `SIGTERM` then `SIGKILL` on timeout or on the
 wrapper itself being interrupted; the helper's `gh` calls (`spawnSync`) use

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -159,6 +159,26 @@ create an issue before deferring a valid follow-up, warn when non-test scope
 approaches twice the baseline, and pause for reclassification after two
 review-triggered patch cycles instead of starting a third automatically.
 
+**Stage timing and gh-lookup deadlines.** Both the wrapper and the helper
+append one best-effort JSON line per stage (`target-selection`, `bundle-prep`,
+`engine-invocation` from the helper; `prepare-bundle`, `verification` from the
+wrapper) to `.tmp/agent-autoreview/durations.jsonl` (gitignored), each shaped
+`{"ts","stage","seconds","mode"}`. `AGENT_AUTOREVIEW_DURATIONS_DIR` overrides
+that directory; `AGENT_AUTOREVIEW_STAGE_SUMMARY` (any non-empty value) also
+echoes a filterable `agent:autoreview: stage-timing ...` line per stage to
+stderr — off by default so it never violates the reviewer-cleanliness stderr
+contract. Logging failure never aborts or fails a run. Automatic `gh`-based PR
+lookups (base-branch detection, `--feedback-pr auto` resolution, feedback
+capture) are bounded by `AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS` (default 60s)
+so a hung `gh` process cannot stall autoreview indefinitely; a lookup that
+exceeds the deadline fails closed like any other lookup error. The wrapper's
+own `gh`/subprocess deadlines (`run_with_deadline`) run the command in its own
+process group and escalate `SIGTERM` then `SIGKILL` on timeout or on the
+wrapper itself being interrupted; the helper's `gh` calls (`spawnSync`) use
+`SIGKILL` directly, since a synchronous child-process call blocks until the
+child actually exits and a `SIGTERM`-ignoring child would otherwise hang it
+despite the timeout.
+
 This adapter uses the repo-local helper at `scripts/agent-autoreview.mjs` and
 keeps the repo's branch-local target: merge-base-to-`HEAD` commits plus current
 tracked and untracked work. It includes deterministic Mento checks and selected

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -1902,6 +1902,21 @@ const GH_LOOKUP_TIMEOUT_MS = (() => {
     : 60_000;
 })();
 
+// spawnSync's built-in timeout only signals the direct child; it does not
+// reach descendants the child has already forked (a gh helper call that
+// backgrounds a subprocess, say). The lookups below spawn with
+// detached: true so the child leads its own process group, letting this sweep
+// the whole group after a timeout instead of leaving an orphan running.
+function killProcessGroup(pid) {
+  if (!pid) return;
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // Already exited, or not a process group leader on this platform --
+    // nothing left to clean up.
+  }
+}
+
 function detectPrBase(repo, branch) {
   if (!branch) return null;
   const gh = resolveTrustedCommand("gh", repo, { required: false });
@@ -1937,12 +1952,14 @@ function detectPrBase(repo, branch) {
         // SIGTERM would hang this call (and autoreview) indefinitely despite
         // the "timeout" option. SIGKILL can't be caught or ignored.
         killSignal: "SIGKILL",
+        detached: true,
       },
     );
     if (
       repoResult.error?.code === "ETIMEDOUT" ||
       repoResult.signal === "SIGKILL"
     ) {
+      killProcessGroup(repoResult.pid);
       throw new Error(
         `failed to inspect repository owner: gh repo view timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
       );
@@ -1994,9 +2011,11 @@ function detectPrBase(repo, branch) {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: GH_LOOKUP_TIMEOUT_MS,
         killSignal: "SIGKILL",
+        detached: true,
       },
     );
     if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGKILL") {
+      killProcessGroup(result.pid);
       throw new Error(
         `failed to inspect PR base: gh pr list timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
       );
@@ -4288,43 +4307,52 @@ async function main() {
   }
   stageDurationsContext = { repo, mode: args.mode };
   const targetSelectionStartedAt = Date.now();
-  const selectionState = targetSelectionState(repo);
-  const targetSelectionSourceSnapshot = args.dryRun
-    ? null
-    : selectionState.snapshot;
+  let selectionState;
   let target;
-  try {
-    target = chooseTarget(repo, args, selectionState);
-  } catch (error) {
-    if (
-      args.dryRun &&
-      error.message ===
-        "no review target: clean main checkout and no forced mode"
-    ) {
-      target = { mode: "none", ref: null };
-    } else {
-      throw error;
-    }
-  }
+  let targetSelectionSourceSnapshot;
   let reviewSourceSnapshot = null;
-  if (!args.dryRun) {
-    target = freezeTargetRef(repo, target, selectionState);
-    assertTargetSelectionSnapshot(
-      repo,
-      targetSelectionSourceSnapshot,
-      "source changed while the review target was being selected; rerun autoreview against the updated tree",
-    );
-    reviewSourceSnapshot = sourceSnapshot(
-      repo,
-      snapshotOptionsForTarget(target),
-    );
-    assertTargetSelectionSnapshot(
-      repo,
-      targetSelectionSourceSnapshot,
-      "source changed while the review target was being selected; rerun autoreview against the updated tree",
-    );
+  try {
+    selectionState = targetSelectionState(repo);
+    targetSelectionSourceSnapshot = args.dryRun
+      ? null
+      : selectionState.snapshot;
+    try {
+      target = chooseTarget(repo, args, selectionState);
+    } catch (error) {
+      if (
+        args.dryRun &&
+        error.message ===
+          "no review target: clean main checkout and no forced mode"
+      ) {
+        target = { mode: "none", ref: null };
+      } else {
+        throw error;
+      }
+    }
+    if (!args.dryRun) {
+      target = freezeTargetRef(repo, target, selectionState);
+      assertTargetSelectionSnapshot(
+        repo,
+        targetSelectionSourceSnapshot,
+        "source changed while the review target was being selected; rerun autoreview against the updated tree",
+      );
+      reviewSourceSnapshot = sourceSnapshot(
+        repo,
+        snapshotOptionsForTarget(target),
+      );
+      assertTargetSelectionSnapshot(
+        repo,
+        targetSelectionSourceSnapshot,
+        "source changed while the review target was being selected; rerun autoreview against the updated tree",
+      );
+    }
+  } finally {
+    // Record the span even when selection throws -- e.g. an automatic gh base
+    // lookup timing out, or a post-freeze source-state check failing -- so a
+    // failed run still reports where it spent time. The top-level `.finally`
+    // flushes whatever spans were recorded.
+    recordStageDuration("target-selection", targetSelectionStartedAt);
   }
-  recordStageDuration("target-selection", targetSelectionStartedAt);
   const bundlePrepStartedAt = Date.now();
   const guardTargetSelectionDuringReview = args.mode === "auto";
   const branch = selectionState.branch || "detached";
@@ -4340,105 +4368,115 @@ async function main() {
   console.log(`web_search: ${args.webSearch ? "on" : "off"}`);
   if (args.dryRun) return 0;
 
-  const paths = changedPaths(repo, target);
-  if (paths.size === 0) {
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed while the review target was being selected; rerun autoreview against the updated tree",
-    );
-    recordStageDuration("bundle-prep", bundlePrepStartedAt);
-    console.log("autoreview clean: no changed files for selected target");
-    return 0;
-  }
-  const baseline = scopeBaseline(repo, target, paths);
-  console.log(
-    `scope_baseline: changed_files=${baseline.changedFiles} non_test_loc=${baseline.nonTestLoc}`,
-  );
-
-  const needsBundle =
-    args.engine !== "local" ||
-    args.prepareOnly ||
-    Boolean(args.bundleOutput) ||
-    args.prompts.length > 0 ||
-    args.promptFiles.length > 0 ||
-    args.datasets.length > 0;
+  let paths;
   let prompts = [];
-  let bundleOutputs = [];
-  if (needsBundle) {
-    const bundle =
-      target.mode === "local"
-        ? localBundle(repo, target)
-        : target.mode === "branch"
-          ? branchBundle(repo, target)
-          : target.mode === "branch-local"
-            ? branchLocalBundle(repo, target)
-            : commitBundle(repo, target.ref);
-    assertReviewableBundle(paths, bundle);
-    assertNoSecretLikeContent("current branch", branch);
-    if (target.requested_ref) {
-      assertNoSecretLikeContent(
-        "requested review target ref",
-        target.requested_ref,
+  try {
+    paths = changedPaths(repo, target);
+    if (paths.size === 0) {
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed while the review target was being selected; rerun autoreview against the updated tree",
       );
-    }
-    if (target.ref) assertNoSecretLikeContent("review target ref", target.ref);
-    const bundleBytes = utf8Size(bundle);
-    const extras = loadExtras(repo, args, MAX_REVIEW_INPUT_BYTES - bundleBytes);
-    prompts = buildBoundedReviewPrompts(bundle, (chunk, position) =>
-      renderReviewPrompt(target, branch, baseline, chunk, extras, position),
-    );
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed while the review bundle was being created; rerun autoreview against the updated tree",
-    );
-    console.log(
-      `bundle: ${bundleBytes} bytes; review passes: ${prompts.length}`,
-    );
-    if (args.prepareOnly) {
-      const displayedBundleOutput =
-        args.bundleOutputDisplay || args.bundleOutput;
-      if (args.bundleOutput) {
-        writeReviewPromptOutputs(args.bundleOutput, prompts);
-        bundleOutputs = reviewPromptOutputPaths(
-          displayedBundleOutput,
-          prompts.length,
-        );
-        console.log(`bundle_output: ${displayedBundleOutput}`);
-      }
-      console.log(
-        JSON.stringify(
-          {
-            target,
-            branch,
-            engine: args.engine,
-            changed_paths: [...paths].sort(),
-            scope_baseline: baseline,
-            bundle_bytes: bundleBytes,
-            review_passes: prompts.length,
-            prompt_bytes: prompts.map(utf8Size),
-            bundle_output: displayedBundleOutput,
-            bundle_outputs: bundleOutputs,
-            behavior_validation_required: true,
-            recommended_next_step:
-              "Inside Codex, adapter-published bundles must follow their README: verify before review, retain the printed manifest digest, have one fresh-context read-only subagent inspect every listed bounded pass, then run the bound post-review check with that retained digest. Standalone-helper output may proceed directly to the reviewer. In either case, also run the separate quality, browser, runtime, or generated-artifact proof required by the change.",
-          },
-          null,
-          2,
-        ),
-      );
-      recordStageDuration("bundle-prep", bundlePrepStartedAt);
+      console.log("autoreview clean: no changed files for selected target");
       return 0;
     }
+    const baseline = scopeBaseline(repo, target, paths);
+    console.log(
+      `scope_baseline: changed_files=${baseline.changedFiles} non_test_loc=${baseline.nonTestLoc}`,
+    );
+
+    const needsBundle =
+      args.engine !== "local" ||
+      args.prepareOnly ||
+      Boolean(args.bundleOutput) ||
+      args.prompts.length > 0 ||
+      args.promptFiles.length > 0 ||
+      args.datasets.length > 0;
+    let bundleOutputs = [];
+    if (needsBundle) {
+      const bundle =
+        target.mode === "local"
+          ? localBundle(repo, target)
+          : target.mode === "branch"
+            ? branchBundle(repo, target)
+            : target.mode === "branch-local"
+              ? branchLocalBundle(repo, target)
+              : commitBundle(repo, target.ref);
+      assertReviewableBundle(paths, bundle);
+      assertNoSecretLikeContent("current branch", branch);
+      if (target.requested_ref) {
+        assertNoSecretLikeContent(
+          "requested review target ref",
+          target.requested_ref,
+        );
+      }
+      if (target.ref)
+        assertNoSecretLikeContent("review target ref", target.ref);
+      const bundleBytes = utf8Size(bundle);
+      const extras = loadExtras(
+        repo,
+        args,
+        MAX_REVIEW_INPUT_BYTES - bundleBytes,
+      );
+      prompts = buildBoundedReviewPrompts(bundle, (chunk, position) =>
+        renderReviewPrompt(target, branch, baseline, chunk, extras, position),
+      );
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed while the review bundle was being created; rerun autoreview against the updated tree",
+      );
+      console.log(
+        `bundle: ${bundleBytes} bytes; review passes: ${prompts.length}`,
+      );
+      if (args.prepareOnly) {
+        const displayedBundleOutput =
+          args.bundleOutputDisplay || args.bundleOutput;
+        if (args.bundleOutput) {
+          writeReviewPromptOutputs(args.bundleOutput, prompts);
+          bundleOutputs = reviewPromptOutputPaths(
+            displayedBundleOutput,
+            prompts.length,
+          );
+          console.log(`bundle_output: ${displayedBundleOutput}`);
+        }
+        console.log(
+          JSON.stringify(
+            {
+              target,
+              branch,
+              engine: args.engine,
+              changed_paths: [...paths].sort(),
+              scope_baseline: baseline,
+              bundle_bytes: bundleBytes,
+              review_passes: prompts.length,
+              prompt_bytes: prompts.map(utf8Size),
+              bundle_output: displayedBundleOutput,
+              bundle_outputs: bundleOutputs,
+              behavior_validation_required: true,
+              recommended_next_step:
+                "Inside Codex, adapter-published bundles must follow their README: verify before review, retain the printed manifest digest, have one fresh-context read-only subagent inspect every listed bounded pass, then run the bound post-review check with that retained digest. Standalone-helper output may proceed directly to the reviewer. In either case, also run the separate quality, browser, runtime, or generated-artifact proof required by the change.",
+            },
+            null,
+            2,
+          ),
+        );
+        return 0;
+      }
+    }
+  } finally {
+    // Record the span even when bundle prep throws -- e.g. scopeBaseline or
+    // bundle assembly failing -- so a failed run still reports where it spent
+    // time. The top-level `.finally` flushes whatever spans were recorded.
+    recordStageDuration("bundle-prep", bundlePrepStartedAt);
   }
-  recordStageDuration("bundle-prep", bundlePrepStartedAt);
 
   if (args.engine !== "local" && prompts.length > 1) {
     throw new Error(

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -130,6 +130,8 @@ const attestedNodeLibraryPathRecords = new Map();
 let trustedExecutableCleanupRegistered = false;
 let pendingTerminationSignal = null;
 let reviewerForceKillTimer = null;
+const stageTimings = [];
+let stageDurationsContext = null;
 
 function usage() {
   console.log(`Usage:
@@ -1887,6 +1889,19 @@ function githubRepositorySlug(repo) {
   return `${match[1]}/${match[2]}`;
 }
 
+// Bound each automatic PR-base gh lookup so a hung GitHub CLI cannot stall
+// autoreview indefinitely; a timeout fails closed like any other lookup error.
+// Overridable (seconds) so tests can exercise the timeout path quickly.
+const GH_LOOKUP_TIMEOUT_MS = (() => {
+  const configured = Number.parseInt(
+    process.env.AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS || "",
+    10,
+  );
+  return Number.isFinite(configured) && configured > 0
+    ? configured * 1000
+    : 60_000;
+})();
+
 function detectPrBase(repo, branch) {
   if (!branch) return null;
   const gh = resolveTrustedCommand("gh", repo, { required: false });
@@ -1916,8 +1931,18 @@ function detectPrBase(repo, branch) {
         env,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: GH_LOOKUP_TIMEOUT_MS,
+        killSignal: "SIGTERM",
       },
     );
+    if (
+      repoResult.error?.code === "ETIMEDOUT" ||
+      repoResult.signal === "SIGTERM"
+    ) {
+      throw new Error(
+        `failed to inspect repository owner: gh repo view timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
+      );
+    }
     if (repoResult.error) {
       throw new Error(
         `failed to inspect repository owner: ${repoResult.error.message}`,
@@ -1963,8 +1988,15 @@ function detectPrBase(repo, branch) {
         env,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: GH_LOOKUP_TIMEOUT_MS,
+        killSignal: "SIGTERM",
       },
     );
+    if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
+      throw new Error(
+        `failed to inspect PR base: gh pr list timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
+      );
+    }
     if (result.error) {
       throw new Error(`failed to inspect PR base: ${result.error.message}`);
     }
@@ -4180,6 +4212,53 @@ function assertReviewSourceState(
   assertSourceSnapshot(repo, expectedSource, target, message);
 }
 
+function recordStageDuration(stage, startedAtMs) {
+  stageTimings.push({ stage, seconds: (Date.now() - startedAtMs) / 1000 });
+}
+
+// Stage-duration logging is best-effort observability; it mirrors the gate's
+// `.tmp/agent-<tool>/durations.jsonl` convention and must never fail the review.
+function flushStageDurations() {
+  if (!stageDurationsContext || stageTimings.length === 0) return;
+  const { repo, mode } = stageDurationsContext;
+  const timings = stageTimings.splice(0);
+  const ts = new Date().toISOString();
+  try {
+    const dir =
+      process.env.AGENT_AUTOREVIEW_DURATIONS_DIR ||
+      path.join(repo, ".tmp", "agent-autoreview");
+    mkdirSync(dir, { recursive: true });
+    const lines = timings
+      .map((entry) =>
+        JSON.stringify({
+          ts,
+          stage: entry.stage,
+          seconds: entry.seconds,
+          mode,
+        }),
+      )
+      .join("\n");
+    writeFileSync(path.join(dir, "durations.jsonl"), `${lines}\n`, {
+      flag: "a",
+    });
+  } catch {
+    // Never let logging failure abort or fail the review.
+  }
+  // The durable JSONL above is always written; the human-readable stderr
+  // summary is opt-in so it cannot leak into the wrapper's strict reviewer-
+  // cleanliness stderr contract.
+  if (!process.env.AGENT_AUTOREVIEW_STAGE_SUMMARY) return;
+  const summary = timings
+    .map(
+      (entry) =>
+        `agent:autoreview: stage-timing   ${entry.stage} ${entry.seconds.toFixed(2)}s`,
+    )
+    .join("\n");
+  console.error(
+    `agent:autoreview: stage-timing summary (mode=${mode}):\n${summary}`,
+  );
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   if (argv[0] === "--serialize-untracked-file") {
@@ -4203,6 +4282,8 @@ async function main() {
     );
     return 0;
   }
+  stageDurationsContext = { repo, mode: args.mode };
+  const targetSelectionStartedAt = Date.now();
   const selectionState = targetSelectionState(repo);
   const targetSelectionSourceSnapshot = args.dryRun
     ? null
@@ -4239,6 +4320,8 @@ async function main() {
       "source changed while the review target was being selected; rerun autoreview against the updated tree",
     );
   }
+  recordStageDuration("target-selection", targetSelectionStartedAt);
+  const bundlePrepStartedAt = Date.now();
   const guardTargetSelectionDuringReview = args.mode === "auto";
   const branch = selectionState.branch || "detached";
 
@@ -4263,6 +4346,7 @@ async function main() {
       guardTargetSelectionDuringReview,
       "source changed while the review target was being selected; rerun autoreview against the updated tree",
     );
+    recordStageDuration("bundle-prep", bundlePrepStartedAt);
     console.log("autoreview clean: no changed files for selected target");
     return 0;
   }
@@ -4346,9 +4430,11 @@ async function main() {
           2,
         ),
       );
+      recordStageDuration("bundle-prep", bundlePrepStartedAt);
       return 0;
     }
   }
+  recordStageDuration("bundle-prep", bundlePrepStartedAt);
 
   if (args.engine !== "local" && prompts.length > 1) {
     throw new Error(
@@ -4357,6 +4443,7 @@ async function main() {
   }
 
   let report;
+  const engineStartedAt = Date.now();
   if (args.engine === "local") {
     assertReviewSourceState(
       repo,
@@ -4398,6 +4485,7 @@ async function main() {
       "source changed during semantic review; rerun autoreview against the updated tree",
     );
   }
+  recordStageDuration("engine-invocation", engineStartedAt);
 
   if (args.bundleOutput) {
     const displayedBundleOutput = args.bundleOutputDisplay || args.bundleOutput;
@@ -4436,4 +4524,7 @@ entrypoint()
     }
     process.exitCode = 1;
   })
-  .finally(finishPendingProcessTermination);
+  .finally(() => {
+    flushStageDurations();
+    finishPendingProcessTermination();
+  });

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -4448,48 +4448,55 @@ async function main() {
 
   let report;
   const engineStartedAt = Date.now();
-  if (args.engine === "local") {
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed before local review; rerun autoreview against the updated tree",
-    );
-    report = runLocalReview(repo, target, paths);
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed during local review; rerun autoreview against the updated tree",
-    );
-  } else {
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed before semantic review; rerun autoreview against the updated tree",
-    );
-    const raw =
-      args.engine === "codex"
-        ? await runCodex(repo, args, prompts[0])
-        : await runClaude(repo, args, prompts[0]);
-    report = validateReport(extractReviewJson(raw), paths);
-    assertReviewSourceState(
-      repo,
-      reviewSourceSnapshot,
-      target,
-      targetSelectionSourceSnapshot,
-      guardTargetSelectionDuringReview,
-      "source changed during semantic review; rerun autoreview against the updated tree",
-    );
+  try {
+    if (args.engine === "local") {
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed before local review; rerun autoreview against the updated tree",
+      );
+      report = runLocalReview(repo, target, paths);
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed during local review; rerun autoreview against the updated tree",
+      );
+    } else {
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed before semantic review; rerun autoreview against the updated tree",
+      );
+      const raw =
+        args.engine === "codex"
+          ? await runCodex(repo, args, prompts[0])
+          : await runClaude(repo, args, prompts[0]);
+      report = validateReport(extractReviewJson(raw), paths);
+      assertReviewSourceState(
+        repo,
+        reviewSourceSnapshot,
+        target,
+        targetSelectionSourceSnapshot,
+        guardTargetSelectionDuringReview,
+        "source changed during semantic review; rerun autoreview against the updated tree",
+      );
+    }
+  } finally {
+    // Record the engine span even when the invocation throws -- a nonzero
+    // engine exit, or a post-invocation source-state check failing -- so the
+    // runs operators most need to profile still get an engine-invocation
+    // duration. The top-level `.finally` flushes whatever spans were recorded.
+    recordStageDuration("engine-invocation", engineStartedAt);
   }
-  recordStageDuration("engine-invocation", engineStartedAt);
 
   if (args.bundleOutput) {
     const displayedBundleOutput = args.bundleOutputDisplay || args.bundleOutput;

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -1932,12 +1932,16 @@ function detectPrBase(repo, branch) {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
         timeout: GH_LOOKUP_TIMEOUT_MS,
-        killSignal: "SIGTERM",
+        // SIGKILL, not SIGTERM: spawnSync blocks until the child actually
+        // exits after the timeout fires, so a child that handles or ignores
+        // SIGTERM would hang this call (and autoreview) indefinitely despite
+        // the "timeout" option. SIGKILL can't be caught or ignored.
+        killSignal: "SIGKILL",
       },
     );
     if (
       repoResult.error?.code === "ETIMEDOUT" ||
-      repoResult.signal === "SIGTERM"
+      repoResult.signal === "SIGKILL"
     ) {
       throw new Error(
         `failed to inspect repository owner: gh repo view timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
@@ -1989,10 +1993,10 @@ function detectPrBase(repo, branch) {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
         timeout: GH_LOOKUP_TIMEOUT_MS,
-        killSignal: "SIGTERM",
+        killSignal: "SIGKILL",
       },
     );
-    if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
+    if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGKILL") {
       throw new Error(
         `failed to inspect PR base: gh pr list timed out after ${GH_LOOKUP_TIMEOUT_MS / 1000}s; pass --base explicitly`,
       );

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -3080,6 +3080,11 @@ attested_helper_runtime_dir=""
 attested_helper_runtime_identity=""
 attested_helper_runtime_manifest=""
 
+# Bound each automatic-lookup gh call (and the multi-call feedback capture) so a
+# hung GitHub CLI cannot stall autoreview forever. Overridable for tests.
+gh_lookup_deadline_seconds="${AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS:-60}"
+feedback_capture_deadline_seconds="${AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS:-120}"
+
 resolved_command_is_trusted() {
   local candidate="$1"
   if [[ "$candidate" == "$node_bin" ]]; then
@@ -3144,6 +3149,83 @@ run_trusted_external() {
     return 127
   }
   return "$status"
+}
+
+# Bound a foreground command with a wall-clock deadline without depending on a
+# timeout(1) binary (absent on stock macOS). Stdout is captured and replayed so
+# $(...) callers still receive it; stderr passes through. The job runs in its
+# own process group so a hung child tree is fully signalled on timeout, and 124
+# is returned so callers fail closed exactly as they do for other lookup errors.
+run_with_deadline() {
+  local label="$1"
+  local deadline="$2"
+  shift 2
+  local out_file
+  local child
+  local waited=0
+  local status
+  local had_monitor=0
+  if ! out_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/autoreview-deadline.XXXXXX")"; then
+    echo "agent:autoreview: failed to allocate a deadline capture file for $label" >&2
+    return 1
+  fi
+  case "$-" in
+    *m*) had_monitor=1 ;;
+  esac
+  set -m
+  "$@" >"$out_file" &
+  child=$!
+  if [[ "$had_monitor" -eq 0 ]]; then
+    set +m
+  fi
+  while [[ "$waited" -lt "$deadline" ]] && kill -0 "$child" 2>/dev/null; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$child" 2>/dev/null; then
+    kill -TERM "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null || true
+    sleep 1
+    kill -KILL "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null || true
+    wait "$child" 2>/dev/null || true
+    echo "agent:autoreview: $label timed out after ${deadline}s" >&2
+    rm -f "$out_file"
+    return 124
+  fi
+  if wait "$child"; then
+    status=0
+  else
+    status=$?
+  fi
+  cat "$out_file"
+  rm -f "$out_file"
+  return "$status"
+}
+
+stage_epoch_seconds() {
+  /bin/date +%s 2>/dev/null || printf '0'
+}
+
+# Best-effort per-stage timing that mirrors the gate's durations-file
+# convention (gitignored .tmp/agent-<tool>/durations.jsonl). It appends one JSON
+# line and echoes a filterable summary line; logging failure never aborts a run.
+record_stage_duration() {
+  local stage="$1"
+  local seconds="$2"
+  local mode="$3"
+  local dir="${AGENT_AUTOREVIEW_DURATIONS_DIR:-$repo_root/.tmp/agent-autoreview}"
+  local ts
+  ts="$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf 'unknown')"
+  {
+    mkdir -p "$dir" 2>/dev/null &&
+      printf '{"ts":"%s","stage":"%s","seconds":%s,"mode":"%s"}\n' \
+        "$ts" "$stage" "$seconds" "$mode" >>"$dir/durations.jsonl"
+  } 2>/dev/null || true
+  # The JSONL above is always written; the stderr summary is opt-in so it never
+  # violates the wrapper's strict reviewer-cleanliness stderr contract.
+  if [[ -n "${AGENT_AUTOREVIEW_STAGE_SUMMARY:-}" ]]; then
+    printf 'agent:autoreview: stage-timing   %s %ss (mode=%s)\n' \
+      "$stage" "$seconds" "$mode" >&2
+  fi
 }
 
 run_trusted_node() {
@@ -3583,7 +3665,9 @@ detect_unique_pr_record() {
   if ! lookup="$(
     cd "$repo" &&
       unset GH_HOST GH_REPO &&
-      GH_PAGER=cat GH_PROMPT_DISABLED=1 run_trusted_external "$gh_bin" pr list \
+      GH_PAGER=cat GH_PROMPT_DISABLED=1 run_with_deadline "gh pr list" \
+        "$gh_lookup_deadline_seconds" \
+        run_trusted_external "$gh_bin" pr list \
         --repo "$repository_slug" \
         --head "$branch" \
         --state open \
@@ -3635,7 +3719,9 @@ detect_unique_pr_record() {
       if ! repository_owner="$(
         cd "$repo" &&
           unset GH_HOST GH_REPO &&
-          GH_PAGER=cat GH_PROMPT_DISABLED=1 run_trusted_external "$gh_bin" repo view \
+          GH_PAGER=cat GH_PROMPT_DISABLED=1 run_with_deadline "gh repo view" \
+            "$gh_lookup_deadline_seconds" \
+            run_trusted_external "$gh_bin" repo view \
             "$repository_slug" \
             --json owner \
             --jq '.owner.login'
@@ -4262,7 +4348,9 @@ capture_feedback_state() {
   fi
   (
     cd "$repo"
-    run_trusted_node_in_clean_env \
+    run_with_deadline "PR feedback capture" \
+      "$feedback_capture_deadline_seconds" \
+      run_trusted_node_in_clean_env \
       "${#env_args[@]}" \
       "${env_args[@]}" \
       "$runtime_dir/scripts/pr-feedback-state.mjs" \
@@ -4765,6 +4853,13 @@ bundle_content_manifest() {
   shift 2
   local ignored_root_entries=("$@")
   local digest
+  # Test-only observability hook: when a counter file is provided, record one
+  # line per manifest call so regressions can assert each distinct (tree,moment)
+  # is hashed exactly once. Unset in production, so this is a no-op there.
+  if [[ -n "${AGENT_AUTOREVIEW_MANIFEST_COUNTER_FILE:-}" ]]; then
+    printf '%s\t%s\n' "$root" "$expected_root_identity" \
+      >>"$AGENT_AUTOREVIEW_MANIFEST_COUNTER_FILE" 2>/dev/null || true
+  fi
   assert_bundle_tree_acl_trusted "$root" "$expected_root_identity" || return 1
   # The single-quoted string is JavaScript source, not shell interpolation.
   # shellcheck disable=SC2016
@@ -6598,12 +6693,19 @@ EOF
     trusted_helper_runtime_dir=""
     trusted_helper_runtime_identity=""
     prepared_helper_override=""
-  fi
-  if ! expected_bundle_manifest="$(
-    bundle_content_manifest "$staging_dir" "$staging_identity"
-  )"; then
-    echo "agent:autoreview: prepared-bundle staging changed before publication" >&2
-    return 1
+    # Removing the trusted-runtime subtree changes the staging tree, so the
+    # publishable manifest is a new moment that must be hashed independently.
+    if ! expected_bundle_manifest="$(
+      bundle_content_manifest "$staging_dir" "$staging_identity"
+    )"; then
+      echo "agent:autoreview: prepared-bundle staging changed before publication" >&2
+      return 1
+    fi
+  else
+    # No subtree was removed and prompt validation is read-only, so the staging
+    # tree is byte-identical to the post-source-validation snapshot. Reuse that
+    # digest rather than re-hashing the same (tree,moment) for publication.
+    expected_bundle_manifest="$post_snapshot_bundle_manifest"
   fi
   publish_bundle_with_reservation \
     "$staging_dir" \
@@ -6620,12 +6722,19 @@ EOF
 }
 
 if [[ -n "$verify_bundle_dir" ]]; then
+  stage_timer_start="$(stage_epoch_seconds)"
   verify_context_bundle "$verify_bundle_dir" "$verify_expected_manifest"
+  record_stage_duration "verification" \
+    "$(($(stage_epoch_seconds) - stage_timer_start))" "verify"
   exit 0
 fi
 
 if [[ -n "$prepare_bundle_dir" ]]; then
+  stage_timer_start="$(stage_epoch_seconds)"
   prepare_context_bundle "$prepare_bundle_dir" "$feedback_pr" "$@"
+  record_stage_duration "prepare-bundle" \
+    "$(($(stage_epoch_seconds) - stage_timer_start))" \
+    "$(arg_value --mode auto "$@")"
   exit 0
 fi
 

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -3178,6 +3178,13 @@ run_with_deadline() {
   if [[ "$had_monitor" -eq 0 ]]; then
     set +m
   fi
+  # If the wrapper itself is interrupted while this job is running, kill the
+  # whole backgrounded process group instead of leaving it to run orphaned and
+  # undetected -- exactly the hung-command class this function exists to
+  # bound. Re-raise the signal against ourselves afterward so the interrupted
+  # script still terminates with the expected signal-death semantics.
+  trap 'kill -TERM "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null || true; sleep 1; kill -KILL "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; rm -f "$out_file"; trap - INT TERM; kill -s TERM "$$"' TERM
+  trap 'kill -TERM "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null || true; sleep 1; kill -KILL "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; rm -f "$out_file"; trap - INT TERM; kill -s INT "$$"' INT
   while [[ "$waited" -lt "$deadline" ]] && kill -0 "$child" 2>/dev/null; do
     sleep 1
     waited=$((waited + 1))
@@ -3189,6 +3196,7 @@ run_with_deadline() {
     wait "$child" 2>/dev/null || true
     echo "agent:autoreview: $label timed out after ${deadline}s" >&2
     rm -f "$out_file"
+    trap - INT TERM
     return 124
   fi
   if wait "$child"; then
@@ -3196,6 +3204,7 @@ run_with_deadline() {
   else
     status=$?
   fi
+  trap - INT TERM
   cat "$out_file"
   rm -f "$out_file"
   return "$status"

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -3085,6 +3085,17 @@ attested_helper_runtime_manifest=""
 gh_lookup_deadline_seconds="${AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS:-60}"
 feedback_capture_deadline_seconds="${AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS:-120}"
 
+# Unify per-stage timing between the wrapper and the helper. When a runtime-
+# changing PR is reviewed from a separate trusted checkout, repo_root names that
+# trusted wrapper checkout while the helper resolves the reviewed checkout from
+# its working directory, so their default durations targets diverge and neither
+# log holds the whole run. Pin one shared directory -- the reviewed checkout the
+# helper already defaults to -- and export it so both processes agree. A caller-
+# provided value still wins; an unresolved checkout keeps the per-process default.
+if [[ -z "${AGENT_AUTOREVIEW_DURATIONS_DIR:-}" && "$checkout_root_found" -eq 1 ]]; then
+  export AGENT_AUTOREVIEW_DURATIONS_DIR="$checkout_root/.tmp/agent-autoreview"
+fi
+
 resolved_command_is_trusted() {
   local candidate="$1"
   if [[ "$candidate" == "$node_bin" ]]; then

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -3082,8 +3082,23 @@ attested_helper_runtime_manifest=""
 
 # Bound each automatic-lookup gh call (and the multi-call feedback capture) so a
 # hung GitHub CLI cannot stall autoreview forever. Overridable for tests.
+#
+# Validate the overrides here rather than trusting them into run_with_deadline:
+# its `[[ "$waited" -lt "$deadline" ]]` loop evaluates $deadline as arithmetic,
+# and under this script's `set -u` a non-numeric value (e.g. a typo'd
+# AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS=foo) aborts the subshell there -- after
+# the job has already been backgrounded -- leaving it orphaned instead of
+# bounded.
 gh_lookup_deadline_seconds="${AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS:-60}"
+if ! [[ "$gh_lookup_deadline_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "agent:autoreview: AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS='$gh_lookup_deadline_seconds' is not a positive integer; using default 60s" >&2
+  gh_lookup_deadline_seconds=60
+fi
 feedback_capture_deadline_seconds="${AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS:-120}"
+if ! [[ "$feedback_capture_deadline_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "agent:autoreview: AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS='$feedback_capture_deadline_seconds' is not a positive integer; using default 120s" >&2
+  feedback_capture_deadline_seconds=120
+fi
 
 # Unify per-stage timing between the wrapper and the helper. When a runtime-
 # changing PR is reviewed from a separate trusted checkout, repo_root names that

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -3589,6 +3589,103 @@ GH
   expect_stderr_contains "gh pr list timed out after 1s"
 }
 
+run_deadline_gh_lookup_kill_regression() {
+  # Exercise the wrapper's own run_with_deadline (not the helper's spawnSync
+  # timeout) through its real caller. Branch-mode bundle prep with no explicit
+  # --base resolves the PR base via detect_unique_pr_record, which bounds
+  # `gh pr list` with run_with_deadline. A gh that ignores SIGTERM proves the
+  # deadline escalates to a process-group SIGKILL, fails closed with exit 124,
+  # and leaves no orphaned child -- unlike run_gh_lookup_timeout_regression,
+  # whose --dry-run path resolves entirely through the helper's own timeout.
+  local review_repo="$tmp_dir/deadline-gh-lookup-kill"
+  local fake_bin="$tmp_dir/deadline-gh-lookup-kill-bin"
+  local bundle_dir="$tmp_dir/deadline-gh-lookup-kill-bundle"
+  local pid_file="$tmp_dir/deadline-gh-lookup-kill.pid"
+  init_review_repo "$review_repo"
+  git -C "$review_repo" remote add origin \
+    https://github.com/mento-protocol/monitoring-monorepo.git
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+  mkdir "$fake_bin"
+  cat >"$fake_bin/gh" <<'GH'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  # Ignore SIGTERM so only run_with_deadline's SIGKILL escalation can stop us,
+  # proving the deadline signals the whole backgrounded process group rather
+  # than blocking on the child until the fake one-hour sleep elapses.
+  trap '' TERM
+  printf '%s\n' "$$" >"$AUTOREVIEW_FAKE_GH_PID_FILE"
+  while true; do
+    sleep 1
+  done
+fi
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+  printf '%s\n' '{"owner":{"login":"mento-protocol"}}'
+  exit 0
+fi
+exit 82
+GH
+  chmod +x "$fake_bin/gh"
+
+  : >"$stdout"
+  : >"$stderr"
+  : >"$pid_file"
+  local started_at
+  started_at="$(date +%s)"
+  local status=0
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$fake_bin:$PATH" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "AUTOREVIEW_FAKE_GH_PID_FILE=$pid_file" \
+      "AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS=2" \
+      "$adapter_wrapper" \
+      --prepare-bundle-dir "$bundle_dir" \
+      --mode branch \
+      --engine local >"$stdout" 2>"$stderr"
+  ) || status=$?
+  cleanup_retained_test_command_runtimes
+  local elapsed=$(($(date +%s) - started_at))
+
+  if [[ "$status" -eq 0 ]]; then
+    printf 'hung gh pr list during PR detection unexpectedly succeeded\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains "gh pr list timed out after 2s"
+  expect_stderr_contains "failed to inspect PR metadata for head branch feature"
+  if [[ "$elapsed" -ge 60 ]]; then
+    printf 'run_with_deadline did not bound the hung gh lookup: took %ss\n' \
+      "$elapsed" >&2
+    exit 1
+  fi
+
+  # The escalation must reach the whole process group: the SIGTERM-ignoring gh
+  # child is gone, not orphaned. Poll briefly because the group SIGKILL and the
+  # reparented child's reaping race with the wrapper's own exit.
+  local gh_pid
+  gh_pid="$(cat "$pid_file")"
+  if [[ -z "$gh_pid" ]]; then
+    printf 'fake gh never recorded its pid; the lookup call site was not reached\n' >&2
+    exit 1
+  fi
+  local waited=0
+  while [[ "$waited" -lt 10 ]] && kill -0 "$gh_pid" 2>/dev/null; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$gh_pid" 2>/dev/null; then
+    kill -KILL "$gh_pid" 2>/dev/null || true
+    printf 'SIGTERM-ignoring gh child survived the deadline: pid %s still alive\n' \
+      "$gh_pid" >&2
+    exit 1
+  fi
+}
+
 run_target_selection_drift_regression() {
   local review_repo="$tmp_dir/target-selection-drift"
   local fake_bin="$tmp_dir/target-selection-drift-bin"
@@ -4171,6 +4268,65 @@ run_stage_timing_manifest_regression() {
   if [[ "$staging_hashes" -ne 4 ]]; then
     printf 'expected staging tree hashed 4 times, saw %s\ncounter:\n%s\n' \
       "$staging_hashes" "$(cat "$counter_file")" >&2
+    exit 1
+  fi
+}
+
+run_stage_timing_split_checkout_regression() {
+  # With no explicit AGENT_AUTOREVIEW_DURATIONS_DIR, a separate trusted wrapper
+  # checkout (adapter_runtime) reviewing a different checkout must still write
+  # the wrapper and helper stages to one log -- the reviewed checkout the helper
+  # already defaults to -- instead of splitting the run across the trusted
+  # wrapper checkout (repo_root) and the reviewed checkout.
+  local review_repo="$tmp_dir/stage-timing-split-checkout"
+  local bundle_dir="$tmp_dir/stage-timing-split-checkout-bundle"
+  local durations_file="$review_repo/.tmp/agent-autoreview/durations.jsonl"
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c release >/dev/null 2>&1
+  printf 'release\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" release
+  git -C "$review_repo" update-ref refs/remotes/origin/release HEAD
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature change\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+
+  : >"$stdout"
+  : >"$stderr"
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$PATH" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "$adapter_wrapper" \
+      --prepare-bundle-dir "$bundle_dir" \
+      --mode branch \
+      --base origin/release \
+      --engine local >"$stdout" 2>"$stderr"
+  )
+  cleanup_retained_test_command_runtimes
+
+  # The wrapper stage (prepare-bundle) landing in the reviewed checkout's log
+  # alongside the helper stages proves the unification: before the shared
+  # default, prepare-bundle would have gone to the trusted wrapper checkout.
+  expect_file_exists "$durations_file"
+  if ! "$node_bin" -e '
+    const fs = require("node:fs");
+    const stages = new Set(
+      fs
+        .readFileSync(process.argv[1], "utf8")
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line).stage),
+    );
+    for (const stage of ["prepare-bundle", "target-selection", "bundle-prep"]) {
+      if (!stages.has(stage)) throw new Error("missing stage " + stage);
+    }
+  ' "$durations_file"; then
+    printf 'reviewed-checkout durations log did not hold the whole run\nlog:\n%s\n' \
+      "$(cat "$durations_file")" >&2
     exit 1
   fi
 }
@@ -5691,6 +5847,7 @@ run_target_selection_family() {
   run_branch_local_deleted_reference_fixed_regression
   run_pr_base_detection_regression
   run_gh_lookup_timeout_regression
+  run_deadline_gh_lookup_kill_regression
   run_target_selection_drift_regression
   run_dry_run_unresolved_ref_regression
   run_dirty_source_drift_regression
@@ -5719,6 +5876,7 @@ run_runtime_trust_family() {
 run_bundle_integrity_family() {
   run_frozen_checklist_provenance_regression
   run_stage_timing_manifest_regression
+  run_stage_timing_split_checkout_regression
   run_prepared_unsupported_path_regressions
   run_frozen_checklist_symlink_regression
   run_prepared_untracked_symlink_regression

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -1220,7 +1220,8 @@ expect_empty_stderr() {
   local unexpected
   unexpected="$(
     grep -v \
-      '^agent:autoreview: leaving external-command runtime because an explicit helper may have surviving same-UID writers: ' \
+      -e '^agent:autoreview: leaving external-command runtime because an explicit helper may have surviving same-UID writers: ' \
+      -e '^agent:autoreview: stage-timing' \
       "$stderr" || true
   )"
   if [[ -n "$unexpected" ]]; then
@@ -1346,6 +1347,9 @@ init_review_repo() {
   git -C "$review_repo" init -b main >/dev/null
   git -C "$review_repo" config user.name "Agent Test"
   git -C "$review_repo" config user.email "agent-test@example.invalid"
+  # Match the real repo: the gitignored scratch dir that receives best-effort
+  # stage-duration logs must never enter the reviewed source enumeration.
+  printf '%s\n' '.tmp/' >>"$review_repo/.git/info/exclude"
 }
 
 commit_review_repo() {
@@ -3539,6 +3543,52 @@ GH
   expect_stderr_contains "open PR for head branch feature is not owned by mento-protocol"
 }
 
+run_gh_lookup_timeout_regression() {
+  local review_repo="$tmp_dir/gh-lookup-timeout"
+  local fake_bin="$tmp_dir/gh-lookup-timeout-bin"
+  init_review_repo "$review_repo"
+  git -C "$review_repo" remote add origin \
+    https://github.com/mento-protocol/monitoring-monorepo.git
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+  mkdir "$fake_bin"
+  cat >"$fake_bin/gh" <<GH
+#!/usr/bin/env bash
+git rev-parse --show-toplevel >/dev/null || exit 81
+if [[ "\$1" == "repo" && "\$2" == "view" ]]; then
+  printf '%s\n' '{"owner":{"login":"mento-protocol"}}'
+  exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
+  exec sleep 3600
+fi
+exit 82
+GH
+  chmod +x "$fake_bin/gh"
+
+  : >"$stdout"
+  : >"$stderr"
+  local status=0
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$fake_bin:$PATH" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS=1" \
+      "$repo_root/scripts/agent-autoreview.sh" \
+      --engine local --dry-run >"$stdout" 2>"$stderr"
+  ) || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'hung gh pr list lookup unexpectedly succeeded\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains "gh pr list timed out after 1s"
+}
+
 run_target_selection_drift_regression() {
   local review_repo="$tmp_dir/target-selection-drift"
   local fake_bin="$tmp_dir/target-selection-drift-bin"
@@ -4045,6 +4095,84 @@ run_frozen_checklist_provenance_regression() {
     "$local_bundle/patches/unstaged.diff" \
     "malicious local checklist injection"
   expect_empty_stderr
+}
+
+run_stage_timing_manifest_regression() {
+  local review_repo="$tmp_dir/stage-timing-manifest"
+  local bundle_dir="$tmp_dir/stage-timing-manifest-bundle"
+  local durations_dir="$tmp_dir/stage-timing-manifest-durations"
+  local counter_file="$tmp_dir/stage-timing-manifest-counter"
+  local durations_file="$durations_dir/durations.jsonl"
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c release >/dev/null 2>&1
+  printf 'release\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" release
+  git -C "$review_repo" update-ref refs/remotes/origin/release HEAD
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature change\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+
+  : >"$counter_file"
+  : >"$stdout"
+  : >"$stderr"
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$PATH" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "AGENT_AUTOREVIEW_DURATIONS_DIR=$durations_dir" \
+      "AGENT_AUTOREVIEW_MANIFEST_COUNTER_FILE=$counter_file" \
+      "$adapter_wrapper" \
+      --prepare-bundle-dir "$bundle_dir" \
+      --mode branch \
+      --base origin/release \
+      --engine local >"$stdout" 2>"$stderr"
+  )
+  cleanup_retained_test_command_runtimes
+
+  # Item 1: every stage-duration line is parseable JSON with the agreed keys,
+  # and both the wrapper stage and the helper stages were recorded.
+  expect_file_exists "$durations_file"
+  if ! "$node_bin" -e '
+    const fs = require("node:fs");
+    const lines = fs
+      .readFileSync(process.argv[1], "utf8")
+      .split("\n")
+      .filter((line) => line.length > 0);
+    if (lines.length === 0) throw new Error("no duration lines written");
+    const stages = new Set();
+    for (const line of lines) {
+      const record = JSON.parse(line);
+      for (const key of ["ts", "stage", "seconds", "mode"]) {
+        if (!(key in record)) throw new Error("missing key " + key);
+      }
+      if (typeof record.seconds !== "number") {
+        throw new Error("seconds must be numeric");
+      }
+      stages.add(record.stage);
+    }
+    if (!stages.has("prepare-bundle")) throw new Error("missing prepare-bundle stage");
+    if (!stages.has("target-selection")) throw new Error("missing target-selection stage");
+    if (!stages.has("bundle-prep")) throw new Error("missing bundle-prep stage");
+  ' "$durations_file"; then
+    printf 'stage-duration log was not valid\nlog:\n%s\n' \
+      "$(cat "$durations_file")" >&2
+    exit 1
+  fi
+
+  # Item 2: the staging tree is hashed exactly once per distinct (tree,moment):
+  # pre/post helper evidence + pre/post source-validation snapshot = 4, with the
+  # publication manifest reused from the post-snapshot moment (no re-hash).
+  local staging_hashes
+  staging_hashes="$(grep -c '\.agent-autoreview-context\.' "$counter_file" || true)"
+  if [[ "$staging_hashes" -ne 4 ]]; then
+    printf 'expected staging tree hashed 4 times, saw %s\ncounter:\n%s\n' \
+      "$staging_hashes" "$(cat "$counter_file")" >&2
+    exit 1
+  fi
 }
 
 run_prepared_unsupported_path_regressions() {
@@ -5562,6 +5690,7 @@ run_target_selection_family() {
   run_branch_local_deleted_reference_regression
   run_branch_local_deleted_reference_fixed_regression
   run_pr_base_detection_regression
+  run_gh_lookup_timeout_regression
   run_target_selection_drift_regression
   run_dry_run_unresolved_ref_regression
   run_dirty_source_drift_regression
@@ -5589,6 +5718,7 @@ run_runtime_trust_family() {
 
 run_bundle_integrity_family() {
   run_frozen_checklist_provenance_regression
+  run_stage_timing_manifest_regression
   run_prepared_unsupported_path_regressions
   run_frozen_checklist_symlink_regression
   run_prepared_untracked_symlink_regression


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The autoreview pipeline is un-instrumented: there is no per-stage wall-clock, so slow prepared-bundle runs are opaque and hard to profile.
- `bundle_content_manifest` re-hashes the full staging tree once per consumer even when a consumer needs the same (tree, moment) another already computed.
- Every `gh` lookup (PR-base detection and feedback capture) runs unbounded, so a hung GitHub CLI can stall autoreview indefinitely.

## The Solution

- Record wall-clock per stage (target selection, bundle prep, engine invocation in the helper; prepare-bundle and verification in the wrapper) and append one `{ts,stage,seconds,mode}` JSON line per stage to a gitignored `.tmp/agent-autoreview/durations.jsonl`, mirroring the gate's durations-file convention. Logging is best-effort and never fails a run; an opt-in stderr summary keeps the wrapper's strict reviewer-cleanliness contract intact.
- Map each manifest call site to its (tree, moment) pair and reuse the post-source-validation snapshot digest as the publication manifest whenever no trusted-runtime subtree was removed (the only true same-moment duplicate); every tamper-evidence pre/post pair is still computed independently.
- Bound each `gh` invocation with a ~60s deadline (a 120s bound on the multi-call feedback capture): the helper uses `spawnSync`'s built-in timeout, and the wrapper uses a portable process-group watchdog. A timeout fails closed exactly like any other lookup error, with a clear stderr message naming the call.

## Details

- **Stage timers.** `scripts/agent-autoreview.mjs` times target-selection, bundle-prep, and engine-invocation and flushes buffered records once at process end (so the durations file never appears mid-enumeration). `scripts/agent-autoreview.sh` times the top-level prepare-bundle and verification dispatch with `date +%s`. Both honor `AGENT_AUTOREVIEW_DURATIONS_DIR`; the human summary is gated behind `AGENT_AUTOREVIEW_STAGE_SUMMARY`.
- **Hash-once mapping.** The prepared-bundle staging tree is hashed at four distinct (tree, moment) points that MUST stay independent — pre/post helper-evidence and pre/post source-validation snapshot — plus one publication manifest and one post-publish `verify_context_bundle` hash of the *published* tree. The attested-helper-runtime seal and its per-launch before/after re-verifications hash a *different* tree. In the owning-checkout path the trusted runtime is materialized inside staging and removed before publication, so the publication manifest is a genuinely new moment and is still hashed independently. Only when no subtree is removed (external-wrapper / explicit-helper prepare) is the publication manifest a true duplicate of the post-snapshot moment; that is the single case deduplicated. Net effect: one fewer full-tree walk on the external-wrapper prepare path; owning-checkout semantics unchanged.
- **gh timeouts.** Helper: `timeout`/`killSignal` on both `spawnTrustedSync` gh calls, plus explicit `ETIMEDOUT`/`SIGTERM` detection that throws a named error (fail-closed, since `detectPrBase` propagates). Wrapper: `run_with_deadline` runs the gh call in its own process group and signals the whole tree on timeout, returning 124 so callers fail closed; feedback capture is bounded the same way. Both deadlines are overridable via `AGENT_AUTOREVIEW_GH_DEADLINE_SECONDS` / `AGENT_AUTOREVIEW_FEEDBACK_DEADLINE_SECONDS` for tests.
- **Runtime-change verification.** These edits change the autoreview runtime, so the owning-checkout refusal machinery is intentionally left intact and not bypassed. The new runtime is validated by its own test suites in this PR (families run below); post-merge it becomes the pinned `origin/main` runtime that the wrapper self-verifies against. No pre-change-wrapper cross-checkout dance is required because validation runs the suites directly, not a self-review of the dirty runtime.
- **Test-only hooks.** `AGENT_AUTOREVIEW_MANIFEST_COUNTER_FILE` records one line per `bundle_content_manifest` call (unset in production → no-op). `init_review_repo` now excludes `.tmp/` from reviewed-source enumeration, matching the real repo's `.gitignore`, so best-effort durations logs never perturb untracked-scope or source-drift checks.

## Validation

- `node --check scripts/agent-autoreview.mjs` → ok
- `bash -n scripts/agent-autoreview.sh` / `bash -n scripts/agent-autoreview.test.sh` → ok
- `node scripts/agent-autoreview-core.test.mjs` → `agent-autoreview core tests passed`
- `pnpm lint:scripts` → clean (exit 0)
- `AUTOREVIEW_TEST_FOCUS=target-selection` → `focused autoreview target-selection tests passed` (new `run_gh_lookup_timeout_regression`: hung gh → `gh pr list timed out after 1s`, fail-closed; existing PR-base happy path via the wrapper gh path)
- `AUTOREVIEW_TEST_FOCUS=bundle-integrity` → `focused autoreview bundle-integrity tests passed` (new `run_stage_timing_manifest_regression`: durations JSONL parseable with `ts/stage/seconds/mode` and all stages present; staging tree hashed exactly 4× confirming the dedup)
- `AUTOREVIEW_TEST_FOCUS=adapter` → `focused autoreview adapter tests passed` (full local review through the new stage timers; wrapper gh detect happy path; stderr stays clean)
- `AUTOREVIEW_TEST_FOCUS=signal-cleanup` and `AUTOREVIEW_TEST_FOCUS=suite-wrapper-signal` → passed
- Remaining families (`runtime-trust`, `prepared-bundle-safety`, `review-target-trust`, `cleanup-race`, and the rest of `engine-isolation`) deferred to the orchestrator's full background run. Note: the `suite-process-cleanup` harness meta-test hangs in this local unsandboxed shell; it exercises only plain-`node` fixtures and none of the changed source or test paths, so the hang is pre-existing and environmental.

## Deferrals

- [#1469](https://github.com/mento-protocol/monitoring-monorepo/issues/1469) — stage-timing `durations.jsonl` splits across the trusted/reviewed checkouts in owning-checkout (runtime-changing PR) mode.
- [#1470](https://github.com/mento-protocol/monitoring-monorepo/issues/1470) — `run_with_deadline` (wrapper gh/subprocess timeout + interrupt cleanup) has no direct regression coverage.

## Ship Checklist

- [x] Changes are minimal and scoped to the three issue items.
- [x] Static checks green (`node --check`, `bash -n`, `pnpm lint:scripts`, core test).
- [x] New + changed-path test families pass locally.
- [x] Runtime-change refusal machinery left intact; new runtime validated by its suites.
- [ ] Full autoreview suite green in CI / orchestrator background run.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Refs #1415
Refs #1404

