### PR TITLE
fix(tooling): validate navigation fixtures in local gate

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -78,15 +78,16 @@ Indexer changes additionally route the protected
 [`docs/pr-checklists/indexer-handler-invariants.md`](../pr-checklists/indexer-handler-invariants.md)
 policy into prepared autoreview bundles.
 
-The gate defaults to dry-run mode and maps changed paths to the package checks
-and PR checklists that apply. Review the checklist output, then run the mapped
-safe local commands with:
+The dry-run gate maps changed paths to package checks and PR checklists. For a
+routing-sensitive source, the shared classifier adds the offline
+`pnpm docs:navigation-eval -- --check-fixtures` check. It invokes no model or
+scheduled evaluation. Review the output, then run:
 
 ```bash
 pnpm agent:quality-gate --run
 ```
 
-The execution mode is intentionally local-only: lint, typecheck, tests, codegen,
+Execution stays local: lint, typecheck, tests, codegen,
 Trunk, and formatting/validation commands. It never runs deploy commands or
 Terraform apply. Terraform formatting receives an explicit Git-visible source
 list, so tracked and non-ignored untracked Terraform files are checked without

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -426,6 +426,37 @@ if [[ ! -s "$changed_paths_file" ]]; then
   exit 0
 fi
 
+routing_sensitive_paths_changed=""
+if ! routing_sensitive_paths_changed="$(
+  node --input-type=module - \
+    "$script_source_dir/docs-navigation-eval-helpers.mjs" \
+    "$changed_paths_file" <<'NODE'
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const [classifierPath, changedPathsPath] = process.argv.slice(2);
+const { isRoutingSensitivePath } = await import(
+  pathToFileURL(classifierPath).href
+);
+const changedPaths = readFileSync(changedPathsPath, "utf8")
+  .split(/\r?\n/)
+  .filter(Boolean);
+process.stdout.write(
+  changedPaths.some(isRoutingSensitivePath) ? "true" : "false",
+);
+NODE
+)"; then
+  echo "error: failed to classify routing-sensitive changed paths" >&2
+  exit 2
+fi
+case "$routing_sensitive_paths_changed" in
+  true|false) ;;
+  *)
+    echo "error: routing-sensitive path classifier returned an invalid result" >&2
+    exit 2
+    ;;
+esac
+
 preflight_commands=()
 codegen_commands=()
 post_codegen_commands=()
@@ -2371,6 +2402,10 @@ while IFS= read -r path; do
   esac
 done < "$changed_paths_file"
 
+if [[ "$routing_sensitive_paths_changed" == "true" ]]; then
+  add_command "pnpm docs:navigation-eval -- --check-fixtures" "routing-sensitive source changed"
+fi
+
 add_trunk_check_command
 sort_codegen_commands
 compact_turbo_quality_commands
@@ -2436,6 +2471,7 @@ implementation_signature() {
     scripts/agent-quality-gate.sh \
     scripts/agent-quality-gate.test.sh \
     scripts/check-agent-quality-gate-package-scripts.sh \
+    scripts/docs-navigation-eval-helpers.mjs \
     scripts/terraform-fmt-check.mjs \
     scripts/terraform-fmt-check.test.mjs \
     turbo.json \

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -376,6 +376,23 @@ assert_script_occurrences 1 "command -v shasum"
 assert_script_occurrences 0 "shasum -a 256 | awk"
 assert_script_occurrences 0 'shasum -a 256 "$1"'
 
+classifier_missing_helper_dir="$(mktemp -d)"
+cp scripts/agent-quality-gate.sh "$classifier_missing_helper_dir/agent-quality-gate.sh"
+printf 'ui-dashboard/src/app/page.tsx\n' > "$paths_file"
+classifier_missing_helper_exit=0
+if bash "$classifier_missing_helper_dir/agent-quality-gate.sh" \
+    --changed-paths-file "$paths_file" \
+    --base origin/test \
+    > "$output_file" 2>&1; then
+  classifier_missing_helper_exit=0
+else
+  classifier_missing_helper_exit=$?
+fi
+rm -rf "$classifier_missing_helper_dir"
+[[ "$classifier_missing_helper_exit" -eq 2 ]] ||
+  fail "missing routing classifier helper exited $classifier_missing_helper_exit instead of 2"
+assert_contains "error: failed to classify routing-sensitive changed paths"
+
 write_turbo_facts
 
 assert_turbo_task_has_input "build" '$TURBO_ROOT$/shared-config/src/**'
@@ -704,8 +721,11 @@ assert_not_contains "- pnpm --filter @mento-protocol/metrics-bridge lint (metric
 # supported opt-out or a restricted real HOME.
 : > "$paths_file"
 printf 'metrics-bridge/src/main.ts\n' >> "$paths_file"
+node_executable_dir="$(dirname "$(node -p 'process.execPath')")"
 turbo_cache_writable_home="$(mktemp -d)"
-env -u TURBO_CACHE_DIR -u AGENT_TURBO_SHARED_CACHE HOME="$turbo_cache_writable_home" \
+env -u TURBO_CACHE_DIR -u AGENT_TURBO_SHARED_CACHE \
+  HOME="$turbo_cache_writable_home" \
+  PATH="$node_executable_dir:$PATH" \
   AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
   scripts/agent-quality-gate.sh \
   --changed-paths-file "$paths_file" \
@@ -747,7 +767,9 @@ assert_not_contains "Turbo cache dir: "
 # environment whose writable allowlist excludes it.
 turbo_cache_unwritable_home="$(mktemp -d)"
 : > "$turbo_cache_unwritable_home/.cache"
-env -u TURBO_CACHE_DIR HOME="$turbo_cache_unwritable_home" \
+env -u TURBO_CACHE_DIR \
+  HOME="$turbo_cache_unwritable_home" \
+  PATH="$node_executable_dir:$PATH" \
   AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
   scripts/agent-quality-gate.sh \
   --changed-paths-file "$paths_file" \
@@ -2931,6 +2953,9 @@ printf '%s\n' "$((count + 1))" > "$counter_file"
 STUB
   cat > bin/node <<'STUB'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--input-type=module" ]]; then
+  exec "${REAL_NODE:?}" "$@"
+fi
 exit 0
 STUB
   cat > bin/pnpm <<'STUB'
@@ -2942,10 +2967,12 @@ STUB
   git commit -qm init
   base_ref="$(git rev-parse --verify HEAD)"
   printf '# changed\n' >> .github/workflows/metrics-bridge.yml
-  COUNTER_FILE="$workflow_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+  REAL_NODE="$(command -v node)" \
+    COUNTER_FILE="$workflow_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
     PATH="$workflow_fresh_stamp_repo/bin:$PATH" \
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run > "$output_file" 2>&1
-  COUNTER_FILE="$workflow_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+  REAL_NODE="$(command -v node)" \
+    COUNTER_FILE="$workflow_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
     PATH="$workflow_fresh_stamp_repo/bin:$PATH" \
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --skip-if-fresh >> "$output_file" 2>&1
   [[ "$(cat "$workflow_fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
@@ -3115,6 +3142,7 @@ signature_stamp_repo="$(mktemp -d)"
   printf 'fixture\n' > fixture.txt
   printf 'second fixture\n' > second.txt
   printf '# fixture gate implementation\n' > scripts/agent-quality-gate.sh
+  printf '# fixture routing classifier\n' > scripts/docs-navigation-eval-helpers.mjs
   cat > tools/trunk <<'STUB'
 #!/usr/bin/env bash
 counter_file="${COUNTER_FILE:?}"
@@ -3170,6 +3198,17 @@ STUB
       > "$output_file" 2>&1
   [[ "$(cat "$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "4" ]] ||
     fail "fresh gate stamp was reused after the gate implementation changed"
+
+  printf '# changed fixture routing classifier\n' >> scripts/docs-navigation-eval-helpers.mjs
+  COUNTER_FILE="$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --changed-paths-file changed-paths-two.txt \
+      --base "$base_two" \
+      --run \
+      --skip-if-fresh \
+      > "$output_file" 2>&1
+  [[ "$(cat "$signature_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "5" ]] ||
+    fail "fresh gate stamp was reused after the routing classifier changed"
 )
 rm -rf "$signature_stamp_repo"
 assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
@@ -3690,30 +3729,49 @@ assert_contains "- pnpm docs:garden:test (documentation garden issue automation 
 run_gate "scripts/docs-navigation-eval.mjs"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation changed)"
 assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 assert_contains "- pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json (documentation navigation evaluation changed)"
 assert_contains "- pnpm docs:index --check (documentation navigation evaluation consumes the catalog)"
 
 run_gate "scripts/docs-navigation-eval-helpers.mjs"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation changed)"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 
 run_gate "scripts/docs-navigation-eval-result.mjs"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation changed)"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 
 run_gate "scripts/docs-navigation-eval.test.mjs"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation changed)"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 
 run_gate "docs/evals/documentation-navigation-fixtures.json"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation contract changed)"
 assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation contract changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 assert_contains "- pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json (documentation navigation evaluation contract changed)"
 
 run_gate "docs/evals/documentation-navigation-2026-08-post-garden.json"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation contract changed)"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation evaluation contract changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 assert_contains "- pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json (documentation navigation evaluation contract changed)"
 
 run_gate "docs/evals/documentation-navigation-baseline.json"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation baseline changed)"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (documentation navigation baseline changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
 assert_contains "- pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json (documentation navigation baseline changed)"
+
+run_gate "docs/notes/agent-quality-gate-mechanics.md"
+assert_contains "- pnpm docs:navigation-eval -- --check-fixtures (routing-sensitive source changed)"
+assert_occurrences 1 "- pnpm docs:navigation-eval -- --check-fixtures"
+
+run_gate "ui-dashboard/src/app/page.tsx"
+assert_not_contains_mapped "- pnpm docs:navigation-eval -- --check-fixtures"
 
 run_gate "scripts/agent-context-budget.mjs"
 assert_contains "- pnpm agent:context-budget:test (agent context budget helper changed)"

--- a/scripts/docs-navigation-eval.test.mjs
+++ b/scripts/docs-navigation-eval.test.mjs
@@ -883,7 +883,7 @@ test("issue scheduling rejects an invalid committed baseline before discovery", 
   assert.equal(listed, false);
 });
 
-test("generated result artifacts do not create routing-change reminders", () => {
+test("routing-sensitive path classification covers gate source families", () => {
   assert.equal(
     isRoutingSensitivePath("docs/evals/documentation-navigation-baseline.json"),
     false,
@@ -902,13 +902,26 @@ test("generated result artifacts do not create routing-change reminders", () => 
   );
   for (const pathname of [
     "AGENTS.md",
+    "ui-dashboard/AGENTS.md",
+    "package.json",
     "README.md",
+    "ui-dashboard/README.md",
     "docs/evals/documentation-navigation-fixtures.json",
     "docs/evals/documentation-navigation-result.schema.json",
     "docs/evals/documentation-navigation.md",
+    ".agents/skills/ship/SKILL.md",
+    ".claude/skills/ship/SKILL.md",
+    ".claude/commands/verify-ui.md",
     ".github/workflows/documentation-garden.yml",
   ]) {
     assert.equal(isRoutingSensitivePath(pathname), true, pathname);
+  }
+  for (const pathname of [
+    "ui-dashboard/src/app/page.tsx",
+    "scripts/agent-quality-gate.sh",
+    ".github/dependabot.yml",
+  ]) {
+    assert.equal(isRoutingSensitivePath(pathname), false, pathname);
   }
 });
 


### PR DESCRIPTION
## The Problem

- Routing-sensitive documentation and agent-entry changes could pass the local quality gate, then fail hosted CI when an accepted navigation route exceeded its byte budget.
- The local gate only selected the offline fixture check for navigation evaluator files, not every source family used by the evaluator routing contract.

## The Solution

- Reuse the evaluator shared routing-sensitive path classifier so the local gate adds `pnpm docs:navigation-eval -- --check-fixtures` once whenever a relevant document, instruction, skill, command, or workflow changes.

## Details

- Classification runs once for the complete changed-path set and fails closed on import, execution, or output-contract errors.
- Existing specialized navigation mappings keep their original reason through first-wins command deduplication.
- The classifier source participates in quality-gate freshness invalidation.
- The added check is offline; it invokes no model and does not run the scheduled navigation evaluation.
- Regression coverage includes accepted and unrelated routes, classifier families, deduplication, missing-helper failure, constrained runtime paths, and freshness invalidation.

## Validation

- `pnpm agent:quality-gate --run --parallel 1` — all 10 mapped commands passed on the final base; `agent:quality-gate:test` took 3m09s and the new fixture check took 1s.
- `pnpm agent:autoreview -- --mode branch --base origin/main --engine local --prompt-file docs/pr-checklists/recurring-review-patterns.md` — clean.
- Fresh-context immutable semantic review — clean at 0.96 confidence; bundle manifest `d41e01ec1ce4e33937ce675bc225625adc92e34173eaa8f6857c988cf5660688` verified before and after review.

Closes #1533

## Deferrals

- #1546 tracks the feedback-state parser false-positive exposed by Claude clean-review comment 5060594122. It is outside the navigation-gate scope of this PR.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned