### PR TITLE
fix: clarify partial Kraken liquidity

### DIFF
--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -411,7 +411,7 @@ describe("PegMonitoringPageClient", () => {
       "At the last confirmed check, net pool inflow was at 80% of the active on-chain trading limit. Warn at 80%.",
     );
   });
-  it("labels capped supporting-market prices as partial fills", () => {
+  it("labels fresh listed capped supporting-market prices as partial liquidity", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;
     state.current = {
@@ -421,8 +421,14 @@ describe("PegMonitoringPageClient", () => {
           {
             ...item,
             sources: item.sources.map((source) =>
-              source.id === "kraken_eur"
-                ? { ...source, capped: true, filledFraction: 0.4 }
+              source.id === "kraken_eur" || source.id === "kraken_usd"
+                ? {
+                    ...source,
+                    capped: true,
+                    filledFraction: 0.4,
+                    listingState: "listed",
+                    listingCheckedAt: response.producedAt - 8,
+                  }
                 : source,
             ),
           },
@@ -436,13 +442,70 @@ describe("PegMonitoringPageClient", () => {
     const supporting = container.querySelector(
       '[data-testid="peg-supporting-source-kraken_eur"]',
     );
+    expect(supporting?.textContent).toContain("Partial liquidity");
     expect(supporting?.textContent).toContain(
-      "partial fill: 40% of the test sale",
+      "0.9968 EUR per EUROP · filled 20,000 of 50,000 EUROP (40%) · checked 28s ago",
     );
-    expect(supporting?.textContent).not.toContain(
-      "for a 50,000 EUROP test sale",
+    const convertedSupporting = container.querySelector(
+      '[data-testid="peg-supporting-source-kraken_usd"]',
+    );
+    expect(convertedSupporting?.textContent).toContain("Partial liquidity");
+    expect(convertedSupporting?.textContent).toContain(
+      "Converted from USD to EUR using rate feed 0xec5748…c318ca on chain 137.",
     );
   });
+  it.each([
+    ["unhealthy", { healthy: false }],
+    ["unlisted", { listingState: null }],
+    ["listing check missing", { listingCheckedAt: null }],
+    ["listing halted", { listingState: "halted" }],
+    ["venue halted", { venueState: "halted" }],
+    [
+      "listing check stale",
+      { listingCheckedAt: PEG_FIXTURE_PRODUCED_AT - 301 },
+    ],
+    [
+      "price observation stale",
+      { observationAt: PEG_FIXTURE_PRODUCED_AT - 301 },
+    ],
+  ] as const)(
+    "keeps %s capped supporting-market evidence unavailable",
+    (_, overrides) => {
+      const response = makePegMonitoringResponse();
+      const item = response.packages[0]!;
+      state.current = {
+        data: {
+          ...response,
+          packages: [
+            {
+              ...item,
+              sources: item.sources.map((source) =>
+                source.id === "kraken_eur"
+                  ? {
+                      ...source,
+                      capped: true,
+                      filledFraction: 0.4,
+                      listingState: "listed",
+                      listingCheckedAt: response.producedAt - 8,
+                      ...overrides,
+                    }
+                  : source,
+              ),
+            },
+          ],
+        },
+        isLoading: false,
+        hasError: false,
+      };
+
+      render();
+      const supporting = container.querySelector(
+        '[data-testid="peg-supporting-source-kraken_eur"]',
+      );
+      expect(supporting?.textContent).toContain("Unavailable");
+      expect(supporting?.textContent).not.toContain("Partial liquidity");
+    },
+  );
   it("expires source evidence while its package is still current", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -459,7 +459,12 @@ describe("PegMonitoringPageClient", () => {
     ["unlisted", { listingState: null }],
     ["listing check missing", { listingCheckedAt: null }],
     ["listing halted", { listingState: "halted" }],
+    ["listing absent", { listingState: "absent" }],
     ["venue halted", { venueState: "halted" }],
+    ["price observation missing", { observationAt: null }],
+    ["executable price missing", { executablePrice: null }],
+    ["filled fraction missing", { filledFraction: null }],
+    ["reference size missing", { referenceSize: null }],
     [
       "listing check stale",
       { listingCheckedAt: PEG_FIXTURE_PRODUCED_AT - 301 },
@@ -510,6 +515,44 @@ describe("PegMonitoringPageClient", () => {
       );
     },
   );
+  it("suppresses capped fill details when the package is stale", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.current = {
+      data: {
+        ...response,
+        packages: [
+          {
+            ...item,
+            sources: item.sources.map((source) =>
+              source.id === "kraken_eur"
+                ? {
+                    ...source,
+                    capped: true,
+                    filledFraction: 0.4,
+                    listingState: "listed",
+                    listingCheckedAt: response.producedAt - 8,
+                  }
+                : source,
+            ),
+          },
+        ],
+      },
+      isLoading: false,
+      hasError: true,
+    };
+
+    render();
+    const supporting = container.querySelector(
+      '[data-testid="peg-supporting-source-kraken_eur"]',
+    );
+    expect(supporting?.textContent).toContain("Unavailable");
+    expect(supporting?.textContent).not.toContain("Partial liquidity");
+    expect(supporting?.textContent).not.toContain("partial fill");
+    expect(supporting?.textContent).not.toContain(
+      "filled 20,000 of 50,000 EUROP (40%)",
+    );
+  });
   it("expires source evidence while its package is still current", () => {
     const response = makePegMonitoringResponse();
     const item = response.packages[0]!;

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -504,6 +504,10 @@ describe("PegMonitoringPageClient", () => {
       );
       expect(supporting?.textContent).toContain("Unavailable");
       expect(supporting?.textContent).not.toContain("Partial liquidity");
+      expect(supporting?.textContent).not.toContain("partial fill");
+      expect(supporting?.textContent).not.toContain(
+        "filled 20,000 of 50,000 EUROP (40%)",
+      );
     },
   );
   it("expires source evidence while its package is still current", () => {

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-market-evidence.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-market-evidence.tsx
@@ -61,9 +61,9 @@ function supportingSourceStatus(
   nowMs: number,
   confirmedAtMs: number,
   stale: boolean,
+  partialLiquidity: boolean,
 ): React.ComponentProps<typeof StatusPill> {
-  if (hasPartialLiquidity(source, nowMs, stale))
-    return { label: "Partial liquidity", tone: "warn" };
+  if (partialLiquidity) return { label: "Partial liquidity", tone: "warn" };
   if (!sourceHasUnavailableEvidence(source, stale ? confirmedAtMs : nowMs))
     return {
       label: stale ? "Last confirmed" : "Available",
@@ -82,8 +82,7 @@ function supportingSaleDetail(
     source.filledFraction !== null
   )
     return ` · filled ${formatNumber(source.referenceSize * source.filledFraction)} of ${formatNumber(source.referenceSize)} ${source.baseCurrency} (${formatFraction(source.filledFraction)})`;
-  if (source.capped)
-    return ` · partial fill: ${formatFraction(source.filledFraction)} of the test sale`;
+  if (source.capped) return "";
   return source.referenceSize === null
     ? ""
     : ` for a ${formatNumber(source.referenceSize)} ${source.baseCurrency} test sale`;
@@ -138,7 +137,13 @@ function SupportingSource({
 }): React.JSX.Element {
   const checkedAge = observationAge(source, nowMs);
   const partialLiquidity = hasPartialLiquidity(source, nowMs, stale);
-  const status = supportingSourceStatus(source, nowMs, confirmedAtMs, stale);
+  const status = supportingSourceStatus(
+    source,
+    nowMs,
+    confirmedAtMs,
+    stale,
+    partialLiquidity,
+  );
   const priceCurrency = source.convertVia?.toCurrency ?? source.quoteCurrency;
   return (
     <article

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-market-evidence.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-market-evidence.tsx
@@ -31,6 +31,64 @@ function conversionText(source: PegSource): string | null {
     : `Converted from ${conversion.fromCurrency} to ${conversion.toCurrency} using rate feed ${shortAddress(conversion.rateFeedId)} on chain ${conversion.chainId}.`;
 }
 
+function hasPartialLiquidity(
+  source: PegSource,
+  nowMs: number,
+  stale: boolean,
+): boolean {
+  if (stale) return false;
+  if (
+    !source.healthy ||
+    source.capped !== true ||
+    source.listingState !== "listed" ||
+    source.listingCheckedAt === null ||
+    source.venueState === "halted" ||
+    source.observationAt === null ||
+    source.executablePrice === null ||
+    source.filledFraction === null ||
+    source.referenceSize === null
+  )
+    return false;
+  const staleAfterMs = source.policy.staleAfterSeconds * 1_000;
+  return (
+    nowMs - source.listingCheckedAt * 1_000 <= staleAfterMs &&
+    nowMs - source.observationAt * 1_000 <= staleAfterMs
+  );
+}
+
+function supportingSourceStatus(
+  source: PegSource,
+  nowMs: number,
+  confirmedAtMs: number,
+  stale: boolean,
+): React.ComponentProps<typeof StatusPill> {
+  if (hasPartialLiquidity(source, nowMs, stale))
+    return { label: "Partial liquidity", tone: "warn" };
+  if (!sourceHasUnavailableEvidence(source, stale ? confirmedAtMs : nowMs))
+    return {
+      label: stale ? "Last confirmed" : "Available",
+      tone: stale ? "neutral" : "good",
+    };
+  return { label: "Unavailable", tone: "warn" };
+}
+
+function supportingSaleDetail(
+  source: PegSource,
+  partialLiquidity: boolean,
+): string {
+  if (
+    partialLiquidity &&
+    source.referenceSize !== null &&
+    source.filledFraction !== null
+  )
+    return ` · filled ${formatNumber(source.referenceSize * source.filledFraction)} of ${formatNumber(source.referenceSize)} ${source.baseCurrency} (${formatFraction(source.filledFraction)})`;
+  if (source.capped)
+    return ` · partial fill: ${formatFraction(source.filledFraction)} of the test sale`;
+  return source.referenceSize === null
+    ? ""
+    : ` for a ${formatNumber(source.referenceSize)} ${source.baseCurrency} test sale`;
+}
+
 export function SaleMeasurement({
   source,
   nowMs,
@@ -79,10 +137,8 @@ function SupportingSource({
   stale: boolean;
 }): React.JSX.Element {
   const checkedAge = observationAge(source, nowMs);
-  const usable = !sourceHasUnavailableEvidence(
-    source,
-    stale ? confirmedAtMs : nowMs,
-  );
+  const partialLiquidity = hasPartialLiquidity(source, nowMs, stale);
+  const status = supportingSourceStatus(source, nowMs, confirmedAtMs, stale);
   const priceCurrency = source.convertVia?.toCurrency ?? source.quoteCurrency;
   return (
     <article
@@ -93,12 +149,7 @@ function SupportingSource({
         <p className="break-words text-sm font-medium text-slate-100">
           {marketName(source)}
         </p>
-        <StatusPill
-          label={
-            usable ? (stale ? "Last confirmed" : "Available") : "Unavailable"
-          }
-          tone={usable ? (stale ? "neutral" : "good") : "warn"}
-        />
+        <StatusPill {...status} />
       </div>
       {source.executablePrice === null ? (
         <p className="mt-2 text-xs leading-5 text-slate-300">
@@ -109,11 +160,7 @@ function SupportingSource({
           {stale ? "At the last confirmed check: " : ""}
           {formatNumber(source.executablePrice)} {priceCurrency} per{" "}
           {source.baseCurrency}
-          {source.capped
-            ? ` · partial fill: ${formatFraction(source.filledFraction)} of the test sale`
-            : source.referenceSize === null
-              ? ""
-              : ` for a ${formatNumber(source.referenceSize)} ${source.baseCurrency} test sale`}
+          {supportingSaleDetail(source, partialLiquidity)}
           {checkedAge === null ? "" : ` · checked ${checkedAge} ago`}
         </p>
       )}


### PR DESCRIPTION
## The Problem

- Kraken can execute part of the 50,000 EUROP reference sale, but the dashboard labels that result `Unavailable`.
- The label hides useful price and liquidity evidence and makes a partial fill look like a failed data source.

## The Solution

- Label fresh, healthy, listed Kraken results as `Partial liquidity` and show the exact filled amount, reference amount, percentage, price, and check age.
- Keep stale, unhealthy, unlisted, or halted evidence fail-closed as `Unavailable`.
- Closes #1797.

## Details

- This changes presentation only. Capped Kraken sources remain supporting evidence and do not set peg status or satisfy the decision-source quorum.
- Listing and price freshness are checked independently before the dashboard uses the partial-liquidity label.
- Direct EUR and converted USD source details keep their existing market and conversion context.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed. One parallel coverage run timed out in two unrelated browser-policy tests; the isolated rerun passed all 4,202 tests and the push gate then passed cleanly.
- Codex-native autoreview — four cycles; all findings fixed; final fresh-context pass clean; bundle manifest verified before and after review.
- Browser fixture verification — fresh capped EUR and USD sources show `Partial liquidity` with exact amounts; a stale listing check remains `Unavailable`; no console errors or horizontal overflow.
- Lighthouse — Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this preserves the existing evidence and decision model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to supporting-market evidence labels and copy; peg status and decision-source selection are untouched.
> 
> **Overview**
> Supporting-market cards no longer treat **fresh, healthy, listed** capped Kraken quotes as **Unavailable**. They now show a **Partial liquidity** warning pill and spell out **filled vs reference size**, **fill %**, **price**, and **check age** (including converted USD→EUR sources).
> 
> **Partial liquidity** only applies when listing and price observations are both within each source’s `staleAfterSeconds` window; package-level stale view, unhealthy/unlisted/halted venues, and stale listing or price checks still render **Unavailable** with no partial label. Peg decision logic and source usability counts are unchanged—this is evidence copy and status pills in `peg-monitoring-market-evidence.tsx` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf41e57de86eaa9d24fea42e591f464ff528163. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->