### PR TITLE
fix(sentry-autofix): keep exact path bytes in the diff guard (#1526)

### DIFF
--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -267,6 +267,27 @@ function isWorkTreeSymlink(workRoot, path) {
   }
 }
 
+// A changed path is STRUCTURALLY malformed when it carries leading/trailing
+// whitespace or ANY control byte (C0 U+0000-U+001F or DEL U+007F). These are the
+// bytes behind the whitespace/control-char bypass (#1526). The LOAD-BEARING fix
+// is that evaluateDiffGuard and the CLI now keep EXACT bytes, so the
+// credential/symlink scans lstat the same file the byte-copy will cp; this
+// reject is a fast structural refusal on top of that authoritative scan, not a
+// substitute for it. A legitimate tracked source path never contains these
+// bytes, so refusing them is free.
+function hasUnsafePathBytes(path) {
+  const p = String(path ?? "");
+  if (/^\s/.test(p) || /\s$/.test(p)) return true;
+  // Scan by code point rather than a control-char regex class: the latter trips
+  // eslint's no-control-regex and can embed literal control bytes in source. C0
+  // controls are U+0000-U+001F; U+007F is DEL.
+  for (const ch of p) {
+    const cp = ch.codePointAt(0);
+    if (cp <= 0x1f || cp === 0x7f) return true;
+  }
+  return false;
+}
+
 /**
  * The mechanical diff guard. Returns `{ ok: true }` when the changed-file set
  * is a legitimate scoped autofix, or `{ ok: false, reason }` otherwise. The
@@ -282,15 +303,38 @@ function isWorkTreeSymlink(workRoot, path) {
  * before any write token is minted — closes that exfiltration path.
  */
 export function evaluateDiffGuard(files, { workRoot = null } = {}) {
+  // Keep the EXACT bytes of every path (NO .trim()): the credential scan, the
+  // symlink check, the forbidden check, and the workflow's byte-for-byte copy
+  // must all reason about the identical path the copy will `cp`. A prior
+  // String(f).trim() here (and the CLI's /\r?\n/ split) silently rewrote a path
+  // like "leak.ts " / "leak.ts\r" to a name that lstat's to ENOENT — the scans
+  // were skipped while the raw byte-copy still published the real
+  // credential/symlink-bearing file (#1526). Only drop empty entries.
   const changed = (Array.isArray(files) ? files : [])
-    .map((f) => String(f ?? "").trim())
-    .filter(Boolean);
+    .map((f) => String(f ?? ""))
+    .filter((f) => f.length > 0);
 
   if (changed.length === 0) {
     return {
       ok: false,
       reason:
         "The autofix agent made no code changes — it could not confirm a scoped code-level fix. No PR opened.",
+    };
+  }
+  // Structurally refuse any path carrying leading/trailing whitespace or a
+  // control byte. The exact-byte scans below are the authoritative backstop for
+  // any byte; this is the fast, clear refusal. The reason echoes only a COUNT,
+  // NEVER the offending path: path bytes are agent-controlled and can be named
+  // after a runner token the agent read from process-env (the documented
+  // residual), so publishing them onto the public queue issue would itself be an
+  // exfil channel — omission is the module's standing policy for agent-controlled
+  // text (see the note above buildAnalysisComment). The path-echo hardening for
+  // the other guard reasons (forbidden/credential) is tracked separately (#1551).
+  const malformed = changed.filter(hasUnsafePathBytes);
+  if (malformed.length > 0) {
+    return {
+      ok: false,
+      reason: `The autofix diff contains ${malformed.length} path(s) with leading/trailing whitespace or control characters, which are refused: such bytes make the guard's scans disagree with the byte-for-byte copy that publishes the branch, and a legitimate source path never contains them. No PR opened.`,
     };
   }
   if (changed.length > MAX_CHANGED_FILES) {
@@ -620,10 +664,16 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
       // Optional: the tainted work tree, so the guard can refuse changed paths
       // the agent turned into symlinks (credential-free, before token minting).
       const workRoot = readFlag(args, "--work");
+      // Split on \n ONLY and DO NOT trim, matching the workflow byte-copy's
+      // `IFS= read -r f` (strips the trailing \n delimiter, nothing else).
+      // Trimming or eating a \r here would re-open the #1526 divergence: the
+      // guard would scan a normalized path while the copy publishes raw bytes.
+      // evaluateDiffGuard keeps these exact bytes and structurally refuses
+      // edge-whitespace/control-char paths, so exact-byte lines are what it
+      // must receive.
       const files = readFileMaybe(filesFile)
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean);
+        .split("\n")
+        .filter((line) => line.length > 0);
       stdout.write(
         `${JSON.stringify(evaluateDiffGuard(files, { workRoot }))}\n`,
       );

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -210,6 +210,92 @@ await test("guard refuses a changed path the agent turned into a symlink", () =>
   rmSync(dir, { recursive: true, force: true });
 });
 
+await test("guard refuses a credential file whose path has a trailing space (#1526)", () => {
+  // The load-bearing fix keeps EXACT path bytes: pre-fix, String(f).trim() ate
+  // the trailing space so the credential scan lstat'd ENOENT and skipped it
+  // (ok:true) while the byte-copy still published the real token-bearing file.
+  // The malformed check now refuses it structurally BEFORE the scan runs.
+  const dir = mkdtempSync(join(tmpdir(), "autofix-ws-cred-"));
+  mkdirSync(join(dir, "ui-dashboard"), { recursive: true });
+  writeFileSync(
+    join(dir, "ui-dashboard", "leak.ts "),
+    'const t = "ghs_AbCdEfGhIjKlMnOpQrStUvWxYz012345";\n',
+  );
+  const r = evaluateDiffGuard(["ui-dashboard/leak.ts "], { workRoot: dir });
+  assert(
+    !r.ok && /whitespace or control/i.test(r.reason),
+    "trailing-space credential path refused as malformed",
+  );
+  // Count-only reason — the offending path (which could be named after a real
+  // token) is NEVER echoed.
+  assert(!r.reason.includes("ghs_AbCd"), "reason must not echo the token");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+await test("guard refuses a symlink whose path has a trailing space (#1526)", () => {
+  // Same divergence via the symlink vector: pre-fix the trim hid the trailing
+  // space so the symlink check lstat'd ENOENT and passed; the byte-copy would
+  // then dereference the real symlink and exfiltrate runner secrets.
+  const dir = mkdtempSync(join(tmpdir(), "autofix-ws-symlink-"));
+  mkdirSync(join(dir, "ui-dashboard"), { recursive: true });
+  symlinkSync("/proc/self/environ", join(dir, "ui-dashboard", "evil.ts "));
+  const r = evaluateDiffGuard(["ui-dashboard/evil.ts "], { workRoot: dir });
+  assert(
+    !r.ok && /whitespace or control/i.test(r.reason),
+    "trailing-space symlink path refused as malformed (before the symlink check)",
+  );
+  rmSync(dir, { recursive: true, force: true });
+});
+
+await test("guard refuses edge-whitespace and control-char paths; allows internal whitespace (#1526)", () => {
+  // Every path with leading/trailing whitespace or a control byte (C0 or DEL)
+  // is refused structurally — no workRoot needed, it is a pure string check.
+  for (const p of [
+    "ui-dashboard/leak.ts\r",
+    "ui-dashboard/leak.ts\n",
+    "ui-dashboard/leak.ts\t",
+    " ui-dashboard/leak.ts",
+    "ui-dashboard/leak.ts ",
+    "ui-dashboard/le\x00ak.ts",
+    "ui-dashboard/leak.ts\x7f", // trailing DEL — exercises the widened class
+  ]) {
+    const r = evaluateDiffGuard([p]);
+    assert(
+      !r.ok && /whitespace or control/i.test(r.reason),
+      `edge/control path refused: ${JSON.stringify(p)}`,
+    );
+  }
+  // INTERNAL whitespace never caused guard/copy divergence (the trim only
+  // touched edges) and the byte-copy quotes "${f}" correctly — stays allowed.
+  assert(
+    evaluateDiffGuard(["ui-dashboard/lib/a b.ts"]).ok,
+    "internal-space path allowed",
+  );
+  // Locks the count-only reason (revision 1): a path named after a token must
+  // NOT surface that token in the public refusal reason.
+  const leak = evaluateDiffGuard(["ghs_AAAABBBBCCCCDDDD1234.ts "]);
+  assert(!leak.ok, "token-named trailing-space path refused");
+  assert(
+    !leak.reason.includes("ghs_AAAA"),
+    "malformed reason must not echo the offending path bytes",
+  );
+});
+
+await test("CLI guard refuses a trailing-space line and preserves \\r (split on \\n only) (#1526)", () => {
+  // Proves the CLI parser now passes EXACT bytes (no trim) and keeps a trailing
+  // \r (split on \n only, matching `IFS= read -r`) so the malformed check can
+  // fire. It does NOT exercise the credential scan — malformed short-circuits.
+  const dir = mkdtempSync(join(tmpdir(), "autofix-ws-cli-"));
+  const file = join(dir, "changed.txt");
+  writeFileSync(file, "ui-dashboard/leak.ts \nui-dashboard/other.ts\r\n");
+  const out = JSON.parse(captureCli(["guard", "--files-file", file]));
+  assert(
+    !out.ok && /whitespace or control/i.test(out.reason),
+    "CLI guard refuses the trailing-space / trailing-\\r lines",
+  );
+  rmSync(dir, { recursive: true, force: true });
+});
+
 await test("guard allows ordinary product source", () => {
   for (const path of [
     "ui-dashboard/lib/x.ts",


### PR DESCRIPTION
## The Problem

- The autofix diff guard trimmed every changed path before scanning it, so a
  filename with edge whitespace (`leak.ts `) was scanned as a different,
  non-existent path — the credential-content **and** symlink guards silently
  skipped it (`{ok:true}`) while the workflow byte-copy still published the real
  file into the public branch.
- The CLI `guard` parser split `changed.txt` on `/\r?\n/` and trimmed, diverging
  further from the byte-copy loop (`IFS= read -r`, split on `\n` only) — a
  trailing `\r` filename slipped past on its own.

## The Solution

Keep the EXACT path bytes end to end so the guard scans exactly what the
byte-copy copies, and fail closed on structurally malformed paths.

- `evaluateDiffGuard` no longer trims changed paths, and the CLI `guard` parser
  now splits on `\n` only without trimming — the guard and the byte-copy read
  identical bytes for every path. This is the load-bearing fix: it makes the
  credential and symlink scans authoritative for all bytes.
- A fast structural refusal rejects any changed path with leading/trailing
  whitespace or a C0/DEL control byte (a legitimate tracked source path never
  has them), before the count/forbidden/symlink/credential checks.

## Details

- The malformed-path refusal reason echoes a COUNT only, never the offending
  path bytes: a path can be named after a runner token the agent read from
  process-env, so publishing it onto the public queue issue would itself be an
  exfil channel. The broader path-echo hardening of the other guard reasons
  (forbidden/credential) and treating path NAMES as a credential surface is a
  distinct, pre-existing vector tracked separately in #1551.
- The control-char class is written with escape sequences, not literal
  control bytes, so the source stays diff-clean.
- Impact was already bounded by #1373 (the agent job is read-only), but this
  closes the guard/byte-copy divergence class outright.

## Validation

- `node scripts/sentry-autofix-finalize.test.mjs` → **33 passed, 0 failed**
  (adds: trailing-space credential path, trailing-space symlink path, an
  edge-whitespace/control-char set with an internal-space path still allowed, a
  CLI trailing-space line, and a token-in-filename echo lock).
- `trunk fmt` → clean.

Closes #1526
Refs #1373, #1551
