### PR TITLE
fix(sentry-triage): rework digest Slack message format

### DIFF
--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -52,6 +52,11 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+// The archive leg's approval-label name is owned by the ingest module (it
+// defines the label); import it rather than duplicating the string literal so
+// the two can never drift apart.
+import { APPROVED_ARCHIVE_LABEL } from "./sentry-triage-ingest.mjs";
+
 // Verdict-comment parsing is delegated to the pipeline's single authoritative
 // parser (the same one the label/projection steps run) so the digest can never
 // diverge from what the pipeline decided. The permalink extractor + the
@@ -500,7 +505,7 @@ function renderWontfixLine(entry) {
   // Archiving stays human-gated (ADR 0036 trust boundary): this is a nudge
   // toward the existing `sentry:approved-archive` label flow on the queue
   // issue, never an automatic Sentry mutation from the digest.
-  return `${line}\n    ◦ To archive in Sentry: add \`sentry:approved-archive\` to the queue issue above.`;
+  return `${line}\n    ◦ To archive in Sentry: add \`${APPROVED_ARCHIVE_LABEL}\` to the queue issue above.`;
 }
 
 function renderFailedLine(entry) {

--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -5,7 +5,7 @@
  * that turns one triage-agent run's batch into a single Slack digest payload.
  * The digest is OUTCOME-oriented (issue #1355): a reader must know in two
  * seconds what was handled and what needs them. Sections render in this order,
- * empty ones omitted, with the counts header kept:
+ * empty ones omitted, each header carrying its own count:
  *
  *   1. ⚠️  Needs human — decisions required   (FIRST + visually distinct: each
  *      item is a decision-ready brief — the exact question, the agent's
@@ -16,7 +16,8 @@
  *      linking the PROJECTED owning-repo issue; falls back to the queue-issue
  *      verdict when projection was skipped).
  *   4. 🙅 Wontfix / transient                  (upstream-transient verdicts,
- *      each linking the rationale on the queue issue).
+ *      each linking the rationale on the queue issue, with a nudge toward the
+ *      existing `sentry:approved-archive` label flow for that stub).
  *   5. 🛑 Failed triage                        (batch issues still carrying
  *      sentry:needs-triage — their matrix job died; kept visible, never hidden).
  *
@@ -104,26 +105,6 @@ export const LABEL_TO_VERDICT = {
 // `sentry:needs-triage` (their triage job died before a verdict landed). It
 // must stay visible, never hidden.
 export const FAILED_BUCKET = "failed";
-
-// Counts header order — matches the verdict contract's parenthetical
-// (`code-fix / config-fix / upstream-transient / needs-human`) plus the
-// failed-triage bucket. Kept as-is (issue #1355: "keep the counts header
-// line"); the per-section headers carry the outcome-oriented counts.
-export const COUNTS_ORDER = [
-  "code-fix",
-  "config-fix",
-  "upstream-transient",
-  "needs-human",
-  FAILED_BUCKET,
-];
-
-const BUCKET_LABELS = {
-  "code-fix": "code-fix",
-  "config-fix": "config-fix",
-  "upstream-transient": "upstream-transient",
-  "needs-human": "needs-human",
-  [FAILED_BUCKET]: "failed triage",
-};
 
 // Outcome sections, in RENDER order — needs-human FIRST (decisions required),
 // then autofixed, routed, wontfix, and failed last. Empty sections are omitted.
@@ -427,6 +408,10 @@ function formatUtcTimestamp(date) {
   return `${iso.slice(0, 16).replace("T", " ")} UTC`;
 }
 
+function issueCountText(total) {
+  return `${total} issue${total === 1 ? "" : "s"} triaged`;
+}
+
 function isHttpsUrl(value) {
   try {
     return new URL(String(value)).protocol === "https:";
@@ -440,36 +425,45 @@ function link(url, text) {
   return isHttpsUrl(url) ? `<${url}|${text}>` : text;
 }
 
-/** The linked, escaped SHORT-ID (links to the queue issue) + escaped project,
- * shared by every per-issue line. */
-function idAndProject(entry) {
+/** The linked, escaped SHORT-ID + escaped project, shared by every per-issue
+ * line. Links to the queue issue by default; needs-human overrides the link
+ * target to the Sentry permalink (via `linkUrl`, falling back to the queue
+ * issue when no permalink was recorded). */
+function idAndProject(entry, { linkUrl } = {}) {
   const idText = escapeSlackText(entry.shortId);
-  const linked = isHttpsUrl(entry.url) ? `<${entry.url}|${idText}>` : idText;
+  const url = linkUrl ?? entry.url;
+  const linked = isHttpsUrl(url) ? `<${url}|${idText}>` : idText;
   return { linked, project: escapeSlackText(entry.project) };
 }
 
-/** A needs-human decision-ready brief: multiple indented lines. Decision is
- * always shown (placeholder if somehow absent — the label step requires it);
- * hypotheses / investigated / why-escalated render only when present. */
+/** A needs-human decision-ready brief: a level-1 bullet for the issue, then
+ * level-2 sub-bullets for whatever context is present. Decision is always
+ * shown (placeholder if somehow absent — the label step requires it);
+ * hypotheses / investigated / why-escalated render only when present. The id
+ * links straight to the Sentry issue (falling back to the queue issue when no
+ * permalink was recorded) — the queue issue stays reachable via the Links
+ * sub-bullet. */
 function renderNeedsHumanBrief(entry) {
-  const { linked, project } = idAndProject(entry);
+  const { linked } = idAndProject(entry, {
+    linkUrl: entry.sentryPermalink || entry.url,
+  });
   const confidence = entry.confidence ?? "unknown";
-  const lines = [`⚠️ *${linked}* (${project}) · confidence: ${confidence}`];
+  const lines = [`• *${linked}* · confidence: ${confidence}`];
 
   const decision = entry.humanQuestion
     ? formatBriefText(entry.humanQuestion)
     : "_(no decision recorded — re-triage)_";
-  lines.push(`    *Decision needed:* ${decision}`);
+  lines.push(`    ◦ *Decision needed:* ${decision}`);
 
   const hypotheses = formatBriefList(entry.hypotheses);
-  if (hypotheses) lines.push(`    *Hypotheses:* ${hypotheses}`);
+  if (hypotheses) lines.push(`    ◦ *Hypotheses:* ${hypotheses}`);
 
   const investigated = formatBriefList(entry.investigated);
-  if (investigated) lines.push(`    *Already investigated:* ${investigated}`);
+  if (investigated) lines.push(`    ◦ *Already investigated:* ${investigated}`);
 
   if (entry.escalationReason) {
     lines.push(
-      `    *Why escalated:* ${formatBriefText(entry.escalationReason)}`,
+      `    ◦ *Why escalated:* ${formatBriefText(entry.escalationReason)}`,
     );
   }
 
@@ -478,7 +472,7 @@ function renderNeedsHumanBrief(entry) {
   if (entry.sentryPermalink) {
     linkParts.push(link(entry.sentryPermalink, "Sentry"));
   }
-  if (linkParts.length) lines.push(`    *Links:* ${linkParts.join(" · ")}`);
+  if (linkParts.length) lines.push(`    ◦ *Links:* ${linkParts.join(" · ")}`);
   return lines;
 }
 
@@ -501,7 +495,12 @@ function renderWontfixLine(entry) {
     : "_(no summary)_";
   // The SHORT-ID links the queue issue, which holds the verdict comment (the
   // rationale). Confidence rides along.
-  return `• ${linked} (${project}) — ${summary} (${confidence})`;
+  const line = `• ${linked} (${project}) — ${summary} (${confidence})`;
+  if (!isHttpsUrl(entry.url)) return line;
+  // Archiving stays human-gated (ADR 0036 trust boundary): this is a nudge
+  // toward the existing `sentry:approved-archive` label flow on the queue
+  // issue, never an automatic Sentry mutation from the digest.
+  return `${line}\n    ◦ To archive in Sentry: add \`sentry:approved-archive\` to the queue issue above.`;
 }
 
 function renderFailedLine(entry) {
@@ -621,18 +620,10 @@ export function chunkBriefs(headerLine, briefs, maxLen = MAX_SECTION_TEXT_LEN) {
 export function buildDigest(issues, { channel, now = new Date() } = {}) {
   const entries = (issues ?? []).map(classifyIssue);
 
-  const counts = Object.fromEntries(COUNTS_ORDER.map((key) => [key, 0]));
-  for (const entry of entries) {
-    counts[entry.bucket] = (counts[entry.bucket] ?? 0) + 1;
-  }
-
   const total = entries.length;
-  const headerText = `*Sentry triage — ${total} issue(s) triaged*\n${formatUtcTimestamp(now)}`;
-  const countsText = COUNTS_ORDER.map(
-    (key) => `${BUCKET_LABELS[key]}: ${counts[key] ?? 0}`,
-  ).join(" · ");
+  const headerText = `*Sentry triage — ${issueCountText(total)}*\n${formatUtcTimestamp(now)}`;
 
-  const blocks = [mrkdwnSection(headerText), mrkdwnSection(countsText)];
+  const blocks = [mrkdwnSection(headerText)];
 
   const bySection = new Map(SECTION_ORDER.map((key) => [key, []]));
   for (const entry of entries) bySection.get(entry.section).push(entry);
@@ -661,7 +652,7 @@ export function buildDigest(issues, { channel, now = new Date() } = {}) {
   return {
     channel,
     // Plain-text fallback for notifications/screen readers (no untrusted text).
-    text: `Sentry triage — ${total} issue(s) triaged`,
+    text: `Sentry triage — ${issueCountText(total)}`,
     blocks,
   };
 }

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -819,6 +819,51 @@ await test("autofixed section renders only when fix-PR data exists, linking the 
   assert(!text.includes("📮 Routed"), "expected it not to also route");
 });
 
+await test("section header count reflects multiple entries in the same bucket", () => {
+  // Regression coverage for the counts-header removal: each section header's
+  // "(N)" is now the ONLY place a bucket's count renders, so it must still
+  // count correctly across more than one entry in the same bucket.
+  const payload = buildDigest(
+    [
+      issueFixture({
+        number: 20,
+        shortId: "CF-20",
+        labels: ["sentry:verdict-code-fix"],
+      }),
+      issueFixture({
+        number: 21,
+        shortId: "CF-21",
+        labels: ["sentry:verdict-code-fix"],
+      }),
+      issueFixture({
+        number: 22,
+        shortId: "UP-22",
+        labels: ["sentry:verdict-upstream"],
+      }),
+      issueFixture({
+        number: 23,
+        shortId: "UP-23",
+        labels: ["sentry:verdict-upstream"],
+      }),
+      issueFixture({
+        number: 24,
+        shortId: "UP-24",
+        labels: ["sentry:verdict-upstream"],
+      }),
+    ],
+    { channel: "#engineering", now: NOW },
+  );
+  const text = allText(payload);
+  assert(
+    text.includes("📮 Routed to owning repo (2)"),
+    "expected the routed header to count both code-fix entries",
+  );
+  assert(
+    text.includes("🙅 Wontfix / transient (3)"),
+    "expected the wontfix header to count all three upstream entries",
+  );
+});
+
 await test("buildDigest renders a decision-ready needs-human brief with all fields + links", () => {
   const payload = buildDigest(
     [

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -650,12 +650,12 @@ await test("buildDigest produces a valid chat.postMessage payload shape", () => 
     { channel: "#engineering", now: NOW },
   );
   assertEqual(payload.channel, "#engineering");
-  assertEqual(payload.text, "Sentry triage — 1 issue(s) triaged");
+  assertEqual(payload.text, "Sentry triage — 1 issue triaged");
   assert(Array.isArray(payload.blocks), "expected blocks array");
   assertEqual(payload.blocks[0].type, "section");
   assertEqual(payload.blocks[0].text.type, "mrkdwn");
   assert(
-    payload.blocks[0].text.text.includes("Sentry triage — 1 issue(s) triaged"),
+    payload.blocks[0].text.text.includes("Sentry triage — 1 issue triaged"),
     "expected header text",
   );
   assert(
@@ -677,38 +677,10 @@ await test("every mrkdwn text object sets verbatim: true (no Slack auto-parsing)
     ],
     { channel: "#engineering", now: NOW },
   );
-  assert(payload.blocks.length >= 3, "expected header/counts/section blocks");
+  assert(payload.blocks.length >= 2, "expected header + section blocks");
   for (const block of payload.blocks) {
     assertEqual(block.text.verbatim, true);
   }
-});
-
-await test("buildDigest keeps the counts header line in contract order incl. failed triage", () => {
-  const payload = buildDigest(
-    [
-      issueFixture({ number: 1, labels: ["sentry:verdict-code-fix"] }),
-      issueFixture({ number: 2, labels: ["sentry:verdict-code-fix"] }),
-      issueFixture({ number: 3, labels: ["sentry:verdict-config-fix"] }),
-      issueFixture({
-        number: 4,
-        labels: ["sentry:verdict-needs-human"],
-        comments: [
-          {
-            body: verdictComment({
-              verdict: "needs-human",
-              humanQuestion: "Decide X.",
-            }),
-          },
-        ],
-      }),
-      issueFixture({ number: 5, labels: [NEEDS_TRIAGE_LABEL] }),
-    ],
-    { channel: "#engineering", now: NOW },
-  );
-  assertEqual(
-    payload.blocks[1].text.text,
-    "code-fix: 2 · config-fix: 1 · upstream-transient: 0 · needs-human: 1 · failed triage: 1",
-  );
 });
 
 await test("buildDigest renders sections in order (needs-human first) and omits empty ones", () => {
@@ -874,8 +846,14 @@ await test("buildDigest renders a decision-ready needs-human brief with all fiel
     { channel: "#engineering", now: NOW },
   );
   const text = allText(payload);
-  assert(text.includes("⚠️ *<"), "expected the highlighted needs-human header");
-  assert(text.includes("confidence: low"), "expected confidence");
+  assert(
+    text.includes(`• *<${SENTRY_PERMALINK}|NH-11>* · confidence: low`),
+    "expected a level-1 bullet whose id links straight to the Sentry issue, with no repeated project",
+  );
+  assert(
+    !text.includes("(app-mento-org)"),
+    "expected the project not repeated in parens on the needs-human line",
+  );
   assert(
     text.includes(
       "*Decision needed:* Decide whether to rotate the signing key or wait.",
@@ -998,6 +976,12 @@ await test("wontfix line links the queue-issue rationale with confidence", () =>
     ),
     "expected the wontfix line linking the queue issue",
   );
+  assert(
+    text.includes(
+      "    ◦ To archive in Sentry: add `sentry:approved-archive` to the queue issue above.",
+    ),
+    "expected a sub-bullet nudging the existing human-gated archive label",
+  );
 });
 
 await test("buildDigest renders a distinct failed-triage line with no verdict", () => {
@@ -1058,13 +1042,9 @@ await test("parseIssueNumbers fails loud on non-arrays and bad members", () => {
 
 await test("buildDigest tolerates an empty batch (defensive; job is gated upstream)", () => {
   const payload = buildDigest([], { channel: "#engineering", now: NOW });
-  assertEqual(payload.text, "Sentry triage — 0 issue(s) triaged");
-  assertEqual(
-    payload.blocks[1].text.text,
-    "code-fix: 0 · config-fix: 0 · upstream-transient: 0 · needs-human: 0 · failed triage: 0",
-  );
-  // No section blocks when nothing was triaged.
-  assertEqual(payload.blocks.length, 2);
+  assertEqual(payload.text, "Sentry triage — 0 issues triaged");
+  // No section blocks when nothing was triaged — just the header.
+  assertEqual(payload.blocks.length, 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -1093,7 +1073,7 @@ await test("buildDigest splits a worst-case 6-issue routed batch across sections
   );
   const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
 
-  const sectionBlocks = payload.blocks.slice(2);
+  const sectionBlocks = payload.blocks.slice(1);
   assert(
     sectionBlocks.length >= 2,
     "expected the routed lines split across sections",
@@ -1197,16 +1177,16 @@ await test("needs-human briefs never split across Slack blocks mid-entry", () =>
   );
   const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
   const briefBlocks = payload.blocks
-    .slice(2)
+    .slice(1)
     .map((block) => block.text.text)
     .filter((text) => text.includes("*Decision needed:*"));
   assert(briefBlocks.length >= 2, "expected the two briefs split into blocks");
   for (const text of briefBlocks) {
     assert(text.length <= MAX_SECTION_TEXT_LEN, "expected under the budget");
-    // A block contains only WHOLE briefs: every brief header line ("⚠️ *<…")
+    // A block contains only WHOLE briefs: every brief header line ("• *<…")
     // is matched by its closing links line — a mid-entry split would strand a
     // header without links (or links without a header) in some block.
-    const headers = text.match(/^⚠️ \*/gm) ?? [];
+    const headers = text.match(/^• \*/gm) ?? [];
     const linksLines = text.match(/\*Links:\*/g) ?? [];
     assertEqual(headers.length, linksLines.length);
     assert(headers.length >= 1, "expected at least one whole brief per block");
@@ -1276,7 +1256,7 @@ await test("collectIssues fetches each issue via the injected gh runner", async 
   assertEqual(calls[1][calls[1].indexOf("--repo") + 1], "o/r");
 
   const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
-  assertEqual(payload.text, "Sentry triage — 2 issue(s) triaged");
+  assertEqual(payload.text, "Sentry triage — 2 issues triaged");
 });
 
 await test("collectIssues propagates a single fetch failure (fail loud, no silent drop)", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The Sentry triage Slack digest's headline never pluralized ("8 issue(s) triaged").
- The counts subheader duplicated what each section's own header already shows.
- The "Needs human" section buried decision context in plain indented text instead of readable bullets, and repeated the project name redundantly.

## The Solution

- Pluralize the headline ("1 issue triaged" / "8 issues triaged") and drop the now-redundant counts subheader.
- Render "Needs human" as a level-1 bullet per issue with level-2 sub-bullets for Decision needed / Hypotheses / Already investigated / Why escalated / Links.
- Stop repeating the project name in the needs-human line, and link the issue id straight to the Sentry issue instead of the GitHub queue issue.
- Add a "Wontfix" sub-bullet nudging toward the existing human-gated `sentry:approved-archive` label flow, instead of auto-archiving — this stays a text-only nudge; the script remains a pure read-only consumer (ADR 0036 trust boundary unchanged).

## Details

- **Supersedes closed issue #1355's "keep the counts header line" requirement**, per explicit direction from this PR's author in the originating conversation. Each section header now carries its own count (e.g. "Wontfix / transient (4)"), which was already true before this PR — the aggregate line was redundant, not informational.
- The needs-human id now links to the Sentry permalink (falling back to the GitHub queue issue when no permalink was recorded); the queue issue stays reachable via the "Links" sub-bullet. Routed/Wontfix/Failed lines are unchanged and still link to the queue issue, since that's where the verdict rationale lives.
- The wontfix nudge points at the correct, already-documented ADR 0036 mechanism (`sentry:approved-archive` label → `.github/workflows/sentry-triage-archive.yml`), but that workflow is currently gated off (`SENTRY_ARCHIVE_ENABLED=false` today, verified via `gh variable list`) — adding the label is a harmless no-op until an operator activates it (tracked separately in #1282). The nudge text will become immediately actionable the moment that switch flips, with no further code change.
- Swapped a hardcoded `"sentry:approved-archive"` string literal for the shared `APPROVED_ARCHIVE_LABEL` constant (already used by 4 other sentry-triage scripts) to remove a drift risk between this and the archive script.

## Validation

- `node scripts/sentry-triage-digest.mjs` unit suite: `pnpm sentry:digest:test` — 59/59 passing (added one regression test for a section header's count across multiple entries in the same bucket, since it's now the only place bucket counts render).
- `pnpm lint:scripts` — clean.
- `trunk check` — clean.
- Rendered a full sample digest locally (matching the original 8-issue screenshot scenario) to eyeball the new format end-to-end.

## Deferrals

- #1586 — pre-existing gap (not introduced by this PR, independently flagged by both the local review and Codex review): the shared Sentry-permalink/URL validators don't reject Slack link-control characters (`<`, `>`, `|`) before splicing a URL into `<url|text>` mrkdwn syntax. Not currently triggerable (Sentry/GitHub URLs are structurally clean today), but not structurally guaranteed either.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this is a presentation-layer formatting change; it doesn't touch the ADR 0036 trust boundary (the script stays a read-only consumer, no new Sentry mutation path).

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
