### PR TITLE
docs: one-card PR operating loop, single-homed topics, archived stale plans

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -231,8 +231,12 @@ Include this marker when practical:
 Run the shared readiness probe before calling the PR clean:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json
 ```
+
+Always pass `--repo` bound to the base repository: without it the probe infers
+the repo from the checkout, which inspects the wrong same-number PR on fork
+PRs or repo-bound checkouts.
 
 In a Claude cloud session without the Surface Detection capability exception,
 the probe cannot run; use the `babysit-pr` skill's cloud watch loop (MCP

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -231,8 +231,12 @@ Include this marker when practical:
 Run the shared readiness probe before calling the PR clean:
 
 ```bash
-pnpm pr:ready-state --pr <number> --json
+pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json
 ```
+
+Always pass `--repo` bound to the base repository: without it the probe infers
+the repo from the checkout, which inspects the wrong same-number PR on fork
+PRs or repo-bound checkouts.
 
 In a Claude cloud session without the Surface Detection capability exception,
 the probe cannot run; use the `babysit-pr` skill's cloud watch loop (MCP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ in [`SPEC.md`](SPEC.md).
 
 ## Operating Rule (read this before opening PRs)
 
+The full claim → implement → gate → autoreview → ship → babysit → ready-state →
+merge loop, with its non-negotiables, is one card:
+[`docs/notes/pr-operating-card.md`](docs/notes/pr-operating-card.md). Read it
+first; open the authority docs it names only when a step needs their depth.
+
 Read [`docs/context-standards.md`](docs/context-standards.md) before using or
 moving repository documentation. Canonical context is current operating truth;
 plans and non-canonical notes are historical input that must be verified.
@@ -66,11 +71,9 @@ storage only. Claim before substantive edits:
 pnpm issue:claim --count 3 --agent codex
 ```
 
-When a PR opens, run `pnpm issue:review --pr <number> --issue <issue>`. Use
-`Closes #N` only when the issue's **Done means** is fully satisfied; otherwise
-use `Refs #N`. Release incomplete work with `pnpm issue:release` and choose
-`agent-ready` versus `needs-grooming` from the remaining clarity. Label,
-workboard, Claim ID, and post-merge sync rules live in
+Review linkage (`Closes` vs `Refs`), release, and post-merge sync are on the
+[operating card](docs/notes/pr-operating-card.md); label, workboard, and Claim
+ID depth lives in
 [`docs/notes/agent-issue-workflow.md`](docs/notes/agent-issue-workflow.md).
 
 ## Agent Quality Gate
@@ -79,30 +82,20 @@ Before opening or updating an agent-authored PR, inspect and run the mapped
 local-only checks:
 
 ```bash
-pnpm agent:quality-gate
-pnpm agent:quality-gate --run
-pnpm agent:autoreview # non-trivial completed batches
-pnpm agent:autoreview:test -- --jobs 1  # autoreview runtime changes only
-pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review check; retain the printed manifest
+pnpm agent:quality-gate          # inspect mapped commands and checklists
+pnpm agent:quality-gate --run    # execute the safe local mapped commands
+pnpm agent:autoreview            # non-trivial completed batches
 ```
 
-The gate never deploys or applies Terraform. It refuses package-script or
-package-manager changes until their lifecycle risk is explicitly acknowledged.
-Do not run a competing dashboard server/browser suite or second gate in the
-same worktree. Background `--run` gates and `git push`; a 600s foreground kill
-discards the freshness stamp. Invocation details, parallelism, caching, the
-server-side fallback, and common traps live in
-[`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
-
-Autoreview covers the complete branch-local target without truncation. One
-fresh-context reviewer must inspect every prepared-bundle pass, with manifest
-verification before and after review. Capture, bundle-integrity,
-sensitive-input, and runtime-trust failures are fail-closed; so is an explicitly
-selected unavailable semantic engine. Runtime-changing PRs use the compatible
-last-reviewed owning-checkout wrapper. Autoreview reviews source only: it runs
-no tests and proves no behavior, so mapped gate, browser, generated-artifact,
-and runtime checks still apply. Exact target, bundle, isolation, trust,
-engine-selection, and command contracts live in
+The gate never deploys or applies Terraform, and refuses package-script,
+package-manager, or lockfile changes until their lifecycle risk is explicitly
+acknowledged. Do not run a competing dashboard server/browser suite or second
+gate in the same worktree. Background `--run` gates and `git push`; a 600s
+foreground kill discards the freshness stamp. Autoreview is source review only —
+it runs no tests and proves no behavior, so mapped gate, browser, and runtime
+checks still apply. The full gate → autoreview loop is on the
+[operating card](docs/notes/pr-operating-card.md); invocation, parallelism,
+caching, isolation, trust, and engine contracts live in
 [`docs/notes/agent-quality-gate-mechanics.md`](docs/notes/agent-quality-gate-mechanics.md).
 
 ## Prose Style
@@ -149,17 +142,8 @@ comments/threads, annotations, and failing logs. Reply before resolving:
 - `Fixed in <commit> — <what changed>`
 - `Won't fix: <technical reason why>`
 
-Audit sibling surfaces after one instance of a hazard is found; review is a
-batch-boundary verifier, not the inner edit loop. Never force-push or amend
-while babysitting.
-
-Freeze the intended review baseline before the first pass: the user request,
-target/owner, changed files, and non-test changed lines. Classify additions as
-in-scope, follow-up, or stop; create an issue before deferring valid follow-up
-work, warn near twice the baseline, and pause for reclassification after two
-review-triggered patch cycles rather than starting a third automatically.
-
-Before all-clear, run:
+Audit sibling surfaces after one instance of a hazard is found. Never
+force-push or amend while babysitting. Before all-clear, run:
 
 ```bash
 pnpm --silent pr:feedback-state --pr <number> --json
@@ -168,9 +152,10 @@ pnpm pr:ready-state --pr <number> --json
 
 All-clear requires a clean feedback ledger plus ready-state's current-head
 required state, including the current-head
-`chatgpt-codex-connector[bot]` PR-description approval. Do not post routine or
-duplicate `@codex review` requests. The projection contract, break-glass
-behavior, optional-bot treatment, and watch loop live in
+`chatgpt-codex-connector[bot]` PR-description approval. The review-baseline
+discipline and full babysit → ready-state loop are on the
+[operating card](docs/notes/pr-operating-card.md); the projection contract,
+break-glass behavior, optional-bot treatment, and watch loop live in
 [`docs/notes/pr-ready-state.md`](docs/notes/pr-ready-state.md) and the
 `babysit-pr` skill.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,3 +1,17 @@
+---
+title: "Monitoring Monorepo — Task Backlog (retired)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-05-29
+archived_reason: "Active items migrated to GitHub Issues (label source:backlog) on 2026-05-29; completed work is preserved in git history."
+doc_type: tracker
+scope: repo-wide
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # Monitoring Monorepo — Task Backlog (retired)
 
 This legacy task backlog has been retired. As of 2026-05-29 its active items

--- a/docs/PLAN-cdps-monitoring.md
+++ b/docs/PLAN-cdps-monitoring.md
@@ -1,3 +1,17 @@
+---
+title: "ROADMAP refresh + CDPs monitoring plan (archived)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-07-23
+archived_reason: "Historical execution plan; CDPs indexing + dashboard shipped and debt accounting is superseded by docs/notes/liquity-monitoring-invariants.md. Retained for decision history."
+doc_type: plan
+scope: repo-wide
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # ROADMAP refresh + CDPs monitoring (Liquity v2 indexing & dashboard)
 
 > **Historical plan, not current operating truth.** The implementation has

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md) | Documentation gardening | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md) | Hasura isolation trigger | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/pr-operating-card.md`](notes/pr-operating-card.md) | PR Operating Card | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/reserve-yield-indexer.md`](notes/reserve-yield-indexer.md) | Reserve-Yield Indexer Topology | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
@@ -163,9 +164,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/CODE-REVIEW-UI-DASHBOARD.md`](CODE-REVIEW-UI-DASHBOARD.md) | Code Review — ui-dashboard | non-canonical / archived | reference / repo-wide | eng | 180d |
 | [`docs/context-standards.md`](context-standards.md) | Agent Context Standards | canonical / active | reference / repo-wide | eng | 90d; verified 2026-07-17 |
 | [`docs/metrics/review-process-after-1045-comparison-2026-07-07.md`](metrics/review-process-after-1045-comparison-2026-07-07.md) | Review Process Metrics After PR 1045 | non-canonical / active | reference / repo-wide | eng | 180d; verified 2026-07-07 |
-| [`docs/monad-launch-plan.md`](monad-launch-plan.md) | Monad Monitoring — Launch Runbook | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
-| [`docs/multichain-indexer-analysis.md`](multichain-indexer-analysis.md) | Multichain Indexer Analysis: Merging Celo + Monad into One Envio Instance | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
-| [`docs/mutation-testing.md`](mutation-testing.md) | Mutation Testing | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
+| [`docs/mutation-testing.md`](mutation-testing.md) | Mutation Testing | non-canonical / active | reference / repo-wide | eng | 180d; verified 2026-07-23 |
 | [`docs/notes/liquity-monitoring-invariants.md`](notes/liquity-monitoring-invariants.md) | Liquity Monitoring Invariants | canonical / active | reference / indexer-envio/ui-dashboard | eng | 90d; verified 2026-07-17 |
 | [`docs/notes/terraform-secret-strategy-2026-07.md`](notes/terraform-secret-strategy-2026-07.md) | Terraform secret strategy hardening | canonical / active | reference / terraform/infra | eng | 90d; verified 2026-07-17 |
 | [`docs/README.md`](README.md) | Documentation Catalog | canonical / active | index / repo-wide | eng | 90d; verified 2026-07-17 |
@@ -180,14 +179,16 @@ the rules in [`context-standards.md`](context-standards.md).
 | Document | Title | Authority | Type / scope | Owner | Review |
 | --- | --- | --- | --- | --- | --- |
 | [`BACKLOG.md`](../BACKLOG.md) | Backlog | unmanaged / unmanaged | tracker / repo-wide | unowned | 365d |
-| [`docs/BACKLOG.md`](BACKLOG.md) | Monitoring Monorepo — Task Backlog (retired) | unmanaged / unmanaged | tracker / repo-wide | unowned | 365d |
+| [`docs/BACKLOG.md`](BACKLOG.md) | Monitoring Monorepo — Task Backlog (retired) | non-canonical / archived | tracker / repo-wide | eng | 365d; verified 2026-07-23 |
+| [`docs/monad-launch-plan.md`](monad-launch-plan.md) | Monad Monitoring — Launch Runbook (archived) | non-canonical / archived | runbook / indexer | eng | 365d; verified 2026-07-23 |
+| [`docs/multichain-indexer-analysis.md`](multichain-indexer-analysis.md) | Multichain Indexer Analysis — Celo + Monad merge (archived) | non-canonical / archived | report / indexer | eng | 365d; verified 2026-07-23 |
 | [`docs/notes/file-size-watch.md`](notes/file-size-watch.md) | File-size and lint-hygiene watch list | canonical / active | report / repo-wide | eng | 30d; verified 2026-07-17 |
 | [`docs/notes/indexer-spec-followups.md`](notes/indexer-spec-followups.md) | Indexer SPEC §2 follow-up metrics (archived) | non-canonical / archived | note / indexer-envio | eng | 365d; verified 2026-07-17 |
-| [`docs/notes/react-compiler-annotation-pilot.md`](notes/react-compiler-annotation-pilot.md) | React Compiler annotation-mode pilot | unmanaged / unmanaged | note / repo-wide | unowned | 365d |
+| [`docs/notes/react-compiler-annotation-pilot.md`](notes/react-compiler-annotation-pilot.md) | React Compiler annotation-mode pilot (archived) | non-canonical / archived | note / ui-dashboard | eng | 365d; verified 2026-07-23 |
 | [`docs/notes/review-process-metrics.md`](notes/review-process-metrics.md) | Review process metrics evaluation | non-canonical / archived | report / ci/process | eng | 365d; verified 2026-07-17 |
 | [`docs/notes/terraform-cicd-hardening-decisions-2026-05.md`](notes/terraform-cicd-hardening-decisions-2026-05.md) | Terraform CI/CD hardening — declined alternatives | non-canonical / archived | note / terraform/infra | eng | 365d; verified 2026-07-17 |
-| [`docs/notes/ui-dashboard-performance-plan.md`](notes/ui-dashboard-performance-plan.md) | UI Dashboard Performance Plan — monitoring.mento.org | unmanaged / unmanaged | note / repo-wide | unowned | 365d |
+| [`docs/notes/ui-dashboard-performance-plan.md`](notes/ui-dashboard-performance-plan.md) | UI Dashboard Performance Plan (archived) | non-canonical / archived | plan / ui-dashboard | eng | 365d; verified 2026-07-23 |
 | [`docs/PLAN-ai-review-process.md`](PLAN-ai-review-process.md) | AI Review Process Integration Plan | non-canonical / archived | plan / ci/process | eng | 365d; verified 2026-07-17 |
-| [`docs/PLAN-cdps-monitoring.md`](PLAN-cdps-monitoring.md) | ROADMAP refresh + CDPs monitoring (Liquity v2 indexing & dashboard) | unmanaged / unmanaged | plan / repo-wide | unowned | 365d |
+| [`docs/PLAN-cdps-monitoring.md`](PLAN-cdps-monitoring.md) | ROADMAP refresh + CDPs monitoring plan (archived) | non-canonical / archived | plan / repo-wide | eng | 365d; verified 2026-07-23 |
 | [`docs/PLAN-oracle-health-state.md`](PLAN-oracle-health-state.md) | Oracle health-state decision retrospective | non-canonical / archived | plan / repo-wide | eng | 365d |
 | [`docs/PLAN-peg-monitoring.md`](PLAN-peg-monitoring.md) | Peg monitoring for oracle-less stablecoins (EUROP first) | non-canonical / active | plan / repo-wide | eng | 365d |

--- a/docs/monad-launch-plan.md
+++ b/docs/monad-launch-plan.md
@@ -1,3 +1,17 @@
+---
+title: "Monad Monitoring — Launch Runbook (archived)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-07-23
+archived_reason: "Monad indexing shipped (PR #62) and the Monad chains are live in the merged multichain indexer; retained as the historical launch record."
+doc_type: runbook
+scope: indexer
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # Monad Monitoring — Launch Runbook
 
 > **Status:** Code complete (PR #62 merged). Waiting on Envio hosted deployments.

--- a/docs/multichain-indexer-analysis.md
+++ b/docs/multichain-indexer-analysis.md
@@ -1,3 +1,17 @@
+---
+title: "Multichain Indexer Analysis — Celo + Monad merge (archived)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-07-23
+archived_reason: "Superseded by the shipped Envio v3 multichain config (indexer-envio/config.multichain.mainnet.yaml); retained for the merge-decision rationale."
+doc_type: report
+scope: indexer
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # Multichain Indexer Analysis: Merging Celo + Monad into One Envio Instance
 
 **Date:** 2026-03-18

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,3 +1,15 @@
+---
+title: "Mutation Testing"
+status: active
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+doc_type: reference
+scope: repo-wide
+review_interval_days: 180
+garden_lane: package-readmes-reference
+---
+
 # Mutation Testing
 
 Mutation testing is intentionally scoped to proven pure-logic targets:

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -29,8 +29,8 @@ authority.
    ```
 
    Claiming moves the issue out of the ready queue; if you cannot continue,
-   release it with `pnpm issue:release` and choose `agent-ready` versus
-   `needs-grooming` from how much clarity remains. Authority:
+   release it with `pnpm issue:release --issue <n>` (add `--needs-grooming`
+   when clarity is missing; default restores `agent-ready`). Authority:
    [`agent-issue-workflow.md`](agent-issue-workflow.md).
 
 2. **Implement.** Work in a dedicated per-PR worktree and unique branch, never
@@ -56,7 +56,8 @@ authority.
 
    `--run` maps changed paths to the safe local checks (lint, typecheck, tests,
    browser suite) and stamps freshness so a later pre-push `--skip-if-fresh`
-   cache-hits. It does not run `trunk fmt` — run `trunk fmt` (or Prettier)
+   cache-hits. It does not run `trunk fmt` — run `./tools/trunk fmt` (the
+   checked-in launcher; a global `trunk` may not exist)
    before committing so the required Code Quality CI stays green. The gate never
    deploys and never applies Terraform. It **refuses package-script,
    package-manager, or lockfile changes until their lifecycle risk is reviewed
@@ -73,9 +74,10 @@ authority.
    non-trivial completed batch, run the closeout review. Outside an active
    Codex session — the standalone helper or `--engine claude` — a bare
    `pnpm agent:autoreview` is the closeout, matching the `ship` skill and root
-   [`AGENTS.md`](../../AGENTS.md). Inside an active Codex session, use the
-   prepared-bundle fresh-context flow so a separate reviewer inspects every
-   pass:
+   [`AGENTS.md`](../../AGENTS.md). Inside an active Codex session, a bare
+   invocation silently selects the local deterministic engine — the `ship`
+   skill's bare closeout is NOT sufficient there; use the prepared-bundle
+   fresh-context flow so a separate reviewer inspects every pass:
 
    ```bash
    pnpm agent:autoreview --prepare-bundle-dir <dir>  # publish the review bundle

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -67,16 +67,22 @@ authority.
    Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
-4. **Autoreview.** For a non-trivial completed batch:
+4. **Autoreview.** Freeze the scope baseline first — the initial request,
+   target/owner, changed-file set, and non-test changed-line count — as the
+   reference Babysit (step 6) checks new additions against. Then, for a
+   non-trivial completed batch:
 
    ```bash
    pnpm agent:autoreview --prepare-bundle-dir <dir>  # publish the review bundle
    pnpm agent:autoreview --verify-bundle-dir <dir>   # pre-review manifest check
+   pnpm agent:autoreview --verify-bundle-dir <dir> \
+     --expected-bundle-manifest <digest-from-pre-review-check>  # post-review check
    ```
 
-   Prepare the bundle, then run `--verify-bundle-dir` immediately before
-   review, retain its printed digest outside the bundle, and pass that digest
-   to the post-review check. Autoreview reviews the complete branch-local
+   Prepare the bundle, run `--verify-bundle-dir` immediately before review,
+   retain its printed digest outside the bundle, and pass that digest to the
+   post-review check above so bundle replacement or drift during review
+   cannot go undetected. Autoreview reviews the complete branch-local
    target without truncation, but it is **source review only**: it runs no
    tests and proves no behavior, so the mapped gate, browser,
    generated-artifact, and runtime checks still apply. One fresh-context
@@ -112,10 +118,9 @@ Solution` (approach before implementation detail). PRs open **ready for
    After finding one instance of a hazard, audit its sibling surfaces — bots
    sample, they do not enumerate; review is a batch-boundary verifier, not the
    inner edit loop. Never force-push or amend while babysitting,
-   and `git fetch` before every push because reviewers push mid-session. Freeze
-   the review baseline (user request, target/owner, changed files, non-test
-   changed lines) before the first pass; classify each addition as in-scope,
-   follow-up, or stop; **file a GitHub issue before deferring any valid
+   and `git fetch` before every push because reviewers push mid-session. Check
+   new additions against the scope baseline frozen at step 4; classify each as
+   in-scope, follow-up, or stop; **file a GitHub issue before deferring any valid
    follow-up** and link it from the PR's `## Deferrals` section. Warn as the
    diff approaches twice the baseline, and pause for reclassification after two
    review-triggered patch cycles rather than starting a third. Authority:

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -1,0 +1,166 @@
+---
+title: PR Operating Card
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-23
+doc_type: runbook
+scope: repo-wide
+review_interval_days: 90
+garden_lane: operator-runbooks
+---
+
+# PR Operating Card
+
+The one-card loop for taking an agent task from claim to merge. It replaces the
+old habit of reading the full stack of operating runbooks up front: work the
+steps here, and open an authority doc only when a specific step's decision needs
+its depth. Each step is terse on purpose and names its owning authority. Root
+[`AGENTS.md`](../../AGENTS.md) routes here first; the hard invariants below and
+in the Non-negotiables section are binding even when you never open an
+authority.
+
+## The loop
+
+1. **Claim.** Before substantive edits, claim from the ready queue:
+
+   ```bash
+   pnpm issue:claim --count 3 --agent codex
+   ```
+
+   Claiming moves the issue out of the ready queue; if you cannot continue,
+   release it with `pnpm issue:release` and choose `agent-ready` versus
+   `needs-grooming` from how much clarity remains. Authority:
+   [`agent-issue-workflow.md`](agent-issue-workflow.md).
+
+2. **Implement.** Work in a dedicated per-PR worktree and unique branch, never
+   directly on `main`. Keep the diff surgical: touch only what the task needs,
+   match existing style, do not smuggle in adjacent cleanup. Read the scoped
+   `AGENTS.md` for the package you are editing (see the root Package Routing
+   Index) before touching it. A change to stateful data flow across indexer,
+   GraphQL, or UI first applies
+   [`../pr-checklists/stateful-data-ui.md`](../pr-checklists/stateful-data-ui.md);
+   an architecture change that constrains future work records an ADR in the
+   same PR. When a change adds or alters a command, script, env var, hook, or
+   ordered runbook, audit every live entry point and runbook in the same PR.
+   Before touching or moving docs, read
+   [`../context-standards.md`](../context-standards.md).
+
+3. **Gate.** Before opening or updating an agent-authored PR, inspect then run
+   the mapped local-only checks:
+
+   ```bash
+   pnpm agent:quality-gate          # inspect mapped commands and checklists
+   pnpm agent:quality-gate --run    # execute the safe local mapped commands
+   ```
+
+   `--run` maps changed paths to the safe local checks (lint, typecheck, tests,
+   browser suite) and stamps freshness so a later pre-push `--skip-if-fresh`
+   cache-hits. It does not run `trunk fmt` — run `trunk fmt` (or Prettier)
+   before committing so the required Code Quality CI stays green. The gate never
+   deploys and never applies Terraform. It **refuses package-script,
+   package-manager, or lockfile changes until their lifecycle risk is reviewed
+   and explicitly acknowledged** — do not bypass the refusal; review the surface
+   and pass the acknowledgement flag. Do not run a competing dashboard server,
+   browser suite, or second gate in the same worktree. Background the `--run`
+   gate and the `git push`; a 600s foreground kill discards the freshness stamp.
+   Authority:
+   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
+
+4. **Autoreview.** For a non-trivial completed batch:
+
+   ```bash
+   pnpm agent:autoreview                       # non-trivial completed batch
+   pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review manifest check
+   ```
+
+   Run `--verify-bundle-dir` immediately before review, retain its printed
+   digest outside the bundle, and pass that digest to the post-review check.
+   Autoreview reviews the complete branch-local target without truncation, but
+   it is **source review only**: it runs no tests and proves no behavior, so the
+   mapped gate, browser, generated-artifact, and runtime checks still apply. One
+   fresh-context reviewer must inspect every prepared-bundle pass, with manifest
+   verification before and after review. Capture, bundle-integrity,
+   sensitive-input, runtime-trust, and explicitly-selected-unavailable-engine
+   failures all fail closed. Authority:
+   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
+
+5. **Ship.** Open the PR through the `ship` skill on every surface, including
+   hosted sessions — do not hand-roll PR creation. The description starts with
+   `## The Problem` (at most three plain-language bullets) then `## The
+Solution` (approach before implementation detail). PRs open **ready for
+   review, never as drafts**; use draft only when the user asks or required
+   validation is intentionally pending, and state that reason in the body. Link
+   the issue with `Closes #N` **only when the issue's Done means is fully
+   satisfied**; otherwise use `Refs #N`.
+
+6. **Babysit.** Run the `babysit-pr` skill. Sweep every feedback surface:
+   top-level comments, review bodies, inline comments and threads, annotations,
+   and failing logs. **Reply before resolving**, on the correct surface, in
+   these exact forms:
+   - `Fixed in <commit> — <what changed>`
+   - `Won't fix: <technical reason why>`
+
+   After finding one instance of a hazard, audit its sibling surfaces — bots
+   sample, they do not enumerate; review is a batch-boundary verifier, not the
+   inner edit loop. Never force-push or amend while babysitting,
+   and `git fetch` before every push because reviewers push mid-session. Freeze
+   the review baseline (user request, target/owner, changed files, non-test
+   changed lines) before the first pass; classify each addition as in-scope,
+   follow-up, or stop; **file a GitHub issue before deferring any valid
+   follow-up** and link it from the PR's `## Deferrals` section. Warn as the
+   diff approaches twice the baseline, and pause for reclassification after two
+   review-triggered patch cycles rather than starting a third. Authority:
+   [`agent-issue-workflow.md`](agent-issue-workflow.md) for the deferral and
+   issue-lifecycle rules.
+
+7. **Ready-state.** Before signalling all-clear, run both projections:
+
+   ```bash
+   pnpm --silent pr:feedback-state --pr <number> --json
+   pnpm pr:ready-state --pr <number> --json
+   ```
+
+   Run them in that order and preserve the two-projection contract: the
+   feedback ledger must be clean **first**, then the subsequent current-head
+   `pr:ready-state` must report ready — including the current-head
+   `chatgpt-codex-connector[bot]` PR-description approval, unless a documented
+   break-glass signal applies. Do not block on slow optional bots that branch
+   protection does not require, and do not post routine or duplicate
+   `@codex review` requests. Authority:
+   [`pr-ready-state.md`](pr-ready-state.md).
+
+8. **Merge hygiene.** **Never merge a PR without the user's explicit, direct
+   approval of that specific merge.** Green CI, bot approvals, a READY
+   ready-state, and "ship it" do not authorize a merge. Drive the PR to ready,
+   present the evidence, then stop and ask. After merge, sync the issue state
+   and workboard per [`agent-issue-workflow.md`](agent-issue-workflow.md).
+
+## Non-negotiables
+
+These bind regardless of which step you are on:
+
+- **Never merge without explicit approval** for that specific merge (step 8).
+- **Reply before resolving** every feedback item, in the two forms above; a
+  clear reply stops re-raising bots from looping.
+- **`Closes #N` only when Done means is fully met**, else `Refs #N`.
+- **Knowingly deferred work needs a GitHub issue first**, linked from
+  `## Deferrals`. An evidence-backed won't-fix is not a deferral.
+- **Package-script, package-manager, and lockfile changes require explicit
+  acknowledgement** through the gate; never bypass the refusal.
+- **Background long `--run` gates and pushes**; do not run them in a 600s
+  foreground that a kill would truncate, and do not start a second gate or
+  dashboard suite in the same worktree.
+- **Secrets are IaC-owned and Terraform apply needs human approval** — plan
+  first, never one-off `gh secret set` / `vercel env add` /
+  `gcloud secrets versions add`.
+
+## Authority map
+
+| Step                     | Authority doc                                                        |
+| ------------------------ | -------------------------------------------------------------------- |
+| Claim, defer, merge-sync | [`agent-issue-workflow.md`](agent-issue-workflow.md)                 |
+| Gate, autoreview         | [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md) |
+| Ready-state              | [`pr-ready-state.md`](pr-ready-state.md)                             |
+| Docs and drift           | [`../context-standards.md`](../context-standards.md)                 |
+| Ship, babysit            | `ship` and `babysit-pr` skills                                       |

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -70,19 +70,24 @@ authority.
 4. **Autoreview.** For a non-trivial completed batch:
 
    ```bash
-   pnpm agent:autoreview                       # non-trivial completed batch
-   pnpm agent:autoreview --verify-bundle-dir <dir>  # pre-review manifest check
+   pnpm agent:autoreview --prepare-bundle-dir <dir>  # publish the review bundle
+   pnpm agent:autoreview --verify-bundle-dir <dir>   # pre-review manifest check
    ```
 
-   Run `--verify-bundle-dir` immediately before review, retain its printed
-   digest outside the bundle, and pass that digest to the post-review check.
-   Autoreview reviews the complete branch-local target without truncation, but
-   it is **source review only**: it runs no tests and proves no behavior, so the
-   mapped gate, browser, generated-artifact, and runtime checks still apply. One
-   fresh-context reviewer must inspect every prepared-bundle pass, with manifest
+   Prepare the bundle, then run `--verify-bundle-dir` immediately before
+   review, retain its printed digest outside the bundle, and pass that digest
+   to the post-review check. Autoreview reviews the complete branch-local
+   target without truncation, but it is **source review only**: it runs no
+   tests and proves no behavior, so the mapped gate, browser,
+   generated-artifact, and runtime checks still apply. One fresh-context
+   reviewer must inspect every prepared-bundle pass, with manifest
    verification before and after review. Capture, bundle-integrity,
    sensitive-input, runtime-trust, and explicitly-selected-unavailable-engine
-   failures all fail closed. Authority:
+   failures all fail closed. **If this PR changes `scripts/agent-autoreview*`,
+   the current checkout is not a trust boundary for its own review** — run the
+   wrapper and helper from the last independently reviewed pre-change commit
+   instead, and run `pnpm agent:autoreview:test -- --jobs 1` as the sequential
+   full regression closeout. Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 5. **Ship.** Open the PR through the `ship` skill on every surface, including
@@ -92,7 +97,10 @@ Solution` (approach before implementation detail). PRs open **ready for
    review, never as drafts**; use draft only when the user asks or required
    validation is intentionally pending, and state that reason in the body. Link
    the issue with `Closes #N` **only when the issue's Done means is fully
-   satisfied**; otherwise use `Refs #N`.
+   satisfied**; otherwise use `Refs #N`. For issue-backed work, once the PR is
+   open, run `pnpm issue:review --pr <pr> --issue <issue>` to move the issue
+   out of `agent-active` and into review. Authority:
+   [`agent-issue-workflow.md`](agent-issue-workflow.md).
 
 6. **Babysit.** Run the `babysit-pr` skill. Sweep every feedback surface:
    top-level comments, review bodies, inline comments and threads, annotations,

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -305,11 +305,13 @@ Field expectations:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
    behavioral and runtime verification in the validation record.
 
-5. Run `pnpm --silent pr:feedback-state --pr <number> --json` for the feedback
-   sweep. After its ledger is clean, run
-   `pnpm pr:ready-state --pr <number> --json` for the final required-readiness
-   decision. For a foreground wait loop, use
-   `pnpm pr:ready-state --pr <number> --watch --compact --until-ready`.
+5. Run `pnpm --silent pr:feedback-state --pr <number> --repo <BASE_OWNER/REPO>
+--json` for the feedback sweep. After its ledger is clean, run
+   `pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json` for the
+   final required-readiness decision. For a foreground wait loop, use
+   `pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --watch
+--compact --until-ready`. Bind `--repo` to the base repository — checkout
+   inference can select the wrong same-number PR on fork PRs.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
    `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any

--- a/docs/notes/react-compiler-annotation-pilot.md
+++ b/docs/notes/react-compiler-annotation-pilot.md
@@ -1,3 +1,17 @@
+---
+title: "React Compiler annotation-mode pilot (archived)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-07-23
+archived_reason: "Pilot issue #709 closed 2026-06-17; retained as the evaluation record."
+doc_type: note
+scope: ui-dashboard
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # React Compiler annotation-mode pilot
 
 Issue: #709

--- a/docs/notes/ui-dashboard-performance-plan.md
+++ b/docs/notes/ui-dashboard-performance-plan.md
@@ -1,3 +1,17 @@
+---
+title: "UI Dashboard Performance Plan (archived)"
+status: archived
+owner: eng
+canonical: false
+last_verified: 2026-07-23
+archived: 2026-07-23
+archived_reason: "Execution plan for the local-dev/dashboard performance epic (#1404); shipped levers are live and remaining follow-ups are tracked as GitHub Issues. Retained for the measurement baselines and rationale."
+doc_type: plan
+scope: ui-dashboard
+review_interval_days: 365
+garden_lane: notes-plans-archive
+---
+
 # UI Dashboard Performance Plan — monitoring.mento.org
 
 > Status: draft execution plan (2026-07-06). Grounded in live production measurement


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Every agent task started by reading the same 6-doc operating floor (context-standards, agent-issue-workflow, gate-mechanics, pr-ready-state, plus the `ship` and `babysit-pr` skills) — a measured ~26–31K-token fixed cost before any package-specific docs.
- The five hottest operating topics (gate mechanics, PR feedback/reply rules, `pr:ready-state` invocation, recurring-hazard checklist routing, the read-ADRs-first rule) were restated in 3–12 places, so a rule change had to be chased across root and package `AGENTS.md`, notes, and checklists.
- ~21K words of self-declared historical docs (retired BACKLOG, superseded analyses, completed plans, a closed pilot) carried no `status`/`garden_lane` frontmatter, so agents read them as current operating truth.

## The Solution

- Add one **PR operating card** (`docs/notes/pr-operating-card.md`) that carries the full claim → implement → gate → autoreview → ship → babysit → ready-state → merge loop with its non-negotiables, and make it the first pointer in root `AGENTS.md`. Detail docs stay canonical; the card is the fast path (issue #1416).
- **Single-home** each of the five duplicated topics to exactly one canonical doc and keep every other occurrence a one-line/scoped pointer (issue #1417).
- **Archive/lane** the stale docs with proper frontmatter so they self-describe as historical and stop being read as current; the one that is still an accurate reference gets active laned frontmatter instead of archival.

## Details

### Reading-floor diet (issue #1416, landed in stage 1 of this branch)

`docs/notes/pr-operating-card.md` (canonical `runbook`, lane `operator-runbooks`) holds the whole loop. Root `AGENTS.md`'s four loop sections (Operating Rule, Issue-Driven Backlog, Agent Quality Gate, PR Feedback and Readiness) now lead with the card and keep only their binding one-liners; the routing prose the card now owns was relocated, not deleted.

- Reading floor (independently recomputed by the adversarial review, following the new AGENTS.md literally for a small dashboard change): **~26–31K tokens → ~5,600 tokens** mandatory (AGENTS.md 1,232 w + card 1,115 w + scoped package AGENTS.md 749 w + dashboard-verification 1,145 w), ~8,700 tokens when one authority doc (pr-ready-state) is pulled in — a ~4–5× reduction. The five authority docs are on-demand per step rather than upfront.
- Root `AGENTS.md`: **11,722 → 10,876 bytes** (95.4% → 88.5% of the 12,288 cap); headroom **566 → 1,412** (4.6% → 11.5% free), WARNING → OK.

### Single-homing (issue #1417)

Each topic's rule text now resolves to exactly one canonical home. Verified by grepping distinctive rule phrases across `AGENTS.md`, package `AGENTS.md`, `docs/notes/**`, `docs/pr-checklists/**`, `docs/README.md`, and `.agents/skills/**`:

| Topic | Canonical home | Every other occurrence |
| --- | --- | --- |
| Gate mechanics (`never deploys`, package-script refusal) | `docs/notes/agent-quality-gate-mechanics.md` | AGENTS.md + card = pointers; pr-ready-state / codex-agent-skills / codex-cloud-setup / worktree-and-web-setup = scoped cross-refs. Rule text (`never deploys`) exists only in the canonical doc. |
| PR feedback / reply-before-resolve forms | `docs/notes/pr-operating-card.md` | AGENTS.md = pointer + binding one-liner; `babysit-pr` SKILL = authoritative execution; pr-ready-state step 1 = procedural pointer. |
| `pr:ready-state` invocation + all-clear contract | `docs/notes/pr-ready-state.md` | AGENTS.md + card = pointers; quick-commands = command reference; ci-workflow-gates / review-prompt-exclusions / worktree-and-web-setup = command mentions. `chatgpt-codex-connector` / Codex-desc-approval rule text only in the canonical doc. |
| Recurring-hazard checklist routing | `docs/pr-checklists/recurring-review-patterns.md` | AGENTS.md, indexer-envio/AGENTS.md, ui-dashboard/AGENTS.md, stateful-data-ui.md = scoped-section pointers ("Apply the X section of …"). |
| Read-ADRs-first rule | `docs/adr/README.md` (+ `architecture-decisions.md` for when/how) | AGENTS.md = one-line rule + pointer; 8 package AGENTS.md = uniform one-line scoped pointers; recurring-review-patterns = "Full rules in the linked checklist". |

No further edits were needed for single-homing: stage 1's `AGENTS.md` rewrite plus the repo's existing pointer discipline already collapsed the duplication. Distinctive-phrase greps confirm each rule appears once as a full statement; the remaining hits are pointers, command references in the command-reference doc, or the authoritative `ship`/`babysit-pr` execution skills. Converting those would be churn with zero floor benefit and no rule has been left without a canonical home.

### Archiving / laning (issue #1417)

Each classification was verified against the file's own text before acting. Content was preserved (frontmatter prepended in place, no moves, no deletions).

| File | Body words | Disposition | status / lane | Reason |
| --- | ---: | --- | --- | --- |
| `docs/monad-launch-plan.md` | 840 | Archive | archived / notes-plans-archive | Monad indexing shipped (PR #62); chains live in the multichain indexer. |
| `docs/multichain-indexer-analysis.md` | 2,002 | Archive (superseded) | archived / notes-plans-archive | Superseded by `indexer-envio/config.multichain.mainnet.yaml`. |
| `docs/BACKLOG.md` | 86 | Archive | archived / notes-plans-archive | Self-declared retired; items migrated to GitHub Issues 2026-05-29. |
| `docs/PLAN-cdps-monitoring.md` | 14,180 | Archive | archived / notes-plans-archive | Self-declared historical plan; debt model superseded by `liquity-monitoring-invariants.md`. |
| `docs/notes/ui-dashboard-performance-plan.md` | 3,457 | Archive | archived / notes-plans-archive | Epic #1404 execution plan; shipped levers live, remainder in GitHub Issues. |
| `docs/notes/react-compiler-annotation-pilot.md` | 360 | Archive | archived / notes-plans-archive | Pilot issue #709 closed 2026-06-17. |
| `docs/mutation-testing.md` | 1,535 | Lane active | active / package-readmes-reference | Accurate current reference (commands verified in `package.json`); does not self-describe as historical, so laned active rather than archived. |
| `docs/ROADMAP.md` | — | No action | — | Not present in the repo (already removed). |

Total archived: 6 docs / ~20,925 words now self-describe as historical. `docs/README.md` catalog regenerated (`pnpm docs:index --write`).

### docs-audit hardening (issue #1417 AC3) — skipped, with justification

`scripts/docs-audit.mjs` already surfaces an **authority gap** signal for any doc whose frontmatter is `unmanaged` (no explicit `status`/`canonical`) inside the weekly six-lane garden rotation — this is the recurrence guard for un-laned docs. A new fail-closed "missing explicit lane" check would flag many currently-passing frontmatter-less notes repo-wide, i.e. not the cheap, obvious extension point the task gates on. Per the task's "otherwise skip and say so," no audit change was forced.

## Validation

All checks run from the worktree; each foreground, under the command cap.

- `pnpm docs:index --write` → exit 0; `pnpm docs:index --check` → **exit 0** (catalog clean).
- `pnpm docs:audit` → exit 0; `pnpm docs:audit:test` → **pass 6, fail 0**.
- `node scripts/agent-context-budget.mjs --strict` → **exit 0**; `AGENTS.md — 10,876 bytes (88.5% of root cap), headroom 1,412` (unchanged vs stage 1 — no shrink).
- `pnpm agent:context-check` → `Agent context check passed (114 managed files).`
- `node scripts/docs-navigation-eval.test.mjs` → **pass 33, fail 0**.
- `node scripts/docs-navigation-eval.mjs --check-fixtures` → `valid:true`, `fixture_digest 71c99eb0…` (unchanged — no baseline rebind needed), `total_unique_route_bytes 259,925` (down 569 from the 260,494 main baseline; budgets moved **down**), `total_unique_headroom_bytes 12,075` (positive).
- `bash scripts/check-skills-mirror.sh` → `.agents/skills and .claude/skills are identical` (no skill edits).
- `./tools/trunk check --no-fix <10 changed files>` → **✔ No issues** (docs/README.md is trunk-ignored as generated output).

## Deferrals

- None

## Ship Checklist

- [x] Reading floor measured before/after and recorded.
- [x] No operating rule dropped — only relocated behind the card; each step names its authority.
- [x] Docs-drift grep performed; no orphaned "read this before" references.
- [x] Skills mirror verified byte-identical.
- [x] All CRITICAL hazard checks green (see Validation).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this relocates and lanes documentation; it makes no architectural decision.

Closes #1416
Closes #1417
Refs #1404
