### PR TITLE
fix(docs): accept direct indexer navigation route

### DIFF
--- a/docs/evals/documentation-navigation-fixtures.json
+++ b/docs/evals/documentation-navigation-fixtures.json
@@ -33,6 +33,7 @@
       "category": "packages",
       "question": "You are adding a new indexed contract and event. Which current package documentation defines the config, ABI, handler-entry-point, codegen, and hosted-build mirror procedure?",
       "accepted_routes": [
+        ["indexer-envio/README.md"],
         ["indexer-envio/AGENTS.md", "indexer-envio/README.md"]
       ],
       "sources_requiring_verification": [

--- a/docs/evals/documentation-navigation.md
+++ b/docs/evals/documentation-navigation.md
@@ -3,7 +3,7 @@ title: Documentation Navigation Evaluation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-11
 doc_type: runbook
 scope: ci/process
 review_interval_days: 90
@@ -266,6 +266,20 @@ unqualified non-canonical sources and no question over the context cap.
 Independent review reached the same conclusion: both full-run misses were
 evaluator retrieval mistakes, so no documentation defect issue was required.
 
-Because two full runs have now missed `package-indexer-add-contract`, a third
-independent full-run miss must trigger a fresh review of the accepted route and
-fixture after the required targeted escalation.
+### 2026-08 accepted-route review
+
+The [August evaluation issue](https://github.com/mento-protocol/monitoring-monorepo/issues/1728)
+evaluated default-branch commit
+`028c2222b0f5dfca431eab7c5ffd25e963371445` with `gpt-5.6-sol` at low effort.
+It passed the suite target with 94.4% routing accuracy, zero unqualified
+non-canonical sources, 100% answer evidence, 94.4% shortest useful paths,
+28,161 bootstrap bytes, and 247,648 of 262,000 unique suite bytes. The sole
+miss was `package-indexer-add-contract`, its third independent full-run miss.
+
+The required targeted escalation and independent high-effort review found that
+`indexer-envio/README.md` is canonical and fully owns the requested procedure.
+The current fixture therefore accepts that document as the shortest route and
+retains `indexer-envio/AGENTS.md` followed by the README as the valid full
+edit-time routing chain. The frozen baseline and its fixtures remain unchanged.
+Issue [#1788](https://github.com/mento-protocol/monitoring-monorepo/issues/1788)
+tracks this contract correction and its required post-merge fresh evaluation.

--- a/scripts/docs-navigation-eval.test.mjs
+++ b/scripts/docs-navigation-eval.test.mjs
@@ -903,8 +903,63 @@ test("route order and shortest useful path are measured independently", () => {
   const answer = result.answers.find(
     (candidate) => candidate.question_id === "package-indexer-add-contract",
   );
-  answer.chosen_documents.reverse();
   let scored = score(result);
+  let questionReport = scored.report.questions.find(
+    (question) => question.question_id === answer.question_id,
+  );
+  assert.deepEqual(answer.chosen_documents, ["indexer-envio/README.md"]);
+  assert.equal(questionReport.routing_correct, true);
+  assert.equal(questionReport.shortest_route, true);
+
+  answer.chosen_documents = [
+    "indexer-envio/AGENTS.md",
+    "indexer-envio/README.md",
+  ];
+  answer.evidence.unshift({
+    path: "indexer-envio/AGENTS.md",
+    line_start: 1,
+    line_end: 1,
+    supports:
+      "The scoped package instructions route contract-add work to the package README.",
+  });
+  answer.loaded_sources.push(source("indexer-envio/AGENTS.md"));
+  answer.authority_qualifications.push(
+    qualification("indexer-envio/AGENTS.md"),
+  );
+  scored = score(result);
+  questionReport = scored.report.questions.find(
+    (question) => question.question_id === answer.question_id,
+  );
+  assert.equal(questionReport.routing_correct, true);
+  assert.equal(questionReport.shortest_route, false);
+
+  const orderedSuite = structuredClone(context.suite);
+  const orderedQuestion = orderedSuite.questions.find(
+    (question) => question.id === answer.question_id,
+  );
+  orderedQuestion.accepted_routes = [
+    ["indexer-envio/AGENTS.md", "indexer-envio/README.md"],
+  ];
+  result.fixture_digest = fixtureDigest(orderedSuite);
+  scored = scoreNavigationResult({
+    suite: orderedSuite,
+    result,
+    inventory: context.inventory,
+    repoRoot,
+  });
+  questionReport = scored.report.questions.find(
+    (question) => question.question_id === answer.question_id,
+  );
+  assert.equal(questionReport.routing_correct, true);
+  assert.equal(questionReport.shortest_route, true);
+
+  answer.chosen_documents.reverse();
+  scored = scoreNavigationResult({
+    suite: orderedSuite,
+    result,
+    inventory: context.inventory,
+    repoRoot,
+  });
   const reversedReport = scored.report.questions.find(
     (question) => question.question_id === answer.question_id,
   );
@@ -913,19 +968,6 @@ test("route order and shortest useful path are measured independently", () => {
   assert.equal(scored.report.routing_accuracy_percent, 94.4);
   assert.equal(scored.report.answer_evidence_percent, 100);
   assert.equal(scored.report.passed, true);
-  answer.chosen_documents.reverse();
-  answer.chosen_documents.push("docs/context-standards.md");
-  answer.loaded_sources.push(source("docs/context-standards.md"));
-  answer.authority_qualifications.push(
-    qualification("docs/context-standards.md"),
-  );
-  scored = score(result);
-  assert.equal(
-    scored.report.questions.find(
-      (question) => question.question_id === answer.question_id,
-    ).shortest_route,
-    false,
-  );
 });
 
 test("navigation issue markers are structural and de-duplicate REST pages", () => {


### PR DESCRIPTION
## The Problem

- The navigation fixture rejects `indexer-envio/README.md` even though that canonical document fully owns the add-contract procedure.
- Three independent full runs chose the direct README route, so the fixture measures adherence to a longer router chain instead of the narrowest useful authority.

## The Solution

- Accept the README as the shortest route while retaining the scoped-instructions-to-README chain as a valid alternative.

## Details

- Adds `["indexer-envio/README.md"]` before the existing two-document route for `package-indexer-add-contract`.
- Extends the scorer regression to prove the direct route is shortest, the full edit-time chain remains accepted, and route ordering is still enforced when no shorter route applies.
- Records the August evaluation and independent high-effort route review in the comparison runbook.
- Changes the current fixture digest to `2b9543ecc7a101aeb06510464e93cbc2cab8e6b645899c949d171cfc62e3908a`.
- Leaves the immutable baseline result and frozen fixtures unchanged.

Refs #1788

## Validation

- `pnpm docs:navigation-eval:test` — 34 passed
- `pnpm docs:navigation-eval -- --check-fixtures --json` — valid; 18 questions; 53,257 bytes total headroom; 20,489 bytes reserve surplus
- `pnpm docs:navigation-eval -- --validate docs/evals/documentation-navigation-baseline.json --fixtures docs/evals/documentation-navigation-baseline-fixtures.json` — passed
- `pnpm agent:quality-gate --run` — all eight mapped commands passed
- Fresh-context high-effort semantic autoreview and deterministic guard — clean

## Deferrals

- #1788 tracks the required fresh evaluation from clean `main` after this fixture change merges. That result cannot be generated in this PR because the evaluated commit must already be reachable from the default branch.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new architecture decision; this corrects an accepted evaluation route after the contract-required review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/eval fixture and test-only changes; no runtime services or auth paths affected.
> 
> **Overview**
> After three full runs chose **`indexer-envio/README.md`** alone for `package-indexer-add-contract`, the doc-navigation fixture now treats that canonical README as the **shortest** accepted route and still allows **`indexer-envio/AGENTS.md` → README** as a valid longer chain.
> 
> The evaluation runbook records the August 2026 review (issue #1728) and points follow-up fresh eval work to #1788; frozen baseline artifacts stay unchanged. Scorer tests now assert direct-route vs two-doc routing vs **ordered** multi-doc routes independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cfdcd67956b68f55b7b2f97523926a2d133331. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->