### PR TITLE
docs(alerts): the dead-man switch's real latency is 5h, not 3h

### DIFF
--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -310,11 +310,11 @@ two conditions separately: step 2 covers the threshold, step 3 covers absence.
    a value. The threshold cannot cover a watcher that stops publishing, so
    this is the only step that proves the switch survives its own death.
 
-   Pause the scheduler and leave it paused **more than 5h** — not the 3h the
-   `duration` field reads. The absence condition carries the same 7200s
-   `ALIGN_MAX` aggregation as the threshold, and an aligned point keeps
-   existing while a trailing 2h window still contains the last raw publish. So
-   the 3h absence timer cannot start until 2h after the final point:
+   Pause the scheduler and leave it paused **more than 5h**. The absence
+   condition carries the same 7200s `ALIGN_MAX` aggregation as the threshold,
+   and an aligned point keeps existing while a trailing 2h window still
+   contains the last raw publish. So the 3h `duration` timer cannot start until
+   2h after the final point:
 
    ```text
    last publish + 7200s (alignment empties) + 10800s (duration) = fire

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -230,6 +230,12 @@ cloud-routine experiment ran for weeks producing nothing and nobody noticed.
   condition owns _nothing is reporting at all_: no point for 3h. The absence
   half is the dead-man switch — a watcher that can fail quietly reproduces the
   incident it exists to prevent
+- **Real absence latency is 5h, not the 3h `duration` reads.** Both conditions
+  aggregate over a 7200s `ALIGN_MAX` window, and an aligned point persists
+  while that trailing window still holds the last raw publish, so the absence
+  timer starts 2h late. Worst case from pipeline death to notification is ~6h:
+  up to 1h for the hourly publish that never happens, then 5h. Proven
+  2026-08-10 — last publish 12:00:02Z, alert 17:02:12Z
 - The threshold deliberately does not set `evaluation_missing_data`. Freshness
   is an absolute age rather than a delta, so a gap loses no information: the
   first point after any gap carries the true age and crosses 26h on its own if
@@ -297,17 +303,39 @@ two conditions separately: step 2 covers the threshold, step 3 covers absence.
    a value. The threshold cannot cover a watcher that stops publishing, so
    this is the only step that proves the switch survives its own death.
 
-   Pause the scheduler, leave it paused past the condition's 3h duration, and
-   confirm the `#alerts-infra` message arrives. **Resume it afterwards** — a
-   paused watcher is a disarmed switch:
+   Pause the scheduler and leave it paused **more than 5h** — not the 3h the
+   `duration` field reads. The absence condition carries the same 7200s
+   `ALIGN_MAX` aggregation as the threshold, and an aligned point keeps
+   existing while a trailing 2h window still contains the last raw publish. So
+   the 3h absence timer cannot start until 2h after the final point:
+
+   ```text
+   last publish + 7200s (alignment empties) + 10800s (duration) = fire
+   ```
+
+   Measured on 2026-08-10: last publish 12:00:02Z, alert opened **17:02:12Z** —
+   the derivation plus propagation. **At the 3h mark the alert has provably not
+   fired, and reading `duration = "10800s"` as the wait is what makes an
+   operator conclude the switch is broken.** It cost an investigation to unwind
+   once already.
+
+   **Resume it afterwards** — a paused watcher is a disarmed switch:
 
    ```bash
    gcloud scheduler jobs pause sentry-ingest-freshness-check \
      --location europe-west1 --project "$PROJECT_ID"
-   # wait > 3h, confirm the alert fires, then:
+   # wait > 5h (2h alignment + 3h duration), confirm the alert fires, then:
    gcloud scheduler jobs resume sentry-ingest-freshness-check \
      --location europe-west1 --project "$PROJECT_ID"
+   # verify it took: state must read ENABLED
+   gcloud scheduler jobs describe sentry-ingest-freshness-check \
+     --location europe-west1 --project "$PROJECT_ID" --format='value(state)'
    ```
+
+   The absence message is distinguishable from the threshold's and worth
+   checking rather than assuming: it says _"has not been seen for over 180
+   minutes"_ and carries **no value**, because there is no data point to
+   report. A message quoting a value is the threshold condition, not this one.
 
 Do not sign this off on a passing plan alone — an untested dead-man switch is
 the failure mode being guarded against.

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -233,9 +233,16 @@ cloud-routine experiment ran for weeks producing nothing and nobody noticed.
 - **Real absence latency is 5h, not the 3h `duration` reads.** Both conditions
   aggregate over a 7200s `ALIGN_MAX` window, and an aligned point persists
   while that trailing window still holds the last raw publish, so the absence
-  timer starts 2h late. Worst case from pipeline death to notification is ~6h:
-  up to 1h for the hourly publish that never happens, then 5h. Proven
-  2026-08-10 — last publish 12:00:02Z, alert 17:02:12Z
+  timer starts 2h late. Proven 2026-08-10 — last publish 12:00:02Z, alert
+  17:02:12Z
+- That 5h is measured **from the last published point**, not from the moment
+  the watcher stops, and the two differ by up to the publish interval. A
+  watcher dying just after a publish is caught ~5h later; one dying just
+  before the next is caught ~4h later. The missed run is already inside the
+  window, so it is not added on top
+- It is **watcher-silence** latency, not pipeline-death latency. Ingest dying
+  while the watcher keeps reporting is the threshold condition's job, and that
+  one fires at 26h
 - The threshold deliberately does not set `evaluation_missing_data`. Freshness
   is an absolute age rather than a delta, so a gap loses no information: the
   first point after any gap carries the true age and crosses 26h on its own if

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -233,8 +233,7 @@ cloud-routine experiment ran for weeks producing nothing and nobody noticed.
 - **Real absence latency is 5h, not the 3h `duration` reads.** Both conditions
   aggregate over a 7200s `ALIGN_MAX` window, and an aligned point persists
   while that trailing window still holds the last raw publish, so the absence
-  timer starts 2h late. Proven 2026-08-10 — last publish 12:00:02Z, alert
-  17:02:12Z
+  timer starts 2h late
 - That 5h is measured **from the last published point**, not from the moment
   the watcher stops, and the two differ by up to the publish interval. A
   watcher dying just after a publish is caught ~5h later; one dying just
@@ -320,11 +319,10 @@ two conditions separately: step 2 covers the threshold, step 3 covers absence.
    last publish + 7200s (alignment empties) + 10800s (duration) = fire
    ```
 
-   Measured on 2026-08-10: last publish 12:00:02Z, alert opened **17:02:12Z** —
-   the derivation plus propagation. **At the 3h mark the alert has provably not
-   fired, and reading `duration = "10800s"` as the wait is what makes an
-   operator conclude the switch is broken.** It cost an investigation to unwind
-   once already.
+   Expect the alert about 5h after the last publish, plus a couple of minutes
+   of propagation. **At the 3h mark it has not fired yet, and reading
+   `duration = "10800s"` as the wait is what makes an operator conclude the
+   switch is broken.**
 
    **Resume it afterwards** — a paused watcher is a disarmed switch:
 

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -405,6 +405,14 @@ resource "google_monitoring_alert_policy" "sentry_ingest_staleness_policy" {
         metric.type   = "${local.sentry_ingest_freshness_metric_type}"
       EOF
 
+      # Reads as 3h; the real latency is 5h. The aggregation below means an
+      # aligned point persists while its trailing 7200s window still contains
+      # the last raw publish, so this timer only starts 2h after the watcher
+      # goes quiet. Measured 2026-08-10: last publish 12:00:02Z, alert
+      # 17:02:12Z. Do not "fix" a slow-looking absence alert by shortening
+      # this — see alerts/infra/README.md § "After apply: prove the switch
+      # fires" step 3, and drop the aggregations block instead if 3h is
+      # actually required.
       duration = "10800s"
 
       aggregations {

--- a/alerts/infra/monitoring.tf
+++ b/alerts/infra/monitoring.tf
@@ -408,8 +408,7 @@ resource "google_monitoring_alert_policy" "sentry_ingest_staleness_policy" {
       # Reads as 3h; the real latency is 5h. The aggregation below means an
       # aligned point persists while its trailing 7200s window still contains
       # the last raw publish, so this timer only starts 2h after the watcher
-      # goes quiet. Measured 2026-08-10: last publish 12:00:02Z, alert
-      # 17:02:12Z. Do not "fix" a slow-looking absence alert by shortening
+      # goes quiet. Do not "fix" a slow-looking absence alert by shortening
       # this — see alerts/infra/README.md § "After apply: prove the switch
       # fires" step 3, and drop the aggregations block instead if 3h is
       # actually required.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `alerts/infra/README.md` told operators to pause the watcher and **"wait > 3h"** to prove the dead-man switch fires. At 3h the alert provably has not fired.
- Anyone following that procedure concludes the switch is broken. That happened during today's proof run on #1759: the absence alert was declared missing at the 4h mark and an investigation was opened before it arrived on schedule.
- The `duration = "10800s"` field in `monitoring.tf` reads as 3h too, so the Terraform reinforces the same wrong expectation.

## The Solution

Record the real latency — **5h** — with the arithmetic and the measured proof.

The absence condition carries the same `7200s` / `ALIGN_MAX` aggregation as the threshold. An aligned point exists while a trailing 2h window still contains the last raw publish, so the 3h absence timer cannot start until 2h after the watcher goes quiet.

```text
last publish + 7200s (alignment empties) + 10800s (duration) = fire
```

## Details

**Measured today, end to end** (#1759 step 3):

| | |
|---|---|
| last publish | `12:00:02Z` (watcher Cloud Run logs) |
| predicted | `17:00:02Z` |
| **observed** | **`17:02:12Z`** — within the documented propagation delay |

That confirms the *mechanism*, not just the outcome. **No Google doc states that the alignment period adds to the absence duration** — it follows from the documented aligner semantics ("the aligned point is the maximum value of all points in the most recent N minutes") and is corroborated by the threshold half's measured 7200s window in this same project: the spike injected at 11:38Z stopped influencing `ALIGN_MAX` at exactly 13:38Z.

The 5h is measured **from the last published point**, not from the moment the watcher stops. The absence policy anchors there, so the hourly publish that never happens is already inside the window rather than added to it: a watcher dying just after a publish is caught ~5h later, one dying just before the next ~4h later. Never 6h. This is **watcher-silence** latency — ingest dying while the watcher keeps reporting is the threshold half's job, and that fires at 26h.

The dated measurement lives here and on #1759, not in the runbook. `docs/context-standards.md` reserves dated proof for the change that shipped it, and the derivation is the part that keeps earning its place: it stays true for as long as the aggregation block does, while a timestamp only records one afternoon.

**Also added:**

- The two alert messages are distinguishable and the README now says how. Absence reads *"has not been seen for over 180 minutes"* and carries **no value**, because there is no data point to report. A message quoting a value is the threshold condition. Confusing them would make step 3 look passed when only step 2 had run.
- A resume-verification command. `state` must read `ENABLED` — the pause/resume pair is the easiest thing to half-finish after a five-hour wait, and a paused watcher is a disarmed switch.
- A comment at `duration = "10800s"` in `monitoring.tf`, because that field is what a future reader skims. It warns against "fixing" a slow-looking absence alert by shortening the duration, and points at the aggregations block as the actual lever.

**Not changed:** the alert's behaviour. This is comments and documentation only — `terraform fmt` clean, and the plan is a no-op.

**Deliberately not done:** dropping `aggregations` from `condition_absent`, which *would* bring absence detection to the advertised 3h and does not touch the threshold condition. That is a real option, but it is a behaviour change to a just-proven alarm and belongs in its own decision rather than riding a documentation fix. Worth weighing against the fact that the watcher publishes hourly, so 3h still requires three consecutive missed runs.

## Validation

- All three proof steps passed today and are recorded with evidence on #1759
- `terraform fmt` check clean · `trunk fmt`/`check` clean
- Scheduler verified back to `ENABLED` after the test, next run `18:00:00Z`

## Deferrals

- None

Refs #1759, #1281

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and runbook text only; monitoring alert configuration and behavior are unchanged.
> 
> **Overview**
> Operators were told to pause the watcher **>3h** to prove the dead-man switch, but **`duration = "10800s"` plus the shared 7200s `ALIGN_MAX` aggregation** means absence detection really takes **~5h** (2h alignment tail + 3h timer). The runbook now states that latency, the formula `last publish + 7200s + 10800s`, and the **2026-08-10** measurement (12:00:02Z → 17:02:12Z), plus **~6h** worst case when an hourly publish never happens.
> 
> **Proof step 3** now says wait **>5h**, explains why 3h is a false “broken switch,” and adds how to tell **absence** Slack text (no value, “180 minutes”) from the **threshold** alert. It also adds a **`gcloud scheduler jobs describe`** check that state is **ENABLED** after resume.
> 
> A **`monitoring.tf` comment** at the absence `duration` warns against shortening it without reading the README and points at dropping **`aggregations`** if true 3h detection is required later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c85a8725ee7a679c933870716b4b30a2fefbd6c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
