### PR TITLE
docs: record current mutation baselines

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -109,7 +109,7 @@ jobs:
     # step. The `filter`/`decide` machinery is kept inert here: it self-
     # reactivates the path-gated PR behaviour if a `pull_request` trigger is
     # ever re-added, with no other change. `indexer-envio/stryker.config.mjs`
-    # sets `break: 92`, so when the mutation step runs a score below 92% fails
+    # sets `break: 94`, so when the mutation step runs a score below 94% fails
     # the job.
     name: Indexer logic baseline
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
@@ -194,7 +194,7 @@ jobs:
     # step. The `filter`/`decide` machinery is kept inert here: it self-
     # reactivates the path-gated PR behaviour if a `pull_request` trigger is
     # ever re-added, with no other change. `metrics-bridge/stryker.config.mjs`
-    # sets `break: 84`, so when the mutation step runs a score below 84% fails
+    # sets `break: 85`, so when the mutation step runs a score below 85% fails
     # the job.
     name: Bridge rebalance probe baseline
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -194,7 +194,7 @@ jobs:
     # step. The `filter`/`decide` machinery is kept inert here: it self-
     # reactivates the path-gated PR behaviour if a `pull_request` trigger is
     # ever re-added, with no other change. `metrics-bridge/stryker.config.mjs`
-    # sets `break: 85`, so when the mutation step runs a score below 85% fails
+    # sets `break: 86`, so when the mutation step runs a score below 86% fails
     # the job.
     name: Bridge rebalance probe baseline
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`docs/pr-checklists/dynamic-route-metadata.md`](pr-checklists/dynamic-route-metadata.md) | Dynamic Route Metadata and Private Data Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-23 |
 | [`docs/pr-checklists/indexer-handler-invariants.md`](pr-checklists/indexer-handler-invariants.md) | Indexer Handler Invariants | canonical / active | checklist / indexer-envio | eng | 90d; verified 2026-07-23 |
 | [`docs/pr-checklists/keyboard-a11y-controlled-widgets.md`](pr-checklists/keyboard-a11y-controlled-widgets.md) | Keyboard Accessibility on Controlled Widgets Checklist | canonical / active | checklist / ui-dashboard | eng | 90d; verified 2026-07-23 |
-| [`docs/pr-checklists/mutation-testing.md`](pr-checklists/mutation-testing.md) | Mutation Testing Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-23 |
+| [`docs/pr-checklists/mutation-testing.md`](pr-checklists/mutation-testing.md) | Mutation Testing Checklist | canonical / active | checklist / ci/process | eng | 90d; verified 2026-07-26 |
 | [`docs/pr-checklists/recurring-review-patterns.md`](pr-checklists/recurring-review-patterns.md) | Recurring PR Review Patterns | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-23 |
 | [`docs/pr-checklists/review-prompt-exclusions.md`](pr-checklists/review-prompt-exclusions.md) | Review Prompt Exclusions | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-03 |
 | [`docs/pr-checklists/stateful-data-ui.md`](pr-checklists/stateful-data-ui.md) | Stateful Data and UI Checklist | canonical / active | checklist / repo-wide | eng | 90d; verified 2026-07-23 |
@@ -166,7 +166,7 @@ the rules in [`context-standards.md`](context-standards.md).
 | [`alerts/infra/channels/slack-channels/README.md`](../alerts/infra/channels/slack-channels/README.md) | Slack Channels | canonical / active | reference / alerts/infra/channels/slack-channels | eng | 90d; verified 2026-07-24 |
 | [`alerts/infra/oncall-announcer/README.md`](../alerts/infra/oncall-announcer/README.md) | On-call Announcer | canonical / active | reference / alerts/infra/oncall-announcer | eng | 90d; verified 2026-07-24 |
 | [`docs/context-standards.md`](context-standards.md) | Agent Context Standards | canonical / active | reference / repo-wide | eng | 90d; verified 2026-07-24 |
-| [`docs/mutation-testing.md`](mutation-testing.md) | Mutation Testing | non-canonical / active | reference / repo-wide | eng | 180d; verified 2026-07-24 |
+| [`docs/mutation-testing.md`](mutation-testing.md) | Mutation Testing | canonical / active | reference / repo-wide | eng | 7d; verified 2026-07-26 |
 | [`docs/notes/liquity-monitoring-invariants.md`](notes/liquity-monitoring-invariants.md) | Liquity Monitoring Invariants | canonical / active | reference / indexer-envio/ui-dashboard | eng | 90d; verified 2026-07-24 |
 | [`docs/notes/terraform-secret-strategy-2026-07.md`](notes/terraform-secret-strategy-2026-07.md) | Terraform secret strategy hardening | canonical / active | reference / terraform/infra | eng | 90d; verified 2026-07-24 |
 | [`docs/README.md`](README.md) | Documentation Catalog | canonical / active | index / repo-wide | eng | 90d; verified 2026-07-24 |

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -34,6 +34,10 @@ of [`e86c638d7feed52228afd658bf742ff5124a6da5`](https://github.com/mento-protoco
 v24.13.1, and pnpm 11.9.0. Stryker's native JSON and HTML reports were emitted
 under each package's ignored `reports/mutation/` directory; the table below is
 the retained, reviewable extraction from those reports.
+Review then identified the bridge's `probeInProgress = true` survivor as a
+real first-cycle test gap. The metrics-bridge row records the corrected rerun
+from this proposed tree after adding that test; the other two rows retain the
+clean-checkout measurements.
 
 Run from the repo root:
 
@@ -51,14 +55,15 @@ parallel without scanning transient mutation files.
 
 | Target         | Native report                                                   | Runtime | Score (total / covered) | Mutants (killed / timed out / survived / no coverage / errors) | `break` / margin |
 | -------------- | --------------------------------------------------------------- | ------: | ----------------------- | -------------------------------------------------------------- | ---------------- |
-| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      9s | 87.65% / 87.65%         | 139 / 3 / 20 / 0 / 0                                           | 85 / 2.65 points |
+| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      9s | 88.27% / 88.27%         | 140 / 3 / 19 / 0 / 0                                           | 86 / 2.27 points |
 | Dashboard      | `ui-dashboard/reports/mutation/{mutation.json,mutation.html}`   |     12s | 88.83% / 91.50%         | 172 / 11 / 17 / 6 / 0                                          | 86 / 2.83 points |
 | Indexer        | `indexer-envio/reports/mutation/{mutation.json,mutation.html}`  |     58s | 96.09% / 96.09%         | 161 / 11 / 7 / 0 / 0                                           | 94 / 2.09 points |
 
 The floor is `floor(measured total score) - 2`. Stryker counts timed-out
 mutants as detected in its total score, while retaining their count separately
-in the reports. The indexer floor moves from 92 to 94 because this measured
-baseline supports the existing two-point policy; no targets or schedule change.
+in the reports. The corrected bridge floor moves from 85 to 86, and the indexer
+floor moves from 92 to 94, because these measured baselines support the existing
+two-point policy; no targets or schedule change.
 
 Per-file results:
 
@@ -118,15 +123,13 @@ these classifications.
   `slice(1)`, the namespaced format leaves a single address segment, so
   `join("")` and `join("-")` return the same value.
 
-**Metrics bridge (20 survived)**
+**Metrics bridge (19 survived)**
 
 The survivors are classified as accepted noise or equivalent mutants:
 
-**Test scaffolding (3)** — affect test cleanup, not production behavior:
+**Test scaffolding (2)** — affect test cleanup, not production behavior:
 
 - `_resetProbeInProgressForTests()` body emptied.
-- Module-scope `let probeInProgress = false` flipped to `true`;
-  `runRebalanceProbes()` re-sets it every cycle before reading.
 - Module-scope `let reentryWarnedThisWindow = false` flipped to `true`
   and then reset in the `finally` block.
 

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -54,11 +54,11 @@ mutated files. The indexer baseline writes Stryker's temp sandbox to the repo
 root under `.stryker-tmp/indexer-envio` so the package lint gate can run in
 parallel without scanning transient mutation files.
 
-| Target         | Native report                                                   | Runtime | Score (total / covered) | Mutants (killed / timed out / survived / no coverage / errors) | `break` / margin |
-| -------------- | --------------------------------------------------------------- | ------: | ----------------------- | -------------------------------------------------------------- | ---------------- |
-| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      8s | 88.89% / 88.89%         | 140 / 4 / 18 / 0 / 0                                           | 86 / 2.89 points |
-| Dashboard      | `ui-dashboard/reports/mutation/{mutation.json,mutation.html}`   |     12s | 88.83% / 91.50%         | 172 / 11 / 17 / 6 / 0                                          | 86 / 2.83 points |
-| Indexer        | `indexer-envio/reports/mutation/{mutation.json,mutation.html}`  |     58s | 96.09% / 96.09%         | 161 / 11 / 7 / 0 / 0                                           | 94 / 2.09 points |
+| Target         | Native report                                                     | Runtime | Score (total / covered) | Mutants (killed / timed out / survived / no coverage / errors) | `break` / margin |
+| -------------- | ----------------------------------------------------------------- | ------: | ----------------------- | -------------------------------------------------------------- | ---------------- |
+| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,html/index.html}` |      8s | 88.89% / 88.89%         | 140 / 4 / 18 / 0 / 0                                           | 86 / 2.89 points |
+| Dashboard      | `ui-dashboard/reports/mutation/{mutation.json,html/index.html}`   |     12s | 88.83% / 91.50%         | 172 / 11 / 17 / 6 / 0                                          | 86 / 2.83 points |
+| Indexer        | `indexer-envio/reports/mutation/{mutation.json,html/index.html}`  |     58s | 96.09% / 96.09%         | 161 / 11 / 7 / 0 / 0                                           | 94 / 2.09 points |
 
 The floor is `floor(measured total score) - 2`. Stryker counts timed-out
 mutants as detected in its total score, while retaining their count separately

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -2,11 +2,11 @@
 title: "Mutation Testing"
 status: active
 owner: eng
-canonical: false
-last_verified: 2026-07-24
+canonical: true
+last_verified: 2026-07-26
 doc_type: reference
 scope: repo-wide
-review_interval_days: 180
+review_interval_days: 7
 garden_lane: package-readmes-reference
 ---
 
@@ -24,12 +24,23 @@ Mutation testing is intentionally scoped to proven pure-logic targets:
 
 ## Current Baseline
 
+This document is the canonical record for current mutation measurements,
+runtimes, and accepted survivor classifications. The package configs own only
+the enforced floors; the checklist owns the recurring workflow policy.
+
+The 2026-07-26 baseline ran the three commands serially from a clean checkout
+of [`e86c638d7feed52228afd658bf742ff5124a6da5`](https://github.com/mento-protocol/monitoring-monorepo/commit/e86c638d7feed52228afd658bf742ff5124a6da5)
+(`docs: finish notes and plans garden (#1612)`) on macOS 26.5.2, Node
+v24.13.1, and pnpm 11.9.0. Stryker's native JSON and HTML reports were emitted
+under each package's ignored `reports/mutation/` directory; the table below is
+the retained, reviewable extraction from those reports.
+
 Run from the repo root:
 
 ```bash
-pnpm indexer:mutation
-pnpm dashboard:mutation
 pnpm bridge:mutation
+pnpm dashboard:mutation
+pnpm indexer:mutation
 ```
 
 Each command runs StrykerJS with the Vitest runner and a dedicated mutation
@@ -38,18 +49,23 @@ mutated files. The indexer baseline writes Stryker's temp sandbox to the repo
 root under `.stryker-tmp/indexer-envio` so the package lint gate can run in
 parallel without scanning transient mutation files.
 
-Latest indexer result:
+| Target         | Native report                                                   | Runtime | Score (total / covered) | Mutants (killed / timed out / survived / no coverage / errors) | `break` / margin |
+| -------------- | --------------------------------------------------------------- | ------: | ----------------------- | -------------------------------------------------------------- | ---------------- |
+| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      9s | 87.65% / 87.65%         | 139 / 3 / 20 / 0 / 0                                           | 85 / 2.65 points |
+| Dashboard      | `ui-dashboard/reports/mutation/{mutation.json,mutation.html}`   |     12s | 88.83% / 91.50%         | 172 / 11 / 17 / 6 / 0                                          | 86 / 2.83 points |
+| Indexer        | `indexer-envio/reports/mutation/{mutation.json,mutation.html}`  |     58s | 96.09% / 96.09%         | 161 / 11 / 7 / 0 / 0                                           | 94 / 2.09 points |
 
-- Runtime: 15s on the final root-script run (15-26s observed locally)
-- Mutation score: 94.19% total / covered
-- Mutants: 162 killed, 0 timed out, 10 survived, 0 no coverage
-- Per-file: `helpers.ts` 91.11% total / covered; `tradingLimits.ts`
-  96.63% total / covered; `stables/classifyKind.ts` 90.00% total /
-  covered; `stables/dailyFlush.ts` 100.00% total / covered
-- `indexer-envio/stryker.config.mjs` sets `break: 92` (current baseline
-  94.19% with the standard 2-pt margin). All remaining survivors are
-  classified as equivalent mutants or accepted noise — see the
-  Survivor Classification section below.
+The floor is `floor(measured total score) - 2`. Stryker counts timed-out
+mutants as detected in its total score, while retaining their count separately
+in the reports. The indexer floor moves from 92 to 94 because this measured
+baseline supports the existing two-point policy; no targets or schedule change.
+
+Per-file results:
+
+- Indexer: `helpers.ts` 92.98%, `tradingLimits.ts` 96.63%,
+  `stables/classifyKind.ts` 100.00%, and `stables/dailyFlush.ts` 100.00%.
+- Dashboard: `weekend.ts` 87.71% total / 90.75% covered and `pool-id.ts`
+  96.30% total / covered.
 
 The indexer scope is limited to deterministic helpers with direct tests:
 chain/event/pool/snapshot ID helpers, trading-limit derivation, and stables
@@ -58,26 +74,6 @@ and `priceDifference.ts` ran in 1m07s but scored 65.19% total / 79.03% covered
 because broad branchy math helpers produced many survivors/no-coverage mutants.
 Revisit those one file at a time after adding smaller direct tests; adding them
 now would dilute the baseline.
-
-Latest dashboard result:
-
-- Runtime: 9s on the final root-script run (5-14s observed locally)
-- Mutation score: 88.81% total / 92.70% covered
-- Mutants: 122 killed, 5 timed out, 10 survived, 6 no coverage
-- Per-file: `weekend.ts` 87.07% total / 91.82% covered; `pool-id.ts`
-  96.30% total / covered
-- `ui-dashboard/stryker.config.mjs` sets `break: 86` (current baseline
-  88.81% with the standard 2-pt margin). All remaining survivors are
-  classified as equivalent mutants or accepted noise — see the
-  Survivor Classification section below.
-
-Latest metrics-bridge result:
-
-- Runtime: 9s locally on 2026-07-24
-- Mutation score: **87.65% total / covered**
-- Mutants: 139 killed, 3 timed out, 20 survived, 0 no coverage
-- `metrics-bridge/stryker.config.mjs` sets `break: 85`, leaving a 2.65-point
-  margin below the verified score.
 
 The first dashboard run was worth doing: it found real assertion gaps in the
 default `Date.now()` path, reversed weekend-overlap ranges, and the exact/future
@@ -103,24 +99,28 @@ The metrics-bridge evaluation was mixed:
 
 ## Survivor Classification
 
-Remaining dashboard survivors are accepted noise:
+The 2026-07-26 survivors are accepted noise or equivalent mutants in the
+current target scope. Treat a new survivor as a test gap unless it fits one of
+these classifications.
 
-- `isWeekend()` day-gap mutants are equivalent with the current calendar because
-  close day and reopen day return before the generic modulo branch.
-- `weekendOverlapSeconds()` half-open boundary mutants add or skip zero seconds
-  when a range starts or ends exactly on a weekend boundary.
+**Dashboard (17 survived, 6 no coverage)**
+
+- `isWeekend()` day-gap mutants are equivalent with the current calendar
+  because close and reopen days return before the generic modulo branch.
+- `fxWeekendBands()` and `weekendOverlapSeconds()` boundary mutants only change
+  zero-width ranges or empty-shape presentation at half-open boundaries.
 - `tradingSecondsInRange()` `<=` to `<` is equivalent for equal timestamps
   because the subtraction path still returns zero.
-- `nextMarketHoursTransition()` loop-bound/update mutants return the same
-  boundary for reachable inputs; the final fallback remains an unreachable
-  defensive return.
-- The no-coverage mutants are in that defensive fallback.
+- `nextMarketHoursTransition()` loop-bound and update mutants return the same
+  boundary for reachable inputs. Its final fallback is defensive and has the
+  six no-coverage mutants.
 - `stripChainIdFromPoolId()` has one equivalent separator mutant: after
   `slice(1)`, the namespaced format leaves a single address segment, so
   `join("")` and `join("-")` return the same value.
 
-The 20 metrics-bridge survivors from the 2026-07-24 run are classified as
-accepted noise or equivalent mutants:
+**Metrics bridge (20 survived)**
+
+The survivors are classified as accepted noise or equivalent mutants:
 
 **Test scaffolding (3)** — affect test cleanup, not production behavior:
 
@@ -183,22 +183,15 @@ timeoutMessage` and the fallback now returns
   zero iterations, and the function still reaches the same final
   `rebalanceProbeLastRun` gauge update at the end of the `try` block.
 
-Remaining indexer survivors are accepted noise for this baseline:
+**Indexer (7 survived)**
 
-- `extractAddressFromPoolId()` regex anchor and error-string mutants do not
-  change the currently asserted valid extraction / bare-address /
-  double-namespacing behavior.
-- The `addr === undefined` guard mutant is unreachable after the preceding
-  capture-group match succeeds; it is defensive against future regex edits.
-- Trading-limit `<` to `<=` absolute-value mutants are equivalent for zero,
-  because negating `0n` still yields `0n`.
-- `classifyStableSupplyChangeKind()` broker-cache branch mutants are accepted
-  noise: the test suite already proves first-call classification for broker,
-  NTT helper, NTT transceiver, unknown, null, and cross-chain broker inputs; the
-  surviving mutants only change the cached-repeat path or collapse to the same
-  returned address/null semantics.
-- `_resetBrokerAddressCacheForTest()` body removal affects test cleanup only,
-  not production behavior.
+- `extractAddressFromPoolId()` has three error-message/regex-shape survivors;
+  they do not change the currently asserted valid extraction, bare-address, or
+  double-namespacing behavior. The `addr === undefined` guard is unreachable
+  after the preceding capture-group match succeeds and remains defensive
+  against future regex edits.
+- The three trading-limit `<` to `<=` absolute-value mutants are equivalent for
+  zero because negating `0n` still yields `0n`.
 
 ## Expansion Guidance
 

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -34,9 +34,10 @@ of [`e86c638d7feed52228afd658bf742ff5124a6da5`](https://github.com/mento-protoco
 v24.13.1, and pnpm 11.9.0. Stryker's native JSON and HTML reports were emitted
 under each package's ignored `reports/mutation/` directory; the table below is
 the retained, reviewable extraction from those reports.
-Review then identified the bridge's `probeInProgress = true` survivor as a
-real first-cycle test gap. The metrics-bridge row records the corrected rerun
-from this proposed tree after adding that test; the other two rows retain the
+Review then identified the bridge's `probeInProgress = true` and
+`reentryWarnedThisWindow = true` survivors as real first-cycle test gaps. The
+metrics-bridge row records the corrected rerun from this proposed tree after
+adding one first-window test that kills both; the other two rows retain the
 clean-checkout measurements.
 
 Run from the repo root:
@@ -55,7 +56,7 @@ parallel without scanning transient mutation files.
 
 | Target         | Native report                                                   | Runtime | Score (total / covered) | Mutants (killed / timed out / survived / no coverage / errors) | `break` / margin |
 | -------------- | --------------------------------------------------------------- | ------: | ----------------------- | -------------------------------------------------------------- | ---------------- |
-| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      9s | 88.27% / 88.27%         | 140 / 3 / 19 / 0 / 0                                           | 86 / 2.27 points |
+| Metrics bridge | `metrics-bridge/reports/mutation/{mutation.json,mutation.html}` |      8s | 88.89% / 88.89%         | 140 / 4 / 18 / 0 / 0                                           | 86 / 2.89 points |
 | Dashboard      | `ui-dashboard/reports/mutation/{mutation.json,mutation.html}`   |     12s | 88.83% / 91.50%         | 172 / 11 / 17 / 6 / 0                                          | 86 / 2.83 points |
 | Indexer        | `indexer-envio/reports/mutation/{mutation.json,mutation.html}`  |     58s | 96.09% / 96.09%         | 161 / 11 / 7 / 0 / 0                                           | 94 / 2.09 points |
 
@@ -123,15 +124,13 @@ these classifications.
   `slice(1)`, the namespaced format leaves a single address segment, so
   `join("")` and `join("-")` return the same value.
 
-**Metrics bridge (19 survived)**
+**Metrics bridge (18 survived)**
 
 The survivors are classified as accepted noise or equivalent mutants:
 
-**Test scaffolding (2)** — affect test cleanup, not production behavior:
+**Test scaffolding (1)** — affects test cleanup, not production behavior:
 
 - `_resetProbeInProgressForTests()` body emptied.
-- Module-scope `let reentryWarnedThisWindow = false` flipped to `true`
-  and then reset in the `finally` block.
 
 **`eligibleForProbe` optimization branches (5)** — equivalent mutants
 because NaN-comparison semantics naturally short-circuit downstream:

--- a/docs/pr-checklists/mutation-testing.md
+++ b/docs/pr-checklists/mutation-testing.md
@@ -3,7 +3,7 @@ title: Mutation Testing Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-26
 doc_type: checklist
 scope: ci/process
 review_interval_days: 90
@@ -44,9 +44,10 @@ one of the current mutation targets.
   | ---------------- | ----------------------------------- | ------: | --------------------------------- |
   | `metrics-bridge` | `metrics-bridge/stryker.config.mjs` |      85 | `bridge-rebalance-probe-baseline` |
   | `ui-dashboard`   | `ui-dashboard/stryker.config.mjs`   |      86 | `dashboard-logic-baseline`        |
-  | `indexer-envio`  | `indexer-envio/stryker.config.mjs`  |      92 | `indexer-logic-baseline`          |
+  | `indexer-envio`  | `indexer-envio/stryker.config.mjs`  |      94 | `indexer-logic-baseline`          |
 
-  Measured scores, runtimes, and survivor classifications belong in
+  Measured scores, runtimes, and survivor classifications belong in the
+  canonical
   [`docs/mutation-testing.md`](../mutation-testing.md), not this workflow
   checklist.
 

--- a/docs/pr-checklists/mutation-testing.md
+++ b/docs/pr-checklists/mutation-testing.md
@@ -42,7 +42,7 @@ one of the current mutation targets.
 
   | Package          | Config                              | `break` | Job                               |
   | ---------------- | ----------------------------------- | ------: | --------------------------------- |
-  | `metrics-bridge` | `metrics-bridge/stryker.config.mjs` |      85 | `bridge-rebalance-probe-baseline` |
+  | `metrics-bridge` | `metrics-bridge/stryker.config.mjs` |      86 | `bridge-rebalance-probe-baseline` |
   | `ui-dashboard`   | `ui-dashboard/stryker.config.mjs`   |      86 | `dashboard-logic-baseline`        |
   | `indexer-envio`  | `indexer-envio/stryker.config.mjs`  |      94 | `indexer-logic-baseline`          |
 

--- a/indexer-envio/stryker.config.mjs
+++ b/indexer-envio/stryker.config.mjs
@@ -20,14 +20,12 @@ const config = {
     high: 90,
     low: 80,
     // Blocking gate: `pnpm indexer:mutation` exits non-zero when the
-    // combined score across `src/helpers.ts`, `src/tradingLimits.ts`, and
-    // the stables handler helpers drops below 92%. The CI workflow wires this
-    // into the `indexer-logic-baseline` job (see
-    // `.github/workflows/mutation-testing.yml`). Current baseline: 94.19%
-    // with a 2-pt margin for measurement noise. All remaining survivors are
-    // classified as equivalent mutants or accepted noise — see
-    // `docs/mutation-testing.md` for the taxonomy.
-    break: 92,
+    // combined score across `src/helpers.ts`, `src/tradingLimits.ts`, and the
+    // stables handler helpers drops below 94%. The CI workflow wires this into
+    // the indexer baseline job. The floor preserves the documented two-point
+    // rounded-down safety margin; current evidence and survivor classification
+    // live in `docs/mutation-testing.md`.
+    break: 94,
   },
   ignorePatterns: [
     ".envio/**",

--- a/metrics-bridge/stryker.config.mjs
+++ b/metrics-bridge/stryker.config.mjs
@@ -12,11 +12,11 @@ const config = {
     high: 90,
     low: 80,
     // Blocking gate: `pnpm bridge:mutation` exits non-zero when the mutation
-    // score on `src/rebalance-probe.ts` drops below 85%. The CI workflow wires
+    // score on `src/rebalance-probe.ts` drops below 86%. The CI workflow wires
     // this into the `bridge-rebalance-probe-baseline` job. The floor preserves
     // the documented two-point rounded-down safety margin; current evidence
     // and survivor classification live in `docs/mutation-testing.md`.
-    break: 85,
+    break: 86,
   },
   ignorePatterns: ["coverage/**", "dist/**", "reports/**"],
   vitest: {

--- a/metrics-bridge/stryker.config.mjs
+++ b/metrics-bridge/stryker.config.mjs
@@ -12,12 +12,10 @@ const config = {
     high: 90,
     low: 80,
     // Blocking gate: `pnpm bridge:mutation` exits non-zero when the mutation
-    // score on `src/rebalance-probe.ts` drops below 85%. The CI workflow
-    // wires this into the `bridge-rebalance-probe-baseline` job (see
-    // `.github/workflows/mutation-testing.yml`). Current baseline: 87.65%
-    // with a 2.65-point margin. All remaining survivors are classified as
-    // equivalent mutants or accepted test-scaffolding noise — see
-    // `docs/mutation-testing.md` for the taxonomy.
+    // score on `src/rebalance-probe.ts` drops below 85%. The CI workflow wires
+    // this into the `bridge-rebalance-probe-baseline` job. The floor preserves
+    // the documented two-point rounded-down safety margin; current evidence
+    // and survivor classification live in `docs/mutation-testing.md`.
     break: 85,
   },
   ignorePatterns: ["coverage/**", "dist/**", "reports/**"],

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -44,6 +44,19 @@ import { getRpcClient } from "../src/rpc.js";
 const mockProbe = vi.mocked(probeRebalance);
 const mockGetRpcClient = vi.mocked(getRpcClient);
 
+it("runs the first probe cycle before any test-only mutex reset", async () => {
+  register.resetMetrics();
+  const before = Math.floor(Date.now() / 1000);
+
+  await runRebalanceProbes([]);
+
+  const value = await getGaugeValue(
+    register,
+    "mento_pool_rebalance_probe_last_run",
+  );
+  expect(value).toBeGreaterThanOrEqual(before);
+});
+
 describe("eligibleForProbe — gating mirrors the critical alert rule", () => {
   it("excludes pools without an active breach anchor", () => {
     const pool = makePool({

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -44,17 +44,42 @@ import { getRpcClient } from "../src/rpc.js";
 const mockProbe = vi.mocked(probeRebalance);
 const mockGetRpcClient = vi.mocked(getRpcClient);
 
-it("runs the first probe cycle before any test-only mutex reset", async () => {
+it("runs and warns on an overlapping first cycle before any test-only mutex reset", async () => {
   register.resetMetrics();
+  vi.clearAllMocks();
+  mockGetRpcClient.mockReturnValue({
+    call: vi.fn(),
+  } as unknown as ReturnType<typeof getRpcClient>);
+  const pool = makePool({
+    deviationBreachStartedAt: "1713200000",
+    lastDeviationRatio: "1.50",
+  });
+  let resolveProbe: (value: { kind: "ok" }) => void = () => {};
+  mockProbe.mockReturnValueOnce(
+    new Promise<{ kind: "ok" }>((resolve) => {
+      resolveProbe = resolve;
+    }) as unknown as ReturnType<typeof probeRebalance>,
+  );
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
   const before = Math.floor(Date.now() / 1000);
 
-  await runRebalanceProbes([]);
+  const firstCycle = runRebalanceProbes([pool]);
+  await runRebalanceProbes([pool]);
+
+  expect(mockProbe).toHaveBeenCalledTimes(1);
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("[REBALANCE_PROBE_REENTRY]"),
+  );
+
+  resolveProbe({ kind: "ok" });
+  await firstCycle;
 
   const value = await getGaugeValue(
     register,
     "mento_pool_rebalance_probe_last_run",
   );
   expect(value).toBeGreaterThanOrEqual(before);
+  warn.mockRestore();
 });
 
 describe("eligibleForProbe — gating mirrors the critical alert rule", () => {

--- a/ui-dashboard/stryker.config.mjs
+++ b/ui-dashboard/stryker.config.mjs
@@ -12,13 +12,11 @@ const config = {
     high: 90,
     low: 80,
     // Blocking gate: `pnpm dashboard:mutation` exits non-zero when the
-    // combined score across `src/lib/weekend.ts` + `src/lib/pool-id.ts`
-    // drops below 86%. The CI workflow wires this into the
-    // `dashboard-logic-baseline` job (see
-    // `.github/workflows/mutation-testing.yml`). Current baseline: 88.81%
-    // with a 2-pt margin for measurement noise. All remaining survivors
-    // are classified as equivalent mutants or accepted noise — see
-    // `docs/mutation-testing.md` for the taxonomy.
+    // combined score across `src/lib/weekend.ts` + `src/lib/pool-id.ts` drops
+    // below 86%. The CI workflow wires this into the dashboard baseline job.
+    // The floor preserves the documented two-point rounded-down safety margin;
+    // current evidence and survivor classification live in
+    // `docs/mutation-testing.md`.
     break: 86,
   },
   ignorePatterns: [


### PR DESCRIPTION
## The Problem

- Mutation score prose had drifted across workflow comments, package configs, and checklists.
- Operators lacked one pinned, reproducible record for the three mutation baselines.

## The Solution

- Make the mutation guide the score authority, record fresh native-report evidence, and keep package configs focused on executable floors.

## Details

- Record bridge 88.89%, dashboard 88.83% total and 91.50% covered, and indexer 96.09%.
- The initial three baselines ran from pinned main SHA `e86c638d`; the bridge row records the corrected proposed-tree serial rerun after review exposed two real first-window test gaps.
- Set floors from `floor(total score) - 2`: 86, 86, and 94.
- Preserve the weekly and on-demand schedule and current mutation targets.
- Remove volatile score prose from package configs and align the workflow and checklist.

Closes #1543

## Validation

- `CI=true pnpm agent:quality-gate --run --parallel 1` — all 21 mapped commands passed.
- Serial native reports: bridge 140 killed / 4 timed out / 18 survived; dashboard 172 / 11 / 17; indexer 161 / 11 / 7.
- The first-window bridge test kills both module initializer mutants before any test-only reset.
- Fresh-context review reconciled every current score, count, floor, and authoritative reference.
- Browser fixture suite and React Doctor gates passed as mapped checks.
- `git diff --check` passed.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this records measurements and enforces the existing floor policy.
