### PR TITLE
fix(indexer): isolate median RPC limits per chain

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -205,6 +205,11 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
+- **Effect rate limits are global to each created effect object.** A provider-
+  specific cap in this multichain indexer must be routed through distinct
+  chain/provider-scoped effect objects. Keep preload and processing on the same
+  selected object so Envio still deduplicates identical inputs; never let one
+  chain's public-tier floor throttle every chain.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -205,6 +205,11 @@ Notes:
   their exact-block median timestamp remains unavailable after transient retry
   and fallback. A caught-up deployment with those historical reads missing is
   tainted and requires a clean replay.
+- **Effect rate limits are global to each created effect object.** A provider-
+  specific cap in this multichain indexer must be routed through distinct
+  chain/provider-scoped effect objects. Keep preload and processing on the same
+  selected object so Envio still deduplicates identical inputs; never let one
+  chain's public-tier floor throttle every chain.
 - **Version drift is common around V3 RCs.** Check the installed CLI and package before relying on older docs, memory, or notes; do not reintroduce V2-only fields such as `preload_handlers:`.
 - Development-plan retention and quota rules change independently of this
   repo. Check Envio's current hosted deployment/billing pages instead of

--- a/docs/pr-checklists/indexer-handler-invariants.md
+++ b/docs/pr-checklists/indexer-handler-invariants.md
@@ -32,6 +32,11 @@ propagation, also apply [`stateful-data-ui.md`](stateful-data-ui.md).
 
 - Block-keyed RPC caches must be bounded with an LRU or block-height eviction;
   never retain one entry per block in an unbounded `Map`.
+- Envio stores rate-limit state on each created effect object. In the multichain
+  indexer, a provider-specific floor or burst policy must use a chain/provider-
+  scoped effect object; never apply one chain's RPC limit to an effect shared by
+  every chain. Keep preload and processing on the same selected object so
+  identical-input deduplication still works.
 - Envio V3 runs each handler in a concurrent preload pass and then an ordered
   processing pass. Any direct `context.effect(...)` whose key can be derived
   before writes must be requested before or inside the positive

--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -17,7 +17,7 @@ import {
   decodeInvertRateFeedEffectResult,
   feesEffect,
   invertRateFeedEffect,
-  medianTimestampEffect,
+  medianTimestampEffectForChain,
   numReportersEffect,
   rebalanceThresholdsEffect,
   referenceRateFeedIDEffect,
@@ -224,7 +224,7 @@ indexer.onEvent(
           blockNumber,
         }),
         // preload-effect-exempt: one deployment-time median lookup per pool.
-        context.effect(medianTimestampEffect, {
+        context.effect(medianTimestampEffectForChain(event.chainId), {
           chainId: event.chainId,
           rateFeedID,
           blockNumber,

--- a/indexer-envio/src/handlers/fpmm/limits-and-fees.ts
+++ b/indexer-envio/src/handlers/fpmm/limits-and-fees.ts
@@ -14,7 +14,7 @@ import {
   tradingLimitStateFromEntity,
 } from "../../tradingLimits.js";
 import {
-  medianTimestampEffect,
+  medianTimestampEffectForChain,
   rebalancingStateEffect,
 } from "../../rpc/effects.js";
 import {
@@ -117,7 +117,7 @@ async function resolveThresholdRecompute(args: {
       blockNumber: args.blockNumber,
     }),
     rateFeedID
-      ? args.context.effect(medianTimestampEffect, {
+      ? args.context.effect(medianTimestampEffectForChain(args.chainId), {
           chainId: args.chainId,
           rateFeedID,
           blockNumber: args.blockNumber,

--- a/indexer-envio/src/handlers/fpmm/state-sync.ts
+++ b/indexer-envio/src/handlers/fpmm/state-sync.ts
@@ -46,7 +46,7 @@ import {
   type ResolvedRebalanceState,
 } from "../../priceDifference.js";
 import {
-  medianTimestampEffect,
+  medianTimestampEffectForChain,
   rebalanceIncentiveAtBlockEffect,
   rebalancingStateEffect,
   reservesEffect,
@@ -126,7 +126,7 @@ async function fetchAuthoritativeRebalanceState(args: {
       blockNumber: args.blockNumber,
     }),
     rateFeedID
-      ? args.context.effect(medianTimestampEffect, {
+      ? args.context.effect(medianTimestampEffectForChain(args.chainId), {
           chainId: args.chainId,
           rateFeedID,
           blockNumber: args.blockNumber,

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -38,7 +38,10 @@ import {
   getPoolsWithReferenceFeed,
   getBreakerConfigsByFeed,
 } from "../rpc.js";
-import { medianTimestampEffect, reportExpiryEffect } from "../rpc/effects.js";
+import {
+  medianTimestampEffectForChain,
+  reportExpiryEffect,
+} from "../rpc/effects.js";
 import {
   bootstrapAndResolveBreakerSnapshotFields,
   bootstrapFeedBreakerConfigs,
@@ -394,7 +397,7 @@ indexer.onEvent(
     // makes a warmed exact-block result look absent during processing.
     const requestMedianTimestamp = poolIds.length > 0;
     const medianTimestampPromise = requestMedianTimestamp
-      ? context.effect(medianTimestampEffect, {
+      ? context.effect(medianTimestampEffectForChain(event.chainId), {
           chainId: event.chainId,
           rateFeedID,
           blockNumber,
@@ -547,7 +550,7 @@ indexer.onEvent(
     // module-local state that disappears across hosted workers or restarts.
     const requestMedianTimestamp = poolIds.length > 0;
     const medianTimestampPromise = requestMedianTimestamp
-      ? context.effect(medianTimestampEffect, {
+      ? context.effect(medianTimestampEffectForChain(event.chainId), {
           chainId: event.chainId,
           rateFeedID,
           blockNumber,

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -20,7 +20,7 @@
 // (groups A, B, F) are safe to flip later.
 // ---------------------------------------------------------------------------
 
-import { createEffect as createEnvioEffect, S } from "envio";
+import { S } from "envio";
 import {
   fetchErc20Decimals,
   fetchInvertRateFeed,
@@ -31,7 +31,6 @@ import {
   fetchTradingLimits,
 } from "./pool-state.js";
 import {
-  fetchMedianTimestamp,
   fetchNumReporters,
   fetchRateFeedOracles,
   fetchReferenceRateFeedID,
@@ -53,32 +52,9 @@ import {
   type BreakerKindRpc,
 } from "./breakers.js";
 import { resolveFeeTokenMeta, UNKNOWN_FEE_TOKEN_META } from "../feeToken.js";
-import { trackEffectExecution } from "../performance.js";
+import { createEffect } from "./tracked-effect.js";
 import { fetchSusdsSharePriceUsdWei } from "./susds.js";
 import { fetchStethBalanceOf } from "./steth.js";
-
-type UntypedCreateEffect = (
-  options: unknown,
-  handler: (args: unknown) => Promise<unknown>,
-) => unknown;
-
-const createEffect = ((options: unknown, handler: unknown) => {
-  const effectName =
-    typeof options === "object" &&
-    options !== null &&
-    "name" in options &&
-    typeof (options as { name?: unknown }).name === "string"
-      ? (options as { name: string }).name
-      : "unknown";
-
-  return (createEnvioEffect as unknown as UntypedCreateEffect)(
-    options,
-    (args) =>
-      trackEffectExecution(effectName, () =>
-        (handler as (value: unknown) => Promise<unknown>)(args),
-      ),
-  );
-}) as typeof createEnvioEffect;
 
 // ---------------------------------------------------------------------------
 // Output schemas — defined once so they can be shared / referenced. Sury
@@ -665,29 +641,10 @@ export const reportExpiryEffect = createEffect(
     )) ?? null,
 );
 
-export const medianTimestampEffect = createEffect(
-  {
-    name: "medianTimestamp",
-    input: {
-      chainId: S.int32,
-      rateFeedID: S.string,
-      blockNumber: S.bigint,
-    },
-    output: S.nullable(S.bigint),
-    // dRPC's stressed public-tier floor is 40 eth_call/s. This exact-block
-    // read fans out during Polygon replays, so stay within that floor instead
-    // of creating a retry/fallback storm after transport-level batching.
-    rateLimit: { calls: 40, per: "second" },
-    cache: false,
-  },
-  async ({ input, context }) =>
-    (await fetchMedianTimestamp(
-      input.chainId,
-      input.rateFeedID,
-      input.blockNumber,
-      context.log,
-    )) ?? null,
-);
+export {
+  MEDIAN_TIMESTAMP_RATE_LIMITS,
+  medianTimestampEffectForChain,
+} from "./median-timestamp-effect.js";
 
 // ---------------------------------------------------------------------------
 // Group E — trading limits.

--- a/indexer-envio/src/rpc/median-timestamp-effect.ts
+++ b/indexer-envio/src/rpc/median-timestamp-effect.ts
@@ -1,0 +1,88 @@
+import { S } from "envio";
+import { fetchMedianTimestamp } from "./oracle-state.js";
+import { createEffect } from "./tracked-effect.js";
+
+type MedianTimestampProviderFamily = "polygon" | "celo" | "monad" | "default";
+
+export const MEDIAN_TIMESTAMP_RATE_LIMITS = {
+  // dRPC's stressed public-tier floor is 40 eth_call/s.
+  polygon: { calls: 40, per: "second" },
+  // Restore the rate that Celo replays used successfully before Polygon's
+  // public-tier floor was added to the formerly shared effect.
+  celo: { calls: 200, per: "second" },
+  // Monad capacity has not been measured independently yet.
+  monad: { calls: 40, per: "second" },
+  // New chains stay isolated until their provider capacity is measured and
+  // they are assigned an explicit family above.
+  default: { calls: 40, per: "second" },
+} as const;
+
+function medianTimestampProviderFamily(
+  chainId: number,
+): MedianTimestampProviderFamily {
+  if (chainId === 137 || chainId === 80002) return "polygon";
+  if (chainId === 42220 || chainId === 11142220) return "celo";
+  if (chainId === 143 || chainId === 10143) return "monad";
+  return "default";
+}
+
+function createMedianTimestampEffect(
+  name: string,
+  family: MedianTimestampProviderFamily,
+) {
+  return createEffect(
+    {
+      name,
+      input: {
+        chainId: S.int32,
+        rateFeedID: S.string,
+        blockNumber: S.bigint,
+      },
+      output: S.nullable(S.bigint),
+      // Rate-limit state lives on the effect object in Envio. Keep provider
+      // families on distinct objects so Polygon's public-tier floor cannot
+      // throttle Celo or Monad in the multichain replay.
+      rateLimit: MEDIAN_TIMESTAMP_RATE_LIMITS[family],
+      cache: false,
+    },
+    async ({ input, context }) =>
+      (await fetchMedianTimestamp(
+        input.chainId,
+        input.rateFeedID,
+        input.blockNumber,
+        context.log,
+      )) ?? null,
+  );
+}
+
+const polygonMedianTimestampEffect = createMedianTimestampEffect(
+  "medianTimestampPolygon",
+  "polygon",
+);
+const celoMedianTimestampEffect = createMedianTimestampEffect(
+  "medianTimestampCelo",
+  "celo",
+);
+const monadMedianTimestampEffect = createMedianTimestampEffect(
+  "medianTimestampMonad",
+  "monad",
+);
+const defaultMedianTimestampEffect = createMedianTimestampEffect(
+  "medianTimestampDefault",
+  "default",
+);
+
+/** Select one stable effect object per provider family. Using the same object
+ * in preload and processing preserves Envio's identical-input deduplication. */
+export function medianTimestampEffectForChain(chainId: number) {
+  switch (medianTimestampProviderFamily(chainId)) {
+    case "polygon":
+      return polygonMedianTimestampEffect;
+    case "celo":
+      return celoMedianTimestampEffect;
+    case "monad":
+      return monadMedianTimestampEffect;
+    case "default":
+      return defaultMedianTimestampEffect;
+  }
+}

--- a/indexer-envio/src/rpc/tracked-effect.ts
+++ b/indexer-envio/src/rpc/tracked-effect.ts
@@ -1,0 +1,26 @@
+import { createEffect as createEnvioEffect } from "envio";
+import { trackEffectExecution } from "../performance.js";
+
+type UntypedCreateEffect = (
+  options: unknown,
+  handler: (args: unknown) => Promise<unknown>,
+) => unknown;
+
+/** Envio effect factory with the repo's optional performance instrumentation. */
+export const createEffect = ((options: unknown, handler: unknown) => {
+  const effectName =
+    typeof options === "object" &&
+    options !== null &&
+    "name" in options &&
+    typeof (options as { name?: unknown }).name === "string"
+      ? (options as { name: string }).name
+      : "unknown";
+
+  return (createEnvioEffect as unknown as UntypedCreateEffect)(
+    options,
+    (args) =>
+      trackEffectExecution(effectName, () =>
+        (handler as (value: unknown) => Promise<unknown>)(args),
+      ),
+  );
+}) as typeof createEnvioEffect;

--- a/indexer-envio/test/medianTimestampEffects.test.ts
+++ b/indexer-envio/test/medianTimestampEffects.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+  MEDIAN_TIMESTAMP_RATE_LIMITS,
+  medianTimestampEffectForChain,
+} from "../src/rpc/effects.js";
+
+describe("medianTimestamp effect rate limits", () => {
+  it("keeps provider-specific limiter state on distinct effect objects", () => {
+    const polygon = medianTimestampEffectForChain(137);
+    const celo = medianTimestampEffectForChain(42220);
+    const monad = medianTimestampEffectForChain(143);
+    const fallback = medianTimestampEffectForChain(1);
+
+    assert.equal(medianTimestampEffectForChain(80002), polygon);
+    assert.equal(medianTimestampEffectForChain(11142220), celo);
+    assert.equal(medianTimestampEffectForChain(10143), monad);
+    assert.notEqual(polygon, celo);
+    assert.notEqual(polygon, monad);
+    assert.notEqual(celo, monad);
+    assert.notEqual(fallback, polygon);
+    assert.notEqual(fallback, celo);
+    assert.notEqual(fallback, monad);
+  });
+
+  it("protects Polygon without throttling Celo below its proven rate", () => {
+    assert.deepEqual(MEDIAN_TIMESTAMP_RATE_LIMITS, {
+      polygon: { calls: 40, per: "second" },
+      celo: { calls: 200, per: "second" },
+      monad: { calls: 40, per: "second" },
+      default: { calls: 40, per: "second" },
+    });
+  });
+});


### PR DESCRIPTION
## The Problem

- Polygon's public-RPC safety cap was attached to one Envio effect object shared by every indexed chain, unintentionally lowering Celo from its previously successful 200 calls/second to 40.
- The hosted replay consequently ran at roughly one third of the previous production replay rate even though handler CPU time remained low.
- Oracle freshness must remain fail-closed and exact-block; recovering throughput cannot weaken those guarantees.

## The Solution

- Route median-timestamp reads through stable provider-family effect objects: Polygon/Amoy at 40 calls/second, Celo/Celo Sepolia restored to 200, and Monad/default isolated at 40 until separately measured.
- Select the same stable object in preload and processing so Envio retains identical-input deduplication, while preserving the exact request tuple, `cache: false`, fallback, retry, and null semantics.
- Add regression coverage for object identity and rate policy, plus an Envio skill/checklist invariant so a future provider-specific limit cannot silently throttle every chain again.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/medianTimestampEffects.test.ts test/oracleReportedMedianParity.test.ts`
- Fresh-context autoreview: clean, 0 findings, 0.97 confidence
- Bound autoreview bundle manifest verified after review

## Deployment plan

- Keep the current `12a9902` replay running while this PR is reviewed.
- After merge, deploy this commit as the third candidate and compare per-chain slopes for 10-15 minutes.
- Retire only the demonstrably slower candidate; promote only after full catch-up and the normal runtime/log/metric verification.

## Deferrals

- Full elimination of replay-traffic-scaled historical oracle RPCs remains tracked in [#1392](https://github.com/mento-protocol/monitoring-monorepo/issues/1392).

Refs #1392
