### PR TITLE
docs: separate operator contracts from runtime-trust background

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -196,6 +196,10 @@ Authority: canonical
 - [`README.md`](../README.md)
 - [`SPEC.md`](../SPEC.md)
 
+Authority: non-canonical
+
+- [`docs/notes/autoreview-runtime-trust.md`](notes/autoreview-runtime-trust.md)
+
 ## notes-plans-archive
 
 Authority: canonical

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -225,142 +225,32 @@ fresh-context reviewer must inspect every listed pass so cross-pass contracts
 remain visible. Direct Codex or Claude execution fails closed instead of
 launching independent semantic passes, and bundle preparation fails if the full
 review cannot fit the bounded pass budget.
-The direct helper and prepared-bundle adapter enforce one cumulative input
-budget while capturing diffs, untracked files, checklists, and feedback, before
-those bytes can accumulate in memory or staging sidecars.
-For a real review, the helper resolves a symbolic branch base or commit target
-once to an immutable object ID. Direct `--dry-run` instead reports the requested
-ref without resolving or freezing it. Source fingerprints cover the symbolic
-branch or detached state, `HEAD`, and staged/unstaged bytes. They include
-untracked file or symlink state only when local working-tree content is part of
-the selected target (`local` or the adapter's branch-local target); explicit
-branch and commit snapshots ignore unrelated untracked files. The repo adapter
-first brackets target selection with a lightweight `HEAD`/branch/status
-fingerprint, so concurrent dirty-state or checkout changes still fail closed
-without reading untracked file contents. After the target is frozen, explicit
-branch and commit reviews use only the target-scoped source fingerprint, so
-unrelated untracked churn cannot invalidate them; automatic mode retains the
-status guard because its selected target depends on clean/dirty state. Every
-Git path collection uses NUL-delimited output, so enumeration does not depend
-on Git quoting or newline splitting. Because the published changed-path and
-prompt metadata are line-oriented, paths containing tabs or line breaks are
-rejected before review; rename such a path before running autoreview. The
-adapter also resolves `origin/main^{commit}` once to an independently protected
-baseline and sources checklist policy only from that pinned object ID in every
-target mode.
-Checklist edits in a local target, PR-selected base, current head, or selected
-commit stay visible as diff evidence but cannot rewrite the policy used to
-review themselves. The adapter also
-requires the current shell adapter's bytes and executable mode to match frozen
-`HEAD`. In every target mode it requires the shell, MJS helper, and core at that
-frozen `HEAD` to match the pinned protected-main object, then executes MJS files
-materialized from that protected object instead of a PR-selected base or
-mutable worktree. Commit mode also requires the selected commit's executable
-runtime to match the protected baseline. Local and branch-local prepared
-bundles require helper/core worktree bytes to match frozen `HEAD`. Any dirty or
-committed runtime change fails closed and must be reviewed from a separate
-trusted checkout with an explicit compatible `AUTOREVIEW_HELPER`. Direct
-default-helper execution in the owning checkout uses the same frozen-HEAD and
-protected-main checks and materialized MJS runtime. Wrapper-owned Node launches,
-including executable discovery and validation helpers, discard `NODE_OPTIONS`
-and `NODE_PATH`, plus dynamic-loader and interpreter startup-injection
-variables, so ambient hooks cannot run before the pinned helper. An explicit
-helper from a separate checkout remains an explicit trust decision. The adapter
-also requires the physical checkout root to match Git's top level, removes
-reviewed-repo directories from its executable search path, and runs bare shell
-utilities from the system path. Direct Git, Node, GitHub CLI, and semantic-engine
-executables and every canonical ancestor must be owned by the current user or
-root and must not be group/other-writable. On Darwin, Homebrew-style paths that
-fail only that ancestry rule are accepted solely through sealed private
-snapshots of native Mach-O executables whose linked-library closure is entirely
-system-only. On Linux, and only for a root-run wrapper, an otherwise
-path-untrusted Node may be recovered only when its inode matches a live wrapper
-ancestor across an uninterrupted all-root UID chain; this includes root- or
-foreign-owned writable/hard-linked toolcache layouts, while set-ID semantics
-remain forbidden. Direct helper invocation receives no runtime exception. The
-wrapper copies bytes from the bound `/proc/<pid>/exe` descriptor into a
-root-owned `0500`, single-link snapshot, then re-hashes both the ancestor and
-candidate descriptors before launch. Bounded ELF parsing
-rejects unsafe interpreters, RPATH/RUNPATH and loader-injection tags, and
-path-qualified dependencies. The glibc-only fallback recursively resolves every
-static `DT_NEEDED` name to a root-owned, non-writable target, publishes those
-names through a private `0700` alias directory, and launches with that exact
-controlled `LD_LIBRARY_PATH`; `/etc/ld.so.preload` must remain absent. The
-helper reproduces the wrapper-sealed loader path/symlink/stat/content
-fingerprint and validates the handed-off current snapshot, sealed manifest,
-loader, alias names, targets, and ancestry before and after semantic-engine
-launches. This exception trusts the
-UID-0 wrapper/runtime and covers the static startup closure, not later
-application-level `dlopen`, provider, or plugin loads. Scripts and native
-executables with relative or non-system library closure fail closed. Node
-discovery never executes a version-manager
-shim: Volta is queried through a sealed native `volta which node`, and the
-returned Node path is revalidated before launch. Git invocations ignore
-inherited repository-routing variables such as `GIT_DIR` and
-`GIT_WORK_TREE`.
 
-The required `autoreview-root-runtime` CI job is the focused Linux/root proof.
-It selects the repository's Node version through Blacksmith's x64
-`/opt/hostedtoolcache` layout, launches that exact runtime through `sudo` and a
-minimal `env -i`, and requires the target-guard suite to observe the sealed
-snapshot rather than silently taking the ordinary trusted-path branch. The job
-does not install workspace dependencies or run the full autoreview suite. Its
-test-only diagnostic switch retains only the deepest allowlisted trust stage,
-prints that one stage if Node resolution fails, and is unset before the helper
-or semantic engine starts; normal invocations keep the generic trusted-Node
-error.
+Because the published changed-path and prompt metadata are line-oriented, paths
+containing tabs or line breaks are rejected before review; rename such a path
+before running autoreview.
 
-Prepared repo-context bundles apply the same target-scoped
-before/after fingerprint while every artifact remains in an adjacent ephemeral
-directory. The destination parent's canonical inode and the freshly created
-staging directory's `dev:ino` are pinned before content generation. After
-the wrapper stages its evidence, it manifests that evidence before and after
-the helper runs, excluding only the helper-owned prompt and metadata outputs.
-After prompt validation, the adapter also hashes the complete staged evidence
-before and after the final helper source-fingerprint call. It rejects symlinks,
-special files, externally linked regular files, and any identity or content
-change. The
-validated Node runtime exclusively reserves the destination, rechecks the
-staging identity throughout transfer, and verifies the same manifest after
-transfer and again immediately before hard-linking
-`.agent-autoreview-complete` last. That marker contains the manifest digest;
-`pnpm agent:autoreview --verify-bundle-dir <dir>` reopens every file without
-following symlinks and checks the marker plus manifest. Run it immediately
-before reading every pass and retain its printed digest outside the bundle;
-after review, pass that digest back with
-`--expected-bundle-manifest <retained-digest>` so replacing the bundle and its
-marker cannot reset the second check. A destination created during the final
-race window is never replaced; an interrupted or unverified bundle must not be
-reviewed. Failures before an explicit helper runs, plus failures from the
-wrapper-attested default helper runtime, receive pinned-identity cleanup. The
-adapter atomically moves the candidate into a random adjacent quarantine, opens
-the moved directory without following symlinks, verifies its recorded
-`dev:ino`, and pins that inode with `fchdir` before recursive deletion. Later
-pathname cleanup is non-recursive and fails closed on identity drift. Once an
-explicit `AUTOREVIEW_HELPER` has run, however, the adapter retains failed
-staging without recursive deletion: an unattested helper may leave a same-UID
-writer that can substitute child directories even beneath a descriptor-pinned
-root. Canonical secret-scan failures use the attested helper and therefore do
-not leave raw diff sidecars behind. It cleans up its private marker while its
-inode still
-matches, but never recursively deletes a failed destination reservation;
-inspect and remove an incomplete, unmarked destination before retrying. The
-mutable repo helper is not re-entered for publication. The published
-`helper-output.txt` reports the final prompt/pass paths, never the discarded
-staging directory. A detached producing wrapper can verify the bundle from a
-non-Git working directory. On macOS, preparation, publication, and verification
-also reject write-granting extended ACLs on every canonical parent ancestor and
-bundle entry; those ACL checks bracket evidence hashing.
-Prepared bundles reject `--dry-run`: publication requires completed content
-validation and the main prompt plus every strictly ordered, deterministic
-indexed bounded pass. Prompt-index validation normalizes a UTF-8 BOM, CRLF line
-endings, and leading blank lines before applying the strict pass-order and
-companion-file checks, and rejects any undeclared extra pass file.
-Direct `--bundle-output` publication uses an exclusive same-directory link and
-refuses to replace any existing destination, including a file created during
-the final publication race window. A failed multi-pass write therefore cannot
-corrupt a previously valid index and its companions. Use a fresh output path or
-deliberately remove the old set first.
+Autoreview runs the review in an isolated, credential-stripped workspace: the
+helper and core runtime are pinned to protected `main`, evidence capture is
+bounded and fail-closed, prepared bundles are identity- and manifest-checked,
+and sensitive inputs are rejected before they reach a semantic engine. Every one
+of those checks fails closed, and none of them is a knob. Operators need only
+the invocation contract in this runbook; the defenses themselves are background
+in [`autoreview-runtime-trust.md`](autoreview-runtime-trust.md).
+
+One consequence reaches the invocation contract: a dirty or committed change to
+the autoreview runtime itself fails closed and must be reviewed from a separate
+trusted checkout with an explicit compatible `AUTOREVIEW_HELPER`, using the
+procedure below.
+
+An interrupted or unverified prepared bundle must not be reviewed. A failed
+destination reservation is never recursively deleted, so inspect and remove an
+incomplete, unmarked destination before retrying. Prepared bundles also reject
+`--dry-run`: publication requires completed content validation, the main prompt,
+and every strictly ordered, deterministic indexed bounded pass. Direct
+`--bundle-output` publication refuses to replace an existing destination, so a
+failed multi-pass write cannot corrupt a previously valid index — use a fresh
+output path or deliberately remove the old set first.
 
 When `--base` is omitted, automatic PR-base lookup falls back to `origin/main`
 only when GitHub CLI is absent or the lookup confirms zero matching PRs.
@@ -373,62 +263,16 @@ preventing a same-named branch in a fork from selecting the wrong PR. Pass
 `--base` explicitly as the offline escape hatch.
 When prepared-bundle feedback selection is `auto`, the adapter resolves the
 unique PR base, number, and canonical repository slug together and reuses that
-one GitHub snapshot for the frozen diff and `feedback-state.json`. It
-materializes the feedback-state Node runtime from the same pinned protected-main
-object ID used for checklist policy, never from the PR-selected base, current
-`HEAD`, or a selected commit's parent. Prepared-bundle generation fails closed
-when that protected baseline is unavailable; feedback capture also fails when
-its bounded regular runtime blobs are unavailable. It executes the pinned
-runtime directly from the repo root with frozen canonical `--repo` routing; no
-reviewed package script or pnpm lifecycle runs. Missing GitHub CLI, zero or
-multiple matches, and malformed metadata fail closed. Before publication it
-also verifies that the feedback ledger still names that PR, base branch, current
-head branch, and frozen head object ID.
+one GitHub snapshot for the frozen diff and `feedback-state.json`. Missing
+GitHub CLI, zero or multiple matches, and malformed metadata fail closed.
 An explicit `--base` therefore requires an explicit `--feedback-pr` number
 instead of `auto`. Commit-mode reviews also require an explicit feedback PR
 number because the current branch's automatic PR cannot prove membership for an
 arbitrary selected commit.
 
-Semantic Codex and Claude passes run from an empty temporary workspace with
-repo/project instructions, hooks, plugins, and inherited environment restricted
-to the review contract. Reviewer credentials remain available only to launch
-the selected engine; repository tooling and unrelated environment state do not.
-For Claude/Bedrock this includes standard AWS web-identity and container
-credential-chain inputs. Explicit `AWS_CONFIG_FILE` and
-`AWS_SHARED_CREDENTIALS_FILE` locators opt into trusted static/profile files;
-their private snapshots reject `credential_process`. When either locator is
-absent, the helper supplies a private empty snapshot so the AWS SDK cannot fall
-back implicitly to `~/.aws/config` or `~/.aws/credentials`; users who need
-those files must set the locators explicitly. Claude's other file-valued cloud
-credential/config locators, plus `SSL_CERT_FILE` for both Claude and Codex,
-must resolve outside the reviewed repository to a root- or reviewer-owned
-regular file with no shared-write mode, unsafe non-sticky ancestry, or
-write-granting ACL. The helper opens each explicit source no-follow, revalidates
-its identity and ancestry while copying it into a private per-run `0600`
-snapshot, and passes only that snapshot to the selected engine. Snapshot files
-are removed with the engine workspace during normal completion and partial
-setup failure. On process interruption they are identity-checked and unlinked
-before the bounded process-group termination path settles, so even an escaped
-descendant holding
-reviewer pipes cannot retain a credential path or block parent termination. An
-untrusted or repo-contained source fails closed before the selected engine
-starts. Semantic autoreview rejects non-empty `SSL_CERT_DIR` because a
-directory of trust anchors loaded on demand cannot be frozen safely; unset it
-or provide a trusted external PEM bundle through snapshotted `SSL_CERT_FILE`.
-Closure of the direct engine leader triggers immediate `SIGKILL` for its
-remaining process group before tracking or escalation timers are released,
-including ordinary success and failure as well as timeout or interruption.
 Direct supplemental-evidence paths must be repo-relative, regular UTF-8 files
-confined to the worktree. The narrow trusted exceptions are adapter-generated
-feedback state and protected-main checklist copies inside its
-prepared-bundle directory. Sensitive paths,
-credential-like content, private keys, wallet recovery phrases, Stripe live
-keys, common Slack/Discord/Telegram webhook URLs, and secret-bearing URL query parameters
-fail closed before any prepared-bundle artifact is published or review input is
-sent to a semantic engine. Evidence reads reject symlinks and verify that the
-opened descriptor still identifies the file that was inspected, closing
-path-swap races. A quiet semantic reviewer emits a progress heartbeat every 60
-seconds.
+confined to the worktree. A quiet semantic reviewer emits a progress heartbeat
+every 60 seconds.
 
 Inside an active Codex sandbox, and only when no engine was selected explicitly,
 the adapter defaults to the helper's local deterministic engine because nested
@@ -439,23 +283,12 @@ Set `AUTOREVIEW_HELPER` only when intentionally testing or replacing the
 pinned repo helper with a compatible implementation of its CLI contract.
 Prepared-bundle replacements receive only the final prompt handoff and must
 support the helper's `--bundle-output`, `--bundle-output-display`, and
-`--trusted-input-root` flags. Source fingerprints and untracked-file
-serialization remain wrapper-owned operations executed by the attested helper;
-a trusted wrapper physically outside the reviewed checkout copies its sibling helper/core no-follow into the
-private command runtime and binds that snapshot to an identity plus full
-content manifest before use. The source directory is descriptor-pinned across
-both copies; its POSIX ancestry, source identities, and macOS ACLs are stable
-and non-write-granting before and after the copy. This attestation also applies
-when an explicit `AUTOREVIEW_HELPER` resolves to that external wrapper's own
-default sibling helper, as in the runtime-review command below. In the owning checkout, an explicit override is
+`--trusted-input-root` flags. In the owning checkout an explicit override is
 accepted only when the current shell wrapper matches pinned protected main and
 compatible helper/core blobs can be materialized from that same protected
 object. Otherwise the command fails closed with the separate-trusted-checkout
 instruction used for runtime-changing reviews; a wrapper nested anywhere inside
-the reviewed checkout is never treated as external. An explicit replacement cannot
-run before wrapper-owned recursive cleanup is finished. After that handoff, the wrapper performs no recursive cleanup and
-retains its command runtime plus failed staging because the replacement may
-have left a same-UID writer. The old autoreview
+the reviewed checkout is never treated as external. The old autoreview
 `--parallel-tests` path is removed: the mapped quality gate owns test execution
 and isolation.
 
@@ -503,25 +336,21 @@ Use a directory outside the repo worktree whose parent already exists so
 local-mode bundles do not include their own generated files. Every canonical
 ancestor of that parent must be owned by the current user or root; a
 group/other-writable ancestor is accepted only when its sticky bit protects
-other users' entries (for example `/tmp`), and macOS write-granting ACLs are
-always rejected. The bundle
-contains changed paths, patch files, repo-selected checklist/prompt context,
-and the helper's
-`autoreview-prompt.md`. Add
-`--feedback-pr <number>` to include the current `pr:feedback-state` ledger as a
-review dataset for feedback-fix batches. Prepared-bundle mode owns that prompt
-path, so do not combine `--prepare-bundle-dir` with `--bundle-output`.
+other users' entries (for example `/tmp`). The bundle contains changed paths,
+patch files, repo-selected checklist/prompt context, and the helper's
+`autoreview-prompt.md`. Add `--feedback-pr <number>` to include the current
+`pr:feedback-state` ledger as a review dataset for feedback-fix batches.
+Prepared-bundle mode owns that prompt path, so do not combine
+`--prepare-bundle-dir` with `--bundle-output`.
 The generated README names the exact producing wrapper in both verification
 commands; a runtime-changing review must not replace those commands with the
 reviewed checkout's package script.
 Retain the pre-review digest in reviewer state outside the bundle. After the
 fresh-context reviewer has read every bounded pass, repeat
 `--verify-bundle-dir` with that digest as `--expected-bundle-manifest`; both
-checks must pass and must name the same digest. These checks detect persistent
-drift and retain/revalidate every staged entry during each scan. They are not an
-OS-level immutable filesystem against a malicious same-UID process that can
-mutate and restore files between checks, so external helpers must leave no
-background writer behind.
+checks must pass and must name the same digest. They detect persistent drift,
+not a malicious same-UID process that can mutate and restore files between
+checks, so an external helper must leave no background writer behind.
 
 Autoreview answers whether the source bundle contains review findings. It does
 not prove CLI/API behavior, generated artifacts, deployment/runtime behavior,
@@ -592,20 +421,13 @@ does not fire and execution begins, each mapped command is skipped (printed as
 only when a stamp exists whose fingerprint and command both match this run
 exactly, and whose age is within the same two-hour TTL. Every
 other outcome — parse error, missing file, fingerprint mismatch, TTL expiry —
-fails toward rerun. Because the fingerprint includes the content hash of every
-changed file, ANY edit to a validated file invalidates every per-command stamp;
-that invalidation, plus a start-of-run prune that drops non-matching and expired
-entries, keeps the file bounded. Only
+fails toward rerun. Any edit to a validated file invalidates every per-command
+stamp, and a start-of-run prune drops non-matching and expired entries. Only
 quality/serialized/parallel commands are stamped. Prerequisite phases
 (install/codegen/quality-setup) always re-run: their outputs (node_modules,
 generated code, built packages) are invisible to the source fingerprint, so a
-stamp could skip them after their outputs were deleted. The Trunk check and
-the gate self-test are also exempt and always re-run: they validate repo/gate
-state cheaply and self-referentially. The ADR
-reminder also re-runs every time, for a mechanical reason rather than an
-exemption: its command string embeds the run's temporary changed-paths file
-path, so its stamp key never matches a prior run (fail-safe — an advisory,
-self-suppressing check that only ever over-runs).
+stamp could skip them after their outputs were deleted. The Trunk check, the
+gate self-test, and the advisory ADR reminder also always re-run.
 
 Each mapped command has a watchdog (default 900 seconds; override with
 `--command-timeout <n>` or `AGENT_QUALITY_COMMAND_TIMEOUT_SECONDS`). On timeout

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -1,0 +1,230 @@
+---
+title: Autoreview Runtime Trust Model
+status: active
+owner: eng
+canonical: false
+last_verified: 2026-07-29
+doc_type: reference
+scope: repo-wide
+review_interval_days: 180
+garden_lane: package-readmes-reference
+---
+
+# Autoreview Runtime Trust Model
+
+This note is background on the defenses `scripts/agent-autoreview*` enforces:
+which runtime may execute a review, what evidence it may capture, and how a
+prepared bundle proves it was not tampered with. Every check described here
+fails closed — one that cannot prove its property stops the review instead of
+degrading it — and none of them is an operator knob. The operator contract
+(invocation, engine selection, prepared-bundle commands, and the
+trusted-checkout procedure for runtime-changing PRs) lives in
+[`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
+
+## Input budget and target freezing
+
+The direct helper and prepared-bundle adapter enforce one cumulative input
+budget while capturing diffs, untracked files, checklists, and feedback, before
+those bytes can accumulate in memory or staging sidecars.
+
+For a real review, the helper resolves a symbolic branch base or commit target
+once to an immutable object ID. Direct `--dry-run` instead reports the requested
+ref without resolving or freezing it. Source fingerprints cover the symbolic
+branch or detached state, `HEAD`, and staged/unstaged bytes. They include
+untracked file or symlink state only when local working-tree content is part of
+the selected target (`local` or the adapter's branch-local target); explicit
+branch and commit snapshots ignore unrelated untracked files. The repo adapter
+first brackets target selection with a lightweight `HEAD`/branch/status
+fingerprint, so concurrent dirty-state or checkout changes still fail closed
+without reading untracked file contents. After the target is frozen, explicit
+branch and commit reviews use only the target-scoped source fingerprint, so
+unrelated untracked churn cannot invalidate them; automatic mode retains the
+status guard because its selected target depends on clean/dirty state. Every
+Git path collection uses NUL-delimited output, so enumeration does not depend
+on Git quoting or newline splitting.
+
+The adapter also resolves `origin/main^{commit}` once to an independently
+protected baseline and sources checklist policy only from that pinned object ID
+in every target mode. Checklist edits in a local target, PR-selected base,
+current head, or selected commit stay visible as diff evidence but cannot
+rewrite the policy used to review themselves.
+
+When prepared-bundle feedback selection is `auto`, the adapter materializes the
+feedback-state Node runtime from that same pinned protected-main object ID,
+never from the PR-selected base, current `HEAD`, or a selected commit's parent.
+Prepared-bundle generation fails closed when that protected baseline is
+unavailable; feedback capture also fails when its bounded regular runtime blobs
+are unavailable. It executes the pinned runtime directly from the repo root with
+frozen canonical `--repo` routing; no reviewed package script or pnpm lifecycle
+runs. Before publication it also verifies that the feedback ledger still names
+that PR, base branch, current head branch, and frozen head object ID.
+
+## Pinned runtime and executable ancestry
+
+The adapter requires the current shell adapter's bytes and executable mode to
+match frozen `HEAD`. In every target mode it requires the shell, MJS helper, and
+core at that frozen `HEAD` to match the pinned protected-main object, then
+executes MJS files materialized from that protected object instead of a
+PR-selected base or mutable worktree. Commit mode also requires the selected
+commit's executable runtime to match the protected baseline. Local and
+branch-local prepared bundles require helper/core worktree bytes to match frozen
+`HEAD`. Any dirty or committed runtime change fails closed and must be reviewed
+from a separate trusted checkout with an explicit compatible
+`AUTOREVIEW_HELPER`. Direct default-helper execution in the owning checkout uses
+the same frozen-`HEAD` and protected-main checks and materialized MJS runtime.
+
+Wrapper-owned Node launches, including executable discovery and validation
+helpers, discard `NODE_OPTIONS` and `NODE_PATH`, plus dynamic-loader and
+interpreter startup-injection variables, so ambient hooks cannot run before the
+pinned helper. An explicit helper from a separate checkout remains an explicit
+trust decision. The adapter also requires the physical checkout root to match
+Git's top level, removes reviewed-repo directories from its executable search
+path, and runs bare shell utilities from the system path. Direct Git, Node,
+GitHub CLI, and semantic-engine executables and every canonical ancestor must be
+owned by the current user or root and must not be group/other-writable. Node
+discovery never executes a version-manager shim: Volta is queried through a
+sealed native `volta which node`, and the returned Node path is revalidated
+before launch. Git invocations ignore inherited repository-routing variables
+such as `GIT_DIR` and `GIT_WORK_TREE`.
+
+On Darwin, Homebrew-style paths that fail only that ancestry rule are accepted
+solely through sealed private snapshots of native Mach-O executables whose
+linked-library closure is entirely system-only.
+
+## Linux root recovery, ELF validation, and loader control
+
+On Linux, and only for a root-run wrapper, an otherwise path-untrusted Node may
+be recovered only when its inode matches a live wrapper ancestor across an
+uninterrupted all-root UID chain; this includes root- or foreign-owned
+writable/hard-linked toolcache layouts, while set-ID semantics remain forbidden.
+Direct helper invocation receives no runtime exception. The wrapper copies bytes
+from the bound `/proc/<pid>/exe` descriptor into a root-owned `0500`,
+single-link snapshot, then re-hashes both the ancestor and candidate descriptors
+before launch.
+
+Bounded ELF parsing rejects unsafe interpreters, RPATH/RUNPATH and
+loader-injection tags, and path-qualified dependencies. The glibc-only fallback
+recursively resolves every static `DT_NEEDED` name to a root-owned,
+non-writable target, publishes those names through a private `0700` alias
+directory, and launches with that exact controlled `LD_LIBRARY_PATH`;
+`/etc/ld.so.preload` must remain absent. The helper reproduces the
+wrapper-sealed loader path/symlink/stat/content fingerprint and validates the
+handed-off current snapshot, sealed manifest, loader, alias names, targets, and
+ancestry before and after semantic-engine launches. This exception trusts the
+UID-0 wrapper/runtime and covers the static startup closure, not later
+application-level `dlopen`, provider, or plugin loads. Scripts and native
+executables with relative or non-system library closure fail closed.
+
+## The `autoreview-root-runtime` CI job
+
+The required `autoreview-root-runtime` CI job is the focused Linux/root proof.
+It selects the repository's Node version through Blacksmith's x64
+`/opt/hostedtoolcache` layout, launches that exact runtime through `sudo` and a
+minimal `env -i`, and requires the target-guard suite to observe the sealed
+snapshot rather than silently taking the ordinary trusted-path branch. The job
+does not install workspace dependencies or run the full autoreview suite. Its
+test-only diagnostic switch retains only the deepest allowlisted trust stage,
+prints that one stage if Node resolution fails, and is unset before the helper
+or semantic engine starts; normal invocations keep the generic trusted-Node
+error.
+
+## Prepared-bundle staging, manifests, and cleanup
+
+Prepared repo-context bundles apply the same target-scoped before/after
+fingerprint while every artifact remains in an adjacent ephemeral directory. The
+destination parent's canonical inode and the freshly created staging directory's
+`dev:ino` are pinned before content generation. After the wrapper stages its
+evidence, it manifests that evidence before and after the helper runs, excluding
+only the helper-owned prompt and metadata outputs. After prompt validation, the
+adapter also hashes the complete staged evidence before and after the final
+helper source-fingerprint call. It rejects symlinks, special files, externally
+linked regular files, and any identity or content change. The validated Node
+runtime exclusively reserves the destination, rechecks the staging identity
+throughout transfer, and verifies the same manifest after transfer and again
+immediately before hard-linking `.agent-autoreview-complete` last. That marker
+contains the manifest digest, which `--verify-bundle-dir` reopens without
+following symlinks and checks against the manifest. A destination created during
+the final race window is never replaced.
+
+Failures before an explicit helper runs, plus failures from the wrapper-attested
+default helper runtime, receive pinned-identity cleanup. The adapter atomically
+moves the candidate into a random adjacent quarantine, opens the moved directory
+without following symlinks, verifies its recorded `dev:ino`, and pins that inode
+with `fchdir` before recursive deletion. Later pathname cleanup is non-recursive
+and fails closed on identity drift. Once an explicit `AUTOREVIEW_HELPER` has
+run, however, the adapter retains failed staging without recursive deletion: an
+unattested helper may leave a same-UID writer that can substitute child
+directories even beneath a descriptor-pinned root. Canonical secret-scan
+failures use the attested helper and therefore do not leave raw diff sidecars
+behind. It cleans up its private marker while its inode still matches, but never
+recursively deletes a failed destination reservation. The mutable repo helper is
+not re-entered for publication. The published `helper-output.txt` reports the
+final prompt/pass paths, never the discarded staging directory. A detached
+producing wrapper can verify the bundle from a non-Git working directory. On
+macOS, preparation, publication, and verification also reject write-granting
+extended ACLs on every canonical parent ancestor and bundle entry; those ACL
+checks bracket evidence hashing.
+
+Prompt-index validation normalizes a UTF-8 BOM, CRLF line endings, and leading
+blank lines before applying the strict pass-order and companion-file checks, and
+rejects any undeclared extra pass file. Direct `--bundle-output` publication uses
+an exclusive same-directory link and refuses to replace any existing
+destination, including a file created during the final publication race window.
+
+## Semantic-engine isolation and credential snapshots
+
+Semantic Codex and Claude passes run from an empty temporary workspace with
+repo/project instructions, hooks, plugins, and inherited environment restricted
+to the review contract. Reviewer credentials remain available only to launch
+the selected engine; repository tooling and unrelated environment state do not.
+For Claude/Bedrock this includes standard AWS web-identity and container
+credential-chain inputs. Explicit `AWS_CONFIG_FILE` and
+`AWS_SHARED_CREDENTIALS_FILE` locators opt into trusted static/profile files;
+their private snapshots reject `credential_process`. When either locator is
+absent, the helper supplies a private empty snapshot so the AWS SDK cannot fall
+back implicitly to `~/.aws/config` or `~/.aws/credentials`; users who need
+those files must set the locators explicitly. Claude's other file-valued cloud
+credential/config locators, plus `SSL_CERT_FILE` for both Claude and Codex,
+must resolve outside the reviewed repository to a root- or reviewer-owned
+regular file with no shared-write mode, unsafe non-sticky ancestry, or
+write-granting ACL. The helper opens each explicit source no-follow, revalidates
+its identity and ancestry while copying it into a private per-run `0600`
+snapshot, and passes only that snapshot to the selected engine. Snapshot files
+are removed with the engine workspace during normal completion and partial
+setup failure. On process interruption they are identity-checked and unlinked
+before the bounded process-group termination path settles, so even an escaped
+descendant holding reviewer pipes cannot retain a credential path or block
+parent termination. An untrusted or repo-contained source fails closed before
+the selected engine starts. Semantic autoreview rejects non-empty `SSL_CERT_DIR`
+because a directory of trust anchors loaded on demand cannot be frozen safely;
+unset it or provide a trusted external PEM bundle through snapshotted
+`SSL_CERT_FILE`. Closure of the direct engine leader triggers immediate
+`SIGKILL` for its remaining process group before tracking or escalation timers
+are released, including ordinary success and failure as well as timeout or
+interruption.
+
+The narrow trusted exceptions to the repo-relative supplemental-evidence rule
+are adapter-generated feedback state and protected-main checklist copies inside
+the prepared-bundle directory. Sensitive paths, credential-like content, private
+keys, wallet recovery phrases, Stripe live keys, common Slack/Discord/Telegram
+webhook URLs, and secret-bearing URL query parameters fail closed before any
+prepared-bundle artifact is published or review input is sent to a semantic
+engine. Evidence reads reject symlinks and verify that the opened descriptor
+still identifies the file that was inspected, closing path-swap races.
+
+## Explicit helper attestation
+
+Source fingerprints and untracked-file serialization remain wrapper-owned
+operations executed by the attested helper; a trusted wrapper physically outside
+the reviewed checkout copies its sibling helper/core no-follow into the private
+command runtime and binds that snapshot to an identity plus full content
+manifest before use. The source directory is descriptor-pinned across both
+copies; its POSIX ancestry, source identities, and macOS ACLs are stable and
+non-write-granting before and after the copy. This attestation also applies when
+an explicit `AUTOREVIEW_HELPER` resolves to that external wrapper's own default
+sibling helper, as in the runtime-review command in the operator runbook.
+
+An explicit replacement cannot run before wrapper-owned recursive cleanup is
+finished. After that handoff, the wrapper performs no recursive cleanup and
+retains its command runtime plus failed staging because the replacement may have
+left a same-UID writer.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -3,7 +3,7 @@ title: PR Ready State
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-29
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -104,60 +104,15 @@ terminal state so late feedback is not missed.
 
 ### Bounded clean-Claude protocol
 
-`pr:feedback-state` accepts one bounded clean-Claude grammar plus one exact
-observed-payload compatibility exception. A Claude comment that makes a
-clean-verdict claim fails closed unless its complete protocol matches.
-
-The legacy `Verdict: LGTM` plus `Findings` and `Roll-up` protocol requires:
-
-- The optional Claude completion line may include only its fixed GitHub Actions
-  `View job` suffix; other suffixes fail closed.
-- An optional `Review: <title>` must equal the PR title after whitespace and
-  CommonMark ASCII-punctuation escape normalization. Title words are labels,
-  not finding evidence.
-- An optional `What I checked` block needs one or more checked (`[x]`) bounded
-  single-line subjects from the neutral-topic grammar (optionally joined by
-  `and`) or the narrow legacy matcher. Unknown prose, inline-code labels,
-  declarative claims, unchecked entries, and mixed safe/actionable checklists
-  fail closed.
-- Non-empty `Findings` then `Roll-up` sections are mandatory. Generalized
-  entries require an explicit `[P3]` clean marker, approved positive evidence,
-  and plain-text syntax; only exact observed legacy Markdown lines use the
-  compatibility matcher. Unknown prose, Markdown/HTML syntax, actionable
-  suffixes, negation, hedging, malformed or duplicate headings, higher
-  priorities, and mixed clean/actionable items remain blocking. Markdown
-  code-block indentation on any non-empty protocol line also fails closed.
-
-The parser validates title, checklist, Findings, and Roll-up as separate
-structural regions. Do not broaden the Findings/Roll-up positive-evidence
-allowlist merely to accept a new title or checklist subject.
-
-`Overall verdict: LGTM` is an observed-payload compatibility registry, not a
-reusable prose grammar. A registered payload must first match this structural
-envelope:
-
-- The fixed Claude completion line with its GitHub Actions `View job` suffix,
-  followed by `Code Review — PR #<current-number>`.
-- A fully checked checklist in exact order: gather context, understand the
-  request, one or more ``Review `<repo-relative-path>` changes`` entries,
-  then post findings. Review targets cannot be absolute paths or contain
-  traversal.
-- The exact clean verdict, a non-empty `Summary`, then
-  `Verification notes (no issues found)` with sequential numbered notes. Each
-  note needs a bold label and non-empty evidence.
-- A final `No P1/P2/P3 findings` conclusion with nothing after it.
-
-After structural validation, the parser hashes the raw UTF-8 body without
-trimming, newline conversion, or other normalization. It accepts a match only
-when the digest is registered for the same Claude author, PR number, comment
-ID, and current head SHA. The registry currently contains
-[PR #1544 comment 5060594122](https://github.com/mento-protocol/monitoring-monorepo/pull/1544#issuecomment-5060594122):
-digest `039923882eee9f880165543ef85e1ca251d84b995a78647b41c2b788d02a4885`,
-comment ID `5060594122`, and head
-`aab83bc74ae0585147a058d92f1f13afac7be109`.
-
-Unseen `Overall verdict` payloads fail closed pending deliberate registration.
-Any body or binding change, including line-ending changes, remains blocking.
+`pr:feedback-state` accepts a clean verdict from Claude only through a bounded
+parser over registered comment shapes. Anything ambiguous or unregistered fails
+closed: unknown prose, Markdown or HTML syntax, hedging, negation, malformed
+headings, and mixed clean/actionable items stay blocking. A small compatibility
+registry holds exact observed payloads, each bound to its Claude author, PR
+number, comment ID, head SHA, and a digest of the untrimmed raw body, so any
+body or binding change — including line endings — blocks again. The exact
+grammar and registry live in `scripts/pr-feedback-state-claude.mjs`; do not
+broaden them to accept a new title or checklist subject.
 
 ## Expected CLI contract
 
@@ -317,8 +272,8 @@ Field expectations:
 
 ## Agent workflow
 
-1. Sweep feedback surfaces and reply to all review comments.
-   Use `Fixed in <commit> — <what changed>` or
+1. Sweep feedback surfaces and build the feedback ledger before editing, then
+   reply to every review comment. Use `Fixed in <commit> — <what changed>` or
    `Won't fix: <technical reason why>`; never resolve a thread before replying.
 2. Freeze the original request, target/owner, changed files, and non-test
    changed-line count as the scope baseline. Batch review fixes locally,
@@ -326,22 +281,21 @@ Field expectations:
    follow-up, or stop; open an issue before deferring valid follow-up work, warn
    near twice the baseline, and pause for reclassification after two
    review-triggered patch cycles rather than starting a third automatically.
-3. Run the mapped local gate once for the batch.
+3. Run `pnpm agent:quality-gate --run` once for the batch; it owns test
+   execution.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
-   run `pnpm agent:autoreview` as a structured source-review closeout. Verify
-   accepted findings before editing and rerun focused checks plus autoreview if
-   those fixes change the batch. The exact target, prepared-bundle, isolation,
-   and trust contracts live in
-   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
-   behavioral and runtime verification in the validation record.
-
-5. Run `pnpm --silent pr:feedback-state --pr <number> --repo <BASE_OWNER/REPO>
---json` for the feedback sweep. After its ledger is clean, run
-   `pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --json` for the
-   final required-readiness decision. For a foreground wait loop, use
-   `pnpm pr:ready-state --pr <number> --repo <BASE_OWNER/REPO> --watch
---compact --until-ready`. Bind `--repo` to the base repository — checkout
-   inference can select the wrong same-number PR on fork PRs.
+   run `pnpm agent:autoreview` as a structured source-review closeout at the
+   batch boundary rather than as an inner loop. Verify accepted findings before
+   editing and rerun focused checks plus autoreview if those fixes change the
+   batch. The exact target, prepared-bundle, isolation, and trust contracts live
+   in [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md);
+   keep behavioral and runtime verification in the validation record.
+5. Run the suggested invocation pair above: `pnpm --silent pr:feedback-state`
+   for the feedback sweep, then, once its ledger is clean, `pnpm pr:ready-state`
+   for the final required-readiness decision. Add `--watch --compact
+--until-ready` to the readiness call for a foreground wait loop. Bind
+   `--repo` to the base repository — checkout inference can select the wrong
+   same-number PR on fork PRs.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
    `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any
@@ -374,21 +328,3 @@ settings must change, or the gate must be intentionally overridden with the
 head-scoped comment syntax above. If the limit reply is only historical and the
 current head is `requested` or `in_flight` for another Codex signal, keep
 watching until Codex approves, posts new feedback, or the signal becomes stale.
-
-## Babysitting Speed Discipline
-
-- Build a feedback ledger before editing, then batch sibling fixes before the
-  next push.
-- Avoid broad bot review as an inner loop; use review at batch boundaries.
-- Use `pnpm agent:autoreview` for local structured closeout on non-trivial
-  batches before pushing, not as a replacement for `pr:ready-state`.
-- Keep the frozen scope baseline visible through review; pause after two patch
-  cycles or when scope approaches twice the baseline.
-- Run tests through `pnpm agent:quality-gate --run`; autoreview no longer has a
-  parallel-test execution mode.
-- Cap manual Codex fallback to one request per head.
-- If `codexReviewSignal` is `requested` or `in_flight`, wait instead of posting
-  another `@codex review`.
-- Declare all-clear only after the feedback ledger is clean and the
-  required-only readiness result is ready; optional reviewer lag does not need
-  to clear first.

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -3,7 +3,7 @@ title: New Worktree / Clone Setup and Claude Code on the Web Setup
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-29
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -46,23 +46,12 @@ every fresh macOS worktree. Linux still requires a per-worktree successful
 Playwright installer marker because `--with-deps` also provisions host libraries
 there.
 
-To keep a fresh per-PR worktree from starting with a 100% cold Turbo cache,
-`setup.sh`, `bootstrap-worktree.sh`, and the agent quality gate export
-`TURBO_CACHE_DIR="$HOME/.cache/turbo-monitoring-monorepo"` (unless the caller
-already set `TURBO_CACHE_DIR`, or opted out with `AGENT_TURBO_SHARED_CACHE=0`),
-so every worktree reads and writes one shared local Turbo cache outside any
-worktree. When `HOME` is unset or that directory cannot be created or written to
-(e.g. a sandboxed agent whose writable allowlist excludes it), the scripts leave
-`TURBO_CACHE_DIR` unset and fall back to Turbo's per-worktree default, so those
-runs stay cold. Turbo 2.9.x writes each cache artifact through a temp file plus
-atomic rename with PID-namespaced temp names and only reaps orphaned `.tmp` files
-older than an hour, so concurrent gate runs in two worktrees share the dir
-safely. The shared dir is not reclaimed when a worktree is deleted and grows
-without bound; it is pure cache, so `rm -rf
-"$HOME/.cache/turbo-monitoring-monorepo"` any time to reclaim disk (see
-[agent-quality-gate-mechanics.md](agent-quality-gate-mechanics.md)). Remote
-caching stays disabled (`turbo.json` `remoteCache.enabled: false`); this is local
-sharing only. Refs GitHub issue 1411.
+Fresh per-PR worktrees start warm because `setup.sh`,
+`bootstrap-worktree.sh`, and the agent quality gate all point Turbo at one
+shared local cache directory outside any worktree. The mechanics, the fallback
+when that directory is unset or unwritable, and the `AGENT_TURBO_SHARED_CACHE=0`
+opt-out are owned by
+[agent-quality-gate-mechanics.md](agent-quality-gate-mechanics.md).
 
 ## Claude Code on the web setup
 


### PR DESCRIPTION
## The Problem

- `agent-quality-gate-mechanics.md` spent ~270 of its 664 lines on
  autoreview's internal security defenses — background an operator running
  the gate never acts on.
- `pr-ready-state.md` restated its own nine-step workflow in a second
  section and carried a hardcoded legacy-payload registry entry in prose.
- `worktree-and-web-setup.md` duplicated the Turbo shared-cache mechanics
  the gate doc owns, sentence for sentence.

## The Solution

Single-owner the content: runtime-trust background moves to a non-canonical
reference note, operator contracts stay where operators look, and duplicated
passages become pointers.

## Details

- `agent-quality-gate-mechanics.md` 664 → 486; new
  `docs/notes/autoreview-runtime-trust.md` (230 lines, `canonical: false`)
  holds the extracted trust model with a fail-closed preamble.
- `pr-ready-state.md` 394 → 330: Babysitting Speed Discipline folded into
  the workflow steps (its two clauses missing from the steps were folded in,
  the rest was duplication); the clean-Claude parser grammar compressed to
  its fail-closed summary plus a pointer at
  `scripts/pr-feedback-state-claude.mjs`; the stale single-entry registry
  listing removed from prose.
- `worktree-and-web-setup.md` 102 → 91: Turbo cache passage reduced to two
  sentences and a pointer at the owning doc.

## Validation

- `pnpm agent:quality-gate --run` green; `pnpm agent:context-check` green;
  `pnpm docs:index --write` regenerated the catalog with the new note;
  `pnpm docs:navigation-eval --check-fixtures --json` valid; `trunk fmt`
  clean.
- Every operator-facing anchor verified present after the extraction
  (bundle command sequence, refusal rules, trusted-checkout procedure,
  freshness behavior, traps).
- Claude Security scan: skipped (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdQUxQhvNHcacM9cMVXACV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation index updates only; no application, auth, or CI behavior changes.
> 
> **Overview**
> **Docs-only refactor** so operator runbooks stay short and deep security/trust material has a single non-canonical home.
> 
> `agent-quality-gate-mechanics.md` **drops** the long autoreview trust narrative (pinning, ELF/loader, bundle manifests, credential snapshots, etc.) in favor of a short fail-closed summary plus a link to the new **`docs/notes/autoreview-runtime-trust.md`** (`canonical: false`), which **holds** that extracted model. Operator-facing pieces (bundle prep/verify, trusted-checkout for runtime PRs, path rejection, feedback `auto` fail-closed rules) **remain** in the gate runbook.
> 
> `pr-ready-state.md` **removes** the duplicate **Babysitting Speed Discipline** section by **folding** its missing bits into the numbered agent workflow (ledger-before-edit, `agent:quality-gate --run` owns tests, autoreview at batch boundaries, explicit `pr:feedback-state` then `pr:ready-state`). The **bounded clean-Claude** section is **compressed** to a fail-closed summary and a pointer at **`scripts/pr-feedback-state-claude.mjs`**; the **stale in-doc registry entry** (PR #1544 digest) is **removed** from prose.
> 
> `worktree-and-web-setup.md` **replaces** duplicated Turbo shared-cache mechanics with **two sentences** pointing at the gate doc. **`docs/README.md`** **adds** the new note to the generated catalog under non-canonical reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e5a2c65db46e5284f5517878bc5848eaeb1fcc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->