### PR TITLE
fix(dashboard): skip redundant Monad strategy probes

### DIFF
--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -28,6 +28,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 vi.mock("@/lib/strategy-detection", () => ({
   detectProbedStrategies: mockDetectProbedStrategies,
+  RUNTIME_STRATEGY_PROBE_TIMEOUT_MS: 3000,
 }));
 
 import * as Sentry from "@sentry/nextjs";
@@ -691,6 +692,11 @@ describe("fetchNetworkData — happy path", () => {
       reservePoolIds: new Set([reservePool.id]),
     });
     mockRequest((query) => {
+      if (query.includes("AllActivePoolLiquidityStrategies")) {
+        throw new Error(
+          "field 'PoolLiquidityStrategy' not found in type: 'query_root'",
+        );
+      }
       if (query.includes("OlsPool")) return { OlsPool: [] };
       if (query.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
       if (query.includes("PoolDailyFeeSnapshotsPage"))

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/characterization-fixtures.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/characterization-fixtures.ts
@@ -96,14 +96,17 @@ function queryNameOf(document: string): string {
   return /query\s+(\w+)/.exec(document)?.[1] ?? "";
 }
 
-type Reply = Record<string, unknown> | { reject: unknown };
+type Reply =
+  | Record<string, unknown>
+  | { reject: unknown }
+  | Promise<Record<string, unknown>>;
 
 export function reject(reason: unknown): Reply {
   return { reject: reason };
 }
 
 function isRejectReply(reply: Reply): reply is { reject: unknown } {
-  return "reject" in reply;
+  return !(reply instanceof Promise) && "reject" in reply;
 }
 
 /**

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
@@ -429,7 +429,9 @@ describe("fetchNetworkData characterization — each source failing alone", () =
     const result = await resultPromise;
     dateNow.mockRestore();
 
-    expect(result.strategyError).toBeNull();
+    expect(result.strategyError?.message).toBe(
+      "strategy-detection: schema-lag fallback skipped because its source budget was exhausted",
+    );
     expect(result.reservePoolIds).toEqual(new Set());
     expect(mockDetectProbedStrategies).not.toHaveBeenCalled();
   });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
@@ -345,6 +345,49 @@ describe("fetchNetworkData characterization — each source failing alone", () =
     expect(result.reservePoolIds).toEqual(new Set());
   });
 
+  it("Monad uses its indexed strategy registry without issuing fallback RPC probes", async () => {
+    const pool = makePool("143-0xstrategy-registry", {
+      chainId: 143,
+      rebalancerAddress: "0x000000000000000000000000000000000000d0d0",
+    });
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllActivePoolLiquidityStrategies: {
+        PoolLiquidityStrategy: [
+          {
+            poolId: pool.id,
+            strategyAddress: pool.rebalancerAddress,
+            kind: "RESERVE",
+          },
+        ],
+      },
+    });
+
+    const result = await fetchNetworkData(MONAD_NETWORK, WINDOWS);
+
+    expect(result.strategyError).toBeNull();
+    expect(result.reservePoolIds).toEqual(new Set([pool.id]));
+    expect(mockDetectProbedStrategies).not.toHaveBeenCalled();
+  });
+
+  it("Monad does not issue fallback RPC probes when its strategy registry transport fails", async () => {
+    const pool = makePool("143-0xstrategy-transport-fail", {
+      chainId: 143,
+      rebalancerAddress: "0x000000000000000000000000000000000000d0d0",
+    });
+    const err = new Error("strategy registry transport down");
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllActivePoolLiquidityStrategies: reject(err),
+    });
+
+    const result = await fetchNetworkData(MONAD_NETWORK, WINDOWS);
+
+    expect(result.strategyError).toBe(err);
+    expect(result.reservePoolIds).toEqual(new Set());
+    expect(mockDetectProbedStrategies).not.toHaveBeenCalled();
+  });
+
   it("missing strategy registry schema falls back to legacy OLS and CDP rows", async () => {
     const rebalancer = "0x000000000000000000000000000000000000d0d0";
     const pool = makePool("42220-0xstrategy-schema-lag", {
@@ -533,5 +576,6 @@ describe("fetchNetworkData characterization — each source failing alone", () =
     expect(result.strategyError).toBe(err);
     expect(result.reservePoolIds).toEqual(new Set());
     expect(result.cdpPoolIds).toEqual(new Set());
+    expect(mockDetectProbedStrategies).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts
@@ -12,6 +12,7 @@
 //   - the top-level pools query failing
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GraphQLClient } from "@/lib/graphql-fetch";
 
 const { mockDetectProbedStrategies } = vi.hoisted(() => ({
   mockDetectProbedStrategies: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 vi.mock("@/lib/strategy-detection", () => ({
   detectProbedStrategies: mockDetectProbedStrategies,
+  RUNTIME_STRATEGY_PROBE_TIMEOUT_MS: 3000,
 }));
 
 vi.mock("@/lib/graphql-fetch", () => {
@@ -384,6 +386,50 @@ describe("fetchNetworkData characterization — each source failing alone", () =
     const result = await fetchNetworkData(MONAD_NETWORK, WINDOWS);
 
     expect(result.strategyError).toBe(err);
+    expect(result.reservePoolIds).toEqual(new Set());
+    expect(mockDetectProbedStrategies).not.toHaveBeenCalled();
+  });
+
+  it("Monad skips the schema-lag fallback when the registry used its probe budget", async () => {
+    const pool = makePool("143-0xstrategy-schema-lag-budget", {
+      chainId: 143,
+      rebalancerAddress: "0x000000000000000000000000000000000000d0d0",
+    });
+    let rejectRegistry!: (reason: unknown) => void;
+    const delayedSchemaLag = new Promise<Record<string, unknown>>(
+      (_resolve, rejectPromise) => {
+        rejectRegistry = rejectPromise;
+      },
+    );
+    let nowMs = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    installGraphQLMock({
+      AllPoolsWithHealth: { Pool: [pool] },
+      AllActivePoolLiquidityStrategies: delayedSchemaLag,
+    });
+
+    const resultPromise = fetchNetworkData(MONAD_NETWORK, WINDOWS);
+    await vi.waitFor(() => {
+      const requests = (
+        GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      expect(
+        requests.some(([arg]) =>
+          JSON.stringify(arg).includes("AllActivePoolLiquidityStrategies"),
+        ),
+      ).toBe(true);
+    });
+    nowMs = 2001;
+    rejectRegistry(
+      new Error(
+        "field 'PoolLiquidityStrategy' not found in type: 'query_root'",
+      ),
+    );
+
+    const result = await resultPromise;
+    dateNow.mockRestore();
+
+    expect(result.strategyError).toBeNull();
     expect(result.reservePoolIds).toEqual(new Set());
     expect(mockDetectProbedStrategies).not.toHaveBeenCalled();
   });

--- a/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
+++ b/ui-dashboard/src/lib/network-fetcher/__tests__/fetch.characterization.windows.test.ts
@@ -24,6 +24,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 vi.mock("@/lib/strategy-detection", () => ({
   detectProbedStrategies: mockDetectProbedStrategies,
+  RUNTIME_STRATEGY_PROBE_TIMEOUT_MS: 3000,
 }));
 
 vi.mock("@/lib/graphql-fetch", () => {

--- a/ui-dashboard/src/lib/network-fetcher/sources.ts
+++ b/ui-dashboard/src/lib/network-fetcher/sources.ts
@@ -1,10 +1,12 @@
-// Fires the 14-way parallel fan-out behind `fetchNetworkData`: fee/daily/
+// Fires the independent data-source fan-out behind `fetchNetworkData`: fee/daily/
 // broker snapshots, LP addresses, legacy OLS pools, the active strategy
 // registry, breach rollup, health cursor,
 // rebalance-threshold-known, VP oracle freshness, VP deprecation x2, indexed
-// CDP pools, and fallback strategy probes. Each branch is isolated behind
-// `Promise.allSettled` so one query's schema-lag or timeout degrades only
-// its own slice instead of failing the whole pool list.
+// CDP pools, and fallback strategy probes. The fallback deliberately waits on
+// the strategy registry: it only exists for the narrow schema-lag window, so
+// a successful registry response must never trigger browser-side RPC traffic.
+// Each branch is isolated behind `Promise.allSettled` so one query's schema-lag
+// or timeout degrades only its own slice instead of failing the whole pool list.
 
 import type { GraphQLClient } from "@/lib/graphql-fetch";
 import type { Network } from "@/lib/networks";
@@ -132,9 +134,9 @@ type SourcesArgs = {
 };
 
 // Positional tuple matching `fetchNetworkSources`'s destructure order below —
-// kept as its own function so the 14-item fan-out (with its per-branch
-// isolation rationale) stays readable as one literal instead of folded into
-// a larger function body.
+// kept as its own function so the independent requests, plus the intentionally
+// registry-dependent fallback, stay readable as one literal instead of folded
+// into a larger function body.
 function buildSourcePromises(
   args: SourcesArgs,
 ): [
@@ -168,6 +170,19 @@ function buildSourcePromises(
     truncated: false,
     error: null,
   };
+  const activeStrategies = requestActiveLiquidityStrategies(network, timed);
+  // PoolLiquidityStrategy is authoritative whenever its query succeeds,
+  // including an empty row set. Only its explicit missing-field compatibility
+  // result needs the legacy runtime probe. A transport failure is deliberately
+  // not a fallback trigger: `resolveStrategyError` surfaces it instead of
+  // multiplying an upstream outage into public-RPC traffic.
+  const fallbackStrategies = activeStrategies.then(
+    (result) =>
+      result.available
+        ? emptyStrategyIds()
+        : requestFallbackStrategies(network, pools),
+    () => emptyStrategyIds(),
+  );
 
   return [
     fetchAllFeeSnapshotPages(client, network.chainId, network.id),
@@ -191,7 +206,7 @@ function buildSourcePromises(
           error: null,
         }),
     timed<OlsPoolsResult>(ALL_OLS_POOLS, chainVariables),
-    requestActiveLiquidityStrategies(network, timed),
+    activeStrategies,
     // Uptime rollup — isolated from ALL_POOLS_WITH_HEALTH so a schema-
     // lag fail degrades just the uptime column to "—", not the entire
     // pools page.
@@ -224,7 +239,7 @@ function buildSourcePromises(
     // runtime probe is a non-Celo Reserve fallback and must not produce CDP
     // badges.
     requestIndexedCdpPools(network, timed),
-    requestFallbackStrategies(network, pools),
+    fallbackStrategies,
   ];
 }
 

--- a/ui-dashboard/src/lib/network-fetcher/sources.ts
+++ b/ui-dashboard/src/lib/network-fetcher/sources.ts
@@ -126,7 +126,9 @@ async function requestFallbackStrategies(
   // Starting the fixed-length RPC probe with less time remaining would turn a
   // near-timeout schema-lag response into an additional three-second delay.
   if (Date.now() + RUNTIME_STRATEGY_PROBE_TIMEOUT_MS > deadlineMs) {
-    return emptyStrategyIds();
+    throw new Error(
+      "strategy-detection: schema-lag fallback skipped because its source budget was exhausted",
+    );
   }
   return detectProbedStrategies(network, pools);
 }
@@ -181,7 +183,8 @@ function buildSourcePromises(
   };
   // The compatibility probe is sequential by design, so make it consume the
   // same five-second budget as the registry query rather than extending this
-  // source phase beyond the rest of the fan-out.
+  // source phase beyond the rest of the fan-out. A budget-exhausted fallback
+  // rejects so the partial classification cannot enter the healthy SSR cache.
   const strategySourceDeadlineMs = Date.now() + REQUEST_TIMEOUT_MS;
   const activeStrategies = requestActiveLiquidityStrategies(network, timed);
   // PoolLiquidityStrategy is authoritative whenever its query succeeds,

--- a/ui-dashboard/src/lib/network-fetcher/sources.ts
+++ b/ui-dashboard/src/lib/network-fetcher/sources.ts
@@ -29,6 +29,7 @@ import {
   fetchAllDailySnapshotPages,
   fetchAllFeeSnapshotPages,
   fetchAllLpAddressPages,
+  REQUEST_TIMEOUT_MS,
 } from "./pagination";
 import {
   emptyStrategyIds,
@@ -116,9 +117,17 @@ function requestIndexedCdpPools(
 async function requestFallbackStrategies(
   network: Network,
   pools: Pool[],
+  deadlineMs: number,
 ): Promise<Readonly<ProbedStrategies>> {
   if (!usesRuntimeStrategyProbe(network)) return emptyStrategyIds();
-  const { detectProbedStrategies } = await import("@/lib/strategy-detection");
+  const { detectProbedStrategies, RUNTIME_STRATEGY_PROBE_TIMEOUT_MS } =
+    await import("@/lib/strategy-detection");
+  // The registry and its compatibility probe share one source-phase budget.
+  // Starting the fixed-length RPC probe with less time remaining would turn a
+  // near-timeout schema-lag response into an additional three-second delay.
+  if (Date.now() + RUNTIME_STRATEGY_PROBE_TIMEOUT_MS > deadlineMs) {
+    return emptyStrategyIds();
+  }
   return detectProbedStrategies(network, pools);
 }
 
@@ -170,6 +179,10 @@ function buildSourcePromises(
     truncated: false,
     error: null,
   };
+  // The compatibility probe is sequential by design, so make it consume the
+  // same five-second budget as the registry query rather than extending this
+  // source phase beyond the rest of the fan-out.
+  const strategySourceDeadlineMs = Date.now() + REQUEST_TIMEOUT_MS;
   const activeStrategies = requestActiveLiquidityStrategies(network, timed);
   // PoolLiquidityStrategy is authoritative whenever its query succeeds,
   // including an empty row set. Only its explicit missing-field compatibility
@@ -180,7 +193,7 @@ function buildSourcePromises(
     (result) =>
       result.available
         ? emptyStrategyIds()
-        : requestFallbackStrategies(network, pools),
+        : requestFallbackStrategies(network, pools, strategySourceDeadlineMs),
     () => emptyStrategyIds(),
   );
 

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -48,7 +48,10 @@ const MAX_CACHE_ENTRIES = 256;
 // ~5s total, and detection runs alongside the other GraphQL queries there.
 // Viem's http() default timeout is 10s, which would blow the outer budget
 // on the first wedged RPC, so we cap each probe chain here to a fraction.
-const PROBE_TIMEOUT_MS = 3000;
+// Kept public for the source orchestrator, which needs to avoid starting a
+// fallback probe when a delayed schema-lag response has already used its
+// source-phase budget.
+export const RUNTIME_STRATEGY_PROBE_TIMEOUT_MS = 3000;
 
 // Sentry throttle: without this, a 30s poll loop × N rebalancers × M flaky
 // networks would fan out to the same captureException on every cycle and
@@ -189,7 +192,9 @@ export async function detectProbedStrategies(
 
   if (poolsByRebalancer.size === 0) return emptyStrategies();
 
-  const client = getViemClient(network.rpcUrl, { timeoutMs: PROBE_TIMEOUT_MS });
+  const client = getViemClient(network.rpcUrl, {
+    timeoutMs: RUNTIME_STRATEGY_PROBE_TIMEOUT_MS,
+  });
   const typeByRebalancer = new Map<string, StrategyType>();
 
   await Promise.all(
@@ -218,7 +223,7 @@ export async function detectProbedStrategies(
           new Promise<never>((_, reject) => {
             timeoutId = setTimeout(
               () => reject(new Error("strategy-detection: probe timed out")),
-              PROBE_TIMEOUT_MS,
+              RUNTIME_STRATEGY_PROBE_TIMEOUT_MS,
             );
           }),
         ]);


### PR DESCRIPTION
## The Problem

- The dashboard runs fallback Monad strategy probes even when indexed `PoolLiquidityStrategy` rows already cover the pool.
- Cold browser sessions can rate-limit the public Monad RPC, adding Sentry noise and delaying refreshes.

## The Solution

Use the indexed strategy registry as the gate for fallback probing. Successful registry queries make zero browser RPC calls; the fallback remains available only for the explicit missing-schema rollout case, within the registry source's existing five-second budget.

## Details

- Registry transport failures remain visible through the existing strategy error channel and do not trigger public-RPC retries.
- A delayed schema-lag response skips the fixed three-second probe when there is not enough time left in the shared source-phase budget.
- Regression coverage proves no probes for registry success, transport failure, and delayed schema lag, while retaining the fast schema-lag fallback.

### Invariants

- An indexed registry response, including an empty result, is authoritative and never starts a browser-side strategy probe.
- Registry transport failures remain observable as strategy errors rather than being masked by a public-RPC retry.
- The fallback probe only runs for the explicit missing-schema compatibility case and cannot extend its source phase beyond five seconds.

### Degraded behavior

- During missing-schema rollout lag, the dashboard keeps legacy strategy classification only when at least the probe's full timeout remains; otherwise it surfaces a strategy-data degradation so incomplete classification cannot enter the healthy SSR cache.

### Intentional non-goals

- This PR does not remove runtime fallback support for schema-lag deployments or change indexed strategy classification.

## Validation

- `pnpm agent:quality-gate --run` (initial implementation)
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/network-fetcher/__tests__/fetch.characterization.sources.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- Dashboard browser suite: 24/24 passed (initial implementation)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
