### PR TITLE
fix: bound Metrics Bridge build context

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,33 +1,26 @@
-# Restrict Cloud Build upload to metrics-bridge build inputs only.
-# Without this file, gcloud falls back to .gitignore which uploads the
-# entire repo minus gitignored files.
+# Upload only the files used by metrics-bridge/Dockerfile. A default-deny
+# boundary keeps unrelated packages, local caches, credentials, and sensitive
+# draft directories out of both CI and direct-deploy Cloud Build archives.
+*
 
-.git/
-.trunk/
-.vercel/
-.next/
-.reviews/
-.claude/
+!.gcloudignore
+!cloudbuild.yaml
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!patches/
+!patches/**
+!metrics-bridge/
+!metrics-bridge/**
+!shared-config/
+!shared-config/**
 
-ui-dashboard/
-indexer-envio/
-docs/
-terraform/
-
-# shared-config/ is a workspace dep of metrics-bridge (shared chain/token
-# metadata). Must be uploaded so Cloud Build can resolve it at `pnpm install`.
-
-**/node_modules/
-**/dist/
-**/coverage/
-
+# Reapply the repository's normal local-output exclusions inside the allowed
+# directories. gcloud does not read .gitignore unless it is included explicitly.
+#!include:.gitignore
+metrics-bridge/reports/
+metrics-bridge/stryker.log
 *.env
 *.env.*
 terraform.tfvars
-
-# Credentials file written into the workspace root by
-# google-github-actions/auth during CI. This file has its own ignore rules
-# (it does not fall back to .gitignore), so the pattern must be repeated here
-# to keep the CI credential file out of the `gcloud builds submit` source
-# archive. Left unanchored on purpose, matching .gitignore.
 gha-creds-*.json

--- a/scripts/deploy-staging-contract.test.mjs
+++ b/scripts/deploy-staging-contract.test.mjs
@@ -153,6 +153,50 @@ function expectFailure(files, expected) {
 
 const files = repositoryFiles();
 
+const rootGcloudIgnoreEntries = files[".gcloudignore"]
+  .split(/\r?\n/u)
+  .map((line) => line.trim())
+  .filter((line) => line && !line.startsWith("# "));
+assert.equal(
+  rootGcloudIgnoreEntries[0],
+  "*",
+  ".gcloudignore must default-deny the direct Cloud Build source archive",
+);
+assert.deepEqual(
+  rootGcloudIgnoreEntries.filter(
+    (line) => line.startsWith("!") && !line.startsWith("#!"),
+  ),
+  [
+    "!.gcloudignore",
+    "!cloudbuild.yaml",
+    "!package.json",
+    "!pnpm-lock.yaml",
+    "!pnpm-workspace.yaml",
+    "!patches/",
+    "!patches/**",
+    "!metrics-bridge/",
+    "!metrics-bridge/**",
+    "!shared-config/",
+    "!shared-config/**",
+  ],
+  ".gcloudignore must allow only Metrics Bridge build inputs",
+);
+assert(
+  rootGcloudIgnoreEntries.includes("#!include:.gitignore"),
+  ".gcloudignore must reapply repository-local output exclusions",
+);
+for (const entry of [
+  "*.env",
+  "*.env.*",
+  "terraform.tfvars",
+  "gha-creds-*.json",
+]) {
+  assert(
+    rootGcloudIgnoreEntries.includes(entry),
+    `.gcloudignore must exclude direct-deploy credentials via ${entry}`,
+  );
+}
+
 assert.equal(
   shouldScanFile("scripts/new-deploy.bash", { mode: 0o100755 }, false),
   true,


### PR DESCRIPTION
## The Problem

- The direct `pnpm bridge:deploy` canary tried to archive 216,428 files totaling 27.3 GiB because local caches entered the Cloud Build source context.
- The explicit `.gcloudignore` did not reuse the repo local-output rules, so ignored credentials and sensitive draft directories could also enter a direct upload.
- This blocks the required direct Bridge canary before the Peg policy foundation can go live.

## The Solution

- Default-deny the Cloud Build archive and allow only the files copied by the Metrics Bridge Docker build.
- Reapply `.gitignore` plus explicit env, tfvars, and CI credential exclusions inside that allowlist.

## Details

- The allowlist contains only `cloudbuild.yaml`, root pnpm manifests, `patches/`, `metrics-bridge/`, and `shared-config/`.
- The deployment source-staging test now locks both the allowlist and credential exclusions.
- The canary stopped before the oversized archive uploaded, so this PR does not reconcile any partial deployment.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm tf:test`
- Fresh-context closeout review: clean after one credential-exclusion fix
- `gcloud meta list-files-for-upload .`: 123 files, 1.54 MiB, zero paths outside the allowlist, zero cache, credential, tfvars, or sensitive-draft paths

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this enforces the existing reduced build-context contract.

Refs #1444

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Cloud Build source packaging and test assertions; no runtime service or auth logic.
> 
> **Overview**
> **Replaces the root `.gcloudignore` allowlist** with a default-deny (`*`) pattern so `gcloud builds submit` archives only Metrics Bridge Docker inputs—root pnpm manifests, `patches/`, `metrics-bridge/`, `shared-config/`, and `cloudbuild.yaml`—instead of the whole monorepo and local caches.
> 
> **Adds layered exclusions** via `#!include:.gitignore`, package-local paths (`metrics-bridge/reports/`, `stryker.log`), and explicit blocks for `*.env`, `terraform.tfvars`, and `gha-creds-*.json` so credentials and ignored artifacts stay out of direct-deploy uploads.
> 
> **Extends `deploy-staging-contract.test.mjs`** to assert the default-deny rule, the exact allowlist, the gitignore include, and credential exclusion patterns so the contract cannot regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac4d00d9cc78f1d06dec39d6c6528ac4b26a757. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->