### PR TITLE
perf(tooling): share the turbo cache across worktrees

### DIFF
--- a/bootstrap-worktree.sh
+++ b/bootstrap-worktree.sh
@@ -4,6 +4,18 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# Shared Turbo cache across worktrees (GitHub issue #1411): keep the local Turbo
+# filesystem cache at one stable per-repo location outside any worktree so a
+# fresh per-PR worktree reuses warm entries instead of starting 100% cold.
+# Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
+# opt out and fall back to Turbo's per-worktree default.
+if [[ -z "${TURBO_CACHE_DIR:-}" &&
+  "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" &&
+  "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" &&
+  -n "${HOME:-}" ]]; then
+  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+fi
+
 echo "📦 Installing dependencies..."
 pnpm install --frozen-lockfile
 

--- a/bootstrap-worktree.sh
+++ b/bootstrap-worktree.sh
@@ -8,12 +8,18 @@ cd "$(dirname "$0")"
 # filesystem cache at one stable per-repo location outside any worktree so a
 # fresh per-PR worktree reuses warm entries instead of starting 100% cold.
 # Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
-# opt out and fall back to Turbo's per-worktree default.
+# opt out and fall back to Turbo's per-worktree default. Also fall back when
+# the candidate directory cannot be created or written to: sandboxed/agent
+# environments can have a restricted writable allowlist that excludes paths
+# outside the repo.
 if [[ -z "${TURBO_CACHE_DIR:-}" &&
   "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" &&
   "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" &&
   -n "${HOME:-}" ]]; then
-  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+  turbo_cache_candidate="${HOME}/.cache/turbo-monitoring-monorepo"
+  if mkdir -p "$turbo_cache_candidate" 2>/dev/null && [[ -w "$turbo_cache_candidate" ]]; then
+    export TURBO_CACHE_DIR="$turbo_cache_candidate"
+  fi
 fi
 
 echo "📦 Installing dependencies..."

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -702,8 +702,21 @@ outcome, and the `implementation_signature`/stamp machinery does not need to
 fingerprint it. Editing this script does re-hash `implementation_signature` and
 invalidate existing stamps once (expected). Turbo 2.9.x writes each cache
 artifact via temp file + atomic rename with PID-namespaced temp names, so two
-worktrees' gates writing the shared dir concurrently cannot corrupt it. Refs
-GitHub issue 1411.
+worktrees' gates writing the shared dir concurrently cannot corrupt it.
+
+When `HOME` is unset or `$HOME/.cache/turbo-monitoring-monorepo` cannot be
+created or written to — e.g. a sandboxed agent whose writable allowlist excludes
+paths outside the repo — the gate leaves `TURBO_CACHE_DIR` unset and falls back
+to Turbo's per-worktree default, so those runs stay cold and share nothing. The
+`Turbo cache dir:` header line is printed only when the shared path is active;
+its absence means the fallback (or the opt-out) is in effect.
+
+The shared cache lives outside every worktree, so unlike the old per-worktree
+`.turbo/cache` it is not reclaimed when a worktree is deleted. Turbo only reaps
+its own orphaned `.tmp` files, never finished entries, so the directory grows
+without bound as task hashes accumulate. It is pure cache — delete it any time to
+reclaim disk and Turbo repopulates on the next run: `rm -rf
+"$HOME/.cache/turbo-monitoring-monorepo"`. Refs GitHub issue 1411.
 
 ## Common local-gate traps
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -693,30 +693,17 @@ install, dep-cruiser, coverage floors, mutation baselines, and Terraform.
 The gate exports `TURBO_CACHE_DIR="$HOME/.cache/turbo-monitoring-monorepo"`
 before running any Turbo task (unless the caller already set `TURBO_CACHE_DIR`,
 or opted out with `AGENT_TURBO_SHARED_CACHE=0`), so every worktree shares one
-local Turbo cache outside any worktree and a fresh per-PR worktree reuses warm
-typecheck/lint/knip/build/size-limit entries instead of starting 100% cold. The
-cache location is deliberately absent from the gate's freshness stamp: Turbo
-restores a cache entry only when the entry's own content-addressed input hash
-matches, so the cache directory changes a command's speed, never its pass/fail
-outcome, and the `implementation_signature`/stamp machinery does not need to
-fingerprint it. Editing this script does re-hash `implementation_signature` and
-invalidate existing stamps once (expected). Turbo 2.9.x writes each cache
-artifact via temp file + atomic rename with PID-namespaced temp names, so two
-worktrees' gates writing the shared dir concurrently cannot corrupt it.
-
-When `HOME` is unset or `$HOME/.cache/turbo-monitoring-monorepo` cannot be
-created or written to — e.g. a sandboxed agent whose writable allowlist excludes
-paths outside the repo — the gate leaves `TURBO_CACHE_DIR` unset and falls back
-to Turbo's per-worktree default, so those runs stay cold and share nothing. The
-`Turbo cache dir:` header line is printed only when the shared path is active;
-its absence means the fallback (or the opt-out) is in effect.
-
-The shared cache lives outside every worktree, so unlike the old per-worktree
-`.turbo/cache` it is not reclaimed when a worktree is deleted. Turbo only reaps
-its own orphaned `.tmp` files, never finished entries, so the directory grows
-without bound as task hashes accumulate. It is pure cache — delete it any time to
-reclaim disk and Turbo repopulates on the next run: `rm -rf
-"$HOME/.cache/turbo-monitoring-monorepo"`. Refs GitHub issue 1411.
+Turbo cache and a fresh per-PR worktree reuses warm entries instead of starting
+cold. The location is deliberately absent from the freshness stamp: Turbo
+restores an entry only on a content-addressed input-hash match, so the
+directory changes speed, never pass/fail. Turbo 2.9.x writes artifacts via
+temp file + atomic rename with PID-namespaced temp names, so concurrent gates
+cannot corrupt the shared dir. When `HOME` is unset or the dir is unwritable
+(e.g. a sandbox allowlist excluding it), the gate leaves `TURBO_CACHE_DIR`
+unset and falls back to Turbo's per-worktree default; the `Turbo cache dir:`
+header prints only when sharing is active. The shared dir is pure cache and
+grows without bound — delete it any time to reclaim disk:
+`rm -rf "$HOME/.cache/turbo-monitoring-monorepo"`. Refs GitHub issue 1411.
 
 ## Common local-gate traps
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -690,6 +690,21 @@ instead of mapping a separate dashboard build command for size-limit checks.
 High-risk or cross-layer commands stay outside Turbo, including codegen,
 install, dep-cruiser, coverage floors, mutation baselines, and Terraform.
 
+The gate exports `TURBO_CACHE_DIR="$HOME/.cache/turbo-monitoring-monorepo"`
+before running any Turbo task (unless the caller already set `TURBO_CACHE_DIR`,
+or opted out with `AGENT_TURBO_SHARED_CACHE=0`), so every worktree shares one
+local Turbo cache outside any worktree and a fresh per-PR worktree reuses warm
+typecheck/lint/knip/build/size-limit entries instead of starting 100% cold. The
+cache location is deliberately absent from the gate's freshness stamp: Turbo
+restores a cache entry only when the entry's own content-addressed input hash
+matches, so the cache directory changes a command's speed, never its pass/fail
+outcome, and the `implementation_signature`/stamp machinery does not need to
+fingerprint it. Editing this script does re-hash `implementation_signature` and
+invalidate existing stamps once (expected). Turbo 2.9.x writes each cache
+artifact via temp file + atomic rename with PID-namespaced temp names, so two
+worktrees' gates writing the shared dir concurrently cannot corrupt it. Refs
+GitHub issue 1411.
+
 ## Common local-gate traps
 
 - `codespell` flags short variable names that match common abbreviations (e.g. a two-letter loop var that looks like a misspelling). Use descriptive names like `netData` to avoid this.

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -46,6 +46,17 @@ every fresh macOS worktree. Linux still requires a per-worktree successful
 Playwright installer marker because `--with-deps` also provisions host libraries
 there.
 
+To keep a fresh per-PR worktree from starting with a 100% cold Turbo cache,
+`setup.sh`, `bootstrap-worktree.sh`, and the agent quality gate export
+`TURBO_CACHE_DIR="$HOME/.cache/turbo-monitoring-monorepo"` (unless the caller
+already set `TURBO_CACHE_DIR`, or opted out with `AGENT_TURBO_SHARED_CACHE=0`),
+so every worktree reads and writes one shared local Turbo cache outside any
+worktree. Turbo 2.9.x writes each cache artifact through a temp file plus atomic
+rename with PID-namespaced temp names and only reaps orphaned `.tmp` files older
+than an hour, so concurrent gate runs in two worktrees share the dir safely.
+Remote caching stays disabled (`turbo.json` `remoteCache.enabled: false`); this
+is local sharing only. Refs GitHub issue 1411.
+
 ## Claude Code on the web setup
 
 Claude Code on the web sessions run in a hosted container that does not inherit

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -51,11 +51,18 @@ To keep a fresh per-PR worktree from starting with a 100% cold Turbo cache,
 `TURBO_CACHE_DIR="$HOME/.cache/turbo-monitoring-monorepo"` (unless the caller
 already set `TURBO_CACHE_DIR`, or opted out with `AGENT_TURBO_SHARED_CACHE=0`),
 so every worktree reads and writes one shared local Turbo cache outside any
-worktree. Turbo 2.9.x writes each cache artifact through a temp file plus atomic
-rename with PID-namespaced temp names and only reaps orphaned `.tmp` files older
-than an hour, so concurrent gate runs in two worktrees share the dir safely.
-Remote caching stays disabled (`turbo.json` `remoteCache.enabled: false`); this
-is local sharing only. Refs GitHub issue 1411.
+worktree. When `HOME` is unset or that directory cannot be created or written to
+(e.g. a sandboxed agent whose writable allowlist excludes it), the scripts leave
+`TURBO_CACHE_DIR` unset and fall back to Turbo's per-worktree default, so those
+runs stay cold. Turbo 2.9.x writes each cache artifact through a temp file plus
+atomic rename with PID-namespaced temp names and only reaps orphaned `.tmp` files
+older than an hour, so concurrent gate runs in two worktrees share the dir
+safely. The shared dir is not reclaimed when a worktree is deleted and grows
+without bound; it is pure cache, so `rm -rf
+"$HOME/.cache/turbo-monitoring-monorepo"` any time to reclaim disk (see
+[agent-quality-gate-mechanics.md](agent-quality-gate-mechanics.md)). Remote
+caching stays disabled (`turbo.json` `remoteCache.enabled: false`); this is local
+sharing only. Refs GitHub issue 1411.
 
 ## Claude Code on the web setup
 

--- a/scripts/agent-prewarm.mjs
+++ b/scripts/agent-prewarm.mjs
@@ -53,6 +53,14 @@ export function extractTurboPrewarmCommands(gateOutput) {
   return commands;
 }
 
+export function extractTurboCacheDir(gateOutput) {
+  for (const line of gateOutput.split(/\r?\n/)) {
+    const match = line.match(/^Turbo cache dir: (.+)$/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
 export function isDashboardNextWorkspaceCommand(command) {
   const commandWithoutEnvironment = command.replace(
     /^(?:[A-Z0-9_]+=[^\s]+ )+/,
@@ -336,6 +344,19 @@ async function main() {
 
   const commands = extractTurboPrewarmCommands(gateResult.stdout ?? "");
   const packageScriptRisk = hasPackageScriptRisk(gateResult.stdout ?? "");
+
+  // The quality gate resolves the shared Turbo cache dir (issue #1411) inside
+  // its own shell, so that export never reaches this Node parent — the gate ran
+  // only as a child to produce the dry-run plan. Mirror the gate by reading the
+  // "Turbo cache dir:" line it printed and applying the same value to the Turbo
+  // commands we spawn, so prewarm writes the same cache the gate later reads.
+  // The line is absent when the gate fell back to Turbo's per-worktree default
+  // (caller opt-out or unwritable home); then we leave TURBO_CACHE_DIR unset and
+  // both sides fall back identically.
+  const turboCacheDir = extractTurboCacheDir(gateResult.stdout ?? "");
+  if (turboCacheDir) {
+    process.env.TURBO_CACHE_DIR = turboCacheDir;
+  }
 
   console.log("Agent prewarm");
   console.log();

--- a/scripts/agent-prewarm.test.mjs
+++ b/scripts/agent-prewarm.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  extractTurboCacheDir,
   extractTurboPrewarmCommands,
   hasPackageScriptRisk,
   parseParallelism,
@@ -107,5 +108,24 @@ assert.equal(
   parallelResults[1].command,
   'node -e "setTimeout(() => process.exit(0), 10)"',
 );
+
+// Prewarm must reuse the gate's resolved shared Turbo cache (issue #1411) so it
+// warms the same dir the gate later reads; parse it from the printed line.
+assert.equal(
+  extractTurboCacheDir(`Agent quality gate
+
+Base: origin/main
+Head: HEAD
+Mode: dry-run
+Turbo cache dir: /home/agent/.cache/turbo-monitoring-monorepo
+
+Changed paths:
+- ui-dashboard/src/app/page.tsx
+`),
+  "/home/agent/.cache/turbo-monitoring-monorepo",
+);
+
+// Absent line (caller opt-out or unwritable home) => no shared dir to apply.
+assert.equal(extractTurboCacheDir(gateOutput), null);
 
 console.log("agent prewarm tests passed");

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -236,12 +236,18 @@ export CI="${CI:-true}"
 # PID-namespaced temp names, and its GC only removes orphaned .tmp files older
 # than an hour, so concurrent gate runs sharing this dir cannot corrupt it.
 # Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
-# opt out and fall back to Turbo's per-worktree default.
+# opt out and fall back to Turbo's per-worktree default. Also fall back when
+# the candidate directory cannot be created or written to: sandboxed/agent
+# environments can have a restricted writable allowlist that excludes paths
+# outside the repo, same reasoning as the TMPDIR check above.
 if [[ -z "${TURBO_CACHE_DIR:-}" &&
   "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" &&
   "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" &&
   -n "${HOME:-}" ]]; then
-  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+  turbo_cache_candidate="${HOME}/.cache/turbo-monitoring-monorepo"
+  if mkdir -p "$turbo_cache_candidate" 2>/dev/null && [[ -w "$turbo_cache_candidate" ]]; then
+    export TURBO_CACHE_DIR="$turbo_cache_candidate"
+  fi
 fi
 
 tmpfiles=()

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -227,6 +227,23 @@ fi
 # for TTY confirmation.
 export CI="${CI:-true}"
 
+# Shared Turbo cache across worktrees (GitHub issue #1411): a fresh per-PR
+# worktree otherwise starts with a 100% cold Turbo cache and re-runs every
+# typecheck/lint/knip/build from scratch even when inputs match main. Point
+# Turbo's local filesystem cache at one stable per-repo location outside any
+# worktree so warm entries carry across worktrees. Turbo 2.9.x writes every
+# cache artifact (.tar.zst, manifest, meta) via temp-file + atomic rename with
+# PID-namespaced temp names, and its GC only removes orphaned .tmp files older
+# than an hour, so concurrent gate runs sharing this dir cannot corrupt it.
+# Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
+# opt out and fall back to Turbo's per-worktree default.
+if [[ -z "${TURBO_CACHE_DIR:-}" &&
+  "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" &&
+  "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" &&
+  -n "${HOME:-}" ]]; then
+  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+fi
+
 tmpfiles=()
 # Set by run_with_timeout for the most recent mapped command so callers can tell
 # a timeout apart from an ordinary non-zero exit. Read only right after the call.
@@ -2436,6 +2453,9 @@ echo
 echo "Base: ${base_ref}"
 echo "Head: ${head_ref}"
 echo "Mode: ${mode}"
+if [[ -n "${TURBO_CACHE_DIR:-}" ]]; then
+  echo "Turbo cache dir: ${TURBO_CACHE_DIR}"
+fi
 echo
 echo "Changed paths:"
 sed 's/^/- /' "$changed_paths_file"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -695,6 +695,28 @@ assert_contains "- pnpm exec turbo run lint --filter=@mento-protocol/metrics-bri
 # emitted alongside the cached one unnoticed.
 assert_not_contains "- pnpm --filter @mento-protocol/metrics-bridge lint (metrics-bridge changed)"
 
+# Shared Turbo cache across worktrees (GitHub issue #1411): with TURBO_CACHE_DIR
+# unset the gate exports the stable per-repo default so all worktrees share one
+# cache; a caller-provided TURBO_CACHE_DIR is preserved untouched.
+: > "$paths_file"
+printf 'metrics-bridge/src/main.ts\n' >> "$paths_file"
+env -u TURBO_CACHE_DIR AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_raw_contains "Turbo cache dir: "
+assert_raw_contains "/.cache/turbo-monitoring-monorepo"
+
+TURBO_CACHE_DIR="/tmp/agentqg-caller-turbo-cache" \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_raw_contains "Turbo cache dir: /tmp/agentqg-caller-turbo-cache"
+assert_not_contains "/.cache/turbo-monitoring-monorepo"
+
 run_gate_expect_failure "ui-dashboard/package.json"
 assert_contains "Refusing to run because package manifests, patches, or lockfile changed."
 assert_contains "re-run with --allow-package-script-changes if they are safe."

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -717,6 +717,38 @@ TURBO_CACHE_DIR="/tmp/agentqg-caller-turbo-cache" \
 assert_raw_contains "Turbo cache dir: /tmp/agentqg-caller-turbo-cache"
 assert_not_contains "/.cache/turbo-monitoring-monorepo"
 
+# AGENT_TURBO_SHARED_CACHE=0/false is the documented operator escape hatch;
+# assert it actually suppresses the export, not just documented intent.
+env -u TURBO_CACHE_DIR AGENT_TURBO_SHARED_CACHE=0 \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_not_contains "Turbo cache dir: "
+
+env -u TURBO_CACHE_DIR AGENT_TURBO_SHARED_CACHE=false \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_not_contains "Turbo cache dir: "
+
+# Falls back to Turbo's per-worktree default (no TURBO_CACHE_DIR export) when
+# the shared-cache candidate cannot be created, e.g. a sandboxed agent
+# environment whose writable allowlist excludes it.
+turbo_cache_unwritable_home="$(mktemp -d)"
+: > "$turbo_cache_unwritable_home/.cache"
+env -u TURBO_CACHE_DIR HOME="$turbo_cache_unwritable_home" \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+  scripts/agent-quality-gate.sh \
+  --changed-paths-file "$paths_file" \
+  --base origin/test \
+  > "$output_file"
+assert_not_contains "Turbo cache dir: "
+rm -rf "$turbo_cache_unwritable_home"
+
 run_gate_expect_failure "ui-dashboard/package.json"
 assert_contains "Refusing to run because package manifests, patches, or lockfile changed."
 assert_contains "re-run with --allow-package-script-changes if they are safe."

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -698,15 +698,21 @@ assert_not_contains "- pnpm --filter @mento-protocol/metrics-bridge lint (metric
 # Shared Turbo cache across worktrees (GitHub issue #1411): with TURBO_CACHE_DIR
 # unset the gate exports the stable per-repo default so all worktrees share one
 # cache; a caller-provided TURBO_CACHE_DIR is preserved untouched.
+# Pin a temporary writable HOME and explicitly clear AGENT_TURBO_SHARED_CACHE so
+# this default-path case stays valid when the suite itself is invoked under the
+# supported opt-out or a restricted real HOME.
 : > "$paths_file"
 printf 'metrics-bridge/src/main.ts\n' >> "$paths_file"
-env -u TURBO_CACHE_DIR AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+turbo_cache_writable_home="$(mktemp -d)"
+env -u TURBO_CACHE_DIR -u AGENT_TURBO_SHARED_CACHE HOME="$turbo_cache_writable_home" \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
   scripts/agent-quality-gate.sh \
   --changed-paths-file "$paths_file" \
   --base origin/test \
   > "$output_file"
 assert_raw_contains "Turbo cache dir: "
 assert_raw_contains "/.cache/turbo-monitoring-monorepo"
+rm -rf "$turbo_cache_writable_home"
 
 TURBO_CACHE_DIR="/tmp/agentqg-caller-turbo-cache" \
   AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,18 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Shared Turbo cache across worktrees (GitHub issue #1411): keep the local Turbo
+# filesystem cache at one stable per-repo location outside any worktree so a
+# fresh per-PR worktree reuses warm entries instead of starting 100% cold.
+# Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
+# opt out and fall back to Turbo's per-worktree default.
+if [ -z "${TURBO_CACHE_DIR:-}" ] &&
+  [ "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" ] &&
+  [ "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" ] &&
+  [ -n "${HOME:-}" ]; then
+  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+fi
+
 hash_inputs() {
   local file_list
   file_list="$(mktemp "${TMPDIR:-/tmp}/monitoring-setup-hash.XXXXXX")"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,12 +21,18 @@ cd "$REPO_ROOT"
 # filesystem cache at one stable per-repo location outside any worktree so a
 # fresh per-PR worktree reuses warm entries instead of starting 100% cold.
 # Respect a caller-provided TURBO_CACHE_DIR; set AGENT_TURBO_SHARED_CACHE=0 to
-# opt out and fall back to Turbo's per-worktree default.
+# opt out and fall back to Turbo's per-worktree default. Also fall back when
+# the candidate directory cannot be created or written to: sandboxed/agent
+# environments can have a restricted writable allowlist that excludes paths
+# outside the repo.
 if [ -z "${TURBO_CACHE_DIR:-}" ] &&
   [ "${AGENT_TURBO_SHARED_CACHE:-1}" != "0" ] &&
   [ "${AGENT_TURBO_SHARED_CACHE:-1}" != "false" ] &&
   [ -n "${HOME:-}" ]; then
-  export TURBO_CACHE_DIR="${HOME}/.cache/turbo-monitoring-monorepo"
+  turbo_cache_candidate="${HOME}/.cache/turbo-monitoring-monorepo"
+  if mkdir -p "$turbo_cache_candidate" 2>/dev/null && [ -w "$turbo_cache_candidate" ]; then
+    export TURBO_CACHE_DIR="$turbo_cache_candidate"
+  fi
 fi
 
 hash_inputs() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The team creates one git worktree per PR, but Turbo's local cache lives inside each worktree, so every fresh worktree starts 100% cold.
- A cold worktree re-runs full typecheck/lint/knip/build/size-limit from scratch even when the inputs are byte-identical to `main` — e.g. a cold `ui-dashboard` typecheck measured 19.456s here.
- Nothing shared those results across worktrees, so the cost repeated on every new PR checkout.

## The Solution

- Point Turbo's local filesystem cache at one stable per-repo location outside any worktree — `$HOME/.cache/turbo-monitoring-monorepo` — by exporting `TURBO_CACHE_DIR` in the three entry points that drive Turbo tasks or bootstrap a worktree: `scripts/agent-quality-gate.sh`, `scripts/setup.sh`, and `bootstrap-worktree.sh`.
- Every worktree now reads and writes the same cache, so a fresh per-PR worktree replays warm entries instead of recomputing them.
- A caller-provided `TURBO_CACHE_DIR` is respected, and `AGENT_TURBO_SHARED_CACHE=0` opts out back to Turbo's per-worktree default.

## Details

- **Wiring.** Each script exports `TURBO_CACHE_DIR` only when it is unset, the opt-out is not `0`/`false`, and `HOME` is set. In the gate the export sits next to the existing `CI` env setup; in `setup.sh`/`bootstrap-worktree.sh` it sits right after the `cd` to the repo root. Turbo reads the local cache dir from `TURBO_CACHE_DIR` (verified against the installed 2.9.14 binary: `--cache-dir <CACHE_DIR>` "Override the filesystem cache directory", and empirically — setting the env var redirected the local cache and produced cross-invocation `FULL TURBO` hits). The gate keeps using `--cache=local:rw`; the shared dir comes purely from the env var. `turbo.json` `remoteCache.enabled: false` is unchanged — this is local sharing only.
- **Concurrency safety (established from repo-vendored evidence).** Turbo 2.9.14's `crates/turborepo-cache/src/fs.rs` writes every cache artifact — the `.tar.zst` archive, the manifest, and the `-meta.json` — via write-to-temp-then-atomic-rename, and the temp file is PID-namespaced (`.{hash}-meta.json.{pid}.tmp`). Its cache GC only removes orphaned `.tmp` files older than one hour, with an explicit in-source comment "to avoid racing with in-progress writes from concurrent processes." Cache artifacts are content-addressed by input hash, so two worktrees writing the same key write byte-identical content, and atomic rename means a concurrent reader sees either the absent-old or the complete-new file, never a partial tarball. Two worktrees' gates sharing this dir therefore cannot corrupt it. The `AGENT_TURBO_SHARED_CACHE=0` opt-out is retained as an operator escape hatch, not because safety is in doubt.
- **Stamp / implementation-signature reasoning (no stamp change needed).** Editing `scripts/agent-quality-gate.sh` re-hashes `implementation_signature` and invalidates existing freshness stamps once — expected and called out in the issue. Going forward the cache **location** is deliberately NOT folded into the stamp: Turbo restores a cache entry only when the entry's own content-addressed input hash matches, so the cache directory changes a command's *speed*, never its pass/fail *outcome*. The stamp answers "would re-running the mapped commands produce the same result?", which the cache dir cannot affect; Turbo's own input hashing is the correctness guarantee against stale reuse, so the gate stamp does not need to duplicate it. The mapped Turbo commands (`pnpm exec turbo run … --cache=local:rw`) do not mention the cache dir, so `command_plan_hash` is unaffected too.
- **Scope of the setup/bootstrap exports.** `setup.sh` and `bootstrap-worktree.sh` currently invoke package tasks via direct `pnpm --filter` (not `turbo run`), so the export is inert there today; it is included for consistency, documentation of intent, and any future Turbo use from those scripts, per the issue's expected-files list.

## Validation

- `bash -n` on all four edited shell scripts: OK.
- Gate self-test: `bash scripts/agent-quality-gate.test.sh` → exit 0, `agent quality gate tests passed` (the new fixture asserts the gate exports the `$HOME/.cache/turbo-monitoring-monorepo` default when `TURBO_CACHE_DIR` is unset and preserves a caller-provided `TURBO_CACHE_DIR=/tmp/agentqg-caller-turbo-cache` untouched).
- `./tools/trunk check --ignore-git-state` on the 6 changed files → `Checked 6 files / ✔ No issues`.
- **Two-worktree cache demo** (`pnpm exec turbo run typecheck --filter=@mento-protocol/ui-dashboard --cache=local:rw`, shared `TURBO_CACHE_DIR=$HOME/.cache/turbo-1411-demo`):
  - Cold, worktree `turbo-share` (empty shared dir): `cache miss, executing 9e5c8ef604ade654`; turbo `Time: 19.456s` (`real 19.98`). Wrote `9e5c8ef604ade654.tar.zst` + manifest + meta into the shared dir.
  - Control re-run, same worktree, external shared dir: `cache hit, replaying logs 9e5c8ef604ade654`; `Time: 93ms >>> FULL TURBO` (`real 0.71`).
  - Cross-worktree, same inputs (transient detached worktree at the same HEAD, different path `.claude/worktrees/turbo-1411-demo-wt`): identical hash `9e5c8ef604ade654`, `cache … status HIT, source LOCAL, timeSaved 19392ms`; real execution `Time: 155ms >>> FULL TURBO` (`real 0.28`). Same hash from a different worktree path proves the key is worktree-path-independent and the hit came from the shared external dir.
  - `dx` worktree (`.claude/worktrees/dx`, branch `feat/local-dev-tier1`): `cache miss` (hash `7b6911d593f79282`) — a legitimate miss because that worktree is a different branch with different inputs, i.e. correct content-addressed behavior, not a cache fault. The transient same-input worktree above is the faithful acceptance demo.
  - Transient demo worktree and demo cache dir were removed after measuring; `git status` shows only the 6 intended files.

## Deferrals

- None

## Ship Checklist

- [x] Branch `perf/1411-shared-turbo-cache`, forked from `main` after PR #1492.
- [x] Only intended files changed (4 scripts + 2 docs); no stray edits, no git history writes.
- [x] Gate self-test green; `trunk check` clean on changed files.
- [x] Docs updated in the same PR (worktree setup note + gate mechanics note), each Refs GitHub issue 1411.
- [x] Acceptance demo recorded with verbatim timings.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #1411
Refs #1404
