### PR TITLE
fix(autoreview): treat GitHub Actions context expressions as references, not literal tokens

### DIFF
--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -769,10 +769,19 @@ export function sensitivePathReason(rawPath) {
   return null;
 }
 
+// A value is a placeholder (never a committed literal secret) when it is an
+// env/context REFERENCE rather than an inline value. The `${{ <context>.path }}`
+// clause covers GitHub Actions expressions: their contents resolve at runtime,
+// so `${{ github.token }}` or `${{ steps.app-token.outputs.token }}` are as safe
+// to bundle as `${{ secrets.X }}` — a real literal secret cannot take that form.
+// The context set is the fixed GHA list (github, env, inputs, matrix, needs,
+// steps, job(s), runner, strategy, secrets, vars); the trailing path only allows
+// [A-Z0-9_.-], so a trailing inline secret (`"${{ secrets.X }}ghp_real"`) still
+// fails the `^…$` anchor and is caught.
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
-    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var)\.[A-Z0-9_.-]+)$/i.test(
+    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
     ) ||
     /^(?:process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])|\$\{process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])\})$/i.test(

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -604,6 +604,28 @@ assert.equal(
   null,
   "service token placeholders remain allowed",
 );
+assert.equal(
+  secretLikeReason("GH_TOKEN: ${{ github.token }}"),
+  null,
+  "GitHub Actions github.* context expressions are references, not literal tokens",
+);
+assert.equal(
+  secretLikeReason("APP_TOKEN: ${{ steps.app-token.outputs.token }}"),
+  null,
+  "steps.*.outputs.* expressions are references, not literal tokens",
+);
+assert.equal(
+  secretLikeReason("PROBE_TOKEN: ${{ needs.build.outputs.token }}"),
+  null,
+  "needs.*.outputs.* expressions are references, not literal tokens",
+);
+assert.match(
+  secretLikeReason(
+    `service_token: "\${{ github.token }}${genericTokenCredential}"`,
+  ),
+  /literal generic token assignment/,
+  "a real literal trailing a github.* expression is still rejected (anchor holds)",
+);
 const publicEvmTokenAddress = ["0x", "0".repeat(39), "1"].join("");
 assert.match(
   secretLikeReason(`USDC_TOKEN="${publicEvmTokenAddress}"`),


### PR DESCRIPTION
## The Problem

- The `agent:autoreview` review-bundle secret scanner (`secretLikeReason`) flags
  `GH_TOKEN: ${{ github.token }}` as a "literal generic token assignment" and
  refuses to build the bundle.
- It already treats `${{ secrets.* }}` and `${{ vars.* }}` as safe references,
  but not the other GitHub Actions contexts — so any PR that adds or changes a
  workflow using the standard `${{ github.token }}` or
  `${{ steps.<id>.outputs.token }}` idioms cannot be autoreviewed at all.

## The Solution

Teach the placeholder recognizer that **all** GitHub Actions context expressions
are references, not committed literal secrets.

- Extend the `${{ … }}` clause in `placeholderValue` from `(?:secrets|vars)` to
  the full GHA context set: `github, env, inputs, matrix, needs, steps, job,
  jobs, runner, strategy` (plus `secrets`, `vars`).
- These expressions resolve at runtime, so `${{ github.token }}` is exactly as
  safe to include in a review bundle as `${{ secrets.X }}`.

## Details

- The change is confined to the `${{ … }}` alternation. The `^…$` anchor and the
  `[A-Z0-9_.-]` path class are unchanged, so a real literal trailing an
  expression — `"${{ github.token }}ghp_REAL…"` — still fails the anchor and is
  rejected. Verified with an explicit anti-bypass test.
- Regression + anti-bypass tests added to `agent-autoreview-core.test.mjs`
  (`github.token`, `steps.*.outputs.token`, `needs.*.outputs.token` are safe; a
  trailing literal still flags). Full existing scanner suite still passes.
- Surfaced while running `agent:autoreview` locally on a PR that adds a workflow
  (#1577); the scanner aborted on its own `${{ github.token }}` line.

## Validation

- `node scripts/agent-autoreview-core.test.mjs` → passes (with the new cases).
- Direct checks: `secretLikeReason("GH_TOKEN: ${{ github.token }}")` → `null`;
  `secretLikeReason('service_token: "${{ github.token }}<36-char literal>"')` →
  still `literal generic token assignment`.
- `eslint` + `trunk fmt` clean on both files.

## Deferrals

- None.
