### PR TITLE
docs(sentry): add a scenario matrix to the pipeline note

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -81,6 +81,49 @@ by `.github/workflows/claude.yml` on feature-branch `pull_request` events, which
 main-only environment would break); it is inference-only, so its residual
 exposure is bounded to inference-quota abuse.
 
+## What happens to an issue
+
+Two things decide the outcome: **where the code lives** and **what the agent
+decides**. Depth for each cell is in the sections below; this is the index.
+
+`analytics-mento-org` is the only project whose source is in this repo
+(`ui-dashboard/`). `app-mento-org`, `governance-mento-org` and
+`reserve-mento-org` map to `frontend-monorepo`; `analytics-api` and
+`minipay-dapp` to their own repos. That list is fixed in `ALLOWED_OWNING_REPOS`
+and mirrored in `.github/prompts/sentry-triage.md`.
+
+| Verdict              | `analytics-mento-org` (local)                                                   | Every other project (external)                        |
+| -------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `code-fix`           | **Autofix-eligible** — the only path in the pipeline that writes code           | Projects an issue into the owning repo. Never autofix |
+| `config-fix`         | Record only: no projection (this repo is not an allowlisted target), no autofix | Projects an issue into the owning repo                |
+| `upstream-transient` | Closes. Nothing downstream                                                      | Same                                                  |
+| `needs-human`        | Stays open with a decision-ready brief                                          | Same                                                  |
+
+Autofix outcomes, for a local `code-fix` (`sentry-autofix-finalize.mjs`):
+
+| Agent produced                                                                                                     | Result                                               |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| A diff within `MAX_CHANGED_FILES`, no forbidden path, no symlink                                                   | PR opened, `sentry:fix-pr-opened`. Never auto-merges |
+| A larger diff, or one touching `FORBIDDEN_PREFIXES` (`.github/`, `terraform/`, `tools/`, lockfiles, `vercel.json`) | `sentry:fix-refused`                                 |
+| No changes                                                                                                         | `sentry:fix-refused`                                 |
+
+`sentry:fix-refused` is terminal — selection never reconsiders that stub. The
+forbidden prefixes are also why `config-fix` is not autofixable: the files a
+configuration fix would change are the ones the guard rejects, and the rest
+(env vars, third-party dashboards) are not in the repo at all.
+
+Cases that are not a verdict:
+
+| Situation                                      | Handling                                                                                                                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The Sentry issue recurs after its stub closed  | Ingest reopens it when `lastSeen` is newer than `closedAt`, and it re-triages. This is the safety net under every close above                                     |
+| A human wants it archived in Sentry            | Only via the `sentry:approved-archive` label. Never automatic, for any verdict                                                                                    |
+| Sentry unreadable, or the turn budget runs out | The agent posts `needs-human` saying so, rather than failing silently                                                                                             |
+| No verdict, or one from a stale round          | The label step fails loudly and leaves `sentry:needs-triage` for the next run                                                                                     |
+| `SENTRY_PROJECTION_TOKEN` absent               | An external actionable verdict gets **neither routing nor an open escalation** — the stub closes with a skipped note and resurfaces only on regression. Known gap |
+| Filed on a weekend                             | Ingest runs daily; the triage agent runs weekdays only. A missing weekend verdict is not a defect                                                                 |
+| `sentry:candidate-noise`                       | Written by ingest from a title match and read by nothing today                                                                                                    |
+
 ## Non-negotiable invariants
 
 - This repository is public. Queue issues and verdicts must never reproduce

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -92,6 +92,11 @@ decides**. Depth for each cell is in the sections below; this is the index.
 `minipay-dapp` to their own repos. That list is fixed in `ALLOWED_OWNING_REPOS`
 and mirrored in `.github/prompts/sentry-triage.md`.
 
+Ingest queues **every** project in the Sentry org, so a project outside that
+map is possible. Its actionable verdict does not project: it takes
+`skipped-repo`, and the stub closes with a note naming the unrecognised repo.
+Adding a project means adding it to the allowlist, not only to Sentry.
+
 | Verdict              | `analytics-mento-org` (local)                                                   | Every other project (external)                        |
 | -------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `code-fix`           | **Autofix-eligible** — the only path in the pipeline that writes code           | Projects an issue into the owning repo. Never autofix |


### PR DESCRIPTION
## The Problem

Answering "what happens to an `app-mento-org` issue that needs human review?" currently means synthesising four sources: the settlement table in this note, the project→repo map in `.github/prompts/sentry-triage.md`, `LOCAL_SENTRY_PROJECT` in the selector, and the caps in `sentry-autofix-finalize.mjs`.

Three things a reader needs are in none of them:

- **The project→repo map is absent from the note entirely** — grep it for `analytics-mento-org` or `minipay-dapp` and you get nothing.
- **Local vs external is the axis that decides the outcome**, and it appears only inside one table cell ("eligible local issues may later enter autofix").
- **Autofix refusal outcomes** — the diff cap, "made no code changes", `sentry:fix-refused` being terminal — appear once, in a retry runbook, not where someone asks what autofix does.

## The Solution

A `## What happens to an issue` section near the top: the project map, a verdict × local/external matrix, autofix outcomes, and the cases that are not a verdict at all.

Placed early on purpose. The note is 1,146 lines and this is the question most readers arrive with — the matrix answers it, then points them at the section that owns each cell.

## Details

44 lines, four small tables, minimal prose. It **indexes rather than restates**: no label names, no queue transitions, no mechanism — those stay in `## Verdict and settlement contract`, `### Local autofix PRs` and `### Human-approved archive`, per the context-standards rule about not restating an authority.

Two things it records that were previously only in code:

- `FORBIDDEN_PREFIXES` is why `config-fix` cannot be autofixed — the files a configuration fix would touch are exactly the ones the guard rejects, and the rest (env vars, third-party dashboards) are not in the repo.
- With `SENTRY_PROJECTION_TOKEN` absent, an external actionable verdict gets **neither routing nor an open escalation**. That gap already existed; #1791 increased exposure by producing more projectable verdicts. Writing it down is not a decision about it — it is the row a reader needs to not misdiagnose the stub.

## Validation

- `pnpm agent:quality-gate --run` — green, including `docs:index --check`, `agent:context-check` and the navigation eval.
- Every claim checked against the source rather than recalled: `ALLOWED_OWNING_REPOS` and `LOCAL_SENTRY_PROJECT`, `AUTOFIX_VERDICT`, `MAX_CHANGED_FILES` and `FORBIDDEN_PREFIXES`, the archive's approval precondition, and the ingest reopen rule.
- Deliberately no literal values that would drift: the section names `MAX_CHANGED_FILES` and `FORBIDDEN_PREFIXES` rather than copying the number or the full list.

Refs #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an operator runbook; no runtime, security, or pipeline behavior is modified.
> 
> **Overview**
> Adds a **`## What happens to an issue`** index near the top of the Sentry triage pipeline note so readers can answer outcome questions without piecing together the settlement table, project map, and autofix caps.
> 
> The new section records the project→repo map, a **verdict × local/external** matrix, autofix accept/refuse outcomes (including terminal `sentry:fix-refused`), and non-verdict edge cases such as missing `SENTRY_PROJECTION_TOKEN` and weekend ingest timing. It indexes existing contracts rather than restating mechanism detail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566654cfd73270820ac62786020a19741a822890. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->