### PR TITLE
Clarify peg monitoring status

### DIFF
--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -77,6 +77,7 @@ describe("PegMonitoringPageClient", () => {
     state.current = { ...state.current, hasError: true };
     render();
     expect(container.textContent).toContain("Stale — last confirmed package");
+    expect(container.textContent).toContain("Last confirmed conclusion");
     expect(container.textContent).toContain("europ-schuman / EUR");
     state.current = { data: null, isLoading: false, hasError: true };
     render();
@@ -188,6 +189,120 @@ describe("PegMonitoringPageClient", () => {
     render();
 
     expect(container.textContent).toContain("1 of 2 breakers OK");
+  });
+  it("keeps a current critical condition red when another check is incomplete", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            structural: { ...item.structural, blind: true },
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0.995,
+                    deviationBps: item.policy.criticalDeviationBps,
+                    premiumBps: 0,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+
+    const aggregate = container.querySelector(
+      '[data-testid="peg-aggregate-status"]',
+    );
+    expect(aggregate?.textContent).toContain("Critical condition detected");
+    expect(aggregate?.className).toContain("border-red");
+    expect(container.textContent).toContain(
+      "Critical condition in the current package",
+    );
+    expect(container.textContent).toContain(
+      "The alert only fires if enough readings stay there long enough.",
+    );
+    expect(container.textContent).not.toContain("Action required");
+    expect(
+      container.querySelector('[data-testid="peg-current-europ-schuman"]')
+        ?.className,
+    ).toContain("bg-red-600");
+  });
+  it("renders source-adjusted thresholds on the centered distance rail", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    policy: { ...source.policy, conversionErrorBps: 30 },
+                    executablePrice: 0.9975,
+                    deviationBps: 25,
+                    premiumBps: 0,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+
+    const rail = container.querySelector(
+      '[role="img"][aria-label*="Downside warning begins at 55 bps"]',
+    );
+    expect(rail?.getAttribute("aria-label")).toContain(
+      "downside critical at 80 bps",
+    );
+    expect(rail?.getAttribute("aria-label")).toContain(
+      "premium warning at 55 bps",
+    );
+    expect(container.textContent).toContain("30 bps remaining");
+    expect(
+      container.querySelector('[data-testid="peg-current-europ-schuman"]')
+        ?.className,
+    ).toContain("bg-emerald-600");
+
+    state.current = {
+      ...state.current,
+      data: {
+        ...state.current.data!,
+        packages: state.current.data!.packages.map((asset) => ({
+          ...asset,
+          sources: asset.sources.map((source) =>
+            source.id === asset.policy.deepVenueSource
+              ? {
+                  ...source,
+                  executablePrice: 0.9945,
+                  deviationBps: 55,
+                }
+              : source,
+          ),
+        })),
+      },
+    };
+    render();
+    expect(
+      container.querySelector('[data-testid="peg-current-europ-schuman"]')
+        ?.className,
+    ).toContain("bg-amber-500");
   });
   it("renders non-null listing evidence from a schema-version-1 package", () => {
     const response = makePegMonitoringResponse();

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -115,6 +115,26 @@ describe("PegMonitoringPageClient", () => {
     );
     expect(staleAge?.textContent).toContain("Produced 1m ago;");
     expect(staleLiveStatus?.contains(staleAge ?? null)).toBe(false);
+
+    const aggregateStatus = container.querySelector(
+      '[data-testid="peg-aggregate-status"]',
+    );
+    const aggregateAge = container.querySelector(
+      '[data-testid="peg-aggregate-age"]',
+    );
+    const aggregateText = aggregateStatus?.textContent;
+    expect(aggregateText).toContain("Latest data is stale");
+    expect(aggregateText).toContain(
+      "values below are the last confirmed measurements",
+    );
+    expect(aggregateText).not.toMatch(/\b\d+[smh]\b/);
+    expect(aggregateStatus?.contains(aggregateAge ?? null)).toBe(false);
+
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(aggregateStatus?.textContent).toBe(aggregateText);
+    expect(
+      container.querySelector('[data-testid="peg-aggregate-age"]')?.textContent,
+    ).toContain("2m old");
   });
   it("renders previous-policy, partial source evidence, disabled breaker, and null breaker distinctly", () => {
     const response = makePegMonitoringResponse();
@@ -223,7 +243,7 @@ describe("PegMonitoringPageClient", () => {
       '[data-testid="peg-aggregate-status"]',
     );
     expect(aggregate?.textContent).toContain("Critical condition detected");
-    expect(aggregate?.className).toContain("border-red");
+    expect(aggregate?.parentElement?.className).toContain("border-red");
     expect(container.textContent).toContain(
       "Critical condition in the current package",
     );

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -184,6 +184,61 @@ describe("PegMonitoringPageClient", () => {
       container.querySelector('[data-testid="peg-current-europ-schuman"]'),
     ).toBeNull();
   });
+  it("expires structural checks while price evidence and the package remain current", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            policy: { ...item.policy, freshnessGraceSeconds: 60 },
+            sources: item.sources.map((source) => ({
+              ...source,
+              executablePrice:
+                source.id === item.policy.deepVenueSource
+                  ? 0.999
+                  : source.executablePrice,
+              deviationBps:
+                source.id === item.policy.deepVenueSource
+                  ? 10
+                  : source.deviationBps,
+              premiumBps:
+                source.id === item.policy.deepVenueSource
+                  ? 0
+                  : source.premiumBps,
+              policy: {
+                ...source.policy,
+                pollIntervalSeconds: Math.min(
+                  source.policy.pollIntervalSeconds,
+                  60,
+                ),
+              },
+            })),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+    expect(container.textContent).toContain("All pegs healthy");
+    expect(container.textContent).toContain("1 pool reachable");
+
+    act(() => vi.advanceTimersByTime(50_000));
+    expect(container.textContent).toContain("Current package");
+    expect(container.textContent).toContain("Monitoring checks incomplete");
+    expect(container.textContent).toContain("Check expired");
+    expect(container.textContent).toContain("3 of 3 sources usable");
+    expect(container.textContent).toContain(
+      "The structural checks are older than the policy's freshness window.",
+    );
+    expect(
+      container.querySelector('[data-testid="peg-current-europ-schuman"]'),
+    ).not.toBeNull();
+  });
   it("renders previous-policy, partial source evidence, disabled breaker, and null breaker distinctly", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -166,10 +166,17 @@ describe("PegMonitoringPageClient", () => {
     render();
     expect(container.textContent).toContain("Current package");
     expect(container.textContent).toContain("All pegs healthy");
+    expect(container.textContent).toContain("3 of 3 sources usable");
 
     act(() => vi.advanceTimersByTime(10_000));
     expect(container.textContent).toContain("Current package");
     expect(container.textContent).toContain("Price check unavailable");
+    expect(container.textContent).toContain("2 of 3 sources usable");
+    expect(container.textContent).not.toContain("3 of 3 sources healthy");
+    const marketLabel = Array.from(container.querySelectorAll("dt")).find(
+      ({ textContent }) => textContent === "Market",
+    );
+    expect(marketLabel?.nextElementSibling?.textContent).toBe("Unavailable");
     expect(container.textContent).toContain(
       "The policy-selected market observation is older than its allowed freshness window.",
     );

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -359,6 +359,52 @@ describe("PegMonitoringPageClient", () => {
         ?.className,
     ).toContain("bg-red-600");
   });
+  it("renders confirmed blind-while-stressed evidence as critical", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            structural: {
+              ...item.structural,
+              blind: true,
+              blindConsecutivePolls: item.policy.blindConsecutivePolls,
+            },
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    capped: true,
+                    executablePrice:
+                      item.policy.target *
+                      (1 -
+                        (item.policy.criticalDeviationBps +
+                          source.policy.conversionErrorBps) /
+                          10_000),
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+
+    const aggregate = container.querySelector(
+      '[data-testid="peg-aggregate-status"]',
+    );
+    expect(aggregate?.textContent).toContain("Critical condition detected");
+    expect(aggregate?.parentElement?.className).toContain("border-red");
+    expect(container.textContent).toContain(
+      "available partial price crossed the critical downside limit",
+    );
+  });
   it("renders source-adjusted thresholds on the centered distance rail", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -158,6 +158,36 @@ describe("PegMonitoringPageClient", () => {
     );
     expect(disabled?.className).toContain("text-red-300");
     expect(container.textContent).toContain("Breaker unavailable");
+    expect(container.textContent).toContain("0 of 2 breakers OK");
+  });
+  it("keeps unavailable breakers in the health-summary denominator", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    const monitor = item.monitors[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            monitors: [
+              monitor,
+              {
+                ...monitor,
+                rateFeedId: "0x6666666666666666666666666666666666666666",
+                breaker: null,
+              },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+
+    expect(container.textContent).toContain("1 of 2 breakers OK");
   });
   it("renders non-null listing evidence from a schema-version-1 package", () => {
     const response = makePegMonitoringResponse();

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -136,6 +136,47 @@ describe("PegMonitoringPageClient", () => {
       container.querySelector('[data-testid="peg-aggregate-age"]')?.textContent,
     ).toContain("2m old");
   });
+  it("expires source evidence while its package is still current", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0.999,
+                    deviationBps: 10,
+                    premiumBps: 0,
+                    observationAt: response.producedAt - 100,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+    expect(container.textContent).toContain("Current package");
+    expect(container.textContent).toContain("All pegs healthy");
+
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(container.textContent).toContain("Current package");
+    expect(container.textContent).toContain("Price check unavailable");
+    expect(container.textContent).toContain(
+      "The policy-selected market observation is older than its allowed freshness window.",
+    );
+    expect(
+      container.querySelector('[data-testid="peg-current-europ-schuman"]'),
+    ).toBeNull();
+  });
   it("renders previous-policy, partial source evidence, disabled breaker, and null breaker distinctly", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -239,6 +239,66 @@ describe("PegMonitoringPageClient", () => {
       container.querySelector('[data-testid="peg-current-europ-schuman"]'),
     ).not.toBeNull();
   });
+  it("expires breaker conclusions with the structural check", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            policy: { ...item.policy, freshnessGraceSeconds: 60 },
+            monitors: item.monitors.map((monitor) => ({
+              ...monitor,
+              breaker:
+                monitor.breaker === null
+                  ? null
+                  : { ...monitor.breaker, enabled: false },
+            })),
+            sources: item.sources.map((source) => ({
+              ...source,
+              executablePrice:
+                source.id === item.policy.deepVenueSource
+                  ? 0.999
+                  : source.executablePrice,
+              deviationBps:
+                source.id === item.policy.deepVenueSource
+                  ? 10
+                  : source.deviationBps,
+              premiumBps:
+                source.id === item.policy.deepVenueSource
+                  ? 0
+                  : source.premiumBps,
+              policy: {
+                ...source.policy,
+                pollIntervalSeconds: Math.min(
+                  source.policy.pollIntervalSeconds,
+                  60,
+                ),
+              },
+            })),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+
+    render();
+    expect(container.textContent).toContain("Critical condition detected");
+    expect(container.textContent).toContain("0 of 1 breakers OK");
+
+    act(() => vi.advanceTimersByTime(50_000));
+    expect(container.textContent).toContain("Monitoring checks incomplete");
+    expect(container.textContent).not.toContain(
+      "Critical condition in the current package",
+    );
+    const breakerLabel = Array.from(container.querySelectorAll("dt")).find(
+      ({ textContent }) => textContent === "Breaker",
+    );
+    expect(breakerLabel?.nextElementSibling?.textContent).toBe("Check expired");
+  });
   it("renders previous-policy, partial source evidence, disabled breaker, and null breaker distinctly", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/page.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/page.tsx
@@ -4,7 +4,7 @@ import { PegMonitoringPageClient } from "./peg-monitoring-page-client";
 export const metadata: Metadata = {
   title: "Peg monitoring | Mento Monitoring",
   description:
-    "Current executable-price, structural, source, and breaker evidence for Mento peg monitoring.",
+    "Current peg measurements, decision status, and supporting evidence for Mento monitoring.",
 };
 export default function PegMonitoringPage(): React.JSX.Element {
   return <PegMonitoringPageClient />;

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-evidence-primitives.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-evidence-primitives.tsx
@@ -52,14 +52,14 @@ export function EvidenceItem({
 }): React.JSX.Element {
   return (
     <div className="min-w-0 rounded-md border border-slate-800/80 bg-slate-950/40 px-3 py-2.5">
-      <dt className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+      <dt className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
         {label}
       </dt>
       <dd className="mt-1 break-words text-sm font-medium text-slate-200">
         {value}
       </dd>
       {detail ? (
-        <dd className="mt-0.5 break-words text-[11px] text-slate-500">
+        <dd className="mt-0.5 break-words text-[11px] text-slate-400">
           {detail}
         </dd>
       ) : null}

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
@@ -1,4 +1,4 @@
-const cards = ["furthest", "warning", "freshness"];
+const cards = ["warning", "freshness"];
 const evidenceItems = ["market", "sources", "pool", "breaker"];
 
 function Bar({ className }: { className: string }): React.JSX.Element {
@@ -19,7 +19,7 @@ export function PegMonitoringLoading(): React.JSX.Element {
       </div>
       <div
         data-testid="peg-skeleton-headlines"
-        className="grid gap-3 md:grid-cols-3"
+        className="grid gap-3 md:grid-cols-2"
       >
         {cards.map((card) => (
           <div

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
@@ -1,138 +1,82 @@
-const LOADING_MONITOR_KEYS = [
-  "t",
-  "u",
-  "v",
-  "w",
-  "x",
-  "y",
-  "z",
-  "aa",
-  "ab",
-  "ac",
-];
-const LOADING_SOURCE_KEYS = ["bitvavo-eur", "kraken-eur", "kraken-usd"];
-const LOADING_SOURCE_EVIDENCE_KEYS = [
-  "ac",
-  "ad",
-  "ae",
-  "af",
-  "ag",
-  "ah",
-  "ai",
-  "aj",
-  "ak",
-  "al",
-];
+const cards = ["furthest", "warning", "freshness"];
+const evidenceItems = ["market", "sources", "pool", "breaker"];
 
-function LoadingMonitors(): React.JSX.Element {
-  return (
-    <section data-testid="peg-skeleton-monitors" className="space-y-3">
-      <div className="h-5 w-48 animate-pulse rounded bg-slate-800" />
-      <article className="space-y-4 rounded-lg border border-slate-800 bg-slate-950/35 p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-2">
-            <div className="h-4 w-16 animate-pulse rounded bg-slate-800" />
-            <div className="h-5 w-36 animate-pulse rounded bg-slate-800" />
-          </div>
-          <div className="h-7 w-24 animate-pulse rounded-full bg-slate-800" />
-        </div>
-        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-          {LOADING_MONITOR_KEYS.map((key) => (
-            <div
-              key={key}
-              className={`${key === "ab" || key === "ac" ? "h-16" : "h-24"} animate-pulse rounded-md border border-slate-800/80 bg-slate-950/40`}
-            />
-          ))}
-        </div>
-      </article>
-    </section>
-  );
-}
-
-function LoadingSources(): React.JSX.Element {
-  return (
-    <section data-testid="peg-skeleton-sources" className="space-y-3">
-      <div className="h-5 w-44 animate-pulse rounded bg-slate-800" />
-      {LOADING_SOURCE_KEYS.map((sourceKey) => (
-        <article
-          key={sourceKey}
-          className="space-y-4 rounded-lg border border-slate-800 bg-slate-950/35 p-4"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div className="space-y-2">
-              <div className="h-5 w-40 animate-pulse rounded bg-slate-800" />
-              <div className="h-4 w-52 animate-pulse rounded bg-slate-800" />
-            </div>
-            <div className="h-7 w-44 animate-pulse rounded-full bg-slate-800" />
-          </div>
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-            {LOADING_SOURCE_EVIDENCE_KEYS.map((key) => (
-              <div
-                key={`${sourceKey}-${key}`}
-                // The converted source policy carries both the listing threshold
-                // and conversion provenance, which occupy two extra lines.
-                className={`${sourceKey === "kraken-usd" && key === "al" ? "h-32" : "h-20"} animate-pulse rounded-md border border-slate-800/80 bg-slate-950/40`}
-              />
-            ))}
-          </div>
-        </article>
-      ))}
-    </section>
-  );
+function Bar({ className }: { className: string }): React.JSX.Element {
+  return <div className={`rounded bg-slate-800 ${className}`} />;
 }
 
 export function PegMonitoringLoading(): React.JSX.Element {
   return (
-    <section aria-label="Loading peg monitoring" className="space-y-6">
+    <section
+      aria-label="Loading peg monitoring"
+      className="space-y-5 animate-pulse"
+    >
       <div
         data-testid="peg-skeleton-status"
-        className="h-12 animate-pulse rounded-lg border border-slate-800 bg-slate-900/45"
-      />
-      <div data-testid="peg-skeleton-snapshot" className="space-y-3">
-        <div className="h-7 w-28 animate-pulse rounded bg-slate-800" />
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-          {["a", "b", "c", "d", "e"].map((key) => (
-            <div
-              key={key}
-              className="h-28 animate-pulse rounded-md border border-slate-800 bg-slate-950/40"
-            />
-          ))}
-        </div>
+        className="rounded-xl border border-slate-800 bg-slate-900/45 p-5"
+      >
+        <Bar className="h-5 w-44" />
       </div>
       <div
-        data-testid="peg-skeleton-package"
-        className="space-y-6 rounded-xl border border-slate-800 bg-slate-900/45 p-4 sm:p-6"
+        data-testid="peg-skeleton-headlines"
+        className="grid gap-3 md:grid-cols-3"
       >
-        <div
-          data-testid="peg-skeleton-package-header"
-          className="flex flex-wrap items-start justify-between gap-4"
-        >
-          <div className="h-12 w-1/3 animate-pulse rounded bg-slate-800" />
+        {cards.map((card) => (
+          <div
+            key={card}
+            className="space-y-5 rounded-xl border border-slate-800 bg-slate-900/45 p-5"
+          >
+            <Bar className="h-3 w-32" />
+            <Bar className="h-7 w-3/4" />
+            <Bar className="h-3 w-2/3" />
+          </div>
+        ))}
+      </div>
+      <article
+        data-testid="peg-skeleton-scorecard"
+        className="rounded-xl border border-slate-800 bg-slate-900/45 p-5"
+      >
+        <div className="grid gap-6 xl:grid-cols-[minmax(13rem,0.8fr)_minmax(20rem,1.4fr)_minmax(13rem,0.8fr)] xl:items-center">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <Bar className="h-6 w-36" />
+              <Bar className="h-7 w-20 rounded-full" />
+            </div>
+            <Bar className="h-9 w-44" />
+            <Bar className="h-3 w-56 max-w-full" />
+          </div>
+          <div className="space-y-3">
+            <div className="flex justify-between gap-3">
+              <Bar className="h-4 w-28" />
+              <Bar className="h-4 w-36" />
+            </div>
+            <Bar className="h-3 w-full rounded-full" />
+            <div className="flex justify-between gap-3">
+              <Bar className="h-3 w-12" />
+              <Bar className="h-3 w-24" />
+              <Bar className="h-3 w-24" />
+            </div>
+          </div>
+          <div className="space-y-4 rounded-lg border border-slate-800 p-4">
+            <Bar className="h-3 w-32" />
+            <Bar className="h-5 w-full" />
+            <Bar className="h-3 w-3/4" />
+          </div>
         </div>
-        <section data-testid="peg-skeleton-structural" className="space-y-3">
-          <div className="h-5 w-40 animate-pulse rounded bg-slate-800" />
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-6">
-            {["f", "g", "h", "i", "j", "k"].map((key) => (
-              <div
-                key={key}
-                className="h-20 animate-pulse rounded-md border border-slate-800/80 bg-slate-950/40"
-              />
-            ))}
-          </div>
-        </section>
-        <section data-testid="peg-skeleton-policy" className="space-y-3">
-          <div className="h-5 w-48 animate-pulse rounded bg-slate-800" />
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-            {["l", "m", "n", "o", "p", "q", "r", "s"].map((key) => (
-              <div
-                key={key}
-                className="h-20 animate-pulse rounded-md border border-slate-800/80 bg-slate-950/40"
-              />
-            ))}
-          </div>
-        </section>
-        <LoadingMonitors />
-        <LoadingSources />
+        <div className="mt-5 grid gap-4 border-t border-slate-800 pt-4 sm:grid-cols-4">
+          {evidenceItems.map((item) => (
+            <div key={item} className="space-y-2">
+              <Bar className="h-3 w-20" />
+              <Bar className="h-4 w-32 max-w-full" />
+            </div>
+          ))}
+        </div>
+      </article>
+      <div
+        data-testid="peg-skeleton-evidence"
+        className="rounded-xl border border-slate-800 bg-slate-950/35 p-5"
+      >
+        <Bar className="h-5 w-40" />
       </div>
     </section>
   );

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -242,7 +242,7 @@ function Monitor({ monitor }: { monitor: PegMonitor }): React.JSX.Element {
     <article className="rounded-lg border border-slate-800 bg-slate-950/35 p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs text-slate-500">Chain {monitor.chainId}</p>
+          <p className="text-xs text-slate-400">Chain {monitor.chainId}</p>
           <Link
             href={`${buildPoolDetailHref(`${monitor.chainId}-${monitor.poolAddress}`)}?tab=oracle`}
             className="mt-1 inline-flex font-mono text-sm text-indigo-400 hover:text-indigo-300"
@@ -325,7 +325,7 @@ function Source({ source }: { source: PegSource }): React.JSX.Element {
           <h4 className="font-medium text-white">
             {source.provider} · {source.pair}
           </h4>
-          <p className="mt-1 text-xs text-slate-500">
+          <p className="mt-1 text-xs text-slate-400">
             {source.id} · {source.registryRole} role · {source.authority}{" "}
             authority
           </p>
@@ -419,7 +419,7 @@ function Package({
           <h2 id={heading} className="text-xl font-semibold text-white">
             {item.asset} / {item.peg}
           </h2>
-          <p className="mt-1 text-xs text-slate-500">
+          <p className="mt-1 text-xs text-slate-400">
             {item.coverageClass} · {item.sources.length} sources ·{" "}
             {item.monitors.length} monitors
           </p>

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -466,13 +466,15 @@ export function PegMonitoringPageClient(): React.JSX.Element {
     const timer = window.setInterval(() => setNow(Date.now()), 10_000);
     return () => window.clearInterval(timer);
   }, []);
+  const nowMs = Math.max(now, Date.now());
   const state = classifyPegMonitoringState({
     ...result,
-    nowMs: Math.max(now, Date.now()),
+    nowMs,
   });
   const presentation =
     state.kind === "current" || state.kind === "stale"
       ? presentPegMonitoring(state.data, {
+          nowMs,
           packageIsStale: state.kind === "stale",
           usesPreviousPolicy:
             state.data.policySlot === "previous" ||

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -42,8 +42,8 @@ function Header(): React.JSX.Element {
         </h1>
       </div>
       <p className="max-w-3xl text-sm leading-6 text-slate-400">
-        See whether a monitored asset is off peg or nearing action from its
-        current measurement and supporting evidence.
+        See whether a monitored asset is off peg or nearing a warning threshold
+        from its current measurement and supporting evidence.
       </p>
     </header>
   );

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -13,6 +13,7 @@ import {
   type PegMonitoringViewState,
   type PegSource,
 } from "@/lib/peg-monitoring";
+import { presentPegMonitoring } from "@/lib/peg-monitoring-presentation";
 import { buildPoolDetailHref } from "@/lib/routing";
 import {
   EvidenceItem,
@@ -27,31 +28,23 @@ import {
   titleCase,
 } from "./peg-monitoring-evidence-primitives";
 import { PegMonitoringLoading } from "./peg-monitoring-loading";
+import { PegMonitoringScorecard } from "./peg-monitoring-scorecard";
 
 function Header(): React.JSX.Element {
   return (
     <header className="space-y-3">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400">
-          Incident evidence
+          Peg monitoring
         </p>
         <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">
-          Peg monitoring
+          Peg status
         </h1>
       </div>
       <p className="max-w-3xl text-sm leading-6 text-slate-400">
-        Current executable-price, market, structural, and breaker evidence from
-        the Metrics Bridge decision package. Grafana remains authoritative for
-        duration windows, coverage, pending and firing state, and history.
+        See whether a monitored asset is off peg or nearing action from its
+        current measurement and supporting evidence.
       </p>
-      <a
-        href={PEG_GRAFANA_ALERTS_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex text-sm font-medium text-indigo-400 transition-colors hover:text-indigo-300"
-      >
-        Open Peg Monitoring rules and history in Grafana ↗
-      </a>
     </header>
   );
 }
@@ -477,8 +470,18 @@ export function PegMonitoringPageClient(): React.JSX.Element {
     ...result,
     nowMs: Math.max(now, Date.now()),
   });
+  const presentation =
+    state.kind === "current" || state.kind === "stale"
+      ? presentPegMonitoring(state.data, {
+          packageIsStale: state.kind === "stale",
+          usesPreviousPolicy:
+            state.data.policySlot === "previous" ||
+            state.data.producedPolicyVersion !==
+              state.data.approvedActivePolicyVersion,
+        })
+      : null;
   return (
-    <div data-testid="peg-monitoring-page" className="space-y-8">
+    <main data-testid="peg-monitoring-page" className="space-y-8">
       <Header />
       {state.kind === "loading" ? (
         <PegMonitoringLoading />
@@ -486,15 +489,36 @@ export function PegMonitoringPageClient(): React.JSX.Element {
         <ErrorBox message="Peg monitoring is unavailable. No confirmed decision package can be shown." />
       ) : (
         <div className="space-y-6">
-          <SnapshotStatus state={state} />
-          <Snapshot data={state.data} />
-          <div className="space-y-5">
-            {state.data.packages.map((item, index) => (
-              <Package key={item.asset} item={item} index={index} />
-            ))}
-          </div>
+          <PegMonitoringScorecard
+            presentation={presentation!}
+            ageMs={state.ageMs}
+            stale={state.kind === "stale"}
+          />
+          <details
+            data-testid="peg-evidence-policy"
+            className="rounded-xl border border-slate-800 bg-slate-950/35 p-4 sm:p-6"
+          >
+            <summary className="cursor-pointer text-lg font-semibold text-white">
+              Evidence and policy
+            </summary>
+            <div className="mt-6 space-y-5">
+              <SnapshotStatus state={state} />
+              <Snapshot data={state.data} />
+              {state.data.packages.map((item, index) => (
+                <Package key={item.asset} item={item} index={index} />
+              ))}
+              <a
+                href={PEG_GRAFANA_ALERTS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex text-sm font-medium text-indigo-400 transition-colors hover:text-indigo-300"
+              >
+                Open Peg Monitoring rules and history in Grafana ↗
+              </a>
+            </div>
+          </details>
         </div>
       )}
-    </div>
+    </main>
   );
 }

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -64,18 +64,23 @@ function DistanceRail({
 }: {
   asset: PegAssetPresentation;
 }): React.JSX.Element {
-  const warning =
-    asset.warningThresholdBps ?? asset.asset.policy.warnDeviationBps;
-  const critical = asset.asset.policy.criticalDeviationBps;
-  const premiumDirection = asset.direction === "above";
-  const rangeMax = Math.max(1, (premiumDirection ? warning : critical) * 1.25);
+  const downsideWarning = asset.asset.policy.warnDeviationBps;
+  const downsideCritical = asset.asset.policy.criticalDeviationBps;
+  const premiumWarning = asset.asset.policy.premiumWarnBps;
+  const rangeMax =
+    Math.max(1, downsideWarning, downsideCritical, premiumWarning) * 1.25;
   const value = asset.distanceBps ?? 0;
-  const marker = Math.min(100, Math.max(0, (value / rangeMax) * 100));
-  const warningMarker = Math.min(100, (warning / rangeMax) * 100);
-  const criticalMarker = Math.min(100, (critical / rangeMax) * 100);
-  const thresholdDescription = premiumDirection
-    ? `Premium warning begins at ${formatScorecardBps(warning)}.`
-    : `Warning begins at ${formatScorecardBps(warning)} and critical at ${formatScorecardBps(critical)}.`;
+  const directionSign =
+    asset.direction === "below" ? -1 : asset.direction === "above" ? 1 : 0;
+  const marker = Math.min(
+    100,
+    Math.max(0, 50 + directionSign * (value / rangeMax) * 50),
+  );
+  const downsideWarningMarker = 50 - (downsideWarning / rangeMax) * 50;
+  const downsideCriticalMarker = 50 - (downsideCritical / rangeMax) * 50;
+  const premiumWarningMarker = 50 + (premiumWarning / rangeMax) * 50;
+  const thresholdDescription = `Downside warning begins at ${formatScorecardBps(downsideWarning)}, downside critical at ${formatScorecardBps(downsideCritical)}, and premium warning at ${formatScorecardBps(premiumWarning)}.`;
+  const railBackground = `linear-gradient(to right, rgb(127 29 29 / 0.95) 0%, rgb(127 29 29 / 0.95) ${downsideCriticalMarker}%, rgb(120 53 15 / 0.9) ${downsideCriticalMarker}%, rgb(120 53 15 / 0.9) ${downsideWarningMarker}%, rgb(6 78 59 / 0.86) ${downsideWarningMarker}%, rgb(6 78 59 / 0.86) ${premiumWarningMarker}%, rgb(120 53 15 / 0.9) ${premiumWarningMarker}%, rgb(120 53 15 / 0.9) 100%)`;
   return (
     <div className="space-y-2">
       <div className="flex items-baseline justify-between gap-3">
@@ -89,36 +94,61 @@ function DistanceRail({
       <div
         role="img"
         aria-label={`${asset.assetName} distance from target: ${distanceText(asset)}. ${thresholdDescription}`}
-        className="relative h-3 overflow-visible rounded-full border border-slate-700 bg-gradient-to-r from-emerald-950 via-amber-900 to-red-950"
+        className="relative h-3 overflow-visible rounded-full border border-slate-700"
+        style={{ background: railBackground }}
       >
         <span
-          className="absolute inset-y-0 border-l border-amber-200/60"
-          style={{ left: `${warningMarker}%` }}
+          className="absolute inset-y-0 border-l border-red-200/60"
+          style={{ left: `${downsideCriticalMarker}%` }}
         />
-        {premiumDirection ? null : (
-          <span
-            className="absolute inset-y-0 border-l border-red-200/60"
-            style={{ left: `${criticalMarker}%` }}
-          />
-        )}
+        <span
+          className="absolute inset-y-0 border-l border-amber-200/60"
+          style={{ left: `${downsideWarningMarker}%` }}
+        />
+        <span
+          data-testid={`peg-target-${asset.asset.asset}`}
+          className="absolute -inset-y-1 border-l-2 border-white"
+          style={{ left: "50%" }}
+        />
+        <span
+          className="absolute inset-y-0 border-l border-amber-200/60"
+          style={{ left: `${premiumWarningMarker}%` }}
+        />
         {asset.distanceBps === null ? null : (
           <span
             aria-hidden="true"
-            className="absolute -top-1 h-5 w-1 rounded bg-white shadow-[0_0_0_2px_rgba(15,23,42,0.9)]"
-            style={{ left: `calc(${marker}% - 2px)` }}
+            data-testid={`peg-current-${asset.asset.asset}`}
+            className="absolute -top-1.5 h-6 w-6 -translate-x-1/2 rounded-full border-4 border-emerald-50 bg-emerald-600 shadow-[0_0_0_4px_rgba(5,150,105,0.2)]"
+            style={{ left: `${marker}%` }}
           />
         )}
       </div>
-      <p className="flex justify-between text-[11px] text-slate-400">
-        <span>Target</span>
-        <span>
-          {premiumDirection ? "Premium warning" : "Warning"}{" "}
-          {formatScorecardBps(warning)}
+      <div className="relative h-6 text-[10px] text-slate-400">
+        <span
+          className="absolute -translate-x-1/2 whitespace-nowrap"
+          style={{ left: `${downsideCriticalMarker}%` }}
+        >
+          −{formatScorecardBps(downsideCritical)}
         </span>
-        {premiumDirection ? null : (
-          <span>Critical {formatScorecardBps(critical)}</span>
-        )}
-      </p>
+        <span
+          className="absolute -translate-x-1/2 whitespace-nowrap"
+          style={{ left: `${downsideWarningMarker}%` }}
+        >
+          −{formatScorecardBps(downsideWarning)}
+        </span>
+        <span
+          className="absolute -translate-x-1/2 whitespace-nowrap text-slate-200"
+          style={{ left: "50%" }}
+        >
+          Target
+        </span>
+        <span
+          className="absolute -translate-x-1/2 whitespace-nowrap"
+          style={{ left: `${premiumWarningMarker}%` }}
+        >
+          +{formatScorecardBps(premiumWarning)}
+        </span>
+      </div>
     </div>
   );
 }
@@ -137,9 +167,7 @@ function HealthSummary({
     ({ breaker }) =>
       breaker !== null && breaker.enabled && breaker.status === "OK",
   ).length;
-  const breakerCount = asset.asset.monitors.filter(
-    ({ breaker }) => breaker !== null,
-  ).length;
+  const breakerCount = asset.asset.monitors.length;
   const sourceCoverage =
     asset.asset.sources.length === 1
       ? `${coverage} source healthy`
@@ -150,9 +178,9 @@ function HealthSummary({
       : `${pools} of ${asset.asset.monitors.length} pools reachable`;
   const breakerHealth =
     breakerCount === 0
-      ? "No breaker data"
-      : breakerCount === 1
-        ? `${breakers} breaker OK`
+      ? "No monitored breakers"
+      : breakerCount === 1 && breakers === 1
+        ? "1 breaker OK"
         : `${breakers} of ${breakerCount} breakers OK`;
   return (
     <dl className="mt-5 grid gap-2 border-t border-slate-800 pt-4 sm:grid-cols-4">
@@ -188,8 +216,10 @@ function HealthSummary({
 
 function AssetScorecard({
   asset,
+  stale,
 }: {
   asset: PegAssetPresentation;
+  stale: boolean;
 }): React.JSX.Element {
   const source = asset.decisionSource;
   return (
@@ -217,7 +247,9 @@ function AssetScorecard({
             </span>
           </p>
           <p className="mt-2 text-xs text-slate-400">
-            Current executable price{" "}
+            {stale
+              ? "Last confirmed executable price"
+              : "Current executable price"}{" "}
             {source
               ? `from ${source.provider} ${source.pair}`
               : "is unavailable"}
@@ -233,7 +265,7 @@ function AssetScorecard({
           <p className="mt-2 text-sm font-medium">{decisionText(asset)}</p>
           {asset.reasons[0] ? (
             <p className="mt-2 text-xs leading-5 text-slate-300">
-              {asset.reasons[0]}
+              {asset.uncertaintyReason ?? asset.reasons[0]}
             </p>
           ) : null}
         </div>
@@ -267,6 +299,7 @@ function HeadlineCard({
 
 function closestWarningHeadline(
   closest: PegAssetPresentation | null,
+  stale: boolean,
 ): Pick<
   React.ComponentProps<typeof HeadlineCard>,
   "value" | "detail" | "tone"
@@ -285,7 +318,7 @@ function closestWarningHeadline(
         : `${formatScorecardBps(closest.warningDistanceBps)} remaining`;
   return {
     value,
-    detail: `${closest.assetName} relative to its warning threshold`,
+    detail: `${closest.assetName} ${stale ? "last confirmed" : "current"} measurement`,
     tone: closest.thresholdTone,
   };
 }
@@ -299,43 +332,53 @@ export function PegMonitoringScorecard({
   ageMs: number;
   stale: boolean;
 }): React.JSX.Element {
-  const furthest = presentation.furthest;
-  const closestHeadline = closestWarningHeadline(presentation.closestWarning);
+  const closestHeadline = closestWarningHeadline(
+    presentation.closestWarning,
+    stale,
+  );
+  const aggregateDetail = stale
+    ? `No fresh monitoring package has arrived; the last confirmed package is ${formatAge(ageMs)} old.`
+    : presentation.aggregate.detail;
   return (
     <section aria-label="Peg decision scorecard" className="space-y-5">
       <div
         data-testid="peg-aggregate-status"
         role="status"
-        aria-label={presentation.aggregate.label}
-        className={`rounded-xl border px-5 py-4 text-lg font-semibold ${toneClasses[presentation.aggregate.tone]}`}
+        aria-label={
+          aggregateDetail
+            ? `${presentation.aggregate.label}. ${aggregateDetail}`
+            : presentation.aggregate.label
+        }
+        className={`rounded-xl border px-5 py-4 ${toneClasses[presentation.aggregate.tone]}`}
       >
-        {presentation.aggregate.label}
+        {aggregateDetail ? (
+          <>
+            <p className="text-lg font-semibold">
+              {presentation.aggregate.label}
+            </p>
+            <p className="mt-1 text-sm font-normal text-slate-300">
+              {aggregateDetail}
+            </p>
+          </>
+        ) : (
+          presentation.aggregate.label
+        )}
       </div>
       <div
         data-testid="peg-headline-cards"
-        className="grid gap-3 md:grid-cols-3"
+        className="grid gap-3 md:grid-cols-2"
       >
-        <HeadlineCard
-          label="Furthest from target"
-          value={furthest ? distanceText(furthest) : "Unavailable"}
-          detail={
-            furthest
-              ? `${furthest.assetName} current executable measurement`
-              : "No executable price is available"
-          }
-          tone={furthest?.thresholdTone ?? "uncertain"}
-        />
-        <HeadlineCard label="Closest to warning" {...closestHeadline} />
+        <HeadlineCard label="Nearest warning" {...closestHeadline} />
         <HeadlineCard
           label="Data freshness"
-          value={stale ? "Stale" : "Current"}
+          value={stale ? "Stale" : "Fresh"}
           detail={`${stale ? "Last confirmed package" : "Package produced"} ${formatAge(ageMs)} ago`}
           tone={stale ? "warning" : "healthy"}
         />
       </div>
       <div className="space-y-4">
         {presentation.assets.map((asset) => (
-          <AssetScorecard key={asset.asset.asset} asset={asset} />
+          <AssetScorecard key={asset.asset.asset} asset={asset} stale={stale} />
         ))}
       </div>
     </section>

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -355,32 +355,43 @@ export function PegMonitoringScorecard({
     stale,
   );
   const aggregateDetail = stale
-    ? `No fresh monitoring package has arrived; the last confirmed package is ${formatAge(ageMs)} old.`
+    ? "No fresh monitoring package has arrived; values below are the last confirmed measurements."
     : presentation.aggregate.detail;
   return (
     <section aria-label="Peg decision scorecard" className="space-y-5">
       <div
-        data-testid="peg-aggregate-status"
-        role="status"
-        aria-label={
-          aggregateDetail
-            ? `${presentation.aggregate.label}. ${aggregateDetail}`
-            : presentation.aggregate.label
-        }
         className={`rounded-xl border px-5 py-4 ${toneClasses[presentation.aggregate.tone]}`}
       >
-        {aggregateDetail ? (
-          <>
-            <p className="text-lg font-semibold">
-              {presentation.aggregate.label}
-            </p>
-            <p className="mt-1 text-sm font-normal text-slate-300">
-              {aggregateDetail}
-            </p>
-          </>
-        ) : (
-          presentation.aggregate.label
-        )}
+        <div
+          data-testid="peg-aggregate-status"
+          role="status"
+          aria-label={
+            aggregateDetail
+              ? `${presentation.aggregate.label}. ${aggregateDetail}`
+              : presentation.aggregate.label
+          }
+        >
+          {aggregateDetail ? (
+            <>
+              <p className="text-lg font-semibold">
+                {presentation.aggregate.label}
+              </p>
+              <p className="mt-1 text-sm font-normal text-slate-300">
+                {aggregateDetail}
+              </p>
+            </>
+          ) : (
+            presentation.aggregate.label
+          )}
+        </div>
+        {stale ? (
+          <p
+            data-testid="peg-aggregate-age"
+            className="mt-1 text-sm font-normal text-slate-300"
+          >
+            Last confirmed package {formatAge(ageMs)} old.
+          </p>
+        ) : null}
       </div>
       <div
         data-testid="peg-headline-cards"

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -175,7 +175,6 @@ function HealthSummary({
   asset: PegAssetPresentation;
 }): React.JSX.Element {
   const source = asset.decisionSource;
-  const coverage = asset.asset.sources.filter(({ healthy }) => healthy).length;
   const pools = asset.asset.monitors.filter(
     ({ indexedPoolReachable }) => indexedPoolReachable,
   ).length;
@@ -186,8 +185,8 @@ function HealthSummary({
   const breakerCount = asset.asset.monitors.length;
   const sourceCoverage =
     asset.asset.sources.length === 1
-      ? `${coverage} source healthy`
-      : `${coverage} of ${asset.asset.sources.length} sources healthy`;
+      ? `${asset.usableSourceCount} source usable`
+      : `${asset.usableSourceCount} of ${asset.asset.sources.length} sources usable`;
   const poolHealth =
     asset.asset.monitors.length === 1
       ? `${pools} pool reachable`

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -195,9 +195,11 @@ function HealthSummary({
   const breakerHealth =
     breakerCount === 0
       ? "No monitored breakers"
-      : breakerCount === 1 && breakers === 1
-        ? "1 breaker OK"
-        : `${breakers} of ${breakerCount} breakers OK`;
+      : !asset.structuralEvidenceCurrent
+        ? "Check expired"
+        : breakerCount === 1 && breakers === 1
+          ? "1 breaker OK"
+          : `${breakers} of ${breakerCount} breakers OK`;
   return (
     <dl className="mt-5 grid gap-2 border-t border-slate-800 pt-4 sm:grid-cols-4">
       <div>

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -187,8 +187,9 @@ function HealthSummary({
     asset.asset.sources.length === 1
       ? `${asset.usableSourceCount} source usable`
       : `${asset.usableSourceCount} of ${asset.asset.sources.length} sources usable`;
-  const poolHealth =
-    asset.asset.monitors.length === 1
+  const poolHealth = !asset.structuralEvidenceCurrent
+    ? "Check expired"
+    : asset.asset.monitors.length === 1
       ? `${pools} pool reachable`
       : `${pools} of ${asset.asset.monitors.length} pools reachable`;
   const breakerHealth =

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -1,0 +1,343 @@
+import { formatAge, formatNumber } from "./peg-monitoring-evidence-primitives";
+import type {
+  PegAssetPresentation,
+  PegMonitoringPresentation,
+  PegPresentationTone,
+} from "@/lib/peg-monitoring-presentation";
+
+const toneClasses: Record<PegPresentationTone | "uncertain", string> = {
+  healthy: "border-emerald-500/30 bg-emerald-950/30 text-emerald-200",
+  warning: "border-amber-500/30 bg-amber-950/30 text-amber-100",
+  critical: "border-red-500/30 bg-red-950/30 text-red-100",
+  uncertain: "border-amber-500/30 bg-amber-950/30 text-amber-100",
+};
+const conciseBps = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
+function formatScorecardBps(value: number): string {
+  return value > 0 && value < 0.01
+    ? "<0.01 bps"
+    : `${conciseBps.format(value)} bps`;
+}
+
+function HealthLabel({
+  asset,
+}: {
+  asset: PegAssetPresentation;
+}): React.JSX.Element {
+  const label = asset.uncertain
+    ? "Status uncertain"
+    : asset.tone === "healthy"
+      ? "Healthy"
+      : asset.tone === "critical"
+        ? "Action required"
+        : "Warning";
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClasses[asset.uncertain ? "uncertain" : asset.tone]}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function decisionText(asset: PegAssetPresentation): string {
+  if (asset.uncertain) return "Current status cannot be confirmed";
+  if (asset.tone === "critical")
+    return "Action required from the current measurement";
+  if (asset.tone === "warning")
+    return "Review the current measurement and evidence";
+  return "Within the current measurement thresholds";
+}
+
+function distanceText(asset: PegAssetPresentation): string {
+  if (asset.distanceBps === null || asset.direction === null)
+    return "Current price unavailable";
+  return asset.direction === "at target"
+    ? "At target"
+    : `${formatScorecardBps(asset.distanceBps)} ${asset.direction} target`;
+}
+
+function DistanceRail({
+  asset,
+}: {
+  asset: PegAssetPresentation;
+}): React.JSX.Element {
+  const warning =
+    asset.warningThresholdBps ?? asset.asset.policy.warnDeviationBps;
+  const critical = asset.asset.policy.criticalDeviationBps;
+  const premiumDirection = asset.direction === "above";
+  const rangeMax = Math.max(1, (premiumDirection ? warning : critical) * 1.25);
+  const value = asset.distanceBps ?? 0;
+  const marker = Math.min(100, Math.max(0, (value / rangeMax) * 100));
+  const warningMarker = Math.min(100, (warning / rangeMax) * 100);
+  const criticalMarker = Math.min(100, (critical / rangeMax) * 100);
+  const thresholdDescription = premiumDirection
+    ? `Premium warning begins at ${formatScorecardBps(warning)}.`
+    : `Warning begins at ${formatScorecardBps(warning)} and critical at ${formatScorecardBps(critical)}.`;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-sm font-semibold text-slate-100">
+          Distance to target
+        </span>
+        <span className="text-xs font-medium text-slate-300">
+          {distanceText(asset)}
+        </span>
+      </div>
+      <div
+        role="img"
+        aria-label={`${asset.assetName} distance from target: ${distanceText(asset)}. ${thresholdDescription}`}
+        className="relative h-3 overflow-visible rounded-full border border-slate-700 bg-gradient-to-r from-emerald-950 via-amber-900 to-red-950"
+      >
+        <span
+          className="absolute inset-y-0 border-l border-amber-200/60"
+          style={{ left: `${warningMarker}%` }}
+        />
+        {premiumDirection ? null : (
+          <span
+            className="absolute inset-y-0 border-l border-red-200/60"
+            style={{ left: `${criticalMarker}%` }}
+          />
+        )}
+        {asset.distanceBps === null ? null : (
+          <span
+            aria-hidden="true"
+            className="absolute -top-1 h-5 w-1 rounded bg-white shadow-[0_0_0_2px_rgba(15,23,42,0.9)]"
+            style={{ left: `calc(${marker}% - 2px)` }}
+          />
+        )}
+      </div>
+      <p className="flex justify-between text-[11px] text-slate-400">
+        <span>Target</span>
+        <span>
+          {premiumDirection ? "Premium warning" : "Warning"}{" "}
+          {formatScorecardBps(warning)}
+        </span>
+        {premiumDirection ? null : (
+          <span>Critical {formatScorecardBps(critical)}</span>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function HealthSummary({
+  asset,
+}: {
+  asset: PegAssetPresentation;
+}): React.JSX.Element {
+  const source = asset.decisionSource;
+  const coverage = asset.asset.sources.filter(({ healthy }) => healthy).length;
+  const pools = asset.asset.monitors.filter(
+    ({ indexedPoolReachable }) => indexedPoolReachable,
+  ).length;
+  const breakers = asset.asset.monitors.filter(
+    ({ breaker }) =>
+      breaker !== null && breaker.enabled && breaker.status === "OK",
+  ).length;
+  const breakerCount = asset.asset.monitors.filter(
+    ({ breaker }) => breaker !== null,
+  ).length;
+  const sourceCoverage =
+    asset.asset.sources.length === 1
+      ? `${coverage} source healthy`
+      : `${coverage} of ${asset.asset.sources.length} sources healthy`;
+  const poolHealth =
+    asset.asset.monitors.length === 1
+      ? `${pools} pool reachable`
+      : `${pools} of ${asset.asset.monitors.length} pools reachable`;
+  const breakerHealth =
+    breakerCount === 0
+      ? "No breaker data"
+      : breakerCount === 1
+        ? `${breakers} breaker OK`
+        : `${breakers} of ${breakerCount} breakers OK`;
+  return (
+    <dl className="mt-5 grid gap-2 border-t border-slate-800 pt-4 sm:grid-cols-4">
+      <div>
+        <dt className="text-[11px] uppercase tracking-wide text-slate-400">
+          Market
+        </dt>
+        <dd className="mt-1 text-sm text-slate-200">
+          {source?.healthy ? "Measured" : "Unavailable"}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-[11px] uppercase tracking-wide text-slate-400">
+          Source coverage
+        </dt>
+        <dd className="mt-1 text-sm text-slate-200">{sourceCoverage}</dd>
+      </div>
+      <div>
+        <dt className="text-[11px] uppercase tracking-wide text-slate-400">
+          Pool
+        </dt>
+        <dd className="mt-1 text-sm text-slate-200">{poolHealth}</dd>
+      </div>
+      <div>
+        <dt className="text-[11px] uppercase tracking-wide text-slate-400">
+          Breaker
+        </dt>
+        <dd className="mt-1 text-sm text-slate-200">{breakerHealth}</dd>
+      </div>
+    </dl>
+  );
+}
+
+function AssetScorecard({
+  asset,
+}: {
+  asset: PegAssetPresentation;
+}): React.JSX.Element {
+  const source = asset.decisionSource;
+  return (
+    <article
+      data-testid={`peg-scorecard-${asset.asset.asset}`}
+      className="rounded-xl border border-slate-700 bg-slate-900/50 p-5 shadow-lg shadow-slate-950/20"
+    >
+      <div className="grid gap-6 xl:grid-cols-[minmax(13rem,0.8fr)_minmax(20rem,1.4fr)_minmax(13rem,0.8fr)] xl:items-center">
+        <div>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight text-white">
+                {asset.assetName} / {asset.asset.peg}
+              </h2>
+              <p className="mt-1 text-xs text-slate-400">
+                {asset.asset.coverageClass}
+              </p>
+            </div>
+            <HealthLabel asset={asset} />
+          </div>
+          <p className="mt-5 text-3xl font-semibold tracking-tight text-white">
+            {formatNumber(source?.executablePrice ?? null)}{" "}
+            <span className="text-base font-medium text-slate-400">
+              {asset.asset.peg}
+            </span>
+          </p>
+          <p className="mt-2 text-xs text-slate-400">
+            Current executable price{" "}
+            {source
+              ? `from ${source.provider} ${source.pair}`
+              : "is unavailable"}
+          </p>
+        </div>
+        <DistanceRail asset={asset} />
+        <div
+          className={`rounded-lg border p-4 ${toneClasses[asset.uncertain ? "uncertain" : asset.tone]}`}
+        >
+          <p className="text-xs font-semibold uppercase tracking-wide">
+            Current conclusion
+          </p>
+          <p className="mt-2 text-sm font-medium">{decisionText(asset)}</p>
+          {asset.reasons[0] ? (
+            <p className="mt-2 text-xs leading-5 text-slate-300">
+              {asset.reasons[0]}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <HealthSummary asset={asset} />
+    </article>
+  );
+}
+
+function HeadlineCard({
+  label,
+  value,
+  detail,
+  tone = "healthy",
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: PegPresentationTone | "uncertain";
+}): React.JSX.Element {
+  return (
+    <section className={`rounded-xl border p-5 ${toneClasses[tone]}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.08em]">
+        {label}
+      </p>
+      <p className="mt-4 text-2xl font-semibold tracking-tight">{value}</p>
+      <p className="mt-2 text-xs text-slate-300">{detail}</p>
+    </section>
+  );
+}
+
+function closestWarningHeadline(
+  closest: PegAssetPresentation | null,
+): Pick<
+  React.ComponentProps<typeof HeadlineCard>,
+  "value" | "detail" | "tone"
+> {
+  if (closest === null)
+    return {
+      value: "Unavailable",
+      detail: "No warning threshold can be evaluated",
+      tone: "uncertain",
+    };
+  const value =
+    closest.warningDistanceBps === null
+      ? "Unavailable"
+      : closest.warningDistanceBps <= 0
+        ? `${formatScorecardBps(Math.abs(closest.warningDistanceBps))} beyond warning`
+        : `${formatScorecardBps(closest.warningDistanceBps)} remaining`;
+  return {
+    value,
+    detail: `${closest.assetName} relative to its warning threshold`,
+    tone: closest.thresholdTone,
+  };
+}
+
+export function PegMonitoringScorecard({
+  presentation,
+  ageMs,
+  stale,
+}: {
+  presentation: PegMonitoringPresentation;
+  ageMs: number;
+  stale: boolean;
+}): React.JSX.Element {
+  const furthest = presentation.furthest;
+  const closestHeadline = closestWarningHeadline(presentation.closestWarning);
+  return (
+    <section aria-label="Peg decision scorecard" className="space-y-5">
+      <div
+        data-testid="peg-aggregate-status"
+        role="status"
+        aria-label={presentation.aggregate.label}
+        className={`rounded-xl border px-5 py-4 text-lg font-semibold ${toneClasses[presentation.aggregate.tone]}`}
+      >
+        {presentation.aggregate.label}
+      </div>
+      <div
+        data-testid="peg-headline-cards"
+        className="grid gap-3 md:grid-cols-3"
+      >
+        <HeadlineCard
+          label="Furthest from target"
+          value={furthest ? distanceText(furthest) : "Unavailable"}
+          detail={
+            furthest
+              ? `${furthest.assetName} current executable measurement`
+              : "No executable price is available"
+          }
+          tone={furthest?.thresholdTone ?? "uncertain"}
+        />
+        <HeadlineCard label="Closest to warning" {...closestHeadline} />
+        <HeadlineCard
+          label="Data freshness"
+          value={stale ? "Stale" : "Current"}
+          detail={`${stale ? "Last confirmed package" : "Package produced"} ${formatAge(ageMs)} ago`}
+          tone={stale ? "warning" : "healthy"}
+        />
+      </div>
+      <div className="space-y-4">
+        {presentation.assets.map((asset) => (
+          <AssetScorecard key={asset.asset.asset} asset={asset} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-scorecard.tsx
@@ -11,6 +11,15 @@ const toneClasses: Record<PegPresentationTone | "uncertain", string> = {
   critical: "border-red-500/30 bg-red-950/30 text-red-100",
   uncertain: "border-amber-500/30 bg-amber-950/30 text-amber-100",
 };
+const markerClasses: Record<PegAssetPresentation["thresholdTone"], string> = {
+  healthy:
+    "border-emerald-50 bg-emerald-600 shadow-[0_0_0_4px_rgba(5,150,105,0.2)]",
+  warning:
+    "border-amber-50 bg-amber-500 shadow-[0_0_0_4px_rgba(245,158,11,0.2)]",
+  critical: "border-red-50 bg-red-600 shadow-[0_0_0_4px_rgba(220,38,38,0.2)]",
+  uncertain:
+    "border-slate-100 bg-slate-500 shadow-[0_0_0_4px_rgba(100,116,139,0.2)]",
+};
 const conciseBps = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 2,
 });
@@ -26,16 +35,23 @@ function HealthLabel({
 }: {
   asset: PegAssetPresentation;
 }): React.JSX.Element {
-  const label = asset.uncertain
-    ? "Status uncertain"
-    : asset.tone === "healthy"
-      ? "Healthy"
-      : asset.tone === "critical"
-        ? "Action required"
-        : "Warning";
+  const label = asset.currentCritical
+    ? "Critical"
+    : asset.uncertain
+      ? "Status uncertain"
+      : asset.tone === "healthy"
+        ? "Healthy"
+        : asset.tone === "critical"
+          ? "Critical"
+          : "Warning";
+  const tone = asset.currentCritical
+    ? "critical"
+    : asset.uncertain
+      ? "uncertain"
+      : asset.tone;
   return (
     <span
-      className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClasses[asset.uncertain ? "uncertain" : asset.tone]}`}
+      className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClasses[tone]}`}
     >
       {label}
     </span>
@@ -43,9 +59,9 @@ function HealthLabel({
 }
 
 function decisionText(asset: PegAssetPresentation): string {
+  if (asset.currentCritical) return "Critical condition in the current package";
   if (asset.uncertain) return "Current status cannot be confirmed";
-  if (asset.tone === "critical")
-    return "Action required from the current measurement";
+  if (asset.tone === "critical") return "Critical condition detected";
   if (asset.tone === "warning")
     return "Review the current measurement and evidence";
   return "Within the current measurement thresholds";
@@ -64,9 +80,9 @@ function DistanceRail({
 }: {
   asset: PegAssetPresentation;
 }): React.JSX.Element {
-  const downsideWarning = asset.asset.policy.warnDeviationBps;
-  const downsideCritical = asset.asset.policy.criticalDeviationBps;
-  const premiumWarning = asset.asset.policy.premiumWarnBps;
+  const downsideWarning = asset.downsideWarningThresholdBps;
+  const downsideCritical = asset.downsideCriticalThresholdBps;
+  const premiumWarning = asset.premiumWarningThresholdBps;
   const rangeMax =
     Math.max(1, downsideWarning, downsideCritical, premiumWarning) * 1.25;
   const value = asset.distanceBps ?? 0;
@@ -118,7 +134,7 @@ function DistanceRail({
           <span
             aria-hidden="true"
             data-testid={`peg-current-${asset.asset.asset}`}
-            className="absolute -top-1.5 h-6 w-6 -translate-x-1/2 rounded-full border-4 border-emerald-50 bg-emerald-600 shadow-[0_0_0_4px_rgba(5,150,105,0.2)]"
+            className={`absolute -top-1.5 h-6 w-6 -translate-x-1/2 rounded-full border-4 ${markerClasses[asset.thresholdTone]}`}
             style={{ left: `${marker}%` }}
           />
         )}
@@ -257,15 +273,17 @@ function AssetScorecard({
         </div>
         <DistanceRail asset={asset} />
         <div
-          className={`rounded-lg border p-4 ${toneClasses[asset.uncertain ? "uncertain" : asset.tone]}`}
+          className={`rounded-lg border p-4 ${toneClasses[asset.currentCritical ? "critical" : asset.uncertain ? "uncertain" : asset.tone]}`}
         >
           <p className="text-xs font-semibold uppercase tracking-wide">
-            Current conclusion
+            {stale ? "Last confirmed conclusion" : "Current conclusion"}
           </p>
           <p className="mt-2 text-sm font-medium">{decisionText(asset)}</p>
           {asset.reasons[0] ? (
             <p className="mt-2 text-xs leading-5 text-slate-300">
-              {asset.uncertaintyReason ?? asset.reasons[0]}
+              {asset.currentCritical
+                ? asset.reasons[0]
+                : (asset.uncertaintyReason ?? asset.reasons[0])}
             </p>
           ) : null}
         </div>

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -83,13 +83,17 @@ describe("presentPegMonitoring", () => {
     });
 
     expect(atBoundary.aggregate.label).toBe("All pegs healthy");
-    expect(atBoundary.assets[0]?.decisionSource).not.toBeNull();
+    expect(atBoundary.assets[0]).toMatchObject({
+      decisionSource: expect.any(Object),
+      usableSourceCount: 3,
+    });
     expect(expired.aggregate.label).toBe("Price check unavailable");
     expect(expired.assets[0]).toMatchObject({
       decisionSource: null,
       distanceBps: null,
       thresholdTone: "uncertain",
       uncertain: true,
+      usableSourceCount: 2,
       uncertaintyReason:
         "The policy-selected market observation is older than its allowed freshness window.",
     });

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -99,6 +99,49 @@ describe("presentPegMonitoring", () => {
     });
   });
 
+  it("expires structural evidence strictly after the asset freshness grace", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const shortGrace = {
+      ...response,
+      packages: [
+        {
+          ...item,
+          policy: { ...item.policy, freshnessGraceSeconds: 60 },
+          sources: item.sources.map((source) => ({
+            ...source,
+            policy: {
+              ...source.policy,
+              pollIntervalSeconds: Math.min(
+                source.policy.pollIntervalSeconds,
+                60,
+              ),
+            },
+          })),
+        },
+      ],
+    };
+    const atBoundary = presentPegMonitoring(shortGrace, {
+      ...CURRENT_CONTEXT,
+      nowMs: (response.producedAt + 60) * 1_000,
+    });
+    const expired = presentPegMonitoring(shortGrace, {
+      ...CURRENT_CONTEXT,
+      nowMs: (response.producedAt + 61) * 1_000,
+    });
+
+    expect(atBoundary.aggregate.label).toBe("All pegs healthy");
+    expect(atBoundary.assets[0]?.structuralEvidenceCurrent).toBe(true);
+    expect(expired.aggregate.label).toBe("Monitoring checks incomplete");
+    expect(expired.assets[0]).toMatchObject({
+      decisionSource: expect.any(Object),
+      structuralEvidenceCurrent: false,
+      uncertain: true,
+      uncertaintyReason:
+        "The structural checks are older than the policy's freshness window.",
+    });
+  });
+
   it("marks a current deep critical reading and disabled breaker as a critical condition", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -45,7 +45,7 @@ describe("presentPegMonitoring", () => {
     });
   });
 
-  it("marks deep critical downside and disabled breakers as action required", () => {
+  it("marks a current deep critical reading and disabled breaker as a critical condition", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;
     const critical = presentPegMonitoring(
@@ -75,11 +75,15 @@ describe("presentPegMonitoring", () => {
       { packageIsStale: false, usesPreviousPolicy: false },
     );
 
-    expect(critical.aggregate.label).toBe("Peg action required");
+    expect(critical.aggregate.label).toBe("Critical condition detected");
     expect(critical.assets[0]).toMatchObject({
       tone: "critical",
+      currentCritical: true,
       thresholdTone: "critical",
     });
+    expect(critical.aggregate.detail).toContain(
+      "The alert only fires if enough readings stay there long enough.",
+    );
   });
 
   it("uses the directional warning threshold for an above-target measurement", () => {
@@ -114,6 +118,98 @@ describe("presentPegMonitoring", () => {
       warningThresholdBps: item.policy.premiumWarnBps,
       thresholdTone: "warning",
     });
+  });
+
+  it("adds the selected source conversion allowance to every price threshold", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const withDistance = (distance: number) => ({
+      ...response,
+      packages: [
+        {
+          ...item,
+          sources: item.sources.map((source) =>
+            source.id === item.policy.deepVenueSource
+              ? {
+                  ...source,
+                  policy: { ...source.policy, conversionErrorBps: 30 },
+                  executablePrice: 1 - distance / 10_000,
+                  deviationBps: distance,
+                  premiumBps: 0,
+                }
+              : source,
+          ),
+        },
+      ],
+    });
+
+    const belowAdjustedWarning = presentPegMonitoring(withDistance(25), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+    const adjustedWarning = presentPegMonitoring(withDistance(55), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+    const adjustedCritical = presentPegMonitoring(withDistance(80), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+
+    expect(belowAdjustedWarning.assets[0]).toMatchObject({
+      tone: "healthy",
+      downsideWarningThresholdBps: 55,
+      downsideCriticalThresholdBps: 80,
+      premiumWarningThresholdBps: 55,
+      warningThresholdBps: 55,
+      thresholdTone: "healthy",
+    });
+    expect(belowAdjustedWarning.assets[0]?.warningDistanceBps).toBeCloseTo(30);
+    expect(adjustedWarning.assets[0]).toMatchObject({
+      tone: "warning",
+      warningDistanceBps: 0,
+      thresholdTone: "warning",
+    });
+    expect(adjustedCritical.assets[0]).toMatchObject({
+      tone: "critical",
+      currentCritical: true,
+      thresholdTone: "critical",
+    });
+  });
+
+  it("matches the alert rule's strict spread warning boundary", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const withSpread = (spreadBps: number) => ({
+      ...response,
+      packages: [
+        {
+          ...item,
+          sources: item.sources.map((source) =>
+            source.id === item.policy.deepVenueSource
+              ? { ...source, spreadBps }
+              : source,
+          ),
+        },
+      ],
+    });
+    const envelope = item.sources.find(
+      ({ id }) => id === item.policy.deepVenueSource,
+    )!.policy.spreadEnvelopeBps;
+
+    const atBoundary = presentPegMonitoring(withSpread(envelope), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+    const beyondBoundary = presentPegMonitoring(withSpread(envelope + 0.01), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+
+    expect(atBoundary.aggregate.label).toBe("All pegs healthy");
+    expect(atBoundary.assets[0]?.tone).toBe("healthy");
+    expect(beyondBoundary.aggregate.label).toBe("Some pegs need attention");
+    expect(beyondBoundary.assets[0]?.tone).toBe("warning");
   });
 
   it("does not infer a critical downside threshold from the warning threshold", () => {
@@ -325,6 +421,40 @@ describe("presentPegMonitoring", () => {
     expect(presentation.closestWarning).toBeNull();
   });
 
+  it("does not use a deep observation with missing decision metrics", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0.999,
+                    deviationBps: null,
+                    premiumBps: null,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.aggregate.label).toBe("Price check unavailable");
+    expect(presentation.assets[0]).toMatchObject({
+      uncertain: true,
+      decisionSource: null,
+      distanceBps: null,
+      thresholdTone: "uncertain",
+    });
+  });
+
   it("does not replace a missing policy-selected deep source with another deep source", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;
@@ -375,6 +505,38 @@ describe("presentPegMonitoring", () => {
     expect(presentation.furthest?.asset.asset).toBe("europ-schuman");
   });
 
+  it("selects the asset nearest the warning boundary after multiple assets cross it", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const crossedBy = (asset: string, distanceBps: number) => ({
+      ...item,
+      asset,
+      sources: item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource
+          ? {
+              ...source,
+              executablePrice: 1 - distanceBps / 10_000,
+              deviationBps: distanceBps,
+              premiumBps: 0,
+            }
+          : source,
+      ),
+    });
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          crossedBy("far-beyond-warning", 125),
+          crossedBy("near-warning", 30),
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.closestWarning?.asset.asset).toBe("near-warning");
+    expect(presentation.closestWarning?.warningDistanceBps).toBeCloseTo(-5);
+  });
+
   it("ranks mixed packages by severity and treats stale or previous packages as uncertain", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;
@@ -383,7 +545,11 @@ describe("presentPegMonitoring", () => {
       asset: "eurox-schuman",
       sources: item.sources.map((source) =>
         source.id === item.policy.deepVenueSource
-          ? { ...source, deviationBps: item.policy.criticalDeviationBps }
+          ? {
+              ...source,
+              executablePrice: 0.995,
+              deviationBps: item.policy.criticalDeviationBps,
+            }
           : source,
       ),
     };
@@ -421,8 +587,20 @@ describe("presentPegMonitoring", () => {
       },
       { packageIsStale: false, usesPreviousPolicy: false },
     );
+    const currentCriticalWithIncompleteChecks = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...criticalItem,
+            structural: { ...item.structural, blind: true },
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
 
-    expect(mixed.aggregate.label).toBe("Peg action required");
+    expect(mixed.aggregate.label).toBe("Critical condition detected");
     expect(mixed.assets[0]?.asset.asset).toBe("eurox-schuman");
     expect(stale.aggregate.label).toBe("Latest data is stale");
     expect(stale.assets[0]).toMatchObject({
@@ -439,15 +617,25 @@ describe("presentPegMonitoring", () => {
     expect(staleCritical.aggregate.label).toBe("Latest data is stale");
     expect(staleCritical.assets[0]).toMatchObject({
       tone: "critical",
+      currentCritical: false,
       uncertain: true,
     });
     expect(previousCritical.aggregate.label).toBe("Policy update pending");
     expect(previousCritical.assets[0]).toMatchObject({
       tone: "critical",
+      currentCritical: false,
       uncertain: true,
     });
     expect(confirmedCriticalWithUncertainSibling.aggregate.label).toBe(
-      "Peg action required",
+      "Critical condition detected",
     );
+    expect(currentCriticalWithIncompleteChecks.aggregate.label).toBe(
+      "Critical condition detected",
+    );
+    expect(currentCriticalWithIncompleteChecks.assets[0]).toMatchObject({
+      tone: "critical",
+      currentCritical: true,
+      uncertain: true,
+    });
   });
 });

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -209,13 +209,117 @@ describe("presentPegMonitoring", () => {
       { packageIsStale: false, usesPreviousPolicy: false },
     );
 
-    expect(presentation.aggregate.label).toBe("Current status uncertain");
+    expect(presentation.aggregate.label).toBe("Price check unavailable");
     expect(presentation.assets[0]).toMatchObject({
       tone: "warning",
       uncertain: true,
       thresholdTone: "uncertain",
       decisionSource: null,
       distanceBps: null,
+    });
+    expect(presentation.furthest).toBeNull();
+    expect(presentation.closestWarning).toBeNull();
+  });
+
+  it("treats a confirmed structural threshold breach as a warning rather than uncertainty", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const packageThreshold = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            structural: {
+              ...item.structural,
+              structuralSaturation: item.policy.structuralWarnFraction,
+            },
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+    const monitorThreshold = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            monitors: item.monitors.map((monitor) => ({
+              ...monitor,
+              structuralSaturation: item.policy.structuralWarnFraction,
+            })),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+    const incompleteQuery = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            structural: {
+              ...item.structural,
+              structuralQuerySaturated: true,
+            },
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(packageThreshold.aggregate.label).toBe("Some pegs need attention");
+    expect(packageThreshold.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: false,
+    });
+    expect(monitorThreshold.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: false,
+    });
+    expect(incompleteQuery.aggregate.label).toBe(
+      "Monitoring checks incomplete",
+    );
+    expect(incompleteQuery.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+    });
+  });
+
+  it("does not use a capped deep observation as decision evidence", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    capped: true,
+                    executablePrice: 0.99,
+                    deviationBps: item.policy.criticalDeviationBps * 2,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.aggregate.label).toBe("Price check unavailable");
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+      decisionSource: null,
+      distanceBps: null,
+      direction: null,
     });
     expect(presentation.furthest).toBeNull();
     expect(presentation.closestWarning).toBeNull();
@@ -237,7 +341,7 @@ describe("presentPegMonitoring", () => {
       { packageIsStale: false, usesPreviousPolicy: false },
     );
 
-    expect(presentation.aggregate.label).toBe("Current status uncertain");
+    expect(presentation.aggregate.label).toBe("Price check unavailable");
     expect(presentation.assets[0]).toMatchObject({
       tone: "warning",
       uncertain: true,
@@ -320,19 +424,24 @@ describe("presentPegMonitoring", () => {
 
     expect(mixed.aggregate.label).toBe("Peg action required");
     expect(mixed.assets[0]?.asset.asset).toBe("eurox-schuman");
-    expect(stale.aggregate.label).toBe("Current status uncertain");
-    expect(stale.assets[0]).toMatchObject({ tone: "warning", uncertain: true });
-    expect(previous.aggregate.label).toBe("Current status uncertain");
+    expect(stale.aggregate.label).toBe("Latest data is stale");
+    expect(stale.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+      thresholdTone: "healthy",
+    });
+    expect(previous.aggregate.label).toBe("Policy update pending");
     expect(previous.assets[0]).toMatchObject({
       tone: "warning",
       uncertain: true,
+      thresholdTone: "healthy",
     });
-    expect(staleCritical.aggregate.label).toBe("Current status uncertain");
+    expect(staleCritical.aggregate.label).toBe("Latest data is stale");
     expect(staleCritical.assets[0]).toMatchObject({
       tone: "critical",
       uncertain: true,
     });
-    expect(previousCritical.aggregate.label).toBe("Current status uncertain");
+    expect(previousCritical.aggregate.label).toBe("Policy update pending");
     expect(previousCritical.assets[0]).toMatchObject({
       tone: "critical",
       uncertain: true,

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -183,6 +183,182 @@ describe("presentPegMonitoring", () => {
     );
   });
 
+  it("matches every confirmed blind-while-stressed critical alert leg", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const confirmedBlindStreak = {
+      ...item.structural,
+      // The alert contract intentionally keys off the confirmed streak rather
+      // than the separate instantaneous blind gauge.
+      blind: false,
+      blindConsecutivePolls: item.policy.blindConsecutivePolls,
+    };
+    const withSources = (
+      update: (
+        source: (typeof item.sources)[number],
+      ) => (typeof item.sources)[number],
+    ) =>
+      item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource ? update(source) : source,
+      );
+    const presentations = [
+      presentPegMonitoring(
+        {
+          ...response,
+          packages: [
+            {
+              ...item,
+              structural: {
+                ...confirmedBlindStreak,
+                structuralSaturation: item.policy.structuralWarnFraction,
+                indexedPoolReachable: true,
+              },
+            },
+          ],
+        },
+        CURRENT_CONTEXT,
+      ),
+      presentPegMonitoring(
+        {
+          ...response,
+          packages: [
+            {
+              ...item,
+              structural: confirmedBlindStreak,
+              sources: withSources((source) => ({
+                ...source,
+                spreadBps: source.policy.spreadEnvelopeBps + 0.01,
+              })),
+            },
+          ],
+        },
+        CURRENT_CONTEXT,
+      ),
+      presentPegMonitoring(
+        {
+          ...response,
+          packages: [
+            {
+              ...item,
+              structural: confirmedBlindStreak,
+              sources: withSources((source) => ({
+                ...source,
+                capped: true,
+                executablePrice:
+                  item.policy.target *
+                  (1 -
+                    (item.policy.criticalDeviationBps +
+                      source.policy.conversionErrorBps) /
+                      10_000),
+              })),
+            },
+          ],
+        },
+        CURRENT_CONTEXT,
+      ),
+    ];
+
+    const expectedDetails = [
+      "on-chain pool activity crossed its warning limit",
+      "buy and sell prices moved too far apart",
+      "available partial price crossed the critical downside limit",
+    ];
+    for (const [index, presentation] of presentations.entries()) {
+      expect(presentation.aggregate).toMatchObject({
+        tone: "critical",
+        label: "Critical condition detected",
+      });
+      expect(presentation.aggregate.detail).toContain(
+        `${item.policy.blindConsecutivePolls} consecutive checks`,
+      );
+      expect(presentation.aggregate.detail).toContain(expectedDetails[index]);
+      expect(presentation.assets[0]).toMatchObject({
+        tone: "critical",
+        currentCritical: true,
+      });
+    }
+    expect(presentations.map(({ assets }) => assets[0]?.uncertain)).toEqual([
+      false,
+      false,
+      true,
+    ]);
+    expect(presentations[2]?.assets[0]?.decisionSource).toBeNull();
+  });
+
+  it("keeps blind-while-stressed alert boundaries fail closed", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const deepSource = item.sources.find(
+      ({ id }) => id === item.policy.deepVenueSource,
+    )!;
+    const withBlindStress = (
+      blindConsecutivePolls: number,
+      spreadBps: number,
+    ) => ({
+      ...response,
+      packages: [
+        {
+          ...item,
+          structural: {
+            ...item.structural,
+            blind: true,
+            blindConsecutivePolls,
+          },
+          sources: item.sources.map((source) =>
+            source.id === item.policy.deepVenueSource
+              ? { ...source, spreadBps }
+              : source,
+          ),
+        },
+      ],
+    });
+    const belowBlindLimit = presentPegMonitoring(
+      withBlindStress(
+        item.policy.blindConsecutivePolls - 1,
+        deepSource.policy.spreadEnvelopeBps + 0.01,
+      ),
+      CURRENT_CONTEXT,
+    );
+    const atSpreadBoundary = presentPegMonitoring(
+      withBlindStress(
+        item.policy.blindConsecutivePolls,
+        deepSource.policy.spreadEnvelopeBps,
+      ),
+      CURRENT_CONTEXT,
+    );
+    const atFreshnessBoundary = presentPegMonitoring(
+      withBlindStress(
+        item.policy.blindConsecutivePolls,
+        deepSource.policy.spreadEnvelopeBps + 0.01,
+      ),
+      {
+        ...CURRENT_CONTEXT,
+        nowMs:
+          (deepSource.observationAt! + deepSource.policy.staleAfterSeconds) *
+          1_000,
+      },
+    );
+    const afterFreshnessBoundary = presentPegMonitoring(
+      withBlindStress(
+        item.policy.blindConsecutivePolls,
+        deepSource.policy.spreadEnvelopeBps + 0.01,
+      ),
+      {
+        ...CURRENT_CONTEXT,
+        nowMs:
+          (deepSource.observationAt! +
+            deepSource.policy.staleAfterSeconds +
+            1) *
+          1_000,
+      },
+    );
+
+    expect(belowBlindLimit.assets[0]?.currentCritical).toBe(false);
+    expect(atSpreadBoundary.assets[0]?.currentCritical).toBe(false);
+    expect(atFreshnessBoundary.assets[0]?.currentCritical).toBe(true);
+    expect(afterFreshnessBoundary.assets[0]?.currentCritical).toBe(false);
+  });
+
   it("uses the directional warning threshold for an above-target measurement", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -889,6 +889,62 @@ describe("presentPegMonitoring", () => {
     expect(presentation.closestWarning?.warningDistanceBps).toBeCloseTo(-5);
   });
 
+  it("uses the nearer directional warning boundary for an asset at target", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const atTarget = {
+      ...item,
+      asset: "at-target",
+      policy: {
+        ...item.policy,
+        warnDeviationBps: 100,
+        criticalDeviationBps: 150,
+        premiumWarnBps: 10,
+      },
+      sources: item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource
+          ? {
+              ...source,
+              executablePrice: item.policy.target,
+              deviationBps: 0,
+              premiumBps: 0,
+            }
+          : source,
+      ),
+    };
+    const twentyBpsFromWarning = {
+      ...item,
+      asset: "twenty-bps-from-warning",
+      sources: item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource
+          ? {
+              ...source,
+              executablePrice: 0.9995,
+              deviationBps: 5,
+              premiumBps: 0,
+            }
+          : source,
+      ),
+    };
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [twentyBpsFromWarning, atTarget],
+      },
+      CURRENT_CONTEXT,
+    );
+    const atTargetPresentation = presentation.assets.find(
+      ({ asset }) => asset.asset === "at-target",
+    );
+
+    expect(atTargetPresentation).toMatchObject({
+      direction: "at target",
+      warningThresholdBps: 10,
+      warningDistanceBps: 10,
+    });
+    expect(presentation.closestWarning?.asset.asset).toBe("at-target");
+  });
+
   it("ranks mixed packages by severity and treats stale or previous packages as uncertain", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { presentPegMonitoring } from "../peg-monitoring-presentation";
-import { makePegMonitoringResponse } from "@/test-utils/peg-monitoring-fixture";
+import {
+  makePegMonitoringResponse,
+  PEG_FIXTURE_PRODUCED_AT,
+} from "@/test-utils/peg-monitoring-fixture";
+
+const CURRENT_CONTEXT = {
+  nowMs: PEG_FIXTURE_PRODUCED_AT * 1_000,
+  packageIsStale: false,
+  usesPreviousPolicy: false,
+} as const;
 
 function healthyResponse() {
   const response = makePegMonitoringResponse();
@@ -32,16 +41,57 @@ function healthyResponse() {
 
 describe("presentPegMonitoring", () => {
   it("derives a healthy decision from the deep source without treating legacy listing or inactive structural windows as unhealthy", () => {
-    const presentation = presentPegMonitoring(healthyResponse(), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
+    const presentation = presentPegMonitoring(
+      healthyResponse(),
+      CURRENT_CONTEXT,
+    );
 
     expect(presentation.aggregate.label).toBe("All pegs healthy");
     expect(presentation.assets[0]).toMatchObject({
       assetName: "EUROP",
       tone: "healthy",
       direction: "below",
+    });
+  });
+
+  it("expires deep-source evidence strictly after its own freshness limit", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const sourceProduced40SecondsEarlier = {
+      ...response,
+      packages: [
+        {
+          ...item,
+          sources: item.sources.map((source) =>
+            source.id === item.policy.deepVenueSource
+              ? {
+                  ...source,
+                  observationAt: response.producedAt - 40,
+                }
+              : source,
+          ),
+        },
+      ],
+    };
+    const atBoundary = presentPegMonitoring(sourceProduced40SecondsEarlier, {
+      ...CURRENT_CONTEXT,
+      nowMs: (response.producedAt + 80) * 1_000,
+    });
+    const expired = presentPegMonitoring(sourceProduced40SecondsEarlier, {
+      ...CURRENT_CONTEXT,
+      nowMs: (response.producedAt + 81) * 1_000,
+    });
+
+    expect(atBoundary.aggregate.label).toBe("All pegs healthy");
+    expect(atBoundary.assets[0]?.decisionSource).not.toBeNull();
+    expect(expired.aggregate.label).toBe("Price check unavailable");
+    expect(expired.assets[0]).toMatchObject({
+      decisionSource: null,
+      distanceBps: null,
+      thresholdTone: "uncertain",
+      uncertain: true,
+      uncertaintyReason:
+        "The policy-selected market observation is older than its allowed freshness window.",
     });
   });
 
@@ -72,7 +122,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(critical.aggregate.label).toBe("Critical condition detected");
@@ -108,7 +158,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.aggregate.label).toBe("Some pegs need attention");
@@ -143,18 +193,18 @@ describe("presentPegMonitoring", () => {
       ],
     });
 
-    const belowAdjustedWarning = presentPegMonitoring(withDistance(25), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
-    const adjustedWarning = presentPegMonitoring(withDistance(55), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
-    const adjustedCritical = presentPegMonitoring(withDistance(80), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
+    const belowAdjustedWarning = presentPegMonitoring(
+      withDistance(25),
+      CURRENT_CONTEXT,
+    );
+    const adjustedWarning = presentPegMonitoring(
+      withDistance(55),
+      CURRENT_CONTEXT,
+    );
+    const adjustedCritical = presentPegMonitoring(
+      withDistance(80),
+      CURRENT_CONTEXT,
+    );
 
     expect(belowAdjustedWarning.assets[0]).toMatchObject({
       tone: "healthy",
@@ -197,14 +247,14 @@ describe("presentPegMonitoring", () => {
       ({ id }) => id === item.policy.deepVenueSource,
     )!.policy.spreadEnvelopeBps;
 
-    const atBoundary = presentPegMonitoring(withSpread(envelope), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
-    const beyondBoundary = presentPegMonitoring(withSpread(envelope + 0.01), {
-      packageIsStale: false,
-      usesPreviousPolicy: false,
-    });
+    const atBoundary = presentPegMonitoring(
+      withSpread(envelope),
+      CURRENT_CONTEXT,
+    );
+    const beyondBoundary = presentPegMonitoring(
+      withSpread(envelope + 0.01),
+      CURRENT_CONTEXT,
+    );
 
     expect(atBoundary.aggregate.label).toBe("All pegs healthy");
     expect(atBoundary.assets[0]?.tone).toBe("healthy");
@@ -238,7 +288,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.assets[0]).toMatchObject({
@@ -269,7 +319,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.assets[0]).toMatchObject({
@@ -302,7 +352,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.aggregate.label).toBe("Price check unavailable");
@@ -333,7 +383,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
     const monitorThreshold = presentPegMonitoring(
       {
@@ -348,7 +398,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
     const incompleteQuery = presentPegMonitoring(
       {
@@ -363,7 +413,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(packageThreshold.aggregate.label).toBe("Some pegs need attention");
@@ -406,7 +456,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.aggregate.label).toBe("Price check unavailable");
@@ -443,7 +493,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.aggregate.label).toBe("Price check unavailable");
@@ -468,7 +518,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.aggregate.label).toBe("Price check unavailable");
@@ -498,7 +548,7 @@ describe("presentPegMonitoring", () => {
     };
     const presentation = presentPegMonitoring(
       { ...response, packages: [healthyItem, structuralWarningItem] },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.assets[0]?.asset.asset).toBe("eurox-schuman");
@@ -530,7 +580,7 @@ describe("presentPegMonitoring", () => {
           crossedBy("near-warning", 30),
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(presentation.closestWarning?.asset.asset).toBe("near-warning");
@@ -555,23 +605,23 @@ describe("presentPegMonitoring", () => {
     };
     const mixed = presentPegMonitoring(
       { ...response, packages: [item, criticalItem] },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
     const stale = presentPegMonitoring(response, {
+      ...CURRENT_CONTEXT,
       packageIsStale: true,
-      usesPreviousPolicy: false,
     });
     const previous = presentPegMonitoring(response, {
-      packageIsStale: false,
+      ...CURRENT_CONTEXT,
       usesPreviousPolicy: true,
     });
     const staleCritical = presentPegMonitoring(
       { ...response, packages: [criticalItem] },
-      { packageIsStale: true, usesPreviousPolicy: false },
+      { ...CURRENT_CONTEXT, packageIsStale: true },
     );
     const previousCritical = presentPegMonitoring(
       { ...response, packages: [criticalItem] },
-      { packageIsStale: false, usesPreviousPolicy: true },
+      { ...CURRENT_CONTEXT, usesPreviousPolicy: true },
     );
     const confirmedCriticalWithUncertainSibling = presentPegMonitoring(
       {
@@ -585,7 +635,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
     const currentCriticalWithIncompleteChecks = presentPegMonitoring(
       {
@@ -597,7 +647,7 @@ describe("presentPegMonitoring", () => {
           },
         ],
       },
-      { packageIsStale: false, usesPreviousPolicy: false },
+      CURRENT_CONTEXT,
     );
 
     expect(mixed.aggregate.label).toBe("Critical condition detected");

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -183,6 +183,85 @@ describe("presentPegMonitoring", () => {
     );
   });
 
+  it("expires breaker decisions strictly after the structural freshness grace", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const baseBreaker = item.monitors[0]!.breaker!;
+    const withBreaker = (breaker: typeof baseBreaker | null) => ({
+      ...response,
+      packages: [
+        {
+          ...item,
+          policy: { ...item.policy, freshnessGraceSeconds: 60 },
+          monitors: item.monitors.map((monitor) => ({
+            ...monitor,
+            breaker,
+          })),
+          sources: item.sources.map((source) => ({
+            ...source,
+            policy: {
+              ...source.policy,
+              pollIntervalSeconds: Math.min(
+                source.policy.pollIntervalSeconds,
+                60,
+              ),
+            },
+          })),
+        },
+      ],
+    });
+    const contextAt = (seconds: number) => ({
+      ...CURRENT_CONTEXT,
+      nowMs: (response.producedAt + seconds) * 1_000,
+    });
+
+    for (const unsafeBreaker of [
+      { ...baseBreaker, enabled: false },
+      { ...baseBreaker, status: "TRIPPED" as const },
+    ]) {
+      const atBoundary = presentPegMonitoring(
+        withBreaker(unsafeBreaker),
+        contextAt(60),
+      );
+      const expired = presentPegMonitoring(
+        withBreaker(unsafeBreaker),
+        contextAt(61),
+      );
+
+      expect(atBoundary.aggregate.label).toBe("Critical condition detected");
+      expect(atBoundary.assets[0]).toMatchObject({
+        structuralEvidenceCurrent: true,
+        currentCritical: true,
+      });
+      expect(expired.aggregate.label).toBe("Monitoring checks incomplete");
+      expect(expired.assets[0]).toMatchObject({
+        structuralEvidenceCurrent: false,
+        currentCritical: false,
+        uncertain: true,
+        uncertaintyReason:
+          "The structural checks are older than the policy's freshness window.",
+      });
+      expect(expired.assets[0]?.reasons).not.toContain(
+        "A monitored breaker is disabled or tripped.",
+      );
+    }
+
+    const unavailableExpired = presentPegMonitoring(
+      withBreaker(null),
+      contextAt(61),
+    );
+    expect(unavailableExpired.assets[0]).toMatchObject({
+      structuralEvidenceCurrent: false,
+      currentCritical: false,
+      uncertain: true,
+      uncertaintyReason:
+        "The structural checks are older than the policy's freshness window.",
+    });
+    expect(unavailableExpired.assets[0]?.reasons).not.toContain(
+      "A monitored breaker is unavailable.",
+    );
+  });
+
   it("matches every confirmed blind-while-stressed critical alert leg", () => {
     const response = healthyResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring-presentation.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+import { presentPegMonitoring } from "../peg-monitoring-presentation";
+import { makePegMonitoringResponse } from "@/test-utils/peg-monitoring-fixture";
+
+function healthyResponse() {
+  const response = makePegMonitoringResponse();
+  const item = response.packages[0]!;
+  return {
+    ...response,
+    packages: [
+      {
+        ...item,
+        structural: { ...item.structural, structuralSaturation: null },
+        monitors: item.monitors.map((monitor) => ({
+          ...monitor,
+          structuralSaturation: null,
+        })),
+        sources: item.sources.map((source) =>
+          source.id === item.policy.deepVenueSource
+            ? {
+                ...source,
+                executablePrice: 0.999,
+                deviationBps: 10,
+                premiumBps: 0,
+              }
+            : source,
+        ),
+      },
+    ],
+  };
+}
+
+describe("presentPegMonitoring", () => {
+  it("derives a healthy decision from the deep source without treating legacy listing or inactive structural windows as unhealthy", () => {
+    const presentation = presentPegMonitoring(healthyResponse(), {
+      packageIsStale: false,
+      usesPreviousPolicy: false,
+    });
+
+    expect(presentation.aggregate.label).toBe("All pegs healthy");
+    expect(presentation.assets[0]).toMatchObject({
+      assetName: "EUROP",
+      tone: "healthy",
+      direction: "below",
+    });
+  });
+
+  it("marks deep critical downside and disabled breakers as action required", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const critical = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0.995,
+                    deviationBps: item.policy.criticalDeviationBps,
+                  }
+                : source,
+            ),
+            monitors: [
+              {
+                ...item.monitors[0]!,
+                breaker: { ...item.monitors[0]!.breaker!, enabled: false },
+              },
+            ],
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(critical.aggregate.label).toBe("Peg action required");
+    expect(critical.assets[0]).toMatchObject({
+      tone: "critical",
+      thresholdTone: "critical",
+    });
+  });
+
+  it("uses the directional warning threshold for an above-target measurement", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 1.003,
+                    deviationBps: 0,
+                    premiumBps: item.policy.premiumWarnBps,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.aggregate.label).toBe("Some pegs need attention");
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "warning",
+      direction: "above",
+      warningThresholdBps: item.policy.premiumWarnBps,
+      thresholdTone: "warning",
+    });
+  });
+
+  it("does not infer a critical downside threshold from the warning threshold", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            policy: {
+              ...item.policy,
+              warnDeviationBps: 20,
+              criticalDeviationBps: 45,
+            },
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0.996,
+                    deviationBps: 40,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "warning",
+      thresholdTone: "warning",
+    });
+    expect(presentation.assets[0]?.warningDistanceBps).toBeCloseTo(-20);
+  });
+
+  it("keeps a zero executable price as a measurable critical deviation", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    executablePrice: 0,
+                    deviationBps: 10_000,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "critical",
+      distanceBps: 10_000,
+      direction: "below",
+    });
+  });
+
+  it("keeps unavailable deep evidence conservative and calls it uncertain", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === item.policy.deepVenueSource
+                ? {
+                    ...source,
+                    healthy: false,
+                    executablePrice: null,
+                    observationAt: null,
+                    fetchedAt: null,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.aggregate.label).toBe("Current status uncertain");
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+      thresholdTone: "uncertain",
+      decisionSource: null,
+      distanceBps: null,
+    });
+    expect(presentation.furthest).toBeNull();
+    expect(presentation.closestWarning).toBeNull();
+  });
+
+  it("does not replace a missing policy-selected deep source with another deep source", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const presentation = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          {
+            ...item,
+            policy: { ...item.policy, deepVenueSource: "missing-deep-source" },
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.aggregate.label).toBe("Current status uncertain");
+    expect(presentation.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+      deepSource: null,
+      decisionSource: null,
+      distanceBps: null,
+    });
+    expect(presentation.furthest).toBeNull();
+    expect(presentation.closestWarning).toBeNull();
+  });
+
+  it("selects furthest distance independently from severity ranking", () => {
+    const response = healthyResponse();
+    const healthyItem = response.packages[0]!;
+    const structuralWarningItem = {
+      ...healthyItem,
+      asset: "eurox-schuman",
+      structural: { ...healthyItem.structural, blind: true },
+      sources: healthyItem.sources.map((source) =>
+        source.id === healthyItem.policy.deepVenueSource
+          ? { ...source, executablePrice: 0.9995, deviationBps: 5 }
+          : source,
+      ),
+    };
+    const presentation = presentPegMonitoring(
+      { ...response, packages: [healthyItem, structuralWarningItem] },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(presentation.assets[0]?.asset.asset).toBe("eurox-schuman");
+    expect(presentation.furthest?.asset.asset).toBe("europ-schuman");
+  });
+
+  it("ranks mixed packages by severity and treats stale or previous packages as uncertain", () => {
+    const response = healthyResponse();
+    const item = response.packages[0]!;
+    const criticalItem = {
+      ...item,
+      asset: "eurox-schuman",
+      sources: item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource
+          ? { ...source, deviationBps: item.policy.criticalDeviationBps }
+          : source,
+      ),
+    };
+    const mixed = presentPegMonitoring(
+      { ...response, packages: [item, criticalItem] },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+    const stale = presentPegMonitoring(response, {
+      packageIsStale: true,
+      usesPreviousPolicy: false,
+    });
+    const previous = presentPegMonitoring(response, {
+      packageIsStale: false,
+      usesPreviousPolicy: true,
+    });
+    const staleCritical = presentPegMonitoring(
+      { ...response, packages: [criticalItem] },
+      { packageIsStale: true, usesPreviousPolicy: false },
+    );
+    const previousCritical = presentPegMonitoring(
+      { ...response, packages: [criticalItem] },
+      { packageIsStale: false, usesPreviousPolicy: true },
+    );
+    const confirmedCriticalWithUncertainSibling = presentPegMonitoring(
+      {
+        ...response,
+        packages: [
+          criticalItem,
+          {
+            ...item,
+            asset: "uncertain-euro",
+            structural: { ...item.structural, blind: true },
+          },
+        ],
+      },
+      { packageIsStale: false, usesPreviousPolicy: false },
+    );
+
+    expect(mixed.aggregate.label).toBe("Peg action required");
+    expect(mixed.assets[0]?.asset.asset).toBe("eurox-schuman");
+    expect(stale.aggregate.label).toBe("Current status uncertain");
+    expect(stale.assets[0]).toMatchObject({ tone: "warning", uncertain: true });
+    expect(previous.aggregate.label).toBe("Current status uncertain");
+    expect(previous.assets[0]).toMatchObject({
+      tone: "warning",
+      uncertain: true,
+    });
+    expect(staleCritical.aggregate.label).toBe("Current status uncertain");
+    expect(staleCritical.assets[0]).toMatchObject({
+      tone: "critical",
+      uncertain: true,
+    });
+    expect(previousCritical.aggregate.label).toBe("Current status uncertain");
+    expect(previousCritical.assets[0]).toMatchObject({
+      tone: "critical",
+      uncertain: true,
+    });
+    expect(confirmedCriticalWithUncertainSibling.aggregate.label).toBe(
+      "Peg action required",
+    );
+  });
+});

--- a/ui-dashboard/src/lib/peg-monitoring-presentation-safety.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation-safety.ts
@@ -1,0 +1,373 @@
+import type { PegAssetPackage, PegSource } from "./peg-monitoring-schema";
+
+export type PegPresentationTone = "healthy" | "warning" | "critical";
+
+export type PackageContext = {
+  nowMs: number;
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+};
+
+export type SourceSelection = {
+  deepSource: PegSource | null;
+  decisionSource: PegSource | null;
+  sourceExpired: boolean;
+};
+
+type SafetySignals = {
+  tone: PegPresentationTone;
+  currentCritical: boolean;
+  reasons: string[];
+  uncertain: boolean;
+  uncertaintyReason: string | null;
+};
+
+type EffectiveThresholds = {
+  downsideWarningThresholdBps: number;
+  downsideCriticalThresholdBps: number;
+  premiumWarningThresholdBps: number;
+};
+
+export function assetName(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): string {
+  return (
+    source?.baseCurrency ??
+    item.asset.split("-")[0]?.toUpperCase() ??
+    item.asset
+  );
+}
+
+function sourceEvidenceExpired(
+  source: PegSource | null,
+  nowMs: number,
+): boolean {
+  if (source === null || source.observationAt === null) return false;
+  return (
+    nowMs - source.observationAt * 1_000 >
+    source.policy.staleAfterSeconds * 1_000
+  );
+}
+
+export function sourceHasUnavailableEvidence(
+  source: PegSource | null,
+  nowMs: number,
+): boolean {
+  return (
+    source === null ||
+    !source.healthy ||
+    source.observationAt === null ||
+    sourceEvidenceExpired(source, nowMs) ||
+    source.executablePrice === null ||
+    source.deviationBps === null ||
+    source.premiumBps === null ||
+    source.capped === true ||
+    source.listingState === "halted" ||
+    source.listingState === "absent" ||
+    source.venueState === "halted"
+  );
+}
+
+export function selectSources(
+  item: PegAssetPackage,
+  nowMs: number,
+): SourceSelection {
+  const deepSource =
+    item.sources.find((source) => source.id === item.policy.deepVenueSource) ??
+    null;
+  const sourceExpired = sourceEvidenceExpired(deepSource, nowMs);
+  return {
+    deepSource,
+    decisionSource: sourceHasUnavailableEvidence(deepSource, nowMs)
+      ? null
+      : deepSource,
+    sourceExpired,
+  };
+}
+
+function isStructuralWarning(item: PegAssetPackage): boolean {
+  const structural = item.structural;
+  const packageWarning =
+    structural.blind ||
+    !structural.indexedPoolReachable ||
+    structural.structuralQuerySaturated ||
+    (structural.structuralSaturation !== null &&
+      structural.structuralSaturation >= item.policy.structuralWarnFraction);
+  return (
+    packageWarning ||
+    item.monitors.some(
+      (monitor) =>
+        !monitor.indexedPoolReachable ||
+        monitor.structuralQuerySaturated ||
+        (monitor.structuralSaturation !== null &&
+          monitor.structuralSaturation >= item.policy.structuralWarnFraction),
+    )
+  );
+}
+
+function hasUnavailableStructuralEvidence(item: PegAssetPackage): boolean {
+  const structural = item.structural;
+  return (
+    structural.blind ||
+    !structural.indexedPoolReachable ||
+    structural.structuralQuerySaturated ||
+    item.monitors.some(
+      (monitor) =>
+        !monitor.indexedPoolReachable || monitor.structuralQuerySaturated,
+    )
+  );
+}
+
+export function effectiveThresholds(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): EffectiveThresholds {
+  const conversionAllowance = source?.policy.conversionErrorBps ?? 0;
+  return {
+    downsideWarningThresholdBps:
+      item.policy.warnDeviationBps + conversionAllowance,
+    downsideCriticalThresholdBps:
+      item.policy.criticalDeviationBps + conversionAllowance,
+    premiumWarningThresholdBps:
+      item.policy.premiumWarnBps + conversionAllowance,
+  };
+}
+
+function isSourceWarning(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): boolean {
+  if (source === null) return true;
+  const thresholds = effectiveThresholds(item, source);
+  return (
+    (source.deviationBps !== null &&
+      source.deviationBps >= thresholds.downsideWarningThresholdBps) ||
+    (source.premiumBps !== null &&
+      source.premiumBps >= thresholds.premiumWarningThresholdBps) ||
+    (source.spreadBps !== null &&
+      source.spreadBps > source.policy.spreadEnvelopeBps)
+  );
+}
+
+function isDeepCritical(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): boolean {
+  const thresholds = effectiveThresholds(item, source);
+  return (
+    source?.deviationBps !== null &&
+    source !== null &&
+    source.deviationBps >= thresholds.downsideCriticalThresholdBps
+  );
+}
+
+function blindWhileStressedReason(
+  item: PegAssetPackage,
+  source: PegSource | null,
+  nowMs: number,
+  structuralExpired: boolean,
+): string | null {
+  // The paging rule deliberately uses the confirmed streak. The producer
+  // resets it on the same poll that restores a usable full-size price.
+  if (
+    structuralExpired ||
+    item.structural.blindConsecutivePolls < item.policy.blindConsecutivePolls
+  )
+    return null;
+
+  const structuralStress =
+    item.structural.structuralSaturation !== null &&
+    item.structural.structuralSaturation >=
+      item.policy.structuralWarnFraction &&
+    item.structural.indexedPoolReachable;
+  const blindReason = `The deep market could not price the full test amount for ${item.policy.blindConsecutivePolls} consecutive checks`;
+  if (structuralStress)
+    return `${blindReason}, while on-chain pool activity crossed its warning limit.`;
+
+  const sourceIsCurrent =
+    source !== null &&
+    source.observationAt !== null &&
+    !sourceEvidenceExpired(source, nowMs);
+  const spreadStress =
+    sourceIsCurrent &&
+    source.spreadBps !== null &&
+    source.spreadBps > source.policy.spreadEnvelopeBps;
+  if (spreadStress)
+    return `${blindReason}, while its buy and sell prices moved too far apart.`;
+
+  const cappedCriticalShortfall =
+    sourceIsCurrent &&
+    source.capped === true &&
+    source.executablePrice !== null &&
+    ((item.policy.target - source.executablePrice) / item.policy.target) *
+      10_000 >=
+      item.policy.criticalDeviationBps + source.policy.conversionErrorBps;
+  return cappedCriticalShortfall
+    ? `${blindReason}, while its available partial price crossed the critical downside limit.`
+    : null;
+}
+
+function hasUnsafeBreaker(item: PegAssetPackage): boolean {
+  return item.monitors.some(
+    ({ breaker }) =>
+      breaker !== null && (!breaker.enabled || breaker.status === "TRIPPED"),
+  );
+}
+
+function hasUnavailableBreaker(item: PegAssetPackage): boolean {
+  return item.monitors.some(({ breaker }) => breaker === null);
+}
+
+function currentBreakerSignals(
+  item: PegAssetPackage,
+  structuralExpired: boolean,
+) {
+  if (structuralExpired)
+    return { breakerUnavailable: false, unsafeBreaker: false };
+  return {
+    breakerUnavailable: hasUnavailableBreaker(item),
+    unsafeBreaker: hasUnsafeBreaker(item),
+  };
+}
+
+function uncertaintyReason(input: {
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+  sourceUnavailable: boolean;
+  sourceExpired: boolean;
+  structuralExpired: boolean;
+  structuralUnavailable: boolean;
+  breakerUnavailable: boolean;
+}): string | null {
+  if (input.packageIsStale) return "No fresh monitoring package is available.";
+  if (input.usesPreviousPolicy)
+    return "The latest complete package uses the previous approved policy.";
+  if (input.sourceExpired)
+    return "The policy-selected market observation is older than its allowed freshness window.";
+  if (input.sourceUnavailable)
+    return "The policy-selected market has no usable full-size price.";
+  if (input.structuralExpired)
+    return "The structural checks are older than the policy's freshness window.";
+  if (input.structuralUnavailable)
+    return "Structural or pool evidence is unavailable or incomplete.";
+  if (input.breakerUnavailable)
+    return "A monitored breaker check is unavailable.";
+  return null;
+}
+
+function safetyReasons(input: {
+  structuralWarning: boolean;
+  structuralExpired: boolean;
+  structuralUnavailable: boolean;
+  sourceUnavailable: boolean;
+  sourceExpired: boolean;
+  sourceWarning: boolean;
+  breakerUnavailable: boolean;
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+  deepCritical: boolean;
+  blindWhileStressedReason: string | null;
+  unsafeBreaker: boolean;
+}): string[] {
+  const reasons: string[] = [];
+  if (input.blindWhileStressedReason)
+    reasons.push(input.blindWhileStressedReason);
+  if (input.deepCritical)
+    reasons.push(
+      "The latest deep-market price crossed the critical threshold. The alert only fires if enough readings stay there long enough.",
+    );
+  if (input.unsafeBreaker)
+    reasons.push("A monitored breaker is disabled or tripped.");
+  if (input.structuralExpired)
+    reasons.push(
+      "The structural checks are older than the policy's freshness window.",
+    );
+  else if (input.structuralUnavailable)
+    reasons.push(
+      "Current structural or pool evidence is unavailable or incomplete.",
+    );
+  else if (input.structuralWarning)
+    reasons.push("Structural saturation crossed its warning threshold.");
+  if (input.sourceUnavailable)
+    reasons.push(
+      input.sourceExpired
+        ? "The deep market observation is older than its allowed freshness window."
+        : "The deep market source is unavailable or unhealthy.",
+    );
+  else if (input.sourceWarning)
+    reasons.push("The deep market measurement crossed a warning threshold.");
+  if (input.breakerUnavailable)
+    reasons.push("A monitored breaker is unavailable.");
+  if (input.packageIsStale)
+    reasons.push("The package is stale; this is the last confirmed evidence.");
+  if (input.usesPreviousPolicy)
+    reasons.push("The package uses the previous approved policy.");
+  return reasons;
+}
+
+export function classifySafety(
+  item: PegAssetPackage,
+  selection: SourceSelection,
+  context: PackageContext,
+  structuralExpired: boolean,
+): SafetySignals {
+  const structuralWarning = !structuralExpired && isStructuralWarning(item);
+  const structuralUnavailable =
+    structuralExpired || hasUnavailableStructuralEvidence(item);
+  const sourceUnavailable = selection.decisionSource === null;
+  const sourceWarning = isSourceWarning(item, selection.decisionSource);
+  const { breakerUnavailable, unsafeBreaker } = currentBreakerSignals(
+    item,
+    structuralExpired,
+  );
+  const deepCritical = isDeepCritical(item, selection.decisionSource);
+  const confirmedBlindWhileStressedReason = blindWhileStressedReason(
+    item,
+    selection.deepSource,
+    context.nowMs,
+    structuralExpired,
+  );
+  const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
+  const critical =
+    deepCritical || confirmedBlindWhileStressedReason !== null || unsafeBreaker;
+  return {
+    tone: critical
+      ? "critical"
+      : structuralWarning ||
+          sourceWarning ||
+          breakerUnavailable ||
+          policyWarning
+        ? "warning"
+        : "healthy",
+    currentCritical: critical && !policyWarning,
+    uncertain:
+      structuralUnavailable ||
+      sourceUnavailable ||
+      breakerUnavailable ||
+      policyWarning,
+    uncertaintyReason: uncertaintyReason({
+      packageIsStale: context.packageIsStale,
+      usesPreviousPolicy: context.usesPreviousPolicy,
+      sourceUnavailable,
+      sourceExpired: selection.sourceExpired,
+      structuralExpired,
+      structuralUnavailable,
+      breakerUnavailable,
+    }),
+    reasons: safetyReasons({
+      structuralWarning,
+      structuralExpired,
+      structuralUnavailable,
+      sourceUnavailable,
+      sourceExpired: selection.sourceExpired,
+      sourceWarning,
+      breakerUnavailable,
+      packageIsStale: context.packageIsStale,
+      usesPreviousPolicy: context.usesPreviousPolicy,
+      deepCritical,
+      blindWhileStressedReason: confirmedBlindWhileStressedReason,
+      unsafeBreaker,
+    }),
+  };
+}

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -213,6 +213,52 @@ function isDeepCritical(
   );
 }
 
+function blindWhileStressedReason(
+  item: PegAssetPackage,
+  source: PegSource | null,
+  nowMs: number,
+  structuralExpired: boolean,
+): string | null {
+  // The paging rule deliberately uses the confirmed streak. The producer
+  // resets it on the same poll that restores a usable full-size price.
+  if (
+    structuralExpired ||
+    item.structural.blindConsecutivePolls < item.policy.blindConsecutivePolls
+  )
+    return null;
+
+  const structuralStress =
+    item.structural.structuralSaturation !== null &&
+    item.structural.structuralSaturation >=
+      item.policy.structuralWarnFraction &&
+    item.structural.indexedPoolReachable;
+  const blindReason = `The deep market could not price the full test amount for ${item.policy.blindConsecutivePolls} consecutive checks`;
+  if (structuralStress)
+    return `${blindReason}, while on-chain pool activity crossed its warning limit.`;
+
+  const sourceIsCurrent =
+    source !== null &&
+    source.observationAt !== null &&
+    !sourceEvidenceExpired(source, nowMs);
+  const spreadStress =
+    sourceIsCurrent &&
+    source.spreadBps !== null &&
+    source.spreadBps > source.policy.spreadEnvelopeBps;
+  if (spreadStress)
+    return `${blindReason}, while its buy and sell prices moved too far apart.`;
+
+  const cappedCriticalShortfall =
+    sourceIsCurrent &&
+    source.capped === true &&
+    source.executablePrice !== null &&
+    ((item.policy.target - source.executablePrice) / item.policy.target) *
+      10_000 >=
+      item.policy.criticalDeviationBps + source.policy.conversionErrorBps;
+  return cappedCriticalShortfall
+    ? `${blindReason}, while its available partial price crossed the critical downside limit.`
+    : null;
+}
+
 function hasUnsafeBreaker(item: PegAssetPackage): boolean {
   return item.monitors.some(
     ({ breaker }) =>
@@ -260,9 +306,12 @@ function safetyReasons(input: {
   packageIsStale: boolean;
   usesPreviousPolicy: boolean;
   deepCritical: boolean;
+  blindWhileStressedReason: string | null;
   unsafeBreaker: boolean;
 }): string[] {
   const reasons: string[] = [];
+  if (input.blindWhileStressedReason)
+    reasons.push(input.blindWhileStressedReason);
   if (input.deepCritical)
     reasons.push(
       "The latest deep-market price crossed the critical threshold. The alert only fires if enough readings stay there long enough.",
@@ -309,9 +358,16 @@ function classifySafety(
   const sourceWarning = isSourceWarning(item, selection.decisionSource);
   const breakerUnavailable = hasUnavailableBreaker(item);
   const deepCritical = isDeepCritical(item, selection.decisionSource);
+  const confirmedBlindWhileStressedReason = blindWhileStressedReason(
+    item,
+    selection.deepSource,
+    context.nowMs,
+    structuralExpired,
+  );
   const unsafeBreaker = hasUnsafeBreaker(item);
   const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
-  const critical = deepCritical || unsafeBreaker;
+  const critical =
+    deepCritical || confirmedBlindWhileStressedReason !== null || unsafeBreaker;
   return {
     tone: critical
       ? "critical"
@@ -347,6 +403,7 @@ function classifySafety(
       packageIsStale: context.packageIsStale,
       usesPreviousPolicy: context.usesPreviousPolicy,
       deepCritical,
+      blindWhileStressedReason: confirmedBlindWhileStressedReason,
       unsafeBreaker,
     }),
   };

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -12,6 +12,7 @@ export type PegAssetPresentation = {
   assetName: string;
   decisionSource: PegSource | null;
   deepSource: PegSource | null;
+  structuralEvidenceCurrent: boolean;
   usableSourceCount: number;
   distanceBps: number | null;
   direction: "below" | "above" | "at target" | null;
@@ -228,6 +229,7 @@ function uncertaintyReason(input: {
   usesPreviousPolicy: boolean;
   sourceUnavailable: boolean;
   sourceExpired: boolean;
+  structuralExpired: boolean;
   structuralUnavailable: boolean;
   breakerUnavailable: boolean;
 }): string | null {
@@ -238,6 +240,8 @@ function uncertaintyReason(input: {
     return "The policy-selected market observation is older than its allowed freshness window.";
   if (input.sourceUnavailable)
     return "The policy-selected market has no usable full-size price.";
+  if (input.structuralExpired)
+    return "The structural checks are older than the policy's freshness window.";
   if (input.structuralUnavailable)
     return "Structural or pool evidence is unavailable or incomplete.";
   if (input.breakerUnavailable)
@@ -247,6 +251,7 @@ function uncertaintyReason(input: {
 
 function safetyReasons(input: {
   structuralWarning: boolean;
+  structuralExpired: boolean;
   structuralUnavailable: boolean;
   sourceUnavailable: boolean;
   sourceExpired: boolean;
@@ -264,7 +269,11 @@ function safetyReasons(input: {
     );
   if (input.unsafeBreaker)
     reasons.push("A monitored breaker is disabled or tripped.");
-  if (input.structuralUnavailable)
+  if (input.structuralExpired)
+    reasons.push(
+      "The structural checks are older than the policy's freshness window.",
+    );
+  else if (input.structuralUnavailable)
     reasons.push(
       "Current structural or pool evidence is unavailable or incomplete.",
     );
@@ -291,9 +300,11 @@ function classifySafety(
   item: PegAssetPackage,
   selection: SourceSelection,
   context: PackageContext,
+  structuralExpired: boolean,
 ): SafetySignals {
-  const structuralWarning = isStructuralWarning(item);
-  const structuralUnavailable = hasUnavailableStructuralEvidence(item);
+  const structuralWarning = !structuralExpired && isStructuralWarning(item);
+  const structuralUnavailable =
+    structuralExpired || hasUnavailableStructuralEvidence(item);
   const sourceUnavailable = selection.decisionSource === null;
   const sourceWarning = isSourceWarning(item, selection.decisionSource);
   const breakerUnavailable = hasUnavailableBreaker(item);
@@ -321,11 +332,13 @@ function classifySafety(
       usesPreviousPolicy: context.usesPreviousPolicy,
       sourceUnavailable,
       sourceExpired: selection.sourceExpired,
+      structuralExpired,
       structuralUnavailable,
       breakerUnavailable,
     }),
     reasons: safetyReasons({
       structuralWarning,
+      structuralExpired,
       structuralUnavailable,
       sourceUnavailable,
       sourceExpired: selection.sourceExpired,
@@ -427,8 +440,11 @@ function describeDistance(
 function buildAssetPresentation(
   item: PegAssetPackage,
   context: PackageContext,
+  producedAtMs: number,
 ): PegAssetPresentation {
   const selection = selectSources(item, context.nowMs);
+  const structuralExpired =
+    context.nowMs - producedAtMs > item.policy.freshnessGraceSeconds * 1_000;
   return {
     asset: item,
     assetName: assetName(
@@ -437,11 +453,12 @@ function buildAssetPresentation(
     ),
     decisionSource: selection.decisionSource,
     deepSource: selection.deepSource,
+    structuralEvidenceCurrent: !structuralExpired,
     usableSourceCount: item.sources.filter(
       (source) => !sourceHasUnavailableEvidence(source, context.nowMs),
     ).length,
     ...describeDistance(item, selection),
-    ...classifySafety(item, selection, context),
+    ...classifySafety(item, selection, context, structuralExpired),
   };
 }
 
@@ -543,7 +560,9 @@ export function presentPegMonitoring(
   context: PackageContext,
 ): PegMonitoringPresentation {
   const assets = sortBySeverityAndDistance(
-    data.packages.map((item) => buildAssetPresentation(item, context)),
+    data.packages.map((item) =>
+      buildAssetPresentation(item, context, data.producedAt * 1_000),
+    ),
   );
   return {
     assets,

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -46,6 +46,7 @@ export type PegMonitoringPresentation = {
 };
 
 type PackageContext = {
+  nowMs: number;
   packageIsStale: boolean;
   usesPreviousPolicy: boolean;
 };
@@ -53,6 +54,7 @@ type PackageContext = {
 type SourceSelection = {
   deepSource: PegSource | null;
   decisionSource: PegSource | null;
+  sourceExpired: boolean;
 };
 
 type SafetySignals = {
@@ -92,10 +94,23 @@ function assetName(item: PegAssetPackage, source: PegSource | null): string {
   );
 }
 
-function sourceHasUnavailableEvidence(source: PegSource | null): boolean {
+function sourceEvidenceExpired(source: PegSource | null, nowMs: number) {
+  if (source === null || source.observationAt === null) return false;
+  return (
+    nowMs - source.observationAt * 1_000 >
+    source.policy.staleAfterSeconds * 1_000
+  );
+}
+
+function sourceHasUnavailableEvidence(
+  source: PegSource | null,
+  nowMs: number,
+): boolean {
   return (
     source === null ||
     !source.healthy ||
+    source.observationAt === null ||
+    sourceEvidenceExpired(source, nowMs) ||
     source.executablePrice === null ||
     source.deviationBps === null ||
     source.premiumBps === null ||
@@ -106,15 +121,17 @@ function sourceHasUnavailableEvidence(source: PegSource | null): boolean {
   );
 }
 
-function selectSources(item: PegAssetPackage): SourceSelection {
+function selectSources(item: PegAssetPackage, nowMs: number): SourceSelection {
   const deepSource =
     item.sources.find((source) => source.id === item.policy.deepVenueSource) ??
     null;
+  const sourceExpired = sourceEvidenceExpired(deepSource, nowMs);
   return {
     deepSource,
-    decisionSource: sourceHasUnavailableEvidence(deepSource)
+    decisionSource: sourceHasUnavailableEvidence(deepSource, nowMs)
       ? null
       : deepSource,
+    sourceExpired,
   };
 }
 
@@ -170,7 +187,7 @@ function isSourceWarning(
   item: PegAssetPackage,
   source: PegSource | null,
 ): boolean {
-  if (source === null || sourceHasUnavailableEvidence(source)) return true;
+  if (source === null) return true;
   const thresholds = effectiveThresholds(item, source);
   return (
     (source.deviationBps !== null &&
@@ -209,12 +226,15 @@ function uncertaintyReason(input: {
   packageIsStale: boolean;
   usesPreviousPolicy: boolean;
   sourceUnavailable: boolean;
+  sourceExpired: boolean;
   structuralUnavailable: boolean;
   breakerUnavailable: boolean;
 }): string | null {
   if (input.packageIsStale) return "No fresh monitoring package is available.";
   if (input.usesPreviousPolicy)
     return "The latest complete package uses the previous approved policy.";
+  if (input.sourceExpired)
+    return "The policy-selected market observation is older than its allowed freshness window.";
   if (input.sourceUnavailable)
     return "The policy-selected market has no usable full-size price.";
   if (input.structuralUnavailable)
@@ -228,6 +248,7 @@ function safetyReasons(input: {
   structuralWarning: boolean;
   structuralUnavailable: boolean;
   sourceUnavailable: boolean;
+  sourceExpired: boolean;
   sourceWarning: boolean;
   breakerUnavailable: boolean;
   packageIsStale: boolean;
@@ -249,7 +270,11 @@ function safetyReasons(input: {
   else if (input.structuralWarning)
     reasons.push("Structural saturation crossed its warning threshold.");
   if (input.sourceUnavailable)
-    reasons.push("The deep market source is unavailable or unhealthy.");
+    reasons.push(
+      input.sourceExpired
+        ? "The deep market observation is older than its allowed freshness window."
+        : "The deep market source is unavailable or unhealthy.",
+    );
   else if (input.sourceWarning)
     reasons.push("The deep market measurement crossed a warning threshold.");
   if (input.breakerUnavailable)
@@ -263,18 +288,15 @@ function safetyReasons(input: {
 
 function classifySafety(
   item: PegAssetPackage,
-  deepSource: PegSource | null,
+  selection: SourceSelection,
   context: PackageContext,
 ): SafetySignals {
   const structuralWarning = isStructuralWarning(item);
   const structuralUnavailable = hasUnavailableStructuralEvidence(item);
-  const sourceUnavailable = sourceHasUnavailableEvidence(deepSource);
-  const sourceWarning = isSourceWarning(item, deepSource);
+  const sourceUnavailable = selection.decisionSource === null;
+  const sourceWarning = isSourceWarning(item, selection.decisionSource);
   const breakerUnavailable = hasUnavailableBreaker(item);
-  const deepCritical = isDeepCritical(
-    item,
-    sourceUnavailable ? null : deepSource,
-  );
+  const deepCritical = isDeepCritical(item, selection.decisionSource);
   const unsafeBreaker = hasUnsafeBreaker(item);
   const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
   const critical = deepCritical || unsafeBreaker;
@@ -297,6 +319,7 @@ function classifySafety(
       packageIsStale: context.packageIsStale,
       usesPreviousPolicy: context.usesPreviousPolicy,
       sourceUnavailable,
+      sourceExpired: selection.sourceExpired,
       structuralUnavailable,
       breakerUnavailable,
     }),
@@ -304,6 +327,7 @@ function classifySafety(
       structuralWarning,
       structuralUnavailable,
       sourceUnavailable,
+      sourceExpired: selection.sourceExpired,
       sourceWarning,
       breakerUnavailable,
       packageIsStale: context.packageIsStale,
@@ -341,13 +365,13 @@ function decisionDistanceBps(
 }
 
 function thresholdTone(input: {
-  deepSource: PegSource | null;
+  decisionSource: PegSource | null;
   direction: PegAssetPresentation["direction"];
   distanceBps: number | null;
   warningDistanceBps: number | null;
   criticalDeviationBps: number;
 }): PegThresholdTone {
-  if (sourceHasUnavailableEvidence(input.deepSource)) return "uncertain";
+  if (input.decisionSource === null) return "uncertain";
   if (
     input.direction === "below" &&
     input.distanceBps !== null &&
@@ -390,7 +414,7 @@ function describeDistance(
     warningThresholdBps,
     warningDistanceBps,
     thresholdTone: thresholdTone({
-      deepSource: selection.deepSource,
+      decisionSource: selection.decisionSource,
       direction,
       distanceBps: currentDistanceBps,
       warningDistanceBps,
@@ -403,7 +427,7 @@ function buildAssetPresentation(
   item: PegAssetPackage,
   context: PackageContext,
 ): PegAssetPresentation {
-  const selection = selectSources(item);
+  const selection = selectSources(item, context.nowMs);
   return {
     asset: item,
     assetName: assetName(
@@ -413,7 +437,7 @@ function buildAssetPresentation(
     decisionSource: selection.decisionSource,
     deepSource: selection.deepSource,
     ...describeDistance(item, selection),
-    ...classifySafety(item, selection.deepSource, context),
+    ...classifySafety(item, selection, context),
   };
 }
 

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -270,6 +270,18 @@ function hasUnavailableBreaker(item: PegAssetPackage): boolean {
   return item.monitors.some(({ breaker }) => breaker === null);
 }
 
+function currentBreakerSignals(
+  item: PegAssetPackage,
+  structuralExpired: boolean,
+) {
+  if (structuralExpired)
+    return { breakerUnavailable: false, unsafeBreaker: false };
+  return {
+    breakerUnavailable: hasUnavailableBreaker(item),
+    unsafeBreaker: hasUnsafeBreaker(item),
+  };
+}
+
 function uncertaintyReason(input: {
   packageIsStale: boolean;
   usesPreviousPolicy: boolean;
@@ -356,7 +368,10 @@ function classifySafety(
     structuralExpired || hasUnavailableStructuralEvidence(item);
   const sourceUnavailable = selection.decisionSource === null;
   const sourceWarning = isSourceWarning(item, selection.decisionSource);
-  const breakerUnavailable = hasUnavailableBreaker(item);
+  const { breakerUnavailable, unsafeBreaker } = currentBreakerSignals(
+    item,
+    structuralExpired,
+  );
   const deepCritical = isDeepCritical(item, selection.decisionSource);
   const confirmedBlindWhileStressedReason = blindWhileStressedReason(
     item,
@@ -364,7 +379,6 @@ function classifySafety(
     context.nowMs,
     structuralExpired,
   );
-  const unsafeBreaker = hasUnsafeBreaker(item);
   const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
   const critical =
     deepCritical || confirmedBlindWhileStressedReason !== null || unsafeBreaker;

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -1,0 +1,401 @@
+import type {
+  PegAssetPackage,
+  PegMonitoringResponse,
+  PegSource,
+} from "./peg-monitoring-schema";
+
+export type PegPresentationTone = "healthy" | "warning" | "critical";
+type PegThresholdTone = PegPresentationTone | "uncertain";
+
+export type PegAssetPresentation = {
+  asset: PegAssetPackage;
+  assetName: string;
+  decisionSource: PegSource | null;
+  deepSource: PegSource | null;
+  distanceBps: number | null;
+  direction: "below" | "above" | "at target" | null;
+  warningThresholdBps: number | null;
+  warningDistanceBps: number | null;
+  thresholdTone: PegThresholdTone;
+  tone: PegPresentationTone;
+  reasons: string[];
+  uncertain: boolean;
+};
+
+export type PegMonitoringPresentation = {
+  assets: PegAssetPresentation[];
+  aggregate: {
+    tone: PegPresentationTone | "uncertain";
+    label:
+      | "All pegs healthy"
+      | "Peg action required"
+      | "Some pegs need attention"
+      | "Current status uncertain";
+  };
+  furthest: PegAssetPresentation | null;
+  closestWarning: PegAssetPresentation | null;
+};
+
+type PackageContext = {
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+};
+
+type SourceSelection = {
+  deepSource: PegSource | null;
+  decisionSource: PegSource | null;
+};
+
+type SafetySignals = {
+  tone: PegPresentationTone;
+  reasons: string[];
+  uncertain: boolean;
+};
+
+type DistanceGeometry = Pick<
+  PegAssetPresentation,
+  | "distanceBps"
+  | "direction"
+  | "warningThresholdBps"
+  | "warningDistanceBps"
+  | "thresholdTone"
+>;
+
+const severity = { healthy: 0, warning: 1, critical: 2 } as const;
+
+function assetName(item: PegAssetPackage, source: PegSource | null): string {
+  return (
+    source?.baseCurrency ??
+    item.asset.split("-")[0]?.toUpperCase() ??
+    item.asset
+  );
+}
+
+function sourceHasUnavailableEvidence(source: PegSource | null): boolean {
+  return (
+    source === null ||
+    !source.healthy ||
+    source.executablePrice === null ||
+    source.listingState === "halted" ||
+    source.listingState === "absent" ||
+    source.venueState === "halted"
+  );
+}
+
+function selectSources(item: PegAssetPackage): SourceSelection {
+  const deepSource =
+    item.sources.find((source) => source.id === item.policy.deepVenueSource) ??
+    null;
+  return {
+    deepSource,
+    decisionSource: sourceHasUnavailableEvidence(deepSource)
+      ? null
+      : deepSource,
+  };
+}
+
+function isStructuralWarning(item: PegAssetPackage): boolean {
+  const structural = item.structural;
+  const packageWarning =
+    structural.blind ||
+    !structural.indexedPoolReachable ||
+    structural.structuralQuerySaturated ||
+    (structural.structuralSaturation !== null &&
+      structural.structuralSaturation >= item.policy.structuralWarnFraction);
+  return (
+    packageWarning ||
+    item.monitors.some(
+      (monitor) =>
+        !monitor.indexedPoolReachable ||
+        monitor.structuralQuerySaturated ||
+        (monitor.structuralSaturation !== null &&
+          monitor.structuralSaturation >= item.policy.structuralWarnFraction),
+    )
+  );
+}
+
+function isSourceWarning(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): boolean {
+  if (source === null || sourceHasUnavailableEvidence(source)) return true;
+  return (
+    (source.deviationBps !== null &&
+      source.deviationBps >= item.policy.warnDeviationBps) ||
+    (source.premiumBps !== null &&
+      source.premiumBps >= item.policy.premiumWarnBps) ||
+    (source.spreadBps !== null &&
+      source.spreadBps >= source.policy.spreadEnvelopeBps)
+  );
+}
+
+function isDeepCritical(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): boolean {
+  return (
+    source?.deviationBps !== null &&
+    source !== null &&
+    source.deviationBps >= item.policy.criticalDeviationBps
+  );
+}
+
+function hasUnsafeBreaker(item: PegAssetPackage): boolean {
+  return item.monitors.some(
+    ({ breaker }) =>
+      breaker !== null && (!breaker.enabled || breaker.status === "TRIPPED"),
+  );
+}
+
+function hasUnavailableBreaker(item: PegAssetPackage): boolean {
+  return item.monitors.some(({ breaker }) => breaker === null);
+}
+
+function safetyReasons(input: {
+  structuralWarning: boolean;
+  sourceUnavailable: boolean;
+  sourceWarning: boolean;
+  breakerUnavailable: boolean;
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+  deepCritical: boolean;
+  unsafeBreaker: boolean;
+}): string[] {
+  const reasons: string[] = [];
+  if (input.deepCritical)
+    reasons.push("Deep-source downside has reached the critical threshold.");
+  if (input.unsafeBreaker)
+    reasons.push("A monitored breaker is disabled or tripped.");
+  if (input.structuralWarning)
+    reasons.push(
+      "Current structural or pool evidence is unavailable or crossed its warning threshold.",
+    );
+  if (input.sourceUnavailable)
+    reasons.push("The deep market source is unavailable or unhealthy.");
+  else if (input.sourceWarning)
+    reasons.push("The deep market measurement crossed a warning threshold.");
+  if (input.breakerUnavailable)
+    reasons.push("A monitored breaker is unavailable.");
+  if (input.packageIsStale)
+    reasons.push("The package is stale; this is the last confirmed evidence.");
+  if (input.usesPreviousPolicy)
+    reasons.push("The package uses the previous approved policy.");
+  return reasons;
+}
+
+function classifySafety(
+  item: PegAssetPackage,
+  deepSource: PegSource | null,
+  context: PackageContext,
+): SafetySignals {
+  const structuralWarning = isStructuralWarning(item);
+  const sourceUnavailable = sourceHasUnavailableEvidence(deepSource);
+  const sourceWarning = isSourceWarning(item, deepSource);
+  const breakerUnavailable = hasUnavailableBreaker(item);
+  const deepCritical = isDeepCritical(item, deepSource);
+  const unsafeBreaker = hasUnsafeBreaker(item);
+  const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
+  const critical = deepCritical || unsafeBreaker;
+  return {
+    tone: critical
+      ? "critical"
+      : structuralWarning ||
+          sourceWarning ||
+          breakerUnavailable ||
+          policyWarning
+        ? "warning"
+        : "healthy",
+    uncertain:
+      structuralWarning ||
+      sourceUnavailable ||
+      breakerUnavailable ||
+      policyWarning,
+    reasons: safetyReasons({
+      structuralWarning,
+      sourceUnavailable,
+      sourceWarning,
+      breakerUnavailable,
+      packageIsStale: context.packageIsStale,
+      usesPreviousPolicy: context.usesPreviousPolicy,
+      deepCritical,
+      unsafeBreaker,
+    }),
+  };
+}
+
+function distanceBps(source: PegSource | null, target: number): number | null {
+  if (source?.executablePrice === null || source === null) return null;
+  return Math.abs((source.executablePrice / target - 1) * 10_000);
+}
+
+function signedDistanceBps(
+  source: PegSource | null,
+  target: number,
+): number | null {
+  if (source?.executablePrice === null || source === null) return null;
+  return (source.executablePrice / target - 1) * 10_000;
+}
+
+function directionFrom(
+  signedDistance: number | null,
+): PegAssetPresentation["direction"] {
+  if (signedDistance === null) return null;
+  if (signedDistance === 0) return "at target";
+  return signedDistance < 0 ? "below" : "above";
+}
+
+function thresholdTone(input: {
+  deepSource: PegSource | null;
+  context: PackageContext;
+  direction: PegAssetPresentation["direction"];
+  distanceBps: number | null;
+  warningDistanceBps: number | null;
+  criticalDeviationBps: number;
+}): PegThresholdTone {
+  if (
+    sourceHasUnavailableEvidence(input.deepSource) ||
+    input.context.packageIsStale ||
+    input.context.usesPreviousPolicy
+  )
+    return "uncertain";
+  if (
+    input.direction === "below" &&
+    input.distanceBps !== null &&
+    input.distanceBps >= input.criticalDeviationBps
+  )
+    return "critical";
+  return input.warningDistanceBps !== null && input.warningDistanceBps <= 0
+    ? "warning"
+    : "healthy";
+}
+
+function describeDistance(
+  item: PegAssetPackage,
+  selection: SourceSelection,
+  context: PackageContext,
+): DistanceGeometry {
+  const signedDistance = signedDistanceBps(
+    selection.decisionSource,
+    item.policy.target,
+  );
+  const direction = directionFrom(signedDistance);
+  const currentDistanceBps = distanceBps(
+    selection.decisionSource,
+    item.policy.target,
+  );
+  const warningThresholdBps =
+    direction === null
+      ? null
+      : direction === "above"
+        ? item.policy.premiumWarnBps
+        : item.policy.warnDeviationBps;
+  const warningDistanceBps =
+    currentDistanceBps === null || warningThresholdBps === null
+      ? null
+      : warningThresholdBps - currentDistanceBps;
+  return {
+    distanceBps: currentDistanceBps,
+    direction,
+    warningThresholdBps,
+    warningDistanceBps,
+    thresholdTone: thresholdTone({
+      deepSource: selection.deepSource,
+      context,
+      direction,
+      distanceBps: currentDistanceBps,
+      warningDistanceBps,
+      criticalDeviationBps: item.policy.criticalDeviationBps,
+    }),
+  };
+}
+
+function buildAssetPresentation(
+  item: PegAssetPackage,
+  context: PackageContext,
+): PegAssetPresentation {
+  const selection = selectSources(item);
+  return {
+    asset: item,
+    assetName: assetName(
+      item,
+      selection.deepSource ?? selection.decisionSource,
+    ),
+    decisionSource: selection.decisionSource,
+    deepSource: selection.deepSource,
+    ...describeDistance(item, selection, context),
+    ...classifySafety(item, selection.deepSource, context),
+  };
+}
+
+function aggregatePresentation(assets: PegAssetPresentation[]) {
+  const confirmedCritical = assets.some(
+    ({ tone, uncertain }) => tone === "critical" && !uncertain,
+  );
+  if (confirmedCritical)
+    return { tone: "critical" as const, label: "Peg action required" as const };
+  if (assets.some(({ uncertain }) => uncertain))
+    return {
+      tone: "uncertain" as const,
+      label: "Current status uncertain" as const,
+    };
+  if (assets.some(({ tone }) => tone === "warning"))
+    return {
+      tone: "warning" as const,
+      label: "Some pegs need attention" as const,
+    };
+  return { tone: "healthy" as const, label: "All pegs healthy" as const };
+}
+
+function sortBySeverityAndDistance(
+  assets: PegAssetPresentation[],
+): PegAssetPresentation[] {
+  return [...assets].sort(
+    (left, right) =>
+      severity[right.tone] - severity[left.tone] ||
+      (right.distanceBps ?? -1) - (left.distanceBps ?? -1),
+  );
+}
+
+function selectFurthest(
+  assets: PegAssetPresentation[],
+): PegAssetPresentation | null {
+  return assets.reduce<PegAssetPresentation | null>(
+    (furthest, asset) =>
+      asset.distanceBps !== null &&
+      (furthest === null ||
+        asset.distanceBps > (furthest.distanceBps ?? Number.NEGATIVE_INFINITY))
+        ? asset
+        : furthest,
+    null,
+  );
+}
+
+function selectClosestWarning(
+  assets: PegAssetPresentation[],
+): PegAssetPresentation | null {
+  return assets.reduce<PegAssetPresentation | null>(
+    (closest, asset) =>
+      asset.distanceBps !== null &&
+      (closest === null ||
+        (asset.warningDistanceBps ?? Number.POSITIVE_INFINITY) <
+          (closest.warningDistanceBps ?? Number.POSITIVE_INFINITY))
+        ? asset
+        : closest,
+    null,
+  );
+}
+
+export function presentPegMonitoring(
+  data: PegMonitoringResponse,
+  context: PackageContext,
+): PegMonitoringPresentation {
+  const assets = sortBySeverityAndDistance(
+    data.packages.map((item) => buildAssetPresentation(item, context)),
+  );
+  return {
+    assets,
+    aggregate: aggregatePresentation(assets),
+    furthest: selectFurthest(assets),
+    closestWarning: selectClosestWarning(assets),
+  };
+}

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -14,10 +14,14 @@ export type PegAssetPresentation = {
   deepSource: PegSource | null;
   distanceBps: number | null;
   direction: "below" | "above" | "at target" | null;
+  downsideWarningThresholdBps: number;
+  downsideCriticalThresholdBps: number;
+  premiumWarningThresholdBps: number;
   warningThresholdBps: number | null;
   warningDistanceBps: number | null;
   thresholdTone: PegThresholdTone;
   tone: PegPresentationTone;
+  currentCritical: boolean;
   reasons: string[];
   uncertain: boolean;
   uncertaintyReason: string | null;
@@ -29,7 +33,7 @@ export type PegMonitoringPresentation = {
     tone: PegPresentationTone | "uncertain";
     label:
       | "All pegs healthy"
-      | "Peg action required"
+      | "Critical condition detected"
       | "Some pegs need attention"
       | "Latest data is stale"
       | "Policy update pending"
@@ -53,6 +57,7 @@ type SourceSelection = {
 
 type SafetySignals = {
   tone: PegPresentationTone;
+  currentCritical: boolean;
   reasons: string[];
   uncertain: boolean;
   uncertaintyReason: string | null;
@@ -62,9 +67,19 @@ type DistanceGeometry = Pick<
   PegAssetPresentation,
   | "distanceBps"
   | "direction"
+  | "downsideWarningThresholdBps"
+  | "downsideCriticalThresholdBps"
+  | "premiumWarningThresholdBps"
   | "warningThresholdBps"
   | "warningDistanceBps"
   | "thresholdTone"
+>;
+
+type EffectiveThresholds = Pick<
+  PegAssetPresentation,
+  | "downsideWarningThresholdBps"
+  | "downsideCriticalThresholdBps"
+  | "premiumWarningThresholdBps"
 >;
 
 const severity = { healthy: 0, warning: 1, critical: 2 } as const;
@@ -82,6 +97,8 @@ function sourceHasUnavailableEvidence(source: PegSource | null): boolean {
     source === null ||
     !source.healthy ||
     source.executablePrice === null ||
+    source.deviationBps === null ||
+    source.premiumBps === null ||
     source.capped === true ||
     source.listingState === "halted" ||
     source.listingState === "absent" ||
@@ -134,18 +151,34 @@ function hasUnavailableStructuralEvidence(item: PegAssetPackage): boolean {
   );
 }
 
+function effectiveThresholds(
+  item: PegAssetPackage,
+  source: PegSource | null,
+): EffectiveThresholds {
+  const conversionAllowance = source?.policy.conversionErrorBps ?? 0;
+  return {
+    downsideWarningThresholdBps:
+      item.policy.warnDeviationBps + conversionAllowance,
+    downsideCriticalThresholdBps:
+      item.policy.criticalDeviationBps + conversionAllowance,
+    premiumWarningThresholdBps:
+      item.policy.premiumWarnBps + conversionAllowance,
+  };
+}
+
 function isSourceWarning(
   item: PegAssetPackage,
   source: PegSource | null,
 ): boolean {
   if (source === null || sourceHasUnavailableEvidence(source)) return true;
+  const thresholds = effectiveThresholds(item, source);
   return (
     (source.deviationBps !== null &&
-      source.deviationBps >= item.policy.warnDeviationBps) ||
+      source.deviationBps >= thresholds.downsideWarningThresholdBps) ||
     (source.premiumBps !== null &&
-      source.premiumBps >= item.policy.premiumWarnBps) ||
+      source.premiumBps >= thresholds.premiumWarningThresholdBps) ||
     (source.spreadBps !== null &&
-      source.spreadBps >= source.policy.spreadEnvelopeBps)
+      source.spreadBps > source.policy.spreadEnvelopeBps)
   );
 }
 
@@ -153,10 +186,11 @@ function isDeepCritical(
   item: PegAssetPackage,
   source: PegSource | null,
 ): boolean {
+  const thresholds = effectiveThresholds(item, source);
   return (
     source?.deviationBps !== null &&
     source !== null &&
-    source.deviationBps >= item.policy.criticalDeviationBps
+    source.deviationBps >= thresholds.downsideCriticalThresholdBps
   );
 }
 
@@ -203,7 +237,9 @@ function safetyReasons(input: {
 }): string[] {
   const reasons: string[] = [];
   if (input.deepCritical)
-    reasons.push("Deep-source downside has reached the critical threshold.");
+    reasons.push(
+      "The latest deep-market price crossed the critical threshold. The alert only fires if enough readings stay there long enough.",
+    );
   if (input.unsafeBreaker)
     reasons.push("A monitored breaker is disabled or tripped.");
   if (input.structuralUnavailable)
@@ -251,6 +287,7 @@ function classifySafety(
           policyWarning
         ? "warning"
         : "healthy",
+    currentCritical: critical && !policyWarning,
     uncertain:
       structuralUnavailable ||
       sourceUnavailable ||
@@ -277,11 +314,6 @@ function classifySafety(
   };
 }
 
-function distanceBps(source: PegSource | null, target: number): number | null {
-  if (source?.executablePrice === null || source === null) return null;
-  return Math.abs((source.executablePrice / target - 1) * 10_000);
-}
-
 function signedDistanceBps(
   source: PegSource | null,
   target: number,
@@ -296,6 +328,16 @@ function directionFrom(
   if (signedDistance === null) return null;
   if (signedDistance === 0) return "at target";
   return signedDistance < 0 ? "below" : "above";
+}
+
+function decisionDistanceBps(
+  source: PegSource | null,
+  direction: PegAssetPresentation["direction"],
+): number | null {
+  if (source === null || direction === null) return null;
+  if (direction === "below") return source.deviationBps;
+  if (direction === "above") return source.premiumBps;
+  return 0;
 }
 
 function thresholdTone(input: {
@@ -321,26 +363,28 @@ function describeDistance(
   item: PegAssetPackage,
   selection: SourceSelection,
 ): DistanceGeometry {
+  const thresholds = effectiveThresholds(item, selection.deepSource);
   const signedDistance = signedDistanceBps(
     selection.decisionSource,
     item.policy.target,
   );
   const direction = directionFrom(signedDistance);
-  const currentDistanceBps = distanceBps(
+  const currentDistanceBps = decisionDistanceBps(
     selection.decisionSource,
-    item.policy.target,
+    direction,
   );
   const warningThresholdBps =
     direction === null
       ? null
       : direction === "above"
-        ? item.policy.premiumWarnBps
-        : item.policy.warnDeviationBps;
+        ? thresholds.premiumWarningThresholdBps
+        : thresholds.downsideWarningThresholdBps;
   const warningDistanceBps =
     currentDistanceBps === null || warningThresholdBps === null
       ? null
       : warningThresholdBps - currentDistanceBps;
   return {
+    ...thresholds,
     distanceBps: currentDistanceBps,
     direction,
     warningThresholdBps,
@@ -350,7 +394,7 @@ function describeDistance(
       direction,
       distanceBps: currentDistanceBps,
       warningDistanceBps,
-      criticalDeviationBps: item.policy.criticalDeviationBps,
+      criticalDeviationBps: thresholds.downsideCriticalThresholdBps,
     }),
   };
 }
@@ -378,12 +422,12 @@ function aggregatePresentation(
   context: PackageContext,
 ) {
   const confirmedCritical = assets.find(
-    ({ tone, uncertain }) => tone === "critical" && !uncertain,
+    ({ currentCritical }) => currentCritical,
   );
   if (confirmedCritical)
     return {
       tone: "critical" as const,
-      label: "Peg action required" as const,
+      label: "Critical condition detected" as const,
       detail:
         confirmedCritical.reasons[0] ??
         `${confirmedCritical.assetName} crossed a critical threshold.`,
@@ -454,16 +498,16 @@ function selectFurthest(
 function selectClosestWarning(
   assets: PegAssetPresentation[],
 ): PegAssetPresentation | null {
-  return assets.reduce<PegAssetPresentation | null>(
-    (closest, asset) =>
-      asset.distanceBps !== null &&
-      (closest === null ||
-        (asset.warningDistanceBps ?? Number.POSITIVE_INFINITY) <
-          (closest.warningDistanceBps ?? Number.POSITIVE_INFINITY))
-        ? asset
-        : closest,
-    null,
-  );
+  return assets.reduce<PegAssetPresentation | null>((closest, asset) => {
+    if (asset.warningDistanceBps === null) return closest;
+    if (
+      closest === null ||
+      closest.warningDistanceBps === null ||
+      Math.abs(asset.warningDistanceBps) < Math.abs(closest.warningDistanceBps)
+    )
+      return asset;
+    return closest;
+  }, null);
 }
 
 export function presentPegMonitoring(

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -3,8 +3,18 @@ import type {
   PegMonitoringResponse,
   PegSource,
 } from "./peg-monitoring-schema";
+import {
+  assetName,
+  classifySafety,
+  effectiveThresholds,
+  selectSources,
+  sourceHasUnavailableEvidence,
+  type PackageContext,
+  type PegPresentationTone,
+  type SourceSelection,
+} from "./peg-monitoring-presentation-safety";
 
-export type PegPresentationTone = "healthy" | "warning" | "critical";
+export type { PegPresentationTone } from "./peg-monitoring-presentation-safety";
 type PegThresholdTone = PegPresentationTone | "uncertain";
 
 export type PegAssetPresentation = {
@@ -47,26 +57,6 @@ export type PegMonitoringPresentation = {
   closestWarning: PegAssetPresentation | null;
 };
 
-type PackageContext = {
-  nowMs: number;
-  packageIsStale: boolean;
-  usesPreviousPolicy: boolean;
-};
-
-type SourceSelection = {
-  deepSource: PegSource | null;
-  decisionSource: PegSource | null;
-  sourceExpired: boolean;
-};
-
-type SafetySignals = {
-  tone: PegPresentationTone;
-  currentCritical: boolean;
-  reasons: string[];
-  uncertain: boolean;
-  uncertaintyReason: string | null;
-};
-
 type DistanceGeometry = Pick<
   PegAssetPresentation,
   | "distanceBps"
@@ -79,349 +69,7 @@ type DistanceGeometry = Pick<
   | "thresholdTone"
 >;
 
-type EffectiveThresholds = Pick<
-  PegAssetPresentation,
-  | "downsideWarningThresholdBps"
-  | "downsideCriticalThresholdBps"
-  | "premiumWarningThresholdBps"
->;
-
 const severity = { healthy: 0, warning: 1, critical: 2 } as const;
-
-function assetName(item: PegAssetPackage, source: PegSource | null): string {
-  return (
-    source?.baseCurrency ??
-    item.asset.split("-")[0]?.toUpperCase() ??
-    item.asset
-  );
-}
-
-function sourceEvidenceExpired(source: PegSource | null, nowMs: number) {
-  if (source === null || source.observationAt === null) return false;
-  return (
-    nowMs - source.observationAt * 1_000 >
-    source.policy.staleAfterSeconds * 1_000
-  );
-}
-
-function sourceHasUnavailableEvidence(
-  source: PegSource | null,
-  nowMs: number,
-): boolean {
-  return (
-    source === null ||
-    !source.healthy ||
-    source.observationAt === null ||
-    sourceEvidenceExpired(source, nowMs) ||
-    source.executablePrice === null ||
-    source.deviationBps === null ||
-    source.premiumBps === null ||
-    source.capped === true ||
-    source.listingState === "halted" ||
-    source.listingState === "absent" ||
-    source.venueState === "halted"
-  );
-}
-
-function selectSources(item: PegAssetPackage, nowMs: number): SourceSelection {
-  const deepSource =
-    item.sources.find((source) => source.id === item.policy.deepVenueSource) ??
-    null;
-  const sourceExpired = sourceEvidenceExpired(deepSource, nowMs);
-  return {
-    deepSource,
-    decisionSource: sourceHasUnavailableEvidence(deepSource, nowMs)
-      ? null
-      : deepSource,
-    sourceExpired,
-  };
-}
-
-function isStructuralWarning(item: PegAssetPackage): boolean {
-  const structural = item.structural;
-  const packageWarning =
-    structural.blind ||
-    !structural.indexedPoolReachable ||
-    structural.structuralQuerySaturated ||
-    (structural.structuralSaturation !== null &&
-      structural.structuralSaturation >= item.policy.structuralWarnFraction);
-  return (
-    packageWarning ||
-    item.monitors.some(
-      (monitor) =>
-        !monitor.indexedPoolReachable ||
-        monitor.structuralQuerySaturated ||
-        (monitor.structuralSaturation !== null &&
-          monitor.structuralSaturation >= item.policy.structuralWarnFraction),
-    )
-  );
-}
-
-function hasUnavailableStructuralEvidence(item: PegAssetPackage): boolean {
-  const structural = item.structural;
-  return (
-    structural.blind ||
-    !structural.indexedPoolReachable ||
-    structural.structuralQuerySaturated ||
-    item.monitors.some(
-      (monitor) =>
-        !monitor.indexedPoolReachable || monitor.structuralQuerySaturated,
-    )
-  );
-}
-
-function effectiveThresholds(
-  item: PegAssetPackage,
-  source: PegSource | null,
-): EffectiveThresholds {
-  const conversionAllowance = source?.policy.conversionErrorBps ?? 0;
-  return {
-    downsideWarningThresholdBps:
-      item.policy.warnDeviationBps + conversionAllowance,
-    downsideCriticalThresholdBps:
-      item.policy.criticalDeviationBps + conversionAllowance,
-    premiumWarningThresholdBps:
-      item.policy.premiumWarnBps + conversionAllowance,
-  };
-}
-
-function isSourceWarning(
-  item: PegAssetPackage,
-  source: PegSource | null,
-): boolean {
-  if (source === null) return true;
-  const thresholds = effectiveThresholds(item, source);
-  return (
-    (source.deviationBps !== null &&
-      source.deviationBps >= thresholds.downsideWarningThresholdBps) ||
-    (source.premiumBps !== null &&
-      source.premiumBps >= thresholds.premiumWarningThresholdBps) ||
-    (source.spreadBps !== null &&
-      source.spreadBps > source.policy.spreadEnvelopeBps)
-  );
-}
-
-function isDeepCritical(
-  item: PegAssetPackage,
-  source: PegSource | null,
-): boolean {
-  const thresholds = effectiveThresholds(item, source);
-  return (
-    source?.deviationBps !== null &&
-    source !== null &&
-    source.deviationBps >= thresholds.downsideCriticalThresholdBps
-  );
-}
-
-function blindWhileStressedReason(
-  item: PegAssetPackage,
-  source: PegSource | null,
-  nowMs: number,
-  structuralExpired: boolean,
-): string | null {
-  // The paging rule deliberately uses the confirmed streak. The producer
-  // resets it on the same poll that restores a usable full-size price.
-  if (
-    structuralExpired ||
-    item.structural.blindConsecutivePolls < item.policy.blindConsecutivePolls
-  )
-    return null;
-
-  const structuralStress =
-    item.structural.structuralSaturation !== null &&
-    item.structural.structuralSaturation >=
-      item.policy.structuralWarnFraction &&
-    item.structural.indexedPoolReachable;
-  const blindReason = `The deep market could not price the full test amount for ${item.policy.blindConsecutivePolls} consecutive checks`;
-  if (structuralStress)
-    return `${blindReason}, while on-chain pool activity crossed its warning limit.`;
-
-  const sourceIsCurrent =
-    source !== null &&
-    source.observationAt !== null &&
-    !sourceEvidenceExpired(source, nowMs);
-  const spreadStress =
-    sourceIsCurrent &&
-    source.spreadBps !== null &&
-    source.spreadBps > source.policy.spreadEnvelopeBps;
-  if (spreadStress)
-    return `${blindReason}, while its buy and sell prices moved too far apart.`;
-
-  const cappedCriticalShortfall =
-    sourceIsCurrent &&
-    source.capped === true &&
-    source.executablePrice !== null &&
-    ((item.policy.target - source.executablePrice) / item.policy.target) *
-      10_000 >=
-      item.policy.criticalDeviationBps + source.policy.conversionErrorBps;
-  return cappedCriticalShortfall
-    ? `${blindReason}, while its available partial price crossed the critical downside limit.`
-    : null;
-}
-
-function hasUnsafeBreaker(item: PegAssetPackage): boolean {
-  return item.monitors.some(
-    ({ breaker }) =>
-      breaker !== null && (!breaker.enabled || breaker.status === "TRIPPED"),
-  );
-}
-
-function hasUnavailableBreaker(item: PegAssetPackage): boolean {
-  return item.monitors.some(({ breaker }) => breaker === null);
-}
-
-function currentBreakerSignals(
-  item: PegAssetPackage,
-  structuralExpired: boolean,
-) {
-  if (structuralExpired)
-    return { breakerUnavailable: false, unsafeBreaker: false };
-  return {
-    breakerUnavailable: hasUnavailableBreaker(item),
-    unsafeBreaker: hasUnsafeBreaker(item),
-  };
-}
-
-function uncertaintyReason(input: {
-  packageIsStale: boolean;
-  usesPreviousPolicy: boolean;
-  sourceUnavailable: boolean;
-  sourceExpired: boolean;
-  structuralExpired: boolean;
-  structuralUnavailable: boolean;
-  breakerUnavailable: boolean;
-}): string | null {
-  if (input.packageIsStale) return "No fresh monitoring package is available.";
-  if (input.usesPreviousPolicy)
-    return "The latest complete package uses the previous approved policy.";
-  if (input.sourceExpired)
-    return "The policy-selected market observation is older than its allowed freshness window.";
-  if (input.sourceUnavailable)
-    return "The policy-selected market has no usable full-size price.";
-  if (input.structuralExpired)
-    return "The structural checks are older than the policy's freshness window.";
-  if (input.structuralUnavailable)
-    return "Structural or pool evidence is unavailable or incomplete.";
-  if (input.breakerUnavailable)
-    return "A monitored breaker check is unavailable.";
-  return null;
-}
-
-function safetyReasons(input: {
-  structuralWarning: boolean;
-  structuralExpired: boolean;
-  structuralUnavailable: boolean;
-  sourceUnavailable: boolean;
-  sourceExpired: boolean;
-  sourceWarning: boolean;
-  breakerUnavailable: boolean;
-  packageIsStale: boolean;
-  usesPreviousPolicy: boolean;
-  deepCritical: boolean;
-  blindWhileStressedReason: string | null;
-  unsafeBreaker: boolean;
-}): string[] {
-  const reasons: string[] = [];
-  if (input.blindWhileStressedReason)
-    reasons.push(input.blindWhileStressedReason);
-  if (input.deepCritical)
-    reasons.push(
-      "The latest deep-market price crossed the critical threshold. The alert only fires if enough readings stay there long enough.",
-    );
-  if (input.unsafeBreaker)
-    reasons.push("A monitored breaker is disabled or tripped.");
-  if (input.structuralExpired)
-    reasons.push(
-      "The structural checks are older than the policy's freshness window.",
-    );
-  else if (input.structuralUnavailable)
-    reasons.push(
-      "Current structural or pool evidence is unavailable or incomplete.",
-    );
-  else if (input.structuralWarning)
-    reasons.push("Structural saturation crossed its warning threshold.");
-  if (input.sourceUnavailable)
-    reasons.push(
-      input.sourceExpired
-        ? "The deep market observation is older than its allowed freshness window."
-        : "The deep market source is unavailable or unhealthy.",
-    );
-  else if (input.sourceWarning)
-    reasons.push("The deep market measurement crossed a warning threshold.");
-  if (input.breakerUnavailable)
-    reasons.push("A monitored breaker is unavailable.");
-  if (input.packageIsStale)
-    reasons.push("The package is stale; this is the last confirmed evidence.");
-  if (input.usesPreviousPolicy)
-    reasons.push("The package uses the previous approved policy.");
-  return reasons;
-}
-
-function classifySafety(
-  item: PegAssetPackage,
-  selection: SourceSelection,
-  context: PackageContext,
-  structuralExpired: boolean,
-): SafetySignals {
-  const structuralWarning = !structuralExpired && isStructuralWarning(item);
-  const structuralUnavailable =
-    structuralExpired || hasUnavailableStructuralEvidence(item);
-  const sourceUnavailable = selection.decisionSource === null;
-  const sourceWarning = isSourceWarning(item, selection.decisionSource);
-  const { breakerUnavailable, unsafeBreaker } = currentBreakerSignals(
-    item,
-    structuralExpired,
-  );
-  const deepCritical = isDeepCritical(item, selection.decisionSource);
-  const confirmedBlindWhileStressedReason = blindWhileStressedReason(
-    item,
-    selection.deepSource,
-    context.nowMs,
-    structuralExpired,
-  );
-  const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
-  const critical =
-    deepCritical || confirmedBlindWhileStressedReason !== null || unsafeBreaker;
-  return {
-    tone: critical
-      ? "critical"
-      : structuralWarning ||
-          sourceWarning ||
-          breakerUnavailable ||
-          policyWarning
-        ? "warning"
-        : "healthy",
-    currentCritical: critical && !policyWarning,
-    uncertain:
-      structuralUnavailable ||
-      sourceUnavailable ||
-      breakerUnavailable ||
-      policyWarning,
-    uncertaintyReason: uncertaintyReason({
-      packageIsStale: context.packageIsStale,
-      usesPreviousPolicy: context.usesPreviousPolicy,
-      sourceUnavailable,
-      sourceExpired: selection.sourceExpired,
-      structuralExpired,
-      structuralUnavailable,
-      breakerUnavailable,
-    }),
-    reasons: safetyReasons({
-      structuralWarning,
-      structuralExpired,
-      structuralUnavailable,
-      sourceUnavailable,
-      sourceExpired: selection.sourceExpired,
-      sourceWarning,
-      breakerUnavailable,
-      packageIsStale: context.packageIsStale,
-      usesPreviousPolicy: context.usesPreviousPolicy,
-      deepCritical,
-      blindWhileStressedReason: confirmedBlindWhileStressedReason,
-      unsafeBreaker,
-    }),
-  };
-}
 
 function signedDistanceBps(
   source: PegSource | null,
@@ -487,7 +135,12 @@ function describeDistance(
       ? null
       : direction === "above"
         ? thresholds.premiumWarningThresholdBps
-        : thresholds.downsideWarningThresholdBps;
+        : direction === "below"
+          ? thresholds.downsideWarningThresholdBps
+          : Math.min(
+              thresholds.downsideWarningThresholdBps,
+              thresholds.premiumWarningThresholdBps,
+            );
   const warningDistanceBps =
     currentDistanceBps === null || warningThresholdBps === null
       ? null

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -12,6 +12,7 @@ export type PegAssetPresentation = {
   assetName: string;
   decisionSource: PegSource | null;
   deepSource: PegSource | null;
+  usableSourceCount: number;
   distanceBps: number | null;
   direction: "below" | "above" | "at target" | null;
   downsideWarningThresholdBps: number;
@@ -436,6 +437,9 @@ function buildAssetPresentation(
     ),
     decisionSource: selection.decisionSource,
     deepSource: selection.deepSource,
+    usableSourceCount: item.sources.filter(
+      (source) => !sourceHasUnavailableEvidence(source, context.nowMs),
+    ).length,
     ...describeDistance(item, selection),
     ...classifySafety(item, selection, context),
   };

--- a/ui-dashboard/src/lib/peg-monitoring-presentation.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-presentation.ts
@@ -20,6 +20,7 @@ export type PegAssetPresentation = {
   tone: PegPresentationTone;
   reasons: string[];
   uncertain: boolean;
+  uncertaintyReason: string | null;
 };
 
 export type PegMonitoringPresentation = {
@@ -30,7 +31,11 @@ export type PegMonitoringPresentation = {
       | "All pegs healthy"
       | "Peg action required"
       | "Some pegs need attention"
-      | "Current status uncertain";
+      | "Latest data is stale"
+      | "Policy update pending"
+      | "Price check unavailable"
+      | "Monitoring checks incomplete";
+    detail: string | null;
   };
   furthest: PegAssetPresentation | null;
   closestWarning: PegAssetPresentation | null;
@@ -50,6 +55,7 @@ type SafetySignals = {
   tone: PegPresentationTone;
   reasons: string[];
   uncertain: boolean;
+  uncertaintyReason: string | null;
 };
 
 type DistanceGeometry = Pick<
@@ -76,6 +82,7 @@ function sourceHasUnavailableEvidence(source: PegSource | null): boolean {
     source === null ||
     !source.healthy ||
     source.executablePrice === null ||
+    source.capped === true ||
     source.listingState === "halted" ||
     source.listingState === "absent" ||
     source.venueState === "halted"
@@ -110,6 +117,19 @@ function isStructuralWarning(item: PegAssetPackage): boolean {
         monitor.structuralQuerySaturated ||
         (monitor.structuralSaturation !== null &&
           monitor.structuralSaturation >= item.policy.structuralWarnFraction),
+    )
+  );
+}
+
+function hasUnavailableStructuralEvidence(item: PegAssetPackage): boolean {
+  const structural = item.structural;
+  return (
+    structural.blind ||
+    !structural.indexedPoolReachable ||
+    structural.structuralQuerySaturated ||
+    item.monitors.some(
+      (monitor) =>
+        !monitor.indexedPoolReachable || monitor.structuralQuerySaturated,
     )
   );
 }
@@ -151,8 +171,28 @@ function hasUnavailableBreaker(item: PegAssetPackage): boolean {
   return item.monitors.some(({ breaker }) => breaker === null);
 }
 
+function uncertaintyReason(input: {
+  packageIsStale: boolean;
+  usesPreviousPolicy: boolean;
+  sourceUnavailable: boolean;
+  structuralUnavailable: boolean;
+  breakerUnavailable: boolean;
+}): string | null {
+  if (input.packageIsStale) return "No fresh monitoring package is available.";
+  if (input.usesPreviousPolicy)
+    return "The latest complete package uses the previous approved policy.";
+  if (input.sourceUnavailable)
+    return "The policy-selected market has no usable full-size price.";
+  if (input.structuralUnavailable)
+    return "Structural or pool evidence is unavailable or incomplete.";
+  if (input.breakerUnavailable)
+    return "A monitored breaker check is unavailable.";
+  return null;
+}
+
 function safetyReasons(input: {
   structuralWarning: boolean;
+  structuralUnavailable: boolean;
   sourceUnavailable: boolean;
   sourceWarning: boolean;
   breakerUnavailable: boolean;
@@ -166,10 +206,12 @@ function safetyReasons(input: {
     reasons.push("Deep-source downside has reached the critical threshold.");
   if (input.unsafeBreaker)
     reasons.push("A monitored breaker is disabled or tripped.");
-  if (input.structuralWarning)
+  if (input.structuralUnavailable)
     reasons.push(
-      "Current structural or pool evidence is unavailable or crossed its warning threshold.",
+      "Current structural or pool evidence is unavailable or incomplete.",
     );
+  else if (input.structuralWarning)
+    reasons.push("Structural saturation crossed its warning threshold.");
   if (input.sourceUnavailable)
     reasons.push("The deep market source is unavailable or unhealthy.");
   else if (input.sourceWarning)
@@ -189,10 +231,14 @@ function classifySafety(
   context: PackageContext,
 ): SafetySignals {
   const structuralWarning = isStructuralWarning(item);
+  const structuralUnavailable = hasUnavailableStructuralEvidence(item);
   const sourceUnavailable = sourceHasUnavailableEvidence(deepSource);
   const sourceWarning = isSourceWarning(item, deepSource);
   const breakerUnavailable = hasUnavailableBreaker(item);
-  const deepCritical = isDeepCritical(item, deepSource);
+  const deepCritical = isDeepCritical(
+    item,
+    sourceUnavailable ? null : deepSource,
+  );
   const unsafeBreaker = hasUnsafeBreaker(item);
   const policyWarning = context.packageIsStale || context.usesPreviousPolicy;
   const critical = deepCritical || unsafeBreaker;
@@ -206,12 +252,20 @@ function classifySafety(
         ? "warning"
         : "healthy",
     uncertain:
-      structuralWarning ||
+      structuralUnavailable ||
       sourceUnavailable ||
       breakerUnavailable ||
       policyWarning,
+    uncertaintyReason: uncertaintyReason({
+      packageIsStale: context.packageIsStale,
+      usesPreviousPolicy: context.usesPreviousPolicy,
+      sourceUnavailable,
+      structuralUnavailable,
+      breakerUnavailable,
+    }),
     reasons: safetyReasons({
       structuralWarning,
+      structuralUnavailable,
       sourceUnavailable,
       sourceWarning,
       breakerUnavailable,
@@ -246,18 +300,12 @@ function directionFrom(
 
 function thresholdTone(input: {
   deepSource: PegSource | null;
-  context: PackageContext;
   direction: PegAssetPresentation["direction"];
   distanceBps: number | null;
   warningDistanceBps: number | null;
   criticalDeviationBps: number;
 }): PegThresholdTone {
-  if (
-    sourceHasUnavailableEvidence(input.deepSource) ||
-    input.context.packageIsStale ||
-    input.context.usesPreviousPolicy
-  )
-    return "uncertain";
+  if (sourceHasUnavailableEvidence(input.deepSource)) return "uncertain";
   if (
     input.direction === "below" &&
     input.distanceBps !== null &&
@@ -272,7 +320,6 @@ function thresholdTone(input: {
 function describeDistance(
   item: PegAssetPackage,
   selection: SourceSelection,
-  context: PackageContext,
 ): DistanceGeometry {
   const signedDistance = signedDistanceBps(
     selection.decisionSource,
@@ -300,7 +347,6 @@ function describeDistance(
     warningDistanceBps,
     thresholdTone: thresholdTone({
       deepSource: selection.deepSource,
-      context,
       direction,
       distanceBps: currentDistanceBps,
       warningDistanceBps,
@@ -322,28 +368,63 @@ function buildAssetPresentation(
     ),
     decisionSource: selection.decisionSource,
     deepSource: selection.deepSource,
-    ...describeDistance(item, selection, context),
+    ...describeDistance(item, selection),
     ...classifySafety(item, selection.deepSource, context),
   };
 }
 
-function aggregatePresentation(assets: PegAssetPresentation[]) {
-  const confirmedCritical = assets.some(
+function aggregatePresentation(
+  assets: PegAssetPresentation[],
+  context: PackageContext,
+) {
+  const confirmedCritical = assets.find(
     ({ tone, uncertain }) => tone === "critical" && !uncertain,
   );
   if (confirmedCritical)
-    return { tone: "critical" as const, label: "Peg action required" as const };
-  if (assets.some(({ uncertain }) => uncertain))
+    return {
+      tone: "critical" as const,
+      label: "Peg action required" as const,
+      detail:
+        confirmedCritical.reasons[0] ??
+        `${confirmedCritical.assetName} crossed a critical threshold.`,
+    };
+  if (context.packageIsStale)
     return {
       tone: "uncertain" as const,
-      label: "Current status uncertain" as const,
+      label: "Latest data is stale" as const,
+      detail:
+        "No fresh monitoring package is available; values below are the last confirmed measurements.",
     };
-  if (assets.some(({ tone }) => tone === "warning"))
+  if (context.usesPreviousPolicy)
+    return {
+      tone: "uncertain" as const,
+      label: "Policy update pending" as const,
+      detail: "The latest complete package uses the previous approved policy.",
+    };
+  const uncertainAsset = assets.find(({ uncertain }) => uncertain);
+  if (uncertainAsset)
+    return {
+      tone: "uncertain" as const,
+      label:
+        uncertainAsset.decisionSource === null
+          ? ("Price check unavailable" as const)
+          : ("Monitoring checks incomplete" as const),
+      detail: `${uncertainAsset.assetName}: ${uncertainAsset.uncertaintyReason ?? "One or more monitoring checks are unavailable."}`,
+    };
+  const warningAsset = assets.find(({ tone }) => tone === "warning");
+  if (warningAsset)
     return {
       tone: "warning" as const,
       label: "Some pegs need attention" as const,
+      detail:
+        warningAsset.reasons[0] ??
+        `${warningAsset.assetName} crossed a warning threshold.`,
     };
-  return { tone: "healthy" as const, label: "All pegs healthy" as const };
+  return {
+    tone: "healthy" as const,
+    label: "All pegs healthy" as const,
+    detail: null,
+  };
 }
 
 function sortBySeverityAndDistance(
@@ -394,7 +475,7 @@ export function presentPegMonitoring(
   );
   return {
     assets,
-    aggregate: aggregatePresentation(assets),
+    aggregate: aggregatePresentation(assets, context),
     furthest: selectFurthest(assets),
     closestWarning: selectClosestWarning(assets),
   };

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -65,6 +65,9 @@ test("shows a decision scorecard, keeps evidence on demand, and retains stale ev
   await expect(page.getByText("Furthest from target")).toHaveCount(0);
   await expect(page.getByText("Data freshness")).toBeVisible();
   await expect(page.getByText("Fresh", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("3 of 3 sources usable", { exact: true }),
+  ).toBeVisible();
   await expect(page.getByTestId("peg-target-europ-schuman")).toHaveAttribute(
     "style",
     /left: 50%/,

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -5,9 +5,23 @@ import {
 } from "../../src/test-utils/peg-monitoring-fixture";
 
 const now = PEG_FIXTURE_PRODUCED_AT;
-const payload = makePegMonitoringResponse();
+const initialPayload = makePegMonitoringResponse();
+const initialPackage = initialPayload.packages[0]!;
+const payload = {
+  ...initialPayload,
+  packages: [
+    {
+      ...initialPackage,
+      sources: initialPackage.sources.map((source) =>
+        source.id === initialPackage.policy.deepVenueSource
+          ? { ...source, executablePrice: 0.999, deviationBps: 10 }
+          : source,
+      ),
+    },
+  ],
+};
 
-test("intercepts peg monitoring, retains stale evidence, and keeps regional loading geometry", async ({
+test("shows a decision scorecard, keeps evidence on demand, and retains stale evidence", async ({
   page,
 }) => {
   await page.clock.install({ time: new Date(now * 1000 + 20_000) });
@@ -31,81 +45,57 @@ test("intercepts peg monitoring, retains stale evidence, and keeps regional load
     });
   });
   await page.goto("/peg-monitoring");
-  const skeleton = page.locator('[aria-label="Loading peg monitoring"]');
-  await expect(skeleton).toBeVisible();
-  const regions = [
-    ["status", "peg-skeleton-status", "peg-status", 8],
-    ["snapshot", "peg-skeleton-snapshot", "peg-snapshot", 12],
-    [
-      "package header",
-      "peg-skeleton-package-header",
-      "peg-package-0-header",
-      8,
-    ],
-    [
-      "structural evidence",
-      "peg-skeleton-structural",
-      "peg-package-0-structural",
-      12,
-    ],
-    ["policy context", "peg-skeleton-policy", "peg-package-0-policy", 16],
-    [
-      "pool and breaker evidence",
-      "peg-skeleton-monitors",
-      "peg-package-0-monitors",
-      16,
-    ],
-    [
-      "market-source evidence",
-      "peg-skeleton-sources",
-      "peg-package-0-sources",
-      16,
-    ],
-  ] as const;
-  const skeletonRects = await Promise.all(
-    regions.map(([, skeletonTestId]) =>
-      page.getByTestId(skeletonTestId).boundingBox(),
-    ),
-  );
+  await expect(
+    page.locator('[aria-label="Loading peg monitoring"]'),
+  ).toBeVisible();
+  const loadingHeadlines = page.getByTestId("peg-skeleton-headlines");
+  const loadingScorecard = page.getByTestId("peg-skeleton-scorecard");
+  await expect(loadingHeadlines).toBeVisible();
+  const [loadingHeadlineBox, loadingScorecardBox] = await Promise.all([
+    loadingHeadlines.boundingBox(),
+    loadingScorecard.boundingBox(),
+  ]);
   releaseFirstResponse();
-  await expect(page.getByText(/^Current package ·/)).toBeVisible();
-  const convertedSource = payload.packages[0]?.sources.find(
-    ({ convertVia }) => convertVia !== null,
-  );
-  expect(convertedSource?.convertVia).not.toBeNull();
+
+  const aggregate = page.getByTestId("peg-aggregate-status");
+  await expect(aggregate).toBeVisible();
+  await expect(aggregate).toHaveText("All pegs healthy");
+  await expect(aggregate.locator("*")).toHaveCount(0);
+  await expect(page.getByText("Furthest from target")).toBeVisible();
+  await expect(page.getByText("Closest to warning")).toBeVisible();
+  await expect(page.getByText("Data freshness")).toBeVisible();
+  const [loadedHeadlineBox, loadedScorecardBox] = await Promise.all([
+    page.getByTestId("peg-headline-cards").boundingBox(),
+    page.getByTestId("peg-scorecard-europ-schuman").boundingBox(),
+  ]);
+  expect(loadingHeadlineBox).not.toBeNull();
+  expect(loadingScorecardBox).not.toBeNull();
+  expect(loadedHeadlineBox).not.toBeNull();
+  expect(loadedScorecardBox).not.toBeNull();
+  if (
+    loadingHeadlineBox === null ||
+    loadingScorecardBox === null ||
+    loadedHeadlineBox === null ||
+    loadedScorecardBox === null
+  )
+    throw new Error("Peg skeleton or loaded scorecard geometry is unavailable");
+  expect(
+    Math.abs(loadingHeadlineBox.height - loadedHeadlineBox.height),
+  ).toBeLessThanOrEqual(48);
+  expect(
+    Math.abs(loadingScorecardBox.height - loadedScorecardBox.height),
+  ).toBeLessThanOrEqual(64);
+
+  const evidence = page.getByTestId("peg-evidence-policy");
+  await expect(evidence).not.toHaveAttribute("open", "");
+  await evidence.getByText("Evidence and policy", { exact: true }).click();
+  await expect(evidence).toHaveAttribute("open", "");
   await expect(
     page.getByText(
       "Price conversion: USD → EUR via feed 0xec5748…c318ca · chain 137",
     ),
   ).toBeVisible();
-  await expect(page.getByText("Complete within page limit")).toBeVisible();
-  const loadedRects = await Promise.all(
-    regions.map(([, , loadedTestId]) =>
-      page.getByTestId(loadedTestId).boundingBox(),
-    ),
-  );
-  for (const [index, [name, , , verticalTolerance]] of regions.entries()) {
-    const skeletonRect = skeletonRects[index];
-    const loadedRect = loadedRects[index];
-    expect(skeletonRect).not.toBeNull();
-    expect(loadedRect).not.toBeNull();
-    expect(
-      Math.abs(skeletonRect!.x - loadedRect!.x),
-      `${name} has a different left edge`,
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(skeletonRect!.width - loadedRect!.width),
-      `${name} has a different width`,
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(skeletonRect!.y - loadedRect!.y),
-      `${name} moved more than its text-height allowance`,
-    ).toBeLessThanOrEqual(verticalTolerance);
-    expect(
-      Math.abs(skeletonRect!.height - loadedRect!.height),
-      `${name} changed more than its text-height allowance`,
-    ).toBeLessThanOrEqual(verticalTolerance);
-  }
+
   const grafanaLink = page.getByRole("link", { name: /Open Peg Monitoring/ });
   await expect(grafanaLink).toHaveAttribute(
     "href",
@@ -117,4 +107,5 @@ test("intercepts peg monitoring, retains stale evidence, and keeps regional load
   ).toBeVisible();
   await page.clock.runFor(30_000);
   await expect(page.getByText("Stale — last confirmed package.")).toBeVisible();
+  await expect(page.getByText(/^Last confirmed package \d/)).toBeVisible();
 });

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -124,6 +124,9 @@ test("shows a decision scorecard, keeps evidence on demand, and retains stale ev
   await expect(aggregate).toContainText(
     "No fresh monitoring package has arrived",
   );
+  await expect(
+    page.getByText("Last confirmed conclusion", { exact: true }),
+  ).toBeVisible();
   await expect(page.getByText("Stale — last confirmed package.")).toBeVisible();
   await expect(page.getByText(/^Last confirmed package \d/)).toBeVisible();
 });

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -124,9 +124,15 @@ test("shows a decision scorecard, keeps evidence on demand, and retains stale ev
   await expect(aggregate).toContainText(
     "No fresh monitoring package has arrived",
   );
+  await expect(aggregate).not.toContainText(/\b\d+[smh] old/);
+  await expect(page.getByTestId("peg-aggregate-age")).toContainText(
+    /Last confirmed package \d+[smh] old/,
+  );
   await expect(
     page.getByText("Last confirmed conclusion", { exact: true }),
   ).toBeVisible();
   await expect(page.getByText("Stale — last confirmed package.")).toBeVisible();
-  await expect(page.getByText(/^Last confirmed package \d/)).toBeVisible();
+  await expect(
+    page.getByText(/^Last confirmed package \d+[smh] ago$/),
+  ).toBeVisible();
 });

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -61,9 +61,23 @@ test("shows a decision scorecard, keeps evidence on demand, and retains stale ev
   await expect(aggregate).toBeVisible();
   await expect(aggregate).toHaveText("All pegs healthy");
   await expect(aggregate.locator("*")).toHaveCount(0);
-  await expect(page.getByText("Furthest from target")).toBeVisible();
-  await expect(page.getByText("Closest to warning")).toBeVisible();
+  await expect(page.getByText("Nearest warning")).toBeVisible();
+  await expect(page.getByText("Furthest from target")).toHaveCount(0);
   await expect(page.getByText("Data freshness")).toBeVisible();
+  await expect(page.getByText("Fresh", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("peg-target-europ-schuman")).toHaveAttribute(
+    "style",
+    /left: 50%/,
+  );
+  const currentMarker = page.getByTestId("peg-current-europ-schuman");
+  const targetMarker = page.getByTestId("peg-target-europ-schuman");
+  const [currentMarkerBox, targetMarkerBox] = await Promise.all([
+    currentMarker.boundingBox(),
+    targetMarker.boundingBox(),
+  ]);
+  expect(currentMarkerBox).not.toBeNull();
+  expect(targetMarkerBox).not.toBeNull();
+  expect(currentMarkerBox!.x).toBeLessThan(targetMarkerBox!.x);
   const [loadedHeadlineBox, loadedScorecardBox] = await Promise.all([
     page.getByTestId("peg-headline-cards").boundingBox(),
     page.getByTestId("peg-scorecard-europ-schuman").boundingBox(),
@@ -106,6 +120,10 @@ test("shows a decision scorecard, keeps evidence on demand, and retains stale ev
     page.getByRole("link", { name: "Peg monitoring", exact: true }),
   ).toBeVisible();
   await page.clock.runFor(30_000);
+  await expect(aggregate).toContainText("Latest data is stale");
+  await expect(aggregate).toContainText(
+    "No fresh monitoring package has arrived",
+  );
   await expect(page.getByText("Stale — last confirmed package.")).toBeVisible();
   await expect(page.getByText(/^Last confirmed package \d/)).toBeVisible();
 });


### PR DESCRIPTION
## The Problem

- The peg page makes visitors read detailed evidence before they can answer whether any monitored peg needs attention.
- The old summary labels are hard to understand and do not establish a clear multi-asset health view.

## The Solution

- Lead with one aggregate status, three plain-language decision cards, and one scorecard per monitored asset.
- Keep the complete policy, source, pool, and breaker evidence available in a collapsed section below the decision view.

## Details

### Invariants

- `All pegs healthy` appears only when every monitored asset has current policy-selected deep-source, structural, and breaker evidence inside its exact policy thresholds.
- A missing, unhealthy, stale, or previous-policy decision source fails closed to an uncertain state. Other venues stay supporting evidence and never replace the policy-selected measurement.
- Each asset derives its distance and warning state from its own policy, so adding assets does not assume EUROP thresholds.
- Color always has a matching text label. Raw evidence keeps its existing precision and detail.

### Degraded behavior

- An upstream failure with no confirmed package keeps the existing unavailable state.
- A failed refresh with last-good data keeps the stale package visible and marks the decision uncertain.
- Missing deep-source, structural, or breaker evidence produces an explicit uncertain state instead of a healthy result.

### Intentional non-goals

- This PR does not change peg policy, alert evaluation, source collection, or Grafana rules.
- It does not add historical charts; Grafana remains the history surface.

## Validation

- `CI=true pnpm agent:quality-gate --run`
- Focused Vitest: 2 files, 15 tests
- Production Playwright peg-monitoring flow, including skeleton geometry and stale-data transition
- Manual Chrome verification at 500px and 1440px against the live Metrics Bridge: no console errors or horizontal overflow
- Lighthouse snapshot: accessibility 100, best practices 100, agentic browsing 100
- React Doctor full score: 100
- Fresh-context semantic autoreview plus deterministic local autoreview

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

Closes #1697
Refs #1444

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New client-side decision presentation could mislead operators if classification diverges from alert policy, though backend policy is unchanged and tests encode fail-closed uncertain behavior.
> 
> **Overview**
> The peg monitoring page now leads with a **decision scorecard** instead of dumping evidence first. A new `presentPegMonitoring` helper turns the existing Metrics Bridge package into aggregate labels (e.g. **All pegs healthy**, **Peg action required**, **Current status uncertain**), per-asset health tones, distance-to-target geometry, and headline picks (furthest from target, closest to warning).
> 
> **`PegMonitoringScorecard`** renders that view: one aggregate status bar, three summary cards (furthest / closest to warning / data freshness), and per-asset cards with executable price, a distance rail, a text-labeled conclusion, and a compact market/source/pool/breaker summary. Stale packages and previous-policy fallbacks mark decisions **uncertain**; only the policy-selected deep venue is used for measurement—other sources are not substituted.
> 
> The page header and metadata copy are simplified toward “peg status.” Full snapshot, structural, policy, monitor, and source detail (plus the Grafana link) move into a collapsed **Evidence and policy** `<details>` block. The loading skeleton is reworked to mirror the scorecard layout. Vitest covers presentation rules; Playwright checks scorecard visibility, collapsible evidence, and skeleton-to-loaded geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1cec17895f0238ae68893c1747c9467d4b1a87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->