### PR TITLE
feat(alerts): add source-only peg alert ladder

### DIFF
--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -1,4 +1,4 @@
-<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-07-22 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
+<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-07-24 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
 
 # alerts/rules
 
@@ -7,9 +7,9 @@ templates for Mento monitoring.
 
 ## Scope
 
-- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, VirtualPool oracle freshness, oracle report quality, oracle relayers, reserve balances, trading modes, trading limits, indexer health, CDP (Liquity v2) markets, and metrics-bridge liveness, plus Aegis service-health and Aegis testnet-health rule groups. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis contact points, message templates, mute timings, and protocol folders.
+- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, VirtualPool oracle freshness, oracle report quality, oracle relayers, reserve balances, trading modes, trading limits, indexer health, CDP (Liquity v2) markets, metrics-bridge liveness, and policy-versioned peg monitoring, plus Aegis service-health and Aegis testnet-health rule groups. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis/peg contact points, message templates, mute timings, and protocol folders.
 - **Not in this module:** the Aegis dashboard and the Aegis Grafana folder. Those stay in [`aegis/terraform`](../../aegis/terraform); the relocated rule group references the externally owned Aegis folder UID from `main.tf`.
-- **Folder convention:** one folder per `service` label (`FPMMs`, `Oracles`, `Indexer`, `Metrics Bridge`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`, `CDPs`).
+- **Folder convention:** one folder per `service` label (`FPMMs`, `Oracles`, `Indexer`, `Metrics Bridge`, `Peg Monitoring`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`, `CDPs`).
 
 ## State
 
@@ -45,10 +45,29 @@ Run `pnpm alerts:rules:lint` after changing alert rules or metrics-bridge gauge
 names. The check parses extracted PromQL expressions from `alerts/rules/*.tf`
 and cross-checks every referenced `mento_pool_*` / `mento_cdp_*` metric against
 the gauges registered in `metrics-bridge/src/metrics.ts` and
-`metrics-bridge/src/cdp-metrics.ts`.
+`metrics-bridge/src/cdp-metrics.ts`, and every referenced `mento_peg_*` metric
+against `metrics-bridge/src/peg/metrics.ts`.
 
 CI runs this in the `CI / Lint + test root scripts` job, along with
 `pnpm alerts:rules:lint:test` for extractor and failure-case coverage.
+
+## Peg alert ladder
+
+The source-generated peg ladder reads `peg-thresholds.json` once and creates
+exact-version active and retained-previous rule sets. Market warnings route to
+`#alerts-pools`, producer and source warnings route to `#alerts-infra`, and
+critical rules route to both Splunk On-Call and `#alerts-critical`. Peg rules
+use direct rule-level contact points and never inherit the FX-weekend mute.
+
+The source is not live merely because it is merged. Policy publication and
+authentication, producer activation, the trusted-main Terraform plan, the
+human-approved apply, and live Grafana proof are separate gates. Follow
+[`docs/notes/peg-monitoring.md`](../../docs/notes/peg-monitoring.md) for the
+current dependency boundary, exact source checks, telemetry preconditions,
+activation hold, and rollback order.
+
+Registry-rot and critical-path-unreachable rules are not part of the base
+ladder. They wait for authoritative listing-state metrics from the producer.
 
 ## Producer-first rollout and rollback
 
@@ -57,7 +76,9 @@ metric series exists before approving the `alerts-rules` apply. A merge can
 start the producer deployment and the protected Terraform workflow in
 parallel; keep the `production-infra` approval pending until the producer is
 deployed and the exact rule query returns the expected series. Scheduled mute
-timings, including the FX-weekend mute, are not deployment silences.
+timings, including the FX-weekend mute, are not deployment silences. Peg rules
+never use that mute and require a complete active decision-history window
+before their protected apply can be approved.
 
 Reverse the dependency for rollback. If a service or indexer rollback would
 remove a series required by a no-data-alerting rule, merge and apply the rule
@@ -83,10 +104,10 @@ second resolve message.
 
 ## Service label routing
 
-FPMM pool/deviation-transition, oracle, CDP, indexer, metrics-bridge, and Aegis
-testnet-health rule groups use rule-level `notification_settings`. Relayer,
-reserve, trading-mode, trading-limit, and Aegis service-health rules use the
-global notification policy and route by `service`, `severity`, `chain`, and
-`rateFeed` labels. Aegis testnet-health rules route to `#alerts-testnet` via
+FPMM pool/deviation-transition, oracle, CDP, indexer, metrics-bridge, peg, and
+Aegis testnet-health rule groups use rule-level `notification_settings`.
+Relayer, reserve, trading-mode, trading-limit, and Aegis service-health rules
+use the global notification policy and route by `service`, `severity`, `chain`,
+and `rateFeed` labels. Aegis testnet-health rules route to `#alerts-testnet` via
 `service=aegis-testnet` and do not depend on a testnet metrics bridge or hosted
 testnet pool indexer.

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -58,6 +58,9 @@ exact-version active and retained-previous rule sets. Market warnings route to
 `#alerts-pools`, producer and source warnings route to `#alerts-infra`, and
 critical rules route to both Splunk On-Call and `#alerts-critical`. Peg rules
 use direct rule-level contact points and never inherit the FX-weekend mute.
+Blind rules compare the producer's exact consecutive deep-poll count with
+policy; they do not infer 30-second poll history from Grafana's 60-second
+evaluation clock.
 
 The source is not live merely because it is merged. Policy publication and
 authentication, producer activation, the trusted-main Terraform plan, the

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -21,6 +21,11 @@ resource "grafana_folder" "metrics_bridge" {
   uid   = "metrics-bridge"
 }
 
+resource "grafana_folder" "peg_monitoring" {
+  title = "Peg Monitoring"
+  uid   = "peg-monitoring"
+}
+
 resource "grafana_folder" "indexer" {
   title = "Indexer"
   uid   = "indexer"

--- a/alerts/rules/peg-contact-points.tf
+++ b/alerts/rules/peg-contact-points.tf
@@ -1,0 +1,81 @@
+resource "grafana_contact_point" "peg_market_warning" {
+  name = "Peg market warnings (#alerts-pools)"
+
+  slack {
+    token     = var.slack_bot_token
+    recipient = var.slack_channel_pools
+    title     = local.peg_slack_title
+    text      = local.peg_slack_message
+  }
+
+  depends_on = [
+    grafana_message_template.peg_slack_title,
+    grafana_message_template.peg_slack_message,
+  ]
+}
+
+resource "grafana_contact_point" "peg_ops_warning" {
+  name = "Peg producer warnings (#alerts-infra)"
+
+  slack {
+    token     = var.slack_bot_token
+    recipient = var.slack_channel_infra
+    title     = local.peg_slack_title
+    text      = local.peg_slack_message
+  }
+
+  depends_on = [
+    grafana_message_template.peg_slack_title,
+    grafana_message_template.peg_slack_message,
+  ]
+}
+
+resource "grafana_contact_point" "peg_page" {
+  name = "Peg pages (Splunk On-Call + #alerts-critical)"
+
+  slack {
+    token     = var.slack_bot_token
+    recipient = var.slack_channel_critical
+    title     = local.peg_slack_title
+    text      = local.peg_slack_message
+  }
+
+  victorops {
+    url         = var.splunk_on_call_alerts_webhook_url
+    title       = local.peg_victorops_title
+    description = local.peg_victorops_message
+  }
+
+  depends_on = [
+    grafana_message_template.peg_slack_title,
+    grafana_message_template.peg_slack_message,
+    grafana_message_template.peg_victorops_title,
+    grafana_message_template.peg_victorops_message,
+  ]
+}
+
+locals {
+  peg_notify_market_warning = {
+    contact_point   = grafana_contact_point.peg_market_warning.name
+    group_by        = ["alertname", "grafana_folder", "asset", "source", "policy_version"]
+    group_wait      = "1m"
+    group_interval  = "10m"
+    repeat_interval = "4h"
+  }
+
+  peg_notify_ops_warning = {
+    contact_point   = grafana_contact_point.peg_ops_warning.name
+    group_by        = ["alertname", "grafana_folder", "asset", "source", "policy_version"]
+    group_wait      = "1m"
+    group_interval  = "10m"
+    repeat_interval = "4h"
+  }
+
+  peg_notify_page = {
+    contact_point   = grafana_contact_point.peg_page.name
+    group_by        = ["alertname", "grafana_folder", "asset", "source", "policy_version"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "1h"
+  }
+}

--- a/alerts/rules/peg-message-templates.tf
+++ b/alerts/rules/peg-message-templates.tf
@@ -1,0 +1,94 @@
+# Peg alerts carry a bounded decision package in annotations. Dedicated named
+# templates keep peg-only fields out of the protocol-wide dispatchers. Template
+# names are globally unique inside Grafana; contact points depend on these
+# resources explicitly because their template calls are plain strings.
+
+resource "grafana_message_template" "peg_slack_title" {
+  name     = "Peg - Slack Title"
+  template = <<-EOT
+{{ define "peg.slack.title" -}}
+{{ if (len .Alerts.Firing) }}{{ if eq .CommonLabels.severity "critical" }}🚨{{ else }}🟡{{ end }}{{ else }}✅{{ end }} {{ with .CommonLabels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}
+{{- end }}
+EOT
+}
+
+resource "grafana_message_template" "peg_slack_message" {
+  name     = "Peg - Slack Message"
+  template = <<-EOT
+{{ define "peg.slack.message" }}
+{{ range .Alerts.Firing -}}
+*FIRING: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}* — `{{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}`{{ with .Labels.source }} / `{{ . }}`{{ end }}
+{{ with .Annotations.summary }}{{ . }}{{ end }}
+{{ with .Annotations.executable_price }}*Executable price:* {{ . }}{{ end }}
+{{ with .Annotations.deviation_bps }}*Downside deviation:* {{ . }} bps{{ end }}
+{{ with .Annotations.premium_bps }}*Premium:* {{ . }} bps{{ end }}
+{{ with .Annotations.spread_bps }}*Spread:* {{ . }} bps{{ end }}
+{{ with .Annotations.fill }}*Executable fill:* {{ . }}{{ end }}
+{{ with .Annotations.structural_saturation }}*Structural saturation:* {{ . }}{{ end }}
+{{ with .Annotations.corroboration }}*Corroboration:* {{ . }}{{ end }}
+*Policy:* `{{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}`
+{{ with .Annotations.action }}*Action:* {{ . }}{{ end }}
+*Started:* {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
+*Alert ID:* `{{ .Fingerprint }}`
+{{ end -}}
+{{ range .Alerts.Resolved -}}
+*RESOLVED: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}* — `{{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}`{{ with .Labels.source }} / `{{ . }}`{{ end }}
+*Policy:* `{{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}`
+*Resolved:* {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+*Alert ID:* `{{ .Fingerprint }}`
+{{ end -}}
+{{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}No peg alerts are present in this notification.{{ end }}
+{{ end }}
+EOT
+}
+
+resource "grafana_message_template" "peg_victorops_title" {
+  name     = "Peg - VictorOps Title"
+  template = <<-EOT
+{{ define "peg.victorops.title" -}}
+{{ if (len .Alerts.Firing) -}}
+P1 {{ range $i, $alert := .Alerts.Firing }}{{ if $i }}, {{ end }}{{ with $alert.Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}: {{ with $alert.Labels.alertname }}{{ . }}{{ else }}peg page{{ end }}{{ end }}
+{{- end }}
+{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end -}}
+{{ if (len .Alerts.Resolved) -}}
+RESOLVED {{ range $i, $alert := .Alerts.Resolved }}{{ if $i }}, {{ end }}{{ with $alert.Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}: {{ with $alert.Labels.alertname }}{{ . }}{{ else }}peg page{{ end }}{{ end }}
+{{- end }}
+{{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}Peg status unknown{{ end }}
+{{- end }}
+EOT
+}
+
+resource "grafana_message_template" "peg_victorops_message" {
+  name     = "Peg - VictorOps Message"
+  template = <<-EOT
+{{ define "peg.victorops.message" }}
+{{ range .Alerts.Firing -}}
+PROBLEM: {{ with .Annotations.summary }}{{ . }}{{ else }}A peg page is firing.{{ end }}
+POLICY: {{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}{{ with .Labels.source }} SOURCE: {{ . }}{{ end }}
+{{ with .Annotations.executable_price }}EXECUTABLE PRICE: {{ . }}{{ end }}
+{{ with .Annotations.deviation_bps }}DOWNSIDE DEVIATION: {{ . }} bps{{ end }}
+{{ with .Annotations.premium_bps }}PREMIUM: {{ . }} bps{{ end }}
+{{ with .Annotations.spread_bps }}SPREAD: {{ . }} bps{{ end }}
+{{ with .Annotations.fill }}EXECUTABLE FILL: {{ . }}{{ end }}
+{{ with .Annotations.structural_saturation }}STRUCTURAL SATURATION: {{ . }}{{ end }}
+{{ with .Annotations.corroboration }}CORROBORATION: {{ . }}{{ end }}
+{{ with .Annotations.action }}ACTION: {{ . }}{{ end }}
+Started: {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
+Alert: {{ .GeneratorURL }}
+{{ end -}}
+{{ range .Alerts.Resolved -}}
+RESOLVED: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg page{{ end }} for {{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}.
+Policy: {{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}
+Resolved: {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+{{ end -}}
+{{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}Peg status unknown.{{ end }}
+{{ end }}
+EOT
+}
+
+locals {
+  peg_slack_title       = "{{ template \"peg.slack.title\" . }}"
+  peg_slack_message     = "{{ template \"peg.slack.message\" . }}"
+  peg_victorops_title   = "{{ template \"peg.victorops.title\" . }}"
+  peg_victorops_message = "{{ template \"peg.victorops.message\" . }}"
+}

--- a/alerts/rules/peg-policy-locals.tf
+++ b/alerts/rules/peg-policy-locals.tf
@@ -1,0 +1,74 @@
+# Peg rules are generated from the gated policy artifact. Every PromQL selector
+# names exactly one policy version; active and retained-previous expressions are
+# deliberately separate so a rollover cannot mix samples across semantics.
+#
+# Deviation dwell uses a quantile over the policy window. Two independent
+# coverage predicates make that duration claim honest: producer-side successful
+# polls and producer-side usable uncapped decisions must both meet the approved
+# cadence. The second counter is required because a capped observation advances
+# poll_success while intentionally omitting deviation_bps.
+
+locals {
+  peg_policy_bundle           = jsondecode(file("${path.module}/peg-thresholds.json"))
+  peg_active_policy           = local.peg_policy_bundle.active
+  peg_previous_policy         = local.peg_policy_bundle.previous
+  peg_active_policy_version   = local.peg_active_policy.version
+  peg_previous_policy_version = try(local.peg_previous_policy.version, "no-retained-previous-policy")
+
+  peg_active_assets   = local.peg_active_policy.assets
+  peg_previous_assets = local.peg_previous_policy == null ? {} : local.peg_previous_policy.assets
+
+  peg_active_sources = {
+    for item in flatten([
+      for asset_id, asset in local.peg_active_assets : [
+        for source_id, source in asset.sources : {
+          asset_id    = asset_id
+          asset       = asset
+          source_id   = source_id
+          source      = source
+          policy      = local.peg_active_policy
+          policy_slot = "active"
+        }
+      ]
+    ]) : "${item.asset_id}/${item.source_id}" => item
+  }
+  peg_active_authoritative_sources = {
+    for key, item in local.peg_active_sources : key => item
+    if item.source.authority != "display"
+  }
+  peg_active_deep_sources = {
+    for key, item in local.peg_active_sources : key => item
+    if item.source_id == item.asset.deepVenueSource
+  }
+  peg_active_non_deep_sources = {
+    for key, item in local.peg_active_sources : key => item
+    if item.source_id != item.asset.deepVenueSource
+  }
+
+  peg_previous_sources = {
+    for item in flatten([
+      for asset_id, asset in local.peg_previous_assets : [
+        for source_id, source in asset.sources : {
+          asset_id    = asset_id
+          asset       = asset
+          source_id   = source_id
+          source      = source
+          policy      = local.peg_previous_policy
+          policy_slot = "previous"
+        }
+      ]
+    ]) : "${item.asset_id}/${item.source_id}" => item
+  }
+  peg_previous_authoritative_sources = {
+    for key, item in local.peg_previous_sources : key => item
+    if item.source.authority != "display"
+  }
+  peg_previous_deep_sources = {
+    for key, item in local.peg_previous_sources : key => item
+    if item.source_id == item.asset.deepVenueSource
+  }
+  peg_previous_non_deep_sources = {
+    for key, item in local.peg_previous_sources : key => item
+    if item.source_id != item.asset.deepVenueSource
+  }
+}

--- a/alerts/rules/peg-promql-active.tf
+++ b/alerts/rules/peg-promql-active.tf
@@ -96,16 +96,18 @@ locals {
   }
   peg_active_blind_warning_promql = {
     for asset_id, asset in local.peg_active_assets : asset_id => format(
-      "(mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}) <= bool %d)",
+      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
       asset_id,
+      asset.blindConsecutivePolls,
       asset_id,
       asset.freshnessGraceSeconds,
     )
   }
   peg_active_blind_stressed_promql = {
     for asset_id, asset in local.peg_active_assets : asset_id => format(
-      "mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)))",
+      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)))",
       asset_id,
+      asset.blindConsecutivePolls,
       asset_id,
       asset.freshnessGraceSeconds,
       asset_id,

--- a/alerts/rules/peg-promql-active.tf
+++ b/alerts/rules/peg-promql-active.tf
@@ -1,0 +1,196 @@
+# Active-policy PromQL stays isolated from retained-previous semantics.
+locals {
+  # Active decision expressions. The reserved local names bind every extracted
+  # selector to the active-policy semantic scope in alert-rules-lint.
+  peg_active_downside_warning_promql = {
+    for key, item in local.peg_active_authoritative_sources : key => format(
+      "quantile_over_time(%g, mento_peg_deviation_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      item.asset.warnDeviationBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_active_premium_warning_promql = {
+    for key, item in local.peg_active_authoritative_sources : key => format(
+      "quantile_over_time(%g, mento_peg_premium_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      item.asset.premiumWarnBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_active_critical_deviation_promql = {
+    for key, item in local.peg_active_deep_sources : key => format(
+      "quantile_over_time(%g, mento_peg_deviation_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      item.asset.criticalDeviationBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      ceil(item.asset.criticalSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      ceil(item.asset.criticalSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_active_spread_warning_promql = {
+    for key, item in local.peg_active_deep_sources : key => format(
+      "mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} > %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
+      item.source.spreadEnvelopeBps,
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_active_structural_warning_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_active_blind_warning_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "(mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}) <= bool %d)",
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_active_blind_stressed_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)))",
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].spreadEnvelopeBps,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].staleAfterSeconds,
+      asset_id,
+      asset.deepVenueSource,
+      asset.target,
+      asset_id,
+      asset.deepVenueSource,
+      asset.target,
+      asset.criticalDeviationBps + asset.sources[asset.deepVenueSource].conversionErrorBps,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].staleAfterSeconds,
+    )
+  }
+  peg_active_source_unhealthy_promql = {
+    for key, item in local.peg_active_sources : key => format(
+      "mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == bool 0 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.asset.freshnessGraceSeconds,
+    )
+  }
+  peg_active_heartbeat_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "(time() - max_over_time(mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds]) > bool %d) or absent_over_time(mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"}[%ds])",
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_active_price_promql = {
+    for key, item in local.peg_active_sources : key => format(
+      "mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_active_fill_promql = {
+    for key, item in local.peg_active_sources : key => format(
+      "mento_peg_filled_fraction{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} * 100 or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_active_spread_context_promql = {
+    for key, item in local.peg_active_sources : key => format(
+      "mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_active_structural_context_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} * 100 or on() vector(-1)",
+      asset_id,
+    )
+  }
+  peg_active_corroboration_promql = {
+    for asset_id, asset in local.peg_active_assets : asset_id => format(
+      "max((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)) or max by(asset,policy_version) (mento_peg_deviation_bps{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_active_policy_version}\"} >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_active_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_active_policy_version}\"} <= %d))) or on() vector(0)",
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      asset.criticalDeviationBps + max(concat([0], [for source in values(asset.sources) : source.conversionErrorBps if source.authority == "secondary"])...),
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      min(concat([asset.freshnessGraceSeconds], [for source in values(asset.sources) : source.staleAfterSeconds if source.authority == "secondary"])...),
+    )
+  }
+}

--- a/alerts/rules/peg-promql-active.tf
+++ b/alerts/rules/peg-promql-active.tf
@@ -133,7 +133,9 @@ locals {
   }
   peg_active_source_unhealthy_promql = {
     for key, item in local.peg_active_sources : key => format(
-      "mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == bool 0 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      "(mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} == bool 0 or absent(mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_active_policy_version}\"})) and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
       item.asset_id,
       item.source_id,
       item.asset_id,

--- a/alerts/rules/peg-promql-previous.tf
+++ b/alerts/rules/peg-promql-previous.tf
@@ -1,0 +1,204 @@
+# Retained-previous PromQL remains source-controlled and dormant when previous=null.
+locals {
+  # Previous expressions stay source-controlled and continue evaluating until
+  # the retained previous policy is explicitly removed from the JSON. They are
+  # never suppressed by the first active-policy ACK.
+  peg_previous_downside_warning_promql = {
+    for key, item in local.peg_previous_authoritative_sources : key => format(
+      "quantile_over_time(%g, mento_peg_deviation_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      item.asset.warnDeviationBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_previous_critical_deviation_promql = {
+    for key, item in local.peg_previous_deep_sources : key => format(
+      "quantile_over_time(%g, mento_peg_deviation_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      item.asset.criticalDeviationBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      ceil(item.asset.criticalSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.criticalSustainSeconds,
+      ceil(item.asset.criticalSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_previous_premium_warning_promql = {
+    for key, item in local.peg_previous_authoritative_sources : key => format(
+      "quantile_over_time(%g, mento_peg_premium_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_poll_success_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) increase(mento_peg_usable_decision_total{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset.durationQuantile,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      item.asset.premiumWarnBps + item.source.conversionErrorBps,
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset.warnSustainSeconds,
+      ceil(item.asset.warnSustainSeconds / item.source.pollIntervalSeconds * item.asset.minimumCoverageFraction),
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_previous_spread_warning_promql = {
+    for key, item in local.peg_previous_deep_sources : key => format(
+      "mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} > %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
+      item.source.spreadEnvelopeBps,
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.source_id,
+      item.source.staleAfterSeconds,
+    )
+  }
+  peg_previous_structural_warning_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_previous_blind_warning_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "(mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}) <= bool %d)",
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_previous_blind_stressed_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)))",
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].spreadEnvelopeBps,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].staleAfterSeconds,
+      asset_id,
+      asset.deepVenueSource,
+      asset.target,
+      asset_id,
+      asset.deepVenueSource,
+      asset.target,
+      asset.criticalDeviationBps + asset.sources[asset.deepVenueSource].conversionErrorBps,
+      asset_id,
+      asset.deepVenueSource,
+      asset.sources[asset.deepVenueSource].staleAfterSeconds,
+    )
+  }
+  peg_previous_source_unhealthy_promql = {
+    for key, item in local.peg_previous_sources : key => format(
+      "mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == bool 0 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
+      item.asset_id,
+      item.asset.freshnessGraceSeconds,
+    )
+  }
+  peg_previous_heartbeat_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "(time() - max_over_time(mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds]) > bool %d) or absent_over_time(mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}[%ds])",
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      asset.freshnessGraceSeconds,
+    )
+  }
+  peg_previous_price_promql = {
+    for key, item in local.peg_previous_sources : key => format(
+      "mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_previous_fill_promql = {
+    for key, item in local.peg_previous_sources : key => format(
+      "mento_peg_filled_fraction{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} * 100 or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_previous_spread_context_promql = {
+    for key, item in local.peg_previous_sources : key => format(
+      "mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} or on() vector(-1)",
+      item.asset_id,
+      item.source_id,
+    )
+  }
+  peg_previous_structural_context_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} * 100 or on() vector(-1)",
+      asset_id,
+    )
+  }
+  peg_previous_corroboration_promql = {
+    for asset_id, asset in local.peg_previous_assets : asset_id => format(
+      "max((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)) or max by(asset,policy_version) (mento_peg_deviation_bps{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,source,policy_version) mento_peg_source_healthy{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=~\"^(?:%s)$\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d))) or on() vector(0)",
+      asset_id,
+      asset.structuralWarnFraction,
+      asset_id,
+      asset_id,
+      asset.freshnessGraceSeconds,
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      asset.criticalDeviationBps + max(concat([0], [for source in values(asset.sources) : source.conversionErrorBps if source.authority == "secondary"])...),
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      asset_id,
+      join("|", [for source_id, source in asset.sources : source_id if source.authority == "secondary"]),
+      min(concat([asset.freshnessGraceSeconds], [for source in values(asset.sources) : source.staleAfterSeconds if source.authority == "secondary"])...),
+    )
+  }
+
+  peg_rollover_ack_stuck_promql = format(
+    "absent(mento_peg_policy_version{policy_version=\"${local.peg_active_policy_version}\"})",
+  )
+
+  peg_empty_context_promql    = "vector(-1)"
+  peg_no_corroboration_promql = "vector(0)"
+}

--- a/alerts/rules/peg-promql-previous.tf
+++ b/alerts/rules/peg-promql-previous.tf
@@ -97,16 +97,18 @@ locals {
   }
   peg_previous_blind_warning_promql = {
     for asset_id, asset in local.peg_previous_assets : asset_id => format(
-      "(mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}) <= bool %d)",
+      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
       asset_id,
+      asset.blindConsecutivePolls,
       asset_id,
       asset.freshnessGraceSeconds,
     )
   }
   peg_previous_blind_stressed_promql = {
     for asset_id, asset in local.peg_previous_assets : asset_id => format(
-      "mento_peg_blind{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)))",
+      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1) or (mento_peg_spread_bps{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} > %g and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)) or (mento_peg_capped{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == 1 and on(asset,source,policy_version) ((%g - mento_peg_executable_px{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"}) / %g * 10000 >= %g) and on(asset,source,policy_version) (time() - mento_peg_observation_at{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)))",
       asset_id,
+      asset.blindConsecutivePolls,
       asset_id,
       asset.freshnessGraceSeconds,
       asset_id,

--- a/alerts/rules/peg-promql-previous.tf
+++ b/alerts/rules/peg-promql-previous.tf
@@ -134,7 +134,9 @@ locals {
   }
   peg_previous_source_unhealthy_promql = {
     for key, item in local.peg_previous_sources : key => format(
-      "mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == bool 0 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      "(mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} == bool 0 or absent(mento_peg_source_healthy{asset=\"%s\",source=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"})) and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_previous_policy_version}\"} <= %d)",
+      item.asset_id,
+      item.source_id,
       item.asset_id,
       item.source_id,
       item.asset_id,

--- a/alerts/rules/peg-rule-definitions.tf
+++ b/alerts/rules/peg-rule-definitions.tf
@@ -111,7 +111,7 @@ locals {
       for asset_id, asset in local.peg_active_assets : "active-blind-${asset_id}" => {
         name               = "Peg Blind Warning [${asset_id} · active]"
         expr               = local.peg_active_blind_warning_promql[asset_id]
-        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        for_duration       = "0s"
         no_data_state      = "Alerting"
         severity           = "warning"
         route              = "ops"
@@ -132,7 +132,7 @@ locals {
       for asset_id, asset in local.peg_active_assets : "active-blind-stressed-${asset_id}" => {
         name               = "Peg Blind While Stressed Critical [${asset_id} · active]"
         expr               = local.peg_active_blind_stressed_promql[asset_id]
-        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        for_duration       = "0s"
         no_data_state      = "OK"
         severity           = "critical"
         route              = "page"
@@ -328,7 +328,7 @@ locals {
       for asset_id, asset in local.peg_previous_assets : "previous-blind-${asset_id}" => {
         name               = "Peg Blind Warning [${asset_id} · previous]"
         expr               = local.peg_previous_blind_warning_promql[asset_id]
-        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        for_duration       = "0s"
         no_data_state      = "OK"
         severity           = "warning"
         route              = "ops"
@@ -349,7 +349,7 @@ locals {
       for asset_id, asset in local.peg_previous_assets : "previous-blind-stressed-${asset_id}" => {
         name               = "Peg Blind While Stressed Critical [${asset_id} · previous]"
         expr               = local.peg_previous_blind_stressed_promql[asset_id]
-        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        for_duration       = "0s"
         no_data_state      = "OK"
         severity           = "critical"
         route              = "page"

--- a/alerts/rules/peg-rule-definitions.tf
+++ b/alerts/rules/peg-rule-definitions.tf
@@ -1,0 +1,462 @@
+# Generated rule definitions bind policy data to routing and no-data behavior.
+locals {
+  peg_active_rule_definitions = merge(
+    {
+      for key, item in local.peg_active_authoritative_sources : "active-downside-${key}" => {
+        name               = "Peg Downside Warning [${item.asset_id}/${item.source_id} · active]"
+        expr               = local.peg_active_downside_warning_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Executable downside deviation is sustained above the warning threshold."
+        action             = "Compare the deep and secondary books, then inspect pool-flow saturation before escalating."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for key, item in local.peg_active_authoritative_sources : "active-premium-${key}" => {
+        name               = "Peg Premium Warning [${item.asset_id}/${item.source_id} · active]"
+        expr               = local.peg_active_premium_warning_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Executable sell price is sustained above the premium warning threshold."
+        action             = "Review reserve-side exposure; premium is warning-only and never pages the drain path."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for key, item in local.peg_active_deep_sources : "active-critical-${key}" => {
+        name               = "Peg Deep-Venue Downside Critical [${item.asset_id} · active]"
+        expr               = local.peg_active_critical_deviation_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "critical"
+        route              = "page"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.criticalSustainSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        spread_expr        = local.peg_active_spread_context_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_active_corroboration_promql[item.asset_id]
+        summary            = "The policy-designated deep venue has a sustained executable downside deviation."
+        action             = "Verify the deep book and structural flow, then follow the breaker-multisig decision runbook."
+        notification       = local.peg_notify_page
+      }
+    },
+    {
+      for key, item in local.peg_active_deep_sources : "active-spread-${key}" => {
+        name               = "Peg Deep-Venue Spread Warning [${item.asset_id} · active]"
+        expr               = local.peg_active_spread_warning_promql[key]
+        for_duration       = "${item.asset.warnSustainSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "The deep venue spread exceeds its approved envelope."
+        action             = "Check whether the book is evacuating or merely widening within a transient venue event."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_active_assets : "active-structural-${asset_id}" => {
+        name               = "Peg Structural Saturation Warning [${asset_id} · active]"
+        expr               = local.peg_active_structural_warning_promql[asset_id]
+        for_duration       = "${asset.warnSustainSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = asset_id
+        source             = ""
+        policy_version     = local.peg_active_policy_version
+        query_range        = asset.warnSustainSeconds
+        price_expr         = local.peg_active_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_active_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_active_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Indexed-pool directional flow is near the enforced trading-limit rate."
+        action             = "Inspect pool flow and counterparties; structural saturation alone never pages."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_active_assets : "active-blind-${asset_id}" => {
+        name               = "Peg Blind Warning [${asset_id} · active]"
+        expr               = local.peg_active_blind_warning_promql[asset_id]
+        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        no_data_state      = "Alerting"
+        severity           = "warning"
+        route              = "ops"
+        asset              = asset_id
+        source             = asset.deepVenueSource
+        policy_version     = local.peg_active_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_active_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_active_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_active_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "No usable uncapped price exists on the policy-designated deep venue."
+        action             = "Inspect book depth and venue health; the consecutive-poll duration is derived from policy cadence."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_active_assets : "active-blind-stressed-${asset_id}" => {
+        name               = "Peg Blind While Stressed Critical [${asset_id} · active]"
+        expr               = local.peg_active_blind_stressed_promql[asset_id]
+        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        no_data_state      = "OK"
+        severity           = "critical"
+        route              = "page"
+        asset              = asset_id
+        source             = asset.deepVenueSource
+        policy_version     = local.peg_active_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_active_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_active_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        spread_expr        = local.peg_active_spread_context_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_active_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_active_corroboration_promql[asset_id]
+        summary            = "The deep venue is blind while an independent stress leg is active."
+        action             = "Treat this as a page: verify partial-price shortfall, spread, and structural flow before breaker action."
+        notification       = local.peg_notify_page
+      }
+    },
+    {
+      for key, item in local.peg_active_sources : "active-unhealthy-${key}" => {
+        name               = "Peg Source Unhealthy [${item.asset_id}/${item.source_id} · active]"
+        expr               = local.peg_active_source_unhealthy_promql[key]
+        for_duration       = "${item.source.pollIntervalSeconds * 2}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.freshnessGraceSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "A peg venue adapter is unhealthy while the isolated peg loop remains live."
+        action             = "Inspect bounded peg error channels and venue/API status; this ops signal never pages."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for key, item in local.peg_active_non_deep_sources : "active-dead-${key}" => {
+        name               = "Peg Source Permanently Dead [${item.asset_id}/${item.source_id} · active]"
+        expr               = local.peg_active_source_unhealthy_promql[key]
+        for_duration       = "${item.asset.permanentlyDeadSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_active_policy_version
+        query_range        = item.asset.freshnessGraceSeconds
+        price_expr         = local.peg_active_price_promql[key]
+        fill_expr          = local.peg_active_fill_promql[key]
+        structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "A non-primary peg source has remained unhealthy for the policy dead-source interval."
+        action             = "Re-census the venue and prepare a source-controlled registry/policy cleanup if the listing is gone."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_active_assets : "active-heartbeat-${asset_id}" => {
+        name               = "Peg Heartbeat Missing [${asset_id} · active]"
+        expr               = local.peg_active_heartbeat_promql[asset_id]
+        for_duration       = "0s"
+        no_data_state      = "Alerting"
+        severity           = "warning"
+        route              = "ops"
+        asset              = asset_id
+        source             = ""
+        policy_version     = local.peg_active_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_empty_context_promql
+        fill_expr          = local.peg_empty_context_promql
+        structural_expr    = local.peg_active_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "The isolated peg loop has not completed an asset poll within the freshness grace."
+        action             = "Check metrics-bridge peg-loop logs and policy fetch health before trusting market decisions."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+  )
+
+  # The retained-previous packet intentionally mirrors the decision ladder. It
+  # is empty when previous=null and has no active-ACK exclusion when populated.
+  peg_previous_rule_definitions = merge(
+    {
+      for key, item in local.peg_previous_authoritative_sources : "previous-downside-${key}" => {
+        name               = "Peg Downside Warning [${item.asset_id}/${item.source_id} · previous]"
+        expr               = local.peg_previous_downside_warning_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Retained-policy executable downside deviation remains above warning."
+        action             = "Evaluate this policy version independently; remove retained rules only through the reviewed JSON cleanup."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for key, item in local.peg_previous_authoritative_sources : "previous-premium-${key}" => {
+        name               = "Peg Premium Warning [${item.asset_id}/${item.source_id} · previous]"
+        expr               = local.peg_previous_premium_warning_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Retained-policy executable premium remains above warning."
+        action             = "Review reserve-side exposure under the retained policy."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for key, item in local.peg_previous_deep_sources : "previous-critical-${key}" => {
+        name               = "Peg Deep-Venue Downside Critical [${item.asset_id} · previous]"
+        expr               = local.peg_previous_critical_deviation_promql[key]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "critical"
+        route              = "page"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.criticalSustainSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        spread_expr        = local.peg_previous_spread_context_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_previous_corroboration_promql[item.asset_id]
+        summary            = "The retained policy's deep venue has a sustained critical downside deviation."
+        action             = "Treat this version independently until source-controlled cleanup removes it."
+        notification       = local.peg_notify_page
+      }
+    },
+    {
+      for key, item in local.peg_previous_deep_sources : "previous-spread-${key}" => {
+        name               = "Peg Deep-Venue Spread Warning [${item.asset_id} · previous]"
+        expr               = local.peg_previous_spread_warning_promql[key]
+        for_duration       = "${item.asset.warnSustainSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.warnSustainSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "The retained policy's deep-venue spread exceeds its envelope."
+        action             = "Inspect the retained policy's venue state."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_previous_assets : "previous-structural-${asset_id}" => {
+        name               = "Peg Structural Saturation Warning [${asset_id} · previous]"
+        expr               = local.peg_previous_structural_warning_promql[asset_id]
+        for_duration       = "${asset.warnSustainSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "market"
+        asset              = asset_id
+        source             = ""
+        policy_version     = local.peg_previous_policy_version
+        query_range        = asset.warnSustainSeconds
+        price_expr         = local.peg_previous_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_previous_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_previous_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "Retained-policy structural saturation remains elevated."
+        action             = "Inspect pool flow under the retained policy."
+        notification       = local.peg_notify_market_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_previous_assets : "previous-blind-${asset_id}" => {
+        name               = "Peg Blind Warning [${asset_id} · previous]"
+        expr               = local.peg_previous_blind_warning_promql[asset_id]
+        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = asset_id
+        source             = asset.deepVenueSource
+        policy_version     = local.peg_previous_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_previous_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_previous_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_previous_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "The retained policy has no usable deep-venue price."
+        action             = "Inspect retained-policy venue health; do not gate this rule on the active ACK."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_previous_assets : "previous-blind-stressed-${asset_id}" => {
+        name               = "Peg Blind While Stressed Critical [${asset_id} · previous]"
+        expr               = local.peg_previous_blind_stressed_promql[asset_id]
+        for_duration       = "${asset.blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds}s"
+        no_data_state      = "OK"
+        severity           = "critical"
+        route              = "page"
+        asset              = asset_id
+        source             = asset.deepVenueSource
+        policy_version     = local.peg_previous_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_previous_price_promql["${asset_id}/${asset.deepVenueSource}"]
+        fill_expr          = local.peg_previous_fill_promql["${asset_id}/${asset.deepVenueSource}"]
+        spread_expr        = local.peg_previous_spread_context_promql["${asset_id}/${asset.deepVenueSource}"]
+        structural_expr    = local.peg_previous_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_previous_corroboration_promql[asset_id]
+        summary            = "The retained policy is blind while an independent stress leg is active."
+        action             = "Verify partial-price shortfall, spread, and structural flow before breaker action."
+        notification       = local.peg_notify_page
+      }
+    },
+    {
+      for key, item in local.peg_previous_sources : "previous-unhealthy-${key}" => {
+        name               = "Peg Source Unhealthy [${item.asset_id}/${item.source_id} · previous]"
+        expr               = local.peg_previous_source_unhealthy_promql[key]
+        for_duration       = "${item.source.pollIntervalSeconds * 2}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.freshnessGraceSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "A retained-policy source is unhealthy."
+        action             = "Inspect the retained policy's venue/API path."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for key, item in local.peg_previous_non_deep_sources : "previous-dead-${key}" => {
+        name               = "Peg Source Permanently Dead [${item.asset_id}/${item.source_id} · previous]"
+        expr               = local.peg_previous_source_unhealthy_promql[key]
+        for_duration       = "${item.asset.permanentlyDeadSeconds}s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = item.asset_id
+        source             = item.source_id
+        policy_version     = local.peg_previous_policy_version
+        query_range        = item.asset.freshnessGraceSeconds
+        price_expr         = local.peg_previous_price_promql[key]
+        fill_expr          = local.peg_previous_fill_promql[key]
+        structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "A retained-policy non-primary source is permanently dead."
+        action             = "Remove it only through reviewed retained-policy cleanup."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+    {
+      for asset_id, asset in local.peg_previous_assets : "previous-heartbeat-${asset_id}" => {
+        name               = "Peg Heartbeat Missing [${asset_id} · previous]"
+        expr               = local.peg_previous_heartbeat_promql[asset_id]
+        for_duration       = "0s"
+        no_data_state      = "OK"
+        severity           = "warning"
+        route              = "ops"
+        asset              = asset_id
+        source             = ""
+        policy_version     = local.peg_previous_policy_version
+        query_range        = asset.freshnessGraceSeconds
+        price_expr         = local.peg_empty_context_promql
+        fill_expr          = local.peg_empty_context_promql
+        structural_expr    = local.peg_previous_structural_context_promql[asset_id]
+        corroboration_expr = local.peg_no_corroboration_promql
+        summary            = "The retained policy has no fresh peg-loop heartbeat."
+        action             = "Keep retained rules live until explicit source-controlled cleanup."
+        notification       = local.peg_notify_ops_warning
+      }
+    },
+  )
+
+  peg_rollover_rule_definitions = local.peg_previous_policy == null ? {} : {
+    active-policy-ack = {
+      name               = "Peg Policy Rollover Stuck"
+      expr               = local.peg_rollover_ack_stuck_promql
+      for_duration       = "${local.peg_active_policy.rolloverAckExpectedSeconds}s"
+      no_data_state      = "OK"
+      severity           = "warning"
+      route              = "ops"
+      asset              = "policy"
+      source             = ""
+      policy_version     = local.peg_active_policy_version
+      query_range        = local.peg_active_policy.rolloverAckExpectedSeconds
+      price_expr         = local.peg_empty_context_promql
+      fill_expr          = local.peg_empty_context_promql
+      structural_expr    = local.peg_empty_context_promql
+      corroboration_expr = local.peg_no_corroboration_promql
+      summary            = "The producer has not acknowledged the active gated peg policy within its expected window."
+      action             = "Check private policy fetch/auth and bridge peg-loop logs; do not remove the retained policy."
+      notification       = local.peg_notify_ops_warning
+    }
+  }
+
+  peg_rule_definitions = merge(
+    local.peg_active_rule_definitions,
+    local.peg_previous_rule_definitions,
+    local.peg_rollover_rule_definitions,
+  )
+}

--- a/alerts/rules/rules-peg.tf
+++ b/alerts/rules/rules-peg.tf
@@ -110,7 +110,7 @@ resource "grafana_rule_group" "peg_monitoring" {
         }
         model = jsonencode({
           refId   = "Spread"
-          expr    = try(rule.value.spread_expr, local.peg_empty_context_promql)
+          expr    = try(coalesce(rule.value.spread_expr, local.peg_empty_context_promql), local.peg_empty_context_promql)
           instant = true
         })
       }

--- a/alerts/rules/rules-peg.tf
+++ b/alerts/rules/rules-peg.tf
@@ -1,0 +1,161 @@
+resource "grafana_rule_group" "peg_monitoring" {
+  name             = "Peg Monitoring"
+  folder_uid       = grafana_folder.peg_monitoring.uid
+  interval_seconds = 60
+
+  dynamic "rule" {
+    for_each = local.peg_rule_definitions
+    content {
+      name           = rule.value.name
+      condition      = "threshold"
+      for            = rule.value.for_duration
+      exec_err_state = "Error"
+      no_data_state  = rule.value.no_data_state
+
+      annotations = {
+        summary          = rule.value.summary
+        action           = rule.value.action
+        executable_price = "{{ if and $values.Price (ge $values.Price.Value 0.0) }}{{ printf \"%.6f\" $values.Price.Value }}{{ else }}unavailable{{ end }}"
+        deviation_bps = (
+          startswith(rule.value.name, "Peg Downside Warning") || startswith(rule.value.name, "Peg Deep-Venue Downside Critical")
+          ? "{{ if $values.A }}{{ printf \"%.1f\" $values.A.Value }}{{ end }}"
+          : ""
+        )
+        premium_bps = startswith(rule.value.name, "Peg Premium Warning") ? "{{ if $values.A }}{{ printf \"%.1f\" $values.A.Value }}{{ end }}" : ""
+        spread_bps = startswith(rule.value.name, "Peg Deep-Venue Spread Warning") ? "{{ if $values.A }}{{ printf \"%.1f\" $values.A.Value }}{{ end }}" : (
+          startswith(rule.value.name, "Peg Deep-Venue Downside Critical") || startswith(rule.value.name, "Peg Blind While Stressed Critical")
+          ? "{{ if and $values.Spread (ge $values.Spread.Value 0.0) }}{{ printf \"%.1f\" $values.Spread.Value }}{{ end }}"
+          : ""
+        )
+        fill                  = "{{ if and $values.Fill (ge $values.Fill.Value 0.0) }}{{ printf \"%.1f%%\" $values.Fill.Value }}{{ else }}unavailable{{ end }}"
+        structural_saturation = "{{ if and $values.Structural (ge $values.Structural.Value 0.0) }}{{ printf \"%.1f%%\" $values.Structural.Value }}{{ else }}unavailable{{ end }}"
+        corroboration = startswith(rule.value.name, "Peg Blind While Stressed Critical") ? "blindness plus structural saturation, spread, or partial-price shortfall" : (
+          startswith(rule.value.name, "Peg Deep-Venue Downside Critical")
+          ? "{{ if and $values.Corroboration (gt $values.Corroboration.Value 0.0) }}structural saturation or a distinct fresh uncapped venue{{ else }}none required; deep venue pages alone{{ end }}"
+          : ""
+        )
+      }
+
+      labels = {
+        service        = "peg-monitoring"
+        severity       = rule.value.severity
+        route          = rule.value.route
+        asset          = rule.value.asset
+        source         = rule.value.source
+        policy_version = rule.value.policy_version
+      }
+
+      data {
+        ref_id         = "A"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "A"
+          expr    = rule.value.expr
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "Price"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "Price"
+          expr    = rule.value.price_expr
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "Fill"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "Fill"
+          expr    = rule.value.fill_expr
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "Structural"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "Structural"
+          expr    = rule.value.structural_expr
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "Spread"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "Spread"
+          expr    = try(rule.value.spread_expr, local.peg_empty_context_promql)
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "Corroboration"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = "Corroboration"
+          expr    = rule.value.corroboration_expr
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "threshold"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 0
+          to   = 0
+        }
+        model = jsonencode({
+          refId      = "threshold"
+          type       = "threshold"
+          expression = "A"
+          conditions = [{
+            evaluator = { params = [0], type = "gt" }
+            operator  = { type = "and" }
+            query     = { params = ["threshold"] }
+          }]
+          datasource = { type = "__expr__", uid = "__expr__" }
+        })
+      }
+
+      notification_settings {
+        contact_point   = rule.value.notification.contact_point
+        group_by        = rule.value.notification.group_by
+        group_wait      = rule.value.notification.group_wait
+        group_interval  = rule.value.notification.group_interval
+        repeat_interval = rule.value.notification.repeat_interval
+      }
+    }
+  }
+}

--- a/docs/PLAN-peg-monitoring.md
+++ b/docs/PLAN-peg-monitoring.md
@@ -143,12 +143,12 @@ publishes the same policy as an IaC-owned versioned runtime artifact
 that the bridge polls (never baked into the image;
 content-addressed version suffix verified by runtime and CI;
 `mento_peg_policy_version` asserted by the rules with two-phase
-rollover: previous + new exact versions remain accepted until a reviewed
-follow-up sets `previous=null` after producer ACK. ACK only resolves the
-rollover-stuck condition and never auto-terminates retained rules; previous
-acceptance is never expired by wall-clock alone. Per-source poll cadences live
-in the same artifact so coverage cannot be gamed by an ungated cadence change).
-Per-rule conventions: freshness
+rollover: previous + new exact versions remain active until a separately
+reviewed `previous=null` follow-up after producer ACK. ACK itself only resolves
+the rollover-stuck alert; it never auto-terminates retained rules, and no wall
+clock expires their acceptance. Per-source poll cadences live in the same
+artifact so coverage cannot be gamed by an ungated cadence change). Per-rule
+conventions: freshness
 gate (`time() - mento_peg_observation_at`) on **every** peg rule;
 `no_data_state = "Alerting"` (+~5 min grace, documented) on blindness and
 heartbeat rules; duration-fraction sustain
@@ -172,8 +172,7 @@ Ladder (EUROP initial values; per-asset data):
   second uncapped venue escalates priority. Also: blind-while-stressed.
 - **Warn (Slack, repeat-suppressed):** uncapped deviation
   ≥ 25 bps sustained ≥ 10 min; deep-venue envelope-excess spread; structural
-  saturation; producer-counted blind ≥ M consecutive due deep-venue poll
-  slots.
+  saturation; producer-counted blind ≥ M consecutive deep-venue poll slots.
 - **Ops-noise (Slack low-urgency):** source unhealthy (API errors, 429s);
   never pages. Distinct alerts: "source permanently dead" (N days),
   "critical path unreachable — re-onboard" (deep-venue loss, human ack).

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`alerts/infra/onchain-event-handler/README.md`](../alerts/infra/onchain-event-handler/README.md) | On-chain Event Handler Module | canonical / active | runbook / alerts/infra/onchain-event-handler | eng | 90d; verified 2026-07-22 |
 | [`alerts/infra/onchain-event-listeners/README.md`](../alerts/infra/onchain-event-listeners/README.md) | On-chain Event Listeners Module | canonical / active | runbook / alerts/infra/onchain-event-listeners | eng | 90d; verified 2026-07-22 |
 | [`alerts/infra/README.md`](../alerts/infra/README.md) | Mento Alerts Delivery Infrastructure | canonical / active | runbook / alerts/infra | eng | 90d; verified 2026-07-17 |
-| [`alerts/rules/README.md`](../alerts/rules/README.md) | Grafana Alert Rules | canonical / active | runbook / alerts/rules | eng | 90d; verified 2026-07-22 |
+| [`alerts/rules/README.md`](../alerts/rules/README.md) | Grafana Alert Rules | canonical / active | runbook / alerts/rules | eng | 90d; verified 2026-07-24 |
 | [`docs/deployment.md`](deployment.md) | Deployment Guide | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-17 |
 | [`docs/evals/documentation-navigation.md`](evals/documentation-navigation.md) | Documentation Navigation Evaluation | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/agent-issue-workflow.md`](notes/agent-issue-workflow.md) | Agent Issue Workflow | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
@@ -71,6 +71,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md) | Documentation gardening | canonical / active | runbook / ci/process | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/github-tooling-surfaces.md`](notes/github-tooling-surfaces.md) | GitHub Tooling Surfaces — gh CLI vs MCP | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
 | [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md) | Hasura isolation trigger | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-22 |
+| [`docs/notes/peg-monitoring.md`](notes/peg-monitoring.md) | Peg monitoring alert source validation and activation hold | canonical / active | runbook / alerts/peg-monitoring | eng | 90d; verified 2026-07-24 |
 | [`docs/notes/polygon-monitoring.md`](notes/polygon-monitoring.md) | Polygon monitoring coverage and rollout | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-operating-card.md`](notes/pr-operating-card.md) | PR Operating Card | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/notes/pr-ready-state.md`](notes/pr-ready-state.md) | PR Ready State | canonical / active | runbook / repo-wide | eng | 90d; verified 2026-07-23 |

--- a/docs/adr/0044-peg-thresholds-gated-rules-plane.md
+++ b/docs/adr/0044-peg-thresholds-gated-rules-plane.md
@@ -15,10 +15,10 @@ garden_lane: adrs-architecture
 
 **Status:** Accepted (Jul 2026), in force. PRs #1497 and #1568 landed
 bridge-side policy validation, version-bound decision metrics, and producer
-acknowledgment state. Protected policy publication, Grafana rules, routing, and
-activation remain the Phase 3 rollout in
-[`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md); they are not
-implemented on `main`.
+acknowledgment state. This change implements the source rule ladder and routing.
+Protected policy publication and authentication, producer activation,
+human-approved Grafana application, and live proof remain separate rollout
+gates tracked by [`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md).
 **Scope:** alerts
 
 ## Context
@@ -118,15 +118,15 @@ Phase 3 must implement the following protected artifact and rules contract:
     breach; this is a new idiom in the stack, adopted deliberately for
     thin-market series and documented in the rule file banner. Range
     functions ignore gaps, so the quantile counts as a duration fraction
-    only when a sample-coverage predicate also passes — `increase` over a
+    only when two sample-coverage predicates also pass: `increase` over the
     monotonic per-source poll-success counter
-    (`mento_peg_poll_success_total`) compared against the expected poll
-    cadence. A timestamp-gauge `changes` undercounts polls that land
-    between scrapes, and raw `count_over_time` counts scrapes of a
-    retained gauge; only producer-side successes qualify, and failed polls
-    drop or stale the per-source series instead of holding last-good
-    values — after an API outage a sparse window with one fresh deviated
-    sample must not read as a sustained breach.
+    (`mento_peg_poll_success_total`) and over the monotonic uncapped
+    decision counter (`mento_peg_usable_decision_total`), each compared
+    against the expected poll cadence. A timestamp-gauge `changes`
+    undercounts polls that land between scrapes, and raw `count_over_time`
+    counts scrapes of a retained gauge. Requiring both counters prevents
+    capped or unchanged successes plus one deviated sample from being read
+    as a sustained breach.
   - Severity and routing stay per-rule: warn → Slack, critical → page, each
     with its own contact-point wiring.
 

--- a/docs/adr/0044-peg-thresholds-gated-rules-plane.md
+++ b/docs/adr/0044-peg-thresholds-gated-rules-plane.md
@@ -65,25 +65,22 @@ Phase 3 must implement the following protected artifact and rules contract:
   characters of the SHA-256 digest of its canonical content (excluding the
   version field). Canonicalization recursively sorts object keys by Unicode
   code point, preserves array order, and then hashes the compact JSON encoding;
-  runtime and CI verify that binding so a restarted replica
-  cannot reuse one metric label for changed semantics. Activation is two-phase because artifact publish and
-  bridge pickup cannot be atomic: the generated rules accept both the
-  previous and the new exact policy versions until a reviewed follow-up
-  artifact sets `previous=null` after the producer ACKNOWLEDGES the new
-  version. Acknowledgment resolves only the rollover-stuck condition; it
-  never auto-terminates retained rule acceptance. Old-version acceptance is
-  removed only by that reviewed artifact change and never expires by
-  wall-clock alone, so a delayed or unavailable artifact poll can never
-  leave the rules without an accepted producer version. Deviation
-  evaluation stays live on the previous policy throughout, and a distinct
-  rollover-stuck alert fires when acknowledgment exceeds the expected
-  window — a policy apply never opens a critical-monitoring gap. CI also
-  compares the candidate artifact with the current base policy:
-  a changed active version must retain that exact prior active object as
-  `previous`; an unchanged active version may only preserve or remove its
-  retained predecessor after acknowledgment. A second active rollover is
-  rejected until that predecessor has been cleared by the reviewed
-  `previous=null` update. There is no HCL mirror,
+  runtime and CI verify that binding so a restarted replica cannot reuse one
+  metric label for changed semantics. Activation is two-phase because
+  artifact publish and bridge pickup cannot be atomic: the generated rules
+  evaluate both the previous and new exact policy versions while `previous`
+  is retained. Producer acknowledgment resolves the distinct rollover-stuck
+  alert but never terminates old-version decisions by itself. After
+  acknowledgment and a complete active decision-history window, a separately
+  reviewed policy change sets `previous` to `null`; that apply removes the
+  retained rules and artifact content. No wall-clock expiry can leave the
+  rules without an accepted producer version, and deviation evaluation stays
+  live on the previous policy through cleanup. CI also compares the candidate
+  artifact with the current base policy: a changed active version must retain
+  that exact prior active object as `previous`; an unchanged active version
+  may only preserve or remove its retained predecessor. A second active
+  rollover is rejected until that predecessor has been cleared after
+  acknowledgment. There is no HCL mirror,
   so the existing mirror-drift check is unnecessary for this class; a sibling integrity
   check validates at source level: every threshold source key and the
   deep-venue designation must name an existing registry source id, every
@@ -111,7 +108,10 @@ Phase 3 must implement the following protected artifact and rules contract:
   - Blindness and heartbeat rules set `no_data_state = "Alerting"` with the
     documented justification and ~5-minute grace, following the
     bridge-down/pool-coverage precedent: for these rules, absence of data
-    is the signal.
+    is the signal. The producer publishes a policy-versioned consecutive-blind
+    poll count and resets it on each usable uncapped deep-venue decision. Rules
+    compare that count directly with `blindConsecutivePolls`; Grafana's
+    evaluation interval never stands in for a faster producer cadence.
   - Deviation sustain uses a duration-fraction window
     (`quantile_over_time`) rather than the rule `for` clock alone, so a
     single favorable sample on a thin, flapping book cannot reset a real

--- a/docs/adr/0045-peg-paging-semantics.md
+++ b/docs/adr/0045-peg-paging-semantics.md
@@ -14,10 +14,11 @@ garden_lane: adrs-architecture
 # ADR 0045 — Peg paging measures executable sell price; the deep venue pages alone
 
 **Status:** Accepted (Jul 2026), in force. PRs #1497 and #1568 landed the
-measurement and version-bound decision producer. Grafana paging rules, routing,
-and activation remain the Phase 3 rollout in
-[`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md); they are not
-implemented on `main`.
+measurement and version-bound decision producer. PR #1581 implements the source
+Grafana paging rules and routing. Protected policy publication and
+authentication, producer activation, human-approved Grafana application, and
+live proof remain rollout gates in
+[`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md).
 **Scope:** metrics-bridge / alerts
 
 ## Context
@@ -36,9 +37,10 @@ or structurally missing (thin second venue).
 
 ## Decision
 
-The bridge producer implements the measurement clauses below. Phase 3 rules
-must enforce the paging, blindness, and routing clauses before the producer
-becomes alert-authoritative.
+The bridge producer implements the measurement clauses below. The source rules
+implement paging, blindness, and routing. The producer does not become
+alert-authoritative until the remaining protected activation, application, and
+live-proof gates pass.
 
 - **Measurand.** Deviation is computed from the executable _sell_ price at
   a per-asset reference size tied to real exposure: the binding bound is
@@ -139,9 +141,10 @@ becomes alert-authoritative.
   signals (redemption status, attestations) are runbook inputs, not
   automated sources — this residual risk is documented, not hidden.
 - The bridge metric producer implements the executable-price, capped-depth,
-  blindness, and coverage-class semantics. Phase 3 must implement the alert
-  expressions, states, and routing before activation. Changes to paging
-  semantics remain ADR-level, not tuning.
+  blindness, and coverage-class semantics. The source rules implement the
+  alert expressions, states, and routing; production activation still requires
+  the protected rollout gates. Changes to paging semantics remain ADR-level,
+  not tuning.
 
 ## Evidence
 
@@ -159,4 +162,7 @@ becomes alert-authoritative.
   `metrics-bridge/test/peg-poller.test.ts`, and
   `metrics-bridge/test/peg-metrics.test.ts`
 - `alerts/rules/peg-thresholds.json` (dormant deep-venue and threshold policy)
+- `alerts/rules/peg-promql-active.tf`, `peg-promql-previous.tf`,
+  `peg-rule-definitions.tf`, and `peg-contact-points.tf` (implemented source
+  rules and routing)
 - ADRs 0042, 0043, 0044

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -38,9 +38,11 @@ The production identity bootstrap in
 [#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) must be
 merged and its separately reviewed Terraform apply must complete before this
 alert stack is eligible for a trusted-main apply. The producer changes in
-[#1568](https://github.com/mento-protocol/monitoring-monorepo/pull/1568) must be
-merged and deployed before the duration rules have their required
-`mento_peg_usable_decision_total` input.
+[#1568](https://github.com/mento-protocol/monitoring-monorepo/pull/1568) are
+merged and deployed. They remain intentionally dormant until authenticated
+policy delivery is live, so this milestone alone does not provide the required
+`mento_peg_usable_decision_total` input or satisfy activation precondition 3
+below.
 
 Registry-rot and critical-path-unreachable rules are intentionally absent.
 Those rules require authoritative `mento_peg_listing_state` and

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -51,19 +51,19 @@ Do not add placeholder selectors or infer listing state from source health.
 
 For each active policy, the generated source defines:
 
-| Rule                          | Signal                                                                                | Delivery                              |
-| ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------- |
-| Downside warning              | Fresh uncapped executable sell-price deviation with poll and usable-decision coverage | `#alerts-pools`                       |
-| Premium warning               | Fresh uncapped executable premium with the same coverage gates                        | `#alerts-pools`                       |
-| Deep-venue downside critical  | Sustained critical downside on the policy-designated deep venue                       | Splunk On-Call and `#alerts-critical` |
-| Deep-venue spread warning     | Fresh deep-venue spread above its approved envelope                                   | `#alerts-pools`                       |
-| Structural saturation warning | Fresh reachable indexed-pool saturation above policy                                  | `#alerts-pools`                       |
-| Blind warning                 | No usable uncapped deep-venue price after the approved grace                          | `#alerts-infra`                       |
-| Blind while stressed critical | Blindness plus reachable structural stress, spread stress, or partial-price shortfall | Splunk On-Call and `#alerts-critical` |
-| Source unhealthy              | Expected source unhealthy while the asset heartbeat is fresh                          | `#alerts-infra`                       |
-| Source permanently dead       | Source unhealthy for `permanentlyDeadSeconds`                                         | `#alerts-infra`                       |
-| Heartbeat missing             | The isolated asset poll no longer advances                                            | `#alerts-infra`                       |
-| Policy rollover stuck         | A retained previous policy exists and the active version is not acknowledged in time  | `#alerts-infra`                       |
+| Rule                          | Signal                                                                                                      | Delivery                              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Downside warning              | Fresh uncapped executable sell-price deviation with poll and usable-decision coverage                       | `#alerts-pools`                       |
+| Premium warning               | Fresh uncapped executable premium with the same coverage gates                                              | `#alerts-pools`                       |
+| Deep-venue downside critical  | Sustained critical downside on the policy-designated deep venue                                             | Splunk On-Call and `#alerts-critical` |
+| Deep-venue spread warning     | Fresh deep-venue spread above its approved envelope                                                         | `#alerts-pools`                       |
+| Structural saturation warning | Fresh reachable indexed-pool saturation above policy                                                        | `#alerts-pools`                       |
+| Blind warning                 | Producer count reaches `blindConsecutivePolls` without a usable uncapped deep-venue decision                | `#alerts-infra`                       |
+| Blind while stressed critical | Confirmed consecutive blindness plus reachable structural stress, spread stress, or partial-price shortfall | Splunk On-Call and `#alerts-critical` |
+| Source unhealthy              | Expected source unhealthy while the asset heartbeat is fresh                                                | `#alerts-infra`                       |
+| Source permanently dead       | Source unhealthy for `permanentlyDeadSeconds`                                                               | `#alerts-infra`                       |
+| Heartbeat missing             | The isolated asset poll no longer advances                                                                  | `#alerts-infra`                       |
+| Policy rollover stuck         | A retained previous policy exists and the active version is not acknowledged in time                        | `#alerts-infra`                       |
 
 When `previous` is retained, the same decision ladder remains generated for
 that exact previous version. Previous-version rules do not stop at the first
@@ -72,7 +72,11 @@ active-version acknowledgement; cleanup is a later reviewed policy change.
 Display sources never create deviation or premium rules. Structural saturation
 never pages alone. Blindness does not depend on indexed-pool reachability:
 reachability gates only the structural branch of the independent-stress page,
-so market stress remains observable during an indexer or pool-data outage.
+so market stress remains observable during an indexer or pool-data outage. The
+producer updates `mento_peg_blind_consecutive_polls` at deep-venue poll cadence
+and resets it on each usable uncapped decision. Grafana compares that exact
+count with policy; its 60-second evaluation clock never approximates 30-second
+polls.
 
 ## Local source validation
 
@@ -107,8 +111,8 @@ are true:
 3. #1568 is merged, deployed, and the production bridge exposes the exact
    active `policy_version`.
 4. `mento_peg_last_poll`, `mento_peg_source_healthy`,
-   `mento_peg_observation_at`, and `mento_peg_indexed_pool_reachable` return
-   the expected labelled series.
+   `mento_peg_observation_at`, `mento_peg_indexed_pool_reachable`, and
+   `mento_peg_blind_consecutive_polls` return the expected labelled series.
 5. The full critical window has accumulated. For the current 20-minute deep
    venue window, both counters satisfy the policy-derived floor:
 

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -1,0 +1,143 @@
+---
+title: Peg monitoring alert source validation and activation hold
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-24
+doc_type: runbook
+scope: alerts/peg-monitoring
+review_interval_days: 90
+garden_lane: operator-runbooks
+---
+
+# Peg monitoring alert source validation and activation hold
+
+The peg alert ladder is source configuration only until every production
+precondition in this runbook passes. A merged rule definition, a successful
+Terraform validation, or a clean plan does not prove that peg monitoring is
+live.
+
+The source-owned surfaces are:
+
+- `alerts/rules/peg-thresholds.json`: active and optional retained-previous
+  policy;
+- `alerts/rules/peg-policy-locals.tf`, `peg-promql-active.tf`, and
+  `peg-promql-previous.tf`: exact-version policy and PromQL locals;
+- `alerts/rules/peg-rule-definitions.tf` and `rules-peg.tf`: generated rule
+  definitions and the Grafana rule group; and
+- `alerts/rules/peg-contact-points.tf` and
+  `peg-message-templates.tf`: direct warning, operations, and paging delivery.
+
+## Current boundary
+
+This source packet does not publish or authenticate the private policy
+artifact, change a GitHub Actions workflow or Terraform identity, deploy the
+producer, apply Grafana resources, or prove live telemetry.
+
+The production identity bootstrap in
+[#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) must be
+merged and its separately reviewed Terraform apply must complete before this
+alert stack is eligible for a trusted-main apply. The producer changes in
+[#1568](https://github.com/mento-protocol/monitoring-monorepo/pull/1568) must be
+merged and deployed before the duration rules have their required
+`mento_peg_usable_decision_total` input.
+
+Registry-rot and critical-path-unreachable rules are intentionally absent.
+Those rules require authoritative `mento_peg_listing_state` and
+`mento_peg_listing_checked_at` producer series, which are not part of #1568.
+Do not add placeholder selectors or infer listing state from source health.
+
+## Rule inventory
+
+For each active policy, the generated source defines:
+
+| Rule                          | Signal                                                                                | Delivery                              |
+| ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------- |
+| Downside warning              | Fresh uncapped executable sell-price deviation with poll and usable-decision coverage | `#alerts-pools`                       |
+| Premium warning               | Fresh uncapped executable premium with the same coverage gates                        | `#alerts-pools`                       |
+| Deep-venue downside critical  | Sustained critical downside on the policy-designated deep venue                       | Splunk On-Call and `#alerts-critical` |
+| Deep-venue spread warning     | Fresh deep-venue spread above its approved envelope                                   | `#alerts-pools`                       |
+| Structural saturation warning | Fresh reachable indexed-pool saturation above policy                                  | `#alerts-pools`                       |
+| Blind warning                 | No usable uncapped deep-venue price after the approved grace                          | `#alerts-infra`                       |
+| Blind while stressed critical | Blindness plus reachable structural stress, spread stress, or partial-price shortfall | Splunk On-Call and `#alerts-critical` |
+| Source unhealthy              | Expected source unhealthy while the asset heartbeat is fresh                          | `#alerts-infra`                       |
+| Source permanently dead       | Source unhealthy for `permanentlyDeadSeconds`                                         | `#alerts-infra`                       |
+| Heartbeat missing             | The isolated asset poll no longer advances                                            | `#alerts-infra`                       |
+| Policy rollover stuck         | A retained previous policy exists and the active version is not acknowledged in time  | `#alerts-infra`                       |
+
+When `previous` is retained, the same decision ladder remains generated for
+that exact previous version. Previous-version rules do not stop at the first
+active-version acknowledgement; cleanup is a later reviewed policy change.
+
+Display sources never create deviation or premium rules. Structural saturation
+never pages alone. Blindness does not depend on indexed-pool reachability:
+reachability gates only the structural branch of the independent-stress page,
+so market stress remains observable during an indexer or pool-data outage.
+
+## Local source validation
+
+Run from the repository root:
+
+```bash
+pnpm alerts:rules:lint:test
+pnpm alerts:rules:lint
+pnpm tf validate alerts-rules
+pnpm agent:quality-gate --run
+```
+
+The linter parses map-comprehension `format()` expressions, requires every
+`mento_peg_*` selector to bind one approved policy version, cross-checks metric
+names against the producer registry, and validates active/retained-previous
+rollover scope. Terraform validation proves configuration shape only.
+
+The pull-request alert plan deliberately excludes rule groups with direct
+secret-backed contact-point dependencies. The first complete remote diff is
+therefore the trusted-main plan after merge. Keep its `production-infra` apply
+blocked, inspect the full plan, and do not treat a targeted PR plan as proof of
+the peg rule resources.
+
+## Production activation preconditions
+
+Do not approve the protected `alerts-rules` apply until all of the following
+are true:
+
+1. #1566 is merged and the human-approved identity bootstrap apply is verified.
+2. Policy publication and authenticated producer fetch are live through their
+   owning Terraform/runtime changes.
+3. #1568 is merged, deployed, and the production bridge exposes the exact
+   active `policy_version`.
+4. `mento_peg_last_poll`, `mento_peg_source_healthy`,
+   `mento_peg_observation_at`, and `mento_peg_indexed_pool_reachable` return
+   the expected labelled series.
+5. The full critical window has accumulated. For the current 20-minute deep
+   venue window, both counters satisfy the policy-derived floor:
+
+   ```promql
+   increase(mento_peg_poll_success_total{asset="europ-schuman",source="bitvavo_eur",policy_version="<active>"}[20m]) >= 32
+   ```
+
+   ```promql
+   increase(mento_peg_usable_decision_total{asset="europ-schuman",source="bitvavo_eur",policy_version="<active>"}[20m]) >= 32
+   ```
+
+6. Every exact generated query evaluates in the production Grafana data source
+   without `Error` or unexplained `NoData`.
+7. A human reviews the trusted-main plan and explicitly approves the
+   `production-infra` apply.
+
+Active blindness and heartbeat rules use `no_data_state = "Alerting"`.
+Applying while production peg samples are absent can create incidents by
+design. All price, spread, structural, source-health, retained-previous, and
+rollover rules use their documented non-paging no-data behavior.
+
+After apply, verify every rule exists in the `Peg Monitoring` folder, reports
+`Normal`, `Pending`, or an explained real firing state, and has the expected
+direct contact point. Delivery testing changes production alerting and requires
+its own explicit approval.
+
+## Rollback
+
+Remove or disable the Grafana consumers first through a reviewed,
+human-approved alerts-rules change. Confirm the rules are absent before
+withdrawing any producer series they require. Never remove the producer first:
+active blindness and heartbeat intentionally fail closed on missing data.

--- a/scripts/alert-rules-lint.mjs
+++ b/scripts/alert-rules-lint.mjs
@@ -290,6 +290,19 @@ export function extractExpressions(file, text) {
     out.push(extractedExpression(file, "format", name, unescapeHcl(match[2])));
   }
 
+  // Pass B2: map comprehensions whose value is a format() template. Peg rules
+  // use these to materialize one version-bound expression per asset/source;
+  // missing this shape would leave the generated decision plane unparsed.
+  const mapFmt = new RegExp(
+    String.raw`^\s*([A-Za-z0-9_]+_(?:promql|expr))\s*=\s*\{[\s\S]*?^\s*for\b[^\n]*=>\s*format\(\s*\n?\s*${QUOTED}`,
+    "gm",
+  );
+  for (const match of text.matchAll(mapFmt)) {
+    out.push(
+      extractedExpression(file, "map-format", match[1], unescapeHcl(match[2])),
+    );
+  }
+
   // Pass C: heredocs assigned to expr / *_promql / *_expr.
   const heredoc = new RegExp(
     String.raw`^\s*(expr|[A-Za-z0-9_]*_(?:promql|expr))\s*=\s*<<-?EOT\n([\s\S]*?)^\s*EOT$`,
@@ -754,6 +767,11 @@ function isExactVersionMatcher(operator, value, expectedVersion, policySlot) {
   if (value === APPROVED_POLICY_VERSION_INTERPOLATION[policySlot]) {
     return operator === "=";
   }
+  // Before a rollover, previous-policy templates are dormant and there is no
+  // literal previous version to compare. Keep validating their selector shape
+  // so a later JSON-only rollover cannot activate a wildcard, negative, or
+  // unscoped matcher that was accepted while previous=null.
+  if (typeof expectedVersion !== "string") return false;
   if (operator === "=") {
     return expectedVersion === value;
   }
@@ -803,8 +821,12 @@ function validatePegSelector(
     return;
   }
   if (!isExactVersionMatcher(operator, value, expectedVersion, policySlot)) {
+    const expectedDescription =
+      typeof expectedVersion === "string"
+        ? `${policySlot} version ${expectedVersion}`
+        : `${policySlot} policy local ${APPROVED_POLICY_VERSION_INTERPOLATION[policySlot]}`;
     failures.push(
-      `${location}: ${metric} policy_version matcher must equal ${policySlot} version ${expectedVersion}`,
+      `${location}: ${metric} policy_version matcher must equal ${expectedDescription}`,
     );
   }
 }
@@ -843,11 +865,10 @@ function validatePegRuleScope(expression, policyVersions, selectors, failures) {
     );
     return { kind: "decision", policy: "active" };
   }
-  if (scope.policy === "previous" && policyVersions.previous === null) {
-    failures.push(
-      `${location}: previous decision rule is invalid without a retained previous policy`,
-    );
-  }
+  // Previous-policy templates must exist before a rollover so a JSON-only
+  // policy change can instantiate the full retained rule set. Even while
+  // previous=null keeps those templates dormant, each selector must use exact
+  // equality to the reserved previous-policy local.
   return scope;
 }
 
@@ -881,7 +902,6 @@ export function validatePegPromqlExpressions(expressions, policyVersions) {
           ? "active"
           : scope.policy;
       const expectedVersion = policyVersions[policySlot];
-      if (typeof expectedVersion !== "string") continue;
       validatePegSelector(
         selector,
         metric,
@@ -914,7 +934,7 @@ function policyVersions(bundle) {
 }
 
 function main() {
-  const minExpressions = intEnv("ALERT_RULES_LINT_MIN_EXPRESSIONS", 100);
+  const minExpressions = intEnv("ALERT_RULES_LINT_MIN_EXPRESSIONS", 170);
   const minRegistered = intEnv("ALERT_RULES_LINT_MIN_REGISTERED", 30);
   const minReferenced = intEnv("ALERT_RULES_LINT_MIN_REFERENCED", 25);
 

--- a/scripts/alert-rules-lint.mjs
+++ b/scripts/alert-rules-lint.mjs
@@ -865,6 +865,14 @@ function validatePegRuleScope(expression, policyVersions, selectors, failures) {
     );
     return { kind: "decision", policy: "active" };
   }
+  if (
+    scope.policy === "previous" &&
+    selectors.some(({ metric }) => metric === "mento_peg_policy_version")
+  ) {
+    failures.push(
+      `${location}: previous decision rules must not depend on mento_peg_policy_version; retained rules end only through reviewed policy cleanup`,
+    );
+  }
   // Previous-policy templates must exist before a rollover so a JSON-only
   // policy change can instantiate the full retained rule set. Even while
   // previous=null keeps those templates dormant, each selector must use exact

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -855,7 +855,7 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
     "duration rules must require both counters at a whole-decision coverage floor",
   );
   assert(
-    source.includes("== bool 0 and on(asset,policy_version)") &&
+    source.includes("== bool 0 or absent(mento_peg_source_healthy") &&
       source.includes(
         "item.asset.criticalDeviationBps + item.source.conversionErrorBps",
       ) &&
@@ -865,6 +865,33 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       !source.includes("Critical Path Unreachable"),
     "health comparisons, conversion error bands, and the Phase 4 boundary must stay explicit",
   );
+  for (const policy of ["active", "previous"]) {
+    const policyVersion = `\${local.peg_${policy}_policy_version}`;
+    const sourceUnhealthy =
+      `(mento_peg_source_healthy{asset=\\"%s\\",source=\\"%s\\",policy_version=\\"${policyVersion}\\"} == bool 0 ` +
+      `or absent(mento_peg_source_healthy{asset=\\"%s\\",source=\\"%s\\",policy_version=\\"${policyVersion}\\"})) ` +
+      `and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${policyVersion}\\"} <= %d)`;
+    assert(
+      source.includes(sourceUnhealthy),
+      `${policy} source health must fail closed for an absent exact source while the exact asset heartbeat is fresh`,
+    );
+
+    const failures = validatePegPromqlExpressions(
+      [
+        {
+          file: `peg-promql-${policy}.tf`,
+          kind: "format",
+          expr: sourceUnhealthy.replaceAll('\\"', '"'),
+          pegRule: { kind: "decision", policy },
+        },
+      ],
+      { active: "europ-v2", previous: "europ-v1" },
+    );
+    assert(
+      failures.length === 0,
+      `${policy} absent source-health fallback must retain exact policy scoping: ${failures.join("\\n")}`,
+    );
+  }
   assert(
     source.includes(
       'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d)',

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -259,6 +259,31 @@ EOT
   );
 });
 
+test("extractExpressions parses scoped map-comprehension format templates", () => {
+  const fixture = stripComments(`
+locals {
+  peg_active_deviation_promql = {
+    for source_id, source in local.sources : source_id => format(
+      "mento_peg_deviation_bps > %g",
+      source.threshold,
+    )
+  }
+}
+`);
+  const [expression] = extractExpressions("rules-peg.tf", fixture);
+  assert(expression !== undefined, "expected map format expression");
+  assert(
+    expression.kind === "map-format" &&
+      expression.pegRule?.kind === "decision" &&
+      expression.pegRule.policy === "active",
+    `expected active map scope, got ${JSON.stringify(expression)}`,
+  );
+  assert(
+    lintPromql(neutralize(expression.expr)) === null,
+    `expected extracted map expression to parse: ${expression.expr}`,
+  );
+});
+
 test("extractExpressions parses rendered join() syntax", () => {
   const fixture = stripComments(`
 data {
@@ -732,6 +757,209 @@ test("peg PromQL accepts only the approved policy-derived interpolation", () => 
   assert(
     swapped.some((failure) => failure.includes("must equal active")),
     "expected a policy-slot interpolation used by the wrong rule to fail",
+  );
+});
+
+test("peg PromQL requires exact dormant previous selectors before rollover", () => {
+  const dormantPrevious = (expr) => [
+    {
+      file: "rules-peg.tf",
+      kind: "format",
+      expr,
+      pegRule: { kind: "decision", policy: "previous" },
+    },
+  ];
+  const versions = { active: "europ-v2", previous: null };
+  const failures = validatePegPromqlExpressions(
+    dormantPrevious(
+      'mento_peg_deviation_bps{policy_version="${local.peg_previous_policy_version}"} > 25',
+    ),
+    versions,
+  );
+  assert(
+    failures.length === 0,
+    `expected dormant previous template to pass: ${failures.join("\n")}`,
+  );
+
+  for (const [name, expr, expectedFailure] of [
+    [
+      "missing selector",
+      "mento_peg_deviation_bps > 25",
+      "missing a policy_version selector",
+    ],
+    [
+      "missing matcher",
+      'mento_peg_deviation_bps{asset="europ"} > 25',
+      "missing a policy_version matcher",
+    ],
+    [
+      "negative matcher",
+      'mento_peg_deviation_bps{policy_version!="${local.peg_previous_policy_version}"} > 25',
+      "negative matcher",
+    ],
+    [
+      "wildcard matcher",
+      'mento_peg_deviation_bps{policy_version=~".*"} > 25',
+      "must equal previous policy local",
+    ],
+    [
+      "regex local matcher",
+      'mento_peg_deviation_bps{policy_version=~"${local.peg_previous_policy_version}"} > 25',
+      "must equal previous policy local",
+    ],
+    [
+      "literal matcher",
+      'mento_peg_deviation_bps{policy_version="europ-v1"} > 25',
+      "must equal previous policy local",
+    ],
+  ]) {
+    const rejected = validatePegPromqlExpressions(
+      dormantPrevious(expr),
+      versions,
+    );
+    assert(
+      rejected.some((failure) => failure.includes(expectedFailure)),
+      `expected dormant previous ${name} to fail: ${rejected.join("\n")}`,
+    );
+  }
+});
+
+test("committed peg rules preserve coverage, rollover, and routing invariants", () => {
+  const source = [
+    "peg-policy-locals.tf",
+    "peg-promql-active.tf",
+    "peg-promql-previous.tf",
+    "peg-rule-definitions.tf",
+    "rules-peg.tf",
+  ]
+    .map((file) =>
+      readFileSync(path.resolve(__dirname, "..", "alerts/rules", file), "utf8"),
+    )
+    .join("\n");
+  const contacts = readFileSync(
+    path.resolve(__dirname, "..", "alerts/rules/peg-contact-points.tf"),
+    "utf8",
+  );
+  const templates = readFileSync(
+    path.resolve(__dirname, "..", "alerts/rules/peg-message-templates.tf"),
+    "utf8",
+  );
+
+  assert(
+    source.includes("increase(mento_peg_poll_success_total") &&
+      source.includes("increase(mento_peg_usable_decision_total") &&
+      source.includes("ceil(item.asset.warnSustainSeconds") &&
+      source.includes("ceil(item.asset.criticalSustainSeconds") &&
+      !source.includes("count_over_time(mento_peg_deviation_bps") &&
+      !source.includes("count_over_time(mento_peg_source_healthy"),
+    "duration rules must require both counters at a whole-decision coverage floor",
+  );
+  assert(
+    source.includes("== bool 0 and on(asset,policy_version)") &&
+      source.includes(
+        "item.asset.criticalDeviationBps + item.source.conversionErrorBps",
+      ) &&
+      source.includes(
+        "item.asset.premiumWarnBps + item.source.conversionErrorBps",
+      ) &&
+      !source.includes("Critical Path Unreachable"),
+    "health comparisons, conversion error bands, and the Phase 4 boundary must stay explicit",
+  );
+  assert(
+    source.includes(
+      '(mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"}) <= bool %d)',
+    ) &&
+      source.includes(
+        '(mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"}) <= bool %d)',
+      ) &&
+      source.includes(
+        'max_over_time(mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"}[%ds]) > bool %d',
+      ) &&
+      source.includes(
+        'max_over_time(mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"}[%ds]) > bool %d',
+      ),
+    "blindness and heartbeat templates must preserve explicit zero vectors while healthy without depending on the structural plane",
+  );
+  assert(
+    source.includes(
+      'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1) or (mento_peg_spread_bps',
+    ) &&
+      source.includes(
+        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1) or (mento_peg_spread_bps',
+      ) &&
+      !source.includes(
+        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1 and on(asset,policy_version) mento_peg_indexed_pool_reachable',
+      ) &&
+      !source.includes(
+        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1 and on(asset,policy_version) mento_peg_indexed_pool_reachable',
+      ),
+    "blind-while-stressed must gate only structural saturation on pool reachability so market stress remains independently page-capable",
+  );
+  assert(
+    source.includes("mento_peg_filled_fraction") &&
+      (source.match(/\} \* 100 or on\(\) vector\(-1\)/g) ?? []).length === 4 &&
+      !source.includes("(mul $values.Fill.Value") &&
+      !source.includes("(mul $values.Structural.Value"),
+    "annotation percentages must be scaled in PromQL because Grafana annotation templates do not expose Sprig math",
+  );
+  assert(
+    source.includes(
+      'name               = "Peg Blind Warning [${asset_id} · active]"',
+    ) &&
+      /active-blind-\$\{asset_id\}[\s\S]{0,400}no_data_state\s+=\s+"Alerting"/.test(
+        source,
+      ) &&
+      /active-blind-stressed-\$\{asset_id\}[\s\S]{0,400}no_data_state\s+=\s+"OK"/.test(
+        source,
+      ) &&
+      /previous-blind-\$\{asset_id\}[\s\S]{0,400}no_data_state\s+=\s+"OK"/.test(
+        source,
+      ),
+    "only active blind producer absence should fail closed through NoData",
+  );
+  assert(
+    source.includes(
+      "peg_rollover_rule_definitions = local.peg_previous_policy == null ? {} : {",
+    ),
+    "rollover-stuck rule must exist only while a previous policy is retained",
+  );
+  assert(
+    !/peg_previous_[a-z0-9_]+_(?:promql|expr)[\s\S]{0,300}unless\s+mento_peg_policy_version/.test(
+      source,
+    ),
+    "previous decisions must not stop at the first active-policy ACK",
+  );
+  assert(
+    source.includes("for_each = local.peg_rule_definitions") &&
+      source.includes('name             = "Peg Monitoring"') &&
+      source.includes("notification_settings {") &&
+      contacts.includes("grafana_contact_point.peg_page.name") &&
+      contacts.includes("victorops {") &&
+      contacts.includes("var.slack_channel_critical") &&
+      contacts.includes(
+        '["alertname", "grafana_folder", "asset", "source", "policy_version"]',
+      ) &&
+      templates.includes('{{ define "peg.slack.title"') &&
+      templates.includes('{{ define "peg.slack.message"') &&
+      templates.includes('{{ define "peg.victorops.title"') &&
+      templates.includes('{{ define "peg.victorops.message"') &&
+      templates.includes("range .Alerts.Firing") &&
+      templates.includes("range .Alerts.Resolved") &&
+      templates.includes("EXECUTABLE PRICE:") &&
+      templates.includes("DOWNSIDE DEVIATION:") &&
+      templates.includes("EXECUTABLE FILL:") &&
+      templates.includes("SPREAD:") &&
+      templates.includes("STRUCTURAL SATURATION:") &&
+      source.includes('ref_id         = "Spread"') &&
+      source.includes(
+        "try(rule.value.spread_expr, local.peg_empty_context_promql)",
+      ) &&
+      contacts.includes("grafana_message_template.peg_victorops_message"),
+    "peg rules must route a complete decision package to dedicated warning/ops/page contact points",
+  );
+  assert(
+    !source.includes("mute_timing") && !contacts.includes("mute_timing"),
+    "peg decisions must not inherit the FX weekend mute",
   );
 });
 

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -867,10 +867,14 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
   );
   assert(
     source.includes(
-      '(mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"}) <= bool %d)',
+      'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d)',
     ) &&
       source.includes(
-        '(mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == bool 1) * on(asset,policy_version) ((time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"}) <= bool %d)',
+        'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} <= %d)',
+      ) &&
+      source.includes("asset.blindConsecutivePolls") &&
+      !source.includes(
+        "blindConsecutivePolls * asset.sources[asset.deepVenueSource].pollIntervalSeconds",
       ) &&
       source.includes(
         'max_over_time(mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"}[%ds]) > bool %d',
@@ -878,21 +882,16 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       source.includes(
         'max_over_time(mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"}[%ds]) > bool %d',
       ),
-    "blindness and heartbeat templates must preserve explicit zero vectors while healthy without depending on the structural plane",
+    "blindness must use the producer-side consecutive-poll count while heartbeat remains fail-closed",
   );
   assert(
     source.includes(
-      'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1) or (mento_peg_spread_bps',
+      'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1) or (mento_peg_spread_bps',
     ) &&
       source.includes(
-        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1 and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1) or (mento_peg_spread_bps',
+        'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} <= %d) and on(asset,policy_version) ((mento_peg_structural_saturation{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %g and on(asset,policy_version) mento_peg_indexed_pool_reachable{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1) or (mento_peg_spread_bps',
       ) &&
-      !source.includes(
-        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} == 1 and on(asset,policy_version) mento_peg_indexed_pool_reachable',
-      ) &&
-      !source.includes(
-        'mento_peg_blind{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} == 1 and on(asset,policy_version) mento_peg_indexed_pool_reachable',
-      ),
+      !source.includes("mento_peg_blind{"),
     "blind-while-stressed must gate only structural saturation on pool reachability so market stress remains independently page-capable",
   );
   assert(
@@ -999,22 +998,31 @@ test("peg PromQL ACK and rollover-stuck rules bind only exact active", () => {
   }
 });
 
-test("previous decision may gate on exact active ACK", () => {
-  const failures = validatePegPromqlExpressions(
-    [
-      {
-        file: "rules-peg.tf",
-        kind: "single",
-        expr: 'mento_peg_deviation_bps{policy_version="europ-v1"} > 25 unless mento_peg_policy_version{policy_version="europ-v2"}',
-        pegRule: { kind: "decision", policy: "previous" },
-      },
-    ],
+test("previous decisions cannot terminate on the active ACK", () => {
+  for (const versions of [
     { active: "europ-v2", previous: "europ-v1" },
-  );
-  assert(
-    failures.length === 0,
-    `expected previous decision plus active ACK gate to pass: ${failures.join("\n")}`,
-  );
+    { active: "europ-v2", previous: null },
+  ]) {
+    const failures = validatePegPromqlExpressions(
+      [
+        {
+          file: "rules-peg.tf",
+          kind: "single",
+          expr: 'mento_peg_deviation_bps{policy_version="${local.peg_previous_policy_version}"} > 25 unless mento_peg_policy_version{policy_version="${local.peg_active_policy_version}"}',
+          pegRule: { kind: "decision", policy: "previous" },
+        },
+      ],
+      versions,
+    );
+    assert(
+      failures.some((failure) =>
+        failure.includes(
+          "previous decision rules must not depend on mento_peg_policy_version",
+        ),
+      ),
+      `expected previous decision plus active ACK gate to fail: ${failures.join("\n")}`,
+    );
+  }
 });
 
 test("CLI passes against the real repository", () => {

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -951,10 +951,10 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       templates.includes("STRUCTURAL SATURATION:") &&
       source.includes('ref_id         = "Spread"') &&
       source.includes(
-        "try(rule.value.spread_expr, local.peg_empty_context_promql)",
+        "try(coalesce(rule.value.spread_expr, local.peg_empty_context_promql), local.peg_empty_context_promql)",
       ) &&
       contacts.includes("grafana_message_template.peg_victorops_message"),
-    "peg rules must route a complete decision package to dedicated warning/ops/page contact points",
+    "peg rules must route a complete decision package with a safe spread fallback for absent or null expressions",
   );
   assert(
     !source.includes("mute_timing") && !contacts.includes("mute_timing"),


### PR DESCRIPTION
## The Problem

- Peg measurements now exist, but Grafana has no source-controlled warning, paging, blindness, or rollover rules for them.
- A policy rollover must keep the prior version protected until a separate reviewed cleanup.
- Applying fail-closed rules before authenticated policy delivery and live telemetry would create incidents by design.

## The Solution

Add the complete source-only Peg alert ladder, generated from the gated policy JSON and bound to exact active and retained-previous policy versions. Keep production application blocked behind the documented identity, policy-delivery, telemetry, plan-review, and human-approval gates.

## Details

- Generates per-asset deviation, premium, spread, structural, blindness, source-health, heartbeat, and rollover rules.
- Requires both poll-success and usable-decision counter coverage for duration claims.
- Routes market warnings to `#alerts-pools`, producer warnings to `#alerts-infra`, and critical alerts to Splunk On-Call plus `#alerts-critical`.
- Keeps retained-previous decisions active until a reviewed `previous: null` policy change.
- Extends the PromQL linter for scoped map-comprehension templates and exact policy-version selectors.
- Updates ADR 0044 and the operator runbook with the activation hold and rollback order.
- Does not publish policy, change runtime authentication, deploy the producer, apply Terraform, or claim live Grafana coverage.

Refs #1444

## Validation

- `pnpm agent:quality-gate --base origin/main --run` — all mapped checks passed.
- `terraform -chdir=alerts/rules validate -no-color` — passed through the mapped gate.
- `pnpm alerts:rules:lint` — passed.
- `pnpm alerts:rules:lint:test` — passed.
- `pnpm docs:navigation-eval -- --check-fixtures` — passed.
- Deterministic autoreview — clean.
- Fresh-context semantic autoreview of the exact latest-main bundle — clean, confidence 0.88.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
