### PR TITLE
docs: garden final process checklist shard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,9 +99,9 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/pr-checklists/mutation-testing.md`](pr-checklists/mutation-testing.md) | Mutation Testing Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-23 |
 | [`docs/pr-checklists/recurring-review-patterns.md`](pr-checklists/recurring-review-patterns.md) | Recurring PR Review Patterns | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/pr-checklists/review-prompt-exclusions.md`](pr-checklists/review-prompt-exclusions.md) | Review Prompt Exclusions | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-03 |
-| [`docs/pr-checklists/stateful-data-ui.md`](pr-checklists/stateful-data-ui.md) | Stateful Data and UI Checklist | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/pr-checklists/swr-polling-hasura.md`](pr-checklists/swr-polling-hasura.md) | SWR and Hasura Polling Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-17 |
-| [`docs/pr-checklists/terraform-cloudrun.md`](pr-checklists/terraform-cloudrun.md) | Terraform and Cloud Run Checklist | canonical / active | checklist / terraform/infra | eng | 90d; verified 2026-07-17 |
+| [`docs/pr-checklists/stateful-data-ui.md`](pr-checklists/stateful-data-ui.md) | Stateful Data and UI Checklist | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/pr-checklists/swr-polling-hasura.md`](pr-checklists/swr-polling-hasura.md) | SWR and Hasura Polling Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-23 |
+| [`docs/pr-checklists/terraform-cloudrun.md`](pr-checklists/terraform-cloudrun.md) | Terraform and Cloud Run Checklist | canonical / active | checklist / terraform/infra | eng | 90d; verified 2026-07-23 |
 
 ## adrs-architecture
 

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -3,7 +3,7 @@ title: Stateful Data and UI Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-23
 doc_type: checklist
 scope: repo-wide
 review_interval_days: 90

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -3,7 +3,7 @@ title: SWR and Hasura Polling Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-23
 doc_type: checklist
 scope: ui-dashboard
 review_interval_days: 90

--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -3,7 +3,7 @@ title: Terraform and Cloud Run Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-23
 doc_type: checklist
 scope: terraform/infra
 review_interval_days: 90
@@ -18,7 +18,7 @@ Use this checklist for any change to `terraform/` or to a deploy script that tal
 
 > **Every project-level mutation must be ordered behind the IAM owner binding, and every Cloud Run knob must work on bootstrap, on re-apply, AND on workflow-dispatch retry.**
 
-## 1. Resource refactors
+## 1. Resource refactors and retirement
 
 When you rename a resource, change its address (e.g. remove `count`/`for_each`, move it into a module), or split one resource into two:
 
@@ -26,9 +26,20 @@ When you rename a resource, change its address (e.g. remove `count`/`for_each`, 
   - Fails immediately if the resource has `deletion_protection = true` (Cloud Run services in this repo do)
   - Briefly destroys IAM members, revoking public access for the duration of the apply
   - Loses any drift the team accepted out-of-band (e.g. an image rolled by `gcloud run services update`)
-- [ ] Run `pnpm infra:plan` and confirm the plan shows `# ... will be moved to ...`, NOT `# ... will be destroyed`
+- [ ] When Terraform should stop managing an object but the remote object must
+      survive, replace its resource block with a `removed` block whose
+      `lifecycle` sets `destroy = false`. Simply deleting the resource block
+      plans remote destruction. `removed` blocks require Terraform 1.7 or
+      newer; raise the owning root's `required_version` when needed.
+- [ ] Find the owning stack with `pnpm tf list` or
+      `terraform.stacks.json`, then run `pnpm tf plan <owning-stack>`.
+      `pnpm infra:plan` is only an alias for the `platform` stack. Confirm the
+      plan shows the intended move or state removal and no unintended
+      `# ... will be destroyed` action.
 
-The canonical example is `terraform/metrics-bridge.tf` — the metrics-bridge `moved` blocks added in PR #201.
+Current examples are the metrics-bridge `moved` blocks in
+`terraform/metrics-bridge.tf` and the state-only retirement in
+`terraform/dashboard.tf`.
 
 ## 2. Cloud Run service shape
 
@@ -110,7 +121,8 @@ New GCP project, Cloud Function, or versioned-bucket stacks ship WITH retention 
 
 ## 8. Pre-apply rituals
 
-- [ ] `pnpm infra:plan` ALWAYS before apply; read every `# ... will be destroyed` line
+- [ ] Run `pnpm tf plan <owning-stack>` ALWAYS before apply; read every
+      `# ... will be destroyed` line
 - [ ] If the plan touches `google_cloud_run_v2_service`, double-check that image/API bookkeeping drift is ignored and probe paths still match the deployed app
 - [ ] After apply, hit the public URL once and confirm a 200 from `/health` — Cloud Run can return 503s for ~30s while the new revision rolls
 

--- a/governance-watchdog/README.md
+++ b/governance-watchdog/README.md
@@ -19,6 +19,8 @@ ID. It is not part of the `mento-alerts` or `mento-monitoring` projects.
 - Stack ownership and apply policy: [`docs/terraform.md`](../docs/terraform.md)
   and the `governance-watchdog` row in
   [`terraform.stacks.json`](../terraform.stacks.json).
+- Terraform, Cloud Function, and deploy-input review:
+  [`docs/pr-checklists/terraform-cloudrun.md`](../docs/pr-checklists/terraform-cloudrun.md).
 - Adding an event or changing a QuickNode filter:
   [`ADDING_EVENTS.md`](ADDING_EVENTS.md).
 - First deployment into a new GCP project:

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -180,7 +180,9 @@ gcp_billing_account = "..."
 
 # Container image for the metrics-bridge Cloud Run service.
 # Built by CI on merge to main, or manually via `pnpm bridge:deploy`.
-# Leave empty until first image is built — Cloud Run won't be provisioned.
+# Omit this override to use the digest-pinned bootstrap image in variables.tf.
+# Empty strings are invalid; set a concrete image only when intentionally
+# changing the service's first-creation image.
 # metrics_bridge_image = "europe-west1-docker.pkg.dev/mento-monitoring/metrics-bridge/metrics-bridge:abc123"
 
 # Dev team IAM — defaults to group:eng@mentolabs.xyz in variables.tf.


### PR DESCRIPTION
## The Problem

- The final PR-checklists garden packet needed an evidence-backed disposition
  for all three canonical checklists.
- The Terraform checklist treated a platform-only alias as universal, omitted
  safe state-only resource retirement, and routed governance work weakly.
- The metrics-bridge image example still told operators to use an empty value
  that the current variable validation rejects.

## The Solution

Verify each checklist against its current owners, routing, tests, and runtime
source. Keep the stateful-data and SWR contracts unchanged, tighten the
Terraform operating guidance, correct the stale image example, and add the
missing governance route.

## Details

Audit dispositions:

- **Update — `stateful-data-ui.md`:** refreshed `last_verified` after checking
  root/package routing, quality-gate and autoreview selection, and the current
  trading-time, URL-state, cache-hydration, and day-aligned snapshot owners.
  Its operating rules remain unchanged.
- **Keep — `swr-polling-hasura.md`:** confirmed the 30-second `useGQL`
  defaults, focus/reconnect suppression, visibility/offline-aware retry,
  truncation freshness behavior, regression coverage, and inbound routing.
  Refreshed its verification date only.
- **Update — `terraform-cloudrun.md`:** retained all version/incident
  references after source verification; route plans through
  `pnpm tf plan <owning-stack>`, document `removed` blocks with
  `destroy = false`, correct the bootstrap-image example, and route
  governance-watchdog deploy-input work to the checklist.

No executable workflow or production state changes in this PR.

## Deferrals

- #1549 tracks the separate `bridge:deploy` saved-plan and explicit Terraform
  approval fix.
- #1550 tracks excluding generated coverage from governance-watchdog function
  archives and gcloud upload inputs.

## Validation

- `CI=true pnpm docs:audit --dry-run --date 2026-10-05 --lane pr-checklists-process --shard 2 --format json`
- `CI=true pnpm docs:index --check`
- `CI=true pnpm agent:context-check`
- `CI=true pnpm agent:context-budget --strict`
- `CI=true pnpm agent:quality-gate --run`
  - targeted Trunk checks
  - Terraform format, init, and validate
  - documentation catalog and navigation fixtures
- attested autoreview bundle verified before and after an in-session semantic
  review with manifest
  `e4185d447b16b8efa2b51d15536dbbf85fe7208280bb2ea964533c6cc765aefb`
- deterministic local autoreview: clean

Browser verification does not apply: the diff changes documentation and a
comment-only Terraform example.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1548
Closes #1350
Refs #1341
