### PR TITLE
fix(sentry): cut repeated noise from the triage digest

### DIFF
--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -464,7 +464,12 @@ function idAndProject(entry, { linkUrl } = {}) {
     String(entry.shortId ?? "")
       .toUpperCase()
       .startsWith(`${project.toUpperCase()}-`);
-  return { linked, project: redundant ? "" : project };
+  // A ready-to-render SUFFIX, not a bare value: every renderer used to wrap
+  // this in parentheses unconditionally, so returning "" for the redundant case
+  // produced `ID ()` — punctuation where the repeat used to be. Owning the
+  // parentheses here makes that shape unrepresentable.
+  const shown = redundant ? "" : project;
+  return { linked, project: shown, projectSuffix: shown ? ` (${shown})` : "" };
 }
 
 /** A needs-human decision-ready brief: a level-1 bullet for the issue, then
@@ -521,29 +526,27 @@ function renderNeedsHumanBrief(entry) {
  * <arrow>`, where <arrow> is the linked outcome (fix PR / owning-repo issue /
  * queue-verdict fallback). */
 function renderArrowLine(entry, arrowUrl, arrowLabel) {
-  const { linked, project } = idAndProject(entry);
+  const { linked, projectSuffix } = idAndProject(entry);
   const summary = entry.summary
     ? formatSummaryForSlack(entry.summary)
     : "_(no summary)_";
-  return `• ${linked} (${project}) — ${summary} → ${link(arrowUrl, arrowLabel)}`;
+  return `• ${linked}${projectSuffix} — ${summary} → ${link(arrowUrl, arrowLabel)}`;
 }
 
 function renderWontfixLine(entry) {
-  const { linked, project } = idAndProject(entry);
+  const { linked, projectSuffix } = idAndProject(entry);
   const confidence = entry.confidence ?? "unknown";
   const summary = entry.summary
     ? formatSummaryForSlack(entry.summary)
     : "_(no summary)_";
   // The SHORT-ID links the queue issue, which holds the verdict comment (the
   // rationale). Confidence rides along.
-  const line = `• ${linked} (${project}) — ${summary} (${confidence})`;
-  if (!isHttpsUrl(entry.url)) return line;
-  return line;
+  return `• ${linked}${projectSuffix} — ${summary} (${confidence})`;
 }
 
 function renderFailedLine(entry) {
-  const { linked, project } = idAndProject(entry);
-  return `• ${linked} (${project}) — triage incomplete (still \`${NEEDS_TRIAGE_LABEL}\`)`;
+  const { linked, projectSuffix } = idAndProject(entry);
+  return `• ${linked}${projectSuffix} — triage incomplete (still \`${NEEDS_TRIAGE_LABEL}\`)`;
 }
 
 /** The body lines for one section (excluding its header), one line per entry.
@@ -720,7 +723,7 @@ export function buildDigest(issues, { channel } = {}) {
   if ((bySection.get(WONTFIX_SECTION) ?? []).length > 0) {
     blocks.push(
       mrkdwnSection(
-        `_To archive any of these in Sentry: add \`${APPROVED_ARCHIVE_LABEL}\` to its queue issue._`,
+        `_To archive a *${SECTION_TITLES[WONTFIX_SECTION]}* issue in Sentry: add \`${APPROVED_ARCHIVE_LABEL}\` to its queue issue._`,
       ),
     );
   }

--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -425,12 +425,6 @@ export function classifyIssue(issue) {
 // Slack payload assembly.
 // ---------------------------------------------------------------------------
 
-function formatUtcTimestamp(date) {
-  // 2026-07-17T14:20:33.123Z -> "2026-07-17 14:20 UTC"
-  const iso = new Date(date).toISOString();
-  return `${iso.slice(0, 16).replace("T", " ")} UTC`;
-}
-
 function issueCountText(total) {
   return `${total} issue${total === 1 ? "" : "s"} triaged`;
 }
@@ -458,7 +452,19 @@ function idAndProject(entry, { linkUrl } = {}) {
   const idText = escapeSlackText(entry.shortId);
   const url = linkUrl ?? entry.url;
   const linked = isHttpsUrl(url) ? `<${url}|${idText}>` : idText;
-  return { linked, project: escapeSlackText(entry.project) };
+  // A Sentry SHORT-ID is prefixed with the project's short name, which for
+  // every current project is the upper-cased slug — `GOVERNANCE-MENTO-ORG-5H`
+  // in `governance-mento-org`. Rendering both says it twice. Sentry lets a
+  // project's slug and short name diverge (a slug rename does not rewrite
+  // existing short-ids), so this drops the repeat only when it IS a repeat and
+  // keeps the project whenever it would otherwise be lost.
+  const project = escapeSlackText(entry.project);
+  const redundant =
+    project &&
+    String(entry.shortId ?? "")
+      .toUpperCase()
+      .startsWith(`${project.toUpperCase()}-`);
+  return { linked, project: redundant ? "" : project };
 }
 
 /** A needs-human decision-ready brief: a level-1 bullet for the issue, then
@@ -532,10 +538,7 @@ function renderWontfixLine(entry) {
   // rationale). Confidence rides along.
   const line = `• ${linked} (${project}) — ${summary} (${confidence})`;
   if (!isHttpsUrl(entry.url)) return line;
-  // Archiving stays human-gated (ADR 0036 trust boundary): this is a nudge
-  // toward the existing `sentry:approved-archive` label flow on the queue
-  // issue, never an automatic Sentry mutation from the digest.
-  return `${line}\n    ◦ To archive in Sentry: add \`${APPROVED_ARCHIVE_LABEL}\` to the queue issue above.`;
+  return line;
 }
 
 function renderFailedLine(entry) {
@@ -667,15 +670,20 @@ export function doubleVerdictWarnings(issues) {
 
 /**
  * Build the deterministic Slack `chat.postMessage` payload for one batch.
- * `channel` is passed in (hardcoded by the workflow); `now` is injectable for
- * tests. Pure — no I/O, no escaping omissions: every free-form value is routed
- * through the escape/format helpers here.
+ * `channel` is passed in (hardcoded by the workflow). Pure — no I/O, no
+ * escaping omissions: every free-form value is routed through the
+ * escape/format helpers here.
+ *
+ * The payload carries no clock: Slack stamps every message itself, so the
+ * digest renders nothing time-dependent and needs no injectable `now`.
  */
-export function buildDigest(issues, { channel, now = new Date() } = {}) {
+export function buildDigest(issues, { channel } = {}) {
   const entries = (issues ?? []).map(classifyIssue);
 
   const total = entries.length;
-  const headerText = `*Sentry triage — ${issueCountText(total)}*\n${formatUtcTimestamp(now)}`;
+  // No timestamp: Slack renders its own next to the app name, and a second
+  // one in the body is a line every reader skips.
+  const headerText = `*Sentry triage — ${issueCountText(total)}*`;
 
   const blocks = [mrkdwnSection(headerText)];
 
@@ -701,6 +709,20 @@ export function buildDigest(issues, { channel, now = new Date() } = {}) {
     for (const chunk of chunks) {
       blocks.push(mrkdwnSection(chunk));
     }
+  }
+
+  // The archive nudge, ONCE. It used to hang off every wontfix line, which in a
+  // six-issue digest repeated the same sentence six times and buried the lines
+  // that differ. It is guidance about a flow, not a fact about an issue, so it
+  // belongs at the end and only when the digest actually contains something
+  // archivable. Archiving stays human-gated (ADR 0036): this points at the
+  // `sentry:approved-archive` label flow, never a Sentry mutation from here.
+  if ((bySection.get(WONTFIX_SECTION) ?? []).length > 0) {
+    blocks.push(
+      mrkdwnSection(
+        `_To archive any of these in Sentry: add \`${APPROVED_ARCHIVE_LABEL}\` to its queue issue._`,
+      ),
+    );
   }
 
   return {

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -703,9 +703,11 @@ await test("buildDigest produces a valid chat.postMessage payload shape", () => 
     payload.blocks[0].text.text.includes("Sentry triage — 1 issue triaged"),
     "expected header text",
   );
+  // Slack stamps every message natively; a second timestamp in the body is a
+  // line every reader skips. Asserted absent so it does not creep back.
   assert(
-    payload.blocks[0].text.text.includes("2026-07-17 14:20 UTC"),
-    "expected UTC timestamp",
+    !/\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC/.test(payload.blocks[0].text.text),
+    "expected NO UTC timestamp in the header",
   );
   JSON.parse(JSON.stringify(payload));
 });
@@ -1060,6 +1062,8 @@ await test("wontfix line links the queue-issue rationale with confidence", () =>
     { channel: "#engineering", now: NOW },
   );
   const text = allText(payload);
+  // `UP-14` does not start with `APP-MENTO-ORG-`, so the project still renders:
+  // it is information here, not a repeat of the id.
   assert(
     text.includes(
       "• <https://github.com/mento-protocol/monitoring-monorepo/issues/14|UP-14> (app-mento-org) — third-party outage (high)",
@@ -1067,10 +1071,8 @@ await test("wontfix line links the queue-issue rationale with confidence", () =>
     "expected the wontfix line linking the queue issue",
   );
   assert(
-    text.includes(
-      "    ◦ To archive in Sentry: add `sentry:approved-archive` to the queue issue above.",
-    ),
-    "expected a sub-bullet nudging the existing human-gated archive label",
+    !text.includes("◦ To archive in Sentry:"),
+    "the archive nudge must not repeat per entry — it is one footer per digest",
   );
 });
 
@@ -1451,6 +1453,93 @@ await test("buildDigest fails closed: a queue URL with Slack link-control chars 
       "<https://github.com/mento-protocol/monitoring-monorepo/issues/8|",
     ),
     "a clean queue URL should render as a Slack link",
+  );
+});
+
+await test("the project renders only when the SHORT-ID does not already say it", () => {
+  // `GOVERNANCE-MENTO-ORG-5H (governance-mento-org)` says it twice. But a
+  // project's slug and its SHORT-ID prefix can diverge — renaming a slug does
+  // not rewrite existing ids — and there the project is the only place the
+  // owning project appears, so it must survive.
+  const redundant = allText(
+    buildDigest(
+      [
+        issueFixture({
+          number: 1,
+          shortId: "GOVERNANCE-MENTO-ORG-5H",
+          project: "governance-mento-org",
+          labels: ["sentry:verdict-upstream"],
+          comments: [
+            { body: verdictComment({ verdict: "upstream-transient" }) },
+          ],
+        }),
+      ],
+      { channel: "#c", now: NOW },
+    ),
+  );
+  assert(redundant.includes("GOVERNANCE-MENTO-ORG-5H"), "the id must render");
+  assert(
+    !redundant.includes("(governance-mento-org)"),
+    "the project must not repeat what the id already spells out",
+  );
+
+  const divergent = allText(
+    buildDigest(
+      [
+        issueFixture({
+          number: 2,
+          shortId: "LEGACY-7",
+          project: "governance-mento-org",
+          labels: ["sentry:verdict-upstream"],
+          comments: [
+            { body: verdictComment({ verdict: "upstream-transient" }) },
+          ],
+        }),
+      ],
+      { channel: "#c", now: NOW },
+    ),
+  );
+  assert(
+    divergent.includes("(governance-mento-org)"),
+    "a project the id does NOT spell out is information and must render",
+  );
+});
+
+await test("the archive nudge appears once, and only when something is archivable", () => {
+  const many = allText(
+    buildDigest(
+      [1, 2, 3].map((n) =>
+        issueFixture({
+          number: n,
+          shortId: `UP-${n}`,
+          labels: ["sentry:verdict-upstream"],
+          comments: [
+            { body: verdictComment({ verdict: "upstream-transient" }) },
+          ],
+        }),
+      ),
+      { channel: "#c", now: NOW },
+    ),
+  );
+  // Three archivable issues, one sentence about archiving.
+  assertEqual(many.split("To archive").length - 1, 1);
+
+  const none = allText(
+    buildDigest(
+      [
+        issueFixture({
+          number: 9,
+          shortId: "CF-9",
+          labels: ["sentry:verdict-code-fix"],
+          comments: [{ body: verdictComment({ verdict: "code-fix" }) }],
+        }),
+      ],
+      { channel: "#c", now: NOW },
+    ),
+  );
+  assert(
+    !none.includes("To archive"),
+    "no archivable entries means no archive nudge at all",
   );
 });
 

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -675,8 +675,6 @@ await test("LABEL_TO_VERDICT encodes the upstream label/value asymmetry", () => 
 // Digest payload assembly (shape, counts, section ordering/omission)
 // ---------------------------------------------------------------------------
 
-const NOW = new Date("2026-07-17T14:20:33.000Z");
-
 /** All block text joined — handy for order/substring assertions. */
 function allText(payload) {
   return payload.blocks.map((block) => block.text.text).join("\n");
@@ -692,7 +690,7 @@ await test("buildDigest produces a valid chat.postMessage payload shape", () => 
         comments: [{ body: verdictComment({ summary: "null deref" }) }],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   assertEqual(payload.channel, "#engineering");
   assertEqual(payload.text, "Sentry triage — 1 issue triaged");
@@ -722,7 +720,7 @@ await test("every mrkdwn text object sets verbatim: true (no Slack auto-parsing)
       }),
       issueFixture({ number: 2, labels: [NEEDS_TRIAGE_LABEL] }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   assert(payload.blocks.length >= 2, "expected header + section blocks");
   for (const block of payload.blocks) {
@@ -764,7 +762,7 @@ await test("buildDigest renders sections in order (needs-human first) and omits 
         comments: [{ body: verdictComment({ verdict: "code-fix" }) }],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   const nh = text.indexOf("Needs human — decisions required");
@@ -800,7 +798,7 @@ await test("buildDigest renders a routed line linking the projected owning-repo 
         ],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(
@@ -832,7 +830,7 @@ await test("routed section falls back to the queue-issue verdict when projection
         comments: [{ body: verdictComment({ verdict: "code-fix" }) }],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(
@@ -858,7 +856,7 @@ await test("autofixed section renders only when fix-PR data exists, linking the 
         ],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(withFix);
   assert(text.includes("🤖 Autofixed (1)"), "expected the autofixed section");
@@ -898,7 +896,7 @@ await test("section header count reflects multiple entries in the same bucket", 
         labels: ["sentry:verdict-upstream"],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(
@@ -935,7 +933,7 @@ await test("buildDigest renders a decision-ready needs-human brief with all fiel
         ],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(
@@ -987,7 +985,7 @@ await test("needs-human brief shows a placeholder when human_question is somehow
         comments: [{ body: verdictComment({ verdict: "needs-human" }) }],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   assert(
     allText(payload).includes("_(no decision recorded — re-triage)_"),
@@ -1015,7 +1013,7 @@ await test("needs-human brief escapes every agent-derived field", () => {
         ],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(
@@ -1059,7 +1057,7 @@ await test("wontfix line links the queue-issue rationale with confidence", () =>
         ],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   // `UP-14` does not start with `APP-MENTO-ORG-`, so the project still renders:
@@ -1085,7 +1083,7 @@ await test("buildDigest renders a distinct failed-triage line with no verdict", 
         labels: [NEEDS_TRIAGE_LABEL],
       }),
     ],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   const text = allText(payload);
   assert(text.includes("🛑 Failed triage (1)"), "expected the failed section");
@@ -1099,7 +1097,7 @@ await test("buildDigest renders a distinct failed-triage line with no verdict", 
 await test("routed line shows a placeholder when a verdict issue has no parseable summary", () => {
   const payload = buildDigest(
     [issueFixture({ number: 3, labels: ["sentry:verdict-code-fix"] })],
-    { channel: "#engineering", now: NOW },
+    { channel: "#engineering" },
   );
   assert(
     allText(payload).includes("_(no summary)_"),
@@ -1133,7 +1131,7 @@ await test("parseIssueNumbers fails loud on non-arrays and bad members", () => {
 });
 
 await test("buildDigest tolerates an empty batch (defensive; job is gated upstream)", () => {
-  const payload = buildDigest([], { channel: "#engineering", now: NOW });
+  const payload = buildDigest([], { channel: "#engineering" });
   assertEqual(payload.text, "Sentry triage — 0 issues triaged");
   // No section blocks when nothing was triaged — just the header.
   assertEqual(payload.blocks.length, 1);
@@ -1163,7 +1161,7 @@ await test("buildDigest splits a worst-case 6-issue routed batch across sections
       comments: [{ body: verdictComment({ summary: "<".repeat(300) }) }],
     }),
   );
-  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+  const payload = buildDigest(issues, { channel: "#engineering" });
 
   const sectionBlocks = payload.blocks.slice(1);
   assert(
@@ -1206,7 +1204,7 @@ await test("buildDigest keeps long needs-human briefs under the per-section cap"
       ],
     }),
   );
-  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+  const payload = buildDigest(issues, { channel: "#engineering" });
   for (const block of payload.blocks) {
     assert(
       block.text.text.length <= MAX_SECTION_TEXT_LEN,
@@ -1267,7 +1265,7 @@ await test("needs-human briefs never split across Slack blocks mid-entry", () =>
       ],
     }),
   );
-  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+  const payload = buildDigest(issues, { channel: "#engineering" });
   const briefBlocks = payload.blocks
     .slice(1)
     .map((block) => block.text.text)
@@ -1347,7 +1345,7 @@ await test("collectIssues fetches each issue via the injected gh runner", async 
   assertEqual(calls[0][repoFlagIndex + 1], "o/r");
   assertEqual(calls[1][calls[1].indexOf("--repo") + 1], "o/r");
 
-  const payload = buildDigest(issues, { channel: "#engineering", now: NOW });
+  const payload = buildDigest(issues, { channel: "#engineering" });
   assertEqual(payload.text, "Sentry triage — 2 issues triaged");
 });
 
@@ -1426,7 +1424,7 @@ await test("buildDigest fails closed: a queue URL with Slack link-control chars 
     }),
     url: "https://github.com/mento-protocol/monitoring-monorepo/issues/7|@channel>",
   };
-  const text = allText(buildDigest([poisoned], { channel: "#eng", now: NOW }));
+  const text = allText(buildDigest([poisoned], { channel: "#eng" }));
   // Fail closed: the unsafe URL is dropped entirely (no link splice), not
   // embedded — so neither the URL nor a `<...|` breakout reaches Slack.
   assert(!text.includes("github.com"), "unsafe queue URL must not be linked");
@@ -1445,7 +1443,7 @@ await test("buildDigest fails closed: a queue URL with Slack link-control chars 
           comments: [{ body: verdictComment({ summary: "boom" }) }],
         }),
       ],
-      { channel: "#eng", now: NOW },
+      { channel: "#eng" },
     ),
   );
   assert(
@@ -1474,13 +1472,24 @@ await test("the project renders only when the SHORT-ID does not already say it",
           ],
         }),
       ],
-      { channel: "#c", now: NOW },
+      { channel: "#c" },
     ),
   );
   assert(redundant.includes("GOVERNANCE-MENTO-ORG-5H"), "the id must render");
   assert(
     !redundant.includes("(governance-mento-org)"),
     "the project must not repeat what the id already spells out",
+  );
+  // The assertion above passes for `ID ()` too — dropping the project must
+  // remove the parenthetical, not leave punctuation where it used to be.
+  // Three reviewers caught exactly that, past a weaker version of this test.
+  assert(
+    !/GOVERNANCE-MENTO-ORG-5H\S*\s*\(\)/.test(redundant),
+    "dropping the project must not leave empty parentheses",
+  );
+  assert(
+    redundant.includes("GOVERNANCE-MENTO-ORG-5H> — "),
+    "the id must be followed straight by the summary separator",
   );
 
   const divergent = allText(
@@ -1496,7 +1505,7 @@ await test("the project renders only when the SHORT-ID does not already say it",
           ],
         }),
       ],
-      { channel: "#c", now: NOW },
+      { channel: "#c" },
     ),
   );
   assert(
@@ -1518,7 +1527,7 @@ await test("the archive nudge appears once, and only when something is archivabl
           ],
         }),
       ),
-      { channel: "#c", now: NOW },
+      { channel: "#c" },
     ),
   );
   // Three archivable issues, one sentence about archiving.
@@ -1534,7 +1543,7 @@ await test("the archive nudge appears once, and only when something is archivabl
           comments: [{ body: verdictComment({ verdict: "code-fix" }) }],
         }),
       ],
-      { channel: "#c", now: NOW },
+      { channel: "#c" },
     ),
   );
   assert(


### PR DESCRIPTION
## The Problem

Three things in the triage digest repeat information the reader already has, and they crowd out the part that differs between issues:

- **The archive nudge is per-entry.** `renderWontfixLine` appends "To archive in Sentry: add `sentry:approved-archive` to the queue issue above" to every line. The batch cap is six, so one digest can say the same sentence six times.
- **The project is printed twice.** `GOVERNANCE-MENTO-ORG-5H (governance-mento-org)` — a Sentry SHORT-ID is prefixed with the project's short name, so the parenthetical is the same word again in lower case.
- **The header carries a UTC timestamp** directly under Slack's own, which already stamps every message.

## The Solution

- The archive nudge moves to **one footer line per digest**, and renders only when the digest actually contains an archivable entry. It is guidance about a flow, not a fact about an issue.
- The project renders **only when the SHORT-ID does not already spell it out**.
- The header timestamp is removed.

## Details

The project rule is conditional rather than a straight deletion. Sentry lets a project's slug and its SHORT-ID prefix diverge — renaming a slug does not rewrite existing ids — and in that case the parenthetical is the only place the owning project appears. So it is dropped when it is a repeat and kept when it is information, with a test for each direction.

Removing the header timestamp orphaned `formatUtcTimestamp` and the injectable `now`, both of which existed only to feed it. Both are gone, and the doc comment now says the payload carries no clock at all — the honest state, since Slack supplies the only timestamp that matters.

Nothing about the archive flow changed: archiving stays gated on a human applying `sentry:approved-archive` to the queue issue (ADR 0036). This only stops the digest saying so six times.

## Validation

- `pnpm agent:quality-gate --run` — green.
- Two new tests: the project renders in the divergent case and not in the redundant one; the nudge appears exactly once for three archivable entries and not at all when nothing is archivable.
- Two existing tests were asserting the old output and were updated to assert the new — the header one now asserts **no** timestamp pattern, so it cannot creep back.
- Negative controls, each reverted and each asserted to have landed before reading the result: always rendering the project fails one test; making the footer unconditional fails two.

Refs #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Slack digest formatting; no auth, data, or archive-flow behavior changes.
> 
> **Overview**
> Cuts three sources of repeated noise from the Sentry triage Slack digest so issue lines stay scannable.
> 
> **Archive nudge** moves from a per-wontfix sub-bullet to a **single footer**, rendered only when the digest has archivable entries. Archiving stays human-gated via `sentry:approved-archive`.
> 
> **Project parenthetical** is omitted when the SHORT-ID already starts with that project name (e.g. `GOVERNANCE-MENTO-ORG-5H`), but kept when slug and id prefix diverge.
> 
> **Header UTC timestamp** is removed (Slack already stamps messages), along with `formatUtcTimestamp` and the injectable `now` on `buildDigest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7ae5d23f36b906bcbfbddadbf6ac21965fa157. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->