### PR TITLE
docs: garden ADRs and architecture shard 1

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,11 +1,12 @@
 name: Supply Chain
 
-# Five gates that protect the dependency supply chain:
+# Five controls that protect the dependency supply chain:
 #
-# 1. npm advisory audit — blocks merges when a high/critical advisory exists
-#    against any package in the root or standalone deploy lockfiles. The
-#    governance-watchdog high-audit leg is duplicated in the required Code
-#    Quality job so that deploy lockfile stays covered by a required check.
+# 1. npm advisory audit — fails this advisory workflow when a high/critical
+#    advisory exists against any package in the root or standalone deploy
+#    lockfiles. The governance-watchdog high-audit leg is duplicated in the
+#    required Code Quality job so that deploy lockfile stays covered by a
+#    ruleset-required check.
 #
 # 2. lockfile-lint — validates pnpm-lock.yaml structural integrity for the root
 #    workspace lockfile and the package-local Cloud Build lockfiles:
@@ -17,6 +18,8 @@ name: Supply Chain
 #       files instead. This catches the same class of "poisoned mirror" attacks
 #       that lockfile-lint(1) was designed for — a rogue `registry=` line that
 #       silently redirects all installs to an attacker-controlled server.
+#    c) Override and resolution floors remain bounded so a fresh lockfile
+#       cannot jump to an unreviewed major version.
 #
 # 3. dependency version-skew check — validates every manifest entry for a
 #    cataloged package is either "catalog:" or the exact catalog version. This
@@ -91,8 +94,8 @@ on:
     # notify-slack-on-main-failure.yml.
     - cron: 17 6 * * *
     # Weekly trigger for the non-blocking moderate-advisory report job below.
-    # The blocking audit/lockfile/version-skew jobs also run on this cron; the
-    # duplicate Monday run is harmless.
+    # The fail-closed audit/lockfile/version-skew jobs also run on this cron;
+    # the duplicate Monday run is harmless.
     - cron: 17 7 * * 1
 
 concurrency:
@@ -156,6 +159,7 @@ jobs:
         #      hash (prevents tampered-tarball installs).
         #   2. No custom registry= in any .npmrc or registries: in
         #      pnpm-workspace.yaml (prevents registry-redirect attacks).
+        #   3. Override and resolution floors are bounded.
         run: node scripts/lockfile-lint.mjs
       - name: handler lockfile integrity + registry check
         # Same gate for the package-local lockfile Cloud Build uses as the

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,13 +74,13 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-operating-card.md`](notes/pr-operating-card.md) | PR Operating Card | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
-| [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/quick-commands.md`](notes/quick-commands.md) | Quick Commands | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/reserve-yield-indexer.md`](notes/reserve-yield-indexer.md) | Reserve-Yield Indexer Topology | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/sentry-triage-pipeline.md`](notes/sentry-triage-pipeline.md) | Sentry Triage Pipeline | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/slack-github-subscriptions.md`](notes/slack-github-subscriptions.md) | GitHub-to-Slack notifications for Terraform-applying workflows | canonical / active | runbook / terraform/infra | eng | 30d; verified 2026-07-22 |
 | [`docs/notes/spoken-attention-nudge.md`](notes/spoken-attention-nudge.md) | Spoken Attention Nudge | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/worktree-and-web-setup.md`](notes/worktree-and-web-setup.md) | New Worktree / Clone Setup and Claude Code on the Web Setup | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
-| [`docs/terraform.md`](terraform.md) | Terraform Stacks | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/terraform.md`](terraform.md) | Terraform Stacks | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`governance-watchdog/ADDING_EVENTS.md`](../governance-watchdog/ADDING_EVENTS.md) | Adding Governance Watchdog Events | canonical / active | runbook / governance-watchdog | eng | 90d; verified 2026-07-22 |
 | [`governance-watchdog/DEPLOY_FROM_SCRATCH.md`](../governance-watchdog/DEPLOY_FROM_SCRATCH.md) | Governance Watchdog Bootstrap | canonical / active | runbook / governance-watchdog | eng | 90d; verified 2026-07-22 |
 | [`governance-watchdog/README.md`](../governance-watchdog/README.md) | Governance Watchdog | canonical / active | runbook / governance-watchdog | eng | 90d; verified 2026-07-22 |
@@ -107,16 +107,16 @@ the rules in [`context-standards.md`](context-standards.md).
 
 | Document | Title | Authority | Type / scope | Owner | Review |
 | --- | --- | --- | --- | --- | --- |
-| [`docs/adr/0001-monorepo-independent-deploys.md`](adr/0001-monorepo-independent-deploys.md) | One pnpm+Turbo monorepo with independently deployed services | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-08 |
-| [`docs/adr/0002-envio-hosted-indexer.md`](adr/0002-envio-hosted-indexer.md) | Envio HyperIndex Hosted is the indexer; deploy via a dedicated envio branch | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-17 |
-| [`docs/adr/0003-hasura-graphql-read-api.md`](adr/0003-hasura-graphql-read-api.md) | Hasura auto-generated GraphQL over Postgres is the read API | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0004-two-alert-planes.md`](adr/0004-two-alert-planes.md) | Two alert planes — Grafana metric thresholds and event-driven delivery | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0005-context-as-product.md`](adr/0005-context-as-product.md) | Context is product — canonical authority model with a metadata contract | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0006-github-issues-backlog.md`](adr/0006-github-issues-backlog.md) | GitHub Issues are the canonical agent work queue, not BACKLOG.md | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0007-agent-quality-gate-and-merge-oracle.md`](adr/0007-agent-quality-gate-and-merge-oracle.md) | Local agent quality gate plus pr:ready-state merge oracle and Codex gate | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0008-mandatory-hazard-checklists.md`](adr/0008-mandatory-hazard-checklists.md) | Cross-layer and stateful changes must run dedicated PR checklists | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0009-supply-chain-hardening.md`](adr/0009-supply-chain-hardening.md) | Supply-chain hardening — release-age gate, lockfile-lint, SHA-pinned Actions | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-06 |
-| [`docs/adr/0010-required-checks-no-paths-filters.md`](adr/0010-required-checks-no-paths-filters.md) | Required CI checks carry no paths filters; only advisory jobs may | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-06 |
+| [`docs/adr/0001-monorepo-independent-deploys.md`](adr/0001-monorepo-independent-deploys.md) | One pnpm+Turbo monorepo with independently deployed services | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0002-envio-hosted-indexer.md`](adr/0002-envio-hosted-indexer.md) | Envio HyperIndex Hosted is the indexer; deploy via a dedicated envio branch | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0003-hasura-graphql-read-api.md`](adr/0003-hasura-graphql-read-api.md) | Hasura auto-generated GraphQL over Postgres is the read API | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0004-two-alert-planes.md`](adr/0004-two-alert-planes.md) | Two alert planes — Grafana metric thresholds and event-driven delivery | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0005-context-as-product.md`](adr/0005-context-as-product.md) | Context is product — canonical authority model with a metadata contract | canonical / active | adr / repo-wide | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0006-github-issues-backlog.md`](adr/0006-github-issues-backlog.md) | GitHub Issues are the canonical agent work queue, not BACKLOG.md | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0007-agent-quality-gate-and-merge-oracle.md`](adr/0007-agent-quality-gate-and-merge-oracle.md) | Local agent quality gate plus two-projection PR all-clear and Codex gate | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0008-mandatory-hazard-checklists.md`](adr/0008-mandatory-hazard-checklists.md) | Cross-layer and stateful changes must run dedicated PR checklists | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0009-supply-chain-hardening.md`](adr/0009-supply-chain-hardening.md) | Supply-chain hardening — release-age gate, lockfile-lint, SHA-pinned Actions | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-23 |
+| [`docs/adr/0010-required-checks-no-paths-filters.md`](adr/0010-required-checks-no-paths-filters.md) | Required CI checks carry no paths filters; only advisory jobs may | canonical / active | adr / ci/process | eng | 90d; verified 2026-07-23 |
 | [`docs/adr/0011-shared-config-single-source-of-truth.md`](adr/0011-shared-config-single-source-of-truth.md) | shared-config is the single source of truth for chain and token metadata | canonical / active | adr / shared-config | eng | 90d; verified 2026-07-08 |
 | [`docs/adr/0012-one-multichain-indexer.md`](adr/0012-one-multichain-indexer.md) | One multichain indexer project; Ethereum reserve-yield shares the hosted deployment | canonical / active | adr / indexer-envio | eng | 90d; verified 2026-07-17 |
 | [`docs/adr/0013-vendored-shared-config-mirror.md`](adr/0013-vendored-shared-config-mirror.md) | The indexer vendors a mirror of shared-config because Envio builds outside the workspace | canonical / active | adr / indexer-envio | eng | 90d; verified 2026-07-08 |

--- a/docs/adr/0001-monorepo-independent-deploys.md
+++ b/docs/adr/0001-monorepo-independent-deploys.md
@@ -3,7 +3,7 @@ title: One pnpm+Turbo monorepo with independently deployed services
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-08
+last_verified: 2026-07-23
 scope: repo-wide
 date: 2026-03
 doc_type: adr

--- a/docs/adr/0002-envio-hosted-indexer.md
+++ b/docs/adr/0002-envio-hosted-indexer.md
@@ -3,7 +3,7 @@ title: Envio HyperIndex Hosted is the indexer; deploy via a dedicated envio bran
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-23
 scope: repo-wide
 date: 2026-03
 doc_type: adr
@@ -42,8 +42,10 @@ static production endpoint, with a defined rollback path.
 
 - A promote step gates production: sync a deployment, verify rows, then promote —
   the endpoint hash is static and doesn't change on redeploy.
-- Schema-additive changes must ship as one PR that resyncs and promotes **before**
-  merge, or the dashboard breaks (see the schema-single-PR discipline).
+- Schema-additive changes ship with their consumers in one PR. The indexer may
+  preload and sync before merge with `--no-promote`; after merge, promotion
+  requires an equivalent protected-`main` indexer tree and explicit production
+  authorization.
 - Rollback is re-promote-if-live else rebuild+resync; both are scripted.
 
 ## Evidence

--- a/docs/adr/0003-hasura-graphql-read-api.md
+++ b/docs/adr/0003-hasura-graphql-read-api.md
@@ -3,7 +3,7 @@ title: Hasura auto-generated GraphQL over Postgres is the read API
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: repo-wide
 date: 2026-03
 doc_type: adr
@@ -39,10 +39,11 @@ service between the database and the clients.
 
 - The GraphQL schema is a generated artifact of the Envio schema — schema changes
   propagate straight to query and UI types (hence ADR 0008's cross-layer checklist).
-- Hasura's `_aggregate` is available but deliberately **not** used for hot paths;
-  we precompute snapshot entities instead (ADR 0014, ADR 0020).
-- Verify production behavior via Hasura introspection, not the indexer CLI, because
-  parallel deploys can prune a CLI-reported entry mid-serve.
+- Hosted Hasura disables `_aggregate`; precompute snapshot entities for
+  full-lifetime and hot-path aggregation instead (ADR 0014, ADR 0020).
+- Verify an explicitly promoted deployment with the commit-scoped verifier,
+  the full propagation wait, and an affected data/UI probe. Static-endpoint
+  introspection alone is not rollout proof.
 
 ## Evidence
 

--- a/docs/adr/0004-two-alert-planes.md
+++ b/docs/adr/0004-two-alert-planes.md
@@ -3,7 +3,7 @@ title: Two alert planes — Grafana metric thresholds and event-driven delivery
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: repo-wide
 date: 2026-04
 doc_type: adr

--- a/docs/adr/0005-context-as-product.md
+++ b/docs/adr/0005-context-as-product.md
@@ -3,7 +3,7 @@ title: Context is product — canonical authority model with a metadata contract
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: repo-wide
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0006-github-issues-backlog.md
+++ b/docs/adr/0006-github-issues-backlog.md
@@ -3,7 +3,7 @@ title: GitHub Issues are the canonical agent work queue, not BACKLOG.md
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: ci/process
 date: 2026-05
 doc_type: adr
@@ -25,11 +25,12 @@ with atomic claim + state.
 
 ## Decision
 
-**GitHub Issues are the canonical active-work queue.** Ready work is
-`label:agent-ready`; a helper (`pnpm issue:claim`) atomically flips labels
-(`agent-ready` → `agent-active` → `in-pr`) and syncs a workboard. `BACKLOG.md` is
-demoted to transition storage only; durable context lives in `AGENTS.md`,
-checklists, notes, or tests.
+**GitHub Issues are the canonical active-work queue.** Ready work carries
+`agent-ready`. `pnpm issue:claim` transitions one claimable issue to
+`agent-active`, records and verifies its Project Claim ID, and projects it to
+In Progress. `pnpm issue:review` later transitions an issue represented by an
+open PR to `in-pr`. `BACKLOG.md` is transition storage only; durable context
+lives in `AGENTS.md`, checklists, notes, or tests.
 
 ## Alternatives considered
 

--- a/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
+++ b/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
@@ -1,9 +1,9 @@
 ---
-title: Local agent quality gate plus pr:ready-state merge oracle and Codex gate
+title: Local agent quality gate plus two-projection PR all-clear and Codex gate
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: ci/process
 date: 2026-05
 doc_type: adr
@@ -11,7 +11,7 @@ review_interval_days: 90
 garden_lane: adrs-architecture
 ---
 
-# ADR 0007 — Local agent quality gate + `pr:ready-state` merge oracle + Codex approval gate
+# ADR 0007 — Local agent quality gate + two-projection PR all-clear + Codex approval gate
 
 **Status:** Accepted (Apr–Jun 2026), in force.
 **Scope:** ci/process
@@ -20,20 +20,22 @@ garden_lane: adrs-architecture
 
 Agent-authored PRs failed CI in slow, expensive loops, and "is this PR actually
 ready?" was answered by eyeballing a noisy checks UI where advisory bots lag the
-real status. We needed a cheap local pre-flight and a single machine-readable
+real status. We needed a cheap local pre-flight and a machine-readable
 definition of "ready to merge".
 
 ## Decision
 
-Two mechanisms:
+Two layers:
 
 - **Local agent quality gate** (`pnpm agent:quality-gate`) maps changed paths to
   the exact package checks + checklists and runs them locally before push. It is
   local-only (never deploys) and refuses to run on package-manifest/lockfile
   changes without explicit review.
-- **`pnpm pr:ready-state`** is the **single merge oracle**: required CI green +
-  threads resolved + a Codex 👍 on the PR description for the current head. Advisory
-  bot lag (e.g. Cursor) does not block unless branch protection requires it.
+- **Hosted all-clear** uses two machine-readable projections in order:
+  `pnpm pr:feedback-state` must first report a clean feedback ledger, then
+  `pnpm pr:ready-state` is the final required-readiness oracle for current-head
+  CI, review gates, and the Codex PR-description gate. Advisory bot lag (for
+  example, Cursor) does not block unless branch protection requires it.
 
 ## Alternatives considered
 
@@ -44,11 +46,15 @@ Two mechanisms:
 
 ## Consequences
 
-- A PR is not "clean" until `pr:ready-state` says so _and_ Codex has reacted 👍 on
-  the current head; a review on an older commit does not satisfy the gate.
+- A PR is not clean until `pr:feedback-state` is clean and the subsequent
+  current-head `pr:ready-state` result is ready.
+- The Codex description gate normally requires a current-head 👍. Only the
+  documented, exact-head human break-glass override can replace it; an older
+  review cannot.
 - Review is a batch-boundary verifier, not the inner edit loop.
 
 ## Evidence
 
-- Aggregate CI PR #188; ready-state gate wiring PR #818 (2026-06-09).
+- Aggregate CI PR #188; local gate PR #388; shared ready-state PR #508; gate
+  wiring PR #818; feedback ledger PR #1037; head-scoped override PR #1044.
 - Mechanics in [`docs/notes/agent-quality-gate-mechanics.md`](../notes/agent-quality-gate-mechanics.md) and [`docs/notes/pr-ready-state.md`](../notes/pr-ready-state.md).

--- a/docs/adr/0008-mandatory-hazard-checklists.md
+++ b/docs/adr/0008-mandatory-hazard-checklists.md
@@ -3,7 +3,7 @@ title: Cross-layer and stateful changes must run dedicated PR checklists
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: ci/process
 date: 2026-05
 doc_type: adr
@@ -42,12 +42,14 @@ not discovered in review.
 
 ## Consequences
 
-- Checklists are canonical context (ADR 0005); package `AGENTS.md` files hard-link
-  to the relevant one and mark it mandatory.
+- Checklists are canonical context (ADR 0005). Root and relevant package entry
+  points hard-link the applicable checklist, while the local quality gate maps
+  changed data-flow paths to mandatory review.
 - Recurring automated-review hazards are canonicalized so bots don't re-litigate
   settled patterns.
 
 ## Evidence
 
 - [`docs/pr-checklists/stateful-data-ui.md`](../pr-checklists/stateful-data-ui.md), [`docs/pr-checklists/recurring-review-patterns.md`](../pr-checklists/recurring-review-patterns.md).
-- Enforced from [`AGENTS.md`](../../AGENTS.md) and each package `AGENTS.md` "Before Opening PRs" section.
+- Enforced from [`AGENTS.md`](../../AGENTS.md), relevant package `AGENTS.md`
+  routes, and `scripts/agent-quality-gate.sh`.

--- a/docs/adr/0009-supply-chain-hardening.md
+++ b/docs/adr/0009-supply-chain-hardening.md
@@ -3,7 +3,7 @@ title: Supply-chain hardening — release-age gate, lockfile-lint, SHA-pinned Ac
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: ci/process
 date: 2026-05
 doc_type: adr
@@ -30,10 +30,12 @@ Adopt a defense-in-depth posture:
   younger than 3 days. `@mento-protocol/*` and narrow, reviewed security
   releases may bypass the delay; frozen-lockfile installs verify new entries
   against the same policy.
-- **`pnpm lockfile:lint`** validates lockfile integrity + registry provenance,
-  with no install needed, as a blocking gate.
-- **SHA-pin every GitHub Action** `uses:` ref, enforced by
-  `scripts/check-github-action-pins.mjs`.
+- **`pnpm lockfile:lint`** fails closed when invoked and validates lockfile
+  integrity, registry provenance, and bounded override/resolution floors with
+  no install needed. The advisory Supply Chain workflow runs it on dependency
+  inputs and daily.
+- **SHA-pin every GitHub Action** `uses:` ref, enforced by the ruleset-required
+  Code Quality job through `scripts/check-github-action-pins.mjs`.
 
 ## Alternatives considered
 
@@ -49,5 +51,6 @@ Adopt a defense-in-depth posture:
 
 ## Evidence
 
-- `minimumReleaseAge` PR #418; lockfile-lint PR #447; enforce-pinned-actions PR #922; early action pins PR #177.
+- `minimumReleaseAge` PR #418; lockfile-lint PR #447; advisory workflow split
+  PR #813; enforce-pinned-actions PR #922; early action pins PR #177.
 - Guards in `pnpm-workspace.yaml`, `scripts/check-github-action-pins.mjs`, [`docs/pr-checklists/recurring-review-patterns.md`](../pr-checklists/recurring-review-patterns.md).

--- a/docs/adr/0010-required-checks-no-paths-filters.md
+++ b/docs/adr/0010-required-checks-no-paths-filters.md
@@ -3,7 +3,7 @@ title: Required CI checks carry no paths filters; only advisory jobs may
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-06
+last_verified: 2026-07-23
 scope: ci/process
 date: 2026-04
 doc_type: adr
@@ -25,10 +25,11 @@ the check stays **pending forever** and the PR can never satisfy protection.
 
 ## Decision
 
-**Required checks (and sticky-comment / security-gate jobs) must not use `paths:`
-filters.** They run on every PR via a single required sentinel job that internally
-routes to the right per-package work. Advisory, non-required, non-comment
-workflows may use `paths:` to save cost.
+**Ruleset-required workflows must not use `paths:` or `paths-ignore:` filters.**
+They run on every PR and route internally to the relevant work. Advisory,
+non-required workflows should use workflow-level path filters when safe. A
+workflow whose sticky comment must be cleared when the relevant diff disappears
+stays unfiltered and performs its run/skip decision inside the job.
 
 ## Alternatives considered
 
@@ -39,11 +40,13 @@ workflows may use `paths:` to save cost.
 
 ## Consequences
 
-- Terraform/package routing lives inside the sentinel (backed by
-  `terraform.stacks.json`, ADR 0028), not in workflow `paths:` YAML.
-- Advisory cost is controlled with path filters + Blacksmith runner tuning instead.
+- Required package and Terraform-validation routing lives inside the CI sentinel,
+  with stack classification backed by `terraform.stacks.json` (ADR 0028).
+- Advisory cost is controlled with path filters and Blacksmith runner tuning;
+  workflows with cleanup semantics route inside the job instead.
 
 ## Evidence
 
-- Path-filter unification PR #176; Blacksmith cost/advisory split PR #813.
+- Path-filter unification PR #176; Blacksmith cost/advisory split PR #813;
+  live `main` ruleset verified 2026-07-23.
 - Rule in [`docs/pr-checklists/ci-workflow-gates.md`](../pr-checklists/ci-workflow-gates.md); CI model in [`docs/terraform.md`](../terraform.md) §CI Model.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,7 +63,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | ADR                                                         | Decision                                                                             |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [0006](0006-github-issues-backlog.md)                       | GitHub Issues (not `BACKLOG.md`) are the canonical agent work queue                  |
-| [0007](0007-agent-quality-gate-and-merge-oracle.md)         | Local agent quality gate + `pr:ready-state` merge oracle + Codex approval gate       |
+| [0007](0007-agent-quality-gate-and-merge-oracle.md)         | Local quality gate + two-projection PR all-clear + Codex approval gate               |
 | [0008](0008-mandatory-hazard-checklists.md)                 | Cross-layer/stateful changes must run the dedicated PR checklists before review      |
 | [0009](0009-supply-chain-hardening.md)                      | Supply-chain posture: release-age gate, lockfile-lint, SHA-pinned Actions            |
 | [0010](0010-required-checks-no-paths-filters.md)            | Required CI checks carry no `paths:` filters; only advisory jobs may                 |

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -3,7 +3,7 @@ title: Quick Commands
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -68,8 +68,8 @@ pnpm --silent pr:feedback-state --pr 123 --json  # Normalize unresolved/reply-re
 pnpm pr:ready-state --pr 123 --json              # Final current-head required-readiness probe
 node scripts/review-process-metrics.mjs --before-pr 1034 --limit 20  # Collect review-process baseline metrics
 node scripts/review-process-metrics.mjs --after-pr 1045 --limit 20   # Collect review-process check-in metrics
-pnpm lockfile:lint                 # Lockfile integrity + registry check (blocking; no install needed)
-pnpm skew:check                    # Dependency version-skew check vs the pnpm catalog (blocking; no install needed)
+pnpm lockfile:lint                 # Fail-closed integrity + registry + override-floor check; no install needed
+pnpm skew:check                    # Fail on dependency version skew vs the pnpm catalog; no install needed
 pnpm sanitize:test                 # Fixture tests for scripts/sanitize-terraform-output.sh (terraform output secret redaction)
 pnpm override:prune-report          # pnpm.overrides + minimumReleaseAgeExclude pruning report (advisory; no install needed)
 pnpm adr:check                      # Advisory ADR reminder for architectural changes (new package/stack/workflow); --strict to hard-gate

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@ title: Terraform Stacks
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -57,12 +57,13 @@ Environment approval.
 
 ## CI Model
 
-`.github/workflows/infra.yml` and the required `.github/workflows/ci.yml`
-sentinel use coarse YAML path filters to admit a run. After admission,
-`scripts/tf-stacks.mjs` uses `terraform.stacks.json` to classify changed stacks
-and validate only their registered roots. The registry remains the ownership
-source of truth, but a new `changedPathPatterns` entry must also reach both
-workflow admission filters until
+`.github/workflows/infra.yml` uses coarse YAML path filters to admit a run. The
+required `.github/workflows/ci.yml` sentinel runs on every PR and routes
+internally. Its change filter and `scripts/tf-stacks.mjs` use
+`terraform.stacks.json` to classify changed stacks and validate only their
+registered roots. The registry remains the ownership source of truth, but a new
+`changedPathPatterns` entry must also reach the infra admission filter and the
+CI internal filter until
 [#1501](https://github.com/mento-protocol/monitoring-monorepo/issues/1501)
 replaces that duplication with enforced parity.
 

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -19,6 +19,10 @@ aggregators and cross-chain routers. It publishes the latest snapshot to
 Upstash Redis for the dashboard `/integrations` page. The default mainnet
 probe fleet is Celo (42220), Monad (143), and Polygon (137).
 
+Apply
+[`docs/pr-checklists/stateful-data-ui.md`](../docs/pr-checklists/stateful-data-ui.md)
+when probe snapshot changes propagate through Upstash into the dashboard.
+
 ## Commands
 
 ```bash

--- a/metrics-bridge/AGENTS.md
+++ b/metrics-bridge/AGENTS.md
@@ -19,6 +19,11 @@ garden_lane: agent-entry-points
 `metrics-bridge/` exports Hasura/Envio data, rebalance probes, and isolated
 external peg observations as Prometheus gauges for Grafana alerting.
 
+Apply
+[`docs/pr-checklists/stateful-data-ui.md`](../docs/pr-checklists/stateful-data-ui.md)
+when GraphQL or metric-state changes propagate across the indexer, bridge, or
+downstream alerts/dashboard.
+
 ## Operating Rules
 
 - Keep `/health` as the health endpoint. Cloud Run v2 reserves `/healthz` at the frontend.


### PR DESCRIPTION
## The Problem

- The first ADR garden packet contained stale claims about Envio promotion,
  hosted Hasura, issue transitions, PR all-clear, and CI/supply-chain policy.
- Three still-current decisions needed source-backed semantic verification
  before their freshness dates could move.
- The ADR index, generated catalog, package routes, and linked operator guidance
  had to stay consistent with the corrected decisions.

## The Solution

Re-verify ADRs 0001–0010 against their current code, configuration, runbooks,
history, and live `main` ruleset. Keep every accepted decision in force, correct
only claims that current evidence disproves, and align the directly linked
entry points and generated catalog.

## Details

| Document | Disposition | Current evidence and result |
| --- | --- | --- |
| ADR 0001 | Keep | The pnpm/Turbo workspace, path-routed CI, and independently deployed services remain current; refresh semantic verification only. |
| ADR 0002 | Update | Envio Hosted and the dedicated `envio` branch remain current; pre-merge work now preloads without promotion, then an equivalent protected-`main` tree may promote after merge with explicit authorization. |
| ADR 0003 | Update | Envio-managed Hasura remains the direct read API; hosted `_aggregate` is disabled, and rollout proof uses the commit-scoped verifier, propagation wait, and affected data/UI probe. |
| ADR 0004 | Keep | Metric-threshold and event-driven alert planes still map to the split rules/delivery stacks; refresh semantic verification only. |
| ADR 0005 | Keep | Canonical discovery, metadata enforcement, and the 90-day staleness check remain current; refresh semantic verification only. |
| ADR 0006 | Update | `issue:claim` owns the `agent-ready` to `agent-active` transition and Claim ID verification; `issue:review` separately moves represented work to `in-pr`. |
| ADR 0007 | Update | Hosted all-clear now requires a clean `pr:feedback-state` ledger followed by the final `pr:ready-state` projection, including the narrow current-head Codex override. |
| ADR 0008 | Tighten | The hazard-checklist decision remains current; enforcement now names root/relevant package routes plus quality-gate mapping, with missing bridge/probe routes added. |
| ADR 0009 | Update | Release-age and SHA-pin controls remain current; `lockfile:lint` is fail-closed inside an advisory path-filtered/daily workflow and now also checks bounded override floors. |
| ADR 0010 | Update | Live ruleset-required workflows remain unfiltered; advisory workflows use safe path filters, while sticky-comment cleanup workflows route inside the job. |

The PR also corrects the linked Supply Chain comments, quick-command wording,
and Terraform CI model, then regenerates `docs/README.md`. It preserves the
frozen ten-document packet and records the matching ADR 0014 drift on its
existing lane tracker.

Closes #1558

## Validation

- `CI=true pnpm agent:quality-gate --run` — all 15 mapped commands passed.
- `CI=true pnpm docs:audit --dry-run --date 2026-10-12 --lane adrs-architecture --shard 1 --format json` — reproduced fingerprint `docs-garden:adrs-architecture:1-of-5` with the same ten documents.
- `CI=true pnpm docs:index --check` — passed.
- `CI=true pnpm agent:context-check` — passed for 117 managed files.
- `CI=true pnpm agent:context-budget --strict` — passed with no warnings or oversized routes.
- `CI=true pnpm adr:check` and `CI=true pnpm adr:check:test` — passed; 20 reminder checks.
- Live `main` ruleset query — confirmed `ci`, `Code Quality`, `Vercel`, and
  `Vercel Preview Comments` as the required status contexts.
- Fresh-context Codex autoreview — clean, confidence 0.94; deterministic local
  review also clean; the attested bundle manifest matched before and after.
- Browser verification — not applicable; this changes documentation and
  workflow comments, with no UI behavior.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1351 — the later
  deterministic shard containing ADR 0014 will correct its matching stale
  `_aggregate` and pre-merge promotion claims.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable: this restores current descriptions
  of existing decisions and introduces no new architectural direction.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
