### PR TITLE
fix(sentry): broker the triage agent's Sentry credential

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -252,9 +252,16 @@ jobs:
     #     authoritative target is the read-only file written by the "Pin the
     #     agent write target" step below; the wrapper refuses when the two
     #     disagree, because a disagreement is evidence of exactly that.
+    #   - SENTRY_MCP_BROKER_PORT: the ONLY literal for the broker's port. The
+    #     broker step reads it straight from the environment and the agent
+    #     step's --mcp-config interpolates it, so the two cannot drift. The
+    #     broker script REQUIRES it rather than defaulting — a default would be
+    #     a second source of truth that disagrees only on a live run, as a
+    #     connection refused.
     env:
       GH_TOKEN: ${{ github.token }}
       SENTRY_TRIAGE_COMMENT_ISSUE: ${{ matrix.issue }}
+      SENTRY_MCP_BROKER_PORT: "9401"
     steps:
       # SHA-pinned (not tags) so tag retargeting / a compromised release cannot
       # silently run new code. Bump via Dependabot (.github/dependabot.yml).
@@ -366,6 +373,30 @@ jobs:
       # before any wrapper saw argv, so no check inside the wrapper could stop
       # exfiltration.
       #
+      # OUT OF THE AGENT'S ENV IS NOT ENOUGH — IT MUST BE OUT OF THE AGENT'S
+      # REACH. Every step runs as `runner` and the agent holds `Read`, so
+      # `/proc/<pid>/environ` of ANY process in this job is agent-readable, and
+      # this step logs the broker's PID. So the broker must be EXEC'd without
+      # the token: the value is copied to a shell-local and the exported name
+      # is `unset` before node is spawned, and the token is handed over on
+      # STDIN. Note `/proc/<pid>/environ` is the block captured at `exec` —
+      # deleting the variable inside node afterwards would NOT clear it, which
+      # is why the fix is here and not in the script. The broker independently
+      # refuses to start if it finds the token in its own exec-time env.
+      #
+      # `printf` is a bash BUILTIN, so the token never becomes a process
+      # argument in `/proc/<pid>/cmdline` (a builtin in a pipeline runs in a
+      # forked subshell that never execs, so its cmdline stays the parent
+      # shell's). A pipeline uses an anonymous pipe and creates no file — do NOT
+      # rewrite it as a here-string (`<<<`) or heredoc, where bash may
+      # materialise a temp file the agent could read.
+      #
+      # THIS step's own shell still holds the token in its environment, which is
+      # fine only because each `run:` step is its own process and the runner
+      # gates the next step on this one's exit code — so it is gone before the
+      # agent starts. The broker deliberately outlives this step, which is
+      # precisely why its environment is the one that had to be cleaned.
+      #
       # `--insecure-http` is CLI-only (there is no env var for it), `SENTRY_URL`
       # must be HTTPS and cannot combine with it, and `SENTRY_HOST` takes a
       # hostname with no scheme — so the loopback wiring lives in the MCP
@@ -386,31 +417,49 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Start the Sentry credential broker (trusted)
         env:
-          # Step-scoped. NOT job env, and never written to $GITHUB_ENV — that
-          # would hand it to every later step, including the agent's.
-          SENTRY_MCP_BROKER_TOKEN: ${{ secrets.SENTRY_TRIAGE_TOKEN }}
+          # Step-scoped, and an `env:` binding rather than a `${{ secrets.* }}`
+          # interpolation inside the run body ON PURPOSE: GitHub expands `${{ }}`
+          # BEFORE writing the step script to $RUNNER_TEMP, so an inline secret
+          # would sit in plaintext on disk for the life of the job, readable by
+          # the agent. Through `env:` the script holds only the variable name.
+          # Never written to $GITHUB_ENV either — that would hand it to every
+          # later step, including the agent's.
+          SENTRY_TRIAGE_TOKEN: ${{ secrets.SENTRY_TRIAGE_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [ -z "${SENTRY_MCP_BROKER_TOKEN}" ]; then
+          # Copy to a shell-local and drop the EXPORTED name, so every child
+          # below — including node — is exec'd without it. This is the line that
+          # keeps the token out of /proc/<broker-pid>/environ; a scrub inside
+          # node could not, since that file is fixed at exec.
+          token="${SENTRY_TRIAGE_TOKEN:-}"
+          unset SENTRY_TRIAGE_TOKEN
+
+          if [ -z "${token}" ]; then
             echo "::error::SENTRY_TRIAGE_TOKEN is empty in the triage job; refusing to start the agent without a working Sentry path."
             exit 1
           fi
+
+          # Establishes the heap-residency residual recorded in ADR 0056:
+          # ptrace_scope=1 (or higher) denies /proc/<pid>/mem to a non-descendant
+          # same-user process; 0 does not. Logged, not assumed.
+          echo "yama ptrace_scope: $(cat /proc/sys/kernel/yama/ptrace_scope 2>/dev/null || echo unavailable)"
 
           # The handle is an authenticator for a 127.0.0.1-bound process that
           # dies with this runner, not a secret — $GITHUB_ENV is the right
           # channel for it, and the only one the CLI's --mcp-config expansion
           # can read.
           handle="$(openssl rand -hex 32)"
-          port=9401
           ready_file="${RUNNER_TEMP}/sentry-mcp-broker.ready"
           log_file="${RUNNER_TEMP}/sentry-mcp-broker.log"
           rm -f "${ready_file}"
 
+          # Token on STDIN via a builtin: no env var, no argv, no temp file.
           # Redirecting stdout/stderr to a file releases the step's pipe, so the
-          # backgrounded broker does not hold the step open.
+          # backgrounded broker does not hold the step open. `$!` is the last
+          # element of the pipeline — node, which is the pid we wait on.
+          printf '%s' "${token}" | \
           SENTRY_MCP_BROKER_HANDLE="${handle}" \
-          SENTRY_MCP_BROKER_PORT="${port}" \
           SENTRY_MCP_BROKER_READY_FILE="${ready_file}" \
           SENTRY_MCP_BROKER_TTL_SECONDS=1800 \
             node "${RUNNER_TEMP}/sentry-triage-tools/sentry-mcp-broker.mjs" \
@@ -493,7 +542,7 @@ jobs:
             --model claude-sonnet-5
             --max-turns 50
             --setting-sources user
-            --mcp-config '{"mcpServers":{"sentry":{"command":"npx","args":["-y","@sentry/mcp-server@0.37.0","--host","127.0.0.1:9401","--insecure-http"],"env":{"SENTRY_ACCESS_TOKEN":"${SENTRY_MCP_BROKER_HANDLE}"}}}}'
+            --mcp-config '{"mcpServers":{"sentry":{"command":"npx","args":["-y","@sentry/mcp-server@0.37.0","--host","127.0.0.1:${{ env.SENTRY_MCP_BROKER_PORT }}","--insecure-http"],"env":{"SENTRY_ACCESS_TOKEN":"${SENTRY_MCP_BROKER_HANDLE}"}}}}'
             --allowedTools 'Read,Grep,Glob,Bash(gh issue view:*),Bash(gh issue list:*),Bash(node ${{ runner.temp }}/sentry-triage-tools/sentry-triage-agent-comment.mjs:*),mcp__sentry__find_organizations,mcp__sentry__find_projects,mcp__sentry__get_issue_details,mcp__sentry__get_event_stacktrace,mcp__sentry__get_issue_tag_values,mcp__sentry__get_issue_activity,mcp__sentry__search_issues,mcp__sentry__search_events,mcp__sentry__search_issue_events,mcp__sentry__get_sentry_resource'
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -173,29 +173,41 @@ jobs:
   #     here to poison. Asserted by a test in
   #     scripts/sentry-triage-agent-comment.test.mjs; do not add a step below
   #     the agent.
-  #   - SENTRY_TRIAGE_TOKEN is set as job env (see the env: note below) and is
-  #     consumed via ${VAR} expansion in --mcp-config; it is never echoed and
-  #     never placed in a command. The wrapper drops it (and every other secret
-  #     bar gh's own credential) from the `gh` subprocess env.
-  #   - NOT CONTAINED, stated plainly: SENTRY_TRIAGE_TOKEN and the Claude OAuth
-  #     token are live in the agent's OWN Bash process env, so a successful
-  #     prompt injection can exfiltrate either into a public queue comment. The
-  #     wrapper refuses a body reproducing a token verbatim, but that is hygiene
-  #     against an accident, NOT a leak control: the agent writes the shell
-  #     command, and bash expands and transforms `$VAR` before the wrapper
-  #     receives argv, so a spliced or split value passes. Closing this needs
-  #     the credential out of the agent's process env — per-step env forwarding
-  #     the pinned action does not support, or a credential broker the MCP
-  #     server talks to. Both tokens are read-only / inference scoped and any
-  #     use lands in an auditable public comment.
+  #   - NO SENTRY CREDENTIAL IN THE AGENT'S ENV (issue #1711). The Sentry token
+  #     is step-scoped to the broker step below and is NOT job env. The agent
+  #     step holds only an opaque per-run HANDLE, which the loopback broker
+  #     trades for the real token. That closes the class the old wiring could
+  #     not: with the token in job env, the agent's Bash inherited it, and since
+  #     the agent authors its own shell command, bash expands and transforms
+  #     `$VAR` before any wrapper sees argv — `${TOKEN:0:4}x${TOKEN:4}` posts
+  #     the whole token with one removable character spliced in. No check inside
+  #     the wrapper can stop that.
+  #   - RESIDUAL, stated plainly: CLAUDE_CODE_OAUTH_TOKEN is still live in the
+  #     agent's Bash env. `claude-code-action` puts it there itself, and the
+  #     pinned v1.0.179 offers no per-step or first-class MCP env forwarding to
+  #     move it (upstream's only release tag is v1, Aug 2025 — there is no newer
+  #     version to adopt). It is inference-scoped: worst case is inference-quota
+  #     abuse, not repo or queue compromise, and any use lands in an auditable
+  #     public comment. Re-check on the next action bump.
+  #   - RESIDUAL, stated plainly: the run handle IS in the agent's env, and
+  #     three allow-listed tools (find_projects, search_issues, search_events)
+  #     take an agent-controlled `regionUrl` that the MCP server's
+  #     validateRegionUrl accepts for {sentry.io, us.sentry.io, de.sentry.io}.
+  #     It keeps only the host and re-applies its own protocol, which is http
+  #     under --insecure-http, so an injected agent can send its Authorization
+  #     header to `http://us.sentry.io/...` in cleartext, past the broker. What
+  #     leaks there is the HANDLE, and the handle is worthless outside this run:
+  #     the broker binds 127.0.0.1 only and dies with the runner. Sentry egress
+  #     is NOT closed here and this design does not pretend it is. Tracked
+  #     separately (see the broker script header).
   # ---------------------------------------------------------------------------
   triage:
     needs: select
     if: ${{ needs.select.outputs.count != '' && needs.select.outputs.count != '0' }}
     # sentry-pipeline Environment (issue #1289): server-enforced main-only access
-    # to SENTRY_TRIAGE_TOKEN (job env) and CLAUDE_CODE_OAUTH_TOKEN
-    # (claude-code-action) — a non-main workflow_dispatch is refused before this
-    # matrix job runs.
+    # to SENTRY_TRIAGE_TOKEN (now read only by the broker step) and
+    # CLAUDE_CODE_OAUTH_TOKEN (claude-code-action) — a non-main
+    # workflow_dispatch is refused before this matrix job runs.
     environment: sentry-pipeline
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -213,26 +225,25 @@ jobs:
     # declares its own env: block. Its action.yml says so in as many words for
     # its own MCP vars — "this step's env: block shadows the calling workflow's
     # job-level env vars … Set these in your workflow's job-level env: or via a
-    # prior step that writes to $GITHUB_ENV". RE-VERIFIED for issue #1288
-    # against the version pinned below, v1.0.179 (b76a0776): there is still no
-    # per-step env passthrough and no first-class MCP env input, and
-    # $GITHUB_ENV would expose the value to every LATER step instead of fewer,
-    # so SENTRY_TRIAGE_TOKEN cannot move to step scope. Re-check on the next
-    # major action bump; do not re-open the question without testing a version.
+    # prior step that writes to $GITHUB_ENV". RE-VERIFIED for issue #1288 and
+    # again for #1711 against the version pinned below, v1.0.179 (b76a0776):
+    # there is still no per-step env passthrough and no first-class MCP env
+    # input (upstream's only release tag is v1, Aug 2025). So anything the MCP
+    # server must read has to be job env — which is exactly why the SENTRY
+    # TOKEN IS NO LONGER HERE and an opaque per-run handle is (issue #1711).
+    # Re-check on the next action bump; do not re-open the question without
+    # testing a version.
     #   - GH_TOKEN: gh CLI auth for the agent's read-only `gh issue view/list`
     #     (this job's GITHUB_TOKEN: issues:write + contents:read only) and for
     #     the deterministic steps below.
-    #   - SENTRY_TRIAGE_TOKEN: consumed by ${SENTRY_TRIAGE_TOKEN} expansion in
-    #     --mcp-config when the CLI launches the stdio Sentry MCP server
-    #     (expansion of inline --mcp-config env values verified against the
-    #     CLI). Never echoed. Accepted residual, unchanged by #1288: like
-    #     GH_TOKEN it is visible to the agent's allowlisted Bash subprocesses,
-    #     and an injected agent can exfiltrate it through its own write path —
-    #     see the "NOT CONTAINED" bullet in the job banner for why no check
-    #     inside the wrapper can stop that. What #1288 did buy: the write target
-    #     cannot be model-controlled, agent comments cannot impersonate the
-    #     pipeline's control comments, and `gh` itself no longer receives this
-    #     token. The token is read-only scoped.
+    #   - SENTRY_MCP_BROKER_HANDLE: minted by the broker step below and exported
+    #     through $GITHUB_ENV, then consumed by the ${SENTRY_MCP_BROKER_HANDLE}
+    #     expansion in --mcp-config when the CLI launches the stdio Sentry MCP
+    #     server. $GITHUB_ENV is correct HERE and would be wrong for the token:
+    #     it exposes a value to every LATER step, and this value is not a
+    #     secret. The handle authenticates to a 127.0.0.1-bound broker that dies
+    #     with the runner, so it is worthless outside this run — which is what
+    #     makes the regionUrl steering channel in the job banner survivable.
     #   - SENTRY_TRIAGE_COMMENT_ISSUE: a CROSS-CHECK on the wrapper's write
     #     target, never the binding itself. Env cannot fence the target: bash
     #     arithmetic expansion assigns, so a body containing
@@ -243,7 +254,6 @@ jobs:
     #     disagree, because a disagreement is evidence of exactly that.
     env:
       GH_TOKEN: ${{ github.token }}
-      SENTRY_TRIAGE_TOKEN: ${{ secrets.SENTRY_TRIAGE_TOKEN }}
       SENTRY_TRIAGE_COMMENT_ISSUE: ${{ matrix.issue }}
     steps:
       # SHA-pinned (not tags) so tag retargeting / a compromised release cannot
@@ -326,9 +336,15 @@ jobs:
           tools_dir="${RUNNER_TEMP}/sentry-triage-tools"
           mkdir -p "${tools_dir}"
           chmod 0755 "${tools_dir}"
+          # sentry-mcp-broker.mjs is NOT agent-executable (no grant names it) —
+          # it is staged because this job must execute nothing from the
+          # agent-writable checkout, and staging it keeps that true even if the
+          # broker step ever moves. Its own import closure is itself; the
+          # closure check lives in scripts/sentry-mcp-broker.test.mjs.
           for f in \
             sentry-triage-agent-comment.mjs \
-            sentry-triage-project-core.mjs; do
+            sentry-triage-project-core.mjs \
+            sentry-mcp-broker.mjs; do
             install -m 0444 "scripts/${f}" "${tools_dir}/${f}"
           done
           chmod 0555 "${tools_dir}"
@@ -336,6 +352,90 @@ jobs:
           echo "Pinned write target: ${GITHUB_REPOSITORY}#${QUEUE_ISSUE_NUMBER}"
           ls -ld "${target_dir}" "${tools_dir}"
           ls -l "${target_dir}/target.json" "${tools_dir}"
+
+      # -----------------------------------------------------------------------
+      # Take the Sentry credential OUT of the agent's process env (issue #1711).
+      #
+      # THIS STEP IS TRUSTED and it is the ONLY place SENTRY_TRIAGE_TOKEN
+      # appears in this workflow. It starts a loopback broker holding the real
+      # token, mints an opaque per-run handle, and exports only the handle. The
+      # agent step then points the Sentry MCP server at 127.0.0.1 with the
+      # handle as its access token, so the agent's Bash inherits no Sentry
+      # credential at all. That is the fix: with the token in job env, the agent
+      # authored its own shell command and bash expanded and transformed `$VAR`
+      # before any wrapper saw argv, so no check inside the wrapper could stop
+      # exfiltration.
+      #
+      # `--insecure-http` is CLI-only (there is no env var for it), `SENTRY_URL`
+      # must be HTTPS and cannot combine with it, and `SENTRY_HOST` takes a
+      # hostname with no scheme — so the loopback wiring lives in the MCP
+      # server's `args`, and `SENTRY_HOST` is gone along with the token.
+      #
+      # It runs the IMMUTABLE staged copy, not `scripts/`. This step is ordered
+      # before the agent, so the checkout is still pristine here — but the rule
+      # for this job is that it executes nothing from the agent-writable
+      # checkout, full stop, and a rule with an ordering caveat is one refactor
+      # away from being wrong.
+      #
+      # NO STOP STEP, deliberately. This job must END with the agent: the agent
+      # can append `BASH_ENV=<payload it wrote>` to $GITHUB_ENV, and any later
+      # step's bash would source that payload before running its own command —
+      # an escape from the whole permission allowlist. So the broker bounds its
+      # own life with a TTL instead, set to the job timeout; the runner is
+      # ephemeral and is destroyed with the job either way.
+      # -----------------------------------------------------------------------
+      - name: Start the Sentry credential broker (trusted)
+        env:
+          # Step-scoped. NOT job env, and never written to $GITHUB_ENV — that
+          # would hand it to every later step, including the agent's.
+          SENTRY_MCP_BROKER_TOKEN: ${{ secrets.SENTRY_TRIAGE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SENTRY_MCP_BROKER_TOKEN}" ]; then
+            echo "::error::SENTRY_TRIAGE_TOKEN is empty in the triage job; refusing to start the agent without a working Sentry path."
+            exit 1
+          fi
+
+          # The handle is an authenticator for a 127.0.0.1-bound process that
+          # dies with this runner, not a secret — $GITHUB_ENV is the right
+          # channel for it, and the only one the CLI's --mcp-config expansion
+          # can read.
+          handle="$(openssl rand -hex 32)"
+          port=9401
+          ready_file="${RUNNER_TEMP}/sentry-mcp-broker.ready"
+          log_file="${RUNNER_TEMP}/sentry-mcp-broker.log"
+          rm -f "${ready_file}"
+
+          # Redirecting stdout/stderr to a file releases the step's pipe, so the
+          # backgrounded broker does not hold the step open.
+          SENTRY_MCP_BROKER_HANDLE="${handle}" \
+          SENTRY_MCP_BROKER_PORT="${port}" \
+          SENTRY_MCP_BROKER_READY_FILE="${ready_file}" \
+          SENTRY_MCP_BROKER_TTL_SECONDS=1800 \
+            node "${RUNNER_TEMP}/sentry-triage-tools/sentry-mcp-broker.mjs" \
+            > "${log_file}" 2>&1 &
+          broker_pid=$!
+
+          # Fail CLOSED: if the broker never came up, the agent would run
+          # against a dead endpoint and burn its turn budget on failed reads.
+          for _ in $(seq 1 50); do
+            if [ -s "${ready_file}" ]; then break; fi
+            if ! kill -0 "${broker_pid}" 2>/dev/null; then
+              echo "::error::Sentry credential broker exited before becoming ready."
+              cat "${log_file}" || true
+              exit 1
+            fi
+            sleep 0.2
+          done
+          if [ ! -s "${ready_file}" ]; then
+            echo "::error::Sentry credential broker did not become ready within 10s."
+            cat "${log_file}" || true
+            exit 1
+          fi
+
+          echo "SENTRY_MCP_BROKER_HANDLE=${handle}" >> "${GITHUB_ENV}"
+          echo "Sentry credential broker listening on 127.0.0.1:$(cat "${ready_file}") (pid ${broker_pid})."
 
       - name: Render triage prompt
         id: render
@@ -363,10 +463,26 @@ jobs:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.render.outputs.prompt }}
-          # Sentry MCP (stdio, read-only token) is wired via --mcp-config. The
-          # allowlist excludes every Sentry write/mutation tool (update_issue,
-          # add_issue_note, create_*/update_*/remove_*), the search-tools/
-          # execute-tool meta-executor, and analyze_issue_with_seer.
+          # Sentry MCP (stdio) is wired via --mcp-config, pointed at the
+          # loopback credential broker started above: the agent's process env
+          # holds the opaque per-run handle, never the Sentry token (#1711).
+          # `--insecure-http` is CLI-only, so the loopback wiring goes in `args`
+          # and `SENTRY_HOST` is gone. Plain http is safe here and only here:
+          # the hop is 127.0.0.1 on this runner, and the broker makes the real
+          # HTTPS call to Sentry itself.
+          #
+          # The allowlist excludes every Sentry write/mutation tool
+          # (update_issue, add_issue_note, create_*/update_*/remove_*), the
+          # search-tools/execute-tool meta-executor, and
+          # analyze_issue_with_seer. Note that five names below
+          # (get_issue_details, get_event_stacktrace, get_issue_tag_values,
+          # get_issue_activity, search_issue_events) do not exist at
+          # @sentry/mcp-server@0.37.0 — they are inert grants kept so a version
+          # bump that restores them does not silently lose the grant. The
+          # broker's path allowlist is derived from the five that DO exist
+          # (find_organizations, find_projects, search_issues, search_events,
+          # get_sentry_resource); re-derive it on a version bump, per
+          # docs/notes/sentry-triage-pipeline.md.
           #
           # --setting-sources user: do NOT load the checked-out repo's
           # .claude/settings.json — its permissions.allow list (e.g. `node *`)
@@ -377,7 +493,7 @@ jobs:
             --model claude-sonnet-5
             --max-turns 50
             --setting-sources user
-            --mcp-config '{"mcpServers":{"sentry":{"command":"npx","args":["-y","@sentry/mcp-server@0.37.0"],"env":{"SENTRY_ACCESS_TOKEN":"${SENTRY_TRIAGE_TOKEN}","SENTRY_HOST":"us.sentry.io"}}}}'
+            --mcp-config '{"mcpServers":{"sentry":{"command":"npx","args":["-y","@sentry/mcp-server@0.37.0","--host","127.0.0.1:9401","--insecure-http"],"env":{"SENTRY_ACCESS_TOKEN":"${SENTRY_MCP_BROKER_HANDLE}"}}}}'
             --allowedTools 'Read,Grep,Glob,Bash(gh issue view:*),Bash(gh issue list:*),Bash(node ${{ runner.temp }}/sentry-triage-tools/sentry-triage-agent-comment.mjs:*),mcp__sentry__find_organizations,mcp__sentry__find_projects,mcp__sentry__get_issue_details,mcp__sentry__get_event_stacktrace,mcp__sentry__get_issue_tag_values,mcp__sentry__get_issue_activity,mcp__sentry__search_issues,mcp__sentry__search_events,mcp__sentry__search_issue_events,mcp__sentry__get_sentry_resource'
 
   # ---------------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,6 +181,7 @@ Authority: canonical
 - [`docs/adr/0053-explicit-deployment-source-staging.md`](adr/0053-explicit-deployment-source-staging.md) — Routine GCP deploys use explicit source-staging buckets
 - [`docs/adr/0054-same-project-peg-policy-artifact.md`](adr/0054-same-project-peg-policy-artifact.md) — Peg policy stays private in the monitoring project
 - [`docs/adr/0055-peg-policy-bucket-controller-recovery.md`](adr/0055-peg-policy-bucket-controller-recovery.md) — Peg policy bucket controller recovers authoritative IAM reconciliation
+- [`docs/adr/0056-agent-mcp-credential-broker.md`](adr/0056-agent-mcp-credential-broker.md) — An untrusted agent's MCP credentials sit behind a loopback broker, not in its env
 
 Authority: non-canonical
 

--- a/docs/adr/0036-sentry-triage-pipeline.md
+++ b/docs/adr/0036-sentry-triage-pipeline.md
@@ -61,7 +61,9 @@ trust is earned in phases, and Codex remains the independent PR reviewer.**
   Sentry and are fetched at triage time; noise heuristics run on the raw
   payload in-memory only, and only the resulting label is public.
 - **Stage B — read-only agent triage:** per queue issue, a claude-code-action
-  agent (Sentry MCP stdio, read-only token) posts a structured verdict comment
+  agent (Sentry MCP stdio, read-only token reached through the loopback
+  credential broker of [ADR 0056](0056-agent-mcp-credential-broker.md), so the
+  agent's own env holds no Sentry credential) posts a structured verdict comment
   (`code-fix` / `config-fix` / `upstream-transient` / `needs-human`).
   Sentry payloads are treated as untrusted input (prompt-injection surface):
   the investigating agent's only write is that comment — **verdict labels are

--- a/docs/adr/0056-agent-mcp-credential-broker.md
+++ b/docs/adr/0056-agent-mcp-credential-broker.md
@@ -39,8 +39,41 @@ wrong layer when the adversary controls the shell.
 
 ## Decision
 
-**Keep the credential out of the untrusted agent's process env. A trusted step
-holds it and hands the agent a per-run handle that is worthless off-runner.**
+**Keep the credential out of the untrusted agent's REACH — not merely out of its
+own environment. A trusted step holds it and hands the agent a per-run handle
+that is worthless off-runner.**
+
+Out of the agent's own env is not the property that matters, and stopping there
+is the mistake this ADR exists to name. Every step runs as `runner` and the
+agent holds `Read`, so **every same-UID-readable surface is agent-reachable**:
+`/proc/<pid>/environ` and `/proc/<pid>/cmdline` of every process in the job, and
+every file on disk. A broker that merely inherited the token from its step's
+`env:` would have left it one `Read` away, and the step logs the broker's PID.
+
+**`/proc/<pid>/environ` is the environment captured at `exec`.** Deleting the
+variable inside the process afterwards does not change it, so any scrub after
+start is theatre. The variable must be absent when the process is exec'd. So:
+
+- The trusted step copies the secret to a shell-local, `unset`s the exported
+  name, and only then spawns node — and hands the token over on **stdin**,
+  written by `printf`, a bash **builtin**. That covers all three surfaces: no
+  env var, no argv (a builtin in a pipeline runs in a forked subshell that never
+  execs, so its `cmdline` stays the parent shell's), and no temp file (a
+  pipeline uses an anonymous pipe, unlike `<<<` or `<<`).
+- The broker **refuses to start** if it finds the token in its own exec-time
+  environment, checked against a snapshot taken at module load. A regression in
+  the workflow becomes a loud startup failure rather than a silent leak.
+- The secret reaches the step through an `env:` binding and never through
+  `${{ secrets.* }}` inside the `run:` body. That is deliberate, not style:
+  GitHub expands `${{ }}` **before** writing the step script to `$RUNNER_TEMP`,
+  so an inline secret would sit in plaintext on disk for the life of the job —
+  the same same-UID-readable class. Through `env:` the script holds only the
+  variable name.
+- The trusted step's own shell still holds the token in its environment. That is
+  acceptable only because each `run:` step is its own process and the runner
+  gates the next step on this one's exit code, so it is gone before the agent
+  starts. The broker deliberately outlives its step, which is exactly why its
+  environment is the one that had to be cleaned.
 
 - A trusted step, ordered before the agent and holding the secret **step-scoped**,
   starts `scripts/sentry-mcp-broker.mjs` bound to `127.0.0.1` and mints an
@@ -73,6 +106,13 @@ holds it and hands the agent a per-run handle that is worthless off-runner.**
 - **Scrub or transform the credential in the agent's env.** Rejected: the
   credential must be readable by a child of the agent's own process, so any
   value the MCP server can read, the agent can read.
+- **Let the broker inherit the token and `delete process.env.<name>` at
+  startup.** Rejected, and recorded because it is the plausible wrong fix:
+  `/proc/<pid>/environ` is fixed at `exec`, so the file still shows the original
+  block. A mutation test pins this — scrubbing at runtime must fail the suite.
+- **A temp file the broker reads and unlinks.** Rejected: readable by the agent
+  for the window it exists, and a broker that dies mid-read leaves it behind.
+  Stdin has no such window and no such remnant.
 - **Harden the comment wrapper further.** Rejected on the finding above — no
   check inside a wrapper closes a channel the shell opens before argv exists.
 
@@ -101,6 +141,23 @@ holds it and hands the agent a per-run handle that is worthless off-runner.**
 - **No stop step.** The agent job must end with the agent (a later step's bash
   would source a `$GITHUB_ENV`-injected `BASH_ENV` payload), so the broker
   bounds its own life with a TTL on an ephemeral runner instead.
+- **Accepted residual — heap residency, UNVERIFIED.** The token now lives in the
+  broker's heap. Reading `/proc/<pid>/mem` requires `PTRACE_MODE_ATTACH`, which
+  Yama's `ptrace_scope=1` denies to a non-descendant same-user process — but the
+  GitHub runner's setting is not established, and this ADR does not claim it.
+  The broker step logs `/proc/sys/kernel/yama/ptrace_scope` so the first real
+  run settles it. If it reports `0`, heap residency is genuinely reachable and
+  needs its own mitigation.
+- **Reachability inventory (checked, negative).** Audited for what an agent with
+  `Read` on this runner can actually reach, rather than assumed:
+  **zero** steps across all 31 workflows interpolate `${{ secrets.* }}` into a
+  `run:` body (the only three inline expressions anywhere are `github.base_ref`,
+  `matrix.id` and `github.sha`); the triage job's single `$GITHUB_ENV` write is
+  the broker handle and its single `$GITHUB_OUTPUT` write is the rendered
+  prompt; the staged `sentry-triage-tools` directory is agent-readable by design
+  and holds only files already public in this repo; `target.json` holds a repo
+  name and a public issue number; and the broker's log is method, path, status
+  and refusal reason only. Nothing sensitive in any of them.
 
 ## Evidence
 

--- a/docs/adr/0056-agent-mcp-credential-broker.md
+++ b/docs/adr/0056-agent-mcp-credential-broker.md
@@ -1,0 +1,117 @@
+---
+title: An untrusted agent's MCP credentials sit behind a loopback broker, not in its env
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-30
+scope: ci/process
+date: 2026-07
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0056 — An untrusted agent's MCP credentials sit behind a loopback broker, not in its env
+
+**Status:** Accepted (Jul 2026), in force.
+**Scope:** ci/process (the Sentry triage agent first; the pattern for any future
+MCP credential handed to an untrusted agent).
+
+## Context
+
+[ADR 0036](0036-sentry-triage-pipeline.md) runs Stage B triage as a
+`claude-code-action` agent that reads Sentry over an MCP server. The Claude CLI
+launches that server as a child of the agent's own process, and
+`claude-code-action` is a composite action: GitHub Actions does not pass a
+caller step's `env:` into a composite action's steps, and the pinned v1.0.179
+exposes no per-step passthrough and no first-class MCP env input. So anything
+the MCP server must read had to be **job** env — which the agent's allow-listed
+Bash inherits.
+
+That is not containable downstream. The agent authors its own shell command, so
+bash expands and transforms `$VAR` before any wrapper receives argv:
+`--body "…${TOKEN:0:4}x${TOKEN:4}"` posts the whole token with one removable
+character spliced in, reproduced against the real CLI
+([#1711](https://github.com/mento-protocol/monitoring-monorepo/issues/1711)).
+The verbatim-value scan in `scripts/sentry-triage-agent-comment.mjs` catches the
+accident and was never a leak control. Exact-value scanning is structurally the
+wrong layer when the adversary controls the shell.
+
+## Decision
+
+**Keep the credential out of the untrusted agent's process env. A trusted step
+holds it and hands the agent a per-run handle that is worthless off-runner.**
+
+- A trusted step, ordered before the agent and holding the secret **step-scoped**,
+  starts `scripts/sentry-mcp-broker.mjs` bound to `127.0.0.1` and mints an
+  opaque handle (`openssl rand -hex 32`).
+- The MCP server runs with `--host 127.0.0.1:<port> --insecure-http` and the
+  handle as its access token. The broker validates the handle, substitutes the
+  real credential and forwards over HTTPS.
+- The broker is **read-only and allow-listed**: non-GET is refused outright, and
+  the path allowlist is the empirically derived closure of the granted tools —
+  produced by driving them against a capture server, never guessed from tool
+  names. Upstream redirects are refused rather than relayed, because the MCP
+  client would follow one with the handle.
+- The handle travels through `$GITHUB_ENV`; the credential never does.
+  `$GITHUB_ENV` exposes a value to every later step, which is correct for an
+  authenticator scoped to a loopback process on this runner and wrong for a
+  credential.
+- **The handle's worthlessness is the load-bearing property**, not an
+  afterthought: loopback-only binding is a constant with no override, the handle
+  is minted per run, and the broker dies with the runner.
+
+## Alternatives considered
+
+- **Wait for per-step or first-class MCP env forwarding in
+  `claude-code-action`.** Cheapest fix if it lands. Absent at the pinned
+  v1.0.179 and upstream's only release tag is `v1` (Aug 2025), so there is no
+  newer version to adopt. Re-check on the next bump; the broker generalises to
+  the next MCP credential either way.
+- **Write the resolved `--mcp-config` to `$RUNNER_TEMP`.** Rejected: it
+  relocates the credential to a file the agent's `Read` tool can open.
+- **Scrub or transform the credential in the agent's env.** Rejected: the
+  credential must be readable by a child of the agent's own process, so any
+  value the MCP server can read, the agent can read.
+- **Harden the comment wrapper further.** Rejected on the finding above — no
+  check inside a wrapper closes a channel the shell opens before argv exists.
+
+## Consequences
+
+- Bumping the MCP server means **re-deriving the path allowlist** by the same
+  empirical method. A path the broker refuses fails the leg loudly with the path
+  named in its log, so a stale allowlist is visible, not silent.
+- The broker rewrites `links.regionUrl` on organization payloads to its own
+  origin. This is a correctness requirement, not hardening: the upstream value
+  steers both the MCP server's internal reads and the agent's later calls off
+  the broker. `links.organizationUrl` stays untouched so permalinks stay real.
+- **Accepted residual — regionUrl steering.** Three granted tools take an
+  agent-controlled `regionUrl`, and the MCP server's `validateRegionUrl` accepts
+  a hardcoded SaaS set, keeps only the host and re-applies its own protocol
+  (`http` under `--insecure-http`). An injected agent can therefore send its
+  `Authorization` header to `http://us.sentry.io/...` in cleartext, past the
+  broker. Sentry egress is not closed on the runner and this decision does not
+  assume it is. What leaks is the handle, which is worth nothing outside the
+  run. Tracked in
+  [#1718](https://github.com/mento-protocol/monitoring-monorepo/issues/1718).
+- **Accepted residual — `CLAUDE_CODE_OAUTH_TOKEN`.** `claude-code-action` places
+  it in the agent's process env itself and this decision does not remove it. It
+  is inference-only: worst case is inference-quota abuse, not repo or queue
+  compromise, and any use lands in an auditable public comment.
+- **No stop step.** The agent job must end with the agent (a later step's bash
+  would source a `$GITHUB_ENV`-injected `BASH_ENV` payload), so the broker
+  bounds its own life with a TTL on an ephemeral runner instead.
+
+## Evidence
+
+- [#1711](https://github.com/mento-protocol/monitoring-monorepo/issues/1711) —
+  the reproduced splice past the wrapper's verbatim scan.
+- Probes against the real `@sentry/mcp-server@0.37.0`: `--host` + `--insecure-http`
+  works over loopback; `--insecure-http` is CLI-only; a loopback host disables the
+  `~/.sentry/mcp.json` cache and the device-code OAuth fallback, so a missing
+  token exits 1 rather than falling back; `validateRegionUrl` accepts
+  `{sentry.io, us.sentry.io, de.sentry.io}` and the steering bypass reproduces.
+- Enforced by `scripts/sentry-mcp-broker.mjs`,
+  `scripts/sentry-mcp-broker.test.mjs` (fail-closed and mutation-checked), and
+  `.github/workflows/sentry-triage-agent.yml`. Operator detail in
+  [`docs/notes/sentry-triage-pipeline.md`](../notes/sentry-triage-pipeline.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0038](0038-sentry-central-plane-verdict-projection.md)     | Central Sentry triage plane; actionable verdicts projected into owning repos         |
 | [0040](0040-bounded-documentation-garden-queue.md)          | Weekly bounded documentation packets enter one serialized GitHub Issue queue         |
 | [0041](0041-offline-documentation-navigation-evaluation.md) | Fresh-agent documentation navigation is evaluated offline with deterministic scoring |
+| [0056](0056-agent-mcp-credential-broker.md)                 | An untrusted agent's MCP credentials sit behind a loopback broker, not in its env    |
 
 ### shared-config
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -109,6 +109,7 @@ pnpm issue:board:test                          # Offline tests for the issue-boa
 pnpm sentry:ingest --dry-run                   # Print queue-issue mutations without applying (needs local SENTRY_TRIAGE_TOKEN)
 pnpm sentry:ingest:test                        # Offline tests for the ingest helper (docs/notes/sentry-triage-pipeline.md)
 pnpm sentry:digest:test                        # Offline tests for the per-run Slack verdict-digest collector
+pnpm sentry:broker:test                        # Offline tests for the triage agent's loopback credential broker (ADR 0056)
 SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#engineering'  # Print the Slack digest payload for a batch (needs gh auth; does not post)
 
 # Public config package

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -200,7 +200,10 @@ read-only `sentry-triage-tools` directory under `$RUNNER_TEMP`, and the agent's
 `--allowedTools` grant names **that** path, never `scripts/`.
 `scripts/sentry-triage-agent-comment.test.mjs` recomputes the closure from the
 source and fails if the staging list stops matching it, so the attack cannot
-move one file over. The agent job's checkout also sets
+move one file over. `scripts/sentry-mcp-broker.mjs` is staged alongside it even
+though no grant names it: the rule for this job is that it executes nothing from
+the agent-writable checkout, and a rule with an ordering caveat is one refactor
+away from being wrong. The agent job's checkout also sets
 `persist-credentials: false`, matching the autofix agent job.
 
 **The agent job ends with the agent.** Immutable copies alone would not be
@@ -222,8 +225,9 @@ and that no credential-bearing work follows it.
 The wrapper also refuses a body that does not start with the
 verdict marker and a body carrying its own authorship marker; it appends
 `<!-- sentry-triage-agent-authored:v1 -->` and pipes the result into
-`gh --body-file -` on stdin, handing `gh` an allowlisted environment that
-carries neither the Sentry token nor the Claude OAuth token. Deterministic
+`gh --body-file -` on stdin, handing `gh` an allowlisted environment that drops
+the Claude OAuth token (and would drop a Sentry token, which since #1711 is not
+in that environment to begin with). Deterministic
 scripts and the agent share the `github-actions[bot]` identity, so that marker
 — and the required verdict-marker prefix — are what separate agent text from
 pipeline text.
@@ -237,21 +241,79 @@ forged `Regressed in Sentry …` control comment past every fence. No check
 closes a check-then-use window on a path the attacker can write — removing the
 file removes the window. Do not reintroduce an intermediate file for the body.
 
-**Credential exfiltration is not contained here, and the wrapper does not claim
-to contain it.** `SENTRY_TRIAGE_TOKEN` must sit in job env for the Sentry MCP
-server's `${VAR}` expansion, and `claude-code-action` puts the Claude OAuth
-token in the same process env, so both are live in the agent's Bash. A
-successful prompt injection can put either in a public queue comment. The
-wrapper refuses a body reproducing a token verbatim, which catches the common
-accident — prose that quotes an environment value or a failed command's output
-— but it is not a leak control: the agent writes the shell command, and bash
-expands and transforms `$VAR` before the wrapper sees argv, so a spliced or
-split value passes. Exact-value scanning is the wrong layer when the adversary
-controls the shell. Closing this needs the credential out of the agent's process
-env: per-step or first-class MCP env forwarding, which `claude-code-action` does
-not offer at the pinned v1.0.179, or a local credential broker the MCP server
-talks to so the agent holds no Sentry token at all. Both tokens are read-only or
-inference scoped, and any use lands in an auditable public comment.
+**The Sentry credential is out of the agent's process env** (issue #1711).
+The wrapper's verbatim-token refusal was never a leak control and must not be
+described as one: the agent writes its own shell command, and bash expands and
+transforms `$VAR` before the wrapper sees argv, so a spliced or split value
+passes. Exact-value scanning is the wrong layer when the adversary controls the
+shell. The fix removes the credential instead. See
+[the credential broker](#the-credential-broker) below.
+
+`CLAUDE_CODE_OAUTH_TOKEN` is the remaining credential in the agent's Bash, and
+it stays there: `claude-code-action` places it in that process env itself, and
+the pinned v1.0.179 offers no per-step or first-class MCP env forwarding to move
+it (upstream's only release tag is `v1`, Aug 2025 — there is no newer version to
+adopt). Accepted with its bounding: it is inference-only, so worst case is
+inference-quota abuse, not repo or queue compromise, and any use lands in an
+auditable public comment. Re-check on the next action bump.
+
+### The credential broker
+
+[ADR 0056](../adr/0056-agent-mcp-credential-broker.md) owns the decision and its
+accepted residuals; this is the mechanism.
+
+A trusted step in the triage job — before the agent, holding
+`SENTRY_TRIAGE_TOKEN` step-scoped — starts `scripts/sentry-mcp-broker.mjs` on
+`127.0.0.1:9401` and mints an opaque per-run handle with `openssl rand -hex 32`.
+The agent step receives the handle through `$GITHUB_ENV` and no Sentry
+credential. Its Sentry MCP server runs with
+`--host 127.0.0.1:9401 --insecure-http` and the handle as `SENTRY_ACCESS_TOKEN`;
+the broker validates the handle, swaps in the real token and forwards to
+`https://us.sentry.io`. `--insecure-http` is CLI-only, `SENTRY_URL` must be HTTPS
+and cannot combine with it, and `SENTRY_HOST` takes a bare hostname — so the
+loopback wiring lives in the MCP server's `args` and `SENTRY_HOST` is gone with
+the token. `$GITHUB_ENV` carries the handle and never the token: it exposes a
+value to every later step, which is right for an authenticator that only works
+against a loopback process on this runner and wrong for a credential.
+
+The broker refuses anything that is not a GET on an allow-listed path with the
+exact handle, and refuses to relay an upstream redirect (the MCP client would
+follow it with the handle, off the broker). It also rewrites `links.regionUrl`
+on organization payloads to its own origin — a correctness fix, not hardening:
+Sentry returns `https://us.sentry.io` there, and both the MCP server's internal
+`trace`/`span` path and its `find_organizations` output steer subsequent reads
+off the broker with it. `links.organizationUrl` is left alone so verdict
+comments keep real Sentry permalinks.
+
+**The handle is not a second secret, and that is load-bearing.** Three
+allow-listed tools (`find_projects`, `search_issues`, `search_events`) take an
+agent-controlled `regionUrl`, and the MCP server's `validateRegionUrl` accepts
+the base host plus a hardcoded `{sentry.io, us.sentry.io, de.sentry.io}`, keeps
+only the host and re-applies its own protocol — `http` under `--insecure-http`.
+So an injected agent can send its `Authorization` header to
+`http://us.sentry.io/api/0/...` in cleartext, past the broker. Sentry egress is
+not closed on the runner and this design does not assume it is. What leaks there
+is the handle, which authenticates only to a `127.0.0.1`-bound process that dies
+with the runner, so it is worth nothing off-runner or after the run.
+
+There is deliberately **no stop step**. The triage job must end with the agent —
+the agent can append `BASH_ENV=<payload it wrote>` to `$GITHUB_ENV`, and any
+later step's bash would source that payload before its own command, escaping the
+permission allowlist entirely. The broker bounds its own life with
+`SENTRY_MCP_BROKER_TTL_SECONDS` instead (set to the job timeout), on a runner
+that is destroyed with the job.
+
+**Re-derive the path allowlist on a `@sentry/mcp-server` bump.** It is the
+empirical closure of the granted tools, not a guess from tool names: point the
+pinned MCP server at a capture server with
+`--host 127.0.0.1:<port> --insecure-http`, drive every granted tool over stdio
+(including `get_sentry_resource` across its whole `resourceType` enum and
+`search_events` across every dataset) and collect the request paths. At 0.37.0
+only five of the ten names in `--allowedTools` exist — `find_organizations`,
+`find_projects`, `search_issues`, `search_events`, `get_sentry_resource`; the
+other five are inert grants kept in case a bump restores them. A path the broker
+refuses fails the triage leg loudly with the path named in its log, so a stale
+allowlist is visible rather than silent.
 
 The deterministic parser accepts only comments from
 `github-actions[bot]`. After a regression reopen, it accepts only a verdict

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -264,17 +264,38 @@ accepted residuals; this is the mechanism.
 
 A trusted step in the triage job — before the agent, holding
 `SENTRY_TRIAGE_TOKEN` step-scoped — starts `scripts/sentry-mcp-broker.mjs` on
-`127.0.0.1:9401` and mints an opaque per-run handle with `openssl rand -hex 32`.
-The agent step receives the handle through `$GITHUB_ENV` and no Sentry
-credential. Its Sentry MCP server runs with
-`--host 127.0.0.1:9401 --insecure-http` and the handle as `SENTRY_ACCESS_TOKEN`;
-the broker validates the handle, swaps in the real token and forwards to
-`https://us.sentry.io`. `--insecure-http` is CLI-only, `SENTRY_URL` must be HTTPS
-and cannot combine with it, and `SENTRY_HOST` takes a bare hostname — so the
-loopback wiring lives in the MCP server's `args` and `SENTRY_HOST` is gone with
-the token. `$GITHUB_ENV` carries the handle and never the token: it exposes a
-value to every later step, which is right for an authenticator that only works
-against a loopback process on this runner and wrong for a credential.
+loopback and mints an opaque per-run handle with `openssl rand -hex 32`. The
+agent step receives the handle through `$GITHUB_ENV` and no Sentry credential.
+Its Sentry MCP server runs with `--host 127.0.0.1:<port> --insecure-http` and
+the handle as `SENTRY_ACCESS_TOKEN`; the broker validates the handle, swaps in
+the real token and forwards to `https://us.sentry.io`. `--insecure-http` is
+CLI-only, `SENTRY_URL` must be HTTPS and cannot combine with it, and
+`SENTRY_HOST` takes a bare hostname — so the loopback wiring lives in the MCP
+server's `args` and `SENTRY_HOST` is gone with the token. `$GITHUB_ENV` carries
+the handle and never the token: it exposes a value to every later step, which is
+right for an authenticator that only works against a loopback process on this
+runner and wrong for a credential. The port has exactly one literal — the triage
+job's `env: SENTRY_MCP_BROKER_PORT`. The broker requires it rather than
+defaulting and the agent step interpolates it, so the two cannot drift into a
+connection refused that only a live run would reveal.
+
+**Out of the agent's env is not out of the agent's reach.** Every step runs as
+`runner` and the agent holds `Read`, so `/proc/<pid>/environ` and
+`/proc/<pid>/cmdline` of every process in the job are agent-readable — and the
+step logs the broker's PID. `/proc/<pid>/environ` is the block captured at
+`exec`, so deleting the variable inside the broker would not clear it; any
+runtime scrub is theatre. The step therefore copies the token to a shell-local,
+`unset`s the exported name, and pipes the value to the broker's **stdin** from
+`printf`, a bash builtin: no env var, no argv, no temp file. The broker refuses
+to start if it finds the token in its own exec-time environment. Do not rewrite
+that pipe as a here-string or heredoc, where bash may materialise a file the
+agent can read.
+
+**Secrets reach steps through `env:`, never `${{ secrets.* }}` inside `run:`.**
+GitHub expands `${{ }}` before writing the step script to `$RUNNER_TEMP`, so an
+inline secret sits in plaintext on disk for the whole job — the same
+same-UID-readable class as `/proc`. Audited across all 31 workflows: zero hits,
+and a test in `scripts/sentry-mcp-broker.test.mjs` keeps this workflow that way.
 
 The broker refuses anything that is not a GET on an allow-listed path with the
 exact handle, and refuses to relay an upstream redirect (the MCP client would

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "sentry:autofix:finalize:test": "node scripts/sentry-autofix-finalize.test.mjs",
     "sentry:archive": "node scripts/sentry-triage-archive.mjs",
     "sentry:archive:test": "node scripts/sentry-triage-archive.test.mjs",
+    "sentry:broker:test": "node --test scripts/sentry-mcp-broker.test.mjs",
     "pr:feedback-state": "node scripts/pr-feedback-state.mjs",
     "pr:feedback-state:test": "node scripts/pr-feedback-state.test.mjs",
     "pr:ready-state": "node scripts/pr-ready-state.mjs",

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -764,7 +764,7 @@ classify_root_package_json_changes() {
         echo "workspace"
         return
         ;;
-      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:context-budget|/scripts/agent:context-budget:test|/scripts/docs:index|/scripts/docs:index:test|/scripts/docs:audit|/scripts/docs:audit:test|/scripts/docs:garden|/scripts/docs:garden:test|/scripts/docs:navigation-eval|/scripts/docs:navigation-eval:test|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/sentry:digest|/scripts/sentry:digest:test|/scripts/sentry:autofix:select|/scripts/sentry:autofix:select:test|/scripts/sentry:autofix:finalize:test|/scripts/sentry:archive|/scripts/sentry:archive:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
+      /scripts/agent:quality-gate|/scripts/agent:quality-gate:test|/scripts/agent:prewarm|/scripts/agent:prewarm:test|/scripts/agent:review-materiality|/scripts/agent:review-materiality:test|/scripts/agent:context-check|/scripts/agent:context-budget|/scripts/agent:context-budget:test|/scripts/docs:index|/scripts/docs:index:test|/scripts/docs:audit|/scripts/docs:audit:test|/scripts/docs:garden|/scripts/docs:garden:test|/scripts/docs:navigation-eval|/scripts/docs:navigation-eval:test|/scripts/agent:autoreview|/scripts/issue:board|/scripts/issue:board:test|/scripts/issue:claim|/scripts/issue:review|/scripts/issue:release|/scripts/sentry:ingest|/scripts/sentry:ingest:test|/scripts/sentry:digest|/scripts/sentry:digest:test|/scripts/sentry:autofix:select|/scripts/sentry:autofix:select:test|/scripts/sentry:autofix:finalize:test|/scripts/sentry:archive|/scripts/sentry:archive:test|/scripts/sentry:broker:test|/scripts/pr:feedback-state|/scripts/pr:feedback-state:test|/scripts/pr:ready-state|/scripts/pr:ready-state:test|/scripts/tf|/scripts/tf:test|/scripts/alerts:rules:lint|/scripts/alerts:rules:lint:test|/scripts/lockfile:lint|/scripts/lockfile:lint:test|/scripts/skew:check|/scripts/skew:check:test|/scripts/override:prune-report|/scripts/override:prune-report:test|/scripts/adr:check|/scripts/adr:check:test|/scripts/sanitize:test)
         saw_tooling_script=true
         ;;
       /scripts)
@@ -1264,6 +1264,7 @@ add_root_tooling_package_script_checks() {
   add_command "pnpm sentry:autofix:select:test" "$reason"
   add_command "pnpm sentry:autofix:finalize:test" "$reason"
   add_command "pnpm sentry:archive:test" "$reason"
+  add_command "pnpm sentry:broker:test" "$reason"
   add_command "node scripts/pr-feedback-state.test.mjs" "$reason"
   add_command "node scripts/pr-ready-state.test.mjs" "$reason"
   add_command "node scripts/terraform-fmt-check.test.mjs" "$reason"
@@ -1964,6 +1965,13 @@ while IFS= read -r path; do
         .github/workflows/lighthouse.yml)
           add_checklist "docs/pr-checklists/code-health.md" "Lighthouse CI workflow changed"
           ;;
+        .github/workflows/sentry-triage-agent.yml)
+          # Both suites assert on this file: the agent-comment tests own the
+          # "agent is the last step" and staged-closure invariants, the broker
+          # tests own "no Sentry credential in the agent's env" (#1711).
+          add_command "node scripts/sentry-triage-agent-comment.test.mjs" "Sentry triage agent workflow changed"
+          add_command "pnpm sentry:broker:test" "Sentry triage agent workflow changed"
+          ;;
         .github/actions/pnpm-install/*)
           add_surface "workspace"
           add_preflight_command "pnpm install --frozen-lockfile" "pnpm install action changed"
@@ -2281,6 +2289,9 @@ while IFS= read -r path; do
           ;;
         scripts/sentry-triage-archive.mjs|scripts/sentry-triage-archive.test.mjs)
           add_command "pnpm sentry:archive:test" "Sentry triage archive helper changed"
+          ;;
+        scripts/sentry-mcp-broker.mjs|scripts/sentry-mcp-broker.test.mjs)
+          add_command "pnpm sentry:broker:test" "Sentry credential broker changed"
           ;;
         scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"

--- a/scripts/sentry-mcp-broker.mjs
+++ b/scripts/sentry-mcp-broker.mjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+/**
+ * The Sentry triage agent's credential broker (issue #1711).
+ *
+ * WHY THIS EXISTS. `.github/workflows/sentry-triage-agent.yml` used to put
+ * `SENTRY_TRIAGE_TOKEN` in the triage job's env so the Sentry MCP server —
+ * launched by the Claude CLI, inside the untrusted agent's own process tree —
+ * could read it through a `${SENTRY_TRIAGE_TOKEN}` expansion in
+ * `--mcp-config`. The agent's allow-listed Bash inherits that env, and the
+ * agent writes its own shell commands, so bash expands and transforms `$VAR`
+ * before any wrapper receives argv: `${TOKEN:0:4}x${TOKEN:4}` posts the whole
+ * token with one removable character spliced in. No check inside
+ * `sentry-triage-agent-comment.mjs` can close that — exact-value scanning is
+ * the wrong layer when the adversary controls the shell. The only fix removes
+ * the credential from the agent's environment.
+ *
+ * WHAT THIS DOES. A TRUSTED workflow step (which runs before the agent and
+ * holds the token step-scoped) starts this loopback HTTP broker and mints an
+ * opaque per-run HANDLE. The agent step gets the handle and no Sentry
+ * credential at all. The MCP server is pointed at the broker with
+ * `--host 127.0.0.1:<port> --insecure-http` and authenticates with the handle;
+ * the broker validates the handle, swaps in the real token, and forwards to
+ * Sentry over HTTPS.
+ *
+ * THE HANDLE IS NOT A SECOND SECRET, and that is load-bearing. It is worthless
+ * outside this run and outside this process: the broker binds 127.0.0.1 ONLY
+ * (see BIND_HOST — nothing makes the bind address configurable), the handle is
+ * minted per run and never persisted, and the broker exits with the runner. So
+ * a handle that escapes into a public queue comment buys an attacker nothing,
+ * which is what makes the residual steering channel below survivable.
+ *
+ * THE STEERING CHANNEL, STATED PLAINLY — DO NOT DESIGN AS IF IT WERE CLOSED.
+ * Three allow-listed tools (`find_projects`, `search_issues`, `search_events`)
+ * take an agent-controlled `regionUrl`. The MCP server's `validateRegionUrl`
+ * accepts the base host plus a hardcoded {sentry.io, us.sentry.io,
+ * de.sentry.io}, keeps only the HOST, and re-applies its own protocol — which
+ * is `http` under `--insecure-http`. So an agent that passes
+ * `regionUrl: "https://us.sentry.io"` produces a real cleartext request to
+ * `http://us.sentry.io/api/0/...` carrying its `Authorization` header,
+ * bypassing this broker entirely. Verified against the real
+ * `@sentry/mcp-server@0.37.0`. What leaks there is the HANDLE, not the token,
+ * and the handle is worthless off-runner — that is the whole reason this is an
+ * accepted residual rather than a hole. Sentry egress is NOT closed on the
+ * runner and this design does not assume it is.
+ *
+ * THE REGION-URL REWRITE IS A CORRECTNESS FIX, not decoration. Sentry's own
+ * organization payload carries `links.regionUrl: "https://us.sentry.io"`, and
+ * both the MCP server's internal code (the `trace`/`span` resource path reads
+ * the org first and follows that link) and its `find_organizations` output
+ * ("the Region URL shown above is the `regionUrl` value for later tools") steer
+ * off the broker with it. Verified: served upstream-shaped links, a `trace`
+ * read made exactly ONE request to the broker and sent the rest to
+ * `http://us.sentry.io`. So the broker rewrites `links.regionUrl` on
+ * organization payloads to its own origin, which `validateRegionUrl` accepts as
+ * the base host. `links.organizationUrl` is deliberately NOT rewritten: it is
+ * the human-facing permalink base, and verdict comments carry real Sentry
+ * links.
+ *
+ * THE LOG IS AGENT-READABLE. The workflow points this process's stdout at a
+ * file under `$RUNNER_TEMP`, which the agent holds `Read` on. So nothing here
+ * ever logs the token or the handle — only method, path, status and a refusal
+ * reason. Keep it that way.
+ *
+ * THE PATH ALLOWLIST is the empirically derived closure of the tools the
+ * workflow actually grants, GET only — see
+ * `docs/notes/sentry-triage-pipeline.md` for how to re-derive it. Nothing in
+ * the granted set mutates and `update_issue` is deliberately not granted, so a
+ * non-GET request is refused outright rather than proxied. Bumping
+ * `@sentry/mcp-server` means re-deriving this list: a path the broker refuses
+ * fails the triage leg loudly (the log names the rejected path), it does not
+ * silently degrade.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { realpathSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Loopback ONLY. This is the property that makes a leaked handle worthless off
+ * the runner, so it is a constant with no env override — widening it would
+ * silently convert the handle into a credential that travels.
+ */
+export const BIND_HOST = "127.0.0.1";
+
+/** Sentry SaaS US region. Overridable only for tests via the env below. */
+export const DEFAULT_UPSTREAM = "https://us.sentry.io";
+
+/** Minimum handle length accepted at startup (32 bytes of hex = 64 chars). */
+export const MIN_HANDLE_LENGTH = 32;
+
+/**
+ * One path segment. Deliberately excludes `%`, so no percent-encoded traversal
+ * survives the match; every identifier the granted tools produce (org and
+ * project slugs, numeric issue ids, SHORT-IDs, hex event/trace/replay ids,
+ * monitor slugs, snapshot artifact ids and image file names) is in this set.
+ */
+const SEG = "[A-Za-z0-9._-]+";
+
+const path = (pattern) => new RegExp(`^${pattern}$`);
+
+/**
+ * Every path the workflow's granted Sentry MCP tools produce, derived by
+ * driving those tools against a capture server rather than guessed from tool
+ * names. At `@sentry/mcp-server@0.37.0` the granted-and-existing tools are
+ * `find_organizations`, `find_projects`, `search_issues`, `search_events` and
+ * `get_sentry_resource` (the other five names in `--allowedTools` do not exist
+ * at this version and are inert grants). `get_sentry_resource` is driven across
+ * its whole `resourceType` enum and `search_events` across every dataset,
+ * because the agent can reach all of them.
+ */
+export const ALLOWED_PATHS = [
+  // find_organizations
+  path("/api/0/organizations/"),
+  // organization details — get_sentry_resource(trace|span) reads this first
+  path(`/api/0/organizations/${SEG}/`),
+  // find_projects
+  path(`/api/0/organizations/${SEG}/projects/`),
+  // search_issues; also the shortId lookup behind get_sentry_resource(event)
+  path(`/api/0/organizations/${SEG}/issues/`),
+  // get_sentry_resource(issue) and its enrichment reads
+  path(`/api/0/organizations/${SEG}/issues/${SEG}/`),
+  path(`/api/0/organizations/${SEG}/issues/${SEG}/events/latest/`),
+  path(`/api/0/organizations/${SEG}/issues/${SEG}/events/${SEG}/`),
+  path(`/api/0/organizations/${SEG}/issues/${SEG}/autofix/`),
+  path(`/api/0/organizations/${SEG}/issues/${SEG}/external-issues/`),
+  path(`/api/0/organizations/${SEG}/replay-count/`),
+  // search_events (errors/spans/logs/profiles/metrics)
+  path(`/api/0/organizations/${SEG}/events/`),
+  path(`/api/0/organizations/${SEG}/events/validate/`),
+  // search_events(dataset=replays) and get_sentry_resource(replay)
+  path(`/api/0/organizations/${SEG}/replays/`),
+  path(`/api/0/organizations/${SEG}/replays/${SEG}/`),
+  // get_sentry_resource(trace|span)
+  path(`/api/0/organizations/${SEG}/trace/${SEG}/`),
+  path(`/api/0/organizations/${SEG}/trace-meta/${SEG}/`),
+  // get_sentry_resource(ai_conversation|monitor|snapshot|snapshotImage)
+  path(`/api/0/organizations/${SEG}/ai-conversations/${SEG}/`),
+  path(`/api/0/organizations/${SEG}/monitors/${SEG}/`),
+  path(`/api/0/organizations/${SEG}/preprodartifacts/snapshots/${SEG}/`),
+  path(
+    `/api/0/organizations/${SEG}/preprodartifacts/snapshots/${SEG}/images/${SEG}/`,
+  ),
+  // project resolution behind search_issues/search_events projectSlug
+  path(`/api/0/projects/${SEG}/${SEG}/`),
+];
+
+/** Organization payloads whose `links.regionUrl` must point back at us. */
+const ORGANIZATION_PATHS = [
+  path("/api/0/organizations/"),
+  path(`/api/0/organizations/${SEG}/`),
+];
+
+export function isAllowedPath(pathname) {
+  return ALLOWED_PATHS.some((pattern) => pattern.test(pathname));
+}
+
+function isOrganizationPath(pathname) {
+  return ORGANIZATION_PATHS.some((pattern) => pattern.test(pathname));
+}
+
+/** Constant-time handle comparison; a length mismatch is an early miss. */
+export function handleMatches(provided, expected) {
+  const a = Buffer.from(String(provided ?? ""), "utf8");
+  const b = Buffer.from(String(expected ?? ""), "utf8");
+  if (a.length === 0 || a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Extracts the bearer value from an Authorization header, or "". */
+function bearer(header) {
+  const match = /^Bearer (.+)$/.exec(String(header ?? ""));
+  return match ? match[1] : "";
+}
+
+/**
+ * Points every `links.regionUrl` in an organization payload at the broker, in
+ * place, and returns the payload. Handles both the list and single-object
+ * shapes Sentry returns. `links.organizationUrl` is left alone on purpose.
+ */
+export function rewriteRegionLinks(payload, brokerOrigin) {
+  if (Array.isArray(payload)) {
+    for (const entry of payload) rewriteRegionLinks(entry, brokerOrigin);
+    return payload;
+  }
+  if (payload && typeof payload === "object") {
+    const links = payload.links;
+    if (links && typeof links === "object" && "regionUrl" in links) {
+      links.regionUrl = brokerOrigin;
+    }
+  }
+  return payload;
+}
+
+function deny(res, status, reason) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify({ detail: `sentry-mcp-broker: ${reason}` }));
+  return { status, reason };
+}
+
+/**
+ * Decides an inbound request. Handle first: an unauthenticated caller learns
+ * nothing about the method or path policy.
+ */
+export function classify({ method, authorization, pathname }, handle) {
+  if (!handleMatches(bearer(authorization), handle)) {
+    return { status: 401, reason: "invalid run handle" };
+  }
+  if (method !== "GET") {
+    return {
+      status: 405,
+      reason: `method ${method} is not proxied (read-only broker)`,
+    };
+  }
+  if (!isAllowedPath(pathname)) {
+    return { status: 403, reason: `path not allowed: ${pathname}` };
+  }
+  return null;
+}
+
+/**
+ * Builds the broker's request handler.
+ *
+ * @param {object} config
+ * @param {string} config.token real Sentry token, never sent to the client
+ * @param {string} config.handle per-run handle the MCP server presents
+ * @param {string} config.upstream upstream origin (https)
+ * @param {number} config.timeoutMs upstream request timeout
+ * @param {(url: string, init: object) => Promise<Response>} [config.fetchImpl]
+ * @param {(line: string) => void} [config.log]
+ * @returns {(req, res) => Promise<void>}
+ */
+export function createHandler(config) {
+  const {
+    token,
+    handle,
+    upstream,
+    timeoutMs = 60_000,
+    fetchImpl = fetch,
+    log = (line) => console.log(line),
+  } = config;
+  let brokerOrigin = null;
+
+  const handler = async (req, res) => {
+    // A relative-URL parse resolves `..` segments before anything sees them.
+    const url = new URL(req.url, `http://${BIND_HOST}`);
+    const refusal = classify(
+      {
+        method: req.method,
+        authorization: req.headers.authorization,
+        pathname: url.pathname,
+      },
+      handle,
+    );
+    if (refusal) {
+      log(
+        `sentry-mcp-broker: DENY ${refusal.status} ${req.method} ${url.pathname} — ${refusal.reason}`,
+      );
+      deny(res, refusal.status, refusal.reason);
+      return;
+    }
+
+    const target = new URL(`${url.pathname}${url.search}`, upstream);
+    let upstreamRes;
+    try {
+      upstreamRes = await fetchImpl(target.toString(), {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: {
+          // The whole point: the handle never leaves this process, the token
+          // never enters the agent's.
+          authorization: `Bearer ${token}`,
+          accept: "application/json",
+          "user-agent": String(
+            req.headers["user-agent"] ?? "sentry-mcp-broker",
+          ),
+        },
+      });
+    } catch (error) {
+      log(
+        `sentry-mcp-broker: UPSTREAM-ERROR ${url.pathname} — ${error instanceof Error ? error.message : String(error)}`,
+      );
+      deny(res, 502, "upstream request failed");
+      return;
+    }
+
+    // Never relay a redirect: the MCP client would follow it with the handle,
+    // off the broker and possibly in cleartext. Fail closed and loudly instead.
+    if (upstreamRes.status >= 300 && upstreamRes.status < 400) {
+      log(
+        `sentry-mcp-broker: DENY 502 GET ${url.pathname} — upstream redirect (${upstreamRes.status}) not relayed`,
+      );
+      deny(res, 502, "upstream redirect not relayed");
+      return;
+    }
+
+    const contentType = upstreamRes.headers.get("content-type") ?? "";
+    let body = Buffer.from(await upstreamRes.arrayBuffer());
+
+    if (
+      upstreamRes.status === 200 &&
+      contentType.includes("application/json") &&
+      isOrganizationPath(url.pathname)
+    ) {
+      try {
+        body = Buffer.from(
+          JSON.stringify(
+            rewriteRegionLinks(JSON.parse(body.toString("utf8")), brokerOrigin),
+          ),
+          "utf8",
+        );
+      } catch {
+        // Unparsable JSON is relayed untouched; the MCP server's own schema
+        // validation is the right place for that failure to surface.
+        log(
+          `sentry-mcp-broker: WARN ${url.pathname} — organization payload was not parsable JSON, relayed unmodified`,
+        );
+      }
+    }
+
+    const headers = { "content-type": contentType || "application/json" };
+    // Relayed so cursor pagination keeps working if the granted tool set grows;
+    // the MCP client reads only the `cursor="…"` value out of it.
+    const link = upstreamRes.headers.get("link");
+    if (link) headers.link = link;
+    res.writeHead(upstreamRes.status, headers);
+    res.end(body);
+    log(
+      `sentry-mcp-broker: GET ${url.pathname} -> ${upstreamRes.status} (${body.length}b)`,
+    );
+  };
+
+  handler.setBrokerOrigin = (origin) => {
+    brokerOrigin = origin;
+  };
+  return handler;
+}
+
+/**
+ * Starts the broker on `port`. Binds loopback only.
+ *
+ * @returns {Promise<import("node:http").Server>}
+ */
+export async function startBroker(config) {
+  const handler = createHandler(config);
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      config.log?.(`sentry-mcp-broker: HANDLER-ERROR ${error}`);
+      if (!res.headersSent) deny(res, 500, "internal error");
+      else res.end();
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(config.port ?? 0, BIND_HOST, resolve);
+  });
+  const { port } = server.address();
+  // `validateRegionUrl` demands an https URL and accepts the base host; the MCP
+  // client then keeps the host and re-applies its own (http) protocol, so this
+  // https origin is what routes region-scoped reads back here.
+  handler.setBrokerOrigin(`https://${BIND_HOST}:${port}`);
+  return server;
+}
+
+function requireEnv(env, name) {
+  const value = String(env[name] ?? "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function resolveConfig(env) {
+  const token = requireEnv(env, "SENTRY_MCP_BROKER_TOKEN");
+  const handle = requireEnv(env, "SENTRY_MCP_BROKER_HANDLE");
+  if (handle.length < MIN_HANDLE_LENGTH) {
+    throw new Error(
+      `SENTRY_MCP_BROKER_HANDLE must be at least ${MIN_HANDLE_LENGTH} characters (got ${handle.length}); mint it with \`openssl rand -hex 32\``,
+    );
+  }
+  const upstream = String(
+    env.SENTRY_MCP_BROKER_UPSTREAM ?? DEFAULT_UPSTREAM,
+  ).trim();
+  if (!upstream.startsWith("https://")) {
+    throw new Error(
+      `SENTRY_MCP_BROKER_UPSTREAM must be https (got ${upstream})`,
+    );
+  }
+  const port = Number(env.SENTRY_MCP_BROKER_PORT ?? 9401);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `SENTRY_MCP_BROKER_PORT must be a valid port (got ${port})`,
+    );
+  }
+  // Bounds the credential's lifetime without a step after the agent — the
+  // triage job must END with the agent (a later step's bash would source a
+  // $GITHUB_ENV-injected BASH_ENV payload), so there is nowhere safe to run an
+  // explicit stop. Default matches the job's 30-minute timeout.
+  const ttlSeconds = Number(env.SENTRY_MCP_BROKER_TTL_SECONDS ?? 1800);
+  if (!Number.isInteger(ttlSeconds) || ttlSeconds < 1) {
+    throw new Error(
+      `SENTRY_MCP_BROKER_TTL_SECONDS must be a positive integer (got ${ttlSeconds})`,
+    );
+  }
+  return {
+    token,
+    handle,
+    upstream,
+    port,
+    ttlSeconds,
+    readyFile: String(env.SENTRY_MCP_BROKER_READY_FILE ?? "").trim(),
+  };
+}
+
+async function main(env = process.env) {
+  const config = resolveConfig(env);
+  const server = await startBroker(config);
+  const { port } = server.address();
+  console.log(
+    `sentry-mcp-broker: listening on ${BIND_HOST}:${port} -> ${config.upstream} (ttl ${config.ttlSeconds}s)`,
+  );
+  if (config.readyFile) writeFileSync(config.readyFile, `${port}\n`);
+  setTimeout(() => {
+    console.log("sentry-mcp-broker: TTL reached, exiting");
+    process.exit(0);
+  }, config.ttlSeconds * 1000);
+}
+
+/**
+ * Entry-point check on REALPATHS, not the raw argv string. The workflow runs
+ * this from an immutable staged copy under `$RUNNER_TEMP`, and a `$RUNNER_TEMP`
+ * that traverses a symlink (macOS `/var` -> `/private/var`, for one) makes a
+ * raw string compare fail — node would then exit 0 having started nothing, and
+ * the workflow's readiness wait would report a broker that "exited before
+ * becoming ready" with an empty log. Reproduced locally; do not simplify.
+ */
+export function isEntryPoint(argv1, moduleUrl) {
+  if (!argv1) return false;
+  const resolve = (value) => {
+    try {
+      return realpathSync(value);
+    } catch {
+      return value;
+    }
+  };
+  return resolve(argv1) === resolve(fileURLToPath(moduleUrl));
+}
+
+if (isEntryPoint(process.argv[1], import.meta.url)) {
+  main().catch((error) => {
+    console.error(`sentry-mcp-broker: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/sentry-mcp-broker.mjs
+++ b/scripts/sentry-mcp-broker.mjs
@@ -22,6 +22,43 @@
  * the broker validates the handle, swaps in the real token, and forwards to
  * Sentry over HTTPS.
  *
+ * THE TOKEN ARRIVES ON STDIN, AND EVERY OTHER CHANNEL LEAKS IT. GitHub Actions
+ * runs every step as `runner`, and the agent holds `Read`, so any same-UID
+ * readable surface is agent-reachable. Ruled out, each for a specific reason:
+ *
+ *   - PROCESS ENVIRONMENT. `/proc/<pid>/environ` is world-readable to the same
+ *     UID, so inheriting the token from the step's `env:` block puts it one
+ *     `Read` away — and the workflow logs this process's PID. THE SUBTLETY THAT
+ *     MAKES THIS EASY TO FIX WRONGLY: that file is the environment captured at
+ *     `exec`. `delete process.env.<name>` at runtime does not change it. Any
+ *     scrub after start is theatre. The variable must not exist when this
+ *     process is exec'd, which is why the workflow copies it to a shell-local
+ *     and `unset`s the exported name BEFORE spawning node, and why
+ *     `assertTokenAbsentFromExecEnv` refuses to start if it finds it anyway.
+ *   - ARGV. `/proc/<pid>/cmdline` is readable the same way, so the token is
+ *     never a process argument. The workflow writes it with `printf`, a bash
+ *     BUILTIN — a builtin in a pipeline runs in a forked subshell that never
+ *     `exec`s, so its `/proc/<pid>/cmdline` is the parent shell's command line,
+ *     not the builtin's arguments. That is a property of fork-without-exec, not
+ *     an accident worth relying on silently.
+ *   - THE FILESYSTEM. A temp file is readable for as long as it exists. A
+ *     pipeline uses an anonymous pipe and creates no file, unlike a here-string
+ *     (`<<<`) or heredoc (`<<`), where bash may materialise one — do not
+ *     "simplify" the pipe into either.
+ *   - THE STEP SHELL'S OWN ENVIRONMENT still holds the token, and that is
+ *     acceptable only because each `run:` step is its own process that has
+ *     exited before the next step starts (the runner gates the next step on
+ *     this one's exit code). The agent runs in a later step, so that process is
+ *     gone. This broker deliberately outlives its step, which is exactly why
+ *     ITS environment is the one that matters.
+ *
+ * RESIDUAL, UNVERIFIED: the token then lives in this process's heap. Reading
+ * `/proc/<pid>/mem` needs `PTRACE_MODE_ATTACH`, which Yama's
+ * `ptrace_scope=1` denies to a non-descendant same-user process — but the
+ * runner's setting is not established. The broker step logs
+ * `/proc/sys/kernel/yama/ptrace_scope` so the first real run settles it. Until
+ * then, treat heap residency as unmitigated rather than safe.
+ *
  * THE HANDLE IS NOT A SECOND SECRET, and that is load-bearing. It is worthless
  * outside this run and outside this process: the broker binds 127.0.0.1 ONLY
  * (see BIND_HOST — nothing makes the bind address configurable), the handle is
@@ -77,11 +114,26 @@ import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 
 /**
+ * The environment exactly as this process received it at `exec`, captured at
+ * module load before anything can mutate `process.env`.
+ *
+ * This snapshot — not live `process.env` — is what `/proc/<pid>/environ`
+ * contains for the life of the process. Never replace a use of this with
+ * `process.env`, and never `delete process.env.<name>` anywhere in this file:
+ * a runtime scrub leaves `/proc` untouched and only hides the leak from the
+ * check that exists to find it.
+ */
+const ENV_AT_EXEC = Object.freeze({ ...process.env });
+
+/**
  * Loopback ONLY. This is the property that makes a leaked handle worthless off
  * the runner, so it is a constant with no env override — widening it would
  * silently convert the handle into a credential that travels.
  */
 export const BIND_HOST = "127.0.0.1";
+
+/** Shortest value accepted as a Sentry token; real ones are far longer. */
+export const MIN_TOKEN_LENGTH = 16;
 
 /** Sentry SaaS US region. Overridable only for tests via the env below. */
 export const DEFAULT_UPSTREAM = "https://us.sentry.io";
@@ -369,8 +421,70 @@ function requireEnv(env, name) {
   return value;
 }
 
+/**
+ * Reads the Sentry token from stdin — the channel that leaves no readable
+ * trace. See the header for why every other channel does.
+ *
+ * The workflow pipes it from a bash builtin, so the value never becomes a
+ * process argument and no temporary file is created. Stdin reaches EOF as soon
+ * as the writer exits, and an anonymous pipe keeps no history, so once this
+ * resolves the only copy left is this process's heap.
+ */
+export function readTokenFromStdin(stream = process.stdin, timeoutMs = 10_000) {
+  return new Promise((resolve, reject) => {
+    if (stream.isTTY) {
+      reject(
+        new Error(
+          "the Sentry token must be piped on stdin (stdin is a TTY); the workflow pipes it from a bash builtin",
+        ),
+      );
+      return;
+    }
+    let data = "";
+    const timer = setTimeout(() => {
+      stream.destroy();
+      reject(new Error(`no token arrived on stdin within ${timeoutMs}ms`));
+    }, timeoutMs);
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", () => {
+      clearTimeout(timer);
+      resolve(data.trim());
+    });
+    stream.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+/**
+ * Refuses to start if the token is anywhere in the EXEC-TIME environment.
+ *
+ * This is the enforcement behind the header's central claim, and it must be
+ * given the exec-time snapshot rather than live `process.env`. Deleting a
+ * variable at runtime does NOT change `/proc/<pid>/environ` — that file is the
+ * block captured at `exec` — so a check against live `process.env` would pass
+ * for the exact wiring it exists to catch. Naming a variable here means the
+ * workflow exported the token to this process and the fix belongs in the
+ * workflow, not in a runtime scrub.
+ */
+export function assertTokenAbsentFromExecEnv(token, envAtExec) {
+  for (const [name, value] of Object.entries(envAtExec)) {
+    if (typeof value === "string" && value.includes(token)) {
+      throw new Error(
+        `the Sentry token is present in this process's exec-time environment as ${name}; ` +
+          "any same-UID process can read it from /proc/<pid>/environ. " +
+          "Do not scrub it at runtime — that does not change /proc. " +
+          "Stop exporting it to this process (see the broker step in .github/workflows/sentry-triage-agent.yml).",
+      );
+    }
+  }
+}
+
 export function resolveConfig(env) {
-  const token = requireEnv(env, "SENTRY_MCP_BROKER_TOKEN");
   const handle = requireEnv(env, "SENTRY_MCP_BROKER_HANDLE");
   if (handle.length < MIN_HANDLE_LENGTH) {
     throw new Error(
@@ -385,7 +499,12 @@ export function resolveConfig(env) {
       `SENTRY_MCP_BROKER_UPSTREAM must be https (got ${upstream})`,
     );
   }
-  const port = Number(env.SENTRY_MCP_BROKER_PORT ?? 9401);
+  // REQUIRED, not defaulted. The port is the contract between the broker step
+  // and the agent step's --mcp-config, and it has exactly one literal: the
+  // triage job's `env: SENTRY_MCP_BROKER_PORT`. A default here would be a
+  // second source of truth that could silently disagree with the workflow and
+  // surface only as a connection refused on a live run.
+  const port = Number(requireEnv(env, "SENTRY_MCP_BROKER_PORT"));
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(
       `SENTRY_MCP_BROKER_PORT must be a valid port (got ${port})`,
@@ -402,7 +521,6 @@ export function resolveConfig(env) {
     );
   }
   return {
-    token,
     handle,
     upstream,
     port,
@@ -411,12 +529,40 @@ export function resolveConfig(env) {
   };
 }
 
-async function main(env = process.env) {
-  const config = resolveConfig(env);
+/**
+ * Everything that must hold before a socket is bound: config from the
+ * exec-time environment, token from stdin, and the exec-time env proven clean.
+ *
+ * `envAtExec` is a parameter so a test can hand in a snapshot that still holds
+ * the token while live `process.env` no longer does — the exact shape of the
+ * tempting wrong fix. Passing live `process.env` here instead would make that
+ * case pass, which is why it is threaded through rather than read inline.
+ */
+export async function resolveRuntime({
+  envAtExec = ENV_AT_EXEC,
+  stdin = process.stdin,
+} = {}) {
+  const config = resolveConfig(envAtExec);
+  const token = await readTokenFromStdin(stdin);
+  if (token.length < MIN_TOKEN_LENGTH) {
+    throw new Error(
+      `the token read from stdin is ${token.length} characters; expected at least ${MIN_TOKEN_LENGTH}`,
+    );
+  }
+  // Before the socket binds, so a leaking wiring never serves a single request.
+  assertTokenAbsentFromExecEnv(token, envAtExec);
+  return { ...config, token };
+}
+
+async function main() {
+  const config = await resolveRuntime();
   const server = await startBroker(config);
   const { port } = server.address();
   console.log(
     `sentry-mcp-broker: listening on ${BIND_HOST}:${port} -> ${config.upstream} (ttl ${config.ttlSeconds}s)`,
+  );
+  console.log(
+    "sentry-mcp-broker: token read from stdin; absent from this process's exec-time environment",
   );
   if (config.readyFile) writeFileSync(config.readyFile, `${port}\n`);
   setTimeout(() => {

--- a/scripts/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry-mcp-broker.test.mjs
@@ -1,0 +1,686 @@
+#!/usr/bin/env node
+/**
+ * Tests for the Sentry credential broker (issue #1711).
+ *
+ * The standard here is a DEMONSTRATED failure, not a passing test: every guard
+ * below is asserted on its rejection (status AND reason) and on the upstream
+ * never being reached, so removing the guard turns the test red rather than
+ * merely changing a status code.
+ *
+ * The end-to-end drive through the REAL `@sentry/mcp-server@0.37.0` — handle in,
+ * token out, region links rewritten — is a local verification step, not a repo
+ * test: pulling that package into CI to prove a proxy forwards a header is a
+ * bad trade. The recipe for re-running it (and for re-deriving the path
+ * allowlist on a version bump) is in `docs/notes/sentry-triage-pipeline.md`.
+ */
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { connect } from "node:net";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  ALLOWED_PATHS,
+  BIND_HOST,
+  classify,
+  handleMatches,
+  isAllowedPath,
+  isEntryPoint,
+  resolveConfig,
+  rewriteRegionLinks,
+  startBroker,
+} from "./sentry-mcp-broker.mjs";
+
+const HANDLE = "h".repeat(64);
+const REAL_TOKEN = "sntrys_the_real_read_only_token_value";
+
+/** A stub Sentry that records what it was asked and with which credential. */
+async function startUpstream(respond) {
+  const seen = [];
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    seen.push({
+      method: req.method,
+      pathname: url.pathname,
+      search: url.search,
+      authorization: req.headers.authorization,
+    });
+    respond(req, res, url);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, seen, origin: `http://127.0.0.1:${server.address().port}` };
+}
+
+const jsonUpstream =
+  (payload, status = 200) =>
+  (_req, res) => {
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  };
+
+/**
+ * Boots a broker in front of a stub upstream. `startBroker` takes the origin
+ * directly, so the https-only check in `resolveConfig` (tested separately) does
+ * not stand in the way of an http stub here.
+ */
+async function withBroker(respond, run, overrides = {}) {
+  const upstream = await startUpstream(respond);
+  const logs = [];
+  const broker = await startBroker({
+    token: REAL_TOKEN,
+    handle: HANDLE,
+    upstream: upstream.origin,
+    port: 0,
+    log: (line) => logs.push(line),
+    ...overrides,
+  });
+  const base = `http://127.0.0.1:${broker.address().port}`;
+  try {
+    await run({ base, upstream, broker, logs });
+  } finally {
+    broker.close();
+    upstream.server.close();
+  }
+}
+
+const call = (base, path, init = {}) =>
+  fetch(`${base}${path}`, {
+    headers: { authorization: `Bearer ${HANDLE}` },
+    ...init,
+  });
+
+/** Sends a literal request line, bypassing fetch's URL normalisation. */
+function rawRequest(base, requestLine) {
+  const { hostname, port } = new URL(base);
+  return new Promise((resolve, reject) => {
+    const socket = connect(Number(port), hostname, () => {
+      socket.write(
+        `${requestLine}\r\nHost: ${hostname}:${port}\r\nAuthorization: Bearer ${HANDLE}\r\nConnection: close\r\n\r\n`,
+      );
+    });
+    let out = "";
+    socket.on("data", (chunk) => (out += chunk.toString()));
+    socket.on("end", () => resolve(out));
+    socket.on("error", reject);
+  });
+}
+
+// ── binding ──────────────────────────────────────────────────────────────────
+
+test("the broker binds loopback ONLY — a leaked handle is useless off-runner", async () => {
+  assert.equal(BIND_HOST, "127.0.0.1");
+  await withBroker(jsonUpstream([]), async ({ broker }) => {
+    // Not a restatement of the constant: this is the address the kernel bound.
+    assert.equal(broker.address().address, "127.0.0.1");
+  });
+});
+
+// ── the happy path: handle in, real token out ───────────────────────────────
+
+test("an allowed GET reaches Sentry with the REAL token, never the handle", async () => {
+  await withBroker(
+    jsonUpstream({ id: "777", shortId: "MONITORING-1" }),
+    async ({ base, upstream }) => {
+      const res = await call(
+        base,
+        "/api/0/organizations/mento-org/issues/MONITORING-1/",
+      );
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), {
+        id: "777",
+        shortId: "MONITORING-1",
+      });
+      assert.equal(upstream.seen.length, 1);
+      assert.equal(
+        upstream.seen[0].pathname,
+        "/api/0/organizations/mento-org/issues/MONITORING-1/",
+      );
+      assert.equal(upstream.seen[0].authorization, `Bearer ${REAL_TOKEN}`);
+      assert.ok(
+        !upstream.seen[0].authorization.includes(HANDLE),
+        "the run handle must never reach Sentry",
+      );
+    },
+  );
+});
+
+test("the query string is forwarded verbatim", async () => {
+  await withBroker(
+    jsonUpstream({ data: [], meta: {} }),
+    async ({ base, upstream }) => {
+      await call(
+        base,
+        "/api/0/organizations/mento-org/events/?dataset=errors&query=is%3Aunresolved&per_page=10",
+      );
+      assert.equal(
+        upstream.seen[0].search,
+        "?dataset=errors&query=is%3Aunresolved&per_page=10",
+      );
+    },
+  );
+});
+
+// ── fail closed: handle ──────────────────────────────────────────────────────
+
+test("a WRONG handle is refused and never reaches Sentry", async () => {
+  await withBroker(jsonUpstream([]), async ({ base, upstream, logs }) => {
+    const res = await fetch(`${base}/api/0/organizations/`, {
+      headers: { authorization: `Bearer ${"x".repeat(64)}` },
+    });
+    assert.equal(res.status, 401);
+    assert.deepEqual(await res.json(), {
+      detail: "sentry-mcp-broker: invalid run handle",
+    });
+    assert.equal(upstream.seen.length, 0, "upstream must not be contacted");
+    assert.ok(logs.some((line) => line.includes("DENY 401")));
+  });
+});
+
+test("a MISSING handle is refused and never reaches Sentry", async () => {
+  await withBroker(jsonUpstream([]), async ({ base, upstream }) => {
+    const res = await fetch(`${base}/api/0/organizations/`);
+    assert.equal(res.status, 401);
+    assert.match((await res.json()).detail, /invalid run handle/);
+    assert.equal(upstream.seen.length, 0);
+  });
+});
+
+test("a handle that is a PREFIX of the real one is refused", async () => {
+  await withBroker(jsonUpstream([]), async ({ base, upstream }) => {
+    const res = await fetch(`${base}/api/0/organizations/`, {
+      headers: { authorization: `Bearer ${HANDLE.slice(0, -1)}` },
+    });
+    assert.equal(res.status, 401);
+    assert.equal(upstream.seen.length, 0);
+  });
+});
+
+test("handleMatches rejects empty, short, long and near-miss values", () => {
+  assert.equal(handleMatches(HANDLE, HANDLE), true);
+  assert.equal(handleMatches("", HANDLE), false);
+  assert.equal(handleMatches(undefined, HANDLE), false);
+  assert.equal(handleMatches(HANDLE.slice(0, -1), HANDLE), false);
+  assert.equal(handleMatches(`${HANDLE}x`, HANDLE), false);
+  assert.equal(handleMatches(`${HANDLE.slice(0, -1)}X`, HANDLE), false);
+  // An empty expected handle must not accept an empty presented one.
+  assert.equal(handleMatches("", ""), false);
+});
+
+// ── fail closed: method ──────────────────────────────────────────────────────
+
+for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+  test(`${method} is refused outright — nothing granted mutates`, async () => {
+    await withBroker(jsonUpstream({}), async ({ base, upstream }) => {
+      const res = await call(
+        base,
+        "/api/0/organizations/mento-org/issues/MONITORING-1/",
+        { method, body: method === "DELETE" ? undefined : "{}" },
+      );
+      assert.equal(res.status, 405);
+      assert.equal(
+        (await res.json()).detail,
+        `sentry-mcp-broker: method ${method} is not proxied (read-only broker)`,
+      );
+      assert.equal(upstream.seen.length, 0);
+    });
+  });
+}
+
+// ── fail closed: path ────────────────────────────────────────────────────────
+
+test("a path OUTSIDE the allowlist is refused and never reaches Sentry", async () => {
+  await withBroker(jsonUpstream({}), async ({ base, upstream }) => {
+    const res = await call(base, "/api/0/users/me/");
+    assert.equal(res.status, 403);
+    assert.equal(
+      (await res.json()).detail,
+      "sentry-mcp-broker: path not allowed: /api/0/users/me/",
+    );
+    assert.equal(upstream.seen.length, 0);
+  });
+});
+
+test("dot-segment and percent-encoded traversal are refused", async () => {
+  await withBroker(jsonUpstream({}), async ({ base, upstream }) => {
+    // A raw socket, because fetch normalises `..` client-side and would test
+    // its own URL parser rather than the broker's. This is the shape an
+    // attacker controls.
+    const raw = await rawRequest(
+      base,
+      "GET /api/0/organizations/mento-org/../../../users/me/ HTTP/1.1",
+    );
+    assert.match(raw, /^HTTP\/1\.1 403 /);
+    // Resolved before the allowlist saw it, and refused on the resolved value.
+    assert.match(raw, /path not allowed: \/api\/users\/me\//);
+    assert.ok(!raw.includes(".."), "the raw path must not survive resolution");
+    // `%` is outside the segment charset, so an encoded traversal cannot match.
+    const encoded = await call(base, "/api/0/organizations/%2e%2e/projects/");
+    assert.equal(encoded.status, 403);
+    assert.equal(upstream.seen.length, 0);
+  });
+});
+
+test("the allowlist admits every derived path and nothing adjacent", () => {
+  for (const allowed of [
+    "/api/0/organizations/",
+    "/api/0/organizations/mento-org/",
+    "/api/0/organizations/mento-org/projects/",
+    "/api/0/organizations/mento-org/issues/",
+    "/api/0/organizations/mento-org/issues/MONITORING-1/",
+    "/api/0/organizations/mento-org/issues/777/events/latest/",
+    "/api/0/organizations/mento-org/issues/777/events/abc123/",
+    "/api/0/organizations/mento-org/issues/777/autofix/",
+    "/api/0/organizations/mento-org/issues/777/external-issues/",
+    "/api/0/organizations/mento-org/replay-count/",
+    "/api/0/organizations/mento-org/events/",
+    "/api/0/organizations/mento-org/events/validate/",
+    "/api/0/organizations/mento-org/replays/",
+    "/api/0/organizations/mento-org/replays/abc123/",
+    "/api/0/organizations/mento-org/trace/abc123/",
+    "/api/0/organizations/mento-org/trace-meta/abc123/",
+    "/api/0/organizations/mento-org/ai-conversations/conv-1/",
+    "/api/0/organizations/mento-org/monitors/my-monitor/",
+    "/api/0/organizations/mento-org/preprodartifacts/snapshots/snap-1/",
+    "/api/0/organizations/mento-org/preprodartifacts/snapshots/snap-1/images/img.png/",
+    "/api/0/projects/mento-org/monitoring/",
+  ]) {
+    assert.equal(isAllowedPath(allowed), true, `should allow ${allowed}`);
+  }
+  for (const denied of [
+    // Write and account surfaces the granted tools never touch.
+    "/api/0/users/me/",
+    "/api/0/organizations/mento-org/members/",
+    "/api/0/organizations/mento-org/issues/777/tags/environment/values/",
+    "/api/0/organizations/mento-org/issues/777/activities/",
+    // Prefix and suffix near-misses.
+    "/api/0/organizations/mento-org/issues/777/events/latest/attachments/",
+    "/api/0/organizations",
+    "/api/0/organizations/mento-org/projects",
+    "/organizations/",
+    "/",
+    // A slug carrying a path separator or an escape must not slip through.
+    "/api/0/organizations/mento%2Forg/projects/",
+    "/api/0/projects/mento-org/monitoring/keys/",
+  ]) {
+    assert.equal(isAllowedPath(denied), false, `should deny ${denied}`);
+  }
+  assert.ok(ALLOWED_PATHS.length > 0);
+});
+
+test("classify puts the handle check first and returns null only when all three pass", () => {
+  const allowed = "/api/0/organizations/";
+  assert.equal(
+    classify(
+      { method: "GET", authorization: `Bearer ${HANDLE}`, pathname: allowed },
+      HANDLE,
+    ),
+    null,
+  );
+  // A bad handle is refused even when method and path are fine.
+  assert.equal(
+    classify(
+      { method: "GET", authorization: "Bearer nope", pathname: allowed },
+      HANDLE,
+    ).status,
+    401,
+  );
+  // A bad handle on a disallowed path still reports 401, not 403: an
+  // unauthenticated caller learns nothing about the path policy.
+  assert.equal(
+    classify(
+      {
+        method: "GET",
+        authorization: "Bearer nope",
+        pathname: "/api/0/users/me/",
+      },
+      HANDLE,
+    ).status,
+    401,
+  );
+});
+
+// ── the region-url rewrite ───────────────────────────────────────────────────
+
+test("organization payloads are re-pointed at the broker, so region reads stay local", async () => {
+  const upstreamOrg = {
+    slug: "mento-org",
+    links: {
+      regionUrl: "https://us.sentry.io",
+      organizationUrl: "https://mento-org.sentry.io",
+    },
+  };
+  await withBroker(jsonUpstream([upstreamOrg]), async ({ base, broker }) => {
+    const res = await call(base, "/api/0/organizations/");
+    const [org] = await res.json();
+    assert.equal(
+      org.links.regionUrl,
+      `https://127.0.0.1:${broker.address().port}`,
+    );
+    // The human-facing permalink base is NOT rewritten: verdict comments must
+    // carry real Sentry links.
+    assert.equal(org.links.organizationUrl, "https://mento-org.sentry.io");
+  });
+});
+
+test("the single-organization payload is rewritten too", async () => {
+  await withBroker(
+    jsonUpstream({
+      slug: "mento-org",
+      links: { regionUrl: "https://us.sentry.io" },
+    }),
+    async ({ base, broker }) => {
+      const res = await call(base, "/api/0/organizations/mento-org/");
+      assert.equal(
+        (await res.json()).links.regionUrl,
+        `https://127.0.0.1:${broker.address().port}`,
+      );
+    },
+  );
+});
+
+test("non-organization payloads are relayed byte-for-byte", async () => {
+  const issue = {
+    id: "777",
+    links: { regionUrl: "https://us.sentry.io" },
+    permalink: "https://mento-org.sentry.io/issues/777/",
+  };
+  await withBroker(jsonUpstream(issue), async ({ base }) => {
+    const res = await call(base, "/api/0/organizations/mento-org/issues/777/");
+    assert.deepEqual(await res.json(), issue);
+  });
+});
+
+test("rewriteRegionLinks touches only links.regionUrl", () => {
+  const payload = [
+    {
+      slug: "a",
+      links: {
+        regionUrl: "https://us.sentry.io",
+        organizationUrl: "https://a",
+      },
+    },
+    { slug: "b" },
+    { slug: "c", links: {} },
+  ];
+  rewriteRegionLinks(payload, "https://127.0.0.1:9401");
+  assert.equal(payload[0].links.regionUrl, "https://127.0.0.1:9401");
+  assert.equal(payload[0].links.organizationUrl, "https://a");
+  assert.equal(payload[1].links, undefined);
+  assert.equal("regionUrl" in payload[2].links, false);
+});
+
+// ── fail closed: redirects and upstream failures ─────────────────────────────
+
+test("an upstream redirect is refused, never relayed", async () => {
+  await withBroker(
+    (_req, res) => {
+      res.writeHead(302, {
+        location: "https://us.sentry.io/api/0/organizations/",
+      });
+      res.end();
+    },
+    async ({ base }) => {
+      const res = await call(base, "/api/0/organizations/");
+      assert.equal(res.status, 502);
+      assert.equal(
+        (await res.json()).detail,
+        "sentry-mcp-broker: upstream redirect not relayed",
+      );
+      assert.equal(
+        res.headers.get("location"),
+        null,
+        "a Location header would let the MCP client follow it with the handle",
+      );
+    },
+  );
+});
+
+test("an unreachable upstream fails closed with 502", async () => {
+  const upstream = await startUpstream(jsonUpstream({}));
+  const dead = upstream.origin;
+  await new Promise((resolve) => upstream.server.close(resolve));
+  const broker = await startBroker({
+    token: REAL_TOKEN,
+    handle: HANDLE,
+    upstream: dead,
+    port: 0,
+    log: () => {},
+  });
+  try {
+    const res = await call(
+      `http://127.0.0.1:${broker.address().port}`,
+      "/api/0/organizations/",
+    );
+    assert.equal(res.status, 502);
+    assert.equal(
+      (await res.json()).detail,
+      "sentry-mcp-broker: upstream request failed",
+    );
+  } finally {
+    broker.close();
+  }
+});
+
+test("an upstream error status is relayed, not masked", async () => {
+  await withBroker(
+    jsonUpstream({ detail: "forbidden" }, 403),
+    async ({ base }) => {
+      const res = await call(base, "/api/0/organizations/");
+      assert.equal(res.status, 403);
+      assert.deepEqual(await res.json(), { detail: "forbidden" });
+    },
+  );
+});
+
+// ── configuration ────────────────────────────────────────────────────────────
+
+test("resolveConfig fails loudly on a missing or weak credential wiring", () => {
+  const base = {
+    SENTRY_MCP_BROKER_TOKEN: REAL_TOKEN,
+    SENTRY_MCP_BROKER_HANDLE: HANDLE,
+  };
+  assert.deepEqual(resolveConfig(base).upstream, "https://us.sentry.io");
+  assert.equal(resolveConfig(base).port, 9401);
+  assert.equal(resolveConfig(base).ttlSeconds, 1800);
+
+  assert.throws(
+    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_TOKEN: "  " }),
+    /SENTRY_MCP_BROKER_TOKEN is required/,
+  );
+  assert.throws(
+    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_HANDLE: "" }),
+    /SENTRY_MCP_BROKER_HANDLE is required/,
+  );
+  assert.throws(
+    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_HANDLE: "short" }),
+    /at least 32 characters/,
+  );
+  assert.throws(
+    () =>
+      resolveConfig({
+        ...base,
+        SENTRY_MCP_BROKER_UPSTREAM: "http://us.sentry.io",
+      }),
+    /must be https/,
+  );
+  assert.throws(
+    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_PORT: "0" }),
+    /must be a valid port/,
+  );
+  assert.throws(
+    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_TTL_SECONDS: "0" }),
+    /must be a positive integer/,
+  );
+});
+
+test("the entry-point check survives a symlinked staging path", async () => {
+  const { mkdtempSync, mkdirSync, copyFileSync, symlinkSync } =
+    await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = join(here, "sentry-mcp-broker.mjs");
+
+  // Same file, reached through a symlinked parent — the shape `$RUNNER_TEMP`
+  // takes on any host where the temp root is a link. A raw string compare says
+  // "not the entry point" here, node exits 0 having started nothing, and the
+  // workflow reports a broker that died with an empty log.
+  const root = mkdtempSync(join(tmpdir(), "broker-entry-"));
+  const real = join(root, "real");
+  mkdirSync(real);
+  const staged = join(real, "sentry-mcp-broker.mjs");
+  copyFileSync(source, staged);
+  const linked = join(root, "linked");
+  symlinkSync(real, linked);
+
+  assert.equal(isEntryPoint(staged, `file://${staged}`), true);
+  assert.equal(
+    isEntryPoint(join(linked, "sentry-mcp-broker.mjs"), `file://${staged}`),
+    true,
+    "a symlinked invocation path must still count as the entry point",
+  );
+  assert.equal(isEntryPoint("", `file://${staged}`), false);
+  assert.equal(
+    isEntryPoint(join(root, "other.mjs"), `file://${staged}`),
+    false,
+  );
+});
+
+// ── the workflow wiring this broker exists to enable ────────────────────────
+
+const WORKFLOW = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    ".github",
+    "workflows",
+    "sentry-triage-agent.yml",
+  ),
+  "utf8",
+);
+
+/** The agent job's block, from its key to the next job's. */
+function triageJobBlock() {
+  const start = WORKFLOW.indexOf("\n  triage:");
+  const end = WORKFLOW.indexOf("\n  verdict:");
+  assert.ok(
+    start > 0 && end > start,
+    "triage/verdict job boundaries not found",
+  );
+  return WORKFLOW.slice(start, end);
+}
+
+test("the triage job's env holds NO credential — the issue's Done means", () => {
+  const job = triageJobBlock();
+  const jobEnv = job.slice(
+    job.indexOf("\n    env:"),
+    job.indexOf("\n    steps:"),
+  );
+  assert.ok(jobEnv.length > 0, "the triage job's env: block was not found");
+  assert.ok(
+    !/SENTRY_TRIAGE_TOKEN/.test(jobEnv),
+    "SENTRY_TRIAGE_TOKEN is back in the triage job's env — every step, including the agent's Bash, inherits it",
+  );
+  // Stronger and still true: nothing in job env comes from `secrets.` at all.
+  assert.ok(
+    !/secrets\./.test(jobEnv),
+    `the triage job's env must reference no secret; found: ${jobEnv.trim()}`,
+  );
+  // The handle reaches the agent step through $GITHUB_ENV, minted per run.
+  assert.match(
+    job,
+    /SENTRY_MCP_BROKER_HANDLE=\$\{handle\}" >> "\$\{GITHUB_ENV\}"/,
+  );
+});
+
+test("the Sentry secret is scoped to the broker step alone", () => {
+  const job = triageJobBlock();
+  const uses = [...job.matchAll(/secrets\.SENTRY_TRIAGE_TOKEN/g)];
+  assert.equal(
+    uses.length,
+    1,
+    "the Sentry token must be read exactly once, by the broker step",
+  );
+  const brokerStep = job.slice(
+    job.indexOf("- name: Start the Sentry credential broker"),
+    job.indexOf("- name: Render triage prompt"),
+  );
+  assert.ok(brokerStep.length > 0, "the broker step was not found");
+  assert.match(
+    brokerStep,
+    /SENTRY_MCP_BROKER_TOKEN: \$\{\{ secrets\.SENTRY_TRIAGE_TOKEN \}\}/,
+  );
+  // $GITHUB_ENV would hand the token to every later step, including the
+  // agent's. Line-scoped, so the step's own declaration does not false-match.
+  for (const line of brokerStep.split("\n")) {
+    if (!line.includes("GITHUB_ENV")) continue;
+    assert.ok(
+      !/SENTRY_MCP_BROKER_TOKEN|SENTRY_TRIAGE_TOKEN/.test(line),
+      `the token must never be written to $GITHUB_ENV: ${line.trim()}`,
+    );
+  }
+});
+
+test("the broker runs the immutable staged copy, never the checkout", () => {
+  const job = triageJobBlock();
+  // Its runtime closure is itself — no relative imports to carry along.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "sentry-mcp-broker.mjs"),
+    "utf8",
+  );
+  assert.equal(
+    [...source.matchAll(/from\s+["'](\.\/[^"']+)["']/g)].length,
+    0,
+    "the broker grew a relative import; the staging step must carry it too",
+  );
+  const stagingBlock = job.slice(
+    job.indexOf("Stage immutable agent tools"),
+    job.indexOf("Start the Sentry credential broker"),
+  );
+  assert.ok(
+    stagingBlock.includes("sentry-mcp-broker.mjs"),
+    "the broker is not in the staging step's copy list",
+  );
+  assert.match(
+    job,
+    /node "\$\{RUNNER_TEMP\}\/sentry-triage-tools\/sentry-mcp-broker\.mjs"/,
+  );
+  assert.ok(
+    !/node scripts\//.test(job),
+    "the triage job must execute nothing from the agent-writable checkout",
+  );
+});
+
+test("the broker starts BEFORE the agent — the job must still end with the agent", () => {
+  const job = triageJobBlock();
+  assert.ok(
+    job.indexOf("- name: Start the Sentry credential broker") <
+      job.indexOf("anthropics/claude-code-action@"),
+    "the broker step must precede the agent",
+  );
+  const afterAgent = job.slice(job.indexOf("anthropics/claude-code-action@"));
+  assert.ok(
+    !/- name:|- uses:/.test(afterAgent),
+    "no step may follow the agent — its bash would source a $GITHUB_ENV-injected BASH_ENV payload",
+  );
+});
+
+test("the MCP config points at the loopback broker and carries only the handle", () => {
+  const job = triageJobBlock();
+  const mcpConfig = /--mcp-config '([^']+)'/.exec(job)?.[1];
+  assert.ok(mcpConfig, "--mcp-config was not found in the agent step");
+  const parsed = JSON.parse(mcpConfig);
+  const sentry = parsed.mcpServers.sentry;
+  assert.deepEqual(sentry.env, {
+    SENTRY_ACCESS_TOKEN: "${SENTRY_MCP_BROKER_HANDLE}",
+  });
+  // `--insecure-http` is CLI-only; there is no env var for it.
+  assert.ok(sentry.args.includes("--insecure-http"));
+  const hostIndex = sentry.args.indexOf("--host");
+  assert.ok(hostIndex >= 0, "--host must be passed in args");
+  assert.match(sentry.args[hostIndex + 1], /^127\.0\.0\.1:\d+$/);
+  // SENTRY_HOST cannot carry a scheme, so it is gone with the token.
+  assert.ok(!("SENTRY_HOST" in sentry.env));
+});

--- a/scripts/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry-mcp-broker.test.mjs
@@ -15,6 +15,7 @@
  */
 
 import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { connect } from "node:net";
 import { readFileSync } from "node:fs";
@@ -25,11 +26,14 @@ import { fileURLToPath } from "node:url";
 import {
   ALLOWED_PATHS,
   BIND_HOST,
+  assertTokenAbsentFromExecEnv,
   classify,
   handleMatches,
   isAllowedPath,
   isEntryPoint,
+  readTokenFromStdin,
   resolveConfig,
+  resolveRuntime,
   rewriteRegionLinks,
   startBroker,
 } from "./sentry-mcp-broker.mjs";
@@ -414,7 +418,14 @@ test("rewriteRegionLinks touches only links.regionUrl", () => {
 
 // ── fail closed: redirects and upstream failures ─────────────────────────────
 
-test("an upstream redirect is refused, never relayed", async () => {
+// NOTE ON THIS TEST'S FIDELITY: no test in this file passes `fetchImpl`, so the
+// broker runs on the real global `fetch` throughout — here against a real local
+// server returning a real 302. That matters: `redirect: "manual"` returning an
+// opaque `status: 0` would make the refusal inert, and a stubbed `fetchImpl`
+// would prove nothing about it. On this Node the response is `type: "basic"`
+// with `status: 302`, so the `>= 300 && < 400` check does fire, and this test
+// pins that rather than leaving it to inspection.
+test("an upstream redirect is refused, never relayed (real fetch, real 302)", async () => {
   await withBroker(
     (_req, res) => {
       res.writeHead(302, {
@@ -422,7 +433,14 @@ test("an upstream redirect is refused, never relayed", async () => {
       });
       res.end();
     },
-    async ({ base }) => {
+    async ({ base, upstream }) => {
+      // Pin the premise: real fetch, manual redirect, a non-opaque 3xx.
+      const direct = await fetch(`${upstream.origin}/api/0/organizations/`, {
+        redirect: "manual",
+      });
+      assert.equal(direct.status, 302, "the premise of the guard: a real 3xx");
+      assert.equal(direct.type, "basic", "not an opaque response");
+
       const res = await call(base, "/api/0/organizations/");
       assert.equal(res.status, 502);
       assert.equal(
@@ -477,19 +495,21 @@ test("an upstream error status is relayed, not masked", async () => {
 
 // ── configuration ────────────────────────────────────────────────────────────
 
-test("resolveConfig fails loudly on a missing or weak credential wiring", () => {
+test("resolveConfig fails loudly on a weak wiring, and takes NO token", () => {
   const base = {
-    SENTRY_MCP_BROKER_TOKEN: REAL_TOKEN,
     SENTRY_MCP_BROKER_HANDLE: HANDLE,
+    SENTRY_MCP_BROKER_PORT: "9401",
   };
-  assert.deepEqual(resolveConfig(base).upstream, "https://us.sentry.io");
+  assert.equal(resolveConfig(base).upstream, "https://us.sentry.io");
   assert.equal(resolveConfig(base).port, 9401);
   assert.equal(resolveConfig(base).ttlSeconds, 1800);
-
-  assert.throws(
-    () => resolveConfig({ ...base, SENTRY_MCP_BROKER_TOKEN: "  " }),
-    /SENTRY_MCP_BROKER_TOKEN is required/,
+  // The token has NO env channel at all — it can only arrive on stdin. An env
+  // channel is exactly what puts it in /proc/<pid>/environ.
+  assert.ok(
+    !("token" in resolveConfig(base)),
+    "resolveConfig must not surface a token read from the environment",
   );
+
   assert.throws(
     () => resolveConfig({ ...base, SENTRY_MCP_BROKER_HANDLE: "" }),
     /SENTRY_MCP_BROKER_HANDLE is required/,
@@ -513,6 +533,249 @@ test("resolveConfig fails loudly on a missing or weak credential wiring", () => 
   assert.throws(
     () => resolveConfig({ ...base, SENTRY_MCP_BROKER_TTL_SECONDS: "0" }),
     /must be a positive integer/,
+  );
+  // Required, not defaulted: a default is a second source of truth for a value
+  // the workflow already pins once, and they would disagree only on a live run.
+  const withoutPort = { ...base };
+  delete withoutPort.SENTRY_MCP_BROKER_PORT;
+  assert.throws(
+    () => resolveConfig(withoutPort),
+    /SENTRY_MCP_BROKER_PORT is required/,
+  );
+});
+
+// ── the token's delivery channel ─────────────────────────────────────────────
+
+test("readTokenFromStdin reassembles a chunked pipe and trims the writer's newline", async () => {
+  const { Readable } = await import("node:stream");
+  assert.equal(
+    await readTokenFromStdin(Readable.from([`${REAL_TOKEN}\n`])),
+    REAL_TOKEN,
+  );
+  assert.equal(
+    await readTokenFromStdin(
+      Readable.from([REAL_TOKEN.slice(0, 5), REAL_TOKEN.slice(5)]),
+    ),
+    REAL_TOKEN,
+  );
+});
+
+test("readTokenFromStdin fails closed on a TTY and on silence", async () => {
+  const { Readable } = await import("node:stream");
+  const tty = Readable.from([]);
+  tty.isTTY = true;
+  await assert.rejects(() => readTokenFromStdin(tty), /must be piped on stdin/);
+
+  const silent = new Readable({ read() {} }); // never ends
+  await assert.rejects(
+    () => readTokenFromStdin(silent, 40),
+    /no token arrived on stdin within 40ms/,
+  );
+});
+
+test("assertTokenAbsentFromExecEnv names the leaking variable, never the value", () => {
+  assert.equal(
+    assertTokenAbsentFromExecEnv(REAL_TOKEN, { PATH: "/usr/bin", CI: "true" }),
+    undefined,
+  );
+  for (const leaking of [
+    { SENTRY_TRIAGE_TOKEN: REAL_TOKEN },
+    { SENTRY_MCP_BROKER_TOKEN: REAL_TOKEN },
+    { SOME_URL: `https://x/?t=${REAL_TOKEN}&y=1` }, // embedded counts too
+  ]) {
+    const name = Object.keys(leaking)[0];
+    assert.throws(
+      () => assertTokenAbsentFromExecEnv(REAL_TOKEN, leaking),
+      (error) => {
+        assert.match(error.message, new RegExp(`as ${name};`));
+        assert.match(error.message, /\/proc\/<pid>\/environ/);
+        assert.match(error.message, /Do not scrub it at runtime/);
+        assert.ok(
+          !error.message.includes(REAL_TOKEN),
+          "the refusal must name the variable, never the value",
+        );
+        return true;
+      },
+    );
+  }
+});
+
+// ── the exec-time environment, observed from OUTSIDE the process ────────────
+//
+// The defect this closes: taking the token out of the AGENT's env did not take
+// it out of the agent's REACH. Every step runs as `runner`, the agent holds
+// `Read`, and `/proc/<pid>/environ` is same-UID readable — so the broker
+// inheriting the token from its step's `env:` left it one `Read` away.
+//
+// These tests run on macOS, which has no `/proc`. `ps -E` reads the same
+// exec-time environment block, and the positive control below proves it is the
+// same thing that matters: it still reports a variable the child DELETED at
+// runtime. That is the property, and it is why a runtime scrub is theatre.
+
+const BROKER_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "sentry-mcp-broker.mjs",
+);
+
+/** The exec-time environment of a live process, as an outsider sees it. */
+function execEnvironOf(pid) {
+  try {
+    return execFileSync("ps", ["-E", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** The command line of a live process — the `/proc/<pid>/cmdline` analogue. */
+function commandLineOf(pid) {
+  try {
+    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+const settle = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A concrete free port. `resolveConfig` rejects 0 on purpose — the agent step
+ * has to know the port up front, so "pick an ephemeral one" is never valid
+ * wiring — which means these subprocess tests need a real one.
+ */
+async function freePort() {
+  const probe = createServer();
+  await new Promise((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const { port } = probe.address();
+  await new Promise((resolve) => probe.close(resolve));
+  return port;
+}
+
+test("a RUNTIME scrub does not satisfy the guard — only an exec-time absence does", async () => {
+  const { Readable } = await import("node:stream");
+  const base = {
+    SENTRY_MCP_BROKER_HANDLE: HANDLE,
+    SENTRY_MCP_BROKER_PORT: "9401",
+  };
+  // The tempting wrong fix: the variable is gone from live process.env, but the
+  // exec-time block — what /proc/<pid>/environ serves — still has it.
+  const liveEnvHadItDeleted = { ...base };
+  const execTimeEnv = { ...base, SENTRY_TRIAGE_TOKEN: REAL_TOKEN };
+  assert.ok(!("SENTRY_TRIAGE_TOKEN" in liveEnvHadItDeleted));
+
+  await assert.rejects(
+    () =>
+      resolveRuntime({
+        envAtExec: execTimeEnv,
+        stdin: Readable.from([REAL_TOKEN]),
+      }),
+    /exec-time environment as SENTRY_TRIAGE_TOKEN/,
+    "scrubbing at runtime must not make the guard pass — /proc keeps the exec-time block",
+  );
+
+  // And the clean wiring resolves.
+  const config = await resolveRuntime({
+    envAtExec: base,
+    stdin: Readable.from([`${REAL_TOKEN}\n`]),
+  });
+  assert.equal(config.token, REAL_TOKEN);
+  assert.equal(config.port, 9401);
+});
+
+test("POSITIVE CONTROL: an outsider reads a child's exec-time env, and a runtime delete does NOT clear it", async () => {
+  const child = spawn(
+    process.execPath,
+    ["-e", "delete process.env.PROBE_TOKEN; setTimeout(() => {}, 4000);"],
+    { env: { ...process.env, PROBE_TOKEN: REAL_TOKEN }, stdio: "ignore" },
+  );
+  try {
+    await settle(500);
+    const seen = execEnvironOf(child.pid);
+    assert.ok(seen, "ps -E must work here, or the tests below prove nothing");
+    assert.ok(
+      seen.includes(REAL_TOKEN),
+      "the observation method must detect a token in a child's exec-time env",
+    );
+  } finally {
+    child.kill("SIGKILL");
+  }
+});
+
+test("the broker, spawned the way the workflow spawns it, has NO token in its exec-time env", async () => {
+  // The workflow's shape, reduced to its load-bearing parts: the token starts
+  // in the step's environment, is copied to a shell-local, the exported name is
+  // unset, and only then is node exec'd — with the value on stdin.
+  const port = await freePort();
+  const script = `
+    set -euo pipefail
+    token="\${SENTRY_TRIAGE_TOKEN:-}"
+    unset SENTRY_TRIAGE_TOKEN
+    printf '%s' "\${token}" | \
+      SENTRY_MCP_BROKER_HANDLE="${HANDLE}" \
+      SENTRY_MCP_BROKER_PORT=${port} \
+      SENTRY_MCP_BROKER_TTL_SECONDS=30 \
+      node "${BROKER_PATH}" > /dev/null 2>&1 &
+    echo $!
+  `;
+  const pid = execFileSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: { ...process.env, SENTRY_TRIAGE_TOKEN: REAL_TOKEN },
+  }).trim();
+  try {
+    await settle(700);
+    const environ = execEnvironOf(pid);
+    assert.ok(environ, `the broker (pid ${pid}) must still be running`);
+    assert.ok(
+      !environ.includes(REAL_TOKEN),
+      "the token is in the broker's exec-time environment — /proc/<pid>/environ would hand it to the agent",
+    );
+    assert.ok(
+      environ.includes("SENTRY_MCP_BROKER_HANDLE"),
+      "sanity: the handle IS exported, so an absent token is a real result and not an empty read",
+    );
+    // /proc/<pid>/cmdline is readable the same way; the token is never an argv.
+    assert.ok(
+      !commandLineOf(pid).includes(REAL_TOKEN),
+      "the token must never appear on the broker's command line",
+    );
+  } finally {
+    try {
+      process.kill(Number(pid), "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+});
+
+test("the broker REFUSES to start when the token is in its exec-time env", async () => {
+  // The pre-fix wiring, and the regression tripwire: inheriting the token must
+  // be a startup failure, not a silent leak.
+  const child = spawn(process.execPath, [BROKER_PATH], {
+    env: {
+      ...process.env,
+      SENTRY_TRIAGE_TOKEN: REAL_TOKEN, // the leak
+      SENTRY_MCP_BROKER_HANDLE: HANDLE,
+      SENTRY_MCP_BROKER_PORT: String(await freePort()),
+      SENTRY_MCP_BROKER_TTL_SECONDS: "30",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdin.end(REAL_TOKEN);
+  let stderr = "";
+  child.stderr.on("data", (chunk) => (stderr += chunk));
+  const code = await new Promise((resolve) => child.on("exit", resolve));
+
+  assert.equal(code, 1, "an inherited token must be a non-zero exit");
+  assert.match(stderr, /exec-time environment as SENTRY_TRIAGE_TOKEN/);
+  assert.match(stderr, /Do not scrub it at runtime/);
+  assert.ok(
+    !stderr.includes(REAL_TOKEN),
+    "the refusal must not print the credential it is complaining about",
   );
 });
 
@@ -610,7 +873,7 @@ test("the Sentry secret is scoped to the broker step alone", () => {
   assert.ok(brokerStep.length > 0, "the broker step was not found");
   assert.match(
     brokerStep,
-    /SENTRY_MCP_BROKER_TOKEN: \$\{\{ secrets\.SENTRY_TRIAGE_TOKEN \}\}/,
+    /SENTRY_TRIAGE_TOKEN: \$\{\{ secrets\.SENTRY_TRIAGE_TOKEN \}\}/,
   );
   // $GITHUB_ENV would hand the token to every later step, including the
   // agent's. Line-scoped, so the step's own declaration does not false-match.
@@ -621,6 +884,85 @@ test("the Sentry secret is scoped to the broker step alone", () => {
       `the token must never be written to $GITHUB_ENV: ${line.trim()}`,
     );
   }
+});
+
+test("the broker step drops the exported token BEFORE node is exec'd", () => {
+  const job = triageJobBlock();
+  const brokerStep = job.slice(
+    job.indexOf("- name: Start the Sentry credential broker"),
+    job.indexOf("- name: Render triage prompt"),
+  );
+  const unsetAt = brokerStep.indexOf("unset SENTRY_TRIAGE_TOKEN");
+  const nodeAt = brokerStep.indexOf('node "${RUNNER_TEMP}');
+  assert.ok(unsetAt > 0, "the broker step must unset the exported token");
+  assert.ok(nodeAt > 0, "the broker step must spawn node");
+  assert.ok(
+    unsetAt < nodeAt,
+    "the unset must precede the spawn — /proc/<pid>/environ is fixed at exec, so unsetting after is inert",
+  );
+
+  // Delivered on stdin from a bash BUILTIN: no env var, no argv, no temp file.
+  assert.match(brokerStep, /printf '%s' "\$\{token\}" \| \\/);
+  // A here-string or heredoc may materialise a temp file the agent can read.
+  assert.ok(
+    !/<<</.test(brokerStep) && !/<<\s*['"]?\w+/.test(brokerStep),
+    "the token must not be delivered through a here-string or heredoc",
+  );
+  // And the token must never be a node argument.
+  const nodeLine = brokerStep.slice(nodeAt, brokerStep.indexOf("\n", nodeAt));
+  assert.ok(
+    !/token/.test(nodeLine),
+    `the token must not appear on node's command line: ${nodeLine.trim()}`,
+  );
+});
+
+test("no step in this workflow interpolates a secret INTO a run: body", () => {
+  // GitHub expands ${{ }} before writing the step script to $RUNNER_TEMP, so an
+  // inline secret is plaintext on disk for the life of the job — same
+  // same-UID-readable class as /proc. `env:` bindings are the safe channel:
+  // the script holds only the variable name.
+  for (const [, body] of WORKFLOW.matchAll(
+    /\n {8}run: \|\n([\s\S]*?)(?=\n {6}- |\n {2}\w+:|$)/g,
+  )) {
+    const inline = [...body.matchAll(/\$\{\{\s*([^}]+?)\s*\}\}/g)].map(
+      (m) => m[1],
+    );
+    for (const expression of inline) {
+      assert.ok(
+        !/(^|\W)secrets\./.test(expression),
+        `a secret is interpolated into a run: body (plaintext on disk): ${expression}`,
+      );
+    }
+  }
+});
+
+test("the broker port has ONE literal, shared by the broker and the agent step", () => {
+  const job = triageJobBlock();
+  const jobEnv = job.slice(
+    job.indexOf("\n    env:"),
+    job.indexOf("\n    steps:"),
+  );
+  const declared = /SENTRY_MCP_BROKER_PORT: "(\d+)"/.exec(jobEnv)?.[1];
+  assert.ok(
+    declared,
+    "the triage job must pin the broker port once, in job env",
+  );
+
+  // The agent step must interpolate that same value, not restate it.
+  const mcpConfig = /--mcp-config '([^']+)'/.exec(job)?.[1];
+  assert.ok(
+    mcpConfig.includes("127.0.0.1:${{ env.SENTRY_MCP_BROKER_PORT }}"),
+    "--mcp-config must interpolate the job-level port, not hardcode one",
+  );
+
+  // And no second literal anywhere in the job.
+  const steps = job.slice(job.indexOf("\n    steps:"));
+  const strays = [...steps.matchAll(new RegExp(`\\b${declared}\\b`, "g"))];
+  assert.equal(
+    strays.length,
+    0,
+    `the port literal ${declared} is restated inside the job's steps; it must come from job env`,
+  );
 });
 
 test("the broker runs the immutable staged copy, never the checkout", () => {
@@ -680,7 +1022,11 @@ test("the MCP config points at the loopback broker and carries only the handle",
   assert.ok(sentry.args.includes("--insecure-http"));
   const hostIndex = sentry.args.indexOf("--host");
   assert.ok(hostIndex >= 0, "--host must be passed in args");
-  assert.match(sentry.args[hostIndex + 1], /^127\.0\.0\.1:\d+$/);
+  // The port comes from job env, not a second literal — see the drift test.
+  assert.equal(
+    sentry.args[hostIndex + 1],
+    "127.0.0.1:${{ env.SENTRY_MCP_BROKER_PORT }}",
+  );
   // SENTRY_HOST cannot carry a scheme, so it is gone with the token.
   assert.ok(!("SENTRY_HOST" in sentry.env));
 });

--- a/scripts/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry-mcp-broker.test.mjs
@@ -19,6 +19,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { connect } from "node:net";
 import { readFileSync } from "node:fs";
+import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -607,38 +608,75 @@ test("assertTokenAbsentFromExecEnv names the leaking variable, never the value",
 // `Read`, and `/proc/<pid>/environ` is same-UID readable — so the broker
 // inheriting the token from its step's `env:` left it one `Read` away.
 //
-// These tests run on macOS, which has no `/proc`. `ps -E` reads the same
-// exec-time environment block, and the positive control below proves it is the
-// same thing that matters: it still reports a variable the child DELETED at
-// runtime. That is the property, and it is why a runtime scrub is theatre.
+// READ THIS BEFORE TOUCHING THE PLATFORM SPLIT BELOW. An earlier revision used
+// `ps -E -p <pid>` on every platform. That is BSD/macOS syntax: procps rejects
+// `-E` as an "unsupported SysV option" — its `parse_sysv_option` has no
+// `case 'E'` and falls to that default, while only the bare BSD `e` sets the
+// environment flag. So on the Ubuntu runner the call errored, the reader
+// returned null, and the tests that establish this entire credential boundary
+// could not pass on the one platform we ship to. The defect was A VERIFICATION
+// THAT COULD NOT RUN, not a product bug: the strongest-looking evidence in the
+// change was inert exactly where it mattered. Keep this split, and keep it
+// explicit.
+//
+// On Linux we read `/proc/<pid>/environ` directly. That is not an analogue of
+// the threat — it IS the file a prompt-injected agent would open with `Read`.
+// `ps -E` stays as the macOS fallback so the suite still means something
+// locally. NEITHER READER MAY FAIL SOFT: a silent empty read would make every
+// negative result below meaningless, which is the same class of mistake as the
+// one above, so a failed read throws and turns the suite red rather than
+// skipping. The positive control proves whichever reader is in play actually
+// detects a leak, and that it still reports a variable the child DELETED at
+// runtime — which is why a runtime scrub is theatre.
 
 const BROKER_PATH = join(
   dirname(fileURLToPath(import.meta.url)),
   "sentry-mcp-broker.mjs",
 );
 
-/** The exec-time environment of a live process, as an outsider sees it. */
-function execEnvironOf(pid) {
-  try {
-    return execFileSync("ps", ["-E", "-p", String(pid)], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return null;
-  }
+const ON_LINUX = platform() === "linux";
+
+/** How the exec-time environment is being read, named in failure messages. */
+const READER = ON_LINUX ? "/proc/<pid>/environ" : "ps -E -p <pid>";
+
+/**
+ * Decodes a `/proc/<pid>/environ` block: NUL-separated `KEY=VALUE` entries with
+ * a trailing NUL. Split out so the Linux branch's decoding is covered by a test
+ * even when the suite runs on a host without `/proc` — the file read itself
+ * cannot be, and that gap is stated in the PR rather than papered over.
+ */
+function decodeProcBlock(buffer) {
+  return buffer.toString("utf8").split("\0").join("\n");
 }
 
-/** The command line of a live process — the `/proc/<pid>/cmdline` analogue. */
-function commandLineOf(pid) {
-  try {
-    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return null;
+/**
+ * The exec-time environment of a live process, as an outsider sees it.
+ * Throws on any failure — it must never return a falsy "nothing found".
+ */
+function execEnvironOf(pid) {
+  if (ON_LINUX) {
+    // A dead pid or an EACCES throws out of readFileSync, which is the point:
+    // a failed read must never read as "no token here".
+    return decodeProcBlock(readFileSync(`/proc/${pid}/environ`));
   }
+  return execFileSync("ps", ["-E", "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** The command line of a live process — `/proc/<pid>/cmdline` on Linux. */
+function commandLineOf(pid) {
+  if (ON_LINUX) {
+    return readFileSync(`/proc/${pid}/cmdline`)
+      .toString("utf8")
+      .split("\0")
+      .join(" ");
+  }
+  return execFileSync("ps", ["-o", "command=", "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 const settle = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -687,6 +725,26 @@ test("a RUNTIME scrub does not satisfy the guard — only an exec-time absence d
   assert.equal(config.port, 9401);
 });
 
+test("the Linux reader decodes a real /proc/<pid>/environ block", () => {
+  // Runs on every platform: the decoding half of the Linux branch, which the
+  // macOS host cannot exercise through an actual file read.
+  const block = Buffer.from(
+    `PATH=/usr/bin\0SENTRY_MCP_BROKER_HANDLE=${HANDLE}\0SENTRY_TRIAGE_TOKEN=${REAL_TOKEN}\0`,
+    "utf8",
+  );
+  const decoded = decodeProcBlock(block);
+  assert.ok(decoded.includes(`SENTRY_TRIAGE_TOKEN=${REAL_TOKEN}`));
+  assert.ok(decoded.includes("SENTRY_MCP_BROKER_HANDLE"));
+  // Entries must not run together, or a leak could hide across a boundary.
+  assert.deepEqual(decoded.split("\n").slice(0, 2), [
+    "PATH=/usr/bin",
+    `SENTRY_MCP_BROKER_HANDLE=${HANDLE}`,
+  ]);
+  // An empty block decodes to something falsy-ish, which is exactly why the
+  // reader throws on failure instead of returning a block it never read.
+  assert.equal(decodeProcBlock(Buffer.alloc(0)), "");
+});
+
 test("POSITIVE CONTROL: an outsider reads a child's exec-time env, and a runtime delete does NOT clear it", async () => {
   const child = spawn(
     process.execPath,
@@ -695,11 +753,17 @@ test("POSITIVE CONTROL: an outsider reads a child's exec-time env, and a runtime
   );
   try {
     await settle(500);
+    // No try/catch: a reader that cannot run must fail this test, because every
+    // negative result below is only worth what this positive result is worth.
     const seen = execEnvironOf(child.pid);
-    assert.ok(seen, "ps -E must work here, or the tests below prove nothing");
     assert.ok(
       seen.includes(REAL_TOKEN),
-      "the observation method must detect a token in a child's exec-time env",
+      `${READER} did not detect a token in a child's exec-time env; every assertion below is vacuous until it does`,
+    );
+    // Belt: prove the reader returns a populated block, not a lucky substring.
+    assert.ok(
+      seen.includes("PROBE_TOKEN"),
+      `${READER} returned a block without the variable name — the reader is not reading what it claims`,
     );
   } finally {
     child.kill("SIGKILL");
@@ -728,15 +792,17 @@ test("the broker, spawned the way the workflow spawns it, has NO token in its ex
   }).trim();
   try {
     await settle(700);
+    // Throws if the broker died or the read failed — never a soft null.
     const environ = execEnvironOf(pid);
-    assert.ok(environ, `the broker (pid ${pid}) must still be running`);
     assert.ok(
       !environ.includes(REAL_TOKEN),
-      "the token is in the broker's exec-time environment — /proc/<pid>/environ would hand it to the agent",
+      `the token is in the broker's exec-time environment (read via ${READER}) — the agent could take it straight out of /proc`,
     );
+    // The load-bearing sanity check on BOTH reader paths: without it, a reader
+    // that returned an empty-but-successful block would pass the line above.
     assert.ok(
       environ.includes("SENTRY_MCP_BROKER_HANDLE"),
-      "sanity: the handle IS exported, so an absent token is a real result and not an empty read",
+      `${READER} returned a block without the handle, so the absent token is not a real result`,
     );
     // /proc/<pid>/cmdline is readable the same way; the token is never an argv.
     assert.ok(

--- a/scripts/sentry-triage-agent-comment.mjs
+++ b/scripts/sentry-triage-agent-comment.mjs
@@ -59,10 +59,14 @@
  * script receives argv, so `--body "…${SENTRY_TRIAGE_TOKEN:0:4}x${SENTRY_TRIAGE_TOKEN:4}"`
  * — or any substring split or substitution — arrives as a value this scan
  * cannot match. Exact-value scanning is structurally the wrong layer when the
- * adversary controls the shell. The real residual is recorded in the workflow's
- * containment banner and in docs/notes/sentry-triage-pipeline.md; closing it
- * means removing the credential from the agent's process env, which no check
- * inside this script can do.
+ * adversary controls the shell. That is why the Sentry token no longer reaches
+ * this process at all: issue #1711 put it behind a loopback credential broker
+ * (scripts/sentry-mcp-broker.mjs) and left the agent an opaque per-run handle.
+ * `SENTRY_TRIAGE_TOKEN` stays in SECRET_ENV_VARS below as a regression
+ * tripwire — it should now be unset here, so a body that could match it would
+ * mean the workflow put the token back. The credentials that ARE still live,
+ * and their bounding, are in the workflow's containment banner and in
+ * docs/notes/sentry-triage-pipeline.md.
  *
  * THE BODY NEVER TOUCHES THE FILESYSTEM. It goes to `gh --body-file -` on the
  * child's stdin. An earlier version validated the body, wrote it to a
@@ -100,7 +104,8 @@ export const ISSUE_ENV_VAR = "SENTRY_TRIAGE_COMMENT_ISSUE";
  * refusing. Covers this workflow's own secrets plus the tokens
  * claude-code-action puts in the CLI subprocess env (which the agent's Bash
  * therefore inherits). Hygiene only — a deliberately transformed value passes
- * (see the header). */
+ * (see the header). `SENTRY_TRIAGE_TOKEN` should be unset here since #1711; it
+ * is kept as a tripwire for the workflow putting it back in job env. */
 export const SECRET_ENV_VARS = [
   "SENTRY_TRIAGE_TOKEN",
   "GH_TOKEN",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The triage agent's process env held `SENTRY_TRIAGE_TOKEN`, because the Sentry MCP server read it via `${SENTRY_TRIAGE_TOKEN}` expansion in `--mcp-config`, which forces job-level env.
- The agent authors its own shell commands, so **bash expands and transforms `$VAR` before any wrapper sees argv**. The existing token-value refusal in `sentry-triage-agent-comment.mjs` is hygiene against an accident, not a leak control — `${SENTRY_TRIAGE_TOKEN:0:4}x${SENTRY_TRIAGE_TOKEN:4}` posts the whole token with one removable character spliced in.
- No check inside the wrapper can close that. Only removing the credential can — **and removing it from the agent's own env is not enough.** Every Actions step runs as `runner` and the agent holds `Read`, so `/proc/<pid>/environ` of every process in the job is agent-readable. An earlier revision of this PR let the broker inherit the token from its step's `env:`, which left it one `Read` away while claiming it was gone.

## The Solution

A trusted step starts a loopback broker holding the real token and mints an opaque per-run handle. The MCP server is pointed at `127.0.0.1` with the handle, so the agent's Bash inherits no Sentry credential — and the token is not readable from any other process in the job either.

The upstream fix — per-step or first-class MCP env forwarding in `claude-code-action` — does not exist at the pinned v1.0.179, and upstream's only release tag is `v1` (Aug 2025), so there is no newer version to adopt. Re-verified rather than assumed.

## Details

### Keeping the token off every same-UID-readable surface

`/proc/<pid>/environ` is the environment captured at **`exec`**. Deleting the variable inside the broker would not clear it — any scrub after start is theatre. So the variable must be absent when the process is exec'd:

- The trusted step copies the secret to a shell-local, **`unset`s the exported name**, and only then spawns node, handing the token over on **stdin** written by `printf` — a bash **builtin**. That covers all three surfaces: no env var, no argv (a builtin in a pipeline runs in a forked subshell that never execs, so its `cmdline` stays the parent shell's), and no temp file (a pipeline uses an anonymous pipe, unlike `<<<` or `<<`, where bash may materialise one).
- The broker takes the token **only** from stdin — `resolveConfig` has no token field at all — and **refuses to start** if it finds the token in its own exec-time environment, checked against a snapshot taken at module load. A workflow regression becomes a loud startup failure, not a silent leak.
- The trusted step's own shell still holds the token. That is safe only because each `run:` step is its own process and the runner gates the next step on this one's exit code, so it is gone before the agent starts. The broker deliberately outlives its step, which is exactly why its environment is the one that had to be cleaned.
- The secret reaches the step through an `env:` binding and **never** through `${{ secrets.* }}` inside `run:`. That is deliberate: GitHub expands `${{ }}` *before* writing the step script to `$RUNNER_TEMP`, so an inline secret would sit in plaintext on disk for the whole job.

### The broker

- **`scripts/sentry-mcp-broker.mjs`** (new, no dependencies) binds `127.0.0.1` only, checks `Authorization: Bearer <handle>` with `timingSafeEqual` **before** looking at method or path (an unauthenticated caller learns nothing about the policy), substitutes the real token, and forwards to `https://us.sentry.io`. Refuses non-GET (405), off-allowlist paths (403), bad handle (401), and **upstream redirects (502)** — relaying a `Location` would let the MCP client follow it carrying the handle.
- **The allowlist was derived empirically, not guessed**: the real MCP server was driven over stdio against a capture server, across `get_sentry_resource`'s whole `resourceType` enum and every `search_events` dataset. Path segments are `[A-Za-z0-9._-]+`, so `%`-escaped traversal cannot match, and the pathname used for the allowlist check is the same normalized value used to build the upstream URL — no validate-here-forward-there gap.
- **Five of the ten names in `--allowedTools` do not exist at 0.37.0** (`get_issue_details`, `get_event_stacktrace`, `get_issue_tag_values`, `get_issue_activity`, `search_issue_events`). The real set is 9 tools. The inert grants are left in place and documented rather than silently trimmed — a version bump may restore them.
- **The port has one literal**: the triage job's `env: SENTRY_MCP_BROKER_PORT`. The broker *requires* it rather than defaulting, and the agent step's `--mcp-config` interpolates it, so the three former copies cannot drift into a connection refused that only a live run would surface.
- **`--insecure-http` is CLI-only** (no env var), `SENTRY_URL` must be HTTPS and cannot combine with it, and `SENTRY_HOST` takes a bare hostname — so the loopback wiring lives in the MCP server's `args`, and `SENTRY_HOST` is gone with the token.
- **ADR 0056** records the decision, the rejected alternatives (including the runtime-scrub wrong fix and the temp-file variant), and every residual.

**A design change the plan did not anticipate.** The broker must rewrite `links.regionUrl`, or an *honest* agent breaks triage. Sentry's org payload carries `https://us.sentry.io` there; served that upstream-shaped payload, a `trace` read made exactly one request to the broker and sent everything after it to `http://us.sentry.io/...`, because the MCP server follows that link internally and `find_organizations` output tells the agent to reuse it. So the rewrite is a correctness fix, not hardening. `links.organizationUrl` is left alone so verdict comments keep real Sentry permalinks.

**Two places where an existing repo invariant beat the original plan:**

- **No `if: always()` stop step.** `sentry-triage-agent-comment.test.mjs` enforces that the agent is the **last** step of its job — the agent can append `BASH_ENV=<payload it wrote>` to `$GITHUB_ENV`, and any later step's bash sources it first, escaping the permission allowlist with `GH_TOKEN` in hand. The stronger invariant wins; the broker bounds its own life with a TTL matching the job timeout, on an ephemeral runner.
- **The broker runs the immutable staged copy, not `scripts/`.** The same test bans `node scripts/` anywhere in the triage job. Rather than weaken it with an ordering caveat, `sentry-mcp-broker.mjs` joins the staging list, and a new test asserts its import closure is still just itself so a future relative import cannot silently escape staging.

## Validation

- **The exec-time property, observed from outside the process — on the platform that matters.** On Linux the reader opens `/proc/<pid>/environ` and `/proc/<pid>/cmdline` directly: not analogues of the threat, but the exact files a prompt-injected agent would open with `Read`. `ps -E` is the macOS fallback so the suite still means something locally. A **positive control** proves whichever reader is in play actually detects a leak *and* that a runtime delete is theatre: a child that calls `delete process.env.X` is still reported with `X` set. Neither reader may fail soft — a dead pid or a permissions error throws and turns the suite red rather than reading as "no token here". Against that control, the broker spawned exactly as the workflow spawns it shows **no token in its exec-time environment and none on its command line**, with the handle asserted present on both paths so the absence is a real read rather than an empty one.
- **The Done-means, measured.** The shipped staging and broker step scripts were extracted from the workflow (not retyped) and replayed under Actions env semantics with a sentinel token. The agent step's environment is `GH_TOKEN`, `SENTRY_TRIAGE_COMMENT_ISSUE`, `SENTRY_MCP_BROKER_PORT`, `SENTRY_MCP_BROKER_HANDLE` — the token value appears **nowhere** in it, nowhere in the raw `$GITHUB_ENV` file, and nowhere in the live broker's environment or command line.
- **The wrong fix fails.** A dedicated test asserts that scrubbing at runtime does **not** satisfy the guard, and the broker exits 1 naming the offending variable (never the value) when the token is in its exec-time env.
- **End to end through the real MCP server** (9 requests across `find_organizations`, `find_projects`, `get_sentry_resource(issue)`, `search_issues`): every upstream request carried the real token, **no** upstream request carried the handle.
- **Mutation: 19 of 19 killed** — including the two wrong fixes (guard reading live `process.env`; scrubbing before snapshotting), the guard removed, an exact-match guard that misses an embedded token, the token accepted from env again, the port silently defaulted, the stdin TTY guard dropped, plus the twelve from the first round (handle/method/allowlist/charset/bind/rewrite/redirect/token-forwarding/config checks).
- **The redirect refusal is pinned against real Node semantics, not a stub.** No test passes `fetchImpl`, so the broker runs on the global `fetch` throughout; the redirect test now also asserts the premise (`status: 302`, `type: "basic"`) so an opaque-response regression would fail rather than pass silently.
- `actionlint` clean · `node --test` **75 pass / 0 fail** · `trunk fmt`/`check` clean · `pnpm agent:quality-gate --run --parallel 4` → **exit 0**.
- The quality gate previously ran **neither** sentry test when only `sentry-triage-agent.yml` changed, despite both asserting on it. Fixed here.

### Reachability inventory (checked, negative)

Audited what an agent with `Read` on this runner can actually reach, rather than assumed:

- **Inline secrets in `run:` bodies — zero hits across all 31 workflows** (including `sentry-autofix.yml`). The only three inline expressions anywhere are `github.base_ref`, `matrix.id` and `github.sha`. Every secret reaches its step through `env:`. A test now keeps this workflow that way.
- **`$GITHUB_ENV`** — the triage job's single write is the broker handle. **`$GITHUB_OUTPUT`** — the single write is the rendered prompt (public content).
- **The staged tools directory** is agent-*readable* by design (0444/0555 buy un-writability, not secrecy) and holds only files already public in this repo; `target.json` holds a repo name and a public issue number.
- **The broker's log** is method, path, status and refusal reason only — it is under `$RUNNER_TEMP` and agent-readable, which is why it never logs the token or the handle.

**Not verified.** Two gaps, both stated rather than papered over. (1) The Linux branch of the exec-time reader is not exercised here — no container runtime is available on this host, so `/proc` cannot be opened locally. Its *decoding* has its own test that runs on every platform, and the `ps -E` defect it replaces was confirmed from procps `parser.c` (no `case 'E'` in `parse_sysv_option`; it falls to `default: return _("unsupported SysV option")`), not from memory. First CI run on Linux settles the rest. (2) **A real Actions run**, which cannot happen from a branch: The `sentry-pipeline` environment is main-only, so this needs a `workflow_dispatch` on `main` after merge — worth doing as the first post-merge dry run, since it is also the only way to confirm the derived allowlist covers a production triage end to end.

## Deferrals

- **#1718** — `regionUrl` steering. Three granted tools accept an agent-controlled `regionUrl`; `validateRegionUrl` allowlists `{sentry.io, us.sentry.io, de.sentry.io}`, keeps only the host, and the client re-applies its own protocol, so the agent can bypass the broker entirely. Reproduced in this PR's e2e run: zero broker requests, real `us.sentry.io` reached, handle rejected. Survivable only because what leaks is the handle, not the token — which is why the handle is per-run and loopback-bound.

**Accepted residuals** (recorded in ADR 0056's Consequences rather than as tracked items, because nothing is actionable until upstream changes or a real run reports):

- **#1720** — heap residency, **unverified and deliberately not claimed safe**. The token now lives in the broker's heap. Reading `/proc/<pid>/mem` needs `PTRACE_MODE_ATTACH`, which Yama's `ptrace_scope=1` denies to a non-descendant same-user process — but the GitHub runner's setting is not established and this PR does not assert it. The broker step logs `/proc/sys/kernel/yama/ptrace_scope`, so the **first real run settles it** with no extra work; #1720 records the value and the mitigations to weigh if it reports `0`.
**Accepted, not deferred** — recorded in ADR 0056's Consequences rather than tracked, because nothing is actionable until upstream changes: `CLAUDE_CODE_OAUTH_TOKEN` stays in the agent's env. `claude-code-action` puts it there and no available mechanism removes it. #1711's original "no credential useful outside the run" wording overreached what any proposed solution delivers — the issue's Done-means has been corrected to the Sentry token so this closure is honest. Bounded: inference-only, so the worst case is quota abuse, not repo or queue compromise.

Closes #1711

