### PR TITLE
Preserve the Peg page contact point during support mention rollout

### DIFF
--- a/alerts/rules/peg-contact-points.tf
+++ b/alerts/rules/peg-contact-points.tf
@@ -64,7 +64,10 @@ locals {
   peg_contact_point_names = {
     market_warning = "Peg market warnings (#alerts-pools)"
     ops_warning    = "Peg producer warnings (#alerts-infra)"
-    page           = "Peg pages (Splunk On-Call + @support-engineer in #alerts-critical)"
+    # Grafana uses the contact-point name as identity. Renaming it forces a
+    # delete while alert rules still refer to the old name, which Grafana
+    # rejects. Keep the stable name; the Slack message names @support-engineer.
+    page = "Peg pages (Splunk On-Call + #alerts-critical)"
   }
 
   peg_notify_market_warning = {

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -1017,6 +1017,9 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       contacts.includes("peg_contact_point_names = {") &&
       contacts.includes("name = local.peg_contact_point_names.page") &&
       contacts.includes(
+        'page = "Peg pages (Splunk On-Call + #alerts-critical)"',
+      ) &&
+      contacts.includes(
         "contact_point   = local.peg_contact_point_names.page",
       ) &&
       contacts.includes("victorops {") &&


### PR DESCRIPTION
## The Problem

- PR #1705 renamed the existing Peg critical-page contact point.
- Grafana rejected the production apply with HTTP 409 because active Peg rules still referenced the old contact point, so the @support-engineer mention is not live yet.

## The Solution

- Keep the existing Grafana contact-point name and identity while retaining the @support-engineer mention in the Slack message body.
- Add a regression assertion so a future label edit cannot silently turn into an unsafe contact-point replacement.

## Details

- The failed production run is https://github.com/mento-protocol/monitoring-monorepo/actions/runs/30523038527.
- No manual Grafana deletion, targeted apply, or lifecycle workaround is used.
- A fresh production-state plan keeps grafana_contact_point.peg_page["peg-monitoring"] at its existing ID and reports 0 additions and 0 destroys. The protected main workflow remains the only apply path.

## Validation

- CI=true pnpm agent:quality-gate --run — all mapped commands passed.
- node --test scripts/alert-rules-lint.test.mjs — 43 tests passed.
- Full production-state Terraform plan — 0 to add, 4 in-place updates, 0 to destroy; the Peg page contact point updates in place.
- Fresh-context autoreview plus deterministic guard — clean, zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform label and test-only changes for Peg alerting; no auth, data, or routing logic changes beyond avoiding an unsafe Grafana contact-point rename.
> 
> **Overview**
> Fixes a failed production Terraform apply where renaming the Peg **page** Grafana contact point triggered a delete/recreate while alert rules still referenced the old name (Grafana HTTP 409).
> 
> The **page** contact point label is restored to the stable string `Peg pages (Splunk On-Call + #alerts-critical)` instead of embedding `@support-engineer` in the contact-point **name**. Inline comments document that Grafana treats that name as identity, so label-only renames are unsafe. The guarded `@support-engineer` Slack mention remains in the message template body, not in the contact-point title.
> 
> `scripts/alert-rules-lint.test.mjs` now asserts that exact `page` local string so a future cosmetic label change cannot silently reintroduce a destructive replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b751cc083d8510242b55dacf344a4dfedaccaf8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->