### PR TITLE
fix: restore navigation fixture headroom

### DIFF
--- a/docs/evals/documentation-navigation-fixtures.json
+++ b/docs/evals/documentation-navigation-fixtures.json
@@ -7,7 +7,8 @@
     "answer_evidence_percent": 100,
     "questions_over_context_budget": 0,
     "max_question_source_bytes": 45000,
-    "max_total_unique_source_bytes": 262000
+    "max_total_unique_source_bytes": 262000,
+    "min_total_unique_source_headroom_bytes": 32768
   },
   "bootstrap_sources": ["AGENTS.md", "docs/README.md"],
   "forbidden_sources": [
@@ -159,7 +160,10 @@
       "id": "pr-hazard-package-script-refusal",
       "category": "pr-hazards",
       "question": "Why does the agent quality gate refuse to run after package scripts or lockfiles change, and what explicit flag is required after reviewing that lifecycle surface?",
-      "accepted_routes": [["docs/notes/agent-quality-gate-mechanics.md"]],
+      "accepted_routes": [
+        ["docs/notes/agent-quality-gate-mechanics.md"],
+        ["docs/notes/pr-operating-card.md"]
+      ],
       "sources_requiring_verification": [
         {
           "path": "docs/PLAN-ai-review-process.md",
@@ -185,7 +189,10 @@
       "id": "commands-pr-readiness",
       "category": "commands",
       "question": "What exact shared probe must run before declaring a PR all clear, and which current-head Codex approval or break-glass signal is required?",
-      "accepted_routes": [["docs/notes/pr-ready-state.md"]],
+      "accepted_routes": [
+        ["docs/notes/pr-ready-state.md"],
+        ["docs/notes/pr-operating-card.md"]
+      ],
       "sources_requiring_verification": [
         {
           "path": "docs/PLAN-ai-review-process.md",

--- a/docs/evals/documentation-navigation.md
+++ b/docs/evals/documentation-navigation.md
@@ -3,7 +3,7 @@ title: Documentation Navigation Evaluation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-27
+last_verified: 2026-07-29
 doc_type: runbook
 scope: ci/process
 review_interval_days: 90
@@ -35,7 +35,8 @@ The versioned inputs are:
   before the first six-lane semantic garden in issues #1348–#1353.
 - `documentation-navigation-baseline-fixtures.json` — the frozen fixture
   contract used by that historical run. Current fixture changes never rewrite
-  either baseline artifact.
+  either baseline artifact. This pre-garden contract predates the live
+  headroom-reserve target and remains valid without it.
 
 The prompt deliberately omits accepted routes and historical-source traps. It
 starts from root `AGENTS.md` plus the generated `docs/README.md`, forbids the
@@ -155,8 +156,21 @@ Scores stay separate so a cheap strength cannot hide an expensive failure:
 - **Context bytes** — source bytes are recomputed per question and as a unique
   suite total. No question may exceed 45,000 additional source bytes and the
   complete run may not exceed 262,000 unique source bytes, including bootstrap
-  sources. Fixture validation also proves that the cheapest accepted route for
-  every question, and their unique union, fit those caps before a run begins.
+  sources. The live fixture reserves at least 32,768 bytes below the suite cap,
+  so normal documentation growth cannot consume the last few bytes unnoticed.
+  Fixture validation proves that the cheapest accepted route for every
+  question fits the per-question cap and that their unique union fits both the
+  suite cap and its reserve before a run begins.
+
+The 32 KiB reserve is an authoring margin, not extra model context. Do not raise
+the 262,000-byte cap to absorb normal documentation growth. Restore the reserve
+by routing questions through narrower canonical sources that still contain the
+required answer, and keep deeper authority as an accepted alternative when it
+remains valid. The first enforcement pass applied that rule to the two largest
+single-question selections: package-script refusal and PR readiness now share
+the PR operating card as their narrow route. Run
+`pnpm docs:navigation-eval -- --check-fixtures --json` to inspect the selected
+floor, required reserve, and remaining surplus.
 
 The scorer intentionally does not claim to grade arbitrary prose for semantic
 correctness. Canonical routing plus exact evidence makes the answer reviewable;

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -62,10 +62,10 @@ authority.
    deploys and never applies Terraform. It **refuses package-script,
    package-manager, or lockfile changes until their lifecycle risk is reviewed
    and explicitly acknowledged** — do not bypass the refusal; review the surface
-   and pass the acknowledgement flag. Do not run a competing dashboard server,
-   browser suite, or second gate in the same worktree. Background the `--run`
-   gate and the `git push`; a 600s foreground kill discards the freshness stamp.
-   Authority:
+   and pass `--allow-package-script-changes`. Do not run a competing dashboard
+   server, browser suite, or second gate in the same worktree. Background the
+   `--run` gate and the `git push`; a 600s foreground kill discards the freshness
+   stamp. Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 4. **Autoreview.** Freeze the scope baseline first — the initial request,
@@ -148,9 +148,11 @@ Solution` (approach before implementation detail). PRs open **ready for
    feedback ledger must be clean **first**, then the subsequent current-head
    `pr:ready-state` must report ready — including the current-head
    `chatgpt-codex-connector[bot]` PR-description approval, unless a documented
-   break-glass signal applies. Do not block on slow optional bots that branch
-   protection does not require, and do not post routine or duplicate
-   `@codex review` requests. Authority:
+   human break-glass comment applies:
+   `/pr-ready-override gate=codex-description-approval head=<full-head-sha>
+reason=<why this is safe>`. Do not block on slow optional bots that branch
+   protection does not require, and do not post routine or duplicate `@codex
+review` requests. Authority:
    [`pr-ready-state.md`](pr-ready-state.md).
 
 8. **Merge hygiene.** **Never merge a PR without the user's explicit, direct

--- a/scripts/docs-navigation-eval-helpers.mjs
+++ b/scripts/docs-navigation-eval-helpers.mjs
@@ -110,7 +110,11 @@ export function navigationContextFloor(suite, inventory) {
   };
 }
 
-export function validateFixtureSuite(suite, inventory) {
+export function validateFixtureSuite(
+  suite,
+  inventory,
+  { requireHeadroomReserve = true } = {},
+) {
   const errors = [];
   const records = inventoryMap(inventory);
   if (!isObject(suite)) return ["fixture suite must be a JSON object"];
@@ -156,6 +160,15 @@ export function validateFixtureSuite(suite, inventory) {
       if (!Number.isSafeInteger(targets[field]) || targets[field] <= 0) {
         errors.push(`${field} must be a positive integer`);
       }
+    }
+    const reserve = targets.min_total_unique_source_headroom_bytes;
+    if (
+      (requireHeadroomReserve || reserve !== undefined) &&
+      (!Number.isSafeInteger(reserve) || reserve <= 0)
+    ) {
+      errors.push(
+        "min_total_unique_source_headroom_bytes must be a positive integer",
+      );
     }
   }
 
@@ -313,6 +326,15 @@ export function validateFixtureSuite(suite, inventory) {
     ) {
       errors.push(
         `cheapest accepted route union needs ${floor.total_unique_route_bytes} bytes; max_total_unique_source_bytes is ${targets.max_total_unique_source_bytes}`,
+      );
+    }
+    if (
+      Number.isSafeInteger(targets.min_total_unique_source_headroom_bytes) &&
+      targets.max_total_unique_source_bytes - floor.total_unique_route_bytes <
+        targets.min_total_unique_source_headroom_bytes
+    ) {
+      errors.push(
+        `cheapest accepted route union leaves ${targets.max_total_unique_source_bytes - floor.total_unique_route_bytes} bytes of headroom; min_total_unique_source_headroom_bytes is ${targets.min_total_unique_source_headroom_bytes}`,
       );
     }
   }

--- a/scripts/docs-navigation-eval.mjs
+++ b/scripts/docs-navigation-eval.mjs
@@ -223,7 +223,14 @@ export function loadEvaluationContext(
       `documentation inventory failed:\n${inventory.errors.join("\n")}`,
     );
   }
-  const fixtureErrors = validateFixtureSuite(suite, inventory);
+  const baselineFixturesPath = path.resolve(
+    repoRoot,
+    options.baselineFixturesPath ?? DEFAULT_BASELINE_FIXTURES,
+  );
+  const fixtureErrors = validateFixtureSuite(suite, inventory, {
+    // The immutable pre-garden contract predates the live reserve target.
+    requireHeadroomReserve: fixturesPath !== baselineFixturesPath,
+  });
   if (fixtureErrors.length > 0) {
     throw new Error(
       `navigation fixtures are invalid:\n${fixtureErrors.join("\n")}`,
@@ -261,7 +268,9 @@ function validateHistoricalBaseline({ baselineSuite, baseline, repoRoot }) {
   const fixtureErrors =
     historicalInventory.errors.length > 0
       ? historicalInventory.errors
-      : validateFixtureSuite(baselineSuite, historicalInventory);
+      : validateFixtureSuite(baselineSuite, historicalInventory, {
+          requireHeadroomReserve: false,
+        });
   if (fixtureErrors.length > 0) {
     throw new Error(
       `committed navigation baseline fixtures are invalid:\n${fixtureErrors.join("\n")}`,
@@ -405,6 +414,12 @@ async function main() {
         total_unique_headroom_bytes:
           context.suite.targets.max_total_unique_source_bytes -
           contextFloor.total_unique_route_bytes,
+        min_total_unique_source_headroom_bytes:
+          context.suite.targets.min_total_unique_source_headroom_bytes,
+        total_unique_reserve_surplus_bytes:
+          context.suite.targets.max_total_unique_source_bytes -
+          contextFloor.total_unique_route_bytes -
+          context.suite.targets.min_total_unique_source_headroom_bytes,
       },
     };
     printObject(result, options.json);

--- a/scripts/docs-navigation-eval.test.mjs
+++ b/scripts/docs-navigation-eval.test.mjs
@@ -51,7 +51,14 @@ const committedBaseline = JSON.parse(
     "utf8",
   ),
 );
-const repoBaseCommit = committedBaseline.run.repository_base_commit;
+const repoBaseCommit = execFileSync(
+  "git",
+  ["merge-base", "HEAD", "origin/main"],
+  {
+    cwd: repoRoot,
+    encoding: "utf8",
+  },
+).trim();
 const scriptPath = fileURLToPath(
   new URL("./docs-navigation-eval.mjs", import.meta.url),
 );
@@ -108,7 +115,20 @@ function validResult() {
       bootstrap_sources: context.suite.bootstrap_sources.map(source),
     },
     answers: context.suite.questions.map((question) => {
-      const route = question.accepted_routes[0];
+      const route = [...question.accepted_routes]
+        .map((candidate) => ({
+          route: candidate,
+          bytes: candidate.reduce(
+            (sum, pathname) => sum + records.get(pathname).bytes,
+            0,
+          ),
+        }))
+        .sort(
+          (left, right) =>
+            left.bytes - right.bytes ||
+            left.route.length - right.route.length ||
+            left.route.join("\n").localeCompare(right.route.join("\n")),
+        )[0].route;
       return {
         question_id: question.id,
         chosen_documents: [...route],
@@ -232,14 +252,26 @@ test("fixture validation requires an explicit context-breach target", () => {
 
 test("fixture byte budgets can contain every cheapest accepted route", () => {
   const floor = navigationContextFloor(context.suite, context.inventory);
+  const reserve = context.suite.targets.min_total_unique_source_headroom_bytes;
   assert.ok(
     floor.max_question_route_bytes <
       context.suite.targets.max_question_source_bytes,
   );
   assert.ok(
-    floor.total_unique_route_bytes <
-      context.suite.targets.max_total_unique_source_bytes,
+    context.suite.targets.max_total_unique_source_bytes -
+      floor.total_unique_route_bytes >=
+      reserve,
   );
+  assert.equal(reserve, 32_768);
+  const selectedRoutes = new Map(
+    floor.questions.map((question) => [question.question_id, question.route]),
+  );
+  assert.deepEqual(selectedRoutes.get("pr-hazard-package-script-refusal"), [
+    "docs/notes/pr-operating-card.md",
+  ]);
+  assert.deepEqual(selectedRoutes.get("commands-pr-readiness"), [
+    "docs/notes/pr-operating-card.md",
+  ]);
 
   const questionTooTight = structuredClone(context.suite);
   questionTooTight.targets.max_question_source_bytes =
@@ -255,6 +287,23 @@ test("fixture byte budgets can contain every cheapest accepted route", () => {
   assert.match(
     validateFixtureSuite(suiteTooTight, context.inventory).join("\n"),
     /cheapest accepted route union needs/,
+  );
+
+  const missingReserve = structuredClone(context.suite);
+  delete missingReserve.targets.min_total_unique_source_headroom_bytes;
+  assert.match(
+    validateFixtureSuite(missingReserve, context.inventory).join("\n"),
+    /min_total_unique_source_headroom_bytes must be a positive integer/,
+  );
+
+  const reserveTooHigh = structuredClone(context.suite);
+  reserveTooHigh.targets.min_total_unique_source_headroom_bytes =
+    context.suite.targets.max_total_unique_source_bytes -
+    floor.total_unique_route_bytes +
+    1;
+  assert.match(
+    validateFixtureSuite(reserveTooHigh, context.inventory).join("\n"),
+    /cheapest accepted route union leaves .* bytes of headroom/,
   );
 });
 
@@ -608,9 +657,13 @@ test("historical scoring requires a default-branch ancestor and survives deletio
 test("an over-budget answer is measured and fails", () => {
   const result = validResult();
   const answer = result.answers[0];
-  const large = "docs/notes/sentry-triage-pipeline.md";
-  answer.loaded_sources.push(source(large));
-  answer.authority_qualifications.push(qualification(large));
+  for (const large of [
+    "docs/notes/agent-quality-gate-mechanics.md",
+    "docs/context-standards.md",
+  ]) {
+    answer.loaded_sources.push(source(large));
+    answer.authority_qualifications.push(qualification(large));
+  }
   const scored = score(result);
   assert.equal(scored.report.context.questions_over_budget, 1);
   assert.equal(scored.report.passed, false);
@@ -635,6 +688,9 @@ test("a qualified historical source requires loaded canonical verification", () 
   const answer = result.answers.find(
     (candidate) => candidate.question_id === "commands-pr-readiness",
   );
+  const currentAuthority = "docs/notes/pr-ready-state.md";
+  answer.loaded_sources.push(source(currentAuthority));
+  answer.authority_qualifications.push(qualification(currentAuthority));
   const historical = "docs/PLAN-ai-review-process.md";
   answer.loaded_sources.push(source(historical));
   answer.authority_qualifications.push(
@@ -1078,7 +1134,15 @@ test("CLI checks fixtures and validates a structured result", () => {
   const checked = JSON.parse(check.stdout);
   assert.equal(checked.question_count, 18);
   assert.ok(checked.context_floor.max_question_headroom_bytes > 0);
-  assert.ok(checked.context_floor.total_unique_headroom_bytes > 0);
+  assert.equal(
+    checked.context_floor.min_total_unique_source_headroom_bytes,
+    32_768,
+  );
+  assert.ok(checked.context_floor.total_unique_reserve_surplus_bytes >= 0);
+  assert.ok(
+    checked.context_floor.total_unique_headroom_bytes >=
+      checked.context_floor.min_total_unique_source_headroom_bytes,
+  );
 
   const temp = mkdtempSync(path.join(tmpdir(), "docs-navigation-eval-"));
   try {


### PR DESCRIPTION
## The Problem

- The live documentation-navigation route union had grown past its 262,000-byte cap, and adjacent documentation growth used a temporary cap increase instead of preserving reserve.
- Two questions selected separate deep runbooks even though the canonical PR operating card can answer both, and fixture validation did not protect a growth reserve.

## The Solution

- Route the package-script refusal and PR-readiness questions through the shared PR operating card after adding the exact acknowledgement flag and break-glass syntax there.
- Require 32,768 bytes of live-fixture headroom while preserving the 262,000-byte cap and the immutable pre-garden baseline contract.

## Details

- Against current `main`, the selected route union is 212,073 bytes, leaving 49,927 bytes of total headroom and 17,159 bytes beyond the required reserve.
- Fixture checks fail when the reserve target is missing, invalid, or consumed. Their JSON output reports the configured reserve and remaining surplus.
- Historical baseline validation explicitly permits the frozen contract to omit the newer reserve target; the baseline fixture and result are unchanged.
- Tests derive their source commit from the HEAD/origin-main merge base so feature-branch commits still exercise a default-branch ancestor.
- The merge with #1678 kept the evidence-backed 262,000-byte cap instead of its temporary 263,000-byte stopgap; the integrated fixture still exceeds the 32 KiB reserve.

## Validation

- `pnpm agent:quality-gate --run` — passed all eight mapped checks on integrated head `a139922a`.
- `pnpm docs:navigation-eval:test` — 34/34 passed.
- `pnpm docs:navigation-eval -- --check-fixtures --json` — valid; 212,073-byte floor and 49,927-byte headroom.
- Frozen-baseline validation, docs index, context check, script lint, targeted Trunk, and Terraform contract tests passed through the mapped gate.
- Three prepared-bundle fresh-context reviews completed: the first finding was fixed, the corrected bundle was clean, and the current-main integrated bundle was clean at 0.96 confidence.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1677