### PR TITLE
fix(deps): clear OSV advisories and refresh Sentry agent docs

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -183,12 +183,13 @@ jobs:
   #     the whole token with one removable character spliced in. No check inside
   #     the wrapper can stop that.
   #   - RESIDUAL, stated plainly: CLAUDE_CODE_OAUTH_TOKEN is still live in the
-  #     agent's Bash env. `claude-code-action` puts it there itself, and the
-  #     pinned v1.0.179 offers no per-step or first-class MCP env forwarding to
-  #     move it (upstream's only release tag is v1, Aug 2025 — there is no newer
-  #     version to adopt). It is inference-scoped: worst case is inference-quota
-  #     abuse, not repo or queue compromise, and any use lands in an auditable
-  #     public comment. Re-check on the next action bump.
+  #     agent's Bash env. `claude-code-action` puts it there itself — its
+  #     base-action/src/parse-sdk-options.ts spreads the whole `process.env`
+  #     into the CLI subprocess, deleting only the OIDC request vars — and the
+  #     pinned v1.0.183 offers no per-step or first-class MCP env forwarding to
+  #     move it. It is inference-scoped: worst case is inference-quota abuse,
+  #     not repo or queue compromise, and any use lands in an auditable public
+  #     comment. Re-check on the next action bump.
   #   - RESIDUAL, stated plainly: the run handle IS in the agent's env, and
   #     three allow-listed tools (find_projects, search_issues, search_events)
   #     take an agent-controlled `regionUrl` that the MCP server's
@@ -225,14 +226,17 @@ jobs:
     # declares its own env: block. Its action.yml says so in as many words for
     # its own MCP vars — "this step's env: block shadows the calling workflow's
     # job-level env vars … Set these in your workflow's job-level env: or via a
-    # prior step that writes to $GITHUB_ENV". RE-VERIFIED for issue #1288 and
-    # again for #1711 against the version pinned below, v1.0.179 (b76a0776):
-    # there is still no per-step env passthrough and no first-class MCP env
-    # input (upstream's only release tag is v1, Aug 2025). So anything the MCP
-    # server must read has to be job env — which is exactly why the SENTRY
-    # TOKEN IS NO LONGER HERE and an opaque per-run handle is (issue #1711).
-    # Re-check on the next action bump; do not re-open the question without
-    # testing a version.
+    # prior step that writes to $GITHUB_ENV". RE-VERIFIED for issue #1288, for
+    # #1711, and again on the bump to the version pinned below, v1.0.183
+    # (be7b93b1): its action.yml is byte-identical to the previously verified
+    # v1.0.179 (b76a0776), so there is still no per-step env passthrough and no
+    # first-class MCP env input — upstream deprecated `mcp_config` in favour of
+    # `claude_args: --mcp-config`, which takes a path or JSON, never env. So
+    # anything the MCP server must read has to be job env — which is exactly why
+    # the SENTRY TOKEN IS NO LONGER HERE and an opaque per-run handle is (issue
+    # #1711). Re-check on the next action bump; do not re-open the question
+    # without testing a version. Upstream cuts a GitHub Release per patch, so
+    # "there is no newer version" is never the reason to skip that check.
     #   - GH_TOKEN: gh CLI auth for the agent's read-only `gh issue view/list`
     #     (this job's GITHUB_TOKEN: issues:write + contents:read only) and for
     #     the deterministic steps below.

--- a/aegis/package.json
+++ b/aegis/package.json
@@ -71,7 +71,7 @@
     "@willsoto/nestjs-prometheus": "6.0.2",
     "abitype": "1.1.2",
     "cron": "4.3.4",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "prom-client": "15.1.3",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",

--- a/alerts/infra/oncall-announcer/pnpm-lock.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-lock.yaml
@@ -6,12 +6,13 @@ settings:
 
 overrides:
   '@grpc/grpc-js': 1.14.4
-  brace-expansion@^1.0.0: 5.0.8
-  brace-expansion@>=5.0.0 <6: 5.0.8
-  fast-uri@<3.1.4: 3.1.4
+  brace-expansion@^1.0.0: 5.0.9
+  brace-expansion@>=5.0.0 <6: 5.0.9
+  fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  postcss@<8.5.18: 8.5.18
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  nanoid@<3.3.17: 3.3.17
+  postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   uuid: 11.1.1
@@ -728,8 +729,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -990,8 +991,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1283,8 +1284,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -1480,8 +1481,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1599,8 +1600,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2154,7 +2155,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2699,7 +2700,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2754,7 +2755,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3058,7 +3059,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3377,7 +3378,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3535,11 +3536,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -3547,7 +3548,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -3668,9 +3669,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4061,7 +4062,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/alerts/infra/oncall-announcer/pnpm-workspace.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-workspace.yaml
@@ -13,21 +13,24 @@ minimumReleaseAgeExclude:
   - form-data
   - esbuild
   - js-yaml
-  # GHSA-r28c-9q8g-f849: first patched PostCSS release (2026-07-24).
-  - postcss@8.5.18
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  - postcss@8.5.23
   - protobufjs
   - vite
 
 overrides:
   "@grpc/grpc-js": 1.14.4
-  # GHSA-mh99-v99m-4gvg: all releases through 5.0.7 are vulnerable.
-  "brace-expansion@^1.0.0": 5.0.8
-  "brace-expansion@>=5.0.0 <6": 5.0.8
-  fast-uri@<3.1.4: 3.1.4
+  # GHSA-rgw5-rvv9-x895: the 5.0.8 resource-limit fix is incomplete.
+  "brace-expansion@^1.0.0": 5.0.9
+  "brace-expansion@>=5.0.0 <6": 5.0.9
+  # GHSA-7p8r-x3mc-p8w7: 3.1.5 fixes backslash authority confusion.
+  fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  # GHSA-r28c-9q8g-f849: <=8.5.17 can disclose arbitrary source-map files.
-  postcss@<8.5.18: 8.5.18
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
+  nanoid@<3.3.17: 3.3.17
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   uuid: 11.1.1

--- a/alerts/infra/onchain-event-handler/pnpm-lock.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@^1.0.0: 5.0.8
-  brace-expansion@>=5.0.0 <6: 5.0.8
-  fast-uri@<3.1.4: 3.1.4
+  brace-expansion@^1.0.0: 5.0.9
+  brace-expansion@>=5.0.0 <6: 5.0.9
+  fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   form-data@>=4.0.0 <4.0.6: 4.0.6
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  postcss@<8.5.18: 8.5.18
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  nanoid@<3.3.17: 3.3.17
+  postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   uuid: 11.1.1
@@ -788,8 +789,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1053,8 +1054,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1364,8 +1365,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -1561,8 +1562,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1688,8 +1689,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2273,7 +2274,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2854,7 +2855,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2919,7 +2920,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3225,7 +3226,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3562,7 +3563,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3723,11 +3724,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -3735,7 +3736,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -3875,9 +3876,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4292,7 +4293,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
@@ -11,21 +11,24 @@ minimumReleaseAgeExclude:
   - fast-uri
   - form-data
   - js-yaml
-  # GHSA-r28c-9q8g-f849: first patched PostCSS release (2026-07-24).
-  - postcss@8.5.18
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  - postcss@8.5.23
   - protobufjs
   - vite
 
 overrides:
-  # GHSA-mh99-v99m-4gvg: all releases through 5.0.7 are vulnerable.
-  "brace-expansion@^1.0.0": 5.0.8
-  "brace-expansion@>=5.0.0 <6": 5.0.8
-  fast-uri@<3.1.4: 3.1.4
+  # GHSA-rgw5-rvv9-x895: the 5.0.8 resource-limit fix is incomplete.
+  "brace-expansion@^1.0.0": 5.0.9
+  "brace-expansion@>=5.0.0 <6": 5.0.9
+  # GHSA-7p8r-x3mc-p8w7: 3.1.5 fixes backslash authority confusion.
+  fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   "form-data@>=4.0.0 <4.0.6": 4.0.6
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  # GHSA-r28c-9q8g-f849: <=8.5.17 can disclose arbitrary source-map files.
-  postcss@<8.5.18: 8.5.18
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
+  nanoid@<3.3.17: 3.3.17
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   uuid: 11.1.1

--- a/docs/adr/0056-agent-mcp-credential-broker.md
+++ b/docs/adr/0056-agent-mcp-credential-broker.md
@@ -3,7 +3,7 @@ title: An untrusted agent's MCP credentials sit behind a loopback broker, not in
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-30
+last_verified: 2026-08-10
 scope: ci/process
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0056-agent-mcp-credential-broker.md
+++ b/docs/adr/0056-agent-mcp-credential-broker.md
@@ -23,7 +23,7 @@ MCP credential handed to an untrusted agent).
 `claude-code-action` agent that reads Sentry over an MCP server. The Claude CLI
 launches that server as a child of the agent's own process, and
 `claude-code-action` is a composite action: GitHub Actions does not pass a
-caller step's `env:` into a composite action's steps, and the pinned v1.0.179
+caller step's `env:` into a composite action's steps, and the pinned v1.0.183
 exposes no per-step passthrough and no first-class MCP env input. So anything
 the MCP server must read had to be **job** env — which the agent's allow-listed
 Bash inherits.
@@ -97,10 +97,12 @@ start is theatre. The variable must be absent when the process is exec'd. So:
 ## Alternatives considered
 
 - **Wait for per-step or first-class MCP env forwarding in
-  `claude-code-action`.** Cheapest fix if it lands. Absent at the pinned
-  v1.0.179 and upstream's only release tag is `v1` (Aug 2025), so there is no
-  newer version to adopt. Re-check on the next bump; the broker generalises to
-  the next MCP credential either way.
+  `claude-code-action`.** Cheapest fix if it lands. Still absent at the pinned
+  v1.0.183, whose `action.yml` is byte-identical to the v1.0.179 this ADR was
+  written against; upstream deprecated the old `mcp_config` input in favour of
+  `claude_args: --mcp-config`, which takes a path or JSON and never env.
+  Re-check on the next bump; the broker generalises to the next MCP credential
+  either way.
 - **Write the resolved `--mcp-config` to `$RUNNER_TEMP`.** Rejected: it
   relocates the credential to a file the agent's `Read` tool can open.
 - **Scrub or transform the credential in the agent's env.** Rejected: the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -3,7 +3,7 @@ title: Sentry Triage Pipeline
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-10
 scope: ci/process
 doc_type: runbook
 review_interval_days: 90

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -301,10 +301,11 @@ shell. The fix removes the credential instead. See
 [the credential broker](#the-credential-broker) below.
 
 `CLAUDE_CODE_OAUTH_TOKEN` is the remaining credential in the agent's Bash, and
-it stays there: `claude-code-action` places it in that process env itself, and
-the pinned v1.0.179 offers no per-step or first-class MCP env forwarding to move
-it (upstream's only release tag is `v1`, Aug 2025 — there is no newer version to
-adopt). Accepted with its bounding: it is inference-only, so worst case is
+it stays there: `claude-code-action` places it in that process env itself
+(`base-action/src/parse-sdk-options.ts` spreads the whole `process.env` into the
+CLI subprocess, deleting only the OIDC request vars), and the pinned v1.0.183
+offers no per-step or first-class MCP env forwarding to move it. Accepted with
+its bounding: it is inference-only, so worst case is
 inference-quota abuse, not repo or queue compromise, and any use lands in an
 auditable public comment. Re-check on the next action bump.
 

--- a/governance-watchdog/pnpm-lock.yaml
+++ b/governance-watchdog/pnpm-lock.yaml
@@ -5,17 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@^1.0.0: 5.0.8
-  brace-expansion@>=2.0.0 <3: 5.0.8
-  brace-expansion@>=5.0.0 <6: 5.0.8
+  brace-expansion@^1.0.0: 5.0.9
+  brace-expansion@>=2.0.0 <3: 5.0.9
+  brace-expansion@>=5.0.0 <6: 5.0.9
   flatted: 3.4.2
   esbuild: 0.28.1
-  fast-uri@<3.1.4: 3.1.4
-  postcss@<8.5.18: 8.5.18
+  fast-uri@<3.1.5: 3.1.5
+  postcss@<8.5.23: 8.5.23
   qs@<6.15.2: 6.15.2
   uuid@<11.1.1: 11.1.1
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  nanoid@<3.3.17: 3.3.17
   ws@<8.21.0: 8.21.0
   '@types/node': 24.13.2
 
@@ -910,8 +911,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1169,8 +1170,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1472,8 +1473,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -1668,8 +1669,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1800,8 +1801,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2490,7 +2491,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3008,7 +3009,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3063,7 +3064,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3383,7 +3384,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3714,7 +3715,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3868,15 +3869,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -3884,7 +3885,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -4029,9 +4030,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4445,7 +4446,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -16,15 +16,15 @@ minimumReleaseAgeExclude:
   - brace-expansion
   - fast-uri
   - js-yaml
-  # GHSA-r28c-9q8g-f849: first patched PostCSS release (2026-07-24).
-  - postcss@8.5.18
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  - postcss@8.5.23
   - protobufjs
 
 overrides:
-  # GHSA-mh99-v99m-4gvg: all releases through 5.0.7 are vulnerable.
-  "brace-expansion@^1.0.0": 5.0.8
-  "brace-expansion@>=2.0.0 <3": 5.0.8
-  "brace-expansion@>=5.0.0 <6": 5.0.8
+  # GHSA-rgw5-rvv9-x895: the 5.0.8 resource-limit fix is incomplete.
+  "brace-expansion@^1.0.0": 5.0.9
+  "brace-expansion@>=2.0.0 <3": 5.0.9
+  "brace-expansion@>=5.0.0 <6": 5.0.9
   # Exact pin because ranges resolve forward on fresh installs. 3.4.2 is what
   # both the standalone npm lockfile and this lockfile resolve today.
   flatted: 3.4.2
@@ -33,13 +33,16 @@ overrides:
   esbuild: 0.28.1
   # Google Cloud deps still resolve vulnerable qs/uuid ranges. Pin the
   # vulnerable ranges narrowly instead of overriding whole packages.
-  "fast-uri@<3.1.4": 3.1.4
-  # GHSA-r28c-9q8g-f849: <=8.5.17 can disclose arbitrary source-map files.
-  "postcss@<8.5.18": 8.5.18
+  # GHSA-7p8r-x3mc-p8w7: 3.1.5 fixes backslash authority confusion.
+  "fast-uri@<3.1.5": 3.1.5
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  "postcss@<8.5.23": 8.5.23
   "qs@<6.15.2": 6.15.2
   "uuid@<11.1.1": 11.1.1
   "protobufjs@>=7.0.0 <7.6.5": 7.6.5
-  "js-yaml@>=4.0.0 <4.3.0": 4.3.0
+  "js-yaml@>=4.0.0 <4.3.1": 4.3.1
+  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
+  "nanoid@<3.3.17": 3.3.17
   # isows resolves ws@8.20.1 through viem; 8.21.0 contains the GHSA-96hv-2xvq-fx4p
   # fix and stays compatible with isows' ws peer range.
   "ws@<8.21.0": 8.21.0

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "eslint": "^10.0.2",
     "globals": "^17.4.0",
     "graphql": "16.13.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "jscpd": "4.0.9",
     "turbo": "^2.9.14",
     "typescript": "5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,23 +14,24 @@ overrides:
   envio>react: 19.2.6
   sharp@<0.35.0: 0.35.3
   flatted@<3.4.2: 3.4.2
-  brace-expansion@>=2.0.0 <3: 5.0.8
-  brace-expansion@>=5.0.0 <6: 5.0.8
-  postcss@<8.5.18: 8.5.18
+  brace-expansion@>=2.0.0 <3: 5.0.9
+  brace-expansion@>=5.0.0 <6: 5.0.9
+  postcss@<8.5.23: 8.5.23
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   vite@>=8.0.0 <8.0.16: 8.0.16
   '@grpc/grpc-js': 1.14.4
   esbuild: 0.28.1
   '@babel/core@>=7.0.0 <7.29.6': 7.29.6
-  body-parser@<1.20.3: 1.20.3
+  body-parser@<1.20.6: 1.20.6
   path-to-regexp@<0.1.13: 0.1.13
-  fast-uri@<3.1.4: 3.1.4
+  fast-uri@<3.1.5: 3.1.5
   express@<4.20.0: 4.22.1
   form-data@<2.5.6: 2.5.6
   form-data@>=4.0.0 <4.0.6: 4.0.6
-  '@istanbuljs/load-nyc-config>js-yaml': 4.3.0
-  '@lhci/utils>js-yaml': 4.3.0
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  '@istanbuljs/load-nyc-config>js-yaml': 4.3.1
+  '@lhci/utils>js-yaml': 4.3.1
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  nanoid@<3.3.17: 3.3.17
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   cookie@<0.7.0: 0.7.2
@@ -39,12 +40,13 @@ overrides:
   '@eslint/eslintrc@<3.3.5': 3.3.5
   ajv@^6.0.0: ^6.14.0
   ajv@^8.0.0: ^8.18.0
-  body-parser@>=2.0.0 <2.2.1: 2.2.1
-  brace-expansion@^1.0.0: 5.0.8
+  body-parser@>=2.0.0 <2.3.0: 2.3.0
+  brace-expansion@^1.0.0: 5.0.9
   cron: 4.3.4
   diff@^4.0.0: ^4.0.4
   file-type@^21.0.0: ^21.3.2
   handlebars@<4.7.9: 4.7.9
+  ip-address@<10.3.1: 10.3.1
   lodash@>=4.0.0 <4.17.23: 4.18.1
   minimatch@^3.0.0: ^3.1.4
   minimatch@^9.0.0: ^9.0.7
@@ -53,16 +55,16 @@ overrides:
   '@opentelemetry/core@<2.8.0': 2.8.0
   path-to-regexp@^8.0.0: ^8.4.0
   picomatch@^2.0.0: ^2.3.2
-  '@trunkio/launcher>tar': 7.5.19
-  tar@>=7.0.0 <7.5.19: 7.5.19
+  '@trunkio/launcher>tar': 7.5.21
+  tar@>=7.0.0 <7.5.21: 7.5.21
   '@lhci/cli>tmp': 0.2.7
   external-editor>tmp: 0.2.7
   uuid@<11.1.1: 11.1.1
-  undici@>=7.23.0 <7.28.0: 7.28.0
+  undici@>=7.23.0 <7.29.0: 7.29.0
   webpack@>=5.0.0 <5.104.1: 5.106.2
   lighthouse>ws: 7.5.11
   ws@>=8.0.0 <8.21.0: 8.21.0
-  undici@<6.27.0: 6.27.0
+  undici@<6.28.0: 6.28.0
   yaml@^2.0.0: ^2.8.3
 
 patchedDependencies:
@@ -104,8 +106,8 @@ importers:
         specifier: 16.13.1
         version: 16.13.1
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       jscpd:
         specifier: 4.0.9
         version: 4.0.9
@@ -143,8 +145,8 @@ importers:
         specifier: 4.3.4
         version: 4.3.4
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       prom-client:
         specifier: 15.1.3
         version: 15.1.3
@@ -226,7 +228,7 @@ importers:
     dependencies:
       '@google-cloud/functions-framework':
         specifier: 5.0.5
-        version: 5.0.5(supports-color@5.5.0)
+        version: 5.0.5
       '@google-cloud/logging':
         specifier: ^11.2.1
         version: 11.2.1
@@ -272,7 +274,7 @@ importers:
     dependencies:
       '@google-cloud/functions-framework':
         specifier: 5.0.5
-        version: 5.0.5(supports-color@5.5.0)
+        version: 5.0.5
       '@google-cloud/logging':
         specifier: ^11.2.1
         version: 11.2.1
@@ -327,7 +329,7 @@ importers:
         version: 1.14.1
       '@google-cloud/functions-framework':
         specifier: 5.0.5
-        version: 5.0.5(supports-color@5.5.0)
+        version: 5.0.5
       '@google-cloud/secret-manager':
         specifier: 6.1.3
         version: 6.1.3
@@ -4620,20 +4622,16 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
-  body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  body-parser@2.2.1:
-    resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
-    engines: {node: '>=18'}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5662,8 +5660,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -6076,10 +6074,6 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -6228,8 +6222,8 @@ packages:
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6716,8 +6710,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscpd-sarif-reporter@4.0.7:
@@ -7391,8 +7385,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.14:
-    resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7812,8 +7806,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -7997,8 +7991,8 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
@@ -8503,10 +8497,6 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -8703,8 +8693,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   tdigest@0.1.2:
@@ -9058,12 +9048,12 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -10280,7 +10270,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -10405,10 +10395,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/functions-framework@5.0.5(supports-color@5.5.0)':
+  '@google-cloud/functions-framework@5.0.5':
     dependencies:
       '@types/express': 5.0.6
-      body-parser: 2.3.0(supports-color@5.5.0)
+      body-parser: 2.3.0
       cloudevents: 10.0.0
       express: 5.1.0(supports-color@5.5.0)
       minimist: 1.2.8
@@ -10876,7 +10866,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -11191,7 +11181,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       isomorphic-fetch: 3.0.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lighthouse: 12.6.1(supports-color@5.5.0)
       tree-kill: 1.2.2
     transitivePeerDependencies:
@@ -12445,7 +12435,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       tailwindcss: 4.2.1
 
   '@tokenizer/inflate@0.4.1(supports-color@5.5.0)':
@@ -12464,7 +12454,7 @@ snapshots:
   '@trunkio/launcher@1.3.4':
     dependencies:
       semver: 7.7.4
-      tar: 7.5.19
+      tar: 7.5.21
       yaml: 2.9.0
 
   '@tsconfig/node10@1.0.12': {}
@@ -13003,7 +12993,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@vercel/cli-config@0.2.0':
     dependencies:
@@ -13274,7 +13264,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13552,38 +13542,24 @@ snapshots:
 
   bn.js@5.2.3: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
       qs: 6.15.2
-      raw-body: 2.5.2
+      raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.1(supports-color@5.5.0):
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  body-parser@2.3.0(supports-color@5.5.0):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -13597,7 +13573,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13942,7 +13918,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -14889,7 +14865,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -14924,7 +14900,7 @@ snapshots:
   express@5.1.0(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.1(supports-color@5.5.0)
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -15018,7 +14994,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -15551,14 +15527,6 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
-  http-errors@2.0.0:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -15743,7 +15711,7 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 2.11.4
       tslib: 2.8.1
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -16410,7 +16378,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -16449,7 +16417,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -17250,19 +17218,19 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -17309,7 +17277,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.14: {}
+  nanoid@3.3.17: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -17341,7 +17309,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
@@ -17855,9 +17823,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.14
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -18089,10 +18057,10 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@2.5.2:
+  raw-body@2.5.3:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
@@ -18693,7 +18661,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
@@ -18753,8 +18721,6 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
-
-  statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 
@@ -18965,7 +18931,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.19:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -19341,9 +19307,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -19522,7 +19488,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,11 +51,11 @@ minimumReleaseAgeExclude:
   - "@next/swc-win32-x64-msvc@16.2.11"
   - next-auth@5.0.0-beta.32
   - "@auth/core@0.41.3"
-  # GHSA-r28c-9q8g-f849: first patched PostCSS release (2026-07-24).
-  - postcss@8.5.18
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  - postcss@8.5.23
   - protobufjs
   - tar
-  - undici@7.28.0
+  - undici@7.29.0
   - vite
 
 ignoredBuiltDependencies:
@@ -83,25 +83,29 @@ overrides:
   # Remove once the supported stable Next line selects sharp >=0.35.0.
   "sharp@<0.35.0": 0.35.3
   "flatted@<3.4.2": 3.4.2
-  # GHSA-mh99-v99m-4gvg: all releases through 5.0.7 are vulnerable.
-  "brace-expansion@>=2.0.0 <3": 5.0.8
-  "brace-expansion@>=5.0.0 <6": 5.0.8
-  # GHSA-r28c-9q8g-f849: <=8.5.17 can disclose arbitrary source-map files.
-  "postcss@<8.5.18": 8.5.18
+  # GHSA-rgw5-rvv9-x895: the 5.0.8 resource-limit fix is incomplete.
+  "brace-expansion@>=2.0.0 <3": 5.0.9
+  "brace-expansion@>=5.0.0 <6": 5.0.9
+  # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
+  "postcss@<8.5.23": 8.5.23
   "picomatch@>=4.0.0 <4.0.4": 4.0.4
   "vite@>=8.0.0 <8.0.16": 8.0.16
   "@grpc/grpc-js": 1.14.4
   "esbuild": 0.28.1
   "@babel/core@>=7.0.0 <7.29.6": 7.29.6
-  "body-parser@<1.20.3": 1.20.3
+  # GHSA-v422-hmwv-36x6: enforce limit validation on both supported lines.
+  "body-parser@<1.20.6": 1.20.6
   "path-to-regexp@<0.1.13": 0.1.13
-  "fast-uri@<3.1.4": 3.1.4
+  # GHSA-7p8r-x3mc-p8w7: 3.1.5 fixes backslash authority confusion.
+  "fast-uri@<3.1.5": 3.1.5
   "express@<4.20.0": 4.22.1
   "form-data@<2.5.6": 2.5.6
   "form-data@>=4.0.0 <4.0.6": 4.0.6
-  "@istanbuljs/load-nyc-config>js-yaml": 4.3.0
-  "@lhci/utils>js-yaml": 4.3.0
-  "js-yaml@>=4.0.0 <4.3.0": 4.3.0
+  "@istanbuljs/load-nyc-config>js-yaml": 4.3.1
+  "@lhci/utils>js-yaml": 4.3.1
+  "js-yaml@>=4.0.0 <4.3.1": 4.3.1
+  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
+  "nanoid@<3.3.17": 3.3.17
   "protobufjs@>=7.0.0 <7.6.5": 7.6.5
   "qs@<6.15.2": 6.15.2
   "cookie@<0.7.0": 0.7.2
@@ -110,13 +114,15 @@ overrides:
   "@eslint/eslintrc@<3.3.5": 3.3.5
   "ajv@^6.0.0": ^6.14.0
   "ajv@^8.0.0": ^8.18.0
-  "body-parser@>=2.0.0 <2.2.1": 2.2.1
-  # GHSA-mh99-v99m-4gvg: all releases through 5.0.7 are vulnerable.
-  "brace-expansion@^1.0.0": 5.0.8
+  "body-parser@>=2.0.0 <2.3.0": 2.3.0
+  # GHSA-rgw5-rvv9-x895: the 5.0.8 resource-limit fix is incomplete.
+  "brace-expansion@^1.0.0": 5.0.9
   "cron": 4.3.4
   "diff@^4.0.0": ^4.0.4
   "file-type@^21.0.0": ^21.3.2
   "handlebars@<4.7.9": 4.7.9
+  # GHSA-mwp4-54f8-5fhr: 10.3.1 rejects ambiguous leading-zero IPv4 octets.
+  "ip-address@<10.3.1": 10.3.1
   "lodash@>=4.0.0 <4.17.23": 4.18.1
   "minimatch@^3.0.0": ^3.1.4
   "minimatch@^9.0.0": ^9.0.7
@@ -125,16 +131,19 @@ overrides:
   "@opentelemetry/core@<2.8.0": 2.8.0
   "path-to-regexp@^8.0.0": ^8.4.0
   "picomatch@^2.0.0": ^2.3.2
-  "@trunkio/launcher>tar": 7.5.19
-  "tar@>=7.0.0 <7.5.19": 7.5.19
+  # GHSA-r292-9mhp-454m: 7.5.21 bounds long-path selection recursion.
+  "@trunkio/launcher>tar": 7.5.21
+  "tar@>=7.0.0 <7.5.21": 7.5.21
   "@lhci/cli>tmp": 0.2.7
   "external-editor>tmp": 0.2.7
   "uuid@<11.1.1": 11.1.1
-  "undici@>=7.23.0 <7.28.0": 7.28.0
+  # GHSA-4cwx-7wf7-3272: 7.29.0 fixes private cache directive handling.
+  "undici@>=7.23.0 <7.29.0": 7.29.0
   "webpack@>=5.0.0 <5.104.1": 5.106.2
   "lighthouse>ws": 7.5.11
   "ws@>=8.0.0 <8.21.0": 8.21.0
-  "undici@<6.27.0": 6.27.0
+  # GHSA-8xcm-r25x-g524, GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm.
+  "undici@<6.28.0": 6.28.0
   "yaml@^2.0.0": ^2.8.3
 
 patchedDependencies:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Dependabot bumped `anthropics/claude-code-action` from v1.0.179 to v1.0.183 in #1726, but the security prose that explains the broker and environment boundaries still cited v1.0.179 and included a false claim that upstream had no newer release tag.
- This PR's Code Quality job then exposed new OSV advisories in the governance watchdog graph. A full audit found affected versions in the root workspace and three standalone lockfiles, including moderate and low findings that the original high-severity job had not reported.

## The Solution

- Re-verify the Sentry agent assumptions against v1.0.183's published source and correct every stale reference.
- Raise direct pins and bounded transitive floors for every advisory returned by the complete audits, then regenerate each affected lockfile.

## Details

### Sentry agent verification

- `action.yml` and `base-action/src/parse-sdk-options.ts` are byte-identical between v1.0.179 and v1.0.183. There is still no `mcp_config` input or environment passthrough, and the full `process.env` still reaches the SDK after only the two OIDC request variables are removed.
- `base-action/src/workload-identity.ts` gained an on-disk credential cache, but `setupWorkloadIdentity()` returns early when `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` is set. This pipeline uses the OAuth token, so the new path is inert here.
- `be7b93b1…` is the commit object for v1.0.183. The annotated tag object `672170b4…` dereferences to it.
- The workflow comments, ADR 0056, and the Sentry pipeline note now name v1.0.183/`be7b93b1`, retain v1.0.179/`b76a0776` only as the byte-identical comparison, remove the false release-tag claim, and point future checks at `parse-sdk-options.ts`.

### OSV remediation

- Updated `fast-uri` to 3.1.5, `brace-expansion` to 5.0.9, `js-yaml` to 4.3.1, and `nanoid` to 3.3.17 for the advisories in the failing job.
- The complete audit also raised PostCSS to 8.5.23, `ip-address` to 10.3.1, `tar` to 7.5.21, `body-parser` to 1.20.6/2.3.0, and the affected Undici lines to 6.28.0/7.29.0.
- Regenerated the root, on-chain event handler, on-call announcer, and governance watchdog lockfiles. Selectors remain bounded to the vulnerable ranges.

## Validation

- `pnpm audit` in all four dependency roots: `No known vulnerabilities found`
- `./tools/trunk check --all`: clean across 2,065 files, including OSV
- `pnpm agent:quality-gate --run --allow-package-script-changes --parallel 1`: all mapped commands passed
- Dashboard coverage: 289 files and 4,197 tests passed
- Local dashboard browser smoke: Global Overview loaded with live data and no Chrome console errors
- Fresh-context Codex autoreview: no findings; deterministic autoreview: clean
- Pre-push quality gate: all mapped commands passed

## Risks

- This changes transitive dependency resolutions across build, test, and runtime graphs. Bounded overrides limit the affected ranges; full package coverage, typechecks, builds, Terraform validation, OSV, and browser smoke all pass.

## Deferrals

- None

Refs #1726, #1711, #1288, ADR 0056