### PR TITLE
docs: finish agent entry-point garden

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,10 +45,10 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`indexer-envio/AGENTS.md`](../indexer-envio/AGENTS.md) | Envio Indexer Instructions | canonical / active | agent-instructions / indexer-envio | eng | 90d; verified 2026-07-23 |
 | [`integration-probes/AGENTS.md`](../integration-probes/AGENTS.md) | Integration Probes Instructions | canonical / active | agent-instructions / integration-probes | eng | 90d; verified 2026-07-23 |
 | [`metrics-bridge/AGENTS.md`](../metrics-bridge/AGENTS.md) | Metrics Bridge Instructions | canonical / active | agent-instructions / metrics-bridge | eng | 90d; verified 2026-07-23 |
-| [`scripts/AGENTS.md`](../scripts/AGENTS.md) | Scripts Instructions | canonical / active | agent-instructions / scripts | eng | 90d; verified 2026-05-20 |
-| [`shared-config/AGENTS.md`](../shared-config/AGENTS.md) | Shared Config Instructions | canonical / active | agent-instructions / shared-config | eng | 90d; verified 2026-07-21 |
-| [`terraform/AGENTS.md`](../terraform/AGENTS.md) | Terraform Instructions | canonical / active | agent-instructions / terraform | eng | 90d; verified 2026-05-20 |
-| [`ui-dashboard/AGENTS.md`](../ui-dashboard/AGENTS.md) | Monitoring Dashboard Instructions | canonical / active | agent-instructions / ui-dashboard | eng | 90d; verified 2026-07-17 |
+| [`scripts/AGENTS.md`](../scripts/AGENTS.md) | Scripts Instructions | canonical / active | agent-instructions / scripts | eng | 90d; verified 2026-07-23 |
+| [`shared-config/AGENTS.md`](../shared-config/AGENTS.md) | Shared Config Instructions | canonical / active | agent-instructions / shared-config | eng | 90d; verified 2026-07-23 |
+| [`terraform/AGENTS.md`](../terraform/AGENTS.md) | Terraform Instructions | canonical / active | agent-instructions / terraform | eng | 90d; verified 2026-07-23 |
+| [`ui-dashboard/AGENTS.md`](../ui-dashboard/AGENTS.md) | Monitoring Dashboard Instructions | canonical / active | agent-instructions / ui-dashboard | eng | 90d; verified 2026-07-23 |
 
 ## operator-runbooks
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@ title: Scripts Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-23
 doc_type: agent-instructions
 scope: scripts
 review_interval_days: 90
@@ -12,7 +12,7 @@ garden_lane: agent-entry-points
 
 # AGENTS.md — Scripts
 
-> **Architecture decisions** behind these scripts live in [`docs/adr/`](../docs/adr/README.md) (scopes: `ci/process`, `terraform/infra`) — read the relevant ADR before changing how something here works; it records the _why_ the code can't.
+> **Architecture decisions** behind these scripts live in [`docs/adr/`](../docs/adr/README.md) — read the relevant ADR for the affected subsystem before changing how something here works; it records why the code is built that way.
 
 ## Scope
 
@@ -20,17 +20,30 @@ garden_lane: agent-entry-points
 
 ## Operating Rules
 
-- Shell scripts use `set -euo pipefail`.
+- Shell entrypoints use `set -euo pipefail`; use `set -Eeuo pipefail` when an
+  `ERR` trap needs inheritance. Source-only helpers leave shell options to their
+  caller.
 - Parse JSON with Node, jq, or structured tooling. Do not scrape JSON with grep or sed.
 - Compact/watch scripts must keep machine state and cadence metadata separate
   from human display strings. Gate emissions on stable fields, not volatile
   counters, block heights, or formatted progress lines.
-- Deploy scripts must refuse dirty working trees before mutating external systems.
-- Do not add `--no-verify` to git commands. Local hooks encode repo policy.
+- Wrappers that deploy local checkout state source
+  `scripts/lib/deploy-guard.sh` before mutation. `deploy-indexer:promote` acts
+  on a registered remote deployment; use it through the `deploy-indexer` skill
+  after its clean-tree preflight, verification, and explicit production
+  approval.
+- Do not add `--no-verify` to normal Git commands. `deploy-indexer.sh` uses it
+  only for `envio` trigger-ref pushes, which intentionally skip redundant
+  pre-push hooks; do not generalize that exception.
 - New deploy scripts must print the target, commit, and rollback or verification command before/after mutation.
-- New root scripts must be covered by `pnpm lint:scripts` or a direct test command in `scripts/agent-quality-gate.sh`.
+- New Node root scripts must be covered by `pnpm lint:scripts`; new shell scripts
+  must pass `bash -n`. Add a focused command to `scripts/agent-quality-gate.sh`
+  for behavior that syntax and lint checks cannot verify.
 
 ## Verification
 
-Run `pnpm lint:scripts`, `bash -n scripts/<changed-script>.sh`, and `pnpm agent:quality-gate:test` when quality-gate routing changes.
-For deploy-wrapper changes, also run `node scripts/check-deploy-root-anchors.test.mjs`.
+Run `pnpm agent:quality-gate --run`; its mapping adds `bash -n` for changed
+shell scripts, `pnpm lint:scripts` for changed Node root scripts, and focused
+tests for mapped utilities. Run `pnpm agent:quality-gate:test` when gate routing
+changes. For deploy-wrapper changes, also run
+`node scripts/check-deploy-root-anchors.test.mjs`.

--- a/shared-config/AGENTS.md
+++ b/shared-config/AGENTS.md
@@ -3,7 +3,7 @@ title: Shared Config Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-21
+last_verified: 2026-07-23
 doc_type: agent-instructions
 scope: shared-config
 review_interval_days: 90
@@ -12,7 +12,7 @@ garden_lane: agent-entry-points
 
 # AGENTS.md — Shared Config
 
-> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `shared-config`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `shared-config`) — read the relevant ADR before changing how something here is built; it records why the code is built that way.
 
 ## Scope
 
@@ -21,13 +21,20 @@ garden_lane: agent-entry-points
 ## Operating Rules
 
 - Add or change config data with a cross-reference test.
-- Keep exported modules stable for all consumers; dashboard, indexer, bridge, and integration-probes typechecks are part of the change surface.
-- If `fx-calendar.json` changes, verify trading-seconds assumptions in both dashboard and indexer code paths.
+- Keep exported modules stable for direct workspace consumers; dashboard, bridge,
+  and integration-probes typechecks are part of the change surface. The indexer
+  consumes checked-in mirrors of selected shared config.
+- If `fx-calendar.json` changes, keep
+  `indexer-envio/config/fx-calendar.json` in sync and verify trading-seconds
+  assumptions in both dashboard and indexer code paths. If
+  `deployment-namespaces.json` changes, keep the indexer mirror in sync.
 - Do not hand-edit `dist/` as the source of truth. Update `src/` or JSON inputs, then run the package build.
 - Avoid importing runtime-heavy packages here. `shared-config` is consumed by client bundle code and should stay low-dependency.
-- Public npm releases are tag-driven through `.github/workflows/publish-config.yml`; publish tags must be `config-v<shared-config/package.json version>` and point at `main`. Manual `workflow_dispatch` runs validate and pack the package but do not publish. npm trusted publishing cannot create a brand-new package, so an npm org/package maintainer must seed `@mento-protocol/config` once through an approved maintainer publish before configuring trusted publishing for GitHub Actions with workflow filename `publish-config.yml`, allowed action `npm publish`, repository `mento-protocol/monitoring-monorepo`. Keep the publish job on GitHub-hosted runners because npm trusted publishing does not support self-hosted or third-party runners.
+- Public npm releases are tag-driven through `.github/workflows/publish-config.yml`; publish tags must be `config-v<shared-config/package.json version>` and reference a commit reachable from `origin/main`. Manual `workflow_dispatch` runs validate and pack the package but do not publish. npm trusted publishing cannot create a brand-new package, so an npm org/package maintainer must seed `@mento-protocol/config` once through an approved maintainer publish before configuring trusted publishing for GitHub Actions with workflow filename `publish-config.yml`, allowed action `npm publish`, repository `mento-protocol/monitoring-monorepo`. Keep the publish job on GitHub-hosted runners because npm trusted publishing does not support self-hosted or third-party runners.
 - The package's Node engine follows the repo `.node-version` throughout the pre-1.0 release line. Do not lower the engine floor without adding a matching consumer and publish verification matrix.
 
 ## Verification
 
-Run `@mento-protocol/config` lint, typecheck, test, and build, then typecheck consumers when exported shapes change.
+Run `pnpm agent:quality-gate --run`. Its shared-config mapping covers package
+lint, typecheck, tests, coverage, knip, build, direct-consumer typechecks, the
+dashboard bundle-size limit, and conditional indexer mirror checks.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -3,7 +3,7 @@ title: Terraform Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-05-20
+last_verified: 2026-07-23
 doc_type: agent-instructions
 scope: terraform
 review_interval_days: 90
@@ -12,7 +12,7 @@ garden_lane: agent-entry-points
 
 # AGENTS.md — Terraform
 
-> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `terraform/infra`) — read the relevant ADR before changing how something here is built; it records the _why_ the code can't.
+> **Architecture decisions** for this package live in [`docs/adr/`](../docs/adr/README.md) (scope: `terraform/infra`) — read the relevant ADR before changing how something here is built; it records why the code is built that way.
 
 ## Scope
 
@@ -29,9 +29,14 @@ garden_lane: agent-entry-points
   human-approved plan/apply. If Terraform cannot manage the secret yet, add the
   missing IaC path or ask for direction; do not use `gh secret set`,
   `vercel env add`, or equivalent as an agent workaround.
-- Resource renames/removals need `moved` blocks.
+- Resource address renames need `moved` blocks. To retire a state-managed
+  resource without destroying its remote counterpart, use a `removed` block
+  with an explicit `destroy` choice.
 - Cloud Run services use `/health`, not `/healthz`.
-- Keep `lifecycle.ignore_changes` for images and Cloud Run API bookkeeping fields when rollouts happen through deploy scripts or workflows.
+- For deploy-owned Cloud Run images, retain the necessary
+  `lifecycle.ignore_changes` for the image and provider bookkeeping drift. If a
+  change alters Terraform-owned template shape (env, probes, resources, or
+  template scaling), re-audit or remove `template[0].revision` for that PR.
 - Project-level IAM changes must be ordered behind required bootstrap/API enablement dependencies.
 
 ## Verification

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -3,7 +3,7 @@ title: Monitoring Dashboard Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-23
 doc_type: agent-instructions
 scope: ui-dashboard
 review_interval_days: 90


### PR DESCRIPTION
## The Problem

- The final generated agent-entry-point packet covers three documents, but
  planner repacking left `scripts/AGENTS.md` outside all completed packets.
- Several retained rules no longer matched current consumers, Terraform state
  operations, Cloud Run ownership, or script workflow exceptions.
- The lane cannot close until every current entry point has an evidence-backed
  disposition and the catalog and context budgets pass.

## The Solution

Audit the generated shard and the one-file repacking gap together. Keep the
dashboard instructions unchanged after source verification, update the three
stale instruction files, regenerate the catalog, and prove that the completed
packet union covers all 29 current agent entry points.

## Details

### Dispositions

- **Update — `shared-config/AGENTS.md`:** distinguish the three direct workspace
  consumers from the indexer's checked-in mirrors, add both JSON mirror-sync
  rules, state the publish workflow's `origin/main` ancestry requirement, and
  route verification through the mapped gate.
- **Update — `terraform/AGENTS.md`:** distinguish `moved` address changes from
  `removed` resources, record the explicit destroy choice, and add the Cloud Run
  revision-ignore exception for Terraform-owned template changes.
- **Keep — `ui-dashboard/AGENTS.md`:** the network, ES2017, browser, polling,
  accessibility, CSP, and Liquity rules match their owning sources. Only
  `last_verified` and the generated catalog entry changed.
- **Update — `scripts/AGENTS.md`:** distinguish shell entrypoints from sourced
  helpers, scope the clean-tree guard to local-checkout deploys, document the
  Envio trigger-ref `--no-verify` exception, broaden ADR routing, and align new
  script verification with the quality-gate mapping.

### Lane coverage

At `origin/main` commit `cfc0763ae645363bbaa90edbccae42c9c97e8bfa`, the
lane contains 29 unique documents. Completed packets #1451, #1516, and #1529
cover 25; generated shard #1534 adds three; supplemental #1535 adds the sole
repacking gap, `scripts/AGENTS.md`. The resulting union is 29/29 with no extra
or missing paths.

## Deferrals

- #1351 — ADR 0013's vendored-mirror inventory does not yet name
  `indexer-envio/config/fx-calendar.json`. The in-force decision remains
  unchanged; evidence and the accepted-history handling question are recorded
  on #1351 for its ADR garden packet.

## Validation

- `CI=true pnpm docs:audit --dry-run --date 2026-09-21 --lane agent-entry-points --shard 4 --format json`
- `CI=true pnpm docs:index --write`
- `CI=true pnpm docs:index --check`
- `CI=true pnpm agent:context-check`
- `CI=true pnpm agent:context-budget --strict`
- `CI=true pnpm agent:quality-gate --run` — all mapped commands passed,
  including Terraform init/validate, package lint/typecheck/coverage/knip,
  dependency checks, dashboard browser tests, bundle size, React Doctor, and
  targeted Trunk.
- Fresh-context semantic autoreview and the deterministic local guardrail both
  returned clean with no actionable findings.
- Manual browser verification does not apply because this changes only
  documentation and generated navigation; the mapped browser suite still
  passed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1534
Closes #1535
Closes #1348
