### PR TITLE
docs: reverify process checklists

### DIFF
--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -46,7 +46,7 @@ tldr: five hazards, each raised as a separate review round on PR #1210 — audit
 
 ### Time-unit math — [checklist](stateful-data-ui.md)
 
-tldr: FX-pool metrics use trading-seconds — MUST call `tradingSecondsInRange` (`ui-dashboard/src/lib/weekend.ts:110`), NEVER `now - start` directly. Threshold-derived metrics (peak severity %, etc.) MUST be computed from the per-event threshold, NEVER from the live mutable `pool.rebalanceThreshold`. Full rules in the linked checklist.
+tldr: FX-pool metrics use trading-seconds — MUST call `tradingSecondsInRange` (`ui-dashboard/src/lib/weekend.ts`), NEVER `now - start` directly. Threshold-derived metrics (peak severity %, etc.) MUST be computed from the per-event threshold, NEVER from the live mutable `pool.rebalanceThreshold`. Full rules in the linked checklist.
 
 ### Keyboard a11y on controlled widgets — [checklist](keyboard-a11y-controlled-widgets.md)
 

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -3,7 +3,7 @@ title: Stateful Data and UI Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-27
 doc_type: checklist
 scope: repo-wide
 review_interval_days: 90

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -3,7 +3,7 @@ title: SWR and Hasura Polling Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-27
 doc_type: checklist
 scope: ui-dashboard
 review_interval_days: 90

--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -3,7 +3,7 @@ title: Terraform and Cloud Run Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-27
 doc_type: checklist
 scope: terraform/infra
 review_interval_days: 90


### PR DESCRIPTION
## The Problem

- Documentation garden packet #1657 requires a current evidence-backed disposition for all three canonical process checklists.
- One inbound hazard summary still pointed to a line number that no longer contains `tradingSecondsInRange`.

## The Solution

- Keep the three checklist contracts after checking their current owners, refresh their verification dates, and replace the brittle line-specific pointer with the stable module path.

## Details

Audit dispositions:

- **Keep — `docs/pr-checklists/stateful-data-ui.md`:** current root/package routing and the URL-state, trading-time, event-threshold, day-aligned cutoff, degraded-mode, SSR/cache, and truncation implementations still support the checklist.
- **Keep — `docs/pr-checklists/swr-polling-hasura.md`:** `useGQL` and `useBridgeGQL` still own 30-second defaults, focus/reconnect suppression, visibility/offline-aware retry, bounded pagination, distinct error channels, generated query contracts, and deliberate truncation handling.
- **Keep — `docs/pr-checklists/terraform-cloudrun.md`:** current Terraform, workflows, and deploy scripts support its moved/removed-resource, version floor, Cloud Run scaling/probe/image, revision suffix, IAM, retention, and build-context guidance.
- **Tighten — `docs/pr-checklists/recurring-review-patterns.md`:** remove the stale `weekend.ts:110` suffix; `tradingSecondsInRange` now starts at line 203, and the stable module path avoids repeating this drift.

No paths or classifications changed, so catalog generation produced no diff.

## Validation

- `CI=true pnpm docs:audit --dry-run --date 2026-12-21 --lane pr-checklists-process --shard 2 --format json` — exact three-file packet reproduced
- `CI=true pnpm docs:index --write` — no generated catalog diff
- `CI=true pnpm docs:index --check`
- `CI=true pnpm agent:context-check` — 126 managed files
- `CI=true pnpm agent:context-budget --strict` — all routes within limits
- `CI=true pnpm agent:quality-gate --run` — all four mapped commands passed
- fresh-context semantic autoreview — clean, 0.98 confidence
- deterministic local autoreview — clean

Browser verification does not apply because this changes documentation only.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1657
Refs #1341