### PR TITLE
docs: harden Codex MCP config and review cycles

### DIFF
--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -17,9 +17,11 @@ bundle preparation/verification, runtime-change refusal handling, and other
 adapter mechanics. Follow it rather than duplicating those rules here.
 
 Verify every accepted finding before editing. If fixes are made, rerun focused
-checks and autoreview for that batch; pause for scope reclassification before a
-third review-triggered patch cycle. A clean source review is not test, browser,
-generated-artifact, CLI/API, or runtime proof, so retain every applicable gate.
+checks and autoreview for that batch. Do not pause solely for cycle count before
+five review-triggered patch cycles are complete; pause for scope
+reclassification before starting a sixth. A clean source review is not test,
+browser, generated-artifact, CLI/API, or runtime proof, so retain every
+applicable gate.
 If an autoreview runtime change triggers the owning adapter's self-review
 refusal, keep it intact and follow the trusted pre-change sequence in the owner
 note.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,6 +3,3 @@ project_doc_max_bytes = 18_944
 [mcp_servers.chrome-devtools]
 args = ["chrome-devtools-mcp@latest"]
 command = "npx"
-
-[mcp_servers.upstash]
-enabled = true

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -23,36 +23,20 @@ team-shareable project workflows there instead of relying on local-only
 `~/.agents/skills` and should be exposed to both agents through the
 `~/.codex/skills` and `~/.claude/skills` mirrors. Project-level Codex MCP config
 lives in `.codex/config.toml`; local personal Codex settings belong in
-`~/.codex/config.toml`. Project config may define a credential-free shared MCP
-launcher, as the checked-in `chrome-devtools` server does, or enable or disable
-a server already defined in personal config. An `enabled`-only override requires
-the same named server and its transport in personal config; otherwise Codex
-rejects the incomplete entry. Add that user-level server first through the
-official [Codex MCP configuration guide](https://developers.openai.com/codex/mcp#configure-with-configtoml).
-Keep machine-specific transport and all authentication or secret material,
-including secret-bearing command arguments, environment values, headers, and
-tokens, out of the repository.
+`~/.codex/config.toml`. Project config may define a complete, credential-free
+shared MCP launcher, as the checked-in `chrome-devtools` server does. Do not add
+partial project entries that depend on a personal server definition: Codex
+Cloud does not inherit personal config, and Codex rejects an enabled server
+without a transport. Keep machine-specific transport and all authentication or
+secret material, including secret-bearing command arguments, environment
+values, headers, and tokens, out of the repository. Secret provisioning and
+rotation remain in the owning IaC path under
+[ADR 0030](../adr/0030-iac-before-cli-secrets.md).
 
-The checked-in `upstash` toggle expects this user-level entry, using the
-[upstream Upstash MCP server](https://github.com/upstash/mcp-server#openai-codex):
-
-```toml
-[mcp_servers.upstash]
-command = "npx"
-args = [
-  "-y",
-  "@upstash/mcp-server@latest",
-  "--email",
-  "<UPSTASH_EMAIL>",
-  "--api-key",
-  "<UPSTASH_API_KEY>",
-]
-startup_timeout_sec = 20
-```
-
-Replace the placeholders only in `~/.codex/config.toml`. Create the API key in
-the Upstash Console, prefer a read-only key when its reduced tool set is enough,
-and never commit or paste the populated entry into logs.
+Treat MCP diagnostics as secret-adjacent. Do not use `codex mcp list` in shared
+logs when a personal server may contain credential-bearing arguments; inspect
+only redacted structural fields such as server name, enabled state, and
+transport presence.
 
 ## Autoreview routing
 

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -23,10 +23,15 @@ team-shareable project workflows there instead of relying on local-only
 `~/.agents/skills` and should be exposed to both agents through the
 `~/.codex/skills` and `~/.claude/skills` mirrors. Project-level Codex MCP config
 lives in `.codex/config.toml`; local personal Codex settings belong in
-`~/.codex/config.toml`. Project config may enable or disable a named MCP server,
-but its machine-local transport and authentication stay in the personal config.
-Never copy command arguments, headers, tokens, or credentials into the
-repository.
+`~/.codex/config.toml`. Project config may define a credential-free shared MCP
+launcher, as the checked-in `chrome-devtools` server does, or enable or disable
+a server already defined in personal config. An `enabled`-only override requires
+the same named server and its transport in personal config; otherwise Codex
+rejects the incomplete entry. Add that user-level server first through the
+official [Codex MCP configuration guide](https://developers.openai.com/codex/mcp#configure-with-configtoml).
+Keep machine-specific transport and all authentication or secret material,
+including secret-bearing command arguments, environment values, headers, and
+tokens, out of the repository.
 
 ## Autoreview routing
 

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -33,6 +33,27 @@ Keep machine-specific transport and all authentication or secret material,
 including secret-bearing command arguments, environment values, headers, and
 tokens, out of the repository.
 
+The checked-in `upstash` toggle expects this user-level entry, using the
+[upstream Upstash MCP server](https://github.com/upstash/mcp-server#openai-codex):
+
+```toml
+[mcp_servers.upstash]
+command = "npx"
+args = [
+  "-y",
+  "@upstash/mcp-server@latest",
+  "--email",
+  "<UPSTASH_EMAIL>",
+  "--api-key",
+  "<UPSTASH_API_KEY>",
+]
+startup_timeout_sec = 20
+```
+
+Replace the placeholders only in `~/.codex/config.toml`. Create the API key in
+the Upstash Console, prefer a read-only key when its reduced tool set is enough,
+and never commit or paste the populated entry into logs.
+
 ## Autoreview routing
 
 `autoreview` is pinned through `scripts/agent-autoreview.mjs` and exposed as

--- a/docs/notes/codex-agent-skills.md
+++ b/docs/notes/codex-agent-skills.md
@@ -3,7 +3,7 @@ title: Codex Agent Skills
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-10
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -23,7 +23,10 @@ team-shareable project workflows there instead of relying on local-only
 `~/.agents/skills` and should be exposed to both agents through the
 `~/.codex/skills` and `~/.claude/skills` mirrors. Project-level Codex MCP config
 lives in `.codex/config.toml`; local personal Codex settings belong in
-`~/.codex/config.toml`.
+`~/.codex/config.toml`. Project config may enable or disable a named MCP server,
+but its machine-local transport and authentication stay in the personal config.
+Never copy command arguments, headers, tokens, or credentials into the
+repository.
 
 ## Autoreview routing
 

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -3,7 +3,7 @@ title: PR Operating Card
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-08-10
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -129,8 +129,9 @@ Solution` (approach before implementation detail). PRs open **ready for
    new additions against the scope baseline frozen at step 4; classify each as
    in-scope, follow-up, or stop; **file a GitHub issue before deferring any valid
    follow-up** and link it from the PR's `## Deferrals` section. Warn as the
-   diff approaches twice the baseline, and pause for reclassification after two
-   review-triggered patch cycles rather than starting a third. Authority:
+   diff approaches twice the baseline. Do not pause solely for cycle count
+   before five review-triggered patch cycles are complete; pause for
+   reclassification before starting a sixth. Authority:
    [`agent-issue-workflow.md`](agent-issue-workflow.md) for the deferral and
    issue-lifecycle rules.
 

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -3,7 +3,7 @@ title: PR Ready State
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-10
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -279,8 +279,9 @@ Field expectations:
    changed-line count as the scope baseline. Batch review fixes locally,
    auditing sibling surfaces before pushing. Classify additions as in-scope,
    follow-up, or stop; open an issue before deferring valid follow-up work, warn
-   near twice the baseline, and pause for reclassification after two
-   review-triggered patch cycles rather than starting a third automatically.
+   near twice the baseline, and do not pause solely for cycle count before five
+   review-triggered patch cycles are complete. Pause for reclassification before
+   starting a sixth.
 3. Run `pnpm agent:quality-gate --run` once for the batch; it owns test
    execution.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,


### PR DESCRIPTION
## The Problem

- The checked-in Upstash MCP toggle depended on personal transport and credentials, which breaks Codex Cloud and encouraged secret-bearing setup in shared guidance.
- MCP diagnostics can render credential-bearing arguments into shared logs.
- The PR workflow paused for scope reclassification after only two review-fix cycles.

## The Solution

- Remove the partial Upstash project toggle, document a complete and credential-free project MCP boundary, and allow five review-fix cycles before a cycle-count pause.

## Details

- Keep the credential-free `chrome-devtools` launcher as the project MCP example.
- Route machine-specific transport and secret provisioning to personal config and the owning IaC path.
- Warn that `codex mcp list` can expose configured arguments and require redacted structural inspection.
- Align the operating card, ready-state runbook, and Claude autoreview command on pausing before a sixth review-triggered patch cycle.
- Refresh the canonical runbook verification dates.

## Deferrals

- #1770 owns a pinned, credential-redacted, IaC-managed, Cloud-safe Upstash MCP integration for forensic uploads.

## Validation

- `./tools/trunk check .codex/config.toml docs/notes/codex-agent-skills.md docs/notes/pr-operating-card.md docs/notes/pr-ready-state.md .claude/commands/autoreview.md`
- `node scripts/docs-index.mjs --check`
- `node scripts/check-agent-context.mjs`
- `node scripts/docs-navigation-eval.mjs --check-fixtures`
- `git diff --check`
- The equivalent pnpm wrappers could not start because pnpm attempted a non-interactive `node_modules` purge; their underlying scripts passed directly.