### PR TITLE
perf(tooling): eslint result cache for lint:scripts and governance-watchdog lint

### DIFF
--- a/governance-watchdog/package.json
+++ b/governance-watchdog/package.json
@@ -23,7 +23,7 @@
     "generate:env": "node ./bin/generate-env.mjs",
     "knip": "knip --config knip.json --no-progress",
     "knip:report": "knip --config knip.json --no-exit-code --no-progress",
-    "lint": "eslint src/",
+    "lint": "eslint src/ --cache --cache-strategy content --cache-location .eslintcache",
     "logs": "./bin/get-logs.sh",
     "reprocess:event": "tsx bin/reprocess-event.ts",
     "prestart": "pnpm run build",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "code-health:history": "node scripts/code-health-history.mjs",
     "code-health:duplication": "jscpd --config .jscpd.json",
     "code-health": "pnpm code-health:knip && pnpm code-health:deps",
-    "lint:scripts": "eslint scripts/ eslint.config.mjs .dependency-cruiser.cjs",
+    "lint:scripts": "eslint scripts/ eslint.config.mjs .dependency-cruiser.cjs --cache --cache-strategy content --cache-location .eslintcache",
     "indexer:mutation": "pnpm --filter @mento-protocol/indexer-envio test:mutation",
     "indexer:testnet:codegen": "pnpm --filter @mento-protocol/indexer-envio codegen --config config.multichain.testnet.yaml",
     "indexer:testnet:dev": "pnpm --filter @mento-protocol/indexer-envio dev --config config.multichain.testnet.yaml",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The merged eslint-cache PR (0acd84b5) only sped up the package lint path
  (`eslint-baseline-diff.mjs`), leaving two direct ESLint invocations
  uncached: root `lint:scripts` and `governance-watchdog`'s `lint` (it calls
  `eslint src/` directly, not the shared diff-check script).
- Every run of these two scripts re-parses and re-lints the same files from
  scratch, even when nothing changed since the last run.
- Measured before this change: `pnpm lint:scripts` took 1.92s cold and still
  paid the full uncached cost on a second consecutive run; `pnpm
  gov-watchdog:lint` took 4.21s per run with no reuse either.

## The Solution

- Append ESLint's own result cache flags — `--cache --cache-strategy content
  --cache-location .eslintcache` — to both scripts, matching exactly the
  flags `eslint-baseline-diff.mjs` already uses for every other package's
  `lint` script.
- `.gitignore`'s existing `.eslintcache` entry is unanchored (no leading
  `/`), so it already matches the cache file at the repo root and inside
  `governance-watchdog/` — no `.gitignore` change was needed.

## Details

- Root `package.json` `lint:scripts`: `eslint scripts/ eslint.config.mjs
  .dependency-cruiser.cjs --cache --cache-strategy content --cache-location
  .eslintcache`.
- `governance-watchdog/package.json` `lint`: `eslint src/ --cache
  --cache-strategy content --cache-location .eslintcache` — a package-local
  cache file (cwd is `governance-watchdog/` when the workspace filter runs
  it), so it doesn't collide with the root cache.
- `--cache-strategy content` hashes file content rather than mtime, so the
  cache stays correct across checkouts/CI restores where mtimes are not
  meaningful.
- Scope boundary: only these two direct-invocation scripts changed. Every
  other package's `lint` script already goes through
  `scripts/eslint-baseline-diff.mjs`, which has carried these same flags
  since the merged eslint-cache PR — no changes needed there.
- This is a root `package.json` script edit, so it trips the Agent Quality
  Gate's package-script lifecycle-risk acknowledgment
  (`scripts/check-agent-quality-gate-package-scripts.sh`) — confirmed via
  dry-run below, not bypassed.

## Validation

Cache verified with two consecutive runs each, timed with `/usr/bin/time -h`
(cache file removed before the first run of each pair):

```
$ pnpm lint:scripts   (run 1, cold cache)
1.92s real  2.24s user  0.23s sys

$ pnpm lint:scripts   (run 2, warm cache)
0.69s real  0.59s user  0.12s sys

$ pnpm gov-watchdog:lint   (run 1, cold cache)
4.21s real  5.63s user  0.73s sys

$ pnpm gov-watchdog:lint   (run 2, warm cache)
1.22s real  1.23s user  0.25s sys
```

- `git status --porcelain --ignored` shows both `.eslintcache` and
  `governance-watchdog/.eslintcache` as `!!` (ignored), not `??`
  (untracked) — no new untracked files land in the tree.
- `bash scripts/agent-quality-gate.sh --base origin/main` (dry-run) exits 0
  and lists `bash scripts/check-agent-quality-gate-package-scripts.sh (root
  package script changed)` among the mapped safe local commands, confirming
  the gate correctly flags this as a package-script change requiring
  acknowledgment rather than silently ignoring it. `--run` was left to the
  orchestrator, which will pass the required acknowledgment flag.

## Deferrals

- None

Closes #1428
Refs #1404

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable — this mirrors an existing, already-decided caching pattern, no new architecture.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run (dry-run confirmed; orchestrator runs `--run` with ack flag)
- [ ] PR readiness probe planned (orchestrator's responsibility post-push)
