### PR TITLE
refactor(ci): relocate and narrow the Sentry CI-coverage checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,11 +245,8 @@ jobs:
             rootScripts:
               # `scripts/**` matches every path under scripts/ at any depth,
               # including the extensionless directory symlinks the extension
-              # globs below miss. A Sentry suite reachable only through such a
-              # symlink is one check-sentry-suites-in-ci enumerates (it follows
-              # the link), so its addition must run this job or the suite ships
-              # unwired behind a skipped job (Codex 3754355168). The extension
-              # globs stay to document the common cases this filter targets.
+              # globs below miss. The extension globs stay to document the
+              # common cases this filter targets.
               - scripts/**
               - scripts/**/*.mjs
               - scripts/**/*.cjs
@@ -290,17 +287,14 @@ jobs:
               # Notifier coverage check re-runs when any workflow changes —
               # a new workflow with push-main or schedule must be caught even
               # if only the new workflow file is touched (no script change).
-              # Two further suites in this job read workflow files rather than
-              # scripts: check-autofix-ci-trust.mjs scans every workflow for
-              # PR-reachable secrets, and sentry-mcp-broker.test.mjs parses
-              # sentry-triage-agent.yml. Narrowing this glob would let a
-              # workflow-only edit skip the suites that exist to guard it.
+              # check-autofix-ci-trust.mjs also reads workflow files rather than
+              # scripts, scanning every one for PR-reachable secrets. Narrowing
+              # this glob would let a workflow-only edit skip the checks that
+              # exist to guard it.
               - .github/workflows/**
-              # check-sentry-suites-in-ci recurses into the composite actions
-              # the trusted jobs pull in, scanning each action.yml for a
-              # `$GITHUB_ENV` write that would neuter the Sentry suites. An edit
-              # to any local action must re-run it, so this covers all of them,
-              # not only pnpm-install.
+              # Local composite actions feed this job's steps — the install
+              # action and the ESLint-baseline resolver below. An edit to any of
+              # them must re-run it, so this covers all of them.
               - .github/actions/**
               # The baseline-resolve composite exports ESLINT_BASELINE_MAIN,
               # consumed by scripts/eslint-baseline-diff.mjs — the scripts
@@ -981,23 +975,22 @@ jobs:
         #
         #   INSTALL — `pnpm install` runs the root lifecycle hooks (postinstall
         #   and friends). A package-only PR could add a `postinstall` that
-        #   truncates the Sentry suites and this validator, false-greening the
-        #   direct `node <suite>` steps and the coverage assertion (Codex
-        #   3754887736). Validating first rejects any unsanctioned hook before
-        #   install would execute it. `--ignore-scripts` is NOT used because the
-        #   sanctioned `postinstall` builds @mento-protocol/config, whose dist the
+        #   truncates this validator and the suites below it (Codex 3754887736).
+        #   Validating first rejects any unsanctioned hook before install would
+        #   execute it. `--ignore-scripts` is NOT used because the sanctioned
+        #   `postinstall` builds @mento-protocol/config, whose dist the
         #   `Peg registry integrity` step below imports; this is the fail-close
         #   route that finding calls for instead. The validator needs only Node's
         #   built-in `fs`, so it runs before setup-node like the terraform job's
         #   pre-install `node` step.
         #
-        #   RUN — this job still invokes trusted aliases directly (`pnpm
-        #   lint:scripts`, `pnpm agent:quality-gate:test`, the `docs:*` and
-        #   `agent:context-*` suites); the pin validator keeps that trust safe by
-        #   rejecting a drifted command (e.g. an appended `&& <command>`) before
-        #   it executes. The Sentry suites no longer route through pnpm — they run
-        #   as direct `node <suite>` commands below — so this step no longer
-        #   guards them. check-sentry-suites-in-ci.test.mjs pins this ordering.
+        #   RUN — this job invokes trusted aliases directly (`pnpm lint:scripts`,
+        #   `pnpm agent:quality-gate:test`, the `docs:*` and `agent:context-*`
+        #   suites); the pin validator keeps that trust safe by rejecting a
+        #   drifted command (e.g. an appended `&& <command>`) before it executes.
+        #   check-sentry-suites-in-ci.test.mjs pins this ordering, because the
+        #   `sentry:*` aliases the local quality gate trusts are pinned by the
+        #   same validator.
         run: bash scripts/check-agent-quality-gate-package-scripts.sh
       - uses: ./.github/actions/pnpm-install
       - name: ESLint root scripts
@@ -1112,93 +1105,17 @@ jobs:
         # (issue #1564): ok/drift/malformed classification + CLI exit codes for
         # the daily "default workflow-token permission stays read-only" check.
         run: node scripts/check-workflow-permissions-drift.test.mjs
-      - name: Sentry needs-human brief suite
-        # Behavioral coverage of scripts/sentry-triage-brief.mjs (issue #1748,
-        # redesigned #1769): the rendered brief's fixed order and neutralization,
-        # the updated-in-place COMMENT lifecycle (created on needs-human, updated
-        # on re-triage, deleted on any other verdict), and — the part only a test
-        # can hold — that the leg NEVER writes the stub body, so it cannot drop
-        # the archive freshness baseline in the archive's unlabeled settlement
-        # window. It also asserts the prompt, the pipeline note and the triage
-        # workflow still agree with the contract it renders.
-        #
-        # Invoked as a DIRECT `node scripts/<suite>` (not `pnpm sentry:brief:test`):
-        # scripts/check-sentry-suites-in-ci.test.mjs (issue #1721) rejects the
-        # pnpm-alias form for every Sentry suite because a `scriptShell` override
-        # or a `presentry:*:test` lifecycle hook can false-green or empty it.
-        run: node scripts/sentry-triage-brief.test.mjs
       - name: Override prune report self-tests
         # Behavioral coverage of scripts/override-prune-report.mjs (verdict
         # heuristic, lockfile parsing, git-blame age check). The report
         # itself only runs weekly via supply-chain.yml; this required job is
         # what catches a regression in the script on every PR.
         run: node scripts/override-prune-report.test.mjs
-      # ── Sentry triage and autofix suites (issue #1721) ──────────────────────
-      # These guard the machine-authored triage and autofix legs: queue
-      # transitions, digest and projection shape, autofix selection and
-      # finalize, archive, the credential broker, and the re-queue chokepoint.
-      # Until this block existed they ran only in the local pre-push hook, so a
-      # contributor who bypassed the hook could merge a regression in any of
-      # them. One step per suite: a red check names the leg that broke.
-      #
-      # Each suite is invoked DIRECTLY as `node scripts/<suite>`, not through a
-      # `pnpm <alias>` — the exact command each `sentry:*:test` alias expands to.
-      # The pnpm-run path carried two config-level fail-opens: a `scriptShell:
-      # /bin/true` in pnpm-workspace.yaml false-greens every alias (Codex
-      # 3754704267), and a `presentry:*:test` lifecycle hook runs before the
-      # alias and can empty a suite (Codex 3754704278). A direct node command
-      # consults neither knob, so removing the indirection closes both — see
-      # scripts/check-sentry-suites-in-ci.test.mjs, which now requires the
-      # direct form and rejects a step that reverts to an alias.
-      - name: Sentry triage ingest suite
-        run: node scripts/sentry-triage-ingest.test.mjs
-      - name: Sentry triage digest suite
-        run: node scripts/sentry-triage-digest.test.mjs
-      - name: Sentry triage projection suite
-        run: node scripts/sentry-triage-project.test.mjs
-      - name: Sentry autofix select suite
-        run: node scripts/sentry-autofix-select.test.mjs
-      - name: Sentry autofix finalize suite
-        run: node scripts/sentry-autofix-finalize.test.mjs
-      - name: Sentry triage archive suite
-        run: node scripts/sentry-triage-archive.test.mjs
-      - name: Sentry credential broker suite
-        # Also parses .github/workflows/sentry-triage-agent.yml (token
-        # placement, the --mcp-config shape, the single port literal). The
-        # rootScripts filter already covers .github/workflows/**, so a
-        # workflow-only edit still reaches this step.
-        run: node --test scripts/sentry-mcp-broker.test.mjs
-      - name: Sentry re-queue chokepoint suite
-        run: node scripts/sentry-triage-requeue.test.mjs
-      - name: Sentry triage agent comment suite
-        # Invoked by path, the way every suite above now is.
-        run: node scripts/sentry-triage-agent-comment.test.mjs
-      - name: Sentry-suite gate self-test
-        # scripts/sentry-suite-gate.test.mjs is a scripts/sentry-*.test.mjs, so
-        # check-sentry-suites-in-ci.test.mjs (issue #1721) requires THIS job to
-        # invoke it directly. The new unconditional `sentry-suites` job also runs
-        # it — the gate enumerates and runs its own suite — so the run is
-        # redundant until PR C removes the duplicated suite steps from this job.
-        # See issue #1779 and ADR 0062.
-        run: node scripts/sentry-suite-gate.test.mjs
-      - name: Sentry-suite gate integrity self-test
-        # The gate's integrity half (digest verification, watch-set derivation,
-        # step-summary isolation), split out when its sibling crossed the
-        # 1,000-line cap. Also a scripts/sentry-*.test.mjs, so the same #1721
-        # coverage rule requires a direct invocation here.
-        run: node scripts/sentry-suite-gate-integrity.test.mjs
-      - name: Sentry-suite gate isolation self-test
-        # The gate's isolation half (per-suite snapshots, sibling-snapshot and
-        # shared-checkout tampering), split out when the integrity file reached
-        # the 1,000-line cap in turn. Also a scripts/sentry-*.test.mjs, so the
-        # same #1721 coverage rule requires a direct invocation here.
-        run: node scripts/sentry-suite-gate-isolation.test.mjs
-      - name: Sentry suite CI coverage assertion
-        # The meta-check that keeps this gap from recurring: every
-        # scripts/sentry-*.test.mjs must be invoked by this job as a direct
-        # `node <suite>` command (never a pnpm alias), and the local gate's
-        # tooling allowlist must list every sentry:* script it still runs.
-        run: node scripts/check-sentry-suites-in-ci.test.mjs
+      # The Sentry suites used to run here, one step each (issue #1721). They
+      # now run in the unconditional `sentry-suites` job, which also proves from
+      # their own output that each one asserted (issue #1779, ADR 0062) — a
+      # strictly stronger claim than a step existing. Running them in both jobs
+      # cost a second copy of the whole set and let the two paths disagree.
       - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
         if: always()
 
@@ -1232,14 +1149,14 @@ jobs:
     # The step list is closed-world and its order is load-bearing. The two
     # upstream, SHA-pinned actions are the only things trusted before the gate.
     # `scripts/sentry-suite-gate.mjs` is the FIRST and ONLY PR-authored code that
-    # runs before the suites: there is deliberately no `pnpm install` (its
-    # composite action's postinstall is PR-authored code that would run first)
-    # and no other pre-suite step, which closes the R1 window where such a step
-    # could append `NODE_OPTIONS=--import=…process.exit(0)` to $GITHUB_ENV and
-    # neuter every later suite into a false-green no-op. The gate and every
-    # scripts/sentry-*.mjs it spawns import only `node:` builtins, so no install
-    # is needed. `env -u NODE_OPTIONS` strips a poisoned value from the gate's
-    # own env for defense in depth; the gate additionally refuses to start if
+    # runs before the suites: `pnpm install` is deliberately ordered AFTER it
+    # (the composite action's postinstall is PR-authored code) and there is no
+    # other pre-gate step, which closes the R1 window where such a step could
+    # append `NODE_OPTIONS=--import=…process.exit(0)` to $GITHUB_ENV and neuter
+    # every later suite into a false-green no-op. The gate and every
+    # scripts/sentry-*.mjs it spawns import only `node:` builtins, so it needs no
+    # install. `env -u NODE_OPTIONS` strips a poisoned value from the gate's own
+    # env for defense in depth; the gate additionally refuses to start if
     # NODE_OPTIONS or NODE_PATH is set and re-strips both per spawned suite.
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1254,6 +1171,21 @@ jobs:
           node-version-file: .node-version
       - name: Run and assert the Sentry suites
         run: /usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs
+      # Steps 4-5 run AFTER the gate, and only after it. The install's composite
+      # `postinstall` is PR-authored code, so putting it first would restore the
+      # R1 window the job exists to close; ordering it here keeps that window
+      # shut and still gives the checker the `js-yaml` it needs.
+      - uses: ./.github/actions/pnpm-install
+      - name: Sentry CI wiring assertion
+        # The static half of the pair (issue #1721, relocated by #1779 PR C).
+        # The gate above proves the suites ran; it cannot prove its own job still
+        # exists, is unconditional, and still reaches the required `ci` context —
+        # so this pins that, re-proves the one suite the gate does not run
+        # (sentry-provider-contract, via `pnpm tf:test`), and holds the local
+        # gate's `sentry:*` allowlist to its pins. It ran in the path-gated
+        # `scripts` job until this PR, where a dashboard-only, indexer-only or
+        # non-Markdown doc-asset diff skipped it entirely.
+        run: node scripts/check-sentry-suites-in-ci.test.mjs
 
   autoreview-suite:
     name: Autoreview adversarial suite

--- a/docs/adr/0062-sentry-suites-self-run-gate.md
+++ b/docs/adr/0062-sentry-suites-self-run-gate.md
@@ -3,7 +3,7 @@ title: An unconditional gate job runs the Sentry suites and proves from their ou
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-12
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -28,9 +28,10 @@ and both are structural rather than fixable by more static analysis.
 composite `action.yml` files. It never opens the content of a script a step
 invokes. A trusted step `run: bash x.sh` whose script appends
 `NODE_OPTIONS=--import=…` to `$GITHUB_ENV` neuters every later suite in the same
-job into a false-green no-op. The vector is live today: the `scripts` job's first
-PR-authored step is `run: bash scripts/check-agent-quality-gate-package-scripts.sh`,
-which executes before all ten suites. Reading invoked-script content is not a
+job into a false-green no-op. The vector was live when this was written: the
+`scripts` job's first PR-authored step was
+`run: bash scripts/check-agent-quality-gate-package-scripts.sh`, which executed
+before all ten suites it then held. Reading invoked-script content is not a
 fix — it false-positives on every legitimate script and regresses infinitely
 through whatever those scripts invoke.
 
@@ -58,19 +59,18 @@ its `allowed-skips` — the treatment `production-infra-contract` already gets.
 
 The job's step list is closed-world and its order is load-bearing:
 
-| #   | Step                                                                                | Why it is where it is                                                                                              | Lands in  |
-| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
-| 1   | `actions/checkout` (SHA-pinned, `persist-credentials: false`)                       | Upstream, one of exactly two non-PR-authored things trusted before the suites                                      | this PR   |
-| 2   | `actions/setup-node` (SHA-pinned, `node-version-file: .node-version`)               | Same                                                                                                               | this PR   |
-| 3   | `run: /usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs` | The first and only PR-authored code before the suites; strips both vars, symmetric with the gate's per-child spawn | this PR   |
-| 4   | `uses: ./.github/actions/pnpm-install`                                              | After the suites, so its `postinstall` cannot reach them                                                           | follow-up |
-| 5   | `run: node scripts/check-sentry-suites-in-ci.test.mjs`                              | Needs `js-yaml`; after the suites for the same reason                                                              | follow-up |
+| #   | Step                                                                                | Why it is where it is                                                                                              | Lands in |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
+| 1   | `actions/checkout` (SHA-pinned, `persist-credentials: false`)                       | Upstream, one of exactly two non-PR-authored things trusted before the suites                                      | this PR  |
+| 2   | `actions/setup-node` (SHA-pinned, `node-version-file: .node-version`)               | Same                                                                                                               | this PR  |
+| 3   | `run: /usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs` | The first and only PR-authored code before the suites; strips both vars, symmetric with the gate's per-child spawn | this PR  |
+| 4   | `uses: ./.github/actions/pnpm-install`                                              | After the suites, so its `postinstall` cannot reach them                                                           | PR C     |
+| 5   | `run: node scripts/check-sentry-suites-in-ci.test.mjs`                              | Needs `js-yaml`; after the suites for the same reason                                                              | PR C     |
 
-Steps 1-3 are the security-critical core and land here: no PR-authored step runs
-before the gate, so the R1 window is closed. The static checker keeps running in
-the path-gated `scripts` job until the follow-up PR relocates it into steps 4-5
-and removes the now-duplicated suite steps; redundant runs until then break
-nothing that was green.
+Steps 1-3 are the security-critical core: no PR-authored step runs before the
+gate, so the R1 window is closed. Steps 4-5 landed in PR C, which also deleted
+the duplicated suite steps from the `scripts` job and narrowed the checker's
+charter — see "What PR C retired, and why" below.
 
 `scripts/sentry-suite-gate.mjs` is dependency-free, which is what makes step 3
 possible: every `scripts/sentry-*.mjs` imports only `node:` builtins, so running
@@ -107,9 +107,7 @@ route with its importer. Floors use `>=` semantics.
 
 `scripts/sentry-suite-gate.test.mjs` is the runner's own suite, named `sentry-*`
 so `findSentrySuites` enumerates it and the gate runs it — neutering the runner
-now also requires faking its own suite's count and per-case lines. Because it is
-enumerated, the still-in-place `scripts` job gains a direct step invoking it,
-which keeps the #1754 coverage checker green until that checker relocates.
+now also requires faking its own suite's count and per-case lines.
 
 **Each suite runs from its own immutable snapshot of the derived input set, all
 taken before the first child starts.** Without isolation an alphabetically
@@ -303,6 +301,63 @@ The gate cannot detect its own deletion, so the static checker carries that.
 `scripts/check-sentry-suites-in-ci-gate-job.test.mjs` pins the job. Without it
 every check in the repository stayed green with the whole job deleted.
 
+### What PR C retired, and why
+
+This ADR left the checker's narrowing open. PR C decided it per assertion. The
+rule applied: an assertion goes only when the runtime gate makes a strictly
+stronger claim about the same thing, or when its premise no longer exists.
+
+**Retired — "every suite is invoked by the `scripts` job as a direct
+`node <suite>`", with its pnpm-alias and `presentry:*:test` rejection probes.**
+The gate spawns each non-exempt suite itself, as a `node` child under `env -u`,
+from the manifest it reconciles by exact set equality, and asserts exit 0,
+`fail == 0`, `pass >= floor` and `pass ==` per-case lines. No pnpm alias is on
+that path for any non-exempt suite, so neither config-level fail-open the probes
+covered is reachable, and "a step exists" is strictly weaker than "the suite ran
+and asserted".
+
+**Retired — the whole `rootScripts` reachability proof**
+(`requiredPathsMissing`, `REQUIRED_ROOT_SCRIPT_PATHS`, `PROBE_INPUTS`,
+`dropFilterPath`, `globToRegExp` and the four tests over them). It existed only
+because the checker ran behind a paths filter: every file it read had to be
+routed, or an edit to that file skipped the job silently. The job it runs in now
+has no filter and no `if:`. Measured against the real filter with picomatch, the
+old arrangement skipped the checker for dashboard-only, indexer-only and
+non-Markdown doc-asset diffs; Markdown-only diffs did reach it, because the
+filter lists `**/*.md`.
+
+**Retired — "this check itself runs in the ci.yml `scripts` job".** The checker
+step is now inside `CANONICAL_JOB`, asserted by exact equality, which also
+rejects an appended `|| true`, an `if:`, a `working-directory:` and an `env:` on
+that step — none of which the whole-command probe saw.
+
+**Retired — the escaping-symlink rejection.** Its premise was that a suite
+behind a directory symlink the paths filter cannot resolve ships unwired behind
+a skipped job. The gate follows the same link, reconciles what it finds by set
+equality, and runs the suite, from a job that never skips.
+
+**Retired — `scripts` as a trusted job**, and `sentry-suites` deliberately not
+added in its place. `scripts` runs no Sentry code any more. `sentry-suites` is
+pinned key for key by `CANONICAL_JOB`, which rejects every construct
+`jobBlockers` looks for and everything it does not; its only local composite is
+`pnpm-install`, still scanned through `production-infra-contract`.
+
+**Kept.** The gate-job pin, because a runtime gate cannot detect its own
+deletion. The sentinel, trigger and check-run-ownership assertions, because a
+gate whose result never reaches the required `ci` context proves nothing. The
+exemption's CI half — the gate verifies the `via` alias's command, but only the
+checker verifies that an unconditional job runs it. The env-mutation and
+composite scan on `production-infra-contract`, whose install runs before the one
+suite the gate does not. The alias-resolution and local-allowlist invariants and
+the pin-validator ordering, which are outside the gate's world entirely.
+
+**Residual PR C accepts.** The checker now runs after a PR-authored
+`postinstall`. A `$GITHUB_ENV` `NODE_OPTIONS` poison written there silences the
+checker, and the static composite scan cannot report a write that silences its
+own detector. The gate runs before that install and is unaffected, which is the
+whole reason for the ordering: the gate is the security-critical half, the
+checker is the drift net.
+
 **Both pins are allowlists, not blocklists, and that is load-bearing.** The job
 is asserted by exact equality against a canonical structure — the exact set of
 job-level keys, the exact number and order of steps, and per step the exact key
@@ -348,22 +403,21 @@ reshaped several suites.
    `scripts/sentry-triage-project.test.mjs` to the end of the file (reported
    count 110 → 112). Without it the gate's `pass == per-case-line` check reds on
    that suite, so it is a prerequisite of this PR, not part of it.
-1. **This PR (B).** Add the manifest, `scripts/sentry-suite-gate.mjs`, its own
+1. **PR B (merged).** Add the manifest, `scripts/sentry-suite-gate.mjs`, its own
    suite, and the unconditional `sentry-suites` job wired into `ci.needs` and out
    of `allowed-skips`; add a direct step to the `scripts` job invoking the gate's
-   own suite so the #1754 coverage checker stays green. The suites briefly run in
-   both jobs, so a mistake reds nothing that was green. The structural pin on the
+   own suite so the #1754 coverage checker stays green. The suites briefly ran in
+   both jobs, so a mistake could not red anything already green. The pin on the
    gate job ships here too, in the existing checker
    (`check-sentry-suites-in-ci-gate-job.test.mjs`) — deferring it would have left
    a window where deleting the job was green, which is the exact false-green the
    job exists to close. The local quality gate routes the gate for every
    manifest-owned suite, since editing any of them moves that suite's pass count
    against its committed floor.
-2. **PR C.** Delete the suite steps and the checker step from `scripts`;
-   relocate the #1754 checker into the gate job after `pnpm-install` (steps 4-5
-   above) and narrow its charter to the gate's shape; update
-   `docs/notes/agent-quality-gate-mechanics.md`. The gate-job pin moves with the
-   checker rather than being written there.
+2. **This PR (C).** Deletes the suite steps and the checker step from
+   `scripts`; relocates the #1754 checker into the gate job after
+   `pnpm-install` (steps 4-5 above) and narrows its charter to the gate's shape,
+   recorded above.
 3. **PR D.** Gate-probe robustness pass, with the manifest as the single source
    for `sentry:*` alias-to-suite resolution.
 4. **Operator, out of repo.** Add `Sentry suites` to the branch ruleset's

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1146,14 +1146,13 @@ permission or the environment-secret writes 403 (`terraform/providers.tf`).
 
 ## Verification
 
-These checks are offline unless noted. CI runs all of them in the required
-`Lint + test root scripts` job, one step per suite, so a red check names the leg
-that broke; `scripts/check-sentry-suites-in-ci.test.mjs` fails if a new suite
-lands without a step there.
+These checks are offline unless noted. CI runs all of them in the required,
+unconditional `Sentry suites` job — one gate step, which names the suite that
+broke in its summary table.
 
-An unconditional `sentry-suites` job (no `if:`, in `ci.needs` and absent from
-`alls-green` `allowed-skips`, so it can never be skipped) also runs the suites
-and proves they ran (ADR 0062). It executes `node scripts/sentry-suite-gate.mjs`,
+That job (no `if:`, in `ci.needs` and absent from `alls-green` `allowed-skips`,
+so it can never be skipped) runs the suites and proves they ran (ADR 0062). It
+executes `node scripts/sentry-suite-gate.mjs`,
 which reconciles the `scripts/sentry-*.test.mjs` files against
 `scripts/sentry-suite-manifest.json` by exact set equality (in both directions)
 and, for each non-exempt suite, asserts child exit 0, parsed `fail == 0`, parsed
@@ -1175,48 +1174,40 @@ without declaring is absent from its snapshot, so the suite fails — which is w
 keeps those lists honest. Each snapshot is digested when taken and re-verified
 immediately before its child runs, and the shared checkout is swept afterwards,
 so a suite that writes there is named even though it can no longer change a
-verdict. The per-suite steps in `Lint + test root scripts` and the
-`check-sentry-suites-in-ci` checker stay in place; both jobs run the suites for
-now.
+verdict.
 
-That check parses ci.yml rather than searching it, so a step only counts when
-it runs the suite as its whole command. Adding an `if:`, a
-`continue-on-error:`, a `working-directory:`, an `env:`, a `|| true`, or an
-extra argument makes the step stop counting, and the failure names which one.
+`scripts/check-sentry-suites-in-ci.test.mjs` is the gate's static half and runs
+as the last step of the same job, after the install it needs for `js-yaml`. It
+carries what the gate cannot see: that the gate job still exists, is
+unconditional, matches ADR 0062's canonical shape key for key, and reaches the
+required `ci` context; that the one suite the gate does not run
+(`sentry-provider-contract.test.mjs`, imported by `tf-stacks.test.mjs`) really
+is run by the unconditional `production-infra-contract` job; and that the local
+quality gate's `sentry:*` allowlist stays pinned to exact commands. It parses
+ci.yml rather than searching it, and compares the job by exact equality, so an
+`if:`, a `continue-on-error:`, a `working-directory:`, an `env:`, a `|| true`, a
+reordered step or a key nobody has thought of all fail it by name.
 
-The CI step for each Sentry suite is a DIRECT `node scripts/<file>` invocation
-(`node --test scripts/<file>` for the broker), never a `pnpm <alias>`. The
-pnpm-run path carries two config-level fail-opens a parser cannot see — a
-`scriptShell` override false-greens the alias, and a `presentry:*:test`
-lifecycle hook runs before it and can empty the suite — so the checker rejects an
-alias-based Sentry step and requires the direct form. Reproduce the CI steps
-with:
+Issue #1779 PR C moved that checker out of the path-gated
+`Lint + test root scripts` job, where a diff touching only the dashboard, the
+indexer or a non-Markdown doc asset skipped it, and dropped the per-suite steps
+that job used to duplicate. Reproduce the whole CI job with:
 
 ```bash
-node scripts/sentry-triage-ingest.test.mjs
-node scripts/sentry-triage-digest.test.mjs
-node scripts/sentry-triage-project.test.mjs
-node scripts/sentry-triage-brief.test.mjs
-node scripts/sentry-autofix-select.test.mjs
-node scripts/sentry-autofix-finalize.test.mjs
-node scripts/sentry-triage-archive.test.mjs
-node --test scripts/sentry-mcp-broker.test.mjs
-node scripts/sentry-triage-requeue.test.mjs
-node scripts/sentry-triage-agent-comment.test.mjs
-node scripts/check-sentry-suites-in-ci.test.mjs
-# The self-run gate's own three suites (each a scripts/sentry-*.test.mjs), then
-# the gate itself, which runs every suite above and asserts each one actually
-# ran. The `env -u` prefix matches the CI step and is what lets these run under
-# an ambient NODE_OPTIONS — without it the gate refuses to start by design:
-/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.test.mjs
-/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate-integrity.test.mjs
-/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate-isolation.test.mjs
+# The gate, which runs every scripts/sentry-*.test.mjs and asserts each one
+# actually ran. The `env -u` prefix matches the CI step and is what lets it run
+# under an ambient NODE_OPTIONS — without it the gate refuses to start by design:
 /usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs
+node scripts/check-sentry-suites-in-ci.test.mjs
 ```
 
+To run one suite on its own — the gate names the file it failed on — invoke it
+by path, e.g. `node scripts/sentry-triage-ingest.test.mjs` or
+`node --test scripts/sentry-mcp-broker.test.mjs`.
+
 The `pnpm sentry:*:test` aliases still run these suites for interactive use and
-in the local pre-push gate; CI's direct invocation is the backstop, and the pin
-validator keeps the aliases the gate trusts safe.
+in the local pre-push gate; the CI gate is the backstop, and the pin validator
+keeps the aliases the local gate trusts safe.
 
 ```bash
 # Read-only previews that require local credentials:

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1573,15 +1573,18 @@ compact_turbo_quality_commands() {
 }
 
 # Directory symlinks under scripts/ expose Sentry suites whose real files live
-# OUTSIDE scripts/. findSentrySuites (in check-sentry-suites-in-ci.test.mjs)
-# follows such a link and enumerates scripts/<link>/sentry-*.test.mjs, but the
-# real file's committed path is the symlink TARGET (e.g. fixtures/sentry-x.test.mjs)
-# — which matches neither scripts/* nor the CI rootScripts filter. Adding a suite
-# under a PREVIOUSLY committed link therefore changes neither the link nor any
-# scripts/** path, so both this gate and the path-gated CI job would skip the
-# coverage check while the check itself would demand that suite (Codex 3754704280).
+# OUTSIDE scripts/. Both enumerators — findSentrySuites in the CI-coverage
+# checker, and the gate's own walker — follow such a link and enumerate
+# scripts/<link>/sentry-*.test.mjs, but the real file's committed path is the
+# symlink TARGET (e.g. fixtures/sentry-x.test.mjs), which matches neither
+# scripts/* nor the CI rootScripts filter. Adding a suite under a PREVIOUSLY
+# committed link therefore changes neither the link nor any scripts/** path, so
+# this gate would skip both checks while the suite ships without the manifest
+# entry the CI gate demands (Codex 3754704280, 3766397748). CI itself is now
+# covered — the `sentry-suites` job is unconditional — so this is about the local
+# gate reporting green on a change only CI would catch.
 # Resolve every existing scripts/ directory symlink to its repo-relative target
-# once, so the per-path loop below can route the check for a change beneath a
+# once, so the per-path loop below can route both checks for a change beneath a
 # target too. Guarded, like the routing that consumes it, so the gate's own unit
 # tests (run against stub fixture repos) are unaffected.
 scripts_symlink_targets=()
@@ -1600,6 +1603,20 @@ if [[ "$script_source_dir" == "$repo_root/scripts" && -d "$repo_root/scripts" ]]
     esac
   done < <(find "$repo_root/scripts" -type l 2>/dev/null || true)
 fi
+
+# The self-run Sentry-suite gate pair (#1779, ADR 0062), scheduled from one
+# place because four verbatim copies of these command strings are four places to
+# drift — `add_command` deduplicates on the exact string, so a copy that falls
+# out of step silently schedules a second, different command instead of failing.
+# Neither command substitutes for the other: the self-test proves the gate's
+# logic against throwaway fixture manifests in a temp dir and never reads the
+# committed one, while only the real gate reconciles that manifest against the
+# real suites. Both carry the CI entry point's `env -u` prefix so a developer
+# with an ambient NODE_OPTIONS can run them at all.
+add_sentry_suite_gate_commands() {
+  add_command "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.test.mjs" "$1"
+  add_command "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs" "$1 (validate the committed manifest against the real suites)"
+}
 
 while IFS= read -r path; do
   case "$path" in
@@ -2737,33 +2754,45 @@ while IFS= read -r path; do
         scripts/static-imports.mjs | \
         scripts/check-sentry-suites-in-ci-core-commands.mjs | \
         scripts/sentry-suite-manifest.json)
-        add_command "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.test.mjs" "Sentry-suite gate, manifest, or a manifest-owned suite changed"
-        add_command "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs" "Sentry-suite gate, manifest, or a manifest-owned suite changed (validate the committed manifest against the real suites)"
+        add_sentry_suite_gate_commands "Sentry-suite gate, manifest, or a manifest-owned suite changed"
         ;;
     esac
     # A directory symlink under scripts/ exposes suites the extension patterns
     # above (and the CI `rootScripts` filter) never see: `findSentrySuites`
     # follows the link and enumerates `scripts/<link>/sentry-*.test.mjs`, but the
     # changed paths are the extensionless link itself and its target outside
-    # scripts/, matching neither. Route the check for ANY symlink under scripts/
-    # so the suite it exposes is proven wired rather than silently skipped (Codex
-    # 3754355168). `-L` reads the working tree, matching what the check walks.
+    # scripts/, matching neither. Route BOTH Sentry checks for ANY symlink under
+    # scripts/ so the suite it exposes is proven wired rather than silently
+    # skipped (Codex 3754355168). `-L` reads the working tree, matching what both
+    # enumerators walk.
+    #
+    # The gate pair is what makes this arm load-bearing now. Until #1779 PR C the
+    # checker demanded a direct CI step for every enumerated suite, so it red on
+    # its own; PR C retired that assertion because the unconditional CI gate runs
+    # each suite instead — but the gate is a DIFFERENT command, and this arm was
+    # still scheduling only the checker. A suite added beneath such a link then
+    # left the checker green while the missing manifest entry reds only after
+    # push (Codex 3766397748). Coverage moved jobs; the routing has to move with
+    # it.
     case "$path" in
       scripts/*)
         if [[ -L "$repo_root/$path" ]]; then
           add_command "node scripts/check-sentry-suites-in-ci.test.mjs" "symlink under scripts/ can expose an unwired Sentry suite"
+          add_sentry_suite_gate_commands "symlink under scripts/ can expose an unwired Sentry suite"
         fi
         ;;
     esac
     # The mirror case: a change BENEATH an existing scripts/ directory symlink's
     # real target (resolved once, above). Such a path is a suite findSentrySuites
-    # enumerates through the link, yet it matches neither scripts/* above nor the
-    # rootScripts CI filter — so without this the check would skip while still
-    # demanding the suite (Codex 3754704280).
+    # and the gate's enumerator both reach through the link, yet it matches
+    # neither scripts/* above nor the rootScripts CI filter — so without this the
+    # local gate would skip both checks while the suite goes unwired (Codex
+    # 3754704280, 3766397748).
     for scripts_symlink_target in "${scripts_symlink_targets[@]+"${scripts_symlink_targets[@]}"}"; do
       case "$path" in
         "$scripts_symlink_target"/*)
           add_command "node scripts/check-sentry-suites-in-ci.test.mjs" "change beneath a scripts/ symlink target can expose an unwired Sentry suite"
+          add_sentry_suite_gate_commands "change beneath a scripts/ symlink target can expose an unwired Sentry suite"
           break
           ;;
       esac

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3912,28 +3912,44 @@ assert_contains "$sentry_ci_check"
 run_gate "scripts/sentry-not-yet-written.test.mjs"
 assert_contains "$sentry_ci_check"
 
-# A directory symlink under scripts/ routes the check even though its path is
-# extensionless and matches none of the suite globs: findSentrySuites follows
-# the link, so the check must run to enumerate any suite behind it (Codex
-# 3754355168). Needs a real symlink in the tree because the gate reads `-L`.
+# A directory symlink under scripts/ routes both Sentry checks even though its
+# path is extensionless and matches none of the suite globs: findSentrySuites and
+# the gate's own enumerator each follow the link, so both must run to reach any
+# suite behind it (Codex 3754355168). Needs a real symlink in the tree because
+# the gate reads `-L`.
+#
+# The GATE assertions are what this arm now turns on. #1779 PR C retired the
+# checker's demand for a direct CI step per suite — the unconditional CI gate
+# runs the suites instead — so the checker alone exits 0 on a suite exposed here
+# and only the manifest reconciliation reds. Measured on this branch before the
+# fix: with a link whose target held an unwired suite, `node
+# scripts/check-sentry-suites-in-ci.test.mjs` exited 0 while `node
+# scripts/sentry-suite-gate.mjs` exited 1 naming the missing manifest entry, and
+# this arm scheduled only the former (Codex 3766397748).
 symlink_target="$(mktemp -d)"
 ln -sfn "$symlink_target" "$sentry_symlink_probe"
 run_gate "$sentry_symlink_probe"
-assert_contains "- node scripts/check-sentry-suites-in-ci.test.mjs (symlink under scripts/ can expose an unwired Sentry suite)"
+sentry_symlink_reason="symlink under scripts/ can expose an unwired Sentry suite"
+assert_contains "- node scripts/check-sentry-suites-in-ci.test.mjs ($sentry_symlink_reason)"
+assert_contains "- $sentry_gate_env node scripts/sentry-suite-gate.test.mjs ($sentry_symlink_reason)"
+assert_contains "- $sentry_gate_env node scripts/sentry-suite-gate.mjs ($sentry_symlink_reason (validate the committed manifest against the real suites))"
 rm -f "$sentry_symlink_probe"
 rm -rf "$symlink_target"
 
 # The mirror case: a change BENEATH an existing scripts/ directory symlink's real
-# TARGET routes the check too. findSentrySuites follows the committed link and
-# would demand a suite added under the target, yet that path matches neither
-# scripts/* nor the rootScripts filter — so both this gate and CI would skip
-# without this routing (Codex 3754704280). Needs a real link to a repo-relative
+# TARGET routes both checks too. Both enumerators follow the committed link and
+# reach a suite added under the target, yet that path matches neither scripts/*
+# nor the rootScripts filter — so this gate would skip it entirely without this
+# routing (Codex 3754704280, 3766397748). Needs a real link to a repo-relative
 # directory because the gate resolves the target with `pwd -P`. The changed path
 # under the target need not exist; only the link and its target must.
 mkdir -p "$sentry_symlink_target_dir"
 ln -sfn "../$sentry_symlink_target_dir" "$sentry_symlink_to_target"
 run_gate "$sentry_symlink_target_dir/sentry-new.test.mjs"
-assert_contains "- node scripts/check-sentry-suites-in-ci.test.mjs (change beneath a scripts/ symlink target can expose an unwired Sentry suite)"
+sentry_symlink_target_reason="change beneath a scripts/ symlink target can expose an unwired Sentry suite"
+assert_contains "- node scripts/check-sentry-suites-in-ci.test.mjs ($sentry_symlink_target_reason)"
+assert_contains "- $sentry_gate_env node scripts/sentry-suite-gate.test.mjs ($sentry_symlink_target_reason)"
+assert_contains "- $sentry_gate_env node scripts/sentry-suite-gate.mjs ($sentry_symlink_target_reason (validate the committed manifest against the real suites))"
 rm -f "$sentry_symlink_to_target"
 rm -rf "$sentry_symlink_target_dir"
 

--- a/scripts/check-sentry-suites-in-ci-core.mjs
+++ b/scripts/check-sentry-suites-in-ci-core.mjs
@@ -13,7 +13,6 @@
  */
 
 import assert from "node:assert/strict";
-import { CORE_SCHEMA, load } from "js-yaml";
 import {
   isCommand,
   parseShellScript,
@@ -41,39 +40,6 @@ const PROVEN_INERT_ENV = new Set();
 /** @param {unknown} value */
 export function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-/**
- * A paths-filter glob as a regular expression. Only the four forms this repo's
- * filter uses need to be right — `**` across directories, `*` within one, and
- * literal names — so this is a coverage check on our own constant, not a
- * general glob engine.
- *
- * @param {string} glob
- */
-export function globToRegExp(glob) {
-  let pattern = "";
-  for (let i = 0; i < glob.length; i += 1) {
-    const character = glob[i];
-    if (character === "*") {
-      if (glob[i + 1] === "*" && glob[i + 2] === "/") {
-        pattern += "(?:[^/]*/)*";
-        i += 2;
-      } else if (glob[i + 1] === "*") {
-        pattern += ".*";
-        i += 1;
-      } else {
-        pattern += "[^/]*";
-      }
-    } else if (character === "?") {
-      pattern += "[^/]";
-    } else if (/[.+^${}()|[\]\\]/.test(character)) {
-      pattern += `\\${character}`;
-    } else {
-      pattern += character;
-    }
-  }
-  return new RegExp(`^${pattern}$`);
 }
 
 // ── ci.yml structure ─────────────────────────────────────────────────────────
@@ -828,129 +794,12 @@ export function triggerBlockers(workflow) {
   return blockers;
 }
 
-/**
- * Which of `required` the path filter behind `guard` no longer lists, or why
- * the chain from the guard to that filter could not be followed.
- *
- * Steps existing in a job is not enough. The `scripts` job is path-gated, and
- * the `ci` sentinel lists it under `allowed-skips`, so if the filter loses a
- * path, a PR touching only that path skips the whole job and every suite in it
- * — silently, and this file would not run to complain either.
- *
- * The whole chain is followed from the parsed workflow: the job's `if:` names
- * an output of a job, that output names a step, that step's `filters` value is
- * an inner YAML document, and the key it defines is a list of paths.
- *
- * @param {Record<string, any>} workflow
- * @param {string} guardedJob the job whose `if:` and `needs:` are judged
- * @param {string} guard the gated job's `if:` expression
- * @param {string[]} required
- */
-export function requiredPathsMissing(workflow, guardedJob, guard, required) {
-  const gate =
-    /^\s*(?:\$\{\{\s*)?needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*==\s*'true'\s*(?:\}\})?\s*$/.exec(
-      guard,
-    );
-  if (!gate) {
-    return [
-      `the \`${guardedJob}\` job guard \`${guard}\` is not a form this test can follow — extend the grammar and re-prove it`,
-    ];
-  }
-  const [, gateJob, outputName] = gate;
-
-  // The guard reads `needs.<gateJob>.outputs.…`, which is only populated when
-  // the guarded job actually lists `<gateJob>` in its own `needs`. Drop that
-  // edge and the context is empty, the guard is never `'true'`, and the job
-  // skips on EVERY PR — while the sentinel lists it under `allowed-skips`, so
-  // nothing reports the silence. Proving the filter still covers every input is
-  // moot unless the filter's output still reaches the job.
-  const guardedNeeds = needsList(ciJob(workflow, guardedJob).needs);
-  if (!guardedNeeds.includes(gateJob)) {
-    return [
-      `the \`${guardedJob}\` job's guard reads \`needs.${gateJob}.outputs.${outputName}\`, but ` +
-        `\`${guardedJob}.needs\` does not list \`${gateJob}\` (${JSON.stringify(guardedNeeds)}); the ` +
-        `\`needs.${gateJob}\` context is then empty, so the guard is never true and the job skips on every PR`,
-    ];
-  }
-
-  const producer = ciJob(workflow, gateJob);
-  const expression = producer.outputs?.[outputName];
-  if (typeof expression !== "string") {
-    return [
-      `the \`${gateJob}\` job declares no \`${outputName}\` output, so the \`scripts\` job's guard is never true`,
-    ];
-  }
-  const wired =
-    /^\$\{\{\s*steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*\}\}$/.exec(
-      expression.trim(),
-    );
-  if (!wired) {
-    return [
-      `\`${gateJob}.outputs.${outputName}\` is \`${expression}\`, which this test cannot trace to a step`,
-    ];
-  }
-  const [, stepId, filterKey] = wired;
-
-  const filterStep = (producer.steps ?? []).find(
-    (step) => isPlainObject(step) && step.id === stepId,
-  );
-  if (!filterStep) {
-    return [`the \`${gateJob}\` job has no step with \`id: ${stepId}\``];
-  }
-  if (
-    typeof filterStep.uses !== "string" ||
-    !filterStep.uses.startsWith("dorny/paths-filter@")
-  ) {
-    return [
-      `step \`${stepId}\` is \`${filterStep.uses}\`, not the paths filter this test knows how to read`,
-    ];
-  }
-  const stepIssues = stepBlockers(filterStep);
-  if (stepIssues.length > 0) {
-    return stepIssues.map(
-      (blocker) =>
-        `step \`${stepId}\` has ${blocker}, so \`${outputName}\` may be empty and the \`scripts\` job would skip`,
-    );
-  }
-  // `base:`/`ref:` change what the filter diffs against — `base: HEAD` reports
-  // no changed files and every output goes false. Only `filters:` is proven.
-  const inputs = Object.keys(filterStep.with ?? {});
-  if (inputs.length !== 1 || inputs[0] !== "filters") {
-    return [
-      `step \`${stepId}\` passes inputs beyond \`filters:\` (${JSON.stringify(inputs)}), which can change what it compares`,
-    ];
-  }
-
-  // The value is a YAML string that itself holds a YAML document.
-  const filters = load(filterStep.with?.filters, { schema: CORE_SCHEMA });
-  if (!isPlainObject(filters)) {
-    return [`step \`${stepId}\` has no parsable \`filters:\` document`];
-  }
-  const paths = filters[filterKey];
-  if (!Array.isArray(paths)) {
-    return [
-      `the \`${filterKey}\` filter is ${JSON.stringify(paths)}, not a list of paths`,
-    ];
-  }
-
-  // dorny/paths-filter globs may be negated with a leading `!`, and a negation
-  // cancels an earlier positive for the files it matches: `["scripts/**/*.mjs",
-  // "!scripts/**"]` still literally lists the required path, so `includes()`
-  // reads it as covered while edits under scripts/ no longer trigger the job.
-  // This repo's filters use positive rules only, so any `!` entry is rejected
-  // outright rather than matched against each required path.
-  const negated = paths.filter(
-    (entry) => typeof entry === "string" && entry.startsWith("!"),
-  );
-  if (negated.length > 0) {
-    return [
-      `the \`${filterKey}\` filter uses negative patterns ${JSON.stringify(negated)}, ` +
-        "which can cancel a required path even when it is listed",
-    ];
-  }
-
-  return required.filter((entry) => !paths.includes(entry));
-}
+// `requiredPathsMissing` — the guard → output → paths-filter chain walk — was
+// retired with the rest of the reachability proof in issue #1779 PR C. It
+// existed because this checker ran inside the path-gated `scripts` job, so a
+// filter that stopped routing one of its inputs skipped the job silently. The
+// checker now runs in the unconditional `sentry-suites` job, which has no
+// filter to follow.
 
 // The command-grammar and package.json-alias predicates were moved to
 // check-sentry-suites-in-ci-core-commands.mjs and re-exported at the top of

--- a/scripts/check-sentry-suites-in-ci-coverage.test.mjs
+++ b/scripts/check-sentry-suites-in-ci-coverage.test.mjs
@@ -1,18 +1,27 @@
 /**
- * The suite-coverage and package-script contracts behind
+ * The exemption route and the package-script contracts behind
  * scripts/check-sentry-suites-in-ci.test.mjs.
  *
  * Split out when the entry point reached the repo's 1,000-line hard cap (issue
- * #1803). A pure move: no case renamed, no assertion changed.
+ * #1803).
  *
- * This half asserts that every Sentry suite is actually RUN, and that the
- * commands proving it cannot be subverted through package.json — direct
- * `node <suite>` invocation rather than a `pnpm <alias>`, the alias and
- * lifecycle fail-opens that closes, the provider-contract exemption route, and
- * the local gate's tooling allowlist with its exact-command pins. The entry
- * point keeps the ci.yml workflow-shape assertions (trusted jobs, sentinel,
- * triggers, reachability, env mutation, composite recursion, check-run
- * ownership) and the self/meta checks.
+ * This half asserts the things about running the suites that the runtime gate
+ * cannot see: the provider-contract exemption's CI route (the gate checks the
+ * alias command, but never that a real, unconditional job runs it), that no
+ * `sentry:*:test` alias points somewhere unenumerated, and the local gate's
+ * tooling allowlist with its exact-command pins. The entry point keeps the
+ * ci.yml workflow-shape assertions (trusted job, sentinel, triggers, env
+ * mutation, composite recursion, check-run ownership) and the self/meta checks.
+ *
+ * Issue #1779 PR C retired what used to be this file's main invariant — that
+ * every suite has a direct `node <suite>` step in the `scripts` job, plus the
+ * pnpm-alias and `presentry:*:test` rejection probes behind it. The
+ * `sentry-suites` gate now runs each suite itself, as a `node` child under
+ * `env -u`, reconciled against the manifest by exact set equality, and asserts
+ * from the child's own output that it passed. No pnpm alias is on that path for
+ * any non-exempt suite, so neither fail-open the probes covered is reachable,
+ * and "a step exists" is a strictly weaker claim than "the suite ran and
+ * asserted".
  *
  * The entry point imports this module, so the single
  * `node scripts/check-sentry-suites-in-ci.test.mjs` CI step still runs it.
@@ -42,97 +51,6 @@ import {
   VALIDATOR_PATH,
   validatorPins,
 } from "./check-sentry-suites-in-ci-probes.mjs";
-
-/**
- * Is `file` run by the `scripts` job as a whole-command DIRECT node invocation
- * (`node <file>` or `node --test <file>`)? Shared by invariant 1 and its
- * rejection probe so both exercise the same rule: coverage is proven by the CI
- * command alone and never by a `pnpm <alias>`, the path a `scriptShell`
- * override or a `presentry:*:test` lifecycle hook subverts. It reads no
- * package.json alias, so neither knob can change the verdict.
- *
- * @param {Record<string, any>} workflow
- * @param {string} file
- */
-export function suiteRunDirectly(workflow, file) {
-  const commands = provenCommands(workflow, "scripts");
-  return suiteTargets(file).some((target) => runsCommand(commands, target));
-}
-
-test("every Sentry suite is invoked directly by the ci.yml `scripts` job", () => {
-  // Direct `node scripts/<suite>` (or `node --test …`), never `pnpm <alias>`.
-  // The pnpm-run path is the one a `scriptShell` override or a `presentry:*:test`
-  // lifecycle hook subvert (Codex 3754704267, 3754704278); a direct node command
-  // is on neither knob's path, so requiring it closes both fail-opens.
-  const missing = SENTRY_SUITES.filter(
-    (file) => !RUN_BY_ANOTHER_JOB.has(file) && !suiteRunDirectly(CI, file),
-  );
-  const detail = missing
-    .flatMap((file) =>
-      nearMisses(CI, "scripts", suiteTargets(file)).map(
-        (note) => `  ${file}: ${note}`,
-      ),
-    )
-    .join("\n");
-  assert.deepEqual(
-    missing,
-    [],
-    `these Sentry suites are not invoked directly in CI: ${missing.join(", ")}.\n${detail}\n` +
-      "Add a step to the `scripts` job in .github/workflows/ci.yml that runs " +
-      "`node <suite>` as its whole command (not a pnpm alias), or add an entry " +
-      "to RUN_BY_ANOTHER_JOB naming the job that does run it.",
-  );
-});
-
-test("the checker rejects a Sentry step that reverts to a pnpm alias", () => {
-  // A `scriptShell: /bin/true` (pnpm-workspace.yaml) makes `pnpm <alias>` exit 0
-  // without running the suite; a `presentry:*:test` hook empties it before it
-  // runs. Both act ONLY on the `pnpm run` path. So the coverage proof must
-  // reject a step that runs a suite via its pnpm alias and accept only the
-  // direct node command. Swap each suite's real step for its alias and assert
-  // the suite reads as uncovered — the same predicate invariant 1 uses.
-  let proven = 0;
-  for (const file of SENTRY_SUITES) {
-    if (RUN_BY_ANOTHER_JOB.has(file)) continue;
-    const aliases = aliasesFor(PKG_SCRIPTS, file);
-    if (aliases.length === 0) continue; // no alias form to revert to
-    const directRuns = suiteTargets(file).map((target) => target.join(" "));
-    const workflow = structuredClone(CI);
-    const step = workflow.jobs.scripts.steps.find(
-      (candidate) =>
-        typeof candidate?.run === "string" &&
-        directRuns.includes(candidate.run.trim()),
-    );
-    assert.ok(step, `no direct step found for ${file} to mutate`);
-    step.run = `pnpm ${aliases[0]}`;
-    assert.equal(
-      suiteRunDirectly(workflow, file),
-      false,
-      `the checker still counts ${file} as covered after its step reverted to \`pnpm ${aliases[0]}\``,
-    );
-    proven += 1;
-  }
-  assert.ok(proven > 0, "no Sentry suite with an alias was available to probe");
-});
-
-test("a presentry lifecycle hook cannot empty a directly-invoked Sentry suite", () => {
-  // `pnpm run sentry:ingest:test` fires `presentry:ingest:test` first, which a
-  // malicious PR can point at `cp /dev/null <suite>` (Codex 3754704278). Because
-  // the CI step runs `node scripts/sentry-triage-ingest.test.mjs` directly, no
-  // lifecycle hook is on its path — and suiteRunDirectly reads that CI command,
-  // never a package.json alias, so no `presentry:*:test` hook can change the
-  // verdict. Prove the representative suite is covered by the direct command.
-  const file = "scripts/sentry-triage-ingest.test.mjs";
-  assert.ok(
-    SENTRY_SUITES.includes(file),
-    `${file} is gone — pick another representative suite`,
-  );
-  assert.ok(
-    suiteRunDirectly(CI, file),
-    `${file} is not invoked as a direct node command in the scripts job, so a ` +
-      "presentry:*:test lifecycle hook could still empty it",
-  );
-});
 
 test("the exemption for sentry-provider-contract still holds", () => {
   for (const [file, route] of RUN_BY_ANOTHER_JOB) {

--- a/scripts/check-sentry-suites-in-ci-gate-job.test.mjs
+++ b/scripts/check-sentry-suites-in-ci-gate-job.test.mjs
@@ -39,6 +39,17 @@ export const GATE_COMMAND =
   "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs";
 
 /**
+ * The command the checker step must run, as its whole command. This file is
+ * part of that checker, so the assertion is bootstrapped either way — but
+ * pinning the step inside the canonical shape is strictly stronger than the
+ * separate "this check runs in CI" probe it replaced: exact equality also
+ * rejects an appended `|| true`, an `if:`, a `working-directory:` and an `env:`
+ * on the step.
+ */
+export const CHECKER_COMMAND =
+  "node scripts/check-sentry-suites-in-ci.test.mjs";
+
+/**
  * The canonical `sentry-suites` job, in full.
  *
  * This is an ALLOWLIST, not a list of rejected properties, and that inversion is
@@ -75,6 +86,12 @@ export const CANONICAL_JOB = {
       with: { "node-version-file": ".node-version" },
     },
     { name: "Run and assert the Sentry suites", run: GATE_COMMAND },
+    // Steps 4-5 (issue #1779, PR C). Both run AFTER the gate: the install's
+    // composite `postinstall` is PR-authored code, and putting it in front of
+    // the gate would restore the R1 window this job exists to close. Their
+    // position is pinned by the array-order equality above, not by a comment.
+    { uses: "./.github/actions/pnpm-install" },
+    { name: "Sentry CI wiring assertion", run: CHECKER_COMMAND },
   ],
 };
 

--- a/scripts/check-sentry-suites-in-ci-lifecycle.test.mjs
+++ b/scripts/check-sentry-suites-in-ci-lifecycle.test.mjs
@@ -11,9 +11,9 @@
  *
  * Both are closed by the pin validator (check-agent-quality-gate-package-scripts.sh)
  * running FIRST: it pins each trusted alias to an exact command and rejects any
- * unsanctioned lifecycle hook. These tests pin that ordering, prove the validator
- * rejects a hook, and reject a committed scripts/ directory symlink whose target
- * escapes the tree the CI paths-filter routes.
+ * unsanctioned lifecycle hook. These tests pin that ordering and prove the
+ * validator rejects a hook. That validator is what makes the local gate's trust
+ * in the `sentry:*` aliases safe, which is why this checker carries it.
  *
  * The gate probe is the third execution surface, and its invariants live next
  * door in check-sentry-suites-in-ci-gate-probe.test.mjs.
@@ -24,25 +24,14 @@
  */
 
 import assert from "node:assert/strict";
-import {
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import test from "node:test";
 import { pinValidationOrderBlockers } from "./check-sentry-suites-in-ci-core.mjs";
 import {
   CI,
-  escapingScriptSymlinks,
   INSTALL_ACTION,
   PIN_VALIDATOR_COMMAND,
   PKG,
   runPackageScriptValidator,
-  SCRIPTS_DIR,
   validatorPins,
 } from "./check-sentry-suites-in-ci-probes.mjs";
 
@@ -133,39 +122,11 @@ test("the pin validator rejects an unsanctioned install lifecycle hook", () => {
   }
 });
 
-test("no committed scripts/ directory symlink escapes the CI-routed tree", () => {
-  // A directory symlink under scripts/ pointing outside it exposes a suite whose
-  // real path the static `rootScripts` filter cannot route, so the path-gated
-  // `scripts` job would skip while the checker still demands the suite (Codex
-  // 3754887739). None may exist.
-  assert.deepEqual(
-    escapingScriptSymlinks(SCRIPTS_DIR),
-    [],
-    "a committed scripts/ directory symlink resolves outside scripts/",
-  );
-
-  // Mutation: a synthetic tree with `scripts/linked -> ../fixtures` is flagged,
-  // while a within-scripts link is not — proving the check rejects only the
-  // escaping case, on fixtures so no repo file is touched.
-  const base = mkdtempSync(join(tmpdir(), "sentry-escape-probe-"));
-  try {
-    const scripts = join(base, "scripts");
-    const inside = join(scripts, "real-dir");
-    const outside = join(base, "fixtures");
-    mkdirSync(inside, { recursive: true });
-    mkdirSync(outside, { recursive: true });
-    writeFileSync(join(outside, "sentry-hidden.test.mjs"), "// suite\n");
-    symlinkSync(outside, join(scripts, "escaping"));
-    symlinkSync(inside, join(scripts, "contained"));
-
-    const escaping = escapingScriptSymlinks(scripts);
-    assert.equal(
-      escaping.length,
-      1,
-      `expected only the escaping link flagged, got ${JSON.stringify(escaping)}`,
-    );
-    assert.equal(escaping[0][0], "scripts/escaping");
-  } finally {
-    rmSync(base, { recursive: true, force: true });
-  }
-});
+// The escaping-symlink rejection lived here until issue #1779 PR C. It refused
+// a committed `scripts/<link>` resolving outside scripts/, because such a link
+// exposes suites whose real path the static `rootScripts` filter cannot route:
+// adding one under a previously committed link skipped the path-gated `scripts`
+// job while the checker still demanded the suite (Codex 3754887739). The
+// unconditional `sentry-suites` gate removed the premise. It enumerates through
+// the same link, reconciles what it finds against the manifest by exact set
+// equality, and RUNS the suite — from a job with no paths filter to escape.

--- a/scripts/check-sentry-suites-in-ci-probes.mjs
+++ b/scripts/check-sentry-suites-in-ci-probes.mjs
@@ -27,7 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CORE_SCHEMA, dump, load } from "js-yaml";
 import { isPlainObject } from "./check-sentry-suites-in-ci-core.mjs";
@@ -257,14 +257,17 @@ export const SENTINEL_MUTATIONS = [
   ["`if: false`", (w) => (w.jobs.ci.if = "false")],
   ["a dropped `if: always()`", (w) => delete w.jobs.ci.if],
   [
-    "a `needs` without `scripts`",
-    (w) => (w.jobs.ci.needs = w.jobs.ci.needs.filter((n) => n !== "scripts")),
+    "a `needs` without `production-infra-contract`",
+    (w) =>
+      (w.jobs.ci.needs = w.jobs.ci.needs.filter(
+        (n) => n !== "production-infra-contract",
+      )),
   ],
   ["`continue-on-error`", (w) => (w.jobs.ci["continue-on-error"] = true)],
   [
-    "`scripts` under `allowed-failures`",
+    "`production-infra-contract` under `allowed-failures`",
     (w) => {
-      allsGreenStep(w).with["allowed-failures"] = "scripts";
+      allsGreenStep(w).with["allowed-failures"] = "production-infra-contract";
     },
   ],
   [
@@ -307,26 +310,13 @@ export const SENTINEL_MUTATIONS = [
     (w) => (w.jobs.ci.name = "ci-aggregate"),
   ],
   [
-    "path-gated `scripts` dropped from `allowed-skips`",
-    // `scripts` is path-gated, so it reports "skipped" on any PR outside its
-    // filter. alls-green turns a skip of a job NOT in `allowed-skips` into a gate
-    // failure, so dropping it here reds the required `ci` for every such PR —
-    // while the edit that drops it activates the filter, so the change's own PR
-    // runs the job and never sees the red.
+    "a case-variant `ALLOWED-SKIPS` overriding `allowed-skips`",
+    // The runner matches `with:` keys case-insensitively and the last wins, so
+    // a decoy key makes `sentry-suites` skippable while the real `allowed-skips`
+    // still reads clean — and `gateJobBlockers` reads only the lowercase key.
+    // The collision check here is what stops that reaching the merge gate.
     (w) => {
-      const step = allsGreenStep(w);
-      step.with["allowed-skips"] = step.with["allowed-skips"]
-        .split(",")
-        .filter((job) => job.trim() !== "scripts")
-        .join(",");
-    },
-  ],
-  [
-    "a JSON-encoded `allowed-skips` without `scripts`",
-    // The action `json.loads()` this first, so a comma-only reader would see one
-    // opaque token and wrongly believe `scripts` is still listed.
-    (w) => {
-      allsGreenStep(w).with["allowed-skips"] = '["ui","indexer"]';
+      allsGreenStep(w).with["ALLOWED-SKIPS"] = "sentry-suites";
     },
   ],
   [
@@ -396,55 +386,6 @@ export function findSentrySuites(
 export const SENTRY_SUITES = findSentrySuites(SCRIPTS_DIR);
 
 /**
- * Committed directory symlinks under scripts/ whose real target escapes the
- * scripts/ tree. `findSentrySuites` follows such a link and enumerates the suite
- * behind it, but the suite's real path is the symlink TARGET (e.g.
- * fixtures/sentry-x.test.mjs) — which matches neither `scripts/**` nor the
- * static `rootScripts` filter in ci.yml. Adding a suite beneath a previously
- * committed link would then run the checker locally yet skip the whole path-gated
- * `scripts` job in CI, shipping the unwired suite (Codex 3754887739). CI's
- * paths-filter cannot resolve a symlink, so the fail-closed answer is to reject
- * the link: with none present, every enumerated suite lives under a real
- * `scripts/**` path the filter already routes. A directory symlink whose target
- * stays inside scripts/ is harmless (still covered by `scripts/**`) and allowed.
- *
- * @param {string} dir
- * @param {string} prefix
- * @param {string | null} scriptsRoot resolved scripts/ root; set on recursion
- * @returns {Array<[string, string]>} [repo-relative link path, resolved target]
- */
-export function escapingScriptSymlinks(
-  dir,
-  prefix = "scripts",
-  scriptsRoot = null,
-) {
-  const root = scriptsRoot ?? realpathSync(dir);
-  const escaping = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    const relative = `${prefix}/${entry.name}`;
-    if (entry.isSymbolicLink()) {
-      // A file symlink cannot expose a suite tree; `findSentrySuites` follows
-      // only directory links. A broken link throws there and is that check's
-      // concern, so skip an unresolvable one here rather than double-reporting.
-      let target;
-      try {
-        if (!statSync(full).isDirectory()) continue;
-        target = realpathSync(full);
-      } catch {
-        continue;
-      }
-      if (target !== root && !target.startsWith(root + sep)) {
-        escaping.push([relative, target]);
-      }
-    } else if (entry.isDirectory()) {
-      escaping.push(...escapingScriptSymlinks(full, relative, root));
-    }
-  }
-  return escaping.sort();
-}
-
-/**
  * Run check-agent-quality-gate-package-scripts.sh against a synthetic
  * package.json and report whether it accepted. Lets the lifecycle invariants
  * prove the validator rejects an unsanctioned lifecycle hook (and accepts the
@@ -492,98 +433,35 @@ export const RUN_BY_ANOTHER_JOB = new Map([
  * The jobs this file trusts to run its assertions, and the ONLY `if:` each may
  * carry. `null` means the job must be unconditional.
  *
- * `scripts` is path-gated, so its guard is pinned to an exact string and
- * `the scripts job stays reachable from the paths its suites guard` follows
- * that string through the paths filter. Any edit to the guard fails here and
- * has to be re-proven, which is the point. A non-null guard also marks the job
- * as one that legitimately skips, so `sentinelBlockers` requires it under the
- * sentinel's `allowed-skips`.
- */
-export const TRUSTED_JOBS = new Map([
-  ["scripts", "needs.changes.outputs.rootScripts == 'true'"],
-  ["production-infra-contract", null],
-]);
-
-/**
- * Paths whose edits must re-run the `scripts` job. Every one is an input to a
- * suite that job owns: the suites themselves, the workflow files
- * sentry-mcp-broker.test.mjs parses, the shell scripts this check runs as
- * probes — `gateClassifications` executes agent-quality-gate.sh's own `case`
- * statement and `validatorPins` runs check-agent-quality-gate-package-scripts.sh
- * — the local composite actions the env scan now recurses into, and the
- * manifest holding the aliases the CI steps invoke.
+ * One entry, and the narrowing is the point (issue #1779, PR C).
+ * `production-infra-contract` is here because it runs the one suite the runtime
+ * gate does not — `sentry-provider-contract.test.mjs`, via `pnpm tf:test` — so
+ * the exemption is only as good as that job's trustworthiness.
  *
- * The `.sh` entry matters most where it is least visible: without it, a PR
- * editing only the gate's tooling allowlist or the pin validator would skip the
- * `scripts` job, and the `ci` sentinel lists `scripts` under `allowed-skips`,
- * so nothing would report the gap. `.github/actions/**` is here for the same
- * reason: the env scan reads an `action.yml`, so an edit to one must re-run it.
- */
-export const REQUIRED_ROOT_SCRIPT_PATHS = [
-  // `scripts/**` covers every path under scripts/ at any depth, INCLUDING the
-  // extensionless directory symlinks the `*.mjs`/`*.sh` globs miss. A suite
-  // reachable only through such a symlink is one `findSentrySuites` enumerates
-  // (it follows the link), so its addition must run the `scripts` job — and
-  // hence this checker — or the whole job skips and the unwired suite ships
-  // (Codex 3754355168). The extension globs stay for documentation of intent.
-  "scripts/**",
-  "scripts/**/*.mjs",
-  "scripts/**/*.sh",
-  ".github/workflows/**",
-  ".github/actions/**",
-  "package.json",
-];
-
-/**
- * Every file this check parses or executes to reach a verdict, with the reader
- * that consumes it. `the required paths route every file this check reads`
- * asserts each one is covered by REQUIRED_ROOT_SCRIPT_PATHS: an input the
- * filter does not route is an input whose edit skips the whole `scripts` job.
+ * `scripts` left when the Sentry suites and this checker did: that job no
+ * longer runs a line of Sentry code, so asserting its shape here asserted
+ * nothing about the Sentry legs.
  *
- * The composite `action.yml` files are appended below rather than hard-coded:
- * `collectCompositeActions` discovers exactly what the env scan opens, so a job
- * that adds or nests a composite cannot slip a reader past the filter.
+ * `sentry-suites` is deliberately NOT here. Its whole structure is pinned by
+ * exact equality against `CANONICAL_JOB`
+ * (check-sentry-suites-in-ci-gate-job.test.mjs), which rejects every construct
+ * `jobBlockers` looks for — `uses:`, `container`, `strategy`, `environment`,
+ * `continue-on-error`, an `if:`, an `env:` at either level — plus everything it
+ * does not, since anything outside the canonical shape is rejected whatever it
+ * is called. Its only local composite is `./.github/actions/pnpm-install`,
+ * which this map already routes through `production-infra-contract`, and
+ * `gateJobBlockers` separately requires the sentinel to need it and to tolerate
+ * neither its skip nor its failure. Listing it twice would add a weaker copy.
  */
-const STATIC_PROBE_INPUTS = new Map([
-  [".github/workflows/ci.yml", "the workflow every invariant here walks"],
-  ["package.json", "the alias map `aliasesFor` resolves suites through"],
-  ["scripts/agent-quality-gate.sh", "`gateClassifications` runs its `case`"],
-  [GATE_PROBE, "the probe that lifts the gate's classifier out and re-runs it"],
-  [GATE_PROBE_TESTS, "that probe's own invariants, which this check runs"],
-  [
-    GATE_EXTRACT,
-    "the extractor and probe shells `gateClassifications` runs on",
-  ],
-  [
-    "scripts/check-sentry-suites-in-ci-gate-extract.test.mjs",
-    "the extractor's own invariants, which this check runs",
-  ],
-  [
-    "scripts/check-sentry-suites-in-ci-gate-fixtures.mjs",
-    "the fixtures both gate-probe test modules share",
-  ],
-  [
-    "scripts/check-agent-quality-gate-package-scripts.sh",
-    "`validatorPins` runs it to enumerate the pins it enforces",
-  ],
-  ["scripts/tf-stacks.test.mjs", "`staticImports` parses its import list"],
-  [SELF, "this check itself"],
-  [LIFECYCLE, "the execution-surface invariants this check imports and runs"],
-  [CORE, "every predicate this check asserts with"],
-  [CORE_COMMANDS, "the command-grammar predicates the core re-exports"],
-  [PROBES, "the file reads and probes this check runs"],
-  [STATIC_IMPORTS, "`staticImports` itself — V8's dependency list, shared"],
-]);
+export const TRUSTED_JOBS = new Map([["production-infra-contract", null]]);
 
-export const PROBE_INPUTS = new Map([
-  ...STATIC_PROBE_INPUTS,
-  ...[...TRUSTED_JOBS.keys()].flatMap((name) =>
-    collectCompositeActions(CI.jobs[name]).files.map((file) => [
-      file,
-      `a composite action the \`${name}\` job runs, scanned for \`$GITHUB_ENV\` writes`,
-    ]),
-  ),
-]);
+// The `rootScripts` paths-filter reachability proof lived here until issue
+// #1779 PR C. It existed because this checker ran in the path-gated `scripts`
+// job: every file it read had to be routed by the filter, or an edit to that
+// file skipped the whole job and the `ci` sentinel tolerated the skip. The
+// checker now runs in the unconditional `sentry-suites` job, which has no
+// filter and no `if:` to narrow, so there is no longer a set of paths that must
+// reach it — a dashboard-only or indexer-only diff runs it like any other.
 
 /**
  * The exact commands check-agent-quality-gate-package-scripts.sh pins, read
@@ -625,31 +503,4 @@ export function validatorPins() {
     pins.set(match[1], JSON.parse(match[2]));
   }
   return pins;
-}
-
-/**
- * Remove `target` from every list in every `dorny/paths-filter` step's inner
- * `filters` document. Generic on purpose: the probe below must not re-implement
- * the guard→output→step→document walk it is testing.
- *
- * @param {Record<string, any>} workflow
- * @param {string} target
- */
-export function dropFilterPath(workflow, target) {
-  let removed = 0;
-  for (const job of Object.values(workflow.jobs ?? {})) {
-    for (const step of job.steps ?? []) {
-      if (!isPlainObject(step)) continue;
-      if (!String(step.uses ?? "").startsWith("dorny/paths-filter@")) continue;
-      const filters = load(step.with?.filters, { schema: CORE_SCHEMA });
-      if (!isPlainObject(filters)) continue;
-      for (const [key, paths] of Object.entries(filters)) {
-        if (!Array.isArray(paths) || !paths.includes(target)) continue;
-        filters[key] = paths.filter((entry) => entry !== target);
-        removed += 1;
-      }
-      step.with.filters = dump(filters);
-    }
-  }
-  return removed;
 }

--- a/scripts/check-sentry-suites-in-ci.test.mjs
+++ b/scripts/check-sentry-suites-in-ci.test.mjs
@@ -1,25 +1,47 @@
 #!/usr/bin/env node
 /**
- * Structural assertion: every Sentry suite is reachable from CI, not only from
- * the local pre-push gate.
+ * Structural assertion: the machinery that runs the Sentry suites in CI is
+ * still wired, and still reaches the merge gate.
  *
  * Issue #1721: eight `sentry:*:test` scripts — roughly 400 assertions — were
- * enforced by the pre-push hook alone. `.github/workflows/ci.yml` invoked none
- * of them, so a contributor who bypassed the hook could merge a regression in
- * the triage or autofix leg against a fully green required check. Wiring the
- * suites fixed that instance. This file stops it recurring: the next suite
- * that lands without a CI step fails here, on the `scripts` job that is
- * already required.
+ * enforced by the pre-push hook alone, so a contributor who bypassed the hook
+ * could merge a regression against a fully green required check. This file was
+ * written to prove from configuration text that CI *would* run them.
+ *
+ * Issue #1779 replaced that claim with a stronger one: the unconditional
+ * `sentry-suites` job RUNS the suites and proves from their own output that
+ * each asserted (ADR 0062). What a runtime gate cannot prove is its own
+ * existence — delete the job and every check in the repository stays green — so
+ * this file now carries the three things the gate cannot see:
+ *
+ *   1. The `sentry-suites` job is intact, unconditional, shaped exactly as
+ *      ADR 0062 requires, and its result reaches the required `ci` context
+ *      (check-sentry-suites-in-ci-gate-job.test.mjs, and the sentinel, trigger
+ *      and check-run-ownership assertions here).
+ *   2. The one suite the gate does not run — sentry-provider-contract, reached
+ *      by import from tf-stacks.test.mjs — really is run by an unconditional
+ *      job, and that job is trustworthy.
+ *   3. The local gate's tooling allowlist in scripts/agent-quality-gate.sh
+ *      lists every `sentry:*` script, and every listed script is pinned to an
+ *      exact command by check-agent-quality-gate-package-scripts.sh. The local
+ *      gate runs the `pnpm sentry:*:test` aliases (developer convenience, with
+ *      the CI gate as the backstop); the allowlist grants that trust and the
+ *      pin is what makes it safe.
+ *
+ * PR C of #1779 relocated this file from the path-gated `scripts` job into
+ * `sentry-suites`, which never skips — a dashboard-only, indexer-only or
+ * non-Markdown doc-asset diff used to skip it entirely, measured against the
+ * real filter — and retired the assertions the runtime gate subsumes: that every
+ * suite has a direct `node <suite>` step, and the whole `rootScripts` filter
+ * reachability proof that only mattered while this ran behind a filter.
  *
  * EVERY assertion reads a parsed structure. Six review rounds against the
  * text-matching version of this file found the same defect in a new place each
- * time — a commented-out step, a commented-out import, a commented-out filter
- * path, an `echo` naming a suite, an `if: false`, a `|| true`. Each is
- * invisible to a parser and each defeated a substring search. So:
+ * time — a commented-out step, a commented-out import, an `echo` naming a
+ * suite, an `if: false`, a `|| true`. Each is invisible to a parser and each
+ * defeated a substring search. So:
  *
  *   ci.yml               js-yaml, then walked as objects
- *   the paths filter     js-yaml again, on the inner YAML document that lives
- *                        inside the filter step's string value
  *   `run:` commands      tokenized against a plain-word grammar and matched
  *                        whole, never by prefix
  *   tf-stacks.test.mjs   V8's own parser (vm.SourceTextModule) reports the
@@ -27,8 +49,7 @@
  *   the gate allowlist   bash evaluates its own `case` statement
  *   the validator pins   the validator reports them itself
  *
- * An unparsable ci.yml throws here, and that is correct: this same job runs
- * scripts/check-autofix-ci-trust.mjs, which already fails closed on one.
+ * An unparsable ci.yml throws here, and that is correct.
  *
  * The predicates live in scripts/check-sentry-suites-in-ci-core.mjs and take
  * the structure they judge as an argument rather than reading a module-level
@@ -38,27 +59,8 @@
  * mutation probes are what prove it rejects. This file owns the file reads, the
  * external-process probes, the repo-specific constants, and every `test()`.
  *
- * Three invariants, each guarding a different way the wiring rots:
- *
- *   1. Every `scripts/sentry-*.test.mjs` is invoked by the `scripts` job as a
- *      DIRECT `node scripts/<file>` command (never a `pnpm <alias>`). The
- *      pnpm-run path carries two config-level fail-opens a parser cannot see —
- *      a `scriptShell: /bin/true` false-greens the alias (Codex 3754704267),
- *      and a `presentry:*:test` lifecycle hook runs before it and can empty the
- *      suite (Codex 3754704278) — so the check rejects the alias form and
- *      requires the direct one. A suite may be exempted only by naming the CI
- *      job that does run it, and the exemption is re-proven below.
- *   2. Every `sentry:*:test` package script resolves to a file this check
- *      enumerates, so a stray alias cannot point at a non-suite file.
- *   3. The local gate's tooling allowlist in scripts/agent-quality-gate.sh
- *      lists every `sentry:*` script, and every listed script is pinned to an
- *      exact command by check-agent-quality-gate-package-scripts.sh. The local
- *      gate still runs the `pnpm sentry:*:test` aliases (developer
- *      convenience, with CI's direct invocation as the backstop); the
- *      allowlist grants that trust and the pin is what makes it safe.
- *
  * Run: `node scripts/check-sentry-suites-in-ci.test.mjs`
- * CI:  .github/workflows/ci.yml  (scripts job)
+ * CI:  .github/workflows/ci.yml  (sentry-suites job)
  */
 
 import assert from "node:assert/strict";
@@ -73,15 +75,11 @@ import {
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import test from "node:test";
-import { CORE_SCHEMA, dump, load } from "js-yaml";
 import {
   contextOwnershipBlockers,
   envMutationBlockers,
-  globToRegExp,
   jobBlockers,
-  nearMisses,
   provenCommands,
-  requiredPathsMissing,
   runsCommand,
   sentinelBlockers,
   triggerBlockers,
@@ -110,10 +108,7 @@ import {
   collectCompositeActions,
   compositeFixture,
   CORE,
-  dropFilterPath,
   findSentrySuites,
-  PROBE_INPUTS,
-  REQUIRED_ROOT_SCRIPT_PATHS,
   ROOT,
   SELF,
   SENTINEL_MUTATIONS,
@@ -264,182 +259,25 @@ test("the trigger check rejects a `pull_request` trigger that can miss main", ()
   }
 });
 
-test("the `scripts` job stays reachable from the paths its suites guard", () => {
-  assert.deepEqual(
-    requiredPathsMissing(
-      CI,
-      "scripts",
-      TRUSTED_JOBS.get("scripts"),
-      REQUIRED_ROOT_SCRIPT_PATHS,
-    ),
-    [],
-    "the paths filter behind the `scripts` job no longer covers every input its " +
-      "suites read, so a PR touching only those files skips the job and every " +
-      "Sentry suite in it",
-  );
-});
-
-test("the reachability check rejects dropping the guard producer from `needs`", () => {
-  // Removing `jobs.scripts.needs: changes` while the `if:
-  // needs.changes.outputs.rootScripts == 'true'` guard stays leaves the
-  // `needs.changes` context empty, so the guard is never true and the job skips
-  // on every PR — and the sentinel lists `scripts` under `allowed-skips`, so
-  // nothing reports it. jobBlockers and sentinelBlockers stay green; only the
-  // needs-edge proof catches it.
-  const workflow = structuredClone(CI);
-  delete workflow.jobs.scripts.needs;
-  assert.notDeepEqual(
-    requiredPathsMissing(
-      workflow,
-      "scripts",
-      TRUSTED_JOBS.get("scripts"),
-      REQUIRED_ROOT_SCRIPT_PATHS,
-    ),
-    [],
-    "the reachability check accepts a `scripts` job that no longer needs `changes`",
-  );
-});
-
-test("the required paths route every file this check reads", () => {
-  // The gap this closes was invisible from either side alone: the check reads
-  // two `.sh` files as probes, the filter routed only `.mjs`, and the `ci`
-  // sentinel lists `scripts` under `allowed-skips` — so a PR editing only the
-  // gate's allowlist or the pin validator skipped the job that would have
-  // caught it, and no check reported a thing.
-  const unrouted = [...PROBE_INPUTS].filter(
-    ([path]) =>
-      !REQUIRED_ROOT_SCRIPT_PATHS.some((glob) => globToRegExp(glob).test(path)),
-  );
-  assert.deepEqual(
-    unrouted.map(([path]) => path),
-    [],
-    "REQUIRED_ROOT_SCRIPT_PATHS does not route " +
-      unrouted.map(([path, reader]) => `${path} (${reader})`).join(", ") +
-      " — an edit to one of those files would skip the `scripts` job, and the " +
-      "`ci` sentinel allows that skip",
-  );
-});
-
-test("the reachability check rejects a filter that drops a required path", () => {
-  // Mutation probes on a cloned workflow. The first is the one that matters:
-  // the gate and the pin validator are `.sh`, so without `scripts/**/*.sh` in
-  // the filter a PR editing only those files skips the `scripts` job — and the
-  // `ci` sentinel allows that skip, so nothing reports it.
-  for (const required of REQUIRED_ROOT_SCRIPT_PATHS) {
-    const workflow = structuredClone(CI);
-    assert.ok(
-      dropFilterPath(workflow, required) > 0,
-      `no paths filter in ci.yml lists \`${required}\`, so this probe would prove nothing`,
-    );
-    assert.deepEqual(
-      requiredPathsMissing(
-        workflow,
-        "scripts",
-        TRUSTED_JOBS.get("scripts"),
-        REQUIRED_ROOT_SCRIPT_PATHS,
-      ),
-      [required],
-      `the reachability check accepts a filter with \`${required}\` removed`,
-    );
-  }
-
-  // The chain itself must fail closed, not just the final list comparison.
-  const chainMutations = [
-    [
-      "a filter step that can be skipped",
-      (w) => {
-        for (const job of Object.values(w.jobs)) {
-          for (const step of job.steps ?? []) {
-            if (String(step.uses ?? "").startsWith("dorny/paths-filter@")) {
-              step.if = "false";
-            }
-          }
-        }
-      },
-    ],
-    [
-      "a filter step passing `base:` alongside `filters:`",
-      (w) => {
-        for (const job of Object.values(w.jobs)) {
-          for (const step of job.steps ?? []) {
-            if (String(step.uses ?? "").startsWith("dorny/paths-filter@")) {
-              step.with.base = "HEAD";
-            }
-          }
-        }
-      },
-    ],
-    [
-      "a negated glob that cancels a required path it still lists",
-      // dorny/paths-filter honours `!` negation, so `!scripts/**` cancels the
-      // required `scripts/**/*.mjs`/`.sh` entries while they stay literally
-      // present — a PR touching only scripts/ then skips the job.
-      (w) => {
-        let added = 0;
-        for (const job of Object.values(w.jobs)) {
-          for (const step of job.steps ?? []) {
-            if (!String(step.uses ?? "").startsWith("dorny/paths-filter@")) {
-              continue;
-            }
-            const filters = load(step.with.filters, { schema: CORE_SCHEMA });
-            if (Array.isArray(filters.rootScripts)) {
-              filters.rootScripts.push("!scripts/**");
-              added += 1;
-            }
-            step.with.filters = dump(filters);
-          }
-        }
-        assert.ok(
-          added > 0,
-          "no `rootScripts` filter to negate — probe is inert",
-        );
-      },
-    ],
-  ];
-  for (const [label, mutate] of chainMutations) {
-    const workflow = structuredClone(CI);
-    mutate(workflow);
-    assert.notDeepEqual(
-      requiredPathsMissing(
-        workflow,
-        "scripts",
-        TRUSTED_JOBS.get("scripts"),
-        REQUIRED_ROOT_SCRIPT_PATHS,
-      ),
-      [],
-      `the reachability check accepts ${label}`,
-    );
-  }
-});
-
-test("this check itself runs in the ci.yml `scripts` job", () => {
-  // Without this, the meta-check could be dropped from CI and every invariant
-  // above would go quiet.
-  const commands = provenCommands(CI, "scripts");
-  assert.ok(
-    runsCommand(commands, ["node", SELF]),
-    `the \`scripts\` job must run \`node ${SELF}\` as a whole step command: ` +
-      `${nearMisses(CI, "scripts", [["node", SELF]]).join("; ") || "no step mentions it"}`,
-  );
-});
-
 test("a step proves a suite only when the suite is its whole command", () => {
-  // provenCommands must reject a step whose body runs more than the target: a
-  // sibling bare-word line can rebind it without being a shell keyword —
-  // `cd <dir>` moves the working directory, `PATH=`/`hash` shadows the binary,
-  // `cp /dev/null <suite>` truncates the suite file before `node` reads it — and
-  // `runsCommand` would otherwise match the direct command sitting among them.
-  // All are shellcheck-clean, so only the exactly-one-command rule catches them.
-  const anchor = "node scripts/sentry-triage-ingest.test.mjs";
+  // `provenCommands` is what proves the exempt suite's route — that
+  // `production-infra-contract` really runs tf-stacks.test.mjs — so it must
+  // reject a step whose body runs more than the target: a sibling bare-word line
+  // can rebind it without being a shell keyword — `cd <dir>` moves the working
+  // directory, `PATH=`/`hash` shadows the binary, `cp /dev/null <file>`
+  // truncates the target before `node` reads it — and `runsCommand` would
+  // otherwise match the command sitting among them. All are shellcheck-clean, so
+  // only the exactly-one-command rule catches them.
+  const anchor = "pnpm tf:test";
   const bodies = [
     `cd ui-dashboard\n${anchor}`,
-    `hash -p /bin/true node\n${anchor}`,
+    `hash -p /bin/true pnpm\n${anchor}`,
     `PATH=/tmp/shim:/usr/bin\n${anchor}`,
-    `cp /dev/null scripts/sentry-triage-ingest.test.mjs\n${anchor}`,
+    `cp /dev/null scripts/tf-stacks.test.mjs\n${anchor}`,
   ];
   for (const body of bodies) {
     const workflow = structuredClone(CI);
-    const step = workflow.jobs.scripts.steps.find(
+    const step = workflow.jobs["production-infra-contract"].steps.find(
       (candidate) => candidate.run === anchor,
     );
     assert.ok(
@@ -448,9 +286,9 @@ test("a step proves a suite only when the suite is its whole command", () => {
     );
     step.run = body;
     assert.equal(
-      runsCommand(provenCommands(workflow, "scripts"), [
-        "node",
-        "scripts/sentry-triage-ingest.test.mjs",
+      runsCommand(provenCommands(workflow, "production-infra-contract"), [
+        "pnpm",
+        "tf:test",
       ]),
       false,
       `provenCommands accepted a step whose body is ${JSON.stringify(body)}`,
@@ -462,8 +300,10 @@ test("a trusted job may not mutate the runner environment for later steps", () =
   // A `>> $GITHUB_ENV` / `>> $GITHUB_PATH` write reaches every later step with
   // the same force as a job-level `env:` — which this file rejects — but
   // imperative and unparsable, so the declarative `env:` checks never see it.
-  // Both trusted jobs, and the local composite actions they pull in, must be
-  // clean today, and the blocker must reject each vector.
+  // The trusted job, and the local composite actions it pulls in, must be clean
+  // today, and the blocker must reject each vector. `production-infra-contract`
+  // installs before it runs the exempt suite, so a write in that composite would
+  // neuter the one suite the runtime gate does not run.
   for (const name of TRUSTED_JOBS.keys()) {
     const job = CI.jobs[name];
     assert.deepEqual(
@@ -500,13 +340,15 @@ test("a trusted job may not mutate the runner environment for later steps", () =
     },
   ];
   for (const vector of vectors) {
-    const workflow = structuredClone(CI);
-    workflow.jobs.scripts.steps.splice(2, 0, vector);
-    assert.notDeepEqual(
-      jobBlockers(workflow, "scripts", TRUSTED_JOBS),
-      [],
-      `jobBlockers accepts a \`scripts\` job with a ${vector.name} step`,
-    );
+    for (const name of TRUSTED_JOBS.keys()) {
+      const workflow = structuredClone(CI);
+      workflow.jobs[name].steps.splice(1, 0, vector);
+      assert.notDeepEqual(
+        jobBlockers(workflow, name, TRUSTED_JOBS),
+        [],
+        `jobBlockers accepts a \`${name}\` job with a ${vector.name} step`,
+      );
+    }
     // The same write inside a composite action must also be caught.
     assert.notDeepEqual(
       envMutationBlockers([vector], "composite"),


### PR DESCRIPTION
## The Problem

- The Sentry CI-coverage checker ran in the path-gated `scripts` job, so a diff touching only the dashboard, the indexer or a non-Markdown doc asset skipped it entirely — measured against the real `rootScripts` filter with picomatch. Markdown-only diffs did reach it, because the filter lists `**/*.md`.
- The `scripts` job still ran all thirteen Sentry suites that the unconditional `sentry-suites` gate now also runs, paying for the set twice and letting the two paths disagree.
- Parts of the checker's charter were superseded by the gate but still enforced, which is churn every future round pays for.

## The Solution

Move `scripts/check-sentry-suites-in-ci.test.mjs` into the `sentry-suites` job as ADR 0062's steps 4-5, after the install it needs for `js-yaml` and after the gate — so no PR-authored code runs before the suites. Delete the duplicated per-suite steps from `scripts`. Retire the assertions the gate makes a strictly stronger claim about, and record the per-assertion reasoning in the ADR, which had left that decision open.

This completes PR C of #1779. Phase 5 (adding `Sentry suites` to the branch ruleset's required checks) is still outstanding, so this does not close the issue.

## Details

**Relocated.** `sentry-suites` gains `uses: ./.github/actions/pnpm-install` and `run: node scripts/check-sentry-suites-in-ci.test.mjs` as steps 4 and 5. Both sit after the gate: the install's composite `postinstall` is PR-authored code, and putting it in front would restore the R1 window the job exists to close. `CANONICAL_JOB` pins the new five-step list by exact equality, so the ordering is machine-enforced rather than commented.

**Deleted from `scripts`.** The thirteen per-suite steps, the checker step, and the block comment introducing them. Step list before → after:

| | before | after |
| --- | --- | --- |
| `scripts` | 13 Sentry suite steps + `check-sentry-suites-in-ci` | none |
| `sentry-suites` | `sentry-suite-gate.mjs` | `sentry-suite-gate.mjs` + `pnpm-install` + `check-sentry-suites-in-ci` |

**Retired**, each because the gate covers the same ground more strongly or the premise is gone:

- *"every suite is invoked by `scripts` as a direct `node <suite>`"*, with its pnpm-alias and `presentry:*:test` rejection probes. The gate spawns each non-exempt suite as a `node` child under `env -u`, from a manifest reconciled by exact set equality, and asserts exit 0, `fail == 0`, `pass >= floor`, `pass ==` per-case lines. No pnpm alias is on that path, so neither fail-open is reachable, and "a step exists" is weaker than "the suite ran and asserted".
- *the whole `rootScripts` reachability proof* — `requiredPathsMissing`, `REQUIRED_ROOT_SCRIPT_PATHS`, `PROBE_INPUTS`, `dropFilterPath`, `globToRegExp` and the four tests over them. It existed only because the checker ran behind a filter. The job it runs in now has none.
- *"this check itself runs in the ci.yml `scripts` job"*. The step is inside `CANONICAL_JOB` now, asserted by exact equality, which also rejects `|| true`, an `if:`, a `working-directory:` and an `env:` — none of which the whole-command probe saw.
- *the escaping-symlink rejection*. Its premise was a suite shipping unwired behind a skipped job. The gate follows the same link, reconciles by set equality and runs the suite, from a job that never skips.
- *`scripts` as a trusted job*, and `sentry-suites` deliberately not added in its place: `CANONICAL_JOB` rejects every construct `jobBlockers` looks for and everything it does not, and its only composite is `pnpm-install`, still scanned through `production-infra-contract`.

**Deliberately kept.** The gate-job pin (a runtime gate cannot detect its own deletion). The sentinel, trigger and check-run-ownership assertions (a gate whose result never reaches the required `ci` context proves nothing). The exemption's CI half — the gate checks the `via` alias's command, only the checker checks that an unconditional job runs it. The env-mutation and composite scan on `production-infra-contract`, whose install runs before the one suite the gate does not run. The alias-resolution and local-allowlist invariants and the pin-validator ordering, all outside the gate's world.

**Residual, accepted and recorded in the ADR.** The checker now runs after a PR-authored `postinstall`. A `$GITHUB_ENV` `NODE_OPTIONS` poison written there silences the checker, and a static scan cannot report a write that silences its own detector. The gate runs before that install and is unaffected — which is the reason for the ordering. The gate is the security-critical half; the checker is the drift net.

**Local-gate routing moved with the coverage** (Codex round 1, comment `3766397748`). The local quality gate's two `scripts/` symlink arms were leaning on a retired assertion: they scheduled only the checker, so a suite added beneath a committed link left the local gate green while the missing manifest entry red only after push. Reproduced on this branch — checker exit 0, `sentry-suite-gate.mjs` exit 1 naming the missing entry, and both arms scheduling only the former. Both arms now schedule the gate pair too, from one shared helper: four verbatim copies of those command strings are four places to drift, and `add_command` deduplicates on the exact string, so a drifted copy schedules a second, different command rather than failing. `agent-quality-gate.test.sh` now requires all three commands on both symlink paths, and is red against the pre-fix routing.

Net: 932 deletions against 392 insertions across 11 files.

## Validation

- `node scripts/check-sentry-suites-in-ci.test.mjs` — 43 tests, 43 pass, 0 fail (was 52/52; the 9 removed are the retirements above).
- `/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry-suite-gate.mjs` — 13 suites ran and were asserted from their own output; 1 exempt entry's route verified.
- `bash scripts/agent-quality-gate.test.sh` — passed.
- `bash scripts/agent-quality-gate.sh --run --parallel 4 --base origin/main` — all mapped commands passed.
- `pnpm docs:index --check`, `pnpm agent:context-check`, `pnpm adr:check`, `pnpm sentry:brief:test` — all clean.
- **Negative controls on the relocated arrangement.** Eight mutations of the real ci.yml fed to the real `gateJobBlockers`, each REJECTED, with the unmutated workflow as the positive control: checker step deleted; reverted to a pnpm alias; given `|| true`; given `continue-on-error`; install moved in front of the gate; install deleted; an `if:` on the job; the whole job deleted.
- **A skipped-diff class now runs the checker.** Parsing the real ci.yml and matching the real `rootScripts` globs with picomatch, the matcher `dorny/paths-filter` uses:

| change set | `scripts` job | checker before | checker after |
| --- | --- | --- | --- |
| `ui-dashboard/src/app/page.tsx` | SKIPS | SKIPPED | runs |
| `indexer-envio/src/handlers/fpmm.ts` | SKIPS | SKIPPED | runs |
| `docs/img/pipeline.png` | SKIPS | SKIPPED | runs |
| `docs/notes/sentry-triage-pipeline.md` | runs | runs | runs |
| `.github/workflows/ci.yml` | runs | runs | runs |

  `jobs['sentry-suites'].if` is `null` and it has no `needs`, so nothing gates it.

- **CI wall-clock.** `scripts` loses 13 suite steps and the checker; `sentry-suites` gains an install plus the checker. Locally the checker is 13-42s depending on machine contention (its bash gate-probes dominate) and the suites it no longer duplicates were the same set the gate already runs in 7.6s. Expect the two jobs to net out close to flat, with `sentry-suites` about a minute longer and `scripts` about a minute shorter; no new runner boot, since both jobs already existed.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0062 is updated in this PR with the per-assertion narrowing decision it had left open.

Refs #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TffRJhHRg2aFwuCv3zCsH4
