### PR TITLE
fix(terraform): pin default workflow-token permission to read-only (#1557)

### DIFF
--- a/docs/notes/slack-github-subscriptions.md
+++ b/docs/notes/slack-github-subscriptions.md
@@ -118,10 +118,13 @@ feeds
 .terraform_apply_slack_channel`. To reroute the notification, set the tfvar
 and run `pnpm tf apply platform` (manual-apply stack, human-approved local
 apply — see `docs/terraform.md`); if the new channel is private, `/invite`
-the bot as above. The platform PAT needs **both** `Secrets: Read/write` and
-`Variables: Read/write` — GitHub scopes repo Secrets and repo Variables
-independently, so a Secrets-only PAT makes the
-`github_actions_variable` resource fail with HTTP 403.
+the bot as above. The platform PAT needs `Secrets: Read/write`,
+`Variables: Read/write`, and `Administration: Read/write` — GitHub scopes repo
+Secrets and repo Variables independently (a Secrets-only PAT makes the
+`github_actions_variable` resource fail with HTTP 403), and `Administration`
+is required by `github_workflow_repository_permissions`
+(`terraform/github-actions-permissions.tf`, issue #1557), which pins the
+default workflow-token permission to read-only.
 
 ## 3. `Terraform Deploy Queue Watch`
 

--- a/terraform/github-actions-permissions.tf
+++ b/terraform/github-actions-permissions.tf
@@ -13,8 +13,16 @@
 # the REPO DEFAULT is read-only. The default was `write`, so a future
 # no-`permissions` autofix-reachable job running `actions/checkout` would persist
 # a write-scoped token the checker would NOT flag. Pinning the default to `read`
-# makes the checker's assumption hold; drift back to `write` is caught by the
-# terraform-drift plan (the "check fails on drift" of #1557's done-means).
+# makes the checker's assumption hold.
+#
+# Drift note: enforcement is DECLARATIVE — every `pnpm tf apply platform`
+# re-asserts `read`, and a manual reversion to `write` surfaces as a diff the
+# next time this stack is planned. The platform stack is manual plan/apply and
+# is NOT in the scheduled terraform-drift matrix (it opts in via
+# `ci.drift == "scheduled"`, which platform does not set, and the daily drift job
+# lacks the github/upstash/vercel plan credentials platform needs), so a manual
+# reversion is not caught by a DAILY check. Scheduled drift detection for the
+# platform stack is tracked as a follow-up (issue #1564).
 #
 # `can_approve_pull_request_reviews = false`: no workflow approves PRs via the
 # automatic token (verified), so denying it is free least-privilege hardening.

--- a/terraform/github-actions-permissions.tf
+++ b/terraform/github-actions-permissions.tf
@@ -1,0 +1,31 @@
+# GitHub Actions default workflow-token permissions for `monitoring-monorepo`,
+# managed by the platform stack.
+#
+# The repository's default `GITHUB_TOKEN` permission is pinned READ-ONLY here.
+# Every workflow in this repo already declares explicit least-privilege
+# `permissions:` (verified: no job falls through to the repo default), so this
+# is behaviorally a no-op for existing workflows — it closes a DRIFT surface.
+#
+# Why it matters (issue #1557, found reviewing #1554): the autofix CI-trust
+# checker (`scripts/check-autofix-ci-trust.mjs`) treats a job with no explicit
+# `permissions:` as having no write scope (effectivePermissions=undefined ->
+# hasWritePermission=false -> not flagged). That assumption is only sound when
+# the REPO DEFAULT is read-only. The default was `write`, so a future
+# no-`permissions` autofix-reachable job running `actions/checkout` would persist
+# a write-scoped token the checker would NOT flag. Pinning the default to `read`
+# makes the checker's assumption hold; drift back to `write` is caught by the
+# terraform-drift plan (the "check fails on drift" of #1557's done-means).
+#
+# `can_approve_pull_request_reviews = false`: no workflow approves PRs via the
+# automatic token (verified), so denying it is free least-privilege hardening.
+#
+# APPLY PREREQUISITE: this resource writes the repo's Actions permissions via
+# `PUT /repos/{owner}/{repo}/actions/permissions/workflow`, which requires the
+# provider PAT (`var.github_token`) to hold Repository -> Administration:
+# Read/write (see `providers.tf`). The variables/secrets-only PAT cannot apply
+# this — the operator must widen the PAT before the apply, or it 403s.
+resource "github_workflow_repository_permissions" "default_read" {
+  repository                       = "monitoring-monorepo"
+  default_workflow_permissions     = "read"
+  can_approve_pull_request_reviews = false
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -61,8 +61,10 @@ provider "google" {
 # `monitoring-monorepo` that belong to the platform stack, such as the
 # Vercel automation bypass mirror and integration-probe credentials.
 # `var.github_token` should be a fine-grained PAT scoped to
-# `mento-protocol/monitoring-monorepo` with Repository → Secrets: Read/write
-# and Variables: Read/write.
+# `mento-protocol/monitoring-monorepo` with Repository → Secrets: Read/write,
+# Variables: Read/write, and Administration: Read/write (the last is required by
+# `github_workflow_repository_permissions` in `github-actions-permissions.tf`,
+# which pins the default workflow-token permission to read-only — issue #1557).
 # This keeps the credential repository-scoped and avoids the org-admin scope
 # that an organization-level secret or variable would force.
 provider "github" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -18,9 +18,14 @@ vercel_token = "vcp_..."
 # Create at: https://github.com/settings/personal-access-tokens/new
 #   Resource owner: mento-protocol
 #   Repository access: mento-protocol/monitoring-monorepo
-#   Permissions: Repository → Secrets: Read/write, Variables: Read/write
+#   Permissions: Repository → Secrets: Read/write, Variables: Read/write,
+#     Administration: Read/write
 #     (Variables is required for terraform_apply_slack_channel below;
-#      GitHub scopes repo Secrets and repo Variables independently.)
+#      Administration is required by github_workflow_repository_permissions in
+#      github-actions-permissions.tf — issue #1557 — which pins the default
+#      workflow-token permission to read-only. GitHub scopes these repo
+#      permissions independently. All are repo-level — org-admin is still NOT
+#      needed.)
 github_token = "ghp_..."
 
 # Owner default is already set in variables.tf; override only if managing a

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,14 +27,16 @@ variable "github_owner" {
 
 variable "github_token" {
   description = <<-EOT
-    GitHub PAT for writing repository Actions secrets and variables on
-    `mento-protocol/monitoring-monorepo`. Fine-grained PAT scoped to that
-    repo with Repository → Secrets: Read/write — least-privilege for this
-    stack's use case (org-admin scope is NOT needed because the resources
-    managed here are repo-level, not org-level). The separate
-    "Variables: Read and write" repository permission is also required for
-    `github_actions_variable` resources — GitHub scopes repo Secrets and
-    repo Variables independently.
+    GitHub PAT for writing repository Actions secrets, variables, and the
+    default workflow-token permission on `mento-protocol/monitoring-monorepo`.
+    Fine-grained PAT scoped to that repo with Repository → Secrets: Read/write,
+    Variables: Read/write, and Administration: Read/write — least-privilege for
+    this stack's use case (org-admin scope is NOT needed because the resources
+    managed here are repo-level, not org-level). GitHub scopes these repo
+    permissions independently: Variables for `github_actions_variable`, and
+    Administration for `github_workflow_repository_permissions`
+    (`github-actions-permissions.tf`, issue #1557) — a Secrets-only PAT 403s on
+    the latter two.
   EOT
   type        = string
   sensitive   = true


### PR DESCRIPTION
## The Problem

- The repo's default workflow-token permission was **`write`**
  (`gh api …/actions/permissions/workflow` → `default_workflow_permissions: "write"`),
  and nothing in Terraform enforced it.
- The autofix CI-trust checker treats a job with **no explicit `permissions:`**
  as having no write scope (so it is not flagged) — an assumption that only
  holds when the repo default is read-only. With the default at `write`, that
  assumption was silently violated. Found reviewing #1554.

## The Solution

Pin the repo's default workflow-token permission to **read-only** in Terraform,
so the checker's assumption holds and drift is caught.

- New `github_workflow_repository_permissions.default_read`:
  `default_workflow_permissions = "read"`,
  `can_approve_pull_request_reviews = false`.
- **Behaviorally a no-op**: an audit of every workflow found **no job falls
  through to the repo default** — each declares explicit least-privilege
  `permissions:`. This closes a drift surface, it doesn't change any run.

## Details

- `can_approve_pull_request_reviews = false`: no workflow approves PRs via the
  automatic `GITHUB_TOKEN` (verified), so denying it is free hardening.
- **Enforcement is declarative**: every `pnpm tf apply platform` re-asserts
  `read`, and a manual reversion to `write` surfaces in the next platform plan.
  The platform stack is manual plan/apply and NOT in the scheduled drift matrix
  (the daily drift job lacks its github/vercel/upstash plan credentials), so
  there is no *daily* drift check — that is deferred to #1564.
- **APPLY PREREQUISITE (operator action):** setting Actions permissions needs the
  platform PAT (`var.github_token`) to hold Repository → **Administration:
  Read/write** — the current Secrets/Variables-only PAT will `403`. The provider
  comment, `terraform.tfvars.example`, and the `variables.tf` `github_token`
  description are all updated to state this. `terraform/` is the **manual-apply**
  platform stack (`pnpm tf apply platform`), so merging this PR changes nothing
  until the operator widens the PAT and runs the apply.

## Deferrals

- Scheduled (daily) drift detection for the platform stack (#1564) — needs the
  drift job to supply read-only github/vercel/upstash plan credentials.

## Validation

- `terraform validate` → Success; `terraform fmt` → clean.
- Per-job audit script: **0 jobs** rely on the repo default token permission.
- No workflow references token-based PR approval.

Closes #1557
Refs #1460, #1554
