### PR TITLE
docs: cover budget-exhausted compatibility fallbacks

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -153,6 +153,10 @@ For each non-happy path, decide the behavior explicitly.
 - [ ] chart query fails
 - [ ] some rows predate a new schema field
 - [ ] RPC-derived metadata is missing
+- [ ] a compatibility fallback is skipped because its time budget is exhausted:
+      return an explicit unavailable/error state when classification is
+      incomplete; never fulfil it as an empty successful result that can enter
+      a healthy SSR or persisted cache
 - [ ] total dataset is much larger than the current happy-path sample
 - [ ] search term matches data outside the currently fetched window
 - [ ] empty state vs loading state vs partial-data state are distinct


### PR DESCRIPTION
## The Problem

- A compatibility fallback can be skipped when its time budget is exhausted.
- Treating that skip as a successful empty result can cache incomplete data as healthy.

## The Solution

Add an explicit degraded-mode checklist item for budget-exhausted compatibility fallbacks.

## Details

- The checklist requires an unavailable or error state whenever classification is incomplete.
- This documents the cache-safety rule established by the Monad strategy fallback fix.

## Validation

- `./tools/trunk check docs/pr-checklists/stateful-data-ui.md`
- `pnpm docs:index --check`
- `pnpm agent:context-check`

## Ship Checklist

- [x] ship skill used
- [x] targeted docs checks run
- [x] PR readiness probe planned
