### PR TITLE
docs: garden operator runbooks shard 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,7 @@ last-reviewed owning-checkout wrapper. Autoreview reviews source only: it runs
 no tests and proves no behavior, so mapped gate, browser, generated-artifact,
 and runtime checks still apply. Exact target, bundle, isolation, trust,
 engine-selection, and command contracts live in
-[`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md)
-and [`docs/notes/codex-agent-skills.md`](docs/notes/codex-agent-skills.md).
+[`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 
 ## PR description standard
 
@@ -147,13 +146,15 @@ review-triggered patch cycles rather than starting a third automatically.
 Before all-clear, run:
 
 ```bash
+pnpm --silent pr:feedback-state --pr <number> --json
 pnpm pr:ready-state --pr <number> --json
 ```
 
-All-clear requires its current-head required state to be ready, including the
-current-head `chatgpt-codex-connector[bot]` PR-description approval. Do not post
-routine or duplicate `@codex review` requests. The feedback projection,
-break-glass contract, optional-bot treatment, and watch loop live in
+All-clear requires a clean feedback ledger plus ready-state's current-head
+required state, including the current-head
+`chatgpt-codex-connector[bot]` PR-description approval. Do not post routine or
+duplicate `@codex review` requests. The projection contract, break-glass
+behavior, optional-bot treatment, and watch loop live in
 [`docs/notes/pr-ready-state.md`](docs/notes/pr-ready-state.md) and the
 `babysit-pr` skill.
 
@@ -210,8 +211,8 @@ the `/verify-ui` command owns the route-level smoke sequence.
 ## Agent Tooling and Setup
 
 Reusable project workflows live under `.agents/skills/`; Claude mirrors under
-`.claude/skills/` must stay aligned. Runtime setup, autoreview bundle behavior,
-and skill ownership are in
+`.claude/skills/` must stay aligned. Codex Cloud routing, status-polling
+guidance, the SessionEnd hook, and skill ownership are in
 [`docs/notes/codex-agent-skills.md`](docs/notes/codex-agent-skills.md).
 Claude slash commands live under `.claude/commands/`.
 

--- a/alerts/rules/rules-metrics-bridge.tf
+++ b/alerts/rules/rules-metrics-bridge.tf
@@ -148,7 +148,7 @@ resource "grafana_rule_group" "metrics_bridge" {
 
     annotations = {
       summary     = "Bridge poll errors ({{ $labels.kind }}) — {{ printf \"%.3f\" $values.A.Value }}/s."
-      description = "Kind is one of hasura_rate_limit (Hasura 429 - shared-quota pressure; see docs/notes/hasura-isolation-trigger.md), hasura_query (schema drift or transport), update_metrics, mark_healthy, rebalance_probe, cdp_query, or cdp_update. Stale gauges remain; alert-on-change is degraded."
+      description = "Kind is one of hasura_rate_limit (HTTP 429; corroborate shared-quota pressure before acting — see docs/notes/hasura-isolation-trigger.md), hasura_query (schema drift or transport), update_metrics, mark_healthy, rebalance_probe, cdp_query, or cdp_update. Stale gauges remain; alert-on-change is degraded."
     }
 
     labels = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,16 +64,16 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/evals/documentation-navigation.md`](evals/documentation-navigation.md) | Documentation Navigation Evaluation | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/agent-issue-workflow.md`](notes/agent-issue-workflow.md) | Agent Issue Workflow | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/agent-quality-gate-mechanics.md`](notes/agent-quality-gate-mechanics.md) | Agent Quality Gate — Mechanics | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
-| [`docs/notes/codex-agent-skills.md`](notes/codex-agent-skills.md) | Codex Agent Skills — Mechanics | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-21 |
-| [`docs/notes/codex-cloud-setup.md`](notes/codex-cloud-setup.md) | Codex Cloud Setup and Maintenance | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/notes/cross-protocol-context.md`](notes/cross-protocol-context.md) | Cross-Protocol Context | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-06 |
-| [`docs/notes/dashboard-verification.md`](notes/dashboard-verification.md) | Dashboard Local and Browser Verification | canonical / active | runbook / ui-dashboard | eng | 90d; verified 2026-07-17 |
-| [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md) | Documentation gardening | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-19 |
-| [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md) | Hasura isolation trigger | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-21 |
-| [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/notes/reserve-yield-indexer.md`](notes/reserve-yield-indexer.md) | Reserve-Yield Indexer Topology | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-03 |
+| [`docs/notes/codex-agent-skills.md`](notes/codex-agent-skills.md) | Codex Agent Skills | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/codex-cloud-setup.md`](notes/codex-cloud-setup.md) | Codex Cloud Setup and Maintenance | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/cross-protocol-context.md`](notes/cross-protocol-context.md) | Cross-Protocol Context | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/dashboard-verification.md`](notes/dashboard-verification.md) | Dashboard Local and Browser Verification | canonical / active | runbook / ui-dashboard | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md) | Documentation gardening | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md) | Hasura isolation trigger | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/reserve-yield-indexer.md`](notes/reserve-yield-indexer.md) | Reserve-Yield Indexer Topology | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/sentry-triage-pipeline.md`](notes/sentry-triage-pipeline.md) | Sentry Triage Pipeline | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-19 |
 | [`docs/notes/slack-github-subscriptions.md`](notes/slack-github-subscriptions.md) | GitHub-to-Slack notifications for Terraform-applying workflows | canonical / active | runbook / terraform/infra | eng | 30d; verified 2026-07-17 |
 | [`docs/notes/spoken-attention-nudge.md`](notes/spoken-attention-nudge.md) | Spoken Attention Nudge | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-05 |

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -1,9 +1,9 @@
 ---
-title: Codex Agent Skills — Mechanics
+title: Codex Agent Skills
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -12,264 +12,79 @@ garden_lane: operator-runbooks
 
 # Codex Agent Skills
 
-The invocation pointer (where skills live, autoreview command, Codex Cloud
-scripts) lives in the "Agent Tooling and Setup" section of root `AGENTS.md`. This
-note holds the underlying mechanics.
+The invocation pointer lives in root `AGENTS.md`. This note owns skill placement,
+Codex Cloud routing, the SessionEnd hook, and long-running watch guidance.
+
+## Skill ownership
 
 Repo-tracked project skills live under `.agents/skills/`. Keep durable,
 team-shareable project workflows there instead of relying on local-only
 `~/.codex` or `~/.claude` state. Cross-project personal skills belong in
 `~/.agents/skills` and should be exposed to both agents through the
 `~/.codex/skills` and `~/.claude/skills` mirrors. Project-level Codex MCP config
-lives in `.codex/config.toml`; local personal Codex settings still belong in
+lives in `.codex/config.toml`; local personal Codex settings belong in
 `~/.codex/config.toml`.
 
-`autoreview` is pinned in this repo through `scripts/agent-autoreview.mjs` and
-exposed with `pnpm agent:autoreview`; Claude Code also has `/autoreview` as a
-thin command shim. Its review target remains branch-local: base-to-`HEAD`
-commits plus dirty tracked and untracked work, augmented by deterministic Mento
-checks and repo-selected checklist/feedback context. The complete bundle is
-never truncated. Prepared bundles losslessly split oversized targets into a
-bounded pass index that one fresh-context reviewer must inspect completely.
-Direct semantic-engine execution fails closed when more than one prompt would
-be required, and bundle preparation fails closed if the full input cannot fit
-the pass budget. Direct and prepared capture enforce a cumulative byte budget
-before diffs, untracked files, or supplemental evidence accumulate in memory or
-staging sidecars.
+## Autoreview routing
 
-The repo adapter detects active Codex sandbox sessions and uses the helper's
-local deterministic engine by default only when no engine is explicitly
-selected, so the command does not try to spawn unavailable nested `codex exec`.
-Explicit `--engine` arguments and `AUTOREVIEW_ENGINE` take precedence and fail
-closed when the selected engine is unavailable; there is no silent fallback
-from a semantic engine to local. Semantic engines run from an empty temporary
-workspace with project configuration and inherited environment restricted to
-the review contract. Reviewer web search is disabled by default to keep
-untrusted review evidence off the network; `--web-search` is an explicit opt-in
-for reviews that require public documentation lookup. Claude preserves
-standard Vertex and AWS Bedrock credential-chain inputs. Explicit
-`AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` locators opt into trusted
-static/profile files; their private snapshots reject `credential_process`.
-When either locator is absent, Claude receives a private empty snapshot
-instead, disabling implicit fallback to `~/.aws/config` or
-`~/.aws/credentials`; set the locator explicitly to use a trusted file.
-Claude's other file-valued cloud locators, plus
-`SSL_CERT_FILE` for both Claude and Codex, must resolve outside the reviewed
-repository to trusted owner/mode/ancestry/ACL state; the helper opens each
-explicit source no-follow with identity revalidation and passes a private
-per-run `0600` snapshot rather than the mutable source path. Those snapshots
-are removed with the isolated engine workspace after normal completion or
-partial setup failure.
-Interruption unlinks them before bounded process-group termination, including
-when an escaped descendant holds reviewer pipes. Non-empty `SSL_CERT_DIR` is
-rejected; use a trusted external PEM bundle through `SSL_CERT_FILE` instead.
-Direct engine-leader closure immediately force-kills any remaining process
-group before cleanup tracking is released, including ordinary success and
-failure as well as timeout or interruption. A quiet semantic reviewer emits a
-progress heartbeat every 60 seconds. `AUTOREVIEW_HELPER` is an escape hatch for
-intentional local testing or compatible replacement, not a Cloud prerequisite.
-Prepared-bundle replacements receive only the final prompt handoff and must
-implement `--bundle-output`, `--bundle-output-display`, and
-`--trusted-input-root`. The wrapper-attested helper retains ownership of source
-fingerprints and untracked-file serialization. A trusted wrapper physically
-outside the reviewed checkout uses a private, no-follow, manifest-bound copy of
-its sibling helper/core after pinning the source directory and validating stable
-POSIX ancestry plus non-write-granting macOS ACLs. The same copy is used when
-`AUTOREVIEW_HELPER` explicitly names that default sibling; a nested wrapper is rejected. The owning
-checkout instead requires its shell wrapper to match pinned protected main and
-materializes compatible helper/core blobs from that object; when it cannot, the
-review must run from a separate trusted checkout. An explicit replacement does
-not run before wrapper-owned recursive cleanup finishes. After the handoff,
-the wrapper retains its command runtime and any failed staging without
-recursive deletion because the replacement may have left a same-UID writer.
+`autoreview` is pinned through `scripts/agent-autoreview.mjs` and exposed as
+`pnpm agent:autoreview`; Claude Code's `/autoreview` command is a thin shim. The
+command reviews the complete branch-local target. Oversized targets use a
+lossless prepared-bundle index that one fresh-context reviewer must inspect in
+full.
 
-The adapter also exposes `--prepare-bundle-dir <dir>` to create a repo-context
-review bundle with changed paths, patch files, selected checklists, optional
-`--feedback-pr` feedback state, and the helper's prepared prompt. Supplemental
-evidence supplied directly must be a repo-relative regular UTF-8 file confined
-to the worktree. Adapter-generated feedback state and protected-main checklist
-copies inside the trusted prepared-bundle directory are the only external-path
-exceptions. The adapter resolves `origin/main^{commit}` once and
-uses that protected snapshot as checklist policy in every target mode; checklist
-edits in the reviewed target remain diff evidence and cannot instruct their own
-review. Sensitive paths and
-credential-like content, private keys, wallet recovery phrases, Stripe live
-keys, common webhook URLs,
-and secret-bearing URL query parameters fail closed before a semantic handoff.
-Evidence reads reject symlinks and path-swap races. The requested bundle parent
-must already exist. Every canonical ancestor must be owned by the current user
-or root, and group/other-writable ancestors require sticky-bit protection. On
-macOS, write-granting ACLs on parent ancestors or bundle entries fail
-preparation or verification. The
-adapter canonicalizes and pins that directory plus the
-freshly created staging directory's `dev:ino` before content generation. It
-stages every artifact beside the destination, manifests wrapper-owned evidence
-before and after helper execution, validates the prompt set, and hashes the
-complete evidence both before and after the final helper source check. The
-manifest rejects symlinks, special files, externally linked regular
-files, and any identity or content change. The validated Node runtime
-exclusively reserves the destination, rechecks the staging identity throughout
-transfer, and verifies that manifest after transfer and again immediately
-before hard-linking `.agent-autoreview-complete` last. That marker binds the
-manifest digest. Run `pnpm agent:autoreview --verify-bundle-dir <dir>`
-immediately before one reviewer reads every bounded pass and retain the printed
-digest outside the bundle. After review, rerun with
-`--expected-bundle-manifest <retained-digest>`; the command rehashes the
-no-follow evidence and rejects a changed marker, bundle, or pre/post digest. A
-destination created during the final race window is never replaced; an
-interrupted or unverified bundle must not be reviewed. Failures before an
-explicit helper runs, plus failures from the wrapper-attested default helper,
-receive pinned-identity cleanup: the adapter moves the candidate into a random
-adjacent quarantine, opens it without following symlinks, verifies the recorded
-`dev:ino`, and pins that inode with `fchdir` before recursive deletion. Later
-pathname cleanup is non-recursive and retains replacements on identity drift.
-After an explicit `AUTOREVIEW_HELPER` runs, failed staging is retained without
-recursive deletion because an unattested same-UID writer could substitute a
-child directory beneath the pinned root. Canonical secret-scan failures use the
-attested helper and are cleaned without leaving raw diff sidecars. It never
-recursively removes a failed
-destination reservation; inspect and remove an incomplete, unmarked directory
-before retrying. The repo helper is not
-re-entered for publication. Its `helper-output.txt` names the final published
-prompt/pass paths rather than ephemeral staging locations.
-Prepared-bundle mode owns its `autoreview-prompt.md`, so it cannot be combined
-with `--bundle-output` or `--dry-run`; publication requires completed content
-validation and the main prompt plus every strictly ordered, deterministic
-indexed bounded pass. Prompt-index validation accepts a UTF-8 BOM, CRLF line
-endings, and leading blank lines only after normalization, then enforces the
-same strict pass order and exact companion-file set, rejecting undeclared pass
-files. Direct `--bundle-output` publication uses an exclusive same-directory
-link and refuses every existing destination, including a file created in the
-final race window, so partial multi-pass publication cannot corrupt a valid
-index and its companions; use a fresh path or remove the prior set deliberately.
-Automatic prepared-bundle
-feedback resolves the unique same-repository
-PR base, number, and canonical repository slug together, so the frozen patch
-and `feedback-state.json` share one GitHub snapshot. Capture materializes the
-pinned feedback-state Node modules from the same protected `origin/main` object
-used for checklist policy, never from a PR-selected base, current head, or
-selected commit. It runs that immutable entry point directly from the repo root;
-it does not invoke branch-controlled package scripts or pnpm. The ledger's PR
-number, base, head branch, and head object ID are revalidated before
-publication. Git metadata reads discard caller-selected routing such as
-`GIT_CONFIG`, `GIT_DIR`, and `GIT_WORK_TREE`; GitHub reads similarly discard
-`GH_HOST` and `GH_REPO`. Missing GitHub CLI, zero or multiple PR matches, and malformed
-metadata fail closed when `--feedback-pr auto` was explicitly requested. An
-explicit `--base` or commit-mode target requires an explicit `--feedback-pr`
-number rather than `auto`. The removed `--parallel-tests` mode must not be
-reintroduced;
-`pnpm agent:quality-gate --run` owns test execution and isolation.
+The target-selection, engine-isolation, sensitive-input, runtime-trust,
+prepared-bundle, and runtime-changing-PR contracts live in
+[`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md). Keep that
+note as their single owner instead of copying implementation details here.
+Autoreview is source review only: mapped quality gates, browser checks,
+generated-artifact checks, runtime verification, and final PR readiness remain
+separate.
 
-For a real review, branch and commit targets are frozen to one object ID before
-capture. Direct `--dry-run` reports the requested ref without resolving or
-freezing it. The helper fingerprints symbolic-branch or detached identity plus
-the selected `HEAD` and tracked worktree source. Untracked file and symlink
-state is included only when local working-tree content belongs to the selected
-target (`local` or branch-local); explicit branch and commit source snapshots
-exclude unrelated untracked files. A lightweight `HEAD`/branch/status
-fingerprint brackets target selection first, so a concurrent checkout or
-clean-to-dirty transition fails closed without reading untracked file contents.
-After target selection, explicit branch and commit reviews rely on the
-target-scoped fingerprint and ignore unrelated untracked churn; automatic mode
-retains the status guard because its target class depends on clean/dirty state.
-Every Git path collection uses NUL-delimited output, so enumeration does not
-depend on Git quoting or newline splitting. Because the published changed-path
-and prompt metadata are line-oriented, paths containing tabs or line breaks
-are rejected before review; rename such a path before running autoreview.
-For explicit branch and commit bundles in the owning checkout, the shell
-adapter's bytes and executable mode must match frozen `HEAD`. The shell, MJS
-helper, and core at frozen `HEAD` must also match the pinned protected-main
-object in every target mode. Commit mode additionally compares the selected
-commit with that protected baseline. The adapter executes MJS files
-materialized from protected main, never from a PR-selected base or mutable
-worktree. Local and branch-local bundles also require helper/core worktree bytes
-to match frozen `HEAD`. Runtime changes fail closed for review from a separate
-trusted checkout with an explicit compatible helper. Direct default-helper
-execution in the owning checkout applies the same protected-main runtime pin.
-From the reviewed checkout as the working directory, invoke the wrapper from
-the separate trusted checkout, keep that checkout's MJS path explicit in
-`AUTOREVIEW_HELPER`, and use the same wrapper for both manifest checks; the exact
-runtime-changing-PR command sequence lives in
-[`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
-Wrapper-owned Node launches discard `NODE_OPTIONS` and `NODE_PATH` before
-executable probing, validation helpers, or the pinned MJS entry point can run;
-dynamic-loader and interpreter startup-injection variables are scrubbed as
-well. An explicit external helper remains caller-trusted. These checks protect
-review integrity but are not a
-provenance boundary: invoking the repo command already trusts executable code
-in the active checkout. The adapter compares the target-scoped
-fingerprint around prepared-bundle staging, so a same-commit branch switch,
-moving base ref, or relevant concurrent edit fails closed instead of mixing
-review snapshots. Its executable search path excludes the reviewed worktree,
-requires the physical checkout root to match Git's top level, uses the system
-path for bare shell utilities, and resolves Git, Node, GitHub CLI, and
-semantic-engine executables to external targets before use. Direct targets and
-every canonical ancestor must be owned by the current user or root and must not
-be group/other-writable. On Darwin, Homebrew-style paths that fail only the
-ancestry rule are
-accepted through sealed private snapshots only when they are native Mach-O
-executables with an entirely system-only linked-library closure; scripts and
-relative or non-system library closure fail closed. On Linux, a root-run
-wrapper may recover an otherwise path-untrusted Node (including root- or
-foreign-owned writable/hard-linked toolcache layouts) only when its inode
-belongs to a live wrapper ancestor through an uninterrupted all-root chain;
-direct helper invocation stays fail-closed. It seals that exact ELF plus a glibc-only,
-recursively validated static dependency closure behind a private alias
-directory and controlled `LD_LIBRARY_PATH`. The helper revalidates the snapshot,
-sealed manifest, loader, and alias handoff around semantic-engine launches. This
-does not attest later
-application-level dynamic loads. Node discovery never
-executes a version-manager shim: Volta is queried through a sealed native
-`volta which node`, and the returned Node path is revalidated before launch.
-Git commands ignore inherited repository-routing variables.
-
-When no `--base` is supplied, automatic PR-base lookup falls back to
-`origin/main` only after a confirmed zero-match result or when GitHub CLI is
-absent. Malformed output, ambiguous multiple matches, and operational failures
-fail closed. With GitHub CLI available, lookup requires a canonical
-`github.com` origin, ignores inherited `GH_HOST` and `GH_REPO`, and explicitly
-addresses that origin repository. A unique match must also belong to the
-current repository owner, so a fork PR with the same branch name cannot select
-the review base. Use an explicit `--base` when GitHub lookup is unavailable or
-intentionally bypassed.
-
-Keep the repo-local helper as the source of truth for this repo's required ship
-gate; update it deliberately when taking upstream improvements from a
-personal/global skill. Freeze the review scope baseline before the first pass,
-classify growth as in-scope/follow-up/stop, create an issue for valid follow-up
-work, warn near twice the baseline, and pause after two review-triggered patch
-cycles. A clean source review is not browser, CLI/API, generated-artifact, or
-runtime proof; those verification paths and the final `pr:ready-state` gate
-remain separate and required.
+## Codex Cloud routing
 
 Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
-`~/.claude` directories; setup and maintenance rely on the repo-local helper at
-`scripts/agent-autoreview.mjs`, which fails fast if missing. PR shipping
-requires `pnpm agent:autoreview` as the structured batch-boundary review.
-Configure the environment setup script as `./scripts/codex-cloud-setup.sh` and
-the optional maintenance script as `./scripts/codex-cloud-maintenance.sh`. Full
-mechanics (GitHub CLI bootstrap, Trunk/Foundry install and mirror knobs, OSV
-egress check, maintenance fast-path) live in
-`docs/notes/codex-cloud-setup.md`.
+`~/.claude` directories. Configure the environment setup and optional
+maintenance scripts as:
 
-For workflow continuity, this repo includes thin repo-local `ship` and
-`babysit-pr` skill adapters under `.agents/skills/` with matching
-`.claude/skills/` mirrors. They preserve the familiar command names while
-backing the behavior with repo-visible commands: `pnpm agent:quality-gate`,
-`pnpm agent:autoreview` when available, and `pnpm pr:ready-state`.
+```bash
+./scripts/codex-cloud-setup.sh
+./scripts/codex-cloud-maintenance.sh
+```
 
-The repo-local `doc-garden` skill uses the same exact-mirror contract. It turns
-a generated bounded packet into evidence-backed dispositions, guarded semantic
-edits, link/catalog repair, and normal PR closeout; the detailed cadence and
-queue behavior stay in `docs/notes/documentation-gardening.md`.
+Both paths rely on the repo-local autoreview helper. GitHub CLI bootstrap,
+Git/credential setup, Trunk and Foundry installation, dependency/codegen checks,
+and maintenance behavior live in
+[`codex-cloud-setup.md`](codex-cloud-setup.md).
 
-## SessionEnd hook (reflect nudge)
+## Repo skill adapters
 
-`scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/reflect` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
+The repo-local `ship` and `babysit-pr` skills under `.agents/skills/` have exact
+`.claude/skills/` mirrors. They preserve the familiar workflow names while
+backing behavior with repo-visible commands such as `pnpm agent:quality-gate`,
+`pnpm agent:autoreview`, and `pnpm pr:ready-state`.
 
-- Claude wiring: `.claude/settings.json` → `hooks.SessionEnd`.
-- Codex wiring: `.codex/hooks.json`. Codex auto-disables new hooks until trusted; on first encounter, codex either prompts to trust or you mirror the entry into `~/.codex/hooks.json` and toggle `enabled = true` (set the hash) in `[hooks.state]` of `~/.codex/config.toml`. Or pass `--dangerously-bypass-hook-trust` for automation.
+The `doc-garden` skill uses the same exact-mirror contract. It turns a generated
+bounded packet into evidence-backed dispositions, guarded semantic edits,
+link/catalog repair, and normal PR closeout. The cadence and queue contract live
+in [`documentation-gardening.md`](documentation-gardening.md).
 
-## Status-polling commands use `Monitor`, not `/loop`
+## SessionEnd hook
 
-For commands that watch a long-running external process (Envio sync, PR CI, deploy progress, etc.), prefer the `Monitor` tool over `/loop` + cron. Monitor runs a single shell script that polls internally at 30–60s and only emits stdout lines (== notifications) on state changes worth surfacing. Cron / `/loop` fires a full Stop turn per interval, which triggers a macOS notification regardless of whether anything changed — a 60-min sync produces ~12 idle notifications, vs 2–3 with Monitor. `babysit-indexer-deploy` and `babysit-pr` are the canonical examples; if you find yourself writing a new "watch X every Y minutes" command, model it on those.
+`scripts/agent-session-end-hook.sh` runs on SessionEnd for Claude Code and Codex.
+When the session left commits or working-tree changes, it prints a one-line
+`/reflect` nudge so durable learnings can be routed before context is lost. It is
+silent on no-op sessions.
+
+- Claude wiring: `.claude/settings.json` under `hooks.SessionEnd`.
+- Codex wiring: `.codex/hooks.json`; trust and enable the repo hook when Codex
+  prompts. The checked-in file proves the wiring, not user-local trust state.
+
+## Status polling
+
+For Claude commands that watch a long-running external process, prefer the
+`Monitor` tool over `/loop` plus cron. Monitor can poll internally every 30–60
+seconds while emitting only meaningful state changes; `/loop` creates a full
+turn and notification at every interval. `babysit-indexer-deploy` is the
+canonical Monitor example. The repo-local `babysit-pr` skill instead provides a
+portable readiness-watch fallback when Monitor is unavailable.

--- a/docs/notes/codex-cloud-setup.md
+++ b/docs/notes/codex-cloud-setup.md
@@ -3,7 +3,7 @@ title: Codex Cloud Setup and Maintenance
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -13,60 +13,77 @@ garden_lane: operator-runbooks
 # Codex Cloud Setup and Maintenance
 
 Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
-`~/.claude` directories. Cloud setup and maintenance therefore rely on the
-repo-local helper at `scripts/agent-autoreview.mjs`; they fail fast only if that
-repo-owned executable is missing or an explicit compatible `AUTOREVIEW_HELPER`
-override is not executable. Prepared-bundle overrides must implement the pinned
-helper's final handoff contract, including `--bundle-output`,
-`--bundle-output-display`, and `--trusted-input-root`. The wrapper-attested
-helper owns source fingerprinting and untracked-file serialization from a
-private manifest-bound runtime created before the final handoff. The owning
-checkout must match the pinned protected-main wrapper and materialize compatible
-helper/core blobs from that object; runtime-changing reviews use a separate
-trusted wrapper checkout physically outside the reviewed checkout. An explicit
-override that names that external wrapper's default sibling is still privately
-attested before use. PR shipping requires
-`pnpm agent:autoreview` as the structured batch-boundary review.
-Configure the Codex Cloud environment setup script as:
+`~/.claude` directories. Configure the environment setup script and optional
+cached-container maintenance script as:
 
 ```bash
 ./scripts/codex-cloud-setup.sh
-```
-
-Configure the optional Codex Cloud environment maintenance script as:
-
-```bash
 ./scripts/codex-cloud-maintenance.sh
 ```
 
-Codex Cloud setup expects `GH_TOKEN` (preferred) or `GITHUB_TOKEN` for GitHub
-CLI-backed PR workflows, installs GitHub CLI from the official apt repository if
-the base image lacks it, configures git to use `gh` credentials for fetch/push,
-and refreshes `origin/main` before agent work starts. It also
-prewarms the pinned Trunk CLI and runs `./tools/trunk install` so
-Trunk-managed linters/runtimes are available before a task starts. If the cloud
-proxy blocks Trunk, allowlist
-`https://trunk.io/releases/`; if direct egress is available but the proxy is the
-blocker, set `CODEX_CLOUD_TRUNK_BYPASS_PROXY=1` to add `trunk.io` to `NO_PROXY`
-during setup. If neither route is available, set `CODEX_CLOUD_TRUNK_TARBALL_URL`
-to a reachable mirror of the pinned Linux Trunk tarball and set
-`CODEX_CLOUD_TRUNK_TARBALL_SHA256` so setup verifies the mirrored artifact before
-installing it. Keep `CODEX_CLOUD_TRUNK_INSTALL_TOOLS=true` (the default) for
-normal Cloud runs; set it to `false` only when using a base image with a
-prewarmed Trunk cache. Setup also installs Foundry by default
-(`CODEX_CLOUD_INSTALL_FOUNDRY=true`) so Aegis `forge test` checks can run. Set
-`CODEX_CLOUD_FOUNDRYUP_URL` to use a mirrored installer and
-`CODEX_CLOUD_FOUNDRYUP_SHA256` to verify that mirrored installer before
-execution. Setup checks OSV API egress by POSTing to
-`https://api.osv.dev/v1/querybatch` unless `CODEX_CLOUD_CHECK_OSV_EGRESS=false`,
-and verifies the repo-local autoreview helper at
-`scripts/agent-autoreview.mjs` before tool prewarm. Set `AUTOREVIEW_HELPER` only
-for an intentional compatible executable override; setup fails fast when the
-effective helper is missing.
+## Setup contract
 
-Codex Cloud maintenance runs when Codex resumes a cached container after
-checking out the task branch. It skips apt/tool installation, re-establishes
-repo-local git state, refreshes `origin/main`, verifies that the repo-local
-autoreview helper is still present, syncs branch lockfile changes via
-`CI=true pnpm install --frozen-lockfile --prefer-offline`, regenerates Envio
-types, and runs `pnpm agent:context-check`.
+Setup prepares a fresh container. It:
+
+- marks the checkout safe for Git, configures token-backed GitHub credentials,
+  and adds or rewrites `origin` to HTTPS when required;
+- refreshes `origin/main` and enables `.trunk/hooks`;
+- activates the `packageManager` version from `package.json` through Corepack;
+- verifies the repo-local autoreview helper, prewarms Trunk, installs Foundry,
+  and checks OSV API egress;
+- installs the frozen workspace dependencies; and
+- regenerates and verifies Envio types, then runs `pnpm agent:context-check`.
+
+Setup fails closed when required GitHub auth/fetch, helper, tool installation,
+dependency installation, codegen, or context validation fails. It can modify
+global Git credential configuration and the checkout's `origin` URL; use a
+dedicated Cloud container rather than a developer workstation.
+
+## GitHub and package tooling
+
+Setup expects `GH_TOKEN` (preferred) or `GITHUB_TOKEN`. If `gh` is absent on an
+apt-based image, it first tries the configured apt sources and then adds the
+official GitHub CLI repository as a fallback. It verifies `gh` auth before
+configuring fetch/push credentials and refreshing `origin/main`.
+
+The pinned Trunk CLI is prewarmed and `./tools/trunk install` supplies its
+managed linters and runtimes. If the Cloud proxy blocks Trunk, allowlist
+`https://trunk.io/releases/`; when direct egress works, set
+`CODEX_CLOUD_TRUNK_BYPASS_PROXY=1` to add `trunk.io` to `NO_PROXY`. Otherwise,
+set both `CODEX_CLOUD_TRUNK_TARBALL_URL` and
+`CODEX_CLOUD_TRUNK_TARBALL_SHA256` to a reachable verified mirror. Keep
+`CODEX_CLOUD_TRUNK_INSTALL_TOOLS=true` unless the image already has a prewarmed
+Trunk cache.
+
+Foundry installs by default so Aegis `forge test` checks can run. Set
+`CODEX_CLOUD_INSTALL_FOUNDRY=false` only when the image already supplies it. A
+custom `CODEX_CLOUD_FOUNDRYUP_URL` executes installer code, so always pair it
+with `CODEX_CLOUD_FOUNDRYUP_SHA256`; never use an unverified custom mirror.
+Fail-closed script enforcement is tracked in
+[#1477](https://github.com/mento-protocol/monitoring-monorepo/issues/1477).
+
+Setup POSTs to `https://api.osv.dev/v1/querybatch` to prove osv-scanner egress.
+Set `CODEX_CLOUD_CHECK_OSV_EGRESS=false` only when that check is intentionally
+unavailable and the resulting quality-gate limitation is accepted.
+
+## Autoreview helper
+
+The default helper is `scripts/agent-autoreview.mjs`. Set `AUTOREVIEW_HELPER`
+only for an intentional compatible executable override. The helper and
+prepared-bundle trust contracts live in
+[`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); do not
+duplicate them here.
+
+## Maintenance contract
+
+Maintenance runs after a cached container checks out the task branch. It skips
+apt and tool installation, then re-establishes Git/origin state, refreshes
+`origin/main`, enables repo hooks, activates pnpm, verifies the autoreview
+helper, syncs the branch lockfile with:
+
+```bash
+CI=true pnpm install --frozen-lockfile --prefer-offline
+```
+
+It finishes by regenerating Envio types and running
+`pnpm agent:context-check`.

--- a/docs/notes/cross-protocol-context.md
+++ b/docs/notes/cross-protocol-context.md
@@ -3,7 +3,7 @@ title: Cross-Protocol Context
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -3,7 +3,7 @@ title: Dashboard Local and Browser Verification
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-22
 doc_type: runbook
 scope: ui-dashboard
 review_interval_days: 90
@@ -74,9 +74,9 @@ For a simulated authenticated session:
    render, and authenticated controls are visible.
 
 The `/volume` Organic/All protocol-actor control is authenticated-only.
-Logged-out sessions intentionally hide it and force all-volume queries, so a
-protocol actor appearing while logged out does not disprove organic filtering.
-Verify that filter in a simulated session or query with
+Logged-out sessions intentionally hide it and force all-actor queries, so a
+protocol actor appearing while logged out is expected and does not exercise the
+Organic filter. Verify that filter in a simulated session or query with
 `isProtocolActorIn: [false]`.
 
 ## Production-build differences
@@ -85,10 +85,12 @@ For `pnpm build` plus `pnpm start`:
 
 - `NEXT_PUBLIC_HASURA_URL` must exist at build time; only `pnpm dev` supplies a
   production default.
-- Sentry initializes only when `VERCEL_ENV` is set at build time. Use
-  `VERCEL_ENV=preview` and a placeholder-format `NEXT_PUBLIC_SENTRY_DSN` for
-  local Sentry behavior. `next.config.ts` owns the
-  `NEXT_PUBLIC_VERCEL_ENV` mirror; do not set that mirror directly.
+- Client Sentry initializes only when `VERCEL_ENV` is set at build time because
+  `next.config.ts` inlines its `NEXT_PUBLIC_VERCEL_ENV` mirror. Server and edge
+  instrumentation also read `VERCEL_ENV` at runtime, so keep it set when
+  starting the built app. Use `VERCEL_ENV=preview` and a placeholder-format
+  `NEXT_PUBLIC_SENTRY_DSN` for local Sentry behavior; do not set the public
+  mirror directly.
 - The persisted SWR build salt is derived from
   `VERCEL_DEPLOYMENT_ID ?? VERCEL_GIT_COMMIT_SHA ?? "dev"` and inlined as
   `NEXT_PUBLIC_SWR_CACHE_BUILD_SALT`. Do not configure the public mirror. The
@@ -163,8 +165,11 @@ Current intentional silences are:
 - `no-secrets-in-client-code` in tests/scripts with placeholder public data;
 - `js-tosorted-immutable` for the ES2017 compatibility workaround and
   `effect/no-event-handler` for debounced/URL-state false positives;
-- `knip/files` for runtime-loaded browser fixtures and mutation config;
-- `knip/exports` only for the compatibility `HASURA_TIMEOUT_MS` re-export in
-  `src/lib/graphql.ts`; new server imports use `@/lib/hasura-timeout`.
+- `knip/files` for scripts, runtime-loaded browser fixtures, mutation config,
+  and generated GraphQL;
+- `knip/exports` and `knip/types` for generated GraphQL; outside generated
+  code, the only `knip/exports` exception is the compatibility
+  `HASURA_TIMEOUT_MS` re-export in `src/lib/graphql.ts`. New server imports use
+  `@/lib/hasura-timeout`.
 
 Do not broaden these silences to make a changed file pass.

--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -3,7 +3,7 @@ title: Documentation gardening
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-19
+last_verified: 2026-07-22
 doc_type: runbook
 scope: ci/process
 review_interval_days: 90

--- a/docs/notes/hasura-isolation-trigger.md
+++ b/docs/notes/hasura-isolation-trigger.md
@@ -3,7 +3,7 @@ title: Hasura isolation trigger
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -29,24 +29,30 @@ alerts. Today this is the same hosted endpoint the public dashboard reads.
 
 Envio's small tier has returned HTTP 429 `"Tier Quota"` without `Retry-After`
 when the shared monthly endpoint quota is exhausted
-(`ui-dashboard/src/lib/gql-retry.ts`). The dashboard backs off on those 429s;
-the bridge records them as
-`mento_pool_bridge_poll_errors_total{kind="hasura_rate_limit"}`.
+(`ui-dashboard/src/lib/gql-retry.ts`). The dashboard recognizes that response
+body and backs off. The bridge classifies every GraphQL HTTP 429 as
+`mento_pool_bridge_poll_errors_total{kind="hasura_rate_limit"}` without checking
+the body, so that metric proves rate limiting, not shared-quota exhaustion.
 
 ## Trigger condition
+
+The `Metrics Bridge Poll Errors` Grafana rule fires above `0.01/s` for 10
+minutes. The two-day threshold below is a manual isolation decision after
+corroboration, not the alert's query.
 
 Act when any of these fire:
 
 - The `Metrics Bridge Poll Errors` alert fires with
-  `kind="hasura_rate_limit"` on at least two distinct days within a rolling
-  14-day window.
+  `kind="hasura_rate_limit"`, the underlying response body or Envio usage
+  corroborates shared-quota pressure, and this happens on at least two distinct
+  days within a rolling 14-day window.
 - Dashboard Sentry shows sustained 429 `"Tier Quota"` `ClientError` events
   outside a known quota-burn incident.
 - Envio usage shows more than 80% of the monthly tier quota consumed before
   day 21 of the month.
 
-For non-429 Hasura failures, inspect bridge logs before treating the event as
-quota pressure:
+Inspect bridge logs and Envio usage before treating any bridge 429 or non-429
+Hasura failure as shared-quota pressure:
 
 ```bash
 gcloud run services logs read metrics-bridge --project mento-monitoring --region europe-west1
@@ -56,8 +62,10 @@ gcloud run services logs read metrics-bridge --project mento-monitoring --region
 
 1. Contact Envio support to confirm whether hosted Hasura applies
    per-consumer rate limits and to price a tier upgrade or dedicated endpoint.
-2. Protect paging first: provision a dedicated Envio endpoint or replica for
-   `metrics-bridge` and point its `HASURA_URL` there.
+2. Protect paging first: add a dedicated bridge-only Terraform input, provision
+   a dedicated Envio endpoint or replica, and point `metrics-bridge` at it. The
+   current shared `var.hasura_url` configures both the dashboard and bridge, so
+   changing that value alone does not isolate either consumer.
 3. Reduce public load: route anonymous browser polling through a Next.js route
    handler with short-TTL shared caching.
 

--- a/docs/notes/polygon-monitoring.md
+++ b/docs/notes/polygon-monitoring.md
@@ -3,7 +3,7 @@ title: Polygon monitoring coverage and rollout
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -3,7 +3,7 @@ title: PR Ready State
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -12,14 +12,15 @@ garden_lane: operator-runbooks
 
 # PR Ready State
 
-`pnpm pr:ready-state` is the shared readiness probe for Claude Code and Codex
-PR babysitting. It should answer one question: is the PR ready to report as
-all-clear right now?
+`pnpm pr:ready-state` is the shared required-readiness probe for Claude Code and
+Codex PR babysitting. It answers whether the current head's required GitHub and
+repo-policy gates are clear.
 
-The command must be the source of truth before either agent signals all-clear.
-Agent-specific loops can still gather extra context or post replies, but their
-final readiness decision should come from this command so Claude and Codex do
-not drift.
+The command is the final required-gate source of truth, not a replacement for
+the feedback sweep. Before either agent signals all-clear, `pr:feedback-state`
+must have a clean feedback ledger and the subsequent current-head
+`pr:ready-state` result must be ready. Agent-specific loops may gather extra
+context or post replies, but they must preserve that two-projection contract.
 
 ## Readiness model
 
@@ -84,15 +85,14 @@ separate advisory state: report it in the readiness output, but do not hold the
 all-clear on it unless the Cursor check or review is required by branch
 protection.
 
-Some non-required workflows still post review feedback that can become required
-repo-policy blockers after the required status surface is already green. For
-example, an in-progress `auto-review` job does not block by status alone, but it
-can later create inline threads, unreplied review comments, or actionable
-top-level bot feedback. The probe result remains the readiness source of truth:
-do not block `ready` on those workflows unless branch protection makes them
-required. If one is visibly in progress during handoff, report it as optional
-lag; when you are still babysitting the PR anyway, rerun `pr:feedback-state`
-after it reaches a terminal state so late feedback is not missed.
+Some non-required workflows still post feedback that becomes a repo-policy
+blocker after the required status surface is green. Their workflow status stays
+optional, but inline threads, unreplied review comments, and actionable
+top-level bot feedback do not. `pr:feedback-state` owns that ledger;
+`pr:ready-state` does not project actionable top-level summaries into its
+required blockers. If a review-producing workflow is visibly in progress,
+report it as optional lag and rerun `pr:feedback-state` after it reaches a
+terminal state so late feedback is not missed.
 
 ## Expected CLI contract
 
@@ -206,8 +206,9 @@ Field expectations:
   not flip this to `false`. A PR whose `pr.state` is `MERGED` is terminal-ready;
   a PR whose `pr.state` is `CLOSED` without merge is terminal-blocked with a
   `state` blocker.
-- `required.ready`: mirrors the required-only decision and should be the value
-  agents use for all-clear.
+- `required.ready`: mirrors the required-readiness half of the decision. Agents
+  use it only after `pr:feedback-state` has a clean feedback ledger; it is not
+  sufficient for all-clear by itself.
 - `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe uses
   this before fetching comments, reactions, check sources, and branch
   protection so post-merge babysitting exits quickly and does not mistake
@@ -262,51 +263,17 @@ Field expectations:
    review-triggered patch cycles rather than starting a third automatically.
 3. Run the mapped local gate once for the batch.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
-   run `pnpm agent:autoreview` as a structured closeout review. The command is
-   a repo adapter for the pinned helper at `scripts/agent-autoreview.mjs`. It
-   reviews the complete branch-local target without truncation. Direct semantic
-   engines fail closed if the target needs more than one prompt; prepared
-   bundles preserve a bounded lossless pass index that one fresh-context
-   reviewer must inspect completely. Semantic engines run from an isolated
-   empty workspace with restricted project configuration and environment, and
-   review inputs fail closed when sensitive paths or content are detected. A
-   quiet semantic pass emits a heartbeat every 60 seconds.
-   Verify accepted findings before editing; if review-triggered fixes change
-   code, rerun focused checks and autoreview for that fixed batch. Inside an
-   active Codex sandbox, the adapter may default to the helper's local
-   deterministic engine only when no engine is explicitly selected. An
-   explicitly selected unavailable semantic engine fails closed. For a true
-   fresh-context Codex semantic pass, prepare a bundle and hand it to the
-   reviewer:
+   run `pnpm agent:autoreview` as a structured source-review closeout. Verify
+   accepted findings before editing and rerun focused checks plus autoreview if
+   those fixes change the batch. The exact target, prepared-bundle, isolation,
+   and trust contracts live in
+   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
+   behavioral and runtime verification in the validation record.
 
-   ```bash
-   pnpm agent:autoreview --prepare-bundle-dir <dir>
-   pnpm agent:autoreview --verify-bundle-dir <dir>
-   # Retain the printed digest outside the bundle, review every pass, then:
-   pnpm agent:autoreview --verify-bundle-dir <dir> \
-     --expected-bundle-manifest <retained-pre-review-digest>
-   ```
-
-   Use a directory outside the repo worktree whose parent already exists so
-   local-mode bundles do not include themselves. Every canonical parent
-   ancestor must be owned by the current user or root; group/other-writable
-   ancestors require sticky-bit protection. On macOS, write-granting ACLs on
-   parent ancestors or bundle entries fail preparation or verification. Direct supplemental evidence
-   must be repo-relative; adapter-generated `--feedback-pr <number>` state and
-   protected-main checklist copies inside the trusted bundle directory are the
-   narrow exceptions. The owning-checkout default semantic helper and automatic
-   feedback use Node modules from that same pinned `origin/main` object with
-   canonical repository routing rather than a PR-selected base, mutable
-   worktree, or package scripts; wrapper-owned Node launches discard
-   `NODE_OPTIONS` and `NODE_PATH`. Reviewer web search is disabled by
-   default; opt in only with `--web-search`. Do not pass the removed
-   `--parallel-tests` option; the quality gate owns tests. A clean source review
-   does not prove UI, CLI/API, generated-artifact, or runtime behavior, so keep
-   all applicable verification in the validation record.
-
-5. Run `pnpm --silent pr:feedback-state --pr <number> --json` for a feedback-only sweep,
-   or `pnpm pr:ready-state --pr <number> --json` for the final readiness
-   source of truth. For a foreground wait loop, use
+5. Run `pnpm --silent pr:feedback-state --pr <number> --json` for the feedback
+   sweep. After its ledger is clean, run
+   `pnpm pr:ready-state --pr <number> --json` for the final required-readiness
+   decision. For a foreground wait loop, use
    `pnpm pr:ready-state --pr <number> --watch --compact --until-ready`.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
@@ -319,8 +286,8 @@ Field expectations:
    in-progress review-producing workflows. If you are still watching the PR when
    one finishes, rerun `pr:feedback-state` to catch late feedback; do not treat
    the optional workflow status itself as a blocker.
-9. Signal all-clear only after final ready-state `ready` is true for the
-   current head.
+9. Signal all-clear only after feedback-state has no required blocker and final
+   ready-state `ready` is true for the current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
 Differences between Claude `Monitor` wiring and Codex polling should stay
@@ -355,5 +322,6 @@ watching until Codex approves, posts new feedback, or the signal becomes stale.
 - Cap manual Codex fallback to one request per head.
 - If `codexReviewSignal` is `requested` or `in_flight`, wait instead of posting
   another `@codex review`.
-- Declare all-clear from the required-only readiness result, not from optional
-  reviewer lag clearing first.
+- Declare all-clear only after the feedback ledger is clean and the
+  required-only readiness result is ready; optional reviewer lag does not need
+  to clear first.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -3,7 +3,7 @@ title: Quick Commands
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -46,6 +46,9 @@ pnpm code-health:history           # CodeScene-style git history report → repo
 pnpm code-health:duplication       # jscpd duplication report → reports/jscpd/ (advisory, never blocks)
 pnpm code-health:schema-diff       # GraphQL schema breaking-change diff vs origin/main (advisory, never blocks)
 pnpm code-health                   # Run knip + deps together (everything except history + duplication)
+pnpm agent:quality-gate            # Map changed paths to required local checks and PR checklists
+pnpm agent:quality-gate --run      # Execute the mapped local-only checks
+pnpm agent:context-check           # Validate repo-visible agent instructions, links, and routing
 pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
 pnpm agent:autoreview              # Isolated closeout review; multi-pass uses --prepare-bundle-dir DIR + one fresh-context reviewer; quality gate owns tests
 pnpm agent:autoreview:test         # Full autoreview regression families; defaults to up to 3 workers with progress + timings
@@ -61,6 +64,8 @@ pnpm docs:navigation-eval -- --prompt          # Print the bounded read-only eva
 pnpm docs:navigation-eval -- --prompt --base-commit <full-sha>  # Pin a committed result to a reachable default-branch ancestor
 pnpm docs:navigation-eval -- --validate <result.json>  # Recompute authority, evidence, route, and context scores
 pnpm agent:context-budget --strict # Enforce root, scoped-file, and aggregate-route AGENTS byte caps
+pnpm --silent pr:feedback-state --pr 123 --json  # Normalize unresolved/reply-required feedback before all-clear
+pnpm pr:ready-state --pr 123 --json              # Final current-head required-readiness probe
 node scripts/review-process-metrics.mjs --before-pr 1034 --limit 20  # Collect review-process baseline metrics
 node scripts/review-process-metrics.mjs --after-pr 1045 --limit 20   # Collect review-process check-in metrics
 pnpm lockfile:lint                 # Lockfile integrity + registry check (blocking; no install needed)
@@ -124,9 +129,10 @@ pnpm aegis:lint               # ESLint baseline gate for Aegis
 pnpm aegis:deploy             # Build, stage a locked App Engine app, and deploy Aegis to mento-monitoring
 pnpm aegis:logs               # Tail Aegis App Engine logs from mento-monitoring
 # Alloy deploy requires existing enabled secrets and a verified runtime identity.
-# Bootstrap/rotation is blocked on issue #1473; never run the legacy seed command.
+# Bootstrap/rotation remains blocked by open owner-decision issue #1473; never run the legacy seed command.
 pnpm aegis:agent:deploy       # Deploy the already provisioned Alloy collector
-pnpm aegis:tf:init / aegis:tf:plan
+pnpm aegis:tf:init
+pnpm aegis:tf:plan
 # Apply runs in CI on merge to main (aegis-terraform.yml; production-infra gate).
 
 # Infrastructure (Terraform)
@@ -137,11 +143,15 @@ pnpm infra:plan               # Preview infrastructure changes
 # Never run apply without explicit human approval. Plan first and surface the diff.
 pnpm infra:apply              # Apply infrastructure changes
 # Event-driven alerts stack (Cloud Functions + Slack channels/usergroups + Sentry bridge + QuickNode webhooks):
-pnpm alerts:infra:init / alerts:infra:plan
-pnpm alerts:oncall:typecheck / alerts:oncall:test / alerts:oncall:build
+pnpm alerts:infra:init
+pnpm alerts:infra:plan
+pnpm alerts:oncall:typecheck
+pnpm alerts:oncall:test
+pnpm alerts:oncall:build
 # Grafana metric alert rules (v3 Slack rules):
 pnpm alerts:rules:lint
-pnpm alerts:rules:init / alerts:rules:plan
+pnpm alerts:rules:init
+pnpm alerts:rules:plan
 # Apply happens via CI on merge to main for alerts-rules, alerts-delivery, and Aegis.
 # The production-infra gate enforces required-reviewer approval and allows
 # self-review for the sole-maintainer workflow.

--- a/docs/notes/reserve-yield-indexer.md
+++ b/docs/notes/reserve-yield-indexer.md
@@ -3,7 +3,7 @@ title: Reserve-Yield Indexer Topology
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-03
+last_verified: 2026-07-22
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -14,8 +14,8 @@ garden_lane: operator-runbooks
 
 Reserve-yield actuals are part of the production `mento` Envio project. The
 primary hosted project uses `indexer-envio/config.multichain.mainnet.yaml` for
-Ethereum reserve-yield events, Celo, and Monad; no separate hosted Envio project
-or dashboard endpoint is required.
+Ethereum reserve-yield events, Celo, Monad, and Polygon; no separate hosted
+Envio project or dashboard endpoint is required.
 
 The reserve-yield test harness is:
 


### PR DESCRIPTION
## The Problem

- This bounded operator-runbook packet contained duplicated autoreview mechanics, ambiguous PR all-clear guidance, and several claims that no longer matched their owning implementation.
- The Hasura isolation playbook treated every bridge HTTP 429 as proof of shared-quota exhaustion, which could send operators down the wrong mitigation path.
- All ten packet documents needed an evidence-backed disposition without reintroducing a high-churn documentation catalog.

## The Solution

- Audit every packet document against its owning scripts, configuration, tests, linked issues, and read-only runtime evidence; then tighten only the claims supported by that evidence.
- Consolidate detailed mechanics under their existing canonical owners, clarify the two-projection PR all-clear contract, correct the Hasura alert semantics, and regenerate only the affected catalog rows.

## Dispositions and evidence

| Document | Disposition | Evidence |
| --- | --- | --- |
| `docs/notes/codex-agent-skills.md` | **Tighten** | Reduced 2,523 words to 453 by routing autoreview mechanics to `agent-quality-gate-mechanics.md`; checked skill mirrors, Cloud routing, SessionEnd hook behavior, and Monitor versus portable watch ownership. |
| `docs/notes/codex-cloud-setup.md` | **Update** | Checked setup/maintenance scripts for Git and origin mutations, apt fallback order, Corepack/pnpm activation, Trunk/Foundry installation, dependency/codegen/context failure boundaries, and custom-installer verification behavior. |
| `docs/notes/cross-protocol-context.md` | **Keep** | The documented `mento-master-context` router exists, root instructions still delegate to it, and the verify-live-source caveat remains correct. |
| `docs/notes/dashboard-verification.md` | **Update** | Checked the dev wrapper, protected routes, Auth.js token recipe, fixture isolation, Lighthouse orchestration, Sentry client/server environment reads, volume actor filtering, and React Doctor exceptions. |
| `docs/notes/documentation-gardening.md` | **Keep** | Planner limits, six-lane rotation, Monday schedule, immutable live-issue states, OIDC mutation boundary, and regression tests match the runbook. |
| `docs/notes/hasura-isolation-trigger.md` | **Update** | The bridge classifies every GraphQL HTTP 429 as `hasura_rate_limit`; the Grafana rule fires above `0.01/s` for 10 minutes; dashboard and bridge currently share one Terraform input. The runbook and alert annotation now require corroboration before declaring shared-quota pressure. |
| `docs/notes/polygon-monitoring.md` | **Keep** | Verified contracts version, start blocks, addresses, three production pools, nine probe adapters, service/coverage/reserve alert rules, live production state, and pending-deployment rollout distinction. Groomed #1332 to reflect the existing exact-zero Polygon alerts. |
| `docs/notes/pr-ready-state.md` | **Tighten** | Removed duplicated autoreview internals and aligned root instructions, the babysit skill, `pr:feedback-state`, and `pr:ready-state`: a clean feedback ledger is required before the final current-head required-readiness result. |
| `docs/notes/quick-commands.md` | **Update** | Checked root package scripts, added missing quality/context/readiness commands, split non-executable slash shorthands, and verified that owner-decision issue #1473 remains open. |
| `docs/notes/reserve-yield-indexer.md` | **Update** | Checked the mainnet start block, launch-aligned 600-block stETH sampler, fail-closed batch behavior, test harness, dashboard degradation, live summary/movement rows, and current four-chain production topology including Polygon. |

Net result: 242 additions and 418 deletions across 13 files. `docs/README.md` changes only the ten affected rows; it contains no volatile global document/word counters.

## Validation

- `pnpm docs:index --write`
- `pnpm docs:index --check`
- `pnpm agent:context-check`
- `pnpm agent:context-budget --strict`
- `pnpm agent:quality-gate --run` — passed on current `origin/main`; includes targeted Trunk checks, Terraform fmt/init/validate, and alert-rule lint
- `pnpm agent:autoreview --engine local` — clean
- Manifest-bound fresh-context autoreview — two accepted documentation fixes applied; final complete 13-file pass clean
- Read-only Envio checks: deployment registry, production verification, and pending deployment status
- Browser verification: not applicable; no UI implementation or behavior changed

## Deferrals

- Enforce SHA-256 fail-closed behavior for custom Codex Cloud Foundry installer mirrors: #1477

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1475
Refs #1341
Refs #1349
