### PR TITLE
fix(sentry-autofix): scan changed-path names for credentials, redact reason echoes (#1551)

### DIFF
--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -243,23 +243,31 @@ const DIFF_CREDENTIAL_PATTERNS = [
 //    strip along with an attacker separator, so they are matched SEPARATOR-
 //    TOLERANT on the raw path: the internal dashes may be any separator or absent
 //    (`sk.ant-…` still trips), with the content scan's body floor.
-// Bodies allow `_`: a github_pat suffix legitimately contains underscores
-// (`github_pat_XXXX_YYYY`), and for the ghs_ family an attacker can INSERT `_`
-// to split the body (the collapse keeps `_`). The `_` never causes a false
-// positive here because each pattern still requires the literal credential
-// prefix, which no source filename carries. AWS keys have no `_` (and AWS is not
-// an autofix runner credential), so AKIA keeps the plain alphabet.
+// Filenames are agent-controlled. The GitHub/AWS credential prefixes are
+// distinctive (a literal `_`, or `AKIA`+caps), so they are matched on a FULLY
+// collapsed form of the path — every byte outside the token alphabet
+// `[A-Za-z0-9_]` removed — which rejoins ANY separator an attacker inserts to
+// split the prefix or body (`/`·`.`·`-`·`@`·`+`·whitespace·…). The {16,}/{16}
+// body floors then catch the rejoined token while leaving cross-segment joins too
+// short to match, and the literal prefix keeps it false-positive-free (no source
+// path is named after a token; a github_pat suffix and a `_`-split ghs body both
+// keep their underscores). (#1551)
 const FILENAME_CREDENTIAL_COLLAPSED = [
   /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9_]{16,}/,
   /github_pat_[A-Za-z0-9_]{16,}/,
   /AKIA[A-Z0-9]{16}/,
 ];
-// The internal separators of these prefixes may be ANY non-alphanumeric run (a
-// substituted `-`/`.`/`_`/`/`/space still yields a recoverable token), and the
-// body may contain `-` (real Anthropic/Slack keys do).
-const FILENAME_CREDENTIAL_SEPARATOR_TOLERANT = [
-  /sk[^A-Za-z0-9]*ant[^A-Za-z0-9]*[A-Za-z0-9-]{8,}/i,
-  /xox[^A-Za-z0-9]*[a-z][^A-Za-z0-9]*[A-Za-z0-9-]{8,}/i,
+// The Anthropic/Slack prefixes are SHORT and their collapsed forms (`skant`,
+// `xox`) collide with ordinary words ("riskantenna", camelCase "TaskAntenna"),
+// so they are matched only in CANONICAL dashed form on the raw path — no false
+// positive on normal code. Heavy filename-obfuscation of these lower-value tokens
+// is a documented residual: the Anthropic inference token is an accepted #1373
+// residual (worst case quota abuse, not repo/queue compromise) and Slack is not
+// an autofix runner credential; the content scan still catches a real token
+// written into a file body.
+const FILENAME_CREDENTIAL_CANONICAL = [
+  /sk-ant-[A-Za-z0-9-]{8,}/i,
+  /xox[a-z]-[A-Za-z0-9-]{8,}/i,
 ];
 
 // Full-token patterns (no \b, global) for MASKING a credential wherever it
@@ -328,13 +336,12 @@ export function filesWithCredentialShapedContent(workRoot, files) {
 export function filesWithCredentialShapedName(files) {
   return (Array.isArray(files) ? files : []).filter((f) => {
     const p = String(f ?? "");
-    // Collapse for the separator-less prefixes: rejoin a split prefix/body while
-    // keeping `_` (which those prefixes require). The {16,} floor on this form
-    // both catches the rejoined token and avoids a cross-segment false positive.
-    const collapsed = p.replace(/[/.\s-]/g, "");
+    // Strip EVERY byte outside the token alphabet (not a fixed separator list),
+    // so any separator an attacker inserts to split a GitHub/AWS token rejoins.
+    const collapsed = p.replace(/[^A-Za-z0-9_]/g, "");
     return (
       FILENAME_CREDENTIAL_COLLAPSED.some((re) => re.test(collapsed)) ||
-      FILENAME_CREDENTIAL_SEPARATOR_TOLERANT.some((re) => re.test(p))
+      FILENAME_CREDENTIAL_CANONICAL.some((re) => re.test(p))
     );
   });
 }

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -243,14 +243,23 @@ const DIFF_CREDENTIAL_PATTERNS = [
 //    strip along with an attacker separator, so they are matched SEPARATOR-
 //    TOLERANT on the raw path: the internal dashes may be any separator or absent
 //    (`sk.ant-…` still trips), with the content scan's body floor.
+// Bodies allow `_`: a github_pat suffix legitimately contains underscores
+// (`github_pat_XXXX_YYYY`), and for the ghs_ family an attacker can INSERT `_`
+// to split the body (the collapse keeps `_`). The `_` never causes a false
+// positive here because each pattern still requires the literal credential
+// prefix, which no source filename carries. AWS keys have no `_` (and AWS is not
+// an autofix runner credential), so AKIA keeps the plain alphabet.
 const FILENAME_CREDENTIAL_COLLAPSED = [
-  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9]{16,}/,
-  /github_pat_[A-Za-z0-9]{16,}/,
+  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9_]{16,}/,
+  /github_pat_[A-Za-z0-9_]{16,}/,
   /AKIA[A-Z0-9]{16}/,
 ];
+// The internal separators of these prefixes may be ANY non-alphanumeric run (a
+// substituted `-`/`.`/`_`/`/`/space still yields a recoverable token), and the
+// body may contain `-` (real Anthropic/Slack keys do).
 const FILENAME_CREDENTIAL_SEPARATOR_TOLERANT = [
-  /sk[-._/\s]*ant[-._/\s]*[A-Za-z0-9-]{8,}/i,
-  /xox[-._/\s]*[a-z][-._/\s]*[A-Za-z0-9-]{8,}/i,
+  /sk[^A-Za-z0-9]*ant[^A-Za-z0-9]*[A-Za-z0-9-]{8,}/i,
+  /xox[^A-Za-z0-9]*[a-z][^A-Za-z0-9]*[A-Za-z0-9-]{8,}/i,
 ];
 
 // Full-token patterns (no \b, global) for MASKING a credential wherever it

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -228,20 +228,29 @@ const DIFF_CREDENTIAL_PATTERNS = [
 ];
 
 // For FILENAMES the agent controls the exact bytes, so unlike the CONTENT scan
-// (DIFF_CREDENTIAL_PATTERNS keeps \b + a length floor to avoid false positives on
-// code hashes) the filename match must survive obfuscation: padding before the
-// prefix (`xghs_…` kills a leading \b) and splitting the body with a separator to
-// beat a length floor (`ghs_a1b2/c3d4…`). So it uses NO \b and only a MINIMAL
-// body — the distinctive `_`/`-`-bearing prefix is the low-false-positive signal
-// — and every path is ALSO tested with `/`, `.`, `-`, and whitespace removed so a
-// prefix split across those rejoins. A real source filename is never named after
-// a token, so refusing on the bare prefix is safe and fail-closed. (#1551)
-const FILENAME_CREDENTIAL_PREFIXES = [
-  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9]/,
-  /github_pat_[A-Za-z0-9]/,
-  /sk-ant-[A-Za-z0-9]/,
-  /xox[a-z]-[A-Za-z0-9]/,
-  /AKIA[A-Z0-9]{4}/,
+// (DIFF_CREDENTIAL_PATTERNS keeps \b to avoid false positives on code hashes) the
+// filename match must survive obfuscation: padding before the prefix (`xghs_…`
+// kills a leading \b) and splitting the prefix/body with a separator (`ghs_a1b2/
+// c3d4…`, `g/hs_…`). Two families, matched differently (#1551):
+//
+//  • GitHub/AWS prefixes carry NO literal separator, so they are matched on a
+//    SEPARATOR-COLLAPSED form of the path (`/`·`.`·`-`·whitespace removed, `_`
+//    kept) with the content scan's {16,}/{16} body floor. The collapse rejoins an
+//    attacker's split; the floor still holds because a split token rejoins to full
+//    length — and it simultaneously kills the cross-segment false positive (two
+//    unrelated path segments joining to spell a prefix leave only a short body).
+//  • The Anthropic/Slack prefixes carry literal `-`, which the collapse would
+//    strip along with an attacker separator, so they are matched SEPARATOR-
+//    TOLERANT on the raw path: the internal dashes may be any separator or absent
+//    (`sk.ant-…` still trips), with the content scan's body floor.
+const FILENAME_CREDENTIAL_COLLAPSED = [
+  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9]{16,}/,
+  /github_pat_[A-Za-z0-9]{16,}/,
+  /AKIA[A-Z0-9]{16}/,
+];
+const FILENAME_CREDENTIAL_SEPARATOR_TOLERANT = [
+  /sk[-._/\s]*ant[-._/\s]*[A-Za-z0-9-]{8,}/i,
+  /xox[-._/\s]*[a-z][-._/\s]*[A-Za-z0-9-]{8,}/i,
 ];
 
 // Full-token patterns (no \b, global) for MASKING a credential wherever it
@@ -310,9 +319,13 @@ export function filesWithCredentialShapedContent(workRoot, files) {
 export function filesWithCredentialShapedName(files) {
   return (Array.isArray(files) ? files : []).filter((f) => {
     const p = String(f ?? "");
+    // Collapse for the separator-less prefixes: rejoin a split prefix/body while
+    // keeping `_` (which those prefixes require). The {16,} floor on this form
+    // both catches the rejoined token and avoids a cross-segment false positive.
     const collapsed = p.replace(/[/.\s-]/g, "");
-    return FILENAME_CREDENTIAL_PREFIXES.some(
-      (re) => re.test(p) || re.test(collapsed),
+    return (
+      FILENAME_CREDENTIAL_COLLAPSED.some((re) => re.test(collapsed)) ||
+      FILENAME_CREDENTIAL_SEPARATOR_TOLERANT.some((re) => re.test(p))
     );
   });
 }

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -227,6 +227,51 @@ const DIFF_CREDENTIAL_PATTERNS = [
   /\bAKIA[A-Z0-9]{16}\b/,
 ];
 
+// For FILENAMES the agent controls the exact bytes, so unlike the CONTENT scan
+// (DIFF_CREDENTIAL_PATTERNS keeps \b + a length floor to avoid false positives on
+// code hashes) the filename match must survive obfuscation: padding before the
+// prefix (`xghs_…` kills a leading \b) and splitting the body with a separator to
+// beat a length floor (`ghs_a1b2/c3d4…`). So it uses NO \b and only a MINIMAL
+// body — the distinctive `_`/`-`-bearing prefix is the low-false-positive signal
+// — and every path is ALSO tested with `/`, `.`, `-`, and whitespace removed so a
+// prefix split across those rejoins. A real source filename is never named after
+// a token, so refusing on the bare prefix is safe and fail-closed. (#1551)
+const FILENAME_CREDENTIAL_PREFIXES = [
+  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9]/,
+  /github_pat_[A-Za-z0-9]/,
+  /sk-ant-[A-Za-z0-9]/,
+  /xox[a-z]-[A-Za-z0-9]/,
+  /AKIA[A-Z0-9]{4}/,
+];
+
+// Full-token patterns (no \b, global) for MASKING a credential wherever it
+// appears in a public refusal reason — masks the maximal run, not just the
+// prefix. filesWithCredentialShapedName refuses a credential-bearing path
+// count-only BEFORE any path-echoing reason, so this is an aligned backstop that
+// deliberately does not share the \b-anchored content patterns (#1551).
+const REDACTION_PATTERNS = [
+  /(?:ghs|ghp|gho|ghu|ghr)_[A-Za-z0-9]{16,}/g,
+  /github_pat_[A-Za-z0-9_]{16,}/g,
+  /sk-ant-[A-Za-z0-9-]{8,}/g,
+  /xox[a-z]-[A-Za-z0-9-]{8,}/g,
+  /AKIA[A-Z0-9]{16}/g,
+];
+
+/** Mask any credential-shaped substring before a path is echoed into a public
+ * refusal reason. Changed-path NAMES are agent-controlled and can embed a token
+ * the agent read from process-env (the documented residual); a refusal reason
+ * lands on a public queue issue, so a raw echo would itself be an exfil channel
+ * (#1551). Belt-and-suspenders: filesWithCredentialShapedName already refuses a
+ * credential-bearing path before any of these reasons is reached. Exported for
+ * tests. */
+export function redactCredentialShaped(text) {
+  let out = String(text);
+  for (const re of REDACTION_PATTERNS) {
+    out = out.replace(re, "[redacted]");
+  }
+  return out;
+}
+
 /** Changed paths (present in the work tree as regular files) whose CONTENT
  * contains a credential-shaped string. Pure fs reads from the tainted tree —
  * no git, no execution; the guard runs credential-free from the pristine
@@ -253,6 +298,23 @@ export function filesWithCredentialShapedContent(workRoot, files) {
     }
   }
   return hits;
+}
+
+/** Changed paths whose NAME (not content) carries a runner-credential prefix.
+ * filesWithCredentialShapedContent reads file BODIES, so a token placed in a
+ * clean-content file's PATH would pass it and be published in the public PR's
+ * file tree (and echoed by the forbidden/credential reasons). This scans the
+ * path bytes — see FILENAME_CREDENTIAL_PREFIXES for why it does NOT reuse the
+ * content scan's \b-anchored patterns (agent-controlled names defeat them). Pure
+ * string check — no workRoot needed. (#1551) */
+export function filesWithCredentialShapedName(files) {
+  return (Array.isArray(files) ? files : []).filter((f) => {
+    const p = String(f ?? "");
+    const collapsed = p.replace(/[/.\s-]/g, "");
+    return FILENAME_CREDENTIAL_PREFIXES.some(
+      (re) => re.test(p) || re.test(collapsed),
+    );
+  });
 }
 
 /** True when `path` under `workRoot` is a symlink (lstat, so it never
@@ -328,13 +390,26 @@ export function evaluateDiffGuard(files, { workRoot = null } = {}) {
   // after a runner token the agent read from process-env (the documented
   // residual), so publishing them onto the public queue issue would itself be an
   // exfil channel — omission is the module's standing policy for agent-controlled
-  // text (see the note above buildAnalysisComment). The path-echo hardening for
-  // the other guard reasons (forbidden/credential) is tracked separately (#1551).
+  // text (see the note above buildAnalysisComment). The forbidden/symlink/
+  // credential reasons below redact credential-shaped substrings before echoing a
+  // path, and a credential-shaped NAME is refused outright just below (#1551).
   const malformed = changed.filter(hasUnsafePathBytes);
   if (malformed.length > 0) {
     return {
       ok: false,
       reason: `The autofix diff contains ${malformed.length} path(s) with leading/trailing whitespace or control characters, which are refused: such bytes make the guard's scans disagree with the byte-for-byte copy that publishes the branch, and a legitimate source path never contains them. No PR opened.`,
+    };
+  }
+  // Refuse any changed path whose NAME is credential-shaped. The content scan
+  // (filesWithCredentialShapedContent) reads file BODIES; a token placed in a
+  // clean-content file's PATH would pass it and be published in the public PR's
+  // file tree (#1551). Count-only reason — echoing the offending path would
+  // republish the token.
+  const nameHits = filesWithCredentialShapedName(changed);
+  if (nameHits.length > 0) {
+    return {
+      ok: false,
+      reason: `The autofix diff has ${nameHits.length} changed path(s) whose name is credential-shaped; such paths are refused wholesale (a token in a filename would be published in the public PR file tree). No PR opened.`,
     };
   }
   if (changed.length > MAX_CHANGED_FILES) {
@@ -347,7 +422,7 @@ export function evaluateDiffGuard(files, { workRoot = null } = {}) {
   if (forbidden.length > 0) {
     return {
       ok: false,
-      reason: `The autofix diff touches forbidden path(s): ${forbidden.join(", ")}. Deploy/CI/infra, dependency-manager, and toolchain surfaces are out of scope for autofix. No PR opened.`,
+      reason: `The autofix diff touches forbidden path(s): ${redactCredentialShaped(forbidden.join(", "))}. Deploy/CI/infra, dependency-manager, and toolchain surfaces are out of scope for autofix. No PR opened.`,
     };
   }
   if (workRoot) {
@@ -355,16 +430,17 @@ export function evaluateDiffGuard(files, { workRoot = null } = {}) {
     if (symlinks.length > 0) {
       return {
         ok: false,
-        reason: `The autofix diff replaces path(s) with a symlink: ${symlinks.join(", ")}. Symlinked paths are refused — a symlink would be dereferenced by the credentialed byte-copy and could exfiltrate runner secrets. No PR opened.`,
+        reason: `The autofix diff replaces path(s) with a symlink: ${redactCredentialShaped(symlinks.join(", "))}. Symlinked paths are refused — a symlink would be dereferenced by the credentialed byte-copy and could exfiltrate runner secrets. No PR opened.`,
       };
     }
     const credentialHits = filesWithCredentialShapedContent(workRoot, changed);
     if (credentialHits.length > 0) {
       return {
         ok: false,
-        // Names the FILES, never the matched content — the reason lands on a
-        // public queue issue.
-        reason: `The autofix diff contains credential-shaped content in: ${credentialHits.join(", ")}. Changed files are scanned before any push because a pushed branch is public immediately — a diff carrying anything token-shaped is refused wholesale. No PR opened.`,
+        // Names the FILES, never the matched content — and redacts any
+        // credential-shaped substring in a filename (#1551). The reason lands on
+        // a public queue issue.
+        reason: `The autofix diff contains credential-shaped content in: ${redactCredentialShaped(credentialHits.join(", "))}. Changed files are scanned before any push because a pushed branch is public immediately — a diff carrying anything token-shaped is refused wholesale. No PR opened.`,
       };
     }
   }

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -789,5 +789,28 @@ await test("guard resists sk-ant-/xox- obfuscation and cross-segment false posit
   }
 });
 
+await test("guard catches underscore-containing / underscore-split credential filenames (#1551 review P1)", () => {
+  const T = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+  const GP = "github" + "_pat_";
+  const GHS = "ghs" + "_";
+  for (const p of [
+    `ui-dashboard/src/${GP}AAAAAAAA_BBBBBBBB.ts`, // github_pat suffix contains '_' (P1)
+    `${GP}11ABCDEFG0${T}.ts`, // realistic github_pat shape
+    `${GHS}a1b2_c3d4_e5f6_g7h8_i9j0_k1l2_m3n4_o5p6.ts`, // ghs_ body split with '_'
+    `sk_ant_${T}.ts`, // sk-ant- with '_' substituted for its dashes
+  ]) {
+    assert(
+      filesWithCredentialShapedName([p]).length === 1,
+      `underscore-obfuscated credential filename must be refused: ${p}`,
+    );
+  }
+  // A SCREAMING_SNAKE constants file must not false-positive.
+  assert(
+    filesWithCredentialShapedName(["src/AUTH_CONFIG_CONSTANTS.ts"]).length ===
+      0,
+    "SCREAMING_SNAKE const path allowed",
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exitCode = 1;

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -759,5 +759,35 @@ await test("guard resists filename-credential obfuscation and avoids false posit
   assert(!red.includes(`${G}a1b2`), "padded token masked in a redacted reason");
 });
 
+await test("guard resists sk-ant-/xox- obfuscation and cross-segment false positives (#1551 review)", () => {
+  // Review findings: the sk-ant-/xox- prefixes carry a literal '-' the collapse
+  // used to strip, so a substituted internal dash (sk.ant-…) evaded them (P2);
+  // and stripping '/' across the whole path must not let two segments spell a
+  // prefix (P3). Fixtures concatenated so no contiguous credential literal here.
+  const T = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+  const SK = "sk" + "-" + "ant" + "-";
+  for (const p of [
+    "sk.ant-AAAAAAAAAAAA.ts", // dot substituted for the first required dash
+    "xox.b-AAAAAAAAAAAA.ts",
+    `config/${SK}api03-${T}.ts`, // real Anthropic key shape (dashes in the body)
+    `x/${"xox" + "b-"}${T}.ts`,
+  ]) {
+    assert(
+      filesWithCredentialShapedName([p]).length === 1,
+      `obfuscated Anthropic/Slack filename must be refused: ${p}`,
+    );
+  }
+  for (const p of [
+    "src/gh/s_util.ts", // two segments join to 'ghs_util' — short body, not a token
+    "src/risk-antenna.ts", // 'sk'+'ant' with a short body
+    "src/task-antler.ts",
+  ]) {
+    assert(
+      filesWithCredentialShapedName([p]).length === 0,
+      `legit path must not false-positive: ${p}`,
+    );
+  }
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exitCode = 1;

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -759,34 +759,42 @@ await test("guard resists filename-credential obfuscation and avoids false posit
   assert(!red.includes(`${G}a1b2`), "padded token masked in a redacted reason");
 });
 
-await test("guard resists sk-ant-/xox- obfuscation and cross-segment false positives (#1551 review)", () => {
-  // Review findings: the sk-ant-/xox- prefixes carry a literal '-' the collapse
-  // used to strip, so a substituted internal dash (sk.ant-…) evaded them (P2);
-  // and stripping '/' across the whole path must not let two segments spell a
-  // prefix (P3). Fixtures concatenated so no contiguous credential literal here.
+await test("guard: full-collapse GitHub/AWS, canonical-only Anthropic/Slack, no camelCase FP (#1551 review)", () => {
   const T = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8";
+  const G = "ghs" + "_";
   const SK = "sk" + "-" + "ant" + "-";
+  // GitHub/AWS families collapse EVERY non-token byte, so any inserted separator
+  // (incl. '@', '+') rejoins to trip the {16,} floor.
   for (const p of [
-    "sk.ant-AAAAAAAAAAAA.ts", // dot substituted for the first required dash
-    "xox.b-AAAAAAAAAAAA.ts",
-    `config/${SK}api03-${T}.ts`, // real Anthropic key shape (dashes in the body)
-    `x/${"xox" + "b-"}${T}.ts`,
+    `src/${G}a1b2@c3d4e5f6g7h8i9j0.ts`, // '@' separator
+    `src/${G}a1b2+c3d4+e5f6+g7h8+i9j0.ts`, // '+' separators
+    `${G}a1b2/c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8.ts`, // '/' split
   ]) {
     assert(
       filesWithCredentialShapedName([p]).length === 1,
-      `obfuscated Anthropic/Slack filename must be refused: ${p}`,
+      `must refuse: ${p}`,
     );
   }
-  for (const p of [
-    "src/gh/s_util.ts", // two segments join to 'ghs_util' — short body, not a token
-    "src/risk-antenna.ts", // 'sk'+'ant' with a short body
-    "src/task-antler.ts",
-  ]) {
+  // Anthropic/Slack matched only in CANONICAL dashed form — real keys caught.
+  for (const p of [`config/${SK}api03-${T}.ts`, `x/${"xox" + "b-"}${T}.ts`]) {
     assert(
-      filesWithCredentialShapedName([p]).length === 0,
-      `legit path must not false-positive: ${p}`,
+      filesWithCredentialShapedName([p]).length === 1,
+      `must refuse: ${p}`,
     );
   }
+  // No false positive: canonical-only matching keeps ordinary camelCase and
+  // hyphenated code clear where the short sk-ant/xox collapsed forms would collide.
+  for (const p of [
+    "ui-dashboard/src/TaskAntennaComponentHelperFactory.ts",
+    "src/risk-antenna.ts",
+    "src/task-antler.ts",
+    "src/gh/s_util.ts", // cross-segment join, short body
+    "docs/highschool-curriculum-planning-notes.md",
+  ]) {
+    assert(filesWithCredentialShapedName([p]).length === 0, `must allow: ${p}`);
+  }
+  // Documented residual (NOT asserted; low-value inference/Slack tokens): heavy
+  // obfuscation of the short prefixes, e.g. `sk.ant-…` or `sk-ant-a/bcdefgh`.
 });
 
 await test("guard catches underscore-containing / underscore-split credential filenames (#1551 review P1)", () => {
@@ -797,7 +805,6 @@ await test("guard catches underscore-containing / underscore-split credential fi
     `ui-dashboard/src/${GP}AAAAAAAA_BBBBBBBB.ts`, // github_pat suffix contains '_' (P1)
     `${GP}11ABCDEFG0${T}.ts`, // realistic github_pat shape
     `${GHS}a1b2_c3d4_e5f6_g7h8_i9j0_k1l2_m3n4_o5p6.ts`, // ghs_ body split with '_'
-    `sk_ant_${T}.ts`, // sk-ant- with '_' substituted for its dashes
   ]) {
     assert(
       filesWithCredentialShapedName([p]).length === 1,

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -21,11 +21,13 @@ import {
   buildStaleVerdictCloseComment,
   diffTrees,
   evaluateDiffGuard,
+  filesWithCredentialShapedName,
   fixPrOpenedLabelDef,
   fixRefusedLabelDef,
   isForbiddenPath,
   markerWriteStillValid,
   MAX_CHANGED_FILES,
+  redactCredentialShaped,
   runCli,
 } from "./sentry-autofix-finalize.mjs";
 import { AUTOFIX_COMMENT_PREFIX } from "./sentry-triage-digest.mjs";
@@ -656,6 +658,105 @@ await test("selected-verdict-id fails closed to 'none' (#1506)", () => {
       `fails closed to none for ${f}`,
     );
   }
+});
+
+// ── #1551: credential-shaped FILENAME bypass + reason path-echo redaction ─────
+// Fixtures are built by concatenation so no contiguous credential-shaped literal
+// sits in this source file (avoids tripping secret scanners on a test fixture).
+const CRED = {
+  ghs: "ghs_" + "A".repeat(20),
+  pat: "github_pat_" + "A".repeat(16),
+  skant: "sk-ant-" + "abcdefgh",
+  xox: "xoxb-" + "abcdefghij",
+  akia: "AKIA" + "ABCDEFGHIJKLMNOP",
+};
+
+await test("guard refuses a changed path whose NAME is credential-shaped (#1551)", () => {
+  // The content scan reads file BODIES, so a clean-content file NAMED after a
+  // token passes it and the name is published in the public PR file tree. The
+  // name scan refuses it, count-only — never echoing the token.
+  const dir = mkdtempSync(join(tmpdir(), "autofix-name-"));
+  const name = `${CRED.ghs}.ts`;
+  writeFileSync(join(dir, name), "export const x = 1;\n");
+  const r = evaluateDiffGuard([name], { workRoot: dir });
+  assert(!r.ok, "credential-named path refused");
+  assert(
+    !r.reason.includes(CRED.ghs),
+    "reason must not echo the token embedded in the filename",
+  );
+  // An ordinary source path is unaffected.
+  assert(
+    evaluateDiffGuard(["ui-dashboard/lib/helper.ts"]).ok,
+    "clean path still allowed",
+  );
+  rmSync(dir, { recursive: true, force: true });
+});
+
+await test("filesWithCredentialShapedName matches every credential prefix family (#1551)", () => {
+  const hits = filesWithCredentialShapedName([
+    "clean/path.ts",
+    `${CRED.ghs}.ts`,
+    `${CRED.pat}.md`,
+    `dir/${CRED.skant}.txt`,
+    `${CRED.xox}.json`,
+    `${CRED.akia}.env`,
+  ]);
+  assert(
+    hits.length === 5,
+    `expected 5 credential-named paths, got ${hits.length}`,
+  );
+  assert(!hits.includes("clean/path.ts"), "clean path not flagged");
+});
+
+await test("redactCredentialShaped masks credential substrings in an echoed path (#1551)", () => {
+  const out = redactCredentialShaped(
+    `path/${CRED.ghs}/a, dir/${CRED.skant}.tf, ${CRED.akia}`,
+  );
+  assert(!out.includes(CRED.ghs), "ghs_ token masked");
+  assert(!out.includes(CRED.skant), "sk-ant- token masked");
+  assert(!out.includes(CRED.akia), "AKIA token masked");
+  assert(out.includes("[redacted]"), "redaction marker present");
+  assert(
+    redactCredentialShaped("ui-dashboard/lib/a.ts") === "ui-dashboard/lib/a.ts",
+    "a clean path is unchanged",
+  );
+});
+
+await test("guard resists filename-credential obfuscation and avoids false positives (#1551 red-team)", () => {
+  // Filenames are agent-controlled: padding before the prefix, or splitting the
+  // body/prefix with a separator, must not hide a recoverable token. Fixtures are
+  // concatenated so no contiguous credential literal sits in this source.
+  const TOKEN = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"; // 36 alnum
+  const G = "ghs" + "_";
+  const attacks = [
+    `ui-dashboard/lib/x${G}${TOKEN}.ts`, // padded before the prefix (kills \b)
+    `${G}a1b2/c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8.ts`, // body split by /
+    `${G}a1b2-c3d4-e5f6-g7h8-i9j0-k1l2-m3n4-o5p6.ts`, // body split by -
+    `g/hs_${TOKEN}.ts`, // prefix split by /
+    `x${"github" + "_pat_"}${TOKEN}.ts`, // padded github_pat
+  ];
+  for (const p of attacks) {
+    assert(
+      filesWithCredentialShapedName([p]).length === 1,
+      `obfuscated credential filename must be refused: ${p}`,
+    );
+  }
+  // Legit source paths — including deceptive substrings ("highschool" contains
+  // "ghs", "Graphs" nearly does) — must NOT be refused.
+  for (const p of [
+    "ui-dashboard/src/lib/helper.ts",
+    "docs/highschool-notes.md",
+    "ui-dashboard/components/LightShowGraphs.tsx",
+    "alerts/rules/oracle.tf",
+  ]) {
+    assert(
+      filesWithCredentialShapedName([p]).length === 0,
+      `legit path must not false-positive: ${p}`,
+    );
+  }
+  // A padded token that reaches a path-echoing reason is masked by redaction.
+  const red = redactCredentialShaped(`forbidden: scripts/x${G}${TOKEN}.ts`);
+  assert(!red.includes(`${G}a1b2`), "padded token masked in a redacted reason");
 });
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## The Problem

- The autofix diff guard's credential scan reads file **content** only, so a
  clean-content file whose **name** is a token (`ghs_…​.ts`) passed the guard and
  would be published in the public PR's file tree.
- The forbidden and credential refusal reasons interpolated raw changed-path
  bytes, so a token embedded in a filename would be echoed onto the public queue
  issue.

## The Solution

Scan changed-path **names** for credentials and refuse count-only, and redact any
credential run before echoing a path into a public reason.

- `filesWithCredentialShapedName` refuses any changed path carrying a
  runner-credential prefix — placed before the count/forbidden/symlink/content
  checks, with a count-only reason (echoing the offending name would republish
  the token).
- `redactCredentialShaped` masks credential runs in the forbidden / symlink /
  credential reason echoes as an aligned backstop.

## Details

- Filenames are **agent-controlled**, so the name scan deliberately does NOT
  reuse the content scan's `\b`-anchored, length-floored patterns (those are
  right for content — they avoid false positives on code hashes). An adversarial
  pass showed those patterns are defeated by padding before the prefix
  (`xghs_…` kills the leading `\b`) or splitting the body/prefix with a separator
  to beat the length floor (`ghs_a1b2/c3d4…`). The name scan instead matches the
  distinctive credential **prefix** (the low-false-positive signal) with no `\b`
  and a minimal body, on the raw path **and** a `/`·`.`·`-`·whitespace-collapsed
  form so a split prefix rejoins. A real source filename is never named after a
  token, so refusing on the bare prefix is fail-closed and safe.
- Verified no false positives on deceptive legit paths (`highschool-notes.md`,
  `LightShowGraphs.tsx`).
- The credential **content** scan is unchanged (its `\b` patterns stay correct
  for file bodies). Impact was already bounded by #1373 (read-only agent token).
- The name→content→redaction path-echo separation is distinct from #1526 (the
  whitespace/control-char trim divergence).

## Validation

- `node scripts/sentry-autofix-finalize.test.mjs` → **37 passed, 0 failed**
  (adds a name-scan refusal, a per-prefix-family test, a redaction test, and a
  red-team regression: padded / `/`-split / `-`-split / prefix-split / padded
  `github_pat` all refused; deceptive legit paths allowed; padded token masked).
- `pnpm lint:scripts` clean; `trunk fmt` clean.

Closes #1551
Refs #1526, #1373
