### PR TITLE
fix(autoreview): keep deterministic review scoped on behind branches

### DIFF
--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -3764,7 +3764,7 @@ function reviewDocsDrift(repo, target, paths, findings) {
   }
 }
 
-function diffCheckCommands(target) {
+function diffCheckCommands(repo, target) {
   if (target.mode === "branch") {
     return [["diff", "--check", `${target.ref}...${target.head}`]];
   }
@@ -3772,7 +3772,15 @@ function diffCheckCommands(target) {
     return [["show", "--format=", "--check", target.ref]];
   }
   if (target.mode === "branch-local") {
-    return [["diff", "--check", target.ref]];
+    const mergeBase = runGit(repo, [
+      "merge-base",
+      target.ref,
+      target.head,
+    ]).trim();
+    if (!/^[0-9a-f]{40,64}$/i.test(mergeBase)) {
+      throw new Error("branch-local review target has no valid merge base");
+    }
+    return [["diff", "--check", mergeBase]];
   }
   return [
     ["diff", "--cached", "--check", target.head],
@@ -3782,7 +3790,7 @@ function diffCheckCommands(target) {
 
 function reviewDiffCheck(repo, target, findings) {
   const outputs = [];
-  for (const gitArgs of diffCheckCommands(target)) {
+  for (const gitArgs of diffCheckCommands(repo, target)) {
     const result = runGitResult(repo, gitArgs);
     const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
     if (output) outputs.push(output);

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -1932,6 +1932,39 @@ run_branch_diff_check_regression() {
   expect_empty_stderr
 }
 
+run_branch_local_upstream_whitespace_regression() {
+  local review_repo="$tmp_dir/branch-local-upstream-whitespace"
+  local prompt="$tmp_dir/branch-local-upstream-whitespace.md"
+  init_review_repo "$review_repo"
+  printf 'legacy trailing whitespace   \n' >"$review_repo/upstream.txt"
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  printf 'upstream cleanup\n' >"$review_repo/upstream.txt"
+  commit_review_repo "$review_repo" "fix upstream whitespace"
+  git -C "$review_repo" switch feature >/dev/null 2>&1
+  printf 'local clean\n' >"$review_repo/local.txt"
+
+  run_helper_in_repo "$review_repo" \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$prompt"
+  expect_stdout_contains '"feature.txt"'
+  expect_stdout_contains '"local.txt"'
+  expect_stdout_not_contains '"upstream.txt"'
+  expect_file_not_contains "$prompt" "upstream.txt"
+  expect_empty_stderr
+
+  run_helper_in_repo "$review_repo" --base main --engine local
+  expect_stdout_contains "autoreview target: branch-local"
+  expect_stdout_contains "autoreview clean"
+  expect_stdout_not_contains "Diff contains whitespace"
+  expect_empty_stderr
+}
+
 run_local_deleted_reference_regression() {
   local review_repo="$tmp_dir/deleted-reference"
   init_review_repo "$review_repo"
@@ -5695,6 +5728,7 @@ run_target_selection_family() {
   run_core_target_node_tests
   run_review_target_metadata_regression
   run_branch_diff_check_regression
+  run_branch_local_upstream_whitespace_regression
   run_local_deleted_reference_regression
   run_commit_target_reads_selected_ref_regression
   run_non_utf8_git_blob_regression


### PR DESCRIPTION
## The Problem

- On a feature branch behind `origin/main`, deterministic autoreview could report findings from files changed only on the newer base branch.
- That disagreed with the prepared immutable bundle's branch-local scope and produced false blockers unrelated to the feature patch.

## The Solution

- Derive deterministic review's tracked diff from the frozen effective merge base, matching the bundle's branch-local target while retaining dirty-worktree evidence.

## Details

- Preserves committed feature changes, staged and unstaged overlays, deleted paths, and untracked evidence.
- Excludes findings that exist only on the newer base tip.
- Adds a diverged-branch regression with upstream-only trailing whitespace and local untracked evidence.
- Leaves semantic bundle capture and immutable verification unchanged.

## Validation

- `pnpm agent:autoreview:test` (full suite passed; 940s with one job)
- `pnpm agent:quality-gate --run` (all four mapped commands passed)
- protected-main wrapper/helper immutable bundle preparation and verification
- fresh-context semantic autoreview: clean, confidence 0.98
- bound post-review bundle verification: passed

Closes #1455

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
