### PR TITLE
fix(ci): upgrade composite setup-node callers

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: .node-version
         cache: pnpm

--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -6,7 +6,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
     - name: Install Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: .node-version
     - name: Install npm dependencies


### PR DESCRIPTION
## The Problem

- The setup-node v7 dependency bump updated direct workflow callers but left two live composite actions pinned to v6.4.0.
- Package CI jobs and Trunk Code Quality therefore continued to use the older action.

## The Solution

- Update both composite action pins to the same SHA-pinned setup-node v7.0.0 revision used by the parent workflows.

## Details

- This is a stacked follow-up to #1375 and contains only the review-requested composite action updates.

## Validation

- `git diff --check`
- `node scripts/check-github-action-pins.mjs`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
