### PR TITLE
feat(sentry-autofix): bind the marker guard to a verdict-generation token (#1506)

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -442,6 +442,13 @@ jobs:
       QUEUE_ISSUE: ${{ matrix.entry.issue }}
       SHORT_ID: ${{ matrix.entry.shortId }}
       REPO: ${{ github.repository }}
+      # The generation token (issue #1506): the numeric id of the verdict comment
+      # this fix was selected from, captured by the trusted select job. The marker
+      # guard refuses if the live selected verdict comment no longer matches (a
+      # re-triage replaced it — ABA). Empty for reconcile entries and the rare
+      # unparseable-url fallback, in which case the guard degrades to the #1389
+      # label-presence check. NEVER sourced from the agent job or the artifact.
+      VERDICT_COMMENT_ID: ${{ matrix.entry.verdictCommentId }}
       # Pinned to github.sha (main's HEAD; select refuses off main). The pristine
       # clone that runs every deterministic node helper checks out this SHA, and it
       # is the diff BASE the agent's downloaded tree is compared against.
@@ -471,6 +478,11 @@ jobs:
           fi
           if ! [[ "${SHORT_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*-[A-Za-z0-9]+$ ]]; then
             echo "::error::matrix shortId '${SHORT_ID}' is not a valid Sentry SHORT-ID"; exit 1
+          fi
+          # The #1506 generation token, when present, must be a bare integer (the
+          # numeric #issuecomment id). Empty is allowed (reconcile / fallback).
+          if [ -n "${VERDICT_COMMENT_ID:-}" ] && ! [[ "${VERDICT_COMMENT_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::error::matrix verdictCommentId '${VERDICT_COMMENT_ID}' is not a bare integer"; exit 1
           fi
 
       # Download the agent's working-tree TARBALL (untrusted DATA — never executed). A
@@ -744,20 +756,41 @@ jobs:
           # the selector also dedups on an OPEN autofix PR, withdrawing means
           # CLOSING the PR we opened, not just skipping the label.
 
-          # Live verdict: prints "yes" only when it POSITIVELY confirms
-          # sentry:verdict-code-fix is still present; prints "no" both when the
-          # verdict was shed AND when the read itself fails. Fail CLOSED — an
-          # unverified verdict must not receive the terminal marker (that is the
-          # #1389 suppression bug), and a needlessly-withdrawn PR self-corrects when
-          # the stub is re-selected next run, whereas a wrongly-written marker does
-          # not.
+          # Live verdict: prints "yes" only when it POSITIVELY confirms BOTH
+          # (a) sentry:verdict-code-fix is still present, AND (b) — when select
+          # threaded a generation token (issue #1506) — the currently-selected
+          # verdict comment is still the SAME one this fix was based on. Prints
+          # "no" on a shed label, a REPLACED verdict comment (an ABA re-triage
+          # posts a NEW verdict comment, which label-presence alone cannot see),
+          # or any read/parse failure. Fail CLOSED — an unverified or superseded
+          # verdict must not receive the terminal marker (the #1389 suppression
+          # bug); a needlessly-withdrawn PR self-corrects when the stub is
+          # re-selected next run, whereas a wrongly-written marker does not.
           verdict_live() {
-            local names
-            names=$(gh issue view "${QUEUE_ISSUE}" --repo "${REPO}" \
-              --json labels --jq '.labels[].name' 2>/dev/null) \
+            local json
+            json=$(gh issue view "${QUEUE_ISSUE}" --repo "${REPO}" \
+              --json labels,comments 2>/dev/null) \
               || { printf 'no'; return 0; }
-            printf '%s\n' "${names}" > "${RUNNER_TEMP}/labels-live.txt"
-            node "${fin}" marker-still-valid --labels-file "${RUNNER_TEMP}/labels-live.txt"
+            printf '%s' "${json}" > "${RUNNER_TEMP}/stub-live.json"
+            jq -r '.labels[].name' "${RUNNER_TEMP}/stub-live.json" \
+              > "${RUNNER_TEMP}/labels-live.txt"
+            if [ "$(node "${fin}" marker-still-valid --labels-file "${RUNNER_TEMP}/labels-live.txt")" != "yes" ]; then
+              printf 'no'
+              return 0
+            fi
+            # Generation check (issue #1506): only when select threaded a token.
+            # selected-verdict-id fails closed to "none" (never matches).
+            if [ -n "${VERDICT_COMMENT_ID:-}" ]; then
+              local live_id
+              live_id=$(node "${fin}" selected-verdict-id \
+                --comments-file "${RUNNER_TEMP}/stub-live.json")
+              if [ "${live_id}" != "${VERDICT_COMMENT_ID}" ]; then
+                echo "#${QUEUE_ISSUE} verdict comment changed (was ${VERDICT_COMMENT_ID}, now ${live_id}); a re-triage superseded the verdict this fix was based on (ABA) — withdrawing." >&2
+                printf 'no'
+                return 0
+              fi
+            fi
+            printf 'yes'
           }
 
           # Retry a gh mutation up to 3×; on the final failure emit ::error:: and
@@ -836,9 +869,11 @@ jobs:
           # confirmed, since a stuck marker also suppresses the re-fix — and withdraw
           # the PR, so the re-queued occurrence stays selectable. A regression
           # arriving strictly after this check self-heals on ingest's next re-queue,
-          # which sheds the marker again (REOPEN_SHED_LABELS). This guards a SHED
-          # verdict, not a re-added one: an ABA where a re-triage restores the label
-          # inside the window is tracked for the deterministic finalize job (#1506).
+          # which sheds the marker again (REOPEN_SHED_LABELS). verdict_live also
+          # covers the ABA case (issue #1506): a re-triage that sheds then re-adds
+          # the label posts a NEW verdict comment, so the generation-token check
+          # inside verdict_live sees the mismatch and withdraws even though the label
+          # is present again.
           if [ "$(verdict_live)" = "no" ]; then
             retry3 "remove stale fix-pr-opened marker on #${QUEUE_ISSUE}" remove_stale_marker || exit 1
             withdraw_stale_verdict

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -220,6 +220,17 @@ is that intentional regression-re-queue outcome, not an orphaned run; an
 unconfirmable close fails the run loudly rather than leaving a stale PR that
 would suppress the re-fix.
 
+That re-read also checks the verdict comment's **identity**, not just the label's
+presence (a **generation token**, issue #1506). The trusted select job captures
+the numeric id of the verdict comment the fix was based on and threads it to
+finalize through the matrix; finalize re-selects the live verdict comment and
+withdraws if the id no longer matches. This catches an ABA a re-triage can create
+inside the window — sheds the label, then re-adds it with a **new** verdict
+comment — which label-presence alone cannot see. Reconcile entries carry no token
+(they relink a prior run's PR, whose originating verdict id select never saw), so
+they stay on the label-presence guard; the token is never sourced from the agent
+job or the handoff artifact.
+
 ### Human-approved archive
 
 Archiving is independent of the verdict. An authorized human may apply

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -45,7 +45,11 @@ import {
   FIX_REFUSED_LABEL,
   LABEL_DEFINITIONS,
 } from "./sentry-triage-ingest.mjs";
-import { isValidShortId } from "./sentry-triage-project-core.mjs";
+import {
+  isValidShortId,
+  selectVerdictComment,
+  verdictCommentIdFromUrl,
+} from "./sentry-triage-project-core.mjs";
 
 // The agent's diff may touch at most this many files. A real fix commonly spans
 // the change plus its tests and a couple of related call sites, so the ceiling
@@ -568,6 +572,11 @@ Commands:
       Print "yes" if the stub's labels (newline-separated in the file) still
       include the code-fix verdict, else "no". Re-checked before the marker
       write to catch a mid-run regression re-queue.
+  selected-verdict-id --comments-file <path>
+      Print the numeric id of the currently-selected verdict comment (the #1506
+      generation token), or "none". The file holds the stub's comments JSON
+      (array, or an object with a .comments array). Fail-closed: prints "none"
+      on any parse/selection failure so the workflow withdraws on mismatch.
   stale-verdict-close-comment
       Print the comment posted when a fix PR opened this run is closed because
       the verdict was shed during the push/PR-create span.
@@ -652,6 +661,29 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
         "utf8",
       ).split("\n");
       stdout.write(markerWriteStillValid(labels) ? "yes\n" : "no\n");
+      return;
+    }
+    case "selected-verdict-id": {
+      // Prints the NUMERIC id of the currently-selected verdict comment (the
+      // #1506 generation token), or "none" when there is no usable verdict
+      // comment or the input can't be read/parsed. The workflow compares this
+      // against the id select captured at dispatch: a mismatch means a re-triage
+      // REPLACED the verdict (ABA) and the fix-pr-opened marker must not be
+      // written. Fail CLOSED — any parse/selection failure prints "none", which
+      // the workflow treats as a mismatch and withdraws.
+      let comments;
+      try {
+        const parsed = JSON.parse(
+          readFileMaybe(readFlag(args, "--comments-file")),
+        );
+        comments = Array.isArray(parsed) ? parsed : (parsed.comments ?? []);
+      } catch {
+        stdout.write("none\n");
+        return;
+      }
+      const selected = selectVerdictComment(comments);
+      const id = selected.url ? verdictCommentIdFromUrl(selected.url) : null;
+      stdout.write(id && /^\d+$/.test(id) ? `${id}\n` : "none\n");
       return;
     }
     case "stale-verdict-close-comment": {

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -532,5 +532,45 @@ await test("CLI marker-still-valid reads a labels file; stale-verdict-close-comm
   );
 });
 
+await test("selected-verdict-id prints the numeric verdict-comment id (#1506)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "autofix-genid-"));
+  const file = join(dir, "stub.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      labels: [{ name: "sentry:verdict-code-fix" }],
+      comments: [
+        {
+          body: "<!-- sentry-triage-verdict:v1 -->\nverdict: code-fix\n",
+          createdAt: "2026-07-17T10:00:00Z",
+          author: { login: "github-actions" },
+          url: "https://github.com/o/r/issues/1#issuecomment-777",
+        },
+      ],
+    }),
+  );
+  assert(
+    captureCli(["selected-verdict-id", "--comments-file", file]).trim() ===
+      "777",
+    "prints the live verdict comment's numeric id",
+  );
+});
+
+await test("selected-verdict-id fails closed to 'none' (#1506)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "autofix-genid-none-"));
+  const noVerdict = join(dir, "empty.json");
+  writeFileSync(noVerdict, JSON.stringify({ comments: [] }));
+  const malformed = join(dir, "bad.json");
+  writeFileSync(malformed, "{not json");
+  const missing = join(dir, "nope.json");
+  for (const f of [noVerdict, malformed, missing]) {
+    assert(
+      captureCli(["selected-verdict-id", "--comments-file", f]).trim() ===
+        "none",
+      `fails closed to none for ${f}`,
+    );
+  }
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exitCode = 1;

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -39,6 +39,7 @@ import {
   resolveVerdict,
   selectVerdictComment,
   validateAffectedRepo,
+  verdictCommentIdFromUrl,
 } from "./sentry-triage-project-core.mjs";
 import {
   CODE_FIX_VERDICT_LABEL,
@@ -286,9 +287,10 @@ async function evaluateCandidate(runGh, repo, stub) {
   }
 
   let parsed;
+  let verdictCommentUrl;
   try {
     const full = await readStub(runGh, repo, stub.number);
-    ({ parsed } = resolveVerdict(full, stub.number));
+    ({ parsed, verdictCommentUrl } = resolveVerdict(full, stub.number));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`skip #${stub.number}: ${message}\n`);
@@ -331,7 +333,22 @@ async function evaluateCandidate(runGh, repo, stub) {
     return { issue: stub.number, shortId, reconcile: true };
   }
 
-  return { issue: stub.number, shortId };
+  // Generation token (issue #1506): the numeric id of the verdict comment this
+  // fix is based on, threaded through the matrix to finalize so it can refuse to
+  // mark the stub fixed if a re-triage REPLACED the verdict comment (ABA) during
+  // the run — a change label-presence cannot see. Reconcile entries above carry
+  // no token: they relink a PRIOR run's PR, whose originating verdict id select
+  // never captured. Emit without the token (finalize falls back to the #1389
+  // label-presence guard) only if the url is unparsable — which should not
+  // happen for a real, fence-selected verdict comment.
+  const verdictCommentId = verdictCommentIdFromUrl(verdictCommentUrl);
+  if (!verdictCommentId) {
+    process.stderr.write(
+      `warn #${stub.number}: could not derive a verdict-comment id (url=${verdictCommentUrl}); emitting without a generation token.\n`,
+    );
+    return { issue: stub.number, shortId };
+  }
+  return { issue: stub.number, shortId, verdictCommentId };
 }
 
 /**

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -308,6 +308,42 @@ await test("skips a stub with an unrecognized affected_repo (not confidently loc
   assertDeepEqual(selected, []);
 });
 
+await test("emits the verdict-comment generation token when present (#1506)", async () => {
+  const stubs = [
+    stub({
+      number: 22,
+      shortId: "APP-MENTO-ORG-7T",
+      comments: [
+        {
+          ...verdictComment(),
+          url: "https://github.com/o/r/issues/22#issuecomment-9012",
+        },
+      ],
+    }),
+  ];
+  const { runGh } = makeRunGh({ stubs });
+  const selected = await selectAutofixCandidates({ repo: "o/r" }, { runGh });
+  assertDeepEqual(selected, [
+    { issue: 22, shortId: "APP-MENTO-ORG-7T", verdictCommentId: "9012" },
+  ]);
+});
+
+await test("falls back to no token when the verdict comment url is unparsable (#1506)", async () => {
+  const stubs = [
+    stub({
+      number: 23,
+      shortId: "APP-MENTO-ORG-7U",
+      // url without a #issuecomment anchor → no derivable token
+      comments: [
+        { ...verdictComment(), url: "https://github.com/o/r/issues/23" },
+      ],
+    }),
+  ];
+  const { runGh } = makeRunGh({ stubs });
+  const selected = await selectAutofixCandidates({ repo: "o/r" }, { runGh });
+  assertDeepEqual(selected, [{ issue: 23, shortId: "APP-MENTO-ORG-7U" }]);
+});
+
 await test("skips a stub whose verdict comment is missing/invalid (fail-soft, no throw)", async () => {
   const stubs = [
     stub({ number: 50, shortId: "APP-MENTO-ORG-AA", comments: [] }),

--- a/scripts/sentry-triage-project-core.mjs
+++ b/scripts/sentry-triage-project-core.mjs
@@ -517,7 +517,7 @@ export function selectVerdictComment(comments) {
     .filter((comment) => comment.body.startsWith(VERDICT_MARKER))
     .sort(compareCreatedAt);
   if (verdicts.length === 0)
-    return { body: null, reason: "no-verdict-comment" };
+    return { body: null, reason: "no-verdict-comment", url: null };
   const newestVerdict = verdicts[verdicts.length - 1];
 
   const regressions = list
@@ -528,10 +528,30 @@ export function selectVerdictComment(comments) {
     if (
       !(String(newestVerdict.createdAt) > String(newestRegression.createdAt))
     ) {
-      return { body: null, reason: "stale-verdict" };
+      return { body: null, reason: "stale-verdict", url: null };
     }
   }
-  return { body: newestVerdict.body, reason: null };
+  // `url` identifies which verdict comment was selected — its numeric
+  // #issuecomment-<n> id is the autofix generation token (issue #1506): a
+  // re-triage APPENDS a fresh verdict comment (Stage A reopen sheds the label,
+  // triage re-posts), so a shed-then-re-added verdict changes this url even when
+  // the label is present again, which is what label-presence alone cannot see.
+  return {
+    body: newestVerdict.body,
+    reason: null,
+    url: typeof newestVerdict.url === "string" ? newestVerdict.url : null,
+  };
+}
+
+// Parse the numeric REST id from a GitHub issue-comment url
+// (`…#issuecomment-<n>`). gh's comment `.id` is an opaque GraphQL node id; the
+// numeric id from the url is stable, log-safe, and trivially validated
+// (`^[0-9]+$`) — the shape the autofix matrix threads as its generation token.
+// Returns the numeric string, or null if the url is missing/unparsable.
+export function verdictCommentIdFromUrl(url) {
+  if (typeof url !== "string") return null;
+  const match = url.match(/#issuecomment-(\d+)\s*$/);
+  return match ? match[1] : null;
 }
 
 // Blatant non-decision placeholders that defeat the point of a needs-human
@@ -626,6 +646,9 @@ export function resolveVerdict(issue, queueIssueNumber) {
     parsed,
     verdict: parsed.verdict,
     label: VERDICT_TO_LABEL[parsed.verdict],
+    // The url of the verdict comment this resolution is based on — the autofix
+    // generation token source (issue #1506).
+    verdictCommentUrl: selected.url,
   };
 }
 

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -29,6 +29,7 @@ import {
   sanitizeFreeText,
   selectVerdictComment,
   validateAffectedRepo,
+  verdictCommentIdFromUrl,
   VERDICT_MARKER,
   VERDICT_TO_LABEL,
 } from "./sentry-triage-project.mjs";
@@ -597,6 +598,7 @@ await test("selectVerdictComment ignores marker comments from untrusted authors"
   assertDeepEqual(selectVerdictComment(comments), {
     body: null,
     reason: "no-verdict-comment",
+    url: null,
   });
 });
 
@@ -667,7 +669,44 @@ await test("selectVerdictComment reports no-verdict-comment when none present", 
   assertDeepEqual(selectVerdictComment([botComment("hi", "x")]), {
     body: null,
     reason: "no-verdict-comment",
+    url: null,
   });
+});
+
+await test("selectVerdictComment surfaces the selected comment url (#1506 token)", () => {
+  const url =
+    "https://github.com/mento-protocol/monitoring-monorepo/issues/1#issuecomment-42";
+  const comments = [
+    {
+      ...botComment(verdictComment({ summary: "s" }), "2026-07-17T10:00:00Z"),
+      url,
+    },
+  ];
+  assertEqual(selectVerdictComment(comments).url, url);
+  // A urlless comment (older gh shapes / synthetic) yields null, not undefined.
+  assertEqual(
+    selectVerdictComment([
+      botComment(verdictComment({ summary: "s" }), "2026-07-17T10:00:00Z"),
+    ]).url,
+    null,
+  );
+});
+
+await test("verdictCommentIdFromUrl parses the numeric issuecomment id", () => {
+  assertEqual(
+    verdictCommentIdFromUrl(
+      "https://github.com/o/r/issues/1#issuecomment-4994848410",
+    ),
+    "4994848410",
+  );
+  assertEqual(
+    verdictCommentIdFromUrl("https://github.com/o/r/pull/2#issuecomment-1"),
+    "1",
+  );
+  assertEqual(verdictCommentIdFromUrl("https://github.com/o/r/issues/1"), null);
+  assertEqual(verdictCommentIdFromUrl("#issuecomment-abc"), null);
+  assertEqual(verdictCommentIdFromUrl(null), null);
+  assertEqual(verdictCommentIdFromUrl(undefined), null);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The Problem

- The #1389 marker guard checks label **presence**, not verdict **identity**. An ABA — a re-triage sheds then re-adds `sentry:verdict-code-fix` with a **new** verdict comment during the finalize window — passes label-presence yet marks the stub fixed from the **old** verdict's diff.
- Practically narrow (triage runs for minutes, twice daily), but the guard was a proxy, not a proof.

## The Solution

- Thread a **generation token** — the numeric `#issuecomment` id of the verdict comment each fix was based on — from the trusted `select` job through the matrix to `finalize`.
- `finalize`'s `verdict_live` now re-selects the live verdict comment and **withdraws (fail-closed)** if the id no longer matches, at both the pre- and post-write points. That catches the ABA label-presence can't see.
- Reconcile entries carry no token (they relink a prior run's PR, whose originating verdict id select never saw) and stay on the label-presence guard. The token is **never** sourced from the agent job or the handoff artifact.

## Details

- `selectVerdictComment` surfaces the selected comment `url`; new `verdictCommentIdFromUrl` parses the numeric id (validated `^[0-9]+$` — not the opaque GraphQL node id); `resolveVerdict` passes the url through; `evaluateCandidate` emits `verdictCommentId` (omitted → label-presence fallback → only when the url is unparseable).
- New `selected-verdict-id --comments-file` finalize subcommand re-runs the same fence over the live comments, fail-closed to `none`.
- Verified `select` and `finalize` derive the **same** id from the same live comment (real `#1304 → 4994848410`).

## Validation

- Unit tests: `sentry-autofix-select` 19/0, `sentry-autofix-finalize` 29/0 (+ `selected-verdict-id` and `verdictCommentIdFromUrl` cases), project suite green.
- `actionlint`, `bash -n` on the guard, `check-autofix-ci-trust.mjs` (29 workflows), docs nav-eval — all clean.
- Adversarial red-team (3 opus lenses: fail-open, select↔finalize consistency, trust/spoofing) — **0 defects**.

## Deferrals

- None
