### PR TITLE
docs: note gated Claude Security scan is local-Claude-Code-only in ship skill

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -170,7 +170,7 @@ generated-artifact, or runtime proof; retain all applicable verification.
    onchain code. The plugin exists only in that local setup. On this adapter's
    surfaces, skip it: do not install or imitate the plugin, direct the quality
    gate and closeout review at those surfaces instead, and record
-   "Claude Security scan: skipped (<surface>)" in the final summary so the
+   `Claude Security scan: skipped (<surface>)` in the final summary so the
    user can run the deep pass from local Claude Code.
 
 ## Commit And Push

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -162,6 +162,16 @@ generated-artifact, or runtime proof; retain all applicable verification.
 3. For UI changes, follow the browser verification protocol in `AGENTS.md`.
    If browser tools are unavailable in the session, say so explicitly and do not
    claim browser verification happened.
+
+4. Deep security scan: the user's local Claude Code ship flow adds a gated
+   Claude Security plugin scan (scan-changes job) when the diff adds or
+   changes logic on a security-sensitive surface — authn/authz, secrets
+   handling, injection surfaces, network-facing handlers, deploy/CI paths, or
+   onchain code. The plugin exists only in that local setup. On this adapter's
+   surfaces, skip it: do not install or imitate the plugin, direct the quality
+   gate and closeout review at those surfaces instead, and record
+   "Claude Security scan: skipped (<surface>)" in the final summary so the
+   user can run the deep pass from local Claude Code.
 
 ## Commit And Push
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -164,15 +164,17 @@ generated-artifact, or runtime proof; retain all applicable verification.
    If browser tools are unavailable in the session, say so explicitly and do not
    claim browser verification happened.
 
-4. Deep security scan: the user's local Claude Code ship flow adds a gated
-   Claude Security plugin scan (scan-changes job) when the diff adds or
-   changes logic on a security-sensitive surface — authn/authz, secrets
-   handling, injection surfaces, network-facing handlers, deploy/CI paths, or
-   onchain code. The plugin exists only in that local setup. On this adapter's
-   surfaces, skip it: do not install or imitate the plugin, direct the quality
-   gate and closeout review at those surfaces instead, and record
+4. Deep security scan: when the diff adds or changes logic on a
+   security-sensitive surface — authn/authz, secrets handling, injection
+   surfaces, network-facing handlers, deploy/CI paths, or onchain code —
+   check whether the `claude-security` plugin's scan-changes job is available
+   in this session. The plugin is developer-installed and Claude Code only;
+   this repo does not declare it. When available, run the gated scan as the
+   user's personal ship flow does. When unavailable (Codex, hosted checkouts,
+   or no plugin), do not install or imitate it: direct the quality gate and
+   closeout review at those surfaces instead and record
    `Claude Security scan: skipped (<surface>)` in the final summary so the
-   user can run the deep pass from local Claude Code.
+   deep pass can run from a session that has the plugin.
 
 ## Commit And Push
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -170,7 +170,7 @@ generated-artifact, or runtime proof; retain all applicable verification.
    onchain code. The plugin exists only in that local setup. On this adapter's
    surfaces, skip it: do not install or imitate the plugin, direct the quality
    gate and closeout review at those surfaces instead, and record
-   "Claude Security scan: skipped (<surface>)" in the final summary so the
+   `Claude Security scan: skipped (<surface>)` in the final summary so the
    user can run the deep pass from local Claude Code.
 
 ## Commit And Push

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -162,6 +162,16 @@ generated-artifact, or runtime proof; retain all applicable verification.
 3. For UI changes, follow the browser verification protocol in `AGENTS.md`.
    If browser tools are unavailable in the session, say so explicitly and do not
    claim browser verification happened.
+
+4. Deep security scan: the user's local Claude Code ship flow adds a gated
+   Claude Security plugin scan (scan-changes job) when the diff adds or
+   changes logic on a security-sensitive surface — authn/authz, secrets
+   handling, injection surfaces, network-facing handlers, deploy/CI paths, or
+   onchain code. The plugin exists only in that local setup. On this adapter's
+   surfaces, skip it: do not install or imitate the plugin, direct the quality
+   gate and closeout review at those surfaces instead, and record
+   "Claude Security scan: skipped (<surface>)" in the final summary so the
+   user can run the deep pass from local Claude Code.
 
 ## Commit And Push
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -164,15 +164,17 @@ generated-artifact, or runtime proof; retain all applicable verification.
    If browser tools are unavailable in the session, say so explicitly and do not
    claim browser verification happened.
 
-4. Deep security scan: the user's local Claude Code ship flow adds a gated
-   Claude Security plugin scan (scan-changes job) when the diff adds or
-   changes logic on a security-sensitive surface — authn/authz, secrets
-   handling, injection surfaces, network-facing handlers, deploy/CI paths, or
-   onchain code. The plugin exists only in that local setup. On this adapter's
-   surfaces, skip it: do not install or imitate the plugin, direct the quality
-   gate and closeout review at those surfaces instead, and record
+4. Deep security scan: when the diff adds or changes logic on a
+   security-sensitive surface — authn/authz, secrets handling, injection
+   surfaces, network-facing handlers, deploy/CI paths, or onchain code —
+   check whether the `claude-security` plugin's scan-changes job is available
+   in this session. The plugin is developer-installed and Claude Code only;
+   this repo does not declare it. When available, run the gated scan as the
+   user's personal ship flow does. When unavailable (Codex, hosted checkouts,
+   or no plugin), do not install or imitate it: direct the quality gate and
+   closeout review at those surfaces instead and record
    `Claude Security scan: skipped (<surface>)` in the final summary so the
-   user can run the deep pass from local Claude Code.
+   deep pass can run from a session that has the plugin.
 
 ## Commit And Push
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 .vercel
 .env*.local
 .claude/worktrees
+.claude/projects
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
 .claude/*.jq

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`.agents/skills/forensic-report/SKILL.md`](../.agents/skills/forensic-report/SKILL.md) | Forensic Report Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-06-15 |
 | [`.agents/skills/forensic-report/template.md`](../.agents/skills/forensic-report/template.md) | 0xADDRESS_CASE_PRESERVED — Display Name (persona/ENS if known) | unmanaged / unmanaged | skill / repo-wide | unowned | 90d |
 | [`.agents/skills/monorepo-import/SKILL.md`](../.agents/skills/monorepo-import/SKILL.md) | Monorepo Import Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-05-26 |
-| [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md) | Ship Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`.agents/skills/ship/SKILL.md`](../.agents/skills/ship/SKILL.md) | Ship Skill | canonical / active | skill / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`.claude/agents/dashboard-explorer.md`](../.claude/agents/dashboard-explorer.md) | Dashboard Explorer | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
 | [`.claude/agents/indexer-explorer.md`](../.claude/agents/indexer-explorer.md) | Indexer Explorer | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
 | [`.claude/agents/infra-reader.md`](../.claude/agents/infra-reader.md) | Infra Reader | unmanaged / unmanaged | role / repo-wide | unowned | 180d |
@@ -159,6 +159,8 @@ the rules in [`context-standards.md`](context-standards.md).
 
 | Document | Title | Authority | Type / scope | Owner | Review |
 | --- | --- | --- | --- | --- | --- |
+| [`.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/f_redteam_workflow_hardens_validators.md`](../.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/f_redteam_workflow_hardens_validators.md) | f_redteam_workflow_hardens_validators.md | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
+| [`.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/p_sentry_autofix_activation_gates.md`](../.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/p_sentry_autofix_activation_gates.md) | p_sentry_autofix_activation_gates.md | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
 | [`aegis/README.md`](../aegis/README.md) | Aegis | canonical / active | reference / aegis | eng | 90d; verified 2026-07-17 |
 | [`alerts/infra/channels/slack-channels/README.md`](../alerts/infra/channels/slack-channels/README.md) | Slack Channels | canonical / active | reference / alerts/infra/channels/slack-channels | eng | 90d; verified 2026-07-17 |
 | [`alerts/infra/oncall-announcer/README.md`](../alerts/infra/oncall-announcer/README.md) | On-call Announcer | canonical / active | reference / alerts/infra/oncall-announcer | eng | 90d; verified 2026-07-17 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,8 +159,6 @@ the rules in [`context-standards.md`](context-standards.md).
 
 | Document | Title | Authority | Type / scope | Owner | Review |
 | --- | --- | --- | --- | --- | --- |
-| [`.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/f_redteam_workflow_hardens_validators.md`](../.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/f_redteam_workflow_hardens_validators.md) | f_redteam_workflow_hardens_validators.md | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
-| [`.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/p_sentry_autofix_activation_gates.md`](../.claude/projects/-Users-chapati-code-mento-monitoring-monorepo/memory/p_sentry_autofix_activation_gates.md) | p_sentry_autofix_activation_gates.md | unmanaged / unmanaged | reference / repo-wide | unowned | 180d |
 | [`aegis/README.md`](../aegis/README.md) | Aegis | canonical / active | reference / aegis | eng | 90d; verified 2026-07-17 |
 | [`alerts/infra/channels/slack-channels/README.md`](../alerts/infra/channels/slack-channels/README.md) | Slack Channels | canonical / active | reference / alerts/infra/channels/slack-channels | eng | 90d; verified 2026-07-17 |
 | [`alerts/infra/oncall-announcer/README.md`](../alerts/infra/oncall-announcer/README.md) | On-call Announcer | canonical / active | reference / alerts/infra/oncall-announcer | eng | 90d; verified 2026-07-17 |


### PR DESCRIPTION
## The Problem

- The local Claude Code ship flow now runs a gated Claude Security plugin scan when a diff adds or changes logic on a security-sensitive surface, but this repo's ship adapter never mentions it.
- Codex Cloud and hosted checkouts cannot run the plugin and had no instruction to skip it, compensate, or record the gap.

## The Solution

- Add one review step to the repo ship skill: surfaces without the plugin skip the scan, point the quality gate and closeout review at the same security surfaces, and record `Claude Security scan: skipped (<surface>)` in the final summary.

## Details

- `.claude/skills/ship/SKILL.md` and its `.agents/skills/ship/SKILL.md` mirror change identically; `last_verified` bumped to 2026-07-23.
- `.gitignore` now covers `.claude/projects` — local Claude session memory that trunk swept into the quality gate and the docs indexer briefly cataloged; `docs/README.md` regenerated accordingly.
- Docs-only; no behavior or automation changes. Autoreview skipped: trivial additive note to a skill doc.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed (docs index check, context check, skills-mirror check + test, trunk).

## Deferrals

None.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMrhNsJ5xTYE2uHi16YJaq
