### PR TITLE
fix(deploy): preserve live revision during direct bootstrap

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,15 +194,15 @@ remaining phase-two rollout under
    dedicated builder while the default-Compute source reader remains live.
 2. From the resulting clean `main`, run and verify the direct
    `pnpm bridge:deploy` canary. Its Terraform bootstrap reconciles the applied
-   builder and direct-deployer IAM, then verifies whether Metrics Bridge already
-   exists. It preserves an existing live revision and creates the service only
-   from a guarded no-refresh plan after both live and state checks confirm its
-   absence. If an interrupted first bootstrap left the public binding out of
-   Terraform state, a separate guarded no-refresh plan may create only that
-   binding. The deploy then verifies the live service and public binding;
-   tracked IAM drift or other service-shape drift requires a reviewed full
-   platform plan/apply. The temporary default-Compute reader remains unchanged
-   in this routing phase.
+   builder, direct-deployer IAM, and Peg-policy bucket IAM dependency, then
+   verifies whether Metrics Bridge already exists. It preserves an existing
+   live revision and creates the service only from a guarded no-refresh plan
+   after both live and state checks confirm its absence. If an interrupted
+   first bootstrap left the public binding out of Terraform state, a separate
+   guarded no-refresh plan may create only that binding. The deploy then
+   verifies the live service and public binding; tracked IAM drift or other
+   service-shape drift requires a reviewed full platform plan/apply. The
+   temporary default-Compute reader remains unchanged in this routing phase.
 3. In a separate reviewed cleanup PR, remove that reader. Refresh current
    `main`, inspect a clean platform plan, obtain explicit apply approval, and
    apply it.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,8 +194,10 @@ remaining phase-two rollout under
    dedicated builder while the default-Compute source reader remains live.
 2. From the resulting clean `main`, run and verify the direct
    `pnpm bridge:deploy` canary. Its Terraform bootstrap reconciles the applied
-   builder and direct-deployer IAM, while leaving the temporary default-Compute
-   reader unchanged in this routing phase.
+   builder and direct-deployer IAM, then verifies whether Metrics Bridge already
+   exists. It preserves an existing live revision; only a confirmed first
+   bootstrap creates the service and public binding. The temporary
+   default-Compute reader remains unchanged in this routing phase.
 3. In a separate reviewed cleanup PR, remove that reader. Refresh current
    `main`, inspect a clean platform plan, obtain explicit apply approval, and
    apply it.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -195,9 +195,14 @@ remaining phase-two rollout under
 2. From the resulting clean `main`, run and verify the direct
    `pnpm bridge:deploy` canary. Its Terraform bootstrap reconciles the applied
    builder and direct-deployer IAM, then verifies whether Metrics Bridge already
-   exists. It preserves an existing live revision; only a confirmed first
-   bootstrap creates the service and public binding. The temporary
-   default-Compute reader remains unchanged in this routing phase.
+   exists. It preserves an existing live revision and creates the service only
+   from a guarded no-refresh plan after both live and state checks confirm its
+   absence. If an interrupted first bootstrap left the public binding out of
+   Terraform state, a separate guarded no-refresh plan may create only that
+   binding. The deploy then verifies the live service and public binding;
+   tracked IAM drift or other service-shape drift requires a reviewed full
+   platform plan/apply. The temporary default-Compute reader remains unchanged
+   in this routing phase.
 3. In a separate reviewed cleanup PR, remove that reader. Refresh current
    `main`, inspect a clean platform plan, obtain explicit apply approval, and
    apply it.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -48,8 +48,11 @@ garden_lane: agent-entry-points
   reconcile the builder's project roles, repository writer, developer act-as
   bindings, and build-log reader before submitting and rolling out a build.
   For an existing Metrics Bridge service, that bootstrap must fail closed if it
-  cannot verify the exact service name and must not target the service or public
-  binding; those targets run only for a confirmed absent service.
+  cannot verify the exact service name and must not target the service. A first
+  service create and an interrupted public-binding create must use separate
+  no-refresh saved plans accepted by `check-metrics-bridge-bootstrap-plan.mjs`.
+  The deploy must then verify Terraform state, the live service, and the live
+  public binding before building.
   [ADR 0053](../docs/adr/0053-explicit-deployment-source-staging.md) owns the
   supported static syntax and explicit proof limits. Keep indirect or dynamic
   deploy forms forbidden and inert examples confined to

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@ title: Scripts Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-27
+last_verified: 2026-08-10
 doc_type: agent-instructions
 scope: scripts
 review_interval_days: 90
@@ -47,6 +47,9 @@ garden_lane: agent-entry-points
   and logging mode. It also requires the direct Metrics Bridge bootstrap to
   reconcile the builder's project roles, repository writer, developer act-as
   bindings, and build-log reader before submitting and rolling out a build.
+  For an existing Metrics Bridge service, that bootstrap must fail closed if it
+  cannot verify the exact service name and must not target the service or public
+  binding; those targets run only for a confirmed absent service.
   [ADR 0053](../docs/adr/0053-explicit-deployment-source-staging.md) owns the
   supported static syntax and explicit proof limits. Keep indirect or dynamic
   deploy forms forbidden and inert examples confined to

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -46,7 +46,8 @@ garden_lane: agent-entry-points
   service-account overrides, and verifies that config's exact builder identity
   and logging mode. It also requires the direct Metrics Bridge bootstrap to
   reconcile the builder's project roles, repository writer, developer act-as
-  bindings, and build-log reader before submitting and rolling out a build.
+  bindings, build-log reader, and Peg-policy bucket IAM dependency before
+  submitting and rolling out a build.
   For an existing Metrics Bridge service, that bootstrap must fail closed if it
   cannot verify the exact service name and must not target the service. A first
   service create and an interrupted public-binding create must use separate

--- a/scripts/check-metrics-bridge-bootstrap-plan.mjs
+++ b/scripts/check-metrics-bridge-bootstrap-plan.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const METRICS_BRIDGE_SERVICE_ADDRESS =
+  "google_cloud_run_v2_service.metrics_bridge";
+export const METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS =
+  "google_cloud_run_v2_service_iam_member.metrics_bridge_public";
+
+const PHASE_RULES = {
+  service: {
+    address: METRICS_BRIDGE_SERVICE_ADDRESS,
+    requireCreate: true,
+  },
+  "public-binding": {
+    address: METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS,
+    requireCreate: false,
+  },
+};
+
+function sameActions(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    actual.every((action, index) => action === expected[index])
+  );
+}
+
+export function validateMetricsBridgeBootstrapPlan(plan, phase) {
+  const rule = PHASE_RULES[phase];
+  if (!rule) {
+    return [`unknown Metrics Bridge bootstrap phase: ${String(phase)}`];
+  }
+  if (!plan || typeof plan !== "object" || Array.isArray(plan)) {
+    return ["Terraform plan JSON must be an object"];
+  }
+  if (!Array.isArray(plan.resource_changes)) {
+    return ["Terraform plan JSON must include resource_changes"];
+  }
+
+  const errors = [];
+  if (Array.isArray(plan.resource_drift) && plan.resource_drift.length > 0) {
+    errors.push("bootstrap plan must not contain refreshed resource drift");
+  }
+  if (
+    Array.isArray(plan.deferred_changes) &&
+    plan.deferred_changes.length > 0
+  ) {
+    errors.push("bootstrap plan must not contain deferred changes");
+  }
+
+  let allowedCreates = 0;
+  for (const resourceChange of plan.resource_changes) {
+    const actions = resourceChange?.change?.actions;
+    if (sameActions(actions, ["no-op"]) || sameActions(actions, ["read"])) {
+      continue;
+    }
+    if (
+      resourceChange?.mode === "managed" &&
+      resourceChange?.address === rule.address &&
+      sameActions(actions, ["create"])
+    ) {
+      allowedCreates += 1;
+      continue;
+    }
+    errors.push(
+      `${resourceChange?.address ?? "unknown resource"}: forbidden bootstrap plan actions ${JSON.stringify(actions)}`,
+    );
+  }
+
+  if (allowedCreates > 1) {
+    errors.push(
+      `${phase} bootstrap plan must create its resource at most once`,
+    );
+  }
+  if (rule.requireCreate && allowedCreates !== 1) {
+    errors.push(
+      `${phase} bootstrap plan must create its resource exactly once`,
+    );
+  }
+  return errors;
+}
+
+export function assertMetricsBridgeBootstrapPlan(plan, phase) {
+  const errors = validateMetricsBridgeBootstrapPlan(plan, phase);
+  if (errors.length > 0) {
+    throw new Error(
+      `Unsafe Metrics Bridge ${String(phase)} bootstrap plan:\n- ${errors.join("\n- ")}`,
+    );
+  }
+}
+
+function main() {
+  const phase = process.argv[2];
+  let plan;
+  try {
+    plan = JSON.parse(readFileSync(0, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to parse Terraform plan JSON: ${message}`, {
+      cause: error,
+    });
+  }
+  assertMetricsBridgeBootstrapPlan(plan, phase);
+  process.stdout.write(`Metrics Bridge ${phase} bootstrap plan is safe.\n`);
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -2,9 +2,10 @@
 # Build and deploy the metrics-bridge container to Cloud Run.
 #
 # Handles both first-time bootstrap and subsequent deploys:
-#   1. Ensures GCP project + APIs + Artifact Registry + Cloud Run service
-#      exist (terraform apply). On first run the service boots with the
-#      bootstrap image from var.metrics_bridge_image (gcr.io/cloudrun/hello).
+#   1. Reconciles GCP project APIs, Artifact Registry, and IAM with Terraform,
+#      then verifies the Cloud Run service. Only a confirmed first run creates
+#      the service with the bootstrap image from var.metrics_bridge_image
+#      (gcr.io/cloudrun/hello).
 #   2. Builds and pushes the container image (gcloud builds submit).
 #   3. Rolls a new revision via `gcloud run services update --image=<digest>`.
 #      Image rollouts are intentionally OUT OF terraform — the CR resource
@@ -63,10 +64,11 @@ if [ "$SKIP_CONFIRM" = false ]; then
   fi
 fi
 
-# Step 1: Ensure GCP infra + IAM + Cloud Run service shape exist. On
-# subsequent runs this is a no-op (terraform ignores image drift via
-# `lifecycle.ignore_changes`, so the current running image is preserved
-# even though `var.metrics_bridge_image` defaults to the bootstrap placeholder).
+# Step 1a: Reconcile the GCP APIs, build/runtime IAM, and source staging used by
+# both first-time and routine deploys. Keep the Cloud Run service out of this
+# apply: its revision stays Terraform-managed for reviewed Peg-policy rollovers,
+# so targeting an existing service after a gcloud rollout would mint a redundant
+# Terraform revision before the intended image rollout below.
 echo "Ensuring GCP infrastructure..."
 terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_project.monitoring \
@@ -86,9 +88,36 @@ terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_project_iam_member.dev_cloudbuild_editor \
   -target=google_project_iam_member.dev_logging_viewer \
   -target=google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user \
-  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user \
-  -target=google_cloud_run_v2_service.metrics_bridge \
-  -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public
+  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user
+
+# Step 1b: A successful exact-name list distinguishes an existing service from
+# a first bootstrap. Any gcloud/API/auth failure stops before another mutation.
+echo "Checking Metrics Bridge Cloud Run service..."
+if ! EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --filter='metadata.name=metrics-bridge' \
+  --format='value(metadata.name)' \
+  --limit=2)"; then
+  echo "Unable to verify Metrics Bridge Cloud Run service state; refusing to deploy."
+  exit 1
+fi
+
+case "$EXISTING_METRICS_BRIDGE_SERVICE" in
+  metrics-bridge)
+    echo "Cloud Run service exists; preserving its live revision during Terraform reconciliation."
+    ;;
+  "")
+    echo "Cloud Run service is absent; bootstrapping it with Terraform..."
+    terraform -chdir=terraform apply $TF_APPROVE \
+      -target=google_cloud_run_v2_service.metrics_bridge \
+      -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public
+    ;;
+  *)
+    echo "Unexpected Cloud Run service lookup result; refusing to deploy."
+    exit 1
+    ;;
+esac
 
 # Step 2: Build and push the image.
 echo ""

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -78,11 +78,12 @@ if [ "$SKIP_CONFIRM" = false ]; then
   fi
 fi
 
-# Step 1a: Reconcile the GCP APIs, build/runtime IAM, and source staging used by
-# both first-time and routine deploys. Keep the Cloud Run service out of this
-# apply: its revision stays Terraform-managed for reviewed Peg-policy rollovers,
-# so targeting an existing service after a gcloud rollout would mint a redundant
-# Terraform revision before the intended image rollout below.
+# Step 1a: Reconcile the GCP APIs, build/runtime IAM, source staging, and the
+# Peg-policy bucket IAM dependency used by both first-time and routine deploys.
+# Keep the Cloud Run service out of this apply: its revision stays
+# Terraform-managed for reviewed Peg-policy rollovers, so targeting an existing
+# service after a gcloud rollout would mint a redundant Terraform revision
+# before the intended image rollout below.
 echo "Ensuring GCP infrastructure..."
 terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_project.monitoring \
@@ -97,6 +98,7 @@ terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_storage_bucket_iam_member.cloud_build_source_caller_bucket_reader \
   -target=google_storage_bucket_iam_member.cloud_build_source_caller_object_creator \
   -target=google_storage_bucket_iam_member.cloud_build_source_executor_object_viewer \
+  -target=google_storage_bucket_iam_policy.peg_policy \
   -target=google_project_iam_member.dev_run_admin \
   -target=google_project_iam_member.dev_ar_writer \
   -target=google_project_iam_member.dev_cloudbuild_editor \

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -25,7 +25,21 @@ set -euo pipefail
 PROJECT="${GCP_PROJECT:-mento-monitoring}"
 REGION="${GCP_REGION:-europe-west1}"
 AR_REPO="${REGION}-docker.pkg.dev/${PROJECT}/metrics-bridge"
+METRICS_BRIDGE_SERVICE_ADDRESS="google_cloud_run_v2_service.metrics_bridge"
+METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS="google_cloud_run_v2_service_iam_member.metrics_bridge_public"
 SKIP_CONFIRM=false
+SERVICE_BOOTSTRAP_PLAN=""
+PUBLIC_BINDING_PLAN=""
+
+cleanup() {
+  if [[ -n "$SERVICE_BOOTSTRAP_PLAN" ]]; then
+    rm -f -- "$SERVICE_BOOTSTRAP_PLAN"
+  fi
+  if [[ -n "$PUBLIC_BINDING_PLAN" ]]; then
+    rm -f -- "$PUBLIC_BINDING_PLAN"
+  fi
+}
+trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -103,18 +117,123 @@ if ! EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list \
   exit 1
 fi
 
+# Classify Terraform ownership before acting on the live lookup. Saved plans
+# below use -refresh=false and a strict JSON allowlist so a concurrent state
+# change makes the plan stale instead of refreshing an existing live revision.
+echo "Checking Metrics Bridge Terraform bootstrap state..."
+if ! TERRAFORM_STATE_ADDRESSES="$(terraform -chdir=terraform state list)"; then
+  echo "Unable to read Metrics Bridge Terraform state; refusing to deploy."
+  exit 1
+fi
+
 case "$EXISTING_METRICS_BRIDGE_SERVICE" in
   metrics-bridge)
+    if ! grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then
+      echo "Cloud Run service exists but is not tracked in Terraform state; refusing to deploy."
+      exit 1
+    fi
     echo "Cloud Run service exists; preserving its live revision during Terraform reconciliation."
     ;;
   "")
+    if grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then
+      echo "Cloud Run service is tracked in Terraform state but missing live; run a reviewed platform plan/apply before deploying."
+      exit 1
+    fi
     echo "Cloud Run service is absent; bootstrapping it with Terraform..."
-    terraform -chdir=terraform apply $TF_APPROVE \
-      -target=google_cloud_run_v2_service.metrics_bridge \
-      -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public
+    SERVICE_BOOTSTRAP_PLAN="$(mktemp "${TMPDIR:-/tmp}/metrics-bridge-service-bootstrap.XXXXXX")"
+    terraform -chdir=terraform plan \
+      -refresh=false \
+      -out="$SERVICE_BOOTSTRAP_PLAN" \
+      -target=google_cloud_run_v2_service.metrics_bridge
+    terraform -chdir=terraform show -json "$SERVICE_BOOTSTRAP_PLAN" \
+      | node scripts/check-metrics-bridge-bootstrap-plan.mjs service
+    terraform -chdir=terraform apply "$SERVICE_BOOTSTRAP_PLAN"
+    rm -f -- "$SERVICE_BOOTSTRAP_PLAN"
+    SERVICE_BOOTSTRAP_PLAN=""
+
+    if ! CREATED_METRICS_BRIDGE_SERVICE="$(gcloud run services list \
+      --project="$PROJECT" \
+      --region="$REGION" \
+      --filter='metadata.name=metrics-bridge' \
+      --format='value(metadata.name)' \
+      --limit=2)"; then
+      echo "Unable to verify the created Metrics Bridge Cloud Run service; refusing to deploy."
+      exit 1
+    fi
+    if [[ "$CREATED_METRICS_BRIDGE_SERVICE" != "metrics-bridge" ]]; then
+      echo "Created Metrics Bridge Cloud Run service lookup was not exact; refusing to deploy."
+      exit 1
+    fi
     ;;
   *)
     echo "Unexpected Cloud Run service lookup result; refusing to deploy."
+    exit 1
+    ;;
+esac
+
+# Refresh state addresses after a successful service creation. This also proves
+# that the saved plan recorded the exact service before binding recovery.
+if ! TERRAFORM_STATE_ADDRESSES="$(terraform -chdir=terraform state list)"; then
+  echo "Unable to verify Metrics Bridge Terraform state; refusing to deploy."
+  exit 1
+fi
+if ! grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then
+  echo "Cloud Run service is absent from Terraform state; refusing to deploy."
+  exit 1
+fi
+
+# Step 1c: Resume an incomplete first bootstrap without refreshing the service.
+# The saved-plan guard permits only creation of the public binding, so a pending
+# template change or a live revision cannot slip into this recovery apply.
+if grep -Fqx -- "$METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then
+  echo "Public invoker binding is tracked in Terraform state."
+else
+  echo "Resuming incomplete public invoker binding bootstrap..."
+  PUBLIC_BINDING_PLAN="$(mktemp "${TMPDIR:-/tmp}/metrics-bridge-public-bootstrap.XXXXXX")"
+  terraform -chdir=terraform plan \
+    -refresh=false \
+    -out="$PUBLIC_BINDING_PLAN" \
+    -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public
+  terraform -chdir=terraform show -json "$PUBLIC_BINDING_PLAN" \
+    | node scripts/check-metrics-bridge-bootstrap-plan.mjs public-binding
+  terraform -chdir=terraform apply "$PUBLIC_BINDING_PLAN"
+  rm -f -- "$PUBLIC_BINDING_PLAN"
+  PUBLIC_BINDING_PLAN=""
+
+  if ! TERRAFORM_STATE_ADDRESSES="$(terraform -chdir=terraform state list)"; then
+    echo "Unable to verify Metrics Bridge Terraform state after binding bootstrap."
+    exit 1
+  fi
+  if ! grep -Fqx -- "$METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then
+    echo "Public invoker binding is still absent from Terraform state; refusing to deploy."
+    exit 1
+  fi
+fi
+
+# State presence proves Terraform ownership; the live policy check also catches
+# later out-of-band binding drift before a private revision can be rolled out.
+echo "Checking live Metrics Bridge public invoker binding..."
+if ! LIVE_PUBLIC_INVOKER="$(gcloud run services get-iam-policy metrics-bridge \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --flatten='bindings[].members' \
+  --filter='bindings.role=roles/run.invoker AND bindings.members=allUsers' \
+  --format='value(bindings.members)' \
+  --limit=2)"; then
+  echo "Unable to verify the live public invoker binding; refusing to deploy."
+  exit 1
+fi
+
+case "$LIVE_PUBLIC_INVOKER" in
+  allUsers)
+    echo "Live public invoker binding verified."
+    ;;
+  "")
+    echo "Public invoker binding is tracked but missing live; run a reviewed platform plan/apply before deploying."
+    exit 1
+    ;;
+  *)
+    echo "Unexpected public invoker lookup result; refusing to deploy."
     exit 1
     ;;
 esac

--- a/scripts/deploy-staging-contract.mjs
+++ b/scripts/deploy-staging-contract.mjs
@@ -30,10 +30,10 @@ const METRICS_BRIDGE_DIRECT_BOOTSTRAP_TARGETS = [
   "google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user",
   "google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user",
 ];
-const METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGETS = [
-  "google_cloud_run_v2_service.metrics_bridge",
-  "google_cloud_run_v2_service_iam_member.metrics_bridge_public",
-];
+const METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGET =
+  "google_cloud_run_v2_service.metrics_bridge";
+const METRICS_BRIDGE_PUBLIC_BINDING_TARGET =
+  "google_cloud_run_v2_service_iam_member.metrics_bridge_public";
 const CLOUD_BUILD_SOURCE_EXECUTORS = [
   "serviceAccount:${google_service_account.grafana_agent_builder.email}",
   "serviceAccount:${google_project.monitoring.number}-compute@developer.gserviceaccount.com",
@@ -525,9 +525,21 @@ function validateCallsites(files, errors) {
     'if ! EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
   );
   const serviceProbeEnd = directDeploy.indexOf("\nfi", serviceProbeStart);
+  const initialStateReadStart = directDeploy.indexOf(
+    'if ! TERRAFORM_STATE_ADDRESSES="$(terraform -chdir=terraform state list)"',
+    serviceProbeEnd,
+  );
   const serviceCaseStart = directDeploy.indexOf(
     'case "$EXISTING_METRICS_BRIDGE_SERVICE" in',
     serviceProbeEnd,
+  );
+  const existingServiceStart = directDeploy.indexOf(
+    "  metrics-bridge)",
+    serviceCaseStart,
+  );
+  const existingServiceEnd = directDeploy.indexOf(
+    "    ;;",
+    existingServiceStart,
   );
   const absentServiceStart = directDeploy.indexOf('  "")', serviceCaseStart);
   const absentServiceEnd = directDeploy.indexOf("    ;;", absentServiceStart);
@@ -539,7 +551,10 @@ function validateCallsites(files, errors) {
       errors.push(
         `${directDeployPath}: direct bootstrap must target ${target} exactly once`,
       );
-    } else if (directDeploy.indexOf(matches[0]) > serviceProbeStart) {
+    } else if (
+      serviceProbeStart >= 0 &&
+      directDeploy.indexOf(matches[0]) > serviceProbeStart
+    ) {
       errors.push(
         `${directDeployPath}: direct IAM target ${target} must run before the service lookup`,
       );
@@ -567,28 +582,63 @@ function validateCallsites(files, errors) {
     );
   }
 
-  for (const target of METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGETS) {
-    const matches = directDeploy.match(targetLine(target));
-    const targetIndex =
-      matches?.length === 1 ? directDeploy.indexOf(matches[0]) : -1;
-    if (
-      matches?.length !== 1 ||
-      targetIndex <= absentServiceStart ||
-      targetIndex >= absentServiceEnd
-    ) {
-      errors.push(
-        `${directDeployPath}: ${target} must run exactly once only in the confirmed-absent service branch`,
-      );
-    }
+  const serviceTargetMatches = directDeploy.match(
+    targetLine(METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGET),
+  );
+  const serviceTargetIndex =
+    serviceTargetMatches?.length === 1
+      ? directDeploy.indexOf(serviceTargetMatches[0])
+      : -1;
+  const absentServiceBlock =
+    absentServiceStart >= 0 && absentServiceEnd > absentServiceStart
+      ? directDeploy.slice(absentServiceStart, absentServiceEnd)
+      : "";
+  const expectedServiceBootstrapFragments = [
+    'if grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS"',
+    "Cloud Run service is tracked in Terraform state but missing live",
+    'mktemp "${TMPDIR:-/tmp}/metrics-bridge-service-bootstrap.XXXXXX"',
+    "terraform -chdir=terraform plan",
+    "-refresh=false",
+    '-out="$SERVICE_BOOTSTRAP_PLAN"',
+    'terraform -chdir=terraform show -json "$SERVICE_BOOTSTRAP_PLAN"',
+    "node scripts/check-metrics-bridge-bootstrap-plan.mjs service",
+    'terraform -chdir=terraform apply "$SERVICE_BOOTSTRAP_PLAN"',
+    'if ! CREATED_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+    '[[ "$CREATED_METRICS_BRIDGE_SERVICE" != "metrics-bridge" ]]',
+    "exit 1",
+  ];
+  if (
+    serviceTargetMatches?.length !== 1 ||
+    serviceTargetIndex <= absentServiceStart ||
+    serviceTargetIndex >= absentServiceEnd ||
+    !absentServiceBlock ||
+    expectedServiceBootstrapFragments.some(
+      (fragment) => !absentServiceBlock.includes(fragment),
+    )
+  ) {
+    errors.push(
+      `${directDeployPath}: ${METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGET} must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch`,
+    );
   }
 
   const unexpectedResultStart = directDeploy.indexOf("  *)", absentServiceEnd);
+  const existingServiceBlock =
+    existingServiceStart >= 0 && existingServiceEnd > existingServiceStart
+      ? directDeploy.slice(existingServiceStart, existingServiceEnd)
+      : "";
   const unexpectedResultBlock =
     unexpectedResultStart >= 0 && serviceCaseEnd > unexpectedResultStart
       ? directDeploy.slice(unexpectedResultStart, serviceCaseEnd)
       : "";
   if (
     serviceCaseStart < 0 ||
+    !existingServiceBlock.includes(
+      'if ! grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS"',
+    ) ||
+    !existingServiceBlock.includes(
+      "Cloud Run service exists but is not tracked in Terraform state",
+    ) ||
+    !existingServiceBlock.includes("exit 1") ||
     absentServiceStart < 0 ||
     absentServiceEnd < 0 ||
     serviceCaseEnd < 0 ||
@@ -596,6 +646,122 @@ function validateCallsites(files, errors) {
   ) {
     errors.push(
       `${directDeployPath}: service bootstrap branching must reject unexpected lookup results`,
+    );
+  }
+
+  const postServiceStateReadStart = directDeploy.indexOf(
+    'if ! TERRAFORM_STATE_ADDRESSES="$(terraform -chdir=terraform state list)"',
+    serviceCaseEnd,
+  );
+  const publicBindingStateStart = directDeploy.indexOf(
+    'if grep -Fqx -- "$METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS"',
+    postServiceStateReadStart,
+  );
+  const publicBindingRecoveryStart = directDeploy.indexOf(
+    "\nelse\n",
+    publicBindingStateStart,
+  );
+  const stateClassificationBlock =
+    initialStateReadStart >= 0 &&
+    publicBindingRecoveryStart > initialStateReadStart
+      ? directDeploy.slice(initialStateReadStart, publicBindingRecoveryStart)
+      : "";
+  const publicBindingRecoveryEnd = directDeploy.indexOf(
+    "# State presence proves Terraform ownership",
+    publicBindingRecoveryStart,
+  );
+  const publicBindingRecoveryBlock =
+    publicBindingRecoveryStart >= 0 &&
+    publicBindingRecoveryEnd > publicBindingRecoveryStart
+      ? directDeploy.slice(publicBindingRecoveryStart, publicBindingRecoveryEnd)
+      : "";
+  const publicTargetMatches = directDeploy.match(
+    targetLine(METRICS_BRIDGE_PUBLIC_BINDING_TARGET),
+  );
+  const publicTargetIndex =
+    publicTargetMatches?.length === 1
+      ? directDeploy.indexOf(publicTargetMatches[0])
+      : -1;
+  const expectedRecoveryFragments = [
+    'mktemp "${TMPDIR:-/tmp}/metrics-bridge-public-bootstrap.XXXXXX"',
+    "terraform -chdir=terraform plan",
+    "-refresh=false",
+    '-out="$PUBLIC_BINDING_PLAN"',
+    'terraform -chdir=terraform show -json "$PUBLIC_BINDING_PLAN"',
+    "node scripts/check-metrics-bridge-bootstrap-plan.mjs public-binding",
+    'terraform -chdir=terraform apply "$PUBLIC_BINDING_PLAN"',
+    'grep -Fqx -- "$METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS"',
+    "exit 1",
+  ];
+  const expectedStateFragments = [
+    "terraform -chdir=terraform state list",
+    'if ! grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS"',
+    "Cloud Run service exists but is not tracked in Terraform state",
+    'if grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS"',
+    "Cloud Run service is tracked in Terraform state but missing live",
+    "Cloud Run service is absent from Terraform state",
+    'grep -Fqx -- "$METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS"',
+    "exit 1",
+  ];
+  if (
+    initialStateReadStart <= serviceProbeEnd ||
+    initialStateReadStart >= serviceCaseStart ||
+    postServiceStateReadStart <= serviceCaseEnd ||
+    publicBindingStateStart <= postServiceStateReadStart ||
+    !stateClassificationBlock ||
+    expectedStateFragments.some(
+      (fragment) => !stateClassificationBlock.includes(fragment),
+    ) ||
+    !publicBindingRecoveryBlock ||
+    publicTargetMatches?.length !== 1 ||
+    publicTargetIndex <= publicBindingRecoveryStart ||
+    publicTargetIndex >= publicBindingRecoveryEnd ||
+    expectedRecoveryFragments.some(
+      (fragment) => !publicBindingRecoveryBlock.includes(fragment),
+    )
+  ) {
+    errors.push(
+      `${directDeployPath}: partial bootstrap recovery must apply only a guarded no-refresh public-binding plan`,
+    );
+  }
+
+  const liveBindingProbeStart = directDeploy.indexOf(
+    'if ! LIVE_PUBLIC_INVOKER="$(gcloud run services get-iam-policy metrics-bridge',
+    publicBindingRecoveryEnd,
+  );
+  const liveBindingCaseEnd = directDeploy.indexOf(
+    "esac",
+    liveBindingProbeStart,
+  );
+  const buildStart = directDeploy.indexOf(
+    'echo "Building container image via Cloud Build..."',
+  );
+  const liveBindingBlock =
+    liveBindingProbeStart >= 0 && liveBindingCaseEnd > liveBindingProbeStart
+      ? directDeploy.slice(liveBindingProbeStart, liveBindingCaseEnd)
+      : "";
+  const expectedLiveBindingFragments = [
+    '--project="$PROJECT"',
+    '--region="$REGION"',
+    "--flatten='bindings[].members'",
+    "--filter='bindings.role=roles/run.invoker AND bindings.members=allUsers'",
+    "--format='value(bindings.members)'",
+    "--limit=2",
+    'echo "Unable to verify the live public invoker binding; refusing to deploy."\n  exit 1\nfi',
+    'case "$LIVE_PUBLIC_INVOKER" in',
+    "allUsers)",
+    '  "")\n    echo "Public invoker binding is tracked but missing live; run a reviewed platform plan/apply before deploying."\n    exit 1',
+    '  *)\n    echo "Unexpected public invoker lookup result; refusing to deploy."\n    exit 1',
+  ];
+  if (
+    !liveBindingBlock ||
+    buildStart <= liveBindingCaseEnd ||
+    expectedLiveBindingFragments.some(
+      (fragment) => !liveBindingBlock.includes(fragment),
+    )
+  ) {
+    errors.push(
+      `${directDeployPath}: live public-binding verification must be exact and fail before image rollout`,
     );
   }
 }

--- a/scripts/deploy-staging-contract.mjs
+++ b/scripts/deploy-staging-contract.mjs
@@ -26,6 +26,7 @@ const METRICS_BRIDGE_BUILDER =
 const METRICS_BRIDGE_DIRECT_BOOTSTRAP_TARGETS = [
   "google_project_iam_member.metrics_bridge_builder",
   "google_artifact_registry_repository_iam_member.metrics_bridge_builder_writer",
+  "google_storage_bucket_iam_policy.peg_policy",
   "google_project_iam_member.dev_logging_viewer",
   "google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user",
   "google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user",

--- a/scripts/deploy-staging-contract.mjs
+++ b/scripts/deploy-staging-contract.mjs
@@ -30,6 +30,10 @@ const METRICS_BRIDGE_DIRECT_BOOTSTRAP_TARGETS = [
   "google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user",
   "google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user",
 ];
+const METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGETS = [
+  "google_cloud_run_v2_service.metrics_bridge",
+  "google_cloud_run_v2_service_iam_member.metrics_bridge_public",
+];
 const CLOUD_BUILD_SOURCE_EXECUTORS = [
   "serviceAccount:${google_service_account.grafana_agent_builder.email}",
   "serviceAccount:${google_project.monitoring.number}-compute@developer.gserviceaccount.com",
@@ -512,18 +516,87 @@ function validateCallsites(files, errors) {
 
   const directDeployPath = "scripts/deploy-bridge.sh";
   const directDeploy = requireSource(files, directDeployPath, errors);
-  for (const target of METRICS_BRIDGE_DIRECT_BOOTSTRAP_TARGETS) {
-    const matches = directDeploy.match(
-      new RegExp(
-        `^\\s+-target=${target.replaceAll(".", "\\.")}\\s+\\\\$`,
-        "gmu",
-      ),
+  const targetLine = (target) =>
+    new RegExp(
+      `^\\s+-target=${target.replaceAll(".", "\\.")}\\s*(?:\\\\)?$`,
+      "gmu",
     );
+  const serviceProbeStart = directDeploy.indexOf(
+    'if ! EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+  );
+  const serviceProbeEnd = directDeploy.indexOf("\nfi", serviceProbeStart);
+  const serviceCaseStart = directDeploy.indexOf(
+    'case "$EXISTING_METRICS_BRIDGE_SERVICE" in',
+    serviceProbeEnd,
+  );
+  const absentServiceStart = directDeploy.indexOf('  "")', serviceCaseStart);
+  const absentServiceEnd = directDeploy.indexOf("    ;;", absentServiceStart);
+  const serviceCaseEnd = directDeploy.indexOf("esac", absentServiceEnd);
+
+  for (const target of METRICS_BRIDGE_DIRECT_BOOTSTRAP_TARGETS) {
+    const matches = directDeploy.match(targetLine(target));
     if (matches?.length !== 1) {
       errors.push(
         `${directDeployPath}: direct bootstrap must target ${target} exactly once`,
       );
+    } else if (directDeploy.indexOf(matches[0]) > serviceProbeStart) {
+      errors.push(
+        `${directDeployPath}: direct IAM target ${target} must run before the service lookup`,
+      );
     }
+  }
+
+  const expectedProbeFragments = [
+    '--project="$PROJECT"',
+    '--region="$REGION"',
+    "--filter='metadata.name=metrics-bridge'",
+    "--format='value(metadata.name)'",
+    "--limit=2",
+  ];
+  const probeBlock =
+    serviceProbeStart >= 0 && serviceProbeEnd > serviceProbeStart
+      ? directDeploy.slice(serviceProbeStart, serviceProbeEnd)
+      : "";
+  if (
+    !probeBlock ||
+    !probeBlock.includes("exit 1") ||
+    expectedProbeFragments.some((fragment) => !probeBlock.includes(fragment))
+  ) {
+    errors.push(
+      `${directDeployPath}: existing-service lookup must be exact and fail closed`,
+    );
+  }
+
+  for (const target of METRICS_BRIDGE_SERVICE_BOOTSTRAP_TARGETS) {
+    const matches = directDeploy.match(targetLine(target));
+    const targetIndex =
+      matches?.length === 1 ? directDeploy.indexOf(matches[0]) : -1;
+    if (
+      matches?.length !== 1 ||
+      targetIndex <= absentServiceStart ||
+      targetIndex >= absentServiceEnd
+    ) {
+      errors.push(
+        `${directDeployPath}: ${target} must run exactly once only in the confirmed-absent service branch`,
+      );
+    }
+  }
+
+  const unexpectedResultStart = directDeploy.indexOf("  *)", absentServiceEnd);
+  const unexpectedResultBlock =
+    unexpectedResultStart >= 0 && serviceCaseEnd > unexpectedResultStart
+      ? directDeploy.slice(unexpectedResultStart, serviceCaseEnd)
+      : "";
+  if (
+    serviceCaseStart < 0 ||
+    absentServiceStart < 0 ||
+    absentServiceEnd < 0 ||
+    serviceCaseEnd < 0 ||
+    !unexpectedResultBlock.includes("exit 1")
+  ) {
+    errors.push(
+      `${directDeployPath}: service bootstrap branching must reject unexpected lookup results`,
+    );
   }
 }
 

--- a/scripts/deploy-staging-contract.test.mjs
+++ b/scripts/deploy-staging-contract.test.mjs
@@ -20,6 +20,11 @@ import {
   stripDeployStagingTemplateSuffix,
   validateDeployStagingContract,
 } from "./deploy-staging-contract.mjs";
+import {
+  METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS,
+  METRICS_BRIDGE_SERVICE_ADDRESS,
+  validateMetricsBridgeBootstrapPlan,
+} from "./check-metrics-bridge-bootstrap-plan.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -152,6 +157,95 @@ function expectFailure(files, expected) {
 }
 
 const files = repositoryFiles();
+
+const noOpServiceChange = {
+  address: "google_cloud_run_v2_service.metrics_bridge",
+  mode: "managed",
+  change: { actions: ["no-op"] },
+};
+const publicBindingCreate = {
+  address: METRICS_BRIDGE_PUBLIC_BINDING_ADDRESS,
+  mode: "managed",
+  change: { actions: ["create"] },
+};
+assert.deepEqual(
+  validateMetricsBridgeBootstrapPlan(
+    {
+      resource_changes: [noOpServiceChange, publicBindingCreate],
+    },
+    "public-binding",
+  ),
+  [],
+  "partial bootstrap plan should allow only the public binding create",
+);
+assert.deepEqual(
+  validateMetricsBridgeBootstrapPlan(
+    {
+      resource_changes: [noOpServiceChange],
+    },
+    "public-binding",
+  ),
+  [],
+  "a concurrent no-op recovery should remain safe",
+);
+const serviceCreate = {
+  address: METRICS_BRIDGE_SERVICE_ADDRESS,
+  mode: "managed",
+  change: { actions: ["create"] },
+};
+assert.deepEqual(
+  validateMetricsBridgeBootstrapPlan(
+    { resource_changes: [serviceCreate] },
+    "service",
+  ),
+  [],
+  "first bootstrap plan should allow exactly the service create",
+);
+assert.deepEqual(
+  validateMetricsBridgeBootstrapPlan(
+    { resource_changes: [noOpServiceChange] },
+    "service",
+  ),
+  ["service bootstrap plan must create its resource exactly once"],
+  "a concurrent service state change should stop before apply",
+);
+for (const unsafeChange of [
+  {
+    address: "google_cloud_run_v2_service.metrics_bridge",
+    mode: "managed",
+    change: { actions: ["update"] },
+  },
+  {
+    ...publicBindingCreate,
+    change: { actions: ["delete", "create"] },
+  },
+  {
+    address: "google_project_iam_member.unrelated",
+    mode: "managed",
+    change: { actions: ["create"] },
+  },
+]) {
+  assert.equal(
+    validateMetricsBridgeBootstrapPlan(
+      {
+        resource_changes: [unsafeChange],
+      },
+      "public-binding",
+    ).length,
+    1,
+    `${unsafeChange.address} mutation should fail closed`,
+  );
+}
+assert.deepEqual(
+  validateMetricsBridgeBootstrapPlan(
+    {
+      resource_changes: [publicBindingCreate],
+      resource_drift: [noOpServiceChange],
+    },
+    "public-binding",
+  ),
+  ["bootstrap plan must not contain refreshed resource drift"],
+);
 
 const rootGcloudIgnoreEntries = files[".gcloudignore"]
   .split(/\r?\n/u)
@@ -576,21 +670,24 @@ for (const target of [
   );
 }
 
-for (const [target, targetLine] of [
-  [
-    "google_cloud_run_v2_service.metrics_bridge",
-    "      -target=google_cloud_run_v2_service.metrics_bridge \\\n",
-  ],
-  [
-    "google_cloud_run_v2_service_iam_member.metrics_bridge_public",
-    "      -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public\n",
-  ],
-]) {
-  expectFailure(
-    mutate(files, "scripts/deploy-bridge.sh", targetLine, ""),
-    `scripts/deploy-bridge.sh: ${target} must run exactly once only in the confirmed-absent service branch`,
-  );
-}
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "      -target=google_cloud_run_v2_service.metrics_bridge\n",
+    "",
+  ),
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "    -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public\n",
+    "",
+  ),
+  "scripts/deploy-bridge.sh: partial bootstrap recovery must apply only a guarded no-refresh public-binding plan",
+);
 
 expectFailure(
   mutate(
@@ -633,14 +730,81 @@ expectFailure(
     mutate(
       files,
       "scripts/deploy-bridge.sh",
-      "      -target=google_cloud_run_v2_service.metrics_bridge \\\n",
+      "      -target=google_cloud_run_v2_service.metrics_bridge\n",
       "",
     ),
     "scripts/deploy-bridge.sh",
     "  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user\n",
     "  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user \\\n  -target=google_cloud_run_v2_service.metrics_bridge\n",
   ),
-  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only in the confirmed-absent service branch",
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch",
+);
+expectFailure(
+  mutate(files, "scripts/deploy-bridge.sh", "      -refresh=false \\\n", ""),
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "node scripts/check-metrics-bridge-bootstrap-plan.mjs service",
+    "node scripts/other-plan-checker.mjs service",
+  ),
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    'if ! CREATED_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+    'if CREATED_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+  ),
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only through a guarded no-refresh plan in the confirmed-absent service branch",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "    -refresh=false \\\n" + '    -out="$PUBLIC_BINDING_PLAN" \\\n',
+    '    -out="$PUBLIC_BINDING_PLAN" \\\n',
+  ),
+  "scripts/deploy-bridge.sh: partial bootstrap recovery must apply only a guarded no-refresh public-binding plan",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "node scripts/check-metrics-bridge-bootstrap-plan.mjs public-binding",
+    "node scripts/other-plan-checker.mjs public-binding",
+  ),
+  "scripts/deploy-bridge.sh: partial bootstrap recovery must apply only a guarded no-refresh public-binding plan",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    'if ! grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then',
+    'if grep -Fqx -- "$METRICS_BRIDGE_SERVICE_ADDRESS" <<<"$TERRAFORM_STATE_ADDRESSES"; then',
+  ),
+  "scripts/deploy-bridge.sh: service bootstrap branching must reject unexpected lookup results",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "  --filter='bindings.role=roles/run.invoker AND bindings.members=allUsers' \\\n",
+    "  --filter='bindings.role=roles/run.invoker' \\\n",
+  ),
+  "scripts/deploy-bridge.sh: live public-binding verification must be exact and fail before image rollout",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    '    echo "Public invoker binding is tracked but missing live; run a reviewed platform plan/apply before deploying."\n    exit 1',
+    '    echo "Public invoker binding is tracked but missing live; run a reviewed platform plan/apply before deploying."',
+  ),
+  "scripts/deploy-bridge.sh: live public-binding verification must be exact and fail before image rollout",
 );
 
 const metricsBridgeBuilderExecutor =

--- a/scripts/deploy-staging-contract.test.mjs
+++ b/scripts/deploy-staging-contract.test.mjs
@@ -566,11 +566,82 @@ for (const target of [
   "google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user",
   "google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user",
 ]) {
+  const targetLine = files["scripts/deploy-bridge.sh"]
+    .split("\n")
+    .find((line) => line.includes(`-target=${target}`));
+  assert(targetLine, `direct bootstrap target fixture missing: ${target}`);
   expectFailure(
-    mutate(files, "scripts/deploy-bridge.sh", `  -target=${target} \\\n`, ""),
+    mutate(files, "scripts/deploy-bridge.sh", `${targetLine}\n`, ""),
     `scripts/deploy-bridge.sh: direct bootstrap must target ${target} exactly once`,
   );
 }
+
+for (const [target, targetLine] of [
+  [
+    "google_cloud_run_v2_service.metrics_bridge",
+    "      -target=google_cloud_run_v2_service.metrics_bridge \\\n",
+  ],
+  [
+    "google_cloud_run_v2_service_iam_member.metrics_bridge_public",
+    "      -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public\n",
+  ],
+]) {
+  expectFailure(
+    mutate(files, "scripts/deploy-bridge.sh", targetLine, ""),
+    `scripts/deploy-bridge.sh: ${target} must run exactly once only in the confirmed-absent service branch`,
+  );
+}
+
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    'if ! EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+    'if EXISTING_METRICS_BRIDGE_SERVICE="$(gcloud run services list',
+  ),
+  "scripts/deploy-bridge.sh: existing-service lookup must be exact and fail closed",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    "  --filter='metadata.name=metrics-bridge' \\\n",
+    "  --filter='metadata.name:metrics-bridge' \\\n",
+  ),
+  "scripts/deploy-bridge.sh: existing-service lookup must be exact and fail closed",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    '  echo "Unable to verify Metrics Bridge Cloud Run service state; refusing to deploy."\n  exit 1\nfi',
+    '  echo "Unable to verify Metrics Bridge Cloud Run service state; refusing to deploy."\nfi',
+  ),
+  "scripts/deploy-bridge.sh: existing-service lookup must be exact and fail closed",
+);
+expectFailure(
+  mutate(
+    files,
+    "scripts/deploy-bridge.sh",
+    '    echo "Unexpected Cloud Run service lookup result; refusing to deploy."\n    exit 1\n    ;;',
+    '    echo "Unexpected Cloud Run service lookup result; refusing to deploy."\n    ;;',
+  ),
+  "scripts/deploy-bridge.sh: service bootstrap branching must reject unexpected lookup results",
+);
+expectFailure(
+  mutate(
+    mutate(
+      files,
+      "scripts/deploy-bridge.sh",
+      "      -target=google_cloud_run_v2_service.metrics_bridge \\\n",
+      "",
+    ),
+    "scripts/deploy-bridge.sh",
+    "  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user\n",
+    "  -target=google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user \\\n  -target=google_cloud_run_v2_service.metrics_bridge\n",
+  ),
+  "scripts/deploy-bridge.sh: google_cloud_run_v2_service.metrics_bridge must run exactly once only in the confirmed-absent service branch",
+);
 
 const metricsBridgeBuilderExecutor =
   '    "serviceAccount:${google_service_account.metrics_bridge_builder.email}",\n';

--- a/scripts/deploy-staging-contract.test.mjs
+++ b/scripts/deploy-staging-contract.test.mjs
@@ -656,6 +656,7 @@ for (const [filePath, configFlag] of [
 for (const target of [
   "google_project_iam_member.metrics_bridge_builder",
   "google_artifact_registry_repository_iam_member.metrics_bridge_builder_writer",
+  "google_storage_bucket_iam_policy.peg_policy",
   "google_project_iam_member.dev_logging_viewer",
   "google_service_account_iam_member.dev_metrics_bridge_builder_service_account_user",
   "google_service_account_iam_member.dev_metrics_bridge_runtime_service_account_user",


### PR DESCRIPTION
## The Problem

- The direct Metrics Bridge deploy targeted the existing Cloud Run service during its Terraform bootstrap.
- A first-bootstrap retry could skip a missing public binding, while a concurrent bootstrap could turn a stale service lookup into an unwanted service update.

## The Solution

- Reconcile routine infrastructure and all service dependencies without the Cloud Run service, then compare the exact live service with Terraform state. Preserve an existing revision. Create a missing service or public binding only from separate saved plans that disable refresh and reject every unrelated change.

## Details

- Reconcile the Peg-policy bucket IAM foundation before validating the strict service-create plan.
- Fail closed on lookup errors, unexpected names, or contradictions between the live service and Terraform state.
- Require an exact service create on first bootstrap. A concurrent state change makes the saved plan stale instead of refreshing an existing revision.
- Allow an interrupted bootstrap to create only the missing public binding, then verify both Terraform state and the live `allUsers` invoker binding before any build.
- Extend `pnpm tf:test` with mutation coverage for foundation reconciliation, saved-plan guards, state classification, exact live checks, and build ordering.
- Keep the temporary default-Compute source reader unchanged for the direct canary defined by ADR 0058.
- This implements the existing deployment decision and does not add a new architecture decision.

Refs #1751

## Validation

- `CI=true pnpm agent:quality-gate --run` — all 10 mapped commands passed; the pre-push hook repeated the clean gate after the first feedback batch.
- Fresh-context Codex autoreview — three clean semantic passes across the initial and two feedback batches; final manifest `8ab659f5444a3ee81cb64dac8c6b51eaa7aaa4441d7a2aa105888089f1bde668` verified before and after review.
- `CI=true pnpm agent:autoreview --engine local` — clean deterministic pass after each feedback batch.
- Exact production step-1a target plan, including `google_storage_bucket_iam_policy.peg_policy` — `No changes`.
- Terraform graph — the policy target owns the missing upstream bucket-policy chain; only the service depends on it, so step 1a does not target Cloud Run.
- Production public-binding plan with `-refresh=false` — `No changes`; the saved-plan checker accepted it.
- Production service plan with `-refresh=false` — `No changes`; the service-phase checker rejected it because an existing service must never enter first-bootstrap apply.
- Exact production Cloud Run lookup — returned `metrics-bridge`.
- Exact production public-invoker lookup — returned `allUsers`.
- No Terraform apply or deployment ran from this branch.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every known deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision reviewed: this implements ADR 0058; no new ADR is needed.
