### PR TITLE
fix(peg): refresh expired conversion evidence

### DIFF
--- a/metrics-bridge/src/peg/conversion.ts
+++ b/metrics-bridge/src/peg/conversion.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import type { PublicClient } from "viem";
 import { classifyFxMarketPause } from "../fx-market.js";
 import type { PegConversion } from "./registry.js";
+import type { PegObservation } from "./types.js";
 
 const SORTED_ORACLES_ABI = [
   {
@@ -55,6 +56,11 @@ export interface PegConversionLeg {
   expirySeconds: number;
   authoritative: boolean;
   unavailableReason: "stale" | "future_timestamp" | "fx_market_pause" | null;
+}
+
+export interface ConvertedPegObservation {
+  observation: PegObservation | null;
+  validUntil: number | null;
 }
 
 export function conversionFeedPair(conversion: PegConversion): string {
@@ -175,4 +181,45 @@ export function convertQuotePriceToPeg(
     throw new Error("Conversion leg is not alert-authoritative");
   }
   return quotePrice / conversion.rate;
+}
+
+function convertObservation(
+  observation: PegObservation,
+  conversion: PegConversionLeg,
+): PegObservation {
+  return {
+    ...observation,
+    vwap:
+      observation.vwap === null
+        ? null
+        : convertQuotePriceToPeg(observation.vwap, conversion),
+    bid:
+      observation.bid === null
+        ? null
+        : convertQuotePriceToPeg(observation.bid, conversion),
+    ask:
+      observation.ask === null
+        ? null
+        : convertQuotePriceToPeg(observation.ask, conversion),
+  };
+}
+
+export async function convertPegSourceObservation(
+  observation: PegObservation,
+  conversion: PegConversion | undefined,
+  nowSeconds: number,
+  readConversionLeg: (
+    conversion: PegConversion,
+    nowSeconds: number,
+  ) => Promise<PegConversionLeg>,
+): Promise<ConvertedPegObservation> {
+  if (observation.venueState === "halted" || conversion === undefined) {
+    return { observation, validUntil: null };
+  }
+  const leg = await readConversionLeg(conversion, nowSeconds);
+  if (!leg.authoritative) return { observation: null, validUntil: null };
+  return {
+    observation: convertObservation(observation, leg),
+    validUntil: leg.medianAt + leg.expirySeconds,
+  };
 }

--- a/metrics-bridge/src/peg/poll-cycle.ts
+++ b/metrics-bridge/src/peg/poll-cycle.ts
@@ -41,6 +41,9 @@ export interface PegPollSourceState {
   lastObservationAt: number | null;
   identitiesAtLastObservationAt: Set<string>;
   observation: PegObservation | null;
+  // Internal provider-native book retained only so an expired conversion can
+  // be refreshed without advancing the provider polling cadence.
+  rawObservation: PegObservation | null;
   referenceSize: number | null;
   conversionValidUntil: number | null;
   listingState: MarketState | null;
@@ -101,6 +104,8 @@ function cloneSourceStates(
         ),
         observation:
           state.observation === null ? null : { ...state.observation },
+        rawObservation:
+          state.rawObservation === null ? null : { ...state.rawObservation },
       },
     ]),
   );

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -12,7 +12,7 @@ import {
   type KrakenObservationRequest,
 } from "./adapters/kraken.js";
 import {
-  convertQuotePriceToPeg,
+  convertPegSourceObservation,
   readPegConversionLeg,
   type PegConversionLeg,
 } from "./conversion.js";
@@ -172,6 +172,7 @@ const defaultSourceState = (): SourceState => ({
   lastObservationAt: null,
   identitiesAtLastObservationAt: new Set(),
   observation: null,
+  rawObservation: null,
   referenceSize: null,
   conversionValidUntil: null,
   listingState: null,
@@ -254,27 +255,6 @@ function takeBounded<Value>(
     );
   }
   return values.slice(0, maximum);
-}
-
-function convertObservation(
-  observation: PegObservation,
-  conversion: PegConversionLeg,
-): PegObservation {
-  return {
-    ...observation,
-    vwap:
-      observation.vwap === null
-        ? null
-        : convertQuotePriceToPeg(observation.vwap, conversion),
-    bid:
-      observation.bid === null
-        ? null
-        : convertQuotePriceToPeg(observation.bid, conversion),
-    ask:
-      observation.ask === null
-        ? null
-        : convertQuotePriceToPeg(observation.ask, conversion),
-  };
 }
 
 function observationIsFresh(
@@ -415,7 +395,10 @@ function conversionExpiryDue(
   return (
     source.convertVia !== undefined &&
     state.observation !== null &&
+    state.rawObservation !== null &&
     state.observation.venueState !== "halted" &&
+    state.listingState !== "absent" &&
+    state.listingState !== "halted" &&
     state.conversionValidUntil !== null &&
     context.nowSeconds > state.conversionValidUntil
   );
@@ -423,15 +406,10 @@ function conversionExpiryDue(
 
 function sourceDue(
   state: SourceState,
-  input: PollSourceInput,
   refSize: number,
   observationCadenceDue: boolean,
 ): boolean {
-  return (
-    observationCadenceDue ||
-    state.referenceSize !== refSize ||
-    conversionExpiryDue(state, input.source, input.context)
-  );
+  return observationCadenceDue || state.referenceSize !== refSize;
 }
 
 function fetchSource(
@@ -462,6 +440,7 @@ function fetchSource(
 
 function clearSource(state: SourceState, refSize: number | null): void {
   state.observation = null;
+  state.rawObservation = null;
   state.referenceSize = refSize;
   state.conversionValidUntil = null;
 }
@@ -490,37 +469,10 @@ function cachedObservation(
     !conversionFresh ||
     !observationIsFresh(state.observation, policy, context.nowMs)
   ) {
-    state.observation = null;
+    clearSource(state, state.referenceSize);
     return null;
   }
   return state.observation;
-}
-
-async function convertSourceObservation(
-  source: PegSource,
-  observation: PegObservation,
-  context: CycleContext,
-): Promise<{
-  observation: PegObservation | null;
-  validUntil: number | null;
-}> {
-  if (observation.venueState === "halted") {
-    return { observation, validUntil: null };
-  }
-  if (source.convertVia === undefined) {
-    return { observation, validUntil: null };
-  }
-  const conversion = await context.dependencies.readConversionLeg(
-    source.convertVia,
-    context.nowSeconds,
-  );
-  if (!conversion.authoritative) {
-    return { observation: null, validUntil: null };
-  }
-  return {
-    observation: convertObservation(observation, conversion),
-    validUntil: conversion.medianAt + conversion.expirySeconds,
-  };
 }
 
 function unavailableSourceSnapshot(
@@ -613,12 +565,42 @@ function failSource(
   return unavailableSourceSnapshot(input, state, refSize);
 }
 
+function providerAdvancement(
+  input: PollSourceInput,
+  state: SourceState,
+  rawObservation: PegObservation,
+): { advanced: boolean; failure: string | null } {
+  if (
+    rawObservation.observationAt === null ||
+    rawObservation.sequence === null
+  ) {
+    return {
+      advanced: false,
+      failure: "venue observation has no publication identity",
+    };
+  }
+  if (!observationIsFresh(rawObservation, input.policy, input.context.nowMs)) {
+    return { advanced: false, failure: "stale venue observation" };
+  }
+  return recordProviderAdvancement(
+    state,
+    rawObservation.observationAt,
+    rawObservation.sequence,
+  );
+}
+
+type DueObservation = {
+  raw: PegObservation;
+  converted: Awaited<ReturnType<typeof convertPegSourceObservation>>;
+};
+
 function acceptDueObservation(
   input: PollSourceInput,
   state: SourceState,
   refSize: number,
-  converted: Awaited<ReturnType<typeof convertSourceObservation>>,
+  due: DueObservation,
 ): PegSourceMetricSnapshot {
+  const { raw: rawObservation, converted } = due;
   if (converted.observation === null) {
     return failSource(input, state, refSize, {
       kind: "conversion_unavailable",
@@ -630,6 +612,7 @@ function acceptDueObservation(
     // A halt is diagnostic, not a successful price observation. Preserve the
     // last accepted identity so reopening with the same frozen book fails shut.
     state.observation = observation;
+    state.rawObservation = null;
     state.referenceSize = refSize;
     state.conversionValidUntil = null;
     return sourceSnapshot(input, state, {
@@ -638,28 +621,7 @@ function acceptDueObservation(
       newSuccess: false,
     });
   }
-  if (observation.observationAt === null || observation.sequence === null) {
-    return failSource(input, state, refSize, {
-      kind: "source_freshness",
-      cause: new Error("venue observation has no publication identity"),
-    });
-  }
-  const fresh = observationIsFresh(
-    observation,
-    input.policy,
-    input.context.nowMs,
-  );
-  if (!fresh) {
-    return failSource(input, state, refSize, {
-      kind: "source_freshness",
-      cause: new Error("stale venue observation"),
-    });
-  }
-  const advancement = recordProviderAdvancement(
-    state,
-    observation.observationAt,
-    observation.sequence,
-  );
+  const advancement = providerAdvancement(input, state, rawObservation);
   if (advancement.failure !== null) {
     return failSource(input, state, refSize, {
       kind: "source_freshness",
@@ -667,6 +629,8 @@ function acceptDueObservation(
     });
   }
   state.observation = observation;
+  state.rawObservation =
+    input.source.convertVia === undefined ? null : rawObservation;
   state.referenceSize = refSize;
   state.conversionValidUntil = converted.validUntil;
   // A repeated provider identity remains healthy until its provider timestamp
@@ -675,6 +639,52 @@ function acceptDueObservation(
     referenceSize: refSize,
     observation,
     newSuccess: advancement.advanced,
+  });
+}
+
+async function refreshExpiredConversion(
+  input: PollSourceInput,
+  state: SourceState,
+  refSize: number,
+): Promise<PegSourceMetricSnapshot> {
+  const rawObservation = state.rawObservation;
+  if (
+    rawObservation === null ||
+    !observationIsFresh(rawObservation, input.policy, input.context.nowMs)
+  ) {
+    return failSource(input, state, refSize, {
+      kind: "source_freshness",
+      cause: new Error("stale retained venue observation"),
+    });
+  }
+
+  let converted: Awaited<ReturnType<typeof convertPegSourceObservation>>;
+  try {
+    converted = await convertPegSourceObservation(
+      rawObservation,
+      input.source.convertVia,
+      input.context.nowSeconds,
+      input.context.dependencies.readConversionLeg,
+    );
+  } catch (cause) {
+    return failSource(input, state, refSize, {
+      kind: "conversion",
+      cause,
+    });
+  }
+  if (converted.observation === null) {
+    return failSource(input, state, refSize, {
+      kind: "conversion_unavailable",
+      cause: new Error("conversion leg is not authoritative"),
+    });
+  }
+
+  state.observation = converted.observation;
+  state.conversionValidUntil = converted.validUntil;
+  return sourceSnapshot(input, state, {
+    referenceSize: refSize,
+    observation: converted.observation,
+    newSuccess: false,
   });
 }
 
@@ -739,12 +749,13 @@ async function pollDueSource(
       cause: listingError,
     });
   }
-  let converted: Awaited<ReturnType<typeof convertSourceObservation>>;
+  let converted: Awaited<ReturnType<typeof convertPegSourceObservation>>;
   try {
-    converted = await convertSourceObservation(
-      input.source,
+    converted = await convertPegSourceObservation(
       rawObservation,
-      input.context,
+      input.source.convertVia,
+      input.context.nowSeconds,
+      input.context.dependencies.readConversionLeg,
     );
   } catch (cause) {
     return failSource(input, state, refSize, {
@@ -752,7 +763,32 @@ async function pollDueSource(
       cause,
     });
   }
-  return acceptDueObservation(input, state, refSize, converted);
+  return acceptDueObservation(input, state, refSize, {
+    raw: rawObservation,
+    converted,
+  });
+}
+
+async function pollProviderDue(
+  input: PollSourceInput,
+  state: SourceState,
+  refSize: number,
+  listingCadenceDue: boolean,
+): Promise<PegSourceMetricSnapshot> {
+  const snapshot = await pollDueSource(
+    input,
+    state,
+    refSize,
+    listingCadenceDue,
+  );
+  if (input.blindConsecutivePollLimit !== null) {
+    updateBlindConsecutivePolls(
+      state,
+      input.blindConsecutivePollLimit,
+      snapshot.newUsableDecision,
+    );
+  }
+  return snapshot;
 }
 
 async function pollSource(
@@ -783,27 +819,17 @@ async function pollSource(
       listingCadenceDue,
     );
   }
-  // A changed binding reference size or expired conversion proof requires an
-  // immediate refresh inside the ordinary cadence window.
-  const due = sourceDue(state, input, refSize, observationCadenceDue);
+  // A changed binding reference size requires an immediate provider refresh.
+  const due = sourceDue(state, refSize, observationCadenceDue);
   if (due) {
-    const snapshot = await pollDueSource(
-      input,
-      state,
-      refSize,
-      listingCadenceDue,
-    );
-    if (input.blindConsecutivePollLimit !== null) {
-      updateBlindConsecutivePolls(
-        state,
-        input.blindConsecutivePollLimit,
-        snapshot.newUsableDecision,
-      );
-    }
-    return snapshot;
+    return pollProviderDue(input, state, refSize, listingCadenceDue);
   }
 
   await pollListingOnly(input, state, listingCadenceDue);
+
+  if (conversionExpiryDue(state, input.source, input.context)) {
+    return refreshExpiredConversion(input, state, refSize);
+  }
 
   const observation = cachedObservation(
     state,

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -868,6 +868,9 @@ async function snapshotWithoutReferenceSize(
       newSuccess: false,
     });
   }
+  if (conversionExpiryDue(state, input.source, input.context)) {
+    return refreshExpiredConversion(input, state, state.referenceSize);
+  }
   const observation = cachedObservation(
     state,
     input.source,

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -407,6 +407,33 @@ function sourceCadences(
   };
 }
 
+function conversionExpiryDue(
+  state: SourceState,
+  source: PegSource,
+  context: CycleContext,
+): boolean {
+  return (
+    source.convertVia !== undefined &&
+    state.observation !== null &&
+    state.observation.venueState !== "halted" &&
+    state.conversionValidUntil !== null &&
+    context.nowSeconds > state.conversionValidUntil
+  );
+}
+
+function sourceDue(
+  state: SourceState,
+  input: PollSourceInput,
+  refSize: number,
+  observationCadenceDue: boolean,
+): boolean {
+  return (
+    observationCadenceDue ||
+    state.referenceSize !== refSize ||
+    conversionExpiryDue(state, input.source, input.context)
+  );
+}
+
 function fetchSource(
   input: PollSourceInput,
   refSize: number,
@@ -756,9 +783,9 @@ async function pollSource(
       listingCadenceDue,
     );
   }
-  // A changed binding reference size requires an immediate new decision even
-  // inside the ordinary cadence window.
-  const due = observationCadenceDue || state.referenceSize !== refSize;
+  // A changed binding reference size or expired conversion proof requires an
+  // immediate refresh inside the ordinary cadence window.
+  const due = sourceDue(state, input, refSize, observationCadenceDue);
   if (due) {
     const snapshot = await pollDueSource(
       input,

--- a/metrics-bridge/test/peg-decision-packages.test.ts
+++ b/metrics-bridge/test/peg-decision-packages.test.ts
@@ -197,6 +197,7 @@ function sourceState(lastAttemptAt: number): PegPollSourceState {
     lastObservationAt: null,
     identitiesAtLastObservationAt: new Set(),
     observation: null,
+    rawObservation: null,
     referenceSize: null,
     conversionValidUntil: null,
     listingState: null,
@@ -475,6 +476,7 @@ describe("peg decision-package producer", () => {
     const { dependencies, report } = cycleDependencies();
     const activeKey = sourceStateKey(active.version);
     const original = sourceState(1);
+    original.rawObservation = snapshot(active.version).sources[0]!.observation;
     const sourceStates = new Map([[activeKey, original]]);
     const byteLength = vi
       .spyOn(Buffer, "byteLength")
@@ -489,7 +491,9 @@ describe("peg decision-package producer", () => {
           if (selectedPolicy.version === previous.version) {
             throw new Error("previous build failed");
           }
-          cycle.sourceStates.get(activeKey)!.lastAttemptAt += 100;
+          const stagedState = cycle.sourceStates.get(activeKey)!;
+          stagedState.lastAttemptAt += 100;
+          stagedState.rawObservation!.vwap = 0.5;
           cycle.activeStateKeys.add(activeKey);
           return [snapshot(active.version)];
         },
@@ -505,6 +509,7 @@ describe("peg decision-package producer", () => {
     );
     expect(currentPegDecisionPackagesJson()).toBe(first);
     expect(sourceStates.get(activeKey)).toBe(original);
+    expect(original.rawObservation?.vwap).toBe(0.99);
     expect(await register.metrics()).not.toContain(
       `mento_peg_poll_success_total{asset="asset-one",source="deep_eur",policy_version="${active.version}"} 1`,
     );

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -794,7 +794,9 @@ describe("peg poll cycle freshness and measurements", () => {
     const input = makeInput([spec]);
     let nowMs = 1_800_000_000_000;
     let limit0 = "0";
-    const fetchBitvavo = vi.fn(async () => observation(nowMs));
+    const fetchBitvavo = vi.fn(async () =>
+      observation(nowMs, { capped: true, filledFraction: 0.5 }),
+    );
     const fetchStructuralContext = vi.fn(async () =>
       structuralContext(spec, Math.floor(nowMs / 1_000), {
         limit0,
@@ -812,6 +814,7 @@ describe("peg poll cycle freshness and measurements", () => {
 
     const capSnapshot = (await poller.pollCycle(input))[0]!;
     expect(source(capSnapshot).referenceSize).toBe(50);
+    expect(capSnapshot.blindConsecutivePolls).toBe(1);
     expect(fetchBitvavo.mock.calls[0]?.[0]).toMatchObject({
       market: "PEG-EUR",
       refSize: 50,
@@ -826,6 +829,7 @@ describe("peg poll cycle freshness and measurements", () => {
     nowMs += 1_000;
     const limitedSnapshot = (await poller.pollCycle(input))[0]!;
     expect(source(limitedSnapshot).referenceSize).toBe(20);
+    expect(limitedSnapshot.blindConsecutivePolls).toBe(2);
     expect(fetchBitvavo.mock.calls[1]?.[0].refSize).toBe(20);
   });
 
@@ -1616,7 +1620,7 @@ describe("peg poll cycle conversion and cadence", () => {
     expect(errors.map(({ kind }) => kind)).toContain("conversion_unavailable");
   });
 
-  it("refreshes a healthy converted display source when its conversion expires before source cadence", async () => {
+  it("refreshes short-lived conversion evidence without advancing provider cadence", async () => {
     const spec = primaryAsset({
       sources: [
         primarySource({
@@ -1667,11 +1671,29 @@ describe("peg poll cycle conversion and cadence", () => {
     const refreshed = (await poller.pollCycle(input))[0]!;
     expect(source(refreshed, "kraken_usd")).toMatchObject({
       healthy: true,
-      newSuccess: true,
+      newSuccess: false,
       observation: { vwap: 1 },
     });
-    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(source(refreshed, "kraken_usd")).not.toHaveProperty(
+      "rawObservation",
+    );
+    expect(fetchKraken).toHaveBeenCalledOnce();
     expect(readConversionLeg).toHaveBeenCalledTimes(2);
+
+    nowMs += 61_000;
+    const refreshedAgain = (await poller.pollCycle(input))[0]!;
+    expect(source(refreshedAgain, "kraken_usd")).toMatchObject({
+      healthy: true,
+      newSuccess: false,
+      observation: { vwap: 1 },
+    });
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(3);
+
+    nowMs += 178_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(readConversionLeg).toHaveBeenCalledTimes(4);
   });
 
   it("fails closed once on converted-source expiry without retrying until ordinary cadence", async () => {
@@ -1697,6 +1719,13 @@ describe("peg poll cycle conversion and cadence", () => {
     let authoritative = true;
     const errors: PegPollErrorEvent[] = [];
     const fetchKraken = vi.fn(async () => observation(nowMs));
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative,
+      unavailableReason: authoritative ? null : ("stale" as const),
+    }));
     const poller = createPegPoller({
       nowMs: () => nowMs,
       fetchStructuralContext: vi.fn(async () =>
@@ -1704,13 +1733,7 @@ describe("peg poll cycle conversion and cadence", () => {
       ),
       fetchBitvavo: vi.fn(async () => observation(nowMs)),
       fetchKraken,
-      readConversionLeg: vi.fn(async () => ({
-        rate: 2,
-        medianAt: Math.floor(nowMs / 1_000),
-        expirySeconds: 60,
-        authoritative,
-        unavailableReason: authoritative ? null : ("stale" as const),
-      })),
+      readConversionLeg,
       publish: vi.fn(),
       onError: (event) => errors.push(event),
     });
@@ -1723,21 +1746,206 @@ describe("peg poll cycle conversion and cadence", () => {
       healthy: false,
       observation: null,
     });
-    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
     expect(errors.map(({ kind }) => kind)).toEqual(["conversion_unavailable"]);
 
     nowMs += 15_000;
     await poller.pollCycle(input);
-    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
     expect(errors).toHaveLength(1);
 
-    nowMs += 285_000;
+    nowMs += 223_000;
     await poller.pollCycle(input);
-    expect(fetchKraken).toHaveBeenCalledTimes(3);
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
+    expect(errors).toHaveLength(1);
+
+    nowMs += 1_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(readConversionLeg).toHaveBeenCalledTimes(3);
     expect(errors.map(({ kind }) => kind)).toEqual([
       "conversion_unavailable",
       "conversion_unavailable",
     ]);
+  });
+
+  it("fails closed when retained raw provider evidence expires", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          id: "kraken_usd",
+          provider: "kraken",
+          pair: "PEG/USD",
+          authority: "deep",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    const errors: PegPollErrorEvent[] = [];
+    const fetchKraken = vi.fn(async () =>
+      observation(nowMs, {
+        observationAt: nowMs - 570_000,
+        sequence: `old-sequence-${nowMs}`,
+      }),
+    );
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative: true,
+      unavailableReason: null,
+    }));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchKraken,
+      readConversionLeg,
+      publish: vi.fn(),
+      onError: (event) => errors.push(event),
+    });
+
+    await poller.pollCycle(input);
+    nowMs += 61_000;
+    const stale = (await poller.pollCycle(input))[0]!;
+
+    expect(source(stale, "kraken_usd")).toMatchObject({
+      healthy: false,
+      observation: null,
+    });
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledOnce();
+    expect(errors.map(({ kind }) => kind)).toEqual(["source_freshness"]);
+
+    nowMs += 239_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not count conversion-only refreshes as deep-source cadence slots", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    const fetchBitvavo = vi.fn(async () =>
+      observation(nowMs, {
+        vwap: 2,
+        bid: 1.998,
+        ask: 2.002,
+        capped: true,
+        filledFraction: 0.5,
+      }),
+    );
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative: true,
+      unavailableReason: null,
+    }));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchBitvavo,
+      readConversionLeg,
+      publish: vi.fn(),
+    });
+
+    const initial = (await poller.pollCycle(input))[0]!;
+    expect(initial.blindConsecutivePolls).toBe(1);
+
+    nowMs += 61_000;
+    const firstRefresh = (await poller.pollCycle(input))[0]!;
+    expect(firstRefresh.blindConsecutivePolls).toBe(1);
+    nowMs += 61_000;
+    const secondRefresh = (await poller.pollCycle(input))[0]!;
+    expect(secondRefresh.blindConsecutivePolls).toBe(1);
+    expect(fetchBitvavo).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(3);
+
+    nowMs += 178_000;
+    const ordinaryCadence = (await poller.pollCycle(input))[0]!;
+    expect(ordinaryCadence.blindConsecutivePolls).toBe(2);
+    expect(fetchBitvavo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refresh conversion evidence for a halted converted source", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          id: "kraken_usd",
+          provider: "kraken",
+          pair: "PEG/USD",
+          authority: "deep",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    let halted = false;
+    const fetchKraken = vi.fn(async () =>
+      observation(nowMs, {
+        venueState: halted ? "halted" : "ok",
+        vwap: halted ? null : 2,
+        bid: halted ? null : 1.998,
+        ask: halted ? null : 2.002,
+      }),
+    );
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative: true,
+      unavailableReason: null,
+    }));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchKraken,
+      readConversionLeg,
+      publish: vi.fn(),
+    });
+
+    await poller.pollCycle(input);
+    halted = true;
+    nowMs += 300_000;
+    const haltedSnapshot = (await poller.pollCycle(input))[0]!;
+    expect(source(haltedSnapshot, "kraken_usd")).toMatchObject({
+      healthy: false,
+      observation: { venueState: "halted" },
+    });
+
+    nowMs += 61_000;
+    const retainedHalt = (await poller.pollCycle(input))[0]!;
+    expect(source(retainedHalt, "kraken_usd")).toMatchObject({
+      healthy: false,
+      observation: { venueState: "halted" },
+    });
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(readConversionLeg).toHaveBeenCalledOnce();
   });
 
   it("keeps direct-source polling on ordinary cadence", async () => {

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -1616,6 +1616,168 @@ describe("peg poll cycle conversion and cadence", () => {
     expect(errors.map(({ kind }) => kind)).toContain("conversion_unavailable");
   });
 
+  it("refreshes a healthy converted display source when its conversion expires before source cadence", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+        }),
+        primarySource({
+          id: "kraken_usd",
+          provider: "kraken",
+          pair: "PEG/USD",
+          authority: "display",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    const fetchKraken = vi.fn(async () =>
+      observation(nowMs, { vwap: 2, bid: 1.998, ask: 2.002 }),
+    );
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative: true,
+      unavailableReason: null,
+    }));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchBitvavo: vi.fn(async () => observation(nowMs)),
+      fetchKraken,
+      readConversionLeg,
+      publish: vi.fn(),
+    });
+
+    const initial = (await poller.pollCycle(input))[0]!;
+    expect(source(initial, "kraken_usd")).toMatchObject({
+      healthy: true,
+      observation: { vwap: 1 },
+    });
+
+    nowMs += 61_000;
+    const refreshed = (await poller.pollCycle(input))[0]!;
+    expect(source(refreshed, "kraken_usd")).toMatchObject({
+      healthy: true,
+      newSuccess: true,
+      observation: { vwap: 1 },
+    });
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed once on converted-source expiry without retrying until ordinary cadence", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+        }),
+        primarySource({
+          id: "kraken_usd",
+          provider: "kraken",
+          pair: "PEG/USD",
+          authority: "display",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    let authoritative = true;
+    const errors: PegPollErrorEvent[] = [];
+    const fetchKraken = vi.fn(async () => observation(nowMs));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchBitvavo: vi.fn(async () => observation(nowMs)),
+      fetchKraken,
+      readConversionLeg: vi.fn(async () => ({
+        rate: 2,
+        medianAt: Math.floor(nowMs / 1_000),
+        expirySeconds: 60,
+        authoritative,
+        unavailableReason: authoritative ? null : ("stale" as const),
+      })),
+      publish: vi.fn(),
+      onError: (event) => errors.push(event),
+    });
+
+    await poller.pollCycle(input);
+    authoritative = false;
+    nowMs += 61_000;
+    const expired = (await poller.pollCycle(input))[0]!;
+    expect(source(expired, "kraken_usd")).toMatchObject({
+      healthy: false,
+      observation: null,
+    });
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(errors.map(({ kind }) => kind)).toEqual(["conversion_unavailable"]);
+
+    nowMs += 15_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+    expect(errors).toHaveLength(1);
+
+    nowMs += 285_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(3);
+    expect(errors.map(({ kind }) => kind)).toEqual([
+      "conversion_unavailable",
+      "conversion_unavailable",
+    ]);
+  });
+
+  it("keeps direct-source polling on ordinary cadence", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          id: "kraken_eur",
+          provider: "kraken",
+          pair: "PEG/EUR",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    const fetchKraken = vi.fn(async () => observation(nowMs));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchKraken,
+      publish: vi.fn(),
+    });
+
+    await poller.pollCycle(input);
+    nowMs += 120_000;
+    const cached = (await poller.pollCycle(input))[0]!;
+    expect(source(cached, "kraken_eur")).toMatchObject({
+      healthy: true,
+      newSuccess: false,
+    });
+    expect(fetchKraken).toHaveBeenCalledOnce();
+
+    nowMs += 180_000;
+    await poller.pollCycle(input);
+    expect(fetchKraken).toHaveBeenCalledTimes(2);
+  });
+
   it("honors independent Bitvavo and Kraken source cadences", async () => {
     const spec = primaryAsset({
       sources: [

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -1696,7 +1696,75 @@ describe("peg poll cycle conversion and cadence", () => {
     expect(readConversionLeg).toHaveBeenCalledTimes(4);
   });
 
-  it("fails closed once on converted-source expiry without retrying until ordinary cadence", async () => {
+  it("refreshes expired conversion evidence during a structural outage", async () => {
+    const spec = primaryAsset({
+      sources: [
+        primarySource({
+          id: "kraken_usd",
+          provider: "kraken",
+          pair: "PEG/USD",
+          pollIntervalSeconds: 300,
+          staleAfterSeconds: 600,
+          converted: true,
+        }),
+      ],
+    });
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    let structuralAvailable = true;
+    const fetchKraken = vi.fn(async () =>
+      observation(nowMs, { vwap: 2, bid: 1.998, ask: 2.002 }),
+    );
+    const readConversionLeg = vi.fn(async () => ({
+      rate: 2,
+      medianAt: Math.floor(nowMs / 1_000),
+      expirySeconds: 60,
+      authoritative: true,
+      unavailableReason: null,
+    }));
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () => {
+        if (!structuralAvailable) throw new Error("Hasura unavailable");
+        return structuralContext(spec, Math.floor(nowMs / 1_000));
+      }),
+      fetchKraken,
+      readConversionLeg,
+      publish: vi.fn(),
+    });
+
+    await poller.pollCycle(input);
+    structuralAvailable = false;
+    nowMs += 61_000;
+    const unavailable = (await poller.pollCycle(input))[0]!;
+    expect(unavailable.indexedPoolReachable).toBe(false);
+    expect(source(unavailable, "kraken_usd")).toMatchObject({
+      healthy: true,
+      referenceSize: 50,
+      newSuccess: false,
+      observation: { vwap: 1 },
+    });
+    expect(source(unavailable, "kraken_usd")).not.toHaveProperty(
+      "rawObservation",
+    );
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
+
+    structuralAvailable = true;
+    nowMs += 1_000;
+    const recovered = (await poller.pollCycle(input))[0]!;
+    expect(recovered.indexedPoolReachable).toBe(true);
+    expect(source(recovered, "kraken_usd")).toMatchObject({
+      healthy: true,
+      referenceSize: 50,
+      newSuccess: false,
+      observation: { vwap: 1 },
+    });
+    expect(fetchKraken).toHaveBeenCalledOnce();
+    expect(readConversionLeg).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed once during a structural outage without retrying before ordinary cadence", async () => {
     const spec = primaryAsset({
       sources: [
         primarySource({
@@ -1717,6 +1785,7 @@ describe("peg poll cycle conversion and cadence", () => {
     const input = makeInput([spec]);
     let nowMs = 1_800_000_000_000;
     let authoritative = true;
+    let structuralAvailable = true;
     const errors: PegPollErrorEvent[] = [];
     const fetchKraken = vi.fn(async () => observation(nowMs));
     const readConversionLeg = vi.fn(async () => ({
@@ -1728,9 +1797,10 @@ describe("peg poll cycle conversion and cadence", () => {
     }));
     const poller = createPegPoller({
       nowMs: () => nowMs,
-      fetchStructuralContext: vi.fn(async () =>
-        structuralContext(spec, Math.floor(nowMs / 1_000)),
-      ),
+      fetchStructuralContext: vi.fn(async () => {
+        if (!structuralAvailable) throw new Error("Hasura unavailable");
+        return structuralContext(spec, Math.floor(nowMs / 1_000));
+      }),
       fetchBitvavo: vi.fn(async () => observation(nowMs)),
       fetchKraken,
       readConversionLeg,
@@ -1740,36 +1810,49 @@ describe("peg poll cycle conversion and cadence", () => {
 
     await poller.pollCycle(input);
     authoritative = false;
+    structuralAvailable = false;
     nowMs += 61_000;
     const expired = (await poller.pollCycle(input))[0]!;
+    expect(expired.indexedPoolReachable).toBe(false);
     expect(source(expired, "kraken_usd")).toMatchObject({
       healthy: false,
       observation: null,
     });
     expect(fetchKraken).toHaveBeenCalledOnce();
     expect(readConversionLeg).toHaveBeenCalledTimes(2);
-    expect(errors.map(({ kind }) => kind)).toEqual(["conversion_unavailable"]);
+    expect(
+      errors.filter(({ kind }) => kind === "conversion_unavailable"),
+    ).toHaveLength(1);
 
     nowMs += 15_000;
     await poller.pollCycle(input);
     expect(fetchKraken).toHaveBeenCalledOnce();
     expect(readConversionLeg).toHaveBeenCalledTimes(2);
-    expect(errors).toHaveLength(1);
+    expect(
+      errors.filter(({ kind }) => kind === "conversion_unavailable"),
+    ).toHaveLength(1);
 
+    structuralAvailable = true;
     nowMs += 223_000;
-    await poller.pollCycle(input);
+    const recovered = (await poller.pollCycle(input))[0]!;
+    expect(recovered.indexedPoolReachable).toBe(true);
+    expect(source(recovered, "kraken_usd")).toMatchObject({
+      healthy: false,
+      observation: null,
+    });
     expect(fetchKraken).toHaveBeenCalledOnce();
     expect(readConversionLeg).toHaveBeenCalledTimes(2);
-    expect(errors).toHaveLength(1);
+    expect(
+      errors.filter(({ kind }) => kind === "conversion_unavailable"),
+    ).toHaveLength(1);
 
     nowMs += 1_000;
     await poller.pollCycle(input);
     expect(fetchKraken).toHaveBeenCalledTimes(2);
     expect(readConversionLeg).toHaveBeenCalledTimes(3);
-    expect(errors.map(({ kind }) => kind)).toEqual([
-      "conversion_unavailable",
-      "conversion_unavailable",
-    ]);
+    expect(
+      errors.filter(({ kind }) => kind === "conversion_unavailable"),
+    ).toHaveLength(2);
   });
 
   it("fails closed when retained raw provider evidence expires", async () => {


### PR DESCRIPTION
## The Problem

- The USD-quoted Kraken display source can disappear between its normal five-minute polls when its USD-to-EUR conversion proof expires.
- Fetching Kraken early to repair that proof would silently increase the provider request rate and could distort deep-source blind counters.
- During a structural-data outage, the expired-proof path could discard the retained Kraken book before refreshing its conversion, leaving the source unavailable after structural data recovered.

## The Solution

- Retain the latest provider-native book inside the poller's private source state and refresh only its conversion proof when that proof expires, including while current structural data is temporarily unavailable and a prior reference size is known.
- Keep provider polling and blind counters on their existing cadence. If the retained book is stale or conversion is unavailable, clear the source and wait for the ordinary provider cadence before retrying.

## Details

### Invariants

- An expired conversion proof never supports a healthy observation.
- Conversion-only work does not fetch Kraken, update `lastAttemptAt`, advance provider identity, or change deep-source blind counters.
- A structural-data outage can reuse the last known reference size for the retained book; it does not invent new structural authority or a new reference size.
- Reference-size changes still fetch the provider immediately and keep their existing blind-counter behavior.
- Provider freshness and advancement use the provider-native observation. That raw evidence stays inside source state, is cloned transactionally, never appears in snapshots or metrics, and is cleared on unusable, absent, or halted paths.
- Direct and halted sources keep their existing behavior, and policy-version state remains isolated.

### Degraded behavior

- Stale retained provider evidence clears the source and reports `source_freshness` without reading another conversion proof.
- A thrown or non-authoritative conversion clears both raw and converted evidence, reports the existing conversion error, and cannot retry on the 15-second Peg loop. The next provider attempt remains anchored to the original configured cadence.
- A successful conversion refresh can repeat when another short-lived proof expires while the same provider book remains fresh, without another provider request.
- If structural data is unavailable and no prior reference size exists, the source remains fail-closed.

### Intentional non-goals

- This does not relax provider freshness or sequence checks, change the five-minute provider cadence, or promote the USD-quoted source from display evidence to alert authority.
- This does not change the conversion oracle's report-expiry policy.

Closes #1771.

## Validation

- `CI=true pnpm agent:quality-gate --base origin/main --run` — all 8 mapped commands passed on the final feedback batch, including Metrics Bridge coverage, dependency boundaries, and `pnpm tf:test`.
- Full Metrics Bridge suite — 585 tests passed.
- Metrics Bridge lint, typecheck, build, coverage, knip, dependency boundaries, and targeted Trunk checks passed.
- Autoreview feedback pass 1, fresh-context semantic mode — accepted one P2 source-state fixture/clone finding and fixed it.
- Autoreview feedback rereview, deterministic local mode — clean.
- Autoreview feedback rereview, fresh-context semantic mode — all 5 changed files and required state/cadence contracts reviewed; 0 findings, 0.97 confidence; pre/post bundle SHA-256 `d0093660c37e58dc1c3c77c0cd3dc311360b1e52ac47c21cc86bbb580e582894` verified.
- Autoreview feedback cycle 2, deterministic local mode — clean.
- Autoreview feedback cycle 2, fresh-context semantic mode — the 2-file no-reference delta and structural-outage recovery/failure contracts reviewed; 0 findings, 0.88 confidence; pre/post bundle SHA-256 `f436462e5c723acb239c2b75d8b54a21110c5f653ea581dc545a424a464dacb7` verified.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this restores the existing fail-closed conversion lifecycle recorded in ADR 0042.
