### PR TITLE
fix: roll Peg policy runtime to active-only generation

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@ title: Deployment Guide
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-11
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -304,13 +304,17 @@ broad Storage Admin, Storage Object Admin, or Service Account User fallbacks.
 An explicitly approved, time-bounded emergency controller bootstrap may be
 used only until both bucket policies reconcile; remove it immediately, verify
 its absence, and run a clean plan. That recovery and bootstrap removal are
-complete. The protected workflow published
-`mento-monitoring-peg-policy/peg-policy/current.json` at generation
-`1785276001213660`; Metrics Bridge pins it on
-`metrics-bridge-r-47264e8-30405040839`. The canonical recovery procedure is in
-[`docs/terraform.md`](terraform.md) and [ADR 0055](adr/0055-peg-policy-bucket-controller-recovery.md).
-Audit effective readers, writers, and IAM administrators after future applies
-and before runtime rollovers.
+complete. The first protected publication created
+`mento-monitoring-peg-policy/peg-policy/current.json` generation
+`1785276001213660`; its runtime attachment minted
+`metrics-bridge-r-47264e8-30405040839`. The later protected publication created
+generation `1786443055965590`. The reviewed runtime rollout selects that
+published generation in source, but it is not attached to Cloud Run until the
+approved platform apply and runtime proof complete. The canonical recovery
+procedure is in [`docs/terraform.md`](terraform.md) and
+[ADR 0055](adr/0055-peg-policy-bucket-controller-recovery.md). Audit effective
+readers, writers, and IAM administrators after future applies and before runtime
+rollovers.
 
 The manual `Peg Policy Publication` workflow writes each policy as a versioned
 object. For a future publication, dispatch its `plan` operation from `main`,

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-11
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -37,12 +37,13 @@ are live in Grafana for the policy version published at that time
 [#1685](https://github.com/mento-protocol/monitoring-monorepo/pull/1685)).
 `terraform/peg-policy.tf` owns the policy identities and bucket IAM. Controller
 recovery and bootstrap-grant removal are complete.
-The protected `Peg Policy Publication` root published
-`mento-monitoring-peg-policy/peg-policy/current.json` at generation
+The first protected `Peg Policy Publication` root created
+`mento-monitoring-peg-policy/peg-policy/current.json` generation
 `1785276001213660`. Authenticated, generation-pinned delivery and live producer
-telemetry are proven on `metrics-bridge-r-47264e8-30405040839`, which serves
-active policy `europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`. The
-production dashboard prerequisite is also proven at
+telemetry for that attachment are proven on
+`metrics-bridge-r-47264e8-30405040839`, which serves active policy
+`europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`. The production dashboard
+prerequisite is also proven at
 `https://monitoring.mento.org/peg-monitoring`: the live current package renders
 without console errors. The reviewed source activation sets the
 source-controlled `local.peg_alerts_enabled` switch to the literal `true`. That
@@ -51,24 +52,25 @@ rule group; it is not a workflow, variable, or policy-artifact switch. This
 source change does not prove the consumers exist in Grafana or that their
 queries have live data.
 
-This source cleanup sets `previous` to `null`. It does not itself remove
-retained Grafana rules, publish a new immutable policy generation, or attach
-that generation to Metrics Bridge. Do not claim active-only production
-operation until the human-approved `alerts-rules` cleanup, protected
-publication, reviewed runtime-generation attachment, and post-change
-producer/Grafana checks complete in that order.
+The later protected publication created the active-only `previous: null` object
+at generation `1786443055965590`. This reviewed platform rollout changes the
+source-controlled runtime pin to that generation, sets
+`metrics_bridge_template_rollout_active` to `true`, and removes the generated
+revision-name ignore. It does not attach the new generation to Metrics Bridge.
+Do not claim active-only production operation until the approved platform apply
+and post-change producer/Grafana proof complete.
 
 Source validators now require every policy source to declare
-`listingAbsentConsecutiveChecks`, and the checked-in policy keeps `previous`
-as `null`. Metrics Bridge retains a runtime-only compatibility shim for the
-exact legacy previous version
+`listingAbsentConsecutiveChecks`, and the published policy has `previous` as
+`null`. Metrics Bridge retains a runtime-only compatibility shim for the exact
+legacy previous version
 `europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f`, which defaults the
-missing threshold to `2` while Cloud Run remains pinned to the production
-generation containing that predecessor. The bridge normalizes the value into
-decision packages, so the dashboard schema remains strict. Remove the shim in
-a follow-up PR after the `previous: null` generation is published, pinned, and
-live-verified; [#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
-tracks that removal.
+missing threshold to `2` while the active-only runtime generation awaits its
+approved attachment and live proof. The bridge normalizes the value into decision
+packages, so the dashboard schema remains strict. Remove the shim in a follow-up
+PR after the `previous: null` generation is attached and live-verified;
+[#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750) tracks
+that removal.
 
 The production identity bootstrap in
 [#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) is

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@ title: Terraform Stacks
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-11
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -86,12 +86,17 @@ owns the exact-plan boundary.
 
 `peg-policy-publication` permits only backend-free local validation with
 `pnpm tf validate peg-policy-publication`. Local plan and apply are disabled,
-including `--force-local-apply`. Controller recovery and first publication are
-complete: `mento-monitoring-peg-policy/peg-policy/current.json` is generation
-`1785276001213660` and the runtime attachment pins it. For a future publication,
-dispatch `Peg Policy Publication` from `main`, inspect its read-only plan, then
-choose `apply` and approve the `production-infra` Environment. Its output feeds
-a separately reviewed runtime rollover.
+including `--force-local-apply`. Controller recovery and the first protected
+publication are complete: it created
+`mento-monitoring-peg-policy/peg-policy/current.json` generation
+`1785276001213660`, which the first runtime attachment used. The later protected
+publication produced generation `1786443055965590`. This reviewed platform
+rollout selects that published generation for the runtime; publication alone
+does not attach it to Cloud Run. An approved platform apply and runtime proof
+remain required. For a future publication, dispatch `Peg Policy Publication`
+from `main`, inspect its read-only plan, then choose `apply` and approve the
+`production-infra` Environment. Its output feeds a separately reviewed runtime
+rollover.
 
 ## CI Model
 
@@ -176,12 +181,13 @@ Routing and IAM audit complete. Removal: `0 added, 1 changed, 1 destroyed`;
 plan clean; IAM has no `metrics-bridge-deployer` Token Creator grant. Platform
 owns private buckets and identities; protected `peg-policy-publication` writes
 the policy object.
-Metrics Bridge uses the dedicated runtime identity and pins generation
-`1785276001213660` through paired `PEG_POLICY_*` values. Publication itself
-attaches neither Cloud Run nor Grafana consumers. The reviewed runtime
-activation attached Cloud Run; the separate alerts-rules source change and
-approved apply activate Grafana. Terraform derives the pinned URL and
-`gcp-metadata` mode from that literal.
+Metrics Bridge uses the dedicated runtime identity. The first runtime attachment
+pinned generation `1785276001213660` through paired `PEG_POLICY_*` values; the
+current reviewed rollout changes the source literal to published generation
+`1786443055965590`. Publication itself attaches neither Cloud Run nor Grafana
+consumers. The approved platform apply and runtime proof attach the new pin; the
+separate alerts-rules source change and approved apply activate Grafana.
+Terraform derives the pinned URL and `gcp-metadata` mode from that literal.
 Metrics Bridge ignores `template[0].revision` in steady state so routine plans
 do not clear the generated name stamped by deploys. Any Terraform-owned
 template change, including a policy-generation handoff, sets

--- a/scripts/production-infra-identity-contract/peg-policy.test.mjs
+++ b/scripts/production-infra-identity-contract/peg-policy.test.mjs
@@ -35,18 +35,45 @@ function withConcreteGeneration(files, generation) {
   );
 }
 
-function withTemplateRollout(files) {
-  return mutate(
-    mutate(
-      files,
-      "terraform/metrics-bridge.tf",
-      "  metrics_bridge_template_rollout_active = false",
-      "  metrics_bridge_template_rollout_active = true",
-    ),
-    "terraform/metrics-bridge.tf",
-    "      template[0].revision,\n",
-    "",
+function withTemplateRolloutMarker(files, value) {
+  const marker = files["terraform/metrics-bridge.tf"].match(
+    /^ {2}metrics_bridge_template_rollout_active = (true|false)$/mu,
   );
+  assert(marker, "fixture rollout marker missing");
+  return mutate(
+    files,
+    "terraform/metrics-bridge.tf",
+    marker[0],
+    `  metrics_bridge_template_rollout_active = ${value}`,
+  );
+}
+
+function withTemplateRollout(files) {
+  const markedFiles = withTemplateRolloutMarker(files, true);
+  return markedFiles["terraform/metrics-bridge.tf"].includes(
+    "      template[0].revision,\n",
+  )
+    ? mutate(
+        markedFiles,
+        "terraform/metrics-bridge.tf",
+        "      template[0].revision,\n",
+        "",
+      )
+    : markedFiles;
+}
+
+function withTemplateSteadyState(files) {
+  const markedFiles = withTemplateRolloutMarker(files, false);
+  return markedFiles["terraform/metrics-bridge.tf"].includes(
+    "      template[0].revision,\n",
+  )
+    ? markedFiles
+    : mutate(
+        markedFiles,
+        "terraform/metrics-bridge.tf",
+        "      template[0].containers[0].image,\n",
+        "      template[0].containers[0].image,\n      template[0].revision,\n",
+      );
 }
 
 const activeGenerationFiles = withConcreteGeneration(
@@ -57,6 +84,12 @@ assert.deepEqual(
   validateProductionInfraIdentityContract(activeGenerationFiles),
   [],
 );
+
+const steadyStateFiles = withTemplateSteadyState(validFiles);
+assert.deepEqual(validateProductionInfraIdentityContract(steadyStateFiles), []);
+
+const rolloutFiles = withTemplateRollout(steadyStateFiles);
+assert.deepEqual(validateProductionInfraIdentityContract(rolloutFiles), []);
 
 const maximumGenerationFiles = withConcreteGeneration(
   validFiles,
@@ -69,7 +102,9 @@ assert.deepEqual(
 
 assert.deepEqual(
   validateProductionInfraIdentityContract(
-    withTemplateRollout(withConcreteGeneration(validFiles, "1750000000000000")),
+    withTemplateRollout(
+      withConcreteGeneration(steadyStateFiles, "1750000000000000"),
+    ),
   ),
   [],
 );
@@ -629,7 +664,7 @@ variable "peg_policy_runtime_generation" {
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "      template[0].revision,\n",
     "",
@@ -639,7 +674,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "    ignore_changes = [\n      template[0].containers[0].image,\n      template[0].revision,",
     "    replace_triggered_by = [template[0].revision]\n\n    ignore_changes = [\n      template[0].containers[0].image,",
@@ -649,7 +684,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "  metrics_bridge_template_rollout_active = false",
     "  metrics_bridge_template_rollout_active = true",
@@ -659,7 +694,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "  metrics_bridge_template_rollout_active = false",
     '  metrics_bridge_template_rollout_active = "false"',
@@ -669,7 +704,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "  metrics_bridge_template_rollout_active = false\n",
     "",
@@ -679,7 +714,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     "  metrics_bridge_template_rollout_active = false",
     "  metrics_bridge_template_rollout_active = false\n  metrics_bridge_template_rollout_active = true",
@@ -688,7 +723,7 @@ expectFailure(
 );
 
 const oneLineIgnoreChangesFiles = mutate(
-  validFiles,
+  steadyStateFiles,
   "terraform/metrics-bridge.tf",
   `    ignore_changes = [
       template[0].containers[0].image,
@@ -706,16 +741,10 @@ assert(
 );
 
 const rolloutOneLineIgnoreChangesFiles = mutate(
-  mutate(
-    validFiles,
-    "terraform/metrics-bridge.tf",
-    "  metrics_bridge_template_rollout_active = false",
-    "  metrics_bridge_template_rollout_active = true",
-  ),
+  rolloutFiles,
   "terraform/metrics-bridge.tf",
   `    ignore_changes = [
       template[0].containers[0].image,
-      template[0].revision,
       client,
       client_version,
       scaling[0].manual_instance_count,
@@ -730,7 +759,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    withConcreteGeneration(validFiles, "1750000000000000"),
+    withConcreteGeneration(steadyStateFiles, "1750000000000000"),
     "terraform/metrics-bridge.tf",
     "      template[0].revision,\n      client,",
     "      template[0].revision,\n      template[0].containers[0].env[0].value,\n      client,",
@@ -740,7 +769,7 @@ expectFailure(
 
 expectFailure(
   mutate(
-    validFiles,
+    steadyStateFiles,
     "terraform/metrics-bridge.tf",
     `    ignore_changes = [
       template[0].containers[0].image,

--- a/terraform/metrics-bridge.tf
+++ b/terraform/metrics-bridge.tf
@@ -81,7 +81,7 @@ locals {
   # apply and runtime proof, a separate stabilization change restores false and
   # the ignore so routine platform applies do not mint duplicate revisions.
   # Pause unrelated platform applies while this marker is true.
-  metrics_bridge_template_rollout_active = false
+  metrics_bridge_template_rollout_active = true
 }
 
 resource "google_cloud_run_v2_service" "metrics_bridge" {
@@ -188,7 +188,6 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
     # managed in both phases.
     ignore_changes = [
       template[0].containers[0].image,
-      template[0].revision,
       client,
       client_version,
       scaling[0].manual_instance_count,

--- a/terraform/peg-policy.tf
+++ b/terraform/peg-policy.tf
@@ -10,7 +10,7 @@ locals {
   # After protected publication, set this source-controlled literal to the
   # positive peg_policy_generation output and review the resulting platform
   # plan. Null keeps both PEG_POLICY_* values absent and the peg loop dormant.
-  peg_policy_runtime_generation = "1785276001213660"
+  peg_policy_runtime_generation = "1786443055965590"
 
   peg_policy_runtime_url = local.peg_policy_runtime_generation == null ? null : "https://storage.googleapis.com/download/storage/v1/b/${google_storage_bucket.peg_policy.name}/o/peg-policy%2Fcurrent.json?alt=media&generation=${local.peg_policy_runtime_generation}"
 


### PR DESCRIPTION
## The Problem

- The protected publisher now holds the active-only Peg policy, but Metrics Bridge still points at the older generation that includes the retired policy version.
- Cloud Run cannot safely accept this template change while Terraform retains the provider-generated revision name.

## The Solution

- Pin Metrics Bridge to immutable policy generation 1786443055965590 and enter the guarded template-rollout phase so the approved apply can mint a new Cloud Run revision.

## Details

- Changes only the source-owned policy generation and removes only the generated revision name from lifecycle ignores.
- Keeps the image and other deploy-stamped bookkeeping ignores unchanged.
- Extends the infrastructure contract tests so both steady-state and rollout source layouts stay covered regardless of which phase is checked in.
- Updates current-state runbooks while preserving the first-publication generation and revision as historical evidence.
- Makes no live infrastructure change. After merge, a clean current-main platform plan and separate explicit apply approval remain required.
- Pause unrelated full platform applies while the rollout marker is true. After apply and live proof, a separate no-apply stabilization PR will restore steady state.
- The legacy parser shim remains until active-only runtime behavior is proven, so this PR does not close #1750.

Refs #1750
Refs #1444

## Validation

- `pnpm agent:quality-gate --run` — all mapped checks passed, including Terraform init/validate, the full infrastructure contract suite, script lint, docs checks, and targeted Trunk checks.
- `pnpm tf validate platform` — configuration valid.
- `./tools/trunk fmt` — no issues.
- Fresh-context Codex autoreview — one complete semantic pass, no findings.
- Deterministic local autoreview — no findings.
- Prepared review bundle manifest verified before and after semantic review.
- A feature-branch platform plan was intentionally omitted; the authoritative plan must run from clean current main after merge and before any approved apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production Metrics Bridge policy env and Cloud Run template lifecycle for the alerting pipeline; risk is mitigated by merge-only source prep, exact-plan guards, and explicit post-merge apply/proof gates.
> 
> **Overview**
> Prepares Metrics Bridge to consume the **active-only** Peg policy (`previous: null`) at GCS generation **`1786443055965590`**, replacing the prior pin **`1785276001213660`**.
> 
> In **`terraform/peg-policy.tf`**, `peg_policy_runtime_generation` moves to the new literal so paired `PEG_POLICY_*` env vars target that immutable object. In **`terraform/metrics-bridge.tf`**, the PR enters the guarded rollout phase: `metrics_bridge_template_rollout_active = true` and **`template[0].revision` is dropped from `ignore_changes`** so an approved platform apply can mint a new Cloud Run revision without provider 409s from a stale generated revision name. **Merge alone does not change production**—a clean main plan, human-approved apply, and runtime proof are still required.
> 
> **`peg-policy.test.mjs`** now exercises both steady-state and rollout layouts (`withTemplateSteadyState` / `withTemplateRollout`) so contract validation matches whichever phase is checked in. Runbooks (`deployment.md`, `terraform.md`, `peg-monitoring.md`) are updated to distinguish the first publication/attachment from this rollover and to state that publication does not attach the generation until platform apply completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b988c57997baaecc0ce5bd2d6c83b8f7468248ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->