### PR TITLE
docs: capture stateful limit and Vercel safeguards

### DIFF
--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -3,7 +3,7 @@ title: Dashboard Local and Browser Verification
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-28
 doc_type: runbook
 scope: ui-dashboard
 review_interval_days: 90
@@ -40,6 +40,12 @@ Vercel previews may redirect an agent browser to Vercel login. Unless the
 change concerns preview protection, verify on localhost and use the trusted CI
 preview/Lighthouse checks as deployment proof. Changes to preview access must
 exercise the preview with the workflow's configured bypass path.
+
+Confirm `.vercel/project.json` names `monitoring-dashboard` before using the
+Vercel CLI. Never run `vercel curl --yes` unlinked: it can create/link a project
+and a Deployment Protection bypass secret. If this happens, record project and
+secret IDs; preserve Terraform targets. Delete remote resources only with human
+approval; remove only the confirmed accidental local link.
 
 Interactive `next dev` can rewrite `next-env.d.ts` to import
 `./.next/dev/types/routes.d.ts`. Restore the production

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -41,11 +41,13 @@ change concerns preview protection, verify on localhost and use the trusted CI
 preview/Lighthouse checks as deployment proof. Changes to preview access must
 exercise the preview with the workflow's configured bypass path.
 
-Confirm `.vercel/project.json` names `monitoring-dashboard` before using the
-Vercel CLI. Never run `vercel curl --yes` unlinked: it can create/link a project
-and a Deployment Protection bypass secret. If this happens, record project and
-secret IDs; preserve Terraform targets. Delete remote resources only with human
-approval; remove only the confirmed accidental local link.
+Before Vercel CLI use, run
+`vercel project inspect monitoring-dashboard --scope mentolabs`; require
+`mentolabs/monitoring-dashboard` and its ID to match `.vercel/project.json`.
+Never run `vercel curl --yes` unlinked: it can create/link a project and
+protection bypass secret. If so, record project, organization, and bypass-secret
+IDs; preserve Terraform targets. Remote deletion needs human approval; remove
+only confirmed accidental local links.
 
 Interactive `next dev` can rewrite `next-env.d.ts` to import
 `./.next/dev/types/routes.d.ts`. Restore the production

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -112,10 +112,9 @@ If the PR touches a table with pagination, sort, filter, search, or linked chart
 - [ ] Does search operate on current page, fetched window, or full dataset?
 - [ ] Is that behavior documented in code comments and PR notes?
 - [ ] If bounded, is the cap explicit and user-visible?
-- [ ] Is each datastore read cap based on production size or an operational
-      contract such as its backup/restore limit, not fixture size?
-- [ ] Does a production-sized fixture keep valid state below the cap and
-      degrade explicitly above it?
+- [ ] Does each datastore read cap use production size or an operational
+      contract such as backup/restore, not fixture size?
+- [ ] Does a production-scale fixture verify both sides of the cap?
 - [ ] If unbounded, can the backend/query path actually support it?
 - [ ] If filter options are data-driven, what happens when the selected option
       disappears during refresh or partial failure? Reset to a valid state

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -3,7 +3,7 @@ title: Stateful Data and UI Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-27
+last_verified: 2026-07-28
 doc_type: checklist
 scope: repo-wide
 review_interval_days: 90
@@ -112,6 +112,10 @@ If the PR touches a table with pagination, sort, filter, search, or linked chart
 - [ ] Does search operate on current page, fetched window, or full dataset?
 - [ ] Is that behavior documented in code comments and PR notes?
 - [ ] If bounded, is the cap explicit and user-visible?
+- [ ] Is each datastore read cap based on production size or an operational
+      contract such as its backup/restore limit, not fixture size?
+- [ ] Does a production-sized fixture keep valid state below the cap and
+      degrade explicitly above it?
 - [ ] If unbounded, can the backend/query path actually support it?
 - [ ] If filter options are data-driven, what happens when the selected option
       disappears during refresh or partial failure? Reset to a valid state


### PR DESCRIPTION
## The Problem

- A datastore safety cap chosen from fixture size can reject valid production state even when it fits the system's existing operational envelope.
- Running `vercel curl --yes` from an unlinked worktree can create a project and a Deployment Protection bypass secret, while ambiguous cleanup guidance can cross the IaC ownership boundary.

## The Solution

- Add checklist gates that derive datastore read caps from production size or an existing operational contract and test both sides of the boundary.
- Add a Vercel CLI guard that verifies the intended project link and requires human approval before deleting remote resources.

## Details

- Keep confirmed accidental local unlinking separate from remote project or secret cleanup.
- Refresh the verification dates on both canonical documents.

## Validation

- `pnpm agent:quality-gate --run`
- Fresh-context autoreview of the final verified bundle: no findings
- `git diff --check`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only runbook and checklist edits with no runtime, auth, or data-path changes.
> 
> **Overview**
> **Documentation-only** updates to operator runbooks and PR checklists—no application or infrastructure code changes.
> 
> The **dashboard verification runbook** now requires confirming `.vercel/project.json` points at `monitoring-dashboard` before Vercel CLI use, warns against unlinked `vercel curl --yes` (accidental project link + Deployment Protection bypass secret), and spells out incident handling: record IDs, keep Terraform targets, human approval before remote deletes, and only remove confirmed accidental local links.
> 
> The **stateful data + UI checklist** adds search/filter gates: datastore read caps must follow production size or an operational contract (e.g. backup/restore limits), not fixture size; production-sized fixtures should stay under the cap and degrade clearly above it.
> 
> Both canonical docs bump `last_verified` to **2026-07-28**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8546446629ca0abcce26ed0d36d051e3c2a0f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->