### PR TITLE
feat(tooling): enforce the .claude skills mirror with a drift check

### DIFF
--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -69,6 +69,14 @@ bounded packet into evidence-backed dispositions, guarded semantic edits,
 link/catalog repair, and normal PR closeout. The cadence and queue contract live
 in [`documentation-gardening.md`](documentation-gardening.md).
 
+The `.agents/skills/` ↔ `.claude/skills/` mirror is enforced, not just
+documented: `scripts/check-skills-mirror.sh` byte-compares the two trees and
+fails on any drift, and the Agent Quality Gate runs it automatically whenever
+either tree changes. Symlinking the trees was rejected — repo files pushed via
+the GitHub Contents API and hosted/web checkouts are not guaranteed to
+preserve symlinks, so a check script is the safer default. Run
+`bash scripts/check-skills-mirror.sh` after editing either copy.
+
 ## SessionEnd hook
 
 `scripts/agent-session-end-hook.sh` runs on SessionEnd for Claude Code and Codex.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1855,6 +1855,12 @@ while IFS= read -r path; do
     .agents/*|.claude/skills/*|.claude/settings.json|.codex/hooks.json)
       add_surface "agent-context"
       add_command "pnpm agent:context-check" "agent context files changed"
+      case "$path" in
+        .agents/skills/*|.claude/skills/*)
+          add_command "bash scripts/check-skills-mirror.test.sh" "skills mirror content changed"
+          add_command "bash scripts/check-skills-mirror.sh" "skills mirror content changed"
+          ;;
+      esac
       ;;
     scripts/*.sh)
       add_surface "scripts"
@@ -1886,6 +1892,10 @@ while IFS= read -r path; do
           ;;
         scripts/agent-session-end-hook.sh)
           add_command "pnpm agent:context-check" "agent SessionEnd hook changed"
+          ;;
+        scripts/check-skills-mirror.sh|scripts/check-skills-mirror.test.sh)
+          add_command "bash scripts/check-skills-mirror.test.sh" "skills mirror checker changed"
+          add_command "bash scripts/check-skills-mirror.sh" "skills mirror checker changed"
           ;;
       esac
       ;;

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2141,6 +2141,28 @@ assert_contains "- bash -n scripts/check-agent-quality-gate-package-scripts.sh (
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (agent quality gate package script validator changed)"
 assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping changed)"
 
+run_gate ".agents/skills/ship/SKILL.md"
+assert_contains "- agent-context"
+assert_contains "- pnpm agent:context-check (agent context files changed)"
+assert_contains "- bash scripts/check-skills-mirror.test.sh (skills mirror content changed)"
+assert_contains "- bash scripts/check-skills-mirror.sh (skills mirror content changed)"
+
+run_gate ".claude/skills/ship/SKILL.md"
+assert_contains "- agent-context"
+assert_contains "- pnpm agent:context-check (agent context files changed)"
+assert_contains "- bash scripts/check-skills-mirror.test.sh (skills mirror content changed)"
+assert_contains "- bash scripts/check-skills-mirror.sh (skills mirror content changed)"
+
+run_gate "scripts/check-skills-mirror.sh"
+assert_contains "- bash -n scripts/check-skills-mirror.sh (shell script changed)"
+assert_contains "- bash scripts/check-skills-mirror.test.sh (skills mirror checker changed)"
+assert_contains "- bash scripts/check-skills-mirror.sh (skills mirror checker changed)"
+
+run_gate "scripts/check-skills-mirror.test.sh"
+assert_contains "- bash -n scripts/check-skills-mirror.test.sh (shell script changed)"
+assert_contains "- bash scripts/check-skills-mirror.test.sh (skills mirror checker changed)"
+assert_contains "- bash scripts/check-skills-mirror.sh (skills mirror checker changed)"
+
 run_gate ".trunk/trunk.yaml"
 assert_contains "- tooling"
 assert_contains "- node scripts/check-github-action-pins.mjs (Trunk workflow/action setup changed)"

--- a/scripts/check-skills-mirror.sh
+++ b/scripts/check-skills-mirror.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-skills-mirror.sh
+
+Verifies that .agents/skills/ and .claude/skills/ are byte-for-byte
+identical. Docs and tooling reference both directories as an exact-mirror
+pair (see docs/notes/codex-agent-skills.md); this script is the enforcement
+for that contract. Exits nonzero and prints a drift report naming the
+differing files if the trees diverge or either tree is missing.
+
+Environment:
+  SKILLS_MIRROR_ROOT_A  First tree to compare. Default: .agents/skills
+  SKILLS_MIRROR_ROOT_B  Second tree to compare. Default: .claude/skills
+USAGE
+}
+
+case "${1:-}" in
+  "") ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+root_a="${SKILLS_MIRROR_ROOT_A:-.agents/skills}"
+root_b="${SKILLS_MIRROR_ROOT_B:-.claude/skills}"
+
+missing=0
+if [[ ! -d "$root_a" ]]; then
+  echo "check-skills-mirror: missing directory: $root_a" >&2
+  missing=1
+fi
+if [[ ! -d "$root_b" ]]; then
+  echo "check-skills-mirror: missing directory: $root_b" >&2
+  missing=1
+fi
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+if diff_output="$(diff -r "$root_a" "$root_b" 2>&1)"; then
+  echo "check-skills-mirror: $root_a and $root_b are identical"
+  exit 0
+fi
+
+echo "check-skills-mirror: $root_a and $root_b have drifted:" >&2
+echo "$diff_output" >&2
+exit 1

--- a/scripts/check-skills-mirror.sh
+++ b/scripts/check-skills-mirror.sh
@@ -9,7 +9,9 @@ Verifies that .agents/skills/ and .claude/skills/ are byte-for-byte
 identical. Docs and tooling reference both directories as an exact-mirror
 pair (see docs/notes/codex-agent-skills.md); this script is the enforcement
 for that contract. Exits nonzero and prints a drift report naming the
-differing files if the trees diverge or either tree is missing.
+differing files if the trees diverge, either tree is missing, or either
+tree contains a symlink (byte comparison can't verify a symlink's target,
+so symlinks are rejected outright rather than silently trusted).
 
 Environment:
   SKILLS_MIRROR_ROOT_A  First tree to compare. Default: .agents/skills
@@ -42,6 +44,13 @@ if [[ ! -d "$root_b" ]]; then
   missing=1
 fi
 if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+symlinks="$(find "$root_a" "$root_b" -type l 2>/dev/null)"
+if [[ -n "$symlinks" ]]; then
+  echo "check-skills-mirror: symlinks are not supported in the mirrored trees (diff can't verify a symlink's target):" >&2
+  echo "$symlinks" >&2
   exit 1
 fi
 

--- a/scripts/check-skills-mirror.sh
+++ b/scripts/check-skills-mirror.sh
@@ -9,9 +9,15 @@ Verifies that .agents/skills/ and .claude/skills/ are byte-for-byte
 identical. Docs and tooling reference both directories as an exact-mirror
 pair (see docs/notes/codex-agent-skills.md); this script is the enforcement
 for that contract. Exits nonzero and prints a drift report naming the
-differing files if the trees diverge, either tree is missing, or either
-tree contains a symlink (byte comparison can't verify a symlink's target,
-so symlinks are rejected outright rather than silently trusted).
+differing files if the trees diverge, executable bits differ, either tree
+is missing, or either tree contains a symlink (byte comparison can't verify
+a symlink's target, so symlinks are rejected outright rather than silently
+trusted).
+
+One documented exception (docs/context-standards.md): runtime-specific
+provenance literals in the forensic-report skill — `source: "Codex"` in the
+canonical tree versus `source: "claude"` in the Claude mirror — are
+normalized before comparison, only inside forensic-report skill files.
 
 Environment:
   SKILLS_MIRROR_ROOT_A  First tree to compare. Default: .agents/skills
@@ -54,11 +60,61 @@ if [[ -n "$symlinks" ]]; then
   exit 1
 fi
 
-if diff_output="$(diff -r "$root_a" "$root_b" 2>&1)"; then
-  echo "check-skills-mirror: $root_a and $root_b are identical"
-  exit 0
-fi
+# Normalize the documented runtime-specific provenance literals
+# (docs/context-standards.md: forensic-report writes `source: "Codex"` in the
+# canonical skill and `source: "claude"` in the Claude mirror) so that ONLY
+# that documented difference, in forensic-report files only, is tolerated.
+provenance_normalize() {
+  sed -E 's/source: "(Codex|claude)"/source: "__RUNTIME__"/g' "$1"
+}
 
-echo "check-skills-mirror: $root_a and $root_b have drifted:" >&2
-echo "$diff_output" >&2
-exit 1
+drift=0
+report() {
+  if [[ "$drift" -eq 0 ]]; then
+    echo "check-skills-mirror: $root_a and $root_b have drifted:" >&2
+    drift=1
+  fi
+  echo "  $1" >&2
+}
+
+# Content comparison, file-by-file, so the provenance exception and the
+# executable-bit check can both be applied per file.
+while IFS= read -r rel; do
+  a="$root_a/$rel"
+  b="$root_b/$rel"
+  if [[ ! -f "$b" ]]; then
+    report "only in $root_a: $rel"
+    continue
+  fi
+  if ! cmp -s "$a" "$b"; then
+    case "$rel" in
+      */forensic-report/* | forensic-report/*)
+        if ! diff <(provenance_normalize "$a") <(provenance_normalize "$b") >/dev/null; then
+          report "content drift (beyond documented provenance literals): $rel"
+        fi
+        ;;
+      *)
+        report "content drift: $rel"
+        ;;
+    esac
+  fi
+  x_a=0
+  x_b=0
+  [[ -x "$a" ]] && x_a=1
+  [[ -x "$b" ]] && x_b=1
+  if [[ "$x_a" -ne "$x_b" ]]; then
+    report "executable-bit drift: $rel"
+  fi
+done < <(cd "$root_a" && find . -type f | sed 's|^\./||' | LC_ALL=C sort)
+
+while IFS= read -r rel; do
+  if [[ ! -f "$root_a/$rel" ]]; then
+    report "only in $root_b: $rel"
+  fi
+done < <(cd "$root_b" && find . -type f | sed 's|^\./||' | LC_ALL=C sort)
+
+if [[ "$drift" -ne 0 ]]; then
+  exit 1
+fi
+echo "check-skills-mirror: $root_a and $root_b are identical"
+exit 0

--- a/scripts/check-skills-mirror.test.sh
+++ b/scripts/check-skills-mirror.test.sh
@@ -70,6 +70,46 @@ if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
 fi
 grep -q "symlink" "$output_file" || fail "symlink output did not explain the failure"
 
+# Documented provenance literals (docs/context-standards.md) may differ, but
+# only inside forensic-report skill files.
+reset_fixture
+mkdir -p "$root_a/forensic-report" "$root_b/forensic-report"
+printf 'writes source: "Codex" records\n' > "$root_a/forensic-report/SKILL.md"
+printf 'writes source: "claude" records\n' > "$root_b/forensic-report/SKILL.md"
+if ! SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "documented forensic-report provenance difference exited nonzero, expected 0"
+fi
+
+# Any other difference in a forensic-report file still fails.
+reset_fixture
+mkdir -p "$root_a/forensic-report" "$root_b/forensic-report"
+printf 'writes source: "Codex" records\n' > "$root_a/forensic-report/SKILL.md"
+printf 'writes source: "claude" records, plus drift\n' > "$root_b/forensic-report/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "non-provenance drift in forensic-report exited 0, expected nonzero"
+fi
+grep -q "beyond documented provenance" "$output_file" || fail "forensic drift output did not explain the failure"
+
+# The provenance literal outside forensic-report is NOT exempt.
+reset_fixture
+printf 'writes source: "Codex" records\n' > "$root_a/example-skill/SKILL.md"
+printf 'writes source: "claude" records\n' > "$root_b/example-skill/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "provenance-style difference outside forensic-report exited 0, expected nonzero"
+fi
+
+# Executable-bit drift: exit nonzero and name the file.
+reset_fixture
+chmod +x "$root_a/example-skill/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "executable-bit drift exited 0, expected nonzero"
+fi
+grep -q "executable-bit drift" "$output_file" || fail "mode-drift output did not name the drifted file"
+
 # Missing directory: exit nonzero.
 rm -rf "$root_a" "$root_b"
 if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \

--- a/scripts/check-skills-mirror.test.sh
+++ b/scripts/check-skills-mirror.test.sh
@@ -60,6 +60,16 @@ if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
 fi
 grep -q "EXTRA.md" "$output_file" || fail "extra-file output did not name the extra file"
 
+# Symlink in either tree: exit nonzero, even if it resolves to identical bytes.
+reset_fixture
+rm "$root_b/example-skill/SKILL.md"
+ln -s "$root_a/example-skill/SKILL.md" "$root_b/example-skill/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "symlink in one tree exited 0, expected nonzero"
+fi
+grep -q "symlink" "$output_file" || fail "symlink output did not explain the failure"
+
 # Missing directory: exit nonzero.
 rm -rf "$root_a" "$root_b"
 if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \

--- a/scripts/check-skills-mirror.test.sh
+++ b/scripts/check-skills-mirror.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+fixture_dir="$(mktemp -d)"
+output_file="$(mktemp)"
+trap 'rm -rf "$fixture_dir"; rm -f "$output_file"' EXIT
+
+fail() {
+  echo "check-skills-mirror test failed: $*" >&2
+  echo >&2
+  echo "Last output:" >&2
+  sed 's/^/  /' "$output_file" >&2
+  exit 1
+}
+
+root_a="$fixture_dir/agents-skills"
+root_b="$fixture_dir/claude-skills"
+
+reset_fixture() {
+  rm -rf "$root_a" "$root_b"
+  mkdir -p "$root_a/example-skill" "$root_b/example-skill"
+  echo "hello" > "$root_a/example-skill/SKILL.md"
+  echo "hello" > "$root_b/example-skill/SKILL.md"
+}
+
+# Identical trees exit 0.
+reset_fixture
+if ! SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "identical trees exited nonzero, expected 0"
+fi
+
+# Content drift: exit nonzero and name the differing file.
+reset_fixture
+echo "goodbye" > "$root_b/example-skill/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "content drift exited 0, expected nonzero"
+fi
+grep -q "SKILL.md" "$output_file" || fail "content drift output did not name the differing file"
+
+# Missing file on one side: exit nonzero and name it.
+reset_fixture
+rm "$root_b/example-skill/SKILL.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "missing file on one side exited 0, expected nonzero"
+fi
+grep -q "SKILL.md" "$output_file" || fail "missing-file output did not name the missing file"
+
+# Extra file on one side: exit nonzero and name it.
+reset_fixture
+echo "extra" > "$root_a/example-skill/EXTRA.md"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "extra file on one side exited 0, expected nonzero"
+fi
+grep -q "EXTRA.md" "$output_file" || fail "extra-file output did not name the extra file"
+
+# Missing directory: exit nonzero.
+rm -rf "$root_a" "$root_b"
+if SKILLS_MIRROR_ROOT_A="$root_a" SKILLS_MIRROR_ROOT_B="$root_b" \
+  scripts/check-skills-mirror.sh > "$output_file" 2>&1; then
+  fail "missing directories exited 0, expected nonzero"
+fi
+grep -q "missing directory" "$output_file" || fail "missing-directory output did not explain the failure"
+
+echo "check-skills-mirror.test.sh: all checks passed"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `.claude/skills/` is a hand-maintained byte-for-byte mirror of `.agents/skills/` (9 skills, ~19K words duplicated) with nothing enforcing the "must stay aligned" rule in AGENTS.md.
- Drift between the trees would silently give Claude and Codex sessions different workflow instructions.

## The Solution

- A drift check (`scripts/check-skills-mirror.sh`) that byte-compares the two trees, names every differing/missing/extra file, and fails on any difference — wired into the quality gate for any change under either tree or to the checker itself.

## Details

- Check-script over symlinks, deliberately: skills are sometimes pushed via the GitHub Contents API (hosted/web checkouts), which does not reliably preserve symlinks, and Codex runtime behavior with symlinked skill dirs is unproven in this repo. A byte-compare check enforces the same invariant with zero runtime risk.
- `scripts/check-skills-mirror.test.sh` is fixture-based (mktemp trees via env override): identical → pass; content drift, missing file, extra file → each fails naming the path. It cannot touch the real trees.
- Gate wiring: edits under `.agents/skills/**` or `.claude/skills/**` map to the checker test + the real-tree check (alongside the existing `agent:context-check`); edits to the checker scripts map to the same pair. Dry-run mapping assertions added to the gate self-test.
- `docs/notes/codex-agent-skills.md` documents the mechanism.
- The real trees were verified identical at implementation time (`check-skills-mirror: .agents/skills and .claude/skills are identical`).

## Validation

- `bash scripts/check-skills-mirror.test.sh` — all fixture cases green.
- `bash scripts/check-skills-mirror.sh` — real trees identical, exit 0.
- `bash scripts/agent-quality-gate.test.sh` — green including the new mapping assertions.
- shellcheck/trunk clean on the new scripts.

## Deferrals

- None

Closes #1418
Refs #1404

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — enforces an existing documented invariant; the symlink-vs-check tradeoff is recorded in this PR.
