### PR TITLE
feat(sentry): a judged family settles its siblings instead of escalating (#1614 part 2)

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -895,9 +895,15 @@ jobs:
           # Plain scripts/ is correct HERE for the same reason as the label
           # step above: this job has its own runner and its own pristine
           # checkout, which the agent never touched.
+          # Pass the verdict the LABEL step actually applied. Family
+          # inheritance (#1614) can redirect a needs-human comment to its
+          # family's verdict, and this leg re-resolving the same comment would
+          # then render a "Decision needed" brief onto a stub about to close.
+          # Closed enum from the parser, never agent text.
           if ! node scripts/sentry-triage-brief.mjs \
               --issue "${QUEUE_ISSUE_NUMBER}" \
-              --repo "${GITHUB_REPOSITORY}"; then
+              --repo "${GITHUB_REPOSITORY}" \
+              --effective-verdict "${VERDICT}"; then
             if [ "${VERDICT}" = "needs-human" ]; then
               echo "::warning::Could not render the needs-human brief on issue #${QUEUE_ISSUE_NUMBER} (see the log above); the verdict label and verdict comment already carry the escalation, so leaving the open stub and continuing (best-effort)."
             else

--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -856,8 +856,10 @@ jobs:
       # regardless of any label. Gating this step on `needs-human` — as it was —
       # meant a stub re-triaged from needs-human to code-fix / config-fix /
       # upstream-transient kept a "Decision needed" brief forever, describing a
-      # decision nobody has to make. The verdict it reads is resolved by the
-      # script itself, so the step needs no verdict input to decide.
+      # decision nobody has to make. It decides from --effective-verdict below
+      # — what the LABEL step applied — because family inheritance (#1614) can
+      # settle a stub whose verdict comment still reads needs-human, and a
+      # second resolver reading that comment would brief a stub about to close.
       #
       # RENDER is best-effort, CLEAR is not (#1769 rounds 8 + 10). The failure
       # splits on the verdict:

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -525,6 +525,13 @@ decision (#1614). The label step logs a `::notice::` naming the sibling it
 inherited from, so a closed stub whose comment still reads `needs-human` is
 explained by that line rather than being a defect.
 
+**Security-sensitive escalations are never inherited**, whatever their family
+decided — there the human is deciding disposition, not diagnosis. The check
+reads `escalation_reason`, `human_question` and `hypotheses`, and refuses before
+the family is even looked up, so such a stub stays open on
+`sentry:verdict-needs-human` by design. An open escalation that names a closed
+upstream sibling is that rule working, not a failed inheritance.
+
 Only `upstream-transient` is inheritable. `code-fix` and `config-fix` project
 into another team's repo — and a local `code-fix` can enter autofix — so
 inheriting either would cause a write for a stub no agent examined, on the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -507,6 +507,21 @@ the label and transition below:
 | `upstream-transient` | `sentry:verdict-upstream`    | Close as completed | None                                                                                                                               |
 | `needs-human`        | `sentry:verdict-needs-human` | Keep open          | Human answers the recorded question and decides the next action                                                                    |
 
+**One exception, and it is the only place the applied label differs from the
+stored verdict comment.** A `needs-human` verdict whose `duplicate_of` names a
+queue stub that is already **closed** carrying exactly one verdict label, and
+that label is `sentry:verdict-upstream`, is settled as `upstream-transient`
+instead of escalating — the family was already judged, and a second ask adds no
+decision (#1614). The label step logs a `::notice::` naming the sibling it
+inherited from, so a closed stub whose comment still reads `needs-human` is
+explained by that line rather than being a defect.
+
+Only `upstream-transient` is inheritable. `code-fix` and `config-fix` project
+into another team's repo — and a local `code-fix` can enter autofix — so
+inheriting either would cause a write for a stub no agent examined, on the
+strength of an agent-authored `duplicate_of`. `needs-human` is never inherited:
+an unanswered escalation is not a judgement.
+
 A stub carries exactly one `sentry:verdict-*` label. The label edit adds the
 new one and removes every other verdict label in the same call, so
 re-dispatching an already-verdicted stub — the usual case after a human answers

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -311,12 +311,21 @@ renders reads as current to whoever opens the issue:
 - a `needs-human` verdict creates the comment, or updates it in place if it is
   already there — never a second copy;
 - **any other verdict deletes it**, regardless of any label the stub carries —
-  which is why the workflow step is ungated. The script resolves the verdict
-  itself, so gating the step added nothing and cost a stale "Decision needed"
+  which is why the workflow step is ungated. The step passes
+  `--effective-verdict` — the verdict the label step actually applied — so
+  gating the step added nothing and cost a stale "Decision needed"
   brief on every stub re-triaged to `code-fix`, `config-fix` or
   `upstream-transient` — including one still carrying a stale
   `sentry:approved-archive`, where the old body version yielded and left the
   brief in place for a later close to bury;
+  **`--effective-verdict` is load-bearing, not a convenience.** The script can
+  still resolve the verdict itself, and does when invoked directly, but the
+  workflow must pass what the LABEL step applied: family inheritance (#1614) can
+  settle a stub whose stored verdict comment still reads `needs-human`, and a
+  second resolver reading that comment would render a "Decision needed" brief onto
+  a stub about to close. One authority, one outcome — do not remove the flag to
+  "simplify" the call.
+
 - a re-queue does **not** clear it: the re-queue chokepoint leaves the marked
   brief comment untouched. It writes no stub BODY — that is the invariant
   `scripts/sentry-triage-requeue.test.mjs` pins (issue #1692) — but it may post

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2359,7 +2359,7 @@ while IFS= read -r path; do
           add_command "pnpm sentry:archive:test" "Sentry needs-human brief helper changed"
           add_command "pnpm sentry:project:test" "Sentry needs-human brief helper changed"
           ;;
-        scripts/sentry-triage-project.mjs|scripts/sentry-triage-project-core.mjs|scripts/sentry-triage-project.test.mjs|scripts/sentry-triage-text.mjs|scripts/sentry-triage-projection.mjs)
+        scripts/sentry-triage-project.mjs|scripts/sentry-triage-project-core.mjs|scripts/sentry-triage-project.test.mjs|scripts/sentry-triage-text.mjs|scripts/sentry-triage-projection.mjs|scripts/sentry-triage-inherit.mjs)
           add_command "pnpm sentry:project:test" "Sentry triage projection helper changed"
           # The agent's comment wrapper imports the shared marker contract from
           # sentry-triage-project-core.mjs, so its fences ride on this module.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3734,6 +3734,13 @@ assert_contains "- pnpm sentry:project:test (Sentry re-queue chokepoint changed)
 run_gate "scripts/sentry-triage-project.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 
+# The inheritance lookups live in their own module (#1614 part 2) but their
+# tests live in the project suite, so the routing must carry them: without this
+# pin a change to the sibling search or its revalidation passes the gate on
+# `lint:scripts` alone, never running the tests written for that behaviour.
+run_gate "scripts/sentry-triage-inherit.mjs"
+assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
+
 run_gate "scripts/sentry-triage-project-core.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 assert_contains "- node scripts/sentry-triage-agent-comment.test.mjs (Sentry triage projection helper changed)"

--- a/scripts/sentry-triage-brief.mjs
+++ b/scripts/sentry-triage-brief.mjs
@@ -66,6 +66,7 @@ import {
   isTrustedComment,
   parseShortId,
   resolveVerdict,
+  VALID_VERDICTS,
   verdictCommentIdFromUrl,
 } from "./sentry-triage-project-core.mjs";
 // The terminal marker the write-side guard refuses to write past — one source of
@@ -361,10 +362,15 @@ export async function runBrief({
   repo = DEFAULT_REPO,
   issueNumber,
   dryRun = false,
+  effectiveVerdict = null,
   log = console.log,
 } = {}) {
   const issue = await readQueueIssue(runGh, repo, issueNumber);
-  const { parsed, verdict } = resolveVerdict(issue, issueNumber);
+  const resolved = resolveVerdict(issue, issueNumber);
+  const parsed = resolved.parsed;
+  // What the LABEL step applied. Family inheritance (#1614) can redirect a
+  // needs-human comment, and a second resolver would then brief a settled stub.
+  const verdict = effectiveVerdict ?? resolved.verdict;
   const existing = findBriefComments(issue.comments);
 
   if (verdict !== "needs-human") {
@@ -547,7 +553,12 @@ export async function runBrief({
 // ---------------------------------------------------------------------------
 
 export function parseArgs(argv) {
-  const args = { repo: DEFAULT_REPO, issueNumber: null, dryRun: false };
+  const args = {
+    repo: DEFAULT_REPO,
+    issueNumber: null,
+    dryRun: false,
+    effectiveVerdict: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--issue") {
@@ -556,6 +567,14 @@ export function parseArgs(argv) {
       args.repo = argv[++i];
     } else if (arg === "--dry-run") {
       args.dryRun = true;
+    } else if (arg === "--effective-verdict") {
+      const value = argv[++i]; // closed enum: unknown values fail loud
+      if (!VALID_VERDICTS.includes(value)) {
+        throw new Error(
+          `--effective-verdict must be one of ${VALID_VERDICTS.join(", ")}, got: ${value}`,
+        );
+      }
+      args.effectiveVerdict = value;
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }

--- a/scripts/sentry-triage-brief.test.mjs
+++ b/scripts/sentry-triage-brief.test.mjs
@@ -1846,6 +1846,52 @@ await test("the triage prompt documents the rest of the verdict contract", () =>
   }
 });
 
+// #1614: the label step is the single authority on which verdict settled the
+// stub. Without this override two resolvers read the same comment and can
+// disagree, which is how an inherited settlement ends up closed while still
+// showing "Decision needed".
+await test("an inherited verdict clears the brief instead of rendering one", async () => {
+  const yaml = needsHumanYaml("Decide whether to allowlist the host");
+  const gh = makeRunGh({
+    ...stubIssue(yaml),
+    comments: [
+      briefCommentObject(renderFixture(), 6100),
+      verdictCommentObject(yaml),
+    ],
+  });
+  const result = await runBrief({
+    runGh: gh.runGh,
+    issueNumber: 1731,
+    effectiveVerdict: "upstream-transient",
+    log: () => {},
+  });
+  // Treated exactly like any other non-needs-human verdict: the stale brief is
+  // DELETED and no new one is written, so the stub cannot close showing an
+  // obsolete ask the family already answered. (`written` in the clear branch
+  // means "a delete happened" — the render path is the one that creates.)
+  assertEqual(created(gh).length, 0);
+  assertEqual(patched(gh).length, 0);
+  assertEqual(deleted(gh).length, 1);
+  assertEqual(result.verdict, "upstream-transient");
+});
+
+await test("parseArgs rejects an effective verdict outside the closed enum", () => {
+  let threw = false;
+  try {
+    parseArgs(["--issue", "1", "--effective-verdict", "made-up"]);
+  } catch {
+    threw = true;
+  }
+  assert(threw, "an unrecognised --effective-verdict must fail loudly");
+  assertEqual(
+    parseArgs(["--issue", "1", "--effective-verdict", "upstream-transient"])
+      .effectiveVerdict,
+    "upstream-transient",
+  );
+  // Absent flag stays null so a manual invocation still re-derives.
+  assertEqual(parseArgs(["--issue", "1"]).effectiveVerdict, null);
+});
+
 if (failed > 0) {
   process.stderr.write(`${failed} failed, ${passed} passed\n`);
   process.exitCode = 1;

--- a/scripts/sentry-triage-inherit.mjs
+++ b/scripts/sentry-triage-inherit.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Family-verdict inheritance lookups (#1614 part 2).
+ *
+ * The DECISION is pure and lives in `sentry-triage-queue-contract.mjs`
+ * (`selectInheritableSibling`, `mentionsSecuritySensitiveSurface`). This module
+ * holds only the GitHub reads that feed it, kept out of
+ * `sentry-triage-project.mjs` because that entrypoint is already well past the
+ * repo's file-size budget and appending to it is what the recurring-review
+ * checklist tells us not to do.
+ *
+ * Both functions fail toward the agent's own verdict: inheritance is an
+ * optimisation over escalating, so every error here degrades to the behaviour
+ * that existed before the feature — one extra human read, never a wrong
+ * settlement.
+ */
+
+import {
+  MAX_DUPLICATE_LOOKUPS,
+  parseShortId,
+} from "./sentry-triage-project-core.mjs";
+import { selectInheritableSibling } from "./sentry-triage-queue-contract.mjs";
+import { sanitizeDuplicateIds } from "./sentry-triage-text.mjs";
+
+/**
+ * Read the queue stubs for a family's declared duplicates (#1614 part 2).
+ *
+ * One SEARCH per declared sibling, not one broad listing. A `gh issue list
+ * --limit 200` is newest-first, so once the queue passes 200 stubs an older
+ * judged family silently falls outside the window and its siblings escalate
+ * again — the exact failure this feature exists to prevent, arriving quietly
+ * as the repo grows. `duplicate_of` is already capped at MAX_DUPLICATE_LOOKUPS,
+ * so this is a bounded handful of calls, and only on a needs-human verdict
+ * that declares duplicates at all.
+ *
+ * Failure is NOT fatal: inheritance is an optimisation over escalating, so any
+ * error falls back to the agent's own `needs-human`. The stub still gets a
+ * decision-ready brief; it just does not get collapsed into its family.
+ */
+export async function readSiblingVerdicts(
+  localRun,
+  repo,
+  duplicateOf,
+  selfShortId,
+) {
+  const wanted = sanitizeDuplicateIds(duplicateOf)
+    .filter((id) => id !== selfShortId)
+    .slice(0, MAX_DUPLICATE_LOOKUPS);
+  const out = [];
+  for (const shortId of wanted) {
+    let stdout;
+    try {
+      stdout = await localRun([
+        "issue",
+        "list",
+        "-R",
+        repo,
+        "--label",
+        // THIS REPO IS PUBLIC. Without this filter any user can open an issue
+        // titled `[sentry] <SHORT-ID> (...)` and either shadow the genuine
+        // sibling or, carrying the upstream label, become the judgment source
+        // for someone else's escalation. The label is applied only by the
+        // ingest, so it is the fence between a queue stub and a lookalike.
+        "sentry-triage",
+        "--search",
+        // The queue title is `[sentry] <SHORT-ID> (...)`, so an in:title search
+        // for the id finds the stub at any age. `--state all` because the
+        // inheritable sibling is by definition CLOSED.
+        `${shortId} in:title`,
+        "--state",
+        "all",
+        "--limit",
+        // GitHub title search is token-based, so `GOV-5` also matches `GOV-50`
+        // and `GOV-500` — real shapes, since Sentry short-ids grow in length.
+        // 100 gives 5x headroom over the observed queue and stays ONE bounded
+        // call; paginating until found would put an unbounded loop inside the
+        // label step, whose failure mode is worse than the miss it prevents.
+        "100",
+        "--json",
+        "number,title,state,labels",
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::warning::Could not search for family sibling ${shortId} (${message}); keeping the agent's own verdict.\n`,
+      );
+      return [];
+    }
+    let rows;
+    try {
+      rows = JSON.parse(stdout);
+    } catch (err) {
+      // Same visibility as a search failure. A `gh` output-format change would
+      // otherwise disable inheritance permanently and silently, with nothing in
+      // the logs to explain why families stopped collapsing.
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::warning::Could not parse the sibling search for ${shortId} (${message}); keeping the agent's own verdict.\n`,
+      );
+      return [];
+    }
+    let found = false;
+    for (const row of Array.isArray(rows) ? rows : []) {
+      // Token search is not exact, so re-check the parsed SHORT-ID rather than
+      // trusting the match: `GOV-5` must never resolve to `GOV-57`.
+      if (parseShortId(row?.title) !== shortId) continue;
+      out.push({
+        shortId,
+        number: row?.number,
+        state: row?.state,
+        labels: row?.labels ?? [],
+      });
+      found = true;
+      break;
+    }
+    // Say so when a declared sibling is not resolved. The consequence is only
+    // that this stub escalates — the pre-inheritance behaviour — but a silent
+    // miss and a genuinely absent sibling look identical in the log, and this
+    // is the line that tells them apart if families stop collapsing.
+    if (!found) {
+      process.stderr.write(
+        `::notice::Family sibling ${shortId} not found among queue stubs (returned ${Array.isArray(rows) ? rows.length : 0} rows); not inheriting from it.\n`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Confirm a selected sibling is STILL closed with exactly the inheritable
+ * verdict (#1614). This narrows the window between selection and settlement; it
+ * does not close it, and cannot — the sibling can change state after any read.
+ *
+ * The residual is deliberately bounded rather than eliminated: if a regression
+ * reopens the sibling just after this check, THIS stub closes as
+ * `upstream-transient`, and ingest reopens it on the next event for its own
+ * Sentry issue (the closed-match regression rule). The escalation is deferred
+ * until the error recurs, not destroyed — and an error that never recurs is the
+ * one `upstream-transient` describes.
+ */
+export async function siblingStillSettled(localRun, repo, sibling) {
+  if (!Number.isInteger(sibling?.number)) return false;
+  try {
+    const stdout = await localRun([
+      "issue",
+      "view",
+      String(sibling.number),
+      "-R",
+      repo,
+      "--json",
+      "state,labels",
+    ]);
+    const data = JSON.parse(stdout);
+    return Boolean(
+      selectInheritableSibling(
+        [sibling.shortId],
+        [
+          {
+            shortId: sibling.shortId,
+            state: data?.state,
+            labels: data?.labels ?? [],
+          },
+        ],
+        null,
+      ),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `::warning::Could not re-confirm family sibling ${sibling.shortId} before inheriting (${message}); keeping the agent's own verdict.\n`,
+    );
+    return false;
+  }
+}

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -204,7 +204,14 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf) {
   let rows;
   try {
     rows = JSON.parse(stdout);
-  } catch {
+  } catch (err) {
+    // Same visibility as the listing failure above. A `gh` output-format change
+    // would otherwise disable inheritance permanently and silently, with
+    // nothing in the logs to explain why families stopped collapsing.
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `::warning::Could not parse the queue stub listing for family inheritance (${message}); keeping the agent's own verdict.\n`,
+    );
     return [];
   }
   const out = [];

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -93,7 +93,10 @@ import {
   commentBacklinksShortId,
 } from "./sentry-triage-projection.mjs";
 import { LABEL_DEFINITIONS, VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
-import { selectInheritableSibling } from "./sentry-triage-queue-contract.mjs";
+import {
+  mentionsSecuritySensitiveSurface,
+  selectInheritableSibling,
+} from "./sentry-triage-queue-contract.mjs";
 // Clear any stale needs-human brief before this job CLOSES a projected stub: a
 // stub re-triaged needs-human -> code-fix/config-fix whose brief-clear failed in
 // the matrix would otherwise be projected and closed here still showing the
@@ -584,7 +587,21 @@ export async function runParseOnly(options, deps = {}) {
   // its own is never overridden by a sibling's. See selectInheritableSibling
   // for why only that one verdict is inheritable.
   let inheritedFrom = null;
-  if (verdict === "needs-human" && parsed.duplicateOf?.length) {
+  const securitySensitive = mentionsSecuritySensitiveSurface(
+    parsed.escalationReason,
+    parsed.humanQuestion,
+    parsed.hypotheses ?? [],
+  );
+  if (securitySensitive) {
+    process.stderr.write(
+      `::notice::Issue #${options.queueIssue} escalation reads as security-sensitive; not inheriting a family verdict.\n`,
+    );
+  }
+  if (
+    verdict === "needs-human" &&
+    !securitySensitive &&
+    parsed.duplicateOf?.length
+  ) {
     const selfShortId = parseShortId(issue.title);
     const sibling = selectInheritableSibling(
       parsed.duplicateOf,

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -206,7 +206,12 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
         "--state",
         "all",
         "--limit",
-        "20",
+        // GitHub title search is token-based, so `GOV-5` also matches `GOV-50`
+        // and `GOV-500` — real shapes, since Sentry short-ids grow in length.
+        // 100 gives 5x headroom over the observed queue and stays ONE bounded
+        // call; paginating until found would put an unbounded loop inside the
+        // label step, whose failure mode is worse than the miss it prevents.
+        "100",
         "--json",
         "title,state,labels",
       ]);
@@ -230,12 +235,23 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
       );
       return [];
     }
+    let found = false;
     for (const row of Array.isArray(rows) ? rows : []) {
-      // Search is substring-ish, so re-check the parsed SHORT-ID rather than
+      // Token search is not exact, so re-check the parsed SHORT-ID rather than
       // trusting the match: `GOV-5` must never resolve to `GOV-57`.
       if (parseShortId(row?.title) !== shortId) continue;
       out.push({ shortId, state: row?.state, labels: row?.labels ?? [] });
+      found = true;
       break;
+    }
+    // Say so when a declared sibling is not resolved. The consequence is only
+    // that this stub escalates — the pre-inheritance behaviour — but a silent
+    // miss and a genuinely absent sibling look identical in the log, and this
+    // is the line that tells them apart if families stop collapsing.
+    if (!found) {
+      process.stderr.write(
+        `::notice::Family sibling ${shortId} not found among queue stubs (returned ${Array.isArray(rows) ? rows.length : 0} rows); not inheriting from it.\n`,
+      );
     }
   }
   return out;

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -93,7 +93,7 @@ import {
 } from "./sentry-triage-projection.mjs";
 import { LABEL_DEFINITIONS, VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
 import {
-  mentionsSecuritySensitiveSurface,
+  isInheritanceEligibleEscalation,
   selectInheritableSibling,
 } from "./sentry-triage-queue-contract.mjs";
 import {
@@ -409,9 +409,14 @@ async function markStubProjected(localRun, localRepo, issue, projectedUrl) {
  * this verdict is actionable AND its `affected_repo` is an allowlisted
  * EXTERNAL owning repo. The matrix close step uses `projectable` to decide
  * whether to close the stub itself (upstream/local/unrecognized) or defer it
- * to the serialized `project` job (external actionable). Read-only — one
- * `gh issue view` with the ambient token; the projection PAT is never needed
- * here. Throws on missing/stale/invalid verdicts so the label step fails
+ * to the serialized `project` job (external actionable). Read-only with the
+ * ambient token; the projection PAT is never needed here.
+ *
+ * I/O budget, because this runs inside the verdict-label step's compensation
+ * window and its latency is that step's latency: one `gh issue view` always,
+ * plus — ONLY for an inheritance-eligible `needs-human` that declares
+ * duplicates (#1614) — up to MAX_DUPLICATE_LOOKUPS sibling searches and one
+ * confirmation view. Ordinary verdicts still cost exactly one call. Throws on missing/stale/invalid verdicts so the label step fails
  * loudly and leaves `sentry:needs-triage` in place for retry.
  *
  * It also emits `shed`: the comma-joined verdict labels the label step must
@@ -444,21 +449,21 @@ export async function runParseOnly(options, deps = {}) {
   // its own is never overridden by a sibling's. See selectInheritableSibling
   // for why only that one verdict is inheritable.
   let inheritedFrom = null;
-  const securitySensitive = mentionsSecuritySensitiveSurface(
+  // Positive eligibility, not a blocklist: only an AMBIGUITY escalation can be
+  // answered by a sibling's judgement. Security-sensitive and
+  // conflicting-evidence reasons are decisions the prompt reserves for a human,
+  // and an unrecognised reason is ineligible rather than assumed safe.
+  const inheritable = isInheritanceEligibleEscalation(
     parsed.escalationReason,
     parsed.humanQuestion,
     parsed.hypotheses ?? [],
   );
-  if (securitySensitive) {
+  if (verdict === "needs-human" && !inheritable) {
     process.stderr.write(
-      `::notice::Issue #${options.queueIssue} escalation reads as security-sensitive; not inheriting a family verdict.\n`,
+      `::notice::Issue #${options.queueIssue} escalation is not inheritance-eligible (its reason must read as ambiguity, and must not read as security-sensitive); keeping the escalation.\n`,
     );
   }
-  if (
-    verdict === "needs-human" &&
-    !securitySensitive &&
-    parsed.duplicateOf?.length
-  ) {
+  if (verdict === "needs-human" && inheritable && parsed.duplicateOf?.length) {
     const selfShortId = parseShortId(issue.title);
     const sibling = selectInheritableSibling(
       parsed.duplicateOf,

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -62,6 +62,7 @@ import {
   PROJECTED_COMMENT_PREFIX,
   PROJECTED_LABEL,
   resolveVerdict,
+  sanitizeDuplicateIds,
   selectVerdictComment,
   VALID_VERDICTS,
   validateAffectedRepo,
@@ -165,60 +166,71 @@ async function readQueueIssue(localRun, repo, number) {
 /**
  * Read the queue stubs for a family's declared duplicates (#1614 part 2).
  *
- * One local listing, not one lookup per sibling: the cap is small but a
- * per-sibling `gh issue view` would put up to MAX_DUPLICATE_LOOKUPS extra
- * round-trips inside the label step, which runs before the stub has a verdict
- * label and must not become slow or flaky. `--state all` is required — the
- * inheritable sibling is by definition CLOSED.
+ * One SEARCH per declared sibling, not one broad listing. A `gh issue list
+ * --limit 200` is newest-first, so once the queue passes 200 stubs an older
+ * judged family silently falls outside the window and its siblings escalate
+ * again — the exact failure this feature exists to prevent, arriving quietly
+ * as the repo grows. `duplicate_of` is already capped at MAX_DUPLICATE_LOOKUPS,
+ * so this is a bounded handful of calls, and only on a needs-human verdict
+ * that declares duplicates at all.
  *
- * Failure is NOT fatal: inheritance is an optimisation over escalating, so a
- * listing error falls back to the agent's own `needs-human`. The stub still
- * gets a decision-ready brief; it just does not get collapsed into its family.
+ * Failure is NOT fatal: inheritance is an optimisation over escalating, so any
+ * error falls back to the agent's own `needs-human`. The stub still gets a
+ * decision-ready brief; it just does not get collapsed into its family.
  */
 async function readSiblingVerdicts(localRun, repo, duplicateOf) {
-  const wanted = new Set(duplicateOf ?? []);
-  if (wanted.size === 0) return [];
-  let stdout;
-  try {
-    stdout = await localRun([
-      "issue",
-      "list",
-      "-R",
-      repo,
-      "--label",
-      "sentry-triage",
-      "--state",
-      "all",
-      "--limit",
-      "200",
-      "--json",
-      "title,state,labels",
-    ]);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(
-      `::warning::Could not list queue stubs to check family inheritance (${message}); keeping the agent's own verdict.\n`,
-    );
-    return [];
-  }
-  let rows;
-  try {
-    rows = JSON.parse(stdout);
-  } catch (err) {
-    // Same visibility as the listing failure above. A `gh` output-format change
-    // would otherwise disable inheritance permanently and silently, with
-    // nothing in the logs to explain why families stopped collapsing.
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(
-      `::warning::Could not parse the queue stub listing for family inheritance (${message}); keeping the agent's own verdict.\n`,
-    );
-    return [];
-  }
+  const wanted = sanitizeDuplicateIds(duplicateOf).slice(
+    0,
+    MAX_DUPLICATE_LOOKUPS,
+  );
   const out = [];
-  for (const row of Array.isArray(rows) ? rows : []) {
-    const shortId = parseShortId(row?.title);
-    if (!shortId || !wanted.has(shortId)) continue;
-    out.push({ shortId, state: row?.state, labels: row?.labels ?? [] });
+  for (const shortId of wanted) {
+    let stdout;
+    try {
+      stdout = await localRun([
+        "issue",
+        "list",
+        "-R",
+        repo,
+        "--search",
+        // The queue title is `[sentry] <SHORT-ID> (...)`, so an in:title search
+        // for the id finds the stub at any age. `--state all` because the
+        // inheritable sibling is by definition CLOSED.
+        `${shortId} in:title`,
+        "--state",
+        "all",
+        "--limit",
+        "20",
+        "--json",
+        "title,state,labels",
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::warning::Could not search for family sibling ${shortId} (${message}); keeping the agent's own verdict.\n`,
+      );
+      return [];
+    }
+    let rows;
+    try {
+      rows = JSON.parse(stdout);
+    } catch (err) {
+      // Same visibility as a search failure. A `gh` output-format change would
+      // otherwise disable inheritance permanently and silently, with nothing in
+      // the logs to explain why families stopped collapsing.
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::warning::Could not parse the sibling search for ${shortId} (${message}); keeping the agent's own verdict.\n`,
+      );
+      return [];
+    }
+    for (const row of Array.isArray(rows) ? rows : []) {
+      // Search is substring-ish, so re-check the parsed SHORT-ID rather than
+      // trusting the match: `GOV-5` must never resolve to `GOV-57`.
+      if (parseShortId(row?.title) !== shortId) continue;
+      out.push({ shortId, state: row?.state, labels: row?.labels ?? [] });
+      break;
+    }
   }
   return out;
 }

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -213,7 +213,7 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
         // label step, whose failure mode is worse than the miss it prevents.
         "100",
         "--json",
-        "title,state,labels",
+        "number,title,state,labels",
       ]);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -240,7 +240,12 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
       // Token search is not exact, so re-check the parsed SHORT-ID rather than
       // trusting the match: `GOV-5` must never resolve to `GOV-57`.
       if (parseShortId(row?.title) !== shortId) continue;
-      out.push({ shortId, state: row?.state, labels: row?.labels ?? [] });
+      out.push({
+        shortId,
+        number: row?.number,
+        state: row?.state,
+        labels: row?.labels ?? [],
+      });
       found = true;
       break;
     }
@@ -255,6 +260,53 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
     }
   }
   return out;
+}
+
+/**
+ * Confirm a selected sibling is STILL closed with exactly the inheritable
+ * verdict (#1614). This narrows the window between selection and settlement; it
+ * does not close it, and cannot — the sibling can change state after any read.
+ *
+ * The residual is deliberately bounded rather than eliminated: if a regression
+ * reopens the sibling just after this check, THIS stub closes as
+ * `upstream-transient`, and ingest reopens it on the next event for its own
+ * Sentry issue (the closed-match regression rule). The escalation is deferred
+ * until the error recurs, not destroyed — and an error that never recurs is the
+ * one `upstream-transient` describes.
+ */
+async function siblingStillSettled(localRun, repo, sibling) {
+  if (!Number.isInteger(sibling?.number)) return false;
+  try {
+    const stdout = await localRun([
+      "issue",
+      "view",
+      String(sibling.number),
+      "-R",
+      repo,
+      "--json",
+      "state,labels",
+    ]);
+    const data = JSON.parse(stdout);
+    return Boolean(
+      selectInheritableSibling(
+        [sibling.shortId],
+        [
+          {
+            shortId: sibling.shortId,
+            state: data?.state,
+            labels: data?.labels ?? [],
+          },
+        ],
+        null,
+      ),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `::warning::Could not re-confirm family sibling ${sibling.shortId} before inheriting (${message}); keeping the agent's own verdict.\n`,
+    );
+    return false;
+  }
 }
 
 // Fixed, markup-free phrase from the projected-issue footer, ANDed with the
@@ -544,7 +596,16 @@ export async function runParseOnly(options, deps = {}) {
       ),
       selfShortId,
     );
-    if (sibling) {
+    // Re-read the sibling immediately before committing. Ingest runs in its own
+    // concurrency group, so between the search above and this settlement it can
+    // re-queue the sibling for a regression — shedding its verdict label and
+    // reopening it — and we would then close THIS stub on a judgement that no
+    // longer exists. Fail closed: anything other than a confirmed still-closed,
+    // still-upstream sibling keeps the agent's own escalation.
+    if (
+      sibling &&
+      (await siblingStillSettled(localRun, options.localRepo, sibling))
+    ) {
       inheritedFrom = sibling.shortId;
       verdict = sibling.verdict;
       label = VERDICT_TO_LABEL[verdict];

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -66,6 +66,7 @@ import {
   VALID_VERDICTS,
   validateAffectedRepo,
   verdictCommentIdFromUrl,
+  VERDICT_TO_LABEL,
 } from "./sentry-triage-project-core.mjs";
 
 // Projected-issue rendering lives in its own module (#1769), imported HERE
@@ -91,6 +92,7 @@ import {
   commentBacklinksShortId,
 } from "./sentry-triage-projection.mjs";
 import { LABEL_DEFINITIONS, VERDICT_LABELS } from "./sentry-triage-ingest.mjs";
+import { selectInheritableSibling } from "./sentry-triage-queue-contract.mjs";
 // Clear any stale needs-human brief before this job CLOSES a projected stub: a
 // stub re-triaged needs-human -> code-fix/config-fix whose brief-clear failed in
 // the matrix would otherwise be projected and closed here still showing the
@@ -158,6 +160,60 @@ async function readQueueIssue(localRun, repo, number) {
       .filter(Boolean),
     comments: data.comments ?? [],
   };
+}
+
+/**
+ * Read the queue stubs for a family's declared duplicates (#1614 part 2).
+ *
+ * One local listing, not one lookup per sibling: the cap is small but a
+ * per-sibling `gh issue view` would put up to MAX_DUPLICATE_LOOKUPS extra
+ * round-trips inside the label step, which runs before the stub has a verdict
+ * label and must not become slow or flaky. `--state all` is required — the
+ * inheritable sibling is by definition CLOSED.
+ *
+ * Failure is NOT fatal: inheritance is an optimisation over escalating, so a
+ * listing error falls back to the agent's own `needs-human`. The stub still
+ * gets a decision-ready brief; it just does not get collapsed into its family.
+ */
+async function readSiblingVerdicts(localRun, repo, duplicateOf) {
+  const wanted = new Set(duplicateOf ?? []);
+  if (wanted.size === 0) return [];
+  let stdout;
+  try {
+    stdout = await localRun([
+      "issue",
+      "list",
+      "-R",
+      repo,
+      "--label",
+      "sentry-triage",
+      "--state",
+      "all",
+      "--limit",
+      "200",
+      "--json",
+      "title,state,labels",
+    ]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `::warning::Could not list queue stubs to check family inheritance (${message}); keeping the agent's own verdict.\n`,
+    );
+    return [];
+  }
+  let rows;
+  try {
+    rows = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const shortId = parseShortId(row?.title);
+    if (!shortId || !wanted.has(shortId)) continue;
+    out.push({ shortId, state: row?.state, labels: row?.labels ?? [] });
+  }
+  return out;
 }
 
 // Fixed, markup-free phrase from the projected-issue footer, ANDed with the
@@ -426,9 +482,33 @@ export async function runParseOnly(options, deps = {}) {
   // select job saw on this stub BEFORE the agent ran, so a round that posted
   // nothing cannot settle the stub on the previous round's verdict. Absent flag
   // -> null -> unbound, the pre-#1717 behaviour.
-  const { parsed, verdict, label } = resolveVerdict(issue, options.queueIssue, {
+  let { parsed, verdict, label } = resolveVerdict(issue, options.queueIssue, {
     priorVerdictCommentId: options.priorVerdictCommentId,
   });
+  // Family inheritance (#1614 part 2): an escalation whose family was already
+  // judged `upstream-transient` settles the same way instead of becoming a
+  // second ask. Only needs-human is redirected — a verdict the agent reached on
+  // its own is never overridden by a sibling's. See selectInheritableSibling
+  // for why only that one verdict is inheritable.
+  let inheritedFrom = null;
+  if (verdict === "needs-human" && parsed.duplicateOf?.length) {
+    const sibling = selectInheritableSibling(
+      parsed.duplicateOf,
+      await readSiblingVerdicts(
+        localRun,
+        options.localRepo,
+        parsed.duplicateOf,
+      ),
+    );
+    if (sibling) {
+      inheritedFrom = sibling.shortId;
+      verdict = sibling.verdict;
+      label = VERDICT_TO_LABEL[verdict];
+      process.stderr.write(
+        `::notice::Issue #${options.queueIssue} inherits ${verdict} from family sibling ${sibling.shortId} (already closed with that verdict) instead of escalating.\n`,
+      );
+    }
+  }
   let projectable = false;
   if (PROJECTABLE_VERDICTS.includes(verdict)) {
     const repoCheck = validateAffectedRepo(parsed.affectedRepo);
@@ -447,7 +527,7 @@ export async function runParseOnly(options, deps = {}) {
   // `buildReopenLabelEditArgs` relies on — so the first-pass case (no verdict
   // label yet) costs nothing.
   const shed = VERDICT_LABELS.filter((name) => name !== label).join(",");
-  return { verdict, label, projectable, shed };
+  return { verdict, label, projectable, shed, inheritedFrom };
 }
 
 /**

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -178,11 +178,10 @@ async function readQueueIssue(localRun, repo, number) {
  * error falls back to the agent's own `needs-human`. The stub still gets a
  * decision-ready brief; it just does not get collapsed into its family.
  */
-async function readSiblingVerdicts(localRun, repo, duplicateOf) {
-  const wanted = sanitizeDuplicateIds(duplicateOf).slice(
-    0,
-    MAX_DUPLICATE_LOOKUPS,
-  );
+async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
+  const wanted = sanitizeDuplicateIds(duplicateOf)
+    .filter((id) => id !== selfShortId)
+    .slice(0, MAX_DUPLICATE_LOOKUPS);
   const out = [];
   for (const shortId of wanted) {
     let stdout;
@@ -192,6 +191,13 @@ async function readSiblingVerdicts(localRun, repo, duplicateOf) {
         "list",
         "-R",
         repo,
+        "--label",
+        // THIS REPO IS PUBLIC. Without this filter any user can open an issue
+        // titled `[sentry] <SHORT-ID> (...)` and either shadow the genuine
+        // sibling or, carrying the upstream label, become the judgment source
+        // for someone else's escalation. The label is applied only by the
+        // ingest, so it is the fence between a queue stub and a lookalike.
+        "sentry-triage",
         "--search",
         // The queue title is `[sentry] <SHORT-ID> (...)`, so an in:title search
         // for the id finds the stub at any age. `--state all` because the
@@ -511,13 +517,16 @@ export async function runParseOnly(options, deps = {}) {
   // for why only that one verdict is inheritable.
   let inheritedFrom = null;
   if (verdict === "needs-human" && parsed.duplicateOf?.length) {
+    const selfShortId = parseShortId(issue.title);
     const sibling = selectInheritableSibling(
       parsed.duplicateOf,
       await readSiblingVerdicts(
         localRun,
         options.localRepo,
         parsed.duplicateOf,
+        selfShortId,
       ),
+      selfShortId,
     );
     if (sibling) {
       inheritedFrom = sibling.shortId;

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -62,7 +62,6 @@ import {
   PROJECTED_COMMENT_PREFIX,
   PROJECTED_LABEL,
   resolveVerdict,
-  sanitizeDuplicateIds,
   selectVerdictComment,
   VALID_VERDICTS,
   validateAffectedRepo,
@@ -97,6 +96,10 @@ import {
   mentionsSecuritySensitiveSurface,
   selectInheritableSibling,
 } from "./sentry-triage-queue-contract.mjs";
+import {
+  readSiblingVerdicts,
+  siblingStillSettled,
+} from "./sentry-triage-inherit.mjs";
 // Clear any stale needs-human brief before this job CLOSES a projected stub: a
 // stub re-triaged needs-human -> code-fix/config-fix whose brief-clear failed in
 // the matrix would otherwise be projected and closed here still showing the
@@ -164,152 +167,6 @@ async function readQueueIssue(localRun, repo, number) {
       .filter(Boolean),
     comments: data.comments ?? [],
   };
-}
-
-/**
- * Read the queue stubs for a family's declared duplicates (#1614 part 2).
- *
- * One SEARCH per declared sibling, not one broad listing. A `gh issue list
- * --limit 200` is newest-first, so once the queue passes 200 stubs an older
- * judged family silently falls outside the window and its siblings escalate
- * again — the exact failure this feature exists to prevent, arriving quietly
- * as the repo grows. `duplicate_of` is already capped at MAX_DUPLICATE_LOOKUPS,
- * so this is a bounded handful of calls, and only on a needs-human verdict
- * that declares duplicates at all.
- *
- * Failure is NOT fatal: inheritance is an optimisation over escalating, so any
- * error falls back to the agent's own `needs-human`. The stub still gets a
- * decision-ready brief; it just does not get collapsed into its family.
- */
-async function readSiblingVerdicts(localRun, repo, duplicateOf, selfShortId) {
-  const wanted = sanitizeDuplicateIds(duplicateOf)
-    .filter((id) => id !== selfShortId)
-    .slice(0, MAX_DUPLICATE_LOOKUPS);
-  const out = [];
-  for (const shortId of wanted) {
-    let stdout;
-    try {
-      stdout = await localRun([
-        "issue",
-        "list",
-        "-R",
-        repo,
-        "--label",
-        // THIS REPO IS PUBLIC. Without this filter any user can open an issue
-        // titled `[sentry] <SHORT-ID> (...)` and either shadow the genuine
-        // sibling or, carrying the upstream label, become the judgment source
-        // for someone else's escalation. The label is applied only by the
-        // ingest, so it is the fence between a queue stub and a lookalike.
-        "sentry-triage",
-        "--search",
-        // The queue title is `[sentry] <SHORT-ID> (...)`, so an in:title search
-        // for the id finds the stub at any age. `--state all` because the
-        // inheritable sibling is by definition CLOSED.
-        `${shortId} in:title`,
-        "--state",
-        "all",
-        "--limit",
-        // GitHub title search is token-based, so `GOV-5` also matches `GOV-50`
-        // and `GOV-500` — real shapes, since Sentry short-ids grow in length.
-        // 100 gives 5x headroom over the observed queue and stays ONE bounded
-        // call; paginating until found would put an unbounded loop inside the
-        // label step, whose failure mode is worse than the miss it prevents.
-        "100",
-        "--json",
-        "number,title,state,labels",
-      ]);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `::warning::Could not search for family sibling ${shortId} (${message}); keeping the agent's own verdict.\n`,
-      );
-      return [];
-    }
-    let rows;
-    try {
-      rows = JSON.parse(stdout);
-    } catch (err) {
-      // Same visibility as a search failure. A `gh` output-format change would
-      // otherwise disable inheritance permanently and silently, with nothing in
-      // the logs to explain why families stopped collapsing.
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `::warning::Could not parse the sibling search for ${shortId} (${message}); keeping the agent's own verdict.\n`,
-      );
-      return [];
-    }
-    let found = false;
-    for (const row of Array.isArray(rows) ? rows : []) {
-      // Token search is not exact, so re-check the parsed SHORT-ID rather than
-      // trusting the match: `GOV-5` must never resolve to `GOV-57`.
-      if (parseShortId(row?.title) !== shortId) continue;
-      out.push({
-        shortId,
-        number: row?.number,
-        state: row?.state,
-        labels: row?.labels ?? [],
-      });
-      found = true;
-      break;
-    }
-    // Say so when a declared sibling is not resolved. The consequence is only
-    // that this stub escalates — the pre-inheritance behaviour — but a silent
-    // miss and a genuinely absent sibling look identical in the log, and this
-    // is the line that tells them apart if families stop collapsing.
-    if (!found) {
-      process.stderr.write(
-        `::notice::Family sibling ${shortId} not found among queue stubs (returned ${Array.isArray(rows) ? rows.length : 0} rows); not inheriting from it.\n`,
-      );
-    }
-  }
-  return out;
-}
-
-/**
- * Confirm a selected sibling is STILL closed with exactly the inheritable
- * verdict (#1614). This narrows the window between selection and settlement; it
- * does not close it, and cannot — the sibling can change state after any read.
- *
- * The residual is deliberately bounded rather than eliminated: if a regression
- * reopens the sibling just after this check, THIS stub closes as
- * `upstream-transient`, and ingest reopens it on the next event for its own
- * Sentry issue (the closed-match regression rule). The escalation is deferred
- * until the error recurs, not destroyed — and an error that never recurs is the
- * one `upstream-transient` describes.
- */
-async function siblingStillSettled(localRun, repo, sibling) {
-  if (!Number.isInteger(sibling?.number)) return false;
-  try {
-    const stdout = await localRun([
-      "issue",
-      "view",
-      String(sibling.number),
-      "-R",
-      repo,
-      "--json",
-      "state,labels",
-    ]);
-    const data = JSON.parse(stdout);
-    return Boolean(
-      selectInheritableSibling(
-        [sibling.shortId],
-        [
-          {
-            shortId: sibling.shortId,
-            state: data?.state,
-            labels: data?.labels ?? [],
-          },
-        ],
-        null,
-      ),
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(
-      `::warning::Could not re-confirm family sibling ${sibling.shortId} before inheriting (${message}); keeping the agent's own verdict.\n`,
-    );
-    return false;
-  }
 }
 
 // Fixed, markup-free phrase from the projected-issue footer, ANDed with the

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -3370,6 +3370,24 @@ await test("a security-sensitive escalation is never inherited away", async () =
   assertEqual(searched, false);
 });
 
+await test("the security refusal recognises the contract's own literal reason", () => {
+  // The prompt tells the agent to write exactly this. An earlier revision of
+  // the marker list omitted "security" entirely, so the MOST compliant
+  // escalation was the one it failed to catch — the guard was weakest exactly
+  // where the contract is most explicit.
+  assertEqual(
+    mentionsSecuritySensitiveSurface("security-sensitive surface"),
+    true,
+  );
+  assertEqual(
+    mentionsSecuritySensitiveSurface(
+      "security-sensitive surface",
+      "decide whether the SSO failure needs incident response",
+    ),
+    true,
+  );
+});
+
 await test("the security refusal reads the whole brief, not one field", () => {
   assertEqual(mentionsSecuritySensitiveSurface("ambiguity"), false);
   assertEqual(mentionsSecuritySensitiveSurface("", "", []), false);

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -3189,6 +3189,13 @@ await test("runParseOnly redirects a needs-human escalation to its family verdic
   const calls = [];
   const runGh = async (args) => {
     calls.push(args[1]);
+    // The sibling re-confirmation (#1800) views the sibling by number.
+    if (args[1] === "view" && args[2] === "801") {
+      return JSON.stringify({
+        state: "CLOSED",
+        labels: [{ name: "sentry:verdict-upstream" }],
+      });
+    }
     if (args[1] === "view") {
       return JSON.stringify({
         number: 700,
@@ -3208,6 +3215,7 @@ await test("runParseOnly redirects a needs-human escalation to its family verdic
     }
     return JSON.stringify([
       {
+        number: 801,
         title: "[sentry] GOV-56 (governance-mento-org, error)",
         state: "CLOSED",
         labels: [{ name: "sentry:verdict-upstream" }],
@@ -3260,6 +3268,57 @@ await test("a sibling search never resolves a prefix to the wrong stub", async (
     { localRepo: "o/r", queueIssue: 702, priorVerdictCommentId: null },
     { runGh },
   );
+  assertEqual(out.verdict, "needs-human");
+  assertEqual(out.inheritedFrom, null);
+});
+
+await test("a sibling reopened between search and settle is not inherited", async () => {
+  // The TOCTOU: ingest runs in its own concurrency group and can re-queue the
+  // sibling for a regression after the search sees it closed. This test also
+  // guards the re-read itself — an earlier revision passed the sibling without
+  // its issue number, so the confirmation silently never ran and the guard was
+  // decorative.
+  const views = [];
+  const runGh = async (args) => {
+    if (args[1] === "view" && args[2] === "801") {
+      views.push("sibling");
+      // Regression landed: ingest reopened it and shed the verdict label.
+      return JSON.stringify({
+        state: "OPEN",
+        labels: [{ name: "sentry:needs-triage" }],
+      });
+    }
+    if (args[1] === "view") {
+      return JSON.stringify({
+        number: 703,
+        title: "[sentry] GOV-60 (governance-mento-org, error)",
+        body: "",
+        url: "https://github.com/o/r/issues/703",
+        state: "OPEN",
+        labels: [{ name: "sentry-triage" }],
+        comments: [
+          {
+            url: "https://github.com/o/r/issues/703#issuecomment-9",
+            body: needsHumanVerdictComment(["GOV-56"]),
+            author: { login: "github-actions" },
+          },
+        ],
+      });
+    }
+    return JSON.stringify([
+      {
+        number: 801,
+        title: "[sentry] GOV-56 (governance-mento-org, error)",
+        state: "CLOSED",
+        labels: [{ name: "sentry:verdict-upstream" }],
+      },
+    ]);
+  };
+  const out = await runParseOnly(
+    { localRepo: "o/r", queueIssue: 703, priorVerdictCommentId: null },
+    { runGh },
+  );
+  assertEqual(views.length, 1, "the sibling must actually be re-read");
   assertEqual(out.verdict, "needs-human");
   assertEqual(out.inheritedFrom, null);
 });

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -3099,6 +3099,27 @@ await test("never inherits a verdict that can write outside the queue", () => {
   }
 });
 
+await test("never inherits from a double-labelled sibling", () => {
+  // Reachable via a human edit or a pre-#1745 stub (sentry-triage-digest.mjs
+  // documents the same state). Two verdict labels means the sibling's judgement
+  // is ambiguous, not "upstream plus extra" — settling THIS escalation on it
+  // would be a coin flip.
+  assertEqual(
+    selectInheritableSibling(
+      ["GOV-56"],
+      [
+        SIB(
+          "GOV-56",
+          "CLOSED",
+          "sentry:verdict-upstream",
+          "sentry:verdict-code-fix",
+        ),
+      ],
+    ),
+    null,
+  );
+});
+
 await test("never inherits from an OPEN sibling", () => {
   // An open sibling is mid-flight: its verdict label can still be shed by the
   // re-queue compensation, so reading it is a race, not a judgement.
@@ -3182,6 +3203,44 @@ await test("runParseOnly redirects a needs-human escalation to its family verdic
   // an inherited verdict cannot reach the cross-repo write path.
   assertEqual(out.projectable, false);
   assert(calls.includes("list"), "expected the family listing");
+});
+
+await test("a sibling search never resolves a prefix to the wrong stub", async () => {
+  // `--search "GOV-5 in:title"` matches GOV-57 too. The parsed SHORT-ID is
+  // re-checked so a family can never inherit from a stub it did not name.
+  const runGh = async (args) => {
+    if (args[1] === "view") {
+      return JSON.stringify({
+        number: 702,
+        title: "[sentry] GOV-59 (governance-mento-org, error)",
+        body: "",
+        url: "https://github.com/o/r/issues/702",
+        state: "OPEN",
+        labels: [{ name: "sentry-triage" }],
+        comments: [
+          {
+            url: "https://github.com/o/r/issues/702#issuecomment-9",
+            body: needsHumanVerdictComment(["GOV-5"]),
+            author: { login: "github-actions" },
+          },
+        ],
+      });
+    }
+    // The search for GOV-5 returns the longer id, which must be rejected.
+    return JSON.stringify([
+      {
+        title: "[sentry] GOV-57 (governance-mento-org, error)",
+        state: "CLOSED",
+        labels: [{ name: "sentry:verdict-upstream" }],
+      },
+    ]);
+  };
+  const out = await runParseOnly(
+    { localRepo: "o/r", queueIssue: 702, priorVerdictCommentId: null },
+    { runGh },
+  );
+  assertEqual(out.verdict, "needs-human");
+  assertEqual(out.inheritedFrom, null);
 });
 
 await test("a failed sibling listing keeps the agent's own escalation", async () => {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -41,6 +41,7 @@ import {
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
 import {
   INHERITABLE_VERDICT,
+  isInheritanceEligibleEscalation,
   mentionsSecuritySensitiveSurface,
   selectInheritableSibling,
 } from "./sentry-triage-queue-contract.mjs";
@@ -3385,6 +3386,27 @@ await test("the security refusal recognises the contract's own literal reason", 
       "decide whether the SSO failure needs incident response",
     ),
     true,
+  );
+});
+
+await test("inheritance eligibility is positive, so unknown reasons refuse", () => {
+  // The prompt's three reasons: only ambiguity is answerable by a sibling.
+  assertEqual(isInheritanceEligibleEscalation("ambiguity"), true);
+  assertEqual(
+    isInheritanceEligibleEscalation("security-sensitive surface"),
+    false,
+  );
+  // The second exception the prompt states — follow your own contradicting
+  // evidence — which a blocklist of security words did not catch.
+  assertEqual(isInheritanceEligibleEscalation("conflicting evidence"), false);
+  // Unrecognised, empty and missing all refuse rather than being assumed safe.
+  for (const reason of ["", null, undefined, "because I said so"]) {
+    assertEqual(isInheritanceEligibleEscalation(reason), false);
+  }
+  // Ambiguity whose brief still reads security-sensitive is still refused.
+  assertEqual(
+    isInheritanceEligibleEscalation("ambiguity", "rotate the signing key"),
+    false,
   );
 });
 

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -41,6 +41,7 @@ import {
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
 import {
   INHERITABLE_VERDICT,
+  mentionsSecuritySensitiveSurface,
   selectInheritableSibling,
 } from "./sentry-triage-queue-contract.mjs";
 
@@ -3321,6 +3322,66 @@ await test("a sibling reopened between search and settle is not inherited", asyn
   assertEqual(views.length, 1, "the sibling must actually be re-read");
   assertEqual(out.verdict, "needs-human");
   assertEqual(out.inheritedFrom, null);
+});
+
+await test("a security-sensitive escalation is never inherited away", async () => {
+  // The prompt tells the agent "never inherit past a security-sensitive
+  // surface" — there the human decides DISPOSITION, not diagnosis. A
+  // deterministic path that ignored that would contradict the instruction the
+  // agent is following, and close a live security question.
+  let searched = false;
+  const runGh = async (args) => {
+    if (args[1] === "list") searched = true;
+    if (args[1] === "view") {
+      return JSON.stringify({
+        number: 704,
+        title: "[sentry] GOV-61 (governance-mento-org, error)",
+        body: "",
+        url: "https://github.com/o/r/issues/704",
+        state: "OPEN",
+        labels: [{ name: "sentry-triage" }],
+        comments: [
+          {
+            url: "https://github.com/o/r/issues/704#issuecomment-9",
+            body: verdictComment({
+              verdict: "needs-human",
+              duplicates: JSON.stringify(["GOV-56"]),
+              humanQuestion: "decide whether to rotate the signing key",
+              howToCheck: ["read the wallet connect flow"],
+              decisionBranches: ["Yes -> rotate", "No -> close"],
+              hypotheses: ["a stale auth token (lean: medium)"],
+              investigated: ["read the payload"],
+              escalationReason: "security-sensitive surface",
+            }),
+            author: { login: "github-actions" },
+          },
+        ],
+      });
+    }
+    return JSON.stringify([]);
+  };
+  const out = await runParseOnly(
+    { localRepo: "o/r", queueIssue: 704, priorVerdictCommentId: null },
+    { runGh },
+  );
+  assertEqual(out.verdict, "needs-human");
+  assertEqual(out.inheritedFrom, null);
+  // Refused BEFORE any lookup: the family is never even consulted.
+  assertEqual(searched, false);
+});
+
+await test("the security refusal reads the whole brief, not one field", () => {
+  assertEqual(mentionsSecuritySensitiveSurface("ambiguity"), false);
+  assertEqual(mentionsSecuritySensitiveSurface("", "", []), false);
+  // Any of the brief fields can carry it.
+  assertEqual(
+    mentionsSecuritySensitiveSurface("", "rotate the API token"),
+    true,
+  );
+  assertEqual(
+    mentionsSecuritySensitiveSurface("", "", ["a wallet signature race"]),
+    true,
+  );
 });
 
 await test("a failed sibling listing keeps the agent's own escalation", async () => {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -23,6 +23,7 @@ import {
   parseArgs,
   parseShortId,
   parseVerdictComment,
+  PROJECTABLE_VERDICTS,
   PROJECTED_LABEL,
   runParseOnly,
   runPriorVerdicts,
@@ -38,7 +39,10 @@ import {
   VERDICT_TO_LABEL,
 } from "./sentry-triage-project.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
-import { selectInheritableSibling } from "./sentry-triage-queue-contract.mjs";
+import {
+  INHERITABLE_VERDICT,
+  selectInheritableSibling,
+} from "./sentry-triage-queue-contract.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -3053,6 +3057,18 @@ const SIB = (shortId, state, ...labels) => ({
   shortId,
   state,
   labels: labels.map((name) => ({ name })),
+});
+
+await test("the inheritable verdict can never reach the cross-repo write path", () => {
+  // The load-bearing invariant of the whole design. Inheritance keys on an
+  // agent-authored field, so it is only safe while the verdict it can apply
+  // writes nothing outside this queue. Adding INHERITABLE_VERDICT to
+  // PROJECTABLE_VERDICTS later would silently turn every inherited settlement
+  // into an issue filed in another team's repo.
+  assert(
+    !PROJECTABLE_VERDICTS.includes(INHERITABLE_VERDICT),
+    `${INHERITABLE_VERDICT} is inheritable, so it must NOT be projectable — inheritance would otherwise write into an owning repo for a stub no agent examined`,
+  );
 });
 
 await test("inherits upstream-transient from a closed family sibling", () => {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -3153,6 +3153,27 @@ await test("inheritance is capped and ordered by duplicate_of, not by listing", 
   assertEqual(selectInheritableSibling(many, onlyLastLabelled), null);
 });
 
+await test("a self-reference never consumes the lookup budget", () => {
+  // The agent can name the stub's own SHORT-ID in duplicate_of. Excluding it
+  // AFTER the cap would let it spend one of five slots and push the only judged
+  // sibling out of range — escalating the family this exists to collapse. The
+  // projection path already orders these the same way.
+  const dups = ["SELF-1", "A-2", "A-3", "A-4", "A-5", "A-6"];
+  const siblings = [
+    SIB("A-6", "CLOSED", "sentry:verdict-upstream"),
+    ...["A-2", "A-3", "A-4", "A-5"].map((id) =>
+      SIB(id, "CLOSED", "sentry-triage"),
+    ),
+  ];
+  // With the self-reference excluded first, A-6 is the 5th considered id.
+  assertEqual(
+    selectInheritableSibling(dups, siblings, "SELF-1")?.shortId,
+    "A-6",
+  );
+  // Without the exclusion it would sit past the cap and inherit nothing.
+  assertEqual(selectInheritableSibling(dups, siblings, null), null);
+});
+
 await test("a malformed or unknown duplicate_of inherits nothing", () => {
   for (const dups of [[], null, undefined, ["not a short id"], ["GOV-99"]]) {
     assertEqual(

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -38,6 +38,7 @@ import {
   VERDICT_TO_LABEL,
 } from "./sentry-triage-project.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
+import { selectInheritableSibling } from "./sentry-triage-queue-contract.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -2199,6 +2200,7 @@ await test("runParseOnly returns the validated verdict + mapped label + projecta
     label: "sentry:verdict-code-fix",
     projectable: true,
     shed: "sentry:verdict-config-fix,sentry:verdict-upstream,sentry:verdict-needs-human",
+    inheritedFrom: null,
   });
   // Read-only: exactly one `gh issue view` with the ambient token.
   assertEqual(calls.length, 1);
@@ -2242,6 +2244,7 @@ await test("runParseOnly maps upstream-transient to the asymmetric label", async
     label: "sentry:verdict-upstream",
     projectable: false,
     shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-needs-human",
+    inheritedFrom: null,
   });
 });
 
@@ -2419,6 +2422,7 @@ await test("runParseOnly accepts a needs-human verdict WITH human_question", asy
     label: "sentry:verdict-needs-human",
     projectable: false,
     shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-upstream",
+    inheritedFrom: null,
   });
 });
 
@@ -3026,6 +3030,172 @@ await test("runProjectionBatch survives a failing label ensure", async () => {
     { runGh },
   );
   assertEqual(rows[0].status, "projected");
+});
+
+const needsHumanVerdictComment = (duplicates) =>
+  verdictComment({
+    verdict: "needs-human",
+    duplicates: JSON.stringify(duplicates),
+    humanQuestion: "decide whether to allowlist the host or close as noise",
+    howToCheck: ["grep the app for the blocked hostnames"],
+    decisionBranches: ["Yes -> config-fix", "No -> close as upstream"],
+    hypotheses: ["third-party widget (lean: medium)"],
+    investigated: ["read the payload"],
+    escalationReason: "ambiguity",
+  });
+
+// #1614 part 2. Every test here is about what inheritance must REFUSE. The
+// mechanism keys on `duplicate_of`, which is agent-authored, so the blast
+// radius of a wrong inheritance is the whole point: `upstream-transient` only
+// closes a stub, while any projectable verdict would write into another repo —
+// or, on a local stub, start an autofix run — for an issue no agent examined.
+const SIB = (shortId, state, ...labels) => ({
+  shortId,
+  state,
+  labels: labels.map((name) => ({ name })),
+});
+
+await test("inherits upstream-transient from a closed family sibling", () => {
+  const got = selectInheritableSibling(
+    ["GOV-56"],
+    [SIB("GOV-56", "CLOSED", "sentry-triage", "sentry:verdict-upstream")],
+  );
+  assertEqual(got?.shortId, "GOV-56");
+  assertEqual(got?.verdict, "upstream-transient");
+});
+
+await test("never inherits a verdict that can write outside the queue", () => {
+  // code-fix/config-fix PROJECT (an issue in another team's repo) and code-fix
+  // on a local stub is autofix-eligible. An agent-authored duplicate_of must
+  // never be able to trigger either for a stub nothing examined.
+  for (const label of [
+    "sentry:verdict-code-fix",
+    "sentry:verdict-config-fix",
+    "sentry:verdict-needs-human",
+  ]) {
+    assertEqual(
+      selectInheritableSibling(
+        ["GOV-56"],
+        [SIB("GOV-56", "CLOSED", "sentry-triage", label)],
+      ),
+      null,
+    );
+  }
+});
+
+await test("never inherits from an OPEN sibling", () => {
+  // An open sibling is mid-flight: its verdict label can still be shed by the
+  // re-queue compensation, so reading it is a race, not a judgement.
+  assertEqual(
+    selectInheritableSibling(
+      ["GOV-56"],
+      [SIB("GOV-56", "OPEN", "sentry-triage", "sentry:verdict-upstream")],
+    ),
+    null,
+  );
+});
+
+await test("inheritance is capped and ordered by duplicate_of, not by listing", () => {
+  const many = ["A-1", "A-2", "A-3", "A-4", "A-5", "A-6"];
+  const siblings = many.map((id) =>
+    SIB(id, "CLOSED", "sentry:verdict-upstream"),
+  );
+  // Only the first MAX_DUPLICATE_LOOKUPS are consulted, and the winner is the
+  // first in duplicate_of order however GitHub happened to list them.
+  assertEqual(
+    selectInheritableSibling(many, [...siblings].reverse())?.shortId,
+    "A-1",
+  );
+  // Only the 6th carries the label, so it sits past MAX_DUPLICATE_LOOKUPS and
+  // must not be reached however many unlabelled siblings precede it.
+  const onlyLastLabelled = many.map((id) =>
+    id === "A-6"
+      ? SIB(id, "CLOSED", "sentry:verdict-upstream")
+      : SIB(id, "CLOSED", "sentry-triage"),
+  );
+  assertEqual(selectInheritableSibling(many, onlyLastLabelled), null);
+});
+
+await test("a malformed or unknown duplicate_of inherits nothing", () => {
+  for (const dups of [[], null, undefined, ["not a short id"], ["GOV-99"]]) {
+    assertEqual(
+      selectInheritableSibling(dups, [
+        SIB("GOV-56", "CLOSED", "sentry:verdict-upstream"),
+      ]),
+      null,
+    );
+  }
+});
+
+await test("runParseOnly redirects a needs-human escalation to its family verdict", async () => {
+  const calls = [];
+  const runGh = async (args) => {
+    calls.push(args[1]);
+    if (args[1] === "view") {
+      return JSON.stringify({
+        number: 700,
+        title: "[sentry] GOV-57 (governance-mento-org, error)",
+        body: "",
+        url: "https://github.com/o/r/issues/700",
+        state: "OPEN",
+        labels: [{ name: "sentry-triage" }],
+        comments: [
+          {
+            url: "https://github.com/o/r/issues/700#issuecomment-9",
+            body: needsHumanVerdictComment(["GOV-56"]),
+            author: { login: "github-actions" },
+          },
+        ],
+      });
+    }
+    return JSON.stringify([
+      {
+        title: "[sentry] GOV-56 (governance-mento-org, error)",
+        state: "CLOSED",
+        labels: [{ name: "sentry:verdict-upstream" }],
+      },
+    ]);
+  };
+  const out = await runParseOnly(
+    { localRepo: "o/r", queueIssue: 700, priorVerdictCommentId: null },
+    { runGh },
+  );
+  assertEqual(out.verdict, "upstream-transient");
+  assertEqual(out.label, "sentry:verdict-upstream");
+  // Never projectable: upstream-transient is not in PROJECTABLE_VERDICTS, so
+  // an inherited verdict cannot reach the cross-repo write path.
+  assertEqual(out.projectable, false);
+  assert(calls.includes("list"), "expected the family listing");
+});
+
+await test("a failed sibling listing keeps the agent's own escalation", async () => {
+  const runGh = async (args) => {
+    if (args[1] === "view") {
+      return JSON.stringify({
+        number: 701,
+        title: "[sentry] GOV-58 (governance-mento-org, error)",
+        body: "",
+        url: "https://github.com/o/r/issues/701",
+        state: "OPEN",
+        labels: [{ name: "sentry-triage" }],
+        comments: [
+          {
+            url: "https://github.com/o/r/issues/701#issuecomment-9",
+            body: needsHumanVerdictComment(["GOV-56"]),
+            author: { login: "github-actions" },
+          },
+        ],
+      });
+    }
+    throw new Error("gh list exploded");
+  };
+  const out = await runParseOnly(
+    { localRepo: "o/r", queueIssue: 701, priorVerdictCommentId: null },
+    { runGh },
+  );
+  // Fail toward the escalation: the human still gets the decision-ready brief.
+  assertEqual(out.verdict, "needs-human");
+  assertEqual(out.label, "sentry:verdict-needs-human");
 });
 
 if (failed > 0) {

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -422,15 +422,18 @@ export const INHERITABLE_VERDICT_LABEL = VERDICT_TO_LABEL[INHERITABLE_VERDICT];
  * label. First match in `duplicateOf` order wins, so the result does not
  * depend on GitHub's listing order.
  */
-export function selectInheritableSibling(duplicateOf, siblings) {
+export function selectInheritableSibling(duplicateOf, siblings, selfShortId) {
   const bySid = new Map();
   for (const s of siblings ?? []) {
     if (s?.shortId && !bySid.has(s.shortId)) bySid.set(s.shortId, s);
   }
-  for (const shortId of sanitizeDuplicateIds(duplicateOf).slice(
-    0,
-    MAX_DUPLICATE_LOOKUPS,
-  )) {
+  // Self-exclusion BEFORE the cap, matching the projection path's rule
+  // (sentry-triage-project-core.mjs, MAX_DUPLICATE_LOOKUPS): a stub that names
+  // itself would otherwise spend budget on a self-reference and push the only
+  // judged sibling past the cap — escalating the very family this collapses.
+  for (const shortId of sanitizeDuplicateIds(duplicateOf)
+    .filter((id) => id !== selfShortId)
+    .slice(0, MAX_DUPLICATE_LOOKUPS)) {
     const sib = bySid.get(shortId);
     if (!sib) continue;
     if (String(sib.state).toUpperCase() !== "CLOSED") continue;

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -433,7 +433,13 @@ export const INHERITABLE_VERDICT_LABEL = VERDICT_TO_LABEL[INHERITABLE_VERDICT];
 // human read (the pre-inheritance behaviour), a false negative closes a live
 // security question. Widen this list before narrowing it.
 const SECURITY_SENSITIVE_MARKERS = [
+  // The contract's OWN literal reason first. `.github/prompts/sentry-triage.md`
+  // tells the agent to write `escalation_reason: security-sensitive surface`,
+  // and the first version of this list did not contain "security" at all — so
+  // the single most compliant escalation was the one it failed to recognise.
+  "security",
   "auth",
+  "billing",
   "credential",
   "key",
   "login",
@@ -443,6 +449,7 @@ const SECURITY_SENSITIVE_MARKERS = [
   "secret",
   "session",
   "sign",
+  "sso",
   "token",
   "wallet",
 ];

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -16,7 +16,11 @@
  * their tests keep one import surface.
  */
 
-import { extractYamlBlock } from "./sentry-triage-project-core.mjs";
+import {
+  extractYamlBlock,
+  MAX_DUPLICATE_LOOKUPS,
+} from "./sentry-triage-project-core.mjs";
+import { sanitizeDuplicateIds } from "./sentry-triage-text.mjs";
 
 // ---------------------------------------------------------------------------
 // Untrusted-text neutralization. Sentry titles/culprits/timestamps are
@@ -382,4 +386,56 @@ export function withArchiveBaseline(body, baseline) {
       ].join("\n")
     : stripped;
   return source.replace(block, rebuilt);
+}
+
+// Family-verdict inheritance (#1614 part 2). A stub whose family was already
+// judged should not become a second escalation — that is how one error family
+// became four `needs-human` asks (GOV-55/56/57/59).
+//
+// ONLY `upstream-transient` is inheritable, and the exclusions are the whole
+// design rather than caution:
+//
+//   - `code-fix` / `config-fix` PROJECT. Inheriting one files or reopens an
+//     issue in another team's repo for a stub no agent examined, and on a
+//     LOCAL stub `code-fix` is autofix-eligible, so it can open a PR here.
+//     `duplicate_of` is agent-authored (a family signal, not a confirmed
+//     duplicate — see the note above), so inheritance must never be able to
+//     cause a write outside this queue.
+//   - `needs-human` is an unanswered question, not a judgement.
+//
+// `upstream-transient` only closes the stub, so a wrong inheritance costs one
+// re-opened issue if Sentry regresses it — recoverable, and the regression path
+// already exists.
+export const INHERITABLE_VERDICT = "upstream-transient";
+export const INHERITABLE_VERDICT_LABEL = "sentry:verdict-upstream";
+
+/**
+ * Pure: pick the sibling this stub may inherit from, or null.
+ *
+ * `siblings` is `[{ shortId, state, labels }]` for the stub's declared
+ * duplicates. A candidate must be CLOSED (an open sibling is mid-flight, and
+ * its label may still be shed) and carry exactly the inheritable verdict
+ * label. First match in `duplicateOf` order wins, so the result does not
+ * depend on GitHub's listing order.
+ */
+export function selectInheritableSibling(duplicateOf, siblings) {
+  const bySid = new Map();
+  for (const s of siblings ?? []) {
+    if (s?.shortId && !bySid.has(s.shortId)) bySid.set(s.shortId, s);
+  }
+  for (const shortId of sanitizeDuplicateIds(duplicateOf).slice(
+    0,
+    MAX_DUPLICATE_LOOKUPS,
+  )) {
+    const sib = bySid.get(shortId);
+    if (!sib) continue;
+    if (String(sib.state).toUpperCase() !== "CLOSED") continue;
+    const labels = (sib.labels ?? []).map((l) =>
+      typeof l === "string" ? l : (l?.name ?? ""),
+    );
+    if (labels.includes(INHERITABLE_VERDICT_LABEL)) {
+      return { shortId, verdict: INHERITABLE_VERDICT };
+    }
+  }
+  return null;
 }

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -462,6 +462,28 @@ export function mentionsSecuritySensitiveSurface(...texts) {
   return SECURITY_SENSITIVE_MARKERS.some((m) => haystack.includes(m));
 }
 
+// The prompt gives `escalation_reason` three values -- ambiguity,
+// security-sensitive surface, conflicting evidence -- and a sibling's verdict
+// may override NONE of the last two. A blocklist cannot express that: it must
+// enumerate every phrasing an agent might use for a reason it must not
+// override, and it was wrong twice (no "security" term, then no
+// conflicting-evidence term).
+//
+// Inverted to a positive check: inheritance requires a match on AMBIGUITY, the
+// one reason a family's judgement actually answers -- the agent could not tell
+// what this is, and a sibling already established what it is. Anything else,
+// including an unrecognised or empty reason, refuses. Unknown is not eligible.
+export function isInheritanceEligibleEscalation(
+  escalationReason,
+  ...otherTexts
+) {
+  const reason = String(escalationReason ?? "").toLowerCase();
+  if (!/ambig/.test(reason)) return false;
+  // Belt and braces: an "ambiguity" reason whose brief still reads
+  // security-sensitive is refused. The two are not exclusive in free text.
+  return !mentionsSecuritySensitiveSurface(reason, ...otherTexts);
+}
+
 export function selectInheritableSibling(duplicateOf, siblings, selfShortId) {
   const bySid = new Map();
   for (const s of siblings ?? []) {

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -437,7 +437,18 @@ export function selectInheritableSibling(duplicateOf, siblings) {
     const labels = (sib.labels ?? []).map((l) =>
       typeof l === "string" ? l : (l?.name ?? ""),
     );
-    if (labels.includes(INHERITABLE_VERDICT_LABEL)) {
+    // EXACTLY one verdict label, and it must be the inheritable one. A stub
+    // carrying two is reachable — a human edit, or a pre-shed stub from before
+    // #1745 (sentry-triage-digest.mjs documents the same state) — and its
+    // judgement is then ambiguous, not "upstream plus extra". Inheriting from
+    // an ambiguous sibling would settle THIS escalation on a coin flip.
+    const verdictLabels = labels.filter((name) =>
+      VERDICT_LABELS.includes(name),
+    );
+    if (
+      verdictLabels.length === 1 &&
+      verdictLabels[0] === INHERITABLE_VERDICT_LABEL
+    ) {
       return { shortId, verdict: INHERITABLE_VERDICT };
     }
   }

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -452,7 +452,9 @@ export function selectInheritableSibling(duplicateOf, siblings, selfShortId) {
       verdictLabels.length === 1 &&
       verdictLabels[0] === INHERITABLE_VERDICT_LABEL
     ) {
-      return { shortId, verdict: INHERITABLE_VERDICT };
+      // `number` rides along so the caller can re-confirm this exact stub
+      // before committing — without it the re-read has nothing to look up.
+      return { shortId, number: sib.number, verdict: INHERITABLE_VERDICT };
     }
   }
   return null;

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -422,6 +422,39 @@ export const INHERITABLE_VERDICT_LABEL = VERDICT_TO_LABEL[INHERITABLE_VERDICT];
  * label. First match in `duplicateOf` order wins, so the result does not
  * depend on GitHub's listing order.
  */
+// A security-sensitive escalation is never inheritable, whatever its family
+// decided. `.github/prompts/sentry-triage.md` tells the agent exactly this —
+// "never inherit past a security-sensitive surface", because there the human is
+// deciding DISPOSITION, not diagnosis — and a deterministic path that ignored
+// it would contradict the instruction the agent is following.
+//
+// The signal is the agent's own brief text, which is free-form, so this matches
+// conservatively and FAILS TOWARD THE ESCALATION: a false positive costs one
+// human read (the pre-inheritance behaviour), a false negative closes a live
+// security question. Widen this list before narrowing it.
+const SECURITY_SENSITIVE_MARKERS = [
+  "auth",
+  "credential",
+  "key",
+  "login",
+  "password",
+  "payment",
+  "permission",
+  "secret",
+  "session",
+  "sign",
+  "token",
+  "wallet",
+];
+
+export function mentionsSecuritySensitiveSurface(...texts) {
+  const haystack = texts
+    .flat()
+    .map((v) => String(v ?? "").toLowerCase())
+    .join(" ");
+  return SECURITY_SENSITIVE_MARKERS.some((m) => haystack.includes(m));
+}
+
 export function selectInheritableSibling(duplicateOf, siblings, selfShortId) {
   const bySid = new Map();
   for (const s of siblings ?? []) {

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -19,6 +19,7 @@
 import {
   extractYamlBlock,
   MAX_DUPLICATE_LOOKUPS,
+  VERDICT_TO_LABEL,
 } from "./sentry-triage-project-core.mjs";
 import { sanitizeDuplicateIds } from "./sentry-triage-text.mjs";
 
@@ -407,7 +408,10 @@ export function withArchiveBaseline(body, baseline) {
 // re-opened issue if Sentry regresses it — recoverable, and the regression path
 // already exists.
 export const INHERITABLE_VERDICT = "upstream-transient";
-export const INHERITABLE_VERDICT_LABEL = "sentry:verdict-upstream";
+// Derived, never a second literal: the tests build sibling labels from this
+// same constant, so a hand-copied string would drift with VERDICT_TO_LABEL and
+// silently stop matching real siblings with nothing failing.
+export const INHERITABLE_VERDICT_LABEL = VERDICT_TO_LABEL[INHERITABLE_VERDICT];
 
 /**
  * Pure: pick the sibling this stub may inherit from, or null.


### PR DESCRIPTION
## The Problem

#1614's second escalation trigger: when a sibling in the same duplicate family already carries a verdict, the agent escalates rather than adopting it. That is why one production error family became **four** separate `needs-human` asks (GOV-55/56/57/59) for what was one decision.

PR #1791 addressed this in the prompt. This adds the deterministic half, so a family collapses whether or not the agent follows instructions.

## The Solution

`runParseOnly` — the single parser the workflow's label step already trusts — redirects a `needs-human` verdict to a sibling's when the family was already judged. The hardened bash label step is unchanged: it still applies whatever `label` the parser emits.

**Only `upstream-transient` is inheritable, and the exclusions are the design rather than caution.** `duplicate_of` is agent-authored — a family signal, not a confirmed duplicate — so inheritance must never cause a write for a stub nothing examined:

- `code-fix` / `config-fix` **project**, filing or reopening an issue in another team's repo. On a local `analytics-mento-org` stub, `code-fix` is also autofix-eligible, so it can open a PR here.
- `needs-human` is an unanswered question, not a judgement.

`upstream-transient` only closes the stub. A wrong inheritance costs one reopened issue if Sentry regresses it, and that regression path already exists.

## Details

- `selectInheritableSibling` (pure) lives in `sentry-triage-queue-contract.mjs`, which owns the label/state domain. It requires a **CLOSED** sibling — an open one is mid-flight and its verdict label can still be shed by the re-queue compensation, so reading it is a race — takes the first match in `duplicate_of` order so the result never depends on GitHub's listing order, and caps at `MAX_DUPLICATE_LOOKUPS`.
- `readSiblingVerdicts` does **one** local listing rather than a lookup per sibling: this runs inside the label step, before the stub carries a verdict label, and must not become slow or flaky.
- **Failure falls back to escalating.** A listing error keeps the agent's own `needs-human`, so the human still gets the decision-ready brief; the stub just is not collapsed.
- `runParseOnly` now also emits `inheritedFrom`, and the redirect logs a `::notice::` naming the sibling, so an inherited settlement is auditable rather than silent.

An inherited verdict can never reach the cross-repo write path: `upstream-transient` is not in `PROJECTABLE_VERDICTS`, and there is a test asserting `projectable === false` on the inherited result.

## Validation

- `pnpm agent:quality-gate --run` — green.
- Six new tests, all about what inheritance must **refuse**: projectable and `needs-human` siblings, OPEN siblings, past-the-cap siblings, malformed/unknown `duplicate_of`, and a failed listing.
- Negative controls, each reverted after: dropping the CLOSED requirement, widening the label check to any `sentry:verdict-*`, and removing the fan-out cap each fail exactly one test. The first run of these reported zero failures because my script still mutated the module the code had just been moved out of — worth stating, since a negative control that passes for the wrong reason proves nothing.
- No new `sentry-*.test.mjs` files; tests extend the existing project suite above its summary block.

## What this does not do

`sentry-triage-project-core.mjs` was at 1050 lines against a 1000-line hard cap, so the new logic went into `sentry-triage-queue-contract.mjs`. That is the right home on its merits — it owns verdict labels and stub states — but the cap is what forced the decision rather than the design.

Inheritance is deliberately one hop: it does not follow a sibling's own `duplicate_of`. A chain that needs two hops is a family the agent should be describing in one verdict.

Refs #1614.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how queue stubs get labeled and closed, but inheritance is narrowly scoped to non-projectable `upstream-transient` only, with explicit guards against inheriting write-eligible verdicts.
> 
> **Overview**
> Adds **deterministic family verdict inheritance** so a stub that would escalate as `needs-human` can instead settle like an already-judged sibling, cutting duplicate human asks for the same error family.
> 
> `runParseOnly` (the workflow label step’s parser) now, after the agent verdict resolves to `needs-human` with a non-empty `duplicate_of`, lists queue stubs once via `readSiblingVerdicts` and calls **`selectInheritableSibling`** in `sentry-triage-queue-contract.mjs`. Only a **CLOSED** sibling carrying **`sentry:verdict-upstream`** (`upstream-transient`) is adopted—never `code-fix`, `config-fix`, or another `needs-human`, so agent-authored `duplicate_of` cannot trigger projection, autofix, or spurious escalations. The parser output gains **`inheritedFrom`** and a **`::notice::`** when a redirect happens; listing failures keep the agent’s escalation.
> 
> Tests cover refusal cases (wrong verdict labels, OPEN siblings, cap/order, bad `duplicate_of`) and integration paths for successful inheritance vs failed listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165dff3c148abfcacffb998648f886d698f2d203. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->