### PR TITLE
docs: ratchet context budgets and harden the gardening rubric

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-project_doc_max_bytes = 28_672
+project_doc_max_bytes = 18_944
 
 [mcp_servers.chrome-devtools]
 args = ["chrome-devtools-mcp@latest"]

--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -3,7 +3,7 @@ title: Agent Context Standards
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-26
+last_verified: 2026-07-29
 doc_type: reference
 scope: repo-wide
 review_interval_days: 90
@@ -122,6 +122,14 @@ frontmatter for other managed Markdown.
 - Put repeatable procedures in `.agents/skills`, not in long root prose.
 - Put verification personas in `.agents/roles`; roles are opt-in and do not run automatically.
 - Keep root `AGENTS.md` small enough that every line earns its default-token cost.
+- State current operating rules only. Status narration, completed-migration
+  notes, run links, and dated proof belong in the ADR or PR that shipped the
+  change.
+- Where a file already links an owning authority, keep at most a one-line gist.
+  Never restate that authority's procedure, command block, or rule list.
+- Do not describe what code does. State the non-obvious constraint, and where a
+  linter, test, or CI gate enforces it, name the enforcing check instead of
+  restating its logic.
 
 ## Change-coupled drift audit
 
@@ -144,11 +152,14 @@ Run `pnpm agent:context-check` to verify managed metadata (including the
 `last_verified` staleness window), scoped AGENTS coverage, skill mirrors, and
 Cloud Run revision suffix guardrails. Run `pnpm docs:index --check` for catalog
 drift and broken internal links. Run `pnpm agent:context-budget --strict` to
-enforce a 12 KiB root-file cap, 16 KiB per scoped file, and 28 KiB per combined
+enforce a 10 KiB root-file cap, 9 KiB per scoped file, and 18.5 KiB per combined
 root-to-directory route. The report warns at 90% and includes the blank-line
 separators Codex inserts between layered files. These limits deliberately stay
 below Codex's truncation boundary; route detail into the narrowest canonical
-note, checklist, or skill instead of raising them. Skill
+note, checklist, or skill instead of raising them. Each cap is the measured
+maximum plus about 35% headroom, rounded up to a 512-byte step, and ratchets
+down only; `project_doc_max_bytes` in `.codex/config.toml` tracks the route cap.
+Skill
 mirrors must match their canonical `.agents/skills` source except for documented
 runtime-specific provenance literals, such as forensic-report writes using
 `source: "Codex"` in the Codex skill and `source: "claude"` in the Claude skill.

--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -127,9 +127,11 @@ frontmatter for other managed Markdown.
   change.
 - Where a file already links an owning authority, keep at most a one-line gist.
   Never restate that authority's procedure, command block, or rule list.
-- Do not describe what code does. State the non-obvious constraint, and where a
-  linter, test, or CI gate enforces it, name the enforcing check instead of
-  restating its logic.
+- In agent instruction files (`AGENTS.md` and scoped routers), do not describe
+  what code does. State the non-obvious constraint, and where a linter, test,
+  or CI gate enforces it, name the enforcing check instead of restating its
+  logic. Reference documents such as `SPEC.md` and package READMEs still own
+  behavior and architecture descriptions.
 
 ## Change-coupled drift audit
 

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -43,15 +43,14 @@ separate.
 
 ## Claude global-store shadowing
 
-In Claude Code sessions a user-global skill wins over a repo skill with the
-same name. Today that shadows this repo's `ship` and `babysit-pr`: Claude
-sessions load the user's generic implementations, while the repo copies stay
-canonical for Codex and carry the repo-specific cloud capability-gate
-adaptations (whose rules also live in
-[`github-tooling-surfaces.md`](github-tooling-surfaces.md), so Claude sessions
-lose no binding rule). This split is accepted deliberately; do not "fix" it by
-renaming either side. The user's global `forensic-report` copy was archived on
-2026-07-29 so the repo skill resolves everywhere.
+In a Claude Code session, a user-global skill wins over a repo skill with the
+same name, so personal `ship` or `babysit-pr` implementations shadow the repo
+copies when present. That is accepted: the repo copies stay canonical for
+Codex and for the cloud capability-gate adaptations, whose binding rules also
+live in [`github-tooling-surfaces.md`](github-tooling-surfaces.md), so a
+shadowed Claude session loses no rule. Do not resolve the collision by
+renaming either side; the running session's skill listing, not this note, is
+the runtime truth for which copy loaded.
 
 ## Codex Cloud routing
 

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -3,7 +3,7 @@ title: Codex Agent Skills
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-29
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -40,6 +40,18 @@ note as their single owner instead of copying implementation details here.
 Autoreview is source review only: mapped quality gates, browser checks,
 generated-artifact checks, runtime verification, and final PR readiness remain
 separate.
+
+## Claude global-store shadowing
+
+In Claude Code sessions a user-global skill wins over a repo skill with the
+same name. Today that shadows this repo's `ship` and `babysit-pr`: Claude
+sessions load the user's generic implementations, while the repo copies stay
+canonical for Codex and carry the repo-specific cloud capability-gate
+adaptations (whose rules also live in
+[`github-tooling-surfaces.md`](github-tooling-surfaces.md), so Claude sessions
+lose no binding rule). This split is accepted deliberately; do not "fix" it by
+renaming either side. The user's global `forensic-report` copy was archived on
+2026-07-29 so the repo skill resolves everywhere.
 
 ## Codex Cloud routing
 

--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -3,7 +3,7 @@ title: Documentation gardening
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-29
 doc_type: runbook
 scope: ci/process
 review_interval_days: 90
@@ -133,6 +133,26 @@ Every document receives one evidence-backed disposition: **Keep**,
 Run `pnpm docs:index --check` after a gardening batch. If classification changed,
 regenerate the catalog with `pnpm docs:index --write` and review the generated
 diff before committing it.
+
+### Anti-reinflation: agent entry points and operator runbooks
+
+Consolidation in these two lanes tightens pointers. It never copies an
+authority's content into a router — a consolidation shard once re-inserted
+command blocks a cleanup PR had removed (#1531).
+
+- A shard that would grow a canonical agent file justifies every added line
+  against the three placement rules in
+  [`docs/context-standards.md`](../context-standards.md#placement-rules):
+  current operating rules only, at most a one-line gist where the file already
+  links an owning authority, and constraints or enforcing checks in place of
+  restated code behavior.
+- **Merge** across these lanes moves content to its narrowest owner and leaves a
+  pointer behind. Duplicating the owner's text into the router is not a merge.
+- Prefer **Tighten** over **Update** when a section restates an authority; the
+  correct edit is usually a shorter pointer, not a fresher copy.
+- Run `pnpm agent:context-budget --strict` before opening the gardening PR. The
+  caps ratchet down as files shrink, so a shard that consumes headroom needs the
+  same per-line justification even while the check still passes.
 
 ## Fresh-agent navigation evaluation
 

--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -150,9 +150,11 @@ command blocks a cleanup PR had removed (#1531).
   pointer behind. Duplicating the owner's text into the router is not a merge.
 - Prefer **Tighten** over **Update** when a section restates an authority; the
   correct edit is usually a shorter pointer, not a fresher copy.
-- Run `pnpm agent:context-budget --strict` before opening the gardening PR. The
-  caps ratchet down as files shrink, so a shard that consumes headroom needs the
-  same per-line justification even while the check still passes.
+- Run `pnpm agent:context-budget --strict` before opening the gardening PR.
+  Its caps are fixed constants (measured maximum plus ~35%, lowered manually
+  when files shrink, never raised), so a passing check is not permission to
+  consume freed headroom: a shard that grows a canonical file needs the same
+  per-line justification even while the check passes.
 
 ## Fresh-agent navigation evaluation
 

--- a/scripts/agent-context-budget.mjs
+++ b/scripts/agent-context-budget.mjs
@@ -7,9 +7,9 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 export const DEFAULT_LIMIT_BYTES = 32 * 1024;
-export const MAX_ROUTE_LIMIT_BYTES = 28 * 1024;
-export const ROOT_INSTRUCTION_LIMIT_BYTES = 12 * 1024;
-export const SCOPED_INSTRUCTION_LIMIT_BYTES = 16 * 1024;
+export const MAX_ROUTE_LIMIT_BYTES = 18_944;
+export const ROOT_INSTRUCTION_LIMIT_BYTES = 10 * 1024;
+export const SCOPED_INSTRUCTION_LIMIT_BYTES = 9 * 1024;
 export const WARNING_PERCENT = 90;
 
 const CHAIN_SEPARATOR_BYTES = Buffer.byteLength("\n\n");

--- a/scripts/docs-navigation-eval.test.mjs
+++ b/scripts/docs-navigation-eval.test.mjs
@@ -659,6 +659,7 @@ test("an over-budget answer is measured and fails", () => {
   const answer = result.answers[0];
   for (const large of [
     "docs/notes/agent-quality-gate-mechanics.md",
+    "docs/notes/sentry-triage-pipeline.md",
     "docs/context-standards.md",
   ]) {
     answer.loaded_sources.push(source(large));


### PR DESCRIPTION
## The Problem

- The context-budget caps (12/16/28 KiB) were sized for the pre-slim agent
  files; after #1690/#1691 the largest file uses 44% of its cap, so regrowth
  back to the old bloat would pass CI silently.
- Nothing in the gardening rubric stops a consolidation shard from copying an
  authority's content into a router — the exact regression #1531 introduced
  and #1691 had to re-remove.
- The deliberate Claude global-store shadowing of `ship`/`babysit-pr` was
  undocumented, inviting a future "fix" that breaks either side.

## The Solution

Make the slimming self-enforcing: ratchet the byte caps to measured-max plus
~35% headroom, write the three placement rules the slims followed into
`context-standards.md`, bind an anti-reinflation rule set into the gardening
disposition rubric, and document the skill-store shadowing as accepted.

## Details

- `scripts/agent-context-budget.mjs`: root 12,288 → 10,240 B; scoped
  16,384 → 9,216 B; route 28,672 → 18,944 B (rule: `ceil(max × 1.35 / 512) ×
  512`, ratchets down only). `.codex/config.toml`'s
  `project_doc_max_bytes` tracks the route cap (28_672 → 18_944) — the CLI
  hard-fails when config exceeds policy.
- `docs/context-standards.md`: new cap numbers with the derivation rule, plus
  three placement rules (no status narration; one-line gist where an
  authority is already linked; constraints and enforcing checks instead of
  restated code behavior).
- `docs/notes/documentation-gardening.md`: "Anti-reinflation" subsection for
  the agent-entry-points and operator-runbooks lanes — merge moves content
  and leaves a pointer, Tighten beats Update for restatements, and budget
  headroom is not permission to grow.
- `docs/notes/codex-agent-skills.md`: documents the accepted Claude
  global-store shadowing of `ship`/`babysit-pr` and the archival of the
  global `forensic-report` copy.

## Validation

- `node scripts/agent-context-budget.test.mjs` 17/17;
  `pnpm agent:context-budget --strict` exit 0 with every file under the 90%
  warn line; `docs-audit` and `docs-index` tests green;
  `pnpm agent:context-check` green (129 files); `pnpm docs:index --check`
  clean; nav-eval fixture digest unchanged; `trunk fmt` clean.
- Claude Security scan: skipped (docs and threshold-constants only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdQUxQhvNHcacM9cMVXACV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI threshold constants only; no runtime, auth, or data-path changes. Stricter caps may fail future PRs that grow agent instruction files.
> 
> **Overview**
> **Tightens agent context size limits** so post-slim `AGENTS.md` files cannot silently regrow to old bloat. Root, scoped, and combined route caps drop from 12/16/28 KiB to **10/9/18.5 KiB** in `scripts/agent-context-budget.mjs`, with `.codex/config.toml` **`project_doc_max_bytes`** aligned to the route cap (18_944). Docs now describe caps as measured-max plus ~35% headroom (512-byte steps, **ratchet down only**).
> 
> **Codifies slimming rules** in `docs/context-standards.md`: current rules only (no migration narration), one-line gist when an authority is already linked, and constraints/enforcing checks instead of restated code behavior.
> 
> **Adds anti-reinflation guidance** for agent-entry and operator-runbook gardening lanes in `docs/notes/documentation-gardening.md`—merge leaves pointers, **Tighten** beats **Update** for restatements, and budget headroom is not permission to grow routers.
> 
> **Documents accepted Claude global-store shadowing** of `ship`/`babysit-pr` and archival of the global `forensic-report` skill in `docs/notes/codex-agent-skills.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d79f626538c56d7ad1b207b0e09b81684e7d03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->