### PR TITLE
fix(autoreview): treat local/module/data HCL references as placeholders too

### DIFF
--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -778,7 +778,8 @@ export function sensitivePathReason(rawPath) {
 // steps, job(s), runner, strategy, secrets, vars); the trailing path only allows
 // [A-Z0-9_.-], so a trailing inline secret (`"${{ secrets.X }}ghp_real"`) still
 // fails the `^…$` anchor and is caught.
-// The bare `<scope>.path` clause covers Terraform/HCL traversal references
+// The `<scope>.path` clauses — both bare and the legacy `${…}` interpolation
+// wrapper — cover Terraform/HCL traversal references
 // (var, local, module, data) the same way — `var.x`, `local.audit_token`,
 // `data.terraform_remote_state.platform.outputs.token` name a value resolved at
 // plan/apply time, never an inline secret, so a `github_actions_secret` block
@@ -789,7 +790,7 @@ export function sensitivePathReason(rawPath) {
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
-    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
+    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
     ) ||
     /^(?:process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])|\$\{process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])\})$/i.test(

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -778,10 +778,18 @@ export function sensitivePathReason(rawPath) {
 // steps, job(s), runner, strategy, secrets, vars); the trailing path only allows
 // [A-Z0-9_.-], so a trailing inline secret (`"${{ secrets.X }}ghp_real"`) still
 // fails the `^…$` anchor and is caught.
+// The bare `<scope>.path` clause covers Terraform/HCL traversal references
+// (var, local, module, data) the same way — `var.x`, `local.audit_token`,
+// `data.terraform_remote_state.platform.outputs.token` name a value resolved at
+// plan/apply time, never an inline secret, so a `github_actions_secret` block
+// whose `value = local.x`/`data.x.y` (or a credential-named local set from one)
+// is a reference, not a committed literal. Same `[A-Z0-9_.-]` path + `^…$`
+// anchor, so a trailing inline secret (`local.x ghp_real`, `"local.x"; realKey`)
+// still fails to match and is caught.
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
-    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var)\.[A-Z0-9_.-]+)$/i.test(
+    /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
     ) ||
     /^(?:process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])|\$\{process(?:\.|\?\.)env(?:(?:\.|\?\.)[A-Z_][A-Z0-9_]*|(?:\?\.)?\[["'][A-Z_][A-Z0-9_]*["']\])\})$/i.test(

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -648,6 +648,18 @@ assert.equal(
   null,
   "HCL data.* references are placeholders, not literal credentials",
 );
+// The legacy `${…}` interpolation wrapper must recognize the same HCL scopes as
+// the bare form, or `some_token = ${local.x}` would still trip the scanner.
+assert.equal(
+  secretLikeReason("some_token = ${local.audit_token}"),
+  null,
+  "legacy ${local.*} interpolation is a reference, not a literal token",
+);
+assert.match(
+  secretLikeReason(`some_token = \${local.x}${genericTokenCredential}`),
+  /literal generic token assignment/,
+  "a real literal fused to a ${local.*} interpolation still flags (anchor holds)",
+);
 // Regression: a github_actions_secret block that mirrors a variable into a repo
 // secret carries only references plus the secret's public NAME literal — never a
 // committed secret value.

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -626,6 +626,66 @@ assert.match(
   /literal generic token assignment/,
   "a real literal trailing a github.* expression is still rejected (anchor holds)",
 );
+// Terraform/HCL traversal references (var/local/module/data) name a value
+// resolved at plan/apply time, never an inline secret — the same reference
+// class as the ${{ … }} contexts above. `var.*` was already recognized;
+// local/module/data were not, so a credential-named attribute or local set from
+// one tripped the scanner even though the diff carried no literal.
+assert.equal(
+  secretLikeReason("  audit_token = local.platform_settings_audit_token"),
+  null,
+  "HCL local.* references are placeholders, not literal tokens",
+);
+assert.equal(
+  secretLikeReason("  client_secret = module.github_app.private_key"),
+  null,
+  "HCL module.*.output references are placeholders, not literal credentials",
+);
+assert.equal(
+  secretLikeReason(
+    "  api_key = data.terraform_remote_state.platform.outputs.audit_token",
+  ),
+  null,
+  "HCL data.* references are placeholders, not literal credentials",
+);
+// Regression: a github_actions_secret block that mirrors a variable into a repo
+// secret carries only references plus the secret's public NAME literal — never a
+// committed secret value.
+const githubActionsSecretBlock = [
+  'resource "github_actions_secret" "platform_settings_audit_token" {',
+  '  count       = var.platform_settings_audit_token == "" ? 0 : 1',
+  '  repository  = "monitoring-monorepo"',
+  '  secret_name = "PLATFORM_SETTINGS_AUDIT_TOKEN"',
+  "  value       = var.platform_settings_audit_token",
+  "}",
+].join("\n");
+assert.equal(
+  secretLikeReason(githubActionsSecretBlock),
+  null,
+  "a github_actions_secret block of var references + a secret NAME literal is not a secret",
+);
+assert.equal(
+  secretLikeReason(
+    githubActionsSecretBlock.replace(
+      "value       = var.platform_settings_audit_token",
+      "value       = local.platform_settings_audit_token",
+    ),
+  ),
+  null,
+  "the same block mirroring a local.* reference is likewise reference-only",
+);
+// Anti-bypass: the reference clause is anchored, so a real literal in the same
+// HCL `key = "…"` form — or one trailing an HCL reference — is still rejected.
+assert.match(
+  secretLikeReason(`  auth_token = "${genericTokenCredential}"`),
+  /literal (?:generic token|credential) assignment/,
+  'a real literal credential in HCL key = "…" form is still rejected',
+);
+assert.match(
+  secretLikeReason(`  auth_token = local.x ${genericTokenCredential}`),
+  /literal generic token assignment/,
+  "a real literal trailing an HCL reference fails the ^…$ anchor and is rejected",
+);
 const publicEvmTokenAddress = ["0x", "0".repeat(39), "1"].join("");
 assert.match(
   secretLikeReason(`USDC_TOKEN="${publicEvmTokenAddress}"`),


### PR DESCRIPTION
## The Problem

- Follow-up to #1582. The `agent:autoreview` bundle scanner (`secretLikeReason`)
  recognizes `var.x` as a reference — not a committed literal secret — but not
  the sibling HCL traversal scopes `local.`, `module.`, and `data.`.
- So a credential-named assignment whose value is `local.…`,
  `module.….output`, or `data.terraform_remote_state.….outputs.token` — all
  resolved at plan/apply time, never inline secrets — is falsely flagged, and
  autoreview refuses to bundle the PR.

## The Solution

Extend the bare `<scope>.path` clause in `placeholderValue` from
`(secrets|vars|var)` to add `(local|module|data)` — the same generalization
#1582 applied to GitHub Actions contexts, now for HCL references.

## Details

- One-token change to the existing alternation. The `[A-Z0-9_.-]` path class and
  the `^…$` anchor are unchanged, so a real literal *trailing* a reference —
  `auth_token = local.x ghp_REAL…` or `"local.x"; realKey` — still fails the
  anchor and is caught.
- **No new bypass:** the added scopes carry the identical risk profile to the
  existing `var`/`vars`/`secrets` entries. An attacker who could name a value
  `local.realsecret` could already name it `var.realsecret` today; real
  credential formats (`ghp_`, `github_pat_`, `AKIA`, `sk-…`, npm, JWTs) never
  begin with `local.`/`module.`/`data.` and are still caught by the strong
  pattern + assignment detectors (verified).
- Tests: regression cases (`local.*`, `module.*.output`,
  `data.*.outputs.*`, and a full `github_actions_secret` block with `value =
  local.…` are now clean) and anti-bypass cases (a real literal in `key = "…"`
  form and trailing an HCL reference still flag). Real-secret fixtures are
  array-joined so the test file doesn't self-trip the scanner.
- Surfaced while retrying `agent:autoreview` on a Terraform-secret PR after
  #1582; this is the remaining reference-recognition gap of the same class.

## Validation

- `node scripts/agent-autoreview-core.test.mjs` → passes (with new cases).
- Spot checks: `local.*`/`module.*`/`data.*` refs → `null`; `ghp_<36>`,
  `github_pat_…`, and a literal trailing `local.x` → still flagged.
- `eslint` + `trunk fmt` clean on both files.

## Deferrals

- None.
