### PR TITLE
Activate Peg monitoring alerts

### DIFF
--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -54,20 +54,19 @@ CI runs this in the `CI / Lint + test root scripts` job, along with
 ## Peg alert ladder
 
 The source-generated peg ladder reads `peg-thresholds.json` once and generates
-exact-version active and retained-previous rule sets. Its folder, templates,
-contact points, and rule group remain absent while the source-controlled
-`local.peg_alerts_enabled` switch is `false`. When a reviewed activation change
-sets it to `true`, market warnings route to `#alerts-pools`, producer and source
-warnings route to `#alerts-infra`, and critical rules route to both Splunk
-On-Call and `#alerts-critical`. Peg rules use direct rule-level contact points
-and never inherit the FX-weekend mute. Blind rules compare the producer's exact
+exact-version active and retained-previous rule sets. A reviewed source change
+sets the singleton `local.peg_alerts_enabled` switch to the literal `true`,
+which creates its folder, templates, contact points, and rule group. Market
+warnings route to `#alerts-pools`, producer and source warnings route to
+`#alerts-infra`, and critical rules route to both Splunk On-Call and
+`#alerts-critical`. Peg rules use direct rule-level contact points and never
+inherit the FX-weekend mute. Blind rules compare the producer's exact
 consecutive deep-poll count with policy; they do not infer 30-second poll
 history from Grafana's 60-second evaluation clock.
 
-The source is not live merely because it is merged. After every production
-precondition is verified, a reviewed source change may set the activation
-switch to `true`; the trusted-main plan, human-approved apply, and live Grafana
-proof remain required. Follow
+The reviewed source activation is not live merely because it is merged. The
+current producer preconditions still gate the trusted-main plan and
+human-approved apply; live Grafana proof remains required after apply. Follow
 [`docs/notes/peg-monitoring.md`](../../docs/notes/peg-monitoring.md) for the
 current dependency boundary, exact source checks, activation sequence, and
 rollback order.
@@ -98,11 +97,12 @@ timings, including the FX-weekend mute, are not deployment silences. Peg rules
 never use that mute and require a complete active decision-history window
 before their protected apply can be approved.
 
-Reverse the dependency for rollback. If a service or indexer rollback would
-remove a series used by a rule, merge and apply the rule revert first, confirm
-the consumer is absent, and only then withdraw the producer metric. This order
-also applies to warning rules with `no_data_state = "OK"` so stale rule
-definitions do not conceal an incomplete rollback.
+Reverse the dependency for rollback. First merge a reviewed source change that
+sets `local.peg_alerts_enabled` to `false`, then obtain the human-approved
+`alerts-rules` apply and confirm the Peg consumers are absent. Only then
+withdraw a producer metric or roll back its service/indexer. This order also
+applies to warning rules with `no_data_state = "OK"` so stale rule definitions
+do not conceal an incomplete rollback.
 The Polygon-specific producer checks and ordered steps are in
 [`docs/notes/polygon-monitoring.md`](../../docs/notes/polygon-monitoring.md).
 

--- a/alerts/rules/peg-policy-locals.tf
+++ b/alerts/rules/peg-policy-locals.tf
@@ -10,9 +10,9 @@
 
 locals {
   # This source-controlled switch is the only production activation boundary
-  # for Peg Grafana consumers. Keep it false until the runbook's production
-  # preconditions have been verified and a reviewed source change enables it.
-  peg_alerts_enabled = false
+  # for Peg Grafana consumers. This reviewed source change enables it; the
+  # runbook's producer preconditions still gate the protected apply.
+  peg_alerts_enabled = true
   peg_alert_instances = local.peg_alerts_enabled ? {
     "peg-monitoring" = true
   } : {}

--- a/alerts/rules/peg-rule-definitions.tftest.hcl
+++ b/alerts/rules/peg-rule-definitions.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "grafana" {}
 
-run "peg_rule_definitions_create_one_enabled_consumer_set" {
+run "peg_rule_definitions_preserve_consumer_guard_invariant" {
   command = plan
 
   variables {
@@ -10,17 +10,17 @@ run "peg_rule_definitions_create_one_enabled_consumer_set" {
   }
 
   assert {
-    condition     = local.peg_alerts_enabled == true && length(local.peg_alert_instances) == 1
-    error_message = "Peg Grafana consumers must use one enabled singleton instance."
+    condition     = local.peg_alerts_enabled ? length(local.peg_alert_instances) == 1 : length(local.peg_alert_instances) == 0
+    error_message = "Peg Grafana consumers must use one instance when enabled and none when disabled."
   }
 
   assert {
-    condition     = length(grafana_folder.peg_monitoring) == 1 && length(grafana_rule_group.peg_monitoring) == 1
-    error_message = "Peg activation must create exactly one Grafana folder and rule group."
+    condition     = local.peg_alerts_enabled ? length(grafana_folder.peg_monitoring) == 1 && length(grafana_rule_group.peg_monitoring) == 1 : length(grafana_folder.peg_monitoring) == 0 && length(grafana_rule_group.peg_monitoring) == 0
+    error_message = "Peg Grafana folder and rule group counts must follow the source-controlled consumer guard."
   }
 
   assert {
     condition     = length(local.peg_rule_definitions) > 0
-    error_message = "Peg rule definitions must evaluate with the enabled consumer set."
+    error_message = "Peg rule definitions must evaluate with the source-controlled consumer guard."
   }
 }

--- a/alerts/rules/peg-rule-definitions.tftest.hcl
+++ b/alerts/rules/peg-rule-definitions.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "grafana" {}
 
-run "peg_rule_definitions_evaluate_before_activation" {
+run "peg_rule_definitions_create_one_enabled_consumer_set" {
   command = plan
 
   variables {
@@ -10,12 +10,17 @@ run "peg_rule_definitions_evaluate_before_activation" {
   }
 
   assert {
-    condition     = local.peg_alerts_enabled == false && length(local.peg_alert_instances) == 0
-    error_message = "Peg Grafana consumers must remain disabled by default."
+    condition     = local.peg_alerts_enabled == true && length(local.peg_alert_instances) == 1
+    error_message = "Peg Grafana consumers must use one enabled singleton instance."
+  }
+
+  assert {
+    condition     = length(grafana_folder.peg_monitoring) == 1 && length(grafana_rule_group.peg_monitoring) == 1
+    error_message = "Peg activation must create exactly one Grafana folder and rule group."
   }
 
   assert {
     condition     = length(local.peg_rule_definitions) > 0
-    error_message = "Peg rule definitions must evaluate before a reviewed source change enables their consumers."
+    error_message = "Peg rule definitions must evaluate with the enabled consumer set."
   }
 }

--- a/docs/adr/0054-same-project-peg-policy-artifact.md
+++ b/docs/adr/0054-same-project-peg-policy-artifact.md
@@ -13,9 +13,9 @@ garden_lane: adrs-architecture
 
 # ADR 0054 — Peg policy stays private in the monitoring project
 
-**Status:** Accepted (Jul 2026), live foundation; controller amendment in
-[ADR 0055](0055-peg-policy-bucket-controller-recovery.md). Publication is
-paused pending that recovery.
+**Status:** Accepted (Jul 2026), in force. The controller recovery in
+[ADR 0055](0055-peg-policy-bucket-controller-recovery.md), first protected
+publication, and generation-pinned runtime attachment are complete.
 **Scope:** metrics-bridge / alerts / terraform/infra
 
 ## Context
@@ -72,8 +72,9 @@ the two authoritative bucket IAM policies through the assumed Owner path.
 controller decision: it adds the narrow normal controller, permits one
 explicitly approved and time-bounded project-level bootstrap when recovery
 requires it, and requires removing that bootstrap immediately after both
-policies reconcile. The foundation is applied; policy publication remains
-paused until this recovery completes.
+policies reconcile. Recovery and bootstrap removal are complete; the protected
+workflow has published the policy and the runtime has its generation-pinned
+attachment.
 
 ## Alternatives considered
 
@@ -98,14 +99,12 @@ paused until this recovery completes.
   check before activation.
 - The source foundation creates no policy object. The separate
   `alerts/peg-policy-publication` root creates a policy object only through its
-  manual protected workflow. The dormant runtime attachment assigns the
-  dedicated reader identity to Metrics Bridge, but keeps its paired policy
-  values absent while `local.peg_policy_runtime_generation` is `null`. Those
-  foundation and publication merges do not start Peg polling or activate
-  alerts. A separate reviewed runtime activation replaces `null` with the
-  published generation and removes the Cloud Run template-revision drift ignore
-  to mint the attachment revision; later rollovers keep revision changes
-  managed.
+  manual protected workflow. The first publication created
+  `mento-monitoring-peg-policy/peg-policy/current.json` generation
+  `1785276001213660`; the reviewed runtime attachment pins it and mints
+  `metrics-bridge-r-47264e8-30405040839`. Future rollovers replace the current
+  quoted generation in a reviewed runtime change and keep revision changes
+  managed. Publication and runtime attachment do not apply Grafana consumers.
 
 ## Evidence
 

--- a/docs/adr/0055-peg-policy-bucket-controller-recovery.md
+++ b/docs/adr/0055-peg-policy-bucket-controller-recovery.md
@@ -13,8 +13,9 @@ garden_lane: adrs-architecture
 
 # ADR 0055 — Peg policy bucket controller recovers authoritative IAM reconciliation
 
-**Status:** Accepted (Jul 2026), recovery pending; foundation applied and
-publication paused.
+**Status:** Accepted (Jul 2026), recovery complete. The temporary bootstrap was
+removed after reconciliation; protected publication and the generation-pinned
+runtime attachment then completed.
 **Scope:** terraform/infra
 
 ## Context
@@ -54,8 +55,9 @@ recovery exception, not a retained project-level grant.
   full platform stack, remove the binding immediately after both bucket policies
   reconcile, verify its absence, and run a clean full plan.
 - Do not use `roles/storage.admin`, Storage Object Admin, or Service Account
-  User as a bootstrap or fallback. Do not resume policy publication, runtime
-  attachment, or alert activation until recovery records the clean plan.
+  User as a bootstrap or fallback. For any future recovery, do not resume
+  policy publication, runtime attachment, or alert activation until it records
+  the clean plan.
 
 ## Recovery procedure
 
@@ -109,8 +111,9 @@ check, and clean plan as recovery evidence.
 - The one-time bootstrap remains an operator action outside Terraform state,
   so its removal, live absence check, and clean full plan are mandatory
   evidence.
-- The production foundation stays applied but policy publication remains paused
-  until the recovery sequence is complete.
+- The completed recovery preserved least privilege and unlocked protected policy
+  publication and runtime attachment; Grafana activation remains a separate
+  reviewed apply.
 
 ## Evidence
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -259,18 +259,21 @@ emergency exceptions. Do not retain a project-level controller grant or use
 broad Storage Admin, Storage Object Admin, or Service Account User fallbacks.
 An explicitly approved, time-bounded emergency controller bootstrap may be
 used only until both bucket policies reconcile; remove it immediately, verify
-its absence, and run a clean plan. The foundation is applied, but publication
-is paused pending that recovery. The canonical sequence is in
+its absence, and run a clean plan. That recovery and bootstrap removal are
+complete. The protected workflow published
+`mento-monitoring-peg-policy/peg-policy/current.json` at generation
+`1785276001213660`; Metrics Bridge pins it on
+`metrics-bridge-r-47264e8-30405040839`. The canonical recovery procedure is in
 [`docs/terraform.md`](terraform.md) and [ADR 0055](adr/0055-peg-policy-bucket-controller-recovery.md).
-Audit effective readers, writers, and IAM administrators after applies and
-again before runtime activation.
+Audit effective readers, writers, and IAM administrators after future applies
+and before runtime rollovers.
 
-The manual `Peg Policy Publication` workflow writes the current policy as a
-versioned object. Dispatch its `plan` operation from `main`, inspect the
-read-only result, then dispatch `apply` and approve `production-infra`. Copy
-only its generation-pinned output into the later reviewed runtime-activation
-change. The publication workflow does not set either Cloud Run value or alter
-Grafana. Its WIF-facing plan identity is bound to that exact workflow and may
+The manual `Peg Policy Publication` workflow writes each policy as a versioned
+object. For a future publication, dispatch its `plan` operation from `main`,
+inspect the read-only result, then dispatch `apply` and approve
+`production-infra`. Copy only its generation-pinned output into the later
+reviewed runtime-rollover change. The publication workflow does not set either
+Cloud Run value or alter Grafana. Its WIF-facing plan identity is bound to that exact workflow and may
 impersonate only the publication reader. That reader can view only the
 Terraform state and policy buckets; the shared refresh identity cannot read
 policy objects.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -175,13 +175,12 @@ trading-limit change.
 
 ## 6. Roll out the first activation producer-first
 
-Use this sequence only for the one-time first activation while
-`local.peg_alerts_enabled` is still `false`, and only after the policy
-publication and runtime-pinning infrastructure tracked in
-[Peg monitoring alert source validation and activation
-hold](peg-monitoring.md) are live. The manual `Peg Policy Publication` workflow
-now provides the publication path; it still does not activate the runtime or
-Grafana consumers.
+Use this sequence for the one-time first activation. It starts while
+`local.peg_alerts_enabled` is `false` and ends with step 9's reviewed source
+flip. The verified current boundary is in [Peg monitoring alert source
+validation and activation](peg-monitoring.md). The manual `Peg Policy
+Publication` workflow publishes policy only; runtime attachment and Grafana
+consumers remain separate steps.
 
 Use this order for the first activation topology:
 
@@ -194,9 +193,7 @@ Use this order for the first activation topology:
    Record rejected-source evidence in that change. Never merge a registry-only
    or policy-only source state; the integrity contract requires exact
    active-registry parity. Do not deploy the registry B image yet.
-3. After the bucket-controller recovery in
-   [ADR 0055](../adr/0055-peg-policy-bucket-controller-recovery.md), through
-   the separately reviewed `Peg Policy Publication` workflow, inspect
+3. Through the separately reviewed `Peg Policy Publication` workflow, inspect
    its read-only `main` plan and then approve its `production-infra` apply to
    publish B as the immutable private GCS generation described by
    [ADR 0054](../adr/0054-same-project-peg-policy-artifact.md). Keep the runtime
@@ -223,7 +220,11 @@ Use this order for the first activation topology:
    Keep the asset Configured while producer evidence is absent or stale.
 8. Provision the dashboard's server-only bridge URL through IaC, deploy the
    dashboard, and browser-verify current, stale-last-confirmed, and unavailable
-   behavior against the same policy version.
+   behavior against the same policy version. For this first activation,
+   `https://monitoring.mento.org/peg-monitoring` has a live current package and
+   no console errors. The focused Playwright flow proves the retained-stale
+   transition, and the page-client regression covers unavailable state and
+   recovery.
 9. Only after producer and dashboard proof, merge a reviewed source change that
    sets `local.peg_alerts_enabled` to `true`. Do not open the consumers through
    a workflow, Terraform variable, GitHub variable, or policy artifact. After

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -1,5 +1,5 @@
 ---
-title: Peg monitoring alert source validation and activation hold
+title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
@@ -10,7 +10,7 @@ review_interval_days: 90
 garden_lane: operator-runbooks
 ---
 
-# Peg monitoring alert source validation and activation hold
+# Peg monitoring alert source validation and activation
 
 The peg alert ladder is source configuration only until every production
 precondition in this runbook passes. A merged rule definition, a successful
@@ -30,32 +30,40 @@ The source-owned surfaces are:
 
 ## Current boundary
 
-This source packet does not deploy the producer, apply Grafana resources, or
-prove live telemetry. `terraform/peg-policy.tf` owns the policy identities and
-bucket IAM. The foundation is applied, but the separate manual `Peg Policy
-Publication` root is paused pending the bucket-controller recovery in
-[ADR 0055](../adr/0055-peg-policy-bucket-controller-recovery.md). Its Grafana
-consumers are absent by default because the source-controlled
-`local.peg_alerts_enabled` switch is `false`. That single Terraform local gates
-the Peg folder, templates, contact points, and rule group; it is not a workflow,
-variable, or policy-artifact switch.
+This source packet does not apply Grafana resources or, by itself, prove live
+consumer behavior. The activation evidence records live producer and query
+checks; live consumer states still require the protected apply.
+`terraform/peg-policy.tf` owns the policy identities and bucket IAM. Controller
+recovery and bootstrap-grant removal are complete.
+The protected `Peg Policy Publication` root published
+`mento-monitoring-peg-policy/peg-policy/current.json` at generation
+`1785276001213660`. Authenticated, generation-pinned delivery and live producer
+telemetry are proven on `metrics-bridge-r-47264e8-30405040839`, which serves
+active policy `europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`. The
+production dashboard prerequisite is also proven at
+`https://monitoring.mento.org/peg-monitoring`: the live current package renders
+without console errors. The reviewed source activation sets the
+source-controlled `local.peg_alerts_enabled` switch to the literal `true`. That
+single Terraform local gates the Peg folder, templates, contact points, and
+rule group; it is not a workflow, variable, or policy-artifact switch. This
+source change does not prove the consumers exist in Grafana or that their
+queries have live data.
 
 The production identity bootstrap in
-[#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) must be
-merged and its separately reviewed Terraform apply must complete before this
-alert stack is eligible for a trusted-main apply. The producer changes in
-[#1568](https://github.com/mento-protocol/monitoring-monorepo/pull/1568) are
-merged and deployed. They remain intentionally dormant until authenticated
-policy delivery is live, so this milestone alone does not provide the required
-`mento_peg_usable_decision_total` input or satisfy activation precondition 3
-below.
+[#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) is
+merged and its separately reviewed Terraform apply is complete. The producer
+changes in [#1568](https://github.com/mento-protocol/monitoring-monorepo/pull/1568)
+are merged and deployed. The runtime now fetches the authenticated
+generation-pinned policy and exposes the active `policy_version`. The activation
+PR records a full producer-floor window and production evaluation of all 61
+unique generated query expressions. The protected-main plan, human-approved
+apply, and post-apply Grafana proof follow the source merge.
 
-The listing-confirmation producer and consumer source now includes
+The live listing-confirmation producer and consumer source includes
 `mento_peg_listing_state`, `mento_peg_listing_checked_at`, and the bounded
-`mento_peg_listing_absent_consecutive_checks` gauge. This does not prove those
-series are live: protected policy publication, runtime activation, a
-human-approved Grafana application, and live evidence remain separate gates.
-Listing state must never be inferred from source health.
+`mento_peg_listing_absent_consecutive_checks` gauge. A human-approved Grafana
+application and Grafana query evidence remain separate gates. Listing state
+must never be inferred from source health.
 
 ## Rule inventory
 
@@ -158,12 +166,12 @@ are true:
 
 6. Every exact generated query evaluates in the production Grafana data source
    without `Error` or unexplained `NoData`.
-7. After preconditions 1–6 are verified, a reviewed source change flips
-   `local.peg_alerts_enabled` to `true`. Do not make this activation change
-   earlier or through a workflow, Terraform variable, GitHub variable, or
-   policy-artifact field.
-8. After the reviewed source flip reaches protected `main`, a human reviews the
-   trusted-main plan and explicitly approves the `production-infra` apply.
+7. The reviewed source change sets `local.peg_alerts_enabled` to the literal
+   `true`. Do not control activation through a workflow, Terraform variable,
+   GitHub variable, or policy-artifact field. This source activation does not
+   waive preconditions 1–6.
+8. After the reviewed source change reaches protected `main`, a human reviews
+   the trusted-main plan and explicitly approves the `production-infra` apply.
 
 Active blindness and heartbeat rules use `no_data_state = "Alerting"`.
 Applying while production peg samples are absent can create incidents by
@@ -180,7 +188,8 @@ explicit approval.
 
 ## Rollback
 
-Remove or disable the Grafana consumers first through a reviewed,
-human-approved alerts-rules change. Confirm the rules are absent before
+First make a reviewed source change that sets `local.peg_alerts_enabled` to the
+literal `false`. Obtain the human-approved `alerts-rules` apply and confirm the
+Peg folder, contact points, templates, and rule group are absent before
 withdrawing any producer series they require. Never remove the producer first:
 active blindness and heartbeat intentionally fail closed on missing data.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -54,11 +54,12 @@ through `production-infra` approval.
 
 `peg-policy-publication` permits only backend-free local validation with
 `pnpm tf validate peg-policy-publication`. Local plan and apply are disabled,
-including `--force-local-apply`. The foundation is applied, but publication is
-paused pending the controller recovery below. After that recovery, dispatch
-`Peg Policy Publication` from `main`: inspect its read-only plan, then choose
-`apply` and approve the `production-infra` Environment. Its output supplies one
-generation-pinned URL for a later runtime-activation change.
+including `--force-local-apply`. Controller recovery and first publication are
+complete: `mento-monitoring-peg-policy/peg-policy/current.json` is generation
+`1785276001213660` and the runtime attachment pins it. For a future publication,
+dispatch `Peg Policy Publication` from `main`, inspect its read-only plan, then
+choose `apply` and approve the `production-infra` Environment. Its output feeds
+a separately reviewed runtime rollover.
 
 ## CI Model
 
@@ -139,14 +140,15 @@ Routing and IAM audit complete. Removal: `0 added, 1 changed, 1 destroyed`;
 plan clean; IAM has no `metrics-bridge-deployer` Token Creator grant. Platform
 owns private buckets and identities; protected `peg-policy-publication` writes
 the policy object.
-Metrics Bridge uses the dedicated runtime identity. `PEG_POLICY_*` is absent
-only when `local.peg_policy_runtime_generation = null`; the reviewed first
-activation changes that literal to the protected publisher's exact quoted
-positive output. Publication does not attach Cloud Run or activate Grafana.
-Terraform derives the pinned URL and `gcp-metadata` mode from that literal.
-`null` retains `template[0].revision` in `ignore_changes`; first activation
-removes it, and later concrete pins keep revision changes managed so each
-handoff creates a Cloud Run revision. Buckets, runtime, and publisher are in
+Metrics Bridge uses the dedicated runtime identity and pins generation
+`1785276001213660` through paired `PEG_POLICY_*` values. Publication itself
+attaches neither Cloud Run nor Grafana consumers. The reviewed runtime
+activation attached Cloud Run; the separate alerts-rules source change and
+approved apply activate Grafana. Terraform derives the pinned URL and
+`gcp-metadata` mode from that literal.
+`null` retains `template[0].revision` in `ignore_changes`; the completed first
+activation removed it, and later concrete pins keep revision changes managed so
+each handoff creates a Cloud Run revision. Buckets, runtime, and publisher are in
 `mento-monitoring`; publication plan and reader are in the seed project. Only
 the exact publication workflow selects that read-only chain. Runtime and reader
 have direct bucket-scoped Object Viewer; publisher has direct Object Admin.

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -1139,7 +1139,7 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
   );
 });
 
-test("Peg Grafana consumers stay behind the default-off source activation guard", () => {
+test("Peg Grafana consumers use a literal source activation guard", () => {
   const rulesDir = path.resolve(__dirname, "..", "alerts/rules");
   const policyLocals = readFileSync(
     path.join(rulesDir, "peg-policy-locals.tf"),
@@ -1180,10 +1180,10 @@ test("Peg Grafana consumers stay behind the default-off source activation guard"
     path.join(rulesDir, "peg-rule-definitions.tf"),
     "utf8",
   );
-  const assertDefaultOff = (source) => {
+  const assertLiteralActivation = (source) => {
     assert(
-      /\bpeg_alerts_enabled\s*=\s*false\b/.test(source),
-      "peg alert activation must default to false in source-controlled Terraform",
+      /\bpeg_alerts_enabled\s*=\s*(?:true|false)\b/.test(source),
+      "peg alert activation must be a literal true or false in source-controlled Terraform",
     );
   };
   const assertGuardedResource = (file, marker, source) => {
@@ -1206,12 +1206,12 @@ test("Peg Grafana consumers stay behind the default-off source activation guard"
     throw new Error(message);
   };
 
-  assertDefaultOff(policyLocals);
+  assertLiteralActivation(policyLocals);
   assert(
     /peg_alert_instances\s*=\s*local\.peg_alerts_enabled\s*\?\s*\{\s*"peg-monitoring"\s*=\s*true\s*\}\s*:\s*\{\}/s.test(
       policyLocals,
     ),
-    "peg alert instances must be one stable singleton map derived from the default-off switch",
+    "peg alert instances must be one stable singleton map derived from the literal source switch",
   );
   assert(
     guardedResources.length === 9,
@@ -1228,13 +1228,13 @@ test("Peg Grafana consumers stay behind the default-off source activation guard"
   );
   expectFailure(
     () =>
-      assertDefaultOff(
+      assertLiteralActivation(
         policyLocals.replace(
-          "peg_alerts_enabled = false",
-          "peg_alerts_enabled = true",
+          /\bpeg_alerts_enabled\s*=\s*(?:true|false)\b/,
+          "peg_alerts_enabled = var.peg_alerts_enabled",
         ),
       ),
-    "activation guard test must reject a forced-open default",
+    "activation guard test must reject variable-controlled activation",
   );
   expectFailure(
     () =>

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -16,7 +16,7 @@ garden_lane: agent-entry-points
 
 ## Scope
 
-`terraform/` is the `platform` stack registered in `terraform.stacks.json`. It manages production infrastructure for the monitoring dashboard, Upstash, the monitoring GCP project/APIs, private Peg-policy storage in that project, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, explicit routine-deploy source buckets, the separated Terraform/service-deploy Workload Identity Federation chains, repo-level GitHub Actions secrets and variables owned by the platform stack, and the applied Peg-policy GCS source foundation. Policy publication remains paused until the controller recovery in [`ADR 0055`](../docs/adr/0055-peg-policy-bucket-controller-recovery.md) completes. Alloy values are required sensitive, ephemeral operator inputs that terminate at Google provider 6.50.x write-only Secret Manager arguments; only their explicit rotation counters are non-secret. Alert ownership lives in `alerts/` (`alerts/rules/` for protocol Grafana rules, Aegis service/testnet-health rules, and global routing; `alerts/infra/` for event-driven delivery) while `aegis/terraform/` owns the Aegis dashboard and folder.
+`terraform/` is the `platform` stack registered in `terraform.stacks.json`. It manages production infrastructure for the monitoring dashboard, Upstash, the monitoring GCP project/APIs, private Peg-policy storage in that project, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, explicit routine-deploy source buckets, the separated Terraform/service-deploy Workload Identity Federation chains, repo-level GitHub Actions secrets and variables owned by the platform stack, and the applied Peg-policy GCS source foundation. Controller recovery and protected policy publication are complete; the current runtime attachment pins `mento-monitoring-peg-policy/peg-policy/current.json` generation `1785276001213660`. Alert activation still requires its trusted-main plan, human-approved apply, and Grafana/routing proof. Alloy values are required sensitive, ephemeral operator inputs that terminate at Google provider 6.50.x write-only Secret Manager arguments; only their explicit rotation counters are non-secret. Alert ownership lives in `alerts/` (`alerts/rules/` for protocol Grafana rules, Aegis service/testnet-health rules, and global routing; `alerts/infra/` for event-driven delivery) while `aegis/terraform/` owns the Aegis dashboard and folder.
 
 Alloy's runtime project authority is the custom
 `grafanaAgentActivationReader` role with exactly `appengine.services.get` and
@@ -116,15 +116,15 @@ boundaries.
   run a clean full plan. The recovery sequence is in
   [`docs/terraform.md`](../docs/terraform.md) and
   [ADR 0055](../docs/adr/0055-peg-policy-bucket-controller-recovery.md).
-  Metrics Bridge always uses the dedicated runtime identity, while paired
-  `PEG_POLICY_*` values stay absent until the reviewed source literal
-  `local.peg_policy_runtime_generation` changes from `null` to the protected
-  publisher's current quoted positive generation for activation or rollover.
-  Never supply a URL or auth-mode variable: Terraform derives the canonical
-  pinned GCS URL and `gcp-metadata` mode together. The routine deployer and
+  Metrics Bridge uses the dedicated runtime identity and currently pins
+  generation `1785276001213660` through paired `PEG_POLICY_*` values. A future
+  rollover replaces the current quoted positive generation in the reviewed
+  source literal; never supply a URL or auth-mode variable. Terraform derives
+  the canonical pinned GCS URL and `gcp-metadata` mode together. The routine deployer and
   `gcp_dev_members` receive Service Account User only on that runtime identity;
   never restore a project-wide or default-Compute grant. Audit effective
-  readers, writers, and IAM administrators after applies and before activation.
+  readers, writers, and IAM administrators after applies and before future
+  rollovers.
   Access logs are audit
   telemetry, never an authorization control.
 


### PR DESCRIPTION
## The Problem

- The Peg producer, policy, and dashboard are live, but the Grafana consumers remain source-disabled.
- EUROP can therefore emit trustworthy Peg evidence without creating the warning, infrastructure, and paging rules required by #1444.

## The Solution

- Enable the single source-controlled Peg consumer set after proving the production producer window and every generated query.
- Keep the existing guarded resources, PromQL, routing, message templates, policy, and rollback order unchanged.

## Details

- Sets `local.peg_alerts_enabled` to the literal `true`.
- Keeps exactly nine resources behind `local.peg_alert_instances`: one folder, one rule group, four message templates, and three direct contact points.
- Updates the Terraform and lint contracts for the enabled singleton while preserving a rollback-safe literal `false` path.
- Records the completed controller recovery, protected policy publication, generation-pinned Metrics Bridge rollout, producer/query evidence, and the remaining trusted-main plan/apply/live-proof boundary.
- Does not apply Terraform. After merge, the full trusted-main `alerts-rules` plan must contain only the expected Peg consumers before the already approved, closely monitored apply.

Refs #1444

## Validation

- `pnpm agent:quality-gate --run` — all mapped checks passed.
- `pnpm alerts:rules:lint:test` — 41/41 passed.
- `pnpm alerts:rules:lint` — 180 PromQL expressions parsed and validated.
- `terraform test -no-color` in `alerts/rules` — 1 passed, 0 failed.
- Fresh-context autoreview — ALL CLEAR; frozen manifest `5b8ad7ccde0bf6c6715cfa22ea1997c26cae4726bf3aba3bb90bf0405f0369b0` reverified.
- Deterministic local autoreview — no actionable findings.
- Production 20-minute Bitvavo floor: poll success `36.2559`, usable decisions `36.2621`; required floor is `32` for each.
- Production Prometheus: all 61 unique generated query expressions executed with zero query errors; 36 returned values/context and 25 alert predicates returned expected empty vectors because their conditions were false.
- `pnpm --filter @mento-protocol/ui-dashboard test:browser -- tests/browser/peg-monitoring.test.ts` — 1/1 passed, including current-to-retained-stale behavior.
- Dashboard unit suite — 288 files / 4,156 tests passed, including unavailable and recovery behavior.
- `https://monitoring.mento.org/peg-monitoring` — live current package rendered without console errors; Grafana history link opened the ordinary-user login route.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new architecture decision; this activates the already accepted ADR 0044/0045 design and updates rollout status in ADRs 0054/0055.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on production Peg paging and fail-closed blindness/heartbeat rules once `alerts-rules` is applied; risk is mitigated because apply stays gated and the PR is mostly the activation flag plus documentation.
> 
> **Overview**
> **Enables the Peg Grafana consumer set** by setting `local.peg_alerts_enabled` to the literal `true` in `peg-policy-locals.tf`, which drives the existing `local.peg_alert_instances` singleton and the nine guarded resources (folder, rule group, templates, contact points). PromQL, routing, and rule definitions are unchanged; merge alone does not apply Terraform.
> 
> **Tests and lint** now expect an enabled singleton: `peg-rule-definitions.tftest.hcl` asserts one folder and rule group on plan, and `alert-rules-lint.test.mjs` requires a literal `true`/`false` switch (not variables) while still rejecting unguarded consumers.
> 
> **Runbooks and ADRs** are updated to record completed policy-bucket recovery, first GCS publication, and Metrics Bridge generation pin, and to state that live alerting still needs trusted-main plan, `production-infra` approval, and post-apply Grafana proof. Rollback docs now lead with flipping `peg_alerts_enabled` to `false` before withdrawing producer metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658852798a77e57b2e902b4acc25b6dd1be11bc1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->