### PR TITLE
fix: clarify issue board project scope

### DIFF
--- a/scripts/agent-issue-board.mjs
+++ b/scripts/agent-issue-board.mjs
@@ -244,17 +244,23 @@ function formatGh(args) {
   return `gh ${args.map((arg) => quoteArg(String(arg))).join(" ")}`;
 }
 
-export function githubProjectScopeHint(stderr) {
+export function githubProjectScopeHint(stderr, env = process.env) {
+  const requiredScopes = String(stderr).match(
+    /requires one of the following scopes?\s*:\s*\[([^\r\n]{0,240}?)\]/i,
+  )?.[1];
   if (
-    !/(?:requires one of the following|required) scopes?[\s\S]{0,240}\b(?:read:project|project)\b/i.test(
-      String(stderr),
-    )
+    !requiredScopes ||
+    !/\b(?:read:project|project)\b/i.test(requiredScopes)
   ) {
     return "";
   }
+  const credentialGuidance =
+    env.GH_TOKEN || env.GITHUB_TOKEN
+      ? "Replace the environment-provided GH_TOKEN or GITHUB_TOKEN with one carrying the read/write `project` scope; `gh auth refresh` does not update environment-provided tokens."
+      : "Refresh it with: gh auth refresh -h github.com -s project";
   return [
     "GitHub Project V2 operations require the active gh credential's read/write `project` scope.",
-    "Refresh it with: gh auth refresh -h github.com -s project",
+    credentialGuidance,
     "`read:project` alone can query a project but cannot run claim, review, or sync mutations.",
   ].join("\n");
 }

--- a/scripts/agent-issue-board.mjs
+++ b/scripts/agent-issue-board.mjs
@@ -244,6 +244,21 @@ function formatGh(args) {
   return `gh ${args.map((arg) => quoteArg(String(arg))).join(" ")}`;
 }
 
+export function githubProjectScopeHint(stderr) {
+  if (
+    !/(?:requires one of the following|required) scopes?[\s\S]{0,240}\b(?:read:project|project)\b/i.test(
+      String(stderr),
+    )
+  ) {
+    return "";
+  }
+  return [
+    "GitHub Project V2 operations require the active gh credential's read/write `project` scope.",
+    "Refresh it with: gh auth refresh -h github.com -s project",
+    "`read:project` alone can query a project but cannot run claim, review, or sync mutations.",
+  ].join("\n");
+}
+
 function runGh(args, { dryRun = false, mutates = false } = {}) {
   if (dryRun && mutates) {
     process.stderr.write(`[dry-run] ${formatGh(args)}\n`);
@@ -295,9 +310,10 @@ function runGh(args, { dryRun = false, mutates = false } = {}) {
     child.on("close", (status) => {
       if (failed) return;
       if (status !== 0) {
+        const scopeHint = githubProjectScopeHint(stderr);
         reject(
           new Error(
-            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
+            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}${scopeHint ? `\n${scopeHint}\n` : ""}`,
           ),
         );
         return;

--- a/scripts/agent-issue-board.test.mjs
+++ b/scripts/agent-issue-board.test.mjs
@@ -2,6 +2,7 @@
 import {
   buildClaimComment,
   chooseUntriedCandidate,
+  githubProjectScopeHint,
   isClaimable,
   isReleasable,
   isRecoverableClaimRaceError,
@@ -75,6 +76,38 @@ test("parses repeated, comma-separated, and URL issue references", () => {
       "https://github.com/mento-protocol/monitoring-monorepo/issues/904",
     ]),
     [901, 902, 903, 904],
+  );
+});
+
+test("project scope failures name the read-write gh refresh command", () => {
+  const hint = githubProjectScopeHint(
+    "The 'projectV2' field requires one of the following scopes: ['read:project']",
+  );
+  assert(
+    hint.includes("gh auth refresh -h github.com -s project"),
+    "missing refresh command",
+  );
+  assert(
+    hint.includes("`read:project` alone"),
+    "missing read-only scope warning",
+  );
+});
+
+test("project mutation scope failures receive the same guidance", () => {
+  assert(
+    githubProjectScopeHint(
+      "This mutation requires one of the following scopes: ['project']",
+    ).includes("read/write `project` scope"),
+    "missing mutation scope guidance",
+  );
+});
+
+test("unrelated gh failures do not receive project scope guidance", () => {
+  assertEqual(
+    githubProjectScopeHint(
+      "error connecting to api.github.com; check your internet connection",
+    ),
+    "",
   );
 });
 

--- a/scripts/agent-issue-board.test.mjs
+++ b/scripts/agent-issue-board.test.mjs
@@ -102,6 +102,33 @@ test("project mutation scope failures receive the same guidance", () => {
   );
 });
 
+test("project scope hints ignore scopes that are only granted", () => {
+  assertEqual(
+    githubProjectScopeHint(
+      "The 'repository' field requires one of the following scopes: ['repo']\nThe active token has scopes: ['read:project']",
+    ),
+    "",
+  );
+});
+
+test("environment-provided credentials receive replacement guidance", () => {
+  const stderr =
+    "The 'projectV2' field requires one of the following scopes: ['read:project']";
+  for (const env of [{ GH_TOKEN: "token" }, { GITHUB_TOKEN: "token" }]) {
+    const hint = githubProjectScopeHint(stderr, env);
+    assert(
+      hint.includes(
+        "Replace the environment-provided GH_TOKEN or GITHUB_TOKEN",
+      ),
+      "missing environment credential guidance",
+    );
+    assert(
+      !hint.includes("gh auth refresh -h github.com -s project"),
+      "stored-credential refresh command should be omitted",
+    );
+  }
+});
+
 test("unrelated gh failures do not receive project scope guidance", () => {
   assertEqual(
     githubProjectScopeHint(

--- a/scripts/agent-issue-board.test.mjs
+++ b/scripts/agent-issue-board.test.mjs
@@ -82,6 +82,7 @@ test("parses repeated, comma-separated, and URL issue references", () => {
 test("project scope failures name the read-write gh refresh command", () => {
   const hint = githubProjectScopeHint(
     "The 'projectV2' field requires one of the following scopes: ['read:project']",
+    {},
   );
   assert(
     hint.includes("gh auth refresh -h github.com -s project"),
@@ -97,6 +98,7 @@ test("project mutation scope failures receive the same guidance", () => {
   assert(
     githubProjectScopeHint(
       "This mutation requires one of the following scopes: ['project']",
+      {},
     ).includes("read/write `project` scope"),
     "missing mutation scope guidance",
   );


### PR DESCRIPTION
## The Problem

- Missing GitHub Project V2 scopes currently surface as a long raw GraphQL error.
- The read-only `read:project` scope sounds sufficient even though claim, review, and sync paths also mutate Project #12.

## The Solution

- Detect GitHub's missing project-scope response and append credential-specific guidance while preserving unrelated `gh` errors.

## Details

- Matches `project` only inside GitHub's bracketed required-scope list, avoiding granted-scope false positives.
- Recommends `gh auth refresh -h github.com -s project` for stored `gh` credentials.
- Tells `GH_TOKEN`/`GITHUB_TOKEN` users to replace the environment-provided token because `gh auth refresh` cannot update it.
- Keeps the raw GitHub error intact for diagnosis.
- Audited `AGENTS.md`, `README.md`, `docs/**`, and `scripts/AGENTS.md`; no canonical Project V2 scope guidance needed an update.

## Validation

- `pnpm agent:quality-gate --run` — targeted Trunk checks, `pnpm lint:scripts`, `pnpm issue:board:test`, and `pnpm tf:test` passed on the final head.
- `GH_TOKEN=ambient-test GITHUB_TOKEN=ambient-test pnpm issue:board:test` — 24/24 passed.
- Prepared-bundle fresh-context autoreview — 3 semantic passes across 2 review-fix cycles; 1 test-isolation finding accepted and fixed; final pass clean at `fc6aa972`.
- Deterministic local autoreview — final branch clean.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this changes diagnostic guidance only.