### PR TITLE
docs: garden agent entry points shard 1

### DIFF
--- a/.agents/roles/standards-enforcer.md
+++ b/.agents/roles/standards-enforcer.md
@@ -3,7 +3,7 @@ title: Standards Enforcer Role
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-22
 doc_type: role
 scope: repo-wide
 review_interval_days: 90

--- a/.agents/roles/verifier.md
+++ b/.agents/roles/verifier.md
@@ -3,7 +3,7 @@ title: Verifier Role
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-22
 doc_type: role
 scope: repo-wide
 review_interval_days: 90
@@ -18,8 +18,11 @@ Run diff-scoped verification and report only actionable results.
 
 1. Inspect the branch diff against `origin/main`.
 2. Run `pnpm agent:quality-gate --dry-run` and confirm mapped commands/checklists match changed surfaces.
-3. Run `pnpm agent:quality-gate --run --fail-fast` unless the requester asked for dry verification only.
-4. If a command fails, report the failing command, relevant output, and smallest next fix.
+3. Unless the requester asked for dry verification only, run
+   `pnpm agent:quality-gate --run` as a background task. Do not run another
+   gate, dashboard server, or browser suite concurrently in the same worktree.
+4. Report every failed or skipped command, the relevant output, and the
+   smallest next fix.
 
 ## Output
 

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-28
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -20,27 +20,65 @@ repo command, not a hand-rolled interpretation of green checks.
 
 ## Resolve Target
 
-If no PR number is provided, resolve the current branch PR:
+If no PR number is provided, resolve the current branch PR. For every target,
+capture the PR URL, head repository, branch, and commit:
 
 ```bash
-gh pr view --json number,url,title,headRefName,baseRefName
+gh pr view --json number,url,title,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,isCrossRepository
 ```
 
-For an explicit target, accept a bare number or PR URL. Use `--repo` only when
-the PR is not in `mento-protocol/monitoring-monorepo`.
+For an explicit target, accept a bare number or PR URL. Derive and preserve
+`BASE_REPO` (`owner/name`) from the resolved PR URL before changing checkouts.
+After that initial resolution, pass `--repo <BASE_REPO>` to every `gh pr view`,
+feedback-state, and ready-state call—even when the PR began in the current
+repository.
 
-## Watch Loop
+Before any blocker fix mutates files or Git history, bind the checkout to that
+resolved target:
 
-Run the shared probe:
+- Select `HEAD_REMOTE` only after verifying that its repository equals
+  `headRepository.nameWithOwner`. For a cross-repository PR, use a dedicated
+  checkout with the fork as `HEAD_REMOTE`; keep a separately verified
+  `BASE_REMOTE` for `BASE_REPO` and never swap their roles.
+- `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
+  the resolved `headRefOid`. If either differs, stop or switch to a clean,
+  dedicated checkout at the PR head before editing.
+- Preserve `BASE_REPO`, `BASE_REMOTE`, `HEAD_REMOTE`, and `headRefName` for the
+  full session. Fetch `baseRefName` only from `BASE_REMOTE`.
+
+After each fix commit, push explicitly with `git push <HEAD_REMOTE>
+HEAD:<headRefName>`, re-resolve with `gh pr view <number> --repo <BASE_REPO>`,
+and require the new `headRefOid` to equal local `HEAD` before returning to the
+watch loop. Never rely on the current branch name, implicit push target, or
+repository inferred from the active checkout.
+
+Before the first review pass, freeze the request, target/owner, changed files,
+and non-test changed-line count as the scope baseline. Classify later additions
+as in-scope, follow-up, or stop; create an issue before deferring valid work.
+
+## Feedback and Watch Loop
+
+Use the normalized feedback projection instead of ad hoc API scraping:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm --silent pr:feedback-state --pr <number> --repo <BASE_REPO> --json
+```
+
+Inspect `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
+`unrepliedRootReviewComments`, `blockingTopLevelBotComments`,
+`topLevelBotComments`, and `findings`. Informational deployment/status bot
+comments are context, not blockers.
+
+Use the shared readiness probe for the final decision:
+
+```bash
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --json
 ```
 
 For a foreground wait, use:
 
 ```bash
-pnpm pr:ready-state --pr <number> --watch --compact
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --watch --compact --until-ready
 ```
 
 Keep a practical one-hour wall-clock deadline unless the user asked for a
@@ -57,39 +95,42 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch the base branch, merge or rebase once according to the
-  repo's current workflow, resolve, run focused validation, commit, and push.
-- Unreplied review comment or unresolved thread: fetch every feedback surface,
-  triage each finding, implement valid fixes, and reply to every comment. In
-  Codex, inspect `pnpm pr:ready-state --pr <number> --json` first as a triage
-  shortcut for the currently reported blockers: its `unresolvedReviewThreads[]`
-  and `unrepliedRootReviewComments[]` entries often include the full comment
-  body, URL, path, line, and id needed to understand the finding before making
-  raw `gh api` calls. This does **not** replace the required full feedback
-  sweep across review comments, review bodies, top-level comments, threads,
-  check annotations, and failing check logs before all-clear. Do not resolve a
-  thread without a reply first. Use these exact reply shapes:
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
+  that remote-tracking ref into the already-published PR branch. Resolve, run
+  focused validation, commit, and push through `HEAD_REMOTE`. Do not rebase a
+  published PR because the resulting force-push violates this workflow.
+- Feedback blocker: triage every normalized finding, implement valid fixes,
+  and sweep review bodies, top-level comments, threads, annotations, and
+  failing logs before all-clear. Reply before resolving a thread, using:
   - Fixed: `Fixed in <commit> — <what changed>`
   - Won't fix: `Won't fix: <technical reason why>`
-- Codex current-head approval missing, stale, or in flight: wait for the
-  automatic current-head review path before taking action. Codex re-reviews new
-  pushes automatically in this repo; do not post `@codex review` as a routine
-  post-push step, and do not treat a `stale` signal immediately after a push as
-  permission to comment again. Never post duplicate requests while the probe
-  says a current-head request is `requested`, `in_flight`, or `approved`. Use
-  one manual request only as a fallback when the current head still has no
-  Codex signal after the normal automatic-review window.
+- Codex approval missing or stale: wait for the automatic current-head review.
+  Never post a duplicate request while state is `requested`, `in_flight`, or
+  `approved`; use one manual request only when the normal automatic-review
+  window ended with no current-head signal.
 
-Never force-push or amend while babysitting.
+Batch sibling findings before pushing. Run the mapped quality gate once for
+each fix batch and `pnpm agent:autoreview` for a non-trivial batch. If two
+review-triggered patch cycles have completed, pause for scope reclassification
+instead of automatically starting a third.
+
+Never force-push or amend while babysitting. If target binding fails, move to a
+clean dedicated checkout and repeat the guard before editing; do not continue
+in the unbound checkout.
 
 ## Final Sweep
 
-Before reporting all-clear, rerun:
+Before reporting all-clear, rerun both projections:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm --silent pr:feedback-state --pr <number> --repo <BASE_REPO> --json
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --json
 ```
 
-Only report all-clear when `ready` is `true` for the current head. Include the
-PR URL, head SHA, required blocker count, unresolved thread count, unreplied
-review-comment count, required-check state, and any optional reviewer lag.
+If an optional review-producing workflow finishes while watching, rerun
+feedback-state to catch late findings. Only report all-clear when the feedback
+ledger has no required blocker and ready-state `ready` is `true` for the
+current head. The Codex approval exception is only the exact head-scoped
+break-glass contract in `docs/notes/pr-ready-state.md`; it waives no other
+gate. Include the PR URL, head SHA, required blocker count, unresolved thread
+count, unreplied review-comment count, required-check state, and optional lag.

--- a/.agents/skills/deploy-indexer/SKILL.md
+++ b/.agents/skills/deploy-indexer/SKILL.md
@@ -5,7 +5,7 @@ title: Deploy Indexer Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-29
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -15,78 +15,129 @@ garden_lane: agent-entry-points
 # Deploy Indexer (end-to-end)
 
 Push a commit to the `envio` branch, watch the build + re-index, verify
-deployment health, promote to prod, wait for the static URL to flip, then
-verify the dashboard.
+deployment health, optionally promote an explicitly authorized production
+deploy, wait for the static URL to flip, then verify the dashboard. Read
+`docs/deployment.md` first; it owns the canonical deploy and rollback policy.
 
-Target commit: `HEAD` of the current working directory. The user's request may
-contain the boolean flags `--no-promote` and/or `--no-verify` (see below); it does NOT
-take a commit SHA — the underlying `pnpm deploy:indexer` script always pushes
-`HEAD`, so to deploy a different commit, check it out first.
+In a normal deploy, the target commit is `HEAD` of the current working
+directory. The user's request may contain `--no-promote`, `--no-verify`, or
+the post-merge continuation `--resume-preload <commit>` (see below). Only that
+continuation accepts a commit SHA: it never pushes, and it finishes the
+existing candidate through Phase 6 unless `--no-verify` explicitly skips the
+browser step. The underlying `pnpm deploy:indexer` script always pushes `HEAD`,
+so check out a different commit before a normal deploy.
 
 ## Why pre-merge deploys exist
 
 The default flow is "merge PR → deploy from main". For an indexer change with
 a fresh schema or new event coverage, the dashboard's new UI starts depending
 on the new schema/data as soon as the matching production dashboard deployment
-serves traffic — but the indexer takes ~30–60 min to build + re-sync from
-`start_block`. During that window the new UI can query the OLD indexer (still
+serves traffic — but a full re-index from `start_block` can outlast the
+dashboard rollout. During that window the new UI can query the old indexer (still
 in `prod`) for fields that don't yet exist, breaking pages until the new
 deployment is promoted.
 
 To avoid that gap, this skill supports **pre-merge deploys** from any branch:
-push a feature branch to `envio` ahead of merging, let the indexer sync to
-caught-up while review is still happening, and the moment the PR lands the
-data is already live. The `envio` branch is just a deploy trigger — it does
-not have to track `main`.
+push a feature branch to `envio` ahead of merging and let it sync while review
+is still happening. After merge it is ready for the verification/promotion
+decision. The `envio` branch is a deploy trigger, not a mirror of `main`.
 
-When deploying pre-merge, you typically want to NOT promote yet (the PR
-isn't merged; the new schema isn't live in the codebase). Pass `--no-promote`
-to stop after sync; verify and promote separately once the PR merges. For
-additive schema/data changes that the new dashboard will consume, promote as
-soon as the PR lands, ideally before the matching dashboard deployment serves traffic. If
-the PR removes or renames GraphQL fields/entities consumed by either the
-currently deployed dashboard or the new dashboard, there is no universally safe
-one-shot timing: require a backward-compatible/two-phase rollout, or an
-explicit coordinated cutover/rollback plan, before promotion.
+When deploying pre-merge, pass `--no-promote`: the reviewed code is not on
+`main` yet. After merge, an additive preloaded deployment may be promoted only
+if its `indexer-envio/` tree still matches protected `main` in
+`mento-protocol/monitoring-monorepo`. Removals or renames require a
+backward-compatible two-phase rollout or an explicit cutover/rollback plan.
 
 ## Phase 0 — Preflight
 
-Run from the **main checkout** or whatever local checkout is on the branch
-you want to deploy. The `pnpm deploy:indexer` script reads `HEAD` of the
-current working directory and pushes that commit to `envio`. If you're in a
-worktree on the feature branch, deploy from there directly — no need to
-switch to the main checkout.
+For a normal deploy, run from the checkout whose `HEAD` you want to push. For a
+resume, use any clean checkout that contains the recorded preload commit; the
+resume validates that candidate against the canonical repository's protected
+`main` and never pushes.
 
 In parallel:
 
-- `git fetch origin` and `git rev-parse --abbrev-ref HEAD` — capture as `BRANCH`. If `BRANCH == "HEAD"` the working tree is detached (the documented `git checkout <sha>` flow); skip the upstream/divergence checks below and instead verify the SHA is reachable from `origin`: `git merge-base --is-ancestor HEAD origin/main || git for-each-ref --contains HEAD refs/remotes/origin/ | grep -q .`. If that fails, the commit was never pushed — surface and stop. If `BRANCH` is a regular branch, run the upstream/divergence checks below; `main` is the common case but feature branches are fine for pre-merge deploys.
+- Parse `--no-promote`, `--no-verify`, and the optional pair
+  `--resume-preload <commit>` into `NO_PROMOTE`, `NO_VERIFY`, and
+  `RESUME_PRELOAD`. Reject every other token and reject combining a resume
+  with `--no-promote`: a resume exists only to finish the post-merge pipeline.
 - `git status --porcelain` — must be empty. A dirty tree means uncommitted work; deploying it would ship a commit that doesn't exist on origin. Surface and stop.
-- (Branch-mode only) Verify the branch tracks an upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` must succeed (and `git ls-remote --exit-code origin "$BRANCH"` must find the remote ref). A local-only branch with no upstream is not a valid deploy source — its `HEAD` was never pushed to `origin`, so the deploy would ship unreproducible code. Surface and stop; tell the user to `git push -u origin <branch>` first.
-- (Branch-mode only) `git rev-list --left-right --count @{upstream}...HEAD` — both counts MUST be `0`. The right count (ahead) catches local commits that would silently ship via `envio` without ever landing on the tracked branch; the left count (behind) catches a stale local checkout that would deploy an outdated commit. If either is non-zero, surface the divergence and stop — the user must `git pull --rebase` (behind) or `git push` (ahead) first.
-- `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — count `data.deployments[]` before pushing. The mento hosted indexer can only keep three live deployments. If three entries already exist, Envio has no room to create another deployment: keep the `prod_status == "prod"` deployment and delete, or ask the user to delete, an obsolete non-prod deployment before pushing a fresh SHA.
-- Parse the user's arguments for the boolean flags `--no-promote` and `--no-verify`; capture as `NO_PROMOTE` and `NO_VERIFY`. Any non-flag token (e.g. a stray SHA) is an error — surface and stop, since the underlying script doesn't accept one.
-- `git rev-parse --short=7 HEAD` — capture as `TARGET_COMMIT`. **Use `--short=7` explicitly**, not bare `--short`: Envio's API stores `commit_hash` truncated to exactly 7 chars, and `startswith(target)` matches on that — an 8-char short SHA (which is what `git rev-parse --short` returns once a repo's `core.abbrev` ticks up past 7) silently matches zero rows in the babysit + promote-verify queries. The deploy always uses `HEAD`; to deploy a different commit, the user must check it out first.
-- If `BRANCH != main`: **default `NO_PROMOTE=true`** (fail-closed), and surface the branch name + commit short sha clearly. Override the default only when the user's request explicitly says "promote" / "go live" / similar — never on a bare `/deploy-indexer` from a feature branch. Even with explicit promote wording, classify the schema rollout first: additive fields/entities can be promoted after merge and before the new dashboard serves traffic; removals/renames consumed by either old or new dashboard code require a backward-compatible/two-phase rollout or an explicit coordinated cutover/rollback plan. The reasoning: pre-merge deploys exist precisely because the dashboard codebase doesn't yet query the new schema; promoting before merge is almost always wrong, so make it explicit-opt-in instead of confirm-to-skip.
+- Resolve `CANONICAL_REMOTE` from `git remote -v`, then verify its repository is
+  exactly `mento-protocol/monitoring-monorepo` before trusting it:
+  ```bash
+  gh repo view "$(git remote get-url "$CANONICAL_REMOTE")" --json nameWithOwner --jq .nameWithOwner
+  git fetch "$CANONICAL_REMOTE" main:refs/remotes/"$CANONICAL_REMOTE"/main
+  ```
+  Capture that fetched ref as `CANONICAL_MAIN_REF`. Stop if no verified remote
+  exists. In normal mode, require `CANONICAL_REMOTE=origin` because the deploy
+  wrapper pushes `origin/envio`; a fork `origin` cannot trigger the canonical
+  Envio deployment.
+- In normal mode, `git rev-parse --abbrev-ref HEAD` supplies `BRANCH`. A
+  detached `HEAD` must be reachable from the canonical repository; a branch
+  must have a canonical remote ref/upstream, and
+  `git rev-list --left-right --count @{upstream}...HEAD` must return `0 0`.
+  Otherwise the source is stale or unreproducible: stop before pushing.
+- In normal mode, query the registry with the pinned `envio-cloud` binary and
+  count `data.deployments[]` before pushing:
+  ```bash
+  pnpm exec envio-cloud indexer get mento mento-protocol -o json
+  ```
+  At the current three-deployment limit, retain prod and remove—or ask the user
+  to remove—an obsolete non-prod deployment before creating another.
+- In normal mode, `git rev-parse HEAD` supplies the full `TARGET_COMMIT`. In
+  resume mode, resolve the supplied commit to a full SHA and compare its
+  `indexer-envio/` tree with the freshly fetched canonical main ref:
+  ```bash
+  git diff --quiet "$TARGET_COMMIT" "$CANONICAL_MAIN_REF" -- indexer-envio
+  ```
+  If the candidate is unavailable or its indexer tree differs, stop and deploy
+  the current `main` commit through the normal full pipeline.
+  Skip Phase 1 in resume mode; Phase 2 must still reconfirm that the registered
+  candidate is caught up before Phase 3.
+- Use `git rev-parse --short=7 "$TARGET_COMMIT"` only as `TARGET_DISPLAY`:
+  seven is a minimum, not a guaranteed output width. The wrappers resolve full
+  SHAs against Envio's stored commit prefix; raw queries must test whether the
+  full SHA starts with the stored prefix, never the reverse.
+- In normal mode, if `BRANCH != main`, default `NO_PROMOTE=true` (fail-closed)
+  and surface the branch plus `TARGET_DISPLAY`. Override only when the user
+  explicitly authorized promotion. A resume also requires explicit production
+  authorization; the flag itself is not approval.
 
-If preflight fails, surface the specific cause and stop. Do not push.
+If preflight fails, surface the specific cause and stop. Do not push. A request
+to monitor, preload, or report readiness never authorizes promotion; only an
+explicit end-to-end production deploy request does.
 
 ### Argument flags
 
 The request MAY contain these flags (in any order):
 
-- `--no-promote` — push + sync, but skip Phase 3 (pre-promote deployment verification), Phase 4 (promote), and everything after. Use for pre-merge deploys where the new schema isn't live in the codebase yet. For additive fields/entities, later run `pnpm deploy:indexer:verify <commit>` and then `pnpm deploy:indexer:promote <commit> -y` once the PR merges, ideally before the matching dashboard deployment serves traffic. For removals/renames, do not promote until a compatibility or cutover plan is confirmed.
-- `--no-verify` — skip Phase 6 browser/UI verification. Use when you want the deploy + DNS wait to complete unattended.
+- `--no-promote` — push + sync, then stop. After merge, an additive preload
+  may proceed only when its `indexer-envio/` tree matches canonical protected
+  `main`;
+  removals/renames still require the approved compatibility or cutover plan.
+- `--no-verify` — skip Phase 6 browser/UI verification. Use when you want the deploy + endpoint-propagation wait to complete unattended.
+- `--resume-preload <commit>` — after merge, reuse an already-synced candidate
+  whose `indexer-envio/` tree exactly matches freshly fetched canonical `main`.
+  Skip the push, reconfirm sync, then execute every remaining gate in Phases
+  3–6. This flag does not itself authorize promotion; the request must
+  explicitly authorize the end-to-end production continuation.
 
-The deployed commit is always the current `HEAD` — there's no SHA argument. To
-deploy a specific older commit, `git checkout <sha>` first, then run the skill.
+Outside `--resume-preload`, the deployed commit is always the current `HEAD`.
+To deploy a specific older commit normally, `git checkout <sha>` first.
 
 Examples:
 
 - `/deploy-indexer` — deploy current `HEAD` (most often `main`), full pipeline through verify.
 - `/deploy-indexer --no-promote` — deploy current branch, sync, stop. The default for most pre-merge feature-branch deploys.
 - `/deploy-indexer --no-promote --no-verify` — pre-merge deploy that runs unattended (e.g. you're stepping away during the build).
+- `/deploy-indexer --resume-preload <commit>` — after merge and explicit
+  production authorization, finish the matching synced candidate through
+  verification, promotion, propagation, and UI verification.
 
 ## Phase 1 — Push to `envio`
+
+For `--resume-preload`, do not run this phase and do not move the `envio`
+branch. Continue at Phase 2 with the resolved preloaded `TARGET_COMMIT`.
 
 ```bash
 pnpm deploy:indexer --yes
@@ -100,16 +151,13 @@ previously. Confirm the push succeeded by checking the script exit code is
 `0`. The push output is one of:
 
 - A ref-update line `<old>..<new>  HEAD -> envio` (fast-forward) or `+ <old>...<new>  HEAD -> envio` (forced update) — a real deploy was scheduled.
-- `Everything up-to-date` with no ref-update line — `envio` already at `HEAD`, the re-run / idempotency case. Still success; the prior deployment in `envio-cloud` is what we're babysitting.
+- `Everything up-to-date` with no ref-update line — the wrapper checks whether
+  Envio already registered this SHA. It continues for a legitimate rerun and
+  exits nonzero with a fresh-SHA retrigger procedure when the webhook missed
+  the unchanged ref.
 
 If the push was rejected (non-zero exit, "rejected", "stale info", "would
 clobber existing tag"), do NOT retry with `--force` — surface and stop.
-
-When the previous `envio` tip was a different branch's commit (e.g. you're
-overwriting a still-syncing prior deploy), the prior deployment continues
-to exist in `envio-cloud` and stays available for promote. The new push just
-schedules a fresh build; nothing destructive happens to the running indexer
-or the deployment record list.
 
 ## Phase 2 — Babysit the build + sync
 
@@ -142,12 +190,6 @@ Use `--compact` for agent runs to emit low-noise one-line progress snapshots
 instead of repainting the full status table every poll. For a human terminal,
 drop `--compact` when the full per-poll table is useful.
 
-**If you must background this** (e.g. you're handing off to a Monitor),
-either (a) re-export the same low ceiling, or (b) checkpoint the output file
-yourself at the 5-min mark — do NOT trust the wrapper's worst-case 10-min
-default to give up "soon enough." Silent 10-min waits look identical to
-"the build is just slow" until they aren't.
-
 If registration succeeds, the wrapper transitions automatically into Phase 2b
 (sync watching). If it fails, stop and follow the diagnostic the wrapper
 already printed: check [the Envio dashboard](https://envio.dev/app/mento-protocol/mento), confirm
@@ -163,7 +205,8 @@ volatile progress changes. Drop `--compact` only when the full per-poll table
 is useful in a human terminal.
 
 Watch sync in the active rollout/session and do not leave a background process
-running when you finish.
+running when you finish. The wrapper has no 90-minute sync timeout; the agent or
+monitor must enforce that wall-clock ceiling and interrupt the watch.
 
 The Envio Cloud deployment id is the short Git commit hash (for example
 `b92ff93b`). Once the deployment is registered, this id stays stable.
@@ -179,41 +222,39 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 pnpm deploy:indexer:perf <TARGET_COMMIT>
 ```
 
+Capture the performance snapshot after sync and before verification so the
+final report has a commit-scoped status/metrics/log record.
+
 Treat a successful caught-up exit as `SYNCED_PENDING_DATA_VERIFY`, not
-`READY_TO_PROMOTE`. If the command exits non-zero, the deployment never
-registers within 5-10 min, or full sync is not reached within 90 minutes, stop
+`READY_TO_PROMOTE`. If the command exits non-zero, the deployment does not
+register within five minutes, or full sync is not reached within 90 minutes, stop
 and surface the failure. **Never promote a non-synced deployment.**
 
 If the target is already in `prod_status=prod`, treat it as `ALREADY_PROMOTED`
-and continue through the DNS wait + verify path for idempotency.
+and continue through the endpoint-propagation wait + verify path for idempotency.
 
-**If `--no-promote` was passed, stop here.** Print a summary listing the
-synced commit and the paste-ready promote command for the user to run later
-(typically right after the PR merges for additive fields/entities; not for
-removals/renames until a compatibility or cutover plan is confirmed):
+**If `--no-promote` was passed, stop here.** Print a summary listing the synced
+commit and the guarded continuation for later use (typically right after the
+PR merges for additive fields/entities; not for removals/renames until a
+compatibility or cutover plan is confirmed):
 
 ```text
 Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and pending deployment verification.
-For additive fields/entities, promote after the PR lands and before the matching dashboard deployment serves traffic:
-  pnpm deploy:indexer:verify <TARGET_COMMIT>
-  pnpm deploy:indexer:promote <TARGET_COMMIT> -y
+For additive fields/entities, continue only after merge with explicit production authorization:
+  /deploy-indexer --resume-preload <TARGET_COMMIT>
+That continuation must confirm indexer-envio tree equality, reconfirm sync, and execute Phases 3-6. Never run the promote wrapper as a shortcut.
 For removals/renames, do not promote until compatibility or a coordinated cutover/rollback plan is confirmed.
 ```
 
-Do NOT continue to Phase 3 / 4 / 5 / 6. The new schema isn't live in the
-dashboard codebase yet, so promoting now would point the static URL at a
-schema the deployed UI may not query correctly. For additions this may be
-mostly pointless; for removals/renames it can break production pages until the
-matching dashboard build is live. It also makes the rollback story muddier.
+Do NOT continue to Phase 3 / 4 / 5 / 6. The reviewed schema is not on `main`.
 
 ## Phase 3 — Verify deployment before promotion
 
 Before any promotion path, classify rollout compatibility against the deployed
 dashboard(s), not just the source branch:
 
-- **Additive fields/entities/data only:** continue. Promote after merge as soon
-  as possible, ideally before the matching production dashboard deployment
-  serves traffic.
+- **Additive fields/entities/data only:** continue after merge; a preloaded
+  candidate must also match the merged `indexer-envio/` tree.
 - **Field/entity removals or renames consumed by old or new dashboard code:**
   stop unless the PR or user request already documents a
   backward-compatible/two-phase rollout, or an explicit coordinated
@@ -228,25 +269,11 @@ Run the narrow deployment verifier before promoting:
 pnpm deploy:indexer:verify <TARGET_COMMIT>
 ```
 
-This batches the Envio deployment status, metrics, endpoint resolution, core
-GraphQL rows, and Polygon replay semantics into one pre-promotion gate. The
-Polygon checks require the canonical three FPMMs, exact feed/expiry mappings,
-positive historical oracle anchors and snapshot cursors, valid health
-counters, and a current one-year EURm/EUROP oracle. Do not promote if this
-command exits non-zero. `--allow-syncing` is for diagnostics only here: it can
-waive an in-progress chain status during investigation, but it never waives
-empty rows or semantic failures and is not a promotion approval.
-
-The verifier reads `indexer-envio/config/replay-integrity.json` from the exact
-deployed commit. Missing or outdated marker versions are a hard failure: later
-healthy-looking rows cannot make a candidate replayed by pre-invariant code
-promotion-compatible.
-
-Any `sortedOracles.exactMedianTimestampUnavailable` failure for a tracked pool
-means the event was deliberately rejected and will retry. If an older candidate
-instead reached head after `[RPC_FAILURE] chainId=137 fn=medianTimestamp`,
-classify it as `TAINTED`; never promote it, and deploy a fresh commit for a
-clean replay.
+This combines status, metrics, endpoint, core-row, and Polygon replay checks.
+Do not promote on any failure. `--allow-syncing` is diagnostic only and never
+waives data or replay-semantic failures. A missing replay marker or tainted
+historical RPC replay requires a fresh deployment; `docs/deployment.md` owns
+the exact verifier contract.
 
 ## Phase 4 — Promote
 
@@ -254,34 +281,22 @@ Before promoting, capture the **current** prod commit so the final summary
 can print a paste-ready rollback command:
 
 ```bash
-PREVIOUS_PROD_COMMIT=$(npx envio-cloud indexer get mento mento-protocol -o json \
-  | jq -r --arg target "<TARGET_COMMIT>" '
+PREVIOUS_PROD_COMMIT=$(pnpm --silent exec envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r --arg full "<TARGET_COMMIT>" '
       [.data.deployments[]
        | select(.prod_status=="prod")
-       | select((.commit_hash | startswith($target)) | not)]
-      | sort_by(.created_time) | reverse | .[0].commit_hash // empty' \
-  | head -c 7)
+       | select(.commit_hash as $stored | ($full | startswith($stored) | not))]
+      | sort_by(.created_time) | reverse | .[0].commit_hash // empty')
 ```
 
-The `sort_by(.created_time) | reverse` step is load-bearing: the
-`envio-cloud` API doesn't guarantee deployment order, so an unsorted
-`head -n1` could pick an older prod entry from a long-ago deploy instead
-of the immediately-prior one. Mirroring what `scripts/deploy-indexer-promote.sh`
-does for "auto-detect latest deployment".
+Sorting avoids API-order assumptions; the reverse prefix test handles Envio's
+truncated ids and excludes the target. If no prior prod is discoverable, report
+that no rollback target was captured instead of guessing.
 
-The `select(... | not)` clause excludes `TARGET_COMMIT` itself, which matters
-on the idempotent re-run path: if you re-run `/deploy-indexer` for a commit
-that's already `prod_status=prod`, the unfiltered query would return the
-same SHA and the final summary's "rollback command" would point at the
-commit just deployed — useless during an incident. Excluding the target
-gives you the previous prod commit, which is what rollback actually needs.
-
-If no prior prod commit exists (first-ever promote, or only the current
-target is in prod), `PREVIOUS_PROD_COMMIT` is empty — the rollback line in
-the final summary then reads "(none — no prior prod deploy, no rollback
-target)".
-
-Then promote:
+Promote only when the request explicitly authorized the end-to-end production
+deploy. Otherwise stop after verification and ask for approval to continue
+this skill through Phases 4–6; do not surface the wrapper as a standalone
+shortcut. Once authorized, run:
 
 ```bash
 pnpm deploy:indexer:promote <TARGET_COMMIT> -y
@@ -292,18 +307,18 @@ passes remaining flags through to `envio-cloud deployment promote`, so `-y`
 reaches the underlying CLI cleanly. Using the wrapper keeps org/indexer
 defaults centralized.
 
-Confirm the response line `Deployment '<commit>' of indexer 'mento' promoted to production successfully.` Then verify with:
+Require a zero wrapper exit, then verify with:
 
 ```bash
-npx envio-cloud indexer get mento mento-protocol -o json \
-  | jq -r '.data.deployments[] | select(.commit_hash | startswith("<TARGET_COMMIT>")) | "prod_status=\(.prod_status)"'
+pnpm --silent exec envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r --arg full "<TARGET_COMMIT>" '.data.deployments[] | select(.commit_hash as $stored | $full | startswith($stored)) | "prod_status=\(.prod_status)"'
 ```
 
 `prod_status=prod` is the success signal.
 
-## Phase 5 — Wait for static URL switchover
+## Phase 5 — Wait for static endpoint propagation
 
-The static GraphQL endpoint (e.g. `https://indexer.hyperindex.xyz/60ff18c/v1/graphql`)
+The static GraphQL endpoint (e.g. `https://indexer.hyperindex.xyz/2f3dd15/v1/graphql`)
 takes ~30 s – a few minutes to flip to the newly promoted deployment. During
 that window the dashboard may transiently query the old schema.
 
@@ -311,11 +326,11 @@ Wait **5 minutes wall-clock**, then proceed. Run a one-shot sleep and wait for
 it to finish before continuing to Phase 6:
 
 ```bash
-sleep 300 && echo "dns-window-elapsed"
+sleep 300 && echo "endpoint-propagation-window-elapsed"
 ```
 
 Until the sleep exits, do NOT start UI verification and do NOT poll the static
-URL. Skipping the DNS-flip window produces flaky verify results, which is
+URL. Skipping the propagation window produces flaky verify results, which is
 exactly the failure mode the wait exists to prevent.
 
 Don't poll the static URL with introspection — Envio's edge cache flips
@@ -348,43 +363,47 @@ user to verify manually.
 - **Performance snapshot:** `pnpm deploy:indexer:perf <TARGET_COMMIT>` captured status/metrics/log highlights
 - **Deployment verify:** `pnpm deploy:indexer:verify <TARGET_COMMIT>` passed before promotion
 - **Promote:** ✅ / ❌ (and `PREVIOUS_PROD_COMMIT` captured in Phase 4, for rollback reference)
-- **DNS wait:** 5 min completed
+- **Endpoint propagation wait:** 5 min completed
 - **UI verify:** pages checked + console errors found (✅ if none)
-- **Rollback command (paste-ready):** `pnpm deploy:indexer:promote <PREVIOUS_PROD_COMMIT> -y` — or "(none — first prod deploy)" if `PREVIOUS_PROD_COMMIT` was empty.
+- **Rollback command (paste-ready):** `pnpm deploy:indexer:rollback <PREVIOUS_PROD_COMMIT>` — or "(none captured)" if `PREVIOUS_PROD_COMMIT` was empty.
 
 ## Failure handling
 
 - **Preflight fails** (dirty tree / wrong branch / unpushed commits) → stop. Do not auto-clean; the user owns that state.
 - **Push to envio fails** → stop; never force-push.
-- **Build doesn't register in 30 min** → stop; suggest `pnpm deploy:indexer:logs --build`.
+- **Build doesn't register in 5 min** → stop; check deployment capacity and
+  the wrapper diagnostic. Do not use unscoped logs as proof of the target
+  build.
 - **Sync stalls past 90 min** → stop; report last status. Don't promote.
 - **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, core rows, and semantic replay checks pass. A tainted historical replay requires a fresh deployment, not another promotion attempt.
 - **Promote fails** → stop; the previous deployment is still serving. Surface the error.
-- **DNS wait interrupted** (user cancels) → stop; do not skip to verify.
+- **Endpoint propagation wait interrupted** (user cancels) → stop; do not skip to verify.
 - **Verify UI finds errors** → surface them with file/line, ask the user whether to roll back. Don't auto-rollback — promote-to-prior is destructive.
 
 ## Idempotency
 
-Re-running `/deploy-indexer` for a commit that's already `prod_status=prod`:
-
-- Preflight will pass.
-- Push is a no-op (envio already at that commit).
-- Babysit returns immediately ("already promoted").
-- Deployment verification still runs against the target deployment.
-- Promote is a no-op (already prod).
-- DNS wait still fires the 5-min sleep.
-- Verify still runs.
-
-That's fine — costs ~5 min and re-confirms the dashboard is live. Do not
-short-circuit; the verification is the value on a re-run.
+For a commit already in prod, the wrapper accepts the registered no-op push and
+the status watch returns immediately. Still run deployment verification, the
+five-minute propagation wait, and UI verification; those checks are the value
+of the rerun.
 
 ## Common pre-merge workflow
 
-1. You're working on a feature branch with additive indexer changes (new schema entity, new event coverage, new field) and dashboard changes that consume them.
-2. Before opening the PR (or while it's in review), run `/deploy-indexer --no-promote` from the feature branch checkout — pushes the branch tip to `envio`, builds, syncs to caught-up. ~30–60 min.
-3. The PR review proceeds normally. The new deployment exists in `envio-cloud` but isn't `prod` yet, so the live dashboard keeps querying the old indexer.
-4. PR merges to `main`. Now run `/deploy-indexer` (without `--no-promote`) from `main` immediately, ideally before the matching production dashboard deployment serves traffic — preflight passes, push is fast (or a no-op if `envio` is already at the commit you're about to push, i.e. SHA-identical to step 2's tip), babysit returns immediately ("already promoted"), deployment verification passes, promote flips `prod`, DNS waits 5 min, browser verification passes. The new schema goes live without the usual 30–60 min indexer-lag window.
-5. The fast path in step 4 only holds when the commit you push from `main` is byte-identical to what was already on `envio`. Squash-merge produces a new SHA, so the prior `envio` tip becomes irrelevant and you eat a fresh build + sync. To preserve commit identity through merge: use a merge commit or rebase-merge for branches that were pre-deployed, OR pre-deploy from the merge-base just before merging so the eventual `main` tip matches.
+1. From a feature branch with additive indexer changes, record
+   `PRELOADED_COMMIT=$(git rev-parse HEAD)` and run
+   `/deploy-indexer --no-promote`.
+2. After the PR merges, resolve and fetch `CANONICAL_MAIN_REF` through the
+   verified canonical remote from Phase 0, then run
+   `git diff --quiet "$PRELOADED_COMMIT" "$CANONICAL_MAIN_REF" -- indexer-envio`.
+3. If the trees match and the user explicitly authorizes the production
+   continuation, run `/deploy-indexer --resume-preload "$PRELOADED_COMMIT"`.
+   It skips only the push, reconfirms sync, then executes Phases 3–6—including
+   prior-prod capture, promotion confirmation, propagation wait, UI verification,
+   and the rollback-ready final summary. Merge, squash, and rebase strategies
+   may all change the Git SHA; tree equality—not SHA identity—is the safety
+   check.
+4. If the trees differ, do not promote the stale preload. Deploy the current
+   `main` commit and wait for its fresh build, sync, and verification.
 
 ## Rules
 
@@ -392,7 +411,8 @@ short-circuit; the verification is the value on a re-run.
 - **Never auto-rollback.** Promote-to-prior is the user's call.
 - **Never bypass the babysit phase** — don't promote based on a single status snapshot.
 - **Never bypass the deployment verifier** — run `pnpm deploy:indexer:verify <TARGET_COMMIT>` after sync and before promote.
-- **Always wait the full 5 min** for DNS switchover before verifying — bypassing produces flaky verify results.
-- **Pass the resolved short SHA explicitly** to status and verification steps — don't rely on "latest", since a concurrent deploy by someone else could shift it.
-- **Don't open a PR** to verify the deploy. This skill is a plumbing chain, not a code-review path. The PR (if any) was merged before this skill ran; the deploy is a separate concern.
+- **Always wait the full 5 min** for static-endpoint propagation before verifying — bypassing produces flaky verify results.
+- **Pass the full target SHA explicitly** to status and verification steps — don't rely on "latest", since a concurrent deploy by someone else could shift it.
+- **Don't open a PR** as part of deployment verification. This skill is a
+  plumbing chain; pre-merge code review remains a separate workflow.
 - **Default to `--no-promote` when deploying from a non-`main` branch** unless the user explicitly asked to promote. Additive feature-branch schema changes should be promoted after merge, ideally before the matching dashboard deployment serves traffic. Removals/renames need a backward-compatible/two-phase rollout or an explicit coordinated cutover/rollback plan. Promoting from the feature branch also creates an ambiguous rollback target.

--- a/.agents/skills/doc-garden/SKILL.md
+++ b/.agents/skills/doc-garden/SKILL.md
@@ -5,7 +5,7 @@ title: Documentation Garden Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90

--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -5,7 +5,7 @@ title: Envio Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
 doc_type: skill
 scope: repo-wide
@@ -28,10 +28,11 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
 
 - Treat this repo as HyperIndex V3-first. Verify the exact installed package with `pnpm --filter @mento-protocol/indexer-envio exec envio --version`; the pinned version in `indexer-envio/package.json` is `envio@3.2.1`.
 - V3 preload optimization is always on. There is no `preload_handlers:` config flag, and loader-era patterns should be translated into normal handler code.
-- V3 handlers run twice: a concurrent preload pass for DB reads/effects, then an ordered processing pass for writes. Do not put expensive `context.effect(...)` calls behind an early `if (context.isPreload) return`; do keep writes out of preload.
-- `indexer-envio/test/code-quality-invariants.test.ts` blocks direct effects that exist only after a positive preload return (including exact `await maybePreloadPool(...)` and `await maybePreloadBreaker(...)` wrappers) or after an earlier entity-dependent return. Start event-derived effects before lookups whose empty result can differ between concurrent preload and ordered processing, then reuse the identical effect + input key across both passes. An effect that must remain processing-only for ordered-state correctness, or is permanently bounded, needs an adjacent call-site `// preload-effect-exempt: <ordered-state or bounded-cardinality reason>` comment. A comment on the preload guard never suppresses direct-effect checks.
-- When code that preload cannot eagerly reach—after an entity-dependent return or a positive preload return—calls a helper that directly or transitively reaches `context.effect`, the invariant derives that boundary from TypeScript symbols. Declare the exact used set with one or more adjacent `// preload-effect-helpers: <helper names>` lines plus a non-empty `// preload-handler-note: <reason>` line. Missing and unused helper declarations both fail. A phase-stable event-derived filter may be declared only when the effect is still awaited during preload; say that explicitly. Never exempt replay-traffic-scaled effects merely for convenience; when preloading would violate sequential semantics, state the exact ordering invariant and track a preload-safe redesign.
-- For an effect that is needed only when preloaded entity state meets a condition, carry an event-scoped in-memory preload marker into processing. If a row appears only during ordered processing, stay fail-closed and defer the RPC until the next event instead of issuing a serialized call.
+- V3 handlers run twice: a concurrent preload pass for reads/effects, then an
+  ordered processing pass for writes. Before changing a handler or RPC effect,
+  read `indexer-envio/AGENTS.md` and
+  `docs/pr-checklists/indexer-handler-invariants.md`; that checklist owns effect
+  ordering, preload markers, exemption syntax, helper declarations, and tests.
 - Prefer the installed CLI help over stale docs when they disagree. In this baseline, `envio metrics`, `envio metrics runtime`, `envio tools search-docs`, and `envio tools fetch-docs` exist; `envio benchmark-summary` does not.
 
 ## Mento repo quick reference
@@ -42,13 +43,14 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
 
 ```bash
 pnpm deploy:indexer [--yes]         # Push HEAD to `envio` → Envio auto-builds
-pnpm deploy:indexer:status [--watch] [--compact] [--json]
+pnpm deploy:indexer:status [<commit>] [--watch] [--compact] [--json]
 pnpm deploy:indexer:metrics [<commit>] [--json]
 pnpm deploy:indexer:info [<commit>]
 pnpm deploy:indexer:perf [<commit>] [--json]
 pnpm deploy:indexer:verify [<commit>] [--prod] [--json]
 pnpm deploy:indexer:promote [<commit>]
-pnpm deploy:indexer:logs [--follow] [--level error] [--build]
+pnpm deploy:indexer:logs [<commit>] [--follow] [--level error] [--build]
+pnpm deploy:indexer:rollback <commit> [--dry-run]
 ```
 
 - Dashboard: <https://envio.dev/app/mento-protocol/mento>
@@ -56,11 +58,18 @@ pnpm deploy:indexer:logs [--follow] [--level error] [--build]
 ## Deployment lifecycle
 
 1. **Push** to the `envio` branch — Envio GitHub App picks it up and starts a build. There is **no** `envio deploy` command.
-2. **Build** produces a new deployment keyed by the short commit hash. A deployment with commit X appears in `envio-cloud indexer get mento mento-protocol` a few minutes after push (expect ~5–15 min). Until then `deployment status` returns **404**. If no new deployment appears and `data.deployments[]` already has three entries, Envio has no room to create another deployment; delete, or ask the user to delete, an obsolete non-prod deployment before retrying with a fresh SHA.
+2. **Build** produces a new deployment keyed by a commit-hash prefix. In this
+   repo registration normally takes 2–3 minutes; the deploy skill warns at
+   three and uses a five-minute ceiling. Until registration, deployment status
+   is unavailable. If `data.deployments[]` already has three entries, delete,
+   or ask the user to delete, an obsolete non-prod deployment before retrying.
 3. **Sync** — the new deployment re-indexes from `start_block`. The previous deployment keeps serving the GraphQL endpoint with zero downtime.
 4. **Promote** — when sync completes, call `deployment promote` to swap `prod_status` to `prod`. Only then does the public GraphQL endpoint point at the new deployment.
 
-Every push triggers a full re-index (event handlers, schema, config.yaml, ABIs, or contract-address changes all invalidate cache). Rollback = `deployment promote <older-commit>`.
+Each new deployment performs a full re-index. Use
+`pnpm deploy:indexer:rollback <last-good-sha> --dry-run` and then the guarded
+rollback wrapper; direct promotion is only its fast path when the old
+deployment is still retained.
 
 ### Static vs per-deployment endpoint URLs
 
@@ -93,43 +102,40 @@ Per-chain fields that matter:
 `latest_processed_block === block_height` is a close proxy but can flicker
 because `block_height` keeps advancing.
 
-Add `--watch-till-synced` to block until all chains hit 100%. Useful in CI or a foreground terminal; for agentic monitoring, poll with `-o json` and parse.
+The repo status wrapper owns blocking agent watches; use raw
+`--watch-till-synced` only outside that workflow.
 
 Progress math for a per-chain % estimate: `(latest_processed_block - start_block) / (block_height - start_block)`.
 
 ## Logs
 
 ```bash
-pnpm deploy:indexer:logs --level error        # last 100 runtime error lines
-pnpm deploy:indexer:logs --build              # build logs (useful when a deploy doesn't register)
-pnpm deploy:indexer:logs --follow             # tail (polls every 10s)
+pnpm deploy:indexer:logs <commit> --level error  # runtime errors
+pnpm deploy:indexer:logs <commit> --build        # registered build logs
+pnpm deploy:indexer:logs <commit> --follow       # tail every 10s
 ```
 
-`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the wrapper passes that flag through unchanged. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
+`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the
+wrapper passes that flag through. `--level` is comma-separated and `--build`
+selects build-time logs. If the target never registers, do not substitute an
+unscoped older deployment's logs; use the registration diagnostic and Envio UI.
 
-## envio-cloud CLI cheat sheet
+## `envio-cloud` CLI
 
 ```bash
-envio-cloud login                                         # GitHub OAuth
-envio-cloud config set-org mento-protocol                 # kubectl-style default context
-envio-cloud config set-indexer mento
-envio-cloud indexer list --org mento-protocol             # public indexers
-envio-cloud indexer get mento mento-protocol -o json      # indexer + deployments[]
-envio-cloud indexer env list mento mento-protocol         # dashboard env vars (ENVIO_-prefixed)
-envio-cloud indexer security                              # IP/domain allowlist
-envio-cloud deployment metrics  mento <commit> mento-protocol   # throughput, error rate
-envio-cloud deployment info     mento <commit> mento-protocol   # cache/DB exposure config
-envio-cloud deployment status   mento <commit> mento-protocol
-envio-cloud deployment endpoint mento <commit> mento-protocol   # GraphQL URL
-envio-cloud deployment logs     mento <commit> mento-protocol
-envio-cloud deployment promote  mento <commit> mento-protocol
-envio-cloud deployment restart  mento <commit> mento-protocol
-envio-cloud deployment delete   mento <commit> mento-protocol
+pnpm exec envio-cloud --help
+pnpm exec envio-cloud indexer get mento mento-protocol -o json
+pnpm exec envio-cloud deployment status mento <commit> mento-protocol -o json
+pnpm exec envio-cloud deployment endpoint mento <commit> mento-protocol
+pnpm exec envio-cloud indexer env list mento mento-protocol
 ```
 
-`envio-cloud indexer env list` can print raw `ENVIO_*` secret values. Run it
-only when you specifically need to inspect hosted env configuration, and never
-paste or quote its output in chat, PRs, logs, or docs.
+Use the workspace-pinned CLI and its current `--help`; `envio-cloud` is still
+pre-1.0. Prefer repo wrappers for deploy, verify, promote, rollback, logs,
+metrics, and info so org/indexer defaults and guards stay centralized.
+`envio-cloud indexer env list` masks values by default. Its `--show-values`
+form reveals raw `ENVIO_*` secrets; run that only when explicitly required and
+never paste or quote the output in chat, PRs, logs, or docs.
 
 For CI, set `ENVIO_GITHUB_TOKEN` to skip interactive login.
 
@@ -177,15 +183,17 @@ Notes:
 - Public docs may lag the installed CLI. In `envio@3.2.1`, `envio metrics` and `envio metrics runtime` exist; `envio benchmark-summary` does not.
 - Watch these generic metrics first: `envio_processing_handler_seconds`, `envio_preload_handler_seconds`, `envio_preload_handler_seconds_total`, `envio_effect_call_seconds_total`, `envio_effect_call_total`, `envio_effect_active_calls`, `envio_effect_queue*`, `envio_storage_load_seconds_total`, `envio_storage_write_seconds`, `envio_fetching_block_range_*`, `envio_progress_events`.
 - Combine Envio metrics with this repo's `INDEXER_PERF=1` logs. The repo profiler adds handler/effect/entity summaries and a derived `hit~` count (`effect requests - effect handler executions`) that helps detect preload/cache reuse.
-- If a handler has `if (context.isPreload) return` before expensive `context.effect(...)` calls, preload optimization is disabled for those calls. The preferred shape is: perform preload DB reads and independent `context.effect(...)` calls first, then return before entity writes. The processing pass should call the same effect key so it reuses preload results.
-- Do not remove every `context.isPreload` guard blindly: storage writes still belong only in the processing pass. The fix is to move bottleneck reads/effects before the guard's return.
+- Apply `docs/pr-checklists/indexer-handler-invariants.md` before moving any
+  effect or preload guard; it distinguishes batchable calls from ordered-state
+  exceptions and owns the required regression coverage.
 
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Hosted deployment cap is three live deployments.** `envio-cloud indexer get mento mento-protocol -o json` shows the full `data.deployments[]` list. If it already contains three entries, a new push can fail to register because Envio has no capacity for another deployment. Keep the `prod_status == "prod"` deployment and remove an obsolete non-prod deployment before retrying.
-- **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
+- **Re-index on every new deployment.** Schema changes, handler edits, ABI
+  bumps, and config tweaks all require replay. Do not promise a fixed duration;
+  monitor the exact commit with the status wrapper.
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).
 - **Celo Sepolia / Monad Testnet may fall back to RPC** instead of HyperSync. Slower but works; set `ENVIO_API_TOKEN` for HyperRPC access on testnets.
@@ -197,16 +205,31 @@ Notes:
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
+- Development-plan retention and quota rules change independently of this
+  repo. Check Envio's current hosted deployment/billing pages instead of
+  copying those limits into an operational answer.
 
 ## Monitoring playbook (agentic)
 
 When asked to "monitor the latest deployment until ready to promote":
 
 1. `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — required to surface `deployments[]` + `prod_status`. Filter for the newest entry where `prod_status !== "prod"`. (`pnpm deploy:indexer:info <commit>` is the wrapper for inspecting a specific known commit, not for the "find newest pending" step.) If no pending deployment exists, count `deployments[]` first: three live entries means Envio has no room for a new deployment and you must delete, or ask the user to delete, an obsolete non-prod deployment before retrying. If fewer than three deployments exist, cross-check `git rev-parse origin/envio` — if the branch HEAD commit has no deployment record, the build is still pending (or failed → check `--build` logs).
-2. Poll `deployment status <commit> -o json` every 5–15 min (Envio builds finish fast, syncs take minutes–hours).
+2. Run `pnpm deploy:indexer:status <commit> --watch --compact`; the wrapper
+   owns registration diagnostics and polling. Enforce the separate sync
+   deadline in the active agent/monitor.
 3. Caught-up condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`; classify this as `SYNCED_PENDING_DATA_VERIFY`.
 4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, core rows, and Polygon replay semantics before promotion. Polygon semantic failures are never waived by `--allow-syncing`.
-5. Only a passing verifier transitions the candidate to `READY_TO_PROMOTE`. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
+5. A passing verifier yields `VERIFIED_PENDING_PROMOTION`, not permission to
+   run the promote wrapper by itself. If this monitor belongs to an active
+   `/deploy-indexer` run, return control to Phase 4 so it captures prior prod
+   and completes promotion, propagation, and UI verification after explicit
+   authorization.
+6. Otherwise treat the candidate's provenance as unclassified. With explicit
+   production authorization, route it through
+   `/deploy-indexer --resume-preload <commit>`; that guarded continuation binds
+   protected main to the canonical repository, checks tree equality, reconfirms
+   sync, and executes Phases 3–6. Never suggest a bare
+   `pnpm deploy:indexer:promote` command as monitor closeout.
 
 ## Useful links
 

--- a/.claude/commands/babysit-indexer-deploy.md
+++ b/.claude/commands/babysit-indexer-deploy.md
@@ -1,6 +1,9 @@
 # Babysit Indexer Deploy
 
-Monitor an in-flight Envio HyperIndex deployment for `mento-protocol/mento` until every chain is caught up, then prompt the user to verify it before promotion. Never auto-promote.
+Monitor an in-flight Envio HyperIndex deployment for `mento-protocol/mento`
+until every chain is caught up, then hand the exact commit to the guarded
+verification/promotion workflow. Never auto-promote or offer the bare promote
+wrapper as closeout.
 
 Target commit: `$1` (default: derive from `git fetch origin envio && git rev-parse --short origin/envio`)
 
@@ -108,7 +111,7 @@ while true; do
     emit "REGISTERED prod_status=$PROD_STATUS elapsed=$(elapsed_min)m"
     REGISTERED=1
     if [[ "$PROD_STATUS" == "prod" ]]; then
-      emit "ALREADY_PROMOTED commit=$TARGET — re-run case, no further action needed"
+      emit "ALREADY_PROMOTED commit=$TARGET — promotion is complete; full deploy closeout still owns propagation and UI verification"
       exit 0
     fi
   fi
@@ -127,17 +130,18 @@ while true; do
   # `(.data | length) > 0 and (... | all)` guards against the vacuous-truth
   # case: `[.data[]? | …] | all` returns true on an empty array, so a
   # `data: []` response (e.g. before any chain row is created) would
-  # otherwise emit a false READY_TO_PROMOTE.
+  # otherwise emit a false SYNCED_PENDING_DATA_VERIFY.
   ALL_CAUGHT_UP=$(echo "$STATUS_JSON" | jq -r \
     '(.data | length) > 0 and ([.data[] | (.timestamp_caught_up_to_head_or_endblock // "") != ""] | all)' 2>/dev/null)
 
   if [[ "$ALL_CAUGHT_UP" == "true" ]]; then
     PER_CHAIN=$(echo "$STATUS_JSON" | jq -r \
       '.data[]? | "  \(.network // .chain_id): caught_up=\(.timestamp_caught_up_to_head_or_endblock)"')
-    emit "READY_TO_PROMOTE elapsed=$(elapsed_min)m commit=$TARGET"
+    emit "SYNCED_PENDING_DATA_VERIFY elapsed=$(elapsed_min)m commit=$TARGET"
     emit "$PER_CHAIN"
     emit "Run: pnpm deploy:indexer:verify $TARGET"
-    emit "Then: pnpm deploy:indexer:promote $TARGET -y"
+    emit "Then: return to /deploy-indexer Phase 4, or use /deploy-indexer --resume-preload $TARGET for an unclassified/preloaded candidate after explicit production authorization"
+    emit "Never run pnpm deploy:indexer:promote as a standalone monitor shortcut"
     exit 0
   fi
 
@@ -147,16 +151,16 @@ done
 
 ### Emit policy
 
-| Event                                             | Emit                                                                   |
-| ------------------------------------------------- | ---------------------------------------------------------------------- |
-| Deployment first registers                        | `REGISTERED prod_status=<status> elapsed=<m>m`                         |
-| Found `prod_status: "prod"` (re-run / idempotent) | `ALREADY_PROMOTED commit=<sha>` then `exit 0`                          |
-| All chains caught up                              | `READY_TO_PROMOTE elapsed=<m>m commit=<sha>` + per-chain timestamps    |
-| Build not registered after 30 min                 | `BUILD_FAILED elapsed=30m+` then `exit 1`                              |
-| Sync not all-caught-up after 90 min               | `SYNC_DEADLINE elapsed=90m` + last snapshot then `exit 1`              |
-| Auth-expired / network failure                    | `ERROR auth_or_network: <msg>` (debounced — only emits on kind change) |
-| Status fetch failure                              | `ERROR status_fetch: <msg>` (debounced)                                |
-| All other progress (per-chain blocks ticking up)  | silent — internal poll only                                            |
+| Event                                             | Emit                                                                          |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Deployment first registers                        | `REGISTERED prod_status=<status> elapsed=<m>m`                                |
+| Found `prod_status: "prod"` (re-run / idempotent) | `ALREADY_PROMOTED commit=<sha>` then `exit 0`                                 |
+| All chains caught up                              | `SYNCED_PENDING_DATA_VERIFY elapsed=<m>m commit=<sha>` + per-chain timestamps |
+| Build not registered after 30 min                 | `BUILD_FAILED elapsed=30m+` then `exit 1`                                     |
+| Sync not all-caught-up after 90 min               | `SYNC_DEADLINE elapsed=90m` + last snapshot then `exit 1`                     |
+| Auth-expired / network failure                    | `ERROR auth_or_network: <msg>` (debounced — only emits on kind change)        |
+| Status fetch failure                              | `ERROR status_fetch: <msg>` (debounced)                                       |
+| All other progress (per-chain blocks ticking up)  | silent — internal poll only                                                   |
 
 The emit-on-error rule preserves the visibility the cron version got implicitly from "the next cycle's network/auth failure surfaces loudly". Without it, a stuck Monitor with expired auth would sit silent until the wall-clock deadline. Kind-debouncing prevents a flapping outage from flooding the chat.
 
@@ -168,10 +172,14 @@ Each emit is either **terminal** (the script exits after emitting) or **transien
 
 **Terminal emits** — the calling skill treats these as the final result:
 
-- `READY_TO_PROMOTE` → success; run deployment verification, surface the
-  paste-ready promote command, and wait for explicit user approval. Never
-  promote from this monitor-only command.
-- `ALREADY_PROMOTED` → success; report that no promotion action remains.
+- `SYNCED_PENDING_DATA_VERIFY` → success; run deployment verification, then
+  return to the active `/deploy-indexer` pipeline. If provenance is not already
+  bound to that pipeline, use its guarded `--resume-preload <commit>` path after
+  explicit production authorization. Never surface or run a bare promote
+  command from this monitor-only command.
+- `ALREADY_PROMOTED` → success; report that no promotion action remains, but
+  preserve propagation/UI verification when this is part of full deploy
+  closeout.
 - `BUILD_FAILED` / `SYNC_DEADLINE` → failure; stop without promoting.
 
 **Transient emits** — the script keeps polling after these; the calling skill should NOT stop on them:
@@ -183,7 +191,10 @@ The Monitor process exits cleanly on terminal events — no `TaskStop` needed. C
 
 ## Rules
 
-- **Never auto-promote.** Surface `pnpm deploy:indexer:verify <commit>` first, then `pnpm deploy:indexer:promote <commit>` only after verification passes — the user runs promotion, not you.
+- **Never auto-promote or hand off a bare promote command.** Run
+  `pnpm deploy:indexer:verify <commit>`, then return to the active
+  `/deploy-indexer` pipeline or its guarded `--resume-preload` continuation;
+  explicit production authorization is still required.
 - **Prefer the `pnpm deploy:indexer:*` wrappers** over raw `envio-cloud` calls (they handle auth + repo defaults), with two exceptions:
   - `indexer get` — no wrapper exists.
   - `deployment status <commit>` — wrapper auto-resolves _latest_ (we want explicit commit targeting).
@@ -196,9 +207,14 @@ The Monitor process exits cleanly on terminal events — no `TaskStop` needed. C
 
 Callers (notably the `deploy-indexer` skill, Phase 2) invoke this command with a target commit string and treat the Monitor's terminal emit as the result:
 
-- `READY_TO_PROMOTE` / `ALREADY_PROMOTED` → success, continue to deployment verification before promotion
+- `SYNCED_PENDING_DATA_VERIFY` → success; continue to deployment verification,
+  then the guarded full deploy continuation before promotion
+- `ALREADY_PROMOTED` → success; preserve full deploy propagation/UI closeout
 - `BUILD_FAILED` / `SYNC_DEADLINE` → failure, stop, do not promote
 - User-cancelled (`TaskStop`) → stop, do not promote
 - `ERROR <kind>` is **non-terminal** — keep waiting; the Monitor will continue polling. A stuck error eventually escalates via the wall-clock deadline checks above.
 
-The terminal-emit names (`READY_TO_PROMOTE`, `ALREADY_PROMOTED`, `BUILD_FAILED`, `SYNC_DEADLINE`) replace the previous cron-based version's prose returns (`"ready to promote"`, etc.) — `deploy-indexer` Phase 2 needs to map to the new names.
+The terminal-emit names (`SYNCED_PENDING_DATA_VERIFY`, `ALREADY_PROMOTED`,
+`BUILD_FAILED`, `SYNC_DEADLINE`) replace the previous cron-based prose returns.
+`deploy-indexer` Phase 2 maps caught-up state to verification—not direct
+promotion.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-28
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -20,27 +20,65 @@ repo command, not a hand-rolled interpretation of green checks.
 
 ## Resolve Target
 
-If no PR number is provided, resolve the current branch PR:
+If no PR number is provided, resolve the current branch PR. For every target,
+capture the PR URL, head repository, branch, and commit:
 
 ```bash
-gh pr view --json number,url,title,headRefName,baseRefName
+gh pr view --json number,url,title,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,isCrossRepository
 ```
 
-For an explicit target, accept a bare number or PR URL. Use `--repo` only when
-the PR is not in `mento-protocol/monitoring-monorepo`.
+For an explicit target, accept a bare number or PR URL. Derive and preserve
+`BASE_REPO` (`owner/name`) from the resolved PR URL before changing checkouts.
+After that initial resolution, pass `--repo <BASE_REPO>` to every `gh pr view`,
+feedback-state, and ready-state call—even when the PR began in the current
+repository.
 
-## Watch Loop
+Before any blocker fix mutates files or Git history, bind the checkout to that
+resolved target:
 
-Run the shared probe:
+- Select `HEAD_REMOTE` only after verifying that its repository equals
+  `headRepository.nameWithOwner`. For a cross-repository PR, use a dedicated
+  checkout with the fork as `HEAD_REMOTE`; keep a separately verified
+  `BASE_REMOTE` for `BASE_REPO` and never swap their roles.
+- `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
+  the resolved `headRefOid`. If either differs, stop or switch to a clean,
+  dedicated checkout at the PR head before editing.
+- Preserve `BASE_REPO`, `BASE_REMOTE`, `HEAD_REMOTE`, and `headRefName` for the
+  full session. Fetch `baseRefName` only from `BASE_REMOTE`.
+
+After each fix commit, push explicitly with `git push <HEAD_REMOTE>
+HEAD:<headRefName>`, re-resolve with `gh pr view <number> --repo <BASE_REPO>`,
+and require the new `headRefOid` to equal local `HEAD` before returning to the
+watch loop. Never rely on the current branch name, implicit push target, or
+repository inferred from the active checkout.
+
+Before the first review pass, freeze the request, target/owner, changed files,
+and non-test changed-line count as the scope baseline. Classify later additions
+as in-scope, follow-up, or stop; create an issue before deferring valid work.
+
+## Feedback and Watch Loop
+
+Use the normalized feedback projection instead of ad hoc API scraping:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm --silent pr:feedback-state --pr <number> --repo <BASE_REPO> --json
+```
+
+Inspect `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
+`unrepliedRootReviewComments`, `blockingTopLevelBotComments`,
+`topLevelBotComments`, and `findings`. Informational deployment/status bot
+comments are context, not blockers.
+
+Use the shared readiness probe for the final decision:
+
+```bash
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --json
 ```
 
 For a foreground wait, use:
 
 ```bash
-pnpm pr:ready-state --pr <number> --watch --compact
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --watch --compact --until-ready
 ```
 
 Keep a practical one-hour wall-clock deadline unless the user asked for a
@@ -57,39 +95,42 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch the base branch, merge or rebase once according to the
-  repo's current workflow, resolve, run focused validation, commit, and push.
-- Unreplied review comment or unresolved thread: fetch every feedback surface,
-  triage each finding, implement valid fixes, and reply to every comment. In
-  Codex, inspect `pnpm pr:ready-state --pr <number> --json` first as a triage
-  shortcut for the currently reported blockers: its `unresolvedReviewThreads[]`
-  and `unrepliedRootReviewComments[]` entries often include the full comment
-  body, URL, path, line, and id needed to understand the finding before making
-  raw `gh api` calls. This does **not** replace the required full feedback
-  sweep across review comments, review bodies, top-level comments, threads,
-  check annotations, and failing check logs before all-clear. Do not resolve a
-  thread without a reply first. Use these exact reply shapes:
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
+  that remote-tracking ref into the already-published PR branch. Resolve, run
+  focused validation, commit, and push through `HEAD_REMOTE`. Do not rebase a
+  published PR because the resulting force-push violates this workflow.
+- Feedback blocker: triage every normalized finding, implement valid fixes,
+  and sweep review bodies, top-level comments, threads, annotations, and
+  failing logs before all-clear. Reply before resolving a thread, using:
   - Fixed: `Fixed in <commit> — <what changed>`
   - Won't fix: `Won't fix: <technical reason why>`
-- Codex current-head approval missing, stale, or in flight: wait for the
-  automatic current-head review path before taking action. Codex re-reviews new
-  pushes automatically in this repo; do not post `@codex review` as a routine
-  post-push step, and do not treat a `stale` signal immediately after a push as
-  permission to comment again. Never post duplicate requests while the probe
-  says a current-head request is `requested`, `in_flight`, or `approved`. Use
-  one manual request only as a fallback when the current head still has no
-  Codex signal after the normal automatic-review window.
+- Codex approval missing or stale: wait for the automatic current-head review.
+  Never post a duplicate request while state is `requested`, `in_flight`, or
+  `approved`; use one manual request only when the normal automatic-review
+  window ended with no current-head signal.
 
-Never force-push or amend while babysitting.
+Batch sibling findings before pushing. Run the mapped quality gate once for
+each fix batch and `pnpm agent:autoreview` for a non-trivial batch. If two
+review-triggered patch cycles have completed, pause for scope reclassification
+instead of automatically starting a third.
+
+Never force-push or amend while babysitting. If target binding fails, move to a
+clean dedicated checkout and repeat the guard before editing; do not continue
+in the unbound checkout.
 
 ## Final Sweep
 
-Before reporting all-clear, rerun:
+Before reporting all-clear, rerun both projections:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm --silent pr:feedback-state --pr <number> --repo <BASE_REPO> --json
+pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --json
 ```
 
-Only report all-clear when `ready` is `true` for the current head. Include the
-PR URL, head SHA, required blocker count, unresolved thread count, unreplied
-review-comment count, required-check state, and any optional reviewer lag.
+If an optional review-producing workflow finishes while watching, rerun
+feedback-state to catch late findings. Only report all-clear when the feedback
+ledger has no required blocker and ready-state `ready` is `true` for the
+current head. The Codex approval exception is only the exact head-scoped
+break-glass contract in `docs/notes/pr-ready-state.md`; it waives no other
+gate. Include the PR URL, head SHA, required blocker count, unresolved thread
+count, unreplied review-comment count, required-check state, and optional lag.

--- a/.claude/skills/deploy-indexer/SKILL.md
+++ b/.claude/skills/deploy-indexer/SKILL.md
@@ -5,7 +5,7 @@ title: Deploy Indexer Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-29
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -15,78 +15,129 @@ garden_lane: agent-entry-points
 # Deploy Indexer (end-to-end)
 
 Push a commit to the `envio` branch, watch the build + re-index, verify
-deployment health, promote to prod, wait for the static URL to flip, then
-verify the dashboard.
+deployment health, optionally promote an explicitly authorized production
+deploy, wait for the static URL to flip, then verify the dashboard. Read
+`docs/deployment.md` first; it owns the canonical deploy and rollback policy.
 
-Target commit: `HEAD` of the current working directory. The user's request may
-contain the boolean flags `--no-promote` and/or `--no-verify` (see below); it does NOT
-take a commit SHA — the underlying `pnpm deploy:indexer` script always pushes
-`HEAD`, so to deploy a different commit, check it out first.
+In a normal deploy, the target commit is `HEAD` of the current working
+directory. The user's request may contain `--no-promote`, `--no-verify`, or
+the post-merge continuation `--resume-preload <commit>` (see below). Only that
+continuation accepts a commit SHA: it never pushes, and it finishes the
+existing candidate through Phase 6 unless `--no-verify` explicitly skips the
+browser step. The underlying `pnpm deploy:indexer` script always pushes `HEAD`,
+so check out a different commit before a normal deploy.
 
 ## Why pre-merge deploys exist
 
 The default flow is "merge PR → deploy from main". For an indexer change with
 a fresh schema or new event coverage, the dashboard's new UI starts depending
 on the new schema/data as soon as the matching production dashboard deployment
-serves traffic — but the indexer takes ~30–60 min to build + re-sync from
-`start_block`. During that window the new UI can query the OLD indexer (still
+serves traffic — but a full re-index from `start_block` can outlast the
+dashboard rollout. During that window the new UI can query the old indexer (still
 in `prod`) for fields that don't yet exist, breaking pages until the new
 deployment is promoted.
 
 To avoid that gap, this skill supports **pre-merge deploys** from any branch:
-push a feature branch to `envio` ahead of merging, let the indexer sync to
-caught-up while review is still happening, and the moment the PR lands the
-data is already live. The `envio` branch is just a deploy trigger — it does
-not have to track `main`.
+push a feature branch to `envio` ahead of merging and let it sync while review
+is still happening. After merge it is ready for the verification/promotion
+decision. The `envio` branch is a deploy trigger, not a mirror of `main`.
 
-When deploying pre-merge, you typically want to NOT promote yet (the PR
-isn't merged; the new schema isn't live in the codebase). Pass `--no-promote`
-to stop after sync; verify and promote separately once the PR merges. For
-additive schema/data changes that the new dashboard will consume, promote as
-soon as the PR lands, ideally before the matching dashboard deployment serves traffic. If
-the PR removes or renames GraphQL fields/entities consumed by either the
-currently deployed dashboard or the new dashboard, there is no universally safe
-one-shot timing: require a backward-compatible/two-phase rollout, or an
-explicit coordinated cutover/rollback plan, before promotion.
+When deploying pre-merge, pass `--no-promote`: the reviewed code is not on
+`main` yet. After merge, an additive preloaded deployment may be promoted only
+if its `indexer-envio/` tree still matches protected `main` in
+`mento-protocol/monitoring-monorepo`. Removals or renames require a
+backward-compatible two-phase rollout or an explicit cutover/rollback plan.
 
 ## Phase 0 — Preflight
 
-Run from the **main checkout** or whatever local checkout is on the branch
-you want to deploy. The `pnpm deploy:indexer` script reads `HEAD` of the
-current working directory and pushes that commit to `envio`. If you're in a
-worktree on the feature branch, deploy from there directly — no need to
-switch to the main checkout.
+For a normal deploy, run from the checkout whose `HEAD` you want to push. For a
+resume, use any clean checkout that contains the recorded preload commit; the
+resume validates that candidate against the canonical repository's protected
+`main` and never pushes.
 
 In parallel:
 
-- `git fetch origin` and `git rev-parse --abbrev-ref HEAD` — capture as `BRANCH`. If `BRANCH == "HEAD"` the working tree is detached (the documented `git checkout <sha>` flow); skip the upstream/divergence checks below and instead verify the SHA is reachable from `origin`: `git merge-base --is-ancestor HEAD origin/main || git for-each-ref --contains HEAD refs/remotes/origin/ | grep -q .`. If that fails, the commit was never pushed — surface and stop. If `BRANCH` is a regular branch, run the upstream/divergence checks below; `main` is the common case but feature branches are fine for pre-merge deploys.
+- Parse `--no-promote`, `--no-verify`, and the optional pair
+  `--resume-preload <commit>` into `NO_PROMOTE`, `NO_VERIFY`, and
+  `RESUME_PRELOAD`. Reject every other token and reject combining a resume
+  with `--no-promote`: a resume exists only to finish the post-merge pipeline.
 - `git status --porcelain` — must be empty. A dirty tree means uncommitted work; deploying it would ship a commit that doesn't exist on origin. Surface and stop.
-- (Branch-mode only) Verify the branch tracks an upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` must succeed (and `git ls-remote --exit-code origin "$BRANCH"` must find the remote ref). A local-only branch with no upstream is not a valid deploy source — its `HEAD` was never pushed to `origin`, so the deploy would ship unreproducible code. Surface and stop; tell the user to `git push -u origin <branch>` first.
-- (Branch-mode only) `git rev-list --left-right --count @{upstream}...HEAD` — both counts MUST be `0`. The right count (ahead) catches local commits that would silently ship via `envio` without ever landing on the tracked branch; the left count (behind) catches a stale local checkout that would deploy an outdated commit. If either is non-zero, surface the divergence and stop — the user must `git pull --rebase` (behind) or `git push` (ahead) first.
-- `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — count `data.deployments[]` before pushing. The mento hosted indexer can only keep three live deployments. If three entries already exist, Envio has no room to create another deployment: keep the `prod_status == "prod"` deployment and delete, or ask the user to delete, an obsolete non-prod deployment before pushing a fresh SHA.
-- Parse the user's arguments for the boolean flags `--no-promote` and `--no-verify`; capture as `NO_PROMOTE` and `NO_VERIFY`. Any non-flag token (e.g. a stray SHA) is an error — surface and stop, since the underlying script doesn't accept one.
-- `git rev-parse --short=7 HEAD` — capture as `TARGET_COMMIT`. **Use `--short=7` explicitly**, not bare `--short`: Envio's API stores `commit_hash` truncated to exactly 7 chars, and `startswith(target)` matches on that — an 8-char short SHA (which is what `git rev-parse --short` returns once a repo's `core.abbrev` ticks up past 7) silently matches zero rows in the babysit + promote-verify queries. The deploy always uses `HEAD`; to deploy a different commit, the user must check it out first.
-- If `BRANCH != main`: **default `NO_PROMOTE=true`** (fail-closed), and surface the branch name + commit short sha clearly. Override the default only when the user's request explicitly says "promote" / "go live" / similar — never on a bare `/deploy-indexer` from a feature branch. Even with explicit promote wording, classify the schema rollout first: additive fields/entities can be promoted after merge and before the new dashboard serves traffic; removals/renames consumed by either old or new dashboard code require a backward-compatible/two-phase rollout or an explicit coordinated cutover/rollback plan. The reasoning: pre-merge deploys exist precisely because the dashboard codebase doesn't yet query the new schema; promoting before merge is almost always wrong, so make it explicit-opt-in instead of confirm-to-skip.
+- Resolve `CANONICAL_REMOTE` from `git remote -v`, then verify its repository is
+  exactly `mento-protocol/monitoring-monorepo` before trusting it:
+  ```bash
+  gh repo view "$(git remote get-url "$CANONICAL_REMOTE")" --json nameWithOwner --jq .nameWithOwner
+  git fetch "$CANONICAL_REMOTE" main:refs/remotes/"$CANONICAL_REMOTE"/main
+  ```
+  Capture that fetched ref as `CANONICAL_MAIN_REF`. Stop if no verified remote
+  exists. In normal mode, require `CANONICAL_REMOTE=origin` because the deploy
+  wrapper pushes `origin/envio`; a fork `origin` cannot trigger the canonical
+  Envio deployment.
+- In normal mode, `git rev-parse --abbrev-ref HEAD` supplies `BRANCH`. A
+  detached `HEAD` must be reachable from the canonical repository; a branch
+  must have a canonical remote ref/upstream, and
+  `git rev-list --left-right --count @{upstream}...HEAD` must return `0 0`.
+  Otherwise the source is stale or unreproducible: stop before pushing.
+- In normal mode, query the registry with the pinned `envio-cloud` binary and
+  count `data.deployments[]` before pushing:
+  ```bash
+  pnpm exec envio-cloud indexer get mento mento-protocol -o json
+  ```
+  At the current three-deployment limit, retain prod and remove—or ask the user
+  to remove—an obsolete non-prod deployment before creating another.
+- In normal mode, `git rev-parse HEAD` supplies the full `TARGET_COMMIT`. In
+  resume mode, resolve the supplied commit to a full SHA and compare its
+  `indexer-envio/` tree with the freshly fetched canonical main ref:
+  ```bash
+  git diff --quiet "$TARGET_COMMIT" "$CANONICAL_MAIN_REF" -- indexer-envio
+  ```
+  If the candidate is unavailable or its indexer tree differs, stop and deploy
+  the current `main` commit through the normal full pipeline.
+  Skip Phase 1 in resume mode; Phase 2 must still reconfirm that the registered
+  candidate is caught up before Phase 3.
+- Use `git rev-parse --short=7 "$TARGET_COMMIT"` only as `TARGET_DISPLAY`:
+  seven is a minimum, not a guaranteed output width. The wrappers resolve full
+  SHAs against Envio's stored commit prefix; raw queries must test whether the
+  full SHA starts with the stored prefix, never the reverse.
+- In normal mode, if `BRANCH != main`, default `NO_PROMOTE=true` (fail-closed)
+  and surface the branch plus `TARGET_DISPLAY`. Override only when the user
+  explicitly authorized promotion. A resume also requires explicit production
+  authorization; the flag itself is not approval.
 
-If preflight fails, surface the specific cause and stop. Do not push.
+If preflight fails, surface the specific cause and stop. Do not push. A request
+to monitor, preload, or report readiness never authorizes promotion; only an
+explicit end-to-end production deploy request does.
 
 ### Argument flags
 
 The request MAY contain these flags (in any order):
 
-- `--no-promote` — push + sync, but skip Phase 3 (pre-promote deployment verification), Phase 4 (promote), and everything after. Use for pre-merge deploys where the new schema isn't live in the codebase yet. For additive fields/entities, later run `pnpm deploy:indexer:verify <commit>` and then `pnpm deploy:indexer:promote <commit> -y` once the PR merges, ideally before the matching dashboard deployment serves traffic. For removals/renames, do not promote until a compatibility or cutover plan is confirmed.
-- `--no-verify` — skip Phase 6 browser/UI verification. Use when you want the deploy + DNS wait to complete unattended.
+- `--no-promote` — push + sync, then stop. After merge, an additive preload
+  may proceed only when its `indexer-envio/` tree matches canonical protected
+  `main`;
+  removals/renames still require the approved compatibility or cutover plan.
+- `--no-verify` — skip Phase 6 browser/UI verification. Use when you want the deploy + endpoint-propagation wait to complete unattended.
+- `--resume-preload <commit>` — after merge, reuse an already-synced candidate
+  whose `indexer-envio/` tree exactly matches freshly fetched canonical `main`.
+  Skip the push, reconfirm sync, then execute every remaining gate in Phases
+  3–6. This flag does not itself authorize promotion; the request must
+  explicitly authorize the end-to-end production continuation.
 
-The deployed commit is always the current `HEAD` — there's no SHA argument. To
-deploy a specific older commit, `git checkout <sha>` first, then run the skill.
+Outside `--resume-preload`, the deployed commit is always the current `HEAD`.
+To deploy a specific older commit normally, `git checkout <sha>` first.
 
 Examples:
 
 - `/deploy-indexer` — deploy current `HEAD` (most often `main`), full pipeline through verify.
 - `/deploy-indexer --no-promote` — deploy current branch, sync, stop. The default for most pre-merge feature-branch deploys.
 - `/deploy-indexer --no-promote --no-verify` — pre-merge deploy that runs unattended (e.g. you're stepping away during the build).
+- `/deploy-indexer --resume-preload <commit>` — after merge and explicit
+  production authorization, finish the matching synced candidate through
+  verification, promotion, propagation, and UI verification.
 
 ## Phase 1 — Push to `envio`
+
+For `--resume-preload`, do not run this phase and do not move the `envio`
+branch. Continue at Phase 2 with the resolved preloaded `TARGET_COMMIT`.
 
 ```bash
 pnpm deploy:indexer --yes
@@ -100,16 +151,13 @@ previously. Confirm the push succeeded by checking the script exit code is
 `0`. The push output is one of:
 
 - A ref-update line `<old>..<new>  HEAD -> envio` (fast-forward) or `+ <old>...<new>  HEAD -> envio` (forced update) — a real deploy was scheduled.
-- `Everything up-to-date` with no ref-update line — `envio` already at `HEAD`, the re-run / idempotency case. Still success; the prior deployment in `envio-cloud` is what we're babysitting.
+- `Everything up-to-date` with no ref-update line — the wrapper checks whether
+  Envio already registered this SHA. It continues for a legitimate rerun and
+  exits nonzero with a fresh-SHA retrigger procedure when the webhook missed
+  the unchanged ref.
 
 If the push was rejected (non-zero exit, "rejected", "stale info", "would
 clobber existing tag"), do NOT retry with `--force` — surface and stop.
-
-When the previous `envio` tip was a different branch's commit (e.g. you're
-overwriting a still-syncing prior deploy), the prior deployment continues
-to exist in `envio-cloud` and stays available for promote. The new push just
-schedules a fresh build; nothing destructive happens to the running indexer
-or the deployment record list.
 
 ## Phase 2 — Babysit the build + sync
 
@@ -142,12 +190,6 @@ Use `--compact` for agent runs to emit low-noise one-line progress snapshots
 instead of repainting the full status table every poll. For a human terminal,
 drop `--compact` when the full per-poll table is useful.
 
-**If you must background this** (e.g. you're handing off to a Monitor),
-either (a) re-export the same low ceiling, or (b) checkpoint the output file
-yourself at the 5-min mark — do NOT trust the wrapper's worst-case 10-min
-default to give up "soon enough." Silent 10-min waits look identical to
-"the build is just slow" until they aren't.
-
 If registration succeeds, the wrapper transitions automatically into Phase 2b
 (sync watching). If it fails, stop and follow the diagnostic the wrapper
 already printed: check [the Envio dashboard](https://envio.dev/app/mento-protocol/mento), confirm
@@ -163,7 +205,8 @@ volatile progress changes. Drop `--compact` only when the full per-poll table
 is useful in a human terminal.
 
 Watch sync in the active rollout/session and do not leave a background process
-running when you finish.
+running when you finish. The wrapper has no 90-minute sync timeout; the agent or
+monitor must enforce that wall-clock ceiling and interrupt the watch.
 
 The Envio Cloud deployment id is the short Git commit hash (for example
 `b92ff93b`). Once the deployment is registered, this id stays stable.
@@ -179,41 +222,39 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 pnpm deploy:indexer:perf <TARGET_COMMIT>
 ```
 
+Capture the performance snapshot after sync and before verification so the
+final report has a commit-scoped status/metrics/log record.
+
 Treat a successful caught-up exit as `SYNCED_PENDING_DATA_VERIFY`, not
-`READY_TO_PROMOTE`. If the command exits non-zero, the deployment never
-registers within 5-10 min, or full sync is not reached within 90 minutes, stop
+`READY_TO_PROMOTE`. If the command exits non-zero, the deployment does not
+register within five minutes, or full sync is not reached within 90 minutes, stop
 and surface the failure. **Never promote a non-synced deployment.**
 
 If the target is already in `prod_status=prod`, treat it as `ALREADY_PROMOTED`
-and continue through the DNS wait + verify path for idempotency.
+and continue through the endpoint-propagation wait + verify path for idempotency.
 
-**If `--no-promote` was passed, stop here.** Print a summary listing the
-synced commit and the paste-ready promote command for the user to run later
-(typically right after the PR merges for additive fields/entities; not for
-removals/renames until a compatibility or cutover plan is confirmed):
+**If `--no-promote` was passed, stop here.** Print a summary listing the synced
+commit and the guarded continuation for later use (typically right after the
+PR merges for additive fields/entities; not for removals/renames until a
+compatibility or cutover plan is confirmed):
 
 ```text
 Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and pending deployment verification.
-For additive fields/entities, promote after the PR lands and before the matching dashboard deployment serves traffic:
-  pnpm deploy:indexer:verify <TARGET_COMMIT>
-  pnpm deploy:indexer:promote <TARGET_COMMIT> -y
+For additive fields/entities, continue only after merge with explicit production authorization:
+  /deploy-indexer --resume-preload <TARGET_COMMIT>
+That continuation must confirm indexer-envio tree equality, reconfirm sync, and execute Phases 3-6. Never run the promote wrapper as a shortcut.
 For removals/renames, do not promote until compatibility or a coordinated cutover/rollback plan is confirmed.
 ```
 
-Do NOT continue to Phase 3 / 4 / 5 / 6. The new schema isn't live in the
-dashboard codebase yet, so promoting now would point the static URL at a
-schema the deployed UI may not query correctly. For additions this may be
-mostly pointless; for removals/renames it can break production pages until the
-matching dashboard build is live. It also makes the rollback story muddier.
+Do NOT continue to Phase 3 / 4 / 5 / 6. The reviewed schema is not on `main`.
 
 ## Phase 3 — Verify deployment before promotion
 
 Before any promotion path, classify rollout compatibility against the deployed
 dashboard(s), not just the source branch:
 
-- **Additive fields/entities/data only:** continue. Promote after merge as soon
-  as possible, ideally before the matching production dashboard deployment
-  serves traffic.
+- **Additive fields/entities/data only:** continue after merge; a preloaded
+  candidate must also match the merged `indexer-envio/` tree.
 - **Field/entity removals or renames consumed by old or new dashboard code:**
   stop unless the PR or user request already documents a
   backward-compatible/two-phase rollout, or an explicit coordinated
@@ -228,25 +269,11 @@ Run the narrow deployment verifier before promoting:
 pnpm deploy:indexer:verify <TARGET_COMMIT>
 ```
 
-This batches the Envio deployment status, metrics, endpoint resolution, core
-GraphQL rows, and Polygon replay semantics into one pre-promotion gate. The
-Polygon checks require the canonical three FPMMs, exact feed/expiry mappings,
-positive historical oracle anchors and snapshot cursors, valid health
-counters, and a current one-year EURm/EUROP oracle. Do not promote if this
-command exits non-zero. `--allow-syncing` is for diagnostics only here: it can
-waive an in-progress chain status during investigation, but it never waives
-empty rows or semantic failures and is not a promotion approval.
-
-The verifier reads `indexer-envio/config/replay-integrity.json` from the exact
-deployed commit. Missing or outdated marker versions are a hard failure: later
-healthy-looking rows cannot make a candidate replayed by pre-invariant code
-promotion-compatible.
-
-Any `sortedOracles.exactMedianTimestampUnavailable` failure for a tracked pool
-means the event was deliberately rejected and will retry. If an older candidate
-instead reached head after `[RPC_FAILURE] chainId=137 fn=medianTimestamp`,
-classify it as `TAINTED`; never promote it, and deploy a fresh commit for a
-clean replay.
+This combines status, metrics, endpoint, core-row, and Polygon replay checks.
+Do not promote on any failure. `--allow-syncing` is diagnostic only and never
+waives data or replay-semantic failures. A missing replay marker or tainted
+historical RPC replay requires a fresh deployment; `docs/deployment.md` owns
+the exact verifier contract.
 
 ## Phase 4 — Promote
 
@@ -254,34 +281,22 @@ Before promoting, capture the **current** prod commit so the final summary
 can print a paste-ready rollback command:
 
 ```bash
-PREVIOUS_PROD_COMMIT=$(npx envio-cloud indexer get mento mento-protocol -o json \
-  | jq -r --arg target "<TARGET_COMMIT>" '
+PREVIOUS_PROD_COMMIT=$(pnpm --silent exec envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r --arg full "<TARGET_COMMIT>" '
       [.data.deployments[]
        | select(.prod_status=="prod")
-       | select((.commit_hash | startswith($target)) | not)]
-      | sort_by(.created_time) | reverse | .[0].commit_hash // empty' \
-  | head -c 7)
+       | select(.commit_hash as $stored | ($full | startswith($stored) | not))]
+      | sort_by(.created_time) | reverse | .[0].commit_hash // empty')
 ```
 
-The `sort_by(.created_time) | reverse` step is load-bearing: the
-`envio-cloud` API doesn't guarantee deployment order, so an unsorted
-`head -n1` could pick an older prod entry from a long-ago deploy instead
-of the immediately-prior one. Mirroring what `scripts/deploy-indexer-promote.sh`
-does for "auto-detect latest deployment".
+Sorting avoids API-order assumptions; the reverse prefix test handles Envio's
+truncated ids and excludes the target. If no prior prod is discoverable, report
+that no rollback target was captured instead of guessing.
 
-The `select(... | not)` clause excludes `TARGET_COMMIT` itself, which matters
-on the idempotent re-run path: if you re-run `/deploy-indexer` for a commit
-that's already `prod_status=prod`, the unfiltered query would return the
-same SHA and the final summary's "rollback command" would point at the
-commit just deployed — useless during an incident. Excluding the target
-gives you the previous prod commit, which is what rollback actually needs.
-
-If no prior prod commit exists (first-ever promote, or only the current
-target is in prod), `PREVIOUS_PROD_COMMIT` is empty — the rollback line in
-the final summary then reads "(none — no prior prod deploy, no rollback
-target)".
-
-Then promote:
+Promote only when the request explicitly authorized the end-to-end production
+deploy. Otherwise stop after verification and ask for approval to continue
+this skill through Phases 4–6; do not surface the wrapper as a standalone
+shortcut. Once authorized, run:
 
 ```bash
 pnpm deploy:indexer:promote <TARGET_COMMIT> -y
@@ -292,18 +307,18 @@ passes remaining flags through to `envio-cloud deployment promote`, so `-y`
 reaches the underlying CLI cleanly. Using the wrapper keeps org/indexer
 defaults centralized.
 
-Confirm the response line `Deployment '<commit>' of indexer 'mento' promoted to production successfully.` Then verify with:
+Require a zero wrapper exit, then verify with:
 
 ```bash
-npx envio-cloud indexer get mento mento-protocol -o json \
-  | jq -r '.data.deployments[] | select(.commit_hash | startswith("<TARGET_COMMIT>")) | "prod_status=\(.prod_status)"'
+pnpm --silent exec envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r --arg full "<TARGET_COMMIT>" '.data.deployments[] | select(.commit_hash as $stored | $full | startswith($stored)) | "prod_status=\(.prod_status)"'
 ```
 
 `prod_status=prod` is the success signal.
 
-## Phase 5 — Wait for static URL switchover
+## Phase 5 — Wait for static endpoint propagation
 
-The static GraphQL endpoint (e.g. `https://indexer.hyperindex.xyz/60ff18c/v1/graphql`)
+The static GraphQL endpoint (e.g. `https://indexer.hyperindex.xyz/2f3dd15/v1/graphql`)
 takes ~30 s – a few minutes to flip to the newly promoted deployment. During
 that window the dashboard may transiently query the old schema.
 
@@ -311,11 +326,11 @@ Wait **5 minutes wall-clock**, then proceed. Run a one-shot sleep and wait for
 it to finish before continuing to Phase 6:
 
 ```bash
-sleep 300 && echo "dns-window-elapsed"
+sleep 300 && echo "endpoint-propagation-window-elapsed"
 ```
 
 Until the sleep exits, do NOT start UI verification and do NOT poll the static
-URL. Skipping the DNS-flip window produces flaky verify results, which is
+URL. Skipping the propagation window produces flaky verify results, which is
 exactly the failure mode the wait exists to prevent.
 
 Don't poll the static URL with introspection — Envio's edge cache flips
@@ -348,43 +363,47 @@ user to verify manually.
 - **Performance snapshot:** `pnpm deploy:indexer:perf <TARGET_COMMIT>` captured status/metrics/log highlights
 - **Deployment verify:** `pnpm deploy:indexer:verify <TARGET_COMMIT>` passed before promotion
 - **Promote:** ✅ / ❌ (and `PREVIOUS_PROD_COMMIT` captured in Phase 4, for rollback reference)
-- **DNS wait:** 5 min completed
+- **Endpoint propagation wait:** 5 min completed
 - **UI verify:** pages checked + console errors found (✅ if none)
-- **Rollback command (paste-ready):** `pnpm deploy:indexer:promote <PREVIOUS_PROD_COMMIT> -y` — or "(none — first prod deploy)" if `PREVIOUS_PROD_COMMIT` was empty.
+- **Rollback command (paste-ready):** `pnpm deploy:indexer:rollback <PREVIOUS_PROD_COMMIT>` — or "(none captured)" if `PREVIOUS_PROD_COMMIT` was empty.
 
 ## Failure handling
 
 - **Preflight fails** (dirty tree / wrong branch / unpushed commits) → stop. Do not auto-clean; the user owns that state.
 - **Push to envio fails** → stop; never force-push.
-- **Build doesn't register in 30 min** → stop; suggest `pnpm deploy:indexer:logs --build`.
+- **Build doesn't register in 5 min** → stop; check deployment capacity and
+  the wrapper diagnostic. Do not use unscoped logs as proof of the target
+  build.
 - **Sync stalls past 90 min** → stop; report last status. Don't promote.
 - **Deployment verification fails** → stop; do not promote until status, metrics, endpoint, core rows, and semantic replay checks pass. A tainted historical replay requires a fresh deployment, not another promotion attempt.
 - **Promote fails** → stop; the previous deployment is still serving. Surface the error.
-- **DNS wait interrupted** (user cancels) → stop; do not skip to verify.
+- **Endpoint propagation wait interrupted** (user cancels) → stop; do not skip to verify.
 - **Verify UI finds errors** → surface them with file/line, ask the user whether to roll back. Don't auto-rollback — promote-to-prior is destructive.
 
 ## Idempotency
 
-Re-running `/deploy-indexer` for a commit that's already `prod_status=prod`:
-
-- Preflight will pass.
-- Push is a no-op (envio already at that commit).
-- Babysit returns immediately ("already promoted").
-- Deployment verification still runs against the target deployment.
-- Promote is a no-op (already prod).
-- DNS wait still fires the 5-min sleep.
-- Verify still runs.
-
-That's fine — costs ~5 min and re-confirms the dashboard is live. Do not
-short-circuit; the verification is the value on a re-run.
+For a commit already in prod, the wrapper accepts the registered no-op push and
+the status watch returns immediately. Still run deployment verification, the
+five-minute propagation wait, and UI verification; those checks are the value
+of the rerun.
 
 ## Common pre-merge workflow
 
-1. You're working on a feature branch with additive indexer changes (new schema entity, new event coverage, new field) and dashboard changes that consume them.
-2. Before opening the PR (or while it's in review), run `/deploy-indexer --no-promote` from the feature branch checkout — pushes the branch tip to `envio`, builds, syncs to caught-up. ~30–60 min.
-3. The PR review proceeds normally. The new deployment exists in `envio-cloud` but isn't `prod` yet, so the live dashboard keeps querying the old indexer.
-4. PR merges to `main`. Now run `/deploy-indexer` (without `--no-promote`) from `main` immediately, ideally before the matching production dashboard deployment serves traffic — preflight passes, push is fast (or a no-op if `envio` is already at the commit you're about to push, i.e. SHA-identical to step 2's tip), babysit returns immediately ("already promoted"), deployment verification passes, promote flips `prod`, DNS waits 5 min, browser verification passes. The new schema goes live without the usual 30–60 min indexer-lag window.
-5. The fast path in step 4 only holds when the commit you push from `main` is byte-identical to what was already on `envio`. Squash-merge produces a new SHA, so the prior `envio` tip becomes irrelevant and you eat a fresh build + sync. To preserve commit identity through merge: use a merge commit or rebase-merge for branches that were pre-deployed, OR pre-deploy from the merge-base just before merging so the eventual `main` tip matches.
+1. From a feature branch with additive indexer changes, record
+   `PRELOADED_COMMIT=$(git rev-parse HEAD)` and run
+   `/deploy-indexer --no-promote`.
+2. After the PR merges, resolve and fetch `CANONICAL_MAIN_REF` through the
+   verified canonical remote from Phase 0, then run
+   `git diff --quiet "$PRELOADED_COMMIT" "$CANONICAL_MAIN_REF" -- indexer-envio`.
+3. If the trees match and the user explicitly authorizes the production
+   continuation, run `/deploy-indexer --resume-preload "$PRELOADED_COMMIT"`.
+   It skips only the push, reconfirms sync, then executes Phases 3–6—including
+   prior-prod capture, promotion confirmation, propagation wait, UI verification,
+   and the rollback-ready final summary. Merge, squash, and rebase strategies
+   may all change the Git SHA; tree equality—not SHA identity—is the safety
+   check.
+4. If the trees differ, do not promote the stale preload. Deploy the current
+   `main` commit and wait for its fresh build, sync, and verification.
 
 ## Rules
 
@@ -392,7 +411,8 @@ short-circuit; the verification is the value on a re-run.
 - **Never auto-rollback.** Promote-to-prior is the user's call.
 - **Never bypass the babysit phase** — don't promote based on a single status snapshot.
 - **Never bypass the deployment verifier** — run `pnpm deploy:indexer:verify <TARGET_COMMIT>` after sync and before promote.
-- **Always wait the full 5 min** for DNS switchover before verifying — bypassing produces flaky verify results.
-- **Pass the resolved short SHA explicitly** to status and verification steps — don't rely on "latest", since a concurrent deploy by someone else could shift it.
-- **Don't open a PR** to verify the deploy. This skill is a plumbing chain, not a code-review path. The PR (if any) was merged before this skill ran; the deploy is a separate concern.
+- **Always wait the full 5 min** for static-endpoint propagation before verifying — bypassing produces flaky verify results.
+- **Pass the full target SHA explicitly** to status and verification steps — don't rely on "latest", since a concurrent deploy by someone else could shift it.
+- **Don't open a PR** as part of deployment verification. This skill is a
+  plumbing chain; pre-merge code review remains a separate workflow.
 - **Default to `--no-promote` when deploying from a non-`main` branch** unless the user explicitly asked to promote. Additive feature-branch schema changes should be promoted after merge, ideally before the matching dashboard deployment serves traffic. Removals/renames need a backward-compatible/two-phase rollout or an explicit coordinated cutover/rollback plan. Promoting from the feature branch also creates an ambiguous rollback target.

--- a/.claude/skills/doc-garden/SKILL.md
+++ b/.claude/skills/doc-garden/SKILL.md
@@ -5,7 +5,7 @@ title: Documentation Garden Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -5,7 +5,7 @@ title: Envio Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
 doc_type: skill
 scope: repo-wide
@@ -28,10 +28,11 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
 
 - Treat this repo as HyperIndex V3-first. Verify the exact installed package with `pnpm --filter @mento-protocol/indexer-envio exec envio --version`; the pinned version in `indexer-envio/package.json` is `envio@3.2.1`.
 - V3 preload optimization is always on. There is no `preload_handlers:` config flag, and loader-era patterns should be translated into normal handler code.
-- V3 handlers run twice: a concurrent preload pass for DB reads/effects, then an ordered processing pass for writes. Do not put expensive `context.effect(...)` calls behind an early `if (context.isPreload) return`; do keep writes out of preload.
-- `indexer-envio/test/code-quality-invariants.test.ts` blocks direct effects that exist only after a positive preload return (including exact `await maybePreloadPool(...)` and `await maybePreloadBreaker(...)` wrappers) or after an earlier entity-dependent return. Start event-derived effects before lookups whose empty result can differ between concurrent preload and ordered processing, then reuse the identical effect + input key across both passes. An effect that must remain processing-only for ordered-state correctness, or is permanently bounded, needs an adjacent call-site `// preload-effect-exempt: <ordered-state or bounded-cardinality reason>` comment. A comment on the preload guard never suppresses direct-effect checks.
-- When code that preload cannot eagerly reach—after an entity-dependent return or a positive preload return—calls a helper that directly or transitively reaches `context.effect`, the invariant derives that boundary from TypeScript symbols. Declare the exact used set with one or more adjacent `// preload-effect-helpers: <helper names>` lines plus a non-empty `// preload-handler-note: <reason>` line. Missing and unused helper declarations both fail. A phase-stable event-derived filter may be declared only when the effect is still awaited during preload; say that explicitly. Never exempt replay-traffic-scaled effects merely for convenience; when preloading would violate sequential semantics, state the exact ordering invariant and track a preload-safe redesign.
-- For an effect that is needed only when preloaded entity state meets a condition, carry an event-scoped in-memory preload marker into processing. If a row appears only during ordered processing, stay fail-closed and defer the RPC until the next event instead of issuing a serialized call.
+- V3 handlers run twice: a concurrent preload pass for reads/effects, then an
+  ordered processing pass for writes. Before changing a handler or RPC effect,
+  read `indexer-envio/AGENTS.md` and
+  `docs/pr-checklists/indexer-handler-invariants.md`; that checklist owns effect
+  ordering, preload markers, exemption syntax, helper declarations, and tests.
 - Prefer the installed CLI help over stale docs when they disagree. In this baseline, `envio metrics`, `envio metrics runtime`, `envio tools search-docs`, and `envio tools fetch-docs` exist; `envio benchmark-summary` does not.
 
 ## Mento repo quick reference
@@ -42,13 +43,14 @@ Docs: <https://docs.envio.dev/docs/HyperIndex/hosted-service>
 
 ```bash
 pnpm deploy:indexer [--yes]         # Push HEAD to `envio` → Envio auto-builds
-pnpm deploy:indexer:status [--watch] [--compact] [--json]
+pnpm deploy:indexer:status [<commit>] [--watch] [--compact] [--json]
 pnpm deploy:indexer:metrics [<commit>] [--json]
 pnpm deploy:indexer:info [<commit>]
 pnpm deploy:indexer:perf [<commit>] [--json]
 pnpm deploy:indexer:verify [<commit>] [--prod] [--json]
 pnpm deploy:indexer:promote [<commit>]
-pnpm deploy:indexer:logs [--follow] [--level error] [--build]
+pnpm deploy:indexer:logs [<commit>] [--follow] [--level error] [--build]
+pnpm deploy:indexer:rollback <commit> [--dry-run]
 ```
 
 - Dashboard: <https://envio.dev/app/mento-protocol/mento>
@@ -56,11 +58,18 @@ pnpm deploy:indexer:logs [--follow] [--level error] [--build]
 ## Deployment lifecycle
 
 1. **Push** to the `envio` branch — Envio GitHub App picks it up and starts a build. There is **no** `envio deploy` command.
-2. **Build** produces a new deployment keyed by the short commit hash. A deployment with commit X appears in `envio-cloud indexer get mento mento-protocol` a few minutes after push (expect ~5–15 min). Until then `deployment status` returns **404**. If no new deployment appears and `data.deployments[]` already has three entries, Envio has no room to create another deployment; delete, or ask the user to delete, an obsolete non-prod deployment before retrying with a fresh SHA.
+2. **Build** produces a new deployment keyed by a commit-hash prefix. In this
+   repo registration normally takes 2–3 minutes; the deploy skill warns at
+   three and uses a five-minute ceiling. Until registration, deployment status
+   is unavailable. If `data.deployments[]` already has three entries, delete,
+   or ask the user to delete, an obsolete non-prod deployment before retrying.
 3. **Sync** — the new deployment re-indexes from `start_block`. The previous deployment keeps serving the GraphQL endpoint with zero downtime.
 4. **Promote** — when sync completes, call `deployment promote` to swap `prod_status` to `prod`. Only then does the public GraphQL endpoint point at the new deployment.
 
-Every push triggers a full re-index (event handlers, schema, config.yaml, ABIs, or contract-address changes all invalidate cache). Rollback = `deployment promote <older-commit>`.
+Each new deployment performs a full re-index. Use
+`pnpm deploy:indexer:rollback <last-good-sha> --dry-run` and then the guarded
+rollback wrapper; direct promotion is only its fast path when the old
+deployment is still retained.
 
 ### Static vs per-deployment endpoint URLs
 
@@ -93,43 +102,40 @@ Per-chain fields that matter:
 `latest_processed_block === block_height` is a close proxy but can flicker
 because `block_height` keeps advancing.
 
-Add `--watch-till-synced` to block until all chains hit 100%. Useful in CI or a foreground terminal; for agentic monitoring, poll with `-o json` and parse.
+The repo status wrapper owns blocking agent watches; use raw
+`--watch-till-synced` only outside that workflow.
 
 Progress math for a per-chain % estimate: `(latest_processed_block - start_block) / (block_height - start_block)`.
 
 ## Logs
 
 ```bash
-pnpm deploy:indexer:logs --level error        # last 100 runtime error lines
-pnpm deploy:indexer:logs --build              # build logs (useful when a deploy doesn't register)
-pnpm deploy:indexer:logs --follow             # tail (polls every 10s)
+pnpm deploy:indexer:logs <commit> --level error  # runtime errors
+pnpm deploy:indexer:logs <commit> --build        # registered build logs
+pnpm deploy:indexer:logs <commit> --follow       # tail every 10s
 ```
 
-`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the wrapper passes that flag through unchanged. `--level` is comma-separated: `trace,debug,info,warn,error`. `--build` flips to build-time logs — check these first if a push never produces a deployment record.
+`envio-cloud` defaults to 100 log lines and supports `--limit` up to 100; the
+wrapper passes that flag through. `--level` is comma-separated and `--build`
+selects build-time logs. If the target never registers, do not substitute an
+unscoped older deployment's logs; use the registration diagnostic and Envio UI.
 
-## envio-cloud CLI cheat sheet
+## `envio-cloud` CLI
 
 ```bash
-envio-cloud login                                         # GitHub OAuth
-envio-cloud config set-org mento-protocol                 # kubectl-style default context
-envio-cloud config set-indexer mento
-envio-cloud indexer list --org mento-protocol             # public indexers
-envio-cloud indexer get mento mento-protocol -o json      # indexer + deployments[]
-envio-cloud indexer env list mento mento-protocol         # dashboard env vars (ENVIO_-prefixed)
-envio-cloud indexer security                              # IP/domain allowlist
-envio-cloud deployment metrics  mento <commit> mento-protocol   # throughput, error rate
-envio-cloud deployment info     mento <commit> mento-protocol   # cache/DB exposure config
-envio-cloud deployment status   mento <commit> mento-protocol
-envio-cloud deployment endpoint mento <commit> mento-protocol   # GraphQL URL
-envio-cloud deployment logs     mento <commit> mento-protocol
-envio-cloud deployment promote  mento <commit> mento-protocol
-envio-cloud deployment restart  mento <commit> mento-protocol
-envio-cloud deployment delete   mento <commit> mento-protocol
+pnpm exec envio-cloud --help
+pnpm exec envio-cloud indexer get mento mento-protocol -o json
+pnpm exec envio-cloud deployment status mento <commit> mento-protocol -o json
+pnpm exec envio-cloud deployment endpoint mento <commit> mento-protocol
+pnpm exec envio-cloud indexer env list mento mento-protocol
 ```
 
-`envio-cloud indexer env list` can print raw `ENVIO_*` secret values. Run it
-only when you specifically need to inspect hosted env configuration, and never
-paste or quote its output in chat, PRs, logs, or docs.
+Use the workspace-pinned CLI and its current `--help`; `envio-cloud` is still
+pre-1.0. Prefer repo wrappers for deploy, verify, promote, rollback, logs,
+metrics, and info so org/indexer defaults and guards stay centralized.
+`envio-cloud indexer env list` masks values by default. Its `--show-values`
+form reveals raw `ENVIO_*` secrets; run that only when explicitly required and
+never paste or quote the output in chat, PRs, logs, or docs.
 
 For CI, set `ENVIO_GITHUB_TOKEN` to skip interactive login.
 
@@ -177,15 +183,17 @@ Notes:
 - Public docs may lag the installed CLI. In `envio@3.2.1`, `envio metrics` and `envio metrics runtime` exist; `envio benchmark-summary` does not.
 - Watch these generic metrics first: `envio_processing_handler_seconds`, `envio_preload_handler_seconds`, `envio_preload_handler_seconds_total`, `envio_effect_call_seconds_total`, `envio_effect_call_total`, `envio_effect_active_calls`, `envio_effect_queue*`, `envio_storage_load_seconds_total`, `envio_storage_write_seconds`, `envio_fetching_block_range_*`, `envio_progress_events`.
 - Combine Envio metrics with this repo's `INDEXER_PERF=1` logs. The repo profiler adds handler/effect/entity summaries and a derived `hit~` count (`effect requests - effect handler executions`) that helps detect preload/cache reuse.
-- If a handler has `if (context.isPreload) return` before expensive `context.effect(...)` calls, preload optimization is disabled for those calls. The preferred shape is: perform preload DB reads and independent `context.effect(...)` calls first, then return before entity writes. The processing pass should call the same effect key so it reuses preload results.
-- Do not remove every `context.isPreload` guard blindly: storage writes still belong only in the processing pass. The fix is to move bottleneck reads/effects before the guard's return.
+- Apply `docs/pr-checklists/indexer-handler-invariants.md` before moving any
+  effect or preload guard; it distinguishes batchable calls from ordered-state
+  exceptions and owns the required regression coverage.
 
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Hosted deployment cap is three live deployments.** `envio-cloud indexer get mento mento-protocol -o json` shows the full `data.deployments[]` list. If it already contains three entries, a new push can fail to register because Envio has no capacity for another deployment. Keep the `prod_status == "prod"` deployment and remove an obsolete non-prod deployment before retrying.
-- **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
+- **Re-index on every new deployment.** Schema changes, handler edits, ABI
+  bumps, and config tweaks all require replay. Do not promise a fixed duration;
+  monitor the exact commit with the status wrapper.
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).
 - **Celo Sepolia / Monad Testnet may fall back to RPC** instead of HyperSync. Slower but works; set `ENVIO_API_TOKEN` for HyperRPC access on testnets.
@@ -197,16 +205,31 @@ Notes:
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
+- Development-plan retention and quota rules change independently of this
+  repo. Check Envio's current hosted deployment/billing pages instead of
+  copying those limits into an operational answer.
 
 ## Monitoring playbook (agentic)
 
 When asked to "monitor the latest deployment until ready to promote":
 
 1. `pnpm exec envio-cloud indexer get mento mento-protocol -o json` — required to surface `deployments[]` + `prod_status`. Filter for the newest entry where `prod_status !== "prod"`. (`pnpm deploy:indexer:info <commit>` is the wrapper for inspecting a specific known commit, not for the "find newest pending" step.) If no pending deployment exists, count `deployments[]` first: three live entries means Envio has no room for a new deployment and you must delete, or ask the user to delete, an obsolete non-prod deployment before retrying. If fewer than three deployments exist, cross-check `git rev-parse origin/envio` — if the branch HEAD commit has no deployment record, the build is still pending (or failed → check `--build` logs).
-2. Poll `deployment status <commit> -o json` every 5–15 min (Envio builds finish fast, syncs take minutes–hours).
+2. Run `pnpm deploy:indexer:status <commit> --watch --compact`; the wrapper
+   owns registration diagnostics and polling. Enforce the separate sync
+   deadline in the active agent/monitor.
 3. Caught-up condition: every chain in `data[]` has a non-empty `timestamp_caught_up_to_head_or_endblock`; classify this as `SYNCED_PENDING_DATA_VERIFY`.
 4. Run `pnpm deploy:indexer:verify <commit>` to batch status, metrics, endpoint resolution, core rows, and Polygon replay semantics before promotion. Polygon semantic failures are never waived by `--allow-syncing`.
-5. Only a passing verifier transitions the candidate to `READY_TO_PROMOTE`. Surface the result with a progress table and `pnpm deploy:indexer:promote <commit>` as the suggested next step — **do not promote without the user's OK.**
+5. A passing verifier yields `VERIFIED_PENDING_PROMOTION`, not permission to
+   run the promote wrapper by itself. If this monitor belongs to an active
+   `/deploy-indexer` run, return control to Phase 4 so it captures prior prod
+   and completes promotion, propagation, and UI verification after explicit
+   authorization.
+6. Otherwise treat the candidate's provenance as unclassified. With explicit
+   production authorization, route it through
+   `/deploy-indexer --resume-preload <commit>`; that guarded continuation binds
+   protected main to the canonical repository, checks tree equality, reconfirms
+   sync, and executes Phases 3–6. Never suggest a bare
+   `pnpm deploy:indexer:promote` command as monitor closeout.
 
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,13 @@ The status watcher only proves a deployment caught up. Promotion additionally
 requires `deploy:indexer:verify` to pass core-row and Polygon replay semantics;
 `--allow-syncing` never waives those data-integrity checks.
 
+For an agent-operated production rollout, use the repo's `/deploy-indexer`
+skill: it also captures the prior production commit, confirms promotion, waits
+for endpoint propagation, and verifies the dashboard in the browser. After a
+pre-merge `/deploy-indexer --no-promote`, finish a tree-matching candidate with
+an explicitly authorized `/deploy-indexer --resume-preload <commit>`; do not
+use the bare promote command as a shortcut.
+
 If a promotion turns out bad, roll back with
 `pnpm deploy:indexer:rollback <last-good-sha>` - see
 [docs/deployment.md](./docs/deployment.md#rollback-a-bad-promotion).

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,12 +20,12 @@ the rules in [`context-standards.md`](context-standards.md).
 
 | Document | Title | Authority | Type / scope | Owner | Review |
 | --- | --- | --- | --- | --- | --- |
-| [`.agents/roles/standards-enforcer.md`](../.agents/roles/standards-enforcer.md) | Standards Enforcer Role | canonical / active | role / repo-wide | eng | 90d; verified 2026-05-20 |
-| [`.agents/roles/verifier.md`](../.agents/roles/verifier.md) | Verifier Role | canonical / active | role / repo-wide | eng | 90d; verified 2026-05-20 |
-| [`.agents/skills/babysit-pr/SKILL.md`](../.agents/skills/babysit-pr/SKILL.md) | Babysit PR Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-05-28 |
-| [`.agents/skills/deploy-indexer/SKILL.md`](../.agents/skills/deploy-indexer/SKILL.md) | Deploy Indexer Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-05-29 |
-| [`.agents/skills/doc-garden/SKILL.md`](../.agents/skills/doc-garden/SKILL.md) | Documentation Garden Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-21 |
-| [`.agents/skills/envio/SKILL.md`](../.agents/skills/envio/SKILL.md) | Envio Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-21 |
+| [`.agents/roles/standards-enforcer.md`](../.agents/roles/standards-enforcer.md) | Standards Enforcer Role | canonical / active | role / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/roles/verifier.md`](../.agents/roles/verifier.md) | Verifier Role | canonical / active | role / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/babysit-pr/SKILL.md`](../.agents/skills/babysit-pr/SKILL.md) | Babysit PR Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/deploy-indexer/SKILL.md`](../.agents/skills/deploy-indexer/SKILL.md) | Deploy Indexer Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/doc-garden/SKILL.md`](../.agents/skills/doc-garden/SKILL.md) | Documentation Garden Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/envio/SKILL.md`](../.agents/skills/envio/SKILL.md) | Envio Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`.agents/skills/forensic-report/SKILL.md`](../.agents/skills/forensic-report/SKILL.md) | Forensic Report Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-06-15 |
 | [`.agents/skills/forensic-report/template.md`](../.agents/skills/forensic-report/template.md) | 0xADDRESS_CASE_PRESERVED — Display Name (persona/ENS if known) | unmanaged / unmanaged | skill / repo-wide | unowned | 90d |
 | [`.agents/skills/monorepo-import/SKILL.md`](../.agents/skills/monorepo-import/SKILL.md) | Monorepo Import Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-05-26 |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,13 +70,17 @@ pnpm deploy:indexer:promote "$COMMIT"
 
 Promotion authority depends on the request. For a monitor-only or babysit
 request, wait until every chain is caught up, run
-`pnpm deploy:indexer:verify "$COMMIT"`, surface the paste-ready promote
-command, and stop until the user explicitly approves promotion. For a
-pre-merge feature-branch preload, `/deploy-indexer --no-promote` stops after
-sync and prints the later verify/promote commands without running them. Do not
-infer promotion approval from a request to monitor, preload, or report
-readiness; an explicitly authorized end-to-end production deploy is a separate
-case.
+`pnpm deploy:indexer:verify "$COMMIT"`, then stop until the user explicitly
+approves the guarded `/deploy-indexer` continuation; do not offer the bare
+promote wrapper as monitor closeout. For a pre-merge feature-branch preload,
+`/deploy-indexer --no-promote` stops after sync. After merge,
+`/deploy-indexer --resume-preload "$COMMIT"` first requires the preloaded
+`indexer-envio/` tree to match freshly fetched protected `main` from the
+canonical `mento-protocol/monitoring-monorepo` remote, then reconfirms sync and
+runs the complete verify, prior-prod capture, promote, propagation-wait, and
+UI-verification path. Do not infer promotion approval from a request to
+monitor, preload, or report readiness; an explicitly authorized end-to-end
+production deploy is a separate case.
 
 ### Force Retrigger Without Code Changes
 
@@ -94,9 +98,10 @@ pnpm deploy:indexer --yes
 2. Inspect build and runtime errors with explicit commit-scoped logs (`pnpm deploy:indexer:logs "$COMMIT" --build` and `pnpm deploy:indexer:logs "$COMMIT" --level error,warn --since 2h`).
 3. Capture a combined status/metrics/log snapshot for comparison (`pnpm deploy:indexer:perf "$COMMIT"`).
 4. Verify sync, metrics, endpoint resolution, core rows, and fail-closed Polygon replay semantics (`pnpm deploy:indexer:verify "$COMMIT"`). The verifier reads `indexer-envio/config/replay-integrity.json` from that exact commit, so a pre-invariant replay cannot pass merely because later rows look healthy. A caught-up status alone is only `SYNCED_PENDING_DATA_VERIFY`.
-5. Promote the same caught-up, semantically verified commit (`pnpm deploy:indexer:promote "$COMMIT"`) so the static production endpoint serves it.
-6. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
-7. Verify monitoring.mento.org loads data.
+5. Capture the current production commit for rollback, then promote the same caught-up, semantically verified commit (`pnpm deploy:indexer:promote "$COMMIT"`) and confirm its `prod_status=prod`. The `deploy-indexer` skill owns the exact prefix-safe query and guarded rollback command.
+6. Wait the full five-minute static-endpoint propagation window.
+7. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
+8. Verify monitoring.mento.org in the browser, including the affected pages and console errors. A bare successful promote is not rollout closeout.
 
 Reserve-yield actuals deploy through the primary `mento` Envio project. The
 Ethereum sUSDS handlers in `config.multichain.mainnet.yaml` are event-only, and


### PR DESCRIPTION
## The Problem

- The first `agent-entry-points` garden shard mixed verified entry points with stale or incomplete PR-babysitting and Envio rollout instructions.
- The two largest skills duplicated lower-level policy and contained version-sensitive guidance that had drifted from current scripts, runbooks, and provider tooling.

## The Solution

Audit every document in #1451 against its owning implementation and current provider evidence, keep the verified entry points, update unsafe or stale paths, trim duplicated detail, keep Claude mirrors exact, align directly affected operator runbooks, and regenerate the documentation catalog.

## Dispositions and evidence

| Document | Disposition | Evidence and result |
| --- | --- | --- |
| `.agents/roles/standards-enforcer.md` | **Keep** | `docs/context-standards.md`, the quality-gate dry run, and `agent:context-check` still match the role; refreshed its verified date. |
| `.agents/roles/verifier.md` | **Update** | Aligned the role with the quality gate's bounded-parallel background execution and complete failed/skipped-command ledger instead of mandatory sequential fail-fast execution. |
| `.agents/skills/babysit-pr/SKILL.md` | **Update** | Added the normalized feedback projection, `--until-ready`, frozen scope/two-cycle discipline, merge-without-rebase policy, and fail-closed binding of base repo, head repo, remotes, branch, and `headRefOid`. |
| `.agents/skills/deploy-indexer/SKILL.md` | **Update** | Corrected full-SHA/prefix handling, registration ownership, explicit promotion authority, previous-prod capture, guarded rollback, and preloaded-candidate continuation. Protected-main comparison is now bound to the canonical repository, and every promotion path retains verification, propagation wait, and UI closeout. |
| `.agents/skills/doc-garden/SKILL.md` | **Keep** | Reproduced the live planner packet and verified the scheduler plus issue lifecycle against the current workflow; refreshed its verified date. |
| `.agents/skills/envio/SKILL.md` | **Update** | Checked the pinned local CLIs and current [Envio deployment](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment) and [Envio Cloud CLI](https://docs.envio.dev/docs/HyperIndex/envio-cloud-cli) docs; removed stale plan/timing claims, routed handler invariants to their owner, and removed bare-promotion monitor closeout. |

The four `.claude/skills/**` copies remain byte-for-byte mirrors. `README.md`, `docs/deployment.md`, and the Claude deploy monitor were updated only for directly proven workflow drift. Across the six canonical packet documents, the result is 798 words leaner.

## Validation

- `CI=true pnpm agent:quality-gate --run` — passed all mapped Trunk, catalog, and context checks.
- `CI=true pnpm agent:context-budget --strict` — all instruction routes remain within budget.
- `CI=true node scripts/pr-ready-state.test.mjs` — 75 passed.
- `CI=true node scripts/pr-feedback-state.test.mjs` — 25 passed.
- Exact mirror comparisons and `git diff --check` — passed.
- Two bounded fresh-context review cycles completed; all five P1 findings were fixed in two in-scope batches, and the retained bundle manifests verified before/after review. Per the two-cycle cap, no third reviewer loop was started.
- Docs-only change; no dashboard behavior changed, so browser verification is not applicable.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1451
