### PR TITLE
docs: slim agent entry points to gotchas and pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@ title: Monitoring Monorepo Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-26
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: repo-wide
 review_interval_days: 90
@@ -63,52 +63,13 @@ rule are in
 ## PR Workflow
 
 GitHub Issues are the canonical active-work queue; `BACKLOG.md` is transition
-storage only. Claim before substantive edits, then follow the
-[operating card](docs/notes/pr-operating-card.md) through implementation,
-review, shipping, readiness, and merge sync:
+storage only. Claim before substantive edits, then work the
+[operating card](docs/notes/pr-operating-card.md) end to end. Never merge
+without the user's explicit approval for that specific merge.
 
-```bash
-pnpm issue:claim --count 3 --agent codex
-pnpm agent:quality-gate
-pnpm agent:quality-gate --run
-```
-
-Claude cloud sessions run issue helpers only behind the capability gate;
-otherwise use the MCP workboard fallback in
+Claude cloud sessions run the issue and PR helpers only behind the capability
+gate; otherwise use the MCP workboard fallback and its qualified all-clear in
 [`docs/notes/github-tooling-surfaces.md`](docs/notes/github-tooling-surfaces.md).
-For non-trivial batches, use the card's surface-correct autoreview flow. Inside
-an active Codex session that means a verified prepared bundle and one
-fresh-context reviewer; a bare deterministic review is not the semantic
-closeout. Autoreview proves source review only, so mapped tests, browser checks,
-generated artifacts, and runtime evidence still apply.
-
-Open every PR through the `ship` skill, ready for review unless the user
-explicitly requests a draft or required validation is intentionally pending.
-The body starts with `## The Problem` (at most three plain-language bullets)
-then `## The Solution` (approach before implementation detail). Use `Closes
-#N` only when the issue's Done means is complete; otherwise use `Refs #N`.
-Knowingly deferred valid work needs a linked issue before the deferral reply.
-
-Reply to every review item before resolving it:
-
-- `Fixed in <commit> — <what changed>`
-- `Won't fix: <technical reason why>`
-
-Never force-push or amend while babysitting. Before all-clear, require a clean
-feedback ledger followed by current-head readiness:
-
-```bash
-pnpm --silent pr:feedback-state --pr <number> --repo <BASE_REPO> --json
-pnpm pr:ready-state --pr <number> --repo <BASE_REPO> --json
-```
-
-The current-head `chatgpt-codex-connector[bot]` description approval is part of
-readiness. Never merge without the user's explicit approval for that specific
-merge. Claude cloud sessions use these helpers only behind the capability gate;
-the MCP fallback and its qualified all-clear live in
-[`docs/notes/github-tooling-surfaces.md`](docs/notes/github-tooling-surfaces.md).
-Label, workboard, Claim ID, release, and merge-sync depth lives in
-[`docs/notes/agent-issue-workflow.md`](docs/notes/agent-issue-workflow.md).
 
 ## Prose Style
 

--- a/aegis/AGENTS.md
+++ b/aegis/AGENTS.md
@@ -3,7 +3,7 @@ title: Aegis Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-27
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: aegis
 review_interval_days: 90
@@ -38,67 +38,22 @@ garden_lane: agent-entry-points
 
 Run `pnpm aegis:lint`, `pnpm aegis:typecheck`, `pnpm --filter @mento-protocol/aegis test:cov`, `pnpm aegis:build`, and Terraform fmt/init/validate for `aegis/terraform` when relevant.
 
-Aegis Jest coverage floors were measured on 2026-06-03 after adding config,
-metrics, query, and watcher specs: statements 87.91, branches 79.23, functions
-89.61, lines 87.97. The enforced floor keeps a two-point variance margin at
-statements 85, branches 77, functions 87, and lines 85.
+Coverage floors are enforced by `coverageThreshold` in `aegis/package.json`:
+statements 85, branches 77, functions 87, lines 85.
 
-## RPC Error Handling and Retry Posture
+## RPC Error Handling
 
-Aegis uses a simple primary-then-fallback retry model with no circuit breaker or backoff:
+A call tries the chain's primary `httpRpcUrl`, then its optional
+`fallbackHttpRpcUrl` once. No backoff, no breaker, no per-endpoint health
+tracking, and `retryCount: 0` on both viem clients. That is deliberate: metrics
+poll on a schedule, so backoff would silently extend stale windows.
 
-- **Primary RPC**: the `httpRpcUrl` configured per chain in `config.yaml`. All calls attempt this first.
-- **Fallback RPC**: the optional `fallbackHttpRpcUrl` field on a chain config. If a primary call throws, Aegis retries once against the fallback (if configured). If the fallback also throws, or no fallback is configured, the error propagates to the outer handler.
-- **No breaker / no backoff**: the retry is a single immediate attempt. There is no exponential backoff, no half-open state, and no per-endpoint health tracking. This is intentional — Aegis metrics are already polled on a schedule; adding backoff would silently extend stale windows.
-- **No internal viem retries**: both primary and fallback clients are created with `http(url, { retryCount: 0 })`. viem defaults to `retryCount = 3` (with 150 ms delay between attempts); leaving that enabled would compound latency on transport failures and undermine the explicit single-fallback posture above.
+Deterministic failures — reverts, any ABI/encoding/argument error, invalid
+address — never retry the fallback and never increment
+`view_call_rpc_errors_total`; only transport failure of every configured
+endpoint increments it. Keep that counter's labels bounded to `contract`,
+`functionName`, and `chain`; never add dynamic strings.
 
-### Transport vs. deterministic error classification
-
-Aegis classifies every caught error before deciding whether to retry the fallback or increment the counter:
-
-- **Transport errors** (network down, HTTP 5xx, timeout, connection refused): the endpoint is unhealthy. These trigger the fallback retry and, if all endpoints fail, increment `view_call_rpc_errors_total`. Identified when the error is `HttpRequestError`, `TimeoutError`, `WebSocketRequestError`, or an `RpcRequestError` that does NOT carry revert semantics — and when none of the deterministic markers below are found.
-- **Deterministic errors** (contract revert, any ABI/encoding/argument error, invalid address): the call itself is broken — it would reproduce on every healthy endpoint. These do NOT retry the fallback and do NOT increment the counter. The error is logged and `query()` returns `undefined`, identical to a parse failure.
-
-**How deterministic is detected (using `BaseError.walk()`):** The implementation walks the full error chain and flags a cause as deterministic if any of the following match:
-
-- `ContractFunctionRevertedError` (on-chain revert)
-- Any error whose `.name` matches `/^Abi[A-Za-z]*Error$/` — this covers the entire viem `Abi*` family: `AbiDecodingZeroDataError`, `AbiDecodingDataSize*Error`, `AbiEncodingArrayLengthMismatchError`, `AbiEncodingBytesSizeMismatchError`, `AbiEncodingLengthMismatchError`, `AbiErrorSignatureNotFoundError`, `AbiFunctionNotFoundError`, `AbiFunctionOutputsNotFoundError`, and all other `Abi*Error` classes in `viem/errors/abi.ts`
-- Any error whose `.name` matches `/^Invalid(?:Abi|Array|Definition|Address)[A-Za-z]*Error$/` — covers `InvalidAbiEncodingTypeError`, `InvalidAbiDecodingTypeError`, `InvalidArrayError`, `InvalidDefinitionTypeError`, `InvalidAddressError`
-- An `RpcRequestError` with JSON-RPC error code 3 (execution reverted) or a message containing "execution reverted"/"revert"
-
-If the error is not a viem `BaseError` at all (unexpected type), the implementation defaults to TRANSPORT so genuine outages are still captured.
-
-**Important — `ContractFunctionExecutionError` is NOT a determinism signal.** viem's `readContract` wraps nearly _all_ failures — including transport-level errors (network down, HTTP 5xx, timeout) — inside `ContractFunctionExecutionError`. The outer wrapper alone tells you nothing; only the specific cause types listed above are deterministic. The implementation examines the full walked chain, not the outermost error class.
-
-This prevents Grafana from seeing false RPC-outage signals when a metric is misconfigured or a contract reverts.
-
-### `view_call_rpc_errors_total` counter
-
-The counter `view_call_rpc_errors_total` (labels: `contract`, `functionName`, `chain`) increments **only when both the primary and fallback fail with transport errors** (or when there is no fallback and the primary fails with a transport error). It does NOT increment on a successful fallback retry, and it does NOT increment on deterministic call failures (reverts, any ABI/encoding/argument errors, invalid addresses).
-
-This lets Grafana distinguish "RPC endpoint was temporarily down but recovered via fallback" (counter stays flat, metric value updates normally) from "both endpoints unreachable" (counter increments, metric goes stale).
-
-Staleness alerting — driven by `isOldestReportExpired` and `view_call_query_duration{status="error"}` — remains the primary on-call signal. `view_call_rpc_errors_total` is a diagnostic aid to identify which endpoint is causing problems.
-
-### Label discipline
-
-Labels on `view_call_rpc_errors_total` are bounded to the same closed set as `view_call_query_duration`: `contract`, `functionName`, and `chain`. These are configuration-driven identifiers with a fixed cardinality. Never add `message`, `error`, or other dynamic string labels — unbounded cardinality breaks Prometheus.
-
-### Adding a fallback RPC to a chain
-
-Add `fallbackHttpRpcUrl` to the chain entry in `config.yaml`:
-
-```yaml
-chains:
-  - id: celo
-    label: celo
-    httpRpcUrl: https://forno.celo.org
-    fallbackHttpRpcUrl: https://rpc.ankr.com/celo
-```
-
-Verify the URL with the chain's real concurrent polling shape before committing;
-an `eth_blockNumber` smoke test alone does not expose burst throttling. Testnets
-and low-metric-count chains should normally remain single-endpoint, but add an
-independent-provider fallback when production logs demonstrate throttling or
-availability failures. Polygon Amoy is the current exception: its six-call
-oracle/breaker burst uses PublicNode first and dRPC as the single fallback.
+Verify a new `fallbackHttpRpcUrl` under the chain's real concurrent polling
+burst — an `eth_blockNumber` smoke test does not expose burst throttling. The
+classification rules and config example are in [`README.md`](README.md).

--- a/aegis/README.md
+++ b/aegis/README.md
@@ -288,6 +288,63 @@ SortedOracles_isOldestReportExpired{rateFeed="CELOBRL",rateFeedValue="0xe8537a3d
 1. Ensure that it worked by reviewing the main Aegis dashboard in Grafana
 1. If anything went wrong, roll back your changes to `dashboard.tf` and keep editing until you get it right :)
 
+## RPC error handling
+
+Every call attempts the chain's primary `httpRpcUrl` first. Aegis classifies a
+caught error before deciding whether to retry the fallback or count it.
+
+- **Transport errors** (network down, HTTP 5xx, timeout, connection refused)
+  mean the endpoint is unhealthy. They trigger the single fallback retry and, if
+  every configured endpoint fails, increment `view_call_rpc_errors_total`.
+- **Deterministic errors** (contract revert, any ABI/encoding/argument error,
+  invalid address) mean the call itself is broken and would reproduce on every
+  healthy endpoint. They do not retry the fallback and do not increment the
+  counter; the error is logged and `query()` returns `undefined`, the same as a
+  parse failure.
+
+Detection walks the full error chain with `BaseError.walk()` and treats a cause
+as deterministic when it is a `ContractFunctionRevertedError`, its `.name`
+matches `/^Abi[A-Za-z]*Error$/` (the whole viem `Abi*` family) or
+`/^Invalid(?:Abi|Array|Definition|Address)[A-Za-z]*Error$/`, or it is an
+`RpcRequestError` carrying JSON-RPC code 3 or an "execution reverted"/"revert"
+message. An error that is not a viem `BaseError` at all defaults to transport,
+so genuine outages are still captured.
+
+`ContractFunctionExecutionError` is not a determinism signal: viem's
+`readContract` wraps nearly all failures in it, transport ones included. Only
+the walked causes above decide, never the outermost class. This keeps Grafana
+from reading a misconfigured metric or a reverting contract as an RPC outage.
+
+`view_call_rpc_errors_total` (labels `contract`, `functionName`, `chain`)
+therefore increments only when every endpoint fails with a transport error —
+not on a successful fallback retry, and not on deterministic failures. Grafana
+can then separate "primary was down but the fallback covered it" (counter flat,
+values fresh) from "both unreachable" (counter climbs, metric goes stale).
+Staleness alerting on `isOldestReportExpired` and
+`view_call_query_duration{status="error"}` stays the primary on-call signal;
+this counter is the diagnostic that names the failing endpoint. Its labels are
+the same closed, configuration-driven set as `view_call_query_duration`; never
+add `message`, `error`, or another dynamic string, because unbounded
+cardinality breaks Prometheus.
+
+To add a fallback, set `fallbackHttpRpcUrl` on the chain entry in
+`config.yaml`:
+
+```yaml
+chains:
+  - id: celo
+    label: celo
+    httpRpcUrl: https://forno.celo.org
+    fallbackHttpRpcUrl: https://rpc.ankr.com/celo
+```
+
+Verify the URL against the chain's real concurrent polling shape before
+committing; an `eth_blockNumber` smoke test does not expose burst throttling.
+Testnets and low-metric-count chains normally stay single-endpoint — add an
+independent-provider fallback when production logs show throttling or
+availability failures. Polygon Amoy is the current exception: its six-call
+oracle/breaker burst uses PublicNode first and dRPC as the single fallback.
+
 ## Terraform for Grafana
 
 We use `aegis/terraform` to deploy the Aegis Grafana dashboard and folder.

--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -57,15 +57,3 @@ routing.
 - `pnpm agent:quality-gate` for any combined edit — path-aware routing.
 
 For Cloud Function deploy verification, follow `docs/pr-checklists/terraform-cloudrun.md`.
-
-<!--
-TODO(test-coverage): the `source_hash` + `var.chain_key` plumbing in
-`alerts/infra/onchain-event-listeners/main.tf` (the QuickNode webhook
-state-rm dance) is currently only covered by `pnpm alerts:infra:plan`
-diffing. Vitest can't reach Terraform-side logic cleanly. If we need
-true regression coverage there, options are: (1) a `terraform test`
-HCL block exercising the `local-exec` provisioner against a fake
-state, or (2) a snapshot test against `terraform plan -out` JSON. Both
-are out of scope for the onchain-event-handler test suite — track
-separately if drift becomes a real issue.
--->

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -1,4 +1,4 @@
-<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-07-24 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
+<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-07-29 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
 
 # alerts/rules
 
@@ -64,12 +64,15 @@ inherit the FX-weekend mute. Blind rules compare the producer's exact
 consecutive deep-poll count with policy; they do not infer 30-second poll
 history from Grafana's 60-second evaluation clock.
 
-The reviewed source activation is not live merely because it is merged. The
-current producer preconditions still gate the trusted-main plan and
-human-approved apply; live Grafana proof remains required after apply. Follow
+The Peg activation apply is complete and its rules are live in Grafana
+([#1680](https://github.com/mento-protocol/monitoring-monorepo/pull/1680),
+[#1685](https://github.com/mento-protocol/monitoring-monorepo/pull/1685)).
+Later rule changes take the ordinary trusted-main plan and human-approved
+apply; `peg-thresholds.json` rollovers go through the protected publication
+and generation-pin sequence in
+[`docs/deployment.md`](../../docs/deployment.md). Follow
 [`docs/notes/peg-monitoring.md`](../../docs/notes/peg-monitoring.md) for the
-current dependency boundary, exact source checks, activation sequence, and
-rollback order.
+dependency boundary, exact source checks, and rollback order.
 
 Registry-rot rules cover every non-deep policy source, including display-only
 sources. Critical-path-unreachable rules cover only the policy-designated deep

--- a/docs/README.md
+++ b/docs/README.md
@@ -193,6 +193,7 @@ Authority: canonical
 - [`docs/README.md`](README.md)
 - [`indexer-envio/README.md`](../indexer-envio/README.md)
 - [`indexer-envio/STATUS.md`](../indexer-envio/STATUS.md)
+- [`integration-probes/README.md`](../integration-probes/README.md)
 - [`README.md`](../README.md)
 - [`SPEC.md`](../SPEC.md)
 

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -30,9 +30,11 @@ The source-owned surfaces are:
 
 ## Current boundary
 
-This source packet does not apply Grafana resources or, by itself, prove live
-consumer behavior. The activation evidence records live producer and query
-checks; live consumer states still require the protected apply.
+This source packet does not apply Grafana resources by itself. The activation
+apply is complete: the Peg folder, templates, contact points, and rule group
+are live in Grafana for both the active and retained policy versions
+([#1680](https://github.com/mento-protocol/monitoring-monorepo/pull/1680),
+[#1685](https://github.com/mento-protocol/monitoring-monorepo/pull/1685)).
 `terraform/peg-policy.tf` owns the policy identities and bucket IAM. Controller
 recovery and bootstrap-grant removal are complete.
 The protected `Peg Policy Publication` root published
@@ -57,7 +59,7 @@ are merged and deployed. The runtime now fetches the authenticated
 generation-pinned policy and exposes the active `policy_version`. The activation
 PR records a full producer-floor window and production evaluation of all 61
 unique generated query expressions. The protected-main plan, human-approved
-apply, and post-apply Grafana proof follow the source merge.
+apply, and post-apply Grafana proof are complete.
 
 The live listing-confirmation producer and consumer source includes
 `mento_peg_listing_state`, `mento_peg_listing_checked_at`, and the bounded

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -124,12 +124,10 @@ enumeration, Hasura row caps, and effect-layer boundaries:
 
 Read
 [`../docs/notes/liquity-monitoring-invariants.md`](../docs/notes/liquity-monitoring-invariants.md)
-before changing Liquity handlers, schema, queries, or KPIs. The deployed
-ActivePool does not emit debt updates; `systemDebt` is coordinated between
-open-trove transition deltas and observed DefaultPool redistribution deltas.
-Never replace it with cached `activePoolDebt + defaultPoolDebt`. Rebalance
-redemptions are a subset discriminated by transaction target, not a distinct
-event type.
+before changing Liquity handlers, schema, queries, or KPIs. Never replace
+`systemDebt` with cached `activePoolDebt + defaultPoolDebt`; the deployed
+ActivePool emits no debt updates. Rebalance redemptions are a subset
+discriminated by transaction target, not a distinct event type.
 
 ## Observability
 

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -3,7 +3,7 @@ title: Integration Probes Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: integration-probes
 review_interval_days: 90
@@ -59,12 +59,9 @@ pnpm --filter @mento-protocol/integration-probes knip
   follow Fly's quote and distributions APIs and pass only if the distributions
   response exposes a registered Mento v3 pool address. Celo LI.FI checks do not
   use Fly fallback evidence; they must return direct Mento address evidence.
-- LI.FI quote attempts are capped at 180 per scheduled run, and repeated
-  request/HTTP errors during route discovery are capped at two attempts per
-  route, so an aggregator outage or discovery loop cannot starve the scheduled
-  writer. Budgeted adapters run pair probes serially so downstream follow-up
-  requests, such as LI.FI-to-Fly evidence checks, cannot be starved by other
-  in-flight pair probes.
+- Per-run request budgets, the per-route discovery error cap, and serial pair
+  probes for budgeted adapters are load-bearing anti-starvation guards; do not
+  loosen them without live scheduled-probe evidence.
 - Squid quote probes are capped and paced between requests because bursty
   route checks can trigger 429s. Do not remove or lower the request delay
   without live route evidence that the scheduled probe remains healthy.
@@ -87,26 +84,6 @@ pnpm --filter @mento-protocol/integration-probes knip
 - `integration-probes:latest` expires after 3 days so failed scheduled probes
   degrade the dashboard instead of showing stale health forever. Dated history
   keys expire after 90 days.
-
-## Env Vars
-
-- `INTEGRATION_PROBES_HASURA_URL` overrides `NEXT_PUBLIC_HASURA_URL` for the
-  pool discovery query.
-- `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are required only
-  when writing snapshots.
-- Adapter credentials are optional at the infrastructure layer and should
-  surface as `needs_key` when missing: `LIFI_API_KEY`, `OPENOCEAN_API_KEY`,
-  `ZEROX_API_KEY`, `ONEINCH_API_KEY`, `SQUID_INTEGRATOR_ID`, and
-  `SOCKET_API_KEY`.
-- `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with
-  `x-lifi-api-key`; keep it server-side and Terraform-managed.
-- `FLYTRADE_API_KEY` authenticates the Fly.trade follow-up requests behind
-  Monad LI.FI routes with the `apikey` header against the authenticated
-  `api.magpiefi.xyz` origin; without it the probe falls back to the public
-  `api.fly.trade` origin. It is optional (not part of `credentialEnv`), so a
-  missing key never renders LI.FI as `needs_key`. Keep it server-side and
-  Terraform-managed.
-- `SQUID_INTEGRATOR_ID` authenticates Squid quote probes with
-  `x-integrator-id`; keep it server-side and Terraform-managed.
-- `SQUID_CELO_RPC_URL` optionally overrides the default Forno Celo RPC used for
-  Squid Uniswap-liquidity discovery sizing. It is not a credential.
+- Adapter credentials are optional and must surface as `needs_key` when
+  missing. Keep every key server-side and Terraform-managed; the variable
+  reference is [`README.md`](README.md).

--- a/integration-probes/README.md
+++ b/integration-probes/README.md
@@ -1,0 +1,33 @@
+<!-- agent-context: title="Integration Probes" status=active owner=eng canonical=true last_verified=2026-07-29 doc_type=reference scope=integration-probes review_interval_days=90 garden_lane=package-readmes-reference -->
+
+# Integration Probes
+
+`@mento-protocol/integration-probes` runs quote-only checks against DEX
+aggregators and cross-chain routers and publishes the latest snapshot to Upstash
+Redis for the dashboard `/integrations` page. The default mainnet fleet is Celo
+(42220), Monad (143), and Polygon (137).
+
+Probe policy, evidence rules, and adapter tiering live in
+[`AGENTS.md`](AGENTS.md); commands are listed there and in
+[`../docs/notes/quick-commands.md`](../docs/notes/quick-commands.md).
+
+## Environment variables
+
+- `INTEGRATION_PROBES_HASURA_URL` overrides `NEXT_PUBLIC_HASURA_URL` for the
+  pool discovery query.
+- `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are required only when
+  writing snapshots.
+- Adapter credentials are optional at the infrastructure layer and surface as
+  `needs_key` when missing: `LIFI_API_KEY`, `OPENOCEAN_API_KEY`, `ZEROX_API_KEY`,
+  `ONEINCH_API_KEY`, `SQUID_INTEGRATOR_ID`, and `SOCKET_API_KEY`.
+- `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with `x-lifi-api-key`.
+- `FLYTRADE_API_KEY` authenticates the Fly.trade follow-up requests behind Monad
+  LI.FI routes with the `apikey` header against the authenticated
+  `api.magpiefi.xyz` origin; without it the probe falls back to the public
+  `api.fly.trade` origin. It is optional and not part of `credentialEnv`, so a
+  missing key never renders LI.FI as `needs_key`.
+- `SQUID_INTEGRATOR_ID` authenticates Squid quote probes with `x-integrator-id`.
+- `SQUID_CELO_RPC_URL` optionally overrides the default Forno Celo RPC used for
+  Squid Uniswap-liquidity discovery sizing. It is not a credential.
+
+Keep every credential server-side and Terraform-managed.

--- a/metrics-bridge/AGENTS.md
+++ b/metrics-bridge/AGENTS.md
@@ -3,7 +3,7 @@ title: Metrics Bridge Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: metrics-bridge
 review_interval_days: 90
@@ -54,48 +54,25 @@ and `build`. For Cloud Run/runtime changes, apply
 ## Peg policy bootstrap
 
 `PEG_POLICY_URL` and `PEG_POLICY_AUTH_MODE` are paired raw configuration for
-the IaC-published, versioned peg-policy artifact. When both are absent, the peg
-loop remains intentionally dormant until the protected artifact plane is
-provisioned. Production mode is `gcp-metadata` and accepts only the canonical,
-generation-pinned GCS JSON download endpoint. `none` is limited to deliberate
-local or test HTTPS artifacts and requires the code-only
-`allowUnauthenticatedPolicy` option; environment configuration cannot enable
-it. A blank, malformed, missing, or mismatched pair belongs to the peg loop's
-bounded error channel and must not abort startup or affect the primary Hasura
-poller.
+the IaC-published, versioned peg-policy artifact; when both are absent the peg
+loop stays intentionally dormant. A blank, malformed, missing, or mismatched
+pair belongs to the peg loop's bounded error channel: it degrades peg coverage
+only, never startup or the primary Hasura poller.
 
-Platform Terraform attaches Cloud Run to
-`metrics-bridge-runtime@mento-monitoring.iam.gserviceaccount.com`, whose direct
-grant is only the private policy bucket's Object Viewer role. The platform
-grants the routine deployer and `gcp_dev_members` Service Account User only on
-that identity, never project-wide or on the default Compute service account.
-The `template[0].revision` drift ignore remains while the generation literal is
-`null`, then the same reviewed concrete-generation change removes it to create
-a Cloud Run revision. The platform
-accepts no production policy URL or auth-mode input: a reviewed
-`local.peg_policy_runtime_generation` literal derives both values together.
-It stays `null` only until protected publication reports the first real
-generation. After activation it remains concrete; each later rollover replaces
-the current quoted generation literal in a reviewed platform change and creates
-a new Cloud Run revision.
+Production runs `gcp-metadata` against the generation-pinned GCS endpoint that
+platform Terraform derives from a reviewed source literal — never an
+env-supplied URL or auth mode. `none` is code-only for local or test artifacts
+and needs the `allowUnauthenticatedPolicy` option; environment configuration
+cannot enable it.
 
-Policy versions are content-addressed: the final 32 lowercase hexadecimal
-characters must match the canonical policy-content SHA-256 prefix. Canonical
-JSON recursively sorts object keys by Unicode code point and preserves array
-order. Do not reuse a version prefix or hand-edit its suffix; runtime and CI
-verify the binding and require a rollover to retain the exact base-branch
-active policy as `previous`. After producer ACK, land a reviewed
-`previous=null` artifact update before a second active rollover; CI and the
-runtime reject chained rollovers.
-
-The service validates and fetches thresholds at runtime. The Docker image
-contains `metrics-bridge/peg-registry.json` at the path resolved by the
-compiled registry loader, but it never contains `peg-thresholds.json`. The
-manual `Peg Policy Publication` workflow publishes the protected artifact;
-runtime activation remains a separate reviewed `production-infra` change.
-Private transport, generation pinning, project placement, and the activation
-boundary are fixed by
-[ADR 0054](../docs/adr/0054-same-project-peg-policy-artifact.md).
+Policy versions are content-addressed, and a rollover must retain the exact
+prior active version as `previous`; CI and the runtime verify that binding and
+reject a second rollover until an ACK cleanup sets `previous` back to `null`.
+Do not reuse a version prefix or hand-edit its suffix. Private transport,
+generation pinning, project placement, and the activation boundary are fixed by
+[ADR 0054](../docs/adr/0054-same-project-peg-policy-artifact.md); the runtime
+identity's IAM belongs to
+[`terraform/AGENTS.md`](../terraform/AGENTS.md).
 
 ## RPC overrides
 

--- a/shared-config/AGENTS.md
+++ b/shared-config/AGENTS.md
@@ -31,7 +31,7 @@ garden_lane: agent-entry-points
   code paths.
 - Do not hand-edit `dist/` as the source of truth. Update `src/` or JSON inputs, then run the package build.
 - Avoid importing runtime-heavy packages here. `shared-config` is consumed by client bundle code and should stay low-dependency.
-- Public npm releases are tag-driven through `.github/workflows/publish-config.yml`; publish tags must be `config-v<shared-config/package.json version>` and reference a commit reachable from `origin/main`. Manual `workflow_dispatch` runs validate and pack the package but do not publish. npm trusted publishing cannot create a brand-new package, so an npm org/package maintainer must seed `@mento-protocol/config` once through an approved maintainer publish before configuring trusted publishing for GitHub Actions with workflow filename `publish-config.yml`, allowed action `npm publish`, repository `mento-protocol/monitoring-monorepo`. Keep the publish job on GitHub-hosted runners because npm trusted publishing does not support self-hosted or third-party runners.
+- Public npm releases are tag-driven through `.github/workflows/publish-config.yml`; publish tags must be `config-v<shared-config/package.json version>` and reference a commit reachable from `origin/main`. Manual `workflow_dispatch` runs validate and pack the package but do not publish. Keep the publish job on GitHub-hosted runners because npm trusted publishing does not support self-hosted or third-party runners.
 - The package's Node engine follows the repo `.node-version` throughout the pre-1.0 release line. Do not lower the engine floor without adding a matching consumer and publish verification matrix.
 
 ## Verification

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -89,8 +89,11 @@ image pull depend on the exact boundaries.
   expose — logs, metrics, artifacts — as part of the confidentiality review.
   Add only an exact missing permission named by a provider denial.
 - Peg policy: the runtime attachment pins the current generation as a reviewed
-  source literal and the Grafana consumers are live, so rule and threshold
-  changes take the ordinary plan → approved-apply path. Never retain a
+  source literal and the Grafana consumers are live. Grafana rule changes take
+  the ordinary plan → approved-apply path; `peg-thresholds.json` rollovers
+  instead go through the manual protected `Peg Policy Publication` workflow and
+  a separate reviewed platform change that re-pins the generation
+  ([`docs/deployment.md`](../docs/deployment.md)). Never retain a
   project-level controller grant or broad Storage Admin, Storage Object Admin,
   or Service Account User fallbacks. An approved,
   time-bounded emergency bootstrap may grant only `pegPolicyBucketController` at

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -3,7 +3,7 @@ title: Terraform Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: terraform
 review_interval_days: 90
@@ -16,17 +16,24 @@ garden_lane: agent-entry-points
 
 ## Scope
 
-`terraform/` is the `platform` stack registered in `terraform.stacks.json`. It manages production infrastructure for the monitoring dashboard, Upstash, the monitoring GCP project/APIs, private Peg-policy storage in that project, Metrics Bridge Cloud Run shape, Aegis App Engine/Grafana Alloy bootstrap, explicit routine-deploy source buckets, the separated Terraform/service-deploy Workload Identity Federation chains, repo-level GitHub Actions secrets and variables owned by the platform stack, and the applied Peg-policy GCS source foundation. Controller recovery and protected policy publication are complete; the current runtime attachment pins `mento-monitoring-peg-policy/peg-policy/current.json` generation `1785276001213660`. Alert activation still requires its trusted-main plan, human-approved apply, and Grafana/routing proof. Alloy values are required sensitive, ephemeral operator inputs that terminate at Google provider 6.50.x write-only Secret Manager arguments; only their explicit rotation counters are non-secret. Alert ownership lives in `alerts/` (`alerts/rules/` for protocol Grafana rules, Aegis service/testnet-health rules, and global routing; `alerts/infra/` for event-driven delivery) while `aegis/terraform/` owns the Aegis dashboard and folder.
+`terraform/` is the `platform` stack registered in `terraform.stacks.json`. It
+manages the monitoring dashboard, Upstash, the monitoring GCP project and APIs,
+private Peg-policy storage, Metrics Bridge Cloud Run shape, Aegis App
+Engine/Grafana Alloy bootstrap, deploy source buckets, the separated
+Terraform/service-deploy Workload Identity Federation chains, and repo-level
+GitHub Actions secrets and variables. Alerts live elsewhere: `alerts/rules/`
+owns protocol and Aegis Grafana rules plus global routing, `alerts/infra/` owns
+event-driven delivery, and `aegis/terraform/` owns the Aegis dashboard and
+folder.
 
-Alloy's runtime project authority is the custom
-`grafanaAgentActivationReader` role with exactly `appengine.services.get` and
-`appengine.versions.list`, plus the predefined `roles/logging.logWriter` role
-required to start App Engine Flex instances. It also has repository-level
-`roles/artifactregistry.reader` on only the Terraform-managed `us.gcr.io`
-repository so the version can pull its image. Do not replace these grants with
-project-wide Artifact Registry or predefined App Engine viewer access; the
-active/passive collector handshake and image-pull path depend on these exact
-boundaries.
+Alloy values are sensitive, ephemeral operator inputs that terminate at Google
+provider 6.50.x write-only Secret Manager arguments; only their rotation
+counters are non-secret. Alloy's runtime authority is the custom
+`grafanaAgentActivationReader` role, `roles/logging.logWriter`, and
+repository-scoped `roles/artifactregistry.reader` on the Terraform-managed
+`us.gcr.io` repository. Never widen those to project-wide Artifact Registry or
+predefined App Engine viewer access; the active/passive collector handshake and
+image pull depend on the exact boundaries.
 
 ## Operating Rules
 
@@ -43,90 +50,59 @@ boundaries.
   `--force-local-apply` does not bypass this secret-input guard. The wrapper
   executes the verified commit from a temporary source snapshot; gitignored
   tfvars stay external and are passed by absolute file path.
-- Alloy deploy operators receive the exact metadata-only
-  `grafanaAgentPreflightReader` custom role so the mandatory live preflight can
-  inspect project and `us.gcr.io` repository IAM, secret metadata, runtime
-  identity, and traffic without reading secret payloads. Its description
-  carries Terraform's `gcp_dev_members` fingerprint; both operator and builder
-  policies must match it.
+- Alloy deploy operators receive the metadata-only
+  `grafanaAgentPreflightReader` custom role: enough for the mandatory live
+  preflight, never enough to read secret payloads. Its description carries
+  Terraform's `gcp_dev_members` fingerprint; operator and builder policies must
+  match it.
 - Never set GitHub Actions, Vercel, GCP Secret Manager, Upstash, Grafana, or
   other platform secrets manually with CLI commands. Secrets owned by this stack
   must be modeled as Terraform variables/resources and delivered by a
-  human-approved plan/apply. If Terraform cannot manage the secret yet, add the
-  missing IaC path or ask for direction; do not use `gh secret set`,
-  `vercel env add`, or equivalent as an agent workaround.
+  human-approved plan/apply. If Terraform cannot manage a secret yet, add the
+  missing IaC path or ask for direction; never reach for `gh secret set`,
+  `vercel env add`, or an equivalent workaround.
 - Resource address renames need `moved` blocks. To retire a state-managed
   resource without destroying its remote counterpart, use a `removed` block
   with an explicit `destroy` choice.
-- Keep the Alloy `us.gcr.io` repository state-managed with `prevent_destroy`;
-  production already completed its one-time import.
+- Keep the Alloy `us.gcr.io` repository state-managed with `prevent_destroy`.
 - Cloud Run services use `/health`, not `/healthz`.
 - For deploy-owned Cloud Run images, retain the necessary
   `lifecycle.ignore_changes` for the image and provider bookkeeping drift. If a
   change alters Terraform-owned template shape (env, probes, resources, or
-  template scaling), re-audit `template[0].revision` for that PR. The Peg
-  runtime attachment retains it while
-  `local.peg_policy_runtime_generation` is `null`, and removes it only in the
-  same reviewed change that sets a concrete generation.
+  template scaling), re-audit `template[0].revision` for that PR.
 - Project-level IAM changes must be ordered behind required bootstrap/API enablement dependencies.
 - Keep routine Cloud Build and App Engine uploads on the explicit buckets and
   scoped roles in
-  [`ADR 0053`](../docs/adr/0053-explicit-deployment-source-staging.md). Apply
-  this additive bucket/IAM prerequisite from clean current `main`, after its
-  infrastructure-only PR merges and with explicit approval. Verify it live
-  before merging the routing follow-up for automatic deploy workflows; canary
+  [`ADR 0053`](../docs/adr/0053-explicit-deployment-source-staging.md); canary
   all paths before removing broad fallback roles.
 - Keep routine deploy, PR plan, trusted-main refresh, and production apply
   identities separate as required by
-  [`ADR 0047`](../docs/adr/0047-separated-terraform-ci-identities.md). The
-  IaC-owned workflow selectors are
-  `vars.GCP_PRODUCTION_INFRA_WORKLOAD_IDENTITY_PROVIDER`,
-  `vars.GCP_PRODUCTION_INFRA_SERVICE_ACCOUNT`,
-  `vars.GCP_TERRAFORM_REFRESH_WORKLOAD_IDENTITY_PROVIDER`, and
-  `vars.GCP_TERRAFORM_REFRESH_SERVICE_ACCOUNT`. The five trusted-main plan
-  workflows and `terraform-drift.yml` enter the refresh provider. Policy
-  publication selects its dedicated plan account; the other workflows select
-  the shared refresh account. The shared account's WIF binding must list only
-  those five regular workflow refs; a pool-wide main-ref binding would let
-  publication bypass its dedicated chain. Routing is live, and run
-  [#30212385280](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/30212385280)
-  completed the full-refresh proof. The legacy-authority removal, run drain,
-  and final IAM/WIF audit are complete.
+  [`ADR 0047`](../docs/adr/0047-separated-terraform-ci-identities.md). Policy
+  publication selects its dedicated plan account; the other trusted-main
+  workflows select the shared refresh account, whose WIF binding must list only
+  those five regular workflow refs. A pool-wide main-ref binding would let
+  publication bypass its dedicated chain.
 - Build trusted-main refresh access from curated non-basic project read roles;
-  never use basic `roles/viewer`. Keep Secret Accessor limited to the exact
-  Terraform-managed secrets and Storage Object Viewer limited to state and
-  deployment-source buckets. Treat service data exposed by predefined readers
-  (including logs, metrics, and artifacts) as part of the confidentiality
-  review. The merged `main` route completed full-refresh, unlocked plans for
-  every CI-managed Google-provider stack. Add only an exact missing permission
-  named by a provider denial.
-- The Peg-policy foundation creates no policy object. Both buckets, the
-  runtime, and publisher live in `mento-monitoring`; the workflow-only plan and
-  reader identities live in the seed project. The shared refresh identity must
-  not read policy objects, while the runtime and publication reader have exact
-  bucket-scoped Object Viewer grants. Direct bucket grants stay authoritative
-  and exact. The org-Terraform account normally reconciles both policies through
-  `pegPolicyBucketController` with only bucket get/update and IAM-policy get/set.
-  The protected org-Terraform project Owner and organization IAM administrators
-  are audited emergency exceptions; inherited grants still apply. Do not retain
-  a project-level controller grant or broad Storage Admin, Storage Object Admin,
-  or Service Account User fallbacks. An explicitly approved, time-bounded
-  emergency bootstrap may grant only `pegPolicyBucketController` at project level
-  until both policies reconcile; remove it immediately, verify its absence, and
-  run a clean full plan. The recovery sequence is in
-  [`docs/terraform.md`](../docs/terraform.md) and
+  never basic `roles/viewer`. Keep Secret Accessor limited to the exact
+  Terraform-managed secrets and Storage Object Viewer to state and
+  deployment-source buckets, and count the service data predefined readers
+  expose — logs, metrics, artifacts — as part of the confidentiality review.
+  Add only an exact missing permission named by a provider denial.
+- Peg policy: the runtime attachment pins the current generation as a reviewed
+  source literal and the Grafana consumers are live, so rule and threshold
+  changes take the ordinary plan → approved-apply path. Never retain a
+  project-level controller grant or broad Storage Admin, Storage Object Admin,
+  or Service Account User fallbacks. An approved,
+  time-bounded emergency bootstrap may grant only `pegPolicyBucketController` at
+  project level until both policies reconcile; remove it immediately, verify its
+  absence, and run a clean full plan. The routine deployer and `gcp_dev_members`
+  receive Service Account User only on the Metrics Bridge runtime identity.
+  Terraform derives the pinned GCS URL and `gcp-metadata` mode together from the
+  reviewed generation literal; never supply a URL or auth-mode variable. See
+  [`docs/terraform.md`](../docs/terraform.md),
+  [ADR 0054](../docs/adr/0054-same-project-peg-policy-artifact.md), and
   [ADR 0055](../docs/adr/0055-peg-policy-bucket-controller-recovery.md).
-  Metrics Bridge uses the dedicated runtime identity and currently pins
-  generation `1785276001213660` through paired `PEG_POLICY_*` values. A future
-  rollover replaces the current quoted positive generation in the reviewed
-  source literal; never supply a URL or auth-mode variable. Terraform derives
-  the canonical pinned GCS URL and `gcp-metadata` mode together. The routine deployer and
-  `gcp_dev_members` receive Service Account User only on that runtime identity;
-  never restore a project-wide or default-Compute grant. Audit effective
-  readers, writers, and IAM administrators after applies and before future
-  rollovers.
-  Access logs are audit
-  telemetry, never an authorization control.
+- Access logs are audit telemetry, never an authorization control.
 
 ## Verification
 

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -3,7 +3,7 @@ title: Monitoring Dashboard Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-29
 doc_type: agent-instructions
 scope: ui-dashboard
 review_interval_days: 90
@@ -49,27 +49,16 @@ Keep runtime Zod guards for hosted-Hasura rollout drift.
 
 ## Browser Target — Explicit Runtime Floor, No Blocklist Polyfills
 
-Client code is transpiled to ES2017. The app adds no polyfill for the closed
-blocklist below; Next.js still injects selected framework polyfills such as
-`fetch`, `URL`, and `Object.assign`. The runtime support floor is Chrome 111+,
-Edge 111+, Firefox 111+, and Safari 16.4+, pinned in `package.json`. APIs
-available across that floor are allowed, including `Array.prototype.at`,
-`findLast`, `findLastIndex`, `flatMap`, and `Promise.allSettled`.
-
-Lint blocks this closed set of known hazards in client-shipped code:
-`Array.prototype.toSorted`, `toReversed`, `toSpliced`, and `with`;
-`TypedArray.prototype.toSorted`, `toReversed`, and `with`;
-`Object.groupBy`, `Map.groupBy`, `String.prototype.isWellFormed`, and
-`String.prototype.toWellFormed`. Use `sortedCopy` from
-`@/lib/immutable-sort` for immutable sorting. Any module imported directly or
-transitively by a `"use client"` component ships to the browser; the lint rule
-exempts explicit server-only routes, OG helpers, and tests. The blocklist is
-not an exhaustive compatibility checker for every JavaScript built-in; update
-the policy and its regression fixtures before adding another API outside the
-browser floor.
-
-See [ADR 0023](../docs/adr/0023-es2017-no-polyfill.md) before changing the
-transpilation target, browser floor, polyfill posture, or restriction.
+Client code is transpiled to ES2017 and the app adds no blocklist polyfill. The
+runtime floor is Chrome 111+, Edge 111+, Firefox 111+, and Safari 16.4+, pinned
+in `package.json`. Lint owns the closed blocklist of post-floor APIs in
+client-shipped code — any module a `"use client"` component imports directly or
+transitively ships to the browser — so use `sortedCopy` from
+`@/lib/immutable-sort` for immutable sorting. The blocklist is not an exhaustive
+compatibility checker: update the policy and its regression fixtures before
+adding an API outside the floor, and read
+[ADR 0023](../docs/adr/0023-es2017-no-polyfill.md) before changing the
+transpilation target, floor, or polyfill posture.
 
 ## Browser and Quality Verification
 
@@ -89,45 +78,32 @@ use only a narrowly justified inline suppression.
 
 Apply
 [`../docs/pr-checklists/swr-polling-hasura.md`](../docs/pr-checklists/swr-polling-hasura.md)
-for every Hasura-polling hook. In particular:
-
-- keep focus and reconnect revalidation disabled in `useGQL`, keep retry
-  behavior visibility-aware, and use an explicit abort timeout below the
-  refresh interval only for polling paths that must fail or degrade quickly;
-- distinguish loading (`data === undefined && !error`) from resolved zero or
-  empty data;
-- use pre-rolled entities for lifetime aggregates. Hosted Hasura caps rows at
-  1,000 and disables `_aggregate`; multi-field `order_by` uses array syntax;
-- isolate new schema fields so an older hosted schema degrades only the new
-  annotation during deploy/resync.
-
-FX durations use trading-seconds and live paths call
-`tradingSecondsInRange`; threshold-derived history uses the threshold captured
-at event time. The stateful checklist owns the full time-unit contract.
+to every Hasura-polling hook; it owns revalidation, retry, loading-versus-empty
+semantics, row caps, and schema-rollout isolation. Two domain facts it does not
+carry: lifetime aggregates read pre-rolled entities, and FX durations use
+trading-seconds — live paths call `tradingSecondsInRange`, and
+threshold-derived history uses the threshold captured at event time.
 
 ## Interaction, URL, and Accessibility Invariants
 
-- Async mutations require a synchronous in-flight ref guard in addition to
-  disabled React state; wire abort cleanup and suppress teardown-only errors.
-- URL state that does not require server involvement uses
-  `history.replaceState`. Initialize from `useSearchParams`, use
-  `window.location.search` after mount/action time, and preserve sibling params
-  when history-only and router-backed writers coexist. Apply the URL section of
-  the stateful checklist.
+- Async mutations need a synchronous in-flight ref guard alongside disabled
+  React state; wire abort cleanup and suppress teardown-only errors.
+- Server-free URL state uses `history.replaceState`: initialize from
+  `useSearchParams`, read `window.location.search` after mount or action time,
+  and preserve sibling params when history-only and router-backed writers
+  coexist.
 - Dynamic status uses `role="status"` or `role="alert"`; sortable headers expose
   `aria-sort`. Add deterministic axe coverage for new shared semantic controls.
-- Source files have a 600-line soft cap and 1,000-line lint cap. Split route
-  pages into `_lib`, `_components`, or `_tabs` before crossing the soft cap;
-  see
-  [`../docs/pr-checklists/recurring-review-patterns.md`](../docs/pr-checklists/recurring-review-patterns.md).
+- Source files have a 600-line soft cap and 1,000-line lint cap; split route
+  pages into `_lib`, `_components`, or `_tabs` before crossing the soft cap.
 
 ## Server Boundaries and CSP
 
 Apply the dashboard server/client and Security/CSP sections of
 [`../docs/pr-checklists/recurring-review-patterns.md`](../docs/pr-checklists/recurring-review-patterns.md).
 Client-hook modules cannot enter OG, API, or server-route import graphs; shared
-constants belong in zero-dependency modules. CSP is set only by middleware with
-a per-request nonce. Keep `script-src` free of unsafe inline/eval, retain
+constants belong in zero-dependency modules. Only middleware sets CSP, with a
+per-request nonce. Keep `script-src` free of unsafe inline/eval, retain
 attribute-style support in `style-src`, and update CSP tests with every
 `connect-src` change.
 


### PR DESCRIPTION
## The Problem

- Agent entry-point files accumulated status narration, restated checklist
  content, and code-describing sections that cost context every session and
  rot as the system moves.
- Root `AGENTS.md`'s PR Workflow section regressed into duplicating the
  operating card it points at (#1518 trimmed it to a pointer; #1531
  re-inserted the command blocks).
- `terraform/AGENTS.md` still described Peg alert activation as pending after
  #1680/#1685 shipped it.

## The Solution

Re-apply the single-owner discipline across every agent entry point: each file
keeps safety rails, non-derivable gotchas, and pointers, while detail lives at
its owning surface (ADRs, checklists, package READMEs). This follows
Anthropic's published Claude 5 context-engineering guidance: judgment over
rules, progressive disclosure over front-loading, one owner per fact.

## Details

- Root `AGENTS.md` 189 → 150 lines; PR Workflow is again a pointer plus the
  queue fact and the merge-approval rule.
- `terraform/AGENTS.md` 133 → 109: completed-state narration and the
  run-link proof removed; the peg generation literal no longer appears in two
  agent files; the stale activation line now states the live Grafana state.
- `aegis/AGENTS.md` 104 → 59: RPC error-classification detail moved to a new
  `aegis/README.md` section; the dated coverage snapshot replaced by the
  enforced `coverageThreshold` values.
- `metrics-bridge/AGENTS.md` 105 → 82: peg bootstrap compressed to service
  invariants; runtime-identity IAM delegated to `terraform/AGENTS.md` and
  ADR 0054.
- `integration-probes/AGENTS.md` 112 → 89: env-var reference moved to a new
  package README; anti-starvation guards kept as policy, not mechanics.
- `ui-dashboard/AGENTS.md` 142 → 118: the lint-owned API blocklist is now
  policy plus pointer instead of an enumerated list.
- `indexer-envio/AGENTS.md` light trim; `alerts/AGENTS.md` TODO comment
  removed (tracked in the linked issue); `shared-config/AGENTS.md` one-time
  npm-seeding prose removed after verifying `@mento-protocol/config@0.1.0` is
  published.

## Validation

- `pnpm agent:quality-gate --run` green; `pnpm agent:context-check` green
  (128 managed files); `pnpm agent:context-budget --strict` OK with headroom;
  `pnpm docs:index --write` regenerated the catalog;
  `pnpm docs:navigation-eval --check-fixtures --json` valid; `trunk fmt`
  clean.
- Peg activation state verified against merged #1680/#1685 (live Grafana
  proof: 39 rules, health ok) before rewriting the stale line.
- Claude Security scan: skipped (docs-only change).

## Deferrals

- Terraform-side regression coverage for the QuickNode webhook state-rm plumbing moved from an `alerts/AGENTS.md` TODO comment to https://github.com/mento-protocol/monitoring-monorepo/issues/1689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdQUxQhvNHcacM9cMVXACV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, Terraform, or application code changes; risk is limited to agents following outdated instructions if pointers are wrong.
> 
> **Overview**
> **Docs-only refactor** that applies single-owner discipline across agent entry points: each `AGENTS.md` keeps safety rails, non-derivable gotchas, and pointers; long-form detail moves to package READMEs, ADRs, and checklists.
> 
> Root **`AGENTS.md`** PR Workflow is trimmed again to the operating-card pointer, queue/claim fact, merge-approval rule, and Claude capability-gate note — duplicated command blocks and babysit/ready-state prose are removed.
> 
> **`aegis/AGENTS.md`** drops the long RPC classification essay and dated coverage snapshot; **`aegis/README.md`** gains an **RPC error handling** section (transport vs deterministic, `view_call_rpc_errors_total`, fallback config). **`integration-probes/AGENTS.md`** drops inline env-var lists in favor of a new **`integration-probes/README.md`**; anti-starvation rules stay as policy. **`metrics-bridge/AGENTS.md`** compresses peg bootstrap and delegates runtime IAM to **`terraform/AGENTS.md`**.
> 
> **`terraform/AGENTS.md`** removes completed-state narration and duplicate peg generation literals; peg policy now states live Grafana consumers and the ordinary plan/apply path instead of pending activation. **`ui-dashboard/AGENTS.md`**, **`indexer-envio/AGENTS.md`**, and **`shared-config/AGENTS.md`** get similar trims (checklist pointers vs repeated lists). **`alerts/AGENTS.md`** loses an inline Terraform-coverage TODO; **`docs/README.md`** catalogs the new integration-probes README. **`last_verified`** bumps on touched agent files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03af4274ecc9bb36d74e96c621e4c8bc13b3ce2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
