### PR TITLE
fix(sentry): ingest must see escalating issues, not only regressed ones

### DIFF
--- a/.github/workflows/sentry-triage-ingest.yml
+++ b/.github/workflows/sentry-triage-ingest.yml
@@ -2,7 +2,7 @@ name: Sentry Triage Ingest
 
 # Stage A of the Sentry triage pipeline (ADR 0036,
 # docs/adr/0036-sentry-triage-pipeline.md): a deterministic, no-LLM ingest that
-# turns every new/regressed Sentry issue across the `mento-labs` org (6
+# turns every new/regressed/escalating Sentry issue across the `mento-labs` org (6
 # projects, 4 repos) into exactly one labeled GitHub queue issue in this repo,
 # idempotent by Sentry short ID. Read-only against Sentry — GET only, never
 # resolves/archives/assigns.

--- a/docs/adr/0036-sentry-triage-pipeline.md
+++ b/docs/adr/0036-sentry-triage-pipeline.md
@@ -52,7 +52,8 @@ repo, with GitHub Issues as the durable queue and Claude Code as the engine;
 trust is earned in phases, and Codex remains the independent PR reviewer.**
 
 - **Stage A — deterministic ingest (no LLM):** a scheduled script turns every
-  new/regressed Sentry issue org-wide into exactly one labeled queue issue
+  new, regressed, or escalating Sentry issue org-wide into exactly one labeled
+  queue issue
   (`sentry-triage`), idempotent by Sentry short-ID. The queue reuses the
   ADR 0006 machinery for state, dedup, audit, and recovery — no bespoke DB.
   **This repo is public, so queue issues carry only non-sensitive coordinates**

--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -26,7 +26,8 @@ boundary and token isolation from the triage agent remain in force.
 
 ADR 0036 runs Sentry triage as a staged GitHub Actions pipeline in **this**
 repo, with GitHub Issues as the durable queue: one deterministic ingest turns
-every new/regressed Sentry issue org-wide into a redacted queue stub here, and a
+every new, regressed, or escalating Sentry issue org-wide into a redacted queue
+stub here, and a
 read-only agent posts a structured verdict (`code-fix` / `config-fix` /
 `upstream-transient` / `needs-human`). ADR 0036 named Stage C ("phased
 mutations") but deliberately left its shape open until the first live run

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -152,8 +152,10 @@ Cases that are not a verdict:
 
 ## Queue contract
 
-Ingest queries unresolved new and regressed issues for the `mento-labs`
-organization. The project set, mapping, pagination, default lookback, and noise
+Ingest queries unresolved issues for the `mento-labs` organization on three
+axes: newly seen, regressed, and **escalating**. The last is separate because
+Sentry's grammar treats `is:regressed` and `is:escalating` as distinct filters
+and the archive leg only ever produces the second (#1765). The project set, mapping, pagination, default lookback, and noise
 heuristics are owned by `scripts/sentry-triage-ingest.mjs`; do not duplicate
 those lists here.
 
@@ -792,7 +794,8 @@ refuses in both directions where it has none:
 Neither path mutates anything; both remove the approval so a bare re-dispatch
 cannot skip the decision, and both write the refusal on the stub. Recovery is to
 un-archive the Sentry issue and let it re-triage — the event is invisible to
-ingest while it stays archived, since both queries match only unresolved issues.
+ingest while it stays archived, since every ingest query matches only unresolved
+issues.
 
 **Queue rollback reconciles; it does not replay.** Every failure from the Sentry
 PUT onward re-reads the stub and corrects only what live state actually shows to
@@ -854,10 +857,11 @@ asymmetry is deliberate. A failed settlement leaves an archive whose premise
 still holds — the human approved it and nothing contradicted that. A freshness
 refusal is the opposite: it is positive evidence that an event landed which the
 approver never saw, so the approval's premise is void. Leaving the archive there
-would bury that event, because an `archived_until_escalating` issue matches
-neither ingest query (both are `is:unresolved`) and a single already-counted
-event does not reliably trip Sentry's escalation forecast. Reverting puts it back
-in front of both.
+would bury that event, because a still-archived issue matches no ingest query
+(all of them are `is:unresolved`) and a single already-counted event does not
+reliably trip Sentry's escalation forecast — so the `is:escalating` query that
+does catch an escalated archive (#1765) never fires either. Reverting puts the
+event back in front of ingest.
 
 **There are two baselines, and they answer different questions.** The live read
 above is what THIS RUN observed, and only this run's own gates may use it: the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -768,10 +768,12 @@ and then failed to settle its queue stub has left Sentry in exactly the state a
 SUCCESSFUL archive would have produced — the state a human already approved.
 Reverting it bought nothing and cost a check-then-PUT race against Sentry's own
 transitions: the check can still read `archived_until_escalating` while Sentry is
-concurrently flipping a freshly-escalated issue to `unresolved/regressed`, and
-the PUT then erases that regression signal. Since ingest finds old issues only
-through `is:regressed`, the event would vanish from both systems. Only the queue
-stub is rolled back.
+concurrently flipping a freshly-escalated issue to `unresolved`, and the PUT
+then erases that signal. Ingest finds old issues through `is:regressed` **and
+`is:escalating`** — two separate queries, because Sentry's grammar treats them
+as distinct filters and the archive leg only ever produces the second (#1765).
+Erase the signal and the event vanishes from both systems regardless. Only the
+queue stub is rolled back.
 
 That makes re-approval the standard recovery, so it carries its own guard. A run
 over an issue that is ALREADY archived needs a baseline it can stand behind, and

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -836,7 +836,7 @@ path, and because settlement consumes the approval before it writes the body, th
 stub cannot yet carry a baseline — so that retry is REFUSED as
 `skipped-unbaselined-retry` rather than recording its own read time. Nothing in
 the dead run's window is absorbed, but nothing is recovered either: the Sentry
-issue stays archived and is invisible to both ingest queries until someone acts.
+issue stays archived and is invisible to every ingest query until someone acts.
 Closing that would take a durable intent record written before the PUT, which is
 not what this change does. The mitigation is operational: a killed archive run
 leaves a red or cancelled run in Actions — un-archive the Sentry issue so ingest
@@ -1109,8 +1109,8 @@ permission or the environment-secret writes 403 (`terraform/providers.tf`).
     **un-archive the Sentry issue**. Leaving the approval off is not enough on
     its own: ingest skips an open stub, the triage agent selects on open stubs
     carrying `sentry:needs-triage` — so a closed one stays invisible however it
-    is labelled — and while the issue stays archived it matches neither ingest
-    query, so nothing re-surfaces it. Un-archiving puts it back in front of the
+    is labelled — and while the issue stays archived it matches no ingest query
+    (all of them are `is:unresolved`), so nothing re-surfaces it. Un-archiving puts it back in front of the
     pipeline,
     after which the next archive records a baseline it can stand behind.
 

--- a/scripts/sentry-triage-archive.mjs
+++ b/scripts/sentry-triage-archive.mjs
@@ -616,7 +616,7 @@ export function buildStaleRetryRefusalComment(shortId, recorded, observed) {
     `baseline this stub recorded (${yamlScalar(recorded ?? "")}). Settling now`,
     "would stamp the newer timestamp as the baseline, and the reopen gate would",
     "then never fire for the event in between — it would be archived and",
-    "invisible to both ingest queries, which only match unresolved issues.",
+    "invisible to every ingest query, which all match only unresolved issues.",
     "",
     "Nothing was changed, and the `sentry:approved-archive` label was removed.",
     "Re-applying it will refuse again — the recorded baseline is still older and",

--- a/scripts/sentry-triage-archive.mjs
+++ b/scripts/sentry-triage-archive.mjs
@@ -1012,9 +1012,10 @@ export function settlementHeld({ state, labels, body } = {}, expected = null) {
  * produced — the state a human already approved. Reverting it bought nothing and
  * cost a check-then-PUT race against Sentry's own transitions, where the GET can
  * still read `archived_until_escalating` while Sentry is concurrently flipping a
- * freshly-escalated issue to `unresolved/regressed`; the PUT then erases that
- * regression signal, and since ingest finds old issues only through
- * `is:regressed`, the event vanishes from both systems. Removing the revert
+ * freshly-escalated issue to `unresolved`; the PUT then erases that signal.
+ * Ingest finds old issues through `is:regressed` AND `is:escalating` (#1765),
+ * but an issue forced back to archived matches neither — every ingest query is
+ * `is:unresolved` — so the event still vanishes from both systems. Removing the revert
  * removes that failure mode instead of guarding it.
  *
  * Returns a report; the caller decides how loud to be. Never throws on a

--- a/scripts/sentry-triage-archive.test.mjs
+++ b/scripts/sentry-triage-archive.test.mjs
@@ -2677,8 +2677,8 @@ await test("an unusable or foreign baseline counts as absent", async () => {
 
 await test("a retry refuses outright when Sentry moved past the recorded baseline", async () => {
   // Positive evidence of an untriaged event. Stamping the newer timestamp would
-  // bury it: an archived issue matches neither ingest query, so nothing would
-  // ever reopen the stub for it.
+  // bury it: an archived issue matches NO ingest query — all three are
+  // `is:unresolved` (#1765) — so nothing would ever reopen the stub for it.
   const recorded = "2026-07-19T11:59:00.000Z";
   const stub = makeStub({
     state: "CLOSED",

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -470,7 +470,13 @@ export function mergeSentryIssues(
 ) {
   const byId = new Map();
   for (const issue of newIssues ?? []) {
-    byId.set(issue.id, { ...issue, isRegressed: false });
+    // PRESERVE an already-set flag rather than forcing false. The escalating
+    // pass feeds this function pass one's OUTPUT as `newIssues`, so forcing
+    // false here wiped `isRegressed` from every regressed-only issue and
+    // silently disabled the regression reopen path entirely — a worse failure
+    // than the escalation gap this all exists to close. A raw Sentry payload
+    // never carries the field, so this is a no-op on the first pass.
+    byId.set(issue.id, { ...issue, isRegressed: issue.isRegressed === true });
   }
   for (const issue of reopenCandidates ?? []) {
     const existing = byId.get(issue.id);

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -91,6 +91,21 @@ export function buildNewIssuesQuery(lookbackDays = DEFAULT_LOOKBACK_DAYS) {
 
 export const REGRESSED_ISSUES_QUERY = "is:unresolved is:regressed";
 
+// `is:regressed` and `is:escalating` are DISTINCT filters in Sentry's search
+// grammar, and the archive leg only ever sets `archived_until_escalating` (ADR
+// 0036, never a hard resolve). So a pipeline-archived issue that Sentry later
+// escalates becomes `is:unresolved` with substatus `escalating` — matching
+// neither the firstSeen window (it is long-lived) nor the regressed query. It
+// entered no fetch set, `decideDedupAction` was never called for it, and the
+// archive freshness baseline that exists to reopen it (#1371, #1692, #1693) was
+// unreachable for exactly the issues the archive leg produces (#1765).
+//
+// Kept as a separate query rather than `(is:regressed OR is:escalating)`: the
+// boolean form is a search-grammar dependency that would fail SILENTLY — an
+// unsupported query returns no rows, and no rows is indistinguishable from a
+// genuine absence of escalations — rebuilding this same blind spot.
+export const ESCALATING_ISSUES_QUERY = "is:unresolved is:escalating";
+
 /**
  * CLI flag wins over the env var; default 8. Fails loud on anything that is
  * not an integer in [1, 90] — a typo'd override should turn the run red, not
@@ -432,12 +447,17 @@ export function mapSentryIssue(raw) {
   };
 }
 
-export function mergeSentryIssues(newIssues, regressedIssues) {
+/**
+ * `reopenCandidates` is every issue Sentry currently considers live again —
+ * both `is:regressed` and `is:escalating` (#1765). They collapse to one flag
+ * because `decideDedupAction` asks only "is this active again?".
+ */
+export function mergeSentryIssues(newIssues, reopenCandidates) {
   const byId = new Map();
   for (const issue of newIssues ?? []) {
     byId.set(issue.id, { ...issue, isRegressed: false });
   }
-  for (const issue of regressedIssues ?? []) {
+  for (const issue of reopenCandidates ?? []) {
     const existing = byId.get(issue.id);
     byId.set(
       issue.id,
@@ -510,21 +530,32 @@ async function fetchAllSentryIssues({
   return collected.map(mapSentryIssue);
 }
 
-async function defaultFetchMergedSentryIssues(options) {
+// Exported for the fetch-to-decision test (#1765): while this was private, no
+// test could reach the query SET, which is exactly where the blind spot lived.
+export async function defaultFetchMergedSentryIssues(options) {
   const common = {
     org: options.org,
     baseUrl: options.sentryBaseUrl,
     token: options.sentryToken,
-    fetchImpl: fetch,
+    // Injectable so the query SET is testable without a network call. It was
+    // hardcoded, which is why nothing could cover the gap in #1765 — and why a
+    // test written against it silently reached the real Sentry API.
+    fetchImpl: options.fetchImpl ?? fetch,
   };
-  const [newIssues, regressedIssues] = await Promise.all([
+  const [newIssues, regressedIssues, escalatingIssues] = await Promise.all([
     fetchAllSentryIssues({
       ...common,
       query: buildNewIssuesQuery(options.lookbackDays),
     }),
     fetchAllSentryIssues({ ...common, query: REGRESSED_ISSUES_QUERY }),
+    fetchAllSentryIssues({ ...common, query: ESCALATING_ISSUES_QUERY }),
   ]);
-  return mergeSentryIssues(newIssues, regressedIssues);
+  // Both regressed and escalating are "Sentry says this is live again", which
+  // is the only distinction `decideDedupAction` draws.
+  return mergeSentryIssues(newIssues, [
+    ...regressedIssues,
+    ...escalatingIssues,
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -450,23 +450,38 @@ export function mapSentryIssue(raw) {
   };
 }
 
+// Why a stub is being reopened. `decideDedupAction` treats these identically —
+// it asks only "is this active again?" — but the per-issue audit comment must
+// not tell a reader that Sentry regressed an issue it actually escalated
+// (#1765), so the provenance survives the merge instead of collapsing into the
+// boolean.
+export const REOPEN_CAUSE_REGRESSED = "regressed";
+export const REOPEN_CAUSE_ESCALATING = "escalating";
+
 /**
- * `reopenCandidates` is every issue Sentry currently considers live again —
- * both `is:regressed` and `is:escalating` (#1765). They collapse to one flag
- * because `decideDedupAction` asks only "is this active again?".
+ * `reopenCandidates` is every issue Sentry currently considers live again.
+ * Pass `cause` so an escalation is recorded as one; an issue returned by BOTH
+ * queries keeps the first cause seen, which is the regressed one.
  */
-export function mergeSentryIssues(newIssues, reopenCandidates) {
+export function mergeSentryIssues(
+  newIssues,
+  reopenCandidates,
+  cause = REOPEN_CAUSE_REGRESSED,
+) {
   const byId = new Map();
   for (const issue of newIssues ?? []) {
     byId.set(issue.id, { ...issue, isRegressed: false });
   }
   for (const issue of reopenCandidates ?? []) {
     const existing = byId.get(issue.id);
+    // An issue already marked by an earlier candidate set keeps that cause: the
+    // regressed query is merged first, and "regressed" is the stronger claim.
+    const reopenCause = existing?.reopenCause ?? cause;
     byId.set(
       issue.id,
       existing
-        ? { ...existing, isRegressed: true }
-        : { ...issue, isRegressed: true },
+        ? { ...existing, isRegressed: true, reopenCause }
+        : { ...issue, isRegressed: true, reopenCause },
     );
   }
   return byId;
@@ -905,6 +920,16 @@ export async function reopenQueueIssue(
       cause: REQUEUE_CAUSE_SENTRY_EVIDENCE,
       lastSeen: sentryIssue.lastSeen,
       dedupeFence: true,
+      // The fence LINE is the machine-read contract and stays exactly as it is;
+      // provenance goes in the prose the chokepoint renders beneath it. Without
+      // this an escalated archive is audited as "Regressed in Sentry", which is
+      // the one distinction an operator reading this stub needs (#1765).
+      fenceProse:
+        sentryIssue.reopenCause === REOPEN_CAUSE_ESCALATING
+          ? [
+              "Sentry escalated this issue out of `archived_until_escalating` — it was not a regression.",
+            ]
+          : null,
     },
   );
 }

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -576,8 +576,8 @@ export async function defaultFetchMergedSentryIssues(options) {
   ]);
   // Merged in two passes, not one concatenation: a single call would apply the
   // default cause to both sets and an escalation-only reopen would be audited
-  // as a regression again. Regressed merges first, so an issue returned by BOTH
-  // queries keeps the stronger claim.
+  // as a regression again. Regressed merges first, so an issue in BOTH
+  // reopen candidate sets keeps the stronger claim.
   const withRegressed = mergeSentryIssues(
     newIssues,
     regressedIssues,

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -2,8 +2,8 @@
 /**
  * Stage A of the Sentry triage pipeline (ADR 0036,
  * docs/adr/0036-sentry-triage-pipeline.md): a deterministic, no-LLM ingest
- * that turns every new or regressed Sentry issue across the `mento-labs` org
- * into exactly one labeled GitHub queue issue in this repo, idempotent by
+ * that turns every new, regressed, or escalating Sentry issue across the
+ * `mento-labs` org into one labeled GitHub queue issue, idempotent by
  * Sentry short ID. Read-only against Sentry (GET only) — never resolves,
  * archives, assigns, or otherwise mutates a Sentry issue.
  *
@@ -568,12 +568,20 @@ export async function defaultFetchMergedSentryIssues(options) {
     fetchAllSentryIssues({ ...common, query: REGRESSED_ISSUES_QUERY }),
     fetchAllSentryIssues({ ...common, query: ESCALATING_ISSUES_QUERY }),
   ]);
-  // Both regressed and escalating are "Sentry says this is live again", which
-  // is the only distinction `decideDedupAction` draws.
-  return mergeSentryIssues(newIssues, [
-    ...regressedIssues,
-    ...escalatingIssues,
-  ]);
+  // Merged in two passes, not one concatenation: a single call would apply the
+  // default cause to both sets and an escalation-only reopen would be audited
+  // as a regression again. Regressed merges first, so an issue returned by BOTH
+  // queries keeps the stronger claim.
+  const withRegressed = mergeSentryIssues(
+    newIssues,
+    regressedIssues,
+    REOPEN_CAUSE_REGRESSED,
+  );
+  return mergeSentryIssues(
+    [...withRegressed.values()],
+    escalatingIssues,
+    REOPEN_CAUSE_ESCALATING,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -926,9 +934,7 @@ export async function reopenQueueIssue(
       // the one distinction an operator reading this stub needs (#1765).
       fenceProse:
         sentryIssue.reopenCause === REOPEN_CAUSE_ESCALATING
-          ? [
-              "Sentry escalated this issue out of `archived_until_escalating` — it was not a regression.",
-            ]
+          ? ["Sentry marked this issue as escalating, not regressed."]
           : null,
     },
   );

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -383,7 +383,10 @@ export function buildRunRecordBody(counts, timestampIso) {
     `- Fetched: ${counts.fetched}`,
     `- Created: ${counts.created}`,
     `- Skipped (existing): ${counts.skippedExisting}`,
-    `- Reopened (regressed): ${counts.reopened}`,
+    // "regressed or escalating": both reach this counter (#1765), and an
+    // operator reading the record must not conclude a reopen was a
+    // regression when Sentry actually escalated an archived issue.
+    `- Reopened (regressed or escalating): ${counts.reopened}`,
     `- Recovered (stranded needs-triage): ${counts.recovered}`,
     `- Errors: ${counts.errors}`,
   ].join("\n");

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -3168,6 +3168,10 @@ await test("an escalated archived issue reaches a reopen decision", async () => 
   const entry = merged.get("900");
   assert(entry, "the escalated issue must be in the merged set at all");
   assertEqual(entry.isRegressed, true);
+  // Asserted through the PRODUCTION fetch path, not a hand-built merge. An
+  // earlier revision wired the cause only into the direct-reopen tests, so the
+  // fetch path silently kept collapsing both sets and nothing failed.
+  assertEqual(entry.reopenCause, ESCALATING_REOPEN_CAUSE);
 
   // And it must survive the archive freshness gate: events after the recorded
   // baseline are what the reopen exists for.
@@ -3211,7 +3215,7 @@ await test("an escalation-only reopen is not audited as a regression", async () 
   const fence = posted.find((b) => b.includes("Regressed in Sentry"));
   assert(fence, "the machine-read fence line must still be posted verbatim");
   assert(
-    fence.includes("escalated this issue out of"),
+    fence.includes("escalating, not regressed"),
     "an escalation must say so beneath the fence, not read as a regression",
   );
 });
@@ -3234,7 +3238,7 @@ await test("a regressed reopen carries no escalation prose", async () => {
   const fence = posted.find((b) => b.includes("Regressed in Sentry"));
   assert(fence, "expected the fence");
   assert(
-    !fence.includes("escalated this issue out of"),
+    !fence.includes("escalating, not regressed"),
     "a genuine regression must not claim it was an escalation",
   );
 });

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -1275,7 +1275,12 @@ await test("run record body includes counts and the rolling-comment marker", () 
   assert(body.includes("Fetched: 5"), "missing fetched count");
   assert(body.includes("Created: 2"), "missing created count");
   assert(body.includes("Skipped (existing): 2"), "missing skipped count");
-  assert(body.includes("Reopened (regressed): 1"), "missing reopened count");
+  // Both regressed and escalating land in this counter (#1765); the label must
+  // not tell an operator a reopen was a regression when it was an escalation.
+  assert(
+    body.includes("Reopened (regressed or escalating): 1"),
+    "missing reopened count",
+  );
   assert(
     body.includes("Recovered (stranded needs-triage): 3"),
     "missing recovered count",

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -3243,6 +3243,49 @@ await test("a regressed reopen carries no escalation prose", async () => {
   );
 });
 
+await test("adding the escalating pass does not disable regression reopens", async () => {
+  // The regression I shipped and did not catch: the escalating pass feeds pass
+  // one's OUTPUT back in as `newIssues`, and the merge used to force
+  // `isRegressed: false` for that argument. A regressed-only issue therefore
+  // came out of the fetch with its flag wiped, `decideDedupAction` answered
+  // "closed, not regressed", and every regression reopen silently stopped —
+  // while all the escalation tests kept passing.
+  const regressedOnly = {
+    id: "700",
+    shortId: "GOV-700",
+    title: "boom",
+    project: { slug: "governance-mento-org" },
+    lastSeen: "2026-08-12T10:00:00Z",
+  };
+  const { fetchImpl } = sentryFetchStub({
+    [REGRESSED_ISSUES_QUERY]: [regressedOnly],
+  });
+  const merged = await defaultFetchMergedSentryIssues({
+    org: "mento-labs",
+    sentryBaseUrl: "https://us.sentry.io",
+    sentryToken: "t",
+    lookbackDays: 8,
+    fetchImpl,
+  });
+
+  const entry = merged.get("700");
+  assert(entry, "the regressed issue must survive the escalating pass");
+  assertEqual(entry.isRegressed, true);
+  assertEqual(entry.reopenCause, REGRESSED_REOPEN_CAUSE);
+
+  // And it must still reach the reopen it always did.
+  const decision = decideDedupAction({
+    existingIssue: {
+      state: "CLOSED",
+      closedAt: "2026-08-10T12:00:00Z",
+      labels: [],
+    },
+    isRegressed: entry.isRegressed,
+    lastSeen: entry.lastSeen,
+  });
+  assertEqual(decision.action, "reopen");
+});
+
 if (failed > 0) {
   process.stderr.write(`${failed} failed, ${passed} passed\n`);
   process.exitCode = 1;

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -18,6 +18,8 @@ import {
   classifyNoise,
   defaultFetchMergedSentryIssues,
   ESCALATING_ISSUES_QUERY,
+  REOPEN_CAUSE_ESCALATING as ESCALATING_REOPEN_CAUSE,
+  REOPEN_CAUSE_REGRESSED as REGRESSED_REOPEN_CAUSE,
   REGRESSED_ISSUES_QUERY,
   decideDedupAction,
   defangBackticks,
@@ -3182,6 +3184,59 @@ await test("an escalated archived issue reaches a reopen decision", async () => 
     sentryIssueId: "900",
   });
   assertEqual(decision.action, "reopen");
+});
+
+await test("an escalation-only reopen is not audited as a regression", async () => {
+  // #1765 follow-through: the summary counter was fixed first, but the
+  // PER-ISSUE comment is what a person reads on the stub. The fence LINE stays
+  // exactly as it is — it is the machine-read contract — so the provenance has
+  // to arrive as prose beneath it.
+  const posted = [];
+  const runGh = async (args) => {
+    if (args[0] === "issue" && args[1] === "comment") {
+      posted.push(args[args.indexOf("--body") + 1]);
+    }
+    if (args[0] === "issue" && args[1] === "view") return JSON.stringify([]);
+    return "";
+  };
+  await reopenQueueIssue(
+    { repo: "o/r", dryRun: false },
+    { number: 42 },
+    {
+      lastSeen: "2026-08-12T10:00:00Z",
+      reopenCause: ESCALATING_REOPEN_CAUSE,
+    },
+    { runGh, claim: () => {} },
+  );
+  const fence = posted.find((b) => b.includes("Regressed in Sentry"));
+  assert(fence, "the machine-read fence line must still be posted verbatim");
+  assert(
+    fence.includes("escalated this issue out of"),
+    "an escalation must say so beneath the fence, not read as a regression",
+  );
+});
+
+await test("a regressed reopen carries no escalation prose", async () => {
+  const posted = [];
+  const runGh = async (args) => {
+    if (args[0] === "issue" && args[1] === "comment") {
+      posted.push(args[args.indexOf("--body") + 1]);
+    }
+    if (args[0] === "issue" && args[1] === "view") return JSON.stringify([]);
+    return "";
+  };
+  await reopenQueueIssue(
+    { repo: "o/r", dryRun: false },
+    { number: 43 },
+    { lastSeen: "2026-08-12T10:00:00Z", reopenCause: REGRESSED_REOPEN_CAUSE },
+    { runGh, claim: () => {} },
+  );
+  const fence = posted.find((b) => b.includes("Regressed in Sentry"));
+  assert(fence, "expected the fence");
+  assert(
+    !fence.includes("escalated this issue out of"),
+    "a genuine regression must not claim it was an escalation",
+  );
 });
 
 if (failed > 0) {

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -14,7 +14,11 @@ import {
   buildRequeueShedLabelArgs,
   buildRunRecordBody,
   buildStrandedRecoveryComment,
+  ARCHIVED_LABEL,
   classifyNoise,
+  defaultFetchMergedSentryIssues,
+  ESCALATING_ISSUES_QUERY,
+  REGRESSED_ISSUES_QUERY,
   decideDedupAction,
   defangBackticks,
   defangMentions,
@@ -3087,6 +3091,92 @@ await test("a round that DOES post a verdict still settles the swept stub (#1717
   const result = await triageRoundHelpers(after).settle(prior["42"]);
   assertEqual(result.verdict, "needs-human");
   assertEqual(result.label, "sentry:verdict-needs-human");
+});
+
+// #1765. The archive leg only ever sets `archived_until_escalating`, and Sentry
+// surfaces that as substatus `escalating` — a DISTINCT filter from
+// `is:regressed`. With only the two original queries an escalated archived
+// issue entered no fetch set at all, so the reopen machinery built by #1371,
+// #1692 and #1693 was unreachable for exactly the issues the archive produces.
+// These drive the real fetch, not a hand-built merge, because the gap was in
+// the query SET and nothing that stubbed the merge could ever have seen it.
+function sentryFetchStub(byQuery) {
+  const seen = [];
+  const fetchImpl = async (url) => {
+    const query = new URL(url).searchParams.get("query");
+    seen.push(query);
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => byQuery[query] ?? [],
+      headers: { get: () => null },
+    };
+  };
+  return { fetchImpl, seen };
+}
+
+await test("ingest fetches escalating issues, not only regressed ones", async () => {
+  const { fetchImpl, seen } = sentryFetchStub({});
+  await defaultFetchMergedSentryIssues({
+    org: "mento-labs",
+    sentryBaseUrl: "https://us.sentry.io",
+    sentryToken: "t",
+    lookbackDays: 8,
+    fetchImpl,
+  });
+  assert(
+    seen.includes(ESCALATING_ISSUES_QUERY),
+    `expected an ${ESCALATING_ISSUES_QUERY} query; saw ${JSON.stringify(seen)}`,
+  );
+  // The other two must survive: escalating is an ADDITION, not a replacement.
+  assert(seen.includes(REGRESSED_ISSUES_QUERY), "regressed query must remain");
+  assert(
+    seen.some((q) => q.startsWith("is:unresolved firstSeen:")),
+    "firstSeen query must remain",
+  );
+});
+
+await test("an escalated archived issue reaches a reopen decision", async () => {
+  // Fetch-to-decision, the path #1765 says nothing covers: the issue is
+  // returned ONLY by the escalating query, exactly as Sentry would.
+  const escalated = {
+    id: "900",
+    shortId: "GOV-900",
+    title: "boom",
+    project: { slug: "governance-mento-org" },
+    lastSeen: "2026-08-12T10:00:00Z",
+  };
+  const { fetchImpl } = sentryFetchStub({
+    [ESCALATING_ISSUES_QUERY]: [escalated],
+  });
+  const merged = await defaultFetchMergedSentryIssues({
+    org: "mento-labs",
+    sentryBaseUrl: "https://us.sentry.io",
+    sentryToken: "t",
+    lookbackDays: 8,
+    fetchImpl,
+  });
+
+  const entry = merged.get("900");
+  assert(entry, "the escalated issue must be in the merged set at all");
+  assertEqual(entry.isRegressed, true);
+
+  // And it must survive the archive freshness gate: events after the recorded
+  // baseline are what the reopen exists for.
+  const decision = decideDedupAction({
+    existingIssue: {
+      state: "CLOSED",
+      closedAt: "2026-08-10T12:00:00Z",
+      labels: [ARCHIVED_LABEL],
+    },
+    isRegressed: entry.isRegressed,
+    lastSeen: entry.lastSeen,
+    archiveBaseline: "2026-08-10T11:00:00Z",
+    archiveBaselineIssueId: "900",
+    sentryIssueId: "900",
+  });
+  assertEqual(decision.action, "reopen");
 });
 
 if (failed > 0) {


### PR DESCRIPTION
## The Problem

The archive leg only ever sets `archived_until_escalating` (ADR 0036, never a hard resolve). When Sentry later escalates such an issue it becomes `is:unresolved` with substatus **`escalating`** — and `is:regressed` and `is:escalating` are distinct filters in Sentry's search grammar.

Ingest fetched two queries. A long-lived archived issue matches neither: it is outside the `firstSeen` window, and it is not `is:regressed`. So it entered no fetch set, `decideDedupAction` was never called for it, and the archive freshness baseline built by #1371, #1692 and #1693 — the entire reopen mechanism — was unreachable for **exactly the issues the archive leg produces**.

Nothing is buried today: the archive path first ran for real on 2026-08-10 (stubs #1731/#1734/#1736) and nothing has escalated yet. Those three are the first issues this would have silently lost.

## The Solution

A third query, `is:unresolved is:escalating`, fetched alongside the other two and merged into the same reopen-candidate set — both states mean "Sentry says this is live again", which is the only distinction `decideDedupAction` draws.

Deliberately **not** the boolean form `(is:regressed OR is:escalating)`. That is one request instead of two, but it is a search-grammar dependency that fails *silently*: an unsupported query returns no rows, and no rows is indistinguishable from a genuine absence of escalations. That is how this blind spot was built the first time.

## Details

Two seams had to open, and both are the reason the gap survived this long:

- **`defaultFetchMergedSentryIssues` was private**, so no test could reach the query *set* — the one place the defect lived. It is exported now.
- **Its `fetchImpl` was hardcoded to `fetch`**, so it was not injectable. I found this the direct way: my first version of the test hit the real Sentry API and failed on a 401.

`mergeSentryIssues`'s second parameter is renamed `reopenCandidates`, since it is no longer only regressions.

## Validation

- `pnpm agent:quality-gate --run` — green, including the new `sentry-suite-gate.mjs` (ingest suite 112 against a floor of 110).
- Two new tests driving the **real fetch**, not a stubbed merge: one asserting all three queries are issued (and that the original two survive — escalating is an addition, not a replacement), one driving fetch → `decideDedupAction` for an issue returned *only* by the escalating query, ending in `reopen`.
- **Negative control**, which is this issue's stated Done-means: reverting to the two original queries fails both new tests, with the mutation asserted to have landed first.
- `docs/notes/sentry-triage-pipeline.md` said ingest "finds old issues only through `is:regressed`" — true when written, wrong after this. Corrected in the same PR.

One thing worth flagging for the reviewer: an existing guard caught a comment of mine containing the phrase `from "nothing escalated"`, which the workflow-runtime import scanner read as an import specifier. Reworded. The guard was right.

Refs #1765, #1371, #1692, #1693, #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sentry ingest fetch/merge behavior that drives reopen decisions for archived issues. Scope is additive and well-tested, but a wrong query set could still miss or mishandle live issues.
> 
> **Overview**
> **Fixes a blind spot** where pipeline-archived issues that Sentry later escalates never entered ingest's fetch set.
> 
> Ingest now also queries `is:unresolved is:escalating` alongside the existing new/regressed queries, and merges both into the same reopen-candidate set (still surfaced as `isRegressed` for `decideDedupAction`). The queries stay separate on purpose — a boolean OR would fail silently if unsupported.
> 
> `defaultFetchMergedSentryIssues` is exported and accepts an injectable `fetchImpl` so tests can cover the query set. Docs and fetch-to-decision tests are updated for #1765.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b73b7b8608c9f9e39c3d7947f98e7d5b10fa9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->