### PR TITLE
fix: correct Peg alert evaluation and Grafana link

### DIFF
--- a/alerts/rules/peg-promql-active.tf
+++ b/alerts/rules/peg-promql-active.tf
@@ -96,7 +96,7 @@ locals {
   }
   peg_active_blind_warning_promql = {
     for asset_id, asset in local.peg_active_assets : asset_id => format(
-      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
+      "mento_peg_blind_consecutive_polls{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} >= bool %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\"%s\",policy_version=\"${local.peg_active_policy_version}\"} <= %d)",
       asset_id,
       asset.blindConsecutivePolls,
       asset_id,

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -946,7 +946,7 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
   }
   assert(
     source.includes(
-      'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d)',
+      'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} >= bool %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_active_policy_version}\\"} <= %d)',
     ) &&
       source.includes(
         'mento_peg_blind_consecutive_polls{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} >= %d and on(asset,policy_version) (time() - mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"} <= %d)',
@@ -961,7 +961,7 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       source.includes(
         'max_over_time(mento_peg_last_poll{asset=\\"%s\\",policy_version=\\"${local.peg_previous_policy_version}\\"}[%ds]) > bool %d',
       ),
-    "blindness must use the producer-side consecutive-poll count while heartbeat remains fail-closed",
+    "active blindness must retain a healthy false series with bool while missing or stale inputs remain NoData, and previous policy semantics stay unchanged",
   );
   assert(
     source.includes(

--- a/ui-dashboard/src/lib/peg-monitoring.ts
+++ b/ui-dashboard/src/lib/peg-monitoring.ts
@@ -4,7 +4,7 @@ export const PEG_MONITORING_REFRESH_MS = 30_000;
 export const PEG_MONITORING_STALE_AFTER_MS = 90_000;
 const MAX_FUTURE_CLOCK_SKEW_MS = 60_000;
 export const PEG_GRAFANA_ALERTS_URL =
-  "https://clabsmento.grafana.net/alerting/list?search=Peg%20Monitoring";
+  "https://clabsmento.grafana.net/alerting/list?search=Peg";
 export type {
   PegMonitoringResponse,
   PegAssetPackage,

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -106,9 +106,12 @@ test("intercepts peg monitoring, retains stale evidence, and keeps regional load
       `${name} changed more than its text-height allowance`,
     ).toBeLessThanOrEqual(verticalTolerance);
   }
-  await expect(
-    page.getByRole("link", { name: /Open Peg Monitoring/ }),
-  ).toHaveAttribute("rel", /noopener/);
+  const grafanaLink = page.getByRole("link", { name: /Open Peg Monitoring/ });
+  await expect(grafanaLink).toHaveAttribute(
+    "href",
+    "https://clabsmento.grafana.net/alerting/list?search=Peg",
+  );
+  await expect(grafanaLink).toHaveAttribute("rel", /noopener/);
   await expect(
     page.getByRole("link", { name: "Peg monitoring", exact: true }),
   ).toBeVisible();


### PR DESCRIPTION
## The Problem

- The active Peg Blind Warning fires as `Alerting (NoData)` while its live blind-poll metric is present and healthy at `0`, because the comparison filters a false result out of the query.
- The dashboard's Grafana link searches for `Peg Monitoring`, which currently returns no matching rules.

## The Solution

- Make the active blind comparison return a labelled `0` when healthy, so Grafana stays Normal while genuinely missing or stale inputs still fail closed through NoData.
- Link to the working `Peg` Grafana search and lock the exact destination in the browser test.

## Details

- Only `peg_active_blind_warning_promql` gains the PromQL `bool` modifier. Active blind-while-stressed and all retained-previous expressions keep their existing semantics.
- Alert thresholds, durations, labels, and direct contact points do not change.
- The live false warning routes to `#alerts-infra`; this fix does not change paging behavior or Splunk On-Call routing.

## Invariants

- A present blind count below policy threshold must evaluate to `0`, not an empty vector.
- A missing blind series or stale/missing exact-policy heartbeat must still produce NoData and use the rule's fail-closed `no_data_state = "Alerting"`.
- Retained-previous rules stay no-data-safe and unchanged.

## Degraded behavior

- Missing or stale active producer evidence still raises the operations warning.
- The Grafana destination remains an authenticated operator surface; the dashboard only changes the working search filter.

## Validation

- `pnpm agent:quality-gate --run` — all mapped Terraform, alert-lint, dashboard lint/type/coverage/browser, dependency, React Doctor, and size checks passed.
- `pnpm alerts:rules:lint:test` — 41/41 passed.
- Terraform Peg rule test — 1/1 passed.
- Focused Peg dashboard browser test — 1/1 passed.
- Local deterministic autoreview — clean.
- Fresh-context bundle review — ALL CLEAR, confidence 0.96; bundle integrity verified before and after review.
- Live browser proof: `search=Peg%20Monitoring` returned no rules; `search=Peg` returned Peg rules with no console errors.
- Live Grafana proof: 39 rules and all health `ok`; the current false Blind Warning has blind count `0`, a fresh heartbeat, and `Alerting (NoData)`.

Refs #1444

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Grafana alert query semantics for the fail-closed active blind warning; scope is narrow (one PromQL template) but incorrect evaluation directly affects ops paging.
> 
> **Overview**
> Fixes **active Peg Blind Warning** showing `Alerting (NoData)` when blind poll count is healthy at `0`, and points the dashboard **Grafana alerts** link at a search that actually returns rules.
> 
> **Alert evaluation:** `peg_active_blind_warning_promql` now uses PromQL **`>= bool`** on the blind consecutive-polls comparison so a below-threshold count yields a labelled **`0`** instead of an empty vector (which Grafana treated as NoData). Active blind-while-stressed and all **previous-policy** blind expressions are unchanged.
> 
> **Dashboard:** `PEG_GRAFANA_ALERTS_URL` uses `search=Peg` instead of `search=Peg%20Monitoring`; the Peg monitoring browser test asserts that exact `href` plus `rel=noopener`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441e16e98abba4021fb09209b299434e04765bd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->