### PR TITLE
fix(sentry): make two unreachable tests in the project suite able to fail CI

### DIFF
--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -2983,13 +2983,6 @@ await test("parseArgs rejects a non-integer issue and unknown options", () => {
   assertThrows(() => parseArgs(["--nope"], {}), /Unknown option/);
 });
 
-if (failed > 0) {
-  process.stderr.write(`${failed} failed, ${passed} passed\n`);
-  process.exitCode = 1;
-} else {
-  process.stdout.write(`${passed} passed\n`);
-}
-
 await test("runProjectionBatch self-heals the sentry:projected label from LABEL_DEFINITIONS", async () => {
   const stubs = { 500: queueIssue({ number: 500 }) };
   const { runGh, calls } = makeRunGh({ stubs, createdUrl: CREATED_URL });
@@ -3034,3 +3027,10 @@ await test("runProjectionBatch survives a failing label ensure", async () => {
   );
   assertEqual(rows[0].status, "projected");
 });
+
+if (failed > 0) {
+  process.stderr.write(`${failed} failed, ${passed} passed\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`${passed} passed\n`);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `scripts/sentry-triage-project.test.mjs` prints a `"N passed"` summary and
  sets `process.exitCode` from an `if (failed > 0) { ... }` block that ran
  BEFORE the final two `await test(...)` calls in the file.
- Those two tests (`runProjectionBatch self-heals the sentry:projected label
  from LABEL_DEFINITIONS` and `runProjectionBatch survives a failing label
  ensure`) still executed and printed their own `ok`/`not ok` line, but their
  pass/fail state could never change `process.exitCode` — the exit decision
  had already been made and the summary already printed.
- Net effect: the suite reported `110 passed` while 112 `ok` lines actually
  ran, and those two tests could not fail CI no matter what they asserted.

## The Solution

- Move the summary-line + exit-code block to run after every
  `await test(...)` call completes, instead of before the last two.

## Details

- Pure reordering: the `if (failed > 0) { ... } else { ... }` block that
  prints the summary and sets `process.exitCode` moved from immediately
  before `runProjectionBatch self-heals the sentry:projected label...` to
  immediately after the final test (`runProjectionBatch survives a failing
  label ensure`), at the end of the file.
- No test assertion, test name, or test body changed. `git diff` for this PR
  touches only line position of the summary/exit-code block (7
  insertions / 7 deletions).
- Scope is intentionally narrow: this is PR A of the #1779 plan — the live
  test-correctness bug the design discussion surfaced. It is not the
  redesign itself.

## Validation

- Before fix: `node scripts/sentry-triage-project.test.mjs` printed
  `110 passed` while emitting 112 `ok` lines (`grep -c '^ok ' <output>` = 112),
  exit code 0.
- After fix: same command prints `112 passed`, matching the 112 `ok` lines,
  exit code 0.
- Deliberate-failure proof: temporarily added a failing `assert(false, ...)`
  inside each of the two previously-unreachable tests. Reran the suite —
  exit code became `1`, with both `not ok` lines reported and
  `2 failed, 110 passed` printed. Then reverted both deliberate failures
  (confirmed via `git diff` showing only the ordering change, no leftover
  assertions).
- `node scripts/check-sentry-suites-in-ci.test.mjs`: 30/30 pass, exit 0.
- `./tools/trunk fmt scripts/sentry-triage-project.test.mjs`: no issues.
- `bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main`:
  all mapped commands passed (trunk check, lint:scripts, all `sentry:*:test`
  suites, the CI-suites checker, and `tf:test`).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — no architecture change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only reordering with no production or assertion changes; lowers risk by restoring correct CI signal for projection batch tests.
> 
> **Overview**
> Fixes a **test harness ordering bug** in `scripts/sentry-triage-project.test.mjs`: the block that prints the pass count and sets `process.exitCode` ran **before** the final two `await test(...)` cases (`runProjectionBatch` label self-heal and failing label ensure).
> 
> Those tests still ran and emitted `ok`/`not ok`, but their failures could not change the exit code or the printed total (e.g. `110 passed` vs 112 `ok` lines). The summary/exit logic is now **after every test**, so the full suite count is accurate and those two cases can fail CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca268fa40885f61a4f173e8ca5e7b30ef7d449d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->