### PR TITLE
fix(sentry): close the approval-to-run baseline window and the reopen label race

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -660,8 +660,10 @@ Ingest reads the OTHER one. The live read happens after the human applied
 on a dispatch — so an event landing in that window is folded into the value
 meant to detect it, and `lastSeen > baseline` is false for that exact event
 forever. The reopen baseline is taken from the stub body's own `last_seen`,
-written by ingest at creation or on its last reopen and never rewritten since,
-so it predates the approval by construction. It can be weeks old; that only
+written by ingest when it **created** the stub and never rewritten since — a
+reopen edits the stub's labels, comments and state, never its body — so it
+predates the approval by construction. On a stub that has flapped it is still
+the creation instant and can be as old as the stub itself; that only
 makes reopens more eager, which is the intended bias — a spurious reopen costs
 one triage cycle, a buried regression costs an incident. Two guards keep it from
 being the worse choice: an unparsable stub `last_seen` falls back to the live

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -137,11 +137,11 @@ bulk:
 - no matching queue issue: create one;
 - open match: leave it open;
 - closed match with a regression whose `lastSeen` is newer than
-  `closed_at`: post the regression fence comment, shed the stale
-  verdict/projection/autofix/archive labels, restore `sentry:needs-triage`, and
-  reopen — in that order;
+  `closed_at`: post the regression fence comment, restore `sentry:needs-triage`,
+  shed the stale verdict/projection/autofix/archive labels, and reopen — in that
+  order;
 - closed match carrying `sentry:archived`: compare `lastSeen` against the
-  archive freshness baseline in the stub's own body instead of `closed_at` (see
+  archive reopen baseline in the stub's own body instead of `closed_at` (see
   the archive section below), falling back to `closed_at` when the body carries
   no parseable baseline;
 - other closed match: leave it closed.
@@ -151,8 +151,15 @@ Every re-queue in the pipeline runs through one function,
 `requeueQueueStub` in `scripts/sentry-triage-requeue.mjs`, which takes the CAUSE
 as an argument and decides the fence from it. The fence goes first so no
 interruption can leave a stub re-queued for triage without it; the state change
-goes last so none can leave it open but unselectable. Every interruption point
-then lands on a state that is inert or recoverable. On this path the fence post
+goes last so none can leave it open but unselectable. Inside the label step the
+restore and the shed are two ordered `gh issue edit` calls, never one call
+carrying both flags: `gh` sends `--add-label` and `--remove-label` as discrete,
+concurrent GraphQL mutations, and a lost add half used to leave a closed stub
+with `sentry:archived` shed and `sentry:needs-triage` never applied — a pairing
+the baseline branch and the stranded sweep are both blind to. Adding first means
+every interruption lands on a pairing one of them still reads. Every
+interruption point then lands on a state that is inert or recoverable. On this
+path the fence post
 is additionally guarded by an author-fenced identity check, so a retry completes
 the sequence without duplicating it — a guard the caller declares, and one that
 disarms itself whenever `lastSeen` does not parse, because the rendered body
@@ -641,10 +648,35 @@ neither ingest query (both are `is:unresolved`) and a single already-counted
 event does not reliably trip Sentry's escalation forecast. Reverting puts it back
 in front of both.
 
-**The baseline lives in the stub BODY, never in a comment.** It is written into
-the same yaml block ingest creates the stub with, as
-`archive_baseline_last_seen` plus the Sentry issue id it mutated, and the write
-happens before anything marks the stub settled. Placement is the entire trust
+**There are two baselines, and they answer different questions.** The live read
+above is what THIS RUN observed, and only this run's own gates may use it: the
+post-PUT mutation-window comparison, and the two already-archived retry refusals
+(`skipped-stale-retry`, `skipped-unbaselined-retry`), which exist to say whether
+anything moved since the archive that already happened. Repointing those at any
+earlier value would refuse every legitimate `workflow_dispatch` retry as stale.
+
+Ingest reads the OTHER one. The live read happens after the human applied
+`sentry:approved-archive` — 30-90 seconds later on the label trigger, unbounded
+on a dispatch — so an event landing in that window is folded into the value
+meant to detect it, and `lastSeen > baseline` is false for that exact event
+forever. The reopen baseline is taken from the stub body's own `last_seen`,
+written by ingest at creation or on its last reopen and never rewritten since,
+so it predates the approval by construction. It can be weeks old; that only
+makes reopens more eager, which is the intended bias — a spurious reopen costs
+one triage cycle, a buried regression costs an incident. Two guards keep it from
+being the worse choice: an unparsable stub `last_seen` falls back to the live
+read (the pre-#1692 behaviour, so a stale body field can never make a human
+approval unspendable), and a stub `last_seen` newer than the live read loses to
+it.
+
+**The baselines live in the stub BODY, never in a comment.** They are written
+into the same yaml block ingest creates the stub with, as
+`archive_baseline_last_seen` (the live read) and
+`archive_reopen_baseline_last_seen` (the pre-approval instant ingest compares
+against), plus the Sentry issue id the run mutated, and the write
+happens before anything marks the stub settled. A stub archived before the
+second field existed carries only the first, and ingest falls back to it, so
+those stubs behave exactly as they did. Placement is the entire trust
 boundary here, and it is structural rather than cryptographic. The Stage B
 triage agent is an LLM reading attacker-controlled Sentry payloads, and
 `.github/workflows/sentry-triage-agent.yml` grants it

--- a/scripts/sentry-triage-archive.mjs
+++ b/scripts/sentry-triage-archive.mjs
@@ -153,8 +153,11 @@ function readYamlField(body, key) {
  * `lastSeen` is the ingest-written `last_seen`, and it is here for one reason:
  * it is the only instant in reach that provably predates the human approval, so
  * it is what `pickReopenBaseline` hands ingest's reopen gate (issue #1692).
- * Ingest writes it at creation and on a reopen and nothing rewrites it after
- * that, so it may be far older than this run — which is the point.
+ * Ingest writes it ONCE, when it creates the stub (`buildIssueBody`, called only
+ * from `createQueueIssue`); a reopen edits labels, comments and state and never
+ * the body. So on a stub that has regressed and reopened since, this is still
+ * the CREATION-time value and can be as old as the stub itself — which is the
+ * point: earlier only makes the reopen gate more eager.
  */
 export function parseStubMetadata(body) {
   const permalinkRaw = readYamlField(body, "permalink");
@@ -457,9 +460,12 @@ export function isUsableBaseline(lastSeen) {
  * must describe what THIS run saw — so it stays exactly where it is, and ingest
  * gets its own value instead.
  *
- * That value is the stub body's `last_seen`, written by ingest at creation or on
- * its last reopen and never rewritten since; it therefore predates the approval
- * by construction, whatever the shape of the approval-to-run window.
+ * That value is the stub body's `last_seen`, written by ingest when it CREATED
+ * the stub and never rewritten since — no reopen or re-queue step edits a stub
+ * body — so it predates the approval by construction, whatever the shape of the
+ * approval-to-run window. On a stub that has flapped it is still the creation
+ * instant, potentially the stub's whole lifetime old, which widens this gate and
+ * can never narrow it.
  *
  * Two guards on top of it, both taking the EARLIER of the two candidates:
  *   - an unparsable stub `last_seen` (a hand-edited body, a stub created when

--- a/scripts/sentry-triage-archive.mjs
+++ b/scripts/sentry-triage-archive.mjs
@@ -149,6 +149,12 @@ function readYamlField(body, key) {
  * `sentry_issue_id`, so `sentryIssueId` is normally the numeric Sentry id
  * directly; `resolveIssueIdFromShortId` is the fallback for a stub that lacks
  * a usable numeric id.
+ *
+ * `lastSeen` is the ingest-written `last_seen`, and it is here for one reason:
+ * it is the only instant in reach that provably predates the human approval, so
+ * it is what `pickReopenBaseline` hands ingest's reopen gate (issue #1692).
+ * Ingest writes it at creation and on a reopen and nothing rewrites it after
+ * that, so it may be far older than this run — which is the point.
  */
 export function parseStubMetadata(body) {
   const permalinkRaw = readYamlField(body, "permalink");
@@ -156,6 +162,7 @@ export function parseStubMetadata(body) {
     shortId: readYamlField(body, "short_id"),
     sentryIssueId: readYamlField(body, "sentry_issue_id"),
     project: readYamlField(body, "project"),
+    lastSeen: readYamlField(body, "last_seen"),
     permalink: isSafeSentryPermalink(permalinkRaw) ? permalinkRaw : null,
   };
 }
@@ -227,6 +234,7 @@ export function buildAuditComment({
   timestampIso,
   alreadyArchived = false,
   baselineLastSeen = null,
+  reopenBaselineLastSeen = null,
 }) {
   const safeApprover = sanitizeApprover(approver);
   const safeShortId = truncateTitle(neutralizeUntrusted(shortId), 90);
@@ -247,7 +255,17 @@ export function buildAuditComment({
   // comment cannot hold it, because the triage LLM can post comments under this
   // same bot identity (see isSettledAuditComment).
   lines.push(
-    `- Freshness baseline recorded in the issue body: ${auditBaselineToken(baselineLastSeen)}.`,
+    `- Freshness baseline this run observed in Sentry: ${auditBaselineToken(baselineLastSeen)}.`,
+  );
+  // Two baselines, two readers, and the note says which is which because an
+  // operator debugging a reopen that did or did not happen is reading the
+  // second one (issue #1692). Only the first is the audit dedup token.
+  if (reopenBaselineLastSeen) {
+    lines.push(
+      `- Reopen baseline recorded in the issue body (predates the approval; ingest compares against this): \`${yamlScalar(reopenBaselineLastSeen)}\`.`,
+    );
+  }
+  lines.push(
     "",
     "Never hard-resolved: the issue stays archived only until it escalates. If",
     "it escalates/regresses in Sentry, Stage A's regression-reopen path reopens",
@@ -427,11 +445,49 @@ export function isUsableBaseline(lastSeen) {
 }
 
 /**
+ * The baseline INGEST compares against, which is a different question from the
+ * one `baselineLastSeen` answers (issue #1692).
+ *
+ * The archive reads Sentry after the human applied `sentry:approved-archive`, so
+ * an event landing in between is folded into that read: ingest asks
+ * `lastSeen > baseline`, and for the very event that moved `lastSeen` the answer
+ * is false. Forever. The live read still has two jobs the earlier value cannot
+ * do — the post-PUT mutation-window comparison, and the evidence behind the
+ * `skipped-stale-retry` / `skipped-unbaselined-retry` refusals, both of which
+ * must describe what THIS run saw — so it stays exactly where it is, and ingest
+ * gets its own value instead.
+ *
+ * That value is the stub body's `last_seen`, written by ingest at creation or on
+ * its last reopen and never rewritten since; it therefore predates the approval
+ * by construction, whatever the shape of the approval-to-run window.
+ *
+ * Two guards on top of it, both taking the EARLIER of the two candidates:
+ *   - an unparsable stub `last_seen` (a hand-edited body, a stub created when
+ *     Sentry returned none) falls back to the live read, which is the pre-#1692
+ *     behaviour rather than a refusal — the archive already fails closed on an
+ *     unusable live baseline, and a stub's own stale field must not become a
+ *     second, unfixable way to make a human approval unspendable;
+ *   - a stub `last_seen` NEWER than the live read (a stale Sentry replica on
+ *     this run) would widen the gate rather than narrow it, so the live read
+ *     wins there.
+ * Both cases resolve the same way: never later than the live read, and as early
+ * as the evidence honestly allows.
+ */
+export function pickReopenBaseline(stubLastSeen, liveLastSeen) {
+  const stubMs = Date.parse(stubLastSeen ?? "");
+  const liveMs = Date.parse(liveLastSeen ?? "");
+  if (Number.isNaN(stubMs)) return liveLastSeen;
+  if (Number.isNaN(liveMs)) return stubLastSeen;
+  return stubMs <= liveMs ? stubLastSeen : liveLastSeen;
+}
+
+/**
  * True when `comment` is THIS pipeline's settled audit comment for the Sentry
  * issue being archived — the at-most-once key for the audit post.
  *
  * This governs a HUMAN-READABLE note only. The machine-readable baseline lives
- * in the stub body (scripts/sentry-triage-ingest.mjs, `withArchiveBaseline`),
+ * in the stub body (scripts/sentry-triage-queue-contract.mjs,
+ * `withArchiveBaseline`),
  * because the Stage B triage agent is an LLM reading attacker-controlled Sentry
  * payloads and holds `Bash(gh issue comment <its stub>:*)` — so it can post a
  * comment under the trusted Actions identity, on the right stub, with any
@@ -883,8 +939,9 @@ async function consumeApprovalLabel(runGh, repo, queueIssue) {
  * deliberately absent — settlement consumed it.
  *
  * Read AFTER the settlement writes, because ingest's regression reopen does not
- * need `sentry:approved-archive` to run: `buildReopenLabelEditArgs` only
- * `--remove-label`s it, which no-ops once this run's CAS took it. So a reopen
+ * need `sentry:approved-archive` to run: the chokepoint's shed step
+ * (`buildRequeueShedLabelArgs`) only `--remove-label`s it, which no-ops once
+ * this run's CAS took it. So a reopen
  * can complete entirely inside the settlement window, and the close would then
  * land on a stub ingest just reopened for a live regression. Any of the three
  * signals catches it whichever order the two runs interleave — the reopen sheds
@@ -905,10 +962,15 @@ export function settlementHeld({ state, labels, body } = {}, expected = null) {
   // body edit racing between the write and this check — and state-and-labels
   // alone would call that settled, reporting success on a closed
   // `sentry:archived` stub whose body sends ingest straight back to `closedAt`.
+  // Both fields, because they answer to different consumers and only one of them
+  // is the reopen gate: a body carrying this run's live read but the previous
+  // archive's (or no) pre-approval baseline would pass a lastSeen-only check
+  // while ingest compared against the wrong instant.
   const recorded = parseArchiveBaseline(body);
   return (
     !!recorded &&
     recorded.lastSeen === String(expected.lastSeen ?? "") &&
+    recorded.reopenLastSeen === String(expected.reopenLastSeen ?? "") &&
     recorded.sentryIssueId === String(expected.sentryIssueId ?? "")
   );
 }
@@ -951,7 +1013,9 @@ export function settlementHeld({ state, labels, body } = {}, expected = null) {
  * baseline are equivalent for reconciliation even if they differ elsewhere. */
 function baselineOf(body) {
   const parsed = parseArchiveBaseline(body);
-  return parsed ? `${parsed.lastSeen}|${parsed.sentryIssueId}` : "";
+  return parsed
+    ? `${parsed.lastSeen}|${parsed.reopenLastSeen}|${parsed.sentryIssueId}`
+    : "";
 }
 
 export async function reconcileToTarget(
@@ -1156,6 +1220,7 @@ async function settleQueueStub(
     timestampIso,
     alreadyArchived,
     baselineLastSeen,
+    reopenBaselineLastSeen,
     onTarget,
   },
 ) {
@@ -1255,6 +1320,7 @@ async function settleQueueStub(
   const bodySource = await readQueueIssue(runGh, repo, queueIssue);
   const nextBody = withArchiveBaseline(bodySource.body, {
     lastSeen: baselineLastSeen,
+    reopenLastSeen: reopenBaselineLastSeen,
     sentryIssueId,
   });
   if (!nextBody) {
@@ -1311,6 +1377,7 @@ async function settleQueueStub(
   if (
     !settlementHeld(verify, {
       lastSeen: baselineLastSeen,
+      reopenLastSeen: reopenBaselineLastSeen,
       sentryIssueId,
     })
   ) {
@@ -1360,6 +1427,7 @@ async function settleQueueStub(
           timestampIso,
           alreadyArchived,
           baselineLastSeen,
+          reopenBaselineLastSeen,
         }),
       ]);
     } catch (err) {
@@ -1462,6 +1530,17 @@ export async function runArchive(options, deps = {}) {
       status: "skipped-no-baseline",
     };
   }
+
+  // The baseline INGEST reads (issue #1692). Derived from the stub's own
+  // `last_seen`, so it predates the human approval and an event that landed
+  // between the approval and the read above still reopens the stub. Computed
+  // here, next to the live read it is deliberately NOT, so the two are one edit
+  // apart. `baselineLastSeen` is already known usable at this point, so this
+  // never returns an unparsable value.
+  const reopenBaselineLastSeen = pickReopenBaseline(
+    meta.lastSeen,
+    baselineLastSeen,
+  );
 
   // Live-regression guard. If Sentry has flagged the issue as regressed/
   // escalating, DO NOT archive: closing the stub after that regression's
@@ -1816,6 +1895,7 @@ export async function runArchive(options, deps = {}) {
       timestampIso: now().toISOString(),
       alreadyArchived,
       baselineLastSeen,
+      reopenBaselineLastSeen,
       onTarget: (t) => {
         settleTarget = t;
       },

--- a/scripts/sentry-triage-archive.test.mjs
+++ b/scripts/sentry-triage-archive.test.mjs
@@ -18,6 +18,7 @@ import {
   isNotFoundError,
   isSelectableForTriage,
   isNumericId,
+  pickReopenBaseline,
   settlementHeld,
   isSafeSentryPermalink,
   isSettledAuditComment,
@@ -38,6 +39,7 @@ import {
   buildRegressedComment,
   buildStrandedRecoveryComment,
   parseArchiveBaseline,
+  reopenBaselineOf,
   withArchiveBaseline,
 } from "./sentry-triage-ingest.mjs";
 import {
@@ -841,6 +843,138 @@ await test("runArchive happy path archives and settles the queue stub", async ()
   );
 });
 
+// ---------------------------------------------------------------------------
+// The approval-to-run window (issue #1692).
+//
+// The archive reads Sentry AFTER the human applied `sentry:approved-archive`,
+// so an event landing in between is folded into the value meant to detect it.
+// The fix is a second baseline for ingest, taken from the stub's own
+// ingest-written `last_seen`; the live read stays exactly where it is, because
+// the mutation-window guard and both already-archived retry refusals have to
+// describe what THIS run saw.
+// ---------------------------------------------------------------------------
+
+/** The stub body's own `last_seen`, written by ingest long before any approval. */
+const STUB_LAST_SEEN = "2026-07-14T10:00:00Z";
+
+await test("the recorded reopen baseline predates the approval, not the archive read", async () => {
+  // `makeFetch` serves BASELINE_LAST_SEEN, five days newer than the stub's
+  // `last_seen` — that gap models the event that landed after the approval.
+  const stub = makeStub();
+  const { runGh, calls: ghCalls, model } = makeRunGh({ stub });
+  const { fetchImpl } = makeFetch();
+
+  const result = await runArchive(baseOptions(), {
+    runGh,
+    fetchImpl,
+    now: FIXED_NOW,
+  });
+  assertEqual(result.status, "archived");
+
+  const recorded = parseArchiveBaseline(model.body);
+  // The live read is still recorded — the archive's own consumers need it.
+  assertEqual(recorded.lastSeen, BASELINE_LAST_SEEN);
+  // And ingest gets an instant that provably predates the approval, so the
+  // absorbed event is strictly newer than the value its gate compares against.
+  assertEqual(recorded.reopenLastSeen, STUB_LAST_SEEN);
+  assertEqual(reopenBaselineOf(recorded), STUB_LAST_SEEN);
+  assertEqual(
+    lastSeenMoved(reopenBaselineOf(recorded), BASELINE_LAST_SEEN),
+    true,
+  );
+
+  // The audit note names both, because an operator debugging a reopen that did
+  // or did not fire is reading the second one.
+  const comment = ghCall(ghCalls, "comment");
+  const auditBody = comment[comment.indexOf("--body") + 1];
+  assert(
+    auditBody.includes(BASELINE_LAST_SEEN) &&
+      auditBody.includes(STUB_LAST_SEEN),
+    `audit note must name both baselines: ${auditBody}`,
+  );
+});
+
+await test("a legitimate retry still measures itself against the LIVE archive read", async () => {
+  // The sharp half of the same change: repointing the already-archived retry
+  // gates at the earlier baseline would refuse every honest dispatch retry as
+  // stale. This stub carries both fields; Sentry's `lastSeen` still reads what
+  // the first run saw, so the retry must proceed.
+  const stub = makeStub({
+    body: withArchiveBaseline(stubBody(), {
+      lastSeen: BASELINE_LAST_SEEN,
+      reopenLastSeen: STUB_LAST_SEEN,
+      sentryIssueId: "6197137101",
+    }),
+  });
+  const { runGh } = makeRunGh({ stub });
+  const { fetchImpl } = makeFetch({
+    issue: { status: "ignored", substatus: "archived_until_escalating" },
+  });
+
+  const result = await runArchive(baseOptions(), {
+    runGh,
+    fetchImpl,
+    now: FIXED_NOW,
+  });
+  assertEqual(result.status, "already-archived");
+});
+
+await test("pickReopenBaseline takes the earlier value and never a worse one", () => {
+  // Normal case: the stub's own `last_seen`, which predates the approval.
+  assertEqual(
+    pickReopenBaseline(STUB_LAST_SEEN, BASELINE_LAST_SEEN),
+    STUB_LAST_SEEN,
+  );
+  // A stub `last_seen` NEWER than this run's read (a stale Sentry replica)
+  // would widen the gate, so the live read wins.
+  assertEqual(
+    pickReopenBaseline("2026-07-25T00:00:00Z", BASELINE_LAST_SEEN),
+    BASELINE_LAST_SEEN,
+  );
+  // An unusable stub `last_seen` degrades to the pre-#1692 behaviour rather
+  // than making a human approval unspendable.
+  for (const junk of [undefined, null, "", "   ", "not-a-date"]) {
+    assertEqual(
+      pickReopenBaseline(junk, BASELINE_LAST_SEEN),
+      BASELINE_LAST_SEEN,
+    );
+  }
+  // Equal timestamps are not a reason to prefer the later name for the value.
+  assertEqual(
+    pickReopenBaseline(BASELINE_LAST_SEEN, BASELINE_LAST_SEEN),
+    BASELINE_LAST_SEEN,
+  );
+});
+
+await test("settlementHeld rejects a body carrying the wrong reopen baseline", () => {
+  const expected = {
+    lastSeen: BASELINE_LAST_SEEN,
+    reopenLastSeen: STUB_LAST_SEEN,
+    sentryIssueId: "6197137101",
+  };
+  const settled = {
+    state: "CLOSED",
+    labels: ["sentry-triage", "sentry:archived", "sentry:verdict-upstream"],
+    body: withArchiveBaseline(stubBody(), expected),
+  };
+  assertEqual(settlementHeld(settled, expected), true);
+  // A body that kept only the live read is the pre-#1692 shape, and it sends
+  // ingest back to comparing against a post-approval instant.
+  assertEqual(
+    settlementHeld(
+      {
+        ...settled,
+        body: withArchiveBaseline(stubBody(), {
+          lastSeen: BASELINE_LAST_SEEN,
+          sentryIssueId: "6197137101",
+        }),
+      },
+      expected,
+    ),
+    false,
+  );
+});
+
 await test("runArchive is idempotent when the issue is already archived", async () => {
   const stub = makeStub({ body: settledStubBody() });
   const { runGh, calls: ghCalls } = makeRunGh({ stub });
@@ -897,10 +1031,19 @@ await test("runArchive refuses and re-queues a live regression instead of archiv
   );
   assert(!ghCall(ghCalls, "close"), "must not close over the regression");
   assert(ghCall(ghCalls, "comment"), "posts a refusal comment");
-  const edit = ghCall(ghCalls, "edit");
-  assert(edit, "re-queues via a label edit");
-  assertEqual(edit[edit.indexOf("--add-label") + 1], "sentry:needs-triage");
-  const removed = edit[edit.indexOf("--remove-label") + 1];
+  // Two ordered label calls, add before shed: one edit carrying both flags is
+  // two concurrent mutations, and losing the add half strands the stub (#1693).
+  const edits = ghCalls.filter((args) => args[1] === "edit");
+  assertEqual(edits.length, 2);
+  assertEqual(
+    edits[0][edits[0].indexOf("--add-label") + 1],
+    "sentry:needs-triage",
+  );
+  assert(
+    !edits[0].includes("--remove-label"),
+    "the add must not ride along with the shed",
+  );
+  const removed = edits[1][edits[1].indexOf("--remove-label") + 1];
   assert(
     removed.includes("sentry:approved-archive") &&
       removed.includes("sentry:verdict-upstream"),

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -24,6 +24,7 @@ import {
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
   parseArchiveBaseline,
+  reopenBaselineOf,
   truncateTitle,
 } from "./sentry-triage-queue-contract.mjs";
 import {
@@ -42,6 +43,7 @@ export {
   APPROVED_ARCHIVE_LABEL,
   ARCHIVE_BASELINE_FIELD,
   ARCHIVE_BASELINE_ID_FIELD,
+  ARCHIVE_REOPEN_BASELINE_FIELD,
   ARCHIVED_LABEL,
   CODE_FIX_VERDICT_LABEL,
   defangBackticks,
@@ -53,6 +55,7 @@ export {
   neutralizeUntrusted,
   parseArchiveBaseline,
   PROJECTED_LABEL,
+  reopenBaselineOf,
   REOPEN_SHED_LABELS,
   sanitizeFreeText,
   truncateTitle,
@@ -61,7 +64,8 @@ export {
 } from "./sentry-triage-queue-contract.mjs";
 export {
   buildRegressedComment,
-  buildReopenLabelEditArgs,
+  buildRequeueAddLabelArgs,
+  buildRequeueShedLabelArgs,
   buildStrandedRecoveryComment,
 } from "./sentry-triage-requeue.mjs";
 
@@ -190,13 +194,21 @@ export function indexQueueIssuesByShortId(issues) {
  * regression is silent, a wrongly reopened one merely re-triages.
  * Closed match, not regressed -> skip (stays closed). No match -> create.
  *
- * An ARCHIVED stub (`sentry:archived`) compares against `archiveBaseline` — the
- * Sentry `lastSeen` the archive leg observed just before it mutated the issue —
- * instead of `closedAt` (issue #1371). The archive's close postdates any event
+ * An ARCHIVED stub (`sentry:archived`) compares against `archiveBaseline` —
+ * `reopenBaselineOf` over the baseline the archive leg wrote into the stub body
+ * — instead of `closedAt` (issue #1371). The archive's close postdates any event
  * that landed inside its mutation window, so `closedAt` would hide that event
  * forever. A missing, unparsable, or non-date baseline falls back to the
  * `closedAt` comparison, which keeps every stub archived before this contract
  * existed working exactly as before.
+ *
+ * The value that arrives here is deliberately the archive's PRE-APPROVAL
+ * baseline, not the `lastSeen` it read at archive time (issue #1692). That read
+ * happens after the human applied `sentry:approved-archive`, so an event landing
+ * between the two is folded into the baseline and this comparison answers false
+ * for it permanently. The earlier value only ever reopens more eagerly, which is
+ * the correct bias: a spurious reopen costs a triage cycle, a buried regression
+ * costs an incident.
  *
  * Order matters, and it is deliberate: a usable, bound baseline wins over
  * `closedAt` even when `closedAt` itself is missing or unparsable. The baseline
@@ -983,7 +995,11 @@ export async function runIngest(options, deps = {}) {
         existingIssue,
         isRegressed: sentryIssue.isRegressed,
         lastSeen: sentryIssue.lastSeen,
-        archiveBaseline: baseline?.lastSeen ?? null,
+        // The REOPEN baseline, never the archive's own live read: that read
+        // happens after the human approved, so it absorbs any event that landed
+        // in between (issue #1692). `reopenBaselineOf` falls back to the live
+        // read for stubs archived before the second field existed.
+        archiveBaseline: reopenBaselineOf(baseline),
         archiveBaselineIssueId: baseline?.sentryIssueId ?? null,
         sentryIssueId: sentryIssue.id,
       });

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -6,7 +6,8 @@ import {
   buildQueueLabels,
   buildQueueTitle,
   buildRegressedComment,
-  buildReopenLabelEditArgs,
+  buildRequeueAddLabelArgs,
+  buildRequeueShedLabelArgs,
   buildRunRecordBody,
   buildStrandedRecoveryComment,
   classifyNoise,
@@ -28,6 +29,7 @@ import {
   parseLinkHeader,
   PROJECTED_LABEL,
   recoverStrandedQueueIssue,
+  reopenBaselineOf,
   reopenQueueIssue,
   REOPEN_SHED_LABELS,
   resolveLookbackDays,
@@ -757,6 +759,98 @@ await test("dedup: a baseline on a stub without sentry:archived is ignored", () 
   );
 });
 
+await test("dedup: an event absorbed by the approval-to-run window still reopens (#1692)", () => {
+  // T0 the stub's own `last_seen`; T1 the human approves; T2 the event lands;
+  // T3 the archive reads Sentry and sees T2. Comparing T2 against the archive's
+  // T3 read answers "skip" — for the very event that produced it, forever. The
+  // archive now records T0 for this gate, and T2 > T0 is a reopen.
+  const absorbedEvent = "2026-07-17T07:59:30Z";
+  const archiveRead = absorbedEvent; // the archive's read IS the absorbed event
+  const preApproval = "2026-07-14T10:00:00Z";
+  const stub = archivedStub("2026-07-17T08:00:00Z");
+
+  const decide = (archiveBaseline) =>
+    decideDedupAction({
+      existingIssue: stub,
+      isRegressed: true,
+      lastSeen: absorbedEvent,
+      archiveBaseline,
+      archiveBaselineIssueId: "6197137101",
+      sentryIssueId: "6197137101",
+    }).action;
+
+  assertEqual(decide(archiveRead), "skip", "the window this issue closes");
+  assertEqual(decide(preApproval), "reopen");
+});
+
+await test("reopenBaselineOf prefers the pre-approval field and falls back to the live read", () => {
+  const body = (fields) =>
+    ["<!-- sentry-triage:v1 -->", "", "```yaml", ...fields, "```"].join("\n");
+  const both = parseArchiveBaseline(
+    body([
+      'archive_baseline_last_seen: "2026-07-19T11:59:00.000Z"',
+      'archive_reopen_baseline_last_seen: "2026-07-14T10:00:00Z"',
+      'archive_baseline_sentry_issue_id: "6197137101"',
+    ]),
+  );
+  assertEqual(reopenBaselineOf(both), "2026-07-14T10:00:00Z");
+
+  // A stub archived before the second field existed keeps its old behaviour
+  // rather than losing the baseline entirely.
+  const legacy = parseArchiveBaseline(
+    body([
+      'archive_baseline_last_seen: "2026-07-19T11:59:00.000Z"',
+      'archive_baseline_sentry_issue_id: "6197137101"',
+    ]),
+  );
+  assertEqual(legacy.reopenLastSeen, "");
+  assertEqual(reopenBaselineOf(legacy), "2026-07-19T11:59:00.000Z");
+  assertEqual(reopenBaselineOf(null), null);
+});
+
+await test("an archived stub's PRE-APPROVAL baseline drives the reopen decision (#1692)", async () => {
+  // Wiring, end to end: runIngest must hand decideDedupAction the reopen
+  // baseline out of the body, not the archive-time read sitting beside it.
+  const sentryIssue = mapSentryIssue({
+    id: 9,
+    shortId: "X-9",
+    title: "Regressed bug",
+    lastSeen: "2026-07-19T11:59:00Z",
+  });
+  let reopenCount = 0;
+  const result = await runIngest(
+    { repo: "owner/repo", trackerIssue: 1282 },
+    {
+      fetchMergedSentryIssues: async () => mergeSentryIssues([], [sentryIssue]),
+      listQueueIssues: async () => [
+        {
+          number: 200,
+          title: buildQueueTitle("X-9", "unknown", "error"),
+          state: "CLOSED",
+          closedAt: "2026-07-19T12:00:00Z",
+          labels: ["sentry-triage", "sentry:archived"],
+          // The archive read exactly this event, so the old baseline skips it.
+          body: archivedStubBody({
+            lastSeen: "2026-07-19T11:59:00Z",
+            reopenLastSeen: "2026-07-19T00:00:00Z",
+          }),
+        },
+      ],
+      ensureLabels: async () => {},
+      createIssue: async () => {
+        throw new Error("unexpected create in this scenario");
+      },
+      reopenIssue: async () => {
+        reopenCount += 1;
+      },
+      postRunRecord: async () => {},
+      now: () => new Date("2026-07-20T05:30:00.000Z"),
+    },
+  );
+  assertEqual(result.reopened, 1);
+  assertEqual(reopenCount, 1);
+});
+
 await test("parseArchiveBaseline reads the yaml fields and tolerates junk", () => {
   const parsed = parseArchiveBaseline(
     [
@@ -1319,8 +1413,10 @@ await test("reopen shed set is every verdict label plus projected + autofix + ar
 });
 
 await test("reopen label edit re-queues triage and sheds stale verdict + projected + autofix + archive labels", () => {
-  const args = buildReopenLabelEditArgs(200, "owner/repo");
-  assertDeepEqual(args, [
+  // Two calls, never one: `--add-label X --remove-label Y` on a single
+  // `gh issue edit` is two concurrent mutations, and losing the add half strands
+  // the stub (#1693).
+  assertDeepEqual(buildRequeueAddLabelArgs(200, "owner/repo"), [
     "issue",
     "edit",
     "200",
@@ -1328,6 +1424,13 @@ await test("reopen label edit re-queues triage and sheds stale verdict + project
     "owner/repo",
     "--add-label",
     "sentry:needs-triage",
+  ]);
+  assertDeepEqual(buildRequeueShedLabelArgs(200, "owner/repo"), [
+    "issue",
+    "edit",
+    "200",
+    "-R",
+    "owner/repo",
     "--remove-label",
     "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-upstream,sentry:verdict-needs-human,sentry:projected,sentry:fix-pr-opened,sentry:fix-refused,sentry:approved-archive,sentry:archived",
   ]);
@@ -1450,7 +1553,7 @@ await test("a regressed, previously closed issue is reopened exactly once", asyn
 });
 
 /** A stub body carrying an archive baseline, as the archive leg writes it. */
-function archivedStubBody({ lastSeen, sentryIssueId = "9" }) {
+function archivedStubBody({ lastSeen, sentryIssueId = "9", reopenLastSeen }) {
   return withArchiveBaseline(
     buildIssueBody(
       toMetadata({
@@ -1461,7 +1564,7 @@ function archivedStubBody({ lastSeen, sentryIssueId = "9" }) {
         permalink: "https://mento-labs.sentry.io/issues/9/",
       }),
     ),
-    { lastSeen, sentryIssueId },
+    { lastSeen, reopenLastSeen, sentryIssueId },
   );
 }
 
@@ -1687,6 +1790,13 @@ function makeFakeGitHub({
   issues = [],
   ambiguousOn = () => false,
   rejectOn = () => false,
+  // `gh issue edit --add-label X --remove-label Y` is NOT one write: the CLI
+  // fires addLabels and removeLabels as discrete, concurrent GraphQL mutations
+  // (cli/cli, pkg/cmd/pr/shared/editable_http.go). This hook models the half the
+  // pipeline cannot afford to lose — the removes land, the adds do not, and the
+  // CLI reports failure (issue #1693). It fires per CALL, so a sequence that
+  // never puts both flags on one call keeps whatever it added earlier.
+  dropAddLabelsOn = () => false,
 } = {}) {
   const state = new Map(
     issues.map((issue) => [
@@ -1724,6 +1834,9 @@ function makeFakeGitHub({
     if (verb === "edit") {
       for (const name of splitLabels(flag(args, "--remove-label"))) {
         issue.labels = issue.labels.filter((label) => label !== name);
+      }
+      if (dropAddLabelsOn(args)) {
+        throw fail(args);
       }
       for (const name of splitLabels(flag(args, "--add-label"))) {
         if (!issue.labels.includes(name)) issue.labels.push(name);
@@ -2014,9 +2127,10 @@ await test("stranded recovery re-queues, sheds stale markers, and changes state 
   // on the snapshot it was handed — and the state change still comes last.
   assertDeepEqual(
     fake.calls.map((args) => args[1]),
-    ["view", "edit", "comment", "reopen"],
+    ["view", "edit", "edit", "comment", "reopen"],
   );
-  assertDeepEqual(fake.calls[1], buildReopenLabelEditArgs(42, REPO));
+  assertDeepEqual(fake.calls[1], buildRequeueAddLabelArgs(42, REPO));
+  assertDeepEqual(fake.calls[2], buildRequeueShedLabelArgs(42, REPO));
   const issue = fake.get(42);
   assertEqual(issue.state, "OPEN");
   assertDeepEqual(issue.labels, ["sentry-triage", NEEDS_TRIAGE_LABEL]);
@@ -2456,6 +2570,59 @@ for (const verb of ["comment", "edit", "reopen"]) {
     });
   }
 }
+
+await test("a half-applied label edit leaves a stub some later run recovers (#1693)", async () => {
+  // The label write is TWO concurrent GraphQL mutations. When the remove lands
+  // and the add does not, the pre-#1693 single edit left a CLOSED stub with
+  // `sentry:archived` shed and `sentry:needs-triage` never applied — a state
+  // `decideDedupAction`'s baseline branch cannot see (it gates on
+  // `sentry:archived`) and the stranded sweep cannot see either (it gates on
+  // `sentry:needs-triage`). Nothing frees it but a human.
+  let halfFailureArmed = true;
+  const fake = makeFakeGitHub({
+    issues: [
+      {
+        ...REGRESSED_STUB,
+        labels: ["sentry-triage", "sentry:verdict-upstream", "sentry:archived"],
+      },
+    ],
+    // One transient half-failure, on the first call that carries a remove; the
+    // recovery run below then meets a healthy GitHub, which is what makes this
+    // a test about the state left behind rather than about a permanent outage.
+    dropAddLabelsOn: (args) => {
+      if (!halfFailureArmed || !args.includes("--remove-label")) return false;
+      halfFailureArmed = false;
+      return true;
+    },
+  });
+
+  let threw = false;
+  try {
+    await reopenQueueIssue({ repo: REPO }, { number: 200 }, REGRESSED_SENTRY, {
+      runGh: fake.runGh,
+    });
+  } catch {
+    threw = true;
+  }
+  assert(threw, "the interrupted label write must surface as a rejection");
+
+  // The invariant: the stub still wears a marker SOME recovery path reads.
+  const stranded = fake.get(200);
+  assert(
+    stranded.labels.includes(NEEDS_TRIAGE_LABEL) ||
+      stranded.labels.includes("sentry:archived"),
+    `no recovery path can see this stub: labels=${JSON.stringify(stranded.labels)}`,
+  );
+
+  // And the next scheduled run actually frees it.
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake),
+  );
+  assertEqual(counts.errors, 0);
+  assertEqual(counts.recovered, 1);
+  assertDeepEqual(fake.selectable(), [200]);
+});
 
 await test("an interrupted regression reopen retries without double-posting the fence", async () => {
   // Crash after the fence lands but before the state change — the widest

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
   buildIssueBody,
   buildMetadataYaml,
@@ -849,6 +853,27 @@ await test("an archived stub's PRE-APPROVAL baseline drives the reopen decision 
   );
   assertEqual(result.reopened, 1);
   assertEqual(reopenCount, 1);
+});
+
+await test("the stub body is rendered once, at creation (#1692)", () => {
+  // `buildIssueBody` is the only thing that renders `last_seen` into a body, and
+  // the reopen baseline's whole worth is that the value it renders is never
+  // refreshed: that is what makes it provably earlier than the human approval a
+  // later archive run acts on. A second call site — a "freshen it on reopen"
+  // edit being the obvious one — would move the baseline later and narrow the
+  // gate this issue exists to widen, so the docstrings on `parseStubMetadata`
+  // and `pickReopenBaseline` name creation specifically. Pin it.
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "sentry-triage-ingest.mjs"),
+    "utf8",
+  );
+  const calls = src.match(/(?<!function\s)\bbuildIssueBody\s*\(/g) ?? [];
+  // Exactly one — the declaration is excluded by the lookbehind.
+  assertEqual(calls.length, 1);
+  assert(
+    /async function createQueueIssue\([\s\S]*?buildIssueBody\(/.test(src),
+    "the single call must sit inside createQueueIssue",
+  );
 });
 
 await test("parseArchiveBaseline reads the yaml fields and tolerates junk", () => {

--- a/scripts/sentry-triage-project-core.mjs
+++ b/scripts/sentry-triage-project-core.mjs
@@ -48,10 +48,9 @@ export const PROJECTED_COMMENT_PREFIX = "Projected to owning repo: ";
 // just text any comment author can write. The freshness baseline (issue #1371)
 // lives in the queue-stub BODY for that reason — no untrusted step holds a tool
 // grant that edits a body. Defined here — the pure contract module — for
-// the same reason as PROJECTED_COMMENT_PREFIX above (emitter and consumer can
-// never drift) and because sentry-triage-archive.mjs already imports from
-// sentry-triage-ingest.mjs, so the consumer importing it from the emitter would
-// be a cycle.
+// the same reason as PROJECTED_COMMENT_PREFIX above: the emitter
+// (sentry-triage-archive.mjs) and any consumer read one definition, so the two
+// cannot drift.
 export const ARCHIVE_COMMENT_MARKER = "<!-- sentry-triage-archive:v1 -->";
 
 // Only ACTIONABLE verdicts project. `needs-human` / `upstream-transient` stay

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -249,6 +249,27 @@ export const REOPEN_SHED_LABELS = [
 export const ARCHIVE_BASELINE_FIELD = "archive_baseline_last_seen";
 export const ARCHIVE_BASELINE_ID_FIELD = "archive_baseline_sentry_issue_id";
 
+// The SECOND baseline, and the one ingest's reopen gate actually compares
+// against (issue #1692). `ARCHIVE_BASELINE_FIELD` above is read from Sentry
+// AFTER the human applied `sentry:approved-archive`, so an event landing between
+// the approval and that read is folded into the value meant to detect it: ingest
+// asks `lastSeen > baseline`, which is false for the event that produced the
+// baseline. The archive's own consumers still need that live read — it is the
+// only thing the post-PUT mutation-window check and the already-archived retry
+// refusals can compare against — so the fix is a second field rather than a
+// different value in the first.
+//
+// This one carries an instant that provably PREDATES the approval: the stub
+// body's own `last_seen`, written by ingest when it created or last reopened the
+// stub. Nothing rewrites it afterwards, so it can be weeks old — which only
+// makes reopens more eager, and that is the intended bias (a spurious reopen
+// costs one triage cycle, a buried regression costs an incident).
+//
+// A stub archived before this field existed carries only the first one, so
+// `reopenBaselineOf` falls back to it and those stubs behave exactly as they did.
+export const ARCHIVE_REOPEN_BASELINE_FIELD =
+  "archive_reopen_baseline_last_seen";
+
 /** Read one scalar out of a stub's yaml block. Keys are fixed literals (no regex
  * injection) written one per line as `key: "value"`. */
 function readBaselineField(block, key) {
@@ -268,6 +289,12 @@ function readBaselineField(block, key) {
  * never been archived. The timestamp comes back RAW; validity is the caller's
  * `Date.parse` gate, so a garbage value degrades to the `closedAt` fallback
  * instead of throwing.
+ *
+ * `reopenLastSeen` is the RAW second field and is `""` when the body does not
+ * carry one. Faithfulness matters here: the archive's rollback reads a baseline
+ * back out and writes it onto the live body, so inventing a value a pre-#1692
+ * stub never had would make the rollback rewrite fields it is meant to restore.
+ * Consumers that want the resolved value ask `reopenBaselineOf`.
  */
 export function parseArchiveBaseline(issueBody) {
   const block = extractYamlBlock(issueBody);
@@ -277,7 +304,20 @@ export function parseArchiveBaseline(issueBody) {
   return {
     lastSeen,
     sentryIssueId: readBaselineField(block, ARCHIVE_BASELINE_ID_FIELD),
+    reopenLastSeen: readBaselineField(block, ARCHIVE_REOPEN_BASELINE_FIELD),
   };
+}
+
+/**
+ * The instant ingest's reopen gate compares a regression's `lastSeen` against:
+ * the pre-approval baseline when the stub carries one, else the archive-time
+ * read (issue #1692). One accessor so no consumer has to remember the fallback,
+ * and so a stub archived before the second field existed keeps its old
+ * behaviour rather than losing its baseline entirely.
+ */
+export function reopenBaselineOf(baseline) {
+  if (!baseline) return null;
+  return baseline.reopenLastSeen || baseline.lastSeen || null;
 }
 
 /**
@@ -294,6 +334,10 @@ export function parseArchiveBaseline(issueBody) {
  * Returns null when the body has no yaml block to extend — the archive treats
  * that as a hard refusal rather than inventing structure, since a stub whose
  * body it cannot parse is one ingest cannot read a baseline back out of either.
+ *
+ * `baseline.reopenLastSeen` renders only when it is set, which is what keeps
+ * this an exact inverse of `parseArchiveBaseline`: feeding a parsed pre-#1692
+ * baseline straight back writes the same two fields it came from.
  */
 export function withArchiveBaseline(body, baseline) {
   const source = String(body ?? "");
@@ -304,14 +348,20 @@ export function withArchiveBaseline(body, baseline) {
     .filter(
       (line) =>
         !new RegExp(
-          `^(${ARCHIVE_BASELINE_FIELD}|${ARCHIVE_BASELINE_ID_FIELD}):`,
+          `^(${ARCHIVE_BASELINE_FIELD}|${ARCHIVE_REOPEN_BASELINE_FIELD}|${ARCHIVE_BASELINE_ID_FIELD}):`,
         ).test(line.trim()),
     )
     .join("\n");
+  const reopenLastSeen = String(baseline?.reopenLastSeen ?? "");
   const rebuilt = baseline
     ? [
         stripped,
         `${ARCHIVE_BASELINE_FIELD}: ${JSON.stringify(String(baseline.lastSeen ?? ""))}`,
+        ...(reopenLastSeen
+          ? [
+              `${ARCHIVE_REOPEN_BASELINE_FIELD}: ${JSON.stringify(reopenLastSeen)}`,
+            ]
+          : []),
         `${ARCHIVE_BASELINE_ID_FIELD}: ${JSON.stringify(String(baseline.sentryIssueId ?? ""))}`,
       ].join("\n")
     : stripped;

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -260,10 +260,14 @@ export const ARCHIVE_BASELINE_ID_FIELD = "archive_baseline_sentry_issue_id";
 // different value in the first.
 //
 // This one carries an instant that provably PREDATES the approval: the stub
-// body's own `last_seen`, written by ingest when it created or last reopened the
-// stub. Nothing rewrites it afterwards, so it can be weeks old — which only
-// makes reopens more eager, and that is the intended bias (a spurious reopen
-// costs one triage cycle, a buried regression costs an incident).
+// body's own `last_seen`, written by ingest when it CREATED the stub and never
+// rewritten — a reopen edits labels, comments and state, never the body, which
+// is the same property that keeps the archive leg the only stub-body writer
+// (see the trust-boundary note above). So on a stub that has regressed and
+// reopened since, this is still the creation instant and can be as old as the
+// stub itself — which only makes reopens more eager, and that is the intended
+// bias (a spurious reopen costs one triage cycle, a buried regression costs an
+// incident).
 //
 // A stub archived before this field existed carries only the first one, so
 // `reopenBaselineOf` falls back to it and those stubs behave exactly as they did.

--- a/scripts/sentry-triage-requeue.mjs
+++ b/scripts/sentry-triage-requeue.mjs
@@ -35,7 +35,11 @@
  *     line; it can never author the fence line itself.
  *  3. Post the fence BEFORE mutating labels; change state LAST. An interrupted run
  *     must leave a fenced-but-unqueued stub (inert, retried), never a
- *     queued-but-unfenced one (the close-over-a-live-regression setup).
+ *     queued-but-unfenced one (the close-over-a-live-regression setup). Inside
+ *     the label step the same rule again: ADD `sentry:needs-triage` in its own
+ *     call before SHEDDING the previous round's markers, because one `gh issue
+ *     edit` carrying both flags is two concurrent mutations and the losable half
+ *     is the one every recovery path reads (`buildRequeueAddLabelArgs`).
  *  4. The exclusion set records ATTEMPTS, not successes: `claim` fires before any
  *     I/O, so a re-queue that throws half-way is never inherited by the
  *     fence-free bookkeeping sweep inside the same run.
@@ -196,12 +200,38 @@ export function isSelectableForTriage({ state, labels } = {}) {
 }
 
 /**
- * The label edit every re-queue makes: restore `sentry:needs-triage` and shed
- * every marker describing the previous round (REOPEN_SHED_LABELS). Removing an
- * absent label is a no-op for `gh issue edit` (the labels themselves always
- * exist because the ingest label bootstrap runs first). Exported for tests.
+ * The label edit every re-queue makes, as TWO ordered calls: restore
+ * `sentry:needs-triage` first, then shed every marker describing the previous
+ * round (REOPEN_SHED_LABELS). Removing an absent label is a no-op for
+ * `gh issue edit` (the labels themselves always exist because the ingest label
+ * bootstrap runs first). Exported for tests.
+ *
+ * ONE `gh issue edit --add-label … --remove-label …` is NOT one write (issue
+ * #1693). The CLI fires `addLabels` and `removeLabels` as discrete, concurrent
+ * GraphQL mutations (cli/cli, `pkg/cmd/pr/shared/editable_http.go`: "Labels are
+ * updated through discrete mutations"), so a partial failure can land the remove
+ * without the add. On the regression-reopen path that produced a CLOSED stub
+ * with `sentry:archived` shed and `sentry:needs-triage` never applied — a state
+ * NEITHER recovery path can see. `decideDedupAction` gates its baseline branch
+ * on `sentry:archived`, so it falls back to `closedAt`, which postdates the very
+ * regression the baseline exists to catch; the stranded sweep gates on
+ * `sentry:needs-triage`, which is absent. The run goes red once and the stub
+ * never self-heals after that.
+ *
+ * Ordering the two calls removes the state rather than narrowing it. Add first
+ * and every interruption lands on a pairing something still sees: nothing
+ * written yet (the markers survive, ingest keeps its baseline branch, next run
+ * retries), or `sentry:needs-triage` written and the shed not (the stranded
+ * pairing, which the sweep reopens — and on a fencing cause the fence is already
+ * on the stub, because the fence goes first). The reverse order is what today's
+ * single call can degrade to, so the cost is one API call per re-queue.
+ *
+ * It does briefly leave `sentry:needs-triage` beside a stale verdict marker.
+ * That window is not new — the concurrent mutations can already produce it — and
+ * the state change goes last, so the stub is still CLOSED and invisible to Stage
+ * B's `--state open` selector for the whole of it on the ingest path.
  */
-export function buildReopenLabelEditArgs(issueNumber, repo) {
+export function buildRequeueAddLabelArgs(issueNumber, repo) {
   return [
     "issue",
     "edit",
@@ -210,6 +240,16 @@ export function buildReopenLabelEditArgs(issueNumber, repo) {
     repo,
     "--add-label",
     NEEDS_TRIAGE_LABEL,
+  ];
+}
+
+export function buildRequeueShedLabelArgs(issueNumber, repo) {
+  return [
+    "issue",
+    "edit",
+    String(issueNumber),
+    "-R",
+    repo,
     "--remove-label",
     REOPEN_SHED_LABELS.join(","),
   ];
@@ -513,10 +553,15 @@ export async function requeueQueueStub(
     }
   }
 
-  // Labels: restore `sentry:needs-triage`, shed the previous round's markers.
+  // Labels: restore `sentry:needs-triage`, THEN shed the previous round's
+  // markers — two ordered calls, never one edit carrying both flags. See
+  // `buildRequeueAddLabelArgs`: the single edit is two concurrent GraphQL
+  // mutations, and the half that can be lost is the one both recovery paths
+  // depend on (issue #1693).
   let labelError = null;
   try {
-    await writeGh(buildReopenLabelEditArgs(issueNumber, repo));
+    await writeGh(buildRequeueAddLabelArgs(issueNumber, repo));
+    await writeGh(buildRequeueShedLabelArgs(issueNumber, repo));
   } catch (err) {
     if (!verifyEndState) throw err;
     // Must NOT propagate past the end-state verification below — that is exactly

--- a/scripts/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry-triage-requeue.test.mjs
@@ -654,6 +654,76 @@ await test("verify-end-state fails RED on a marker the shed left behind", async 
   );
 });
 
+// ---------------------------------------------------------------------------
+// The stub BODY is nobody's to rewrite here.
+// ---------------------------------------------------------------------------
+
+await test("no re-queue path rewrites the stub body (#1692)", async () => {
+  // The reopen baseline `pickReopenBaseline` hands ingest is the stub body's
+  // `last_seen`, and its whole worth is that ingest wrote it ONCE, at creation:
+  // that is what makes it provably earlier than the human approval. A body write
+  // on this path would break two things at once. It would move the baseline
+  // later, narrowing the gate #1692 exists to widen; and because
+  // `gh issue edit --body` replaces the WHOLE body, it would put a second writer
+  // beside the archive leg — the only one the trust boundary in
+  // sentry-triage-queue-contract.mjs allows — racing it over the
+  // `archive_*_last_seen` fields ingest reads back.
+  //
+  // Bodies are still written here, as COMMENTS. The distinction is the property.
+  let reads = 0;
+  const cases = [
+    [
+      {},
+      {
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+      },
+    ],
+    [
+      {},
+      {
+        cause: REQUEUE_CAUSE_BOOKKEEPING,
+        note: buildStrandedRecoveryComment(),
+      },
+    ],
+    [
+      {
+        // Closed and unlabelled on the first read, so the verifier's own repair
+        // writes run too; selectable on the next, so it settles.
+        readStub: async () => {
+          reads += 1;
+          return reads === 1
+            ? { state: "CLOSED", labels: ["sentry-triage"], comments: [] }
+            : {
+                state: "OPEN",
+                labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+                comments: [fenceAt("2026-07-22T10:00:00Z")],
+              };
+        },
+      },
+      {
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+        onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
+      },
+    ],
+  ];
+  for (const [deps, options] of cases) {
+    const w = makeWriter();
+    await requeueQueueStub(
+      { writeGh: w.writeGh, ...deps },
+      { repo: REPO, issueNumber: 42, ...options },
+    );
+    assert(w.calls.length > 0, "the case must actually write something");
+    for (const args of w.calls) {
+      assert(
+        !args.includes("--body") || args[1] === "comment",
+        `a re-queue wrote a body outside a comment: ${args.join(" ")}`,
+      );
+    }
+  }
+});
+
 if (failed > 0) {
   process.stderr.write(`${failed} failed, ${passed} passed\n`);
   process.exitCode = 1;

--- a/scripts/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry-triage-requeue.test.mjs
@@ -25,7 +25,8 @@ import {
 import { NEEDS_TRIAGE_LABEL } from "./sentry-triage-queue-contract.mjs";
 import {
   buildRegressedComment,
-  buildReopenLabelEditArgs,
+  buildRequeueAddLabelArgs,
+  buildRequeueShedLabelArgs,
   buildRequeueFence,
   buildStrandedRecoveryComment,
   hasAdmissibleVerdict,
@@ -219,12 +220,13 @@ await test("a Sentry-evidence re-queue posts the fence before it touches labels"
       lastSeen: "2026-07-20T08:00:00Z",
     },
   );
-  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+  assertDeepEqual(w.verbs(), ["comment", "edit", "edit", "reopen"]);
   assertEqual(
     w.calls[0][w.calls[0].indexOf("--body") + 1],
     buildRegressedComment("2026-07-20T08:00:00Z"),
   );
-  assertDeepEqual(w.calls[1], buildReopenLabelEditArgs(42, REPO));
+  assertDeepEqual(w.calls[1], buildRequeueAddLabelArgs(42, REPO));
+  assertDeepEqual(w.calls[2], buildRequeueShedLabelArgs(42, REPO));
 });
 
 await test("a bookkeeping re-queue writes labels, its note, then the state", async () => {
@@ -238,9 +240,9 @@ await test("a bookkeeping re-queue writes labels, its note, then the state", asy
       note: buildStrandedRecoveryComment(),
     },
   );
-  assertDeepEqual(w.verbs(), ["edit", "comment", "reopen"]);
+  assertDeepEqual(w.verbs(), ["edit", "edit", "comment", "reopen"]);
   assertEqual(
-    w.calls[1][w.calls[1].indexOf("--body") + 1],
+    w.calls[2][w.calls[2].indexOf("--body") + 1],
     buildStrandedRecoveryComment(),
   );
 });
@@ -263,6 +265,61 @@ await test("an interrupted fence post never leaves the stub queued", async () =>
     ),
   );
   assertDeepEqual(w.verbs(), ["comment"]);
+});
+
+await test("no re-queue write mixes --add-label with --remove-label (#1693)", async () => {
+  // `gh issue edit --add-label X --remove-label Y` is TWO concurrent GraphQL
+  // mutations, not one write. The half that can be lost is the add, and losing
+  // it on the regression path leaves a CLOSED stub with `sentry:archived` shed
+  // and `sentry:needs-triage` never applied — invisible to `decideDedupAction`'s
+  // baseline branch AND to the stranded sweep. Ordering the two flags into two
+  // calls is what removes that state, so no single call may carry both again.
+  for (const [cause, extra] of [
+    [REQUEUE_CAUSE_SENTRY_EVIDENCE, { lastSeen: "2026-07-20T08:00:00Z" }],
+    [REQUEUE_CAUSE_BOOKKEEPING, { note: buildStrandedRecoveryComment() }],
+  ]) {
+    const w = makeWriter();
+    await requeueQueueStub(
+      { writeGh: w.writeGh },
+      { repo: REPO, issueNumber: 42, cause, ...extra },
+    );
+    for (const args of w.calls) {
+      assert(
+        !(args.includes("--add-label") && args.includes("--remove-label")),
+        `one call carried both label flags: ${args.join(" ")}`,
+      );
+    }
+    // And in the order that makes every interruption sweep-visible.
+    const labelEdits = w.calls.filter((args) => args[1] === "edit");
+    assertDeepEqual(labelEdits, [
+      buildRequeueAddLabelArgs(42, REPO),
+      buildRequeueShedLabelArgs(42, REPO),
+    ]);
+  }
+});
+
+await test("a failed needs-triage add never proceeds to the shed (#1693)", async () => {
+  // Abort ordering, stated as the property that matters: the stub keeps the
+  // markers ingest's baseline branch reads, because the shed never ran.
+  const w = makeWriter({
+    failOn: (args) =>
+      args.includes("--add-label") ? "gh issue edit: 500" : null,
+  });
+  await assertRejects(
+    requeueQueueStub(
+      { writeGh: w.writeGh },
+      {
+        repo: REPO,
+        issueNumber: 42,
+        cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
+        lastSeen: "2026-07-20T08:00:00Z",
+      },
+    ),
+  );
+  assert(
+    !w.calls.some((args) => args.includes("--remove-label")),
+    "the shed must not run once the add has failed",
+  );
 });
 
 await test("the state change is the last write on both causes", async () => {
@@ -417,7 +474,7 @@ await test("the dedup read is author-fenced", async () => {
       dedupeFence: true,
     },
   );
-  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+  assertDeepEqual(w.verbs(), ["comment", "edit", "edit", "reopen"]);
 });
 
 await test("the bot's own identical fence is deduped", async () => {
@@ -436,7 +493,7 @@ await test("the bot's own identical fence is deduped", async () => {
       dedupeFence: true,
     },
   );
-  assertDeepEqual(w.verbs(), ["edit", "reopen"]);
+  assertDeepEqual(w.verbs(), ["edit", "edit", "reopen"]);
 });
 
 await test("a fence that identifies no occurrence is never deduped", async () => {
@@ -459,7 +516,7 @@ await test("a fence that identifies no occurrence is never deduped", async () =>
         dedupeFence: true,
       },
     );
-    assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+    assertDeepEqual(w.verbs(), ["comment", "edit", "edit", "reopen"]);
   }
 });
 
@@ -478,7 +535,7 @@ await test("dedup is opt-in: a site that does not declare it always posts", asyn
       lastSeen: "2026-07-20T08:00:00Z",
     },
   );
-  assertDeepEqual(w.verbs(), ["comment", "edit", "reopen"]);
+  assertDeepEqual(w.verbs(), ["comment", "edit", "edit", "reopen"]);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The Problem

- The archive's freshness baseline is read from Sentry **after** the human
  applied `sentry:approved-archive`, so an event landing in that window is
  folded into the value meant to detect it — ingest asks `lastSeen > baseline`
  and gets `false` for that exact event, permanently (#1692).
- The re-queue chokepoint restored `sentry:needs-triage` and shed the previous
  round's markers in **one** `gh issue edit`. `gh` sends `--add-label` and
  `--remove-label` as discrete concurrent GraphQL mutations, so a lost add half
  left a closed stub with `sentry:archived` shed and `sentry:needs-triage` never
  applied — a state neither recovery path can see (#1693).
- Two comments still described the pre-#1722 module layout, recorded on #1694's
  close comment.

## The Solution

**#1692 — a second baseline, not a different value in the first.** The live
pre-PUT read has two jobs the earlier value cannot do: the post-PUT
mutation-window comparison, and the evidence behind the `skipped-stale-retry` /
`skipped-unbaselined-retry` refusals. Repointing those at an earlier instant
would refuse every legitimate dispatch retry as stale. So the live read stays
exactly where it is, and the stub body gains a second field,
`archive_reopen_baseline_last_seen`, which is what ingest's reopen gate reads.

Its value is the stub body's own `last_seen` — written by ingest when it
**created** the stub and never rewritten since, because a reopen edits a stub's
labels, comments and state and never its body — so it predates the approval by
construction. On a stub that has flapped it is still the creation instant, so it
can be as old as the stub itself; that only makes reopens more eager, which is
the bias the issue argues for.

**#1693 — split the label write, add before shed.** Every interruption then
lands on a pairing something still reads: nothing written yet (markers survive,
`decideDedupAction` keeps its baseline branch, next run retries), or
`sentry:needs-triage` written and the shed not (the stranded pairing the sweep
reopens — and on a fencing cause the fence is already on the stub). All
re-queuing still runs through `requeueQueueStub`; the change is inside the
chokepoint.

## Details

- `scripts/sentry-triage-queue-contract.mjs` — new
  `ARCHIVE_REOPEN_BASELINE_FIELD` and `reopenBaselineOf`. `parseArchiveBaseline`
  returns the raw second field (`""` when absent) rather than resolving the
  fallback itself, so the archive's rollback stays an exact inverse of the
  write and cannot invent a field a pre-#1692 stub never had.
- `scripts/sentry-triage-archive.mjs` — `parseStubMetadata` now reads
  `last_seen`; `pickReopenBaseline` takes the earlier of it and the live read,
  falling back to the live read when the stub's value does not parse (a stale
  body field must not become a second way to make a human approval
  unspendable). `settlementHeld` and the reconciler's `baselineOf` verify both
  fields; the audit note names both.
- `scripts/sentry-triage-ingest.mjs` — `decideDedupAction` is fed
  `reopenBaselineOf(baseline)`. Stubs archived before the second field existed
  fall back to the old value and behave exactly as before.
- `scripts/sentry-triage-requeue.mjs` — `buildReopenLabelEditArgs` becomes
  `buildRequeueAddLabelArgs` + `buildRequeueShedLabelArgs`, called in that
  order; invariant 3 in the module header now states the sub-ordering.
- Comment fixes only: `sentry-triage-project-core.mjs` no longer justifies
  `ARCHIVE_COMMENT_MARKER`'s placement with an import cycle the current graph
  falsifies, and `sentry-triage-archive.mjs` points at `queue-contract` for
  `withArchiveBaseline`. The pointers at `archive.mjs:148` and `:384` are
  accurate and untouched.
- `docs/notes/sentry-triage-pipeline.md` — the two baselines, which consumer
  reads which, the fallback for older stubs, and the corrected label write
  order.

## Validation

Every fix has a test that fails without it, verified by reverting each change
in turn:

- Add a body write to `requeueQueueStub` →
  `no re-queue path rewrites the stub body (#1692)` fails
  (`a re-queue wrote a body outside a comment: issue edit …`), and a second
  `buildIssueBody` call in `reopenQueueIssue` →
  `the stub body is rendered once, at creation (#1692)` fails
  (`expected 1, got 2`). These two pin the property the reopen baseline rests
  on: the value is written once, at creation, and nothing refreshes it.
- Revert `pickReopenBaseline` to the live read →
  `the recorded reopen baseline predates the approval, not the archive read`
  fails (`expected "2026-07-14T10:00:00Z", got "2026-07-19T11:59:00.000Z"`).
- Revert ingest's wiring to `baseline?.lastSeen` →
  `an archived stub's PRE-APPROVAL baseline drives the reopen decision (#1692)`
  fails (`expected 1, got 0`).
- Restore the single combined label edit →
  `a half-applied label edit leaves a stub some later run recovers (#1693)`
  fails (`expected 0, got 1` errors, no recovery). The fake models the real
  failure shape: the removes land, the adds do not, and the CLI reports failure.

Suites: `pnpm sentry:archive:test` 117 passed, `pnpm sentry:ingest:test` 107
passed, `pnpm sentry:requeue:test` 27 passed, `pnpm sentry:project:test` 99
passed, `node scripts/sentry-triage-agent-comment.test.mjs` 36 passed.

`pnpm agent:quality-gate --run --parallel 4`: all 11 mapped commands passed
(trunk check, `docs:index --check`, `agent:context-check`, `lint:scripts`, the
four Sentry suites, `tf:test`, `docs:navigation-eval --check-fixtures`).
`./tools/trunk fmt` run on every touched file before the commit.

`pnpm agent:autoreview --engine local` — clean, no findings. The codex CLI is
not on PATH in this environment and `--engine claude` refuses here, so the
local deterministic pass was followed by a line-by-line self-audit of the full
diff; **the independent-model review for this PR comes from the PR's external
Codex reviewer.**

## Deferrals

- #1765 — an escalated archived issue matches neither ingest fetch query, so
  the reopen gate this PR fixes is unreachable for it. Sentry sets substatus
  `escalating` (not `regressed`) when an `archived_until_escalating` issue
  escalates, and `is:regressed` / `is:escalating` are distinct filters; the
  repo already models them as distinct in `isActivelyRegressing`. Nothing is
  buried today — the archive path first ran for real on 2026-08-10 and no
  archived issue has escalated yet. Out of scope here: this PR changes which
  instant the gate compares against, #1765 changes whether the gate runs.

## Notes

Branched from `origin/main` at cddc558d. No overlap with #1754 or #1764 — this
touches no workflow file, and the only shared doc section with #1764
(`docs/notes/sentry-triage-pipeline.md`) is a different part of the file, so a
rebase should be mechanical if #1764 lands first.

Closes #1692
Closes #1693

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core ingest/archive dedup and re-queue recovery invariants; mistakes could miss regressions or strand queue stubs, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes two Sentry triage queue races where regressions could stay buried or stubs could become unrecoverable.
> 
> **#1692 — ingest reopen gate vs archive-time read.** Archive still records the live Sentry `lastSeen` for mutation-window checks and already-archived retry refusals, but ingest’s archived-stub reopen logic now compares against **`archive_reopen_baseline_last_seen`**, derived via `pickReopenBaseline` from the stub body’s ingest-written `last_seen` (capped by the live read). That instant predates human approval, so events between approval and the archive run can still trigger reopen. Legacy stubs without the second field keep prior behavior through `reopenBaselineOf`. Settlement and rollback verify both baseline fields; audit comments name both.
> 
> **#1693 — re-queue label writes.** `requeueQueueStub` no longer passes `--add-label` and `--remove-label` on one `gh issue edit`; it calls **`buildRequeueAddLabelArgs` then `buildRequeueShedLabelArgs`** so a partial GraphQL failure cannot shed `sentry:archived` without restoring `sentry:needs-triage`. Docs and tests cover the ordering and recovery paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1668a86d2b2c2deb917e4c4cbb82958d638ccf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
