### PR TITLE
fix(tooling): generalize clean Claude review grammar

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -97,33 +97,25 @@ terminal state so late feedback is not missed.
 ### Bounded clean-Claude protocol
 
 `pr:feedback-state` treats a current-head Claude `Verdict: LGTM` review as clean
-only when the complete comment matches the bounded protocol below. The protocol
-generalizes review labels without treating arbitrary clean-sounding prose as
-evidence:
+only when the complete comment matches this bounded protocol:
 
-- An optional `Review: <title>` heading is accepted only when the bounded title
-  matches the pull request's actual title after whitespace and Markdown-escape
-  normalization across the complete CommonMark ASCII punctuation set. Title
-  words are labels, not finding evidence, so ordinary PR titles may mention
-  fixes or errors without becoming false findings.
-- An optional `What I checked` block must contain one or more checked (`[x]`)
-  entries. Each subject is a bounded single line that matches a positive
-  grammar of recognized neutral topic labels, optionally joined by `and`. A
-  narrow compatibility matcher retains the already-observed legacy subjects;
-  arbitrary inline-code labels, noun phrases, declarative claims, and unknown
-  prose do not become safe merely because their vocabulary avoids known hazard
-  terms. Unchecked, malformed, empty, or mixed safe/actionable checklists fail
-  closed.
-- `Findings` followed by `Roll-up` is mandatory, in that order, with both
-  sections non-empty. Every generalized entry keeps an explicit `[P3]` clean
-  marker, at least one non-empty approved positive-evidence clause, and raw
-  plain-text syntax. A narrow compatibility matcher retains the exact
-  already-observed legacy Markdown lines; do not expand it. Unknown prose,
-  discarded Markdown/HTML syntax, actionable suffixes, negation, hedging,
-  malformed/duplicate headings, higher priorities, and mixed clean/actionable
-  items remain blocking. Any non-empty protocol line beginning with Markdown
-  code-block indentation (four spaces, or a tab after up to three leading
-  spaces) also remains blocking before regional parsing or normalization.
+- The optional Claude completion line may include only its fixed GitHub Actions
+  `View job` suffix; other suffixes fail closed.
+- An optional `Review: <title>` must equal the PR title after whitespace and
+  CommonMark ASCII-punctuation escape normalization. Title words are labels,
+  not finding evidence.
+- An optional `What I checked` block needs one or more checked (`[x]`) bounded
+  single-line subjects from the neutral-topic grammar (optionally joined by
+  `and`) or the narrow legacy matcher. Unknown prose, inline-code labels,
+  declarative claims, unchecked entries, and mixed safe/actionable checklists
+  fail closed.
+- Non-empty `Findings` then `Roll-up` sections are mandatory. Generalized
+  entries require an explicit `[P3]` clean marker, approved positive evidence,
+  and plain-text syntax; only exact observed legacy Markdown lines use the
+  compatibility matcher. Unknown prose, Markdown/HTML syntax, actionable
+  suffixes, negation, hedging, malformed or duplicate headings, higher
+  priorities, and mixed clean/actionable items remain blocking. Markdown
+  code-block indentation on any non-empty protocol line also fails closed.
 
 The parser validates title, checklist, Findings, and Roll-up as separate
 structural regions. Do not broaden the Findings/Roll-up positive-evidence

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -94,6 +94,41 @@ required blockers. If a review-producing workflow is visibly in progress,
 report it as optional lag and rerun `pr:feedback-state` after it reaches a
 terminal state so late feedback is not missed.
 
+### Bounded clean-Claude protocol
+
+`pr:feedback-state` treats a current-head Claude `Verdict: LGTM` review as clean
+only when the complete comment matches the bounded protocol below. The protocol
+generalizes review labels without treating arbitrary clean-sounding prose as
+evidence:
+
+- An optional `Review: <title>` heading is accepted only when the bounded title
+  matches the pull request's actual title after whitespace and Markdown-escape
+  normalization across the complete CommonMark ASCII punctuation set. Title
+  words are labels, not finding evidence, so ordinary PR titles may mention
+  fixes or errors without becoming false findings.
+- An optional `What I checked` block must contain one or more checked (`[x]`)
+  entries. Each subject is a bounded single line that matches a positive
+  grammar of recognized neutral topic labels, optionally joined by `and`. A
+  narrow compatibility matcher retains the already-observed legacy subjects;
+  arbitrary inline-code labels, noun phrases, declarative claims, and unknown
+  prose do not become safe merely because their vocabulary avoids known hazard
+  terms. Unchecked, malformed, empty, or mixed safe/actionable checklists fail
+  closed.
+- `Findings` followed by `Roll-up` is mandatory, in that order, with both
+  sections non-empty. Every generalized entry keeps an explicit `[P3]` clean
+  marker, at least one non-empty approved positive-evidence clause, and raw
+  plain-text syntax. A narrow compatibility matcher retains the exact
+  already-observed legacy Markdown lines; do not expand it. Unknown prose,
+  discarded Markdown/HTML syntax, actionable suffixes, negation, hedging,
+  malformed/duplicate headings, higher priorities, and mixed clean/actionable
+  items remain blocking. Any non-empty protocol line beginning with Markdown
+  code-block indentation (four spaces, or a tab after up to three leading
+  spaces) also remains blocking before regional parsing or normalization.
+
+The parser validates title, checklist, Findings, and Roll-up as separate
+structural regions. Do not broaden the Findings/Roll-up positive-evidence
+allowlist merely to accept a new title or checklist subject.
+
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -4167,6 +4167,7 @@ materialize_feedback_runtime() {
   local runtime_paths=(
     scripts/pr-feedback-state.mjs \
     scripts/pr-feedback-state-core.mjs \
+    scripts/pr-feedback-state-claude.mjs \
     scripts/pr-ready-state.mjs \
     scripts/pr-ready-state-core.mjs \
     scripts/pr-ready-state-format.mjs

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -4158,6 +4158,8 @@ materialize_feedback_runtime() {
   local snapshot_ref="$2"
   local runtime_dir="$3"
   local relative_path
+  local optional_entry
+  local optional_runtime_path="scripts/pr-feedback-state-claude.mjs"
   local output_path
   local mode
   local size
@@ -4167,11 +4169,26 @@ materialize_feedback_runtime() {
   local runtime_paths=(
     scripts/pr-feedback-state.mjs \
     scripts/pr-feedback-state-core.mjs \
-    scripts/pr-feedback-state-claude.mjs \
     scripts/pr-ready-state.mjs \
     scripts/pr-ready-state-core.mjs \
     scripts/pr-ready-state-format.mjs
   )
+
+  if ! optional_entry="$(
+    git_output "$repo" ls-tree "$snapshot_ref" -- "$optional_runtime_path"
+  )"; then
+    echo "agent:autoreview: cannot inspect optional trusted feedback runtime: $optional_runtime_path" >&2
+    return 1
+  fi
+  if [[ -n "$optional_entry" ]]; then
+    if ! mode="$(
+      git_blob_mode "$repo" "$snapshot_ref" "$optional_runtime_path"
+    )" || [[ "$mode" != "100644" && "$mode" != "100755" ]]; then
+      echo "agent:autoreview: trusted feedback runtime is not a regular Git blob: $optional_runtime_path" >&2
+      return 1
+    fi
+    runtime_paths+=("$optional_runtime_path")
+  fi
 
   for relative_path in "${runtime_paths[@]}"; do
     if ! mode="$(git_blob_mode "$repo" "$snapshot_ref" "$relative_path")" ||

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -4914,6 +4914,7 @@ run_feedback_runtime_aggregate_regression() {
   dd if=/dev/zero bs=1100000 count=1 2>/dev/null |
     tr '\000' 'b' >"$review_repo/scripts/pr-feedback-state-core.mjs"
   for runtime_file in \
+    pr-feedback-state-claude.mjs \
     pr-ready-state.mjs \
     pr-ready-state-core.mjs \
     pr-ready-state-format.mjs; do
@@ -6493,6 +6494,7 @@ process.stdout.write(`${JSON.stringify(state)}\n`);
 FEEDBACK_RUNTIME
 for feedback_runtime_file in \
   pr-feedback-state-core.mjs \
+  pr-feedback-state-claude.mjs \
   pr-ready-state.mjs \
   pr-ready-state-core.mjs \
   pr-ready-state-format.mjs; do

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6492,9 +6492,9 @@ state.testEvidence = {
 };
 process.stdout.write(`${JSON.stringify(state)}\n`);
 FEEDBACK_RUNTIME
+# Model the bootstrap snapshot that predates the split Claude grammar module.
 for feedback_runtime_file in \
   pr-feedback-state-core.mjs \
-  pr-feedback-state-claude.mjs \
   pr-ready-state.mjs \
   pr-ready-state-core.mjs \
   pr-ready-state-format.mjs; do

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1964,7 +1964,7 @@ while IFS= read -r path; do
         scripts/sentry-triage-archive.mjs|scripts/sentry-triage-archive.test.mjs)
           add_command "pnpm sentry:archive:test" "Sentry triage archive helper changed"
           ;;
-        scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state.test.mjs)
+        scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"
           ;;
         scripts/pr-ready-state.mjs|scripts/pr-ready-state-core.mjs|scripts/pr-ready-state-format.mjs|scripts/pr-ready-state.test.mjs)

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3426,6 +3426,9 @@ assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper change
 run_gate "scripts/sentry-triage-archive.test.mjs"
 assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper changed)"
 
+run_gate "scripts/pr-feedback-state-claude.mjs"
+assert_contains "- pnpm pr:feedback-state:test (PR feedback-state helper changed)"
+
 run_gate "scripts/sanitize-terraform-output.sh"
 assert_contains "- pnpm sanitize:test (Terraform output sanitizer changed)"
 

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -1,0 +1,36 @@
+const COMMONMARK_ASCII_PUNCTUATION_ESCAPE =
+  /\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/g;
+
+function normalizedReviewTitle(value) {
+  return String(value ?? "")
+    .replace(COMMONMARK_ASCII_PUNCTUATION_ESCAPE, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function hasControlCharacter(value) {
+  return Array.from(String(value ?? "")).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f);
+  });
+}
+
+export function isOrdinaryReviewTitle(value, expectedTitle) {
+  const title = String(value ?? "").trim();
+  if (
+    !title ||
+    title.length > 200 ||
+    hasControlCharacter(title) ||
+    /<!--|-->/.test(title)
+  )
+    return false;
+  const normalized = normalizedReviewTitle(title);
+  return (
+    normalized.length > 0 && normalized === normalizedReviewTitle(expectedTitle)
+  );
+}
+
+export function hasMarkdownCodeBlockIndentation(lines) {
+  return lines.some((line) => line.trim() && /^(?: {4}| {0,3}\t)/.test(line));
+}

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -1,20 +1,63 @@
 import { createHash } from "node:crypto";
+import {
+  hasControlCharacter,
+  hasMarkdownCodeBlockIndentation,
+  isOrdinaryReviewTitle,
+} from "./pr-feedback-state-claude.mjs";
 
 const FINDING_EXCERPT_LENGTH = 240;
 const FAILURE_TERM = /\b(?:error|errors|fail|fails|failed|failure|failures)\b/i;
 const NEGATED_FAILURE =
   /\b(?:no|zero|0)[ \t]+(?:errors?|fails?|failed|failures?)(?:[ \t]+(?:and|or)[ \t]+(?:errors?|fails?|failed|failures?))?(?:[ \t]+(?:are|was|were)[ \t]+(?:found|observed|reported))?(?=[ \t]*(?:[.,;:]|$))/gi;
 const CLEAN_FINDING_MARKER =
-  /^(?:None\s+blocking|No\s+action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
+  /^(?:None\s+blocking|No[- ]action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
 const UNSAFE_EVIDENCE_QUALIFIER =
-  /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could)\b/i;
+  /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could|appears?|seems?|probably|likely|possibly|perhaps|unclear|unknown)\b/i;
 const POSITIVE_EVIDENCE =
   /^(?:clean(?:,\s+well\s+scoped)?(?:\s+fix)?|well\s+scoped(?:\s+fix)?|correct|covered|bounded|mechanical|verified|complete|exact\s+removal\s+condition|(?:no|zero|0)\s+(?:errors?|fails?|failed|failures?)(?:\s+(?:and|or)\s+(?:errors?|fails?|failed|failures?))?(?:\s+(?:are|was|were)\s+(?:found|observed|reported))?|no\s+unrelated\s+version\s+bumps?|no\s+vulnerable\s+sharp@0\.34\.5\s+remains?\s+anywhere\s+in\s+(?:the\s+)?repo(?:'s)?\s+lockfiles|parser\s+should\s+continue\s+rejecting\s+malformed\s+input|fallback\s+should\s+stay|fix\s+is\s+correct|override\s+selector\s+is\s+correctly\s+bounded|lockfile\s+churn\s+beyond\s+sharp\s+itself\s+is\s+confirmed\s+mechanical,\s+not\s+scope\s+creep|(?:the\s+)?bounded\s+selector\s+matches\s+the\s+repo(?:'s)?\s+established\s+override\s+pattern|matches\s+repo\s+convention|(?:the\s+)?inline\s+comment\s+documents\s+the\s+advisory|removal\s+condition\s+comment\s+satisfies\s+the\s+temporary\s+override\s+documentation\s+expectation|tests\s+cover\s+the\s+changed\s+paths)$/i;
-const SAFE_CLAUDE_PREAMBLE_LINE =
-  /^(?:\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*|---|#{1,6}\s+Review:\s+fix\(deps\):\s+upgrade\s+sharp\s+past\s+vulnerable\s+libvips|#{1,6}\s+What\s+I\s+checked|(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?|-\s+\[[xX]\]\s+(?:`pnpm-workspace\.yaml`\s+override\s+syntax\/scope|`pnpm-lock\.yaml`\s+regeneration\s+for\s+unrelated\s+drift|Supply-chain\/lockfile-lint\s+compliance\s+and\s+CI\s+status|Other\s+standalone\s+lockfiles\s+for\s+leftover\s+vulnerable\s+`sharp@0\.34\.5`))$/i;
-const SAFE_NON_P3_FINDING =
-  /^(?:\d+[.)]\s+Confirmed\s+no\s+leftover\s+sharp@0\.34\.5\s+anywhere|\d+[.)]\s+Supply\s+Chain\s+CI\s+already\s+passed\s+on\s+this\s+PR|No\s+inline\s+comments\s+filed\s+(?:—\s+)?nothing\s+rose\s+to\s+an\s+actionable,\s+line\s+specific\s+issue)[.!?]?$/i;
-const CLEAN_ROLLUP_ENTRY = /^\d+[.)]\s+\[[Pp]3\]\s+(No\s+action:.*)$/i;
+const CLAUDE_TASK_COMPLETION_LINE =
+  /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*$/i;
+const CLAUDE_REVIEW_TITLE_LINE = /^#{1,6}\s+Review:\s+(.{1,200})$/i;
+const CLAUDE_VERDICT_LINE = /^(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?$/i;
+const CLAUDE_CHECKLIST_HEADING = /^#{1,6}\s+What\s+I\s+checked$/i;
+const CLAUDE_CHECKLIST_ENTRY = /^-\s+\[([^\]])\]\s+(.{1,200})$/;
+const SAFE_CLAUDE_CHECKLIST_TOPICS = new Set([
+  "api contract",
+  "authentication boundary",
+  "checklist routing",
+  "ci status",
+  "configuration scope",
+  "dependency resolution",
+  "documentation examples",
+  "generated artifacts",
+  "operator documentation",
+  "parser behavior",
+  "parser structure",
+  "regression-test coverage",
+  "request-path coverage",
+  "review title",
+  "runtime behavior",
+  "schema compatibility",
+  "session lifecycle",
+  "type safety",
+  "unit tests",
+  "unit-test coverage",
+]);
+const LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT =
+  /^(?:`pnpm-workspace\.yaml`\s+override\s+syntax\/scope|`pnpm-lock\.yaml`\s+regeneration\s+for\s+unrelated\s+drift|Supply-chain\/lockfile-lint\s+compliance\s+and\s+CI\s+status|Other\s+standalone\s+lockfiles\s+for\s+leftover\s+vulnerable\s+`sharp@0\.34\.5`)$/i;
+const LEGACY_SAFE_CLAUDE_FINDING_LINES = new Set([
+  "1. **[P3] None blocking — clean, well-scoped fix.** The bounded selector matches the repo's established override pattern.",
+  "2. **[P3] Good hygiene:** the inline comment documents the advisory and exact removal condition.",
+  "3. **[P3] Lockfile diff is fully mechanical.** No unrelated version bumps.",
+  "4. Confirmed no leftover `sharp@0.34.5` anywhere.",
+  "5. Supply Chain CI already passed on this PR.",
+  "No inline comments filed — nothing rose to an actionable, line-specific issue.",
+]);
+const LEGACY_SAFE_CLAUDE_ROLLUP_LINES = new Set([
+  "2. [P3] No-action: removal-condition comment satisfies the temporary-override documentation expectation.",
+  "4. [P3] No-action: no vulnerable `sharp@0.34.5` remains anywhere in the repo's lockfiles.",
+]);
+const CLEAN_ROLLUP_ENTRY = /^\d+[.)]\s+\[[Pp]3\]\s+(No[- ]action:.*)$/i;
 const CLEAN_REVIEW_SUMMARY =
   /\b(?:no\s+changes\s+requested|no\s+[Pp][0-2]\s+(?:issues?|findings?)|(?:no|zero|0)\s+(?:Critical|High|Medium|Low)\s+Severity\s+(?:issues?|findings?))\b/gi;
 const REVIEW_CONTRADICTION =
@@ -75,37 +118,97 @@ function hasReviewContradiction(value) {
     .replace(CLEAN_REVIEW_SUMMARY, "");
   return REVIEW_CONTRADICTION.test(body) || hasUnnegatedFailure(body);
 }
+function isBenignChecklistSubject(value) {
+  const subject = String(value ?? "").trim();
+  if (
+    !subject ||
+    subject.length > 200 ||
+    hasControlCharacter(subject) ||
+    (subject.match(/`/g)?.length ?? 0) % 2 !== 0
+  )
+    return false;
+  if (LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT.test(subject)) return true;
+  const topics = subject.toLowerCase().split(/\s+and\s+/);
+  return (
+    topics.length <= 3 &&
+    topics.every((topic) => SAFE_CLAUDE_CHECKLIST_TOPICS.has(topic))
+  );
+}
+function isSafeClaudePreamble(lines, pr) {
+  const preamble = lines.map((line) => line.trim()).filter(Boolean);
+  let index = 0;
+
+  if (CLAUDE_TASK_COMPLETION_LINE.test(preamble[index] ?? "")) index += 1;
+  if (preamble[index] === "---") index += 1;
+
+  const reviewTitle = (preamble[index] ?? "").match(CLAUDE_REVIEW_TITLE_LINE);
+  if (reviewTitle) {
+    if (!isOrdinaryReviewTitle(reviewTitle[1], pr?.title)) return false;
+    index += 1;
+  }
+
+  if (!CLAUDE_VERDICT_LINE.test(preamble[index] ?? "")) return false;
+  index += 1;
+  if (index === preamble.length) return true;
+  if (!CLAUDE_CHECKLIST_HEADING.test(preamble[index] ?? "")) return false;
+  index += 1;
+
+  let checklistEntries = 0;
+  for (; index < preamble.length; index += 1) {
+    const entry = preamble[index].match(CLAUDE_CHECKLIST_ENTRY);
+    if (
+      !entry ||
+      entry[1].toLowerCase() !== "x" ||
+      !isBenignChecklistSubject(entry[2])
+    )
+      return false;
+    checklistEntries += 1;
+  }
+  return checklistEntries > 0;
+}
 function hasPositiveCleanEvidence(value) {
-  const tail = normalizeText(value).match(CLEAN_FINDING_MARKER)?.[1];
+  const tail = String(value ?? "")
+    .trim()
+    .match(CLEAN_FINDING_MARKER)?.[1];
   if (tail === undefined) return false;
-  return tail
+  const evidenceClauses = tail
     .split(/(?:[!?;]+|\.(?=\s|$)|\b(?:and|but|however|although|yet)\b)/i)
-    .every((clause) => {
-      const evidence = clause.trim();
+    .map((clause) => clause.trim())
+    .filter(Boolean);
+  return (
+    evidenceClauses.length > 0 &&
+    evidenceClauses.every((evidence) => {
       const withoutSafeNegation = evidence.replace(
         /,\s+not\s+scope\s+creep$/i,
         "",
       );
       return (
-        !evidence ||
-        (!UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
-          POSITIVE_EVIDENCE.test(evidence))
+        !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
+        POSITIVE_EVIDENCE.test(evidence)
       );
-    });
+    })
+  );
 }
 function isCleanFindingLine(line) {
-  const normalized = normalizeText(line);
-  const p3 = normalized.match(/^\d+[.)]\s+\[[Pp]3\]\s+(.+)$/);
+  const raw = String(line ?? "").trim();
+  if (LEGACY_SAFE_CLAUDE_FINDING_LINES.has(raw)) return true;
+  const p3 = raw.match(/^\d+[.)]\s+\[[Pp]3\]\s+(.+)$/);
   if (p3) return hasPositiveCleanEvidence(p3[1]);
-  return SAFE_NON_P3_FINDING.test(normalized);
+  return false;
 }
-function isExplicitlyCleanClaudeReview(comment) {
+function isCleanRollupLine(line) {
+  const raw = String(line ?? "").trim();
+  if (LEGACY_SAFE_CLAUDE_ROLLUP_LINES.has(raw)) return true;
+  const entry = raw.match(CLEAN_ROLLUP_ENTRY)?.[1];
+  return entry !== undefined && hasPositiveCleanEvidence(entry);
+}
+function isExplicitlyCleanClaudeReview(comment, pr) {
   const author = String(comment.author ?? "").toLowerCase();
   if (author !== "claude" && author !== "claude[bot]") return false;
   const body = String(comment.body ?? "");
-  if (!/^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body)) return false;
-  if (hasReviewContradiction(body)) return false;
   const lines = body.split(/\r?\n/);
+  if (hasMarkdownCodeBlockIndentation(lines)) return false;
+  if (!/^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body)) return false;
   const headings = lines.filter((line) =>
     /^\s*#{1,6}\s+(?:Findings|Roll[- ]up)\s*$/i.test(line),
   );
@@ -113,37 +216,29 @@ function isExplicitlyCleanClaudeReview(comment) {
   if (!/^Findings,Roll up$/i.test(headingOrder)) return false;
   const findingsIndex = lines.indexOf(headings[0]);
   const rollupIndex = lines.indexOf(headings[1]);
-  if (
-    !lines
-      .slice(0, findingsIndex)
-      .every(
-        (line) => !line.trim() || SAFE_CLAUDE_PREAMBLE_LINE.test(line.trim()),
-      )
-  )
-    return false;
+  if (!isSafeClaudePreamble(lines.slice(0, findingsIndex), pr)) return false;
   const nonempty = (line) => line.trim();
   const findings = lines.slice(findingsIndex + 1, rollupIndex).filter(nonempty);
   const rollup = lines.slice(rollupIndex + 1).filter(nonempty);
+  if (hasReviewContradiction([...findings, ...rollup].join("\n"))) return false;
   return (
     findings.length > 0 &&
     findings.every(isCleanFindingLine) &&
     rollup.length > 0 &&
-    rollup.every((line) =>
-      hasPositiveCleanEvidence(
-        normalizeText(line).match(CLEAN_ROLLUP_ENTRY)?.[1],
-      ),
-    )
+    rollup.every(isCleanRollupLine)
   );
 }
-function isActionableReviewBotComment(comment) {
+function isActionableReviewBotComment(comment, pr) {
   if (!isReviewBotComment(comment)) return false;
   const body = String(comment.body ?? "");
+  const isClaudeLgtm =
+    /^claude(?:\[bot\])?$/i.test(comment.author ?? "") &&
+    /^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body);
+  if (isClaudeLgtm) return !isExplicitlyCleanClaudeReview(comment, pr);
   if (hasReviewContradiction(body)) return true;
   const actionableSignal =
-    /(?:\[[Pp]3\]|\*\*[Pp]3\*\*|\b[Pp]3\s*(?::|[-—|]|Badge\b))/.test(body) ||
-    (/^claude(?:\[bot\])?$/i.test(comment.author ?? "") &&
-      /^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body));
-  return actionableSignal && !isExplicitlyCleanClaudeReview(comment);
+    /(?:\[[Pp]3\]|\*\*[Pp]3\*\*|\b[Pp]3\s*(?::|[-—|]|Badge\b))/.test(body);
+  return actionableSignal;
 }
 
 function normalizeText(value) {
@@ -358,33 +453,35 @@ function botCommentSections(comment) {
 
 function botCommentFindings(comments = [], pr, blockingComments = []) {
   const blockingKeys = new Set(blockingComments.map(feedbackCommentKey));
-  return comments.filter(isActionableReviewBotComment).flatMap((comment) => {
-    const currentHead = isCurrentHeadComment(comment, pr);
-    const blocking = blockingKeys.has(feedbackCommentKey(comment));
-    const source = comment.commitOid
-      ? "top-level-bot-review"
-      : "top-level-bot-comment";
-    return botCommentSections(comment).map((section, index) =>
-      buildFinding({
-        source,
-        sourceId: findingSourceId(comment.id, index),
-        author: comment.author ?? null,
-        url: comment.url ?? null,
-        title: section.title,
-        body: section.body,
-        state: blocking
-          ? "blocking-current-head"
-          : currentHead
-            ? "current-head"
-            : "stale",
-        currentHead,
-        outdated: currentHead ? false : true,
-        replied: null,
-        unresolved: blocking,
-        blocking,
-      }),
-    );
-  });
+  return comments
+    .filter((comment) => isActionableReviewBotComment(comment, pr))
+    .flatMap((comment) => {
+      const currentHead = isCurrentHeadComment(comment, pr);
+      const blocking = blockingKeys.has(feedbackCommentKey(comment));
+      const source = comment.commitOid
+        ? "top-level-bot-review"
+        : "top-level-bot-comment";
+      return botCommentSections(comment).map((section, index) =>
+        buildFinding({
+          source,
+          sourceId: findingSourceId(comment.id, index),
+          author: comment.author ?? null,
+          url: comment.url ?? null,
+          title: section.title,
+          body: section.body,
+          state: blocking
+            ? "blocking-current-head"
+            : currentHead
+              ? "current-head"
+              : "stale",
+          currentHead,
+          outdated: currentHead ? false : true,
+          replied: null,
+          unresolved: blocking,
+          blocking,
+        }),
+      );
+    });
 }
 
 export function buildFeedbackFindings(readyState, blockingTopLevelBotComments) {
@@ -434,7 +531,7 @@ export function summarizeFeedbackState(readyState) {
   const blockingTopLevelBotComments = topLevelBotComments.filter(
     (comment) =>
       isCurrentHeadComment(comment, readyState.pr) &&
-      isActionableReviewBotComment(comment),
+      isActionableReviewBotComment(comment, readyState.pr),
   );
   const findings = buildFeedbackFindings(
     readyState,

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -16,7 +16,7 @@ const UNSAFE_EVIDENCE_QUALIFIER =
 const POSITIVE_EVIDENCE =
   /^(?:clean(?:,\s+well\s+scoped)?(?:\s+fix)?|well\s+scoped(?:\s+fix)?|correct|covered|bounded|mechanical|verified|complete|exact\s+removal\s+condition|(?:no|zero|0)\s+(?:errors?|fails?|failed|failures?)(?:\s+(?:and|or)\s+(?:errors?|fails?|failed|failures?))?(?:\s+(?:are|was|were)\s+(?:found|observed|reported))?|no\s+unrelated\s+version\s+bumps?|no\s+vulnerable\s+sharp@0\.34\.5\s+remains?\s+anywhere\s+in\s+(?:the\s+)?repo(?:'s)?\s+lockfiles|parser\s+should\s+continue\s+rejecting\s+malformed\s+input|fallback\s+should\s+stay|fix\s+is\s+correct|override\s+selector\s+is\s+correctly\s+bounded|lockfile\s+churn\s+beyond\s+sharp\s+itself\s+is\s+confirmed\s+mechanical,\s+not\s+scope\s+creep|(?:the\s+)?bounded\s+selector\s+matches\s+the\s+repo(?:'s)?\s+established\s+override\s+pattern|matches\s+repo\s+convention|(?:the\s+)?inline\s+comment\s+documents\s+the\s+advisory|removal\s+condition\s+comment\s+satisfies\s+the\s+temporary\s+override\s+documentation\s+expectation|tests\s+cover\s+the\s+changed\s+paths)$/i;
 const CLAUDE_TASK_COMPLETION_LINE =
-  /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*$/i;
+  /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*(?:\s+——\s+\[View\s+job\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+\))?$/i;
 const CLAUDE_REVIEW_TITLE_LINE = /^#{1,6}\s+Review:\s+(.{1,200})$/i;
 const CLAUDE_VERDICT_LINE = /^(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?$/i;
 const CLAUDE_CHECKLIST_HEADING = /^#{1,6}\s+What\s+I\s+checked$/i;

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -108,12 +108,15 @@ const ACTIONABLE_CLAUDE_REVIEW_LOOKALIKE = {
     "4. [P2] Action required: remove the remaining vulnerable `sharp@0.34.5` lockfile entry.",
   ),
 };
-function normalizedReadyStateForClaudeReview(comment) {
+function normalizedReadyStateForClaudeReview(
+  comment,
+  { title = "fix(deps): upgrade sharp past vulnerable libvips" } = {},
+) {
   return summarizeReadyState({
     pr: {
       number: 1431,
       url: "https://github.com/mento-protocol/monitoring-monorepo/pull/1431",
-      title: "fix(deps): upgrade sharp past vulnerable libvips",
+      title,
       state: "OPEN",
       author: { login: "chapati23" },
       isDraft: false,
@@ -830,6 +833,343 @@ test("agrees with ready-state on the normalized PR #1431 clean Claude review", (
   assertEqual(feedbackState.counts.topLevelBotComments, 1);
   assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
   assertEqual(feedbackState.counts.blockingFindings, 0);
+});
+
+function structuredClaudeReview({
+  title,
+  checklist = ["Parser structure and unit-test coverage", "Runtime behavior"],
+  findings = [
+    "1. [P3] No action: tests cover the changed paths.",
+    "2. [P3] No action: fix is correct and covered.",
+  ],
+  rollup = ["1. [P3] No-action: fix is correct."],
+}) {
+  return `### Review: ${title}
+
+**Verdict: LGTM**
+
+#### What I checked
+${checklist.map((subject) => `- [x] ${subject}`).join("\n")}
+
+#### Findings
+${findings.join("\n")}
+
+#### Roll-up
+${rollup.join("\n")}`;
+}
+
+test("accepts bounded clean Claude reviews for unrelated ordinary PR titles", () => {
+  const cleanReviews = [
+    {
+      title: "feat(auth): add secure session refresh",
+      checklist: [
+        "Authentication boundary and session lifecycle",
+        "Unit tests and operator documentation",
+      ],
+    },
+    {
+      title: "fix(api): handle failed request errors",
+      checklist: ["Request-path coverage", "Schema compatibility"],
+    },
+    {
+      title: "docs(agent): explain Roll-up handling #1476",
+      checklist: [
+        "Review title and checklist routing",
+        "Documentation examples and unit tests",
+      ],
+    },
+  ];
+
+  let fixtureId = 5043638300;
+  for (const fixture of cleanReviews) {
+    const normalizedReadyState = normalizedReadyStateForClaudeReview(
+      {
+        ...PR_1431_CLEAN_CLAUDE_REVIEW,
+        id: fixtureId++,
+        body: structuredClaudeReview(fixture),
+      },
+      { title: fixture.title },
+    );
+    const feedbackState = summarizeFeedbackState(normalizedReadyState);
+    assertEqual(normalizedReadyState.ready, true);
+    assertEqual(feedbackState.ready, normalizedReadyState.required.ready);
+    assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
+    assertEqual(feedbackState.counts.blockingFindings, 0);
+  }
+});
+
+test("accepts CommonMark punctuation escapes in exact Claude review titles", () => {
+  const escapedTitles = [
+    [
+      "docs(parser): explain pipe | handling",
+      "docs(parser): explain pipe \\| handling",
+    ],
+    [
+      "docs(parser): explain colon : handling",
+      "docs(parser)\\: explain colon \\: handling",
+    ],
+    [
+      "docs(parser): explain tilde ~ handling",
+      "docs(parser): explain tilde \\~ handling",
+    ],
+  ];
+
+  let fixtureId = 5043638350;
+  for (const [title, reviewTitle] of escapedTitles) {
+    const normalizedReadyState = normalizedReadyStateForClaudeReview(
+      {
+        ...PR_1431_CLEAN_CLAUDE_REVIEW,
+        id: fixtureId++,
+        body: structuredClaudeReview({ title: reviewTitle }),
+      },
+      { title },
+    );
+    const feedbackState = summarizeFeedbackState(normalizedReadyState);
+    assertEqual(normalizedReadyState.ready, true);
+    assertEqual(feedbackState.ready, normalizedReadyState.required.ready);
+    assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
+  }
+});
+
+test("fails closed on adversarial Claude review protocol variants", () => {
+  const title = "feat(auth): add secure session refresh";
+  const clean = structuredClaudeReview({ title });
+  const replaceChecklist = (entry) =>
+    clean.replace("- [x] Parser structure and unit-test coverage", entry);
+  const replaceFinding = (entry) =>
+    clean.replace("1. [P3] No action: tests cover the changed paths.", entry);
+  const replaceRollup = (entry) =>
+    clean.replace("1. [P3] No-action: fix is correct.", entry);
+  const blockingReviews = [
+    ["mismatched title", clean, "fix(auth): different change"],
+    [
+      "oversized title",
+      structuredClaudeReview({ title: "x".repeat(201) }),
+      "x".repeat(201),
+    ],
+    [
+      "escaped punctuation still requires exact title equality",
+      structuredClaudeReview({
+        title: "feat(auth)\\: add secure session refresh \\| changed",
+      }),
+      title,
+    ],
+    ["unchecked checklist", replaceChecklist("- [ ] Unit tests"), title],
+    ["malformed checklist", replaceChecklist("- [yes] Unit tests"), title],
+    [
+      "empty checklist",
+      clean.replace(
+        "- [x] Parser structure and unit-test coverage\n- [x] Runtime behavior",
+        "",
+      ),
+      title,
+    ],
+    [
+      "actionable checklist suffix",
+      replaceChecklist("- [x] Unit tests — but please restore validation"),
+      title,
+    ],
+    [
+      "negated checklist",
+      replaceChecklist("- [x] Authorization coverage does not include writes"),
+      title,
+    ],
+    [
+      "hedged checklist",
+      replaceChecklist("- [x] Session-boundary coverage might be complete"),
+      title,
+    ],
+    [
+      "semantically actionable checklist",
+      replaceChecklist(
+        "- [x] Tests confirm the fallback allows unauthenticated writes",
+      ),
+      title,
+    ],
+    [
+      "unknown plaintext-secret claim",
+      replaceChecklist("- [x] API logs private keys in plaintext"),
+      title,
+    ],
+    [
+      "unknown credential-storage claim",
+      replaceChecklist(
+        "- [x] Telemetry stores authentication tokens without encryption",
+      ),
+      title,
+    ],
+    [
+      "unknown credential-tracing claim",
+      replaceChecklist("- [x] Request traces contain signing credentials"),
+      title,
+    ],
+    [
+      "unknown declarative checklist",
+      replaceChecklist("- [x] The implementation matches the specification"),
+      title,
+    ],
+    [
+      "unknown code-label injection",
+      replaceChecklist("- [x] `API logs private keys in plaintext` behavior"),
+      title,
+    ],
+    [
+      "hyphenated code-label injection",
+      replaceChecklist("- [x] `API-logs-private-keys-in-plaintext` behavior"),
+      title,
+    ],
+    [
+      "underscored code-label injection",
+      replaceChecklist("- [x] `P1_action_required` behavior"),
+      title,
+    ],
+    [
+      "malformed Findings heading",
+      clean.replace("#### Findings", "#### Findings:"),
+      title,
+    ],
+    [
+      "malformed Roll-up heading",
+      clean.replace("#### Roll-up", "#### Roll_up"),
+      title,
+    ],
+    [
+      "four-space-indented review heading",
+      clean.replace(`### Review: ${title}`, `    ### Review: ${title}`),
+      title,
+    ],
+    [
+      "tab-indented checklist entry",
+      clean.replace("- [x] Runtime behavior", "\t- [x] Runtime behavior"),
+      title,
+    ],
+    [
+      "one-space-tab-indented verdict",
+      clean.replace("**Verdict: LGTM**", " \t**Verdict: LGTM**"),
+      title,
+    ],
+    [
+      "four-space-indented Findings heading",
+      clean.replace("#### Findings", "    #### Findings"),
+      title,
+    ],
+    [
+      "tab-indented finding",
+      replaceFinding("\t1. [P3] No action: tests cover the changed paths."),
+      title,
+    ],
+    [
+      "two-space-tab-indented finding",
+      replaceFinding("  \t1. [P3] No action: tests cover the changed paths."),
+      title,
+    ],
+    [
+      "four-space-indented Roll-up heading",
+      clean.replace("#### Roll-up", "    #### Roll-up"),
+      title,
+    ],
+    [
+      "tab-indented roll-up",
+      replaceRollup("\t1. [P3] No-action: fix is correct."),
+      title,
+    ],
+    [
+      "three-space-tab-indented roll-up",
+      replaceRollup("   \t1. [P3] No-action: fix is correct."),
+      title,
+    ],
+    [
+      "actionable finding suffix",
+      replaceFinding(
+        "1. [P3] No action: tests cover the changed paths. Remove the fallback.",
+      ),
+      title,
+    ],
+    ["marker-only finding", replaceFinding("1. [P3] No action:"), title],
+    [
+      "delimiter-only finding",
+      replaceFinding("1. [P3] No action: .; !"),
+      title,
+    ],
+    [
+      "backtick finding label",
+      replaceFinding("1. [P3] No action: `clean`."),
+      title,
+    ],
+    [
+      "Markdown-link finding target",
+      replaceFinding(
+        "1. [P3] No action: [clean](https://example.invalid/audit).",
+      ),
+      title,
+    ],
+    [
+      "HTML-comment finding",
+      replaceFinding("1. [P3] No action: clean. <!-- metadata -->"),
+      title,
+    ],
+    [
+      "Markdown-link roll-up target",
+      replaceRollup(
+        "1. [P3] No-action: [clean](https://example.invalid/audit).",
+      ),
+      title,
+    ],
+    [
+      "negated finding",
+      replaceFinding("1. [P3] No action: fix is not correct."),
+      title,
+    ],
+    [
+      "hedged finding",
+      replaceFinding("1. [P3] No action: fix is probably correct."),
+      title,
+    ],
+    [
+      "unknown finding prose",
+      replaceFinding("1. [P3] No action: authentication looks fine."),
+      title,
+    ],
+    [
+      "unknown roll-up prose",
+      replaceRollup("1. [P3] No-action: authentication looks fine."),
+      title,
+    ],
+    [
+      "mixed clean and actionable findings",
+      replaceFinding(
+        "1. [P3] No action: tests cover the changed paths.\n2. [P2] Restore validation.",
+      ),
+      title,
+    ],
+    [
+      "mixed clean and actionable roll-up",
+      replaceRollup(
+        "1. [P3] No-action: fix is correct.\n2. [P3] No-action: clean but please remove the fallback.",
+      ),
+      title,
+    ],
+  ];
+
+  let fixtureId = 5043638400;
+  for (const [label, body, prTitle] of blockingReviews) {
+    const normalizedReadyState = normalizedReadyStateForClaudeReview(
+      {
+        ...PR_1431_CLEAN_CLAUDE_REVIEW,
+        id: fixtureId++,
+        body,
+      },
+      { title: prTitle },
+    );
+    const feedbackState = summarizeFeedbackState(normalizedReadyState);
+    assertEqual(normalizedReadyState.required.ready, true);
+    assert(
+      feedbackState.ready === false,
+      `${label}: expected feedback-state to fail closed`,
+    );
+    assertEqual(feedbackState.counts.blockingTopLevelBotComments, 1);
+    assertEqual(feedbackState.counts.blockingFindings > 0, true);
+  }
 });
 
 test("classifies clean and actionable Claude review variants", () => {

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -931,6 +931,45 @@ test("accepts CommonMark punctuation escapes in exact Claude review titles", () 
   }
 });
 
+test("accepts only the bounded Claude completion View-job wrapper", () => {
+  const title = "feat(auth): add secure session refresh";
+  const review = structuredClaudeReview({ title });
+  const completion =
+    "**Claude finished @chapati23's task in 5m 0s** —— [View job](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/29940793241)";
+  const wrappedReview = `${completion}\n\n---\n${review}`;
+  const normalizedReadyState = normalizedReadyStateForClaudeReview(
+    {
+      ...PR_1431_CLEAN_CLAUDE_REVIEW,
+      id: 5043638390,
+      body: wrappedReview,
+    },
+    { title },
+  );
+  const feedbackState = summarizeFeedbackState(normalizedReadyState);
+  assertEqual(normalizedReadyState.ready, true);
+  assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
+
+  const malformedWrappers = [
+    completion.replace("https://github.com/", "https://example.invalid/"),
+    completion.replace("29940793241", "not-a-run"),
+    `${completion} trailing text`,
+  ];
+  for (const [index, malformed] of malformedWrappers.entries()) {
+    const blockedReadyState = normalizedReadyStateForClaudeReview(
+      {
+        ...PR_1431_CLEAN_CLAUDE_REVIEW,
+        id: 5043638391 + index,
+        body: `${malformed}\n\n---\n${review}`,
+      },
+      { title },
+    );
+    const blockedFeedbackState = summarizeFeedbackState(blockedReadyState);
+    assertEqual(blockedReadyState.required.ready, true);
+    assertEqual(blockedFeedbackState.ready, false);
+    assertEqual(blockedFeedbackState.counts.blockingTopLevelBotComments, 1);
+  }
+});
+
 test("fails closed on adversarial Claude review protocol variants", () => {
   const title = "feat(auth): add secure session refresh";
   const clean = structuredClaudeReview({ title });


### PR DESCRIPTION
## The Problem

- Clean Claude reviews were recognized only when their title and checklist matched one historical fixture exactly.
- Structurally equivalent clean reviews for other PRs could therefore block readiness, while broad text matching would risk hiding actionable feedback.

## The Solution

- Generalize the bounded review grammar around the actual PR title and a small positive set of explicitly benign checklist structures, while keeping every unknown, malformed, ambiguous, or actionable shape fail closed.

## Details

- Requires the review heading to match the real PR title within strict size and structure bounds.
- Accepts only checked checklist entries that match recognized neutral topic labels, constrained code-reference categories, or the exact legacy subjects.
- Keeps unchecked, malformed, declarative, negated, hedged, mixed, and actionable entries blocking.
- Preserves strict Findings and Roll-up evidence classification.
- Adds adversarial fixtures across title, checklist, suffix, negation, hedging, heading, and mixed-content variants; updates canonical readiness documentation.

## Validation

- `pnpm pr:feedback-state:test` (29/29 passed)
- `pnpm pr:ready-state:test` (75/75 passed)
- `pnpm agent:quality-gate --run` (all five mapped commands passed)
- deterministic autoreview: clean
- immutable fresh-context semantic autoreview and bound manifest verification

Closes #1476

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
