### PR TITLE
ci: remove Node 20 warning from Trunk pnpm setup action

### DIFF
--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - name: Install Node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:


### PR DESCRIPTION
## The Problem

- The required Code Quality workflow emits a Node.js 20 deprecation warning because Trunk's composite setup action still pins `pnpm/action-setup` v4.

## The Solution

- Reuse the repository's reviewed, immutable `pnpm/action-setup` v6.0.9 commit so the Trunk setup runs on the current action runtime without weakening SHA pinning.

## Details

- Keeps the existing composite action inputs and install flow unchanged.
- Uses the same verified commit already pinned by the repository's other pnpm setup steps.
- No operator-facing workflow contract changed, so canonical docs remain current.

## Validation

- `node scripts/check-github-action-pins.test.mjs` (8/8 passed)
- `node scripts/check-github-action-pins.mjs`
- `pnpm agent:quality-gate --run`
- immutable autoreview bundle plus deterministic and fresh-context semantic review
- PR Code Quality annotations will be checked during readiness babysitting

Closes #1464

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
