### PR TITLE
fix(sentry): unbreak triage ingest — label descriptions over GitHub's 100-char limit

### DIFF
--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -196,7 +196,7 @@ export const LABEL_DEFINITIONS = [
     name: "sentry:fix-refused",
     color: "bfdadc",
     description:
-      "Autofix attempt declined to open a PR (no change or guard-refused); remove the label to allow a retry (ADR 0036 Phase 2b)",
+      "Autofix declined to open a PR (no change or guard-refused); remove the label to retry (ADR 0036)",
   },
   {
     name: "sentry:approved-archive",
@@ -208,7 +208,7 @@ export const LABEL_DEFINITIONS = [
     name: "sentry:archived",
     color: "6e7681",
     description:
-      "Underlying Sentry issue archived (archived_until_escalating) via the human-approved archive loop (Phase 2a, ADR 0036)",
+      "Sentry issue archived (archived_until_escalating) via the Phase 2a archive loop (ADR 0036)",
   },
 ];
 

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -196,7 +196,7 @@ export const LABEL_DEFINITIONS = [
     name: "sentry:fix-refused",
     color: "bfdadc",
     description:
-      "Autofix declined to open a PR (no change or guard-refused); remove the label to retry (ADR 0036)",
+      "Autofix declined to open a PR (no change/guard-refused); remove to retry (ADR 0036 Phase 2b)",
   },
   {
     name: "sentry:approved-archive",

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -16,6 +16,7 @@ import {
   ghPaginate,
   indexQueueIssuesByShortId,
   isSafeNextPageUrl,
+  LABEL_DEFINITIONS,
   mapSentryIssue,
   mergeSentryIssues,
   normalizeRestIssues,
@@ -96,6 +97,22 @@ await test("title truncation cuts at 90 chars and adds an ellipsis", () => {
   assertEqual(truncated.length, 91);
   assert(truncated.endsWith("…"), "expected ellipsis suffix");
   assertEqual(truncated.slice(0, 90), "x".repeat(90));
+});
+
+// ---------------------------------------------------------------------------
+// Label definitions must satisfy GitHub's limits — the bootstrap `gh label
+// create` calls them at ingest startup, and an over-length description returns
+// HTTP 422 that fails the whole scheduled run (this test guards that at PR
+// time, since the ensure calls are mocked elsewhere).
+// ---------------------------------------------------------------------------
+
+await test("every label description is within GitHub's 100-char limit", () => {
+  for (const { name, description } of LABEL_DEFINITIONS) {
+    assert(
+      description.length <= 100,
+      `label ${name} description is ${description.length} chars (max 100): ${description}`,
+    );
+  }
 });
 
 await test("queue title format matches the normative v2 contract", () => {


### PR DESCRIPTION
## The Problem

- The scheduled Sentry-triage **ingest has failed every run since 2026-07-19** (it succeeded that morning, has been red twice a day since).
- Root cause: ingest startup bootstraps labels with `gh label create --force` for each `LABEL_DEFINITIONS` entry, and GitHub rejects a label description over **100 characters** with `HTTP 422: description is too long`, failing the whole run before any ingest work happens.
- Two Phase-2a/2b labels were over the limit: `sentry:fix-refused` (121 chars) and `sentry:archived` (117).

## The Solution

- Shortened both descriptions to ≤100 chars (96 and 90) without losing meaning.
- Added a guard test asserting **every** `LABEL_DEFINITIONS` description is ≤100 chars. The suite mocks the `gh label create` calls, so nothing caught this at PR time — now a future over-length label fails the unit test instead of a production run.

## Validation

- `node scripts/sentry-triage-ingest.test.mjs` — 55 pass (incl. the new guard); max description length is now 96.
- The next scheduled ingest will bootstrap the labels successfully and resume triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJKvqjifpKxC6hUJ4hNBcp
