### PR TITLE
docs: clarify documentation garden pickup

### DIFF
--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -57,11 +57,12 @@ workflow owns only the issue envelope; `eng` owns the cadence and recovery
 contract, while the eventual issue assignee owns semantic review and PR
 closeout.
 
-A successful run stops at issue creation. It does not assign the issue, start
-an agent, or send a Slack success notification. The issue stays `agent-ready`
-until an active agent session claims it with `pnpm issue:claim`. Only workflow
-failures route to `#ci-failures`; successful issue notifications, when wanted,
-come from a Slack-side GitHub App subscription.
+The garden issue sync stops at issue creation. It does not assign the issue,
+start an agent, or send a Slack success notification. The issue stays
+`agent-ready` until an active agent session claims it with `pnpm issue:claim`.
+Scheduled workflow failures route to `#ci-failures`; manual-dispatch failures
+do not. Successful issue notifications, when wanted, come from a Slack-side
+GitHub App subscription.
 
 The queue is deliberately serialized:
 

--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -57,6 +57,12 @@ workflow owns only the issue envelope; `eng` owns the cadence and recovery
 contract, while the eventual issue assignee owns semantic review and PR
 closeout.
 
+A successful run stops at issue creation. It does not assign the issue, start
+an agent, or send a Slack success notification. The issue stays `agent-ready`
+until an active agent session claims it with `pnpm issue:claim`. Only workflow
+failures route to `#ci-failures`; successful issue notifications, when wanted,
+come from a Slack-side GitHub App subscription.
+
 The queue is deliberately serialized:
 
 - no live marked issue: create the selected occurrence as `agent-ready`;


### PR DESCRIPTION
## The Problem

- The gardening runbook did not plainly say who starts work after the weekly issue is created.
- It also left successful Slack notification behavior unclear.

## The Solution

- State that a successful run creates an unassigned `agent-ready` issue, which an active agent session must claim.
- State that only workflow failures reach `#ci-failures`; successful issue notices require a Slack-side GitHub App subscription.

## Details

- Documentation-only clarification. No workflow behavior changes.

## Validation

- The mandatory pre-push quality gate passed its four mapped documentation checks: targeted Trunk, documentation catalog, agent context, and navigation fixtures.

## Ship Checklist

- [x] ship skill used
- [x] mapped local gate passed
- [x] PR readiness probe planned