### PR TITLE
fix(autofix): drop the agent step's github_token, document the credential residual (#1373)

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -19,11 +19,18 @@ name: Sentry Autofix
 #     reads, so it needs no gh tool or token in env. It cannot execute code, so
 #     an injected verdict cannot exfiltrate secrets by running JS. A
 #     prompt-injected agent can, at most, produce a bad DIFF, which the mechanical
-#     diff guard + required CI + human review catch. (Residual: claude-code-action
-#     itself holds its `github_token` input + the Claude OAuth token in the CLI
-#     process env, which the agent's Read tool could in principle reach via a
-#     process-env surface — inherent to the action, same as claude.yml, tracked
-#     as a sandboxing follow-up.)
+#     diff guard + required CI + human review catch. (Residual, issue #1373: the
+#     CLI must hold the Claude OAuth *inference* token in its process env to
+#     authenticate, and a process can always read its own /proc/self/environ, so
+#     an injected agent's Read tool CAN reach that token — this cannot be blocked
+#     on a hosted runner while claude-code-action runs inference and the tool
+#     loop in one process; a true sandbox needs an upstream action feature. We
+#     shrink the blast radius instead: `github_token` is NOT passed (above), so
+#     the only credential in the env is the inference token, which is
+#     inference-only (no repo/cloud scope) and rotatable. It can only leave via a
+#     DIFF the agent writes — no network/gh tool — which the finalize
+#     credential-scan inspects; the accepted residual is a leaked, rotatable
+#     inference token under a successful prompt injection.)
 #   - NO git AT ALL against the agent-tainted checkout, and NO write credential
 #     in the LLM step. The agent has Write access to the checkout INCLUDING
 #     .git/, so any git command there would run agent-planted hooks / clean-smudge
@@ -202,10 +209,12 @@ jobs:
     # Deliberately NO GH_TOKEN at job level: it must not reach the claude-code
     # LLM step's process env, where a prompt-injected agent could read it from a
     # process-environment surface. Each deterministic step that needs GitHub auth
-    # sets GH_TOKEN itself. (Residual: claude-code-action still holds its own
-    # `github_token` input + the Claude OAuth token in the CLI process; see the
-    # containment note — that exposure is inherent to the action and tracked as a
-    # sandboxing follow-up.) These non-secret vars are safe at job level.
+    # sets GH_TOKEN itself. And the agent step drops the action's optional
+    # `github_token` input (see there), so the ONLY credential in the CLI env is
+    # the Claude OAuth inference token — inference-only and rotatable. That token
+    # can't be removed (the CLI needs it to authenticate) and self-environ reads
+    # can't be sandboxed on a hosted runner; the residual is documented at the
+    # containment note (issue #1373). These non-secret vars are safe at job level.
     env:
       QUEUE_ISSUE: ${{ matrix.entry.issue }}
       SHORT_ID: ${{ matrix.entry.shortId }}
@@ -285,7 +294,11 @@ jobs:
       - uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1.0.174
         if: ${{ matrix.entry.reconcile != true }}
         with:
-          github_token: ${{ github.token }}
+          # NO github_token: the fix agent has no GitHub/gh tools and posts
+          # nothing — every GitHub write is deterministic downstream via the App
+          # token. Omitting it (the action's `github_token` is optional) keeps
+          # this credential OUT of the CLI process env, shrinking what a
+          # prompt-injected agent's Read tool can reach (issue #1373).
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.render.outputs.prompt }}
           # NO --mcp-config: the fix agent gets no Sentry access at all — its

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -851,14 +851,22 @@ the agent's job**: it cannot run tests, so the fix PR's own full required CI
 (typecheck, tests, lint) plus independent review is the verification — which is
 exactly why merge stays human.
 
-_Residual (accepted, tracked):_ `anthropics/claude-code-action` still holds its
-own `github_token` input and the Claude OAuth token in the CLI process env,
-which the agent's unrestricted `Read` tool could in principle reach via a
-process-environment surface and then write into an edited file or the summary.
-This exposure is inherent to the action and identical to the repo's existing
-`claude.yml` agents; the OAuth token is inference-only and rotatable, and any
-leak would have to survive human PR/comment review. Full OS-level
-process/filesystem sandboxing of the agent is a follow-up.
+_Residual (accepted, issue #1373):_ `anthropics/claude-code-action` must hold
+the Claude OAuth **inference** token in the CLI process env to authenticate, and
+a process can always read its own `/proc/self/environ`, so the agent's
+unrestricted `Read` tool can reach that token and write it into an edited file
+(the summary channel is closed — agent free-text is never published). This
+**cannot be sandboxed on a hosted runner** while the action runs inference and
+the tool loop in one process; a true sandbox needs an upstream action feature.
+We shrink the blast radius instead: the agent step no longer passes the action's
+optional `github_token` (the agent has no GitHub tools; every GitHub write is
+the App token downstream), so the ONLY credential in the env is the inference
+token — inference-only (no repo/cloud scope), rotatable, exfiltrable solely via
+a DIFF the finalize credential-scan inspects, and only under a successful prompt
+injection. The credential-scan catches verbatim/known-shape tokens but cannot
+prove a fragmented/encoded token is absent, so the accepted residual is: a
+leaked, rotatable inference token under injection. True OS-level isolation
+remains an upstream ask tracked in #1373.
 
 **Selection (deterministic).** The select job lists `sentry:verdict-code-fix`
 queue stubs across `--state all` (verdicted stubs auto-close — closed is the


### PR DESCRIPTION
## The Problem

- #1373 asked to sandbox the autofix agent so it can't read the runner's process-env credentials. That literal ask is **infeasible on a hosted runner**: `claude-code-action`'s CLI must hold the Claude OAuth *inference* token in its own process env to authenticate, and any process can always read its own `/proc/self/environ`. seccomp/AppArmor/hidepid hide *other* processes' env, not self's — true isolation needs an upstream action feature.
- So a prompt-injected agent's `Read` tool can reach that token and write it into an edited file. The exposed credential is inference-only and rotatable, but the exposure is real.

## The Solution

- **Shrink the blast radius** (the accepted approach — a same-account dedicated token buys nothing): stop passing the action's **optional** `github_token` input. The agent has no GitHub/`gh` tools and posts nothing — every GitHub write is the App token in the deterministic downstream steps — so the token was unnecessary in the CLI env. Now the **only** credential there is the inference OAuth token: inference-only (no repo/cloud scope), rotatable, and exfiltrable only via a diff the finalize credential-scan inspects, under a successful prompt injection.
- **Document the ceiling** honestly: the workflow header note, the job comment, and the pipeline trust-boundary note now state that self-environ reads can't be sandboxed on a hosted runner, that the residual is a leaked rotatable inference token under injection, and that true OS-level isolation remains an upstream ask.

## Details

`anthropics/claude-code-action@v1.0.174`'s `github_token` input is `required: false` ("optional if using GitHub App"), so dropping it is safe — verified against the action's own `action.yml`. Before flipping `SENTRY_AUTOFIX_ENABLED`, a single `workflow_dispatch` run on a throwaway eligible stub confirms the agent still produces a fix without the token.

## Validation

- All 29 workflows still pass `scripts/check-autofix-ci-trust.mjs`.
- `sentry-autofix.yml` parses; trunk clean.

## Deferrals

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJKvqjifpKxC6hUJ4hNBcp
