### PR TITLE
fix(ci): flag checkout token persistence and workflow_run chains in autofix trust checker (#1460, #1461)

### DIFF
--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -63,6 +63,13 @@ permissions:
 
 jobs:
   notify:
+    # autofix-ci-trust: fires only for upstream runs where
+    #   workflow_run.head_branch == 'main' (see the if: gate below), so a
+    #   sentry-autofix/* upstream run never reaches it; and this job checks out
+    #   no PR-head code — it reads workflow_run.* metadata into env and posts to
+    #   Slack. The == 'main' equality is a STRONGER exclusion than the
+    #   mechanically-credited !startsWith(head_branch,'sentry-autofix/') shape,
+    #   which the checker cannot recognize — hence this annotation.
     # Test-fire path: workflow_dispatch always posts (no failure gate).
     # Real path: only post when a watched workflow's push-to-main run failed.
     # Catch every "silent failure" conclusion, not just plain `failure`:

--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           # Need full history to `git show` the base-ref schema.
           fetch-depth: 0
+          # The sticky-comment action authenticates via the API token it is
+          # handed directly; the write-scoped GITHUB_TOKEN must not persist into
+          # .git/config, where PR-head code (incl. a machine-authored autofix
+          # diff) could read it. autofix CI-trust boundary — see
+          # check-autofix-ci-trust.mjs, issue #1460.
+          persist-credentials: false
       - id: filter
         # `continue-on-error: true` keeps a failed path-detection step from
         # failing the job; the `decide` step below interprets a missing/failed

--- a/scripts/check-autofix-ci-trust.mjs
+++ b/scripts/check-autofix-ci-trust.mjs
@@ -20,7 +20,9 @@
  *  2. Every JOB that can receive a CREDENTIAL in a workflow REACHABLE on an
  *     autofix branch — the eventual `pull_request`, the `push` the finalizer
  *     makes to `sentry-autofix/*` before the PR exists (when its branch filter
- *     admits that branch), or the `create` event of that branch — must guard or
+ *     admits that branch), the `create` event of that branch, or a
+ *     `workflow_run` fired by an upstream workflow that itself ran on that
+ *     branch — must guard or
  *     annotate. "Credential" is: a `${{ secrets.* }}` reference (its own or
  *     inherited from workflow-level `env:`), a reusable-workflow `secrets:`
  *     forward or local reusable-workflow (`uses: ./…`) call, an
@@ -33,7 +35,10 @@
  *           'sentry-autofix/')` for pull_request (GUARD_PATTERN),
  *           `!startsWith(github.ref, 'refs/heads/sentry-autofix/')` (or
  *           `github.ref_name`, `'sentry-autofix/'`) for push/create
- *           (PUSH_GUARD_PATTERN); nothing looser counts — or
+ *           (PUSH_GUARD_PATTERN),
+ *           `!startsWith(github.event.workflow_run.head_branch,
+ *           'sentry-autofix/')` for workflow_run (WORKFLOW_RUN_GUARD_PATTERN);
+ *           nothing looser counts — or
  *       (b) carry an `# autofix-ci-trust:` annotation COMMENT LINE stating
  *           WHY no guard is needed (secret step-scoped away from PR-head code
  *           execution, actor-gated job, paths the autofix diff guard forbids,
@@ -97,6 +102,16 @@ const GUARD_PATTERN =
 // `sentry-autofix/…`.
 const PUSH_GUARD_PATTERN =
   /!\s*startsWith\s*\(\s*github\.(?:ref\s*,\s*'refs\/heads\/sentry-autofix\/'|ref_name\s*,\s*'sentry-autofix\/')\s*\)/i;
+// The workflow_run analogue: `github.event.workflow_run.head_branch` is the
+// SHORT branch name of the upstream run (`sentry-autofix/…`, NOT a
+// `refs/heads/…` ref), so the excluding guard tests that short prefix directly
+// — a `refs/heads/` literal would never match head_branch and would be a broken
+// guard (evaluates true → job runs). head_branch excludes the whole autofix
+// namespace regardless of the upstream run's repository, so this is the
+// autofix-trust key; broader fork exclusion via head_repository.full_name is a
+// separate concern this checker does not model.
+const WORKFLOW_RUN_GUARD_PATTERN =
+  /!\s*startsWith\s*\(\s*github\.event\.workflow_run\.head_branch\s*,\s*'sentry-autofix\/'\s*\)/i;
 const ANNOTATION = "# autofix-ci-trust:";
 const ANNOTATION_LINE = /^\s*#\s*autofix-ci-trust:/;
 
@@ -315,6 +330,74 @@ export function hasWritePermission(permissions) {
   return false;
 }
 
+/**
+ * True when a step `uses:` value invokes `actions/checkout` at ANY ref — the
+ * canonical `actions/checkout@<ref>`, a bare `actions/checkout`, or a subpath
+ * action under that repo — matched case-insensitively (GitHub resolves action
+ * owner/repo case-insensitively). Anchored on the path segment so a LOOKALIKE
+ * like `actions/checkout-something-else` is NOT credited: the `checkout`
+ * segment must terminate at `@`, `/`, or end-of-string.
+ *
+ * The value is TRIMMED first: js-yaml preserves leading/trailing whitespace
+ * inside a QUOTED scalar (`uses: " actions/checkout@v4"`), and the anchored
+ * match would otherwise MISS it — a fail-OPEN. Trimming can only ever match
+ * MORE, never fewer, so it is strictly fail-closed (this checker refuses to
+ * depend on whether GitHub happens to trim such a value at resolve time).
+ */
+function isCheckoutAction(uses) {
+  return /^actions\/checkout(?=@|\/|$)/i.test(uses.trim());
+}
+
+/**
+ * True when a job with an effective WRITE permission runs `actions/checkout`
+ * that PERSISTS the automatic GITHUB_TOKEN into `.git/config`. checkout's
+ * `persist-credentials` defaults to TRUE, writing the run's write-scoped
+ * `GITHUB_TOKEN` into the working tree's git config, where any later step —
+ * including one executing a machine-authored autofix diff's own code — can read
+ * it and push/mutate the repo. So a write-permission job that checks out
+ * WITHOUT `persist-credentials: false` holds a mutating credential even when it
+ * never names `github.token` textually.
+ *
+ * A step opts OUT only with the boolean `false` or a string that
+ * case-insensitively equals "false" — exactly what actions/checkout's own
+ * core.getBooleanInput accepts (false/False/FALSE; js-yaml's CORE_SCHEMA yields
+ * a boolean for unquoted `false`, a string for a quoted `"false"`). ANY other
+ * value (true, an expression, unset, a missing `with:` block) leaves the token
+ * on disk. Multiple checkout steps: if ANY persists, the token is written →
+ * flag (a persist-credentials:false step does not undo a sibling plain
+ * checkout).
+ *
+ * Fails CLOSED on ambiguity: reached only for object jobs; a missing/non-array
+ * `steps`, non-object steps, steps without a string `uses`, or a non-object
+ * `with:` contribute no opt-out and cannot clear the job.
+ *
+ * ASSUMPTIONS (kept explicit, same as the github.token branch): a job with no
+ * explicit `permissions:` anywhere resolves to effectivePermissions=undefined →
+ * hasWritePermission=false → not flagged; this relies on the repo default token
+ * being read-only. A composite/local action that internally checks out is not
+ * followed cross-file.
+ *
+ * Exported for tests.
+ * @param {any} job
+ * @param {any} effectivePermissions the job's effective `permissions:` (own or inherited)
+ */
+export function jobPersistsWriteCheckout(job, effectivePermissions) {
+  if (!hasWritePermission(effectivePermissions)) return false;
+  if (!job || typeof job !== "object" || !Array.isArray(job.steps))
+    return false;
+  for (const step of job.steps) {
+    if (!step || typeof step !== "object") continue;
+    if (typeof step.uses !== "string" || !isCheckoutAction(step.uses)) continue;
+    const w = step.with;
+    const pc =
+      w != null && typeof w === "object" ? w["persist-credentials"] : undefined;
+    const optsOut =
+      pc === false || (typeof pc === "string" && pc.toLowerCase() === "false");
+    if (!optsOut) return true;
+  }
+  return false;
+}
+
 const THIS_REPO = "mento-protocol/monitoring-monorepo";
 
 /** True when a job's `uses:` value names a reusable workflow IN THIS REPO —
@@ -375,6 +458,11 @@ export function jobReceivesCredential(job, inherited) {
   ) {
     return true;
   }
+  // A write-permission job that runs actions/checkout WITHOUT
+  // `persist-credentials: false` leaves the run's write-scoped GITHUB_TOKEN in
+  // .git/config, readable by any later step that executes PR-head (autofix-diff)
+  // code — a mutating credential even with no textual github.token reference.
+  if (jobPersistsWriteCheckout(job, effectivePermissions)) return true;
   // A `secrets:` key exists only on a reusable-workflow (`uses:`) call and
   // always forwards the caller's secrets — `inherit` (string) or a map.
   if (job.secrets != null) return true;
@@ -398,19 +486,26 @@ export function jobReceivesCredential(job, inherited) {
 
 /** True when a parsed job's OWN job-level `if:` carries the excluding guard for
  * the given trigger CONTEXT — `"pull_request"` excludes on the PR head ref,
- * `"push"` excludes on `github.ref`. The contexts are independent: a job
- * reachable via both must exclude in both. `js-yaml` already dropped any
- * trailing comment, so the value is exactly the expression GitHub evaluates; a
- * step-level `if:` lives under `steps[]` and is correctly not consulted here.
+ * `"push"` excludes on `github.ref`, `"workflow_run"` excludes on the upstream
+ * run's `github.event.workflow_run.head_branch`. The contexts are independent:
+ * a job reachable via several must exclude in each. `js-yaml` already dropped
+ * any trailing comment, so the value is exactly the expression GitHub
+ * evaluates; a step-level `if:` lives under `steps[]` and is correctly not
+ * consulted here.
  *
  * Exported for tests.
  * @param {any} job
- * @param {"pull_request"|"push"} context
+ * @param {"pull_request"|"push"|"workflow_run"} context
  */
 export function jobGuarded(job, context = "pull_request") {
   if (!job || typeof job !== "object") return false;
   const expr = String(job.if ?? "");
-  const pattern = context === "push" ? PUSH_GUARD_PATTERN : GUARD_PATTERN;
+  const pattern =
+    context === "push"
+      ? PUSH_GUARD_PATTERN
+      : context === "workflow_run"
+        ? WORKFLOW_RUN_GUARD_PATTERN
+        : GUARD_PATTERN;
   return pattern.test(expr);
 }
 
@@ -624,6 +719,16 @@ export function evaluateWorkflow(body) {
   // `create` fires when the finalizer creates the sentry-autofix/* branch; the
   // job then sees that ref, so it needs the same ref-based exclusion as push.
   if (triggers.has("create")) contextSet.add("push");
+  // `workflow_run` fires when an upstream workflow (CI, …) COMPLETES. On an
+  // autofix-branch PR that upstream run is on the sentry-autofix/* head, and the
+  // downstream job can check out github.event.workflow_run.head_sha — running
+  // autofix-authored code while holding this repo's secrets and a privileged
+  // token. Every pull_request/push workflow here is already autofix-reachable,
+  // so ANY workflow_run listening to a repo-internal workflow is reachable too:
+  // treat every workflow_run trigger as an autofix context (conservative fail
+  // closed; no cross-workflow resolution). Its excluding guard tests
+  // github.event.workflow_run.head_branch.
+  if (triggers.has("workflow_run")) contextSet.add("workflow_run");
   const contexts = [...contextSet];
   if (contexts.length === 0) {
     return { ok: true };
@@ -666,7 +771,7 @@ export function evaluateWorkflow(body) {
   return {
     ok: false,
     reason:
-      `triggers on ${via} (reachable on an autofix branch), and job(s) [${offenders.join(", ")}] can receive a credential without an excluding autofix guard (${via.includes("push") ? "`!startsWith(github.ref, 'refs/heads/sentry-autofix/')` for push, " : ""}\`!startsWith(github.event.pull_request.head.ref, 'sentry-autofix/')\` for pull_request, on the job's if:) or an '${ANNOTATION}' annotation in that job (or a file-level annotation above \`jobs:\`). ` +
+      `triggers on ${via} (reachable on an autofix branch), and job(s) [${offenders.join(", ")}] can receive a credential without an excluding autofix guard (${via.includes("push") ? "`!startsWith(github.ref, 'refs/heads/sentry-autofix/')` for push, " : ""}${via.includes("workflow_run") ? "`!startsWith(github.event.workflow_run.head_branch, 'sentry-autofix/')` for workflow_run, " : ""}\`!startsWith(github.event.pull_request.head.ref, 'sentry-autofix/')\` for pull_request, on the job's if:) or an '${ANNOTATION}' annotation in that job (or a file-level annotation above \`jobs:\`). ` +
       "Machine-authored autofix PRs pass every fork/dependabot check, and the finalizer pushes the sentry-autofix/* branch before the PR exists, so each credential-bearing job reachable on that branch must exclude it " +
       "or document why its secrets are unreachable from autofix-branch code execution.",
   };

--- a/scripts/check-autofix-ci-trust.test.mjs
+++ b/scripts/check-autofix-ci-trust.test.mjs
@@ -5,6 +5,7 @@ import {
   grantsOidc,
   hasPullRequestTrigger,
   jobGuarded,
+  jobPersistsWriteCheckout,
   jobReceivesCredential,
   parseWorkflow,
   pushAdmitsAutofix,
@@ -974,6 +975,339 @@ test("a quoted-scalar continuation ending in | is not a block introducer", () =>
   assert(
     !v.ok && /\[leak\]/.test(v.reason),
     "marker inside the pipe-ending quoted scalar is not an annotation",
+  );
+});
+
+// ── #1460: write-permission jobs with a credential-persisting checkout ────────
+// A pull_request workflow (autofix-reachable) whose `build` job has a write
+// permission + a checkout but NO secret/github.token reference, so ONLY the
+// #1460 checkout-persistence path can make it credential-bearing.
+const WRITE_PERM_1460 = ["    permissions:", "      contents: write"];
+const READ_PERM_1460 = ["    permissions:", "      contents: read"];
+
+function prBuildJob(jobLines) {
+  return [
+    "on:",
+    "  pull_request:",
+    "jobs:",
+    "  build:",
+    "    runs-on: ubuntu-latest",
+    ...jobLines,
+  ].join("\n");
+}
+
+test("#1460 write-perm job with a plain checkout is flagged (persists GITHUB_TOKEN)", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+    ]),
+  );
+  assert(
+    !v.ok && /\[build\]/.test(v.reason),
+    "write-perm + plain checkout flagged",
+  );
+});
+
+test("#1460 write-perm job with persist-credentials:false is cleared", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+      "        with:",
+      "          persist-credentials: false",
+    ]),
+  );
+  assert(v.ok, "persist-credentials:false clears it");
+});
+
+test("#1460 read-only job with a checkout is cleared", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...READ_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+    ]),
+  );
+  assert(v.ok, "read-only + checkout is not a credential");
+});
+
+test("#1460 workflow-level write perm inherited by a no-perms job + checkout is flagged", () => {
+  const v = evaluateWorkflow(
+    [
+      "on:",
+      "  pull_request:",
+      "permissions:",
+      "  contents: write",
+      "jobs:",
+      "  build:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+    ].join("\n"),
+  );
+  assert(
+    !v.ok && /\[build\]/.test(v.reason),
+    "inherited write perm + checkout flagged",
+  );
+});
+
+test("#1460 persist-credentials as an expression still persists (flagged)", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+      "        with:",
+      "          persist-credentials: ${{ inputs.persist }}",
+    ]),
+  );
+  assert(
+    !v.ok && /\[build\]/.test(v.reason),
+    "expression persist-credentials flagged",
+  );
+});
+
+test("#1460 a subpath actions/checkout/foo@v1 is treated as a checkout (flagged)", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout/foo@v1",
+    ]),
+  );
+  assert(!v.ok && /\[build\]/.test(v.reason), "subpath checkout flagged");
+});
+
+test("#1460 a matrix job with a checkout is flagged", () => {
+  const v = evaluateWorkflow(
+    [
+      "on:",
+      "  pull_request:",
+      "jobs:",
+      "  build:",
+      "    runs-on: ubuntu-latest",
+      "    permissions:",
+      "      contents: write",
+      "    strategy:",
+      "      matrix:",
+      "        node: [18, 20]",
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+    ].join("\n"),
+  );
+  assert(
+    !v.ok && /\[build\]/.test(v.reason),
+    "matrix job with checkout flagged",
+  );
+});
+
+test('#1460 a quoted "False" persist-credentials opt-out is honored (case-insensitive)', () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+      "        with:",
+      '          persist-credentials: "False"',
+    ]),
+  );
+  assert(v.ok, "capitalized False opt-out clears it");
+});
+
+test("#1460 a leading-whitespace quoted checkout uses is still detected (fail-closed)", () => {
+  const v = evaluateWorkflow(
+    prBuildJob([
+      ...WRITE_PERM_1460,
+      "    steps:",
+      '      - uses: " actions/checkout@v4"',
+    ]),
+  );
+  assert(
+    !v.ok && /\[build\]/.test(v.reason),
+    "space-prefixed quoted checkout flagged",
+  );
+});
+
+test("#1460 jobPersistsWriteCheckout fails closed on odd step shapes", () => {
+  const wp = { contents: "write" };
+  assert(
+    jobPersistsWriteCheckout({ permissions: wp }, wp) === false,
+    "missing steps → false",
+  );
+  assert(
+    jobPersistsWriteCheckout({ steps: "nope" }, wp) === false,
+    "non-array steps → false",
+  );
+  assert(
+    jobPersistsWriteCheckout({ steps: [null, 42, {}] }, wp) === false,
+    "junk steps contribute nothing → false",
+  );
+  assert(
+    jobPersistsWriteCheckout(
+      { steps: [{ uses: "actions/checkout@v4" }] },
+      { contents: "read" },
+    ) === false,
+    "no write perm short-circuits → false",
+  );
+  assert(
+    jobPersistsWriteCheckout(
+      { steps: [{ uses: "actions/checkout@v4" }] },
+      wp,
+    ) === true,
+    "write perm + plain checkout → true",
+  );
+  assert(
+    jobPersistsWriteCheckout(
+      {
+        steps: [
+          {
+            uses: "actions/checkout@v4",
+            with: { "persist-credentials": false },
+          },
+          { uses: "actions/checkout@v4" },
+        ],
+      },
+      wp,
+    ) === true,
+    "a persisting sibling checkout is not undone by an opt-out sibling → true",
+  );
+  assert(
+    jobPersistsWriteCheckout(
+      { steps: [{ uses: "actions/checkout-lookalike@v4" }] },
+      wp,
+    ) === false,
+    "actions/checkout-lookalike is not a checkout → false",
+  );
+});
+
+// ── #1461: workflow_run chains from autofix-branch upstream runs ───────────────
+const WF_RUN_ON = [
+  "on:",
+  "  workflow_run:",
+  "    workflows: [CI]",
+  "    types: [completed]",
+];
+
+function wfRunNotifyJob(jobLines) {
+  return [
+    ...WF_RUN_ON,
+    "jobs:",
+    "  notify:",
+    "    runs-on: ubuntu-latest",
+    ...jobLines,
+  ].join("\n");
+}
+
+test("#1461 an unguarded credential-bearing workflow_run job is flagged (names the head_branch guard form)", () => {
+  const v = evaluateWorkflow(wfRunNotifyJob([SECRET_STEP]));
+  assert(
+    !v.ok && /\[notify\]/.test(v.reason),
+    "workflow_run secret job flagged",
+  );
+  assert(
+    /workflow_run\.head_branch/.test(v.reason),
+    "reason names the workflow_run guard form, not just the token 'workflow_run'",
+  );
+});
+
+test("#1461 a workflow_run job guarded on head_branch startsWith is cleared", () => {
+  const v = evaluateWorkflow(
+    wfRunNotifyJob([
+      "    if: ${{ !startsWith(github.event.workflow_run.head_branch, 'sentry-autofix/') }}",
+      SECRET_STEP,
+    ]),
+  );
+  assert(v.ok, "short head_branch startsWith guard clears it");
+});
+
+test("#1461 an annotated workflow_run job is cleared", () => {
+  const v = evaluateWorkflow(
+    [
+      ...WF_RUN_ON,
+      "jobs:",
+      "  notify:",
+      "    # autofix-ci-trust: reads only workflow_run metadata; gated to main below",
+      "    runs-on: ubuntu-latest",
+      SECRET_STEP,
+    ].join("\n"),
+  );
+  assert(v.ok, "annotation clears the workflow_run job");
+});
+
+test("#1461 a workflow_run workflow with no credential job passes", () => {
+  const v = evaluateWorkflow(
+    [
+      ...WF_RUN_ON,
+      "jobs:",
+      "  notify:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - run: echo hi",
+    ].join("\n"),
+  );
+  assert(v.ok, "no-credential workflow_run passes");
+});
+
+test("#1461 a full refs/heads prefix on the SHORT head_branch field is NOT credited (flagged)", () => {
+  // head_branch is the short branch name; a refs/heads/ literal never matches it,
+  // so it is a broken guard and must be rejected — mirror of the push short-prefix rule.
+  const v = evaluateWorkflow(
+    wfRunNotifyJob([
+      "    if: ${{ !startsWith(github.event.workflow_run.head_branch, 'refs/heads/sentry-autofix/') }}",
+      SECRET_STEP,
+    ]),
+  );
+  assert(
+    !v.ok && /\[notify\]/.test(v.reason),
+    "refs/heads prefix on head_branch rejected",
+  );
+});
+
+test("#1461 a workflow_run job gated ONLY by head_branch == 'main' is flagged; an annotation clears it", () => {
+  const equality = wfRunNotifyJob([
+    "    if: ${{ github.event.workflow_run.head_branch == 'main' }}",
+    SECRET_STEP,
+  ]);
+  assert(
+    !evaluateWorkflow(equality).ok,
+    "== 'main' equality is not auto-credited",
+  );
+  const annotated = [
+    ...WF_RUN_ON,
+    "jobs:",
+    "  notify:",
+    "    # autofix-ci-trust: gated to head_branch == 'main' (stronger than the credited startsWith)",
+    "    runs-on: ubuntu-latest",
+    "    if: ${{ github.event.workflow_run.head_branch == 'main' }}",
+    SECRET_STEP,
+  ].join("\n");
+  assert(
+    evaluateWorkflow(annotated).ok,
+    "annotation documents the equality gate",
+  );
+});
+
+test("#1461 jobGuarded distinguishes the workflow_run context", () => {
+  const wfGuarded = {
+    if: "${{ !startsWith(github.event.workflow_run.head_branch, 'sentry-autofix/') }}",
+  };
+  const prGuarded = {
+    if: "${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}",
+  };
+  assert(
+    jobGuarded(wfGuarded, "workflow_run") === true,
+    "wf guard matches workflow_run context",
+  );
+  assert(
+    jobGuarded(prGuarded, "workflow_run") === false,
+    "a PR guard does not vouch for the workflow_run context",
+  );
+  assert(
+    jobGuarded(wfGuarded, "pull_request") === false,
+    "a workflow_run guard does not vouch for the pull_request context",
   );
 });
 


### PR DESCRIPTION
## The Problem

- The autofix CI-trust checker classifies a job as credential-bearing by its
  textual token/secret references, so a job with a **write** permission and a
  default `actions/checkout` (which persists the write-scoped `GITHUB_TOKEN` in
  `.git/config`) passed as credential-free (#1460).
- The checker models `pull_request`, `push`, and `create`, but not
  **`workflow_run`** — a credential-bearing workflow that fires when an upstream
  workflow completes on a `sentry-autofix/*` head runs autofix-authored code
  with secrets outside every guarded context (#1461).

## The Solution

Broaden what the checker counts as an autofix-reachable credential so it fails
closed on both gaps, and guard the two real workflows that would otherwise
newly flag.

- **#1460:** a new `jobPersistsWriteCheckout` treats a write-permission job that
  runs `actions/checkout` without `persist-credentials: false` as
  credential-bearing.
- **#1461:** `workflow_run` is now a reachable context; its credential-bearing
  jobs must exclude the autofix head on
  `github.event.workflow_run.head_branch` or annotate.

## Details

- Checkout matching (`isCheckoutAction`) trims the `uses:` value before an
  anchored `^actions/checkout(?=@|/|$)` match — a quoted `" actions/checkout@v4"`
  cannot slip past (fail-open closed), while `actions/checkout-lookalike` is not
  credited. The `persist-credentials` opt-out honors the boolean `false` and a
  case-insensitive string `"false"` (matching checkout's own `getBooleanInput`);
  any other value (expression, unset, missing `with:`) persists. Multiple
  checkouts: if any persists, the job flags. Fails closed on odd step shapes.
- `WORKFLOW_RUN_GUARD_PATTERN` keys on the SHORT `head_branch` field (a
  `refs/heads/` literal would never match it and is correctly rejected).
  `jobGuarded` gains a `"workflow_run"` context; the offenders message names the
  new guard form. Conservative fail-closed: any `workflow_run` trigger is an
  autofix context (no cross-workflow resolution).
- **Companion edits (required to keep the checker's own CI run green):**
  - `schema-diff.yml` — its write-perm PR job now sets
    `persist-credentials: false` (it authenticates via a handed API token, not
    the persisted `GITHUB_TOKEN`).
  - `notify-slack-on-main-failure.yml` — the sole real `on: workflow_run`
    workflow; its `notify` job is gated to `head_branch == 'main'` (a stronger
    exclusion than the credited `startsWith` shape, which the checker cannot
    recognize) and checks out no PR-head code, so it carries an
    `# autofix-ci-trust:` annotation. The checker deliberately does not
    auto-credit the `== 'main'` equality.

## Validation

- `node scripts/check-autofix-ci-trust.test.mjs` → **56 passed, 0 failed**
  (+17 cases across both gaps: plain/opt-out/read-only/inherited/expression/
  subpath/matrix/case-insensitive/leading-space checkout, and guarded/unguarded/
  annotated/no-credential/refs-heads-rejected/equality-only `workflow_run`).
- `node scripts/check-autofix-ci-trust.mjs` → **green** over all 29 real
  workflows, with both companion edits.
- `trunk fmt` → clean.

Closes #1460
Closes #1461
Refs #1388, #1373
