### PR TITLE
fix(ci): exclude the CODECOV_TOKEN step on autofix heads (#1453)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,18 @@ name: CI
 # .github/workflows/claude.yml — update via Dependabot
 # (.github/dependabot.yml).
 #
-# autofix-ci-trust: the only repository secret here is CODECOV_TOKEN, and it
-# is step-scoped to the pinned codecov-action's `with: token` — it is never in
-# a job/workflow `env:` and never in the environment of a step that executes
-# PR-head code. Every checkout also sets `persist-credentials: false`, so no
-# checkout token sits in .git/config while PR code (incl. a machine-authored
-# sentry-autofix diff) builds or tests. See check-autofix-ci-trust.mjs.
+# autofix-ci-trust: the only repository secret here is CODECOV_TOKEN. It is
+# step-scoped to the pinned codecov-action's `with: token`, but each package
+# quality job runs the PR's build and tests EARLIER in the SAME job, and that
+# PR-head code can write $GITHUB_ENV/$GITHUB_PATH to influence the later upload
+# step — so step-scoping alone does not isolate the token from PR-controlled
+# code (issue #1453). Therefore every codecov upload step additionally carries
+# `if: !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/')`: on a
+# machine-authored sentry-autofix/* PR the upload step never runs, so
+# CODECOV_TOKEN is never interpolated and never enters the runner while the
+# autofix diff builds or tests. Every checkout also sets
+# `persist-credentials: false`, so no checkout token sits in .git/config either.
+# See check-autofix-ci-trust.mjs.
 
 on:
   pull_request:
@@ -346,6 +352,7 @@ jobs:
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/config test:coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: config
@@ -464,6 +471,7 @@ jobs:
           path: ui-dashboard/test-results/
           retention-days: 7
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: ui-dashboard
@@ -547,6 +555,7 @@ jobs:
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/indexer-envio test:coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: indexer-envio
@@ -593,6 +602,7 @@ jobs:
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/metrics-bridge test:coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: metrics-bridge
@@ -630,6 +640,7 @@ jobs:
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/integration-probes test:coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: integration-probes
@@ -712,12 +723,14 @@ jobs:
           find alerts/infra -name '*.sh' -not -path '*/node_modules/*' -print0 \
             | xargs -0 -I {} bash -n {}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: alerts-onchain-event-handler
           directory: alerts/infra/onchain-event-handler/coverage
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: alerts-oncall-announcer
@@ -777,6 +790,7 @@ jobs:
           find governance-watchdog/infra/quicknode-filter-functions -name '*.js' -print0 \
             | xargs -0 -I {} node --check {}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: governance-watchdog
@@ -880,6 +894,7 @@ jobs:
         working-directory: aegis
         run: forge test -vvv
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}
         with:
           fail_ci_if_error: false
           flags: aegis

--- a/scripts/check-autofix-ci-trust.test.mjs
+++ b/scripts/check-autofix-ci-trust.test.mjs
@@ -1314,7 +1314,6 @@ test("#1461 jobGuarded distinguishes the workflow_run context", () => {
   );
 });
 
-
 // ── #1453: CODECOV_TOKEN is isolated from PR-controlled steps on autofix heads ─
 test("#1453 every codecov upload step in ci.yml excludes sentry-autofix heads", () => {
   // The token step shares a job with PR-head build/test, which can write

--- a/scripts/check-autofix-ci-trust.test.mjs
+++ b/scripts/check-autofix-ci-trust.test.mjs
@@ -10,6 +10,9 @@ import {
   pushAdmitsAutofix,
   usesPullRequestTarget,
 } from "./check-autofix-ci-trust.mjs";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 let passed = 0;
 let failed = 0;
@@ -975,6 +978,49 @@ test("a quoted-scalar continuation ending in | is not a block introducer", () =>
     !v.ok && /\[leak\]/.test(v.reason),
     "marker inside the pipe-ending quoted scalar is not an annotation",
   );
+});
+
+// ── #1453: CODECOV_TOKEN is isolated from PR-controlled steps on autofix heads ─
+test("#1453 every codecov upload step in ci.yml excludes sentry-autofix heads", () => {
+  // The token step shares a job with PR-head build/test, which can write
+  // $GITHUB_ENV/$GITHUB_PATH — so step-scoping alone does not isolate it. Each
+  // codecov step must therefore carry the excluding autofix guard so the token
+  // never runs on a machine-authored sentry-autofix/* PR (issue #1453). jobGuarded
+  // reads `.if`, so it validates a STEP's guard exactly as it does a job's, using
+  // the canonical GUARD_PATTERN (cannot drift from the checker's own definition).
+  const ciPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    ".github",
+    "workflows",
+    "ci.yml",
+  );
+  const doc = parseWorkflow(readFileSync(ciPath, "utf8"));
+  assert(doc && typeof doc.jobs === "object", "ci.yml parses with a jobs map");
+  const codecovSteps = [];
+  for (const job of Object.values(doc.jobs)) {
+    if (!job || typeof job !== "object" || !Array.isArray(job.steps)) continue;
+    for (const step of job.steps) {
+      if (
+        step &&
+        typeof step === "object" &&
+        typeof step.uses === "string" &&
+        step.uses.includes("codecov/codecov-action")
+      ) {
+        codecovSteps.push(step);
+      }
+    }
+  }
+  assert(
+    codecovSteps.length >= 9,
+    `expected at least 9 codecov upload steps in ci.yml, found ${codecovSteps.length}`,
+  );
+  for (const step of codecovSteps) {
+    assert(
+      jobGuarded(step, "pull_request"),
+      `a codecov upload step is not guarded against sentry-autofix heads: ${JSON.stringify(step.uses)}`,
+    );
+  }
 });
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## The Problem

- `ci.yml`'s `# autofix-ci-trust:` annotation claimed the `CODECOV_TOKEN` was
  safe because it is step-scoped. That is weaker than claimed: each package
  quality job runs the PR's build and tests **earlier in the same job**, and
  that PR-controlled code can write `$GITHUB_ENV`/`$GITHUB_PATH` to influence the
  later Codecov upload step — so step-scoping alone does not isolate the token
  from PR-controlled code.
- For a machine-authored `sentry-autofix/*` PR, that PR code is the autofix diff.

## The Solution

Skip the token-bearing Codecov step entirely on autofix heads, and correct the
annotation to state the real guarantee.

- Every `codecov/codecov-action` step now carries
  `if: ${{ !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') }}`,
  so on an autofix PR the step never runs and `CODECOV_TOKEN` is never
  interpolated into the runner while the diff builds or tests. Non-autofix PRs
  are unchanged (the token stays step-scoped).

## Details

- The annotation is reworded to acknowledge the same-job weakness and document
  the new exclusion; its first line stays `# autofix-ci-trust:` above `jobs:`, so
  the checker still recognizes it. It is NOT dropped: the checker sees the static
  `secrets.CODECOV_TOKEN` reference regardless of the `if:`, so each job stays
  credential-bearing and still needs the annotation.
- `ci.yml` is the only workflow that references `CODECOV_TOKEN`.
- A regression test parses `ci.yml` and asserts every Codecov step is guarded via
  the checker's own exported `jobGuarded(step, "pull_request")` — it cannot drift
  from the canonical `GUARD_PATTERN`, and it fails if a future Codecov step is
  added without the exclusion.

## Details — coordination

- Shares `scripts/check-autofix-ci-trust.test.mjs` with #1460 + #1461 (PR B).
  Both append disjoint test blocks; whichever lands first, the other needs a
  trivial rebase of its test append. No runtime coupling.

## Validation

- `node scripts/check-autofix-ci-trust.test.mjs` → **40 passed, 0 failed**
  (+ the codecov-guard regression test).
- `node scripts/check-autofix-ci-trust.mjs` → **green** (the reworded annotation
  still clears `ci.yml`).
- 9 Codecov steps guarded (`grep -c` on the exclusion expression).
- `trunk fmt` → clean.

Closes #1453
Refs #1388
