### PR TITLE
feat: record EUROP operational admission evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ Authority: canonical
 - [`docs/notes/cross-protocol-context.md`](notes/cross-protocol-context.md)
 - [`docs/notes/dashboard-verification.md`](notes/dashboard-verification.md)
 - [`docs/notes/documentation-gardening.md`](notes/documentation-gardening.md)
+- [`docs/notes/europ-operational-admission.md`](notes/europ-operational-admission.md)
 - [`docs/notes/github-tooling-surfaces.md`](notes/github-tooling-surfaces.md)
 - [`docs/notes/hasura-isolation-trigger.md`](notes/hasura-isolation-trigger.md)
 - [`docs/notes/peg-monitoring-onboarding.md`](notes/peg-monitoring-onboarding.md)

--- a/docs/notes/europ-operational-admission.md
+++ b/docs/notes/europ-operational-admission.md
@@ -1,0 +1,209 @@
+---
+title: EUROP operational admission evidence
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-11
+doc_type: runbook
+scope: peg-monitoring / operational-admission
+review_interval_days: 90
+garden_lane: operator-runbooks
+---
+
+# EUROP operational admission evidence
+
+## Decision
+
+EUROP is **Blocked** from operational **Live** admission. The public price
+monitor, dashboard, and alerts are already deployed; this decision only says
+that the stronger proof that responders can keep EURm loss within the approved
+budget is incomplete.
+
+The pinned input and deterministic evaluator are
+[`2026-08-11.json`](../../scripts/fixtures/europ-operational-admission/2026-08-11.json)
+and
+[`europ-operational-admission.mjs`](../../scripts/europ-operational-admission.mjs).
+The evaluator always returns `BLOCKED`; static numbers and flags cannot grant
+readiness. A future implementation must execute and authenticate the complete
+sequential loss model before the canonical onboarding gate can consider a Live
+decision.
+
+## Pinned Polygon configuration
+
+All mutable values below were read at Polygon block `91830875`, hash
+`0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25`,
+timestamp `2026-08-11T12:29:00Z`.
+PublicNode, dRPC, and 1RPC returned the same pin.
+The deterministic diagnostic was evaluated at `2026-08-11T12:35:00Z` with a
+maximum evidence age of 900 seconds; the pin was 360 seconds old.
+
+| Area                | Measured configuration                                                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pool                | EURm/EUROP FPMM `0xcd8c6811d975981f57e7fb32e59f0bee66af3201`                                                                                                                                                 |
+| Assets              | EURm token0 `0x4D502d735B4C574B487Ed641ae87cEaE884731C7` (18 decimals); EUROP token1 `0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51` (6 decimals)                                                               |
+| Reserves            | `6,932.949238266138502114` EURm and `10,399.423858` EUROP                                                                                                                                                    |
+| Pool administration | The FPMM owner and fee setter are the control Safe.                                                                                                                                                          |
+| Fees                | 3 bps LP + 2 bps protocol = 5 bps total                                                                                                                                                                      |
+| Trading-limit state | L0: 50,000 EUROP / 300 s, netflow `3,498.25` EUROP, last update `1785520845`; L1: 250,000 EUROP / 86,400 s, netflow `9,229.728525` EUROP, last update `1785453845`. Both use TradingLimitsV2 fixed-15 scale. |
+| Control Safe        | `0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458`; 4-of-6, nonce 9 at the pin.                                                                                                                                    |
+| Manual-rate control | Feed `0xc22418a83DfC262B10a1f57E25309DB83E7eA79e`; rate 1, last updated `2026-07-16T15:19:19Z`, non-expired. The ValueDelta breaker is enabled with a 50-bps threshold.                                      |
+| Enabled strategies  | Open `0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f` and Reserve `0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B`, each with a 300-second cooldown.                                                                 |
+| Reserve access      | ReserveV2 `0x4255Cf38e51516766180b33122029A88Cb853806`; its direct EURm and EUROP balances were zero at the pin. Those balances are not an approved liquid-reserve value or a loss cap.                      |
+
+Both trading-limit windows were expired at the pin. The six-hour capacity below
+does not rely on that favorable state; it uses the durable worst reachable
+limit state required by the onboarding runbook.
+
+The checked-in snapshot is diagnostic evidence. The evaluator validates field
+shape, Safe threshold/owner-count consistency, freshness, and arithmetic, but
+it does not authenticate the RPC reads or any claimed Safe, rate, strategy,
+budget, or model control. Those claims cannot clear the Blocked result.
+It refuses to calculate capacity unless the snapshot identifies Polygon 137,
+the expected pool and EUROP/EURm contracts and decimals, and a well-formed
+positive block number and hash. Numeric fields use canonical integers only;
+timestamps require an explicit UTC offset and valid calendar values.
+A well-formed block number and hash are still unauthenticated. They are reported
+separately from the expected EUROP/Polygon protocol identity so a future fresh
+block is never mislabeled as the dated pinned block above.
+
+The protected-system boundary is every EURm movement involving the FPMM, its
+enabled liquidity strategies, ReserveV2, and the protocol-fee recipient. It
+includes transfers, minting, and burning. The Safe and rate breaker are control
+inputs; they are not treated as economic asset holders.
+The Safe diagnostic's expected-control-structure field covers its address and
+4-of-6 structure only. Nonce is reported as mutable point-in-time data and is
+not part of that field; all Safe fields remain unauthenticated snapshot claims.
+
+## Approved operating choices recorded for this review
+
+[#1687](https://github.com/mento-protocol/monitoring-monorepo/issues/1687)
+records the owner decisions:
+
+- Philip Paetz owns signer coverage, with Bogdan Dumitru as backup.
+- The active `@support-engineer` is the escalation route, resolved from the
+  VictorOps / Splunk On-Call rotation.
+- The end-to-end response time is `S = 6 hours` (`21,600` seconds).
+- Safe nonce 8 is accepted as execution proof for the current threshold.
+- The starter budget rule is `B = min(100,000 EURm, 0.5% of approved current
+liquid reserve assets)`.
+
+The policy does not yet define which custody accounts count as “current liquid
+reserve assets,” which valuation feeds and haircuts apply, or how that result
+becomes `B`. The exact current liquid-reserve value and approved numeric `B`
+are therefore absent. The above human attestations also have no explicit expiry
+or independent reviewer recorded yet.
+
+There is one **unapproved conditional calculation** in the pinned snapshot:
+the registered assets held by ReserveV2 plus its listed other-reserve Safe hold
+`120,812.444400` USDC; with contemporaneous USDC/USD `0.9998` and EUR/USD
+`1.15364`, that is `104,701.884392982212822024` EURm and produces
+`523.509421964911064110` EURm at 0.5%. This is not `B`. It becomes usable only
+if the accountable owner explicitly approves that custody boundary, valuation
+method, and resulting number. The evaluator keeps `B` empty until then.
+
+That inventory is shared. ReserveV2 also serves the enabled USDC/USDm pool
+`0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5`, while the Open strategy also
+serves the active EURm/USDm pool
+`0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61`. The conditional figure is a
+same-block inventory value only. A durable model must include or enforceably
+exclude concurrent reachable transitions in those pools before treating the
+inventory as available to EUROP.
+
+## Six-hour swap capacity
+
+The evaluator applies the canonical TradingLimitsV2 capacity formula with
+`S = 21,600` seconds:
+
+```text
+D_live,i(S) = 2L_i + L_i * ceil(S / W_i)
+D_net(S) = min(D_live,i(S))
+```
+
+| Limit                         |                Six-hour capacity |
+| ----------------------------- | -------------------------------: |
+| L0 (50,000 EUROP / 300 s)     | 3,700,000 EUROP fixed-15 netflow |
+| L1 (250,000 EUROP / 86,400 s) |   750,000 EUROP fixed-15 netflow |
+| Binding `D_net(S)`            |   750,000 EUROP fixed-15 netflow |
+| Fee-adjusted maximum input    |             750,375.187593 EUROP |
+
+The pinned L0 and L1 signed netflows are inside their enforced `[-L, +L]`
+intervals. The evaluator blocks values one fixed-15 unit beyond either edge.
+
+This is a **monotone EUROP-input capacity**, not a EURm-loss result. `B` is in
+EURm, so the two numbers cannot be compared directly. A future executable model
+must derive a boundary-aligned EURm result for that capacity and separately
+derive the full worst-case EURm result before either can be compared with `B`.
+
+## Why the decision stays Blocked
+
+- **No executable authenticated loss model:** the repository has no program
+  that authenticates the inputs, advances every reachable swap, rate, and
+  strategy transition, and calculates net EURm outflow across the protected
+  boundary. This is an unconditional blocker in the current evaluator.
+- **Static control claims are untrusted:** editing Safe, rate, strategy, budget,
+  certificate, model flags, or claimed loss numbers in JSON cannot grant
+  readiness or produce a passing budget comparison.
+- **No numeric budget:** the approved liquid-reserve value and exact `B` are
+  absent. The available `523.509421964911064110` EURm figure is only an
+  unapproved conditional calculation.
+- **No enforceable rate-transition bound:** the current configuration does not
+  provide an enforced no-change, no-arbitrage, or maximum-successful-transition
+  control for the six-hour interval.
+- **Incomplete strategy boundary:** both strategies are enabled and neither
+  has a documented, enforceable EURm-outflow bound for the six-hour interval.
+  The Reserve strategy has EURm/USDm mint and burn permissions and no
+  enforceable per-interval mint cap, so visible EURm balances cannot serve as
+  that bound. Both strategy action checks were not rebalancable at the pin;
+  that is a point-in-time observation, not a six-hour guarantee.
+- **No complete loss model:** there is no deterministic, protected-boundary
+  result that covers both rate transitions and every enabled strategy, either
+  for the monotone capacity or for the worst case.
+- **Incomplete certificate:** signer coverage, escalation route, execution
+  proof, and budget approval have no explicit expiry; a reviewer is also not
+  recorded. Expiries are checked against the explicit evaluation time, not the
+  observation time.
+
+The result is intentionally conservative. Any absent, stale, malformed, or
+unsupported input remains a blocker rather than becoming an assumption.
+
+## Re-run and review
+
+Use the tracked snapshot to reproduce the current result:
+
+```bash
+node scripts/europ-operational-admission.mjs \
+  --snapshot scripts/fixtures/europ-operational-admission/2026-08-11.json
+```
+
+The expected result is JSON with `status: BLOCKED` and process exit `1`.
+Unreadable or invalid JSON exits `2`. Treat either nonzero result as a
+fail-closed outcome; this command is not a success probe.
+
+For a future decision, replace the snapshot with fresh same-block reads and
+an explicit evaluation time and maximum evidence age. The current evaluator
+still returns `BLOCKED` because it does not fetch or authenticate chain data and
+does not execute the sequential loss model. Both budget comparisons remain
+`not_evaluable`, even when a snapshot contains plausible-looking result values.
+An owner-approved numeric `B` can be supplied directly with its accountable
+approver and approval reference; otherwise the snapshot must include an
+approved liquid-reserve denominator that reproduces the starter rule. Neither
+choice clears the unconditional model and authentication blockers.
+
+The governing procedure remains
+[Peg monitoring onboarding and re-census](peg-monitoring-onboarding.md),
+especially its response-SLA and loss-bound sections. Re-run the calculation
+after any change to the Safe, rate control, fee, limits, strategy, protected
+boundary, response SLA, budget, or certificate.
+
+## Sources
+
+- The checked-in snapshot above is the source of the pinned on-chain values and
+  the current `BLOCKED` result.
+- [Issue #1687](https://github.com/mento-protocol/monitoring-monorepo/issues/1687)
+  records the accountable-owner decisions and accepted execution proof.
+- The model follows the canonical
+  [onboarding runbook](peg-monitoring-onboarding.md), including its
+  TradingLimitsV2 formula and protected-boundary requirement.
+- The control interpretation was verified against `mento-core`
+  `07ecf3df5650a33ea6957f1ad2966e02c5082253`, in `TradingLimitsV2`, `FPMM`,
+  and `ReserveLiquidityStrategy`.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -483,3 +483,13 @@ until accountable owners supply and approve:
 Do not copy the dated market-depth figures from
 [`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md) into an approval.
 Repeat the census and attach current evidence.
+
+The current six-hour EUROP operational-admission record is in
+[EUROP operational admission evidence](europ-operational-admission.md). Its
+deterministic evaluator preserves the current **Blocked** decision until a
+fresh same-block input includes the numeric budget, enforceable controls,
+explicit certificate expiries, and a boundary-aligned EURm calculation. Its
+TradingLimitsV2 capacity output alone never proves the loss-budget gate. The
+current evaluator cannot grant readiness: it remains Blocked until an
+executable model authenticates the inputs and reproduces every sequential
+protected-boundary transition.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -3,7 +3,7 @@ title: Quick Commands
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-26
+last_verified: 2026-08-11
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -95,6 +95,10 @@ pnpm bridge:mutation          # Targeted StrykerJS baseline for metrics-bridge r
 pnpm integrations:probe        # Quote-only Mento v3 route coverage snapshot
 pnpm integrations:probe --write-upstash  # Publish latest snapshot for /integrations
 pnpm integrations:probe:test   # Unit tests for probe adapters/parsers
+
+# EUROP operational admission (the tracked 2026-08-11 evidence snapshot is intentionally Blocked)
+node scripts/europ-operational-admission.mjs --snapshot scripts/fixtures/europ-operational-admission/2026-08-11.json  # Expected exit 1 + JSON Blocked; exit 2 means unreadable/invalid JSON
+node --test scripts/europ-operational-admission.test.mjs  # Regression tests for the fail-closed capacity and budget checks
 
 # Agent issue workboard
 # (Claude cloud sessions without the capability gate: MCP fallback in

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2489,6 +2489,9 @@ while IFS= read -r path; do
           add_command "node scripts/check-peg-registry-integrity.mjs" "peg registry integrity checker changed"
           add_command "node scripts/check-peg-registry-integrity.test.mjs" "peg registry integrity checker changed"
           ;;
+        scripts/europ-operational-admission.mjs|scripts/europ-operational-admission.test.mjs)
+          add_command "node --test scripts/europ-operational-admission.test.mjs" "EUROP operational-admission evaluator changed"
+          ;;
         scripts/check-pr-description.mjs|scripts/check-pr-description.test.mjs)
           add_command "node scripts/check-pr-description.test.mjs" "PR description validator changed"
           ;;
@@ -2615,6 +2618,11 @@ while IFS= read -r path; do
           add_adr_reminder "top-level package.json changed — ADR reminder (a new package/service likely needs an ADR)"
           ;;
       esac
+      ;;
+  esac
+  case "$path" in
+    scripts/fixtures/europ-operational-admission/*)
+      add_command "node --test scripts/europ-operational-admission.test.mjs" "EUROP operational-admission evaluator changed"
       ;;
   esac
   # `pnpm tf:test` owns the fail-closed production identity contract. Route

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3946,6 +3946,15 @@ run_gate "scripts/check-peg-registry-integrity.test.mjs"
 assert_contains "- node scripts/check-peg-registry-integrity.mjs (peg registry integrity checker changed)"
 assert_contains "- node scripts/check-peg-registry-integrity.test.mjs (peg registry integrity checker changed)"
 
+run_gate "scripts/europ-operational-admission.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/europ-operational-admission.test.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/fixtures/europ-operational-admission/2026-08-11.json"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
 run_gate "scripts/check-pr-description.mjs"
 assert_contains "- node scripts/check-pr-description.test.mjs (PR description validator changed)"
 

--- a/scripts/europ-operational-admission.mjs
+++ b/scripts/europ-operational-admission.mjs
@@ -1,0 +1,936 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const BASIS_POINTS = 10_000n;
+const FIXED_15 = 10n ** 15n;
+const MAX_BUDGET_EURM_RAW = 100_000n * 10n ** 18n;
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+const BLOCK_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+const CANONICAL_INTEGER_PATTERN = /^(?:0|-?[1-9][0-9]*)$/u;
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|[+-]\d{2}:\d{2})$/u;
+const EXPECTED_CHAIN_ID = 137n;
+const EXPECTED_POOL_ADDRESS = "0xcd8c6811d975981f57e7fb32e59f0bee66af3201";
+const EXPECTED_QUOTE_TOKEN_ADDRESS =
+  "0x4d502d735b4c574b487ed641ae87ceae884731c7";
+const EXPECTED_MONITORED_TOKEN_ADDRESS =
+  "0x888883b5f5d21fb10dfeb70e8f9722b9fb0e5e51";
+const EXPECTED_QUOTE_TOKEN_DECIMALS = 18n;
+const EXPECTED_MONITORED_TOKEN_DECIMALS = 6n;
+const EXPECTED_SAFE_ADDRESS = "0x58099b74f4acd642da77b4b7966b4138ec5ba458";
+const EXPECTED_SAFE_THRESHOLD = 4n;
+const EXPECTED_SAFE_OWNER_COUNT = 6n;
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return value;
+}
+
+function requiredArray(value, field) {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  return value;
+}
+
+function integer(value, field) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${field} must be a safe integer number`);
+    }
+    return BigInt(value);
+  }
+  if (typeof value === "string" && CANONICAL_INTEGER_PATTERN.test(value)) {
+    return BigInt(value);
+  }
+  throw new Error(
+    `${field} must be a canonical integer string or safe integer number`,
+  );
+}
+
+function nonNegative(value, field) {
+  const parsed = integer(value, field);
+  if (parsed < 0n) throw new Error(`${field} must be non-negative`);
+  return parsed;
+}
+
+function positive(value, field) {
+  const parsed = nonNegative(value, field);
+  if (parsed === 0n) throw new Error(`${field} must be positive`);
+  return parsed;
+}
+
+function optionalNonNegative(value, field) {
+  if (value === null || value === undefined) return null;
+  return nonNegative(value, field);
+}
+
+function ceilDiv(numerator, denominator) {
+  if (numerator < 0n || denominator <= 0n) {
+    throw new Error(
+      "ceilDiv requires a non-negative numerator and positive denominator",
+    );
+  }
+  return (numerator + denominator - 1n) / denominator;
+}
+
+function min(values) {
+  if (values.length === 0) throw new Error("cannot take minimum of no values");
+  return values.reduce((current, value) => (value < current ? value : current));
+}
+
+function issue(code, message) {
+  return { code, message };
+}
+
+function hasText(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isLeapYear(year) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function daysInMonth(year, month) {
+  const days = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return days[month - 1] ?? 0;
+}
+
+function timestamp(value) {
+  if (!hasText(value)) return null;
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match) return null;
+
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    millisecondText,
+    offsetText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const millisecond = millisecondText ? Number(millisecondText) : 0;
+
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth(year, month) ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return null;
+  }
+
+  let offsetMinutes = 0;
+  if (offsetText !== "Z") {
+    if (offsetText === "-00:00") return null;
+    const offsetHours = Number(offsetText.slice(1, 3));
+    const offsetMinutePart = Number(offsetText.slice(4, 6));
+    if (
+      offsetHours > 14 ||
+      offsetMinutePart > 59 ||
+      (offsetHours === 14 && offsetMinutePart !== 0)
+    ) {
+      return null;
+    }
+    offsetMinutes = offsetHours * 60 + offsetMinutePart;
+    if (offsetText.startsWith("-")) offsetMinutes = -offsetMinutes;
+  }
+
+  const wallClock = new Date(0);
+  wallClock.setUTCFullYear(year, month - 1, day);
+  wallClock.setUTCHours(hour, minute, second, millisecond);
+  const parsed = wallClock.getTime() - offsetMinutes * 60_000;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function permanentBlockers() {
+  return [
+    issue(
+      "EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED",
+      "No executable sequential loss model authenticates state, advances every reachable transition, and calculates protected-boundary EURm outflow.",
+    ),
+    issue(
+      "SNAPSHOT_NOT_AUTHENTICATED",
+      "The checked-in snapshot is diagnostic evidence, not authenticated proof of Safe, rate, strategy, or budget state.",
+    ),
+  ];
+}
+
+function blockedResult({
+  blockers,
+  evidenceIdentity = null,
+  evaluation = null,
+  budget = null,
+  monotoneSwapEnvelope = null,
+  safeDiagnostics = null,
+  rateDiagnostics = null,
+  strategyDiagnostics = null,
+  certificate = null,
+  boundaryModelClaims = null,
+}) {
+  const reason =
+    "An executable authenticated sequential loss model is not implemented.";
+  const approvedBudgetEurmRaw = budget?.approvedBudgetEurmRaw ?? null;
+  return {
+    status: "BLOCKED",
+    evidenceIdentity,
+    evaluation,
+    budget,
+    monotoneSwapEnvelope,
+    safeDiagnostics,
+    rateDiagnostics,
+    strategyDiagnostics,
+    certificate,
+    boundaryModelClaims,
+    monotoneCapacityBudgetComparison: {
+      status: "not_evaluable",
+      reason,
+      approvedBudgetEurmRaw,
+    },
+    worstCaseBudgetComparison: {
+      status: "not_evaluable",
+      reason,
+      approvedBudgetEurmRaw,
+    },
+    blockers,
+  };
+}
+
+function inspectEvidenceIdentity(snapshot, blockers) {
+  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
+  const pool = requiredObject(snapshot.pool, "snapshot.pool");
+  const quoteAsset = requiredObject(
+    pool.quoteAsset,
+    "snapshot.pool.quoteAsset",
+  );
+  const monitoredAsset = requiredObject(
+    pool.monitoredAsset,
+    "snapshot.pool.monitoredAsset",
+  );
+  const chainId = nonNegative(evidence.chainId, "evidence.chainId");
+  const blockNumber = positive(evidence.blockNumber, "evidence.blockNumber");
+  const quoteAssetDecimals = nonNegative(
+    quoteAsset.decimals,
+    "pool.quoteAsset.decimals",
+  );
+  const monitoredAssetDecimals = nonNegative(
+    monitoredAsset.decimals,
+    "pool.monitoredAsset.decimals",
+  );
+  const poolMonitoredAssetDecimals = nonNegative(
+    pool.monitoredAssetDecimals,
+    "pool.monitoredAssetDecimals",
+  );
+
+  const blockReferenceWellFormed =
+    hasText(evidence.blockHash) && BLOCK_HASH_PATTERN.test(evidence.blockHash);
+  if (!blockReferenceWellFormed) {
+    blockers.push(
+      issue(
+        "BLOCK_REFERENCE_INVALID",
+        "The block reference must contain a positive canonical block number and 32-byte hash.",
+      ),
+    );
+  }
+
+  const invalidProtocolFields = [];
+  for (const [field, value] of [
+    ["pool.address", pool.address],
+    ["pool.quoteAsset.address", quoteAsset.address],
+    ["pool.monitoredAsset.address", monitoredAsset.address],
+  ]) {
+    if (!hasText(value) || !ADDRESS_PATTERN.test(value))
+      invalidProtocolFields.push(field);
+  }
+  for (const [field, value] of [
+    ["evidence.asset", evidence.asset],
+    ["evidence.quoteAsset", evidence.quoteAsset],
+    ["pool.quoteAsset.symbol", quoteAsset.symbol],
+    ["pool.monitoredAsset.symbol", monitoredAsset.symbol],
+  ]) {
+    if (!hasText(value)) invalidProtocolFields.push(field);
+  }
+
+  if (invalidProtocolFields.length > 0) {
+    blockers.push(
+      issue(
+        "PROTOCOL_IDENTITY_INVALID",
+        `Protocol identity fields are malformed: ${invalidProtocolFields.join(", ")}.`,
+      ),
+    );
+  }
+
+  const mismatches = [];
+  if (chainId !== EXPECTED_CHAIN_ID) mismatches.push("chainId");
+  if (evidence.asset !== "EUROP") mismatches.push("asset");
+  if (evidence.quoteAsset !== "EURm") mismatches.push("quoteAsset");
+  if (
+    hasText(pool.address) &&
+    pool.address.toLowerCase() !== EXPECTED_POOL_ADDRESS
+  ) {
+    mismatches.push("pool.address");
+  }
+  if (
+    hasText(quoteAsset.address) &&
+    quoteAsset.address.toLowerCase() !== EXPECTED_QUOTE_TOKEN_ADDRESS
+  ) {
+    mismatches.push("pool.quoteAsset.address");
+  }
+  if (
+    hasText(monitoredAsset.address) &&
+    monitoredAsset.address.toLowerCase() !== EXPECTED_MONITORED_TOKEN_ADDRESS
+  ) {
+    mismatches.push("pool.monitoredAsset.address");
+  }
+  if (quoteAsset.symbol !== "EURm") mismatches.push("pool.quoteAsset.symbol");
+  if (monitoredAsset.symbol !== "EUROP") {
+    mismatches.push("pool.monitoredAsset.symbol");
+  }
+  if (quoteAssetDecimals !== EXPECTED_QUOTE_TOKEN_DECIMALS) {
+    mismatches.push("pool.quoteAsset.decimals");
+  }
+  if (
+    monitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS ||
+    poolMonitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS
+  ) {
+    mismatches.push("pool.monitoredAsset.decimals");
+  }
+
+  if (mismatches.length > 0) {
+    blockers.push(
+      issue(
+        "PROTOCOL_IDENTITY_MISMATCH",
+        `Snapshot identity does not match EUROP/EURm on Polygon: ${mismatches.join(", ")}.`,
+      ),
+    );
+  }
+
+  const matchesExpectedEuropPolygonIdentity =
+    invalidProtocolFields.length === 0 && mismatches.length === 0;
+  return {
+    protocolIdentity: {
+      chainId,
+      asset: evidence.asset ?? null,
+      quoteAsset: evidence.quoteAsset ?? null,
+      poolAddress: pool.address ?? null,
+      quoteAssetAddress: quoteAsset.address ?? null,
+      monitoredAssetAddress: monitoredAsset.address ?? null,
+      quoteAssetDecimals,
+      monitoredAssetDecimals,
+      matchesExpectedEuropPolygonIdentity,
+      authenticated: false,
+    },
+    blockReference: {
+      blockNumber,
+      blockHash: evidence.blockHash ?? null,
+      wellFormed: blockReferenceWellFormed,
+      authenticated: false,
+    },
+  };
+}
+
+/**
+ * Derive the durable TradingLimitsV2 capacity documented in the canonical
+ * onboarding runbook. This is a fee-adjusted monitored-token netflow envelope,
+ * not a quote-asset loss result.
+ */
+function deriveMonotoneSwapEnvelope(input) {
+  const snapshot = requiredObject(input, "snapshot");
+  const pool = requiredObject(snapshot.pool, "snapshot.pool");
+  const responseSeconds = positive(snapshot.responseSeconds, "responseSeconds");
+  const monitoredAssetDecimals = Number(
+    nonNegative(pool.monitoredAssetDecimals, "pool.monitoredAssetDecimals"),
+  );
+  if (!Number.isSafeInteger(monitoredAssetDecimals)) {
+    throw new Error("pool.monitoredAssetDecimals must be a safe integer");
+  }
+
+  const fee = requiredObject(pool.fee, "pool.fee");
+  const totalFeeBps =
+    nonNegative(fee.lpBps, "pool.fee.lpBps") +
+    nonNegative(fee.protocolBps, "pool.fee.protocolBps");
+  if (totalFeeBps >= BASIS_POINTS) {
+    throw new Error("pool total fee must be below 10,000 bps");
+  }
+
+  const invariantViolations = [];
+  const windows = requiredArray(pool.tradingLimits, "pool.tradingLimits")
+    .map((window, index) => {
+      const parsed = requiredObject(window, `pool.tradingLimits[${index}]`);
+      const limitFixed15 = nonNegative(
+        parsed.limitFixed15,
+        `pool.tradingLimits[${index}].limitFixed15`,
+      );
+      const durationSeconds = positive(
+        parsed.durationSeconds,
+        `pool.tradingLimits[${index}].durationSeconds`,
+      );
+      const netflowFixed15 = integer(
+        parsed.netflowFixed15,
+        `pool.tradingLimits[${index}].netflowFixed15`,
+      );
+      if (limitFixed15 === 0n) return null;
+
+      const name = hasText(parsed.name) ? parsed.name : `window-${index}`;
+      const withinInvariant =
+        netflowFixed15 >= -limitFixed15 && netflowFixed15 <= limitFixed15;
+      if (!withinInvariant) {
+        invariantViolations.push(
+          issue(
+            "TRADING_LIMIT_INVARIANT_VIOLATION",
+            `${name} signed netflow is outside the enforced interval [-L, +L].`,
+          ),
+        );
+      }
+
+      const resetWindows = ceilDiv(responseSeconds, durationSeconds);
+      return {
+        name,
+        durationSeconds,
+        limitFixed15,
+        netflowFixed15,
+        withinInvariant,
+        resetWindows,
+        durableCapacityFixed15: 2n * limitFixed15 + limitFixed15 * resetWindows,
+      };
+    })
+    .filter((window) => window !== null);
+
+  if (windows.length === 0) {
+    throw new Error("at least one positive TradingLimitsV2 window is required");
+  }
+
+  const netflowCapacityFixed15 = min(
+    windows.map((window) => window.durableCapacityFixed15),
+  );
+  const grossInputFixed15 =
+    (netflowCapacityFixed15 * BASIS_POINTS) / (BASIS_POINTS - totalFeeBps);
+
+  let grossMonitoredInputRaw = null;
+  if (monitoredAssetDecimals <= 15) {
+    const fixed15PerMonitoredTokenRaw =
+      FIXED_15 / 10n ** BigInt(monitoredAssetDecimals);
+    grossMonitoredInputRaw = grossInputFixed15 / fixed15PerMonitoredTokenRaw;
+  }
+
+  return {
+    responseSeconds,
+    totalFeeBps,
+    monitoredAssetDecimals,
+    windows,
+    invariantViolations,
+    netflowCapacityFixed15,
+    grossInputFixed15,
+    grossMonitoredInputRaw,
+  };
+}
+
+function inspectEvaluation(snapshot, blockers) {
+  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
+  const evaluation = requiredObject(snapshot.evaluation, "snapshot.evaluation");
+  const observedAt = timestamp(evidence.observedAt);
+  const evaluatedAt = timestamp(evaluation.evaluatedAt);
+  const maxEvidenceAgeSeconds = positive(
+    evaluation.maxEvidenceAgeSeconds,
+    "evaluation.maxEvidenceAgeSeconds",
+  );
+
+  if (observedAt === null) {
+    blockers.push(
+      issue(
+        "EVIDENCE_TIMESTAMP_MISSING_OR_INVALID",
+        "The pinned evidence timestamp is absent or invalid.",
+      ),
+    );
+  }
+  if (evaluatedAt === null) {
+    blockers.push(
+      issue(
+        "EVALUATION_TIMESTAMP_MISSING_OR_INVALID",
+        "The explicit evaluation timestamp is absent or invalid.",
+      ),
+    );
+  }
+
+  let evidenceAgeSeconds = null;
+  if (observedAt !== null && evaluatedAt !== null) {
+    evidenceAgeSeconds = BigInt(Math.floor((evaluatedAt - observedAt) / 1000));
+    if (evidenceAgeSeconds < 0n) {
+      blockers.push(
+        issue(
+          "EVIDENCE_FROM_FUTURE",
+          "The pinned evidence timestamp is later than the explicit evaluation time.",
+        ),
+      );
+    } else if (evidenceAgeSeconds > maxEvidenceAgeSeconds) {
+      blockers.push(
+        issue(
+          "EVIDENCE_STALE",
+          "The pinned evidence is older than the explicit maximum evidence age.",
+        ),
+      );
+    }
+  }
+
+  return {
+    observedAt: evidence.observedAt ?? null,
+    evaluatedAt: evaluation.evaluatedAt ?? null,
+    maxEvidenceAgeSeconds,
+    evidenceAgeSeconds,
+  };
+}
+
+function deriveApprovedBudget(snapshot, blockers) {
+  const budget = requiredObject(snapshot.budget, "snapshot.budget");
+  const liquidReserveAssetsEurmRaw = optionalNonNegative(
+    budget.liquidReserveAssetsEurmRaw,
+    "budget.liquidReserveAssetsEurmRaw",
+  );
+  const approvedBudgetEurmRaw = optionalNonNegative(
+    budget.approvedBudgetEurmRaw,
+    "budget.approvedBudgetEurmRaw",
+  );
+
+  if (approvedBudgetEurmRaw === null) {
+    blockers.push(
+      issue("APPROVED_BUDGET_MISSING", "The exact numeric B is absent."),
+    );
+  } else if (
+    !hasText(budget.approvedBy) ||
+    !hasText(budget.approvalReference)
+  ) {
+    blockers.push(
+      issue(
+        "BUDGET_APPROVAL_EVIDENCE_MISSING",
+        "The recorded B lacks its accountable approver or approval reference.",
+      ),
+    );
+  }
+
+  if (liquidReserveAssetsEurmRaw === null) {
+    if (approvedBudgetEurmRaw === null) {
+      blockers.push(
+        issue(
+          "LIQUID_RESERVE_VALUE_MISSING",
+          "No approved liquid-reserve value is available to calculate B from the starter rule.",
+        ),
+      );
+    }
+    return {
+      liquidReserveAssetsEurmRaw,
+      derivedBudgetEurmRaw: null,
+      approvedBudgetEurmRaw,
+    };
+  }
+
+  const derivedBudgetEurmRaw = min([
+    MAX_BUDGET_EURM_RAW,
+    (liquidReserveAssetsEurmRaw * 5n) / 1000n,
+  ]);
+  if (
+    approvedBudgetEurmRaw !== null &&
+    approvedBudgetEurmRaw !== derivedBudgetEurmRaw
+  ) {
+    blockers.push(
+      issue(
+        "APPROVED_BUDGET_MISMATCH",
+        "The recorded B does not equal min(100,000 EURm, 0.5% of the approved liquid-reserve value).",
+      ),
+    );
+  }
+
+  return {
+    liquidReserveAssetsEurmRaw,
+    derivedBudgetEurmRaw,
+    approvedBudgetEurmRaw,
+  };
+}
+
+function inspectSafe(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const safe = requiredObject(controls.safe, "controls.safe");
+  const address = safe.address;
+  const threshold = positive(safe.threshold, "controls.safe.threshold");
+  const ownerCount = positive(safe.ownerCount, "controls.safe.ownerCount");
+  const nonce = nonNegative(safe.nonce, "controls.safe.nonce");
+  const validAddress = hasText(address) && ADDRESS_PATTERN.test(address);
+  const ownerSetVerifiedAtPin = safe.ownerSetVerifiedAtPin === true;
+  const structurallyValid =
+    validAddress && threshold <= ownerCount && ownerSetVerifiedAtPin;
+  const matchesExpectedControlStructure =
+    validAddress &&
+    address.toLowerCase() === EXPECTED_SAFE_ADDRESS &&
+    threshold === EXPECTED_SAFE_THRESHOLD &&
+    ownerCount === EXPECTED_SAFE_OWNER_COUNT;
+
+  if (!validAddress || threshold > ownerCount) {
+    blockers.push(
+      issue(
+        "SAFE_STRUCTURE_INVALID",
+        "The Safe address, threshold, or owner count is structurally invalid.",
+      ),
+    );
+  }
+  if (!ownerSetVerifiedAtPin) {
+    blockers.push(
+      issue(
+        "SAFE_OWNER_SET_UNVERIFIED",
+        "The snapshot does not record a same-pin Safe owner-set read.",
+      ),
+    );
+  }
+  if (!matchesExpectedControlStructure) {
+    blockers.push(
+      issue(
+        "SAFE_EXPECTED_CONFIGURATION_MISMATCH",
+        "The Safe address or 4-of-6 structure does not match the expected EUROP control structure.",
+      ),
+    );
+  }
+
+  return {
+    address,
+    threshold,
+    ownerCount,
+    nonce,
+    ownerSetVerifiedAtPin,
+    structurallyValid,
+    matchesExpectedControlStructure,
+    authenticated: false,
+  };
+}
+
+function inspectRateControl(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const rate = requiredObject(controls.rate, "controls.rate");
+  const noChangeClaim = rate.enforcedNoChange === true;
+  const noArbitrageClaim = rate.enforcedNoArbitrage === true;
+  const maxSuccessfulTransitionsClaim = optionalNonNegative(
+    rate.maxSuccessfulTransitions,
+    "controls.rate.maxSuccessfulTransitions",
+  );
+
+  if (
+    !noChangeClaim &&
+    !noArbitrageClaim &&
+    maxSuccessfulTransitionsClaim === null
+  ) {
+    blockers.push(
+      issue(
+        "RATE_TRANSITION_BOUND_MISSING",
+        "Bidirectional manual-rate trading has no recorded no-change, no-arbitrage, or maximum-transition control for S.",
+      ),
+    );
+  }
+
+  return {
+    noChangeClaim,
+    noArbitrageClaim,
+    maxSuccessfulTransitionsClaim,
+    authenticated: false,
+  };
+}
+
+function inspectStrategies(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const strategies = requiredArray(controls.strategies, "controls.strategies");
+  const enumerationClaim = controls.strategiesEnumeratedThroughBlock === true;
+
+  if (!enumerationClaim) {
+    blockers.push(
+      issue(
+        "STRATEGY_ENUMERATION_UNVERIFIED",
+        "The snapshot does not record every strategy enabled through the pinned block.",
+      ),
+    );
+  }
+
+  const entries = strategies.map((strategy, index) => {
+    const parsed = requiredObject(strategy, `controls.strategies[${index}]`);
+    const name = hasText(parsed.name) ? parsed.name : `strategy-${index}`;
+    const enabled = parsed.enabled === true;
+    const cooldownSeconds = optionalNonNegative(
+      parsed.cooldownSeconds,
+      `controls.strategies[${index}].cooldownSeconds`,
+    );
+    const maxQuoteOutflowClaimEurmRaw = optionalNonNegative(
+      parsed.maxQuoteOutflowEurmRaw,
+      `controls.strategies[${index}].maxQuoteOutflowEurmRaw`,
+    );
+    const mintsQuoteIntoPoolClaim =
+      parsed.kind === "reserve" && parsed.mintsQuoteIntoPool !== false;
+    const mintCapClaimEurmRaw = mintsQuoteIntoPoolClaim
+      ? optionalNonNegative(
+          parsed.mintCapEurmRaw,
+          `controls.strategies[${index}].mintCapEurmRaw`,
+        )
+      : null;
+
+    if (enabled && maxQuoteOutflowClaimEurmRaw === null) {
+      blockers.push(
+        issue(
+          "STRATEGY_BOUNDARY_MODEL_MISSING",
+          `${name} is enabled without a recorded quote-asset boundary model for S.`,
+        ),
+      );
+    }
+    if (enabled && mintsQuoteIntoPoolClaim && mintCapClaimEurmRaw === null) {
+      blockers.push(
+        issue(
+          "RESERVE_MINT_CAP_MISSING",
+          `${name} can mint quote assets into the pool without a recorded cap for S.`,
+        ),
+      );
+    }
+
+    return {
+      name,
+      kind: parsed.kind ?? "unknown",
+      enabled,
+      cooldownSeconds,
+      maxQuoteOutflowClaimEurmRaw,
+      mintsQuoteIntoPoolClaim,
+      mintCapClaimEurmRaw,
+      authenticated: false,
+    };
+  });
+
+  return { enumerationClaim, authenticated: false, entries };
+}
+
+function inspectCertificate(snapshot, evaluation, blockers) {
+  const certificate = requiredObject(
+    snapshot.certificate,
+    "snapshot.certificate",
+  );
+  for (const field of [
+    "signerCoverageOwner",
+    "escalationRoute",
+    "executionProof",
+    "reviewer",
+  ]) {
+    if (!hasText(certificate[field])) {
+      blockers.push(
+        issue(
+          "CERTIFICATE_FIELD_MISSING",
+          `Certificate field ${field} is missing.`,
+        ),
+      );
+    }
+  }
+
+  const expiries = {};
+  const evaluatedAt = timestamp(evaluation?.evaluatedAt);
+  for (const field of [
+    "signerCoverageExpiresAt",
+    "escalationRouteExpiresAt",
+    "executionProofExpiresAt",
+    "budgetApprovalExpiresAt",
+  ]) {
+    const expiresAt = timestamp(certificate[field]);
+    expiries[field] = certificate[field] ?? null;
+    if (!hasText(certificate[field])) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRY_MISSING",
+          `Certificate field ${field} is missing an explicit expiry.`,
+        ),
+      );
+    } else if (expiresAt === null) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRY_INVALID",
+          `Certificate field ${field} has an invalid expiry.`,
+        ),
+      );
+    } else if (evaluatedAt !== null && expiresAt <= evaluatedAt) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRED",
+          `Certificate field ${field} is expired at the explicit evaluation time.`,
+        ),
+      );
+    }
+  }
+
+  return { expiries, authenticated: false };
+}
+
+function inspectBoundaryModelClaims(snapshot, blockers) {
+  const model = requiredObject(
+    snapshot.boundaryModel,
+    "snapshot.boundaryModel",
+  );
+  const monotoneCapacityNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
+    model.monotoneCapacityNetQuoteOutflowEurmRaw,
+    "boundaryModel.monotoneCapacityNetQuoteOutflowEurmRaw",
+  );
+  const worstCaseNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
+    model.worstCaseNetQuoteOutflowEurmRaw,
+    "boundaryModel.worstCaseNetQuoteOutflowEurmRaw",
+  );
+
+  if (monotoneCapacityNetQuoteOutflowClaimEurmRaw === null) {
+    blockers.push(
+      issue(
+        "MONOTONE_CAPACITY_QUOTE_BOUND_MISSING",
+        "No EURm result is recorded for the documented monotone capacity.",
+      ),
+    );
+  }
+  if (worstCaseNetQuoteOutflowClaimEurmRaw === null) {
+    blockers.push(
+      issue(
+        "BOUNDARY_ALIGNED_LOSS_MODEL_MISSING",
+        "No worst-case net EURm-outflow result is recorded.",
+      ),
+    );
+  }
+
+  return {
+    protectedSystemBoundaryClaim: model.protectedSystemBoundary ?? null,
+    modelIdClaim: model.modelId ?? null,
+    coversBidirectionalRateTransitionsClaim:
+      model.coversBidirectionalRateTransitions === true,
+    coversAllEnabledStrategiesClaim: model.coversAllEnabledStrategies === true,
+    monotoneCapacityNetQuoteOutflowClaimEurmRaw,
+    worstCaseNetQuoteOutflowClaimEurmRaw,
+    executable: false,
+    authenticated: false,
+  };
+}
+
+/**
+ * Fail-closed EUROP operational-admission diagnostic. This implementation
+ * cannot grant readiness or Live admission. It always reports Blocked until an
+ * executable authenticated sequential loss model replaces the static claims.
+ */
+export function evaluateOperationalAdmission(input) {
+  const blockers = permanentBlockers();
+  const partial = {
+    blockers,
+    evidenceIdentity: null,
+    evaluation: null,
+    budget: null,
+    monotoneSwapEnvelope: null,
+    safeDiagnostics: null,
+    rateDiagnostics: null,
+    strategyDiagnostics: null,
+    certificate: null,
+    boundaryModelClaims: null,
+  };
+
+  try {
+    const snapshot = requiredObject(input, "snapshot");
+    partial.evidenceIdentity = inspectEvidenceIdentity(snapshot, blockers);
+    partial.evaluation = inspectEvaluation(snapshot, blockers);
+    if (
+      partial.evidenceIdentity.protocolIdentity
+        .matchesExpectedEuropPolygonIdentity &&
+      partial.evidenceIdentity.blockReference.wellFormed
+    ) {
+      partial.monotoneSwapEnvelope = deriveMonotoneSwapEnvelope(snapshot);
+      blockers.push(...partial.monotoneSwapEnvelope.invariantViolations);
+    }
+    partial.budget = deriveApprovedBudget(snapshot, blockers);
+    partial.safeDiagnostics = inspectSafe(snapshot, blockers);
+    partial.rateDiagnostics = inspectRateControl(snapshot, blockers);
+    partial.strategyDiagnostics = inspectStrategies(snapshot, blockers);
+    partial.certificate = inspectCertificate(
+      snapshot,
+      partial.evaluation,
+      blockers,
+    );
+    partial.boundaryModelClaims = inspectBoundaryModelClaims(
+      snapshot,
+      blockers,
+    );
+  } catch (error) {
+    blockers.push(
+      issue(
+        "INPUT_INVALID",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+
+  return blockedResult(partial);
+}
+
+function jsonValue(value) {
+  if (typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map(jsonValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, jsonValue(nested)]),
+    );
+  }
+  return value;
+}
+
+async function main(args) {
+  const snapshotIndex = args.indexOf("--snapshot");
+  if (snapshotIndex < 0 || !args[snapshotIndex + 1]) {
+    throw new Error(
+      "usage: node scripts/europ-operational-admission.mjs --snapshot <path>",
+    );
+  }
+  const path = resolve(args[snapshotIndex + 1]);
+  let snapshot;
+  try {
+    snapshot = JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    const result = blockedResult({
+      blockers: [
+        ...permanentBlockers(),
+        issue(
+          "INPUT_INVALID",
+          error instanceof Error ? error.message : String(error),
+        ),
+      ],
+    });
+    process.stdout.write(`${JSON.stringify(jsonValue(result), null, 2)}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = evaluateOperationalAdmission(snapshot);
+  process.stdout.write(`${JSON.stringify(jsonValue(result), null, 2)}\n`);
+  if (result.status === "BLOCKED") process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/europ-operational-admission.test.mjs
+++ b/scripts/europ-operational-admission.test.mjs
@@ -1,0 +1,411 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { evaluateOperationalAdmission } from "./europ-operational-admission.mjs";
+
+const fixtureUrl = new URL(
+  "./fixtures/europ-operational-admission/2026-08-11.json",
+  import.meta.url,
+);
+const scriptPath = fileURLToPath(
+  new URL("./europ-operational-admission.mjs", import.meta.url),
+);
+const fixturePath = fileURLToPath(fixtureUrl);
+
+async function currentSnapshot() {
+  return JSON.parse(await readFile(fixtureUrl, "utf8"));
+}
+
+function blockerCodes(result) {
+  return new Set(result.blockers.map((blocker) => blocker.code));
+}
+
+test("derives the canonical six-hour TradingLimitsV2 monotone capacity", async () => {
+  const result = evaluateOperationalAdmission(await currentSnapshot());
+  const envelope = result.monotoneSwapEnvelope;
+
+  assert.equal(result.status, "BLOCKED");
+  assert.equal(envelope.netflowCapacityFixed15, 750000000000000000000n);
+  assert.equal(envelope.grossInputFixed15, 750375187593796898449n);
+  assert.equal(envelope.grossMonitoredInputRaw, 750375187593n);
+  assert.deepEqual(envelope.invariantViolations, []);
+  assert.deepEqual(
+    envelope.windows.map((window) => [
+      window.name,
+      window.resetWindows,
+      window.durableCapacityFixed15,
+    ]),
+    [
+      ["L0", 72n, 3700000000000000000000n],
+      ["L1", 1n, 750000000000000000000n],
+    ],
+  );
+});
+
+test("keeps the current pinned evidence explicitly Blocked", async () => {
+  const result = evaluateOperationalAdmission(await currentSnapshot());
+
+  assert.equal(result.status, "BLOCKED");
+  assert.equal(result.monotoneCapacityBudgetComparison.status, "not_evaluable");
+  assert.equal(result.worstCaseBudgetComparison.status, "not_evaluable");
+  assert.equal(
+    result.evidenceIdentity.protocolIdentity
+      .matchesExpectedEuropPolygonIdentity,
+    true,
+  );
+  assert.equal(result.evidenceIdentity.protocolIdentity.authenticated, false);
+  assert.equal(result.evidenceIdentity.blockReference.wellFormed, true);
+  assert.equal(result.evidenceIdentity.blockReference.authenticated, false);
+  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, true);
+  assert.deepEqual(
+    blockerCodes(result),
+    new Set([
+      "EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED",
+      "SNAPSHOT_NOT_AUTHENTICATED",
+      "APPROVED_BUDGET_MISSING",
+      "LIQUID_RESERVE_VALUE_MISSING",
+      "RATE_TRANSITION_BOUND_MISSING",
+      "STRATEGY_BOUNDARY_MODEL_MISSING",
+      "RESERVE_MINT_CAP_MISSING",
+      "CERTIFICATE_FIELD_MISSING",
+      "ATTESTATION_EXPIRY_MISSING",
+      "MONOTONE_CAPACITY_QUOTE_BOUND_MISSING",
+      "BOUNDARY_ALIGNED_LOSS_MODEL_MISSING",
+    ]),
+  );
+});
+
+test("CLI exits 1 and prints JSON for a valid-but-Blocked snapshot", () => {
+  const child = spawnSync(
+    process.execPath,
+    [scriptPath, "--snapshot", fixturePath],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 1);
+  assert.equal(child.signal, null);
+  assert.equal(child.stderr, "");
+  assert.equal(JSON.parse(child.stdout).status, "BLOCKED");
+});
+
+test("CLI preserves exit 2 and structured JSON for an unreadable snapshot", () => {
+  const child = spawnSync(
+    process.execPath,
+    [scriptPath, "--snapshot", `${fixturePath}.missing`],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 2);
+  assert.equal(child.signal, null);
+  assert.equal(child.stderr, "");
+  const result = JSON.parse(child.stdout);
+  assert.equal(result.status, "BLOCKED");
+  assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+});
+
+test("arbitrary complete-looking claims cannot grant readiness", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.budget.liquidReserveAssetsEurmRaw = "40000000000000000000000000";
+  snapshot.budget.approvedBudgetEurmRaw = "100000000000000000000000";
+  snapshot.budget.approvedBy = "asserted treasury owner";
+  snapshot.budget.approvalReference = "asserted approval";
+  snapshot.controls.rate.enforcedNoChange = true;
+  snapshot.controls.strategies = snapshot.controls.strategies.map(
+    (strategy) => ({
+      ...strategy,
+      maxQuoteOutflowEurmRaw: "1",
+      mintCapEurmRaw: strategy.kind === "reserve" ? "1" : null,
+    }),
+  );
+  snapshot.certificate = {
+    signerCoverageOwner: "asserted owner",
+    escalationRoute: "asserted route",
+    executionProof: "asserted proof",
+    reviewer: "asserted reviewer",
+    signerCoverageExpiresAt: "2027-01-01T00:00:00Z",
+    escalationRouteExpiresAt: "2027-01-01T00:00:00Z",
+    executionProofExpiresAt: "2027-01-01T00:00:00Z",
+    budgetApprovalExpiresAt: "2027-01-01T00:00:00Z",
+  };
+  snapshot.boundaryModel = {
+    protectedSystemBoundary: "asserted boundary",
+    modelId: "asserted-model",
+    coversBidirectionalRateTransitions: true,
+    coversAllEnabledStrategies: true,
+    monotoneCapacityNetQuoteOutflowEurmRaw: "1",
+    worstCaseNetQuoteOutflowEurmRaw: "1",
+  };
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.equal(result.monotoneCapacityBudgetComparison.status, "not_evaluable");
+  assert.equal(result.worstCaseBudgetComparison.status, "not_evaluable");
+  assert.ok(blockerCodes(result).has("EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED"));
+  assert.ok(blockerCodes(result).has("SNAPSHOT_NOT_AUTHENTICATED"));
+});
+
+test("accepts signed netflow only inside the closed interval [-L, +L]", async () => {
+  const base = await currentSnapshot();
+  const limit = BigInt(base.pool.tradingLimits[0].limitFixed15);
+
+  for (const netflow of [limit, -limit]) {
+    const snapshot = structuredClone(base);
+    snapshot.pool.tradingLimits[0].netflowFixed15 = netflow.toString();
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.equal(
+      blockerCodes(result).has("TRADING_LIMIT_INVARIANT_VIOLATION"),
+      false,
+    );
+  }
+
+  for (const netflow of [limit + 1n, -limit - 1n]) {
+    const snapshot = structuredClone(base);
+    snapshot.pool.tradingLimits[0].netflowFixed15 = netflow.toString();
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(blockerCodes(result).has("TRADING_LIMIT_INVARIANT_VIOLATION"));
+  }
+});
+
+test("returns structured Blocked results for malformed snapshots", async () => {
+  const malformedInteger = await currentSnapshot();
+  malformedInteger.pool.tradingLimits[0].netflowFixed15 = "not-an-integer";
+
+  for (const snapshot of [null, {}, malformedInteger]) {
+    let result;
+    assert.doesNotThrow(() => {
+      result = evaluateOperationalAdmission(snapshot);
+    });
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+    assert.ok(
+      blockerCodes(result).has("EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED"),
+    );
+  }
+});
+
+test("rejects ambiguous and lossy integer representations", async () => {
+  const base = await currentSnapshot();
+  const invalidIntegers = [
+    true,
+    false,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+    " 1",
+    "1 ",
+    "+1",
+    "01",
+    "-0",
+    "1.0",
+    "1e3",
+    "",
+  ];
+
+  for (const value of invalidIntegers) {
+    const snapshot = structuredClone(base);
+    snapshot.pool.tradingLimits[0].netflowFixed15 = value;
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+  }
+});
+
+test("accepts canonical integer strings and safe integer numbers", async () => {
+  const base = await currentSnapshot();
+  for (const value of ["0", "42", "-42", 0, 42, -42]) {
+    const snapshot = structuredClone(base);
+    snapshot.pool.tradingLimits[0].netflowFixed15 = value;
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.equal(blockerCodes(result).has("INPUT_INVALID"), false);
+    assert.notEqual(result.monotoneSwapEnvelope, null);
+  }
+});
+
+test("refuses to calculate capacity for a mismatched evidence identity", async () => {
+  const base = await currentSnapshot();
+  const mutations = [
+    (snapshot) => {
+      snapshot.evidence.chainId = 1;
+    },
+    (snapshot) => {
+      snapshot.evidence.asset = "USDm";
+    },
+    (snapshot) => {
+      snapshot.evidence.quoteAsset = "USDm";
+    },
+    (snapshot) => {
+      snapshot.pool.address = "0x0000000000000000000000000000000000000001";
+    },
+    (snapshot) => {
+      snapshot.pool.quoteAsset.address =
+        "0x0000000000000000000000000000000000000002";
+    },
+    (snapshot) => {
+      snapshot.pool.monitoredAsset.decimals = 18;
+    },
+  ];
+
+  for (const mutate of mutations) {
+    const snapshot = structuredClone(base);
+    mutate(snapshot);
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(blockerCodes(result).has("PROTOCOL_IDENTITY_MISMATCH"));
+    assert.equal(
+      result.evidenceIdentity.protocolIdentity
+        .matchesExpectedEuropPolygonIdentity,
+      false,
+    );
+    assert.equal(result.monotoneSwapEnvelope, null);
+  }
+});
+
+test("rejects malformed block identity before calculating capacity", async () => {
+  const malformedHash = await currentSnapshot();
+  malformedHash.evidence.blockHash = "0x1234";
+  const hashResult = evaluateOperationalAdmission(malformedHash);
+  assert.equal(hashResult.status, "BLOCKED");
+  assert.ok(blockerCodes(hashResult).has("BLOCK_REFERENCE_INVALID"));
+  assert.equal(hashResult.evidenceIdentity.blockReference.wellFormed, false);
+  assert.equal(hashResult.monotoneSwapEnvelope, null);
+
+  const noncanonicalBlock = await currentSnapshot();
+  noncanonicalBlock.evidence.blockNumber = "091830875";
+  const blockResult = evaluateOperationalAdmission(noncanonicalBlock);
+  assert.equal(blockResult.status, "BLOCKED");
+  assert.ok(blockerCodes(blockResult).has("INPUT_INVALID"));
+  assert.equal(blockResult.monotoneSwapEnvelope, null);
+});
+
+test("validates Safe structure for diagnostics without authenticating it", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.controls.safe.threshold = "7";
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.ok(blockerCodes(result).has("SAFE_STRUCTURE_INVALID"));
+  assert.ok(blockerCodes(result).has("SAFE_EXPECTED_CONFIGURATION_MISMATCH"));
+  assert.equal(result.safeDiagnostics.structurallyValid, false);
+  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, false);
+  assert.equal(result.safeDiagnostics.authenticated, false);
+});
+
+test("reports Safe nonce without including it in expected control structure", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.controls.safe.nonce = "10";
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.equal(result.safeDiagnostics.nonce, 10n);
+  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, true);
+  assert.equal(result.safeDiagnostics.authenticated, false);
+  assert.equal(
+    blockerCodes(result).has("SAFE_EXPECTED_CONFIGURATION_MISMATCH"),
+    false,
+  );
+});
+
+test("treats an alternate valid block reference as well-formed but unauthenticated", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.evidence.blockNumber = "91830876";
+  snapshot.evidence.blockHash =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.equal(
+    result.evidenceIdentity.protocolIdentity
+      .matchesExpectedEuropPolygonIdentity,
+    true,
+  );
+  assert.equal(result.evidenceIdentity.blockReference.wellFormed, true);
+  assert.equal(result.evidenceIdentity.blockReference.authenticated, false);
+  assert.equal(result.evidenceIdentity.blockReference.blockNumber, 91830876n);
+  assert.equal(
+    result.evidenceIdentity.blockReference.blockHash,
+    snapshot.evidence.blockHash,
+  );
+  assert.equal(
+    Object.hasOwn(result.evidenceIdentity, "matchesExpected"),
+    false,
+  );
+  assert.notEqual(result.monotoneSwapEnvelope, null);
+});
+
+test("fails stale evidence against explicit evaluation time and maximum age", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.evaluation.evaluatedAt = "2026-08-11T13:00:00Z";
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.ok(blockerCodes(result).has("EVIDENCE_STALE"));
+});
+
+test("requires strict ISO-8601 timestamps with an explicit UTC offset", async () => {
+  for (const observedAt of [
+    "2026-08-11T12:29:00",
+    "2026-02-30T12:29:00Z",
+    "2026-08-11T12:29:00-00:00",
+  ]) {
+    const snapshot = await currentSnapshot();
+    snapshot.evidence.observedAt = observedAt;
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(
+      blockerCodes(result).has("EVIDENCE_TIMESTAMP_MISSING_OR_INVALID"),
+    );
+  }
+
+  const explicitOffset = await currentSnapshot();
+  explicitOffset.evidence.observedAt = "2026-08-11T14:29:00+02:00";
+  explicitOffset.evaluation.evaluatedAt = "2026-08-11T14:35:00+02:00";
+  const validResult = evaluateOperationalAdmission(explicitOffset);
+  assert.equal(
+    blockerCodes(validResult).has("EVIDENCE_TIMESTAMP_MISSING_OR_INVALID"),
+    false,
+  );
+  assert.equal(
+    blockerCodes(validResult).has("EVALUATION_TIMESTAMP_MISSING_OR_INVALID"),
+    false,
+  );
+  assert.equal(validResult.evaluation.evidenceAgeSeconds, 360n);
+});
+
+test("rejects timezone-less and normalized-invalid certificate expiries", async () => {
+  for (const expiry of ["2027-01-01T00:00:00", "2026-02-30T00:00:00Z"]) {
+    const snapshot = await currentSnapshot();
+    snapshot.certificate.signerCoverageExpiresAt = expiry;
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.status, "BLOCKED");
+    assert.ok(blockerCodes(result).has("ATTESTATION_EXPIRY_INVALID"));
+  }
+});
+
+test("compares certificate expiry with explicit evaluation time", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.certificate = {
+    signerCoverageOwner: "Philip Paetz",
+    escalationRoute: "@support-engineer",
+    executionProof: "accepted Safe execution",
+    reviewer: "independent reviewer",
+    signerCoverageExpiresAt: "2026-08-11T12:34:59Z",
+    escalationRouteExpiresAt: "2026-08-11T12:34:59Z",
+    executionProofExpiresAt: "2026-08-11T12:34:59Z",
+    budgetApprovalExpiresAt: "2026-08-11T12:34:59Z",
+  };
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assert.equal(result.status, "BLOCKED");
+  assert.ok(blockerCodes(result).has("ATTESTATION_EXPIRED"));
+});

--- a/scripts/fixtures/europ-operational-admission/2026-08-11.json
+++ b/scripts/fixtures/europ-operational-admission/2026-08-11.json
@@ -1,0 +1,137 @@
+{
+  "evidence": {
+    "observedAt": "2026-08-11T12:29:00Z",
+    "chainId": 137,
+    "blockNumber": "91830875",
+    "blockHash": "0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25",
+    "asset": "EUROP",
+    "quoteAsset": "EURm"
+  },
+  "evaluation": {
+    "evaluatedAt": "2026-08-11T12:35:00Z",
+    "maxEvidenceAgeSeconds": "900"
+  },
+  "responseSeconds": "21600",
+  "budget": {
+    "rule": "min(100,000 EURm, 0.5% of approved current liquid reserve assets)",
+    "liquidReserveAssetsEurmRaw": null,
+    "approvedBudgetEurmRaw": null,
+    "approvedBy": null,
+    "approvalReference": null,
+    "conditionalCandidate": {
+      "status": "unapproved",
+      "proposedCustodyBoundary": "registered assets held by ReserveV2 plus its listed other-reserve Safe",
+      "usdcRaw": "120812444400",
+      "usdcUsd": "0.9998",
+      "eurUsd": "1.15364",
+      "eurmValueRaw": "104701884392982212822024",
+      "candidateBudgetEurmRaw": "523509421964911064110",
+      "sameBlockInventoryOnly": true,
+      "sharedReservePool": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
+      "sharedOpenPool": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61"
+    }
+  },
+  "pool": {
+    "address": "0xcd8c6811d975981f57e7fb32e59f0bee66af3201",
+    "quoteAsset": {
+      "address": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+      "symbol": "EURm",
+      "decimals": 18,
+      "reserveRaw": "6932949238266138502114"
+    },
+    "monitoredAsset": {
+      "address": "0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51",
+      "symbol": "EUROP",
+      "decimals": 6,
+      "reserveRaw": "10399423858"
+    },
+    "monitoredAssetDecimals": 6,
+    "fee": {
+      "lpBps": 3,
+      "protocolBps": 2
+    },
+    "rebalanceIncentiveBps": 1,
+    "rebalanceThresholdAboveBps": 5000,
+    "rebalanceThresholdBelowBps": 3333,
+    "tradingLimits": [
+      {
+        "name": "L0",
+        "limitFixed15": "50000000000000000000",
+        "durationSeconds": 300,
+        "netflowFixed15": "3498250000000000000",
+        "lastUpdated": "1785520845"
+      },
+      {
+        "name": "L1",
+        "limitFixed15": "250000000000000000000",
+        "durationSeconds": 86400,
+        "netflowFixed15": "9229728525000000000",
+        "lastUpdated": "1785453845"
+      }
+    ]
+  },
+  "controls": {
+    "safe": {
+      "address": "0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458",
+      "threshold": "4",
+      "ownerCount": 6,
+      "nonce": "9",
+      "ownerSetVerifiedAtPin": true
+    },
+    "rate": {
+      "manualRateFeedId": "0xc22418a83DfC262B10a1f57E25309DB83E7eA79e",
+      "manualRate": "1",
+      "manualRateUpdatedAt": "2026-07-16T15:19:19Z",
+      "valueDeltaBreakerBps": 50,
+      "enforcedNoChange": false,
+      "enforcedNoArbitrage": false,
+      "maxSuccessfulTransitions": null
+    },
+    "strategiesEnumeratedThroughBlock": true,
+    "strategies": [
+      {
+        "name": "OpenLiquidityStrategy",
+        "address": "0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f",
+        "kind": "open",
+        "enabled": true,
+        "cooldownSeconds": 300,
+        "maxQuoteOutflowEurmRaw": null
+      },
+      {
+        "name": "ReserveLiquidityStrategy",
+        "address": "0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B",
+        "kind": "reserve",
+        "enabled": true,
+        "cooldownSeconds": 300,
+        "mintsQuoteIntoPool": true,
+        "mintCapEurmRaw": null,
+        "maxQuoteOutflowEurmRaw": null,
+        "reserveV2": "0x4255Cf38e51516766180b33122029A88Cb853806",
+        "visibleReserveBalances": {
+          "EURm": "0",
+          "EUROP": "0"
+        }
+      }
+    ]
+  },
+  "certificate": {
+    "signerCoverageOwner": "Philip Paetz",
+    "signerCoverageBackup": "Bogdan Dumitru",
+    "escalationRoute": "active @support-engineer resolved from VictorOps / Splunk On-Call",
+    "executionProof": "Safe nonce 8 is accepted as proof that the threshold can execute within six hours.",
+    "reviewer": null,
+    "signerCoverageExpiresAt": null,
+    "escalationRouteExpiresAt": null,
+    "executionProofExpiresAt": null,
+    "budgetApprovalExpiresAt": null
+  },
+  "boundaryModel": {
+    "implementationStatus": "not_implemented",
+    "protectedSystemBoundary": "EURm movements involving the FPMM, enabled liquidity strategies, ReserveV2, and protocol fee recipient",
+    "modelId": null,
+    "coversBidirectionalRateTransitions": false,
+    "coversAllEnabledStrategies": false,
+    "monotoneCapacityNetQuoteOutflowEurmRaw": null,
+    "worstCaseNetQuoteOutflowEurmRaw": null
+  }
+}


### PR DESCRIPTION
## The Problem

- EUROP's public peg monitor is live, but its stronger operational-admission check has no reproducible current record for the six-hour loss budget.
- Static snapshot fields could be mistaken for proof even though the exact budget and authenticated sequential loss model are still absent.

## The Solution

- Record the current pinned Polygon evidence and add a deterministic evaluator that reports the evidence gaps and always returns `BLOCKED`.
- Reject malformed, stale, or wrong-market inputs and calculate the six-hour swap-capacity diagnostic without presenting it as a EURm loss bound.

## Details

- The evaluator cannot produce `Ready` or `Live`; static Safe, strategy, rate, certificate, model, or budget claims cannot clear its permanent authentication and executable-model blockers.
- The CLI exits `1` for a valid Blocked result and `2` for unreadable or invalid JSON, while preserving structured JSON output.
- The record pins Polygon block `91830875`, the EUROP/EURm pool, the 4-of-6 Safe, both enabled strategies, current fees and limits, and the owner decisions already recorded in #1687.
- The calculated `750,000 EUROP` six-hour netflow capacity is explicitly diagnostic. It is not compared with `B` and is not described as EURm loss.
- The command, fixture, documentation index, onboarding runbook, and agent quality-gate routing are updated together.
- This PR changes no dashboard, alert, Terraform, Safe, protocol, or production runtime state.

## Validation

- `node --test scripts/europ-operational-admission.test.mjs` — 18/18 passed.
- `pnpm agent:quality-gate --run` — all mapped docs, scripts, Terraform, formatting, and navigation checks passed; the signal-cleanup self-test also passed outside the sandbox.
- Fresh-context Codex autoreview — no findings, confidence 0.97.
- Deterministic local autoreview — clean.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1687 — Live admission still needs a treasury/risk-approved custody boundary and numeric `B`, enforceable control changes, and an authenticated sequential loss model.

Continues #1687.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this records a fail-closed diagnostic and does not select the future Live-admission architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to offline scripts, fixtures, documentation, and CI mapping; the evaluator is intentionally fail-closed and does not alter dashboard, alerts, or on-chain state.
> 
> **Overview**
> Adds a **reproducible EUROP operational-admission record** for the six-hour loss-budget gate: a pinned Polygon evidence snapshot, a deterministic evaluator that **always returns `BLOCKED`**, and operator docs that explain why Live admission stays blocked.
> 
> The new `europ-operational-admission.mjs` CLI validates snapshot shape, EUROP/EURm identity, freshness, Safe/rate/strategy/certificate fields, and computes the **TradingLimitsV2 six-hour swap-capacity diagnostic** without treating it as EURm loss or comparing to budget `B`. Permanent blockers prevent JSON flags from granting readiness; budget comparisons stay `not_evaluable`. Exit **1** for valid Blocked output, **2** for bad JSON.
> 
> **Docs and CI:** new runbook `europ-operational-admission.md`, peg onboarding cross-link, docs catalog and quick-commands entries, plus agent quality-gate routing and tests when the script, tests, or fixture change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6fd7d2fc0647876046c19b96f46ccb72ca1ec4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->