### PR TITLE
fix(tooling): make gate interrupt cleanup race-safe

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -133,15 +133,10 @@ parallel pool because it temporarily mutates tracked fixture files; this keeps
 source-fingerprinting tests such as autoreview from observing synthetic drift.
 A browser setup failure still lets independent lint/typecheck/unit/knip
 feedback run. `--fail-fast` stays sequential so it still stops before starting
-the next mapped command. Each parallel worker runs in a dedicated process group
-created with stock Bash job control, which works on both macOS Bash 3.2 and
-Linux without `setsid(1)`. The parent defers INT/TERM handling across worker
-launch and process-group registration. On interruption it signals every
-registered group with TERM, then KILL after the normal grace period, and reaps
-the group leaders. This still reaches descendants when a worker leader has
-already exited and the descendants have reparented. A mapped command that
-explicitly creates a new session or process group could escape this boundary;
-none of the mapped commands do so.
+the next mapped command. Parallel workers use Bash job-control groups on macOS
+Bash 3.2 and Linux. INT/TERM waits for PGID registration; teardown TERM→KILLs
+each group and reaps its leader after descendants reparent. New sessions can
+escape (none of the mapped commands create one).
 
 Two manifest-class changes are narrowed away from the full workspace suite
 instead of escalating unconditionally (Refs #1414). Every ambiguity fails toward
@@ -660,17 +655,12 @@ exemption: its command string embeds the run's temporary changed-paths file
 path, so its stamp key never matches a prior run (fail-safe — an advisory,
 self-suppressing check that only ever over-runs).
 
-Every mapped command runs under a per-command watchdog so no single check can
-hang forever. A command that runs longer than the timeout (default 900 seconds,
-override with `--command-timeout <n>` or `AGENT_QUALITY_COMMAND_TIMEOUT_SECONDS`)
-has its process tree signalled (TERM, then KILL after a short grace; a
-self-daemonizing child that reparents away from the tree can escape — no
-mapped command does this) and
-is reported as an ordinary failure — `Command timed out after <n>s: <command>`,
-logged with status `fail` in the durations log. The timeout is strictly
-per command; it never bounds the whole run. Parent interruption of the parallel
-pool uses the registered worker process groups described above, so that path
-does not depend on finding descendants below a still-live worker PID.
+Each mapped command has a watchdog (default 900 seconds; override with
+`--command-timeout <n>` or `AGENT_QUALITY_COMMAND_TIMEOUT_SECONDS`). On timeout
+it TERM→KILLs the process tree, reports
+`Command timed out after <n>s: <command>`, and logs durations status `fail`. A
+self-daemonizing child can escape the tree (none do). The timeout never bounds
+the whole run.
 
 Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
 local dashboard browser tests, and dashboard React Doctor checks run through

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -133,7 +133,15 @@ parallel pool because it temporarily mutates tracked fixture files; this keeps
 source-fingerprinting tests such as autoreview from observing synthetic drift.
 A browser setup failure still lets independent lint/typecheck/unit/knip
 feedback run. `--fail-fast` stays sequential so it still stops before starting
-the next mapped command.
+the next mapped command. Each parallel worker runs in a dedicated process group
+created with stock Bash job control, which works on both macOS Bash 3.2 and
+Linux without `setsid(1)`. The parent defers INT/TERM handling across worker
+launch and process-group registration. On interruption it signals every
+registered group with TERM, then KILL after the normal grace period, and reaps
+the group leaders. This still reaches descendants when a worker leader has
+already exited and the descendants have reparented. A mapped command that
+explicitly creates a new session or process group could escape this boundary;
+none of the mapped commands do so.
 
 Two manifest-class changes are narrowed away from the full workspace suite
 instead of escalating unconditionally (Refs #1414). Every ambiguity fails toward
@@ -660,7 +668,9 @@ self-daemonizing child that reparents away from the tree can escape — no
 mapped command does this) and
 is reported as an ordinary failure — `Command timed out after <n>s: <command>`,
 logged with status `fail` in the durations log. The timeout is strictly
-per command; it never bounds the whole run.
+per command; it never bounds the whole run. Parent interruption of the parallel
+pool uses the registered worker process groups described above, so that path
+does not depend on finding descendants below a still-live worker PID.
 
 Package-local gate tasks for `lint`, `typecheck`, `knip`, dashboard size-limit,
 local dashboard browser tests, and dashboard React Doctor checks run through

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -259,16 +259,26 @@ timeout_seq=0
 # PIDs (command + watchdog) of any in-flight timed command in THIS process, so a
 # wrapper SIGINT/SIGTERM tears them down instead of leaking the watchdog's
 # background sleeps. Sequential commands run in the gate process; parallel
-# members run in their own `&` subshells, each maintaining its own copy — which
-# the parent's signal traps cannot see, so the parallel pool ALSO registers its
-# worker subshell PIDs in active_worker_pids below.
+# members run in their own process-group worker subshells, each maintaining its
+# own copy — which the parent's signal traps cannot see.
 active_timeout_pids=()
 
-# Worker subshell PIDs of the in-flight parallel pool, maintained by the pool's
-# parent loop. A SIGTERM-ignoring mapped command inside a worker would survive
-# a gate interrupt if teardown only signalled active_timeout_pids (which are
-# empty in the parent during --parallel runs).
-active_worker_pids=()
+# Process-group IDs of the in-flight parallel workers. Non-interactive Bash job
+# control gives each worker a dedicated group whose ID equals its leader PID.
+# Group tracking survives the leader exiting and descendants reparenting, unlike
+# a process-tree walk rooted at that leader.
+active_worker_pgids=()
+
+# A signal can arrive after Bash creates a parallel worker but before the parent
+# records its process group. Defer INT/TERM handling across that short registry
+# update, then replay the first pending signal after the group is reachable.
+worker_registration_in_progress=0
+pending_terminating_signal=""
+worker_registration_test_barrier="${AGENT_QUALITY_GATE_TEST_WORKER_REGISTRATION_BARRIER:-}"
+if [[ -n "$worker_registration_test_barrier" && "${NODE_ENV:-}" != "test" ]]; then
+  echo "AGENT_QUALITY_GATE_TEST_WORKER_REGISTRATION_BARRIER: test-only override requires NODE_ENV=test" >&2
+  exit 2
+fi
 
 kill_process_tree() {
   local pid="$1"
@@ -294,34 +304,43 @@ collect_process_tree() {
 
 teardown_active_timeouts() {
   local pid
-  local -a roots=(
-    "${active_timeout_pids[@]+"${active_timeout_pids[@]}"}"
-    "${active_worker_pids[@]+"${active_worker_pids[@]}"}"
-  )
+  local pgid
+  local -a roots=("${active_timeout_pids[@]+"${active_timeout_pids[@]}"}")
+  local -a worker_pgids=("${active_worker_pgids[@]+"${active_worker_pgids[@]}"}")
   active_timeout_pids=()
-  active_worker_pids=()
-  [[ ${#roots[@]} -gt 0 ]] || return 0
+  active_worker_pgids=()
+  [[ -n "${roots[*]-}" || -n "${worker_pgids[*]-}" ]] || return 0
   # Snapshot every descendant BEFORE signalling: TERM kills intermediate
   # subshells first, which reparents a SIGTERM-ignoring survivor away from the
   # tree, so a post-TERM re-walk would miss it. The KILL pass targets the
-  # saved pid list, not a fresh walk.
+  # saved pid list, not a fresh walk. Parallel workers do not need a snapshot:
+  # their registered process groups remain addressable after reparenting.
   local -a tree=()
-  for pid in "${roots[@]}"; do
+  for pid in "${roots[@]+"${roots[@]}"}"; do
     while IFS= read -r child_pid; do
       [[ -n "$child_pid" ]] && tree+=("$child_pid")
     done < <(collect_process_tree "$pid")
   done
-  [[ ${#tree[@]} -gt 0 ]] || return 0
-  for pid in "${tree[@]}"; do
+  for pid in "${tree[@]+"${tree[@]}"}"; do
     kill "-TERM" "$pid" 2>/dev/null || true
+  done
+  for pgid in "${worker_pgids[@]+"${worker_pgids[@]}"}"; do
+    kill -TERM -- "-$pgid" 2>/dev/null || true
   done
   # Same TERM-then-KILL grace as run_with_timeout's watchdog: a manual
   # interrupt (Ctrl-C/TERM to the gate) must not leave a SIGTERM-ignoring
   # mapped command (or descendant) running just because it wasn't the
   # timeout path that tore it down.
   sleep 3
-  for pid in "${tree[@]}"; do
+  for pid in "${tree[@]+"${tree[@]}"}"; do
     kill "-KILL" "$pid" 2>/dev/null || true
+  done
+  for pgid in "${worker_pgids[@]+"${worker_pgids[@]}"}"; do
+    kill -KILL -- "-$pgid" 2>/dev/null || true
+    # The group leader is the direct child the gate can reap. If it already
+    # exited, wait returns immediately; the negative-PGID signals above still
+    # reached any surviving reparented descendants.
+    wait "$pgid" 2>/dev/null || true
   done
 }
 
@@ -335,9 +354,35 @@ trap cleanup_tmpfiles EXIT
 
 on_terminating_signal() {
   local signal="$1"
+  if [[ "$worker_registration_in_progress" -eq 1 ]]; then
+    [[ -n "$pending_terminating_signal" ]] ||
+      pending_terminating_signal="$signal"
+    return 0
+  fi
+  trap '' INT TERM
   teardown_active_timeouts
   trap - "$signal"
   kill "-${signal}" "$$" 2>/dev/null || exit 143
+}
+
+finish_worker_registration() {
+  local signal
+  worker_registration_in_progress=0
+  if [[ -n "$pending_terminating_signal" ]]; then
+    signal="$pending_terminating_signal"
+    pending_terminating_signal=""
+    on_terminating_signal "$signal"
+  fi
+}
+
+drain_worker_process_group() {
+  local pgid="$1"
+  if kill -0 -- "-$pgid" 2>/dev/null; then
+    kill -TERM -- "-$pgid" 2>/dev/null || true
+    sleep 3
+    kill -KILL -- "-$pgid" 2>/dev/null || true
+  fi
+  wait "$pgid" 2>/dev/null || true
 }
 trap 'on_terminating_signal INT' INT
 trap 'on_terminating_signal TERM' TERM
@@ -3117,6 +3162,7 @@ run_mapped_entries_parallel() {
   local timed_out
   local phase_start_ts last_heartbeat_ts now_ts hb_cmd
   local heartbeat_interval=20
+  local had_monitor=0
 
   if [[ "$total" -eq 0 ]]; then
     return
@@ -3152,14 +3198,43 @@ run_mapped_entries_parallel() {
 
       echo
       echo "+ ${command}"
-      run_mapped_command_to_files "$command" "$output_file" "$status_file" "$elapsed_file" "$timeout_file" &
+      worker_registration_in_progress=1
+      had_monitor=0
+      case "$-" in
+        *m*) had_monitor=1 ;;
+      esac
+      # macOS has no setsid(1). Bash job control is available in stock Bash
+      # 3.2 and gives this background worker a dedicated process group whose ID
+      # is the worker PID, so the parent can tear down the group after the
+      # leader exits or its descendants reparent.
+      set -m
+      (
+        # The parent needs monitor mode only to create this worker group. Turn
+        # it back off inside the worker so run_with_timeout's command and
+        # watchdog children stay in that group instead of becoming new jobs.
+        set +m
+        run_mapped_command_to_files \
+          "$command" "$output_file" "$status_file" "$elapsed_file" "$timeout_file"
+      ) </dev/null &
       pid="$!"
+      if [[ "$had_monitor" -eq 0 ]]; then
+        set +m
+      fi
+
+      # Private deterministic barrier for the signal-registration regression.
+      # It is inert unless the test suite opts in.
+      if [[ -n "$worker_registration_test_barrier" ]]; then
+        if [[ ! -e "${worker_registration_test_barrier}.ready" ]]; then
+          printf '%s\n' "$pid" > "${worker_registration_test_barrier}.ready"
+        fi
+        while [[ ! -e "${worker_registration_test_barrier}.release" ]]; do
+          sleep 0.05 || true
+        done
+      fi
 
       active_pids+=("$pid")
-      # Mirror into the signal-trap teardown set so an interrupt reaches the
-      # worker's whole tree (the worker-local active_timeout_pids are invisible
-      # to the parent's traps).
-      active_worker_pids+=("$pid")
+      active_worker_pgids+=("$pid")
+      finish_worker_registration
       active_commands+=("$command")
       active_output_files+=("$output_file")
       active_status_files+=("$status_file")
@@ -3193,6 +3268,10 @@ run_mapped_entries_parallel() {
       if ! wait "$pid"; then
         :
       fi
+      # A worker normally leaves an empty group because run_with_timeout reaps
+      # its command and watchdog. If the leader exited unexpectedly, drain any
+      # surviving same-group descendants before unregistering the PGID.
+      drain_worker_process_group "$pid"
 
       command="${active_commands[$i]}"
       output_file="${active_output_files[$i]}"
@@ -3226,7 +3305,7 @@ run_mapped_entries_parallel() {
     done
 
     active_pids=("${next_active_pids[@]+"${next_active_pids[@]}"}")
-    active_worker_pids=("${next_active_pids[@]+"${next_active_pids[@]}"}")
+    active_worker_pgids=("${next_active_pids[@]+"${next_active_pids[@]}"}")
     active_commands=("${next_active_commands[@]+"${next_active_commands[@]}"}")
     active_output_files=("${next_active_output_files[@]+"${next_active_output_files[@]}"}")
     active_status_files=("${next_active_status_files[@]+"${next_active_status_files[@]}"}")

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4088,74 +4088,236 @@ STUB
 )
 rm -rf "$command_interrupt_repo"
 
-# PR 1492 review: with --parallel greater than 1 the timed commands' pids live
-# only inside the worker subshells, so the parent's interrupt teardown must
-# signal the tracked worker pids (active_worker_pids) or a SIGTERM-ignoring
-# mapped command survives the gate's death. TERM targets ONLY the gate pid.
-parallel_interrupt_repo="$(mktemp -d)"
-(
-  cd "$parallel_interrupt_repo"
-  git init -q
-  git config user.email test@example.invalid
-  git config user.name "Quality Gate Test"
-  mkdir -p bin scripts tools
-  printf 'console.log("fixture");\n' > scripts/agent-prewarm.mjs
-  printf 'console.log("fixture");\n' > scripts/agent-context-budget.mjs
-  cat > tools/trunk <<'STUB'
+# GitHub issue #1522: every parallel mapped command must be registered as a
+# dedicated process group before INT/TERM teardown can run. Cover both sides of
+# the original race:
+# - registration: INT lands after launch but before the parent records the PGID;
+# - execution: the worker leader dies first, so only its still-live process
+#   group can reach the reparented TERM-ignoring descendants.
+run_parallel_interrupt_regression() {
+  local phase="$1"
+  local signal="$2"
+  local expected_exit="$3"
+  local parallel_interrupt_repo
+  parallel_interrupt_repo="$(mktemp -d)"
+  (
+    cd "$parallel_interrupt_repo"
+    git init -q
+    git config user.email test@example.invalid
+    git config user.name "Quality Gate Test"
+    mkdir -p bin scripts tools
+    printf 'console.log("fixture");\n' > scripts/agent-prewarm.mjs
+    printf 'console.log("fixture");\n' > scripts/agent-context-budget.mjs
+    cat > tools/trunk <<'STUB'
 #!/usr/bin/env bash
-exit 0
+if [[ "${QG_FAST_RUN:-0}" == "1" ]]; then
+  exit 0
+fi
+exec qg-par-victim
 STUB
-  cat > bin/qg-par-victim <<'STUB'
+    cat > bin/qg-par-descendant <<'STUB'
 #!/usr/bin/env bash
 trap '' TERM
+printf '%s\n' "$$" > "${QG_DESCENDANT_PID_FILE:?}"
 while :; do sleep 1; done
 STUB
-  cat > bin/pnpm <<'STUB'
+    cat > bin/qg-par-victim <<'STUB'
 #!/usr/bin/env bash
-if [[ "$*" == "agent:prewarm:test" ]]; then
-  exec qg-par-victim
-fi
-if [[ "$*" == "agent:context-budget:test" ]]; then
-  exec sleep 45
-fi
-exit 0
+trap '' TERM
+printf '%s\n' "$$" > "${QG_VICTIM_PID_FILE:?}"
+qg-par-descendant &
+wait
 STUB
-  chmod +x bin/pnpm bin/qg-par-victim tools/trunk
-  git add .
-  git commit -qm init
-  printf 'scripts/agent-prewarm.mjs\nscripts/agent-context-budget.mjs\n' > changed-paths.txt
-  set +e
-  PATH="$parallel_interrupt_repo/bin:$PATH" \
-    "$repo_root/scripts/agent-quality-gate.sh" \
-      --changed-paths-file changed-paths.txt \
-      --base HEAD \
-      --run \
-      --parallel 2 \
-      > "$output_file" 2>&1 &
-  gate_pid=$!
-  waited=0
-  until pgrep -f "qg-par-victim" >/dev/null 2>&1; do
-    sleep 1
-    waited=$((waited + 1))
-    if [[ "$waited" -ge 20 ]]; then
-      kill -KILL "$gate_pid" 2>/dev/null
-      pkill -KILL -f "qg-par-victim" 2>/dev/null
-      fail "parallel interrupt fixture never started its victim"
+    cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+if [[ "${QG_FAST_RUN:-0}" == "1" ]]; then
+  exit 0
+fi
+exec sleep 45
+STUB
+    chmod +x bin/pnpm bin/qg-par-victim bin/qg-par-descendant tools/trunk
+    git add .
+    git commit -qm init
+    printf 'scripts/agent-prewarm.mjs\nscripts/agent-context-budget.mjs\n' > changed-paths.txt
+
+    local barrier="$parallel_interrupt_repo/registration"
+    local gate_output="$parallel_interrupt_repo/gate-output"
+    local next_gate_output="$parallel_interrupt_repo/next-gate-output"
+    local victim_pid_file="$parallel_interrupt_repo/victim.pid"
+    local descendant_pid_file="$parallel_interrupt_repo/descendant.pid"
+    local gate_pid=""
+    local next_gate_pid=""
+    local worker_pgid=""
+    local victim_pid=""
+    local descendant_pid=""
+    local launched=0
+    local settled=0
+    local attempt
+    local interrupt_exit
+    local next_gate_exit
+
+    # Invoked indirectly by the EXIT trap below.
+    # shellcheck disable=SC2329
+    cleanup_parallel_interrupt_fixture() {
+      if [[ "$worker_pgid" =~ ^[1-9][0-9]*$ ]]; then
+        kill -KILL -- "-$worker_pgid" 2>/dev/null || true
+      fi
+      if [[ "$gate_pid" =~ ^[1-9][0-9]*$ ]]; then
+        kill -CONT "$gate_pid" 2>/dev/null || true
+        kill -KILL "$gate_pid" 2>/dev/null || true
+        wait "$gate_pid" 2>/dev/null || true
+      fi
+      if [[ "$next_gate_pid" =~ ^[1-9][0-9]*$ ]]; then
+        kill -KILL "$next_gate_pid" 2>/dev/null || true
+        wait "$next_gate_pid" 2>/dev/null || true
+      fi
+    }
+    fail_parallel_interrupt_fixture() {
+      cp "$gate_output" "$output_file" 2>/dev/null || true
+      fail "$*"
+    }
+    trap cleanup_parallel_interrupt_fixture EXIT
+
+    if [[ "$phase" == "execution" ]]; then
+      : > "${barrier}.release"
     fi
-  done
-  kill -TERM "$gate_pid" 2>/dev/null
-  wait "$gate_pid"
-  parallel_interrupt_exit=$?
-  set -e
-  [[ "$parallel_interrupt_exit" -ne 0 ]] ||
-    fail "expected the gate to exit nonzero when interrupted during the parallel pool"
-  sleep 5
-  if pgrep -f "qg-par-victim" >/dev/null 2>&1; then
-    pkill -KILL -f "qg-par-victim" 2>/dev/null || true
-    fail "interrupted parallel gate left a SIGTERM-ignoring worker command running"
-  fi
-)
-rm -rf "$parallel_interrupt_repo"
+
+    QG_VICTIM_PID_FILE="$victim_pid_file" \
+      QG_DESCENDANT_PID_FILE="$descendant_pid_file" \
+      NODE_ENV=test \
+      AGENT_QUALITY_GATE_TEST_WORKER_REGISTRATION_BARRIER="$barrier" \
+      PATH="$parallel_interrupt_repo/bin:$PATH" \
+      /usr/bin/perl -e \
+        '$SIG{INT} = "DEFAULT"; $SIG{TERM} = "DEFAULT"; exec @ARGV; die "exec failed: $!\n";' \
+        /bin/bash "$repo_root/scripts/agent-quality-gate.sh" \
+          --changed-paths-file changed-paths.txt \
+          --base HEAD \
+          --run \
+          --parallel 2 \
+          > "$gate_output" 2>&1 &
+    gate_pid=$!
+
+    for ((attempt = 0; attempt < 200; attempt++)); do
+      if [[
+        -s "${barrier}.ready" &&
+          -s "$victim_pid_file" &&
+          -s "$descendant_pid_file"
+      ]]; then
+        launched=1
+        break
+      fi
+      if ! kill -0 "$gate_pid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.05
+    done
+    [[ "$launched" -eq 1 ]] ||
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt fixture never reached its worker"
+
+    worker_pgid="$(cat "${barrier}.ready")"
+    victim_pid="$(cat "$victim_pid_file")"
+    descendant_pid="$(cat "$descendant_pid_file")"
+    [[ "$worker_pgid" =~ ^[1-9][0-9]*$ ]] ||
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt fixture recorded an invalid worker PGID"
+    kill -0 -- "-$worker_pgid" 2>/dev/null ||
+      fail_parallel_interrupt_fixture \
+        "parallel $phase worker did not launch in a dedicated process group"
+
+    if [[ "$phase" == "registration" ]]; then
+      # The gate is blocked after worker launch and before registry insertion.
+      # The signal must remain pending until the PGID is registered.
+      kill "-$signal" "$gate_pid"
+      sleep 0.2 || true
+      : > "${barrier}.release"
+    else
+      # Freeze the parent with the group registered, remove only the group
+      # leader, then interrupt the parent. A PID-tree snapshot rooted at the
+      # dead leader cannot find the surviving group members.
+      sleep 0.2
+      kill -STOP "$gate_pid"
+      kill -KILL "$worker_pgid"
+      sleep 0.1
+      kill "-$signal" "$gate_pid"
+      kill -CONT "$gate_pid"
+    fi
+
+    for ((attempt = 0; attempt < 300; attempt++)); do
+      if ! jobs -pr | grep -Fxq "$gate_pid"; then
+        settled=1
+        break
+      fi
+      sleep 0.05
+    done
+    [[ "$settled" -eq 1 ]] ||
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt did not terminate the gate within 15s"
+
+    set +e
+    wait "$gate_pid"
+    interrupt_exit=$?
+    set -e
+    gate_pid=""
+    [[ "$interrupt_exit" -eq "$expected_exit" ]] ||
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt exited $interrupt_exit, expected $expected_exit"
+
+    for ((attempt = 0; attempt < 100; attempt++)); do
+      if ! kill -0 -- "-$worker_pgid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.05
+    done
+    if kill -0 -- "-$worker_pgid" 2>/dev/null; then
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt left the registered worker group running"
+    fi
+    if kill -0 "$victim_pid" 2>/dev/null ||
+      kill -0 "$descendant_pid" 2>/dev/null; then
+      fail_parallel_interrupt_fixture \
+        "parallel $phase interrupt left a TERM-ignoring descendant running"
+    fi
+    worker_pgid=""
+
+    # The interrupted run must leave no process that a later gate can inherit
+    # or join. Run the same plan with fast fixtures and bound its completion.
+    QG_FAST_RUN=1 \
+      PATH="$parallel_interrupt_repo/bin:$PATH" \
+      /bin/bash "$repo_root/scripts/agent-quality-gate.sh" \
+        --changed-paths-file changed-paths.txt \
+        --base HEAD \
+        --run \
+        --parallel 2 \
+        > "$next_gate_output" 2>&1 &
+    next_gate_pid=$!
+    settled=0
+    for ((attempt = 0; attempt < 200; attempt++)); do
+      if ! jobs -pr | grep -Fxq "$next_gate_pid"; then
+        settled=1
+        break
+      fi
+      sleep 0.05
+    done
+    [[ "$settled" -eq 1 ]] ||
+      fail_parallel_interrupt_fixture \
+        "gate after parallel $phase interrupt did not finish cleanly within 10s"
+    set +e
+    wait "$next_gate_pid"
+    next_gate_exit=$?
+    set -e
+    next_gate_pid=""
+    [[ "$next_gate_exit" -eq 0 ]] ||
+      fail_parallel_interrupt_fixture \
+        "gate after parallel $phase interrupt exited $next_gate_exit"
+
+    trap - EXIT
+  )
+  rm -rf "$parallel_interrupt_repo"
+}
+
+run_parallel_interrupt_regression registration INT 130
+run_parallel_interrupt_regression execution TERM 143
 
 # PR 1492 review: prerequisite commands (install/codegen/setup) produce outputs
 # the source fingerprint cannot see, so they must never be stamped or reused —


### PR DESCRIPTION
## The Problem

- Ctrl-C or TERM could kill a parallel gate worker before the parent captured
  its descendants, leaving the mapped command running after the gate exited.
- A later gate could then encounter work left by the interrupted run.

## The Solution

Each parallel mapped command now runs in a dedicated process group that the
parent registers before handling a pending cancellation signal. Interrupt
cleanup addresses the group directly, so it still reaches descendants after
the worker leader exits and they reparent.

## Details

- Uses stock Bash job control instead of `setsid(1)`, preserving support for
  macOS Bash 3.2 and Linux.
- Defers INT/TERM across the launch-to-registration window, then replays the
  first pending signal after the group is registered.
- Sends TERM, waits through the existing grace period, sends KILL, and reaps
  each group leader. Normal worker completion also drains an unexpectedly
  non-empty group before unregistering it.
- Keeps monitor mode disabled inside the worker so the mapped command and its
  watchdog remain in the registered group; preserves the prior `/dev/null`
  background stdin behavior.
- Adds deterministic regressions for interruption during registration and for
  teardown after the registered worker leader has already died. Both cases
  prove descendants are gone and a subsequent gate finishes cleanly.
- Leaves mapped-check selection, timeout policy, stamps, sequential behavior,
  and parallel-pool accounting unchanged.

## Validation

- `CI=true pnpm agent:quality-gate --run` — passed; self-test 3m48s,
  targeted Trunk 10s, docs/context and Bash syntax checks passed.
- `CI=true pnpm lint:scripts` — passed.
- `CI=true pnpm docs:navigation-eval:test` — passed 33/33; the changed mechanics
  note is 44,843 bytes against the 45,000-byte route budget.
- `CI=true pnpm agent:autoreview --engine local --mode branch --base origin/main`
  — clean on the final merged source.
- Fresh-context immutable autoreview — clean; pre/post manifest
  `f6fa2dc6a118462b52ab68389d02ce394c3c39ac94a87a81ea1c49bc558c7cdb`.

## Risks

- A mapped command that explicitly creates a new session or process group can
  escape the worker boundary. No mapped command does this.

## Deferrals

- #1498 remains the behavior-preserving split of the quality-gate script. This
  PR changes only interrupt cleanup semantics.

Closes #1522

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
