### PR TITLE
docs: reverify ADR garden packet

### DIFF
--- a/docs/adr/0031-governance-watchdog-standalone-root.md
+++ b/docs/adr/0031-governance-watchdog-standalone-root.md
@@ -3,7 +3,7 @@ title: governance-watchdog deploys as a standalone source root in its own GCP pr
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: governance-watchdog
 date: 2026-06
 doc_type: adr

--- a/docs/adr/0032-integration-probes-quote-only.md
+++ b/docs/adr/0032-integration-probes-quote-only.md
@@ -3,7 +3,7 @@ title: Integration probes are quote-only, evidence-gated, and TTL-degraded
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: integration-probes
 date: 2026-06
 doc_type: adr

--- a/docs/adr/0033-adr-process-and-gate.md
+++ b/docs/adr/0033-adr-process-and-gate.md
@@ -3,7 +3,7 @@ title: Architectural decisions are recorded as ADRs, enforced by a reminder gate
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: ci/process
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0034-steth-wallet-daily-sampler.md
+++ b/docs/adr/0034-steth-wallet-daily-sampler.md
@@ -3,7 +3,7 @@ title: stETH actuals use a launch-aligned sub-daily wallet balance sampler
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: indexer-envio
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0035-config-public-npm-package.md
+++ b/docs/adr/0035-config-public-npm-package.md
@@ -3,7 +3,7 @@ title: shared-config publishes as the public @mento-protocol/config package
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: shared-config
 date: 2026-07
 doc_type: adr
@@ -37,7 +37,7 @@ and pack the artifact; untagged workflow runs do not publish.
 ## Current operational status
 
 The decision remains in force, but the release path is not healthy end to end.
-As verified on 2026-07-24, npm still serves `0.1.0` while the repository and tag
+As verified on 2026-08-11, npm still serves `0.1.0` while the repository and tag
 `config-v0.2.0` identify `0.2.0`. Workflow run `29831994804` built and verified
 the package, signed provenance, then failed at `npm publish` with npm `E404` /
 missing permission. Issue [#1573](https://github.com/mento-protocol/monitoring-monorepo/issues/1573)
@@ -82,4 +82,4 @@ claim that every matching tag publishes successfully.
 - `.github/workflows/publish-config.yml`
 - [`shared-config/AGENTS.md`](../../shared-config/AGENTS.md)
 - Failed `config-v0.2.0` publish run `29831994804`; live npm version check on
-  2026-07-24; recovery issue [#1573](https://github.com/mento-protocol/monitoring-monorepo/issues/1573)
+  2026-08-11; recovery issue [#1573](https://github.com/mento-protocol/monitoring-monorepo/issues/1573)

--- a/docs/adr/0036-sentry-triage-pipeline.md
+++ b/docs/adr/0036-sentry-triage-pipeline.md
@@ -3,7 +3,7 @@ title: Sentry triage/autofix runs as a staged GitHub Actions agent pipeline with
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: ci/process
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0037-dashboard-graphql-zod-mini.md
+++ b/docs/adr/0037-dashboard-graphql-zod-mini.md
@@ -3,7 +3,7 @@ title: Native GraphQL transport and client-side Zod Mini for the dashboard
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: ui-dashboard
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -3,7 +3,7 @@ title: Central Sentry triage plane with owning-repo verdict projection
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: ci/process
 date: 2026-07
 doc_type: adr
@@ -16,6 +16,11 @@ garden_lane: adrs-architecture
 **Status:** Accepted (Jul 2026), in force. Refines
 [ADR 0036](0036-sentry-triage-pipeline.md) Stage C ("phased mutations").
 **Scope:** ci/process
+
+**Current refinement:** [ADR 0050](0050-environment-scoped-pipeline-secrets.md)
+moved `SENTRY_PROJECTION_TOKEN` from repository scope to the main-only
+`sentry-pipeline` GitHub Environment. The fixed three-repository Issues-write
+boundary and token isolation from the triage agent remain in force.
 
 ## Context
 
@@ -160,3 +165,5 @@ deterministic step.**
   and monitoring-monorepo#1302.
 - Pipeline tracker [#1282](https://github.com/mento-protocol/monitoring-monorepo/issues/1282);
   refines [ADR 0036](0036-sentry-triage-pipeline.md) Stage C.
+- Current credential placement: `terraform/github-environment.tf` and
+  [ADR 0050](0050-environment-scoped-pipeline-secrets.md).

--- a/docs/adr/0039-multistrategy-pools-historical-fx-volume.md
+++ b/docs/adr/0039-multistrategy-pools-historical-fx-volume.md
@@ -3,7 +3,7 @@ title: Model pool strategies many-to-many and price same-currency swaps from his
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: indexer-envio, ui-dashboard, metrics-bridge
 doc_type: adr
 review_interval_days: 90

--- a/docs/adr/0040-bounded-documentation-garden-queue.md
+++ b/docs/adr/0040-bounded-documentation-garden-queue.md
@@ -3,7 +3,7 @@ title: Documentation gardening runs through one bounded issue queue
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-11
 scope: ci/process
 date: 2026-07
 doc_type: adr


### PR DESCRIPTION
## The Problem

- The scheduled ADR garden packet had not been rechecked against current code, workflows, provider state, and later decisions.
- Two ADRs had current-state drift: the public config package still has not published `0.2.0`, and ADR 0050 changed where the Sentry projection credential lives.

## The Solution

- Reverify all ten ADRs in the frozen packet, refresh their verification dates, and record the two proven refinements without changing accepted decision history.

## Details

The issue embeds fingerprint `docs-garden:adrs-architecture:4-of-6`. The current planner repartitions the lane as `4-of-7`, but the frozen ten-file list and 5,992 source words are unchanged, so this PR honors the issue packet exactly.

| ADR | Disposition | Evidence |
| --- | --- | --- |
| 0031 | Keep | The governance watchdog remains a standalone source root with its own workspace and lockfile, dedicated workflow and GCP project, and registered Terraform stack. |
| 0032 | Keep | Integration probes still use quote evidence, preserve `needs_key` and `unsupported` states, enforce the result TTL, and publish through the documented Upstash key. |
| 0033 | Keep | `adr-reminder.mjs`, its tests, the package command, quality-gate mapping, and PR template still enforce the ADR reminder contract. |
| 0034 | Keep | The sampler still uses the recorded start block, timestamp boundary, 600-second interval, wallet allocation and baseline logic, degraded reads, and focused tests. |
| 0035 | Update | Live npm still serves `@mento-protocol/config@0.1.0`; the repository and `config-v0.2.0` tag identify `0.2.0`, and recovery issue #1573 remains open. The live verification date is now 2026-08-11. |
| 0036 | Keep | The staged Sentry triage pipeline, runbook, workflows, broker boundary, and focused suites still match the accepted decision. |
| 0037 | Keep | The dashboard still uses `graphql-fetch`, the `zod/mini` schema split, `SafeParseSchema`, and the documented size budget. |
| 0038 | Update | ADR 0050 moved `SENTRY_PROJECTION_TOKEN` into the main-only `sentry-pipeline` GitHub Environment. The fixed three-repository write boundary and token isolation remain unchanged. |
| 0039 | Keep | The many-to-many liquidity-strategy model and historical FX-volume path remain implemented and covered by the focused indexer and bridge tests. |
| 0040 | Keep | The bounded immutable issue-only garden scheduler, OIDC path, and queue labels still match the workflow, runbook, and scheduler tests. |

No ADR was removed, merged, archived, or superseded. No inbound link or catalog entry changed.

Closes #1727

## Validation

- `./tools/trunk fmt` — passed on all ten ADRs
- `pnpm docs:index --write && pnpm docs:index --check` — generated catalog unchanged; check passed
- `pnpm agent:context-check` — 144 managed files passed
- `pnpm agent:context-budget --strict` — passed; the existing `terraform/AGENTS.md` warning remains below the limit
- `pnpm agent:quality-gate --run` — passed all mapped checks, including Trunk, docs index, context, navigation fixtures, and `tf:test`
- `pnpm adr:check:test` — 20 passed
- `pnpm integrations:probe:test` — 86 passed
- `pnpm sentry:project:test` — 110 passed
- `pnpm sentry:brief:test` — 54 passed
- `pnpm sentry:broker:test` — 40 passed
- `pnpm docs:garden:test` — 30 passed
- Focused indexer reserve-yield, USD, and liquidity-strategy suites — 65 passed
- Focused dashboard GraphQL and pool-config suites — 27 passed
- Focused metrics-bridge rebalance property suite — 16 passed

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new decision is introduced; this PR re-verifies and refines accepted ADR history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ADR metadata and operational-status refreshes; no runtime, CI, or infrastructure behavior changes.
> 
> **Overview**
> Scheduled **ADR garden re-verification** for the frozen ten-file packet (`0031`–`0040`): each ADR’s `last_verified` metadata moves to **2026-08-11**. Accepted decisions are unchanged; two ADRs get **current-state** wording updates only.
> 
> **ADR 0035** still documents that `@mento-protocol/config` **0.2.0** has not reached npm (live **0.1.0**), with verification dates in *Current operational status* and *Evidence* aligned to **2026-08-11** and recovery **#1573** unchanged.
> 
> **ADR 0038** adds a **Current refinement** callout and evidence pointer that **[ADR 0050](0050-environment-scoped-pipeline-secrets.md)** moved `SENTRY_PROJECTION_TOKEN` into the main-only `sentry-pipeline` GitHub Environment, without altering the three-repo projection boundary or triage-agent isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f8fc997f8861b04f54d45fa93c690a63e08fd7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->