### PR TITLE
fix(sentry): bind the verdict job to the round that produced its verdict

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -51,6 +51,12 @@ jobs:
   # and the secret guard live inside the first step, so a disabled or
   # unprovisioned state is a clean no-op (`[]`, exit 0), never a failure and
   # never an empty matrix expression downstream.
+  #
+  # It also records, per selected stub, the verdict comment already on it — the
+  # round binding for the `verdict` job below (issue #1717). This is the only
+  # job that can: it is trusted AND it runs before the agent, so what it reads
+  # is what the round started from. The read is GitHub-only; no Sentry call and
+  # no Sentry credential enter this job.
   # ---------------------------------------------------------------------------
   select:
     runs-on: ubuntu-latest
@@ -68,7 +74,22 @@ jobs:
     outputs:
       issues: ${{ steps.select.outputs.issues }}
       count: ${{ steps.select.outputs.count }}
+      priorVerdicts: ${{ steps.prior-verdicts.outputs.priorVerdicts }}
     steps:
+      # SHA-pinned (not tags) so tag retargeting / a compromised release cannot
+      # silently run new code. Bump via Dependabot (.github/dependabot.yml).
+      # This checkout is PRISTINE — no agent runs in this job — so the
+      # prior-verdict recorder below is safe to run from the checkout path, the
+      # same reasoning the `verdict` job's plain `scripts/` invocation rests on.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
       - name: Select queue issues (kill-switch + secret guarded)
         id: select
         env:
@@ -136,6 +157,57 @@ jobs:
             echo "count=${count}"
           } >> "${GITHUB_OUTPUT}"
           echo "Selected ${count} issue(s): ${issues}"
+
+      # -----------------------------------------------------------------------
+      # Round binding, recorded BEFORE the agent runs (issue #1717).
+      #
+      # The `verdict` job is `if: always()`, so a triage round that dies before
+      # posting still reaches it, and it settles the stub on the newest
+      # ADMISSIBLE verdict comment. The regression fence only makes a verdict
+      # inadmissible when some producer posted a fence; ingest's stranded-stub
+      # sweep re-queues for BOOKKEEPING and posts none, by design — nothing
+      # about the Sentry issue changed as far as it can see. It reads GitHub
+      # only, so a Sentry occurrence that landed after its own
+      # `fetchMergedSentryIssues()` returned is invisible to it, and the
+      # previous round's verdict — which describes the pre-regression
+      # occurrence — stays admissible. Without this binding the `verdict` job
+      # then labels and closes on it, and the close postdates the occurrence, so
+      # ingest's dedup gate skips the stub until the NEXT occurrence: a live
+      # regression laundered into a settled ledger entry.
+      #
+      # So record what each stub already carried and make the verdict job prove
+      # the round moved it forward. This is the same generation-token plumbing
+      # the autofix leg threads (issue #1506), and it kills the consequence
+      # whatever the re-queue's cause was — no per-stub Sentry lookup is added
+      # to the sweep, which is what makes it a design fix rather than a guard.
+      #
+      # `[]` (kill switch off, secrets unprovisioned, or an empty queue) emits
+      # `{}` and costs nothing. A per-stub read failure records `unknown`, which
+      # the verdict job refuses — fail closed for that stub only, never a
+      # starved batch.
+      # -----------------------------------------------------------------------
+      - name: Record the verdict comment each stub arrives with
+        id: prior-verdicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SELECTED_ISSUES: ${{ steps.select.outputs.issues }}
+        run: |
+          set -euo pipefail
+          # Plain scripts/ is correct here for the same reason it is in the
+          # verdict job and nowhere near the agent: this job has its own runner
+          # and its own pristine checkout, which no agent ever touched.
+          prior_file="${RUNNER_TEMP}/prior-verdicts.json"
+          node scripts/sentry-triage-project.mjs \
+            --prior-verdicts \
+            --issues "${SELECTED_ISSUES}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            > "${prior_file}"
+          # Compact to one line: GITHUB_OUTPUT is line-oriented, and the script
+          # already prints a single line — re-compacting is the cheap assertion
+          # that it stayed that way.
+          prior=$(jq -c . "${prior_file}")
+          echo "priorVerdicts=${prior}" >> "${GITHUB_OUTPUT}"
+          echo "Prior verdict comments: ${prior}"
 
   # ---------------------------------------------------------------------------
   # triage: one claude-code-action run per queue issue (max 2 in parallel).
@@ -610,8 +682,33 @@ jobs:
         id: verdict
         env:
           QUEUE_ISSUE_NUMBER: ${{ matrix.issue }}
+          # The select job's per-stub record of the verdict comment this round
+          # started from (issue #1717). Bot-produced JSON, read with jq below
+          # and shape-checked before it reaches the parser.
+          PRIOR_VERDICTS: ${{ needs.select.outputs.priorVerdicts }}
         run: |
           set -euo pipefail
+          # Round binding (#1717). This job runs under `if: always()`, so it
+          # also runs when the triage round died before posting anything — and
+          # the stub it is settling may have been re-queued by ingest's
+          # stranded-stub sweep, which declares `bookkeeping` and therefore
+          # posts no staleness fence. Without a binding, the resolution below
+          # would then re-apply the PREVIOUS round's verdict and close the stub,
+          # burying a Sentry regression that landed after ingest's own Sentry
+          # query. So require the verdict comment to be strictly newer than the
+          # one select recorded before the agent ran.
+          #
+          # A missing key is treated as `unknown`, which the parser refuses:
+          # every selected stub gets a record, so an absent one means the two
+          # jobs disagree about the batch — exactly when settling a stub is
+          # least defensible. An unset/unparsable PRIOR_VERDICTS fails the jq
+          # under set -e, which leaves sentry:needs-triage on for the next run.
+          prior=$(printf '%s' "${PRIOR_VERDICTS:-}" \
+            | jq -r --arg n "${QUEUE_ISSUE_NUMBER}" '.[$n] // "unknown"')
+          if ! [[ "${prior}" =~ ^([0-9]+|none|unknown)$ ]]; then
+            echo "::error::prior-verdict record for issue #${QUEUE_ISSUE_NUMBER} is '${prior}', not a comment id / none / unknown; refusing to settle the stub."
+            exit 1
+          fi
           # The agent's only write is the verdict comment. The label swap is
           # applied HERE, deterministically, so a prompt-injected agent cannot
           # touch labels at all. The PARSE is delegated to
@@ -621,7 +718,8 @@ jobs:
           # sed-vs-script divergence here could apply a label and then have the
           # projection silently skip while the stub closes as if handled). The
           # script reads the newest <!-- sentry-triage-verdict:v1 --> comment,
-          # applies the regression fence (only a verdict strictly newer than
+          # applies the round binding above and the regression fence (only a
+          # verdict strictly newer than
           # the newest "Regressed in Sentry (last seen " reopen comment counts,
           # so a stale pre-regression verdict never re-labels a regressed
           # issue), validates the verdict against the closed four-value enum,
@@ -646,8 +744,9 @@ jobs:
               --parse-only \
               --issue "${QUEUE_ISSUE_NUMBER}" \
               --repo "${GITHUB_REPOSITORY}" \
+              --prior-verdict-comment "${prior}" \
               > "${parse_file}"; then
-            echo "::error::No usable verdict on issue #${QUEUE_ISSUE_NUMBER} (missing, stale pre-regression, or invalid verdict comment — see the log above); leaving sentry:needs-triage in place for retry."
+            echo "::error::No usable verdict on issue #${QUEUE_ISSUE_NUMBER} (missing, stale pre-regression, invalid, or not produced by this triage round — see the log above); leaving sentry:needs-triage in place for retry."
             exit 1
           fi
           verdict=$(jq -r '.verdict' "${parse_file}")

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -196,6 +196,19 @@ one run — a failed regression re-queue laundered into a bookkeeping one. The
 chokepoint records the attempt before its first write, so the record exists
 whether or not the writes do.
 
+**The sweep has one blind spot, and it is structural.** It decides `bookkeeping`
+from GitHub state, and GitHub state cannot show a Sentry occurrence that landed
+after this run's `fetchMergedSentryIssues()` returned. When one does, the true
+cause was Sentry evidence: the stub goes back in the queue fence-free and the
+previous round's verdict — which describes the pre-regression occurrence — stays
+admissible. Nothing here closes that. A per-stub Sentry lookup in the sweep was
+rejected (it introduces Sentry coupling into a sweep that needs none, and any
+Sentry read has a window after it), and so was fencing every recovery, which
+would discard a good verdict on each genuine bookkeeping strand. The
+CONSEQUENCE is closed instead, one stage later: the settlement is bound to the
+triage round that produced its verdict — see
+[the round binding](#the-round-binding) (issue #1717).
+
 The namespace is separate from the development backlog:
 
 | Label                        | Meaning                                                                |
@@ -426,6 +439,45 @@ Every deterministic close records that the ledger issue will reopen on a
 future Sentry regression. A missing verdict after a scheduled run is an
 operational failure signal, not “no issues found.”
 
+### The round binding
+
+The `verdict` job runs `if: always()`, so a triage round that died before
+posting still reaches it — and it settles the stub on the newest ADMISSIBLE
+verdict comment, which may be the PREVIOUS round's. The regression fence only
+makes one inadmissible when a producer posted a fence, and the stranded-stub
+sweep deliberately posts none. So the settlement is bound to the round instead:
+
+- the `select` job records, per selected stub, the id of the verdict comment
+  already on it (`sentry-triage-project.mjs --prior-verdicts`, which selects
+  through `selectVerdictComment` — the same selector the settlement resolves
+  with, so the two ends cannot disagree about what "the previous verdict" is);
+- the `verdict` job passes that token to `--parse-only`, and `resolveVerdict`
+  refuses unless the comment it selects is strictly NEWER. Refusing on the same
+  id is the common case: the round posted nothing. Refusing on an OLDER id
+  covers the recorded comment having been deleted in between, which equality
+  alone would wave through onto an even older verdict.
+
+Only `select` may record it: it is trusted and it runs before the agent, so what
+it reads is what the round started from. Read afterwards, the token would
+include the round's own comment and prove nothing.
+
+The token is the `#issuecomment-<n>` id — the same generation token the autofix
+leg threads for its ABA check (issue #1506). Ids are unique and never reused, so
+there is no window to race.
+
+Both ends fail CLOSED, per stub and never per batch. A stub `select` could not
+read, or whose verdict comment carries no parseable id, is recorded `unknown`,
+and `unknown` never passes: nothing can be shown to postdate a baseline that was
+never read. That costs one wasted triage round on that stub — loud, and
+self-healing, because that round's own verdict comment becomes the next run's
+baseline. The refusal happens before the label edit, so the stub keeps
+`sentry:needs-triage` and the next scheduled run re-triages it.
+
+This closes the consequence whatever the re-queue's cause was, and it holds for
+the surviving archive-side route as well as the sweep's blind spot. It does not
+make the sweep able to see Sentry, and it is not a substitute for the fence: the
+digest, projection, and autofix consumers still read the fence.
+
 ### External verdict projection
 
 [ADR 0038](../adr/0038-sentry-central-plane-verdict-projection.md) limits projection to
@@ -508,12 +560,19 @@ The cause is the whole rule: one caused by new Sentry events must fence, because
 any prior verdict described the old occurrence; one caused by bookkeeping — the
 stranded-stub sweep above, which declares `bookkeeping` — must not, because
 nothing about the Sentry issue changed and that verdict is still valid. Drop the
-fence and a triage round that dies before posting lets the `verdict` job
-re-apply the previous verdict and close the stub over a live regression. Add one
-where it does not belong and a good verdict is discarded and re-triaged for
-nothing. Neither call site can make that mistake by omission: an undeclared
-cause refuses rather than defaulting either way, and `buildRegressedComment` —
-the fence's one definition — has exactly one caller, inside the chokepoint.
+fence and the digest, projection, and autofix consumers all read a verdict
+describing a dead occurrence. Add one where it does not belong and a good
+verdict is discarded and re-triaged for nothing. Neither call site can make that
+mistake by omission: an undeclared cause refuses rather than defaulting either
+way, and `buildRegressedComment` — the fence's one definition — has exactly one
+caller, inside the chokepoint.
+
+The fence is no longer the only thing standing between a fence-free re-queue and
+a stub closed over a live regression. The `verdict` job is additionally bound to
+the round that produced its verdict ([the round binding](#the-round-binding)),
+which holds whether or not a fence was posted and whether or not the declared
+cause was right. The fence still decides admissibility for every consumer; the
+binding decides whether this run may settle the stub at all.
 
 The refusal will not re-queue a stub it cannot fence, and it decides that by
 asking whether any verdict is still admissible — never by checking that a fence
@@ -851,6 +910,14 @@ permission or the environment-secret writes 403 (`terraform/providers.tf`).
 - A failed or invalid triage verdict retains `sentry:needs-triage`; rerun the
   agent workflow after correcting the underlying failure. Manual
   `issue_number` dispatches must target an open queue issue.
+- **A red `verdict` job saying it refuses to settle a stub "on a verdict this
+  triage round did not produce" is working as designed** ([the round
+  binding](#the-round-binding)). The round posted nothing — usually because the
+  agent leg failed — so the stub keeps `sentry:needs-triage` and the next
+  scheduled run re-triages it. Read the agent leg's failure, not this one. The
+  variant naming an unreadable prior verdict (`unknown`) means the `select`
+  job's per-stub read failed; that also self-heals on the next run. Neither
+  needs a manual label edit.
 - A refused autofix is terminal until a human reviews the refusal, corrects
   any transient cause, and removes `sentry:fix-refused` from the queue issue.
   Then dispatch `Sentry Autofix` from `main` for that issue or let the next

--- a/scripts/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry-triage-agent-comment.test.mjs
@@ -678,6 +678,62 @@ test("a failed verdict post-condition re-queues the stub instead of stranding it
   });
 });
 
+/** The select job's block, from its key to the triage job's. */
+function selectJobBlock() {
+  const start = WORKFLOW.indexOf("\n  select:");
+  const end = WORKFLOW.indexOf("\n  triage:");
+  assert.ok(start > 0 && end > start, "select/triage job boundaries not found");
+  return WORKFLOW.slice(start, end);
+}
+
+test("the round binding is recorded BEFORE the agent runs (#1717)", () => {
+  // Only the select job can record it: it is trusted AND it runs before the
+  // agent, so what it reads is what the round started from. Recorded anywhere
+  // later it would see the round's own comment and prove nothing.
+  const select = selectJobBlock();
+  assert.match(select, /--prior-verdicts/);
+  assert.match(select, /priorVerdicts: \$\{\{ steps\.prior-verdicts\.outputs/);
+  assert.match(select, /node scripts\/sentry-triage-project\.mjs/);
+  // It needs its own pristine checkout to run that script, and no agent runs
+  // in this job.
+  assert.match(select, /actions\/checkout@[0-9a-f]{40}/);
+  assert.match(select, /persist-credentials: false/);
+  // No other job may recompute it: a second recorder would be free to read the
+  // stub after the agent posted, which defeats the whole binding.
+  const elsewhere = WORKFLOW.replace(select, "");
+  assert.ok(
+    !/--prior-verdicts\b/.test(elsewhere),
+    "only the select job may record the prior verdict comment",
+  );
+});
+
+test("the verdict step binds its resolution to the recorded round (#1717)", () => {
+  const job = WORKFLOW.slice(
+    WORKFLOW.indexOf("\n  verdict:"),
+    WORKFLOW.indexOf("\n  project:"),
+  );
+  // The token travels through env + jq, never string-interpolated into the
+  // command line, and its shape is checked against the parser's closed set.
+  assert.match(
+    job,
+    /PRIOR_VERDICTS: \$\{\{ needs\.select\.outputs\.priorVerdicts \}\}/,
+  );
+  assert.match(job, /\^\(\[0-9\]\+\|none\|unknown\)\$/);
+  assert.match(job, /--prior-verdict-comment "\$\{prior\}"/);
+  // A missing record must resolve to `unknown` (which the parser refuses), not
+  // to an empty string that would silently unbind the fence.
+  assert.match(job, /'\.\[\$n\] \/\/ "unknown"'/);
+
+  // The refusal has to land BEFORE the label edit takes sentry:needs-triage
+  // off; after it, a refusal would strand the stub instead of re-queueing it.
+  const parse = job.indexOf("--prior-verdict-comment");
+  const edit = job.indexOf('--remove-label "sentry:needs-triage,${shed}"');
+  assert.ok(
+    parse > 0 && edit > parse,
+    "the binding must be checked before the label edit",
+  );
+});
+
 test("projection and digest wait for the verdict job", () => {
   assert.match(WORKFLOW, /project:\n\s+needs: \[select, triage, verdict\]/);
   assert.match(

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -49,8 +49,15 @@ import {
 import * as ingestModule from "./sentry-triage-ingest.mjs";
 import {
   ARCHIVE_COMMENT_MARKER,
+  REGRESSION_PREFIX,
   selectMarkedComment,
+  selectVerdictComment,
+  VERDICT_MARKER,
 } from "./sentry-triage-project-core.mjs";
+// The two workflow-facing helpers the round binding (#1717) spans: what the
+// select job records before the agent runs, and what the verdict job resolves
+// after it. Imported from the entry module because that is where they live.
+import { runParseOnly, runPriorVerdicts } from "./sentry-triage-project.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -2852,6 +2859,225 @@ await test("one unrecoverable stub is counted without stranding the rest", async
   assertEqual(counts.errors, 1);
   assertEqual(fake.get(43).state, "OPEN");
   assertEqual(fake.get(42).state, "CLOSED");
+});
+
+// ---------------------------------------------------------------------------
+// The sweep's blind spot, and what stops it laundering a regression (#1717).
+//
+// The sweep re-queues with cause `bookkeeping` and posts no staleness fence.
+// That stays correct and is deliberately unchanged here: it reads GitHub only,
+// and fencing every recovery would discard a good verdict on each genuine
+// bookkeeping strand — over-fencing, which is as wrong as under-fencing and
+// quieter. What no GitHub read can see is a Sentry occurrence that landed after
+// this run's `fetchMergedSentryIssues()` returned. The previous round's verdict
+// then stays ADMISSIBLE on a stub that is back in the queue, and the `verdict`
+// job runs `if: always()` — so a triage round that dies before posting used to
+// end with that verdict labeled and the stub closed, its `closed_at` past the
+// occurrence's `last_seen`, which makes ingest's own dedup gate skip it.
+//
+// The fix binds the settlement to the round instead of trying to infer the
+// cause. Both tests below drive the REAL sweep, then the REAL select-side
+// recorder, then the REAL resolver the verdict job runs.
+// ---------------------------------------------------------------------------
+
+/** One trusted verdict comment body, minimal but contract-shaped. */
+function verdictCommentBody(verdict) {
+  return [
+    VERDICT_MARKER,
+    "",
+    "```yaml",
+    `verdict: ${verdict}`,
+    "confidence: medium",
+    "affected_repo: mento-protocol/monitoring-monorepo",
+    "summary: a redacted one-liner",
+    "root_cause: |",
+    "  a redacted cause",
+    "proposed_action: |",
+    "  a redacted action",
+    "duplicate_of: []",
+    "```",
+  ].join("\n");
+}
+
+/** Dress the fake's comment BODIES as `gh issue view --json comments` returns
+ * them: trusted author, ascending createdAt, and the `#issuecomment-<id>` url
+ * the round binding reads its token from. */
+function asViewedComments(bodies, firstId = 9000) {
+  return bodies.map((body, index) => ({
+    body,
+    author: { login: "github-actions" },
+    createdAt: `2026-07-2${index}T00:00:00Z`,
+    url: `https://github.com/${REPO}/issues/42#issuecomment-${firstId + index}`,
+  }));
+}
+
+/** The two GitHub-facing helpers the triage workflow runs around a round, wired
+ * to one fixed comment list: what `select` records before the agent, and what
+ * the `verdict` job resolves after it. */
+function triageRoundHelpers(comments) {
+  const runGh = async () =>
+    JSON.stringify({
+      number: 42,
+      title: buildQueueTitle("X-42", "web", "error"),
+      body: "",
+      url: `https://github.com/${REPO}/issues/42`,
+      state: "OPEN",
+      labels: [{ name: "sentry-triage" }, { name: NEEDS_TRIAGE_LABEL }],
+      comments,
+    });
+  return {
+    recordPriorVerdicts: () =>
+      runPriorVerdicts({ localRepo: REPO, queueIssues: [42] }, { runGh }),
+    settle: (priorVerdictCommentId) =>
+      runParseOnly(
+        { localRepo: REPO, queueIssue: 42, priorVerdictCommentId },
+        { runGh },
+      ),
+  };
+}
+
+async function assertRefuses(promise, pattern) {
+  try {
+    await promise;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!pattern.test(message)) {
+      throw new Error(`expected ${message} to match ${pattern}`, {
+        cause: err,
+      });
+    }
+    return;
+  }
+  throw new Error("expected the resolution to refuse");
+}
+
+await test("a regression landing after the Sentry query is not laundered by the sweep (#1717)", async () => {
+  const verdict = verdictCommentBody("upstream-transient");
+  const fake = makeFakeGitHub({
+    issues: [
+      {
+        number: 42,
+        title: buildQueueTitle("X-42", "web", "error"),
+        state: "CLOSED",
+        labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+        comments: [verdict],
+      },
+    ],
+  });
+
+  // `ingestDeps` sees no Sentry results at all — which IS this scenario: the
+  // query returned before the occurrence arrived, so the regression branch
+  // never claims this stub and the sweep is what reaches it.
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake),
+  );
+  assertEqual(counts.recovered, 1);
+  assertDeepEqual(fake.selectable(), [42]);
+
+  // The re-queue is fence-free — the precondition for the laundering, and the
+  // behaviour this fix deliberately leaves alone.
+  const bodies = fake.get(42).comments;
+  assertDeepEqual(bodies, [verdict, buildStrandedRecoveryComment()]);
+  const comments = asViewedComments(bodies);
+  assertEqual(
+    selectVerdictComment(comments).body,
+    verdict,
+    "the pre-regression verdict must still be admissible, or this test proves nothing",
+  );
+
+  // Select records what the stub arrived with. The round then dies before
+  // posting, so nothing is appended.
+  const { recordPriorVerdicts, settle } = triageRoundHelpers(comments);
+  const prior = await recordPriorVerdicts();
+  assertDeepEqual(prior, { 42: "9000" });
+
+  await assertRefuses(
+    settle(prior["42"]),
+    /round did not produce.*already on the stub before this triage round/s,
+  );
+  // Nothing was written: the stub keeps sentry:needs-triage for the next run,
+  // which is what lets a later occurrence re-fence it properly.
+  assertDeepEqual(fake.selectable(), [42]);
+});
+
+await test("an archive refusal whose fence was deleted is not laundered either (#1717)", async () => {
+  // The surviving archive-side route (R2): the live-regression refusal
+  // re-queued through the chokepoint, someone with write access deleted the
+  // fence comment it posted, and the reopen then failed both attempts —
+  // leaving CLOSED + needs-triage + no fence, with only the archive's audit
+  // comment to show the leg ran. That run was already RED; the laundering is
+  // what a LATER ingest run would otherwise do to it.
+  const verdict = verdictCommentBody("code-fix");
+  const audit = `${ARCHIVE_COMMENT_MARKER}\nArchive refused: the Sentry issue is actively regressing.`;
+  const fake = makeFakeGitHub({
+    issues: [
+      {
+        number: 42,
+        title: buildQueueTitle("X-42", "web", "error"),
+        state: "CLOSED",
+        labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+        comments: [verdict, audit],
+      },
+    ],
+  });
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake),
+  );
+  assertEqual(counts.recovered, 1);
+
+  const bodies = fake.get(42).comments;
+  assert(
+    !bodies.some((body) => body.startsWith(REGRESSION_PREFIX)),
+    "the deleted fence is not restored by the bookkeeping sweep",
+  );
+  const comments = asViewedComments(bodies);
+  assertEqual(
+    selectVerdictComment(comments).body,
+    verdict,
+    "the archive audit comment is not a fence, so the verdict stays admissible",
+  );
+
+  const { recordPriorVerdicts, settle } = triageRoundHelpers(comments);
+  const prior = await recordPriorVerdicts();
+  await assertRefuses(
+    settle(prior["42"]),
+    /round did not produce.*already on the stub before this triage round/s,
+  );
+  assertDeepEqual(fake.selectable(), [42]);
+});
+
+await test("a round that DOES post a verdict still settles the swept stub (#1717)", async () => {
+  // The binding must not become a blanket refusal on every swept stub: a
+  // recovery whose next round works normally settles exactly as before.
+  const fake = makeFakeGitHub({
+    issues: [
+      {
+        number: 42,
+        title: buildQueueTitle("X-42", "web", "error"),
+        state: "CLOSED",
+        labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+        comments: [verdictCommentBody("upstream-transient")],
+      },
+    ],
+  });
+  await runIngest({ repo: REPO, trackerIssue: 1282 }, ingestDeps(fake));
+
+  const before = asViewedComments(fake.get(42).comments);
+  const prior = await triageRoundHelpers(before).recordPriorVerdicts();
+  // The round posts its own verdict, which lands after everything select saw.
+  const after = asViewedComments([
+    ...fake.get(42).comments,
+    verdictCommentBody("needs-human").replace(
+      "duplicate_of: []",
+      "duplicate_of: []\nhuman_question: |\n  Decide whether to roll back or wait for upstream.",
+    ),
+  ]);
+  const result = await triageRoundHelpers(after).settle(prior["42"]);
+  assertEqual(result.verdict, "needs-human");
+  assertEqual(result.label, "sentry:verdict-needs-human");
 });
 
 if (failed > 0) {

--- a/scripts/sentry-triage-project-core.mjs
+++ b/scripts/sentry-triage-project-core.mjs
@@ -624,6 +624,60 @@ export function verdictCommentIdFromUrl(url) {
   return match ? match[1] : null;
 }
 
+// ---------------------------------------------------------------------------
+// Round binding (issue #1717): which verdict comment was already on the stub
+// BEFORE this triage round ran.
+// ---------------------------------------------------------------------------
+
+/** No trusted, admissible verdict comment existed before the round. */
+export const PRIOR_VERDICT_NONE = "none";
+/** The pre-round read failed, or produced a comment with no parseable id.
+ * Distinct from `none` on purpose: `none` is a fact ("nothing was there"),
+ * `unknown` is an absence of evidence, and only one of them may pass. */
+export const PRIOR_VERDICT_UNKNOWN = "unknown";
+
+/** True for the three shapes a prior-verdict token may take: a bare numeric
+ * comment id, `none`, or `unknown`. Everything else is a wiring bug. */
+export function isPriorVerdictToken(value) {
+  return (
+    value === PRIOR_VERDICT_NONE ||
+    value === PRIOR_VERDICT_UNKNOWN ||
+    (typeof value === "string" && /^[0-9]+$/.test(value))
+  );
+}
+
+/**
+ * The round binding itself: given the verdict comment `selectVerdictComment`
+ * picked NOW and the token recorded BEFORE the round, decide whether this
+ * resolution may settle the stub. Returns null to allow, or a refusal reason.
+ *
+ * Accept only a comment strictly NEWER than the one the round started from.
+ * GitHub issue-comment ids come from one monotonically increasing sequence, so
+ * "newer" is a numeric comparison — and comparing rather than merely testing
+ * equality also covers the case where the recorded comment was deleted between
+ * the two reads, which equality would wave through onto an even older verdict.
+ * `unknown` never passes: without a baseline nothing can be proven newer than
+ * it, and settling a stub on an unprovable verdict is the failure this closes.
+ */
+export function priorVerdictRefusal(priorToken, selectedUrl) {
+  if (priorToken == null) return null; // no binding requested (projection path)
+  if (!isPriorVerdictToken(priorToken)) {
+    return `prior-verdict token ${JSON.stringify(priorToken)} is not a comment id, '${PRIOR_VERDICT_NONE}' or '${PRIOR_VERDICT_UNKNOWN}'`;
+  }
+  if (priorToken === PRIOR_VERDICT_UNKNOWN) {
+    return "the verdict comment present before this triage round could not be read, so no verdict can be shown to postdate it";
+  }
+  if (priorToken === PRIOR_VERDICT_NONE) return null;
+  const selectedId = verdictCommentIdFromUrl(selectedUrl);
+  if (selectedId === null) {
+    return `the selected verdict comment carries no parseable comment id (url=${selectedUrl}), so it cannot be shown to postdate comment ${priorToken}`;
+  }
+  if (BigInt(selectedId) > BigInt(priorToken)) return null;
+  return selectedId === priorToken
+    ? `the newest usable verdict comment (${selectedId}) is the one that was already on the stub before this triage round — the round posted no verdict of its own`
+    : `the newest usable verdict comment (${selectedId}) predates the one recorded before this triage round (${priorToken})`;
+}
+
 // Blatant non-decision placeholders that defeat the point of a needs-human
 // escalation — "please look" is not a decision. This is a DETERMINISTIC
 // BACKSTOP against the laziest bypasses, not a full decision-quality judge (a
@@ -683,12 +737,31 @@ export function isDecisionReadyQuestion(text) {
  * stub and then silently skip its projection while the stub closes as if
  * handled; funneling both steps through this one function removes that
  * divergence by construction (PR #1356 review).
+ *
+ * `options.priorVerdictCommentId` binds the resolution to the ROUND that is
+ * settling the stub (issue #1717). The regression fence above only catches a
+ * verdict older than a fence comment somebody posted; a stub re-queued for
+ * bookkeeping reasons carries no fence by design, so without this binding a
+ * triage round that dies before posting lets the `verdict` job label and close
+ * on the PREVIOUS round's verdict — laundering a regression that landed after
+ * ingest's Sentry query into a settled, closed stub. Callers that are already
+ * downstream of a settled verdict (projection, autofix select) pass nothing and
+ * keep the pre-#1717 behaviour.
  */
-export function resolveVerdict(issue, queueIssueNumber) {
+export function resolveVerdict(issue, queueIssueNumber, options = {}) {
   const selected = selectVerdictComment(issue.comments);
   if (!selected.body) {
     throw new Error(
       `No usable verdict comment on issue #${queueIssueNumber} (${selected.reason}).`,
+    );
+  }
+  const refusal = priorVerdictRefusal(
+    options.priorVerdictCommentId ?? null,
+    selected.url,
+  );
+  if (refusal) {
+    throw new Error(
+      `Refusing to settle issue #${queueIssueNumber} on a verdict this triage round did not produce: ${refusal}. Leaving sentry:needs-triage in place for re-triage.`,
     );
   }
   const parsed = parseVerdictComment(selected.body);

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -58,15 +58,20 @@ import {
   commentBacklinksShortId,
   DEFAULT_REPO,
   extractPermalink,
+  isPriorVerdictToken,
   isValidShortId,
   MAX_DUPLICATE_LOOKUPS,
   parseShortId,
+  PRIOR_VERDICT_NONE,
+  PRIOR_VERDICT_UNKNOWN,
   PROJECTABLE_VERDICTS,
   PROJECTED_COMMENT_PREFIX,
   PROJECTED_LABEL,
   resolveVerdict,
+  selectVerdictComment,
   VALID_VERDICTS,
   validateAffectedRepo,
+  verdictCommentIdFromUrl,
 } from "./sentry-triage-project-core.mjs";
 import { LABEL_DEFINITIONS, VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
 
@@ -393,7 +398,13 @@ export async function runParseOnly(options, deps = {}) {
     options.localRepo,
     options.queueIssue,
   );
-  const { parsed, verdict, label } = resolveVerdict(issue, options.queueIssue);
+  // The round binding (#1717): `--prior-verdict-comment` carries what the
+  // select job saw on this stub BEFORE the agent ran, so a round that posted
+  // nothing cannot settle the stub on the previous round's verdict. Absent flag
+  // -> null -> unbound, the pre-#1717 behaviour.
+  const { parsed, verdict, label } = resolveVerdict(issue, options.queueIssue, {
+    priorVerdictCommentId: options.priorVerdictCommentId,
+  });
   let projectable = false;
   if (PROJECTABLE_VERDICTS.includes(verdict)) {
     const repoCheck = validateAffectedRepo(parsed.affectedRepo);
@@ -413,6 +424,64 @@ export async function runParseOnly(options, deps = {}) {
   // label yet) costs nothing.
   const shed = VERDICT_LABELS.filter((name) => name !== label).join(",");
   return { verdict, label, projectable, shed };
+}
+
+/**
+ * `--prior-verdicts` mode: the SELECT job's recorder for the round binding
+ * (issue #1717). For each stub about to be triaged, emit the id of the verdict
+ * comment already on it — `{"<issue>": "<comment-id>" | "none" | "unknown"}` —
+ * so the `verdict` job can later refuse to settle the stub on a comment that
+ * predates the round. It must run in the trusted select job, BEFORE the agent:
+ * read it afterwards and it would see the round's own comment and prove
+ * nothing.
+ *
+ * Selection runs through `selectVerdictComment`, the same single selector the
+ * verdict job resolves with, so the two ends cannot drift into disagreeing
+ * about which comment "the previous verdict" is.
+ *
+ * Fail CLOSED per stub, never per run: an unreadable stub, or a selected
+ * comment whose url carries no parseable id, records `unknown`, which
+ * `resolveVerdict` refuses. That costs one wasted triage round on the affected
+ * stub — loud, and self-healing on the next run, since that round's own verdict
+ * comment becomes the next baseline — where waving it through is exactly the
+ * laundering this closes. One unreadable stub does not fail the whole select
+ * job and starve the rest of the batch.
+ */
+export async function runPriorVerdicts(options, deps = {}) {
+  const runGh = deps.runGh ?? defaultRunGh;
+  const localRun = (args) => runGh(args, {});
+  const priorVerdicts = {};
+  for (const number of options.queueIssues) {
+    let issue;
+    try {
+      // The shared reader, not a leaner `--json comments` of its own: one
+      // reader means one normalization, and the extra fields cost nothing on a
+      // batch capped at ten stubs.
+      issue = await readQueueIssue(localRun, options.localRepo, number);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::warning::Could not read queue issue #${number} to record its prior verdict comment (${message}); recording '${PRIOR_VERDICT_UNKNOWN}', which makes this run refuse to settle it.\n`,
+      );
+      priorVerdicts[String(number)] = PRIOR_VERDICT_UNKNOWN;
+      continue;
+    }
+    const selected = selectVerdictComment(issue.comments);
+    if (!selected.body) {
+      priorVerdicts[String(number)] = PRIOR_VERDICT_NONE;
+      continue;
+    }
+    const id = verdictCommentIdFromUrl(selected.url);
+    if (!id) {
+      process.stderr.write(
+        `::warning::Queue issue #${number} carries a usable verdict comment with no parseable id (url=${selected.url}); recording '${PRIOR_VERDICT_UNKNOWN}', which makes this run refuse to settle it.\n`,
+      );
+      priorVerdicts[String(number)] = PRIOR_VERDICT_UNKNOWN;
+      continue;
+    }
+    priorVerdicts[String(number)] = id;
+  }
+  return priorVerdicts;
 }
 
 export async function runProjection(options, deps = {}) {
@@ -775,6 +844,17 @@ Options:
                        labeling and projection share ONE parser. Fails (exit 1)
                        on a missing, stale pre-regression, or invalid verdict
                        comment.
+  --prior-verdicts     Print {"<issue>": "<comment-id>|${PRIOR_VERDICT_NONE}|${PRIOR_VERDICT_UNKNOWN}"} for
+                       --issues: the verdict comment already on each stub. Run
+                       by the SELECT job, before the triage agent, to record
+                       what the round started from (issue #1717).
+  --prior-verdict-comment <token>
+                       With --parse-only: the id --prior-verdicts recorded for
+                       this stub (or ${PRIOR_VERDICT_NONE} / ${PRIOR_VERDICT_UNKNOWN}). The resolution
+                       then refuses (exit 1) unless the verdict comment it
+                       selects is strictly newer, so a triage round that posted
+                       nothing cannot settle the stub on the previous round's
+                       verdict.
   --verdict <value>    Already-validated verdict from the label step. When set,
                        the script fails loud if its own parse of the newest
                        verdict comment disagrees (never a silent skip).
@@ -818,6 +898,8 @@ export function parseArgs(argv, env = process.env) {
     queueIssues: [],
     batch: false,
     parseOnly: false,
+    priorVerdicts: false,
+    priorVerdictCommentId: null,
     expectedVerdict: null,
     help: false,
   };
@@ -846,6 +928,23 @@ export function parseArgs(argv, env = process.env) {
       case "--parse-only":
         options.parseOnly = true;
         break;
+      case "--prior-verdicts":
+        options.priorVerdicts = true;
+        break;
+      case "--prior-verdict-comment": {
+        // A bare comment id, `none`, or `unknown` — the closed set
+        // `--prior-verdicts` emits. Anything else is a wiring bug between the
+        // two jobs, and a wiring bug that silently degraded to "unbound" would
+        // remove the fence without saying so, so it fails loud here.
+        const value = readValue();
+        if (!isPriorVerdictToken(value)) {
+          throw new Error(
+            `--prior-verdict-comment must be a numeric comment id, ${PRIOR_VERDICT_NONE}, or ${PRIOR_VERDICT_UNKNOWN}, got: ${value}`,
+          );
+        }
+        options.priorVerdictCommentId = value;
+        break;
+      }
       case "--verdict": {
         // Comes from the label step's closed-enum output; anything else is a
         // wiring bug — fail loud rather than carrying an invalid expectation.
@@ -867,7 +966,15 @@ export function parseArgs(argv, env = process.env) {
     }
   }
   if (!options.help) {
-    if (options.batch) {
+    // Only --parse-only consumes the token. Accepting it on a projection run
+    // would silently drop the fence, which is the one failure mode the flag
+    // exists to prevent — so an unconsumed token is a wiring bug, not a no-op.
+    if (options.priorVerdictCommentId !== null && !options.parseOnly) {
+      throw new Error(
+        "--prior-verdict-comment is only consumed by --parse-only; pass both or neither",
+      );
+    }
+    if (options.batch || options.priorVerdicts) {
       options.queueIssues = parseIssueNumbers(issuesRaw);
     } else if (
       !Number.isInteger(options.queueIssue) ||
@@ -889,6 +996,8 @@ async function main() {
   let result;
   if (options.batch) {
     result = await runProjectionBatch(options);
+  } else if (options.priorVerdicts) {
+    result = await runPriorVerdicts(options);
   } else if (options.parseOnly) {
     result = await runParseOnly(options);
   } else {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -25,6 +25,7 @@ import {
   parseVerdictComment,
   PROJECTED_LABEL,
   runParseOnly,
+  runPriorVerdicts,
   runProjection,
   runProjectionBatch,
   sanitizeDuplicateIds,
@@ -2399,6 +2400,247 @@ await test("runParseOnly accepts a needs-human verdict WITH human_question", asy
     projectable: false,
     shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-upstream",
   });
+});
+
+// ---------------------------------------------------------------------------
+// Round binding: the verdict job may only settle a stub on a verdict comment
+// THIS triage round produced (issue #1717).
+// ---------------------------------------------------------------------------
+
+/** A bot comment carrying the `#issuecomment-<id>` url `gh issue view --json
+ * comments` returns — the shape the generation token is parsed from. */
+function botCommentWithId(body, createdAt, id) {
+  return {
+    ...botComment(body, createdAt),
+    url: `https://github.com/mento-protocol/monitoring-monorepo/issues/500#issuecomment-${id}`,
+  };
+}
+
+const PARSE_OPTS = {
+  localRepo: "mento-protocol/monitoring-monorepo",
+  queueIssue: 500,
+};
+
+await test("the round binding refuses a verdict the round did not produce", async () => {
+  // The laundering shape at its narrowest: the stub carries one verdict comment,
+  // select recorded it, and the round posted nothing new. Settling here would
+  // close the stub on a verdict that predates whatever re-queued it.
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(verdictComment(), "2026-07-17T10:00:00Z", "9001"),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  await assertRejects(
+    runParseOnly({ ...PARSE_OPTS, priorVerdictCommentId: "9001" }, { runGh }),
+    /round did not produce.*already on the stub before this triage round/s,
+  );
+});
+
+await test("the round binding accepts the verdict this round posted", async () => {
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(
+        verdictComment({ verdict: "upstream-transient" }),
+        "2026-07-17T10:00:00Z",
+        "9001",
+      ),
+      botCommentWithId(
+        verdictComment({ verdict: "code-fix" }),
+        "2026-07-18T10:00:00Z",
+        "9002",
+      ),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  const result = await runParseOnly(
+    { ...PARSE_OPTS, priorVerdictCommentId: "9001" },
+    { runGh },
+  );
+  assertEqual(result.verdict, "code-fix");
+  assertEqual(result.label, "sentry:verdict-code-fix");
+});
+
+await test("a first-pass stub records `none` and settles normally", async () => {
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(verdictComment(), "2026-07-17T10:00:00Z", "9002"),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  const result = await runParseOnly(
+    { ...PARSE_OPTS, priorVerdictCommentId: "none" },
+    { runGh },
+  );
+  assertEqual(result.verdict, "code-fix");
+});
+
+await test("an unreadable prior verdict refuses rather than settling blind", async () => {
+  // `unknown` is an absence of evidence, not evidence of absence: nothing can be
+  // shown to postdate a baseline that was never read, so the stub goes back in
+  // the queue instead of being settled on an unprovable verdict.
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(verdictComment(), "2026-07-17T10:00:00Z", "9002"),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  await assertRejects(
+    runParseOnly(
+      { ...PARSE_OPTS, priorVerdictCommentId: "unknown" },
+      { runGh },
+    ),
+    /could not be read/,
+  );
+});
+
+await test("the binding fails closed when the selected comment has no id", async () => {
+  // A verdict comment with no parseable `#issuecomment-<n>` url cannot be shown
+  // to postdate the baseline, so it must not settle the stub either.
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [botComment(verdictComment(), "2026-07-17T10:00:00Z")],
+  });
+  const { runGh } = makeRunGh({ issue });
+  await assertRejects(
+    runParseOnly({ ...PARSE_OPTS, priorVerdictCommentId: "9001" }, { runGh }),
+    /no parseable comment id/,
+  );
+});
+
+await test("the binding refuses a verdict OLDER than the recorded one", async () => {
+  // Reachable only if the recorded comment was deleted between the two reads —
+  // the same write-access premise the surviving archive-side footnote needs.
+  // Equality alone would wave this through onto an even older verdict, so the
+  // comparison is strictly-newer, not same-or-not.
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(verdictComment(), "2026-07-16T10:00:00Z", "8999"),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  await assertRejects(
+    runParseOnly({ ...PARSE_OPTS, priorVerdictCommentId: "9001" }, { runGh }),
+    /predates the one recorded before this triage round/,
+  );
+});
+
+await test("an unbound resolution keeps the pre-#1717 behaviour", async () => {
+  // The projection and autofix-select paths run downstream of a verdict the
+  // binding already cleared; they pass no token and must not start refusing.
+  const issue = queueIssue({
+    labels: ["sentry-triage", "sentry:needs-triage"],
+    comments: [
+      botCommentWithId(verdictComment(), "2026-07-17T10:00:00Z", "9001"),
+    ],
+  });
+  const { runGh } = makeRunGh({ issue });
+  const result = await runParseOnly(PARSE_OPTS, { runGh });
+  assertEqual(result.verdict, "code-fix");
+});
+
+await test("--prior-verdicts records ids, absence, and unreadable stubs", async () => {
+  const stubs = {
+    // Carries a verdict comment with a parseable id.
+    501: queueIssue({
+      number: 501,
+      comments: [
+        botCommentWithId(verdictComment(), "2026-07-17T10:00:00Z", "9001"),
+        botCommentWithId(verdictComment(), "2026-07-18T10:00:00Z", "9002"),
+      ],
+    }),
+    // No verdict comment at all — a first-pass stub.
+    502: queueIssue({ number: 502, comments: [botComment("chatter", "x")] }),
+    // A verdict comment whose url carries no id: unprovable later, so unknown.
+    503: queueIssue({
+      number: 503,
+      comments: [botComment(verdictComment(), "2026-07-17T10:00:00Z")],
+    }),
+    // Fenced out by a newer regression comment: nothing admissible is present,
+    // which is `none` — the same answer the verdict job's own selector gives.
+    504: queueIssue({
+      number: 504,
+      comments: [
+        botCommentWithId(verdictComment(), "2026-07-17T09:00:00Z", "9003"),
+        botComment(
+          "Regressed in Sentry (last seen 2026-07-17T11:00:00Z)",
+          "2026-07-17T10:00:00Z",
+        ),
+      ],
+    }),
+  };
+  const runGh = async (args) => {
+    const number = args[2];
+    // 505 models a read that fails outright.
+    if (number === "505") throw new Error("gh issue view failed with exit 1");
+    return JSON.stringify(stubs[number]);
+  };
+  const result = await runPriorVerdicts(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssues: [501, 502, 503, 504, 505],
+    },
+    { runGh },
+  );
+  assertDeepEqual(result, {
+    501: "9002",
+    502: "none",
+    503: "unknown",
+    504: "none",
+    505: "unknown",
+  });
+});
+
+await test("parseArgs validates the prior-verdict token against its closed set", () => {
+  assertEqual(
+    parseArgs(["--issue", "5", "--parse-only", "--prior-verdict-comment", "42"])
+      .priorVerdictCommentId,
+    "42",
+  );
+  for (const token of ["none", "unknown"]) {
+    assertEqual(
+      parseArgs([
+        "--issue",
+        "5",
+        "--parse-only",
+        "--prior-verdict-comment",
+        token,
+      ]).priorVerdictCommentId,
+      token,
+    );
+  }
+  assertEqual(parseArgs(["--issue", "5"]).priorVerdictCommentId, null);
+  // A wiring bug must fail loud: degrading silently to "unbound" would remove
+  // the fence without saying so.
+  for (const bad of ["", "0x1f", "-1", "NONE", "42 "]) {
+    assertThrows(
+      () =>
+        parseArgs([
+          "--issue",
+          "5",
+          "--parse-only",
+          "--prior-verdict-comment",
+          bad,
+        ]),
+      /--prior-verdict-comment must be/,
+    );
+  }
+  // The recorder mode takes the select job's issue array, not a single issue.
+  assertDeepEqual(
+    parseArgs(["--prior-verdicts", "--issues", "[7, 8]"]).queueIssues,
+    [7, 8],
+  );
+  // Only --parse-only consumes the token; anywhere else it would be silently
+  // dropped, which is the failure the flag exists to prevent.
+  assertThrows(
+    () => parseArgs(["--issue", "5", "--prior-verdict-comment", "42"]),
+    /only consumed by --parse-only/,
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The Problem

- Ingest's stranded-stub sweep re-queues with cause `bookkeeping` and posts no staleness fence. It decides that from GitHub state, and GitHub state cannot show a Sentry occurrence that landed after this run's `fetchMergedSentryIssues()` returned.
- The `verdict` job runs `if: always()`, so a triage round that dies before posting still reaches it — and settles the stub on the previous round's verdict, which describes the pre-regression occurrence.
- The close then postdates that occurrence's `last_seen`, so ingest's own dedup gate skips the stub until the next one: a live regression laundered into a settled ledger entry.

## The Solution

Kill the consequence instead of inferring the cause. `select` records, per stub, the id of the verdict comment already on it; the `verdict` job passes that token to `--parse-only`, and `resolveVerdict` refuses unless the comment it selects is strictly newer. A round that posted nothing cannot settle the stub, whatever the re-queue's cause was — and the sweep gains no Sentry call.

## Details

- **Where the binding lives.** `resolveVerdict` takes an optional `priorVerdictCommentId`. Only `--parse-only` passes one; projection and autofix-select run downstream of a verdict the binding already cleared and keep the pre-#1717 behaviour.
- **Why `select`.** It is trusted and it runs before the agent, so what it reads is what the round started from. Recorded any later, the token would include the round's own comment and prove nothing. A workflow-shape test refuses a second recorder anywhere else in the file.
- **One selector, both ends.** The recorder selects through `selectVerdictComment`, the same selector the settlement resolves with, so the two cannot drift into disagreeing about what "the previous verdict" is.
- **Strictly newer, not merely different.** Refusing on the same id is the common case: the round posted nothing. Refusing on an *older* id covers the recorded comment being deleted between the two reads — the same write-access premise the surviving archive-side route needs — which an equality check would wave through onto an even older verdict. GitHub issue-comment ids come from one monotonically increasing sequence, so "newer" is a numeric comparison.
- **Fail closed per stub, never per batch.** An unreadable stub, or a verdict comment with no parseable `#issuecomment-<n>` id, records `unknown`, which never passes. That costs one loud triage round on that stub and self-heals: the round's own verdict comment becomes the next run's baseline. One unreadable stub does not starve the rest of the batch. The refusal lands before the label edit, so the stub keeps `sentry:needs-triage`.
- **Reused plumbing.** The token is the `#issuecomment-<n>` generation token the autofix leg already threads for its ABA check (#1506). The fence is untouched and still decides admissibility for the digest, projection and autofix consumers; the binding decides whether a run may settle the stub at all.
- **The sweep is unchanged, deliberately.** A per-stub Sentry lookup and unconditional fencing were both rejected in the issue — the first couples a sweep that needs no Sentry and is still racy, the second discards a good verdict on every genuine bookkeeping strand. The sweep's blind spot is now written up beside the existing residual in the runbook, which recorded only the within-a-run laundering.
- **Not an ADR.** This refines a mechanism inside ADR 0036/0038's existing decision rather than making a new one; `pnpm adr:check` agrees. The rationale is recorded in the runbook's new "The round binding" section and at each site.
- **Composes with what just landed.** #1764 owns the verdict step's shed list and its post-condition compensation — untouched; the binding refuses before that window opens. #1766's re-queue split and baseline work is upstream of the sweep and unaffected.

## Validation

- `bash scripts/agent-quality-gate.sh --run --parallel 4 --base origin/main` — all 13 mapped commands pass (includes `lint:scripts`, `sentry:project:test`, `sentry:ingest:test`, `sentry-triage-agent-comment.test.mjs`, trunk check on all seven touched files).
- `pnpm agent:autoreview --engine local` — clean, no findings.
- Eleven mutants, each killed by a named test: dropping the binding from `resolveVerdict`; letting `unknown`, an equal id, or an older id pass; recording `none` on a failed read; unthreading the token at either end; accepting an out-of-set token; and three workflow-shape mutants (verdict step stops passing the token, select stops emitting the record, a missing record degrades to empty instead of `unknown`).
- Two of those tests reproduce the laundering end to end against the **real** sweep and the **real** resolver: a regression landing after the Sentry query, and the surviving archive-refusal route whose fence was deleted. Both fail without the binding with `expected the resolution to refuse`.
- A third scenario test pins the other direction — a swept stub whose next round *does* post a verdict still settles normally, so the binding is not a blanket refusal.
- The independent-model review comes from this PR's external reviewers; the codex CLI is not on PATH in this environment.

## Deferrals

- None

Closes #1717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic queue settlement in CI for all triage runs; mis-wiring could block legitimate closes, but failures keep `sentry:needs-triage` and retry.
> 
> **Overview**
> Fixes a path where ingest’s **fence-free bookkeeping** stranded-stub recovery could leave an old verdict admissible, then the always-on **`verdict` job** would re-label and close the stub—burying a Sentry regression that arrived after ingest’s query.
> 
> **Round binding:** Before the agent runs, **`select`** records each stub’s existing verdict comment id via `--prior-verdicts` (GitHub-only). **`verdict`** passes that token to `--parse-only`; **`resolveVerdict`** / `priorVerdictRefusal` only allow settlement when the selected verdict comment is **strictly newer** than the baseline (`none` / numeric id / fail-closed `unknown`). The stranded sweep is unchanged; this closes the consequence at settlement.
> 
> Docs add **“The round binding”** and operator guidance for intentional refusals. Tests cover parser/workflow shape and end-to-end sweep → settle scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14148b237d70dee262c0d297396db7215c3dcc4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->