### PR TITLE
refactor(sentry): give re-queueing one owner that decides the fence

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -57,6 +57,15 @@ invocations. The scripts own parsing, idempotency, and state transitions. The
 ADRs own the trust boundaries and rationale. Update those sources and this
 runbook together when a contract changes.
 
+Two shared modules sit under the stages above.
+`scripts/sentry-triage-project-core.mjs` owns the VERDICT contract — markers,
+parsing, and the two comment selectors every fence is asked through.
+`scripts/sentry-triage-queue-contract.mjs` owns the QUEUE contract — the label
+namespace, the untrusted-text neutralization, and the archive freshness-baseline
+fields. `scripts/sentry-triage-requeue.mjs` is the one place a queue stub is ever
+re-queued for triage; both producers call it and neither reconstructs the
+sequence.
+
 The triage row states an operator requirement, now backed by a mechanical
 guarantee. Every secret-bearing job in these workflows declares the
 `sentry-pipeline` GitHub Environment, whose deployment-branch policy names `main`
@@ -137,11 +146,17 @@ bulk:
   no parseable baseline;
 - other closed match: leave it closed.
 
-That write order is load-bearing at both ends. The fence goes first so no
+That write order is load-bearing at both ends, and no stage writes it by hand.
+Every re-queue in the pipeline runs through one function,
+`requeueQueueStub` in `scripts/sentry-triage-requeue.mjs`, which takes the CAUSE
+as an argument and decides the fence from it. The fence goes first so no
 interruption can leave a stub re-queued for triage without it; the state change
 goes last so none can leave it open but unselectable. Every interruption point
-then lands on a state that is inert or recoverable. The fence post is guarded by
-an exact-body check, so a retry completes the sequence without duplicating it.
+then lands on a state that is inert or recoverable. On this path the fence post
+is additionally guarded by an author-fenced identity check, so a retry completes
+the sequence without duplicating it — a guard the caller declares, and one that
+disarms itself whenever `lastSeen` does not parse, because the rendered body
+then identifies no particular occurrence.
 
 Missing or invalid timestamps fail toward re-triage. The strict timestamp gate
 prevents Sentry's long-lived regressed substatus from causing a reopen/close
@@ -166,6 +181,13 @@ Sentry loop runs, so by the time the sweep reaches a given stub the snapshot can
 be minutes old — long enough for a human to have declined it by removing the
 label, which the sweep would otherwise put straight back. A failed re-read
 leaves the stub stranded for the next run rather than recovering blind.
+
+The sweep also skips any stub the regression path ATTEMPTED this run, not merely
+the ones it re-queued. A Sentry-evidence re-queue that throws half-way would
+otherwise be recovered by the fence-free bookkeeping path seconds later, inside
+one run — a failed regression re-queue laundered into a bookkeeping one. The
+chokepoint records the attempt before its first write, so the record exists
+whether or not the writes do.
 
 The namespace is separate from the development backlog:
 
@@ -373,14 +395,19 @@ refuses a currently regressed/escalating issue, and uses the documented issue
 update API to set `archived_until_escalating`. It then records the approver
 and timestamp, applies `sentry:archived`, and closes the queue issue.
 
-The regression refusal re-queues the stub, and its comment opens with the
-regression fence line so the verdict parser reads the previous round's verdict
-as stale. That is the general rule for every re-queue: one caused by new Sentry
-events must fence, because any prior verdict described the old occurrence; one
-caused by bookkeeping — the stranded-stub sweep above — must not, because
+The regression refusal re-queues the stub through `requeueQueueStub`, declaring
+cause `sentry-evidence`; that is what makes its comment open with the regression
+fence line, so the verdict parser reads the previous round's verdict as stale.
+The cause is the whole rule: one caused by new Sentry events must fence, because
+any prior verdict described the old occurrence; one caused by bookkeeping — the
+stranded-stub sweep above, which declares `bookkeeping` — must not, because
 nothing about the Sentry issue changed and that verdict is still valid. Drop the
 fence and a triage round that dies before posting lets the `verdict` job
-re-apply the previous verdict and close the stub over a live regression.
+re-apply the previous verdict and close the stub over a live regression. Add one
+where it does not belong and a good verdict is discarded and re-triaged for
+nothing. Neither call site can make that mistake by omission: an undeclared
+cause refuses rather than defaulting either way, and `buildRegressedComment` —
+the fence's one definition — has exactly one caller, inside the chokepoint.
 
 The refusal will not re-queue a stub it cannot fence, and it decides that by
 asking whether any verdict is still admissible — never by checking that a fence
@@ -388,7 +415,8 @@ comment exists. Presence is not admissibility: the refusal body is identical
 across runs for one `lastSeen`, so an earlier run's fence can sit on the stub
 underneath a verdict posted after it, where the parser correctly ignores it. Both
 checks on this path run `selectVerdictComment`, the parser's own selector, so the
-guard and the thing it guards against cannot drift apart.
+guard and the thing it guards against cannot drift apart. Both now live in the
+chokepoint, so a future re-queue site inherits them instead of re-deriving them.
 
 If approval disappears during the mutation window, the script rolls the queue
 stub back and leaves it available for fresh triage. It does NOT un-archive the
@@ -791,6 +819,7 @@ pnpm sentry:project:test
 pnpm sentry:autofix:select:test
 pnpm sentry:autofix:finalize:test
 pnpm sentry:archive:test
+pnpm sentry:requeue:test
 
 # Read-only previews that require local credentials:
 pnpm sentry:ingest --dry-run --lookback-days 8

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "sentry:autofix:finalize:test": "node scripts/sentry-autofix-finalize.test.mjs",
     "sentry:archive": "node scripts/sentry-triage-archive.mjs",
     "sentry:archive:test": "node scripts/sentry-triage-archive.test.mjs",
+    "sentry:requeue:test": "node scripts/sentry-triage-requeue.test.mjs",
     "pr:feedback-state": "node scripts/pr-feedback-state.mjs",
     "pr:feedback-state:test": "node scripts/pr-feedback-state.test.mjs",
     "pr:ready-state": "node scripts/pr-ready-state.mjs",

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2282,6 +2282,14 @@ while IFS= read -r path; do
         scripts/sentry-triage-archive.mjs|scripts/sentry-triage-archive.test.mjs)
           add_command "pnpm sentry:archive:test" "Sentry triage archive helper changed"
           ;;
+        scripts/sentry-triage-requeue.mjs|scripts/sentry-triage-requeue.test.mjs|scripts/sentry-triage-queue-contract.mjs)
+          # The single re-queue chokepoint and the queue contract it reads. Both
+          # sites that re-queue a stub run through it, so its suite is never the
+          # whole story — run theirs too.
+          add_command "pnpm sentry:requeue:test" "Sentry re-queue chokepoint changed"
+          add_command "pnpm sentry:ingest:test" "Sentry re-queue chokepoint changed"
+          add_command "pnpm sentry:archive:test" "Sentry re-queue chokepoint changed"
+          ;;
         scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"
           ;;

--- a/scripts/sentry-triage-archive.mjs
+++ b/scripts/sentry-triage-archive.mjs
@@ -23,23 +23,29 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import {
+  ARCHIVE_COMMENT_MARKER,
+  isTrustedComment,
+} from "./sentry-triage-project-core.mjs";
+import {
   APPROVED_ARCHIVE_LABEL,
   ARCHIVED_LABEL,
-  buildRegressedComment,
   LABEL_DEFINITIONS,
   neutralizeUntrusted,
   parseArchiveBaseline,
-  REOPEN_SHED_LABELS,
   truncateTitle,
   withArchiveBaseline,
-} from "./sentry-triage-ingest.mjs";
+} from "./sentry-triage-queue-contract.mjs";
 import {
-  ARCHIVE_COMMENT_MARKER,
-  isTrustedComment,
-  selectVerdictComment,
-} from "./sentry-triage-project-core.mjs";
+  buildRequeueFence,
+  REQUEUE_CAUSE_SENTRY_EVIDENCE,
+  REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+  requeueQueueStub,
+} from "./sentry-triage-requeue.mjs";
 
-const NEEDS_TRIAGE_LABEL = "sentry:needs-triage";
+// The stub-selectability predicate lives with the re-queue chokepoint that
+// drives it; re-exported here because it is part of this module's tested
+// surface.
+export { isSelectableForTriage } from "./sentry-triage-requeue.mjs";
 
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const DEFAULT_ORG = "mento-labs";
@@ -555,41 +561,44 @@ export function buildStaleRetryRefusalComment(shortId, recorded, observed) {
   ].join("\n");
 }
 
-/** Fixed refusal comment for the live-regression path (no marker — this stub is
- * re-queued, not settled).
+/** The human-facing half of the live-regression refusal. The FENCE LINE it sits
+ * under is not written here and cannot be: `buildRequeueFence` renders it from
+ * the declared re-queue cause, so this path can explain itself without being
+ * able to author — or omit — the line `selectVerdictComment` actually reads.
  *
- * THE FIRST LINE IS LOAD-BEARING. It is `buildRegressedComment`, so the body
- * starts with REGRESSION_PREFIX and `selectVerdictComment`
- * (scripts/sentry-triage-project-core.mjs) reads this comment as a regression
+ * `shortId` is Sentry-assigned but still neutralized as defense in depth. */
+function regressionRefusalProse(shortId) {
+  const safeShortId = truncateTitle(neutralizeUntrusted(shortId), 90);
+  return [
+    `**Not archived.** The underlying Sentry issue \`${safeShortId}\` currently`,
+    "shows a live regression/escalation (new events since triage). Archiving it",
+    "now would close this stub over that regression and reset Sentry's escalation",
+    "baseline, hiding a real issue. Re-queued for fresh triage instead — a new",
+    "human approval is required once it is re-triaged.",
+  ];
+}
+
+/** The full refusal comment for the live-regression path (no archive marker —
+ * this stub is re-queued, not settled).
+ *
+ * THE FIRST LINE IS LOAD-BEARING, and the chokepoint owns it. Because the cause
+ * declared here is `sentry-evidence`, `buildRequeueFence` opens the body with
+ * REGRESSION_PREFIX and `selectVerdictComment`
+ * (scripts/sentry-triage-project-core.mjs) reads the comment as a regression
  * fence. Without it the re-queued stub still carries the PREVIOUS round's
  * verdict comment as the newest admissible verdict: when the next triage agent
  * leg dies before posting, the `verdict` job (which runs on `always()`) accepts
  * that stale verdict, relabels the stub and closes it — burying a regression
  * Sentry explicitly reported.
  *
- * The fence belongs to THIS path, not to every re-queue. A re-queue caused by
- * new Sentry events makes any prior verdict stale by definition. A bookkeeping
- * re-queue — a close whose response was lost, repaired by ingest's stranded-stub
- * sweep — must NOT fence: nothing about the Sentry issue changed, the prior
- * verdict is still valid, and fencing it would discard a good verdict and force
- * a pointless re-triage. Any future refusal path that re-queues on SENTRY
- * evidence needs this same first line; one that re-queues for a bookkeeping
- * reason must not have it.
- *
- * `shortId` is Sentry-assigned but still neutralized as defense in depth;
- * `lastSeen` is neutralized and bounded inside `buildRegressedComment`.
- */
+ * Exported because it is the documented shape of this refusal and the tests pin
+ * it; `runArchive` does not call it — it hands the prose to the chokepoint,
+ * which composes exactly this body. */
 export function buildRegressionRefusalComment(shortId, lastSeen) {
-  const safeShortId = truncateTitle(neutralizeUntrusted(shortId), 90);
-  return [
-    buildRegressedComment(lastSeen),
-    "",
-    `**Not archived.** The underlying Sentry issue \`${safeShortId}\` currently`,
-    "shows a live regression/escalation (new events since triage). Archiving it",
-    "now would close this stub over that regression and reset Sentry's escalation",
-    "baseline, hiding a real issue. Re-queued for fresh triage instead — a new",
-    "human approval is required once it is re-triaged.",
-  ].join("\n");
+  return buildRequeueFence(REQUEUE_CAUSE_SENTRY_EVIDENCE, {
+    lastSeen,
+    prose: regressionRefusalProse(shortId),
+  });
 }
 
 /**
@@ -901,179 +910,6 @@ export function settlementHeld({ state, labels, body } = {}, expected = null) {
     !!recorded &&
     recorded.lastSeen === String(expected.lastSeen ?? "") &&
     recorded.sentryIssueId === String(expected.sentryIssueId ?? "")
-  );
-}
-
-/**
- * Would a verdict still be re-appliable to this stub? True means DANGER: the
- * `verdict` job could pick a previous round's verdict off these comments and
- * close the stub with it.
- *
- * PRESENCE IS NOT ADMISSIBILITY, and that distinction is the whole point of this
- * helper. An earlier check here asked "does a trusted fence exist?" — a
- * different question from the one the consumer asks. `selectVerdictComment`
- * selects by RECENCY: it takes the newest verdict and rejects it only when a
- * newer regression comment exists. A fence that exists but PREDATES the newest
- * verdict therefore protects nothing, and this path can produce exactly that,
- * because the refusal comment is byte-identical across runs for one `lastSeen`
- * (same shortId, same timestamp, fixed prose). Re-approve a stub whose Sentry
- * issue is still regressing on an unchanged `lastSeen`, have this run's post
- * fail transiently, and a body check finds LAST round's fence — sitting older
- * than the verdict posted after it — and waves the re-queue through green.
- *
- * So ask the consumer's question with the consumer's own primitive: no
- * admissible verdict may survive. Sharing `selectVerdictComment` is what stops
- * the guard and the thing it guards against from drifting apart again.
- *
- * DO NOT port ingest's reasoning here. `reopenQueueIssue` runs a
- * near-identical-looking body check and is safe, but only because ingest gates
- * on `lastSeen > closedAt`: a verdict implies a later close, which puts
- * `closedAt` past that `lastSeen`, so its gate cannot fire twice for one
- * timestamp with a verdict in between. This path has no such gate — it fires on
- * `isActivelyRegressing`, which reads Sentry's substatus and stays true for days
- * regardless of timestamps. Same-looking code, different premises; assuming they
- * transfer is what produced this bug.
- *
- * Fails CLOSED: a read that throws returns true, so an unverifiable stub counts
- * as unsafe.
- */
-async function admissibleVerdictSurvives(runGh, repo, queueIssue) {
-  try {
-    const live = await readQueueIssue(runGh, repo, queueIssue);
-    return hasAdmissibleVerdict(live.comments);
-  } catch (err) {
-    process.stderr.write(
-      `::notice::Could not re-read #${queueIssue} to check whether a previous verdict is still admissible (${
-        err instanceof Error ? err.message : String(err)
-      }); treating it as unsafe.\n`,
-    );
-    return true;
-  }
-}
-
-/** The pure half, over an already-read comment list. `selectVerdictComment`
- * returns a null body when there is no trusted verdict at all, or when the
- * newest one is fenced out by a newer regression comment — both safe. */
-function hasAdmissibleVerdict(comments) {
-  return selectVerdictComment(comments ?? []).body !== null;
-}
-
-/** The pair Stage B's selector matches: `--state open` AND
- * `sentry:needs-triage`. A stub missing either is invisible to triage, and — if
- * its `closedAt` postdates the regression — to ingest as well. */
-export function isSelectableForTriage({ state, labels } = {}) {
-  return (
-    String(state ?? "").toUpperCase() !== "CLOSED" &&
-    (Array.isArray(labels) ? labels : []).includes(NEEDS_TRIAGE_LABEL)
-  );
-}
-
-/**
- * Drive a stub to the selectable pair and VERIFY it got there, or fail loudly.
- *
- * This exists because checking each write's return value kept missing a layer:
- * the reopen was absent, then a failed read aborted it, then the reopen write
- * itself could fail — three rounds, one location, each fix covering only the
- * failure mode in front of it. Asserting the END STATE covers all of them and
- * whatever comes next, because it observes the thing that actually matters
- * rather than the success of the steps meant to produce it.
- *
- * Observe, correct what is wrong, observe again. Both corrections are idempotent
- * so a retry is safe and cheap, and it runs before failing. When the final
- * observation still disagrees — or could never be taken — the stub is stranded
- * and only a human can free it, so this throws and the run goes RED with an
- * `::error::` naming what was actually seen.
- *
- * `fallbackState` is the caller's pre-run observation, used only to decide
- * whether to attempt a reopen when a read fails; it never satisfies the
- * invariant, which requires a real confirming read.
- *
- * Returns the confirming read, so the caller can judge the rest of the stub's
- * state from what was actually observed rather than from what its own writes
- * reported — the same ambiguous-response discipline the reconciler uses.
- */
-export async function ensureSelectableForTriage(
-  runGh,
-  { repo, queueIssue, fallbackState = "CLOSED", attempts = 2 },
-) {
-  let observed = null;
-  let readError = null;
-
-  const observe = async () => {
-    try {
-      const live = await readQueueIssue(runGh, repo, queueIssue);
-      observed = live;
-      readError = null;
-      return live;
-    } catch (err) {
-      readError = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `::notice::Could not read #${queueIssue} while re-queuing it for triage (${readError}); correcting from its pre-run state (${fallbackState}) and re-checking.\n`,
-      );
-      return null;
-    }
-  };
-
-  for (let round = 1; round <= attempts; round += 1) {
-    const live = await observe();
-    if (live && isSelectableForTriage(live)) return live;
-
-    // Correct whatever is — or, with no read, may be — wrong. Both writes are
-    // idempotent, so a repeat costs nothing and a lost response is harmless.
-    const looksClosed = live
-      ? live.state === "CLOSED"
-      : String(fallbackState ?? "").toUpperCase() === "CLOSED";
-    const missingLabel = live
-      ? !live.labels.includes(NEEDS_TRIAGE_LABEL)
-      : false;
-    if (looksClosed) {
-      try {
-        process.stderr.write(
-          `::notice::Reopening #${queueIssue} so the live regression is visible to triage (round ${round}).\n`,
-        );
-        await runGh(["issue", "reopen", String(queueIssue), "-R", repo]);
-      } catch (err) {
-        process.stderr.write(
-          `::notice::Reopen of #${queueIssue} reported a failure (${
-            err instanceof Error ? err.message : String(err)
-          }); the verification read decides.\n`,
-        );
-      }
-    }
-    if (missingLabel) {
-      try {
-        await runGh([
-          "issue",
-          "edit",
-          String(queueIssue),
-          "-R",
-          repo,
-          "--add-label",
-          NEEDS_TRIAGE_LABEL,
-        ]);
-      } catch (err) {
-        process.stderr.write(
-          `::notice::Re-adding ${NEEDS_TRIAGE_LABEL} to #${queueIssue} reported a failure (${
-            err instanceof Error ? err.message : String(err)
-          }); the verification read decides.\n`,
-        );
-      }
-    }
-  }
-
-  // The mandatory final verification, on the main path — never skippable, and
-  // never reached by a correction whose result nobody looked at.
-  const finalLive = await observe();
-  if (finalLive && isSelectableForTriage(finalLive)) return finalLive;
-
-  const seen = observed
-    ? `state=${observed.state}, labels=${observed.labels.join("|")}`
-    : `unreadable (${readError})`;
-  process.stderr.write(
-    `::error::Queue stub #${queueIssue} could not be confirmed open and carrying ${NEEDS_TRIAGE_LABEL} after refusing to archive over a live regression (${seen}). It is STRANDED — Stage B selects only open stubs, and ingest will skip it while its closedAt postdates the regression. Reopen it by hand.\n`,
-  );
-  throw new Error(
-    `Queue stub #${queueIssue} is not selectable for triage after a live-regression refusal (${seen}).`,
   );
 }
 
@@ -1639,154 +1475,43 @@ export async function runArchive(options, deps = {}) {
     process.stderr.write(
       `::notice::Sentry issue ${meta.shortId} (${issueId}) is a live regression/escalation; refusing to archive over it and re-queuing the stub for triage.\n`,
     );
-    // This comment is prose for a human AND the regression fence for the verdict
-    // parser — its first line is what tells `selectVerdictComment`
-    // (scripts/sentry-triage-project-core.mjs) that the previous round's verdict
-    // describes a dead occurrence.
+    // EVERYTHING about the re-queue below — the fence, its position before the
+    // label write, the state change last, the admissibility gates on both sides
+    // of it, and the end-state verification — belongs to the chokepoint
+    // (scripts/sentry-triage-requeue.mjs). This site declares two things: the
+    // CAUSE, which is what decides the fence, and the prose that renders under
+    // it.
     //
-    // That makes the fence a PRECONDITION of re-queuing, not a note about it,
-    // and it inverts the "safe first, loud second" ordering this block used to
-    // follow. That rule assumed making the stub selectable IS the safe act. With
-    // the fence load-bearing it is not: a selectable stub with no fence is
-    // exactly the close-over-a-live-regression setup, and the archive and agent
-    // workflows hold separate concurrency groups, so a triage run can select it
-    // inside the window between here and any later check. Post the fence, or do
-    // not re-queue at all.
+    // The cause is `sentry-evidence` because Sentry itself reported the new
+    // events. That makes the fence a PRECONDITION of re-queuing rather than a
+    // note about it, and it inverts the "safe first, loud second" ordering this
+    // block used to follow: a selectable stub with no fence IS the
+    // close-over-a-live-regression setup, and the archive and agent workflows
+    // hold separate concurrency groups, so a triage run can select it inside the
+    // window. Post the fence, or do not re-queue at all.
     //
-    // A reported failure is still not proof — that discipline is unchanged. The
-    // post can land and lose its response, so the report is checked against a
-    // READ before anything is decided. Only a fence confirmed absent aborts.
-    const fence = buildRegressionRefusalComment(meta.shortId, current.lastSeen);
-    try {
-      await runGh([
-        "issue",
-        "comment",
-        String(queueIssue),
-        "-R",
+    // `verify-end-state` because this path is past the point its caller's
+    // reconciler can help — settlement never ran, so it holds no target. A
+    // reported write failure may only refine the decision, never skip it: the
+    // sequence completes, the END STATE is read, and anything still wrong is
+    // surfaced as a RED run afterwards. Loud AFTER the stub is safe, never
+    // instead of making it safe.
+    await requeueQueueStub(
+      {
+        writeGh: (args) => runGh(args),
+        readStub: (number) => readQueueIssue(runGh, repo, number),
+      },
+      {
         repo,
-        "--body",
-        fence,
-      ]);
-    } catch (err) {
-      const reported = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `::notice::Posting the regression fence on #${queueIssue} reported a failure (${reported}); re-reading the stub to check whether a previous verdict is still admissible.\n`,
-      );
-      if (await admissibleVerdictSurvives(runGh, repo, queueIssue)) {
-        // Abort BEFORE the re-queue. The stub keeps `sentry:approved-archive`
-        // and its verdict label and stays CLOSED, so: nothing selects it, the
-        // stranded sweep does not see it (no `sentry:needs-triage`), and the
-        // documented workflow_dispatch retry still passes its approval guard and
-        // re-runs this whole refusal, fence included. Leaving a known-live
-        // regression closed until someone retries is the cost, and it is the
-        // right one — this state needs a human to linger, while the alternative
-        // needs only a second failure to bury the regression silently.
-        throw new Error(
-          `Refusing to re-queue #${queueIssue} for triage: the regression fence comment could not be posted (${reported}) and a previous verdict is still admissible, so a failing triage round would close that verdict over this live regression. The stub is unchanged — approval and verdict labels intact — so re-dispatch this workflow to retry the whole refusal.`,
-          { cause: err },
-        );
-      }
-      process.stderr.write(
-        `::notice::No admissible verdict survives on #${queueIssue} despite the reported failure; continuing.\n`,
-      );
-    }
-
-    // Re-queue: add needs-triage, shed the stale approval/verdict/archive
-    // markers. A failure here must NOT propagate past the verifier below — that
-    // is exactly what let a throw skip the guard. Record it and keep going; the
-    // verifier re-adds needs-triage itself, so the stub still becomes
-    // selectable, and the unshed markers surface as a RED run afterwards.
-    let requeueError = null;
-    try {
-      await runGh([
-        "issue",
-        "edit",
-        String(queueIssue),
-        "-R",
-        repo,
-        "--add-label",
-        NEEDS_TRIAGE_LABEL,
-        "--remove-label",
-        REOPEN_SHED_LABELS.join(","),
-      ]);
-    } catch (err) {
-      requeueError = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `::notice::Re-queue label edit on #${queueIssue} reported a failure (${requeueError}); the end-state verification below still runs.\n`,
-      );
-    }
-
-    // THE INVARIANT for this path: when it returns, the stub is OPEN and carries
-    // `sentry:needs-triage` — the exact pair Stage B's selector matches
-    // (.github/workflows/sentry-triage-agent.yml). Anything else is invisible:
-    // the selector filters on `--state open`, and ingest leaves a closed stub
-    // alone whenever this occurrence's `lastSeen` is not newer than the later
-    // `closedAt`, so a regression we KNOW is live would sit unseen indefinitely.
-    //
-    // Enforced by checking the END STATE, not each write's return, and reached
-    // from EVERY exit above rather than only the successful one. Four rounds
-    // fixed this spot one layer at a time — the missing reopen, a read that
-    // aborted it, a reopen write that could fail, and then the verifier itself
-    // being skippable — because each fix covered only the failure in front of
-    // it. Nothing between entering this branch and here can throw past it now.
-    const verified = await ensureSelectableForTriage(runGh, {
-      repo,
-      queueIssue,
-      fallbackState: stub.state,
-    });
-
-    // Judge the FENCE from the same verification read, for the reason the shed
-    // is judged from it below: the post can lose its response exactly like the
-    // label edit can, so the write's return proves nothing in either direction.
-    //
-    // The stub is selectable by now — the invariant this path owes — so this is
-    // loud AFTER it is safe, never instead of making it safe. Red is what gets a
-    // human here before the next triage run.
-    //
-    // Asks the SAME question as the pre-re-queue gate, through the same
-    // primitive: not "is a fence present" but "can a verdict still be
-    // re-applied". A fence deleted between the post and this read, or one that
-    // was always older than the newest verdict, both leave a verdict the
-    // `verdict` job (which runs under always()) would pick up and close the stub
-    // with, over a regression Sentry explicitly reported. Presence would miss the
-    // second case entirely — see admissibleVerdictSurvives for why these two
-    // sites must not diverge.
-    const verdictStillReappliable = hasAdmissibleVerdict(verified.comments);
-
-    // Judge the shed from the VERIFICATION READ, not from what the edit
-    // reported. `gh` can apply the label swap and lose the response, and
-    // throwing on the report alone turned a successful refusal into a red run
-    // claiming markers survived that the very next read shows are gone. Fail
-    // only on markers actually still present — loud after the stub is safe,
-    // never instead of making it safe.
-    const survivingMarkers = REOPEN_SHED_LABELS.filter((name) =>
-      verified.labels.includes(name),
+        issueNumber: queueIssue,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        // The lastSeen THIS RUN observed in Sentry, never the stub body's copy.
+        lastSeen: current.lastSeen,
+        fenceProse: regressionRefusalProse(meta.shortId),
+        onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+        fallbackState: stub.state,
+      },
     );
-
-    // One throw carrying both, so a doubly-broken run cannot report only half.
-    const problems = [];
-    if (verdictStillReappliable) {
-      problems.push(
-        "a previous verdict is still admissible — no regression fence newer than it survives on the stub — so a failing triage round could close that verdict over this live regression; post the fence by hand, or re-run this workflow, before the next triage run",
-      );
-    }
-    if (survivingMarkers.length) {
-      problems.push(
-        `these stale markers survived: ${survivingMarkers.join(", ")}${
-          requeueError ? ` (label edit reported: ${requeueError})` : ""
-        }`,
-      );
-    }
-    if (problems.length) {
-      throw new Error(
-        `Queue stub #${queueIssue} was made selectable for triage, but ${problems.join("; and ")}.`,
-      );
-    }
-    if (requeueError) {
-      process.stderr.write(
-        `::notice::The re-queue label edit on #${queueIssue} reported a failure (${requeueError}) that the verification read disproves; the stale markers are gone.\n`,
-      );
-    }
     return {
       issue: queueIssue,
       shortId: meta.shortId,

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -17,10 +17,53 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { selectMarkedComment } from "./sentry-triage-project-core.mjs";
 import {
-  extractYamlBlock,
-  selectMarkedComment,
-} from "./sentry-triage-project-core.mjs";
+  ARCHIVED_LABEL,
+  LABEL_DEFINITIONS,
+  NEEDS_TRIAGE_LABEL,
+  neutralizeUntrusted,
+  parseArchiveBaseline,
+  truncateTitle,
+} from "./sentry-triage-queue-contract.mjs";
+import {
+  buildStrandedRecoveryComment,
+  REQUEUE_CAUSE_BOOKKEEPING,
+  REQUEUE_CAUSE_SENTRY_EVIDENCE,
+  requeueQueueStub,
+} from "./sentry-triage-requeue.mjs";
+
+// The queue label namespace, the untrusted-text neutralization, and the archive
+// freshness-baseline contract now live in `sentry-triage-queue-contract.mjs`;
+// the re-queue sequence and its fence live in `sentry-triage-requeue.mjs`. Both
+// are re-exported here because ingest is the queue's public surface for the
+// sibling scripts (archive, project, digest, autofix) and their tests.
+export {
+  APPROVED_ARCHIVE_LABEL,
+  ARCHIVE_BASELINE_FIELD,
+  ARCHIVE_BASELINE_ID_FIELD,
+  ARCHIVED_LABEL,
+  CODE_FIX_VERDICT_LABEL,
+  defangBackticks,
+  defangMentions,
+  FIX_PR_OPENED_LABEL,
+  FIX_REFUSED_LABEL,
+  LABEL_DEFINITIONS,
+  NEEDS_TRIAGE_LABEL,
+  neutralizeUntrusted,
+  parseArchiveBaseline,
+  PROJECTED_LABEL,
+  REOPEN_SHED_LABELS,
+  sanitizeFreeText,
+  truncateTitle,
+  VERDICT_LABELS,
+  withArchiveBaseline,
+} from "./sentry-triage-queue-contract.mjs";
+export {
+  buildRegressedComment,
+  buildReopenLabelEditArgs,
+  buildStrandedRecoveryComment,
+} from "./sentry-triage-requeue.mjs";
 
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const DEFAULT_ORG = "mento-labs";
@@ -72,48 +115,11 @@ export const RUN_RECORD_MARKER = "<!-- sentry-triage-ingest:run-record:v1 -->";
 const BODY_MARKER = "<!-- sentry-triage:v1 -->";
 
 // ---------------------------------------------------------------------------
-// Pure helpers: title/body construction, noise classification, dedup
-// decision. Untrusted-input handling lives here (Sentry titles/culprits are
-// attacker-reachable text — never execute/eval anything derived from them).
+// Pure helpers: title/body construction, noise classification, dedup decision.
+// The neutralization these apply to attacker-reachable Sentry text lives in
+// sentry-triage-queue-contract.mjs — never execute/eval anything derived from
+// that text, and never let it reach a public queue issue unneutralized.
 // ---------------------------------------------------------------------------
-
-/** Strip control chars/newlines and collapse whitespace to a single line. */
-export function sanitizeFreeText(text) {
-  return (
-    String(text ?? "")
-      // eslint-disable-next-line no-control-regex -- stripping control chars from untrusted Sentry text is the whole point here
-      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
-      .replace(/[\r\n\t]+/g, " ")
-      .replace(/\s+/g, " ")
-      .trim()
-  );
-}
-
-// Replace every backtick with a visually similar but byte-distinct
-// character. This is what actually prevents an attacker-controlled Sentry
-// title/culprit from closing the ```yaml fence early (or a single-backtick
-// inline-code span) once embedded in the issue body's markdown.
-export function defangBackticks(text) {
-  return text.replace(/`/g, "ˋ");
-}
-
-// Insert a zero-width space after every `@` so `@user` / `@org/team` in
-// attacker-reachable Sentry text can never become a live GitHub mention
-// (which would notify/subscribe real users) once embedded in an issue title
-// or comment. Visual fidelity is preserved for triage.
-export function defangMentions(text) {
-  return text.replace(/@/g, "@\u200B");
-}
-
-export function neutralizeUntrusted(text) {
-  return defangMentions(defangBackticks(sanitizeFreeText(text)));
-}
-
-export function truncateTitle(text, maxLen = 90) {
-  const clean = text ?? "";
-  if (clean.length <= maxLen) return clean;
-  return `${clean.slice(0, maxLen).trimEnd()}…`;
-}
 
 /**
  * `[sentry] <SHORT-ID> (<project>, <level>)` — queue contract v2.
@@ -147,259 +153,11 @@ export function classifyNoise(rawTitle) {
   return NOISE_PATTERNS.some((pattern) => pattern.test(title));
 }
 
-// The queue's "awaiting a current verdict" marker. Stage B's selector filters
-// on it, the digest classifies on it, and the recovery sweep below keys on it —
-// so it is a named constant here rather than a literal at each use site. The
-// LABEL_DEFINITIONS entry keeps its own literal on purpose (the bootstrap must
-// list every label inline).
-export const NEEDS_TRIAGE_LABEL = "sentry:needs-triage";
-
 export function buildQueueLabels(isNoise) {
   const labels = ["sentry-triage", NEEDS_TRIAGE_LABEL];
   if (isNoise) labels.push("sentry:candidate-noise");
   return labels;
 }
-
-// Idempotently created/updated on every run (`gh label create --force`).
-export const LABEL_DEFINITIONS = [
-  {
-    name: "sentry-triage",
-    color: "5319e7",
-    description: "Sentry triage pipeline queue issue (ADR 0036)",
-  },
-  {
-    name: "sentry:needs-triage",
-    color: "fbca04",
-    description: "Awaiting triage-agent verdict",
-  },
-  {
-    name: "sentry:candidate-noise",
-    color: "d4c5f9",
-    description:
-      "Matches known operational-noise heuristics (CSP, timeouts, chunk-load, abort)",
-  },
-  {
-    name: "sentry:verdict-code-fix",
-    color: "0e8a16",
-    description: "Triage verdict: fixable in this repo's code",
-  },
-  {
-    name: "sentry:verdict-config-fix",
-    color: "1d76db",
-    description: "Triage verdict: fixable via configuration",
-  },
-  {
-    name: "sentry:verdict-upstream",
-    color: "e99695",
-    description: "Triage verdict: upstream/third-party, not fixable here",
-  },
-  {
-    name: "sentry:verdict-needs-human",
-    color: "d93f0b",
-    description: "Triage verdict: needs human judgment",
-  },
-  {
-    name: "sentry:projected",
-    color: "0052cc",
-    description:
-      "Actionable verdict projected as an issue in the owning repo (ADR 0038)",
-  },
-  {
-    name: "sentry:fix-pr-opened",
-    color: "006b75",
-    description:
-      "Autofix leg opened a scoped fix PR for this verdict (ADR 0036 Phase 2b)",
-  },
-  {
-    name: "sentry:fix-refused",
-    color: "bfdadc",
-    description:
-      "Autofix declined to open a PR (no change/guard-refused); remove to retry (ADR 0036 Phase 2b)",
-  },
-  {
-    name: "sentry:approved-archive",
-    color: "1a7f37",
-    description:
-      "Human-approved: archive the underlying Sentry issue (Phase 2a, ADR 0036)",
-  },
-  {
-    name: "sentry:archived",
-    color: "6e7681",
-    description:
-      "Sentry issue archived (archived_until_escalating) via the Phase 2a archive loop (ADR 0036)",
-  },
-];
-
-export const PROJECTED_LABEL = "sentry:projected";
-
-// The verdict that makes a queue stub eligible for the autofix leg. The autofix
-// finalize step re-reads this immediately before writing a terminal marker: the
-// diff is only justified while the verdict that produced it still stands, and
-// ingest (its own concurrency group) can shed it mid-run on a regression
-// re-queue. Single source of truth for the JS consumers — the select step
-// imports it as AUTOFIX_SELECT_LABEL and the finalize marker re-read imports it
-// as its expected verdict. The LABEL_DEFINITIONS entry above and the workflow's
-// pre-push grep guard (.github/workflows/sentry-autofix.yml) are deliberate
-// literal twins: the label bootstrap must list every label inline, and a shell
-// `grep -Fxq` cannot import a JS constant.
-export const CODE_FIX_VERDICT_LABEL = "sentry:verdict-code-fix";
-
-// Applied to a `code-fix` queue stub once the autofix leg (ADR 0036 Phase 2b,
-// `.github/workflows/sentry-autofix.yml`) has opened a scoped fix PR for it.
-// The autofix select step reads it as a dedup marker so a stub is never
-// re-fixed. Bootstrapped from LABEL_DEFINITIONS above (single source of truth)
-// and self-healed by the autofix finalize step before it labels the stub.
-export const FIX_PR_OPENED_LABEL = "sentry:fix-pr-opened";
-
-// Applied to a `code-fix` queue stub when an autofix attempt declined to open a
-// PR — the agent made no change or the mechanical diff guard refused the diff.
-// Without it the same unfixable stub is re-picked every run and burns the
-// per-run cap forever (starvation). The autofix select step reads it as a dedup
-// marker exactly like FIX_PR_OPENED_LABEL; a human clears it (removes the label)
-// to allow a fresh retry. Bootstrapped from LABEL_DEFINITIONS above and
-// self-healed by the autofix workflow's refused path before it labels the stub.
-export const FIX_REFUSED_LABEL = "sentry:fix-refused";
-
-// Phase 2a human-approved archive loop (ADR 0036 Stage C,
-// scripts/sentry-triage-archive.mjs + .github/workflows/sentry-triage-archive.yml).
-// APPROVED_ARCHIVE_LABEL is the human-applied approval marker that triggers the
-// archive workflow; ARCHIVED_LABEL is the terminal audit marker the archive
-// script applies once the Sentry issue is archived. Both are bootstrapped by
-// the ingest label set above and self-healed by the archive script — single
-// source of truth for their colors/descriptions.
-export const APPROVED_ARCHIVE_LABEL = "sentry:approved-archive";
-export const ARCHIVED_LABEL = "sentry:archived";
-
-// Archive freshness baseline (issue #1371). The archive script records the
-// Sentry `lastSeen` it observed immediately BEFORE it mutated the issue, plus
-// the Sentry issue id it mutated. `decideDedupAction` compares a regression's
-// `lastSeen` against that instant instead of the stub's `closedAt`: the close
-// necessarily postdates any event that landed while the archive ran, so a
-// `closedAt` comparison would evaluate false for that event permanently and bury
-// a real regression until some later event happened to arrive. These field names
-// are the shared contract with scripts/sentry-triage-archive.mjs.
-//
-// The baseline lives in the queue stub's BODY, in the same yaml block ingest
-// writes at creation — never in a comment. That placement IS the trust boundary,
-// and it is structural rather than cryptographic. The Stage B triage agent is an
-// LLM reading attacker-controlled Sentry payloads, and
-// .github/workflows/sentry-triage-agent.yml grants it
-// `Bash(gh issue comment <matrix.issue>:*)` — its comments post as
-// `github-actions[bot]`, on this exact stub. So no author check, marker check, or
-// id check applied to a COMMENT can be trusted: a prompt-injected payload can
-// satisfy all of them and plant a far-future baseline, after which every later
-// regression of that Sentry issue is skipped indefinitely. The agent's allowlist
-// grants no tool that edits an issue body (`Read,Grep,Glob` + three scoped
-// `gh issue` subcommands; the autofix agent gets file-edit tools and no shell at
-// all), and no script or workflow step ever rewrites a stub body except the
-// archive leg's own deterministic, zero-LLM write. Moving the field into the body
-// therefore removes the forgery surface instead of trying to authenticate inside
-// it, which a shared-secret signature could only match, never beat.
-export const ARCHIVE_BASELINE_FIELD = "archive_baseline_last_seen";
-export const ARCHIVE_BASELINE_ID_FIELD = "archive_baseline_sentry_issue_id";
-
-/** Read one scalar out of a stub's yaml block. Keys are fixed literals (no regex
- * injection) written one per line as `key: "value"`. */
-function readBaselineField(block, key) {
-  const match = new RegExp(`^${key}:[ \\t]*(.+)$`, "m").exec(
-    String(block ?? ""),
-  );
-  if (!match) return "";
-  return match[1]
-    .trim()
-    .replace(/^["']|["']$/g, "")
-    .trim();
-}
-
-/**
- * Parse the archive freshness baseline out of a queue stub's BODY. Returns null
- * when the body carries no baseline field — the normal state for a stub that has
- * never been archived. The timestamp comes back RAW; validity is the caller's
- * `Date.parse` gate, so a garbage value degrades to the `closedAt` fallback
- * instead of throwing.
- */
-export function parseArchiveBaseline(issueBody) {
-  const block = extractYamlBlock(issueBody);
-  if (!block) return null;
-  const lastSeen = readBaselineField(block, ARCHIVE_BASELINE_FIELD);
-  if (!lastSeen) return null;
-  return {
-    lastSeen,
-    sentryIssueId: readBaselineField(block, ARCHIVE_BASELINE_ID_FIELD),
-  };
-}
-
-/**
- * Return `body` with the archive baseline fields set inside its existing yaml
- * block, replacing any previous values (a re-archive supersedes). Used by the
- * archive leg's body rewrite; kept here so the writer and the reader above stay
- * one edit apart.
- *
- * A NULL baseline strips the two fields instead of setting them. The archive's
- * rollback needs that: it must put the baseline back the way it found it while
- * leaving every other part of the body — including edits a human made after the
- * run's snapshot — exactly as it is live.
- *
- * Returns null when the body has no yaml block to extend — the archive treats
- * that as a hard refusal rather than inventing structure, since a stub whose
- * body it cannot parse is one ingest cannot read a baseline back out of either.
- */
-export function withArchiveBaseline(body, baseline) {
-  const source = String(body ?? "");
-  const block = extractYamlBlock(source);
-  if (!block) return null;
-  const stripped = block
-    .split("\n")
-    .filter(
-      (line) =>
-        !new RegExp(
-          `^(${ARCHIVE_BASELINE_FIELD}|${ARCHIVE_BASELINE_ID_FIELD}):`,
-        ).test(line.trim()),
-    )
-    .join("\n");
-  const rebuilt = baseline
-    ? [
-        stripped,
-        `${ARCHIVE_BASELINE_FIELD}: ${JSON.stringify(String(baseline.lastSeen ?? ""))}`,
-        `${ARCHIVE_BASELINE_ID_FIELD}: ${JSON.stringify(String(baseline.sentryIssueId ?? ""))}`,
-      ].join("\n")
-    : stripped;
-  return source.replace(block, rebuilt);
-}
-
-// Stage B's verdict namespace, derived from the definitions above so the two
-// can't drift. A reopened regression must shed its previous verdict — the
-// old verdict described the old occurrence, and downstream consumers filter
-// on `sentry:needs-triage` + absence of a verdict.
-export const VERDICT_LABELS = LABEL_DEFINITIONS.map(
-  (label) => label.name,
-).filter((name) => name.startsWith("sentry:verdict-"));
-
-// Labels a regression reopen must shed: the stale verdict labels, the stale
-// `sentry:projected` marker (ADR 0038), the stale autofix markers
-// (`sentry:fix-pr-opened` / `sentry:fix-refused`, ADR 0036 Phase 2b), AND the
-// stale Phase-2a archive markers (`sentry:approved-archive` / `sentry:archived`).
-// A regression is a NEW occurrence, so every trace of how the OLD occurrence was
-// handled must clear: leaving a verdict/projection would misrepresent a
-// needs-triage stub as already verdicted/projected; leaving an autofix marker
-// would both misrepresent it as fixed/refused AND block the re-triage round from
-// ever being autofixed again (the select step dedups on those markers); and
-// leaving an archive marker would misrepresent it as approved/archived —
-// shedding the approval marker is also an authority-boundary guard, since a
-// regression must not carry a stale human archive approval into a fresh
-// occurrence (a workflow_dispatch retry would otherwise read it as
-// still-approved and re-archive without re-review). If the re-triage round lands
-// on an actionable verdict again, the projection/autofix steps re-apply their
-// markers (idempotently reusing the same owning-repo issue / opening a fresh fix
-// PR), and a fresh archive needs a fresh human approval.
-export const REOPEN_SHED_LABELS = [
-  ...VERDICT_LABELS,
-  PROJECTED_LABEL,
-  FIX_PR_OPENED_LABEL,
-  FIX_REFUSED_LABEL,
-  APPROVED_ARCHIVE_LABEL,
-  ARCHIVED_LABEL,
-];
 
 // Short ID is the first whitespace-delimited token after the `[sentry] `
 // prefix (queue contract v2 title: `[sentry] <SHORT-ID> (<project>, <level>)`).
@@ -497,13 +255,6 @@ export function decideDedupAction({
   if (Number.isNaN(closedAtMs)) return { action: "reopen" };
   if (lastSeenMs > closedAtMs) return { action: "reopen" };
   return { action: "skip", reason: "closed, no events since close" };
-}
-
-export function buildRegressedComment(lastSeen) {
-  // `lastSeen` should be a Sentry-generated ISO timestamp, but it still
-  // transits Sentry's API from event data — neutralize + bound it like every
-  // other Sentry-derived string (no-op for a legitimate timestamp).
-  return `Regressed in Sentry (last seen ${truncateTitle(neutralizeUntrusted(lastSeen), 90)})`;
 }
 
 // The validated permalink is written into the queue-issue body and later read
@@ -932,30 +683,6 @@ async function createQueueIssue(options, sentryIssue) {
 }
 
 /**
- * Label edit for the regression-reopen path: re-queue for triage AND shed
- * any stale `sentry:verdict-*` labels plus the stale `sentry:projected`
- * marker from the previous triage round — the old verdict/projection
- * described the old occurrence, and leaving them would show downstream
- * consumers a needs-triage issue that also reads as verdicted/projected.
- * Removing an absent label is a no-op for `gh issue edit` (the labels
- * themselves always exist because ensureLabelsExist runs first). Exported
- * for tests.
- */
-export function buildReopenLabelEditArgs(issueNumber, repo) {
-  return [
-    "issue",
-    "edit",
-    String(issueNumber),
-    "-R",
-    repo,
-    "--add-label",
-    NEEDS_TRIAGE_LABEL,
-    "--remove-label",
-    REOPEN_SHED_LABELS.join(","),
-  ];
-}
-
-/**
  * CLOSED + `sentry:needs-triage` is an unreachable pairing, never a resting
  * state: Stage B's selector lists `--state open` only, and the regression path
  * above reopens a closed stub solely when Sentry reports events after
@@ -977,49 +704,24 @@ export function buildReopenLabelEditArgs(issueNumber, repo) {
  * added later. Reopening (not stripping the label) is the correct repair —
  * every producer that writes this pairing meant the stub to be triaged.
  *
- * The label edit sheds REOPEN_SHED_LABELS, exactly like the regression reopen,
- * so a hand-edited stub cannot come back carrying both `sentry:needs-triage`
- * and a stale verdict — two verdict labels would misclassify it downstream.
+ * The repair runs through the re-queue chokepoint
+ * (scripts/sentry-triage-requeue.mjs) with cause `bookkeeping`, which is what
+ * makes it fence-free: nothing about the Sentry issue changed, so a verdict
+ * already posted for this stub stays valid and admissible. The counterpart
+ * declaration lives on the producer that DOES know a regression happened — the
+ * archive leg's live-regression refusal names `sentry-evidence`, because Sentry
+ * reported new events there. Fencing here would throw away good verdicts; not
+ * fencing there would close a stub over a live regression. Neither site writes
+ * that decision itself; both name a cause and the chokepoint applies the rule.
  *
- * The recovery note is deliberately NOT the regression comment: that text is
- * the verdict parser's staleness fence, and this repair is bookkeeping rather
- * than a new Sentry occurrence, so a verdict already posted for this stub stays
- * valid and admissible. The counterpart rule lives on the producer that DOES
- * know a regression happened — buildRegressionRefusalComment in
- * scripts/sentry-triage-archive.mjs opens with the fence precisely because
- * Sentry reported new events there. Fencing here would throw away good
- * verdicts; not fencing there would close a stub over a live regression. The
- * two cases are decided at their sources; do not collapse them here.
+ * The chokepoint's label edit sheds REOPEN_SHED_LABELS on both causes, so a
+ * hand-edited stub cannot come back carrying both `sentry:needs-triage` and a
+ * stale verdict — two verdict labels would misclassify it downstream.
  */
 export function isStrandedNeedsTriage(issue) {
   return (
     issue?.state === "CLOSED" &&
     (issue?.labels ?? []).includes(NEEDS_TRIAGE_LABEL)
-  );
-}
-
-/**
- * Fixed text — no Sentry-derived or otherwise untrusted input.
- *
- * Written as INTENT, not outcome, because of where it sits in the sequence: the
- * state change goes last, so this note is posted while the stub is still closed
- * and the reopen may yet fail. Wording it as completed fact ("Reopened…",
- * "Re-queued…") left a closed stub carrying a note about something that had not
- * happened, and every retry added another false entry.
- *
- * The repetition itself is not the bug and must not be suppressed: a stub that
- * keeps failing to reopen SHOULD accumulate a note per attempt, because that
- * repetition is the honest signal. So the text says what this run is doing and
- * what a failure means, and reads correctly either way.
- */
-export function buildStrandedRecoveryComment() {
-  return (
-    "Sentry triage ingest is recovering this queue stub: it was closed while " +
-    "still carrying `sentry:needs-triage`, a pairing no pipeline stage can " +
-    "see — the triage selector lists open stubs only. Its stale verdict, " +
-    "projection and autofix markers have been shed, and a reopen follows this " +
-    "note. If that reopen fails the stub stays closed and the next scheduled " +
-    "run retries, so this note can appear more than once."
   );
 }
 
@@ -1059,56 +761,42 @@ export async function recoverStrandedQueueIssue(
 ) {
   const run = deps.runGh ?? runGh;
 
-  // REVALIDATE before mutating. The queue snapshot this stub came from was
-  // taken before the whole Sentry loop ran, and ingest holds its own concurrency
-  // group, so minutes can pass — long enough for the premise to stop being true.
+  // BOOKKEEPING cause, declared rather than reconstructed: nothing about the
+  // Sentry issue changed, so the chokepoint posts NO fence and the verdict
+  // already computed for this stub stays valid and admissible. The counterpart
+  // declaration lives on the producer that DOES know a regression happened — the
+  // archive leg's live-regression refusal names `sentry-evidence`. Fencing here
+  // would throw away good verdicts; not fencing there would close a stub over a
+  // live regression.
   //
-  // The premise that matters is a human's: removing `sentry:needs-triage` is the
-  // DOCUMENTED way to decline a stub, so re-adding it off a stale snapshot
-  // reverses exactly the action the runbook prescribes. Acting only on what the
-  // stub still shows makes the sweep's decision as fresh as its write.
-  //
-  // A failed read is NOT treated as permission to proceed: it propagates, the
-  // stub stays stranded and visible to the next run, and the run goes nonzero.
-  // Recovering blind is how a snapshot-driven mutation becomes a snapshot-driven
-  // mistake.
-  const live = await readQueueIssueState(
-    options,
-    existingIssue.number,
-    deps.runGh,
+  // `revalidate` is this path's whole premise check. The queue snapshot the stub
+  // came from was taken before the Sentry loop ran, and ingest holds its own
+  // concurrency group, so minutes can pass — long enough for a human to have
+  // declined the stub, which the runbook says to do by REMOVING
+  // `sentry:needs-triage`. Re-adding it off a stale snapshot reverses exactly
+  // that action. A failed read propagates (the chokepoint never treats one as
+  // permission to proceed), the stub stays stranded and visible to the next run,
+  // and the run goes nonzero.
+  const outcome = await requeueQueueStub(
+    {
+      writeGh: (args) => run(args, { dryRun: options.dryRun, mutates: true }),
+      readStub: (number) => readQueueIssueState(options, number, deps.runGh),
+    },
+    {
+      repo: options.repo,
+      issueNumber: existingIssue.number,
+      cause: REQUEUE_CAUSE_BOOKKEEPING,
+      note: buildStrandedRecoveryComment(),
+      revalidate: {
+        check: isStrandedNeedsTriage,
+        declineNote: (live) =>
+          `Queue issue #${existingIssue.number} is no longer closed-and-needing-triage (state=${live.state}, labels=${live.labels.join(",") || "none"}); leaving it as the current state describes.`,
+      },
+    },
   );
-  if (!isStrandedNeedsTriage(live)) {
-    process.stderr.write(
-      `::notice::Queue issue #${existingIssue.number} is no longer closed-and-needing-triage (state=${live.state}, labels=${live.labels.join(",") || "none"}); leaving it as the current state describes.\n`,
-    );
-    return { recovered: false };
-  }
-
-  // Same ordering rule as reopenQueueIssue: the state change goes LAST, so a
-  // partial failure leaves the stub closed and still labeled — i.e. still
-  // stranded, still matched by the sweep, retried on the next run — instead of
-  // reopening it into a state the label edit never finished describing.
-  await run(buildReopenLabelEditArgs(existingIssue.number, options.repo), {
-    dryRun: options.dryRun,
-    mutates: true,
-  });
-  await run(
-    [
-      "issue",
-      "comment",
-      String(existingIssue.number),
-      "-R",
-      options.repo,
-      "--body",
-      buildStrandedRecoveryComment(),
-    ],
-    { dryRun: options.dryRun, mutates: true },
-  );
-  await run(
-    ["issue", "reopen", String(existingIssue.number), "-R", options.repo],
-    { dryRun: options.dryRun, mutates: true },
-  );
-  return { recovered: true };
+  // False when the live re-read no longer shows the stranded pairing, which is a
+  // normal no-op, not a failure.
+  return { recovered: outcome.requeued };
 }
 
 /**
@@ -1126,6 +814,29 @@ async function fetchIssueComments(options, issueNumber, runner) {
   return pages.flat().filter((comment) => typeof comment?.body === "string");
 }
 
+/**
+ * Stage A's regression reopen: Sentry reported events after this stub's close,
+ * so the previous round's verdict describes a dead occurrence.
+ *
+ * SENTRY-EVIDENCE cause, so the chokepoint fences — and it, not this function,
+ * owns the fence text, the fence-before-labels ordering, and the state-change-
+ * last ordering.
+ *
+ * `dedupeFence` is the one policy this path declares that the archive's refusal
+ * deliberately does NOT, and the premise is specific to ingest's gate: an
+ * identical body means an identical `lastSeen`, and `decideDedupAction`'s
+ * `lastSeen > closedAt` cannot fire twice for one `lastSeen` with a verdict in
+ * between — a verdict implies a later close, which puts `closedAt` past that
+ * `lastSeen`. So the guard can only ever suppress a duplicate of a fence already
+ * in place. The archive's refusal fires on `isActivelyRegressing`, which reads
+ * Sentry's substatus and stays true for days regardless of timestamps, so the
+ * same premise does not hold there. (The chokepoint additionally disarms the
+ * guard whenever `lastSeen` does not parse, since the body then identifies no
+ * occurrence at all.)
+ *
+ * `runGh` is injectable so the test can drive this exact sequence against a
+ * stateful fake instead of re-implementing it.
+ */
 export async function reopenQueueIssue(
   options,
   existingIssue,
@@ -1133,99 +844,22 @@ export async function reopenQueueIssue(
   deps = {},
 ) {
   const run = deps.runGh ?? runGh;
-  const fence = buildRegressedComment(sentryIssue.lastSeen);
-
-  // TWO ordering rules, and they point the same way.
-  //
-  // 1. The FENCE COMMENT GOES FIRST. It is what tells the verdict parser that
-  //    the previous round's verdict describes a dead occurrence
-  //    (selectVerdictComment in scripts/sentry-triage-project-core.mjs). With
-  //    the label edit first, a crash between the two writes leaves the stub
-  //    closed, wearing `sentry:needs-triage`, with NO fence — and once Sentry
-  //    drops the issue out of `is:regressed`, the stranded sweep reopens it
-  //    with only its non-fence bookkeeping note, so a later triage round that
-  //    dies before posting lets the `always()` verdict job accept the
-  //    PRE-REGRESSION verdict and close over the new occurrence. Fence first
-  //    makes the interrupted state fenced-but-not-yet-queued, which is inert:
-  //    nothing selects it, and this whole sequence retries.
-  // 2. The REOPEN (state change) GOES LAST. The closed->open transition is what
-  //    flips the next run onto the open-match skip path, so an early reopen
-  //    followed by a failure would leave the issue open without
-  //    `sentry:needs-triage` — reopened but invisible to triage.
-  //
-  // Every interruption point therefore lands on a safe state: fence only
-  // (inert, retried), or fence + label while still closed (the stranded
-  // pairing, but FENCED, which the sweep reopens without loss).
-  //
-  // Posting first widens the window in which a retry could re-post the fence,
-  // so the post is guarded by an exact-body check — but ONLY when `lastSeen`
-  // parses, because that is the sole thing making the body identify a specific
-  // occurrence.
-  //
-  // With a usable timestamp the guard is safe in the direction that matters: an
-  // identical body means an identical `lastSeen`, and the reopen gate
-  // (lastSeen > closedAt) cannot fire twice for one `lastSeen` with a verdict in
-  // between — a verdict implies a later close, which puts closedAt past that
-  // lastSeen. The guard can then only suppress a duplicate of a fence already in
-  // place.
-  //
-  // A MISSING or UNPARSABLE `lastSeen` destroys that argument at both ends, and
-  // it is not a hypothetical: decideDedupAction deliberately fails open there
-  // and reopens on EVERY closed observation, while buildRegressedComment renders
-  // the same constant body every time. Identical bodies then prove nothing about
-  // which occurrence they belong to, so round two would find round one's comment
-  // and skip its own fence — leaving round one's VERDICT (posted after that
-  // fence) newest-admissible over a fresh occurrence. Whenever the timestamp
-  // cannot establish belonging, always post: a duplicate fence is noise, a
-  // missing one buries a regression.
-  // The dedup read is AUTHOR-FENCED, via the same primitive #1715 introduced for
-  // run-record selection. This repo is public: without the author check, anyone
-  // who guesses the regression's exact `lastSeen` — the stub body publishes a
-  // near-miss of it — can pre-post the matching fence body and have this check
-  // suppress the bot's real fence. `selectVerdictComment` would then ignore the
-  // attacker's comment (it does fence on authorship), so the stub ends up
-  // re-queued with the pre-regression verdict still admissible, and a triage
-  // round that dies before posting closes over the new occurrence. An outsider
-  // could drive that from a comment box.
-  //
-  // `selectMarkedComment` anchors with startsWith rather than equality, which is
-  // what we want: the archive's refusal comment opens with this exact fence line
-  // and then adds prose, so a trusted refusal already carrying this `lastSeen`
-  // correctly counts as the fence being in place.
-  const fenceIdentifiesOccurrence = !Number.isNaN(
-    Date.parse(sentryIssue.lastSeen ?? ""),
-  );
-  const alreadyFenced =
-    fenceIdentifiesOccurrence &&
-    selectMarkedComment(
-      await fetchIssueComments(options, existingIssue.number, deps.runGh),
-      fence,
-    ) !== null;
-  if (alreadyFenced) {
-    process.stderr.write(
-      `::notice::Regression fence for ${sentryIssue.lastSeen} already present on #${existingIssue.number}; not re-posting.\n`,
-    );
-  } else {
-    await run(
-      [
-        "issue",
-        "comment",
-        String(existingIssue.number),
-        "-R",
-        options.repo,
-        "--body",
-        fence,
-      ],
-      { dryRun: options.dryRun, mutates: true },
-    );
-  }
-  await run(buildReopenLabelEditArgs(existingIssue.number, options.repo), {
-    dryRun: options.dryRun,
-    mutates: true,
-  });
-  await run(
-    ["issue", "reopen", String(existingIssue.number), "-R", options.repo],
-    { dryRun: options.dryRun, mutates: true },
+  await requeueQueueStub(
+    {
+      writeGh: (args) => run(args, { dryRun: options.dryRun, mutates: true }),
+      readComments: (number) => fetchIssueComments(options, number, deps.runGh),
+      // Records the ATTEMPT in runIngest's exclusion set before the first write,
+      // so a reopen that throws half-way is never inherited by the same run's
+      // fence-free bookkeeping sweep.
+      claim: deps.claim,
+    },
+    {
+      repo: options.repo,
+      issueNumber: existingIssue.number,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: sentryIssue.lastSeen,
+      dedupeFence: true,
+    },
   );
 }
 
@@ -1368,8 +1002,14 @@ export async function runIngest(options, deps = {}) {
         // refactor the other does not: give `reopenIssue` its own try/catch, the
         // way the archive leg wraps its best-effort writes, and the outer catch
         // stops firing while this line still holds.
-        claimedBySentryPath.add(existingIssue.number);
-        await reopenIssue(options, existingIssue, sentryIssue);
+        //
+        // `claim` hands the same rule to the chokepoint, which records the
+        // attempt before its own first write. That is the copy a caller added
+        // later inherits without remembering to; this one covers a caller that
+        // replaces `reopenIssue` wholesale (the tests do).
+        const claim = () => claimedBySentryPath.add(existingIssue.number);
+        claim();
+        await reopenIssue(options, existingIssue, sentryIssue, { claim });
         counts.reopened += 1;
       }
     } catch (err) {

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -1,0 +1,319 @@
+/**
+ * Pure queue contract for the Sentry triage pipeline (ADR 0036): the label
+ * namespace, the untrusted-text neutralization every public-repo write goes
+ * through, and the archive freshness-baseline field pair. NO I/O lives here.
+ *
+ * Why this module exists rather than more arrivals in
+ * `sentry-triage-project-core.mjs`: that module is the VERDICT contract (markers,
+ * parsing, comment selection) and is already the largest shared surface in this
+ * package. The queue-label and archive-baseline contracts are a different thing
+ * with different consumers, and they are what `sentry-triage-requeue.mjs` — the
+ * single re-queue chokepoint — needs. Giving them their own home is what lets the
+ * chokepoint live outside `sentry-triage-ingest.mjs` without an import cycle
+ * (ingest imports the chokepoint; the chokepoint would otherwise import ingest).
+ *
+ * `sentry-triage-ingest.mjs` re-exports everything here, so the queue scripts and
+ * their tests keep one import surface.
+ */
+
+import { extractYamlBlock } from "./sentry-triage-project-core.mjs";
+
+// ---------------------------------------------------------------------------
+// Untrusted-text neutralization. Sentry titles/culprits/timestamps are
+// attacker-reachable text — never execute/eval anything derived from them, and
+// never let them reach a public queue issue unneutralized.
+// ---------------------------------------------------------------------------
+
+/** Strip control chars/newlines and collapse whitespace to a single line. */
+export function sanitizeFreeText(text) {
+  return (
+    String(text ?? "")
+      // eslint-disable-next-line no-control-regex -- stripping control chars from untrusted Sentry text is the whole point here
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+      .replace(/[\r\n\t]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+// Replace every backtick with a visually similar but byte-distinct
+// character. This is what actually prevents an attacker-controlled Sentry
+// title/culprit from closing the ```yaml fence early (or a single-backtick
+// inline-code span) once embedded in the issue body's markdown.
+export function defangBackticks(text) {
+  return text.replace(/`/g, "ˋ");
+}
+
+// Insert a zero-width space after every `@` so `@user` / `@org/team` in
+// attacker-reachable Sentry text can never become a live GitHub mention
+// (which would notify/subscribe real users) once embedded in an issue title
+// or comment. Visual fidelity is preserved for triage.
+export function defangMentions(text) {
+  return text.replace(/@/g, "@\u200B");
+}
+
+export function neutralizeUntrusted(text) {
+  return defangMentions(defangBackticks(sanitizeFreeText(text)));
+}
+
+export function truncateTitle(text, maxLen = 90) {
+  const clean = text ?? "";
+  if (clean.length <= maxLen) return clean;
+  return `${clean.slice(0, maxLen).trimEnd()}…`;
+}
+
+// ---------------------------------------------------------------------------
+// Label namespace.
+// ---------------------------------------------------------------------------
+
+// The queue's "awaiting a current verdict" marker. Stage B's selector filters
+// on it, the digest classifies on it, and the re-queue chokepoint writes it —
+// so it is a named constant here rather than a literal at each use site. The
+// LABEL_DEFINITIONS entry keeps its own literal on purpose (the bootstrap must
+// list every label inline).
+export const NEEDS_TRIAGE_LABEL = "sentry:needs-triage";
+
+// Idempotently created/updated on every run (`gh label create --force`).
+export const LABEL_DEFINITIONS = [
+  {
+    name: "sentry-triage",
+    color: "5319e7",
+    description: "Sentry triage pipeline queue issue (ADR 0036)",
+  },
+  {
+    name: "sentry:needs-triage",
+    color: "fbca04",
+    description: "Awaiting triage-agent verdict",
+  },
+  {
+    name: "sentry:candidate-noise",
+    color: "d4c5f9",
+    description:
+      "Matches known operational-noise heuristics (CSP, timeouts, chunk-load, abort)",
+  },
+  {
+    name: "sentry:verdict-code-fix",
+    color: "0e8a16",
+    description: "Triage verdict: fixable in this repo's code",
+  },
+  {
+    name: "sentry:verdict-config-fix",
+    color: "1d76db",
+    description: "Triage verdict: fixable via configuration",
+  },
+  {
+    name: "sentry:verdict-upstream",
+    color: "e99695",
+    description: "Triage verdict: upstream/third-party, not fixable here",
+  },
+  {
+    name: "sentry:verdict-needs-human",
+    color: "d93f0b",
+    description: "Triage verdict: needs human judgment",
+  },
+  {
+    name: "sentry:projected",
+    color: "0052cc",
+    description:
+      "Actionable verdict projected as an issue in the owning repo (ADR 0038)",
+  },
+  {
+    name: "sentry:fix-pr-opened",
+    color: "006b75",
+    description:
+      "Autofix leg opened a scoped fix PR for this verdict (ADR 0036 Phase 2b)",
+  },
+  {
+    name: "sentry:fix-refused",
+    color: "bfdadc",
+    description:
+      "Autofix declined to open a PR (no change/guard-refused); remove to retry (ADR 0036 Phase 2b)",
+  },
+  {
+    name: "sentry:approved-archive",
+    color: "1a7f37",
+    description:
+      "Human-approved: archive the underlying Sentry issue (Phase 2a, ADR 0036)",
+  },
+  {
+    name: "sentry:archived",
+    color: "6e7681",
+    description:
+      "Sentry issue archived (archived_until_escalating) via the Phase 2a archive loop (ADR 0036)",
+  },
+];
+
+export const PROJECTED_LABEL = "sentry:projected";
+
+// The verdict that makes a queue stub eligible for the autofix leg. The autofix
+// finalize step re-reads this immediately before writing a terminal marker: the
+// diff is only justified while the verdict that produced it still stands, and
+// ingest (its own concurrency group) can shed it mid-run on a regression
+// re-queue. Single source of truth for the JS consumers — the select step
+// imports it as AUTOFIX_SELECT_LABEL and the finalize marker re-read imports it
+// as its expected verdict. The LABEL_DEFINITIONS entry above and the workflow's
+// pre-push grep guard (.github/workflows/sentry-autofix.yml) are deliberate
+// literal twins: the label bootstrap must list every label inline, and a shell
+// `grep -Fxq` cannot import a JS constant.
+export const CODE_FIX_VERDICT_LABEL = "sentry:verdict-code-fix";
+
+// Applied to a `code-fix` queue stub once the autofix leg (ADR 0036 Phase 2b,
+// `.github/workflows/sentry-autofix.yml`) has opened a scoped fix PR for it.
+// The autofix select step reads it as a dedup marker so a stub is never
+// re-fixed. Bootstrapped from LABEL_DEFINITIONS above (single source of truth)
+// and self-healed by the autofix finalize step before it labels the stub.
+export const FIX_PR_OPENED_LABEL = "sentry:fix-pr-opened";
+
+// Applied to a `code-fix` queue stub when an autofix attempt declined to open a
+// PR — the agent made no change or the mechanical diff guard refused the diff.
+// Without it the same unfixable stub is re-picked every run and burns the
+// per-run cap forever (starvation). The autofix select step reads it as a dedup
+// marker exactly like FIX_PR_OPENED_LABEL; a human clears it (removes the label)
+// to allow a fresh retry. Bootstrapped from LABEL_DEFINITIONS above and
+// self-healed by the autofix workflow's refused path before it labels the stub.
+export const FIX_REFUSED_LABEL = "sentry:fix-refused";
+
+// Phase 2a human-approved archive loop (ADR 0036 Stage C,
+// scripts/sentry-triage-archive.mjs + .github/workflows/sentry-triage-archive.yml).
+// APPROVED_ARCHIVE_LABEL is the human-applied approval marker that triggers the
+// archive workflow; ARCHIVED_LABEL is the terminal audit marker the archive
+// script applies once the Sentry issue is archived. Both are bootstrapped by
+// the ingest label set above and self-healed by the archive script — single
+// source of truth for their colors/descriptions.
+export const APPROVED_ARCHIVE_LABEL = "sentry:approved-archive";
+export const ARCHIVED_LABEL = "sentry:archived";
+
+// Stage B's verdict namespace, derived from the definitions above so the two
+// can't drift. A reopened regression must shed its previous verdict — the
+// old verdict described the old occurrence, and downstream consumers filter
+// on `sentry:needs-triage` + absence of a verdict.
+export const VERDICT_LABELS = LABEL_DEFINITIONS.map(
+  (label) => label.name,
+).filter((name) => name.startsWith("sentry:verdict-"));
+
+// Labels a re-queue must shed: the stale verdict labels, the stale
+// `sentry:projected` marker (ADR 0038), the stale autofix markers
+// (`sentry:fix-pr-opened` / `sentry:fix-refused`, ADR 0036 Phase 2b), AND the
+// stale Phase-2a archive markers (`sentry:approved-archive` / `sentry:archived`).
+// A re-queue means the stub is awaiting a fresh verdict, so every trace of how
+// the previous round was handled must clear: leaving a verdict/projection would
+// misrepresent a needs-triage stub as already verdicted/projected; leaving an
+// autofix marker would both misrepresent it as fixed/refused AND block the
+// re-triage round from ever being autofixed again (the select step dedups on
+// those markers); and leaving an archive marker would misrepresent it as
+// approved/archived — shedding the approval marker is also an authority-boundary
+// guard, since a regression must not carry a stale human archive approval into a
+// fresh occurrence (a workflow_dispatch retry would otherwise read it as
+// still-approved and re-archive without re-review). If the re-triage round lands
+// on an actionable verdict again, the projection/autofix steps re-apply their
+// markers (idempotently reusing the same owning-repo issue / opening a fresh fix
+// PR), and a fresh archive needs a fresh human approval.
+export const REOPEN_SHED_LABELS = [
+  ...VERDICT_LABELS,
+  PROJECTED_LABEL,
+  FIX_PR_OPENED_LABEL,
+  FIX_REFUSED_LABEL,
+  APPROVED_ARCHIVE_LABEL,
+  ARCHIVED_LABEL,
+];
+
+// ---------------------------------------------------------------------------
+// Archive freshness baseline (issue #1371).
+// ---------------------------------------------------------------------------
+
+// The archive script records the Sentry `lastSeen` it observed immediately
+// BEFORE it mutated the issue, plus the Sentry issue id it mutated.
+// `decideDedupAction` compares a regression's `lastSeen` against that instant
+// instead of the stub's `closedAt`: the close necessarily postdates any event
+// that landed while the archive ran, so a `closedAt` comparison would evaluate
+// false for that event permanently and bury a real regression until some later
+// event happened to arrive. These field names are the shared contract between
+// scripts/sentry-triage-ingest.mjs and scripts/sentry-triage-archive.mjs.
+//
+// The baseline lives in the queue stub's BODY, in the same yaml block ingest
+// writes at creation — never in a comment. That placement IS the trust boundary,
+// and it is structural rather than cryptographic. The Stage B triage agent is an
+// LLM reading attacker-controlled Sentry payloads, and
+// .github/workflows/sentry-triage-agent.yml grants it
+// `Bash(gh issue comment <matrix.issue>:*)` — its comments post as
+// `github-actions[bot]`, on this exact stub. So no author check, marker check, or
+// id check applied to a COMMENT can be trusted: a prompt-injected payload can
+// satisfy all of them and plant a far-future baseline, after which every later
+// regression of that Sentry issue is skipped indefinitely. The agent's allowlist
+// grants no tool that edits an issue body (`Read,Grep,Glob` + three scoped
+// `gh issue` subcommands; the autofix agent gets file-edit tools and no shell at
+// all), and no script or workflow step ever rewrites a stub body except the
+// archive leg's own deterministic, zero-LLM write. Moving the field into the body
+// therefore removes the forgery surface instead of trying to authenticate inside
+// it, which a shared-secret signature could only match, never beat.
+export const ARCHIVE_BASELINE_FIELD = "archive_baseline_last_seen";
+export const ARCHIVE_BASELINE_ID_FIELD = "archive_baseline_sentry_issue_id";
+
+/** Read one scalar out of a stub's yaml block. Keys are fixed literals (no regex
+ * injection) written one per line as `key: "value"`. */
+function readBaselineField(block, key) {
+  const match = new RegExp(`^${key}:[ \\t]*(.+)$`, "m").exec(
+    String(block ?? ""),
+  );
+  if (!match) return "";
+  return match[1]
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .trim();
+}
+
+/**
+ * Parse the archive freshness baseline out of a queue stub's BODY. Returns null
+ * when the body carries no baseline field — the normal state for a stub that has
+ * never been archived. The timestamp comes back RAW; validity is the caller's
+ * `Date.parse` gate, so a garbage value degrades to the `closedAt` fallback
+ * instead of throwing.
+ */
+export function parseArchiveBaseline(issueBody) {
+  const block = extractYamlBlock(issueBody);
+  if (!block) return null;
+  const lastSeen = readBaselineField(block, ARCHIVE_BASELINE_FIELD);
+  if (!lastSeen) return null;
+  return {
+    lastSeen,
+    sentryIssueId: readBaselineField(block, ARCHIVE_BASELINE_ID_FIELD),
+  };
+}
+
+/**
+ * Return `body` with the archive baseline fields set inside its existing yaml
+ * block, replacing any previous values (a re-archive supersedes). Used by the
+ * archive leg's body rewrite; kept here so the writer and the reader above stay
+ * one edit apart.
+ *
+ * A NULL baseline strips the two fields instead of setting them. The archive's
+ * rollback needs that: it must put the baseline back the way it found it while
+ * leaving every other part of the body — including edits a human made after the
+ * run's snapshot — exactly as it is live.
+ *
+ * Returns null when the body has no yaml block to extend — the archive treats
+ * that as a hard refusal rather than inventing structure, since a stub whose
+ * body it cannot parse is one ingest cannot read a baseline back out of either.
+ */
+export function withArchiveBaseline(body, baseline) {
+  const source = String(body ?? "");
+  const block = extractYamlBlock(source);
+  if (!block) return null;
+  const stripped = block
+    .split("\n")
+    .filter(
+      (line) =>
+        !new RegExp(
+          `^(${ARCHIVE_BASELINE_FIELD}|${ARCHIVE_BASELINE_ID_FIELD}):`,
+        ).test(line.trim()),
+    )
+    .join("\n");
+  const rebuilt = baseline
+    ? [
+        stripped,
+        `${ARCHIVE_BASELINE_FIELD}: ${JSON.stringify(String(baseline.lastSeen ?? ""))}`,
+        `${ARCHIVE_BASELINE_ID_FIELD}: ${JSON.stringify(String(baseline.sentryIssueId ?? ""))}`,
+      ].join("\n")
+    : stripped;
+  return source.replace(block, rebuilt);
+}

--- a/scripts/sentry-triage-requeue.mjs
+++ b/scripts/sentry-triage-requeue.mjs
@@ -1,0 +1,610 @@
+/**
+ * THE ONE WAY TO RE-QUEUE A SENTRY TRIAGE QUEUE STUB.
+ *
+ * "Re-queue" means: make a stub selectable for a fresh triage round — restore
+ * `sentry:needs-triage`, shed every marker describing how the PREVIOUS round was
+ * handled (REOPEN_SHED_LABELS), and reopen it. Before this module that sequence
+ * was open-coded at each producer, and every producer independently decided
+ * whether it also posted the verdict-staleness fence. Seven distinct defects came
+ * out of that arrangement in one PR (#1716), each locally plausible, all of them
+ * the same shape: a re-queue whose fence, ordering, claim, or admissibility check
+ * disagreed with the rule that lived only in prose.
+ *
+ * So the rule lives here, and the cause is an argument:
+ *
+ *   `sentry-evidence` — new Sentry events made the previous verdict describe a
+ *   dead occurrence. MUST fence: `selectVerdictComment`
+ *   (scripts/sentry-triage-project-core.mjs) accepts the newest verdict only when
+ *   it is newer than the newest comment starting with REGRESSION_PREFIX. Without
+ *   the fence, a triage round that dies before posting lets the `verdict` job
+ *   (which runs under `always()`) accept the stale verdict and close the stub over
+ *   a live regression.
+ *
+ *   `bookkeeping` — a close whose response was lost, a hand-edit, a compensation.
+ *   MUST NOT fence: nothing about the Sentry issue changed, so the verdict already
+ *   computed for it is still valid. Fencing it discards a good verdict and forces
+ *   a pointless re-triage. Over-fencing is exactly as wrong as under-fencing, and
+ *   quieter.
+ *
+ * The invariants this module owns, each paid for by one of those defects:
+ *
+ *  1. Fence IFF the cause is Sentry evidence — decided from `cause`, never from
+ *     what a caller passes as the comment body.
+ *  2. The fence text has ONE definition (`buildRegressedComment`) and this module
+ *     is its only caller. A caller contributes prose that renders BELOW the fence
+ *     line; it can never author the fence line itself.
+ *  3. Post the fence BEFORE mutating labels; change state LAST. An interrupted run
+ *     must leave a fenced-but-unqueued stub (inert, retried), never a
+ *     queued-but-unfenced one (the close-over-a-live-regression setup).
+ *  4. The exclusion set records ATTEMPTS, not successes: `claim` fires before any
+ *     I/O, so a re-queue that throws half-way is never inherited by the
+ *     fence-free bookkeeping sweep inside the same run.
+ *  5. "Is this stub protected?" is answered by running `selectVerdictComment` over
+ *     LIVE comments and requiring that no admissible verdict survives — never by
+ *     a fence comment's presence, and never by body equality. Presence is not
+ *     admissibility: the consumer selects by RECENCY, so a fence that exists but
+ *     predates the newest verdict protects nothing.
+ *  6. Every read of a comment body is author-fenced through `selectMarkedComment`.
+ *     This repo is PUBLIC; an unfenced body match is satisfiable by anyone.
+ *  7. Live state is revalidated immediately before mutating when the caller's
+ *     premise is a snapshot, and a failed read aborts rather than proceeding.
+ *
+ * Callers declare a CAUSE and a small, explicit policy. They never reconstruct
+ * the sequence, and they never decide the fence.
+ */
+
+import {
+  NEEDS_TRIAGE_LABEL,
+  neutralizeUntrusted,
+  REOPEN_SHED_LABELS,
+  truncateTitle,
+} from "./sentry-triage-queue-contract.mjs";
+import {
+  selectMarkedComment,
+  selectVerdictComment,
+} from "./sentry-triage-project-core.mjs";
+
+// ---------------------------------------------------------------------------
+// Causes.
+// ---------------------------------------------------------------------------
+
+/** New Sentry events. Any prior verdict describes a dead occurrence. */
+export const REQUEUE_CAUSE_SENTRY_EVIDENCE = "sentry-evidence";
+/** A lost close response, a compensation, a hand-edit. Nothing in Sentry moved. */
+export const REQUEUE_CAUSE_BOOKKEEPING = "bookkeeping";
+
+const REQUEUE_CAUSES = new Set([
+  REQUEUE_CAUSE_SENTRY_EVIDENCE,
+  REQUEUE_CAUSE_BOOKKEEPING,
+]);
+
+/**
+ * THE RULE, as one expression: fence iff the cause is new Sentry evidence.
+ *
+ * An unknown cause THROWS rather than defaulting. Both defaults are wrong — a
+ * silent no-fence buries regressions, a silent fence discards valid verdicts —
+ * and a caller that cannot name its cause has not decided anything yet.
+ */
+export function requeueFences(cause) {
+  if (!REQUEUE_CAUSES.has(cause)) {
+    throw new Error(
+      `Unknown re-queue cause ${JSON.stringify(cause)}; a re-queue must declare ${REQUEUE_CAUSE_SENTRY_EVIDENCE} or ${REQUEUE_CAUSE_BOOKKEEPING} so the verdict-staleness fence is decided rather than inherited.`,
+    );
+  }
+  return cause === REQUEUE_CAUSE_SENTRY_EVIDENCE;
+}
+
+// ---------------------------------------------------------------------------
+// The two comment bodies, each with exactly one definition.
+// ---------------------------------------------------------------------------
+
+/**
+ * THE FENCE. Its prefix is REGRESSION_PREFIX
+ * (scripts/sentry-triage-project-core.mjs), which is what makes
+ * `selectVerdictComment` treat every verdict older than this comment as stale.
+ *
+ * `buildRequeueFence` is its only caller, so no site can post a fence the
+ * chokepoint did not decide on, and none can post a re-queue comment that merely
+ * looks like one.
+ */
+export function buildRegressedComment(lastSeen) {
+  // `lastSeen` should be a Sentry-generated ISO timestamp, but it still
+  // transits Sentry's API from event data — neutralize + bound it like every
+  // other Sentry-derived string (no-op for a legitimate timestamp).
+  return `Regressed in Sentry (last seen ${truncateTitle(neutralizeUntrusted(lastSeen), 90)})`;
+}
+
+/**
+ * THE BOOKKEEPING NOTE. Fixed text — no Sentry-derived or otherwise untrusted
+ * input — and deliberately NOT the fence: this repair is not a new Sentry
+ * occurrence, so a verdict already posted for the stub stays valid and
+ * admissible.
+ *
+ * Written as INTENT, not outcome, because of where it sits in the sequence: the
+ * state change goes last, so this note is posted while the stub is still closed
+ * and the reopen may yet fail. Wording it as completed fact ("Reopened…",
+ * "Re-queued…") left a closed stub carrying a note about something that had not
+ * happened, and every retry added another false entry.
+ *
+ * The repetition itself is not the bug and must not be suppressed: a stub that
+ * keeps failing to reopen SHOULD accumulate a note per attempt, because that
+ * repetition is the honest signal. So the text says what this run is doing and
+ * what a failure means, and reads correctly either way.
+ */
+export function buildStrandedRecoveryComment() {
+  return (
+    "Sentry triage ingest is recovering this queue stub: it was closed while " +
+    "still carrying `sentry:needs-triage`, a pairing no pipeline stage can " +
+    "see — the triage selector lists open stubs only. Its stale verdict, " +
+    "projection and autofix markers have been shed, and a reopen follows this " +
+    "note. If that reopen fails the stub stays closed and the next scheduled " +
+    "run retries, so this note can appear more than once."
+  );
+}
+
+/**
+ * The comment a re-queue posts BEFORE it touches labels, or null when the cause
+ * does not fence.
+ *
+ * `prose` is the caller's human-facing explanation, rendered as lines BELOW the
+ * fence line with one blank line between. The fence line itself is always
+ * `buildRegressedComment`, so a caller can explain a refusal without being able
+ * to author — or omit — the thing the parser reads.
+ */
+export function buildRequeueFence(
+  cause,
+  { lastSeen = null, prose = null } = {},
+) {
+  if (!requeueFences(cause)) return null;
+  const fence = buildRegressedComment(lastSeen);
+  return prose?.length ? [fence, "", ...prose].join("\n") : fence;
+}
+
+// ---------------------------------------------------------------------------
+// Admissibility and selectability.
+// ---------------------------------------------------------------------------
+
+/**
+ * Would a verdict still be re-appliable to this stub? True means DANGER: the
+ * `verdict` job could pick a previous round's verdict off these comments and
+ * close the stub with it.
+ *
+ * PRESENCE IS NOT ADMISSIBILITY, and that distinction is the whole point.
+ * An earlier check asked "does a trusted fence exist?" — a different question
+ * from the one the consumer asks. `selectVerdictComment` selects by RECENCY: it
+ * takes the newest verdict and rejects it only when a newer regression comment
+ * exists. A fence that exists but PREDATES the newest verdict therefore protects
+ * nothing, and the archive's refusal body is byte-identical across runs for one
+ * `lastSeen`, so a stub really can carry an old copy underneath a newer verdict.
+ *
+ * So ask the consumer's question with the consumer's own primitive: no admissible
+ * verdict may survive. Sharing `selectVerdictComment` is what stops the guard and
+ * the thing it guards against from drifting apart again.
+ */
+export function hasAdmissibleVerdict(comments) {
+  return selectVerdictComment(comments ?? []).body !== null;
+}
+
+/** The pair Stage B's selector matches: `--state open` AND
+ * `sentry:needs-triage`. A stub missing either is invisible to triage, and — if
+ * its `closedAt` postdates the regression — to ingest as well. */
+export function isSelectableForTriage({ state, labels } = {}) {
+  return (
+    String(state ?? "").toUpperCase() !== "CLOSED" &&
+    (Array.isArray(labels) ? labels : []).includes(NEEDS_TRIAGE_LABEL)
+  );
+}
+
+/**
+ * The label edit every re-queue makes: restore `sentry:needs-triage` and shed
+ * every marker describing the previous round (REOPEN_SHED_LABELS). Removing an
+ * absent label is a no-op for `gh issue edit` (the labels themselves always
+ * exist because the ingest label bootstrap runs first). Exported for tests.
+ */
+export function buildReopenLabelEditArgs(issueNumber, repo) {
+  return [
+    "issue",
+    "edit",
+    String(issueNumber),
+    "-R",
+    repo,
+    "--add-label",
+    NEEDS_TRIAGE_LABEL,
+    "--remove-label",
+    REOPEN_SHED_LABELS.join(","),
+  ];
+}
+
+/**
+ * Fails CLOSED: a read that throws returns true, so an unverifiable stub counts
+ * as unsafe.
+ */
+async function admissibleVerdictSurvives(readStub, issueNumber) {
+  try {
+    const live = await readStub(issueNumber);
+    return hasAdmissibleVerdict(live.comments);
+  } catch (err) {
+    process.stderr.write(
+      `::notice::Could not re-read #${issueNumber} to check whether a previous verdict is still admissible (${
+        err instanceof Error ? err.message : String(err)
+      }); treating it as unsafe.\n`,
+    );
+    return true;
+  }
+}
+
+/**
+ * Drive a stub to the selectable pair and VERIFY it got there, or fail loudly.
+ *
+ * This exists because checking each write's return value kept missing a layer:
+ * the reopen was absent, then a failed read aborted it, then the reopen write
+ * itself could fail — three rounds, one location, each fix covering only the
+ * failure mode in front of it. Asserting the END STATE covers all of them and
+ * whatever comes next, because it observes the thing that actually matters
+ * rather than the success of the steps meant to produce it.
+ *
+ * Observe, correct what is wrong, observe again. Both corrections are idempotent
+ * so a retry is safe and cheap, and it runs before failing. When the final
+ * observation still disagrees — or could never be taken — the stub is stranded
+ * and only a human can free it, so this throws and the run goes RED with an
+ * `::error::` naming what was actually seen.
+ *
+ * `fallbackState` is the caller's pre-run observation, used only to decide
+ * whether to attempt a reopen when a read fails; it never satisfies the
+ * invariant, which requires a real confirming read.
+ *
+ * Returns the confirming read, so the caller can judge the rest of the stub's
+ * state from what was actually observed rather than from what its own writes
+ * reported — the same ambiguous-response discipline the archive reconciler uses.
+ */
+export async function ensureSelectableForTriage(
+  { writeGh, readStub },
+  { repo, issueNumber, fallbackState = "CLOSED", attempts = 2 },
+) {
+  let observed = null;
+  let readError = null;
+
+  const observe = async () => {
+    try {
+      const live = await readStub(issueNumber);
+      observed = live;
+      readError = null;
+      return live;
+    } catch (err) {
+      readError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::notice::Could not read #${issueNumber} while re-queuing it for triage (${readError}); correcting from its pre-run state (${fallbackState}) and re-checking.\n`,
+      );
+      return null;
+    }
+  };
+
+  for (let round = 1; round <= attempts; round += 1) {
+    const live = await observe();
+    if (live && isSelectableForTriage(live)) return live;
+
+    // Correct whatever is — or, with no read, may be — wrong. Both writes are
+    // idempotent, so a repeat costs nothing and a lost response is harmless.
+    const looksClosed = live
+      ? live.state === "CLOSED"
+      : String(fallbackState ?? "").toUpperCase() === "CLOSED";
+    const missingLabel = live
+      ? !live.labels.includes(NEEDS_TRIAGE_LABEL)
+      : false;
+    if (looksClosed) {
+      try {
+        process.stderr.write(
+          `::notice::Reopening #${issueNumber} so the live regression is visible to triage (round ${round}).\n`,
+        );
+        await writeGh(["issue", "reopen", String(issueNumber), "-R", repo]);
+      } catch (err) {
+        process.stderr.write(
+          `::notice::Reopen of #${issueNumber} reported a failure (${
+            err instanceof Error ? err.message : String(err)
+          }); the verification read decides.\n`,
+        );
+      }
+    }
+    if (missingLabel) {
+      try {
+        await writeGh([
+          "issue",
+          "edit",
+          String(issueNumber),
+          "-R",
+          repo,
+          "--add-label",
+          NEEDS_TRIAGE_LABEL,
+        ]);
+      } catch (err) {
+        process.stderr.write(
+          `::notice::Re-adding ${NEEDS_TRIAGE_LABEL} to #${issueNumber} reported a failure (${
+            err instanceof Error ? err.message : String(err)
+          }); the verification read decides.\n`,
+        );
+      }
+    }
+  }
+
+  // The mandatory final verification, on the main path — never skippable, and
+  // never reached by a correction whose result nobody looked at.
+  const finalLive = await observe();
+  if (finalLive && isSelectableForTriage(finalLive)) return finalLive;
+
+  const seen = observed
+    ? `state=${observed.state}, labels=${observed.labels.join("|")}`
+    : `unreadable (${readError})`;
+  process.stderr.write(
+    `::error::Queue stub #${issueNumber} could not be confirmed open and carrying ${NEEDS_TRIAGE_LABEL} after refusing to archive over a live regression (${seen}). It is STRANDED — Stage B selects only open stubs, and ingest will skip it while its closedAt postdates the regression. Reopen it by hand.\n`,
+  );
+  throw new Error(
+    `Queue stub #${issueNumber} is not selectable for triage after a live-regression refusal (${seen}).`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The chokepoint.
+// ---------------------------------------------------------------------------
+
+/** ABORT: any write failure propagates, leaving the sequence incomplete at a
+ * point the ordering guarantees is safe (ingest's two paths — the run retries).
+ * VERIFY_END_STATE: reported failures are provisional; the sequence completes and
+ * the END STATE is read and judged (the archive's refusal — it is past the point
+ * where its caller's reconciler can help, so the stub must be driven to
+ * selectable and anything still wrong surfaced loudly afterwards). */
+export const REQUEUE_ON_FAILURE_ABORT = "abort";
+export const REQUEUE_ON_FAILURE_VERIFY_END_STATE = "verify-end-state";
+
+/**
+ * Re-queue a queue stub for a fresh triage round.
+ *
+ * deps:
+ *   `writeGh(args)`      — perform a mutating `gh` call. The caller binds its own
+ *                          dry-run / token policy into this.
+ *   `readStub(number)`   — live `{ state, labels, comments? }`. Required whenever
+ *                          the declared policy reads live state.
+ *   `readComments(n)`    — live comment objects (author included). Required only
+ *                          for `dedupeFence`.
+ *   `claim()`            — optional; record this ATTEMPT in the caller's
+ *                          exclusion set. Invoked before any I/O (invariant 4).
+ *
+ * options:
+ *   `cause`              — REQUEUE_CAUSE_*; decides the fence and nothing else may.
+ *   `lastSeen`           — the occurrence the fence names (sentry-evidence).
+ *   `fenceProse`         — extra lines rendered under the fence line.
+ *   `note`               — the bookkeeping note body (bookkeeping causes only).
+ *   `dedupeFence`        — skip the post when an author-trusted, byte-identical
+ *                          fence is already on the stub. Sound ONLY where the
+ *                          gate that produced this re-queue cannot fire twice for
+ *                          one `lastSeen` with a verdict in between; see below.
+ *   `revalidate`         — `{ check(live), declineNote(live) }`. When the caller's
+ *                          premise is a snapshot, re-read and stop unless it still
+ *                          holds. A failed read PROPAGATES.
+ *   `onFailure`          — REQUEUE_ON_FAILURE_*.
+ *   `fallbackState`      — pre-run state, for the verify-end-state reopen.
+ *
+ * Returns `{ requeued, reason, verified, labelError }`.
+ */
+export async function requeueQueueStub(
+  { writeGh, readStub = null, readComments = null, claim = null },
+  {
+    repo,
+    issueNumber,
+    cause,
+    lastSeen = null,
+    fenceProse = null,
+    note = null,
+    dedupeFence = false,
+    revalidate = null,
+    onFailure = REQUEUE_ON_FAILURE_ABORT,
+    fallbackState = "CLOSED",
+  },
+) {
+  // Decide the fence FIRST, from the cause alone. An unknown cause throws here,
+  // before any claim and before any write.
+  const fences = requeueFences(cause);
+  const verifyEndState = onFailure === REQUEUE_ON_FAILURE_VERIFY_END_STATE;
+
+  // INVARIANT 4 — the exclusion set records ATTEMPTS, not successes, and the
+  // record is written before the first thing that can fail. A Sentry-evidence
+  // re-queue that throws half-way must not be inherited by the same run's
+  // fence-free bookkeeping sweep: that laundering is how a regression re-queue
+  // silently loses its fence. `claim` is synchronous, so it survives a throw from
+  // anything below.
+  claim?.();
+
+  // INVARIANT 7 — revalidate a snapshot-derived premise against live state.
+  // A failed read is NOT permission to proceed: it propagates, the stub stays as
+  // it is and visible to the next run, and the run goes nonzero. Recovering blind
+  // is how a snapshot-driven mutation becomes a snapshot-driven mistake.
+  if (revalidate) {
+    const live = await readStub(issueNumber);
+    if (!revalidate.check(live)) {
+      process.stderr.write(`::notice::${revalidate.declineNote(live)}\n`);
+      return {
+        requeued: false,
+        reason: "revalidated-away",
+        verified: null,
+        labelError: null,
+      };
+    }
+  }
+
+  // INVARIANT 1 + 2 + 3 — fence iff Sentry evidence, one definition, posted
+  // BEFORE the labels.
+  //
+  // The ordering is not stylistic. The fence is a PRECONDITION of re-queuing: a
+  // selectable stub with no fence is the close-over-a-live-regression setup, and
+  // the archive, ingest and agent workflows hold separate concurrency groups, so
+  // a triage run can select such a stub inside the window. Post the fence, or do
+  // not re-queue at all. Every interruption point then lands on a safe state:
+  // fence only (inert, retried), or fence + labels while still closed (the
+  // stranded pairing, but FENCED, which the sweep reopens without loss).
+  const fence = buildRequeueFence(cause, { lastSeen, prose: fenceProse });
+  if (fence) {
+    // Posting first widens the window in which a retry could re-post the fence,
+    // so the post can be guarded by an identity check — but ONLY when `lastSeen`
+    // parses, because that is the sole thing making the body identify a specific
+    // occurrence. A missing or unparsable `lastSeen` renders a CONSTANT body, and
+    // ingest's gate deliberately fails open there and re-queues on every closed
+    // observation: round two would then find round one's comment and skip its own
+    // fence, leaving round one's VERDICT (posted after that fence)
+    // newest-admissible over a fresh occurrence. Whenever the timestamp cannot
+    // establish belonging, always post — a duplicate fence is noise, a missing one
+    // buries a regression.
+    //
+    // INVARIANT 6 — the dedup read is AUTHOR-FENCED through `selectMarkedComment`.
+    // This repo is public: without the author check, anyone who guesses the
+    // regression's exact `lastSeen` — the stub body publishes a near-miss of it —
+    // can pre-post the matching body and have this check suppress the bot's real
+    // fence, while `selectVerdictComment` (which does fence on authorship) ignores
+    // theirs. `selectMarkedComment` anchors with startsWith rather than equality,
+    // which is what we want: a trusted refusal that opens with this exact fence
+    // line and then adds prose correctly counts as the fence being in place.
+    const identifiesOccurrence = !Number.isNaN(Date.parse(lastSeen ?? ""));
+    const alreadyFenced =
+      dedupeFence &&
+      identifiesOccurrence &&
+      selectMarkedComment(await readComments(issueNumber), fence) !== null;
+    if (alreadyFenced) {
+      process.stderr.write(
+        `::notice::Regression fence for ${lastSeen} already present on #${issueNumber}; not re-posting.\n`,
+      );
+    } else {
+      try {
+        await writeGh([
+          "issue",
+          "comment",
+          String(issueNumber),
+          "-R",
+          repo,
+          "--body",
+          fence,
+        ]);
+      } catch (err) {
+        if (!verifyEndState) throw err;
+        // A reported failure is not proof. The post can land and lose its
+        // response, so the report is checked against a READ before anything is
+        // decided — and the question asked is the CONSUMER's (invariant 5), not
+        // "is a fence present". Only a stub where a verdict is still admissible
+        // aborts.
+        const reported = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `::notice::Posting the regression fence on #${issueNumber} reported a failure (${reported}); re-reading the stub to check whether a previous verdict is still admissible.\n`,
+        );
+        if (await admissibleVerdictSurvives(readStub, issueNumber)) {
+          // Abort BEFORE the re-queue. The stub is left exactly as it was, so
+          // nothing selects it, the fence-free bookkeeping sweep cannot claim it
+          // (it has no `sentry:needs-triage`), and the documented
+          // workflow_dispatch retry re-runs the whole refusal, fence included.
+          // Leaving a known-live regression closed until someone retries is the
+          // cost, and it is the right one — this state needs a human to linger,
+          // while the alternative needs only a second failure to bury the
+          // regression silently.
+          throw new Error(
+            `Refusing to re-queue #${issueNumber} for triage: the regression fence comment could not be posted (${reported}) and a previous verdict is still admissible, so a failing triage round would close that verdict over this live regression. The stub is unchanged — approval and verdict labels intact — so re-dispatch this workflow to retry the whole refusal.`,
+            { cause: err },
+          );
+        }
+        process.stderr.write(
+          `::notice::No admissible verdict survives on #${issueNumber} despite the reported failure; continuing.\n`,
+        );
+      }
+    }
+  }
+
+  // Labels: restore `sentry:needs-triage`, shed the previous round's markers.
+  let labelError = null;
+  try {
+    await writeGh(buildReopenLabelEditArgs(issueNumber, repo));
+  } catch (err) {
+    if (!verifyEndState) throw err;
+    // Must NOT propagate past the end-state verification below — that is exactly
+    // what let a throw skip the guard. Record it and keep going; the verifier
+    // re-adds `sentry:needs-triage` itself, so the stub still becomes selectable,
+    // and any unshed marker surfaces as a RED run afterwards.
+    labelError = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `::notice::Re-queue label edit on #${issueNumber} reported a failure (${labelError}); the end-state verification below still runs.\n`,
+    );
+  }
+
+  // The bookkeeping note describes the repair rather than gating it, so it rides
+  // with the label write it explains. (A fencing cause has no note: its comment
+  // IS the fence, and that one has to precede the labels.)
+  //
+  // A failure here propagates on BOTH failure modes. That is right for the one
+  // caller that passes a note — the sweep, on `abort`, where the whole sequence
+  // retries next run — and would be wrong for a future one on
+  // `verify-end-state`: the note is no part of the end-state invariant, so
+  // throwing past the verifier would skip a real guard over a comment. Route it
+  // like `labelError` if such a caller ever appears.
+  if (note) {
+    await writeGh([
+      "issue",
+      "comment",
+      String(issueNumber),
+      "-R",
+      repo,
+      "--body",
+      note,
+    ]);
+  }
+
+  // INVARIANT 3, second half — the STATE CHANGE GOES LAST. The closed->open
+  // transition is what flips the next ingest run onto the open-match skip path,
+  // so an early reopen followed by a failure would leave the issue open without
+  // `sentry:needs-triage` — reopened but invisible to triage.
+  let verified = null;
+  if (verifyEndState) {
+    verified = await ensureSelectableForTriage(
+      { writeGh, readStub },
+      { repo, issueNumber, fallbackState },
+    );
+  } else {
+    await writeGh(["issue", "reopen", String(issueNumber), "-R", repo]);
+  }
+
+  if (verifyEndState) {
+    // Judge the fence and the shed from the SAME verification read, for the same
+    // reason: a write can land and lose its response, so its return proves
+    // nothing in either direction. The stub is selectable by now — the invariant
+    // this path owes — so this is loud AFTER it is safe, never instead of making
+    // it safe.
+    //
+    // The fence question is the consumer's again (invariant 5), not "is a fence
+    // present". A fence deleted between the post and this read, and one that was
+    // always older than the newest verdict, both leave a verdict the `verdict`
+    // job would pick up and close the stub with. Presence would miss the second
+    // case entirely.
+    const problems = [];
+    if (fences && hasAdmissibleVerdict(verified.comments)) {
+      problems.push(
+        "a previous verdict is still admissible — no regression fence newer than it survives on the stub — so a failing triage round could close that verdict over this live regression; post the fence by hand, or re-run this workflow, before the next triage run",
+      );
+    }
+    const survivingMarkers = REOPEN_SHED_LABELS.filter((name) =>
+      verified.labels.includes(name),
+    );
+    if (survivingMarkers.length) {
+      problems.push(
+        `these stale markers survived: ${survivingMarkers.join(", ")}${
+          labelError ? ` (label edit reported: ${labelError})` : ""
+        }`,
+      );
+    }
+    // One throw carrying both, so a doubly-broken run cannot report only half.
+    if (problems.length) {
+      throw new Error(
+        `Queue stub #${issueNumber} was made selectable for triage, but ${problems.join("; and ")}.`,
+      );
+    }
+    if (labelError) {
+      process.stderr.write(
+        `::notice::The re-queue label edit on #${issueNumber} reported a failure (${labelError}) that the verification read disproves; the stale markers are gone.\n`,
+      );
+    }
+  }
+
+  return { requeued: true, reason: null, verified, labelError };
+}

--- a/scripts/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry-triage-requeue.test.mjs
@@ -1,0 +1,605 @@
+#!/usr/bin/env node
+/**
+ * Tests for the re-queue chokepoint itself.
+ *
+ * The two call sites are covered end-to-end by
+ * scripts/sentry-triage-ingest.test.mjs and
+ * scripts/sentry-triage-archive.test.mjs. What those cannot reach is the
+ * chokepoint's own contract — the properties a NEW caller would rely on and a
+ * refactor could quietly drop while both existing sites stay green:
+ *
+ *   - the cause decides the fence, and an undeclared cause refuses;
+ *   - the fence text has exactly one definition and one caller;
+ *   - the fence precedes the label write and the state change goes last;
+ *   - the claim records ATTEMPTS, including ones that throw;
+ *   - admissibility is asked by recency, never by presence.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  REGRESSION_PREFIX,
+  VERDICT_MARKER,
+} from "./sentry-triage-project-core.mjs";
+import { NEEDS_TRIAGE_LABEL } from "./sentry-triage-queue-contract.mjs";
+import {
+  buildRegressedComment,
+  buildReopenLabelEditArgs,
+  buildRequeueFence,
+  buildStrandedRecoveryComment,
+  hasAdmissibleVerdict,
+  REQUEUE_CAUSE_BOOKKEEPING,
+  REQUEUE_CAUSE_SENTRY_EVIDENCE,
+  REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+  requeueFences,
+  requeueQueueStub,
+} from "./sentry-triage-requeue.mjs";
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    process.stdout.write(`ok ${name}\n`);
+    passed += 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`not ok ${name}\n  ${message}\n`);
+    failed += 1;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertDeepEqual(actual, expected) {
+  const a = JSON.stringify(actual);
+  const b = JSON.stringify(expected);
+  if (a !== b) throw new Error(`expected ${b}, got ${a}`);
+}
+
+async function assertRejects(promise, pattern) {
+  try {
+    await promise;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (pattern && !pattern.test(message)) {
+      throw new Error(`expected /${pattern.source}/, got: ${message}`, {
+        cause: err,
+      });
+    }
+    return;
+  }
+  throw new Error("expected a rejection");
+}
+
+const REPO = "mento-protocol/monitoring-monorepo";
+const BOT = { author: { login: "github-actions" } };
+
+/** Records every `gh` call the chokepoint makes, and can fail a chosen verb. */
+function makeWriter({ failOn = () => null } = {}) {
+  const calls = [];
+  return {
+    calls,
+    writeGh: async (args) => {
+      calls.push(args);
+      const failure = failOn(args);
+      if (failure) throw new Error(failure);
+      return "";
+    },
+    verbs: () => calls.map((args) => args[1]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The rule itself.
+// ---------------------------------------------------------------------------
+
+await test("the cause, and only the cause, decides the fence", () => {
+  assertEqual(requeueFences(REQUEUE_CAUSE_SENTRY_EVIDENCE), true);
+  assertEqual(requeueFences(REQUEUE_CAUSE_BOOKKEEPING), false);
+});
+
+await test("an undeclared cause refuses instead of defaulting", () => {
+  // Both defaults are wrong. A silent no-fence buries regressions; a silent
+  // fence discards verdicts the pipeline means to keep. A caller that cannot
+  // name its cause has not decided anything yet.
+  for (const bad of [undefined, null, "", "regression", "Sentry-Evidence"]) {
+    let threw = false;
+    try {
+      requeueFences(bad);
+    } catch (err) {
+      threw = /Unknown re-queue cause/.test(err.message);
+    }
+    assert(threw, `cause ${JSON.stringify(bad)} must refuse, not default`);
+  }
+});
+
+await test("buildRequeueFence renders the fence only for Sentry evidence", () => {
+  const fence = buildRequeueFence(REQUEUE_CAUSE_SENTRY_EVIDENCE, {
+    lastSeen: "2026-07-20T08:00:00Z",
+  });
+  assertEqual(fence, buildRegressedComment("2026-07-20T08:00:00Z"));
+  assert(fence.startsWith(REGRESSION_PREFIX), "the parser reads the prefix");
+  assertEqual(
+    buildRequeueFence(REQUEUE_CAUSE_BOOKKEEPING, {
+      lastSeen: "2026-07-20T08:00:00Z",
+    }),
+    null,
+  );
+});
+
+await test("caller prose renders UNDER the fence line, never over it", () => {
+  // A caller can explain its refusal; it can never author — or omit — the line
+  // selectVerdictComment actually reads.
+  const body = buildRequeueFence(REQUEUE_CAUSE_SENTRY_EVIDENCE, {
+    lastSeen: "2026-07-20T08:00:00Z",
+    prose: ["**Not archived.** because reasons", "second line"],
+  });
+  const lines = body.split("\n");
+  assertEqual(lines[0], buildRegressedComment("2026-07-20T08:00:00Z"));
+  assertEqual(lines[1], "");
+  assertEqual(lines[2], "**Not archived.** because reasons");
+  assert(body.startsWith(REGRESSION_PREFIX), "prose cannot displace the fence");
+});
+
+await test("the bookkeeping note is not, and must never become, a fence", () => {
+  assert(
+    !buildStrandedRecoveryComment().startsWith(REGRESSION_PREFIX),
+    "a bookkeeping re-queue must not stale out a still-valid verdict",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// One definition, one caller.
+// ---------------------------------------------------------------------------
+
+await test("buildRegressedComment has exactly one call site: the chokepoint", () => {
+  // #1716 shipped a re-queue that quietly lacked the fence because the fence was
+  // something each producer chose to emit. Keeping the builder to a single
+  // caller is what makes "declare a cause" the only way to get one.
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const offenders = [];
+  for (const file of readdirSync(scriptsDir)) {
+    if (!file.endsWith(".mjs")) continue;
+    if (file.endsWith(".test.mjs")) continue; // tests pin the text, by design
+    if (file === "sentry-triage-requeue.mjs") continue;
+    const src = readFileSync(join(scriptsDir, file), "utf8");
+    // A bare re-export is not a call site.
+    const withoutExports = src.replace(
+      /export\s*\{[^}]*\}\s*from\s*["'][^"']+["'];/g,
+      "",
+    );
+    if (/\bbuildRegressedComment\s*\(/.test(withoutExports)) {
+      offenders.push(file);
+    }
+  }
+  assertDeepEqual(offenders, []);
+});
+
+await test("the chokepoint reaches the fence builder through buildRequeueFence", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "sentry-triage-requeue.mjs"),
+    "utf8",
+  );
+  const calls = src.match(/(?<!function\s)\bbuildRegressedComment\s*\(/g) ?? [];
+  // Exactly one call — the declaration is excluded by the lookbehind.
+  assertEqual(calls.length, 1);
+  assert(
+    /export function buildRequeueFence[\s\S]*?buildRegressedComment\(lastSeen\)/.test(
+      src,
+    ),
+    "the single call must sit inside buildRequeueFence",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Ordering.
+// ---------------------------------------------------------------------------
+
+await test("a Sentry-evidence re-queue posts the fence before it touches labels", async () => {
+  const w = makeWriter();
+  await requeueQueueStub(
+    { writeGh: w.writeGh },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: "2026-07-20T08:00:00Z",
+    },
+  );
+  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+  assertEqual(
+    w.calls[0][w.calls[0].indexOf("--body") + 1],
+    buildRegressedComment("2026-07-20T08:00:00Z"),
+  );
+  assertDeepEqual(w.calls[1], buildReopenLabelEditArgs(42, REPO));
+});
+
+await test("a bookkeeping re-queue writes labels, its note, then the state", async () => {
+  const w = makeWriter();
+  await requeueQueueStub(
+    { writeGh: w.writeGh },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_BOOKKEEPING,
+      note: buildStrandedRecoveryComment(),
+    },
+  );
+  assertDeepEqual(w.verbs(), ["edit", "comment", "reopen"]);
+  assertEqual(
+    w.calls[1][w.calls[1].indexOf("--body") + 1],
+    buildStrandedRecoveryComment(),
+  );
+});
+
+await test("an interrupted fence post never leaves the stub queued", async () => {
+  // The whole reason the fence goes first: the interrupted state must be
+  // fenced-but-unqueued (inert, retried), never queued-but-unfenced.
+  const w = makeWriter({
+    failOn: (args) => (args[1] === "comment" ? "gh issue comment: 500" : null),
+  });
+  await assertRejects(
+    requeueQueueStub(
+      { writeGh: w.writeGh },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+      },
+    ),
+  );
+  assertDeepEqual(w.verbs(), ["comment"]);
+});
+
+await test("the state change is the last write on both causes", async () => {
+  for (const [cause, extra] of [
+    [REQUEUE_CAUSE_SENTRY_EVIDENCE, { lastSeen: "2026-07-20T08:00:00Z" }],
+    [REQUEUE_CAUSE_BOOKKEEPING, { note: buildStrandedRecoveryComment() }],
+  ]) {
+    const w = makeWriter();
+    await requeueQueueStub(
+      { writeGh: w.writeGh },
+      { repo: REPO, issueNumber: 42, cause, ...extra },
+    );
+    assertEqual(w.verbs().at(-1), "reopen");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The exclusion set records ATTEMPTS.
+// ---------------------------------------------------------------------------
+
+await test("the claim lands before the first write, not after the last", async () => {
+  const claimed = [];
+  const w = makeWriter();
+  await requeueQueueStub(
+    {
+      writeGh: async (args) => {
+        claimed.push(`writes-so-far:${claimed.length}`);
+        return w.writeGh(args);
+      },
+      claim: () => claimed.push("claim"),
+    },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: "2026-07-20T08:00:00Z",
+    },
+  );
+  assertEqual(claimed[0], "claim");
+});
+
+await test("a re-queue that throws half-way is still recorded as an attempt", async () => {
+  // The #1716 defect this closes: recording only SUCCESSES left a failed
+  // Sentry-evidence re-queue unclaimed, and the same run's fence-free
+  // bookkeeping sweep then recovered it — laundering the cause.
+  for (const verb of ["comment", "edit", "reopen"]) {
+    const claimed = new Set();
+    const w = makeWriter({
+      failOn: (args) => (args[1] === verb ? `gh issue ${verb}: 500` : null),
+    });
+    await assertRejects(
+      requeueQueueStub(
+        { writeGh: w.writeGh, claim: () => claimed.add(42) },
+        {
+          repo: REPO,
+          issueNumber: 42,
+          cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+          lastSeen: "2026-07-20T08:00:00Z",
+        },
+      ),
+    );
+    assert(claimed.has(42), `a failure on ${verb} must still claim the stub`);
+  }
+});
+
+await test("an undeclared cause refuses before it claims or writes anything", async () => {
+  const claimed = new Set();
+  const w = makeWriter();
+  await assertRejects(
+    requeueQueueStub(
+      { writeGh: w.writeGh, claim: () => claimed.add(42) },
+      { repo: REPO, issueNumber: 42, cause: "regression" },
+    ),
+    /Unknown re-queue cause/,
+  );
+  assertEqual(claimed.size, 0);
+  assertDeepEqual(w.verbs(), []);
+});
+
+// ---------------------------------------------------------------------------
+// Revalidation.
+// ---------------------------------------------------------------------------
+
+await test("a revalidation that no longer holds stops before any write", async () => {
+  const w = makeWriter();
+  const outcome = await requeueQueueStub(
+    {
+      writeGh: w.writeGh,
+      readStub: async () => ({ state: "OPEN", labels: ["sentry-triage"] }),
+    },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_BOOKKEEPING,
+      note: buildStrandedRecoveryComment(),
+      revalidate: {
+        check: (live) => live.labels.includes(NEEDS_TRIAGE_LABEL),
+        declineNote: () => "declined",
+      },
+    },
+  );
+  assertEqual(outcome.requeued, false);
+  assertEqual(outcome.reason, "revalidated-away");
+  assertDeepEqual(w.verbs(), []);
+});
+
+await test("a failed revalidation read aborts rather than proceeding blind", async () => {
+  const w = makeWriter();
+  await assertRejects(
+    requeueQueueStub(
+      {
+        writeGh: w.writeGh,
+        readStub: async () => {
+          throw new Error("gh issue view: 500");
+        },
+      },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_BOOKKEEPING,
+        note: buildStrandedRecoveryComment(),
+        revalidate: { check: () => true, declineNote: () => "declined" },
+      },
+    ),
+    /gh issue view: 500/,
+  );
+  assertDeepEqual(w.verbs(), []);
+});
+
+// ---------------------------------------------------------------------------
+// Author-fenced dedup.
+// ---------------------------------------------------------------------------
+
+await test("the dedup read is author-fenced", async () => {
+  // This repo is PUBLIC. Without the author check, anyone who guesses the
+  // regression's exact lastSeen can pre-post the body and suppress the bot's
+  // real fence, while selectVerdictComment ignores theirs.
+  const fence = buildRegressedComment("2026-07-20T08:00:00Z");
+  const w = makeWriter();
+  await requeueQueueStub(
+    {
+      writeGh: w.writeGh,
+      readComments: async () => [
+        { body: fence, author: { login: "drive-by-account" } },
+      ],
+    },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: "2026-07-20T08:00:00Z",
+      dedupeFence: true,
+    },
+  );
+  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+});
+
+await test("the bot's own identical fence is deduped", async () => {
+  const fence = buildRegressedComment("2026-07-20T08:00:00Z");
+  const w = makeWriter();
+  await requeueQueueStub(
+    {
+      writeGh: w.writeGh,
+      readComments: async () => [{ ...BOT, body: fence }],
+    },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: "2026-07-20T08:00:00Z",
+      dedupeFence: true,
+    },
+  );
+  assertDeepEqual(w.verbs(), ["edit", "reopen"]);
+});
+
+await test("a fence that identifies no occurrence is never deduped", async () => {
+  // buildRegressedComment renders a CONSTANT body for a missing/unparsable
+  // lastSeen, so identical bodies say nothing about which occurrence they
+  // belong to. A duplicate fence is noise; a missing one buries a regression.
+  for (const lastSeen of [null, "not-a-timestamp"]) {
+    const fence = buildRegressedComment(lastSeen);
+    const w = makeWriter();
+    await requeueQueueStub(
+      {
+        writeGh: w.writeGh,
+        readComments: async () => [{ ...BOT, body: fence }],
+      },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen,
+        dedupeFence: true,
+      },
+    );
+    assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+  }
+});
+
+await test("dedup is opt-in: a site that does not declare it always posts", async () => {
+  const fence = buildRegressedComment("2026-07-20T08:00:00Z");
+  const w = makeWriter();
+  await requeueQueueStub(
+    {
+      writeGh: w.writeGh,
+      readComments: async () => [{ ...BOT, body: fence }],
+    },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+      lastSeen: "2026-07-20T08:00:00Z",
+    },
+  );
+  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+});
+
+// ---------------------------------------------------------------------------
+// Admissibility, by recency.
+// ---------------------------------------------------------------------------
+
+const verdictAt = (createdAt) => ({
+  ...BOT,
+  createdAt,
+  body: `${VERDICT_MARKER}\nverdict: upstream-transient`,
+});
+const fenceAt = (createdAt) => ({
+  ...BOT,
+  createdAt,
+  body: buildRegressedComment("2026-07-20T08:00:00Z"),
+});
+
+await test("hasAdmissibleVerdict asks about recency, not presence", () => {
+  // A fence that EXISTS but predates the newest verdict protects nothing.
+  assertEqual(
+    hasAdmissibleVerdict([
+      fenceAt("2026-07-21T10:00:00Z"),
+      verdictAt("2026-07-22T10:00:00Z"),
+    ]),
+    true,
+  );
+  assertEqual(
+    hasAdmissibleVerdict([
+      verdictAt("2026-07-22T10:00:00Z"),
+      fenceAt("2026-07-23T10:00:00Z"),
+    ]),
+    false,
+  );
+  assertEqual(hasAdmissibleVerdict([]), false);
+  assertEqual(
+    hasAdmissibleVerdict([
+      {
+        author: { login: "drive-by" },
+        createdAt: "2026-07-24T10:00:00Z",
+        body: `${VERDICT_MARKER}\nverdict: code-fix`,
+      },
+    ]),
+    false,
+  );
+});
+
+await test("verify-end-state fails RED when a verdict survives the re-queue", async () => {
+  const live = {
+    state: "OPEN",
+    labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+    // A stale fence AND a verdict posted after it: presence passes, recency
+    // does not.
+    comments: [
+      fenceAt("2026-07-21T10:00:00Z"),
+      verdictAt("2026-07-22T10:00:00Z"),
+    ],
+  };
+  const w = makeWriter();
+  await assertRejects(
+    requeueQueueStub(
+      { writeGh: w.writeGh, readStub: async () => live },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+        onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+      },
+    ),
+    /a previous verdict is still admissible/,
+  );
+});
+
+await test("a bookkeeping re-queue is never failed for a surviving verdict", async () => {
+  // The over-fencing error, in its verification form: a bookkeeping re-queue
+  // MEANS to leave the prior verdict admissible, so asserting the opposite here
+  // would turn every correct recovery red.
+  const live = {
+    state: "OPEN",
+    labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+    comments: [verdictAt("2026-07-22T10:00:00Z")],
+  };
+  const w = makeWriter();
+  const outcome = await requeueQueueStub(
+    { writeGh: w.writeGh, readStub: async () => live },
+    {
+      repo: REPO,
+      issueNumber: 42,
+      cause: REQUEUE_CAUSE_BOOKKEEPING,
+      note: buildStrandedRecoveryComment(),
+      onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+    },
+  );
+  assertEqual(outcome.requeued, true);
+});
+
+await test("verify-end-state fails RED on a marker the shed left behind", async () => {
+  const live = {
+    state: "OPEN",
+    labels: ["sentry-triage", NEEDS_TRIAGE_LABEL, "sentry:approved-archive"],
+    comments: [],
+  };
+  const w = makeWriter();
+  await assertRejects(
+    requeueQueueStub(
+      { writeGh: w.writeGh, readStub: async () => live },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+        onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+      },
+    ),
+    /these stale markers survived: sentry:approved-archive/,
+  );
+});
+
+if (failed > 0) {
+  process.stderr.write(`${failed} failed, ${passed} passed\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`${passed} passed\n`);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- "Re-queue this stub" was an open-coded sequence of label writes and comment posts at **14 independent call sites**, each deciding for itself whether to carry the verdict-staleness fence.
- The rule governing that decision — fence when the cause is new Sentry evidence, do **not** when it is bookkeeping — lived only in prose. Over-fencing discards verdicts the pipeline means to keep; under-fencing lets a stub close over a live regression.
- PR #1716 took **seven review rounds and seven distinct defects**, every one in this area, none of them careless. Each was a *pair* of paths disagreeing about cause, so no amount of per-site care would have prevented the next one.

## The Solution

One function owns re-queueing and takes the cause as a required argument. Call sites declare *why*; they no longer reconstruct *how*.

```js
requeueQueueStub({ writeGh, readStub, readComments, claim },
                 { repo, issueNumber, cause, lastSeen, fenceProse, note,
                   dedupeFence, revalidate, onFailure, fallbackState })
```

`requeueFences(cause)` throws on anything that is not `sentry-evidence` or `bookkeeping` — **both defaults are wrong, so an undeclared cause refuses rather than guessing.** That is the difference between a rule and a convention.

## Details

- **`buildRegressedComment` has exactly one caller**, `buildRequeueFence`. A site supplies `fenceProse`, which renders *underneath* the fence line and can neither author nor omit it. A test scans every non-test `.mjs` in `scripts/` to hold that invariant, which is also what stops a fence appearing at the four bash sites below.
- **`onFailure` replaces three knobs that co-varied**: `abort` (ingest — a write failure propagates and the run retries) and `verify-end-state` (archive — reported failures are provisional, so the sequence completes and the end state is read and judged).
- **Sites 1–10 collapse into three calls.** The ingest regression reopen, the stranded-stub recovery, and the archive refusal — including `ensureSelectableForTriage`, whose reopen and label re-add moved inside the chokepoint.
- **Sites 11–14 stay in bash**, deliberately. All four are `gh issue edit` one-liners in `sentry-triage-agent.yml`, all bookkeeping, all correctly fence-free today. Moving them into node would change their `set -e` and guarded-compensation failure semantics for no safety gain; the one-caller test is what prevents a *new* fence appearing there.
- **Two contracts moved out of ingest** because the chokepoint needs them and importing ingest would cycle: the label namespace, untrusted-text neutralization, and the archive freshness-baseline fields, now in `sentry-triage-queue-contract.mjs`. That gives the archive contract its own destination without touching `project-core.mjs`, which is at 957 lines and would just become the next instance of this issue. Ingest re-exports them, so no consumer or test import path changed.

**The seven defects this makes unrepresentable**, each now a property of the chokepoint rather than of a caller: fence-iff-Sentry-evidence; one definition of the fence text; fence posted before labels with state changed last; the exclusion set recording *attempts* including decision-phase failures; "is this stub protected?" answered by running `selectVerdictComment` over live comments rather than by body presence; every body read author-fenced; live state revalidated immediately before mutating, with a failed read aborting.

## Validation

- **48 mutants, 47 killed.** The full inherited set re-derived against the new anchors — sweep S1–S9, fence P1–P5, ordering O1–O5, claim C1–C5, dedup/revalidation F2a–F3e, author fence A1–A2, admissibility R1a–R1e, note N1–N4 — plus 5 for the chokepoint: cause ignored/always-fence, cause ignored/never-fence, undeclared cause defaulting silently, a caller authoring the fence line, and the cause flipped at the archive site.
- **The single survivor is the documented redundant claim pair from #1716** (`C1`, claim-after-write). Verified against `db14fb83` that it and its twin survive there too, and that removing the catch-phase claim kills in **both** trees — so nothing drifted in this refactor. `C3` (both claims removed) and `C5` (chokepoint records successes only) both kill.
- **No test needed a real change.** The only test-file edit adds `{ cause: err }` to a new helper, for the repo's `preserve-caught-error` rule. A test that had needed a semantic change would have meant this refactor moved behaviour.
- ingest **102**, archive **113**, requeue **24** (new), digest **62**, project exit 0, autofix select 19, finalize 44, agent-comment and provider contract exit 0.
- `trunk fmt`/`check` clean · `actionlint` exit 0 · `pnpm agent:quality-gate --run --parallel 4` → exit 0.

**On file sizes:** archive 2265 → **1990**, ingest 1540 → **1180**. The new `sentry-triage-requeue.mjs` is 610 lines, just over the 600 soft cap, and roughly two-thirds of it is the rule statement in comments. It is left whole rather than splitting the rule away from the code it governs — that separation is how the rule became prose-only in the first place.

## Deferrals

- **#1698** stays open for the remaining split: Sentry-client extraction, the freshness-baseline unit, and the audit-comment builders out of `sentry-triage-archive.mjs`. That is a wide mechanical move with no correctness content — exactly the mix #1696 deferred for being hard to review alongside subtle work. Landing it here would bury a diff whose entire value is auditability.

Refs #1698, #1716, #1706, #1282

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes correctness-critical triage state transitions (fencing, labels, reopen ordering) in automation that can close stubs over live regressions or discard valid verdicts if wrong; mitigated by dedicated tests, mutant suite, and unchanged bash re-queue sites.
> 
> **Overview**
> Re-queueing Sentry triage queue stubs is consolidated into **`requeueQueueStub`** in `scripts/sentry-triage-requeue.mjs`. Callers pass a required **cause** (`sentry-evidence` vs `bookkeeping`); the chokepoint alone decides whether to post the verdict-staleness regression fence, write order (fence → labels → reopen), admissibility checks via `selectVerdictComment`, and attempt tracking so a half-failed regression re-queue is not swept as fence-free bookkeeping in the same ingest run.
> 
> **`scripts/sentry-triage-queue-contract.mjs`** holds the label namespace, untrusted-text neutralization, and archive baseline fields (moved out of ingest to avoid import cycles). Ingest and archive **delegate** regression reopen, stranded-stub recovery, and live-regression archive refusal to the chokepoint; large inline helpers (`ensureSelectableForTriage`, local fence/reopen sequences) are removed from those scripts. **`pnpm sentry:requeue:test`**, runbook updates, and quality-gate wiring run requeue plus ingest/archive tests when the chokepoint or contract changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0c0dfd0517be5882095f764d3c3b2adc7b97ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->