### PR TITLE
docs: correct peg drain bound calculation

### DIFF
--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -211,14 +211,16 @@ double-count it. A static pool-reserve snapshot caps loss only when every
 enabled strategy proves unavailable during the response interval.
 
 For each sequentially reachable swap, call
-`FPMM.getAmountOut(portion, monitoredToken)` from the modeled state. Advance
-pool, limit, and strategy state after every successful swap or rebalance. The
-quote already applies the total fee; do not subtract `F` a second time. Define
-loss as **net** quote-asset outflow across a documented protected-system
-boundary: include quote inputs and outputs, mint/burn, and actual strategy
-transfers. Do not use a gross output sum. The model must place flows across the
-relevant window boundaries and cannot replace a sequence with one oversized
-swap when reserves or a strategy can change state.
+`FPMM.getAmountOut(amountIn, tokenIn)` from the modeled state, using that
+transition's actual input amount and token. A monitored-to-quote leg uses the
+monitored token; a reverse leg uses the quote token. Advance pool, limit, and
+strategy state after every successful swap or rebalance. The quote already
+applies the total fee; do not subtract `F` a second time. Define loss as
+**net** quote-asset outflow across a documented protected-system boundary:
+include quote inputs and outputs, mint/burn, and actual strategy transfers. Do
+not use a gross output sum. The model must place flows across the relevant
+window boundaries and cannot replace a sequence with one oversized swap when
+reserves or a strategy can change state.
 
 Record the calls or deterministic calculation. If an exact quote cannot be
 reproduced, use the manual par purchase value plus a documented conservative

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -190,12 +190,12 @@ rebalance, incentive-bearing transfer, or rate transition can leave the system
 at the same or lower signed netflow with more accumulated net quote-asset loss
 than the monotone path, or a bounded bidirectional sequential state model.
 That model must start from every reachable pre-incident **Live** state, not
-only the pin, and maximize loss across mutable pool reserve, rate, limit,
+only the pin, and maximize loss across mutable pool reserve, rate, fee, limit,
 enabled strategy, cooldown, and source-liquidity state. If a mutable state can
 leave the modeled envelope without enforced fail-closed revocation or
 reapproval, maximize across its reachable range or keep the asset **Blocked**.
-Without that proof or model, or with a positive effective rebate, mark the
-asset **Blocked**.
+Without that proof or model, or with a positive effective rebate, mark the asset
+**Blocked**.
 
 At the pin, enumerate every enabled strategy from
 `LiquidityStrategyUpdated` history through that block; do not rely on one
@@ -232,8 +232,13 @@ worst_case_net_quote_outflow(sequential state model) <= B
 
 The accountable treasury/risk owner must supply and approve `B`. Monitoring
 engineers must not derive it from current TVL, trading limits, or intuition.
-Recalculate after any signer-SLA, Safe, fee, pool, rate, reserve-access, or
-trading-limit change.
+Persistent **Live** admission is a fail-closed certificate over the approved
+Safe and signer coverage, escalation route, execution proof, `S`, `B`, and
+modeled on-chain state ranges. Give every human attestation an explicit expiry.
+Before serving **Live**, require every certificate input to remain within its
+approved range and every attestation to remain current; otherwise serve
+**Blocked** until reapproval repeats the pinned reads and loss calculation. If
+that validity check cannot be enforced, onboarding remains **Blocked**.
 
 ## 6. Roll out the first activation producer-first
 

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -141,34 +141,29 @@ Read every trading-limit input live at one pinned block and record:
   `ERC20.decimals()` read; require an exact match or mark the asset **Blocked**;
 - positive enforced L0 and L1 limits in TradingLimitsV2's 15-decimal internal
   scale, converted to token units;
-- each window duration and current `netflow` and `lastUpdated` state;
+- each window duration and pinned `netflow` and `lastUpdated` state for
+  incident-specific diagnostics;
 - pool reserves, manual rate, fee parameters, and the exact quote method;
 - the approved end-to-end signer response SLA `S`; and
 - the treasury/risk-approved survivable quote-asset loss budget `B`.
 
-For each positive enforced window `i`, keep the limit `L_i` and the signed
-`netflow` value `n_i` in TradingLimitsV2's fixed-15 internal scale.
-`D_net(S)` is a bound on this fee-adjusted netflow, not a raw monitored-token
-amount. Let `W_i` be the window duration and evaluate its state at the pinned
-incident start time `t`:
+For persistent **Live** admission, prove the TradingLimitsV2 contract invariant
+`-L_i <= n_i <= L_i` for every positive enforced window `i`; otherwise mark the
+asset **Blocked**. Keep `L_i`, `n_i`, and window duration `W_i` in the contract's
+fixed-15 internal scale. `D_net(S)` is a bound on fee-adjusted netflow, not a
+raw monitored-token amount:
 
 ```text
-active_i = t <= lastUpdated_i + W_i
-R_i = max(0, L_i - n_i)       when active_i
-R_i = L_i                     when not active_i
-D_i(S) = R_i + L_i * ceil(S / W_i)
-D_net(S) = min(D_i(S) for every positive enforced window i)
+D_live,i(S) = 2L_i + L_i * ceil(S / W_i)
+D_net(S) = min(D_live,i(S) for every positive enforced window i)
 ```
 
-An active negative netflow increases the first partial-window capacity; for
-example, `n_i = -L_i` leaves `2L_i`. An expired window has `L_i` available
-because TradingLimitsV2 resets it on the next nonzero flow. The following full
-windows cover a boundary immediately after the incident begins. At equality,
-the old window remains active; reset requires strict expiry. If the pinned
-`netflow` or timestamp is unavailable or cannot be trusted, use
-`2L_i + L_i * ceil(S / W_i)` for that window instead. Disabled zero-valued
-windows do not constrain the minimum. If no positive limit is enforced,
-onboarding fails.
+`2L_i` covers the reachable active state `n_i = -L_i`; the ceiling term covers
+a reset immediately after the incident begins. At equality the old window is
+still active, and reset requires strict expiry. Pinned `n_i` and timestamps can
+support incident-specific diagnostics, but must never reduce persistent
+admission capacity. Disabled zero-valued windows do not constrain the minimum.
+If no positive limit is enforced, onboarding fails.
 
 Read both fees at the same pin and set `F = lpFee + protocolFee` in basis
 points. Require `0 <= F < Q`, use `C = D_net(S)`, `Q = 10,000`, and use only
@@ -193,9 +188,14 @@ Signed netflow permits counterflows to reopen capacity. Before relying on a
 monotone bound, require either a proof that no reachable reverse swap,
 rebalance, incentive-bearing transfer, or rate transition can leave the system
 at the same or lower signed netflow with more accumulated net quote-asset loss
-than the monotone path, or an exhaustive bounded bidirectional state-machine
-model covering limit resets and cooldowns. Without that proof or model, or
-with a positive effective rebate, mark the asset **Blocked**.
+than the monotone path, or a bounded bidirectional sequential state model.
+That model must start from every reachable pre-incident **Live** state, not
+only the pin, and maximize loss across mutable pool reserve, rate, limit,
+enabled strategy, cooldown, and source-liquidity state. If a mutable state can
+leave the modeled envelope without enforced fail-closed revocation or
+reapproval, maximize across its reachable range or keep the asset **Blocked**.
+Without that proof or model, or with a positive effective rebate, mark the
+asset **Blocked**.
 
 At the pin, enumerate every enabled strategy from
 `LiquidityStrategyUpdated` history through that block; do not rely on one

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -165,6 +165,16 @@ support incident-specific diagnostics, but must never reduce persistent
 admission capacity. Disabled zero-valued windows do not constrain the minimum.
 If no positive limit is enforced, onboarding fails.
 
+`D_net(S)`, `A_max`, and `G_mono` bound only cumulative fee-adjusted FPMM swap
+netflow. `FPMM.swap` applies TradingLimitsV2, while `FPMM.rebalance` does not.
+Never use these values as a whole-system quote-asset loss cap. An Open strategy
+contraction can transfer the debt token from the pool to its permissionless
+caller, and a Reserve strategy expansion can mint the debt token into the pool.
+Model each strategy rebalance as a separate transition and include its actual
+protected-boundary transfers, even when its configured incentive is zero. A
+strategy being unreachable at the pin because of its price threshold is a
+pinned diagnostic, not a durable exclusion.
+
 Read both fees at the same pin and set `F = lpFee + protocolFee` in basis
 points. Require `0 <= F < Q`, use `C = D_net(S)`, `Q = 10,000`, and use only
 the verified `d_FPMM` as `d`; never convert capacity through decimal floats or
@@ -196,6 +206,12 @@ leave the modeled envelope without enforced fail-closed revocation or
 reapproval, maximize across its reachable range or keep the asset **Blocked**.
 Without that proof or model, or with a positive effective rebate, mark the asset
 **Blocked**.
+
+Bind either an enforced no-change or no-arbitrage rate condition while trading
+remains bidirectional, or an enforced maximum number of successful rate
+transitions during `S`. Without one, alternating tradable rates plus signed
+counterflows can accumulate quote-asset loss while returning netflow to the same
+state.
 
 At the pin, enumerate every enabled strategy from
 `LiquidityStrategyUpdated` history through that block; do not rely on one

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -136,7 +136,9 @@ delivery time alone.
 
 Read every trading-limit input live at one pinned block and record:
 
-- monitored-token decimals;
+- `d_FPMM` from
+  `FPMM.getTradingLimits(monitoredToken).config.decimals`, plus an independent
+  `ERC20.decimals()` read; require an exact match or mark the asset **Blocked**;
 - positive enforced L0 and L1 limits in TradingLimitsV2's 15-decimal internal
   scale, converted to token units;
 - each window duration and current `netflow` and `lastUpdated` state;
@@ -169,40 +171,61 @@ windows do not constrain the minimum. If no positive limit is enforced,
 onboarding fails.
 
 Read both fees at the same pin and set `F = lpFee + protocolFee` in basis
-points. Require `0 <= F < Q`. For `C = D_net(S)`, monitored-token decimals
-`d`, and `Q = 10,000`, calculate the largest raw token input whose fee-adjusted
-fixed-15 netflow does not exceed `C` with integer arithmetic:
+points. Require `0 <= F < Q`, use `C = D_net(S)`, `Q = 10,000`, and use only
+the verified `d_FPMM` as `d`; never convert capacity through decimal floats or
+apply the fee before fixed-15 scaling.
+
+For `d <= 15`, calculate:
 
 ```text
 A_max = floor(C * Q / (Q - F))
-G_raw = ceil((A_max + 1) * 10^d / 10^15) - 1
-
-scale(x, d) = floor(x * 10^15 / 10^d)
-scale(G_raw, d) - floor(scale(G_raw, d) * F / Q) <= C
+G_mono = floor(A_max / 10^(15 - d))
 ```
 
-`G_raw` is the exact conservative gross-up for the contract's order of
-operations, including tokens with more than 15 decimals. Do not convert the
-capacity through decimal floats or apply the fee before fixed-15 scaling.
+`G_mono` bounds monotone monitored-token inflow only. For `d > 15`, default to
+**Blocked**. An exception needs a reviewed, independently enforceable bound
+`N` on successful calls that covers every swap during `S`, including zero-netflow
+and batched calls. With `k = 10^(d - 15)`, calculate
+`G_N = k * A_max + N * (k - 1)`. Do not quote `G_N` as one swap; model every
+successful transition sequentially.
 
-Quote each sequentially reachable portion of `G_raw` with
-`FPMM.getAmountOut(portion, monitoredToken)`, starting from the pinned state
-and advancing the modeled reserve and rebalance state after each portion. The
-quote already applies the total fee; do not subtract `F` a second time. The
-model must place flows across the relevant window boundaries and cannot replace
-a sequence with one oversized swap when a reserve or rebalance strategy can
-change state.
-Sum the quote-asset outputs. A static pool-reserve snapshot can cap loss only
-when every enabled liquidity or reserve strategy is proved unable to make that
-liquidity available during the response interval. A Reserve strategy can
-replenish or mint debt assets, so static reserves alone do not cap loss.
+Signed netflow permits counterflows to reopen capacity. Before relying on a
+monotone bound, require either a proof that no reachable reverse swap,
+rebalance, incentive-bearing transfer, or rate transition can leave the system
+at the same or lower signed netflow with more accumulated net quote-asset loss
+than the monotone path, or an exhaustive bounded bidirectional state-machine
+model covering limit resets and cooldowns. Without that proof or model, or
+with a positive effective rebate, mark the asset **Blocked**.
+
+At the pin, enumerate every enabled strategy from
+`LiquidityStrategyUpdated` history through that block; do not rely on one
+`rebalancerAddress`.
+For each strategy, record the per-pool
+`liquiditySourceIncentiveExpansion`, `liquiditySourceIncentiveContraction`,
+`protocolIncentiveExpansion`, `protocolIncentiveContraction`,
+`protocolFeeRecipient`, cooldown, reachability, source liquidity, and actual
+transfers. Mark the asset **Blocked** if any strategy cannot be conservatively
+reproduced. `FPMM.rebalanceIncentive` is an exchange-rate discount/tolerance,
+not a separate payout: model its effect through actual transfers and never
+double-count it. A static pool-reserve snapshot caps loss only when every
+enabled strategy proves unavailable during the response interval.
+
+For each sequentially reachable swap, call
+`FPMM.getAmountOut(portion, monitoredToken)` from the modeled state. Advance
+pool, limit, and strategy state after every successful swap or rebalance. The
+quote already applies the total fee; do not subtract `F` a second time. Define
+loss as **net** quote-asset outflow across a documented protected-system
+boundary: include quote inputs and outputs, mint/burn, and actual strategy
+transfers. Do not use a gross output sum. The model must place flows across the
+relevant window boundaries and cannot replace a sequence with one oversized
+swap when reserves or a strategy can change state.
 
 Record the calls or deterministic calculation. If an exact quote cannot be
 reproduced, use the manual par purchase value plus a documented conservative
 margin and keep the limitation explicit. The gate passes only when:
 
 ```text
-worst_case_quote_outflow(G_raw, sequential state model) <= B
+worst_case_net_quote_outflow(sequential state model) <= B
 ```
 
 The accountable treasury/risk owner must supply and approve `B`. Monitoring

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -3,7 +3,7 @@ title: Peg monitoring onboarding and re-census
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 doc_type: runbook
 scope: metrics-bridge / alerts / ui-dashboard
 review_interval_days: 90
@@ -144,28 +144,65 @@ Read every trading-limit input live at one pinned block and record:
 - the approved end-to-end signer response SLA `S`; and
 - the treasury/risk-approved survivable quote-asset loss budget `B`.
 
-For each positive enforced window `i` with token limit `L_i` and duration
-`W_i`, calculate the conservative unknown-boundary token-inflow bound:
+For each positive enforced window `i`, keep the limit `L_i` and the signed
+`netflow` value `n_i` in TradingLimitsV2's fixed-15 internal scale.
+`D_net(S)` is a bound on this fee-adjusted netflow, not a raw monitored-token
+amount. Let `W_i` be the window duration and evaluate its state at the pinned
+incident start time `t`:
 
 ```text
-D_i(S) = L_i * (ceil(S / W_i) + 1)
-D_token(S) = min(D_i(S) for every positive enforced window i)
+active_i = t <= lastUpdated_i + W_i
+R_i = max(0, L_i - n_i)       when active_i
+R_i = L_i                     when not active_i
+D_i(S) = R_i + L_i * ceil(S / W_i)
+D_net(S) = min(D_i(S) for every positive enforced window i)
 ```
 
-The extra window is mandatory because an incident can begin immediately before
-a lazy window reset and consume capacity on both sides of the boundary.
-Disabled zero-valued windows do not constrain the minimum. If no positive
-limit is enforced, onboarding fails.
+An active negative netflow increases the first partial-window capacity; for
+example, `n_i = -L_i` leaves `2L_i`. An expired window has `L_i` available
+because TradingLimitsV2 resets it on the next nonzero flow. The following full
+windows cover a boundary immediately after the incident begins. At equality,
+the old window remains active; reset requires strict expiry. If the pinned
+`netflow` or timestamp is unavailable or cannot be trusted, use
+`2L_i + L_i * ceil(S / W_i)` for that window instead. Disabled zero-valued
+windows do not constrain the minimum. If no positive limit is enforced,
+onboarding fails.
 
-Convert `D_token(S)` into quote-asset outflow with the deployed pool's exact
-pricing and fee logic at the pinned block. Record the call or deterministic
-calculation and cap only at liquidity that is provably unavailable to the
-drain. If an exact quote cannot be reproduced, use the manual par purchase
-value plus a documented conservative margin and keep the limitation explicit.
-The gate passes only when:
+Read both fees at the same pin and set `F = lpFee + protocolFee` in basis
+points. Require `0 <= F < Q`. For `C = D_net(S)`, monitored-token decimals
+`d`, and `Q = 10,000`, calculate the largest raw token input whose fee-adjusted
+fixed-15 netflow does not exceed `C` with integer arithmetic:
 
 ```text
-worst_case_quote_outflow(D_token(S)) <= B
+A_max = floor(C * Q / (Q - F))
+G_raw = ceil((A_max + 1) * 10^d / 10^15) - 1
+
+scale(x, d) = floor(x * 10^15 / 10^d)
+scale(G_raw, d) - floor(scale(G_raw, d) * F / Q) <= C
+```
+
+`G_raw` is the exact conservative gross-up for the contract's order of
+operations, including tokens with more than 15 decimals. Do not convert the
+capacity through decimal floats or apply the fee before fixed-15 scaling.
+
+Quote each sequentially reachable portion of `G_raw` with
+`FPMM.getAmountOut(portion, monitoredToken)`, starting from the pinned state
+and advancing the modeled reserve and rebalance state after each portion. The
+quote already applies the total fee; do not subtract `F` a second time. The
+model must place flows across the relevant window boundaries and cannot replace
+a sequence with one oversized swap when a reserve or rebalance strategy can
+change state.
+Sum the quote-asset outputs. A static pool-reserve snapshot can cap loss only
+when every enabled liquidity or reserve strategy is proved unable to make that
+liquidity available during the response interval. A Reserve strategy can
+replenish or mint debt assets, so static reserves alone do not cap loss.
+
+Record the calls or deterministic calculation. If an exact quote cannot be
+reproduced, use the manual par purchase value plus a documented conservative
+margin and keep the limitation explicit. The gate passes only when:
+
+```text
+worst_case_quote_outflow(G_raw, sequential state model) <= B
 ```
 
 The accountable treasury/risk owner must supply and approve `B`. Monitoring


### PR DESCRIPTION
## The Problem

- TradingLimitsV2 caps fee-adjusted signed netflow, so counterflows can reopen capacity and a monotone gross-input bound is not always sufficient.
- Per-call fixed-15 rounding makes high-decimal tokens unsafe without an independently enforced swap-count bound.
- A pinned state can become stale while an asset remains Live, and pool reserves alone do not bound loss when strategies can replenish liquidity.

## The Solution

- Use the worst reachable starting netflow for persistent Live admission, then model every reachable bidirectional swap, rebalance, fee, rate, and strategy transition.
- Measure net quote-asset outflow across a documented system boundary and keep Live fail closed when an approved input changes or expires.

## Details

- Uses `2L + L * ceil(S / W)` for the durable per-window capacity envelope; pinned state remains diagnostic only.
- Uses `G_mono` only for tokens with at most 15 decimals and monotone inflow.
- Blocks tokens with more than 15 decimals unless an independently enforceable bound covers every successful call, including zero-netflow and batched calls.
- States that TradingLimitsV2 bounds swaps only; strategy rebalances remain separate protected-boundary transitions.
- Binds either a no-change/no-arbitrage rate condition or a maximum rate-transition count during `S`.
- Models every enabled strategy and treats `FPMM.rebalanceIncentive` through actual exchange transfers so it is not double-counted.
- Makes Live an expiring certificate over Safe and signer evidence, `S`, `B`, and the modeled on-chain state ranges.

Refs #1687.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed.
- Fresh-context prepared-bundle autoreview — ALL CLEAR, confidence `0.91`.
- Pre-review and post-review bundle manifest verification — `3b2976802dcd02736e9e4b5ee5b0dcbf7f30378790787aa68a7b6944fff2d46b`.

## Ship Checklist

- [x] ship workflow used
- [x] mapped local gate passed
- [x] fresh-context autoreview passed
- [x] PR readiness probe planned
