### PR TITLE
docs: tighten filter and PR scope checks

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -92,6 +92,9 @@ repository inferred from the active checkout.
 Before the first review pass, freeze the request, target/owner, changed files,
 and non-test changed-line count as the scope baseline. Classify later additions
 as in-scope, follow-up, or stop; create an issue before deferring valid work.
+An explicit user correction updates the request baseline. Before the next push,
+update the PR description so current-head reviewers do not enforce superseded
+behavior.
 
 ## Feedback and Watch Loop
 

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -92,6 +92,9 @@ repository inferred from the active checkout.
 Before the first review pass, freeze the request, target/owner, changed files,
 and non-test changed-line count as the scope baseline. Classify later additions
 as in-scope, follow-up, or stop; create an issue before deferring valid work.
+An explicit user correction updates the request baseline. Before the next push,
+update the PR description so current-head reviewers do not enforce superseded
+behavior.
 
 ## Feedback and Watch Loop
 

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -113,6 +113,10 @@ If the PR touches a table with pagination, sort, filter, search, or linked chart
 - [ ] Is that behavior documented in code comments and PR notes?
 - [ ] If bounded, is the cap explicit and user-visible?
 - [ ] If unbounded, can the backend/query path actually support it?
+- [ ] If filter options are data-driven, what happens when the selected option
+      disappears during refresh or partial failure? Reset to a valid state
+      before paint or show an explicit unavailable state, and cover the case
+      where sibling data still loads.
 
 ### Coupled visualizations
 


### PR DESCRIPTION
## The Problem

- Data-driven filters can retain a selection that disappears during refresh or partial failure.
- An open PR can keep superseded behavior in its description after an explicit user correction, which gives current-head reviewers a stale scope.

## The Solution

- Add a stateful-UI checklist gate for disappearing filter options.
- Update the babysit workflow and its mirror to refresh the request baseline and PR description after explicit corrections.

## Details

- The filter gate requires either a valid reset before paint or an explicit unavailable state, with coverage while sibling data still loads.
- The repository skill and Claude mirror remain byte-identical.
- This is the approved reflection follow-up from merged PR #1523.

## Validation

- `pnpm agent:quality-gate --run` — passed all mapped checks.
- `pnpm agent:autoreview` — clean deterministic review; no actionable findings.
- `cmp -s .agents/skills/babysit-pr/SKILL.md .claude/skills/babysit-pr/SKILL.md` — matched.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this tightens existing review guidance without changing system architecture.
