### PR TITLE
docs: add Prose Style writing system to agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,22 @@ and runtime checks still apply. Exact target, bundle, isolation, trust,
 engine-selection, and command contracts live in
 [`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 
+## Prose Style
+
+Applies to every prose surface an agent writes: PR descriptions, ADRs, docs,
+issue text, review replies, commit messages, and reports. These are a system;
+do not add one-off word or punctuation bans on top of it.
+
+- Prefer the short word. Cut every word that does no work.
+- Prefer active voice.
+- Plain words over jargon, but never swap a precise technical term for a
+  vaguer everyday one.
+- State points directly; avoid the "not X, it's Y" contrast shell except
+  when the misconception is the point, at most once per document.
+- Do not announce what you are about to say — say it.
+- Vary sentence shape. Do not pad lists or examples to three for rhythm.
+- Break any rule above sooner than writing something unclear or imprecise.
+
 ## PR description standard
 
 Every PR description starts with `## The Problem` followed by


### PR DESCRIPTION
## The Problem

- The repo's agent rules have no writing-style guidance, so agent-authored prose (PR descriptions, ADRs, docs, issue text) drifts into recognizable LLM tics.
- Fighting those tics with one-off bans ("no em dashes", "stop saying delve") doesn't scale — each ban catches one symptom and the voice stays the same.

## The Solution

- Add a compact "Prose Style" section to `AGENTS.md` (mirrored automatically via the `CLAUDE.md` symlink) that gives agents a writing system instead of word bans, so every session picks it up globally.
- The system adapts Orwell's six rules plus modern LLM-tic guards, sourced from [this thread](https://x.com/Voxyz_ai/status/2078857039116156978) and adapted for a technical repo.

## Details

- Rules adopted: prefer short words and cut dead words (Orwell 2+3), active voice (Orwell 4), plain words over jargon (Orwell 5), no "not X, it's Y" corrective-juxtaposition shells, no announcing what you're about to say, varied sentence shape / no padded triads, and Orwell's escape hatch reworded for this repo (break any rule sooner than being unclear or imprecise).
- Deliberate adaptations: the jargon rule is qualified to never trade a precise technical term for a vaguer everyday word — verbatim Orwell would push agents away from exact monitoring/DeFi terminology. The escape hatch anchors on clarity and precision rather than "anything outright barbarous".
- Rules from the thread intentionally not adopted: "no stale metaphors" (subsumed by concision in technical prose), "no straw men" (an argumentation rule already covered by the ADR real-alternatives requirement), and "add five lines of your own voice" (a shared repo has a house voice; matching surrounding docs already covers it).
- The section explicitly scopes to agent-authored prose surfaces and forbids stacking new one-off word bans on top of the system, which is the thread's core point.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed (trunk check, `docs:index --check`, `agent:context-budget --strict`, `agent:context-check`, ADR reminder).
- `pnpm agent:autoreview --base origin/main --engine claude` — clean, no actionable findings ("patch is correct (0.85)"). Explicit `--base` was needed because the hosted checkout's origin remote is a local proxy, and the `claude` engine because the default `codex` CLI is unavailable in this session.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHqveiFxMs6yoquF6TYsmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHqveiFxMs6yoquF6TYsmq)_