### PR TITLE
fix(sentry): shed stale verdict labels in the same edit

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -625,10 +625,10 @@ jobs:
           # the newest "Regressed in Sentry (last seen " reopen comment counts,
           # so a stale pre-regression verdict never re-labels a regressed
           # issue), validates the verdict against the closed four-value enum,
-          # and emits {"verdict","label"} JSON. The comment body is
-          # agent-authored from untrusted Sentry data — it is only ever parsed
-          # as data, never interpolated into a command, and the emitted values
-          # are closed-enum. Missing/stale/invalid verdict -> nonzero exit ->
+          # and emits {"verdict","label","projectable","shed"} JSON. The comment
+          # body is agent-authored from untrusted Sentry data — it is only ever
+          # parsed as data, never interpolated into a command, and the emitted
+          # values are closed-enum. Missing/stale/invalid verdict -> nonzero exit ->
           # fail the job loudly and leave sentry:needs-triage in place so the
           # next scheduled run retries this issue. A `needs-human` verdict that
           # omits the required `human_question` field is treated exactly like an
@@ -653,11 +653,38 @@ jobs:
           verdict=$(jq -r '.verdict' "${parse_file}")
           label=$(jq -r '.label' "${parse_file}")
           projectable=$(jq -r '.projectable' "${parse_file}")
+          # `shed` is every OTHER verdict label, comma-joined, from the same
+          # parser (#1745). The select job admits any OPEN numeric issue, so a
+          # human re-dispatching an answered escalation hands this step a stub
+          # that already carries a verdict label — and `--add-label` only adds.
+          # Shedding in the SAME edit is what keeps a stub to exactly one
+          # verdict; the digest buckets on the first matching label, so two
+          # would make it report whichever GitHub ordered first. Removing a
+          # label the stub does not carry is a no-op, so the first-pass case is
+          # unaffected. Closed enum from a closed enum — never agent text.
+          shed=$(jq -r '.shed' "${parse_file}")
           gh issue edit "${QUEUE_ISSUE_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --remove-label 'sentry:needs-triage' \
+            --remove-label "sentry:needs-triage,${shed}" \
             --add-label "${label}"
           echo "Applied ${label} to issue #${QUEUE_ISSUE_NUMBER}."
+          # Post-condition, re-read from GitHub rather than assumed: refuse to
+          # hand a double-verdicted stub to the close/project/digest legs. Only
+          # >1 fails — the edit above already exits nonzero if the --add-label
+          # did not land, so zero is not reachable here. Failing after the edit
+          # is safe to retry: the shed makes the whole step idempotent, so a
+          # re-dispatch replays it onto the label this run already applied.
+          labels_file="${RUNNER_TEMP}/verdict-labels.json"
+          gh issue view "${QUEUE_ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json labels > "${labels_file}"
+          survivor_filter='[.labels[].name | select(startswith("sentry:verdict-"))]'
+          surviving=$(jq -r "${survivor_filter} | join(\", \")" "${labels_file}")
+          survivor_count=$(jq -r "${survivor_filter} | length" "${labels_file}")
+          if [ "${survivor_count}" -gt 1 ]; then
+            echo "::error::Issue #${QUEUE_ISSUE_NUMBER} still carries ${survivor_count} sentry:verdict-* labels (${surviving}) after applying ${label}; downstream buckets on a single verdict label, so this job fails instead of reporting the stub wrong."
+            exit 1
+          fi
           # Hand the VALIDATED verdict + mapped label (closed enums, never
           # agent-authored text) + projectability to the close step below.
           {

--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -668,21 +668,49 @@ jobs:
             --remove-label "sentry:needs-triage,${shed}" \
             --add-label "${label}"
           echo "Applied ${label} to issue #${QUEUE_ISSUE_NUMBER}."
+          # The edit above already took sentry:needs-triage OFF, so every exit
+          # below it must put the stub back in the queue first. Nothing
+          # downstream would: the close step never runs, the project job skips
+          # a stub that is not needs-triage, and the scheduled selector only
+          # admits sentry:needs-triage — a bare `exit 1` here would strand an
+          # open, verdict-labeled stub with no retry path at all. Same
+          # compensation as the close step below (restore sentry:needs-triage,
+          # shed the verdict label + any stale sentry:projected, absent-label
+          # removal being a no-op), with the WHOLE verdict namespace in the
+          # removal list because this is the one branch where more than one of
+          # them can be on the stub, and a re-queued stub must carry none. Both
+          # terms are the parser's closed enum — never a re-read label name,
+          # never a second literal list. Unguarded like the close step's
+          # compensation: this step is failing either way, and a compensation
+          # that itself fails should fail loudly under set -e.
+          requeue_for_retry() {
+            gh issue edit "${QUEUE_ISSUE_NUMBER}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --remove-label "${label},${shed},sentry:projected" \
+              --add-label "sentry:needs-triage"
+          }
           # Post-condition, re-read from GitHub rather than assumed: refuse to
           # hand a double-verdicted stub to the close/project/digest legs. Only
           # >1 fails — the edit above already exits nonzero if the --add-label
-          # did not land, so zero is not reachable here. Failing after the edit
-          # is safe to retry: the shed makes the whole step idempotent, so a
-          # re-dispatch replays it onto the label this run already applied.
+          # did not land, so zero is not reachable here. Fail CLOSED on a read
+          # failure too: an unverifiable stub is treated as a violation and
+          # re-queued, never waved through. Re-queueing is safe to replay: the
+          # shed makes the whole step idempotent, so the retry run applies the
+          # verdict onto a stub in exactly the state this run found it in.
           labels_file="${RUNNER_TEMP}/verdict-labels.json"
-          gh issue view "${QUEUE_ISSUE_NUMBER}" \
+          if ! gh issue view "${QUEUE_ISSUE_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --json labels > "${labels_file}"
+            --json labels > "${labels_file}"; then
+            echo "::error::Could not re-read issue #${QUEUE_ISSUE_NUMBER} to confirm it carries exactly one sentry:verdict-* label; restoring sentry:needs-triage (and shedding the verdict labels + sentry:projected) so the next scheduled run retries it."
+            requeue_for_retry
+            exit 1
+          fi
           survivor_filter='[.labels[].name | select(startswith("sentry:verdict-"))]'
           surviving=$(jq -r "${survivor_filter} | join(\", \")" "${labels_file}")
           survivor_count=$(jq -r "${survivor_filter} | length" "${labels_file}")
           if [ "${survivor_count}" -gt 1 ]; then
-            echo "::error::Issue #${QUEUE_ISSUE_NUMBER} still carries ${survivor_count} sentry:verdict-* labels (${surviving}) after applying ${label}; downstream buckets on a single verdict label, so this job fails instead of reporting the stub wrong."
+            echo "::error::Issue #${QUEUE_ISSUE_NUMBER} still carries ${survivor_count} sentry:verdict-* labels (${surviving}) after applying ${label}; downstream buckets on a single verdict label, so this job restores sentry:needs-triage (and sheds the verdict labels + sentry:projected) and fails instead of reporting the stub wrong."
+            requeue_for_retry
             exit 1
           fi
           # Hand the VALIDATED verdict + mapped label (closed enums, never

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -404,8 +404,12 @@ A stub carries exactly one `sentry:verdict-*` label. The label edit adds the
 new one and removes every other verdict label in the same call, so
 re-dispatching an already-verdicted stub — the usual case after a human answers
 a `needs-human` escalation — replaces the old verdict instead of stacking a
-second one. The step then re-reads the stub and fails its own matrix job if
-more than one survives. The shed list comes from the same `--parse-only` output
+second one. The step then re-reads the stub and fails its own matrix job if the
+read fails or more than one verdict label survives — restoring
+`sentry:needs-triage` and shedding the verdict labels first, the same
+compensation the close and projection failure paths make, so the stub goes back
+in the queue instead of being stranded open with no retry path. The shed list
+comes from the same `--parse-only` output
 as the label, and covers the verdict namespace only: the wider re-queue shed
 also clears the projection, autofix, and archive markers, which must survive a
 verdict change. The digest warns about a double-verdicted stub but never fails

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -400,6 +400,17 @@ the label and transition below:
 | `upstream-transient` | `sentry:verdict-upstream`    | Close as completed | None                                                                                                                               |
 | `needs-human`        | `sentry:verdict-needs-human` | Keep open          | Human answers the recorded question and decides the next action                                                                    |
 
+A stub carries exactly one `sentry:verdict-*` label. The label edit adds the
+new one and removes every other verdict label in the same call, so
+re-dispatching an already-verdicted stub — the usual case after a human answers
+a `needs-human` escalation — replaces the old verdict instead of stacking a
+second one. The step then re-reads the stub and fails its own matrix job if
+more than one survives. The shed list comes from the same `--parse-only` output
+as the label, and covers the verdict namespace only: the wider re-queue shed
+also clears the projection, autofix, and archive markers, which must survive a
+verdict change. The digest warns about a double-verdicted stub but never fails
+on one — it is the batch's single daily notification.
+
 Every deterministic close records that the ledger issue will reopen on a
 future Sentry regression. A missing verdict after a scheduled run is an
 operational failure signal, not “no issues found.”

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2274,6 +2274,9 @@ while IFS= read -r path; do
           ;;
         scripts/sentry-triage-digest.mjs|scripts/sentry-triage-digest.test.mjs)
           add_command "pnpm sentry:digest:test" "Sentry triage digest helper changed"
+          # The digest owns LABEL_TO_VERDICT, one of the three verdict-label
+          # maps the projection suite pins against each other.
+          add_command "pnpm sentry:project:test" "Sentry triage digest helper changed"
           ;;
         scripts/sentry-triage-project.mjs|scripts/sentry-triage-project-core.mjs|scripts/sentry-triage-project.test.mjs)
           add_command "pnpm sentry:project:test" "Sentry triage projection helper changed"
@@ -2303,6 +2306,10 @@ while IFS= read -r path; do
           add_command "pnpm sentry:requeue:test" "Sentry re-queue chokepoint changed"
           add_command "pnpm sentry:ingest:test" "Sentry re-queue chokepoint changed"
           add_command "pnpm sentry:archive:test" "Sentry re-queue chokepoint changed"
+          # The contract owns VERDICT_LABELS, which the verdict step's shed is
+          # derived from and the projection suite pins against the other two
+          # verdict-label maps.
+          add_command "pnpm sentry:project:test" "Sentry re-queue chokepoint changed"
           ;;
         scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3616,9 +3616,14 @@ assert_contains "- pnpm lockfile:lint:test (lockfile lint helper changed)"
 
 run_gate "scripts/sentry-triage-digest.mjs"
 assert_contains "- pnpm sentry:digest:test (Sentry triage digest helper changed)"
+assert_contains "- pnpm sentry:project:test (Sentry triage digest helper changed)"
 
 run_gate "scripts/sentry-triage-digest.test.mjs"
 assert_contains "- pnpm sentry:digest:test (Sentry triage digest helper changed)"
+
+run_gate "scripts/sentry-triage-queue-contract.mjs"
+assert_contains "- pnpm sentry:requeue:test (Sentry re-queue chokepoint changed)"
+assert_contains "- pnpm sentry:project:test (Sentry re-queue chokepoint changed)"
 
 run_gate "scripts/sentry-triage-project.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"

--- a/scripts/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry-triage-agent-comment.test.mjs
@@ -591,6 +591,26 @@ test("the trusted follow-up lives in its own job, on its own runner", () => {
   assert.match(job, /node scripts\/sentry-triage-project\.mjs/);
 });
 
+test("the verdict edit sheds the other verdict labels and proves it landed", () => {
+  const job = WORKFLOW.slice(
+    WORKFLOW.indexOf("\n  verdict:"),
+    WORKFLOW.indexOf("\n  project:"),
+  );
+  // The shed list comes from the SAME --parse-only output as the label, so the
+  // workflow never carries a second literal copy of the verdict namespace.
+  assert.match(job, /shed=\$\(jq -r '\.shed' "\$\{parse_file\}"\)/);
+  assert.match(job, /--remove-label "sentry:needs-triage,\$\{shed\}"/);
+  // Deleting the shed and going back to the bare removal must fail here.
+  assert.ok(
+    !/--remove-label ['"]sentry:needs-triage['"]/.test(job),
+    "the verdict edit removes only sentry:needs-triage; stale verdict labels would survive it",
+  );
+  // Post-condition: the stub is re-read and >1 surviving verdict label fails
+  // this matrix job rather than reaching the close/project/digest legs.
+  assert.match(job, /select\(startswith\("sentry:verdict-"\)\)/);
+  assert.match(job, /if \[ "\$\{survivor_count\}" -gt 1 \]; then/);
+});
+
 test("projection and digest wait for the verdict job", () => {
   assert.match(WORKFLOW, /project:\n\s+needs: \[select, triage, verdict\]/);
   assert.match(

--- a/scripts/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry-triage-agent-comment.test.mjs
@@ -611,6 +611,73 @@ test("the verdict edit sheds the other verdict labels and proves it landed", () 
   assert.match(job, /if \[ "\$\{survivor_count\}" -gt 1 \]; then/);
 });
 
+/**
+ * The verdict label step from the edit that takes `sentry:needs-triage` off to
+ * the end of the step — the window where the stub is invisible to the selector
+ * and every exit therefore owes it a re-queue.
+ */
+function verdictPostConditionBlock() {
+  const job = WORKFLOW.slice(
+    WORKFLOW.indexOf("\n  verdict:"),
+    WORKFLOW.indexOf("\n  project:"),
+  );
+  const start = job.indexOf('--remove-label "sentry:needs-triage,${shed}"');
+  const end = job.indexOf("- name: Close queue stub");
+  assert.ok(
+    start > 0 && end > start,
+    "the verdict label step's post-condition block was not found",
+  );
+  return job.slice(start, end);
+}
+
+test("a failed verdict post-condition re-queues the stub instead of stranding it", () => {
+  const block = verdictPostConditionBlock();
+  const lines = block.split("\n");
+
+  // The compensation: the close step's shape (restore sentry:needs-triage,
+  // shed the verdict label + any stale sentry:projected), widened to the whole
+  // verdict namespace because this is the one branch where a stub can be
+  // wearing more than one verdict label — and a re-queued stub carries none.
+  const open = lines.findIndex(
+    (line) => line.trim() === "requeue_for_retry() {",
+  );
+  assert.ok(open >= 0, "the verdict post-condition has no re-queue helper");
+  const close = lines.findIndex((line, i) => i > open && line.trim() === "}");
+  const helper = lines.slice(open, close).join("\n");
+  assert.match(helper, /gh issue edit "\$\{QUEUE_ISSUE_NUMBER\}"/);
+  assert.match(
+    helper,
+    /--remove-label "\$\{label\},\$\{shed\},sentry:projected"/,
+  );
+  assert.match(helper, /--add-label "sentry:needs-triage"/);
+
+  // Fail CLOSED on the re-read too: an unverifiable stub is re-queued, never
+  // waved through to the close/project/digest legs.
+  assert.match(block, /if ! gh issue view "\$\{QUEUE_ISSUE_NUMBER\}"/);
+
+  // The property the whole block exists for: no exit leaves the stub open,
+  // verdict-labeled and off sentry:needs-triage, which nothing downstream
+  // re-queues — the close step never runs, the project job skips it, and the
+  // scheduled selector requires sentry:needs-triage. Deleting the call from
+  // any failure branch fails here.
+  const meaningful = lines
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+  const exits = meaningful.filter((line) => line === "exit 1");
+  assert.ok(
+    exits.length >= 2,
+    `expected the read-failure and surviving-label exits, found ${exits.length}`,
+  );
+  meaningful.forEach((line, i) => {
+    if (line !== "exit 1") return;
+    assert.equal(
+      meaningful[i - 1],
+      "requeue_for_retry",
+      "an exit from the verdict post-condition must restore sentry:needs-triage first, or the open stub is stranded with no retry path",
+    );
+  });
+});
+
 test("projection and digest wait for the verdict job", () => {
   assert.match(WORKFLOW, /project:\n\s+needs: \[select, triage, verdict\]/);
   assert.match(

--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -381,9 +381,14 @@ export function classifyIssue(issue) {
     : EMPTY_PARSED;
 
   const stillNeedsTriage = labelNames.includes(NEEDS_TRIAGE_LABEL);
-  const verdictLabel = labelNames.find((name) =>
+  // A stub is supposed to carry exactly one verdict label — the workflow's
+  // verdict step sheds the others in the same edit (#1745). Keep the full list
+  // so a violation is reportable; the bucket still takes the first match,
+  // because picking a different loser would not make the answer any more true.
+  const verdictLabels = labelNames.filter((name) =>
     Object.hasOwn(LABEL_TO_VERDICT, name),
   );
+  const verdictLabel = verdictLabels[0];
   const verdictFromLabel = verdictLabel ? LABEL_TO_VERDICT[verdictLabel] : null;
 
   let bucket;
@@ -397,6 +402,7 @@ export function classifyIssue(issue) {
     number: issue?.number,
     shortId: shortId ?? `#${issue?.number}`,
     project: project ?? "unknown",
+    verdictLabels,
     url: typeof issue?.url === "string" ? issue.url : "",
     bucket,
     section: sectionForEntry(bucket, autofixUrl),
@@ -631,6 +637,25 @@ export function chunkBriefs(headerLine, briefs, maxLen = MAX_SECTION_TEXT_LEN) {
 }
 
 /**
+ * Stubs carrying more than one `sentry:verdict-*` label, as ready-to-emit
+ * warning lines. The verdict step enforces the one-label invariant and fails
+ * its own matrix job on a violation (#1745); the digest only REPORTS one,
+ * because it is the batch's single daily Slack notification and taking the run
+ * down would trade a mis-bucketed row for no notification at all. A stub can
+ * still reach here double-labelled if a human hand-labelled it or it predates
+ * the shed. Pure — the caller does the writing.
+ */
+export function doubleVerdictWarnings(issues) {
+  return (issues ?? [])
+    .map(classifyIssue)
+    .filter((entry) => entry.verdictLabels.length > 1)
+    .map(
+      (entry) =>
+        `Issue #${entry.number} carries ${entry.verdictLabels.length} verdict labels (${entry.verdictLabels.join(", ")}); this digest bucketed it as "${entry.bucket}" from the first one. Remove the stale label.`,
+    );
+}
+
+/**
  * Build the deterministic Slack `chat.postMessage` payload for one batch.
  * `channel` is passed in (hardcoded by the workflow); `now` is injectable for
  * tests. Pure — no I/O, no escaping omissions: every free-form value is routed
@@ -850,6 +875,9 @@ async function main() {
   }
 
   const issues = await collectIssues(options.repo, options.issues);
+  for (const warning of doubleVerdictWarnings(issues)) {
+    process.stderr.write(`::warning::${warning}\n`);
+  }
   const payload = buildDigest(issues, {
     channel: options.channel,
     now: new Date(),

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -6,6 +6,7 @@ import {
   chunkLines,
   classifyIssue,
   collectIssues,
+  doubleVerdictWarnings,
   escapeSlackText,
   extractAutofixUrl,
   extractPermalink,
@@ -602,6 +603,49 @@ await test("classifyIssue treats an unlabeled batch issue as failed (visible, no
   const entry = classifyIssue(issueFixture({ labels: ["sentry-triage"] }));
   assertEqual(entry.bucket, "failed");
   assertEqual(entry.section, "failed");
+});
+
+await test("a double-verdicted stub warns and still renders — the digest never fails on it", () => {
+  const doubled = issueFixture({
+    number: 1671,
+    labels: [
+      "sentry-triage",
+      "sentry:verdict-needs-human",
+      "sentry:verdict-config-fix",
+    ],
+  });
+  const entry = classifyIssue(doubled);
+  assertDeepEqual(entry.verdictLabels, [
+    "sentry:verdict-needs-human",
+    "sentry:verdict-config-fix",
+  ]);
+  // First match wins the bucket; the warning is what makes the ambiguity
+  // visible.
+  assertEqual(entry.bucket, "needs-human");
+
+  const warnings = doubleVerdictWarnings([doubled]);
+  assertEqual(warnings.length, 1);
+  assert(warnings[0].includes("#1671"), warnings[0]);
+  assert(warnings[0].includes("sentry:verdict-config-fix"), warnings[0]);
+
+  // Never a hard failure: the digest is the batch's one daily notification, so
+  // the payload must still build.
+  const payload = buildDigest([doubled], {
+    channel: "C123",
+    now: new Date("2026-07-17T14:20:33Z"),
+  });
+  assertEqual(payload.channel, "C123");
+  assert(payload.blocks.length > 0, "expected a rendered digest payload");
+});
+
+await test("a single-verdict stub produces no double-verdict warning", () => {
+  assertDeepEqual(
+    doubleVerdictWarnings([
+      issueFixture({ labels: ["sentry-triage", "sentry:verdict-code-fix"] }),
+      issueFixture({ labels: ["sentry-triage", NEEDS_TRIAGE_LABEL] }),
+    ]),
+    [],
+  );
 });
 
 await test("classifyIssue falls back to #number when the title does not parse", () => {

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -68,7 +68,7 @@ import {
   VALID_VERDICTS,
   validateAffectedRepo,
 } from "./sentry-triage-project-core.mjs";
-import { LABEL_DEFINITIONS } from "./sentry-triage-ingest.mjs";
+import { LABEL_DEFINITIONS, VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
 
 // ---------------------------------------------------------------------------
 // GitHub I/O (via `gh`, mirroring the ingest/digest scripts). `runGh` is
@@ -375,6 +375,15 @@ async function markStubProjected(localRun, localRepo, issue, projectedUrl) {
  * `gh issue view` with the ambient token; the projection PAT is never needed
  * here. Throws on missing/stale/invalid verdicts so the label step fails
  * loudly and leaves `sentry:needs-triage` in place for retry.
+ *
+ * It also emits `shed`: the comma-joined verdict labels the label step must
+ * REMOVE in the same `gh issue edit` (#1745). A re-dispatched stub already
+ * carries a verdict label and `gh issue edit --add-label` only adds, so
+ * without the shed the stub ends up carrying two contradictory verdicts and
+ * the digest — which buckets on the FIRST matching label — reports whichever
+ * one GitHub happens to order first. Bash cannot import a JS constant, so the
+ * list travels through this single authoritative parser's output rather than
+ * becoming a second literal list in the workflow.
  */
 export async function runParseOnly(options, deps = {}) {
   const runGh = deps.runGh ?? defaultRunGh;
@@ -393,7 +402,17 @@ export async function runParseOnly(options, deps = {}) {
     }
     projectable = repoCheck.projectable;
   }
-  return { verdict, label, projectable };
+  // The VERDICT namespace only — deliberately not REOPEN_SHED_LABELS, which
+  // also carries `sentry:projected` and the autofix/archive markers. Shedding
+  // the autofix markers here would un-dedup the select step and let the same
+  // stub be fixed twice; shedding `sentry:archived` would erase an audit
+  // marker. The label being applied is excluded so one name never reaches both
+  // `--remove-label` and `--add-label` in a single edit. Removing a label the
+  // stub does not carry is a no-op — the same property
+  // `buildReopenLabelEditArgs` relies on — so the first-pass case (no verdict
+  // label yet) costs nothing.
+  const shed = VERDICT_LABELS.filter((name) => name !== label).join(",");
+  return { verdict, label, projectable, shed };
 }
 
 export async function runProjection(options, deps = {}) {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { LABEL_TO_VERDICT } from "./sentry-triage-digest.mjs";
+import { VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
 import {
   ALLOWED_OWNING_REPOS,
   bodyBacklinksShortId,
@@ -2153,6 +2155,20 @@ await test("VERDICT_TO_LABEL encodes the upstream label/value asymmetry", () => 
   assertEqual(VERDICT_TO_LABEL["needs-human"], "sentry:verdict-needs-human");
 });
 
+// The shed is derived from VERDICT_LABELS, the digest buckets through
+// LABEL_TO_VERDICT, and the label step maps through VERDICT_TO_LABEL. Nothing
+// else makes the three agree, so a fifth verdict added to one map would ship a
+// label the shed never removes and the digest never recognizes.
+await test("VERDICT_LABELS, VERDICT_TO_LABEL and LABEL_TO_VERDICT pin one label set", () => {
+  const contract = [...VERDICT_LABELS].sort();
+  assert(contract.length > 0, "VERDICT_LABELS is empty");
+  assertDeepEqual(
+    [...new Set(Object.values(VERDICT_TO_LABEL))].sort(),
+    contract,
+  );
+  assertDeepEqual(Object.keys(LABEL_TO_VERDICT).sort(), contract);
+});
+
 await test("runParseOnly returns the validated verdict + mapped label + projectability", async () => {
   const { runGh, calls } = makeRunGh({ issue: queueIssue() });
   const result = await runParseOnly(
@@ -2163,6 +2179,7 @@ await test("runParseOnly returns the validated verdict + mapped label + projecta
     verdict: "code-fix",
     label: "sentry:verdict-code-fix",
     projectable: true,
+    shed: "sentry:verdict-config-fix,sentry:verdict-upstream,sentry:verdict-needs-human",
   });
   // Read-only: exactly one `gh issue view` with the ambient token.
   assertEqual(calls.length, 1);
@@ -2205,7 +2222,56 @@ await test("runParseOnly maps upstream-transient to the asymmetric label", async
     verdict: "upstream-transient",
     label: "sentry:verdict-upstream",
     projectable: false,
+    shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-needs-human",
   });
+});
+
+// The re-dispatch case the double-label bug comes from: a human answers a
+// `needs-human` escalation, re-runs the workflow, and the agent verdicts
+// something else. `--add-label` only adds, so the stale label has to come off
+// in the same edit.
+await test("runParseOnly sheds every verdict label except the one being applied", async () => {
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:verdict-needs-human"],
+    comments: [
+      botComment(
+        verdictComment({ verdict: "config-fix" }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const result = await runParseOnly(
+    { localRepo: "mento-protocol/monitoring-monorepo", queueIssue: 500 },
+    { runGh: makeRunGh({ issue }).runGh },
+  );
+  assertEqual(result.label, "sentry:verdict-config-fix");
+  const shed = result.shed.split(",");
+  assertDeepEqual(shed.sort(), [
+    "sentry:verdict-code-fix",
+    "sentry:verdict-needs-human",
+    "sentry:verdict-upstream",
+  ]);
+  assert(
+    !shed.includes(result.label),
+    "the label being applied must never also be removed in the same edit",
+  );
+});
+
+// REOPEN_SHED_LABELS is the superset the re-queue chokepoint uses. Handing it
+// to this step would strip the autofix dedup markers (re-fixing an already
+// fixed stub) and the archive audit markers.
+await test("runParseOnly sheds ONLY the verdict namespace", async () => {
+  const { runGh } = makeRunGh({ issue: queueIssue() });
+  const result = await runParseOnly(
+    { localRepo: "mento-protocol/monitoring-monorepo", queueIssue: 500 },
+    { runGh },
+  );
+  for (const name of result.shed.split(",")) {
+    assert(
+      name.startsWith("sentry:verdict-"),
+      `shed carries a non-verdict label: ${name}`,
+    );
+  }
 });
 
 await test("runParseOnly fails loud on missing, hostile-author, stale, and invalid verdicts", async () => {
@@ -2331,6 +2397,7 @@ await test("runParseOnly accepts a needs-human verdict WITH human_question", asy
     verdict: "needs-human",
     label: "sentry:verdict-needs-human",
     projectable: false,
+    shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-upstream",
   });
 });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Re-triaging a stub that already has a verdict leaves two contradictory `sentry:verdict-*` labels on it, because `gh issue edit --add-label` only adds.
- The daily Slack digest buckets a stub by the first verdict label it finds, so a double-labelled stub gets reported under whichever verdict GitHub happened to order first.
- The exposure is live, not historical: the three open `needs-human` stubs are exactly the class a human re-dispatches after answering the escalation.

## The Solution

- The verdict step now removes every other verdict label in the same edit that adds the new one, so a stub always carries exactly one.
- The list of labels to remove comes from the same `--parse-only` output that already supplies the label, so bash never grows a second copy of the verdict namespace.
- After the edit the step re-reads the stub and fails its own matrix job if more than one verdict label survived. The digest warns about such a stub but never fails on it.

## Details

- `runParseOnly` (`scripts/sentry-triage-project.mjs`) gains a `shed` field: `VERDICT_LABELS` minus the label being applied, comma-joined. The workflow reads it with `jq` and passes `--remove-label "sentry:needs-triage,${shed}"`.
- Deliberately the **verdict namespace only**, not the re-queue's `REOPEN_SHED_LABELS`. That superset also carries `sentry:projected`, `sentry:fix-pr-opened`, `sentry:fix-refused`, `sentry:approved-archive` and `sentry:archived` — shedding the autofix markers here would un-dedup the select step and let a stub be fixed twice, and shedding `sentry:archived` would erase an audit marker. Those markers must survive a verdict change.
- The label being applied is excluded, so one name never reaches both `--remove-label` and `--add-label` in a single edit. Removing a label a stub does not carry is a no-op — the same property `buildReopenLabelEditArgs` already relies on — so the first-pass case is unchanged.
- The post-edit check only fails on more than one surviving label. Zero is not reachable: the edit itself exits nonzero if `--add-label` did not land. Failing after the edit is safe to retry, because the shed makes the whole step idempotent.
- Three maps could previously drift with nothing asserting they agree: `VERDICT_LABELS` (queue contract), `VERDICT_TO_LABEL` (project core), `LABEL_TO_VERDICT` (digest). A parity test pins them to one label set, so a fifth verdict cannot land in one map and be missed by the shed. The gate now routes queue-contract and digest changes to `sentry:project:test` so that test actually runs when a map moves.
- `classifyIssue` keeps the full list of verdict labels it saw; `doubleVerdictWarnings` turns a violation into a `::warning::` line that `main()` writes to stderr. The digest is the batch's one daily notification, so a violated invariant must not take the run down.
- Issue #1671 — the one historical double-labelled stub — was hand-fixed before this PR. No issue data is touched here.

## Validation

- `pnpm agent:quality-gate --run --parallel 4` — all 16 mapped commands passed, including `pnpm agent:quality-gate:test`, `pnpm tf:test`, `pnpm sentry:project:test`, `pnpm sentry:digest:test`, `node scripts/sentry-triage-agent-comment.test.mjs`, and `trunk check` over all nine touched files.
- `pnpm sentry:project:test` — 100 passed, including the new parity test and two new shed tests: an already-`needs-human` stub verdicting `config-fix` sheds code-fix/upstream/needs-human and never `sentry:verdict-config-fix`, and the shed carries nothing outside `sentry:verdict-*`.
- `pnpm sentry:digest:test` — 64 passed, including a double-verdicted stub that warns, still renders a payload, and never throws.
- `node scripts/sentry-triage-agent-comment.test.mjs` — 37 passed, including the new workflow-shape assertion; deleting the shed or the survivor check from the workflow fails it.
- `actionlint .github/workflows/sentry-triage-agent.yml` — clean.
- End-to-end shape check against a fixture stub carrying `sentry:verdict-needs-human` with a `config-fix` verdict: `--parse-only` prints `{"verdict":"config-fix","label":"sentry:verdict-config-fix","projectable":true,"shed":"sentry:verdict-code-fix,sentry:verdict-upstream,sentry:verdict-needs-human"}`.
- The step's shell logic exercised directly against jq with one, two, zero and empty label payloads: only the two-label case trips the failure branch.
- Not run: `pnpm agent:autoreview`. Neither engine is available in this environment (`codex not found in PATH`; the claude engine needs Claude Code >= 2.1.169 for `--safe-mode`). A manual self-audit of the full diff stood in for it.

## Deferrals

- None

Closes #1745

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic triage settlement and label invariants on queue stubs; mistakes could mis-bucket digest rows or block re-dispatch until retry, but scope is limited to verdict labels with closed enums and idempotent shed logic.
> 
> **Overview**
> **Re-triaging a stub that already has a verdict no longer stacks contradictory `sentry:verdict-*` labels.** The verdict job removes every other verdict label in the same `gh issue edit` that applies the new one, using a `shed` list from `--parse-only` so the workflow does not duplicate the verdict namespace in bash.
> 
> `runParseOnly` now returns **`shed`**: comma-joined `VERDICT_LABELS` minus the label being applied (verdict namespace only—not re-queue projection/autofix/archive markers). After the edit, the job **re-reads labels** and fails if more than one `sentry:verdict-*` remains.
> 
> The digest **warns** on double-verdict stubs (`doubleVerdictWarnings`) but still builds the Slack payload. **Tests and quality gate** pin `VERDICT_LABELS`, `VERDICT_TO_LABEL`, and `LABEL_TO_VERDICT` together and assert workflow shed/survivor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62cd8d34082d59b21c178cb1b2130530491b980. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->