### PR TITLE
fix(peg): stop Kraken source-health alert flapping

### DIFF
--- a/alerts/rules/peg-policy-locals.tf
+++ b/alerts/rules/peg-policy-locals.tf
@@ -49,10 +49,9 @@ locals {
   }
   # Display-only sources remain visible in market context and registry-rot
   # coverage, but do not create operational health alerts.
-  peg_active_operational_sources = {
-    for key, item in local.peg_active_sources : key => item
-    if item.source.authority != "display"
-  }
+  # Operational source health follows the authoritative source set. Keep this
+  # semantic alias because health-rule locals refer to operational sources.
+  peg_active_operational_sources = local.peg_active_authoritative_sources
   peg_active_secondary_sources = {
     for key, item in local.peg_active_sources : key => item
     if item.source.authority == "secondary"
@@ -90,10 +89,8 @@ locals {
     for key, item in local.peg_previous_sources : key => item
     if item.source.authority != "display"
   }
-  peg_previous_operational_sources = {
-    for key, item in local.peg_previous_sources : key => item
-    if item.source.authority != "display"
-  }
+  # See the active alias above; retained-previous health uses the same scope.
+  peg_previous_operational_sources = local.peg_previous_authoritative_sources
   peg_previous_secondary_sources = {
     for key, item in local.peg_previous_sources : key => item
     if item.source.authority == "secondary"

--- a/alerts/rules/peg-policy-locals.tf
+++ b/alerts/rules/peg-policy-locals.tf
@@ -17,12 +17,13 @@ locals {
     "peg-monitoring" = true
   } : {}
 
-  peg_policy_bundle                                           = jsondecode(file("${path.module}/peg-thresholds.json"))
-  peg_active_policy                                           = local.peg_policy_bundle.active
-  peg_previous_policy                                         = local.peg_policy_bundle.previous
-  peg_active_policy_version                                   = local.peg_active_policy.version
-  peg_previous_policy_version                                 = try(local.peg_previous_policy.version, "no-retained-previous-policy")
-  peg_legacy_listing_absent_consecutive_checks_policy_version = "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f"
+  peg_policy_bundle           = jsondecode(file("${path.module}/peg-thresholds.json"))
+  peg_active_policy           = local.peg_policy_bundle.active
+  peg_previous_policy         = local.peg_policy_bundle.previous
+  peg_active_policy_version   = local.peg_active_policy.version
+  peg_previous_policy_version = try(local.peg_previous_policy.version, "no-retained-previous-policy")
+
+  peg_secondary_source_unhealthy_for_duration = "1800s"
 
   peg_active_assets   = local.peg_active_policy.assets
   peg_previous_assets = local.peg_previous_policy == null ? {} : local.peg_previous_policy.assets
@@ -46,6 +47,21 @@ locals {
     for key, item in local.peg_active_sources : key => item
     if item.source.authority != "display"
   }
+  # Display-only sources remain visible in market context and registry-rot
+  # coverage, but do not create operational health alerts.
+  peg_active_operational_sources = {
+    for key, item in local.peg_active_sources : key => item
+    if item.source.authority != "display"
+  }
+  peg_active_secondary_sources = {
+    for key, item in local.peg_active_sources : key => item
+    if item.source.authority == "secondary"
+  }
+  peg_active_source_unhealthy_for_duration = {
+    for key, item in local.peg_active_operational_sources : key => (
+      item.source.authority == "secondary" ? local.peg_secondary_source_unhealthy_for_duration : "${item.source.pollIntervalSeconds * 2}s"
+    )
+  }
   peg_active_deep_sources = {
     for key, item in local.peg_active_sources : key => item
     if item.source_id == item.asset.deepVenueSource
@@ -59,16 +75,13 @@ locals {
     for item in flatten([
       for asset_id, asset in local.peg_previous_assets : [
         for source_id, source in asset.sources : {
-          asset_id    = asset_id
-          asset       = asset
-          source_id   = source_id
-          source      = source
-          policy      = local.peg_previous_policy
-          policy_slot = "previous"
-          listing_absent_consecutive_checks = try(
-            source.listingAbsentConsecutiveChecks,
-            local.peg_previous_policy.version == local.peg_legacy_listing_absent_consecutive_checks_policy_version ? 2 : source.listingAbsentConsecutiveChecks,
-          )
+          asset_id                          = asset_id
+          asset                             = asset
+          source_id                         = source_id
+          source                            = source
+          policy                            = local.peg_previous_policy
+          policy_slot                       = "previous"
+          listing_absent_consecutive_checks = source.listingAbsentConsecutiveChecks
         }
       ]
     ]) : "${item.asset_id}/${item.source_id}" => item
@@ -76,6 +89,19 @@ locals {
   peg_previous_authoritative_sources = {
     for key, item in local.peg_previous_sources : key => item
     if item.source.authority != "display"
+  }
+  peg_previous_operational_sources = {
+    for key, item in local.peg_previous_sources : key => item
+    if item.source.authority != "display"
+  }
+  peg_previous_secondary_sources = {
+    for key, item in local.peg_previous_sources : key => item
+    if item.source.authority == "secondary"
+  }
+  peg_previous_source_unhealthy_for_duration = {
+    for key, item in local.peg_previous_operational_sources : key => (
+      item.source.authority == "secondary" ? local.peg_secondary_source_unhealthy_for_duration : "${item.source.pollIntervalSeconds * 2}s"
+    )
   }
   peg_previous_deep_sources = {
     for key, item in local.peg_previous_sources : key => item

--- a/alerts/rules/peg-rule-definitions.tf
+++ b/alerts/rules/peg-rule-definitions.tf
@@ -216,10 +216,10 @@ locals {
       }
     },
     {
-      for key, item in local.peg_active_sources : "active-unhealthy-${key}" => {
+      for key, item in local.peg_active_operational_sources : "active-unhealthy-${key}" => {
         name               = "Peg Source Unhealthy [${item.asset_id}/${item.source_id} · active]"
         expr               = local.peg_active_source_unhealthy_promql[key]
-        for_duration       = "${item.source.pollIntervalSeconds * 2}s"
+        for_duration       = local.peg_active_source_unhealthy_for_duration[key]
         no_data_state      = "OK"
         severity           = "warning"
         route              = "ops"
@@ -237,7 +237,7 @@ locals {
       }
     },
     {
-      for key, item in local.peg_active_non_deep_sources : "active-dead-${key}" => {
+      for key, item in local.peg_active_secondary_sources : "active-dead-${key}" => {
         name               = "Peg Source Permanently Dead [${item.asset_id}/${item.source_id} · active]"
         expr               = local.peg_active_source_unhealthy_promql[key]
         for_duration       = "${item.asset.permanentlyDeadSeconds}s"
@@ -498,10 +498,10 @@ locals {
       }
     },
     {
-      for key, item in local.peg_previous_sources : "previous-unhealthy-${key}" => {
+      for key, item in local.peg_previous_operational_sources : "previous-unhealthy-${key}" => {
         name               = "Peg Source Unhealthy [${item.asset_id}/${item.source_id} · previous]"
         expr               = local.peg_previous_source_unhealthy_promql[key]
-        for_duration       = "${item.source.pollIntervalSeconds * 2}s"
+        for_duration       = local.peg_previous_source_unhealthy_for_duration[key]
         no_data_state      = "OK"
         severity           = "warning"
         route              = "ops"
@@ -519,7 +519,7 @@ locals {
       }
     },
     {
-      for key, item in local.peg_previous_non_deep_sources : "previous-dead-${key}" => {
+      for key, item in local.peg_previous_secondary_sources : "previous-dead-${key}" => {
         name               = "Peg Source Permanently Dead [${item.asset_id}/${item.source_id} · previous]"
         expr               = local.peg_previous_source_unhealthy_promql[key]
         for_duration       = "${item.asset.permanentlyDeadSeconds}s"

--- a/alerts/rules/peg-rule-definitions.tftest.hcl
+++ b/alerts/rules/peg-rule-definitions.tftest.hcl
@@ -24,4 +24,52 @@ run "peg_rule_definitions_preserve_consumer_guard_invariant" {
     condition     = length(local.peg_rule_definitions) > 0
     error_message = "Peg rule definitions must evaluate with the source-controlled consumer guard."
   }
+
+  assert {
+    condition = alltrue(concat(
+      [
+        for key, item in local.peg_active_sources :
+        item.source.authority != "display" || (
+          try(local.peg_rule_definitions["active-unhealthy-${key}"].for_duration, "absent") == "absent" &&
+          try(local.peg_rule_definitions["active-dead-${key}"].for_duration, "absent") == "absent"
+        )
+      ],
+      [
+        for key, item in local.peg_previous_sources :
+        item.source.authority != "display" || (
+          try(local.peg_rule_definitions["previous-unhealthy-${key}"].for_duration, "absent") == "absent" &&
+          try(local.peg_rule_definitions["previous-dead-${key}"].for_duration, "absent") == "absent"
+        )
+      ],
+    ))
+    error_message = "Display-authority sources must not create Source Unhealthy or Permanently Dead operational rules."
+  }
+
+  assert {
+    condition = alltrue(concat(
+      [
+        for key, item in local.peg_active_sources :
+        item.source.authority != "secondary" || try(local.peg_rule_definitions["active-unhealthy-${key}"].for_duration, "absent") == "1800s"
+      ],
+      [
+        for key, item in local.peg_previous_sources :
+        item.source.authority != "secondary" || try(local.peg_rule_definitions["previous-unhealthy-${key}"].for_duration, "absent") == "1800s"
+      ],
+    ))
+    error_message = "Secondary-source unhealthy rules must require a sustained 30 minutes."
+  }
+
+  assert {
+    condition = alltrue(concat(
+      [
+        for key, item in local.peg_active_sources :
+        item.source.authority != "deep" || try(local.peg_rule_definitions["active-unhealthy-${key}"].for_duration, "absent") == "${item.source.pollIntervalSeconds * 2}s"
+      ],
+      [
+        for key, item in local.peg_previous_sources :
+        item.source.authority != "deep" || try(local.peg_rule_definitions["previous-unhealthy-${key}"].for_duration, "absent") == "${item.source.pollIntervalSeconds * 2}s"
+      ],
+    ))
+    error_message = "Deep-source unhealthy rules must retain their two-poll hold."
+  }
 }

--- a/alerts/rules/peg-thresholds.json
+++ b/alerts/rules/peg-thresholds.json
@@ -50,51 +50,5 @@
       }
     }
   },
-  "previous": {
-    "version": "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f",
-    "rolloverAckExpectedSeconds": 300,
-    "assets": {
-      "europ-schuman": {
-        "target": 1,
-        "warnDeviationBps": 25,
-        "criticalDeviationBps": 50,
-        "premiumWarnBps": 25,
-        "warnSustainSeconds": 600,
-        "criticalSustainSeconds": 1200,
-        "durationQuantile": 0.2,
-        "minimumCoverageFraction": 0.8,
-        "blindConsecutivePolls": 10,
-        "permanentlyDeadSeconds": 259200,
-        "structuralWarnFraction": 0.8,
-        "freshnessGraceSeconds": 300,
-        "deepVenueSource": "bitvavo_eur",
-        "sources": {
-          "bitvavo_eur": {
-            "authority": "deep",
-            "referenceSizeCap": 50000,
-            "pollIntervalSeconds": 30,
-            "staleAfterSeconds": 120,
-            "spreadEnvelopeBps": 30,
-            "conversionErrorBps": 0
-          },
-          "kraken_eur": {
-            "authority": "secondary",
-            "referenceSizeCap": 50000,
-            "pollIntervalSeconds": 60,
-            "staleAfterSeconds": 300,
-            "spreadEnvelopeBps": 75,
-            "conversionErrorBps": 0
-          },
-          "kraken_usd": {
-            "authority": "display",
-            "referenceSizeCap": 50000,
-            "pollIntervalSeconds": 300,
-            "staleAfterSeconds": 600,
-            "spreadEnvelopeBps": 100,
-            "conversionErrorBps": 30
-          }
-        }
-      }
-    }
-  }
+  "previous": null
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,7 @@ Authority: canonical
 - [`docs/adr/0054-same-project-peg-policy-artifact.md`](adr/0054-same-project-peg-policy-artifact.md) — Peg policy stays private in the monitoring project
 - [`docs/adr/0055-peg-policy-bucket-controller-recovery.md`](adr/0055-peg-policy-bucket-controller-recovery.md) — Peg policy bucket controller recovers authoritative IAM reconciliation
 - [`docs/adr/0056-agent-mcp-credential-broker.md`](adr/0056-agent-mcp-credential-broker.md) — An untrusted agent's MCP credentials sit behind a loopback broker, not in its env
+- [`docs/adr/0057-peg-observation-advancement.md`](adr/0057-peg-observation-advancement.md) — Repeated Peg provider observations retain bounded health, never sample authority
 
 Authority: non-canonical
 

--- a/docs/adr/0044-peg-thresholds-gated-rules-plane.md
+++ b/docs/adr/0044-peg-thresholds-gated-rules-plane.md
@@ -140,10 +140,15 @@ Phase 3 must implement the following protected artifact and rules contract:
     consecutive-check gauge. Inferring it from a timestamp gauge with
     `changes()` is forbidden: a listed or halted reset can occur between
     30-second scrapes and never appear in the sampled range. During this
-    field's first rollover only, the exact retained predecessor omits the
-    field and the producer uses the initial value `2`. Remove that
-    compatibility default after the reviewed `previous=null` cleanup; every
-    active policy must declare its own bounded threshold.
+    field's first rollover only, the exact retained predecessor
+    `europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f` omits the field and
+    the bridge uses the initial value `2`. Source-controlled validators now
+    require the field and checked-in policy has `previous: null`; this
+    runtime-only shim remains while production is pinned to the legacy
+    generation. Remove it in a follow-up PR only after the `previous: null`
+    generation is published, pinned, and live-verified; [#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
+    tracks that removal. Every active policy must declare its own bounded
+    threshold.
   - Severity and routing stay per-rule: warn → Slack, critical → page, each
     with its own contact-point wiring.
 

--- a/docs/adr/0044-peg-thresholds-gated-rules-plane.md
+++ b/docs/adr/0044-peg-thresholds-gated-rules-plane.md
@@ -3,7 +3,7 @@ title: Peg alert thresholds stay in the gated alerts-rules plane, read from one 
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-10
 scope: alerts
 date: 2026-07
 doc_type: adr
@@ -21,6 +21,8 @@ routing. Protected policy publication and authentication, producer activation,
 human-approved Grafana application, and live proof remain separate rollout
 gates tracked by
 [`docs/notes/peg-monitoring.md`](../notes/peg-monitoring.md).
+ADR 0057 narrows this record's observation-advancement rule without changing
+the gated-policy ownership or rollover contract.
 **Scope:** alerts
 
 ## Context
@@ -106,7 +108,12 @@ Phase 3 must implement the following protected artifact and rules contract:
     venue-data timestamp or sequence from the venue payload, never on mere
     HTTP fetch success; a source whose venue-side signal stops advancing
     fails closed to unhealthy, so a frozen at-par book behind a healthy
-    endpoint cannot certify freshness or coverage during a real depeg.
+    endpoint cannot certify freshness or coverage during a real depeg. A
+    repeated provider observation may retain source health only while its
+    provider timestamp remains within that source's `staleAfterSeconds`; it
+    never advances a sample or usable decision. Stale, regressing, and
+    identity-invalid inputs fail closed as specified by
+    [ADR 0057](0057-peg-observation-advancement.md).
   - Blindness and heartbeat rules set `no_data_state = "Alerting"` with the
     documented justification and ~5-minute grace, following the
     bridge-down/pool-coverage precedent: for these rules, absence of data

--- a/docs/adr/0057-peg-observation-advancement.md
+++ b/docs/adr/0057-peg-observation-advancement.md
@@ -1,0 +1,81 @@
+---
+title: Repeated Peg provider observations retain bounded health, never sample authority
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-10
+scope: metrics-bridge / alerts
+date: 2026-08
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0057 — Repeated Peg provider observations retain bounded health, never sample authority
+
+**Status:** Accepted (Aug 2026), in force. This record narrows the
+observation-advancement clause in [ADR 0044](0044-peg-thresholds-gated-rules-plane.md).
+**Scope:** metrics-bridge / alerts
+
+## Context
+
+Peg rules use the provider-side timestamp as evidence that a market observation
+is current. A reachable provider can repeat its most recent observation across
+several fetches. Treating each successful fetch as a new observation can make a
+frozen at-par book satisfy coverage and erase a sustained deviation. Treating
+every repeat as immediately unhealthy creates avoidable source-health noise
+while the provider timestamp remains within the policy's approved freshness
+window.
+
+The distinction constrains both the bridge producer and the Grafana consumers:
+source health may describe whether a recent provider observation still exists;
+sample and decision metrics describe whether new decision evidence arrived.
+
+## Decision
+
+- A provider observation with the same timestamp and identity as the currently
+  retained executable observation may retain source health only while that
+  timestamp is within the source policy's `staleAfterSeconds`. A listing halt
+  or absence ends this exception.
+- A repeated observation never advances `mento_peg_observation_at`, counts as
+  a new sample, or creates a usable decision. It cannot replenish the
+  decision-history evidence used by sustain and coverage predicates.
+- A stale or regressing timestamp, a previously seen identity replayed after a
+  different same-timestamp identity, an exceeded identity bound, or an
+  observation that does not match the configured exact pair fails closed. It
+  cannot retain source health, advance a sample, or create a usable decision.
+- This narrows ADR 0044 only. Policy ownership, content-addressed versions,
+  two-phase predecessor retention, and the gated publication/apply sequence
+  remain unchanged.
+
+## Alternatives considered
+
+- **Advance on every successful fetch** — rejected: endpoint availability is
+  not new market evidence and can certify a frozen book.
+- **Mark every repeat unhealthy immediately** — rejected: a still-fresh
+  provider timestamp can honestly retain bounded source health; immediate
+  failure adds noise without improving decision safety.
+- **Accept stale or regressing timestamps as repeats** — rejected: this hides
+  provider rollback or loss of freshness and can keep an invalid source healthy.
+
+## Consequences
+
+- Provider adapters and the poll cycle must retain timestamp and identity state
+  separately from fetch success.
+- Tests must cover repeat-within-window health, repeat-without-new-decision,
+  and fail-closed stale, regressing, and identity-invalid inputs.
+- Operators must wait for the human-approved Grafana cleanup, protected policy
+  publication, runtime-generation attachment, and production checks before
+  claiming the predecessor cleanup is live.
+
+## Evidence
+
+- Issue #1747
+- `metrics-bridge/src/peg/poller.ts` and `metrics-bridge/src/peg/poll-cycle.ts`
+  (provider-observation and decision-production path)
+- `metrics-bridge/test/peg-poller.test.ts` (repeat and freshness regression
+  coverage)
+- `alerts/rules/peg-thresholds.json` and
+  `alerts/rules/peg-promql-active.tf` (gated stale window and exact-version
+  consumer contract)
+- ADRs 0042, 0044, 0045

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -132,6 +132,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0049](0049-peg-decision-package-read-model.md)          | Peg decisions use a bounded Metrics Bridge read model                         |
 | [0054](0054-same-project-peg-policy-artifact.md)         | Peg policy stays private and generation-pinned in the monitoring project      |
 | [0055](0055-peg-policy-bucket-controller-recovery.md)    | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery   |
+| [0057](0057-peg-observation-advancement.md)              | Repeated provider observations retain bounded health, never sample authority  |
 
 ### terraform / infra
 
@@ -148,6 +149,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0053](0053-explicit-deployment-source-staging.md)    | Routine Cloud Build and App Engine deploys use explicit, bucket-scoped source staging                             |
 | [0054](0054-same-project-peg-policy-artifact.md)      | Peg policy stays private and generation-pinned in the monitoring project                                          |
 | [0055](0055-peg-policy-bucket-controller-recovery.md) | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery                                       |
+| [0057](0057-peg-observation-advancement.md)           | Repeated provider observations retain bounded health, never sample authority                                      |
 
 ### governance-watchdog
 

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -3,7 +3,7 @@ title: Peg monitoring onboarding and re-census
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-10
 doc_type: runbook
 scope: metrics-bridge / alerts / ui-dashboard
 review_interval_days: 90
@@ -372,8 +372,15 @@ between scrapes.
 Only an authoritative response advances `mento_peg_listing_checked_at`.
 Unknown, missing, or stale evidence is not delisting. Listing confirmation can
 still succeed when the later book fetch fails, so listing alerts do not gate
-on source health, observation time, or the asset heartbeat. Every policy
-source must declare its bounded listing-confirmation threshold.
+on source health, observation time, or the asset heartbeat. Source validators
+require every policy source to declare its bounded listing-confirmation
+threshold. During the production transition only, Metrics Bridge accepts the
+omission from the exact legacy retained version
+`europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f` and normalizes it to
+`2` in decision packages. Remove that runtime shim in a follow-up PR after the
+`previous: null` generation is published, pinned, and live-verified;
+[#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
+tracks that removal.
 
 A source restoration is not enough by itself. Repeat the executable-depth and
 coverage gates before restoring alert authority.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -23,7 +23,8 @@ The architecture is fixed by ADRs
 [0044](../adr/0044-peg-thresholds-gated-rules-plane.md),
 [0045](../adr/0045-peg-paging-semantics.md),
 [0054](../adr/0054-same-project-peg-policy-artifact.md), and
-[0049](../adr/0049-peg-decision-package-read-model.md).
+[0049](../adr/0049-peg-decision-package-read-model.md), and
+[0057](../adr/0057-peg-observation-advancement.md).
 
 ## Completion states
 
@@ -371,9 +372,8 @@ between scrapes.
 Only an authoritative response advances `mento_peg_listing_checked_at`.
 Unknown, missing, or stale evidence is not delisting. Listing confirmation can
 still succeed when the later book fetch fails, so listing alerts do not gate
-on source health, observation time, or the asset heartbeat. The exact retained
-legacy policy omits `listingAbsentConsecutiveChecks` and has an effective
-threshold of `2`; every newer policy must declare the bounded threshold.
+on source health, observation time, or the asset heartbeat. Every policy
+source must declare its bounded listing-confirmation threshold.
 
 A source restoration is not enough by itself. Repeat the executable-depth and
 coverage gates before restoring alert authority.

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -32,7 +32,7 @@ The source-owned surfaces are:
 
 This source packet does not apply Grafana resources by itself. The activation
 apply is complete: the Peg folder, templates, contact points, and rule group
-are live in Grafana for both the active and retained policy versions
+are live in Grafana for the policy version published at that time
 ([#1680](https://github.com/mento-protocol/monitoring-monorepo/pull/1680),
 [#1685](https://github.com/mento-protocol/monitoring-monorepo/pull/1685)).
 `terraform/peg-policy.tf` owns the policy identities and bucket IAM. Controller
@@ -50,6 +50,13 @@ single Terraform local gates the Peg folder, templates, contact points, and
 rule group; it is not a workflow, variable, or policy-artifact switch. This
 source change does not prove the consumers exist in Grafana or that their
 queries have live data.
+
+This source cleanup sets `previous` to `null`. It does not itself remove
+retained Grafana rules, publish a new immutable policy generation, or attach
+that generation to Metrics Bridge. Do not claim active-only production
+operation until the human-approved `alerts-rules` cleanup, protected
+publication, reviewed runtime-generation attachment, and post-change
+producer/Grafana checks complete in that order.
 
 The production identity bootstrap in
 [#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) is
@@ -80,8 +87,8 @@ For each active policy, the generated source defines:
 | Structural saturation warning | Fresh reachable indexed-pool saturation above policy                                                        | `#alerts-pools`                                              |
 | Blind warning                 | Producer count reaches `blindConsecutivePolls` without a usable uncapped deep-venue decision                | `#alerts-infra`                                              |
 | Blind while stressed critical | Confirmed consecutive blindness plus reachable structural stress, spread stress, or partial-price shortfall | Splunk On-Call and `@support-engineer` in `#alerts-critical` |
-| Source unhealthy              | Expected source unhealthy while the asset heartbeat is fresh                                                | `#alerts-infra`                                              |
-| Source permanently dead       | Source unhealthy for `permanentlyDeadSeconds`                                                               | `#alerts-infra`                                              |
+| Source unhealthy              | Deep source unhealthy for two polls, or secondary source unhealthy for 30 minutes; display sources excluded | `#alerts-infra`                                              |
+| Source permanently dead       | Secondary source unhealthy for `permanentlyDeadSeconds`; display sources excluded                           | `#alerts-infra`                                              |
 | Registry rot                  | A non-deep source, including display-only, is `absent` at its producer-side consecutive-check threshold     | `#alerts-infra`                                              |
 | Critical path unreachable     | The policy-designated deep source is `absent` at its producer-side consecutive-check threshold              | `#alerts-infra`                                              |
 | Indexed pool unreachable      | The registry-bound indexed pool is zero or absent while the exact-version asset poll remains fresh          | `#alerts-infra`                                              |
@@ -91,19 +98,18 @@ For each active policy, the generated source defines:
 When `previous` is retained, the same decision ladder remains generated for
 that exact previous version. Previous-version rules do not stop at the first
 active-version acknowledgement; cleanup is a later reviewed policy change.
-The legacy retained policy
-`europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f` has an effective listing
-absence threshold of two checks. Every newer policy declares its own bounded
-threshold.
+Every policy source declares its own bounded listing-absence threshold.
 
-Display sources never create deviation or premium rules. Structural saturation
-never pages alone. Blindness does not depend on indexed-pool reachability:
-reachability gates only the structural branch of the independent-stress page,
-so market stress remains observable during an indexer or pool-data outage. The
-producer updates `mento_peg_blind_consecutive_polls` at deep-venue poll cadence
-and resets it on each usable uncapped decision. Grafana compares that exact
-count with policy; its 60-second evaluation clock never approximates 30-second
-polls.
+Display sources create registry-rot listing alerts, but never deviation,
+premium, source-unhealthy, or permanently-dead rules. Deep-source health uses
+a two-poll hold; secondary-source health uses a 30-minute hold. Structural
+saturation never pages alone. Blindness does not depend on indexed-pool
+reachability: reachability gates only the structural branch of the
+independent-stress page, so market stress remains observable during an indexer
+or pool-data outage. The producer updates
+`mento_peg_blind_consecutive_polls` at deep-venue poll cadence and resets it on
+each usable uncapped decision. Grafana compares that exact count with policy;
+its 60-second evaluation clock never approximates 30-second polls.
 
 Listing rules follow the same producer-owned discipline. The bridge increments
 the bounded absence streak only on an authoritative exact-pair `absent`
@@ -115,6 +121,11 @@ delisting. `Peg Registry Rot`, `Peg Critical Path Unreachable`, and
 warning severity, and the direct `#alerts-infra` contact point. They never
 page. The [onboarding and re-census runbook](peg-monitoring-onboarding.md)
 owns source admission, response, and cleanup.
+
+Under [ADR 0057](../adr/0057-peg-observation-advancement.md), a repeated
+provider observation may retain source health only while its provider timestamp
+is within `staleAfterSeconds`. It never advances a sample or usable decision.
+Stale, regressing, and identity-invalid provider inputs fail closed.
 
 ## Local source validation
 
@@ -138,6 +149,25 @@ secret-backed contact-point dependencies. The first complete remote diff is
 therefore the trusted-main plan after merge. Keep its `production-infra` apply
 blocked, inspect the full plan, and do not treat a targeted PR plan as proof of
 the peg rule resources.
+
+## Predecessor cleanup deployment proof
+
+After this source change merges, keep the policy predecessor cleanup in the
+following order:
+
+1. Inspect the trusted-main `alerts-rules` plan, then explicitly approve its
+   `production-infra` apply. Confirm retained-previous rules are removed and
+   active rules remain evaluable in Grafana. Removing consumers before their
+   producer series follows the rollback dependency order.
+2. Inspect the trusted-main publication plan, then explicitly approve its
+   `production-infra` apply to publish the `previous: null` artifact.
+3. Review the platform change that pins Metrics Bridge to that exact positive
+   generation, apply it through its owning approved path, and verify the
+   producer reports only the active policy.
+
+Never run these applies from an agent session. A merged source change, a policy
+publication, or a runtime attachment alone is insufficient proof of
+active-only operation.
 
 ## Production activation preconditions
 

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-10
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -58,6 +58,18 @@ operation until the human-approved `alerts-rules` cleanup, protected
 publication, reviewed runtime-generation attachment, and post-change
 producer/Grafana checks complete in that order.
 
+Source validators now require every policy source to declare
+`listingAbsentConsecutiveChecks`, and the checked-in policy keeps `previous`
+as `null`. Metrics Bridge retains a runtime-only compatibility shim for the
+exact legacy previous version
+`europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f`, which defaults the
+missing threshold to `2` while Cloud Run remains pinned to the production
+generation containing that predecessor. The bridge normalizes the value into
+decision packages, so the dashboard schema remains strict. Remove the shim in
+a follow-up PR after the `previous: null` generation is published, pinned, and
+live-verified; [#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
+tracks that removal.
+
 The production identity bootstrap in
 [#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) is
 merged and its separately reviewed Terraform apply is complete. The producer
@@ -98,7 +110,8 @@ For each active policy, the generated source defines:
 When `previous` is retained, the same decision ladder remains generated for
 that exact previous version. Previous-version rules do not stop at the first
 active-version acknowledgement; cleanup is a later reviewed policy change.
-Every policy source declares its own bounded listing-absence threshold.
+Source-controlled policy requires every source to declare its bounded
+listing-absence threshold.
 
 Display sources create registry-rot listing alerts, but never deviation,
 premium, source-unhealthy, or permanently-dead rules. Deep-source health uses
@@ -155,15 +168,20 @@ the peg rule resources.
 After this source change merges, keep the policy predecessor cleanup in the
 following order:
 
-1. Inspect the trusted-main `alerts-rules` plan, then explicitly approve its
+1. Let the automatic Metrics Bridge workflow deploy the compatibility-retaining
+   revision from `main`. Verify it still loads the pinned legacy generation and
+   continues publishing current Peg polls and decision packages.
+2. Inspect the trusted-main `alerts-rules` plan, then explicitly approve its
    `production-infra` apply. Confirm retained-previous rules are removed and
    active rules remain evaluable in Grafana. Removing consumers before their
    producer series follows the rollback dependency order.
-2. Inspect the trusted-main publication plan, then explicitly approve its
+3. Inspect the trusted-main publication plan, then explicitly approve its
    `production-infra` apply to publish the `previous: null` artifact.
-3. Review the platform change that pins Metrics Bridge to that exact positive
+4. Review the platform change that pins Metrics Bridge to that exact positive
    generation, apply it through its owning approved path, and verify the
    producer reports only the active policy.
+5. After active-only production is live-verified, remove the exact legacy
+   runtime shim through [#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750).
 
 Never run these applies from an agent session. A merged source change, a policy
 publication, or a runtime attachment alone is insufficient proof of

--- a/metrics-bridge/src/peg/policy.ts
+++ b/metrics-bridge/src/peg/policy.ts
@@ -53,22 +53,11 @@ export const PEG_POLICY_MAX_ASSETS = 32;
 export const PEG_POLICY_MAX_SOURCES_PER_ASSET = 16;
 export const PEG_POLICY_MAX_BLIND_CONSECUTIVE_POLLS = 1_000;
 export const PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS = 1_000;
-export const PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS = 2;
-export const PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION =
-  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
 
-/**
- * The retained pre-streak policy must stay byte-for-byte intact through its
- * two-phase rollover. Remove this compatibility default after that predecessor
- * is cleared; active policies always declare the field below.
- */
 export function effectiveListingAbsentConsecutiveChecks(source: {
-  listingAbsentConsecutiveChecks?: number | undefined;
+  listingAbsentConsecutiveChecks: number;
 }): number {
-  return (
-    source.listingAbsentConsecutiveChecks ??
-    PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS
-  );
+  return source.listingAbsentConsecutiveChecks;
 }
 
 export const PegSourcePolicySchema = z
@@ -81,8 +70,7 @@ export const PegSourcePolicySchema = z
       .number()
       .int()
       .min(2)
-      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS)
-      .optional(),
+      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS),
     spreadEnvelopeBps: z.number().finite().nonnegative().max(10_000),
     conversionErrorBps: z.number().finite().nonnegative().max(10_000),
   })
@@ -235,44 +223,6 @@ export const PegPolicyVersionSchema = z
     }
   });
 
-function requireListingThresholds(
-  policy: z.infer<typeof PegPolicyVersionSchema>,
-  slot: "active" | "previous",
-  context: z.RefinementCtx,
-): void {
-  if (
-    slot === "previous" &&
-    policy.version ===
-      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION
-  ) {
-    return;
-  }
-  const missing = Object.entries(policy.assets).flatMap(([assetId, asset]) =>
-    Object.entries(asset.sources)
-      .filter(
-        ([, source]) => source.listingAbsentConsecutiveChecks === undefined,
-      )
-      .map(([sourceId]) => ({ assetId, sourceId })),
-  );
-  for (const { assetId, sourceId } of missing) {
-    context.addIssue({
-      code: "custom",
-      path: [
-        slot,
-        "assets",
-        assetId,
-        "sources",
-        sourceId,
-        "listingAbsentConsecutiveChecks",
-      ],
-      message:
-        slot === "active"
-          ? "must be declared by the active policy"
-          : "may be omitted only by the exact pre-streak retained predecessor",
-    });
-  }
-}
-
 export const PegPolicyBundleSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -287,10 +237,6 @@ export const PegPolicyBundleSchema = z
         path: ["previous", "version"],
         message: "must differ from the active version",
       });
-    }
-    requireListingThresholds(bundle.active, "active", context);
-    if (bundle.previous !== null) {
-      requireListingThresholds(bundle.previous, "previous", context);
     }
   });
 

--- a/metrics-bridge/src/peg/policy.ts
+++ b/metrics-bridge/src/peg/policy.ts
@@ -53,11 +53,22 @@ export const PEG_POLICY_MAX_ASSETS = 32;
 export const PEG_POLICY_MAX_SOURCES_PER_ASSET = 16;
 export const PEG_POLICY_MAX_BLIND_CONSECUTIVE_POLLS = 1_000;
 export const PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS = 1_000;
+export const PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS = 2;
+export const PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION =
+  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
 
+/**
+ * The runtime may read the exact retained pre-streak production policy until
+ * the checked-in `previous: null` generation is published, pinned, and live
+ * verified. Source-controlled policy remains strict.
+ */
 export function effectiveListingAbsentConsecutiveChecks(source: {
-  listingAbsentConsecutiveChecks: number;
+  listingAbsentConsecutiveChecks?: number | undefined;
 }): number {
-  return source.listingAbsentConsecutiveChecks;
+  return (
+    source.listingAbsentConsecutiveChecks ??
+    PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS
+  );
 }
 
 export const PegSourcePolicySchema = z
@@ -70,7 +81,8 @@ export const PegSourcePolicySchema = z
       .number()
       .int()
       .min(2)
-      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS),
+      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS)
+      .optional(),
     spreadEnvelopeBps: z.number().finite().nonnegative().max(10_000),
     conversionErrorBps: z.number().finite().nonnegative().max(10_000),
   })
@@ -223,6 +235,44 @@ export const PegPolicyVersionSchema = z
     }
   });
 
+function requireListingThresholds(
+  policy: z.infer<typeof PegPolicyVersionSchema>,
+  slot: "active" | "previous",
+  context: z.RefinementCtx,
+): void {
+  if (
+    slot === "previous" &&
+    policy.version ===
+      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION
+  ) {
+    return;
+  }
+  const missing = Object.entries(policy.assets).flatMap(([assetId, asset]) =>
+    Object.entries(asset.sources)
+      .filter(
+        ([, source]) => source.listingAbsentConsecutiveChecks === undefined,
+      )
+      .map(([sourceId]) => ({ assetId, sourceId })),
+  );
+  for (const { assetId, sourceId } of missing) {
+    context.addIssue({
+      code: "custom",
+      path: [
+        slot,
+        "assets",
+        assetId,
+        "sources",
+        sourceId,
+        "listingAbsentConsecutiveChecks",
+      ],
+      message:
+        slot === "active"
+          ? "must be declared by the active policy"
+          : "may be omitted only by the exact pre-streak retained predecessor",
+    });
+  }
+}
+
 export const PegPolicyBundleSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -237,6 +287,10 @@ export const PegPolicyBundleSchema = z
         path: ["previous", "version"],
         message: "must differ from the active version",
       });
+    }
+    requireListingThresholds(bundle.active, "active", context);
+    if (bundle.previous !== null) {
+      requireListingThresholds(bundle.previous, "previous", context);
     }
   });
 

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -509,16 +509,35 @@ function unavailableSourceSnapshot(
   });
 }
 
+function isCurrentRetainedExecutableObservation(
+  state: SourceState,
+  observationAt: number,
+  sequence: string,
+): boolean {
+  const observation = state.observation;
+  if (observation === null || observation.venueState === "halted") return false;
+  if (state.listingState === "halted" || state.listingState === "absent") {
+    return false;
+  }
+  return (
+    observation.observationAt === observationAt &&
+    observation.sequence === sequence
+  );
+}
+
 function recordProviderAdvancement(
   state: SourceState,
   observationAt: number,
   sequence: string,
-): string | null {
+): { advanced: boolean; failure: string | null } {
   if (
     state.lastObservationAt !== null &&
     observationAt < state.lastObservationAt
   ) {
-    return "venue observation timestamp regressed";
+    return {
+      advanced: false,
+      failure: "venue observation timestamp regressed",
+    };
   }
 
   if (
@@ -528,21 +547,30 @@ function recordProviderAdvancement(
     state.lastObservationAt = observationAt;
     state.identitiesAtLastObservationAt.clear();
     state.identitiesAtLastObservationAt.add(sequence);
-    return null;
+    return { advanced: true, failure: null };
   }
 
+  if (isCurrentRetainedExecutableObservation(state, observationAt, sequence)) {
+    return { advanced: false, failure: null };
+  }
   if (state.identitiesAtLastObservationAt.has(sequence)) {
-    return "venue observation did not advance";
+    return {
+      advanced: false,
+      failure: "venue observation identity replayed",
+    };
   }
   if (
     state.identitiesAtLastObservationAt.size >=
     MAX_IDENTITIES_PER_OBSERVATION_TIMESTAMP
   ) {
-    return "venue observation identity bound exceeded";
+    return {
+      advanced: false,
+      failure: "venue observation identity bound exceeded",
+    };
   }
 
   state.identitiesAtLastObservationAt.add(sequence);
-  return null;
+  return { advanced: true, failure: null };
 }
 
 function failSource(
@@ -600,24 +628,26 @@ function acceptDueObservation(
       cause: new Error("stale venue observation"),
     });
   }
-  const advancementFailure = recordProviderAdvancement(
+  const advancement = recordProviderAdvancement(
     state,
     observation.observationAt,
     observation.sequence,
   );
-  if (advancementFailure !== null) {
+  if (advancement.failure !== null) {
     return failSource(input, state, refSize, {
       kind: "source_freshness",
-      cause: new Error(advancementFailure),
+      cause: new Error(advancement.failure),
     });
   }
   state.observation = observation;
   state.referenceSize = refSize;
   state.conversionValidUntil = converted.validUntil;
+  // A repeated provider identity remains healthy until its provider timestamp
+  // expires, but cannot create new coverage or sustain a price decision.
   return sourceSnapshot(input, state, {
     referenceSize: refSize,
     observation,
-    newSuccess: true,
+    newSuccess: advancement.advanced,
   });
 }
 

--- a/metrics-bridge/test/peg-decision-packages.test.ts
+++ b/metrics-bridge/test/peg-decision-packages.test.ts
@@ -289,15 +289,12 @@ describe("peg decision-package producer", () => {
     );
   });
 
-  it("selects retained previous only as the explicit active-incomplete fallback", () => {
-    const legacyPrevious = structuredClone(previous);
-    delete legacyPrevious.assets["asset-one"]!.sources.deep_eur!
-      .listingAbsentConsecutiveChecks;
+  it("selects a complete retained previous as the active-incomplete fallback", () => {
     const prepared = preparePegDecisionPackages(
-      [snapshot(legacyPrevious.version)],
-      context([active, legacyPrevious], active.version, legacyPrevious.version),
+      [snapshot(previous.version)],
+      context([active, previous], active.version, previous.version),
     )!;
-    expect(prepared.model.producedPolicyVersion).toBe(legacyPrevious.version);
+    expect(prepared.model.producedPolicyVersion).toBe(previous.version);
     expect(prepared.model.policySlot).toBe("previous");
     expect(
       prepared.model.packages[0]?.sources[0]?.policy

--- a/metrics-bridge/test/peg-decision-packages.test.ts
+++ b/metrics-bridge/test/peg-decision-packages.test.ts
@@ -18,7 +18,10 @@ import {
   type PegPollCycleContext,
   type PegPollSourceState,
 } from "../src/peg/poll-cycle.js";
-import type { PegPolicyVersion } from "../src/peg/policy.js";
+import {
+  PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
+  type PegPolicyVersion,
+} from "../src/peg/policy.js";
 import { publishPegPollSnapshot } from "../src/peg/publisher.js";
 import { parsePegRegistry } from "../src/peg/registry.js";
 
@@ -289,12 +292,17 @@ describe("peg decision-package producer", () => {
     );
   });
 
-  it("selects a complete retained previous as the active-incomplete fallback", () => {
+  it("normalizes the exact legacy retained previous in the active-incomplete fallback", () => {
+    const legacyPrevious = policy(
+      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
+    );
+    delete legacyPrevious.assets["asset-one"]!.sources.deep_eur!
+      .listingAbsentConsecutiveChecks;
     const prepared = preparePegDecisionPackages(
-      [snapshot(previous.version)],
-      context([active, previous], active.version, previous.version),
+      [snapshot(legacyPrevious.version)],
+      context([active, legacyPrevious], active.version, legacyPrevious.version),
     )!;
-    expect(prepared.model.producedPolicyVersion).toBe(previous.version);
+    expect(prepared.model.producedPolicyVersion).toBe(legacyPrevious.version);
     expect(prepared.model.policySlot).toBe("previous");
     expect(
       prepared.model.packages[0]?.sources[0]?.policy

--- a/metrics-bridge/test/peg-policy.test.ts
+++ b/metrics-bridge/test/peg-policy.test.ts
@@ -4,7 +4,6 @@ import {
   parsePegPolicyBundle,
   PEG_POLICY_MAX_ASSETS,
   PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS,
-  effectiveListingAbsentConsecutiveChecks,
   PEG_POLICY_MAX_SOURCES_PER_ASSET,
   pegPolicyContentDigest,
   pegPolicyVersionForContent,
@@ -76,7 +75,7 @@ describe("Peg policy", () => {
     ).toThrow(/at most 32/);
   });
 
-  it("parses the checked-in inactive EUROP policy bundle", async () => {
+  it("parses the checked-in post-cleanup EUROP policy bundle", async () => {
     const policy = await productionPolicy();
 
     expect(policy.active.version).toBe(
@@ -89,18 +88,7 @@ describe("Peg policy", () => {
       policy.active.assets["europ-schuman"]?.sources.bitvavo_eur
         ?.referenceSizeCap,
     ).toBe(50_000);
-    expect(policy.previous?.version).toBe(
-      "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f",
-    );
-    expect(
-      policy.previous?.assets["europ-schuman"]?.sources.bitvavo_eur
-        ?.listingAbsentConsecutiveChecks,
-    ).toBeUndefined();
-    expect(
-      effectiveListingAbsentConsecutiveChecks(
-        policy.previous!.assets["europ-schuman"]!.sources.bitvavo_eur!,
-      ),
-    ).toBe(2);
+    expect(policy.previous).toBeNull();
   });
 
   it("rejects a deep designation that does not own deep authority", async () => {
@@ -194,7 +182,7 @@ describe("Peg policy", () => {
     ).toThrow(/>=2/);
   });
 
-  it("accepts a missing threshold only in the exact retained legacy policy", async () => {
+  it("requires every policy source to declare a listing threshold", async () => {
     const policy = await productionPolicy();
     const asset = policy.active.assets["europ-schuman"]!;
     const source = asset.sources.bitvavo_eur!;
@@ -218,14 +206,24 @@ describe("Peg policy", () => {
           },
         },
       }),
-    ).toThrow(/must be declared by the active policy/);
+    ).toThrow(/listingAbsentConsecutiveChecks/);
 
-    const futureLegacy = versioned("europ-2026-07-22-v0", policy.previous!);
+    const previousWithoutThreshold = versioned("europ-2026-07-22-v0", {
+      ...policy.active,
+      assets: {
+        ...policy.active.assets,
+        "europ-schuman": {
+          ...asset,
+          sources: {
+            ...asset.sources,
+            bitvavo_eur: withoutThreshold,
+          },
+        },
+      },
+    });
     expect(() =>
-      parsePegPolicyBundle({ ...policy, previous: futureLegacy }),
-    ).toThrow(
-      /may be omitted only by the exact pre-streak retained predecessor/,
-    );
+      parsePegPolicyBundle({ ...policy, previous: previousWithoutThreshold }),
+    ).toThrow(/listingAbsentConsecutiveChecks/);
   });
 
   it("keeps asset freshness relationships executable", async () => {

--- a/metrics-bridge/test/peg-policy.test.ts
+++ b/metrics-bridge/test/peg-policy.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   parsePegPolicyBundle,
   PEG_POLICY_MAX_ASSETS,
+  PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
   PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS,
+  effectiveListingAbsentConsecutiveChecks,
   PEG_POLICY_MAX_SOURCES_PER_ASSET,
   pegPolicyContentDigest,
   pegPolicyVersionForContent,
@@ -29,6 +31,18 @@ function versioned(
     ...candidate,
     version: pegPolicyVersionForContent(prefix, candidate),
   };
+}
+
+function legacyPrevious(policy: PegPolicyBundle): PegPolicyBundle["active"] {
+  const previous = structuredClone(policy.active);
+  previous.version =
+    PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION;
+  for (const asset of Object.values(previous.assets)) {
+    for (const source of Object.values(asset.sources)) {
+      delete source.listingAbsentConsecutiveChecks;
+    }
+  }
+  return previous;
 }
 
 describe("Peg policy", () => {
@@ -182,7 +196,7 @@ describe("Peg policy", () => {
     ).toThrow(/>=2/);
   });
 
-  it("requires every policy source to declare a listing threshold", async () => {
+  it("accepts and normalizes the exact legacy retained predecessor only", async () => {
     const policy = await productionPolicy();
     const asset = policy.active.assets["europ-schuman"]!;
     const source = asset.sources.bitvavo_eur!;
@@ -206,9 +220,23 @@ describe("Peg policy", () => {
           },
         },
       }),
-    ).toThrow(/listingAbsentConsecutiveChecks/);
+    ).toThrow(/must be declared by the active policy/);
 
-    const previousWithoutThreshold = versioned("europ-2026-07-22-v0", {
+    const exactLegacyPrevious = legacyPrevious(policy);
+    const parsed = parsePegPolicyBundle({
+      ...policy,
+      previous: exactLegacyPrevious,
+    });
+    expect(parsed.previous?.version).toBe(
+      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
+    );
+    expect(
+      effectiveListingAbsentConsecutiveChecks(
+        parsed.previous!.assets["europ-schuman"]!.sources.bitvavo_eur!,
+      ),
+    ).toBe(2);
+
+    const otherPreviousWithoutThreshold = versioned("europ-2026-07-22-v0", {
       ...policy.active,
       assets: {
         ...policy.active.assets,
@@ -222,8 +250,13 @@ describe("Peg policy", () => {
       },
     });
     expect(() =>
-      parsePegPolicyBundle({ ...policy, previous: previousWithoutThreshold }),
-    ).toThrow(/listingAbsentConsecutiveChecks/);
+      parsePegPolicyBundle({
+        ...policy,
+        previous: otherPreviousWithoutThreshold,
+      }),
+    ).toThrow(
+      /may be omitted only by the exact pre-streak retained predecessor/,
+    );
   });
 
   it("keeps asset freshness relationships executable", async () => {

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -4,6 +4,7 @@ import { _resetPegDecisionPackagesForTests } from "../src/peg/decision-packages.
 import type { PegStructuralContextResult } from "../src/peg/graphql.js";
 import {
   _resetPegMetricsForTests,
+  publishPegMetrics,
   type PegAssetMetricSnapshot,
 } from "../src/peg/metrics.js";
 import {
@@ -571,7 +572,7 @@ describe("peg poll cycle freshness and measurements", () => {
     expect(fetchBitvavoListing).toHaveBeenCalledTimes(2);
   });
 
-  it("does not count a frozen at-par book and fails it stale", async () => {
+  it("keeps a fresh frozen at-par book healthy without advancing coverage", async () => {
     const spec = primaryAsset({
       sources: [primarySource({ staleAfterSeconds: 60 })],
     });
@@ -580,13 +581,18 @@ describe("peg poll cycle freshness and measurements", () => {
     let nowMs = baseMs;
     const frozen = observation(baseMs, { sequence: "frozen" });
     const publish = vi.fn<(snapshots: PegAssetMetricSnapshot[]) => void>();
+    const errors: PegPollErrorEvent[] = [];
     const poller = createPegPoller({
       nowMs: () => nowMs,
       fetchStructuralContext: vi.fn(async () =>
         structuralContext(spec, Math.floor(nowMs / 1_000)),
       ),
       fetchBitvavo: vi.fn(async () => frozen),
-      publish,
+      publish: (snapshots) => {
+        publish(snapshots);
+        publishPegMetrics(snapshots);
+      },
+      onError: (event) => errors.push(event),
     });
 
     const first = (await poller.pollCycle(input))[0]!;
@@ -604,11 +610,27 @@ describe("peg poll cycle freshness and measurements", () => {
     nowMs = baseMs + 30_000;
     const second = (await poller.pollCycle(input))[0]!;
     expect(source(second)).toMatchObject({
-      healthy: false,
-      observation: null,
+      healthy: true,
+      observation: { sequence: "frozen" },
       newSuccess: false,
       newUsableDecision: false,
+      deviationBps: 0,
     });
+    expect(second.blind).toBe(false);
+    const freshFrozenMetrics = await register.metrics();
+    expect(freshFrozenMetrics).toContain(
+      `mento_peg_source_healthy{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 1`,
+    );
+    expect(freshFrozenMetrics).toContain(
+      `mento_peg_deviation_bps{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 0`,
+    );
+    expect(freshFrozenMetrics).toContain(
+      `mento_peg_poll_success_total{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 1`,
+    );
+    expect(freshFrozenMetrics).toContain(
+      `mento_peg_usable_decision_total{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 1`,
+    );
+    expect(errors).toEqual([]);
 
     nowMs = baseMs + 61_000;
     const third = (await poller.pollCycle(input))[0]!;
@@ -619,6 +641,22 @@ describe("peg poll cycle freshness and measurements", () => {
       observation: null,
     });
     expect(third.blind).toBe(true);
+    const staleFrozenMetrics = await register.metrics();
+    expect(staleFrozenMetrics).toContain(
+      `mento_peg_source_healthy{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 0`,
+    );
+    expect(staleFrozenMetrics).not.toContain("mento_peg_deviation_bps{");
+    expect(staleFrozenMetrics).toContain(
+      `mento_peg_poll_success_total{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 1`,
+    );
+    expect(staleFrozenMetrics).toContain(
+      `mento_peg_usable_decision_total{asset="asset-one",source="deep_eur",policy_version="${input.policy.version}"} 1`,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      kind: "source_freshness",
+      cause: new Error("stale venue observation"),
+    });
     expect(publish).toHaveBeenCalledTimes(3);
   });
 
@@ -671,7 +709,7 @@ describe("peg poll cycle freshness and measurements", () => {
     );
   });
 
-  it("accepts distinct same-millisecond updates once and rejects A/B replay", async () => {
+  it("accepts distinct same-millisecond updates once and rejects A/B/A replays", async () => {
     const spec = primaryAsset();
     const input = makeInput([spec]);
     const baseMs = 1_800_000_000_000;
@@ -695,20 +733,23 @@ describe("peg poll cycle freshness and measurements", () => {
     });
 
     const successes: boolean[] = [];
+    const healthy: boolean[] = [];
     for (let index = 0; index < 4; index += 1) {
       const snapshot = (await poller.pollCycle(input))[0]!;
       successes.push(source(snapshot).newSuccess);
+      healthy.push(source(snapshot).healthy);
       nowMs += 30_000;
     }
 
     expect(successes).toEqual([true, true, false, false]);
+    expect(healthy).toEqual([true, true, false, false]);
     expect(errors.map(({ kind }) => kind)).toEqual([
       "source_freshness",
       "source_freshness",
     ]);
     expect(errors.map(({ cause }) => cause)).toEqual([
-      new Error("venue observation did not advance"),
-      new Error("venue observation did not advance"),
+      new Error("venue observation identity replayed"),
+      new Error("venue observation identity replayed"),
     ]);
   });
 
@@ -1324,18 +1365,15 @@ describe("peg poll cycle isolation", () => {
     const recovered = (await poller.pollCycle(input))[0]!;
     expect(recovered.indexedPoolReachable).toBe(true);
     expect(source(recovered)).toMatchObject({
-      healthy: false,
-      observation: null,
-      deviationBps: null,
+      healthy: true,
+      observation: { sequence: "frozen" },
       newSuccess: false,
     });
-    expect(recovered.blind).toBe(true);
+    expect(source(recovered).deviationBps).toBeCloseTo(1_000);
+    expect(recovered.blind).toBe(false);
     expect(recovered.blindConsecutivePolls).toBe(2);
     expect(fetchBitvavo).toHaveBeenCalledTimes(2);
-    expect(errors.map(({ kind }) => kind)).toEqual([
-      "structural_query",
-      "source_freshness",
-    ]);
+    expect(errors.map(({ kind }) => kind)).toEqual(["structural_query"]);
   });
 
   it.each([

--- a/scripts/alert-rules-lint.mjs
+++ b/scripts/alert-rules-lint.mjs
@@ -77,8 +77,6 @@ const POLICY_VERSION_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const POLICY_VERSION_DIGEST_PATTERN = /-([0-9a-f]{32})$/;
 const MAX_POLICY_ASSETS = 32;
 const MAX_POLICY_SOURCES = 16;
-const LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION =
-  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
 const APPROVED_POLICY_VERSION_INTERPOLATION = {
   active: "${local.peg_active_policy_version}",
   previous: "${local.peg_previous_policy_version}",
@@ -120,7 +118,7 @@ const SOURCE_NUMBER_RULES = [
 ];
 
 function effectiveListingAbsentConsecutiveChecks(source) {
-  return source.listingAbsentConsecutiveChecks ?? 2;
+  return source.listingAbsentConsecutiveChecks;
 }
 
 const intEnv = (name, fallback) => {
@@ -475,36 +473,11 @@ function collectRegistrySources(registryAsset, location, failures) {
   return sources;
 }
 
-function validatePolicySource(
-  source,
-  registrySource,
-  location,
-  failures,
-  allowLegacyThreshold,
-) {
-  const hasListingThreshold = Object.hasOwn(
-    source,
-    "listingAbsentConsecutiveChecks",
-  );
-  const expectedKeys =
-    allowLegacyThreshold && !hasListingThreshold
-      ? POLICY_SOURCE_KEYS.filter(
-          (key) => key !== "listingAbsentConsecutiveChecks",
-        )
-      : POLICY_SOURCE_KEYS;
-  if (!validateExactObject(source, expectedKeys, location, failures)) {
+function validatePolicySource(source, registrySource, location, failures) {
+  if (!validateExactObject(source, POLICY_SOURCE_KEYS, location, failures)) {
     return;
   }
-  validateNumberFields(
-    source,
-    location,
-    allowLegacyThreshold && !hasListingThreshold
-      ? SOURCE_NUMBER_RULES.filter(
-          ([field]) => field !== "listingAbsentConsecutiveChecks",
-        )
-      : SOURCE_NUMBER_RULES,
-    failures,
-  );
+  validateNumberFields(source, location, SOURCE_NUMBER_RULES, failures);
 
   const expectedAuthority =
     SOURCE_AUTHORITY_BY_REGISTRY_ROLE[registrySource?.role];
@@ -542,7 +515,6 @@ function validatePolicySources(
   location,
   failures,
   registryAligned,
-  allowLegacyListingThreshold,
 ) {
   const registrySources = registryAligned
     ? collectRegistrySources(registryAsset, `registry.${location}`, failures)
@@ -585,7 +557,6 @@ function validatePolicySources(
       registrySources.get(sourceId),
       `${location}.sources.${sourceId}`,
       failures,
-      allowLegacyListingThreshold,
     );
     if (source.authority === "deep") deepSourceCount += 1;
   }
@@ -639,7 +610,6 @@ function validatePolicyAsset(
   location,
   failures,
   registryAligned,
-  allowLegacyListingThreshold,
 ) {
   if (!validateExactObject(asset, POLICY_ASSET_KEYS, location, failures)) {
     return;
@@ -652,7 +622,6 @@ function validatePolicyAsset(
     location,
     failures,
     registryAligned,
-    allowLegacyListingThreshold,
   );
 }
 
@@ -719,8 +688,6 @@ function validatePolicyVersion(
       `${location}.assets.${assetId}`,
       failures,
       registryAligned,
-      !registryAligned &&
-        policy.version === LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
     );
   }
 }

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -455,38 +455,22 @@ test("peg policy requires bounded listing confirmation and matching staleness", 
   );
 });
 
-test("peg policy defaults listing confirmation only for the exact retained legacy version", () => {
+test("peg policy requires every source to declare listing confirmation", () => {
   const policy = freshPegPolicy();
-  const legacyVersion = "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
   assert(
-    policy.previous.version === legacyVersion,
-    "expected the committed retained predecessor to be the exact legacy version",
-  );
-  assert(
-    Object.values(policy.previous.assets["europ-schuman"].sources).every(
-      (source) => source.listingAbsentConsecutiveChecks === undefined,
-    ),
-    "expected the exact legacy predecessor to exercise the default",
+    policy.previous === null,
+    "expected the committed policy predecessor to be cleared",
   );
   assert(
     pegPolicyFailures(policy) === "",
-    "expected the exact retained legacy predecessor to default to two checks",
+    "expected the checked-in active policy to declare every threshold",
   );
 
-  policy.previous.version = "europ-future-policy";
+  delete policy.active.assets["europ-schuman"].sources.bitvavo_eur
+    .listingAbsentConsecutiveChecks;
   assert(
     /listingAbsentConsecutiveChecks/.test(pegPolicyFailures(policy)),
-    "expected any other retained version to require an explicit threshold",
-  );
-
-  const activeWithoutThreshold = freshPegPolicy();
-  delete activeWithoutThreshold.active.assets["europ-schuman"].sources
-    .bitvavo_eur.listingAbsentConsecutiveChecks;
-  assert(
-    /listingAbsentConsecutiveChecks/.test(
-      pegPolicyFailures(activeWithoutThreshold),
-    ),
-    "expected active policy to require an explicit threshold",
+    "expected every policy source to require an explicit threshold",
   );
 });
 
@@ -893,10 +877,7 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
     path.resolve(__dirname, "..", "alerts/rules/peg-message-templates.tf"),
     "utf8",
   );
-  const europPolicies = [
-    pegPolicyFixture.active.assets["europ-schuman"],
-    pegPolicyFixture.previous.assets["europ-schuman"],
-  ];
+  const europPolicies = [pegPolicyFixture.active.assets["europ-schuman"]];
 
   assert(
     source.includes("increase(mento_peg_poll_success_total") &&
@@ -917,6 +898,36 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
       ),
     "health comparisons and conversion error bands must stay explicit",
   );
+  for (const policy of ["active", "previous"]) {
+    assert(
+      source.includes(`peg_${policy}_operational_sources = {`) &&
+        source.includes(`peg_${policy}_secondary_sources = {`) &&
+        source.includes(`peg_${policy}_source_unhealthy_for_duration = {`) &&
+        source.includes(
+          'peg_secondary_source_unhealthy_for_duration = "1800s"',
+        ) &&
+        source.includes('item.source.authority != "display"') &&
+        source.includes(
+          'item.source.authority == "secondary" ? local.peg_secondary_source_unhealthy_for_duration',
+        ) &&
+        ruleDefinitions.includes(
+          `for key, item in local.peg_${policy}_operational_sources : "${policy}-unhealthy-\${key}" => {`,
+        ) &&
+        ruleDefinitions.includes(
+          `for key, item in local.peg_${policy}_secondary_sources : "${policy}-dead-\${key}" => {`,
+        ) &&
+        ruleDefinitions.includes(
+          `for_duration       = local.peg_${policy}_source_unhealthy_for_duration[key]`,
+        ) &&
+        !ruleDefinitions.includes(
+          `for key, item in local.peg_${policy}_sources : "${policy}-unhealthy-\${key}" => {`,
+        ) &&
+        !ruleDefinitions.includes(
+          `for key, item in local.peg_${policy}_non_deep_sources : "${policy}-dead-\${key}" => {`,
+        ),
+      `${policy} source-health rules must skip display sources, hold secondary failures for 30 minutes, and retain deep two-poll duration`,
+    );
+  }
   for (const policy of ["active", "previous"]) {
     const policyVersion = `\${local.peg_${policy}_policy_version}`;
     const sourceUnhealthy =
@@ -1069,13 +1080,14 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
     "listing alerts must use instant exact-version producer state, bounded streak, and fresh authoritative check time",
   );
   assert(
-    /peg_legacy_listing_absent_consecutive_checks_policy_version\s*=\s*"europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f"/.test(
-      source,
+    !source.includes(
+      "peg_legacy_listing_absent_consecutive_checks_policy_version",
     ) &&
+      !source.includes("source.listingAbsentConsecutiveChecks,") &&
       source.includes(
-        "local.peg_previous_policy.version == local.peg_legacy_listing_absent_consecutive_checks_policy_version ? 2 : source.listingAbsentConsecutiveChecks",
+        "listing_absent_consecutive_checks = source.listingAbsentConsecutiveChecks",
       ),
-    "only the exact retained legacy policy may default listing confirmation to two checks",
+    "listing confirmation must come directly from each active or retained policy source",
   );
   assert(
     source.includes(

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -900,7 +900,10 @@ test("committed peg rules preserve coverage, rollover, and routing invariants", 
   );
   for (const policy of ["active", "previous"]) {
     assert(
-      source.includes(`peg_${policy}_operational_sources = {`) &&
+      source.includes(`peg_${policy}_authoritative_sources = {`) &&
+        source.includes(
+          `peg_${policy}_operational_sources = local.peg_${policy}_authoritative_sources`,
+        ) &&
         source.includes(`peg_${policy}_secondary_sources = {`) &&
         source.includes(`peg_${policy}_source_unhealthy_for_duration = {`) &&
         source.includes(

--- a/scripts/check-peg-registry-integrity.mjs
+++ b/scripts/check-peg-registry-integrity.mjs
@@ -38,8 +38,6 @@ const POLICY_SOURCE_NUMBER_FIELDS = [
 const POLICY_AUTHORITIES = new Set(["deep", "secondary", "display"]);
 const POLICY_VERSION_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const POLICY_VERSION_DIGEST_PATTERN = /-([0-9a-f]{32})$/;
-const LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION =
-  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
 
 function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -589,21 +587,13 @@ function compareKeys(expected, actual, path, noun, errors) {
   }
 }
 
-function validatePolicySourceFields(
-  source,
-  path,
-  errors,
-  allowLegacyThreshold,
-) {
+function validatePolicySourceFields(source, path, errors) {
   if (!POLICY_AUTHORITIES.has(source.authority)) {
     errors.push(
       `${path}.authority: expected deep, secondary, or display; received ${printable(source.authority)}`,
     );
   }
   for (const field of POLICY_SOURCE_NUMBER_FIELDS) {
-    if (allowLegacyThreshold && field === "listingAbsentConsecutiveChecks") {
-      continue;
-    }
     if (!Number.isFinite(source[field])) {
       errors.push(`${path}.${field}: missing or non-finite source policy`);
     }
@@ -647,13 +637,7 @@ function validateSourcePolicyConsistency(
   }
 }
 
-function validatePolicyAsset(
-  policyAsset,
-  context,
-  path,
-  errors,
-  allowLegacyListingThreshold,
-) {
+function validatePolicyAsset(policyAsset, context, path, errors) {
   if (!isRecord(policyAsset.sources)) {
     errors.push(`${path}.sources: expected an object`);
     return;
@@ -689,13 +673,7 @@ function validatePolicyAsset(
       errors.push(`${sourcePath}: expected an object`);
       continue;
     }
-    validatePolicySourceFields(
-      policySource,
-      sourcePath,
-      errors,
-      allowLegacyListingThreshold &&
-        policySource.listingAbsentConsecutiveChecks === undefined,
-    );
+    validatePolicySourceFields(policySource, sourcePath, errors);
     if (policySource.authority === "deep") deepSources.push(sourceId);
     const registrySource = context?.sources.get(sourceId);
     if (registrySource) {
@@ -778,8 +756,6 @@ function validatePolicy(policy, contexts, errors) {
         context,
         `${assetsPath}[${printable(slug)}]`,
         errors,
-        versionName === "previous" &&
-          version.version === LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
       );
     }
   }

--- a/scripts/check-peg-registry-integrity.test.mjs
+++ b/scripts/check-peg-registry-integrity.test.mjs
@@ -605,42 +605,26 @@ test("validates retained previous policy internal topology during rollover", asy
   );
 });
 
-test("defaults listing confirmation only for the exact retained legacy policy", async () => {
-  const legacyVersion = "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
+test("requires listing confirmation on every policy source", async () => {
   const committed = await checkFixture({
     mutatePolicy: (policy) => {
-      assert.equal(policy.previous.version, legacyVersion);
-      for (const source of Object.values(
-        policy.previous.assets["europ-schuman"].sources,
-      )) {
-        assert.equal(source.listingAbsentConsecutiveChecks, undefined);
-      }
+      assert.equal(policy.previous, null);
     },
   });
   assert.deepEqual(
     committed.errors,
     [],
-    `expected exact legacy predecessor to use the compatibility default:\n${joinedErrors(committed)}`,
+    `expected the checked-in policy to declare every threshold:\n${joinedErrors(committed)}`,
   );
 
-  const futureOmission = await checkFixture({
-    mutatePolicy: (policy) => {
-      policy.previous.version = "europ-future-policy";
-    },
-  });
-  assert.match(
-    joinedErrors(futureOmission),
-    /listingAbsentConsecutiveChecks: missing or non-finite source policy/,
-  );
-
-  const activeOmission = await checkFixture({
+  const omission = await checkFixture({
     mutatePolicy: (policy) => {
       delete policy.active.assets["europ-schuman"].sources.bitvavo_eur
         .listingAbsentConsecutiveChecks;
     },
   });
   assert.match(
-    joinedErrors(activeOmission),
+    joinedErrors(omission),
     /listingAbsentConsecutiveChecks: missing or non-finite source policy/,
   );
 });

--- a/ui-dashboard/src/lib/__tests__/peg-monitoring.test.ts
+++ b/ui-dashboard/src/lib/__tests__/peg-monitoring.test.ts
@@ -19,56 +19,35 @@ describe("PegMonitoringResponseSchema", () => {
     expect(parsed.packages[0]?.structural.blindConsecutivePolls).toBe(0);
     expect(parsed.packages[0]?.policy.blindConsecutivePolls).toBe(10);
   });
-  it("defaults legacy listing absence confirmation to two checks", () => {
+  it("requires listing absence confirmation from every active policy source", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;
     const source = item.sources[0]!;
-    const legacyPolicy: Record<string, unknown> = { ...source.policy };
-    delete legacyPolicy.listingAbsentConsecutiveChecks;
-
-    const parsed = PegMonitoringResponseSchema.parse({
-      ...response,
-      packages: [
-        {
-          ...item,
-          sources: [{ ...source, policy: legacyPolicy }],
-        },
-      ],
-    });
+    const policyWithoutListingThreshold: Record<string, unknown> = {
+      ...source.policy,
+    };
+    delete policyWithoutListingThreshold.listingAbsentConsecutiveChecks;
 
     expect(
-      parsed.packages[0]?.sources[0]?.policy.listingAbsentConsecutiveChecks,
-    ).toBe(2);
+      PegMonitoringResponseSchema.safeParse({
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: [{ ...source, policy: policyWithoutListingThreshold }],
+          },
+        ],
+      }).success,
+    ).toBe(false);
   });
-  it("defaults the produced legacy policy during a previous-slot rollover", () => {
+  it("requires listing absence confirmation from every previous policy source", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;
     const source = item.sources[0]!;
-    const legacyPolicy: Record<string, unknown> = { ...source.policy };
-    delete legacyPolicy.listingAbsentConsecutiveChecks;
-
-    const parsed = PegMonitoringResponseSchema.parse({
-      ...response,
-      approvedActivePolicyVersion: FUTURE_POLICY_VERSION,
-      policySlot: "previous",
-      packages: [
-        {
-          ...item,
-          sources: [{ ...source, policy: legacyPolicy }],
-        },
-      ],
-    });
-
-    expect(
-      parsed.packages[0]?.sources[0]?.policy.listingAbsentConsecutiveChecks,
-    ).toBe(2);
-  });
-  it("rejects a missing threshold from a future produced previous-slot policy", () => {
-    const response = makePegMonitoringResponse();
-    const item = response.packages[0]!;
-    const source = item.sources[0]!;
-    const legacyPolicy: Record<string, unknown> = { ...source.policy };
-    delete legacyPolicy.listingAbsentConsecutiveChecks;
+    const policyWithoutListingThreshold: Record<string, unknown> = {
+      ...source.policy,
+    };
+    delete policyWithoutListingThreshold.listingAbsentConsecutiveChecks;
 
     expect(
       PegMonitoringResponseSchema.safeParse({
@@ -79,7 +58,7 @@ describe("PegMonitoringResponseSchema", () => {
         packages: [
           {
             ...item,
-            sources: [{ ...source, policy: legacyPolicy }],
+            sources: [{ ...source, policy: policyWithoutListingThreshold }],
           },
         ],
       }).success,
@@ -114,27 +93,6 @@ describe("PegMonitoringResponseSchema", () => {
     expect(
       parsed.packages[0]?.sources[0]?.policy.listingAbsentConsecutiveChecks,
     ).toBe(3);
-  });
-  it("rejects a missing listing absence confirmation threshold from a future policy", () => {
-    const response = makePegMonitoringResponse();
-    const item = response.packages[0]!;
-    const source = item.sources[0]!;
-    const legacyPolicy: Record<string, unknown> = { ...source.policy };
-    delete legacyPolicy.listingAbsentConsecutiveChecks;
-
-    expect(
-      PegMonitoringResponseSchema.safeParse({
-        ...response,
-        approvedActivePolicyVersion: FUTURE_POLICY_VERSION,
-        producedPolicyVersion: FUTURE_POLICY_VERSION,
-        packages: [
-          {
-            ...item,
-            sources: [{ ...source, policy: legacyPolicy }],
-          },
-        ],
-      }).success,
-    ).toBe(false);
   });
   it("rejects invalid listing absence confirmation thresholds", () => {
     const response = makePegMonitoringResponse();

--- a/ui-dashboard/src/lib/peg-monitoring-schema.ts
+++ b/ui-dashboard/src/lib/peg-monitoring-schema.ts
@@ -5,9 +5,6 @@ const MAX_SOURCES = 16;
 const MAX_MONITORS = 8;
 const MAX_TOKENS = 8;
 const MAX_RENDERABLE_UNIX_SECONDS = 8_640_000_000_000;
-const LEGACY_LISTING_ABSENCE_DEFAULT_POLICY_VERSION =
-  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
-
 const policyVersion = z
   .string()
   .min(1)
@@ -106,13 +103,7 @@ const sourcePolicy = z
     referenceSizeCap: z.number().finite().positive(),
     pollIntervalSeconds: z.number().int().min(15).max(3_600),
     staleAfterSeconds: z.number().int().positive().max(86_400),
-    listingAbsentConsecutiveChecks: z
-      .number()
-      .finite()
-      .int()
-      .min(2)
-      .max(1_000)
-      .optional(),
+    listingAbsentConsecutiveChecks: z.number().finite().int().min(2).max(1_000),
     spreadEnvelopeBps: number.max(10_000),
     conversionErrorBps: number.max(10_000),
   })
@@ -120,7 +111,7 @@ const sourcePolicy = z
   .superRefine((value, context) => {
     if (
       value.staleAfterSeconds <
-      value.pollIntervalSeconds * (value.listingAbsentConsecutiveChecks ?? 2)
+      value.pollIntervalSeconds * value.listingAbsentConsecutiveChecks
     )
       context.addIssue({
         code: "custom",
@@ -458,41 +449,8 @@ export const PegMonitoringResponseSchema = z
           message: "duplicate asset package",
         });
       assets.add(item.asset);
-      item.sources.forEach((source, sourceIndex) => {
-        if (
-          source.policy.listingAbsentConsecutiveChecks === undefined &&
-          value.producedPolicyVersion !==
-            LEGACY_LISTING_ABSENCE_DEFAULT_POLICY_VERSION
-        )
-          context.addIssue({
-            code: "custom",
-            path: [
-              "packages",
-              index,
-              "sources",
-              sourceIndex,
-              "policy",
-              "listingAbsentConsecutiveChecks",
-            ],
-            message: "must be present outside the legacy policy rollout",
-          });
-      });
     });
-  })
-  .transform((value) => ({
-    ...value,
-    packages: value.packages.map((item) => ({
-      ...item,
-      sources: item.sources.map((source) => ({
-        ...source,
-        policy: {
-          ...source.policy,
-          listingAbsentConsecutiveChecks:
-            source.policy.listingAbsentConsecutiveChecks ?? 2,
-        },
-      })),
-    })),
-  }));
+  });
 
 export type PegMonitoringResponse = z.infer<typeof PegMonitoringResponseSchema>;
 export type PegAssetPackage = PegMonitoringResponse["packages"][number];


### PR DESCRIPTION
## The Problem

- Kraken can repeat a still-current order book, but the bridge treated every repeat as an outage and repeatedly fired source-health alerts.
- Display-only sources and the retained previous policy multiplied low-value `#alerts-infra` notifications; active and previous Kraken EUR produced 307 Alerting transitions in 24 hours and 2,118 in seven days despite zero `source_fetch` failures in that seven-day window.
- The completed policy rollover still carried its retired predecessor and one-time compatibility defaults.

## The Solution

- Keep an exact repeated executable observation healthy only until its provider timestamp expires, without counting it as a new sample or price decision.
- Exclude display-only health alerts, hold secondary-source warnings for 30 minutes, retain deep-source two-poll checks, and remove the acknowledged predecessor from source-controlled policy and consumers.
- Keep a runtime-only exception for the exact legacy predecessor still pinned in production, then remove it after the protected active-only generation cutover.

## Details

### Invariants

- The active policy object and version remain unchanged: `europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`.
- A fresh A/A repeat preserves health and evidence but does not advance poll-success or usable-decision coverage.
- Stale or regressing observations, A/B/A replays, identity overflow, and reopen-after-halt remain fail-closed.
- Display sources still participate in registry-rot listing checks. Deep depeg pages, thresholds, and routing are unchanged.
- Source-controlled policy validators and the dashboard require explicit listing thresholds. Metrics Bridge alone accepts an omitted threshold from exact previous version `europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f` and normalizes it to `2`.

### Degraded behavior

- A repeated book becomes unhealthy when its provider timestamp exceeds `staleAfterSeconds`.
- Deep-source health warns after two failed polls; secondary-source health warns after 30 minutes; display-only source health does not notify.
- Policy cleanup removes previous-version consumers before withdrawing previous-version producer series.
- The compatibility-retaining bridge revision continues reading the currently pinned legacy generation during the protected alert cleanup, policy publication, and generation-pinning sequence.

### Intentional non-goals

- No Kraken pair, adapter, executable-price, depeg threshold, or critical paging change.
- No production Terraform apply, policy publication, or runtime-generation pin in this PR.

Closes #1747

## Validation

- `CI=true pnpm agent:quality-gate --run` — all mapped commands passed, including Terraform tests/validation, Metrics Bridge and dashboard coverage, browser tests, React Doctor, Trunk, dependency checks, PromQL lint, and documentation checks.
- Focused Metrics Bridge validation — 27 files and 578 tests passed; lint and typecheck passed.
- Alert lint — 43 tests passed; 180 PromQL expressions and 52 referenced metrics checked against 64 gauges.
- Autoreview — three fresh-context semantic cycles plus the deterministic local guardrail; the accepted Terraform/dashboard cleanup and rollout-order finding were fixed, followed by a final clean pass.

## Deferrals

- #1750 removes the exact legacy Metrics Bridge parser shim after the protected `previous: null` generation is published, pinned, and live-verified.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution matches the implemented behavior.
- [x] Details state invariants, degraded behavior, and intentional non-goals.
- [x] Every valid deferral has a GitHub issue.
- [x] ADR 0057 records the observation-advancement decision; ADR 0044 and the runbook record the safe rollout order.
