### PR TITLE
fix(sentry): label the confidence value in the digest

### DIFF
--- a/scripts/sentry-triage-digest.mjs
+++ b/scripts/sentry-triage-digest.mjs
@@ -540,8 +540,10 @@ function renderWontfixLine(entry) {
     ? formatSummaryForSlack(entry.summary)
     : "_(no summary)_";
   // The SHORT-ID links the queue issue, which holds the verdict comment (the
-  // rationale). Confidence rides along.
-  return `• ${linked}${projectSuffix} — ${summary} (${confidence})`;
+  // rationale). Confidence is LABELLED, not a bare parenthetical: on its own
+  // `(medium)` reads as part of the summary sentence rather than as the agent's
+  // self-assessment of its own verdict.
+  return `• ${linked}${projectSuffix} — ${summary} [confidence: ${confidence}]`;
 }
 
 function renderFailedLine(entry) {

--- a/scripts/sentry-triage-digest.test.mjs
+++ b/scripts/sentry-triage-digest.test.mjs
@@ -1064,7 +1064,7 @@ await test("wontfix line links the queue-issue rationale with confidence", () =>
   // it is information here, not a repeat of the id.
   assert(
     text.includes(
-      "• <https://github.com/mento-protocol/monitoring-monorepo/issues/14|UP-14> (app-mento-org) — third-party outage (high)",
+      "• <https://github.com/mento-protocol/monitoring-monorepo/issues/14|UP-14> (app-mento-org) — third-party outage [confidence: high]",
     ),
     "expected the wontfix line linking the queue issue",
   );
@@ -1549,6 +1549,37 @@ await test("the archive nudge appears once, and only when something is archivabl
   assert(
     !none.includes("To archive"),
     "no archivable entries means no archive nudge at all",
+  );
+});
+
+await test("confidence is labelled, never a bare parenthetical", () => {
+  // `— summary (medium)` reads as part of the sentence. The value is the
+  // agent's self-assessment of its own verdict, so it has to say what it is.
+  const text = allText(
+    buildDigest(
+      [
+        issueFixture({
+          number: 21,
+          shortId: "UP-21",
+          labels: ["sentry:verdict-upstream"],
+          comments: [
+            {
+              body: verdictComment({
+                verdict: "upstream-transient",
+                confidence: "medium",
+                summary: "a third-party outage",
+              }),
+            },
+          ],
+        }),
+      ],
+      { channel: "#c" },
+    ),
+  );
+  assert(text.includes("[confidence: medium]"), "expected a labelled value");
+  assert(
+    !/outage \(medium\)/.test(text),
+    "the bare parenthetical must not come back",
   );
 });
 


### PR DESCRIPTION
## The Problem

The wontfix digest line ends with a bare parenthetical:

```
• GOVERNANCE-MENTO-ORG-5H — … the app caught and surfaced the error as designed. (medium)
```

`(medium)` reads as part of the summary sentence. It is not: it is the triage agent's self-assessment of its own verdict, pulled from `confidence` in the verdict YAML. Nothing on the line says so, and a reader who has not read the verdict contract has no way to tell what the word qualifies.

## The Solution

Label it: `[confidence: medium]`.

## Details

One render site. The needs-human brief already spells the field out (`· confidence: medium`) on its own line, so after this both surfaces name the field; they keep different punctuation because one is a trailing annotation on a summary and the other is a header.

Worth stating plainly for anyone reading the digest: this value is **uncalibrated**. It is the agent grading its own verdict, and exactly one verdict has ever been human-corrected, so there is no evidence that `high` is more reliable than `medium`. Naming the field does not make it a probability — it makes it legible as a self-report, which is what it is.

## Validation

- `pnpm agent:quality-gate --run` — green.
- One new test asserting the labelled form renders and the bare parenthetical does not.
- One existing assertion updated from `(high)` to `[confidence: high]`.
- Negative control: reverting the render to `(${confidence})` fails two tests, with the mutation asserted to have landed before the result was read.

Refs #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only Slack formatting change with no logic, security, or data-handling impact.
> 
> **Overview**
> Makes the agent's confidence value legible on **wontfix** Slack digest lines by changing the trailing annotation from a bare `(medium)` to `[confidence: medium]`.
> 
> Previously the parenthetical read as part of the summary sentence. This aligns the field naming with the needs-human brief (which already labels confidence) while keeping trailing-annotation punctuation for the one-liner format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f955dcbc8a9cb96b5c5f6890d906d8e4dff16dec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->