### PR TITLE
docs: garden agent entry points shard 2

### DIFF
--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -5,7 +5,7 @@ title: Forensic Report Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-06-15
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -32,7 +32,10 @@ If the answer fits in `notes` (≤500 chars, single fact like "Binance hot 14"),
 
 Two facts shape every tool choice in this skill:
 
-1. **Mento is multi-chain and growing.** Celo (`42220`) is primary and where most targets live. Monad (`143`) is live in the Mento indexer; the Polygon (`137`) protocol deployment is live and its indexer coverage is configured pending deployment, sync verification, and promotion. Ethereum (`1`) carries reserve-yield monitoring. Never hardcode `42220`; thread the target chain id through every chain-scoped call.
+1. **Mento is multi-chain and growing.** Celo (`42220`), Monad (`143`),
+   Polygon (`137`), and Ethereum (`1`) are live in the production indexer.
+   Ethereum currently carries reserve-yield monitoring. Never hardcode `42220`;
+   thread the target chain id through every chain-scoped call.
 2. **One key, many chains.** If someone controls a private key on Celo, the same EOA almost always has a history on other EVM chains (Ethereum, Base, Arbitrum, …). That cross-chain footprint is usually where the _identity_ lives — ENS, OpenSea, CEX deposits, prior bots — because the richest attribution tools (Arkham, Nansen, EigenPhi, MetaSleuth) index Ethereum/L2s but **not** Celo.
 
 So split the work into two legs and pick tools per leg:
@@ -47,11 +50,22 @@ So split the work into two legs and pick tools per leg:
 Two artefacts:
 
 1. **Local draft** at `.investigations/<address>-<slug>.md` (slug = first-3 words of derived display name, lowercase, kebab-cased). The `.investigations/` folder is gitignored — never commit drafts.
-2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script mirrors the atomic upsert pattern `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` uses — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution — but is a **simplified, non-CAS variant**: the live route additionally takes an `expectedVersion` base-version precondition and returns an `{ok, report}` envelope, whereas this skill does a fire-and-forget always-wins write and returns the bare encoded payload (exact script in the Lua section below). Atomicity still matters: a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
+2. **Optional production upload**: the exact optimistic-concurrency (CAS) Lua
+   upsert owned by `upsertReport()` in
+   `ui-dashboard/src/lib/address-reports.ts`, executed against the `reports`
+   hash through `mcp__upstash__redis_database_run_redis_commands`. Re-read
+   immediately before upload, pass the expected base version, and stop on a
+   conflict. The canonical skill stamps `source: "Codex"`; its Claude mirror
+   stamps `source: "claude"`.
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_, why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
+The literal shape every report follows lives at `template.md` next to this file.
+Its frontmatter is governance metadata and is **not** copied into a report. Read
+the body once, then mirror its named H2 sections, order, evidence blocks,
+confidence tags, and two-line provenance footer exactly. The template is the
+spec: do not invent, drop, or reorder sections. Keep "Related addresses /
+fleet" even when clustering found nothing and record that result in one line.
 
 ## Procedure (how to fill the template)
 
@@ -74,9 +88,9 @@ mkdir -p .investigations
 #   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
   celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;    DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node (repo-canonical rpc2.monad.xyz); DefiLlama may not cover monad yet (Step 5.5 caveat)
-  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
-  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;          DUNE_NS=monad;    DL_NS=monad ;;
+  polygon)  CHAIN_ID=137;   RPC=https://polygon.drpc.org;        DUNE_NS=polygon;  DL_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://ethereum.publicnode.com; DUNE_NS=ethereum; DL_NS=ethereum ;;
   *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
 esac
 ```
@@ -91,11 +105,15 @@ cast --version                                   # tool version, for the footer
 
 For the attribution-anchoring storage reads in Step 3, pin them with `cast call "$ADDR" "<sig>" --block "$HEAD_BLOCK" --rpc-url "$RPC"` (quote the `<sig>` placeholder so bash doesn't read it as a redirection) so a future reader gets the same bytes.
 
-Check whether a report already exists (we may be UPDATING, not creating):
+Discover the production database with
+`mcp__upstash__redis_database_list_databases`: require exactly one database
+named `address-labels`, then carry its returned opaque id as `DATABASE_ID`.
+Never hardcode or derive that id. Check whether a report already exists (we may
+be updating, not creating):
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "reports", "<addrLower>"]],
 });
 ```
@@ -110,52 +128,53 @@ commands: [["HGET", "labels", "<addrLower>"]];
 
 ### Step 1.5 — Check Upstash caches first
 
-Before making any live Arkham API calls, check the five caches populated by the 2026-05 extraction marathon. The API key expires ~2026-05-23; after that, cache is the only option.
+Before making any live Arkham calls, check the five existing caches. Prefer a
+current cache hit; use the live connector only when it is available and the
+result needs refreshing.
 
 ```js
 // All five caches live in the same address-labels database.
-// database_id: c687bf0d-f61f-498e-879a-016de335b4ce
+// DATABASE_ID is the exact-name match discovered in Step 1.
 
 // 1. Full enrichment (multi-chain address_enriched + counterparties)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_deep", "<addrLower>"]],
 });
 
 // 2. Transfer history (transfers?base=<addr>&limit=1000)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_transfers", "<addrLower>"]],
 });
 
 // 3. Wealth snapshot (balances + portfolio 0d/30d/90d/180d)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_wealth", "<addrLower>"]],
 });
 ```
 
 **If all three hit:** use the cached data for Steps 2–5 and skip the live Arkham API calls entirely.
 
-**If the API key is still valid AND the cached entry is older than ~7 days**, you MAY refresh with a live call; otherwise prefer cache.
+If a cache entry is stale and the live connector is available, refresh it;
+otherwise record the cache timestamp and its limitation.
 
 **Entity cache path:** if `intel_deep` returns an entity slug (look for `arkhamEntity.id` or a similar slug field in the payload), check the entity-level caches too:
 
 ```js
 // 4. Entity profile (fetched from /intelligence/entity/{slug})
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_entities", "<entitySlug>"]],
 });
 
 // 5. Entity counterparties (/counterparties/entity/{slug})
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_entity_cps", "<entitySlug>"]],
 });
 ```
-
-Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
 **These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address — **but only consume a hit keyed on the target's own address as identity for an EOA target.** For a CONTRACT target, the same 20-byte address on the chains these caches cover is usually an unrelated account, so a target-address cache hit would mis-attribute the report; run the identity leg on the deployer/operator EOA instead (Step 2), unless shared-deployment is proven.
 
@@ -164,9 +183,14 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 - `intel_deep` (`intel-deep.ts`): `enriched[chain].arkhamEntity.id` is the **entity slug** — the join key into `intel_entities` / `intel_entity_cps` (those hashes are slug-keyed, not address-keyed). `candidate.sources` tells you _why_ it was cached (`cluster-…-caller` / `top-trader` / `top-bridger` / `tier1-attested`) — a free prior classification. `counterparties[chain]` has the top USD counterparties per chain.
 - Use `intel-legacy-fallback.ts` `hgetWithLegacy` semantics — older entries may sit under `arkham_*` legacy keys.
 
-### Step 1.6 — Mento indexer fingerprint (our own Celo/Monad/Polygon source)
+### Step 1.6 — Mento indexer fingerprint (our own multichain source)
 
-**This is the primary on-chain-behaviour source for the target chain** — and it's the one the skill historically ignored. The repo runs its own Envio HyperIndex indexer of Mento protocol events with a **public, unauthenticated** Hasura GraphQL endpoint covering Celo (`42220`) and Monad (`143`), plus Polygon (`137`) after the configured deployment is synced and promoted. Because Arkham/Nansen are blind on Celo and Monad, this is where "what did this address do with Mento" actually gets answered on those chains; always verify the requested chain is live at the endpoint before treating an empty result as evidence. Query it _before_ the funder graph so you walk into Step 2 already knowing the target's Mento footprint.
+**This is the primary on-chain-behaviour source for the target chain.** The
+production Envio endpoint covers Celo (`42220`), Monad (`143`), Polygon (`137`),
+and Ethereum (`1`, currently reserve-yield entities). Because Arkham/Nansen are
+blind on Celo and Monad, this is where "what did this address do with Mento"
+gets answered on those chains. Always verify the requested chain is live before
+treating an empty result as evidence. Query it before the funder graph.
 
 ```bash
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
@@ -179,9 +203,9 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 #     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
 #     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
-# (Ethereum is sUSDS-only in this indexer — that's why SusdsPosition is in the probe; without it an
-#  ethereum target would always look NOT-COVERED despite the indexer serving its sUSDS ledger.)
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} SusdsYieldMovement(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StethPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StethYieldMovement(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# Ethereum reserve-yield coverage includes both sUSDS and stETH positions and
+# movement history; omitting either family can turn real activity into false EMPTY.
 # Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
 # empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
 # `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
@@ -307,10 +331,35 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  # sUSDS yield ledger (Ethereum-only in this indexer) — keyed by `wallet`. Mirrors the coverage probe so
-  # an Ethereum target's position is actually queried, not just probed.
+  # sUSDS current position (Ethereum-only in this indexer).
   SusdsPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
+  }
+}
+{
+  SusdsYieldMovement(
+    where: { _and: [{ _or: [{ from: { _eq: "0xtarget" } }, { to: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }
+    order_by: [{ blockNumber: desc }, { id: desc }]
+    limit: 1000
+  ) {
+    id
+    txHash
+  }
+}
+{
+  # stETH current position plus historical movements (Ethereum-only).
+  StethPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+    id
+  }
+}
+{
+  StethYieldMovement(
+    where: { _and: [{ _or: [{ from: { _eq: "0xtarget" } }, { to: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }
+    order_by: [{ blockNumber: desc }, { id: desc }]
+    limit: 1000
+  ) {
+    id
+    txHash
   }
 }
 {
@@ -380,7 +429,8 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    ```sql
    SELECT block_time, "from", value, hash
    FROM <chain>.transactions
-   WHERE "to" = LOWER('<addr>') AND value > 0   -- value>0 skips zero-value relayer/user calls that aren't funding
+   WHERE "to" = FROM_HEX('<40 hex chars without 0x>') AND value > 0
+   -- Dune addresses are varbinary: use FROM_HEX or a bare 0x literal, never LOWER(text).
    ORDER BY block_time ASC
    LIMIT 5;
    ```
@@ -488,7 +538,11 @@ If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real h
 
 Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` (and most public full nodes) whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree. The free, no-key Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow — point `BS` at the target chain's Blockscout instance:
+**For internal calls and raw state deltas, use Blockscout — not `cast`.**
+`forno.celo.org` (and most public full nodes) exposes no trace methods. The
+free Blockscout v2 API returns paginated, flat internal-transaction records and
+raw state changes; it does not return a nested call tree or dollar-valued flow.
+Point `BS` at the target chain's Blockscout instance:
 
 ```bash
 # Pick the Blockscout v2 base for $CHAIN. Not every chain has one (e.g. Monad — see fallback below).
@@ -498,12 +552,16 @@ case "$CHAIN" in
   *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
 if [ -n "$BS" ]; then   # skip when no Blockscout for $CHAIN — use the RPC-native fallback below instead
-  curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
-  curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+  curl -s "$BS/transactions/$TX/internal-transactions" | jq '{next_page_params, items: [.items[] | {type, from:.from.hash, to:.to.hash, value, error}]}'
+  curl -s "$BS/transactions/$TX/state-changes"         | jq '{next_page_params, items: [.items[] | {addr:.address.hash, type, change}]}'
 fi
 ```
 
-Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
+Follow `next_page_params` until exhausted. Expect internal transactions to be
+empty on simple transfers. Reconstruct nesting only from trace evidence, and
+price raw token/native deltas separately at the transaction timestamp. Keep
+`cast tx` + OpenChain for the top-level selector. On chains without Blockscout,
+use `debug_traceTransaction` only against an archive endpoint that supports it.
 
 > **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
 
@@ -516,17 +574,31 @@ Pass the chain hint through to Sim — Mento is on Celo (`42220`) but the skill 
 ```bash
 # $CHAIN_ID is from Step 1's case switch (Celo 42220 / Monad 143 / …) — do NOT re-hardcode it.
 # Hardcoding 42220 would return empty / unrelated holdings for a Monad (or other-chain) principal.
-dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data | length'
-dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balances | length'
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balances[] | {symbol, amount, value_usd}'
+# For a scam/noise inventory, include unpriced assets instead of accepting the default exclusion:
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID --exclude-unpriced=false -o json | jq '.balances[]'
 ```
 
-Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM` / `voucher`, use DefiLlama as a deterministic noise filter: a token DefiLlama won't price (no entry in the `current` response) or prices with low `confidence` (< ~0.9) has no real DEX liquidity — treat it as noise. Still list it per the template ("confirmed noise"), but keep only DefiLlama-priced, real-confidence holdings in the headline operating-capital number. See Step 5.5. For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+These responses are paginated. Collect the first page's `.balances`, then repeat
+the same command with `--offset <next_offset>` and append each page until
+`next_offset` is absent/null. Do this independently for the priced and
+`--exclude-unpriced=false` runs before summing or classifying holdings.
+
+Sum supported USD values and inventory unpriced assets separately. A missing or
+low-confidence DefiLlama price is evidence that needs corroboration, not proof
+that the token is a scam or has no liquidity. Confirm material holdings with
+pool/liquidity and transfer evidence before including or excluding them from
+operating capital. For tx volume, use a chain explorer or indexed history.
 
 ### Step 5.5 — Historical USD valuation (DefiLlama coins API — free, no Pro key)
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` is the DefiLlama slug set by Step 1's case switch (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` comes from
+Step 1 (including `monad`). Verify novel chains against DefiLlama. Do not
+hardcode `celo:` for another chain. Native CELO uses its ERC20 wrapper, e.g.
+`celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
@@ -538,39 +610,54 @@ curl -s "https://coins.llama.fi/prices/historical/$TS/$DL_NS:<tokenLower>" | jq 
 
 USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/$DL_NS:0xAAA,$DL_NS:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
 
-**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+**Current price** (same response shape) for the Step 5 holdings snapshot:
+`https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. Treat `confidence`
+as price-source reliability. Missing/low-confidence data requires
+corroboration; it is not a deterministic scam or liquidity verdict.
 
 Caveats — surface them in the report when they bite:
 
-- **Newer chains may be absent.** DefiLlama indexes Celo well; Monad and other recent chains may have no coin data. If a key returns nothing, fall back to Sim's spot `value_usd` and say so in the report rather than silently reporting a zero.
+- Coverage is token-specific even on supported chains. If a key returns
+  nothing, corroborate with Sim and venue liquidity and disclose the pricing
+  gap rather than silently reporting zero.
 - `coins.llama.fi` is not on the default sandbox network allowlist. It's a read-only public GET — allowlist the host or run the single command unsandboxed.
 
 ### Step 6 — Why \_\_\_, why these venues
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token through
+two free APIs. Both GeckoTerminal and DexScreener cover the current target
+chains; verify their network lists before trusting a negative.
 
 ```bash
 # GeckoTerminal + DexScreener each use their OWN network slugs (NOT chain ids) — select both per $CHAIN
 # in one switch, like $BS in Step 4. Verify against api.geckoterminal.com/api/v2/networks and
-# DexScreener's docs (a chain may be on one but not the other — GeckoTerminal has no Monad, DexScreener does).
+# DexScreener's docs (a chain may be on one but not the other).
 case "$CHAIN" in
   celo)     GT_NS=celo;        DS_NS=celo ;;
-  monad)    GT_NS="";          DS_NS=monad ;;     # GeckoTerminal: no Monad; DexScreener: yes (verify slug)
+  monad)    GT_NS=monad;       DS_NS=monad ;;
   polygon)  GT_NS=polygon_pos; DS_NS=polygon ;;
   ethereum) GT_NS=eth;         DS_NS=ethereum ;;
   *)        GT_NS=""; DS_NS=""; echo "No GeckoTerminal/DexScreener slug mapped for $CHAIN — verify their network lists, then set GT_NS/DS_NS or skip." >&2 ;;
 esac
-[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug
+[ -n "$GT_NS" ] && curl -s -H 'accept: application/json;version=20230302' "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"
 [ -n "$DS_NS" ] && curl -s "https://api.dexscreener.com/token-pairs/v1/$DS_NS/{tokenAddr}"           # chain-scoped: pairs for this token on $CHAIN only; skipped when no DS slug
 # The chain-scoped token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the
 # token's pairs on ALL chains and risked naming a different chain's venue/TVL for a same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
+GeckoTerminal's public limit is approximately 10 requests/minute; pace and
+cache lookups rather than treating rate-limit responses as empty coverage.
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune's unified `dex.trades` spellbook filtered `WHERE blockchain = '$DUNE_NS'` (it's ONE cross-chain table with a `blockchain` column — there is no per-chain `celo.dex.trades`; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** Borrow the standard taxonomy (arb /
+sandwich / backrun / JIT / liquidation), then derive the classification from
+the indexer and Dune's unified `dex.trades` table filtered by `blockchain`.
+Group cycles by transaction. For sandwiches, use a curated sandwich dataset
+where supported; otherwise prove ordering with transaction position, event
+index, and trace evidence—block number alone cannot order transactions. Use an
+Ethereum/L2 EigenPhi or zeromev result only as cross-chain corroboration.
 
 ### Step 7 — Coverage and dead ends
 
@@ -623,12 +710,17 @@ Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 
 End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
 
 ```
-_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>._
+
+_Investigation date: YYYY-MM-DD._
 ```
 
 ### Step 10 — Push to production (only on user confirmation)
 
-By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the same atomic Lua upsert pattern the API route uses (the simplified non-CAS variant — see the Output section) — never split-read-modify-write, which races the editor and any other skill invocation.
+By default the skill stops at the local draft and asks the user to review. On
+`--upload` (or explicit equivalent), use the dashboard route's exact CAS Lua
+upsert. Never use an older last-writer-wins copy or a split
+read-modify-write sequence.
 
 Keep `mcp__upstash__redis_database_run_redis_commands` out of repo-shared auto-allow lists. The MCP approval prompt is the production write guard for this path.
 
@@ -669,52 +761,20 @@ const partial = {
   body,
   ...(title ? { title: title.slice(0, 200) } : {}),
   authorEmail: AUTHOR_EMAIL, // from git config user.email at runtime
-  source: "claude", // already in the AddressReport enum
+  source: "Codex", // the Claude mirror uses "claude"
 };
 ```
 
-**Write it via Lua EVAL** (atomic — the same upsert pattern as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`, minus the optimistic-concurrency `expectedVersion` check; this skill always wins and returns the bare encoded payload):
+**Write it via the owner implementation.** Immediately before uploading, HGET
+the current record again and derive its normalized base version: `""` for a
+create-only write, otherwise the positive integer version (`1` for a
+legacy/invalid stored version). Copy the current `UPSERT_SCRIPT` from
+`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns normalization,
+the expected-version check, and the response envelope.
 
 ```js
-const UPSERT_SCRIPT = `
-local key = KEYS[1]
-local addr = ARGV[1]
-local payload = cjson.decode(ARGV[2])
-local now = ARGV[3]
-
-local existing = redis.call('HGET', key, addr)
-local prior = nil
-if existing then
-  prior = cjson.decode(existing)
-end
-
-payload.createdAt = (prior and prior.createdAt) or now
-payload.updatedAt = now
--- Mirror upsertReport()'s read-side version normalization. A true first write
--- (no prior record) is version 1. cjson.decode maps JSON null to cjson.null
--- (truthy in Lua), so a legacy/partial {"version": null} must be normalized,
--- not propagated into arithmetic (which would crash the EVAL). Such records
--- read as version 1 in JS, so normalize missing/invalid/<=0 to 1 here too —
--- coercing to 0 would write version 1 over an existing record and regress the
--- version the editor's optimistic-concurrency (CAS) path expects.
-local priorVersion = 0
-if prior then
-  priorVersion = prior.version
-  if type(priorVersion) ~= 'number' or priorVersion <= 0 then
-    priorVersion = 1
-  else
-    priorVersion = math.floor(priorVersion)
-  end
-end
-payload.version = priorVersion + 1
-
-local encoded = cjson.encode(payload)
-redis.call('HSET', key, addr, encoded)
-return encoded
-`;
-
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [
     [
       "EVAL",
@@ -724,23 +784,21 @@ mcp__upstash__redis_database_run_redis_commands({
       addrLower,
       JSON.stringify(partial),
       new Date().toISOString(),
+      expectedVersion, // "" for create-only; otherwise the fresh base version
     ],
   ],
 });
 ```
 
-The script returns the persisted record (already JSON-encoded). It handles every edge case the dashboard data layer handles:
-
-- `createdAt` preserved when updating; stamped fresh on first write
-- `updatedAt` always = now
-- `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
-- Atomic per write and version stays monotonic — **but it is last-writer-wins on the body** (this variant has no `expectedVersion` precondition), so an editor save made between this skill's Step-1 read and the EVAL is silently overwritten. The editor's own CAS path will reject ITS now-stale save, but this skill never loses the race. If a hand-edited report might be in flight, re-read immediately before upload, or upload via the editor route instead.
+Parse the returned `{ok, report}` envelope. If `ok !== true`, stop, show the
+version conflict, re-read the editor's newer report, and ask before reconciling;
+never retry with a new base version automatically.
 
 **Verify:**
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "reports", addrLower]],
 });
 ```
@@ -761,39 +819,41 @@ Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A c
 
 - `body`: required, non-empty, ≤ 50,000 characters (50KB)
 - `title`: optional, ≤ 200 characters, dropped if empty after trim
-- `source`: always set `"claude"` from this skill; the API also accepts other provenance values
+- `source`: `"Codex"` in this canonical skill and `"claude"` in its Claude mirror
 - `version`: starts at 1, increments on each write; preserve `createdAt` from the prior write if updating
 
 These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/address-reports-shared.ts`. If those constants change, mirror the changes here — the skill must not write a payload the API would reject on a manual edit.
 
 ## Tooling matrix (by chain + leg)
 
-Pick the tool that covers the chain you're on and the leg you're working. **A blank in the Celo column does not mean "useless"** — it means use that source on the cross-chain identity leg (operator EOA on Ethereum/L2s) or on another supported target chain such as Polygon. Coverage notes below were web-verified 2026-06-15; re-check before relying on a negative.
+Pick the tool that covers the chain and investigation leg. **A blank in the
+Celo column does not mean "useless"**—it may still serve the cross-chain
+identity leg. Provider coverage changes; re-check before relying on a negative.
 
 **On-chain behaviour leg — Celo/Monad/Polygon-native (free, the workhorses):**
 
-| Source                       | Celo              | Monad | Access            | Answers                                                                        |
-| ---------------------------- | ----------------- | ----- | ----------------- | ------------------------------------------------------------------------------ |
-| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6)                    |
-| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)                           |
-| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`                     |
-| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                                    |
-| GeckoTerminal                | ✅                | ❌    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6); no Monad — use DexScreener there |
-| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                                           |
-| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                                      |
-| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                                       |
-| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**                          |
-| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                                        |
+| Source                       | Celo              | Monad | Access            | Answers                                                     |
+| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | flat internal calls + raw state changes (Step 4)            |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
+| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
+| DefiLlama coins              | ✅                | ✅    | free, no key      | historical + current USD price when the token is covered    |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
 
 **Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
 
-| Source              | Celo | Where it works        | Access                     | Use                                               |
-| ------------------- | ---- | --------------------- | -------------------------- | ------------------------------------------------- |
-| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live (key expired) | entity/persona of operator EOA                    |
-| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)             | labels/Smart-Money on the identity leg + Monad    |
-| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                  | MEV classification of operator's ETH strategy     |
-| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)             | labels incl. Celo — only if free paths fall short |
-| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier           | non-Mento DEX history (Envio covers Mento first)  |
+| Source              | Celo | Where it works        | Access                      | Use                                               |
+| ------------------- | ---- | --------------------- | --------------------------- | ------------------------------------------------- |
+| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live when available | entity/persona of operator EOA                    |
+| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)              | labels/Smart-Money on the identity leg + Monad    |
+| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                   | MEV classification of operator's ETH strategy     |
+| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)              | labels incl. Celo — only if free paths fall short |
+| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier            | non-Mento DEX history (Envio covers Mento first)  |
 
 **Bridge leg:**
 
@@ -819,11 +879,11 @@ Pick the tool that covers the chain you're on and the leg you're working. **A bl
 
 ## Reference: production database
 
-The database id is non-secret. If the address-book database is replaced or
-split, update this value from Terraform or the Upstash console before writing.
+Discover the opaque database id at runtime by exact name (`address-labels`).
+Terraform owns the database; this skill owns only the `reports` hash workflow.
 
 ```
-database_id: c687bf0d-f61f-498e-879a-016de335b4ce
+database name: address-labels
 hash:        reports
 key shape:   <lowercase 0x address>
 value shape: JSON-stringified AddressReport (see schema above)
@@ -831,18 +891,13 @@ value shape: JSON-stringified AddressReport (see schema above)
 
 The `address-labels` Upstash database also holds the `labels` hash (custom address labels) and `minipay:*` keys (the MiniPay tagging cron's bookkeeping). Don't touch those from this skill.
 
-## Worked example
+## Tone reference
 
-The seed report — `0xb64c8b0a3F8008d5028D8F9323b858F17b18C3C4` (Arbitrage Executor / `idontloseiwin.eth`) — is the canonical reference. If a section feels under-specified above, look at how that section is written in the production hash:
-
-```js
-mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
-  commands: [["HGET", "reports", "0xb64c8b0a3f8008d5028d8f9323b858f17b18c3c4"]],
-});
-```
-
-Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the nine named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
+Existing production reports can help calibrate an evidence-anchored,
+plain-language tone, but they are historical data and may predate this
+contract. `template.md` is the sole structural authority. Never copy a seed
+report's facts, section omissions, provider assumptions, or provenance into a
+new investigation.
 
 ## Rules
 

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -766,11 +766,40 @@ const partial = {
 ```
 
 **Write it via the owner implementation.** Immediately before uploading, HGET
-the current record again and derive its normalized base version: `""` for a
-create-only write, otherwise the positive integer version (`1` for a
-legacy/invalid stored version). Copy the current `UPSERT_SCRIPT` from
-`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns normalization,
-the expected-version check, and the response envelope.
+the current record again. Capture the unwrapped HGET value as `currentValue`;
+abort on malformed JSON instead of treating it as an absent report. Derive the
+exact expected-version argument before invoking EVAL:
+
+```js
+const current =
+  currentValue == null
+    ? null
+    : typeof currentValue === "string"
+      ? JSON.parse(currentValue)
+      : currentValue;
+if (
+  current !== null &&
+  (typeof current !== "object" || Array.isArray(current))
+) {
+  throw new Error("stored report is not an object — refusing to upload");
+}
+
+const storedVersion = current?.version;
+const expectedVersion =
+  current === null
+    ? "" // create-only: fail if another writer creates it first
+    : String(
+        typeof storedVersion === "number" &&
+          Number.isFinite(storedVersion) &&
+          storedVersion > 0
+          ? Math.floor(storedVersion)
+          : 1, // legacy, missing, null, or invalid versions normalize to 1
+      );
+```
+
+Copy the current `UPSERT_SCRIPT` from
+`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns the matching
+server-side normalization, expected-version check, and response envelope.
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({

--- a/.agents/skills/forensic-report/template.md
+++ b/.agents/skills/forensic-report/template.md
@@ -1,3 +1,15 @@
+---
+title: Forensic Report Output Template
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-23
+doc_type: skill
+scope: repo-wide
+review_interval_days: 90
+garden_lane: agent-entry-points
+---
+
 # `0xADDRESS_CASE_PRESERVED` — Display Name (persona/ENS if known)
 
 ## TL;DR
@@ -19,7 +31,10 @@ Roles are descriptive, not fixed. Add or drop rows to match the topology. For an
 
 ## Related addresses / fleet
 
-The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5). Each link carries the evidence and a confidence tier — never a bare assertion. Omit this section only if clustering found nothing, and say so in one line rather than dropping the heading.
+The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5).
+Each link carries evidence and a confidence tier—never a bare assertion. Always
+keep this heading. If clustering found nothing, replace the table with one
+evidence-backed sentence saying so.
 
 | Address | Link type                         | Evidence                                            | Confidence |
 | ------- | --------------------------------- | --------------------------------------------------- | ---------- |
@@ -56,7 +71,8 @@ status: ok / sometimes error
 
 - Selector `0x…` (custom — not in 4byte/OpenChain — / matched on OpenChain → name it)
 - Calldata shape: [N dynamic arrays of (tokens, pools, amounts, swap-data, dexIds, minOuts, deadline)] OR [structured args: …]
-- Revert rate: ~N% (normal arb-sniping miss rate / unusual)
+- Revert rate: ~N%, measured over `<window>`; interpret against this chain's
+  ordering model rather than assuming an Ethereum-style baseline
 - Permissioning: [allowlist / open / signature-gated]
 
 ## Capital and scale
@@ -66,7 +82,9 @@ Principal wallet `0x…` holdings on chain `<CHAIN_ID>` (the chain you investiga
 - **`<amount>` `<TOKEN>`** (~$`<usd>` notional) — note any token with dual-native semantics (e.g. CELO is both native gas + ERC20)
 - $`<usd>` stablecoin (split by stablecoin if it matters: USDC / USDT / DAI / chain-native cUSD-cEUR-etc.)
 - `<list any meaningful additional holdings>`
-- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is — filter via DefiLlama price-presence / `confidence`, see skill Step 5.5, not by token name)
+- Unpriced or low-confidence assets listed separately as requiring
+  corroboration. DefiLlama price presence/confidence is evidence quality, not a
+  deterministic scam or liquidity verdict.
 
 Estimated **operating capital ≈ $`<usd>`** (value time-sensitive flows at block time via DefiLlama historical prices — skill Step 5.5 — not current spot). Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
 
@@ -84,14 +102,15 @@ Connect the behaviour to the on-chain economics — don't just describe, explain
 
 One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why. The `EMPTY` (covers this chain, found nothing) vs `NOT-COVERED` (can't see this chain) distinction is the whole point — don't collapse them.
 
-| Source                | Result      | Note                                                          |
-| --------------------- | ----------- | ------------------------------------------------------------- |
-| Arkham (cache / live) | NOT-COVERED | Celo/Monad not indexed; operator EOA on covered chains: `<…>` |
-| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`                           |
-| Sim / Dune            | HIT         | `<…>`                                                         |
-| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead                               |
-| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list)                   |
-| `<…>`                 | `<…>`       | `<…>`                                                         |
+| Source                | Result      | Note                                        |
+| --------------------- | ----------- | ------------------------------------------- |
+| Arkham (target chain) | NOT-COVERED | target chain not indexed (when true)        |
+| Arkham (identity leg) | HIT / EMPTY | operator EOA on supported chains: `<…>`     |
+| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`         |
+| Sim / Dune            | HIT         | `<…>`                                       |
+| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead             |
+| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list) |
+| `<…>`                 | `<…>`       | `<…>`                                       |
 
 **Top alternative hypothesis considered** (skill Step 8.5): `<e.g. MM rebalancer rather than arb bot>` — rejected because `<disconfirming evidence>`.
 
@@ -99,7 +118,12 @@ One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTE
 
 ## Bottom line
 
-Five bullets, one sentence each. The LITERAL placeholder text is below — replace every value with what you actually found. Do NOT ship the placeholders. The skill's worked-example section (`SKILL.md` → "Worked example") points at the seed report's real bottom line for tone calibration; this template stays placeholder-only so a fresh investigation that copy-pastes blindly doesn't accidentally persist seed facts about a different address.
+Five bullets, one sentence each. The LITERAL placeholder text is below—replace
+every value with what you actually found. Do not ship the placeholders. The
+skill's "Tone reference" explains how historical production reports may be used
+without treating them as structural authority; this template remains
+placeholder-only so a fresh investigation cannot persist another target's
+facts.
 
 - **Who**: `<persona / entity, one sentence — who's behind this address>` `[CONFIRMED / PROBABLE / POSSIBLE]`
 - **What**: `<contract type / behavioural class, one sentence — what does it do>`

--- a/.agents/skills/monorepo-import/SKILL.md
+++ b/.agents/skills/monorepo-import/SKILL.md
@@ -5,7 +5,7 @@ title: Monorepo Import Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-26
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -32,14 +32,17 @@ Inspect both the source system and this repo before proposing a layout:
   roots/backends, secrets, scheduled jobs, scripts, docs, and live endpoints
 - existing repo roots and ownership boundaries: `aegis/`, `alerts/`,
   `terraform/`, `metrics-bridge/`, `indexer-envio/`, `ui-dashboard/`,
-  `shared-config/`
+  `shared-config/`, `integration-probes/`, and `governance-watchdog/`
 - existing root scripts, package filters, CI path filters, dependency-cruiser
   boundaries, AGENTS files, README/docs/runbooks
 - current deploy owners: App Engine, Cloud Functions, Terraform, Vercel, Envio,
-  Grafana, QuickNode, Sentry, Slack/Discord
+  Grafana, QuickNode, Sentry, Slack, and the governance watchdog's
+  Discord/Telegram delivery
 
-Do not treat a directory name as authority. For example, `terraform/alerts` is
-the Grafana v3 rule plane, not a generic bucket for every alert-related system.
+Do not treat a directory name as authority. For example, `alerts/rules/` owns
+Grafana rules/routing while `alerts/infra/` owns event-driven delivery; neither
+is a generic bucket for every alert-related system. Use
+`terraform.stacks.json` for Terraform ownership.
 
 ## Phase 2: Choose The Smallest Layout
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -44,24 +44,43 @@ gh→MCP mapping lives in
 ## Preflight
 
 1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
-2. Fetch the base branch:
-
-```bash
-git fetch origin main:refs/remotes/origin/main
-if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-  git fetch --unshallow origin
-  git fetch origin main:refs/remotes/origin/main
-fi
-```
-
-3. Inspect branch, dirty state, commits, and PR state:
+2. Resolve the target before fetching or pushing. If the user supplied a PR
+   URL/number, pass that exact value to `gh pr view`; it overrides local branch
+   discovery. Otherwise query open PRs for the current branch and require zero
+   or one result:
 
 ```bash
 git branch --show-current
+gh pr view <explicit-pr-url-or-number> \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+# No explicit target:
+gh pr list --head <current-branch> --state open \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+```
+
+Do not discard lookup errors. A failed GitHub query is not evidence that no PR
+exists. Verify the resolved PR URL belongs to this repository. For an existing
+PR, identify a git remote whose URL matches the PR's base repository and carry
+its name as `BASE_REMOTE`; identify the head repository separately as
+`HEAD_REMOTE` and carry `headRefName` as `HEAD_REF`.
+
+3. Fetch the resolved base:
+
+```bash
+BASE_REF=<baseRefName> # use main only when there is no existing PR
+git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  git fetch --unshallow "$BASE_REMOTE"
+  git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
+fi
+```
+
+4. Inspect dirty state, commits, and ancestry against that exact base:
+
+```bash
 git status --short
-git log origin/main..HEAD --oneline
-git merge-base --is-ancestor origin/main HEAD
-gh pr view --json number,url,state,isDraft,baseRefName 2>/dev/null
+git log "$BASE_REMOTE/$BASE_REF"..HEAD --oneline
+git merge-base --is-ancestor "$BASE_REMOTE/$BASE_REF" HEAD
 ```
 
 In a Claude cloud session, replace the `gh pr view` lookup with
@@ -69,12 +88,15 @@ In a Claude cloud session, replace the `gh pr view` lookup with
 PR number is known); the git commands run unchanged.
 
 Hard stop on `main` or `master`. The shallow-repository guard prevents hosted
-depth-1 checkouts from producing a false ancestry failure. If
-`git merge-base --is-ancestor origin/main HEAD` still fails, the branch is
-missing commits from current `origin/main`; merge or rebase before pushing
-unless you intentionally created a fresh branch from that same fetched base. If
-unrelated dirty changes are mixed with the intended scope, stop and ask before
-staging anything.
+depth-1 checkouts from producing a false ancestry failure. If an open PR exists,
+its repository, `headRefName`, and `headRefOid` are the push target and starting
+commit. Before creating the ship commit, verify local `HEAD` equals that OID.
+If intended commits already exist locally, require the PR OID to be their
+ancestor and inspect the intervening range. Never infer the target from the
+local branch name. If the branch is missing current base commits, merge
+`"$BASE_REMOTE/$BASE_REF"` into an already-published PR branch; rebase is only
+acceptable before first publication. If unrelated dirty changes are mixed with
+the intended scope, stop and ask before staging anything.
 
 ## Review And Validation
 
@@ -93,65 +115,11 @@ pnpm agent:quality-gate --run
 pnpm agent:autoreview
 ```
 
-The repo-local helper reviews the complete branch-local target without
-truncation. Direct semantic engines fail closed if the target needs more than
-one prompt; prepared bundles retain bounded lossless passes that one
-fresh-context reviewer must inspect completely.
-Semantic engines run from an isolated empty workspace with restricted project
-configuration and environment; sensitive inputs fail closed. Direct
-supplemental evidence must be repo-relative, except for adapter-generated PR
-feedback and protected-main checklist copies inside its trusted bundle
-directory. The owning-checkout default semantic helper and automatic feedback
-run Node modules pinned from that same `origin/main` object, not a PR-selected
-base, mutable worktree, or reviewed package scripts; wrapper-owned Node launches
-discard `NODE_OPTIONS` and `NODE_PATH`.
-Reviewer web search is off by default and requires explicit `--web-search`.
-A quiet reviewer emits a
-60-second heartbeat. Do not pass the removed `--parallel-tests` option; the
-quality gate owns test execution.
-
-If direct semantic execution refuses a multi-pass target, run
-`pnpm agent:autoreview --prepare-bundle-dir <dir>` with a directory outside the
-worktree whose parent already exists. Every canonical parent ancestor must be
-owned by the current user or root; group/other-writable ancestors require
-sticky-bit protection. On macOS, write-granting ACLs on parent ancestors or
-bundle entries fail preparation or verification. Have one fresh-context reviewer
-inspect every pass listed by the bundle index. Run
-`pnpm agent:autoreview --verify-bundle-dir <dir>` immediately before review and
-retain its printed digest outside the bundle. After review, rerun with
-`--expected-bundle-manifest <retained-digest>`; both checks must pass with the
-same digest.
-
-If the change edits the executable autoreview runtime and the owning checkout
-refuses with `executable autoreview runtime differs from its trusted pre-change
-snapshot`, keep that refusal intact. From the reviewed checkout, invoke a clean,
-detached, protocol-compatible wrapper/helper from the last independently
-reviewed pre-change commit (or protected main when it is compatible):
-
-```bash
-reviewed_checkout=/absolute/path/to/reviewed-checkout
-trusted_checkout=/absolute/path/to/trusted-pre-change-checkout
-bundle_parent=/tmp/autoreview-runtime-review
-mkdir -p "$bundle_parent"
-(
-  cd "$reviewed_checkout"
-  AUTOREVIEW_HELPER="$trusted_checkout/scripts/agent-autoreview.mjs" \
-    "$trusted_checkout/scripts/agent-autoreview.sh" \
-    --prepare-bundle-dir "$bundle_parent/context-bundle" \
-    --mode auto --base origin/main --feedback-pr <number>
-)
-"$trusted_checkout/scripts/agent-autoreview.sh" \
-  --verify-bundle-dir "$bundle_parent/context-bundle"
-```
-
-Use that same trusted wrapper for the bound post-review manifest check. Never
-point either path at the runtime-changing checkout, and never invoke that
-checkout's package scripts to bootstrap the review.
-
-Inside an active Codex sandbox, the adapter may choose the local deterministic
-engine only when no engine was explicitly selected. An explicitly selected
-unavailable semantic engine, or a missing repo helper, is a hard stop: report
-the blocker rather than silently substituting local or current-session review.
+`docs/notes/agent-quality-gate-mechanics.md` owns engine selection, trusted
+bundle preparation/verification, runtime-change refusal handling, and the
+source-review boundary. Follow that note instead of copying its volatile
+adapter internals into this skill. An explicitly selected unavailable engine or
+missing helper is a hard stop.
 
 Verify accepted findings before editing. Classify scope growth as in-scope,
 follow-up, or stop, create an issue before deferring valid follow-up work, warn
@@ -172,10 +140,17 @@ change (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, or `refactor:`).
 git status --short
 git add <intended-files>
 git commit -m "<prefix>: <summary>"
+# New PR branch:
 git push -u origin HEAD
+
+# Existing PR branch:
+git push "$HEAD_REMOTE" HEAD:"$HEAD_REF"
 ```
 
-Never force-push or amend unless the user explicitly requests it.
+For an existing PR, the remote must resolve to the PR's `headRepositoryOwner`
+and `headRepository`; do not assume it is `origin`. Re-read the PR after the
+push and require `headRefOid == git rev-parse HEAD` before babysitting. Never
+force-push or amend unless the user explicitly requests it.
 
 ## PR
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -59,15 +59,17 @@ gh pr list --head <current-branch> --state open \
 ```
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
-exists. Verify the resolved PR URL belongs to this repository. For an existing
-PR, identify a git remote whose URL matches the PR's base repository and carry
-its name as `BASE_REMOTE`; identify the head repository separately as
-`HEAD_REMOTE` and carry `headRefName` as `HEAD_REF`.
+exists. Verify the resolved PR URL belongs to this repository and carry its
+base slug as `BASE_REPO`. For an existing PR, identify a git remote whose URL
+matches that base repository and carry its name as `BASE_REMOTE`; identify the
+head repository separately as `HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`,
+and carry `headRefName` as `HEAD_REF`. With no existing PR, verify `origin`
+matches the current repository, then set `BASE_REMOTE=origin`,
+`HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
 
 3. Fetch the resolved base:
 
 ```bash
-BASE_REF=<baseRefName> # use main only when there is no existing PR
 git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
   git fetch --unshallow "$BASE_REMOTE"
@@ -141,7 +143,7 @@ git status --short
 git add <intended-files>
 git commit -m "<prefix>: <summary>"
 # New PR branch:
-git push -u origin HEAD
+git push -u "$HEAD_REMOTE" HEAD:"$HEAD_REF"
 
 # Existing PR branch:
 git push "$HEAD_REMOTE" HEAD:"$HEAD_REF"
@@ -203,15 +205,16 @@ Include this marker when practical:
 
 ## Post-Push
 
-Run the shared readiness probe before calling the PR clean:
+Follow the operating card's Babysit and Ready-state steps. Before calling the PR
+clean, run the feedback projection first and the readiness projection second:
 
 ```bash
-pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json
+pnpm --silent pr:feedback-state --pr <number> --repo "$BASE_REPO" --json
+pnpm pr:ready-state --pr <number> --repo "$BASE_REPO" --json
 ```
 
-Always pass `--repo` bound to the base repository: without it the probe infers
-the repo from the checkout, which inspects the wrong same-number PR on fork
-PRs or repo-bound checkouts.
+Always bind `--repo` to the base repository; checkout inference can inspect the
+wrong same-number PR on fork PRs or repo-bound checkouts.
 
 In a Claude cloud session without the Surface Detection capability exception,
 the probe cannot run; use the `babysit-pr` skill's cloud watch loop (MCP

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -75,12 +75,28 @@ gh pr list --repo "$BASE_REPO" --head "$CURRENT_BRANCH" --state open \
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
 exists. Carry the resolved PR URL's owner/repository as `BASE_REPO`. For an
-existing PR, identify a git remote whose URL matches that base repository and
-carry its name as `BASE_REMOTE`; identify the head repository separately as
-`HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`, and carry `headRefName` as
-`HEAD_REF`. With no existing PR, verify `origin` matches `CURRENT_REPO`, then set
-`BASE_REMOTE=origin`,
-`HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
+existing PR, identify the head repository separately and require a configured
+remote that matches it; carry that name as `HEAD_REMOTE`, `baseRefName` as
+`BASE_REF`, and `headRefName` as `HEAD_REF`. Stop if the PR head repository has
+no matching push remote. With no existing PR, verify `origin` matches
+`CURRENT_REPO`, then set `HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF`
+to the current branch.
+
+For every path, identify a configured remote whose URL matches `BASE_REPO` and
+carry its name as `BASE_REMOTE`. Never substitute a fork's `origin` for its
+parent repository. If no remote matches, add the parent as `upstream`; do not
+overwrite or retarget an existing remote:
+
+```bash
+if [ -z "$BASE_REMOTE" ]; then
+  if git remote get-url upstream >/dev/null 2>&1; then
+    echo "upstream exists but does not match $BASE_REPO" >&2
+    exit 1
+  fi
+  git remote add upstream "https://github.com/${BASE_REPO}.git"
+  BASE_REMOTE=upstream
+fi
+```
 
 3. Fetch the resolved base:
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -44,27 +44,42 @@ gh→MCP mapping lives in
 ## Preflight
 
 1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
-2. Resolve the target before fetching or pushing. If the user supplied a PR
-   URL/number, pass that exact value to `gh pr view`; it overrides local branch
-   discovery. Otherwise query open PRs for the current branch and require zero
-   or one result:
+2. Resolve the checkout repository and its upstream base before querying PRs.
+   A fork checkout uses its parent as `BASE_REPO`; a non-fork uses itself:
 
 ```bash
-git branch --show-current
-gh pr view <explicit-pr-url-or-number> \
+CURRENT_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+BASE_REPO=$(gh repo view --json nameWithOwner,parent \
+  --jq '.parent.nameWithOwner // .nameWithOwner')
+HEAD_OWNER=${CURRENT_REPO%%/*}
+CURRENT_BRANCH=$(git branch --show-current)
+```
+
+If the user supplied a PR URL, pass that exact URL to `gh pr view`; its
+owner/repository overrides the inferred base. For a bare PR number, bind the
+lookup to `BASE_REPO`. With no explicit target, query `BASE_REPO` by branch,
+then filter same-named fork branches by `headRepositoryOwner`; require zero or
+one result after filtering:
+
+```bash
+gh pr view <explicit-pr-url> \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+gh pr view <explicit-pr-number> --repo "$BASE_REPO" \
   --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
 # No explicit target:
-gh pr list --head <current-branch> --state open \
-  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+gh pr list --repo "$BASE_REPO" --head "$CURRENT_BRANCH" --state open \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner \
+  | jq --arg owner "$HEAD_OWNER" \
+    '[.[] | select(.headRepositoryOwner.login == $owner)]'
 ```
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
-exists. Verify the resolved PR URL belongs to this repository and carry its
-base slug as `BASE_REPO`. For an existing PR, identify a git remote whose URL
-matches that base repository and carry its name as `BASE_REMOTE`; identify the
-head repository separately as `HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`,
-and carry `headRefName` as `HEAD_REF`. With no existing PR, verify `origin`
-matches the current repository, then set `BASE_REMOTE=origin`,
+exists. Carry the resolved PR URL's owner/repository as `BASE_REPO`. For an
+existing PR, identify a git remote whose URL matches that base repository and
+carry its name as `BASE_REMOTE`; identify the head repository separately as
+`HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`, and carry `headRefName` as
+`HEAD_REF`. With no existing PR, verify `origin` matches `CURRENT_REPO`, then set
+`BASE_REMOTE=origin`,
 `HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
 
 3. Fetch the resolved base:

--- a/.claude/agents/dashboard-explorer.md
+++ b/.claude/agents/dashboard-explorer.md
@@ -12,22 +12,30 @@ Read-only exploration specialist for `ui-dashboard/`. Locate code, summarize wha
 ## Scope
 
 - **Primary path:** `ui-dashboard/`
-- **Allowed adjacent reads:** `shared-config/` (chain/token metadata via `@mento-protocol/config`), `indexer-envio/config/*.json` (chain list + addresses — the one allowed cross-package data import for dashboard), root `AGENTS.md` for pattern rules
+- **Start with:** `ui-dashboard/AGENTS.md` and
+  `docs/pr-checklists/swr-polling-hasura.md`; they own the current rules.
+- **Allowed adjacent reads:** `shared-config/` (chain/token metadata via
+  `@mento-protocol/config`), root `AGENTS.md`, and indexer config/schema only
+  when tracing a dashboard consumer. Dashboard imports from indexer config are
+  test-only unless the dependency rules explicitly permit them.
 - **Out of scope:** `indexer-envio/src/`, `metrics-bridge/`, `aegis/`, `terraform/` — say "out of scope" if asked
 
 ## Conventions you know
 
-- **Framework:** Next.js 16 (App Router, React 19), Tailwind CSS 4, Plotly.js via react-plotly.js, graphql-request + SWR
+- **Framework:** Next.js App Router, React, Tailwind CSS, Plotly.js, native
+  GraphQL fetch helpers, and SWR. Read `package.json` for current versions.
 - **TS target:** `ES2017` (no polyfill — NEVER use `toSorted`, `findLast`, or any ES2023+ array method in client-shipped code)
 - **SWR + Hasura discipline:** every polling hook MUST set `revalidateOnFocus: false` + `revalidateOnReconnect: false`. Defaults live at `useGQL` (`src/lib/graphql.ts`). `useGQL` and `useBridgeGQL` default to a 30s interval; the bridge wrapper owns an 8s timeout, while other fail-fast paths set a timeout below their interval. Distinguish `isLoading` from "data resolved to zero."
-- **Hasura 1000-row cap:** silent. Any UI `limit:` >1000 or a query feeding a lifetime aggregate is a bug — use pre-rolled snapshot/rollup entities or `fetchAllFeeSnapshotPages` (`src/lib/network-fetcher/fetch.ts:333`), the canonical offset-pagination helper.
+- **Hasura 1000-row cap:** silent. Any UI `limit:` >1000 or a query feeding a lifetime aggregate is a bug — use pre-rolled snapshot/rollup entities or the pagination helpers in `src/lib/network-fetcher/pagination.ts`.
 - **Hasura `order_by`** with ≥2 fields MUST use array syntax `[{a: desc}, {b: asc}]` (object syntax silently drops fields).
 - **Schema-extension queries:** new indexer schema fields ship in an **isolated query** (`POOL_BREACH_ROLLUP` / `POOL_CONFIG_EXT` pattern), never mixed into a page's primary pool query — hosted Hasura rejects unknown columns during the deploy+resync window.
 - **Route-private dirs:** `_components/` and `_tabs/` inside `app/<route>/` are private to that route. Cross-route imports are blocked by `dependency-cruiser`.
 - **Direction rule:** `src/lib/` MUST NOT import from `src/components/`. Allowed direction is `components/ → lib/`.
 - **CSP `connect-src`:** source of truth is `src/lib/csp.ts`'s `CSP_CONNECT_SRC` array. Do NOT widen `script-src` with `unsafe-eval` (Plotly works without it).
 - **Address book + forensic reports:** Upstash Redis, single `labels` and `reports` hashes keyed by lowercase address. No chain scope — same EVM address = same entity. Forensic-report drafts live in gitignored `.investigations/`.
-- **Visual snapshots:** 5 baselined pages under `tests/browser/visual-snapshots.test.ts-snapshots/`. `maxDiffPixelRatio: 0.03`. Re-baseline with `pnpm --filter @mento-protocol/ui-dashboard test:browser:update-snapshots`.
+- **Visual snapshots:** baselines and their tolerance live with the browser
+  tests. Re-baseline only through
+  `pnpm --filter @mento-protocol/ui-dashboard test:browser:update-snapshots`.
 - **Browser tests:** Playwright + local fixture GraphQL server (`tests/browser/fixtures/hasura-fixture-server.mjs`) — never hit hosted Hasura.
 
 ## How to report

--- a/.claude/agents/indexer-explorer.md
+++ b/.claude/agents/indexer-explorer.md
@@ -12,21 +12,34 @@ Read-only exploration specialist for `indexer-envio/`. Locate code, summarize wh
 ## Scope
 
 - **Primary path:** `indexer-envio/`
+- **Start with:** `indexer-envio/AGENTS.md` and
+  `docs/pr-checklists/indexer-handler-invariants.md`; they own the current
+  handler and effect-layer rules.
 - **Allowed adjacent reads:** `shared-config/` (chain/token metadata consumed by handlers), `schema.graphql`, root `AGENTS.md` for pattern rules
 - **Out of scope:** `ui-dashboard/`, `metrics-bridge/`, `aegis/`, `terraform/` — say "out of scope" if asked
 
 ## Conventions you know
 
-- **Entry point:** `src/EventHandlers.ts` — Envio expects all `Contract.Event.handler(...)` registrations reachable from here at module load. Handler logic lives in `src/handlers/*.ts` (non-exhaustive: `fpmm.ts`, `sortedOracles.ts`, `virtualPool.ts`, `feeToken.ts`, `broker.ts`, `biPoolManager.ts`, `openLiquidityStrategy.ts`, `breakerBox.ts`, `medianDeltaBreaker.ts`, `valueDeltaBreaker.ts`, plus `fpmm/`, `liquity/`, and `wormhole/` subdirs), imported as side effects.
-- **RPC split:** `src/rpc.ts` is a barrel re-export + Oracle DB helpers. Real primitives are in `src/rpc/{client,block-fallback,pool-state,oracle-state,biPoolManager,breakers,effects}.ts`. Handlers MUST import via `effects.ts` (Envio Effect API facade with per-batch memoisation) or the `rpc.ts` barrel — never directly from `rpc/*.ts` (blocking via `pnpm code-health:deps`).
-- **Sentinel pattern:** `-1` = not yet attempted (retry), `-2` = "returned no data" / getter missing (stop retrying). All-or-nothing `Promise.all` loses wins; use `Promise.allSettled`.
+- **Entry point:** `src/EventHandlers.ts` is the registration map Envio loads.
+  Follow its side-effect imports into `src/handlers/`; do not maintain a module
+  inventory here.
+- **RPC split:** runtime reads flow through the Effect API facade or the
+  `src/rpc.ts` barrel so batching and memoisation remain intact. Direct
+  runtime/value imports from `src/rpc/*` are blocked; type-only imports may
+  target an implementation module.
+- **Sentinel pattern:** `-1` = not yet attempted (retry), `-2` = "returned no
+  data" / getter missing (stop retrying). Multi-getter effects use
+  `Promise.allSettled` so one failed getter does not discard successful
+  siblings; this is not a blanket ban on `Promise.all`.
 - **Chain list source of truth:** `Object.keys(CONTRACT_NAMESPACE_BY_CHAIN)` from `src/contractAddresses.ts`. NEVER hardcode `[42220, 143]` — testnet runs on `[11142220, 10143]` against the same compiled handlers.
 - **ABI vendoring:** `abis/` is refreshed from `@mento-protocol/contracts` via `pnpm --filter @mento-protocol/indexer-envio generate:abis`. ERC20 stub + Wormhole NTT minimal subsets are hand-vendored (excluded from the script — see `scripts/generateAbis.mjs` header).
 - **Codegen:** `pnpm indexer:codegen` writes `.envio/types.d.ts` (gitignored). Triple-slash from `envio-env.d.ts` makes the `envio` module compile.
 - **Composite IDs:** must be collision-resistant under same-block writes — include `chainId + blockNumber + logIndex` (or `txHash + logIndex`).
-- **HyperRPC limitations:** event-sync + chain-info only; `eth_call` requires a full-node RPC (per `RPC_CONFIG_BY_CHAIN` in `src/rpc/client.ts:161`).
+- **HyperRPC limitations:** event-sync + chain-info only; `eth_call` requires a full-node RPC (see `RPC_CONFIG_BY_CHAIN` in `src/rpc/client.ts`).
 - **mockDb gotcha:** v3 mockDb hides multi-id `set()` within one handler — fall back to pure-function unit tests for backfill/heal logic.
-- **Test fallthrough:** unmocked RPC effects fall through to real RPC under vitest (`vitest.config.ts` `testTimeout: 60_000`); locally fast, CI-slow tests will time out. Mock all RPC effects exercised by heal/backfill paths.
+- **Test fallthrough:** unmocked RPC effects can fall through to real RPC under
+  Vitest. Mock every RPC effect exercised by heal/backfill paths; read
+  `vitest.config.ts` for the current normal and coverage timeouts.
 
 ## How to report
 

--- a/.claude/agents/infra-reader.md
+++ b/.claude/agents/infra-reader.md
@@ -1,6 +1,6 @@
 ---
 name: infra-reader
-description: Read-only Explore agent for infrastructure — terraform/, alerts/{rules,infra}/, aegis/terraform/, .github/workflows/, scripts/, vercel.json. Use for safely inspecting deploy pipelines, Cloud Run config, Vercel project setup, GH Actions wiring, Grafana alert rule Terraform, event-driven alert delivery (QuickNode→Cloud Fn→Discord + Sentry bridge), and supply-chain hardening (lockfile-lint, SHA-pinned actions). Knows the CI required-status pattern (no paths: filters), Cloud Run reserved paths, deploy-job gating rules. Triggers on questions like "where is X env var set", "which workflow promotes prod", "why does this CI check stay pending forever". Read-only — never proposes terraform apply or workflow_dispatch.
+description: Read-only Explore agent for infrastructure — registered Terraform stacks, alerts/{rules,infra}/, package-owned Terraform, .github/workflows/, scripts/, and vercel.json. Use for safely inspecting deploy pipelines, Cloud Run config, Vercel project setup, GH Actions wiring, Grafana alert-rule Terraform, QuickNode/Sentry/Splunk On-Call delivery to Slack, and supply-chain hardening. Knows the CI required-status pattern, Cloud Run reserved paths, and deploy-job gates. Triggers on questions like "where is X env var set", "which workflow promotes prod", "why does this CI check stay pending forever". Read-only — never proposes terraform apply or workflow_dispatch.
 model: sonnet
 tools: Read, Grep, Glob
 ---
@@ -11,7 +11,15 @@ Read-only infrastructure specialist. Inspect deploy/CI/infra config and report f
 
 ## Scope
 
-- **Primary paths:** `terraform/`, `alerts/rules/` (separate stack — Grafana metric alert rules + Slack contact points, scripts `pnpm alerts:rules:{init,plan,apply}`), `alerts/infra/` (event-driven delivery — Cloud Function + Discord channels + Sentry bridge + QuickNode webhooks, scripts `pnpm alerts:infra:{init,plan,apply}`), `aegis/terraform/`, `.github/workflows/`, `scripts/`, `vercel.json`, root `package.json` deploy scripts, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `.npmrc`, all `Dockerfile`s
+- **Start with:** `terraform.stacks.json`, which owns stack roots and CI
+  behavior; then read the relevant package `AGENTS.md`.
+- **Primary paths:** every stack registered in `terraform.stacks.json`
+  (including root infrastructure, alert rules/delivery, Aegis, and governance
+  watchdog), `.github/workflows/`, `scripts/`, `vercel.json`, root package
+  scripts, workspace/lock/registry config, and Dockerfiles. `alerts/rules/` owns
+  Grafana rules/routing; `alerts/infra/` owns QuickNode, Sentry, and on-call
+  delivery to Slack. Use only the `init`/`plan` aliases that actually exist;
+  never invent an apply alias.
 - **Allowed adjacent reads:** root `AGENTS.md` for pattern rules, `docs/pr-checklists/{terraform-cloudrun,ci-workflow-gates}.md`
 - **Out of scope:** `ui-dashboard/src/`, `indexer-envio/src/`, `metrics-bridge/src/`, `aegis/src/` (application code) — say "out of scope" if asked
 
@@ -22,13 +30,18 @@ Read-only infrastructure specialist. Inspect deploy/CI/infra config and report f
 - **Third-party action pinning:** all actions in deploy paths MUST be SHA-pinned (`uses: org/action@<40-char-sha> # vX.Y.Z`).
 - **Concurrency:** deploy workflows MUST set a workflow-name concurrency group with `cancel-in-progress: false`.
 - **Cache keys:** must include every input affecting the cached output (codegen scripts, configs, schema).
-- **Cloud Run reserved path:** `/healthz` is reserved at the frontend in Cloud Run v2 — use `/health`. Bootstrap `image` must respond to the configured probe path (`gcr.io/cloudrun/hello:latest` does NOT serve `/health`).
+- **Cloud Run reserved path:** `/healthz` is reserved at the frontend in Cloud
+  Run v2 — use `/health`. The current digest-pinned bootstrap image serves the
+  configured catch-all health probe; verify any replacement against the probe.
 - **Cloud Run revision suffix:** must start with a lowercase letter (RFC 1035; ~62% of raw hex SHAs fail). Must also be unique per run (`$GITHUB_RUN_ID` or epoch suffix).
 - **WIF requirement:** deployer SAs need `roles/iam.serviceAccountTokenCreator` on the runtime SA they impersonate.
 - **Terraform `moved` blocks:** removing `count` / renaming a resource requires a `moved` block. `deletion_protection = true` makes a missed `moved` block fatal.
 - **Lockfile integrity:** `pnpm lockfile:lint` checks (1) every package has sha512 integrity hash, (2) every `.npmrc` / `pnpm-workspace.yaml registries:` is verified to NOT redirect to a lookalike host.
 - **Terraform from a worktree:** `terraform.tfvars` is gitignored and only lives in the main checkout. From a worktree, either run from `<main-checkout>/` or `terraform init -reconfigure` + `terraform plan -var-file=<main-checkout>/terraform/terraform.tfvars`.
-- **Mutation testing CI gate:** `metrics-bridge/stryker.config.mjs` `break: 84` (current baseline 86.01%). `.github/workflows/mutation-testing.yml` runs weekly (cron) + `workflow_dispatch` only — advisory, not in the `main` ruleset's required checks; the per-PR trigger was removed as a CI-cost control.
+- **Mutation testing:** `.github/workflows/mutation-testing.yml` runs the
+  configured dashboard, indexer, and metrics-bridge jobs on its scheduled and
+  manual triggers. It is advisory, not a required PR check. Read each
+  `stryker.config.*` file for current thresholds instead of copying them here.
 
 ## How to report
 

--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -1,16 +1,19 @@
 # Security guidance — Mento monitoring-monorepo
 
-Project-specific rules for the model-backed security reviewer. Additive to the
-built-in vulnerability checklist. These are guidance; PR review and `/red-team`
-remain the enforcement layers.
+Project-specific semantic rules for the official
+`security-guidance@claude-plugins-official` model-backed diff reviewer. The
+plugin must be installed/enabled by the developer; this repo does not declare a
+user-scoped plugin installation. Regex-enforceable patterns live in
+`.claude/security-patterns.json`; canonical workflow detail lives in package
+instructions and PR checklists. These rules supplement, but do not replace,
+`/security-review`, autoreview, tests, or normal PR gates.
 
 ## Secrets and credentials
 
-- Never log, echo, or persist values from `AUTH_SECRET`, `KV_REST_API_TOKEN`,
-  `KV_REST_API_READ_ONLY_TOKEN`, `ENVIO_HASURA_TOKEN`, `SENTRY_AUTH_TOKEN`,
-  `*_SLACK_BOT_TOKEN`, `DUNE_API_KEY`, `ARKHAM_API_KEY`, or any value sourced
-  from `.env*`. Redact before passing into logs, error messages, or Sentry
-  breadcrumbs.
+- Never log, echo, or persist secrets such as `AUTH_SECRET`,
+  `UPSTASH_REDIS_REST_TOKEN`, `ENVIO_API_TOKEN`, `SENTRY_AUTH_TOKEN`,
+  QuickNode credentials, Slack bot tokens, or third-party API keys. Redact them
+  before logs, errors, or Sentry breadcrumbs.
 - Never commit `.env`, `.env.local`, `.env.production.local`, or any file
   matching `*credential*`, `*secret*`. Example files (`.env.example`,
   `.env.production.local.example`) with placeholder values are allowed.
@@ -20,13 +23,13 @@ remain the enforcement layers.
 
 ## GCP and Terraform
 
-- App code (indexer-envio, ui-dashboard, aegis, metrics-bridge) must never
-  shell out to `gcloud`. Sandbox-side reads use the `mcp__gcloud__*` MCP
-  tools with agent-readonly SA impersonation. Server-side reads use the
-  GCP client libraries with workload identity, not the CLI.
+- App code must never shell out to `gcloud`. Agent-side inspection uses an
+  available read-only connector; server-side reads use GCP client libraries
+  with workload identity.
 - Terraform secret values (`*.tfvars`, `*.auto.tfvars`) stay in the main
   checkout only — never copy them into worktrees, never commit them, never
-  echo them. The GCS backend in `terraform/` is the source of truth.
+  echo them. The backend registered for each Terraform stack is the state source
+  of truth; do not infer ownership from directory names.
 
 ## Indexer (indexer-envio)
 
@@ -37,10 +40,12 @@ remain the enforcement layers.
 - Trading-limit state (Mento v2) is keyed on `bytes32(exchangeId XOR token)`,
   NOT on trader. Logic that "resets" limits by rotating callers is wrong;
   surface this as a finding.
-- RPC handling: handlers must not assume getter calls succeed. Use the
-  `rpc/` helpers (`tryRead`, heal effects), and report missing data via
-  `context.log.error("<area>.<event>", { ... })`. Never `throw` from a
-  handler — it halts the indexer; this is a Sev-1 condition.
+- RPC handling: handlers must not assume getter calls succeed. Use the effect
+  helpers for transient getter/RPC failures and structured error reporting.
+  Invariant violations, corrupt data, and failures before a safe write may
+  intentionally throw and stop processing. Follow
+  `docs/pr-checklists/indexer-handler-invariants.md`; do not apply a blanket
+  throw/no-throw rule.
 - Bridge/NTT transceiver and FPMM addresses must be read from
   `indexer-envio/config/nttAddresses.json` and the chain registry, not
   hardcoded inline. Mismatched addresses across chains have caused outages.
@@ -80,7 +85,7 @@ remain the enforcement layers.
   GCP Cloud Function) MUST verify the QuickNode signature via
   `verify-quicknode-signature.ts` BEFORE parsing the request body. Reject
   unauthenticated requests early.
-- Outbound destinations (Slack, Discord) are templated. Never pass a
+- Outbound Slack destinations are templated. Never pass a
   request-controlled string directly into the channel selector or the
   message body without escaping `<>&` in mrkdwn/HTML targets.
 
@@ -91,8 +96,7 @@ remain the enforcement layers.
   triggers must NOT grant `pull-requests: write` or `contents: write`
   unless they also gate on `github.event.pull_request.head.repo.full_name`
   matching the upstream repo (forks shouldn't get write tokens).
-- **Ruleset-required** CI checks must NOT use `paths:` filters — that creates
-  permanently-pending checks on PRs that don't touch the paths and blocks
-  the merge queue. "Required" = enforced by the `main` ruleset (`ci`,
-  `Code Quality`, the Vercel checks). Advisory workflows (everything else)
-  SHOULD use `paths:` filters to avoid booting a runner on irrelevant PRs.
+- **Ruleset-required** CI checks must not use workflow-level `paths:` filters;
+  skipped workflows leave required checks pending. Advisory workflows should
+  use path filters. Read `docs/pr-checklists/ci-workflow-gates.md` and the live
+  ruleset before changing either class.

--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -22,7 +22,7 @@ third review-triggered patch cycle. A clean source review is not test, browser,
 generated-artifact, CLI/API, or runtime proof, so retain every applicable gate.
 If an autoreview runtime change triggers the owning adapter's self-review
 refusal, keep it intact and follow the trusted pre-change sequence in the owner
-note. For PR work, finish with
-`pnpm pr:ready-state --pr <number> --repo <owner/name> --json`. When a Claude
-cloud surface cannot run that probe, follow the MCP-emulation contract in the
-`babysit-pr` skill and `docs/notes/github-tooling-surfaces.md`.
+note. For PR work, finish the Babysit and Ready-state steps in
+`docs/notes/pr-operating-card.md`. When a Claude cloud surface cannot run the
+probes, follow the MCP-emulation contract in the `babysit-pr` skill and
+`docs/notes/github-tooling-surfaces.md`.

--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -1,94 +1,28 @@
+---
+description: Run the repo-local structured closeout review
+argument-hint: "[agent:autoreview options]"
+---
+
 # Auto Review
 
-Run the repo-local structured closeout review helper. Normal shells default to
-the Codex review engine; active Codex sandbox sessions default to the helper's
-local deterministic engine only when no engine is passed explicitly. An
-explicitly selected unavailable engine fails closed. Pass `--engine claude`
-when the user explicitly asks for Claude review.
-
-Arguments: `$ARGUMENTS`
-
-## Steps
-
-1. Freeze the original request, target/owner, changed files, and non-test
-   changed-line count as the scope baseline. Classify later additions as
-   in-scope, follow-up, or stop; create an issue before deferring valid
-   follow-up work and warn near twice the baseline.
-2. Run:
+Freeze the request, owner, changed files, and non-test changed-line count, then
+run:
 
 ```bash
 pnpm agent:autoreview $ARGUMENTS
 ```
 
-For a fresh-context Codex handoff, pass
-`--prepare-bundle-dir /tmp/autoreview-bundle` using a directory outside the repo
-worktree. Add `--feedback-pr <number>` when reviewing a feedback-fix batch.
-The bundle parent must already exist. Every canonical ancestor must be owned by
-the current user or root; group/other-writable ancestors require sticky-bit
-protection. On macOS, write-granting ACLs on parent ancestors or bundle entries
-fail preparation or verification. The adapter pins the freshly created staging
-directory's `dev:ino` before content generation and rechecks it throughout
-transfer. It manifests wrapper-owned evidence around helper
-execution and all evidence around the final helper source check, rejects
-externally linked regular files, exclusively reserves the destination, and
-writes `.agent-autoreview-complete` last with the verified manifest digest. Run
-`pnpm agent:autoreview --verify-bundle-dir /tmp/autoreview-bundle` immediately
-before reading every pass and retain its printed digest outside the bundle.
-After review, rerun with
-`--expected-bundle-manifest <retained-digest>`; this rehashes the no-follow
-evidence and fails if the marker, content, or pre/post digest changed. Never
-review an interrupted or unverified bundle. The bundle owns its
-`autoreview-prompt.md`; do not combine this mode with `--bundle-output`.
-Direct supplemental evidence must be repo-relative;
-wrapper-generated feedback and protected-main checklist copies inside the
-trusted bundle directory are the exceptions. The owning-checkout default
-semantic helper and automatic feedback execute Node runtime from that same
-pinned `origin/main` object rather than a PR-selected base, mutable worktree, or
-package script; wrapper-owned Node launches discard `NODE_OPTIONS` and
-`NODE_PATH` plus loader/startup injection variables. Direct executables require
-trusted ownership and non-shared-writable ancestry. On Darwin, Homebrew-style
-paths are accepted only through sealed private native Mach-O snapshots with
-system-only library closure. On Linux, a root-run wrapper may recover only the
-exact path-untrusted Node inode (including root- or foreign-owned writable or
-hard-linked toolcache layouts) from a live, uninterrupted all-root ancestor
-chain; direct helper invocation gets no such exception. The wrapper seals the
-exact inode and its validated glibc startup closure, then the helper revalidates
-the snapshot, sealed manifest, loader, and alias handoff before and after
-semantic-engine launches. Scripts and unsafe
-library closure fail closed.
-The helper reviews the complete target
-without truncation. Reviewer network search is off by default; pass
-`--web-search` only when the review explicitly needs public documentation
-lookup. Direct semantic engines
-fail closed if more than one prompt is required; prepared bundles retain
-bounded lossless passes that one fresh-context reviewer must inspect
-completely. Semantic engines use an isolated empty workspace, sensitive inputs
-fail closed, and a quiet reviewer emits a 60-second heartbeat.
-Do not pass the removed `--parallel-tests` option; run tests through the quality
-gate.
+`docs/notes/agent-quality-gate-mechanics.md` owns engine selection, trusted
+bundle preparation/verification, runtime-change refusal handling, and other
+adapter mechanics. Follow it rather than duplicating those rules here.
 
-If this checkout changes the executable autoreview runtime and the owning
-adapter refuses its self-review, keep the refusal intact. Invoke a clean,
-detached, compatible wrapper/helper from the last independently reviewed
-pre-change commit while the current directory remains this reviewed checkout,
-then use that same trusted wrapper for both manifest checks. Follow the exact
-sequence in `docs/notes/agent-quality-gate-mechanics.md`; never point the trusted
-paths at this runtime-changing checkout.
-
-3. Verify every accepted finding before editing. Do not blindly apply review
-   output.
-4. If fixes are made, rerun focused checks and autoreview for the fixed batch.
-   Pause for scope reclassification after two review-triggered patch cycles
-   rather than starting a third automatically.
-5. Treat a clean result as source review, not UI, CLI/API, generated-artifact,
-   or runtime proof. Keep every applicable browser, quality-gate, and runtime
-   verification step.
-6. For PR work, do not call the PR clean until
-   `pnpm pr:ready-state --pr <number> --json` is ready; in a capable Claude
-   cloud variant add `--repo <owner/name>` (gh cannot infer the repo from
-   the proxy remote). In a Claude cloud session without the REST + GraphQL +
-   `--slurp` capability gate the probe cannot run; run the MCP emulation
-   checklist from the `babysit-pr` skill instead, label the result
-   MCP-emulated rather than probe-verified, and leave the probe-verified
-   all-clear to a gh-capable surface
-   (`docs/notes/github-tooling-surfaces.md`).
+Verify every accepted finding before editing. If fixes are made, rerun focused
+checks and autoreview for that batch; pause for scope reclassification before a
+third review-triggered patch cycle. A clean source review is not test, browser,
+generated-artifact, CLI/API, or runtime proof, so retain every applicable gate.
+If an autoreview runtime change triggers the owning adapter's self-review
+refusal, keep it intact and follow the trusted pre-change sequence in the owner
+note. For PR work, finish with
+`pnpm pr:ready-state --pr <number> --repo <owner/name> --json`. When a Claude
+cloud surface cannot run that probe, follow the MCP-emulation contract in the
+`babysit-pr` skill and `docs/notes/github-tooling-surfaces.md`.

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -5,7 +5,7 @@ title: Forensic Report Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-06-15
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -32,7 +32,10 @@ If the answer fits in `notes` (≤500 chars, single fact like "Binance hot 14"),
 
 Two facts shape every tool choice in this skill:
 
-1. **Mento is multi-chain and growing.** Celo (`42220`) is primary and where most targets live. Monad (`143`) is live in the Mento indexer; the Polygon (`137`) protocol deployment is live and its indexer coverage is configured pending deployment, sync verification, and promotion. Ethereum (`1`) carries reserve-yield monitoring. Never hardcode `42220`; thread the target chain id through every chain-scoped call.
+1. **Mento is multi-chain and growing.** Celo (`42220`), Monad (`143`),
+   Polygon (`137`), and Ethereum (`1`) are live in the production indexer.
+   Ethereum currently carries reserve-yield monitoring. Never hardcode `42220`;
+   thread the target chain id through every chain-scoped call.
 2. **One key, many chains.** If someone controls a private key on Celo, the same EOA almost always has a history on other EVM chains (Ethereum, Base, Arbitrum, …). That cross-chain footprint is usually where the _identity_ lives — ENS, OpenSea, CEX deposits, prior bots — because the richest attribution tools (Arkham, Nansen, EigenPhi, MetaSleuth) index Ethereum/L2s but **not** Celo.
 
 So split the work into two legs and pick tools per leg:
@@ -47,11 +50,22 @@ So split the work into two legs and pick tools per leg:
 Two artefacts:
 
 1. **Local draft** at `.investigations/<address>-<slug>.md` (slug = first-3 words of derived display name, lowercase, kebab-cased). The `.investigations/` folder is gitignored — never commit drafts.
-2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script mirrors the atomic upsert pattern `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` uses — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution — but is a **simplified, non-CAS variant**: the live route additionally takes an `expectedVersion` base-version precondition and returns an `{ok, report}` envelope, whereas this skill does a fire-and-forget always-wins write and returns the bare encoded payload (exact script in the Lua section below). Atomicity still matters: a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "claude"` so the editor can distinguish skill-produced from hand-typed reports.
+2. **Optional production upload**: the exact optimistic-concurrency (CAS) Lua
+   upsert owned by `upsertReport()` in
+   `ui-dashboard/src/lib/address-reports.ts`, executed against the `reports`
+   hash through `mcp__upstash__redis_database_run_redis_commands`. Re-read
+   immediately before upload, pass the expected base version, and stop on a
+   conflict. The canonical skill stamps `source: "Codex"`; its Claude mirror
+   stamps `source: "claude"`.
 
 ## Output template
 
-The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same named H2 sections in the same order (TL;DR, Cast of characters, Related addresses / fleet, What it does, Transaction anatomy, Capital and scale, Why \_\_\_, why these venues, Coverage and dead ends, Bottom line), same code-fenced storage / tx blocks, the confidence-tier tags on attribution claims, and the provenance + "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder. ("Related addresses / fleet" may be omitted only when clustering in Step 2.5 found nothing — say so in one line rather than dropping the heading silently.)
+The literal shape every report follows lives at `template.md` next to this file.
+Its frontmatter is governance metadata and is **not** copied into a report. Read
+the body once, then mirror its named H2 sections, order, evidence blocks,
+confidence tags, and two-line provenance footer exactly. The template is the
+spec: do not invent, drop, or reorder sections. Keep "Related addresses /
+fleet" even when clustering found nothing and record that result in one line.
 
 ## Procedure (how to fill the template)
 
@@ -74,9 +88,9 @@ mkdir -p .investigations
 #   DL_NS    → DefiLlama coin-price slug (Step 5.5); may differ from the chain name — verify on DefiLlama
 case "$CHAIN" in
   celo)     CHAIN_ID=42220; RPC=https://forno.celo.org;    DUNE_NS=celo;     DL_NS=celo ;;
-  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;    DUNE_NS=monad;    DL_NS=monad ;;     # Monad full node (repo-canonical rpc2.monad.xyz); DefiLlama may not cover monad yet (Step 5.5 caveat)
-  polygon)  CHAIN_ID=137;   RPC=https://polygon-rpc.com;   DUNE_NS=polygon;  DL_NS=polygon ;;
-  ethereum) CHAIN_ID=1;     RPC=https://eth.llamarpc.com;  DUNE_NS=ethereum; DL_NS=ethereum ;;
+  monad)    CHAIN_ID=143;   RPC=https://rpc2.monad.xyz;          DUNE_NS=monad;    DL_NS=monad ;;
+  polygon)  CHAIN_ID=137;   RPC=https://polygon.drpc.org;        DUNE_NS=polygon;  DL_NS=polygon ;;
+  ethereum) CHAIN_ID=1;     RPC=https://ethereum.publicnode.com; DUNE_NS=ethereum; DL_NS=ethereum ;;
   *) echo "Unsupported CHAIN=$CHAIN — add a case arm with its CHAIN_ID / RPC / DUNE_NS / DL_NS." >&2; exit 1 ;;
 esac
 ```
@@ -91,11 +105,15 @@ cast --version                                   # tool version, for the footer
 
 For the attribution-anchoring storage reads in Step 3, pin them with `cast call "$ADDR" "<sig>" --block "$HEAD_BLOCK" --rpc-url "$RPC"` (quote the `<sig>` placeholder so bash doesn't read it as a redirection) so a future reader gets the same bytes.
 
-Check whether a report already exists (we may be UPDATING, not creating):
+Discover the production database with
+`mcp__upstash__redis_database_list_databases`: require exactly one database
+named `address-labels`, then carry its returned opaque id as `DATABASE_ID`.
+Never hardcode or derive that id. Check whether a report already exists (we may
+be updating, not creating):
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "reports", "<addrLower>"]],
 });
 ```
@@ -110,52 +128,53 @@ commands: [["HGET", "labels", "<addrLower>"]];
 
 ### Step 1.5 — Check Upstash caches first
 
-Before making any live Arkham API calls, check the five caches populated by the 2026-05 extraction marathon. The API key expires ~2026-05-23; after that, cache is the only option.
+Before making any live Arkham calls, check the five existing caches. Prefer a
+current cache hit; use the live connector only when it is available and the
+result needs refreshing.
 
 ```js
 // All five caches live in the same address-labels database.
-// database_id: c687bf0d-f61f-498e-879a-016de335b4ce
+// DATABASE_ID is the exact-name match discovered in Step 1.
 
 // 1. Full enrichment (multi-chain address_enriched + counterparties)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_deep", "<addrLower>"]],
 });
 
 // 2. Transfer history (transfers?base=<addr>&limit=1000)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_transfers", "<addrLower>"]],
 });
 
 // 3. Wealth snapshot (balances + portfolio 0d/30d/90d/180d)
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_wealth", "<addrLower>"]],
 });
 ```
 
 **If all three hit:** use the cached data for Steps 2–5 and skip the live Arkham API calls entirely.
 
-**If the API key is still valid AND the cached entry is older than ~7 days**, you MAY refresh with a live call; otherwise prefer cache.
+If a cache entry is stale and the live connector is available, refresh it;
+otherwise record the cache timestamp and its limitation.
 
 **Entity cache path:** if `intel_deep` returns an entity slug (look for `arkhamEntity.id` or a similar slug field in the payload), check the entity-level caches too:
 
 ```js
 // 4. Entity profile (fetched from /intelligence/entity/{slug})
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_entities", "<entitySlug>"]],
 });
 
 // 5. Entity counterparties (/counterparties/entity/{slug})
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "intel_entity_cps", "<entitySlug>"]],
 });
 ```
-
-Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, `intel_wealth` 80, `intel_entities` 161, `intel_entity_cps` 161.
 
 **These caches ARE the cross-chain identity leg** (see the chain doctrine): they're populated from the target's activity on chains Arkham covers — i.e. NOT Celo/Monad. For a Celo-native address they're often empty, and that emptiness is itself the finding ("no Ethereum/L2 footprint Arkham can see"). When they hit, they're the fastest path to who's behind the address — **but only consume a hit keyed on the target's own address as identity for an EOA target.** For a CONTRACT target, the same 20-byte address on the chains these caches cover is usually an unrelated account, so a target-address cache hit would mis-attribute the report; run the identity leg on the deployer/operator EOA instead (Step 2), unless shared-deployment is proven.
 
@@ -164,9 +183,14 @@ Cache sizes (as of 2026-05-20): `intel_deep` 529 entries, `intel_transfers` 60, 
 - `intel_deep` (`intel-deep.ts`): `enriched[chain].arkhamEntity.id` is the **entity slug** — the join key into `intel_entities` / `intel_entity_cps` (those hashes are slug-keyed, not address-keyed). `candidate.sources` tells you _why_ it was cached (`cluster-…-caller` / `top-trader` / `top-bridger` / `tier1-attested`) — a free prior classification. `counterparties[chain]` has the top USD counterparties per chain.
 - Use `intel-legacy-fallback.ts` `hgetWithLegacy` semantics — older entries may sit under `arkham_*` legacy keys.
 
-### Step 1.6 — Mento indexer fingerprint (our own Celo/Monad/Polygon source)
+### Step 1.6 — Mento indexer fingerprint (our own multichain source)
 
-**This is the primary on-chain-behaviour source for the target chain** — and it's the one the skill historically ignored. The repo runs its own Envio HyperIndex indexer of Mento protocol events with a **public, unauthenticated** Hasura GraphQL endpoint covering Celo (`42220`) and Monad (`143`), plus Polygon (`137`) after the configured deployment is synced and promoted. Because Arkham/Nansen are blind on Celo and Monad, this is where "what did this address do with Mento" actually gets answered on those chains; always verify the requested chain is live at the endpoint before treating an empty result as evidence. Query it _before_ the funder graph so you walk into Step 2 already knowing the target's Mento footprint.
+**This is the primary on-chain-behaviour source for the target chain.** The
+production Envio endpoint covers Celo (`42220`), Monad (`143`), Polygon (`137`),
+and Ethereum (`1`, currently reserve-yield entities). Because Arkham/Nansen are
+blind on Celo and Monad, this is where "what did this address do with Mento"
+gets answered on those chains. Always verify the requested chain is live before
+treating an empty result as evidence. Query it before the funder graph.
 
 ```bash
 HASURA=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql   # public, no key, POST application/json
@@ -179,9 +203,9 @@ curl -s "$HASURA" -H 'content-type: application/json' \
 #     bridges — so a quiet/new chain whose activity is non-swap isn't mis-marked. (BridgeTransfer keys on
 #     sourceChainId/destChainId, not chainId.)
 curl -s "$HASURA" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
-# (Ethereum is sUSDS-only in this indexer — that's why SusdsPosition is in the probe; without it an
-#  ethereum target would always look NOT-COVERED despite the indexer serving its sUSDS ledger.)
+  --data "{\"query\":\"{ SwapEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} LiquidityEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StableSupplyChangeEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} RebalanceEvent(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} BridgeTransfer(where:{_or:[{sourceChainId:{_eq:$CHAIN_ID}},{destChainId:{_eq:$CHAIN_ID}}]},limit:1){id} SusdsPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} SusdsYieldMovement(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StethPosition(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} StethYieldMovement(where:{chainId:{_eq:$CHAIN_ID}},limit:1){id} }\"}" | jq .
+# Ethereum reserve-yield coverage includes both sUSDS and stETH positions and
+# movement history; omitting either family can turn real activity into false EMPTY.
 # Mark the indexer NOT-COVERED for $CHAIN only if EVERY entity above (and the full Step 1.6 battery) is
 # empty AND $CHAIN isn't in the indexer's configured network list — see the `networks:` section of
 # `indexer-envio/config.multichain.mainnet.yaml`. Otherwise an empty result is EMPTY (a real signal).
@@ -307,10 +331,35 @@ Run a small battery keyed on the target address (all fields verified against `in
   }
 }
 {
-  # sUSDS yield ledger (Ethereum-only in this indexer) — keyed by `wallet`. Mirrors the coverage probe so
-  # an Ethereum target's position is actually queried, not just probed.
+  # sUSDS current position (Ethereum-only in this indexer).
   SusdsPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
     id
+  }
+}
+{
+  SusdsYieldMovement(
+    where: { _and: [{ _or: [{ from: { _eq: "0xtarget" } }, { to: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }
+    order_by: [{ blockNumber: desc }, { id: desc }]
+    limit: 1000
+  ) {
+    id
+    txHash
+  }
+}
+{
+  # stETH current position plus historical movements (Ethereum-only).
+  StethPosition(where: { wallet: { _eq: "0xtarget" }, chainId: { _eq: <CHAIN_ID> } }) {
+    id
+  }
+}
+{
+  StethYieldMovement(
+    where: { _and: [{ _or: [{ from: { _eq: "0xtarget" } }, { to: { _eq: "0xtarget" } }] }, { chainId: { _eq: <CHAIN_ID> } }] }
+    order_by: [{ blockNumber: desc }, { id: desc }]
+    limit: 1000
+  ) {
+    id
+    txHash
   }
 }
 {
@@ -380,7 +429,8 @@ Then attribution. Use the `arkham` skill (project-scoped) for the **cross-chain 
    ```sql
    SELECT block_time, "from", value, hash
    FROM <chain>.transactions
-   WHERE "to" = LOWER('<addr>') AND value > 0   -- value>0 skips zero-value relayer/user calls that aren't funding
+   WHERE "to" = FROM_HEX('<40 hex chars without 0x>') AND value > 0
+   -- Dune addresses are varbinary: use FROM_HEX or a bare 0x literal, never LOWER(text).
    ORDER BY block_time ASC
    LIMIT 5;
    ```
@@ -488,7 +538,11 @@ If the target is a **Gnosis Safe** (cheap codehash/proxy check), pull the real h
 
 Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the top-level selector via OpenChain.
 
-**For the call tree + asset flow, use Blockscout — not `cast`.** `forno.celo.org` (and most public full nodes) whitelists no trace methods (`debug_traceTransaction` / `trace_transaction` return `-32601 "method not whitelisted"`), so `cast` cannot produce a call tree. The free, no-key Blockscout v2 REST API gives both the decoded nested-call tree and the exact net asset flow — point `BS` at the target chain's Blockscout instance:
+**For internal calls and raw state deltas, use Blockscout — not `cast`.**
+`forno.celo.org` (and most public full nodes) exposes no trace methods. The
+free Blockscout v2 API returns paginated, flat internal-transaction records and
+raw state changes; it does not return a nested call tree or dollar-valued flow.
+Point `BS` at the target chain's Blockscout instance:
 
 ```bash
 # Pick the Blockscout v2 base for $CHAIN. Not every chain has one (e.g. Monad — see fallback below).
@@ -498,12 +552,16 @@ case "$CHAIN" in
   *)       BS=""; echo "No Blockscout instance mapped for $CHAIN — use the RPC-native debug_traceTransaction fallback below." >&2 ;;
 esac
 if [ -n "$BS" ]; then   # skip when no Blockscout for $CHAIN — use the RPC-native fallback below instead
-  curl -s "$BS/transactions/$TX/internal-transactions" | jq '.items[] | {type, from:.from.hash, to:.to.hash, value, error}'  # decoded CALL/DELEGATECALL/CREATE tree
-  curl -s "$BS/transactions/$TX/state-changes"        | jq '.items[] | {addr:.address.hash, type, change}'                  # per-address coin+token balance_before→after = net flow
+  curl -s "$BS/transactions/$TX/internal-transactions" | jq '{next_page_params, items: [.items[] | {type, from:.from.hash, to:.to.hash, value, error}]}'
+  curl -s "$BS/transactions/$TX/state-changes"         | jq '{next_page_params, items: [.items[] | {addr:.address.hash, type, change}]}'
 fi
 ```
 
-Reachable via plain `curl`/WebFetch or the bundled `mcp__claude_ai_Blockscout__*` tools (pass `chain_id: $CHAIN_ID`). Expect `internal-transactions` to be empty on simple transfers and rich on multi-hop / reverted txs; `state-changes` gives the dollar-accurate flow `cast` can't. Keep `cast tx` + OpenChain for the top-level selector. **Chains without a Blockscout instance (e.g. Monad):** fall back to RPC-native `debug_traceTransaction` against an archive endpoint that supports it (dRPC / QuickNode / Tenderly) — never `cast run` on Celo (CIP-64, below).
+Follow `next_page_params` until exhausted. Expect internal transactions to be
+empty on simple transfers. Reconstruct nesting only from trace evidence, and
+price raw token/native deltas separately at the transaction timestamp. Keep
+`cast tx` + OpenChain for the top-level selector. On chains without Blockscout,
+use `debug_traceTransaction` only against an archive endpoint that supports it.
 
 > **Do NOT use `cast run` on Celo.** It chokes on Celo's CIP-64 fee-currency tx type `0x7b` (the _dominant_ tx type since Gingerbread) with `unknown variant 0x7b`, failing on essentially every Mento-active block — and forno is non-archive anyway. For a full trace prefer Blockscout (above) or an RPC-native `debug_traceTransaction` against a Celo archive endpoint that understands CIP-64 (dRPC / QuickNode / Tenderly on `42220`).
 
@@ -516,17 +574,31 @@ Pass the chain hint through to Sim — Mento is on Celo (`42220`) but the skill 
 ```bash
 # $CHAIN_ID is from Step 1's case switch (Celo 42220 / Monad 143 / …) — do NOT re-hardcode it.
 # Hardcoding 42220 would return empty / unrelated holdings for a Monad (or other-chain) principal.
-dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data | length'
-dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balances | length'
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balances[] | {symbol, amount, value_usd}'
+# For a scam/noise inventory, include unpriced assets instead of accepting the default exclusion:
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID --exclude-unpriced=false -o json | jq '.balances[]'
 ```
 
-Sum the USD value, drop scam airdrops. Rather than eyeballing names like `CLAIM` / `voucher`, use DefiLlama as a deterministic noise filter: a token DefiLlama won't price (no entry in the `current` response) or prices with low `confidence` (< ~0.9) has no real DEX liquidity — treat it as noise. Still list it per the template ("confirmed noise"), but keep only DefiLlama-priced, real-confidence holdings in the headline operating-capital number. See Step 5.5. For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+These responses are paginated. Collect the first page's `.balances`, then repeat
+the same command with `--offset <next_offset>` and append each page until
+`next_offset` is absent/null. Do this independently for the priced and
+`--exclude-unpriced=false` runs before summing or classifying holdings.
+
+Sum supported USD values and inventory unpriced assets separately. A missing or
+low-confidence DefiLlama price is evidence that needs corroboration, not proof
+that the token is a scam or has no liquidity. Confirm material holdings with
+pool/liquidity and transfer evidence before including or excluding them from
+operating capital. For tx volume, use a chain explorer or indexed history.
 
 ### Step 5.5 — Historical USD valuation (DefiLlama coins API — free, no Pro key)
 
 Sim's `value_usd` is _current spot_. A forensic claim like "moved $2M in March" is wrong if the token has since mooned or rugged — value flows **at the time they happened**. DefiLlama's coin price oracle does this, and it lives on the FREE `coins.llama.fi` host: the DefiLlama **Pro** subscription adds nothing to this skill (its Pro-only endpoints — bridges, token-liquidity-by-slug, treasury, unlocks, active users — are protocol-aggregate data, not address-level), so do **not** gate any of this behind a Pro key.
 
-Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` is the DefiLlama slug set by Step 1's case switch (celo→`celo`, polygon→`polygon`, ethereum→`ethereum`; verify novel chains against DefiLlama — Monad may be absent, see the caveat below). Don't hardcode `celo:` for a non-Celo target — you'd query the wrong chain's namespace and price a different token. Native CELO uses its ERC20 wrapper, e.g. `celo:0x471ece3750da237f93b8e339c536989b8978a438`.
+Key format is `$DL_NS:<lowercaseTokenAddress>`, where `$DL_NS` comes from
+Step 1 (including `monad`). Verify novel chains against DefiLlama. Do not
+hardcode `celo:` for another chain. Native CELO uses its ERC20 wrapper, e.g.
+`celo:0x471ece3750da237f93b8e339c536989b8978a438`.
 
 **Historical price at a tx's block time** (Unix seconds — derive from the block: `cast block <n> -f timestamp --rpc-url $RPC`):
 
@@ -538,39 +610,54 @@ curl -s "https://coins.llama.fi/prices/historical/$TS/$DL_NS:<tokenLower>" | jq 
 
 USD value of a raw transfer = `(rawAmount / 10^decimals) * price`. Batch tokens in one call by comma-joining keys: `…/historical/$TS/$DL_NS:0xAAA,$DL_NS:0xBBB`. Use this to put a defensible dollar figure on the representative tx in Step 4 and on flow totals.
 
-**Current price** (same response shape) for the Step 5 holdings snapshot: `https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. The `confidence` field (0–1) is the scam/illiquidity filter referenced in Step 5: a key that returns nothing, or returns `confidence < ~0.9`, has no real DEX liquidity behind it.
+**Current price** (same response shape) for the Step 5 holdings snapshot:
+`https://coins.llama.fi/prices/current/$DL_NS:<tokenLower>`. Treat `confidence`
+as price-source reliability. Missing/low-confidence data requires
+corroboration; it is not a deterministic scam or liquidity verdict.
 
 Caveats — surface them in the report when they bite:
 
-- **Newer chains may be absent.** DefiLlama indexes Celo well; Monad and other recent chains may have no coin data. If a key returns nothing, fall back to Sim's spot `value_usd` and say so in the report rather than silently reporting a zero.
+- Coverage is token-specific even on supported chains. If a key returns
+  nothing, corroborate with Sim and venue liquidity and disclose the pricing
+  gap rather than silently reporting zero.
 - `coins.llama.fi` is not on the default sandbox network allowlist. It's a read-only public GET — allowlist the host or run the single command unsandboxed.
 
 ### Step 6 — Why \_\_\_, why these venues
 
 Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
 
-**Name the venue, don't guess it.** Resolve any non-Mento pool or token the target touched via two free, no-key APIs — turns "an unknown pool" into "USDC/CELO 0.01% on Uniswap V3 Celo, $X TVL". GeckoTerminal covers Celo + many EVM chains but **not Monad** (its `$GT_NS` arm stays empty for Monad — that's correct, skip it); DexScreener is the broader fallback there:
+**Name the venue, don't guess it.** Resolve any non-Mento pool or token through
+two free APIs. Both GeckoTerminal and DexScreener cover the current target
+chains; verify their network lists before trusting a negative.
 
 ```bash
 # GeckoTerminal + DexScreener each use their OWN network slugs (NOT chain ids) — select both per $CHAIN
 # in one switch, like $BS in Step 4. Verify against api.geckoterminal.com/api/v2/networks and
-# DexScreener's docs (a chain may be on one but not the other — GeckoTerminal has no Monad, DexScreener does).
+# DexScreener's docs (a chain may be on one but not the other).
 case "$CHAIN" in
   celo)     GT_NS=celo;        DS_NS=celo ;;
-  monad)    GT_NS="";          DS_NS=monad ;;     # GeckoTerminal: no Monad; DexScreener: yes (verify slug)
+  monad)    GT_NS=monad;       DS_NS=monad ;;
   polygon)  GT_NS=polygon_pos; DS_NS=polygon ;;
   ethereum) GT_NS=eth;         DS_NS=ethereum ;;
   *)        GT_NS=""; DS_NS=""; echo "No GeckoTerminal/DexScreener slug mapped for $CHAIN — verify their network lists, then set GT_NS/DS_NS or skip." >&2 ;;
 esac
-[ -n "$GT_NS" ] && curl -s "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"   # → pair, dex, reserve_usd, vol24h (30 req/min); skipped when no GT slug
+[ -n "$GT_NS" ] && curl -s -H 'accept: application/json;version=20230302' "https://api.geckoterminal.com/api/v2/networks/$GT_NS/pools/{poolAddr}"
 [ -n "$DS_NS" ] && curl -s "https://api.dexscreener.com/token-pairs/v1/$DS_NS/{tokenAddr}"           # chain-scoped: pairs for this token on $CHAIN only; skipped when no DS slug
 # The chain-scoped token-pairs/v1 endpoint avoids the old /latest/dex/tokens form, which returned the
 # token's pairs on ALL chains and risked naming a different chain's venue/TVL for a same-address token.
 ```
 
 (Use `networks/$GT_NS/tokens/{addr}` for token price/FDV in Steps 5/5.5 too. Set `GT_NS` to match `$CHAIN` — GeckoTerminal uses its own slugs, so confirm against `/api/v2/networks` rather than assuming the chain name.)
+GeckoTerminal's public limit is approximately 10 requests/minute; pace and
+cache lookups rather than treating rate-limit responses as empty coverage.
 
-**MEV classification across chains.** The Celo MEV-detection ecosystem is thin (EigenPhi/zeromev are Ethereum-only). Two moves: (a) borrow their **taxonomy** (arb / sandwich / backrun / JIT / liquidation) as vocabulary and derive the classification yourself from the indexer + Dune's unified `dex.trades` spellbook filtered `WHERE blockchain = '$DUNE_NS'` (it's ONE cross-chain table with a `blockchain` column — there is no per-chain `celo.dex.trades`; group by `tx_hash`, detect ≥2-leg cycles, cross-project legs, sandwich via `block_number` ordering); (b) if the operator runs the same strategy on Ethereum/L2s, run it through EigenPhi/zeromev **there** (cross-chain identity leg) and cite the classification as corroboration. See the Tooling matrix.
+**MEV classification across chains.** Borrow the standard taxonomy (arb /
+sandwich / backrun / JIT / liquidation), then derive the classification from
+the indexer and Dune's unified `dex.trades` table filtered by `blockchain`.
+Group cycles by transaction. For sandwiches, use a curated sandwich dataset
+where supported; otherwise prove ordering with transaction position, event
+index, and trace evidence—block number alone cannot order transactions. Use an
+Ethereum/L2 EigenPhi or zeromev result only as cross-chain corroboration.
 
 ### Step 7 — Coverage and dead ends
 
@@ -623,12 +710,17 @@ Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 
 End the report with a **provenance footer** so mutable-state reads are reproducible (this lives in the markdown body — the report JSON has no field for it, and the API silently drops unknown keys):
 
 ```
-_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>. Investigation date: YYYY-MM-DD._
+_Provenance: <chain> head block <N> (hash <0x…>), RPC <endpoint>, cast <version>. Sim/DefiLlama queried <UTC ts>._
+
+_Investigation date: YYYY-MM-DD._
 ```
 
 ### Step 10 — Push to production (only on user confirmation)
 
-By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the same atomic Lua upsert pattern the API route uses (the simplified non-CAS variant — see the Output section) — never split-read-modify-write, which races the editor and any other skill invocation.
+By default the skill stops at the local draft and asks the user to review. On
+`--upload` (or explicit equivalent), use the dashboard route's exact CAS Lua
+upsert. Never use an older last-writer-wins copy or a split
+read-modify-write sequence.
 
 Keep `mcp__upstash__redis_database_run_redis_commands` out of repo-shared auto-allow lists. The MCP approval prompt is the production write guard for this path.
 
@@ -669,52 +761,20 @@ const partial = {
   body,
   ...(title ? { title: title.slice(0, 200) } : {}),
   authorEmail: AUTHOR_EMAIL, // from git config user.email at runtime
-  source: "claude", // already in the AddressReport enum
+  source: "claude", // the Claude mirror uses "claude"
 };
 ```
 
-**Write it via Lua EVAL** (atomic — the same upsert pattern as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`, minus the optimistic-concurrency `expectedVersion` check; this skill always wins and returns the bare encoded payload):
+**Write it via the owner implementation.** Immediately before uploading, HGET
+the current record again and derive its normalized base version: `""` for a
+create-only write, otherwise the positive integer version (`1` for a
+legacy/invalid stored version). Copy the current `UPSERT_SCRIPT` from
+`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns normalization,
+the expected-version check, and the response envelope.
 
 ```js
-const UPSERT_SCRIPT = `
-local key = KEYS[1]
-local addr = ARGV[1]
-local payload = cjson.decode(ARGV[2])
-local now = ARGV[3]
-
-local existing = redis.call('HGET', key, addr)
-local prior = nil
-if existing then
-  prior = cjson.decode(existing)
-end
-
-payload.createdAt = (prior and prior.createdAt) or now
-payload.updatedAt = now
--- Mirror upsertReport()'s read-side version normalization. A true first write
--- (no prior record) is version 1. cjson.decode maps JSON null to cjson.null
--- (truthy in Lua), so a legacy/partial {"version": null} must be normalized,
--- not propagated into arithmetic (which would crash the EVAL). Such records
--- read as version 1 in JS, so normalize missing/invalid/<=0 to 1 here too —
--- coercing to 0 would write version 1 over an existing record and regress the
--- version the editor's optimistic-concurrency (CAS) path expects.
-local priorVersion = 0
-if prior then
-  priorVersion = prior.version
-  if type(priorVersion) ~= 'number' or priorVersion <= 0 then
-    priorVersion = 1
-  else
-    priorVersion = math.floor(priorVersion)
-  end
-end
-payload.version = priorVersion + 1
-
-local encoded = cjson.encode(payload)
-redis.call('HSET', key, addr, encoded)
-return encoded
-`;
-
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [
     [
       "EVAL",
@@ -724,23 +784,21 @@ mcp__upstash__redis_database_run_redis_commands({
       addrLower,
       JSON.stringify(partial),
       new Date().toISOString(),
+      expectedVersion, // "" for create-only; otherwise the fresh base version
     ],
   ],
 });
 ```
 
-The script returns the persisted record (already JSON-encoded). It handles every edge case the dashboard data layer handles:
-
-- `createdAt` preserved when updating; stamped fresh on first write
-- `updatedAt` always = now
-- `version` — first write (no prior) is `1`; updates increment. A legacy/partial prior whose `version` is missing/non-numeric/≤0 normalizes to `1` (matching `upsertReport()`'s read-side normalization), so the next write is `2` — never regressing the version the editor's CAS path expects, and never crashing on `cjson.null`
-- Atomic per write and version stays monotonic — **but it is last-writer-wins on the body** (this variant has no `expectedVersion` precondition), so an editor save made between this skill's Step-1 read and the EVAL is silently overwritten. The editor's own CAS path will reject ITS now-stale save, but this skill never loses the race. If a hand-edited report might be in flight, re-read immediately before upload, or upload via the editor route instead.
+Parse the returned `{ok, report}` envelope. If `ok !== true`, stop, show the
+version conflict, re-read the editor's newer report, and ask before reconciling;
+never retry with a new base version automatically.
 
 **Verify:**
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  database_id: DATABASE_ID,
   commands: [["HGET", "reports", addrLower]],
 });
 ```
@@ -761,39 +819,41 @@ Tag inline, e.g. **Operator EOA** `0x…` **[PROBABLE: codehash + funder]**. A c
 
 - `body`: required, non-empty, ≤ 50,000 characters (50KB)
 - `title`: optional, ≤ 200 characters, dropped if empty after trim
-- `source`: always set `"claude"` from this skill; the API also accepts other provenance values
+- `source`: `"Codex"` in this canonical skill and `"claude"` in its Claude mirror
 - `version`: starts at 1, increments on each write; preserve `createdAt` from the prior write if updating
 
 These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/address-reports-shared.ts`. If those constants change, mirror the changes here — the skill must not write a payload the API would reject on a manual edit.
 
 ## Tooling matrix (by chain + leg)
 
-Pick the tool that covers the chain you're on and the leg you're working. **A blank in the Celo column does not mean "useless"** — it means use that source on the cross-chain identity leg (operator EOA on Ethereum/L2s) or on another supported target chain such as Polygon. Coverage notes below were web-verified 2026-06-15; re-check before relying on a negative.
+Pick the tool that covers the chain and investigation leg. **A blank in the
+Celo column does not mean "useless"**—it may still serve the cross-chain
+identity leg. Provider coverage changes; re-check before relying on a negative.
 
 **On-chain behaviour leg — Celo/Monad/Polygon-native (free, the workhorses):**
 
-| Source                       | Celo              | Monad | Access            | Answers                                                                        |
-| ---------------------------- | ----------------- | ----- | ----------------- | ------------------------------------------------------------------------------ |
-| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6)                    |
-| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | call tree + state-changes + tx/address data (Step 4)                           |
-| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`                     |
-| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                                    |
-| GeckoTerminal                | ✅                | ❌    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6); no Monad — use DexScreener there |
-| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                                           |
-| DefiLlama coins              | ✅                | ⚠️    | free, no key      | historical + current USD price (Step 5.5)                                      |
-| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                                       |
-| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**                          |
-| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                                        |
+| Source                       | Celo              | Monad | Access            | Answers                                                     |
+| ---------------------------- | ----------------- | ----- | ----------------- | ----------------------------------------------------------- |
+| Mento Envio indexer          | ✅                | ✅    | free, no key      | per-address Mento swaps/rebalances/LP/CDP/bridge (Step 1.6) |
+| Blockscout v2 REST/MCP       | ✅                | —     | free, no key      | flat internal calls + raw state changes (Step 4)            |
+| Dune `celo.*`/`monad.*`      | ✅                | ✅    | existing Dune key | funder graph, fleet clustering, fingerprints, `dex.trades`  |
+| Sim (Dune Sim)               | ✅                | ✅    | existing key      | real-time balances/activity                                 |
+| GeckoTerminal                | ✅                | ✅    | free, no key      | pool/token → dex, pair, TVL, volume (Step 6)                |
+| DexScreener                  | ✅                | ✅    | free, no key      | token → all pairs, liquidity, volume                        |
+| DefiLlama coins              | ✅                | ✅    | free, no key      | historical + current USD price when the token is covered    |
+| Sourcify                     | ✅                | ✅    | free, no key      | verified source (Step 3)                                    |
+| `cast` vs forno              | ✅                | n/a   | free              | storage/getter reads, codehash — **no trace methods**       |
+| Dedaub / heimdall / WhatsABI | bytecode-agnostic |       | free / OSS        | decompile unverified contracts (Step 3)                     |
 
 **Cross-chain identity leg — Celo-blind but valuable on the operator's other-chain footprint:**
 
-| Source              | Celo | Where it works        | Access                     | Use                                               |
-| ------------------- | ---- | --------------------- | -------------------------- | ------------------------------------------------- |
-| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live (key expired) | entity/persona of operator EOA                    |
-| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)             | labels/Smart-Money on the identity leg + Monad    |
-| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                  | MEV classification of operator's ETH strategy     |
-| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)             | labels incl. Celo — only if free paths fall short |
-| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier           | non-Mento DEX history (Envio covers Mento first)  |
+| Source              | Celo | Where it works        | Access                      | Use                                               |
+| ------------------- | ---- | --------------------- | --------------------------- | ------------------------------------------------- |
+| Arkham (cache)      | ❌   | ETH + most L2s        | cache / live when available | entity/persona of operator EOA                    |
+| Nansen              | ❌   | ETH/L2s; Monad labels | paid ($49+/mo)              | labels/Smart-Money on the identity leg + Monad    |
+| EigenPhi / zeromev  | ❌   | ETH (+BSC)            | free/paid                   | MEV classification of operator's ETH strategy     |
+| MetaSleuth/BlockSec | ✅\* | many chains           | paid ($599/mo)              | labels incl. Celo — only if free paths fall short |
+| The Graph subgraphs | ⚠️   | per-subgraph          | paid + free tier            | non-Mento DEX history (Envio covers Mento first)  |
 
 **Bridge leg:**
 
@@ -819,11 +879,11 @@ Pick the tool that covers the chain you're on and the leg you're working. **A bl
 
 ## Reference: production database
 
-The database id is non-secret. If the address-book database is replaced or
-split, update this value from Terraform or the Upstash console before writing.
+Discover the opaque database id at runtime by exact name (`address-labels`).
+Terraform owns the database; this skill owns only the `reports` hash workflow.
 
 ```
-database_id: c687bf0d-f61f-498e-879a-016de335b4ce
+database name: address-labels
 hash:        reports
 key shape:   <lowercase 0x address>
 value shape: JSON-stringified AddressReport (see schema above)
@@ -831,18 +891,13 @@ value shape: JSON-stringified AddressReport (see schema above)
 
 The `address-labels` Upstash database also holds the `labels` hash (custom address labels) and `minipay:*` keys (the MiniPay tagging cron's bookkeeping). Don't touch those from this skill.
 
-## Worked example
+## Tone reference
 
-The seed report — `0xb64c8b0a3F8008d5028D8F9323b858F17b18C3C4` (Arbitrage Executor / `idontloseiwin.eth`) — is the canonical reference. If a section feels under-specified above, look at how that section is written in the production hash:
-
-```js
-mcp__upstash__redis_database_run_redis_commands({
-  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
-  commands: [["HGET", "reports", "0xb64c8b0a3f8008d5028d8f9323b858f17b18c3c4"]],
-});
-```
-
-Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the nine named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
+Existing production reports can help calibrate an evidence-anchored,
+plain-language tone, but they are historical data and may predate this
+contract. `template.md` is the sole structural authority. Never copy a seed
+report's facts, section omissions, provider assumptions, or provenance into a
+new investigation.
 
 ## Rules
 

--- a/.claude/skills/forensic-report/SKILL.md
+++ b/.claude/skills/forensic-report/SKILL.md
@@ -766,11 +766,40 @@ const partial = {
 ```
 
 **Write it via the owner implementation.** Immediately before uploading, HGET
-the current record again and derive its normalized base version: `""` for a
-create-only write, otherwise the positive integer version (`1` for a
-legacy/invalid stored version). Copy the current `UPSERT_SCRIPT` from
-`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns normalization,
-the expected-version check, and the response envelope.
+the current record again. Capture the unwrapped HGET value as `currentValue`;
+abort on malformed JSON instead of treating it as an absent report. Derive the
+exact expected-version argument before invoking EVAL:
+
+```js
+const current =
+  currentValue == null
+    ? null
+    : typeof currentValue === "string"
+      ? JSON.parse(currentValue)
+      : currentValue;
+if (
+  current !== null &&
+  (typeof current !== "object" || Array.isArray(current))
+) {
+  throw new Error("stored report is not an object — refusing to upload");
+}
+
+const storedVersion = current?.version;
+const expectedVersion =
+  current === null
+    ? "" // create-only: fail if another writer creates it first
+    : String(
+        typeof storedVersion === "number" &&
+          Number.isFinite(storedVersion) &&
+          storedVersion > 0
+          ? Math.floor(storedVersion)
+          : 1, // legacy, missing, null, or invalid versions normalize to 1
+      );
+```
+
+Copy the current `UPSERT_SCRIPT` from
+`ui-dashboard/src/lib/address-reports.ts` exactly; that file owns the matching
+server-side normalization, expected-version check, and response envelope.
 
 ```js
 mcp__upstash__redis_database_run_redis_commands({

--- a/.claude/skills/forensic-report/template.md
+++ b/.claude/skills/forensic-report/template.md
@@ -1,3 +1,15 @@
+---
+title: Forensic Report Output Template
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-23
+doc_type: skill
+scope: repo-wide
+review_interval_days: 90
+garden_lane: agent-entry-points
+---
+
 # `0xADDRESS_CASE_PRESERVED` — Display Name (persona/ENS if known)
 
 ## TL;DR
@@ -19,7 +31,10 @@ Roles are descriptive, not fixed. Add or drop rows to match the topology. For an
 
 ## Related addresses / fleet
 
-The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5). Each link carries the evidence and a confidence tier — never a bare assertion. Omit this section only if clustering found nothing, and say so in one line rather than dropping the heading.
+The operator's other contracts/EOAs surfaced by clustering (skill Step 2.5).
+Each link carries evidence and a confidence tier—never a bare assertion. Always
+keep this heading. If clustering found nothing, replace the table with one
+evidence-backed sentence saying so.
 
 | Address | Link type                         | Evidence                                            | Confidence |
 | ------- | --------------------------------- | --------------------------------------------------- | ---------- |
@@ -56,7 +71,8 @@ status: ok / sometimes error
 
 - Selector `0x…` (custom — not in 4byte/OpenChain — / matched on OpenChain → name it)
 - Calldata shape: [N dynamic arrays of (tokens, pools, amounts, swap-data, dexIds, minOuts, deadline)] OR [structured args: …]
-- Revert rate: ~N% (normal arb-sniping miss rate / unusual)
+- Revert rate: ~N%, measured over `<window>`; interpret against this chain's
+  ordering model rather than assuming an Ethereum-style baseline
 - Permissioning: [allowlist / open / signature-gated]
 
 ## Capital and scale
@@ -66,7 +82,9 @@ Principal wallet `0x…` holdings on chain `<CHAIN_ID>` (the chain you investiga
 - **`<amount>` `<TOKEN>`** (~$`<usd>` notional) — note any token with dual-native semantics (e.g. CELO is both native gas + ERC20)
 - $`<usd>` stablecoin (split by stablecoin if it matters: USDC / USDT / DAI / chain-native cUSD-cEUR-etc.)
 - `<list any meaningful additional holdings>`
-- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is — filter via DefiLlama price-presence / `confidence`, see skill Step 5.5, not by token name)
+- Unpriced or low-confidence assets listed separately as requiring
+  corroboration. DefiLlama price presence/confidence is evidence quality, not a
+  deterministic scam or liquidity verdict.
 
 Estimated **operating capital ≈ $`<usd>`** (value time-sensitive flows at block time via DefiLlama historical prices — skill Step 5.5 — not current spot). Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
 
@@ -84,14 +102,15 @@ Connect the behaviour to the on-chain economics — don't just describe, explain
 
 One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTED` with a one-line why. The `EMPTY` (covers this chain, found nothing) vs `NOT-COVERED` (can't see this chain) distinction is the whole point — don't collapse them.
 
-| Source                | Result      | Note                                                          |
-| --------------------- | ----------- | ------------------------------------------------------------- |
-| Arkham (cache / live) | NOT-COVERED | Celo/Monad not indexed; operator EOA on covered chains: `<…>` |
-| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`                           |
-| Sim / Dune            | HIT         | `<…>`                                                         |
-| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead                               |
-| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list)                   |
-| `<…>`                 | `<…>`       | `<…>`                                                         |
+| Source                | Result      | Note                                        |
+| --------------------- | ----------- | ------------------------------------------- |
+| Arkham (target chain) | NOT-COVERED | target chain not indexed (when true)        |
+| Arkham (identity leg) | HIT / EMPTY | operator EOA on supported chains: `<…>`     |
+| Mento Envio indexer   | HIT / EMPTY | `<N SwapEvents, isProtocolActor=…>`         |
+| Sim / Dune            | HIT         | `<…>`                                       |
+| Sourcify / Celoscan   | EMPTY       | unverified — decompiled instead             |
+| Sanctions screen      | EMPTY       | not OFAC-listed (Celo oracle + static list) |
+| `<…>`                 | `<…>`       | `<…>`                                       |
 
 **Top alternative hypothesis considered** (skill Step 8.5): `<e.g. MM rebalancer rather than arb bot>` — rejected because `<disconfirming evidence>`.
 
@@ -99,7 +118,12 @@ One row per source attempted — `HIT` / `EMPTY` / `NOT-COVERED` / `NOT-ATTEMPTE
 
 ## Bottom line
 
-Five bullets, one sentence each. The LITERAL placeholder text is below — replace every value with what you actually found. Do NOT ship the placeholders. The skill's worked-example section (`SKILL.md` → "Worked example") points at the seed report's real bottom line for tone calibration; this template stays placeholder-only so a fresh investigation that copy-pastes blindly doesn't accidentally persist seed facts about a different address.
+Five bullets, one sentence each. The LITERAL placeholder text is below—replace
+every value with what you actually found. Do not ship the placeholders. The
+skill's "Tone reference" explains how historical production reports may be used
+without treating them as structural authority; this template remains
+placeholder-only so a fresh investigation cannot persist another target's
+facts.
 
 - **Who**: `<persona / entity, one sentence — who's behind this address>` `[CONFIRMED / PROBABLE / POSSIBLE]`
 - **What**: `<contract type / behavioural class, one sentence — what does it do>`

--- a/.claude/skills/monorepo-import/SKILL.md
+++ b/.claude/skills/monorepo-import/SKILL.md
@@ -5,7 +5,7 @@ title: Monorepo Import Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-26
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -32,14 +32,17 @@ Inspect both the source system and this repo before proposing a layout:
   roots/backends, secrets, scheduled jobs, scripts, docs, and live endpoints
 - existing repo roots and ownership boundaries: `aegis/`, `alerts/`,
   `terraform/`, `metrics-bridge/`, `indexer-envio/`, `ui-dashboard/`,
-  `shared-config/`
+  `shared-config/`, `integration-probes/`, and `governance-watchdog/`
 - existing root scripts, package filters, CI path filters, dependency-cruiser
   boundaries, AGENTS files, README/docs/runbooks
 - current deploy owners: App Engine, Cloud Functions, Terraform, Vercel, Envio,
-  Grafana, QuickNode, Sentry, Slack/Discord
+  Grafana, QuickNode, Sentry, Slack, and the governance watchdog's
+  Discord/Telegram delivery
 
-Do not treat a directory name as authority. For example, `terraform/alerts` is
-the Grafana v3 rule plane, not a generic bucket for every alert-related system.
+Do not treat a directory name as authority. For example, `alerts/rules/` owns
+Grafana rules/routing while `alerts/infra/` owns event-driven delivery; neither
+is a generic bucket for every alert-related system. Use
+`terraform.stacks.json` for Terraform ownership.
 
 ## Phase 2: Choose The Smallest Layout
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -44,24 +44,43 @@ gh→MCP mapping lives in
 ## Preflight
 
 1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
-2. Fetch the base branch:
-
-```bash
-git fetch origin main:refs/remotes/origin/main
-if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-  git fetch --unshallow origin
-  git fetch origin main:refs/remotes/origin/main
-fi
-```
-
-3. Inspect branch, dirty state, commits, and PR state:
+2. Resolve the target before fetching or pushing. If the user supplied a PR
+   URL/number, pass that exact value to `gh pr view`; it overrides local branch
+   discovery. Otherwise query open PRs for the current branch and require zero
+   or one result:
 
 ```bash
 git branch --show-current
+gh pr view <explicit-pr-url-or-number> \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+# No explicit target:
+gh pr list --head <current-branch> --state open \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+```
+
+Do not discard lookup errors. A failed GitHub query is not evidence that no PR
+exists. Verify the resolved PR URL belongs to this repository. For an existing
+PR, identify a git remote whose URL matches the PR's base repository and carry
+its name as `BASE_REMOTE`; identify the head repository separately as
+`HEAD_REMOTE` and carry `headRefName` as `HEAD_REF`.
+
+3. Fetch the resolved base:
+
+```bash
+BASE_REF=<baseRefName> # use main only when there is no existing PR
+git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  git fetch --unshallow "$BASE_REMOTE"
+  git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
+fi
+```
+
+4. Inspect dirty state, commits, and ancestry against that exact base:
+
+```bash
 git status --short
-git log origin/main..HEAD --oneline
-git merge-base --is-ancestor origin/main HEAD
-gh pr view --json number,url,state,isDraft,baseRefName 2>/dev/null
+git log "$BASE_REMOTE/$BASE_REF"..HEAD --oneline
+git merge-base --is-ancestor "$BASE_REMOTE/$BASE_REF" HEAD
 ```
 
 In a Claude cloud session, replace the `gh pr view` lookup with
@@ -69,12 +88,15 @@ In a Claude cloud session, replace the `gh pr view` lookup with
 PR number is known); the git commands run unchanged.
 
 Hard stop on `main` or `master`. The shallow-repository guard prevents hosted
-depth-1 checkouts from producing a false ancestry failure. If
-`git merge-base --is-ancestor origin/main HEAD` still fails, the branch is
-missing commits from current `origin/main`; merge or rebase before pushing
-unless you intentionally created a fresh branch from that same fetched base. If
-unrelated dirty changes are mixed with the intended scope, stop and ask before
-staging anything.
+depth-1 checkouts from producing a false ancestry failure. If an open PR exists,
+its repository, `headRefName`, and `headRefOid` are the push target and starting
+commit. Before creating the ship commit, verify local `HEAD` equals that OID.
+If intended commits already exist locally, require the PR OID to be their
+ancestor and inspect the intervening range. Never infer the target from the
+local branch name. If the branch is missing current base commits, merge
+`"$BASE_REMOTE/$BASE_REF"` into an already-published PR branch; rebase is only
+acceptable before first publication. If unrelated dirty changes are mixed with
+the intended scope, stop and ask before staging anything.
 
 ## Review And Validation
 
@@ -93,65 +115,11 @@ pnpm agent:quality-gate --run
 pnpm agent:autoreview
 ```
 
-The repo-local helper reviews the complete branch-local target without
-truncation. Direct semantic engines fail closed if the target needs more than
-one prompt; prepared bundles retain bounded lossless passes that one
-fresh-context reviewer must inspect completely.
-Semantic engines run from an isolated empty workspace with restricted project
-configuration and environment; sensitive inputs fail closed. Direct
-supplemental evidence must be repo-relative, except for adapter-generated PR
-feedback and protected-main checklist copies inside its trusted bundle
-directory. The owning-checkout default semantic helper and automatic feedback
-run Node modules pinned from that same `origin/main` object, not a PR-selected
-base, mutable worktree, or reviewed package scripts; wrapper-owned Node launches
-discard `NODE_OPTIONS` and `NODE_PATH`.
-Reviewer web search is off by default and requires explicit `--web-search`.
-A quiet reviewer emits a
-60-second heartbeat. Do not pass the removed `--parallel-tests` option; the
-quality gate owns test execution.
-
-If direct semantic execution refuses a multi-pass target, run
-`pnpm agent:autoreview --prepare-bundle-dir <dir>` with a directory outside the
-worktree whose parent already exists. Every canonical parent ancestor must be
-owned by the current user or root; group/other-writable ancestors require
-sticky-bit protection. On macOS, write-granting ACLs on parent ancestors or
-bundle entries fail preparation or verification. Have one fresh-context reviewer
-inspect every pass listed by the bundle index. Run
-`pnpm agent:autoreview --verify-bundle-dir <dir>` immediately before review and
-retain its printed digest outside the bundle. After review, rerun with
-`--expected-bundle-manifest <retained-digest>`; both checks must pass with the
-same digest.
-
-If the change edits the executable autoreview runtime and the owning checkout
-refuses with `executable autoreview runtime differs from its trusted pre-change
-snapshot`, keep that refusal intact. From the reviewed checkout, invoke a clean,
-detached, protocol-compatible wrapper/helper from the last independently
-reviewed pre-change commit (or protected main when it is compatible):
-
-```bash
-reviewed_checkout=/absolute/path/to/reviewed-checkout
-trusted_checkout=/absolute/path/to/trusted-pre-change-checkout
-bundle_parent=/tmp/autoreview-runtime-review
-mkdir -p "$bundle_parent"
-(
-  cd "$reviewed_checkout"
-  AUTOREVIEW_HELPER="$trusted_checkout/scripts/agent-autoreview.mjs" \
-    "$trusted_checkout/scripts/agent-autoreview.sh" \
-    --prepare-bundle-dir "$bundle_parent/context-bundle" \
-    --mode auto --base origin/main --feedback-pr <number>
-)
-"$trusted_checkout/scripts/agent-autoreview.sh" \
-  --verify-bundle-dir "$bundle_parent/context-bundle"
-```
-
-Use that same trusted wrapper for the bound post-review manifest check. Never
-point either path at the runtime-changing checkout, and never invoke that
-checkout's package scripts to bootstrap the review.
-
-Inside an active Codex sandbox, the adapter may choose the local deterministic
-engine only when no engine was explicitly selected. An explicitly selected
-unavailable semantic engine, or a missing repo helper, is a hard stop: report
-the blocker rather than silently substituting local or current-session review.
+`docs/notes/agent-quality-gate-mechanics.md` owns engine selection, trusted
+bundle preparation/verification, runtime-change refusal handling, and the
+source-review boundary. Follow that note instead of copying its volatile
+adapter internals into this skill. An explicitly selected unavailable engine or
+missing helper is a hard stop.
 
 Verify accepted findings before editing. Classify scope growth as in-scope,
 follow-up, or stop, create an issue before deferring valid follow-up work, warn
@@ -172,10 +140,17 @@ change (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, or `refactor:`).
 git status --short
 git add <intended-files>
 git commit -m "<prefix>: <summary>"
+# New PR branch:
 git push -u origin HEAD
+
+# Existing PR branch:
+git push "$HEAD_REMOTE" HEAD:"$HEAD_REF"
 ```
 
-Never force-push or amend unless the user explicitly requests it.
+For an existing PR, the remote must resolve to the PR's `headRepositoryOwner`
+and `headRepository`; do not assume it is `origin`. Re-read the PR after the
+push and require `headRefOid == git rev-parse HEAD` before babysitting. Never
+force-push or amend unless the user explicitly requests it.
 
 ## PR
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -59,15 +59,17 @@ gh pr list --head <current-branch> --state open \
 ```
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
-exists. Verify the resolved PR URL belongs to this repository. For an existing
-PR, identify a git remote whose URL matches the PR's base repository and carry
-its name as `BASE_REMOTE`; identify the head repository separately as
-`HEAD_REMOTE` and carry `headRefName` as `HEAD_REF`.
+exists. Verify the resolved PR URL belongs to this repository and carry its
+base slug as `BASE_REPO`. For an existing PR, identify a git remote whose URL
+matches that base repository and carry its name as `BASE_REMOTE`; identify the
+head repository separately as `HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`,
+and carry `headRefName` as `HEAD_REF`. With no existing PR, verify `origin`
+matches the current repository, then set `BASE_REMOTE=origin`,
+`HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
 
 3. Fetch the resolved base:
 
 ```bash
-BASE_REF=<baseRefName> # use main only when there is no existing PR
 git fetch "$BASE_REMOTE" "$BASE_REF:refs/remotes/$BASE_REMOTE/$BASE_REF"
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
   git fetch --unshallow "$BASE_REMOTE"
@@ -141,7 +143,7 @@ git status --short
 git add <intended-files>
 git commit -m "<prefix>: <summary>"
 # New PR branch:
-git push -u origin HEAD
+git push -u "$HEAD_REMOTE" HEAD:"$HEAD_REF"
 
 # Existing PR branch:
 git push "$HEAD_REMOTE" HEAD:"$HEAD_REF"
@@ -203,15 +205,16 @@ Include this marker when practical:
 
 ## Post-Push
 
-Run the shared readiness probe before calling the PR clean:
+Follow the operating card's Babysit and Ready-state steps. Before calling the PR
+clean, run the feedback projection first and the readiness projection second:
 
 ```bash
-pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json
+pnpm --silent pr:feedback-state --pr <number> --repo "$BASE_REPO" --json
+pnpm pr:ready-state --pr <number> --repo "$BASE_REPO" --json
 ```
 
-Always pass `--repo` bound to the base repository: without it the probe infers
-the repo from the checkout, which inspects the wrong same-number PR on fork
-PRs or repo-bound checkouts.
+Always bind `--repo` to the base repository; checkout inference can inspect the
+wrong same-number PR on fork PRs or repo-bound checkouts.
 
 In a Claude cloud session without the Surface Detection capability exception,
 the probe cannot run; use the `babysit-pr` skill's cloud watch loop (MCP

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -75,12 +75,28 @@ gh pr list --repo "$BASE_REPO" --head "$CURRENT_BRANCH" --state open \
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
 exists. Carry the resolved PR URL's owner/repository as `BASE_REPO`. For an
-existing PR, identify a git remote whose URL matches that base repository and
-carry its name as `BASE_REMOTE`; identify the head repository separately as
-`HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`, and carry `headRefName` as
-`HEAD_REF`. With no existing PR, verify `origin` matches `CURRENT_REPO`, then set
-`BASE_REMOTE=origin`,
-`HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
+existing PR, identify the head repository separately and require a configured
+remote that matches it; carry that name as `HEAD_REMOTE`, `baseRefName` as
+`BASE_REF`, and `headRefName` as `HEAD_REF`. Stop if the PR head repository has
+no matching push remote. With no existing PR, verify `origin` matches
+`CURRENT_REPO`, then set `HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF`
+to the current branch.
+
+For every path, identify a configured remote whose URL matches `BASE_REPO` and
+carry its name as `BASE_REMOTE`. Never substitute a fork's `origin` for its
+parent repository. If no remote matches, add the parent as `upstream`; do not
+overwrite or retarget an existing remote:
+
+```bash
+if [ -z "$BASE_REMOTE" ]; then
+  if git remote get-url upstream >/dev/null 2>&1; then
+    echo "upstream exists but does not match $BASE_REPO" >&2
+    exit 1
+  fi
+  git remote add upstream "https://github.com/${BASE_REPO}.git"
+  BASE_REMOTE=upstream
+fi
+```
 
 3. Fetch the resolved base:
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -44,27 +44,42 @@ gh→MCP mapping lives in
 ## Preflight
 
 1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
-2. Resolve the target before fetching or pushing. If the user supplied a PR
-   URL/number, pass that exact value to `gh pr view`; it overrides local branch
-   discovery. Otherwise query open PRs for the current branch and require zero
-   or one result:
+2. Resolve the checkout repository and its upstream base before querying PRs.
+   A fork checkout uses its parent as `BASE_REPO`; a non-fork uses itself:
 
 ```bash
-git branch --show-current
-gh pr view <explicit-pr-url-or-number> \
+CURRENT_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+BASE_REPO=$(gh repo view --json nameWithOwner,parent \
+  --jq '.parent.nameWithOwner // .nameWithOwner')
+HEAD_OWNER=${CURRENT_REPO%%/*}
+CURRENT_BRANCH=$(git branch --show-current)
+```
+
+If the user supplied a PR URL, pass that exact URL to `gh pr view`; its
+owner/repository overrides the inferred base. For a bare PR number, bind the
+lookup to `BASE_REPO`. With no explicit target, query `BASE_REPO` by branch,
+then filter same-named fork branches by `headRepositoryOwner`; require zero or
+one result after filtering:
+
+```bash
+gh pr view <explicit-pr-url> \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+gh pr view <explicit-pr-number> --repo "$BASE_REPO" \
   --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
 # No explicit target:
-gh pr list --head <current-branch> --state open \
-  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner
+gh pr list --repo "$BASE_REPO" --head "$CURRENT_BRANCH" --state open \
+  --json number,url,state,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner \
+  | jq --arg owner "$HEAD_OWNER" \
+    '[.[] | select(.headRepositoryOwner.login == $owner)]'
 ```
 
 Do not discard lookup errors. A failed GitHub query is not evidence that no PR
-exists. Verify the resolved PR URL belongs to this repository and carry its
-base slug as `BASE_REPO`. For an existing PR, identify a git remote whose URL
-matches that base repository and carry its name as `BASE_REMOTE`; identify the
-head repository separately as `HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`,
-and carry `headRefName` as `HEAD_REF`. With no existing PR, verify `origin`
-matches the current repository, then set `BASE_REMOTE=origin`,
+exists. Carry the resolved PR URL's owner/repository as `BASE_REPO`. For an
+existing PR, identify a git remote whose URL matches that base repository and
+carry its name as `BASE_REMOTE`; identify the head repository separately as
+`HEAD_REMOTE`, carry `baseRefName` as `BASE_REF`, and carry `headRefName` as
+`HEAD_REF`. With no existing PR, verify `origin` matches `CURRENT_REPO`, then set
+`BASE_REMOTE=origin`,
 `HEAD_REMOTE=origin`, `BASE_REF=main`, and `HEAD_REF` to the current branch.
 
 3. Fetch the resolved base:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain
                                           Grafana Alloy / Cloud
 ```
 
-`config.multichain.mainnet.yaml` configures a single Envio project (`mento`) for Celo Mainnet (42220), Monad Mainnet (143), Polygon Mainnet (137), and Ethereum reserve-yield events (1). Polygon becomes live at the static endpoint after the normal indexer deploy, sync verification, and promotion workflow. Pool IDs are namespaced as `{chainId}-{address}` to prevent cross-chain collisions. Ethereum reserve-yield indexing is event-only; the historical sUSDS onBlock heartbeat is not registered in the hosted indexer.
+`config.multichain.mainnet.yaml` configures a single Envio project (`mento`) for Celo Mainnet (42220), Monad Mainnet (143), Polygon Mainnet (137), and Ethereum reserve-yield events (1). Polygon is live at the static production endpoint after completing the normal deploy, sync verification, promotion, and producer checks. Pool IDs are namespaced as `{chainId}-{address}` to prevent cross-chain collisions. Ethereum reserve-yield indexing is event-only; the historical sUSDS onBlock heartbeat is not registered in the hosted indexer.
 
 `metrics-bridge` retains its indexed Hasura poller and owns an isolated peg
 lifecycle. When the protected policy artifact is configured, that loop combines
@@ -51,7 +51,7 @@ conversion views before exporting bounded Prometheus gauges.
 | ------------- | -------- | --------------------------------------------------------------------- |
 | Celo Mainnet  | 42220    | Live in the production multichain indexer                             |
 | Monad Mainnet | 143      | Live in the production multichain indexer                             |
-| Polygon       | 137      | Configured in the production multichain indexer                       |
+| Polygon       | 137      | Live in the production multichain indexer                             |
 | Ethereum      | 1        | Live in the production multichain indexer — reserve-yield events only |
 | Celo Sepolia  | 11142220 | Hosted dashboard support is opt-in via testnet env vars               |
 | Monad Testnet | 10143    | Hosted dashboard support is opt-in via testnet env vars               |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,10 +26,10 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`.agents/skills/deploy-indexer/SKILL.md`](../.agents/skills/deploy-indexer/SKILL.md) | Deploy Indexer Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`.agents/skills/doc-garden/SKILL.md`](../.agents/skills/doc-garden/SKILL.md) | Documentation Garden Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`.agents/skills/envio/SKILL.md`](../.agents/skills/envio/SKILL.md) | Envio Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
-| [`.agents/skills/forensic-report/SKILL.md`](../.agents/skills/forensic-report/SKILL.md) | Forensic Report Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-06-15 |
-| [`.agents/skills/forensic-report/template.md`](../.agents/skills/forensic-report/template.md) | 0xADDRESS_CASE_PRESERVED — Display Name (persona/ENS if known) | unmanaged / unmanaged | skill / repo-wide | unowned | 90d |
-| [`.agents/skills/monorepo-import/SKILL.md`](../.agents/skills/monorepo-import/SKILL.md) | Monorepo Import Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-05-26 |
-| [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md) | Ship Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/forensic-report/SKILL.md`](../.agents/skills/forensic-report/SKILL.md) | Forensic Report Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`.agents/skills/forensic-report/template.md`](../.agents/skills/forensic-report/template.md) | Forensic Report Output Template | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`.agents/skills/monorepo-import/SKILL.md`](../.agents/skills/monorepo-import/SKILL.md) | Monorepo Import Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md) | Ship Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`.claude/agents/dashboard-explorer.md`](../.claude/agents/dashboard-explorer.md) | Dashboard Explorer | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
 | [`.claude/agents/indexer-explorer.md`](../.claude/agents/indexer-explorer.md) | Indexer Explorer | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
 | [`.claude/agents/infra-reader.md`](../.claude/agents/infra-reader.md) | Infra Reader | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
@@ -71,7 +71,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md) | Documentation gardening | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/github-tooling-surfaces.md`](notes/github-tooling-surfaces.md) | GitHub Tooling Surfaces — gh CLI vs MCP | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md) | Hasura isolation trigger | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
-| [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-operating-card.md`](notes/pr-operating-card.md) | PR Operating Card | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |

--- a/docs/notes/polygon-monitoring.md
+++ b/docs/notes/polygon-monitoring.md
@@ -3,7 +3,7 @@ title: Polygon monitoring coverage and rollout
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -152,6 +152,14 @@ must not guess them. Stuck bridge-transfer paging is tracked in #1362.
 
 ## Rollout order and proof
 
+The initial production cutover passed its data-producer boundary on 2026-07-23:
+Envio production deployment `b5d14b7` served all three Polygon pools and four
+active strategy rows at the static endpoint, metrics-bridge exposed exactly
+three `mento_pool_health_status{chain_id="137"}` series, and Aegis recorded
+successful Polygon view calls. Polygon is therefore live in the production
+indexer and producer telemetry. Dashboard and alert-state verification remain
+separate checks in steps 7-8.
+
 The code being merged is configuration, not proof that production has already
 cut over. The `Polygon Pool Coverage Incomplete` rule intentionally treats no
 data as alerting after 10 minutes, and the per-chain Aegis liveness rule does
@@ -193,8 +201,9 @@ Roll out in this order:
    exercise alert delivery only through the repository's documented safe test
    path.
 
-Until the static endpoint and producer checks in steps 4-5 pass, `Configured`
-is the correct status; do not describe Polygon as live.
+For every future cutover or rollback, use `Configured` until the static endpoint
+and producer checks in steps 4-5 pass. Do not infer liveness from configuration
+or sync alone.
 
 ### Rollback order
 

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -38,8 +38,9 @@ All child entities (`poolId` FKs) follow the same format.
 
 `indexer-envio/config.multichain.mainnet.yaml` — covers Ethereum (1)
 sUSDS/stETH reserve-yield accounting, Celo (42220), Monad (143), and Polygon
-(137). Polygon is configured here and becomes production-visible only after the
-normal deploy, sync verification, and promotion workflow completes.
+(137). Polygon is live at the static production endpoint; future replacements
+still require the normal deploy, sync verification, semantic verification, and
+promotion workflow.
 
 Git release branch: `envio` — push to this branch to trigger a redeployment.
 


### PR DESCRIPTION
## The Problem

- Nine agent-facing documents contained stale provider, production, tooling, or repository details.
- The ship and autoreview entry points duplicated owner contracts and could lose the exact PR target across repositories or branches.
- The generated garden packet needed an evidence-backed disposition for every file and an updated catalog.

## The Solution

Audit the complete shard against current code, provider contracts, repository workflows, and read-only production evidence. Update or tighten each document, keep skill mirrors aligned, and route volatile detail to its canonical owner.

## Details

### Packet dispositions

| Document | Disposition | Evidence |
| --- | --- | --- |
| `.agents/skills/forensic-report/SKILL.md` | Update | Checked current Envio, RPC, Upstash, Sim, Arkham, Dune, DefiLlama, GeckoTerminal, and Blockscout contracts. Corrected chain/RPC coverage, pagination, CAS updates, evidence limits, sUSDS/stETH coverage, and report provenance. |
| `.agents/skills/forensic-report/template.md` | Update | Made the template the canonical report structure, required every section, split identity from behavior evidence, and corrected confidence and revert-rate guidance. |
| `.agents/skills/monorepo-import/SKILL.md` | Update | Verified current package roots, `terraform.stacks.json` ownership, alert delivery, integration probes, and governance-watchdog routing. |
| `.agents/skills/ship/SKILL.md` | Tighten | Preserved current surface routing while binding the base repository, base/head remotes, branch refs, and head OID. Existing PR pushes now use the exact head refspec; readiness stays feedback-first and base-repo-bound. |
| `.claude/agents/dashboard-explorer.md` | Update | Routed to dashboard instructions and the current SWR/Hasura checklist; removed stale snapshot counts, line numbers, and legacy GraphQL assumptions. |
| `.claude/agents/indexer-explorer.md` | Tighten | Routed to indexer instructions and handler invariants; removed volatile inventory and timeout claims, and scoped RPC/import and `allSettled` rules to their actual boundaries. |
| `.claude/agents/infra-reader.md` | Update | Verified the Terraform stack registry, current Slack versus Discord/Telegram ownership, script aliases, bootstrap flow, and mutation jobs. |
| `.claude/claude-security-guidance.md` | Tighten | Updated plugin scope, secret names, registered backends, notification ownership, and error-handling guidance without expanding permissions. |
| `.claude/commands/autoreview.md` | Tighten | Replaced duplicated adapter internals with a thin command shim to the quality-gate owner note, PR operating card, and surface-routing contract. |

The `.claude/skills` mirrors stay aligned with their `.agents/skills` owners.
The catalog was regenerated from source metadata.

Read-only production checks directly proved that Polygon is live rather than
still awaiting cutover: Envio deployment `b5d14b7` had chain 137 caught up,
the production GraphQL endpoint returned three Polygon pools and four active
liquidity strategies, Grafana exposed three Polygon pool-health series, and
the 10-minute successful Polygon view-call count was 495. The root network
summary, indexer status, and Polygon runbook now record that state while keeping
dashboard and alert rollout as separate gates.

The nine packet files now total 14,769 words by `wc -w`, down from the frozen
packet's 14,790. No packet file was deleted or silently omitted.

Closes #1516

## Validation

- `CI=true pnpm agent:quality-gate --run` — all 10 mapped commands passed after merging current `origin/main` `f28c8a60`, including indexer codegen, frozen install, Trunk, metadata/catalog checks, mirror checks, lint, typecheck, coverage, knip, and dependency-cruiser. The first sandboxed retry failed only because the sandbox denied the shared `.git/info/exclude` read and loopback test ports; the required unsandboxed run passed.
- `pnpm docs:index --write` and `pnpm docs:index --check` — catalog regenerated and clean.
- `pnpm agent:context-check` and `pnpm agent:context-budget --strict` — passed; root context remains at the existing 93.3% warning level.
- `pnpm docs:navigation-eval --check-fixtures` — all 18 navigation fixtures passed.
- `pnpm agent:autoreview --engine local --base origin/main` — deterministic review clean.
- Fresh-context Codex-native review — the final feedback batch passed with pre/post manifest `28797db5da37e65e1e93140cf33ade9f9d47d0e5f28d22ac5663a9957a9b9e13`; three Codex P2 findings were fixed in `4393f57a` and `2103e214`, replied to, and resolved.
- Read-only Envio, GraphQL, and Grafana checks — Polygon production evidence above confirmed.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1519 — add a runtime-safe metadata carrier for Claude runtime documents that cannot accept generic context frontmatter.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this changes documentation and workflow guidance without choosing a new system architecture.

## Ship Checklist

- [x] ship skill used
- [x] local review and mapped gate run
- [x] PR readiness probe planned
