### PR TITLE
feat: add fail-closed EUROP admission diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -999,6 +999,12 @@ jobs:
         run: node scripts/check-peg-registry-integrity.mjs
       - name: Peg registry integrity checker suite
         run: node scripts/check-peg-registry-integrity.test.mjs
+      - name: EUROP operational-admission evaluator suite
+        run: node --test scripts/europ-operational-admission.test.mjs
+      - name: EUROP local-fork proof runner contract
+        # Static-only: the runner itself needs an operator-supplied read-only
+        # Polygon source and must never run against CI or production.
+        run: node --test scripts/europ-operational-admission-proof.test.mjs
       - name: Lighthouse config assertion suite
         # Exercises route matching, per-route threshold boundaries, and
         # multi-run aggregation through the installed LHCI CLI. Keep this in

--- a/docs/notes/europ-operational-admission.md
+++ b/docs/notes/europ-operational-admission.md
@@ -3,7 +3,7 @@ title: EUROP operational admission evidence
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-12
 doc_type: runbook
 scope: peg-monitoring / operational-admission
 review_interval_days: 90
@@ -14,105 +14,69 @@ garden_lane: operator-runbooks
 
 ## Decision
 
-EUROP is **Blocked** from operational **Live** admission. The public price
-monitor, dashboard, and alerts are already deployed; this decision only says
-that the stronger proof that responders can keep EURm loss within the approved
-budget is incomplete.
+EUROP remains **Blocked** from operational **Live** admission. The public price
+monitor, dashboard, and alerts are deployed. The tracked evaluator always
+returns `BLOCKED` with both budget comparisons `not_evaluable`.
 
-The pinned input and deterministic evaluator are
+The pinned input and diagnostic evaluator are
 [`2026-08-11.json`](../../scripts/fixtures/europ-operational-admission/2026-08-11.json)
 and
 [`europ-operational-admission.mjs`](../../scripts/europ-operational-admission.mjs).
-The evaluator always returns `BLOCKED`; static numbers and flags cannot grant
-readiness. A future implementation must execute and authenticate the complete
-sequential loss model before the canonical onboarding gate can consider a Live
-decision.
+They validate input shape and arithmetic only. They do not authenticate chain
+state, execute a complete sequential loss model, or attest fork-source and
+execution provenance. Static values and claims cannot grant readiness.
 
 ## Pinned Polygon configuration
 
-All mutable values below were read at Polygon block `91830875`, hash
+The checked-in snapshot records Polygon block `91830875`, hash
 `0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25`,
-timestamp `2026-08-11T12:29:00Z`.
-PublicNode, dRPC, and 1RPC returned the same pin.
-The deterministic diagnostic was evaluated at `2026-08-11T12:35:00Z` with a
-maximum evidence age of 900 seconds; the pin was 360 seconds old.
+timestamp `2026-08-11T12:29:00Z`. It records the EURm/EUROP FPMM
+`0xcd8c6811d975981f57e7fb32e59f0bee66af3201`, EURm token0 and EUROP token1,
+the control Safe, manual-rate controls, both enabled strategies, and the
+reviewed LP-custody boundary.
 
-| Area                | Measured configuration                                                                                                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Pool                | EURm/EUROP FPMM `0xcd8c6811d975981f57e7fb32e59f0bee66af3201`                                                                                                                                                 |
-| Assets              | EURm token0 `0x4D502d735B4C574B487Ed641ae87cEaE884731C7` (18 decimals); EUROP token1 `0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51` (6 decimals)                                                               |
-| Reserves            | `6,932.949238266138502114` EURm and `10,399.423858` EUROP                                                                                                                                                    |
-| Pool administration | The FPMM owner and fee setter are the control Safe.                                                                                                                                                          |
-| Fees                | 3 bps LP + 2 bps protocol = 5 bps total                                                                                                                                                                      |
-| Trading-limit state | L0: 50,000 EUROP / 300 s, netflow `3,498.25` EUROP, last update `1785520845`; L1: 250,000 EUROP / 86,400 s, netflow `9,229.728525` EUROP, last update `1785453845`. Both use TradingLimitsV2 fixed-15 scale. |
-| Control Safe        | `0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458`; 4-of-6, nonce 9 at the pin.                                                                                                                                    |
-| Manual-rate control | Feed `0xc22418a83DfC262B10a1f57E25309DB83E7eA79e`; rate 1, last updated `2026-07-16T15:19:19Z`, non-expired. The ValueDelta breaker is enabled with a 50-bps threshold.                                      |
-| Enabled strategies  | Open `0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f` and Reserve `0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B`, each with a 300-second cooldown.                                                                 |
-| Reserve access      | ReserveV2 `0x4255Cf38e51516766180b33122029A88Cb853806`; its direct EURm and EUROP balances were zero at the pin. Those balances are not an approved liquid-reserve value or a loss cap.                      |
-
-Both trading-limit windows were expired at the pin. The six-hour capacity below
-does not rely on that favorable state; it uses the durable worst reachable
-limit state required by the onboarding runbook.
-
-The checked-in snapshot is diagnostic evidence. The evaluator validates field
-shape, Safe threshold/owner-count consistency, freshness, and arithmetic, but
-it does not authenticate the RPC reads or any claimed Safe, rate, strategy,
-budget, or model control. Those claims cannot clear the Blocked result.
-It refuses to calculate capacity unless the snapshot identifies Polygon 137,
-the expected pool and EUROP/EURm contracts and decimals, and a well-formed
-positive block number and hash. Numeric fields use canonical integers only;
-timestamps require an explicit UTC offset and valid calendar values.
-A well-formed block number and hash are still unauthenticated. They are reported
-separately from the expected EUROP/Polygon protocol identity so a future fresh
-block is never mislabeled as the dated pinned block above.
+The evaluator requires Polygon `137`, the expected pool/contracts/decimals, a
+positive canonical block number, a well-formed block hash, canonical integers,
+and timestamps with an explicit UTC offset. It reports identity and arithmetic
+diagnostics separately from authentication. A well-formed value is still an
+unattested snapshot claim.
 
 The protected-system boundary is every EURm movement involving the FPMM, its
-enabled liquidity strategies, ReserveV2, and the protocol-fee recipient. It
-includes transfers, minting, and burning. The Safe and rate breaker are control
-inputs; they are not treated as economic asset holders.
-The Safe diagnostic's expected-control-structure field covers its address and
-4-of-6 structure only. Nonce is reported as mutable point-in-time data and is
-not part of that field; all Safe fields remain unauthenticated snapshot claims.
+enabled liquidity strategies, ReserveV2, the protocol-fee recipient, and LP
+custody Safe `0x3fac3feF4408CFB03aa190fbD94D571C42cFd1f1`. It includes
+transfers, minting, burning, and LP exits. An in-boundary pro-rata burn to the
+approved custody Safe is internal custody movement. The future model must fail
+closed on custody-control drift or an LP exit outside the approved boundary.
 
-## Approved operating choices recorded for this review
+## Approved operating choices
 
 [#1687](https://github.com/mento-protocol/monitoring-monorepo/issues/1687)
-records the owner decisions:
+records the accountable-owner decisions:
 
-- Philip Paetz owns signer coverage, with Bogdan Dumitru as backup.
-- The active `@support-engineer` is the escalation route, resolved from the
-  VictorOps / Splunk On-Call rotation.
-- The end-to-end response time is `S = 6 hours` (`21,600` seconds).
-- Safe nonce 8 is accepted as execution proof for the current threshold.
-- The starter budget rule is `B = min(100,000 EURm, 0.5% of approved current
-liquid reserve assets)`.
+- Philip Paetz owns signer coverage; Bogdan Dumitru is backup.
+- The active `@support-engineer`, resolved from VictorOps / Splunk On-Call, is
+  the escalation route.
+- The response period is `S = 6 hours` (`21,600` seconds).
+- Safe nonce 8 is the accepted execution evidence for the current threshold.
+- Philip approved `B = 100,000 EURm` through [issue comment
+  5254428553](https://github.com/mento-protocol/monitoring-monorepo/issues/1687#issuecomment-5254428553).
+- Philip is the independent reviewer.
+- Signer coverage, escalation, execution evidence, and budget approval expire
+  at `2026-11-09T14:21:33Z`.
+- Open and Reserve strategies remain enabled; the ValueDelta threshold remains
+  50 bps.
+- The emergency halt is the control Safe reporting exact `0.994`
+  (`994000000000000000000000` at 24 decimals) to SortedOracles feed
+  `0xc22418a83DfC262B10a1f57E25309DB83E7eA79e`. The intended effect is trading
+  mode `1`, which stops swaps and both strategy rebalances.
 
-The policy does not yet define which custody accounts count as “current liquid
-reserve assets,” which valuation feeds and haircuts apply, or how that result
-becomes `B`. The exact current liquid-reserve value and approved numeric `B`
-are therefore absent. The above human attestations also have no explicit expiry
-or independent reviewer recorded yet.
-
-There is one **unapproved conditional calculation** in the pinned snapshot:
-the registered assets held by ReserveV2 plus its listed other-reserve Safe hold
-`120,812.444400` USDC; with contemporaneous USDC/USD `0.9998` and EUR/USD
-`1.15364`, that is `104,701.884392982212822024` EURm and produces
-`523.509421964911064110` EURm at 0.5%. This is not `B`. It becomes usable only
-if the accountable owner explicitly approves that custody boundary, valuation
-method, and resulting number. The evaluator keeps `B` empty until then.
-
-That inventory is shared. ReserveV2 also serves the enabled USDC/USDm pool
-`0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5`, while the Open strategy also
-serves the active EURm/USDm pool
-`0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61`. The conditional figure is a
-same-block inventory value only. A durable model must include or enforceably
-exclude concurrent reachable transitions in those pools before treating the
-inventory as available to EUROP.
+These are policy targets and snapshot claims. They do not clear the admission
+blockers.
 
 ## Six-hour swap capacity
 
-The evaluator applies the canonical TradingLimitsV2 capacity formula with
-`S = 21,600` seconds:
+The evaluator derives the documented TradingLimitsV2 monotone EUROP-input
+capacity for `S = 21,600` seconds:
 
 ```text
 D_live,i(S) = 2L_i + L_i * ceil(S / W_i)
@@ -126,84 +90,81 @@ D_net(S) = min(D_live,i(S))
 | Binding `D_net(S)`            |   750,000 EUROP fixed-15 netflow |
 | Fee-adjusted maximum input    |             750,375.187593 EUROP |
 
-The pinned L0 and L1 signed netflows are inside their enforced `[-L, +L]`
-intervals. The evaluator blocks values one fixed-15 unit beyond either edge.
+This is EUROP-input capacity, not a EURm-loss result. It cannot be compared
+with `B` until a future complete boundary-aligned model derives EURm outflow.
 
-This is a **monotone EUROP-input capacity**, not a EURm-loss result. `B` is in
-EURm, so the two numbers cannot be compared directly. A future executable model
-must derive a boundary-aligned EURm result for that capacity and separately
-derive the full worst-case EURm result before either can be compared with `B`.
+## Local-fork diagnostic
+
+The localhost-only runner observes a candidate 51-cycle path from the pinned
+configuration: 2,000 EUROP input, 1,999 EURm output, then Reserve rebalance in
+each cycle. Its local Anvil execution observed 153 successful receipts,
+51 successful Reserve rebalances, 15,080 elapsed seconds, and 101,949 EURm
+external outflow. The amount is 1,949 EURm above the approved budget.
+
+That 101,949 EURm result is useful engineering evidence about the fixed local
+candidate path. It is an unattested local diagnostic. It cannot establish
+fork-source provenance, independent execution provenance, production activity,
+or the complete worst-case loss. It therefore cannot support Live admission or
+change either evaluator budget comparison from `not_evaluable`.
+
+The runner also observes the candidate emergency-halt path: it checks the
+fixed 0.994 report, trading-mode change, swap and both rebalance failures, and
+the 1.0 restoration path. Those observations are likewise unattested local
+diagnostics.
 
 ## Why the decision stays Blocked
 
-- **No executable authenticated loss model:** the repository has no program
-  that authenticates the inputs, advances every reachable swap, rate, and
-  strategy transition, and calculates net EURm outflow across the protected
-  boundary. This is an unconditional blocker in the current evaluator.
-- **Static control claims are untrusted:** editing Safe, rate, strategy, budget,
-  certificate, model flags, or claimed loss numbers in JSON cannot grant
-  readiness or produce a passing budget comparison.
-- **No numeric budget:** the approved liquid-reserve value and exact `B` are
-  absent. The available `523.509421964911064110` EURm figure is only an
-  unapproved conditional calculation.
-- **No enforceable rate-transition bound:** the current configuration does not
-  provide an enforced no-change, no-arbitrage, or maximum-successful-transition
-  control for the six-hour interval.
-- **Incomplete strategy boundary:** both strategies are enabled and neither
-  has a documented, enforceable EURm-outflow bound for the six-hour interval.
-  The Reserve strategy has EURm/USDm mint and burn permissions and no
-  enforceable per-interval mint cap, so visible EURm balances cannot serve as
-  that bound. Both strategy action checks were not rebalancable at the pin;
-  that is a point-in-time observation, not a six-hour guarantee.
-- **No complete loss model:** there is no deterministic, protected-boundary
-  result that covers both rate transitions and every enabled strategy, either
-  for the monotone capacity or for the worst case.
-- **Incomplete certificate:** signer coverage, escalation route, execution
-  proof, and budget approval have no explicit expiry; a reviewer is also not
-  recorded. Expiries are checked against the explicit evaluation time, not the
-  observation time.
+- `EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED`: no complete authenticated
+  sequential model covers every reachable protected-boundary EURm transition.
+- `SNAPSHOT_NOT_AUTHENTICATED`: the checked-in values are diagnostic snapshot
+  claims, not authenticated current state.
+- `LOCAL_FORK_PROVENANCE_UNATTESTED`: the local runner has no independent
+  execution or fork-source attestation.
+- The existing configuration has no enforceable rolling six-hour boundary over
+  swaps, both strategies, Reserve mint-to-exit paths, and unapproved LP exits.
 
-The result is intentionally conservative. Any absent, stale, malformed, or
-unsupported input remains a blocker rather than becoming an assumption.
+The forward control remains an enforceable rolling six-hour, per-pool net
+external EURm-outflow guard of at most 100,000 EURm covering that full
+boundary. A future admission implementation must authenticate current state,
+run the complete model, and obtain independent execution and fork-source
+attestation.
 
-## Re-run and review
+## Run and review
 
-Use the tracked snapshot to reproduce the current result:
+Run the snapshot evaluator:
 
 ```bash
 node scripts/europ-operational-admission.mjs \
   --snapshot scripts/fixtures/europ-operational-admission/2026-08-11.json
 ```
 
-The expected result is JSON with `status: BLOCKED` and process exit `1`.
-Unreadable or invalid JSON exits `2`. Treat either nonzero result as a
-fail-closed outcome; this command is not a success probe.
+It emits `status: BLOCKED`, `worstCaseBudgetComparison.status: not_evaluable`,
+and unattested local-fork labels, then exits `1`. It rejects `--proof-dir` with
+structured `BLOCKED` JSON, blocker
+`LOCAL_FORK_ARTIFACT_IMPORT_UNSUPPORTED`, and exit `2`.
 
-For a future decision, replace the snapshot with fresh same-block reads and
-an explicit evaluation time and maximum evidence age. The current evaluator
-still returns `BLOCKED` because it does not fetch or authenticate chain data and
-does not execute the sequential loss model. Both budget comparisons remain
-`not_evaluable`, even when a snapshot contains plausible-looking result values.
-An owner-approved numeric `B` can be supplied directly with its accountable
-approver and approval reference; otherwise the snapshot must include an
-approved liquid-reserve denominator that reproduces the starter rule. Neither
-choice clears the unconditional model and authentication blockers.
+Run the local diagnostic only with a read-only Polygon source URL:
 
-The governing procedure remains
-[Peg monitoring onboarding and re-census](peg-monitoring-onboarding.md),
-especially its response-SLA and loss-bound sections. Re-run the calculation
-after any change to the Safe, rate control, fee, limits, strategy, protected
-boundary, response SLA, budget, or certificate.
+```bash
+POLYGON_RPC_URL=https://polygon-rpc.example \
+  scripts/europ-operational-admission-proof.sh
+```
+
+The runner starts separate fresh localhost-only Anvil forks for the candidate
+path and halt/restore checks. It rejects an execution RPC URL, uses unlocked
+local Anvil accounts only, and checks the chain, pinned block, receipts, action
+traces, safety assertions, and manifests before it prints its output. Its
+output remains an unattested local diagnostic and is never consumed by the
+evaluator.
+
+No production change is authorized by this runbook. Re-run the review after a
+change to the Safe, rate control, fee, limits, strategy, protected boundary,
+response SLA, budget, or certificate.
 
 ## Sources
 
-- The checked-in snapshot above is the source of the pinned on-chain values and
-  the current `BLOCKED` result.
+- The checked-in snapshot is the source of the dated diagnostic values.
 - [Issue #1687](https://github.com/mento-protocol/monitoring-monorepo/issues/1687)
-  records the accountable-owner decisions and accepted execution proof.
-- The model follows the canonical
-  [onboarding runbook](peg-monitoring-onboarding.md), including its
-  TradingLimitsV2 formula and protected-boundary requirement.
-- The control interpretation was verified against `mento-core`
-  `07ecf3df5650a33ea6957f1ad2966e02c5082253`, in `TradingLimitsV2`, `FPMM`,
-  and `ReserveLiquidityStrategy`.
+  records the owner decisions and expiry details.
+- [Peg monitoring onboarding and re-census](peg-monitoring-onboarding.md)
+  owns the response-SLA and loss-bound procedure.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -3,7 +3,7 @@ title: Peg monitoring onboarding and re-census
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-12
 doc_type: runbook
 scope: metrics-bridge / alerts / ui-dashboard
 review_interval_days: 90
@@ -465,20 +465,26 @@ mutable value before production activation.
   windows at the pinned block and positive-inflow saturation was zero.
 
 This snapshot closes identity, control-address, Safe owner-set and threshold,
-and live-limit discovery only for that dated block. EUROP remains **Blocked**
-until accountable owners supply and approve:
+and live-limit discovery only for that dated block. The later owner decisions
+in [issue #1687](https://github.com/mento-protocol/monitoring-monorepo/issues/1687)
+approve Philip Paetz with Bogdan Dumitru as backup for signer coverage, the
+active `@support-engineer` as the escalation route, `S = 6 hours`, Safe nonce 8
+as execution evidence, and `B = 100,000 EURm`. Philip is the independent
+reviewer. Signer coverage, the escalation route, execution evidence, and
+budget approval expire at `2026-11-09T14:21:33Z`.
 
-- **Signer coverage and end-to-end response SLA:** coverage hours, fallback,
-  holidays, and a worst approved diagnosis-to-finality time.
-- **Escalation owner and maintained route:** a named accountable team or role
-  and the route responders will use.
-- **Execution proof:** a recent drill or transaction showing that four current
-  signers can complete the breaker path inside the approved SLA.
-- **Boundary-aligned drain calculation:** after `S` is approved, refresh the
-  pool, fee, rate, reserve-access, and trading-limit reads, then calculate the
-  exact worst-case quote outflow.
-- **Approved survivable quote-asset loss budget:** treasury/risk must supply
-  `B`; monitoring must not infer it from pool liquidity or trading limits.
+EUROP remains **Blocked** on the following evidence and control gaps:
+
+- **Authenticated complete loss model:** authenticate current on-chain state,
+  contract identities, fork source, and execution, then model every reachable
+  swap, rate change, strategy rebalance, Reserve mint-to-exit path, and LP exit
+  across the protected boundary for the full six-hour response period.
+- **Enforceable loss control:** enforce a rolling six-hour, per-pool net
+  external EURm-outflow ceiling of at most `100,000 EURm` across that full
+  boundary. The current configuration has no such guard.
+- **Boundary-aligned decision:** use the authenticated model to prove
+  `worst_case_net_EURm_outflow <= 100,000 EURm`. TradingLimitsV2 capacity and
+  unattested local-fork output cannot establish this result.
 
 Do not copy the dated market-depth figures from
 [`docs/PLAN-peg-monitoring.md`](../PLAN-peg-monitoring.md) into an approval.
@@ -486,10 +492,11 @@ Repeat the census and attach current evidence.
 
 The current six-hour EUROP operational-admission record is in
 [EUROP operational admission evidence](europ-operational-admission.md). Its
-deterministic evaluator preserves the current **Blocked** decision until a
-fresh same-block input includes the numeric budget, enforceable controls,
-explicit certificate expiries, and a boundary-aligned EURm calculation. Its
-TradingLimitsV2 capacity output alone never proves the loss-budget gate. The
-current evaluator cannot grant readiness: it remains Blocked until an
-executable model authenticates the inputs and executes every sequential
-protected-boundary transition.
+checked-in input records the numeric budget and certificate expiries as
+unattested claims. Its deterministic evaluator preserves the current
+**Blocked** decision because it cannot authenticate those inputs or execute a
+complete boundary-aligned model. TradingLimitsV2 capacity alone never proves
+the loss-budget gate. Admission requires authenticated current state,
+independent execution and fork-source provenance, the enforceable control
+above, and a complete model that executes every sequential protected-boundary
+transition.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -491,5 +491,5 @@ fresh same-block input includes the numeric budget, enforceable controls,
 explicit certificate expiries, and a boundary-aligned EURm calculation. Its
 TradingLimitsV2 capacity output alone never proves the loss-budget gate. The
 current evaluator cannot grant readiness: it remains Blocked until an
-executable model authenticates the inputs and reproduces every sequential
+executable model authenticates the inputs and executes every sequential
 protected-boundary transition.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -96,9 +96,11 @@ pnpm integrations:probe        # Quote-only Mento v3 route coverage snapshot
 pnpm integrations:probe --write-upstash  # Publish latest snapshot for /integrations
 pnpm integrations:probe:test   # Unit tests for probe adapters/parsers
 
-# EUROP operational admission (the tracked 2026-08-11 evidence snapshot is intentionally Blocked)
-node scripts/europ-operational-admission.mjs --snapshot scripts/fixtures/europ-operational-admission/2026-08-11.json  # Expected exit 1 + JSON Blocked; exit 2 means unreadable/invalid JSON
-node --test scripts/europ-operational-admission.test.mjs  # Regression tests for the fail-closed capacity and budget checks
+# EUROP operational admission (the tracked 2026-08-11 evidence snapshot remains Blocked)
+node scripts/europ-operational-admission.mjs --snapshot scripts/fixtures/europ-operational-admission/2026-08-11.json  # Expected exit 1 + BLOCKED/not_evaluable/unattested
+node --test scripts/europ-operational-admission.test.mjs  # Regression tests for fail-closed evaluator provenance and arithmetic diagnostics
+POLYGON_RPC_URL=https://polygon-rpc.example scripts/europ-operational-admission-proof.sh  # Runs two fresh localhost-only Anvil diagnostic scenarios; output is unattested
+node --test scripts/europ-operational-admission-proof.test.mjs  # Static runner safety, arithmetic, manifest, halt, and restore contract
 
 # Agent issue workboard
 # (Claude cloud sessions without the capability gate: MCP fallback in

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2256,6 +2256,9 @@ while IFS= read -r path; do
         scripts/sanitize-terraform-output.sh)
           add_command "pnpm sanitize:test" "Terraform output sanitizer changed"
           ;;
+        scripts/europ-operational-admission-proof.sh)
+          add_command "node --test scripts/europ-operational-admission-proof.test.mjs" "EUROP local-fork proof runner changed"
+          ;;
       esac
       case "$path" in
         scripts/check-agent-quality-gate-package-scripts.sh)
@@ -2513,8 +2516,11 @@ while IFS= read -r path; do
           add_command "node scripts/check-peg-registry-integrity.mjs" "peg registry integrity checker changed"
           add_command "node scripts/check-peg-registry-integrity.test.mjs" "peg registry integrity checker changed"
           ;;
-        scripts/europ-operational-admission.mjs|scripts/europ-operational-admission.test.mjs)
+        scripts/europ-operational-admission.mjs|scripts/europ-operational-admission-contract.mjs|scripts/europ-operational-admission-evidence.mjs|scripts/europ-operational-admission-controls.mjs|scripts/europ-operational-admission-witness.mjs|scripts/europ-operational-admission.test.mjs)
           add_command "node --test scripts/europ-operational-admission.test.mjs" "EUROP operational-admission evaluator changed"
+          ;;
+        scripts/europ-operational-admission-proof.sh|scripts/europ-operational-admission-proof.test.mjs)
+          add_command "node --test scripts/europ-operational-admission-proof.test.mjs" "EUROP local-fork proof runner changed"
           ;;
         scripts/check-pr-description.mjs|scripts/check-pr-description.test.mjs)
           add_command "node scripts/check-pr-description.test.mjs" "PR description validator changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4047,11 +4047,31 @@ assert_contains "- node scripts/check-peg-registry-integrity.test.mjs (peg regis
 run_gate "scripts/europ-operational-admission.mjs"
 assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
 
+run_gate "scripts/europ-operational-admission-contract.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/europ-operational-admission-evidence.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/europ-operational-admission-controls.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/europ-operational-admission-witness.mjs"
+assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
 run_gate "scripts/europ-operational-admission.test.mjs"
 assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
 
 run_gate "scripts/fixtures/europ-operational-admission/2026-08-11.json"
 assert_contains "- node --test scripts/europ-operational-admission.test.mjs (EUROP operational-admission evaluator changed)"
+
+run_gate "scripts/europ-operational-admission-proof.sh"
+assert_contains "- bash -n scripts/europ-operational-admission-proof.sh (shell script changed)"
+assert_contains "- node --test scripts/europ-operational-admission-proof.test.mjs (EUROP local-fork proof runner changed)"
+
+run_gate "scripts/europ-operational-admission-proof.test.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_contains "- node --test scripts/europ-operational-admission-proof.test.mjs (EUROP local-fork proof runner changed)"
 
 run_gate "scripts/check-pr-description.mjs"
 assert_contains "- node scripts/check-pr-description.test.mjs (PR description validator changed)"

--- a/scripts/europ-operational-admission-contract.mjs
+++ b/scripts/europ-operational-admission-contract.mjs
@@ -1,0 +1,236 @@
+export const BASIS_POINTS = 10_000n;
+export const FIXED_15 = 10n ** 15n;
+export const MAX_BUDGET_EURM_RAW = 100_000n * 10n ** 18n;
+export const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+export const BLOCK_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+const CANONICAL_INTEGER_PATTERN = /^(?:0|-?[1-9][0-9]*)$/u;
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|[+-]\d{2}:\d{2})$/u;
+export const EXPECTED_CHAIN_ID = 137n;
+export const EXPECTED_PIN_BLOCK_NUMBER = 91_830_875n;
+export const EXPECTED_PIN_BLOCK_HASH =
+  "0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25";
+export const EXPECTED_POOL_ADDRESS =
+  "0xcd8c6811d975981f57e7fb32e59f0bee66af3201";
+export const EXPECTED_PROTOCOL_FEE_RECIPIENT =
+  "0x0dd57f6f181d0469143fe9380762d8a112e96e4a";
+export const EXPECTED_QUOTE_TOKEN_ADDRESS =
+  "0x4d502d735b4c574b487ed641ae87ceae884731c7";
+export const EXPECTED_MONITORED_TOKEN_ADDRESS =
+  "0x888883b5f5d21fb10dfeb70e8f9722b9fb0e5e51";
+export const EXPECTED_QUOTE_TOKEN_DECIMALS = 18n;
+export const EXPECTED_MONITORED_TOKEN_DECIMALS = 6n;
+export const EXPECTED_SAFE_ADDRESS =
+  "0x58099b74f4acd642da77b4b7966b4138ec5ba458";
+export const EXPECTED_SAFE_THRESHOLD = 4n;
+export const EXPECTED_SAFE_OWNER_COUNT = 6n;
+export const EXPECTED_ORACLE_ADAPTER =
+  "0xeb23e1339b2119c0f4a0097cb294e990c1fa6423";
+export const EXPECTED_SORTED_ORACLES =
+  "0x6f92c745346057a61b259579256159458a0a6a92";
+export const EXPECTED_BREAKER_BOX =
+  "0x9fc1e0d10fb38954da385b8b25ab2bbaf3241722";
+export const EXPECTED_VALUE_DELTA_BREAKER =
+  "0xca2e7563dfc30bc94687f3deacf682e1dbaffa13";
+export const EXPECTED_RATE_FEED = "0xc22418a83dfc262b10a1f57e25309db83e7ea79e";
+export const EXPECTED_OPEN_STRATEGY =
+  "0x54e2ae8c8448912e17ce0b2453bafb7b0d80e40f";
+export const EXPECTED_RESERVE_STRATEGY =
+  "0xa0fb8b16ce6af3634ff9f3f4f40e49e1c1ae4f0b";
+export const EXPECTED_RESERVE_V2 = "0x4255cf38e51516766180b33122029a88cb853806";
+export const EXPECTED_LP_CUSTODY_SAFE =
+  "0x3fac3fef4408cfb03aa190fbd94d571c42cfd1f1";
+export const EXPECTED_RATE_RAW = 1_000_000_000_000_000_000_000_000n;
+export const EXPECTED_HALT_RATE_RAW = 994_000_000_000_000_000_000_000n;
+export const EXPECTED_VALUE_DELTA_THRESHOLD_RAW =
+  5_000_000_000_000_000_000_000n;
+export const EXPECTED_VALUE_DELTA_BPS = 50n;
+export const EXPECTED_RATE_DECIMALS = 24n;
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+export const EXPECTED_WITNESS_MODEL = "europ-reserve-rebalance-51-cycle-v1";
+export const EXPECTED_MENTO_CORE_COMMIT =
+  "07ecf3df5650a33ea6957f1ad2966e02c5082253";
+export const EXPECTED_LP_CUSTODY_BALANCE_RAW = 8_659_037_237_856_031n;
+export const EXPECTED_LP_TOTAL_SUPPLY_RAW = 8_660_537_237_856_031n;
+export const EXPECTED_QUOTE_RESERVE_RAW = 6_932_949_238_266_138_502_114n;
+export const EXPECTED_MONITORED_RESERVE_RAW = 10_399_423_858n;
+export const EXPECTED_TRADING_LIMITS = [
+  {
+    name: "L0",
+    limitFixed15: 50_000_000_000_000_000_000n,
+    durationSeconds: 300n,
+    netflowFixed15: 3_498_250_000_000_000_000n,
+    lastUpdated: 1_785_520_845n,
+  },
+  {
+    name: "L1",
+    limitFixed15: 250_000_000_000_000_000_000n,
+    durationSeconds: 86_400n,
+    netflowFixed15: 9_229_728_525_000_000_000n,
+    lastUpdated: 1_785_453_845n,
+  },
+];
+export const EXPECTED_BUDGET_APPROVER = "Philip Paetz";
+export const EXPECTED_BUDGET_APPROVAL_REFERENCE =
+  "https://github.com/mento-protocol/monitoring-monorepo/issues/1687#issuecomment-5254428553";
+export const EXPECTED_ESCALATION_ROUTE =
+  "active @support-engineer resolved from VictorOps / Splunk On-Call";
+export const EXPECTED_EXECUTION_PROOF_REFERENCE =
+  "https://polygonscan.com/tx/0x967535dc2f331298c2f88feb8a148e60a85fdc8a84dc1d3f83fcea547ef3b8b4";
+export const EXPECTED_RESPONSE_SECONDS = 21_600n;
+export const EXPECTED_EXECUTION_SECONDS = 7_889n;
+
+export function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return value;
+}
+
+export function requiredArray(value, field) {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  return value;
+}
+
+export function integer(value, field) {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${field} must be a safe integer number`);
+    }
+    return BigInt(value);
+  }
+  if (typeof value === "string" && CANONICAL_INTEGER_PATTERN.test(value)) {
+    return BigInt(value);
+  }
+  throw new Error(
+    `${field} must be a canonical integer string or safe integer number`,
+  );
+}
+
+export function nonNegative(value, field) {
+  const parsed = integer(value, field);
+  if (parsed < 0n) throw new Error(`${field} must be non-negative`);
+  return parsed;
+}
+
+export function positive(value, field) {
+  const parsed = nonNegative(value, field);
+  if (parsed === 0n) throw new Error(`${field} must be positive`);
+  return parsed;
+}
+
+export function optionalNonNegative(value, field) {
+  if (value === null || value === undefined) return null;
+  return nonNegative(value, field);
+}
+
+export function ceilDiv(numerator, denominator) {
+  if (numerator < 0n || denominator <= 0n) {
+    throw new Error(
+      "ceilDiv requires a non-negative numerator and positive denominator",
+    );
+  }
+  return (numerator + denominator - 1n) / denominator;
+}
+
+export function min(values) {
+  if (values.length === 0) throw new Error("cannot take minimum of no values");
+  return values.reduce((current, value) => (value < current ? value : current));
+}
+
+export function issue(code, message) {
+  return { code, message };
+}
+
+export function hasText(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function matchesAddress(value, expected) {
+  return (
+    hasText(value) &&
+    ADDRESS_PATTERN.test(value) &&
+    value.toLowerCase() === expected
+  );
+}
+
+function isLeapYear(year) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function daysInMonth(year, month) {
+  const days = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return days[month - 1] ?? 0;
+}
+
+export function timestamp(value) {
+  if (!hasText(value)) return null;
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match) return null;
+
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    millisecondText,
+    offsetText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const millisecond = millisecondText ? Number(millisecondText) : 0;
+
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth(year, month) ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return null;
+  }
+
+  let offsetMinutes = 0;
+  if (offsetText !== "Z") {
+    if (offsetText === "-00:00") return null;
+    const offsetHours = Number(offsetText.slice(1, 3));
+    const offsetMinutePart = Number(offsetText.slice(4, 6));
+    if (
+      offsetHours > 14 ||
+      offsetMinutePart > 59 ||
+      (offsetHours === 14 && offsetMinutePart !== 0)
+    ) {
+      return null;
+    }
+    offsetMinutes = offsetHours * 60 + offsetMinutePart;
+    if (offsetText.startsWith("-")) offsetMinutes = -offsetMinutes;
+  }
+
+  const wallClock = new Date(0);
+  wallClock.setUTCFullYear(year, month - 1, day);
+  wallClock.setUTCHours(hour, minute, second, millisecond);
+  const parsed = wallClock.getTime() - offsetMinutes * 60_000;
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/scripts/europ-operational-admission-controls.mjs
+++ b/scripts/europ-operational-admission-controls.mjs
@@ -1,0 +1,471 @@
+import {
+  EXPECTED_BREAKER_BOX,
+  EXPECTED_HALT_RATE_RAW,
+  EXPECTED_LP_CUSTODY_BALANCE_RAW,
+  EXPECTED_LP_CUSTODY_SAFE,
+  EXPECTED_LP_TOTAL_SUPPLY_RAW,
+  EXPECTED_OPEN_STRATEGY,
+  EXPECTED_ORACLE_ADAPTER,
+  EXPECTED_PROTOCOL_FEE_RECIPIENT,
+  EXPECTED_RATE_DECIMALS,
+  EXPECTED_RATE_FEED,
+  EXPECTED_RATE_RAW,
+  EXPECTED_RESERVE_STRATEGY,
+  EXPECTED_RESERVE_V2,
+  EXPECTED_SAFE_ADDRESS,
+  EXPECTED_SAFE_OWNER_COUNT,
+  EXPECTED_SAFE_THRESHOLD,
+  EXPECTED_SORTED_ORACLES,
+  EXPECTED_VALUE_DELTA_BREAKER,
+  EXPECTED_VALUE_DELTA_BPS,
+  EXPECTED_VALUE_DELTA_THRESHOLD_RAW,
+  EXPECTED_PIN_BLOCK_HASH,
+  EXPECTED_PIN_BLOCK_NUMBER,
+  ZERO_ADDRESS,
+  hasText,
+  issue,
+  matchesAddress,
+  nonNegative,
+  optionalNonNegative,
+  positive,
+  requiredArray,
+  requiredObject,
+} from "./europ-operational-admission-contract.mjs";
+
+export function inspectSafe(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const safe = requiredObject(controls.safe, "controls.safe");
+  const address = safe.address;
+  const threshold = positive(safe.threshold, "controls.safe.threshold");
+  const ownerCount = positive(safe.ownerCount, "controls.safe.ownerCount");
+  const nonce = nonNegative(safe.nonce, "controls.safe.nonce");
+  const validAddress = hasText(address) && /^0x[0-9a-fA-F]{40}$/u.test(address);
+  const ownerSetVerifiedAtPin = safe.ownerSetVerifiedAtPin === true;
+  const structurallyValid =
+    validAddress && threshold <= ownerCount && ownerSetVerifiedAtPin;
+  const matchesExpectedControlStructure =
+    validAddress &&
+    address.toLowerCase() === EXPECTED_SAFE_ADDRESS &&
+    threshold === EXPECTED_SAFE_THRESHOLD &&
+    ownerCount === EXPECTED_SAFE_OWNER_COUNT;
+
+  if (!validAddress || threshold > ownerCount) {
+    blockers.push(
+      issue(
+        "SAFE_STRUCTURE_INVALID",
+        "The Safe address, threshold, or owner count is structurally invalid.",
+      ),
+    );
+  }
+  if (!ownerSetVerifiedAtPin) {
+    blockers.push(
+      issue(
+        "SAFE_OWNER_SET_UNVERIFIED",
+        "The snapshot does not record a same-pin Safe owner-set read.",
+      ),
+    );
+  }
+  if (!matchesExpectedControlStructure) {
+    blockers.push(
+      issue(
+        "SAFE_EXPECTED_CONFIGURATION_MISMATCH",
+        "The Safe address or 4-of-6 structure does not match the expected EUROP control structure.",
+      ),
+    );
+  }
+
+  return {
+    address,
+    threshold,
+    ownerCount,
+    nonce,
+    ownerSetVerifiedAtPin,
+    structurallyValid,
+    matchesExpectedControlStructure,
+    authenticated: false,
+  };
+}
+
+export function inspectRateControl(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const rate = requiredObject(controls.rate, "controls.rate");
+  const rateDecimals = nonNegative(
+    rate.rateDecimals,
+    "controls.rate.rateDecimals",
+  );
+  const manualRateRaw = positive(
+    rate.manualRateRaw,
+    "controls.rate.manualRateRaw",
+  );
+  const valueDeltaBreakerBps = nonNegative(
+    rate.valueDeltaBreakerBps,
+    "controls.rate.valueDeltaBreakerBps",
+  );
+  const valueDeltaThresholdRaw = positive(
+    rate.valueDeltaThresholdRaw,
+    "controls.rate.valueDeltaThresholdRaw",
+  );
+  const valueDeltaCooldownSeconds = nonNegative(
+    rate.valueDeltaCooldownSeconds,
+    "controls.rate.valueDeltaCooldownSeconds",
+  );
+  const currentTradingMode = nonNegative(
+    rate.currentTradingMode,
+    "controls.rate.currentTradingMode",
+  );
+  const configurationMatches =
+    matchesAddress(rate.manualRateFeedId, EXPECTED_RATE_FEED) &&
+    matchesAddress(rate.oracleAdapter, EXPECTED_ORACLE_ADAPTER) &&
+    matchesAddress(rate.sortedOracles, EXPECTED_SORTED_ORACLES) &&
+    matchesAddress(rate.breakerBox, EXPECTED_BREAKER_BOX) &&
+    matchesAddress(rate.valueDeltaBreaker, EXPECTED_VALUE_DELTA_BREAKER) &&
+    rateDecimals === EXPECTED_RATE_DECIMALS &&
+    manualRateRaw === EXPECTED_RATE_RAW &&
+    valueDeltaBreakerBps === EXPECTED_VALUE_DELTA_BPS &&
+    valueDeltaThresholdRaw === EXPECTED_VALUE_DELTA_THRESHOLD_RAW &&
+    valueDeltaCooldownSeconds === 1n &&
+    currentTradingMode === 0n &&
+    rate.valueDeltaBreakerEnabled === true;
+  const noChangeClaim = rate.enforcedNoChange === true;
+  const noArbitrageClaim = rate.enforcedNoArbitrage === true;
+  const maxSuccessfulTransitionsClaim = optionalNonNegative(
+    rate.maxSuccessfulTransitions,
+    "controls.rate.maxSuccessfulTransitions",
+  );
+
+  if (!configurationMatches) {
+    blockers.push(
+      issue(
+        "RATE_CONTROL_CONFIGURATION_MISMATCH",
+        "The rate feed, adapter, breaker wiring, 50-bps threshold, reference rate, cooldown, enablement, or current trading mode differs from the approved EUROP configuration.",
+      ),
+    );
+  }
+
+  if (
+    !noChangeClaim &&
+    !noArbitrageClaim &&
+    maxSuccessfulTransitionsClaim === null
+  ) {
+    blockers.push(
+      issue(
+        "RATE_TRANSITION_BOUND_MISSING",
+        "Bidirectional manual-rate trading has no recorded no-change, no-arbitrage, or maximum-transition control for S.",
+      ),
+    );
+  }
+
+  return {
+    manualRateFeedId: rate.manualRateFeedId ?? null,
+    oracleAdapter: rate.oracleAdapter ?? null,
+    sortedOracles: rate.sortedOracles ?? null,
+    breakerBox: rate.breakerBox ?? null,
+    valueDeltaBreaker: rate.valueDeltaBreaker ?? null,
+    rateDecimals,
+    manualRateRaw,
+    valueDeltaBreakerBps,
+    valueDeltaThresholdRaw,
+    valueDeltaCooldownSeconds,
+    currentTradingMode,
+    configurationMatches,
+    noChangeClaim,
+    noArbitrageClaim,
+    maxSuccessfulTransitionsClaim,
+    authenticated: false,
+  };
+}
+
+export function inspectStrategies(snapshot, blockers) {
+  const controls = requiredObject(snapshot.controls, "snapshot.controls");
+  const strategies = requiredArray(controls.strategies, "controls.strategies");
+  const enumerationClaim = controls.strategiesEnumeratedThroughBlock === true;
+
+  if (!enumerationClaim) {
+    blockers.push(
+      issue(
+        "STRATEGY_ENUMERATION_UNVERIFIED",
+        "The snapshot does not record every strategy enabled through the pinned block.",
+      ),
+    );
+  }
+
+  const entries = strategies.map((strategy, index) => {
+    const parsed = requiredObject(strategy, `controls.strategies[${index}]`);
+    const name = hasText(parsed.name) ? parsed.name : `strategy-${index}`;
+    const enabled = parsed.enabled === true;
+    const cooldownSeconds = optionalNonNegative(
+      parsed.cooldownSeconds,
+      `controls.strategies[${index}].cooldownSeconds`,
+    );
+    const lastRebalance = optionalNonNegative(
+      parsed.lastRebalance,
+      `controls.strategies[${index}].lastRebalance`,
+    );
+    const incentives = requiredObject(
+      parsed.incentives,
+      `controls.strategies[${index}].incentives`,
+    );
+    const liquiditySourceExpansionBps = nonNegative(
+      incentives.liquiditySourceExpansionBps,
+      `controls.strategies[${index}].incentives.liquiditySourceExpansionBps`,
+    );
+    const protocolExpansionBps = nonNegative(
+      incentives.protocolExpansionBps,
+      `controls.strategies[${index}].incentives.protocolExpansionBps`,
+    );
+    const liquiditySourceContractionBps = nonNegative(
+      incentives.liquiditySourceContractionBps,
+      `controls.strategies[${index}].incentives.liquiditySourceContractionBps`,
+    );
+    const protocolContractionBps = nonNegative(
+      incentives.protocolContractionBps,
+      `controls.strategies[${index}].incentives.protocolContractionBps`,
+    );
+    const maxQuoteOutflowClaimEurmRaw = optionalNonNegative(
+      parsed.maxQuoteOutflowEurmRaw,
+      `controls.strategies[${index}].maxQuoteOutflowEurmRaw`,
+    );
+    const mintsQuoteIntoPoolClaim =
+      parsed.kind === "reserve" && parsed.mintsQuoteIntoPool !== false;
+    const mintCapClaimEurmRaw = mintsQuoteIntoPoolClaim
+      ? optionalNonNegative(
+          parsed.mintCapEurmRaw,
+          `controls.strategies[${index}].mintCapEurmRaw`,
+        )
+      : null;
+
+    if (enabled && maxQuoteOutflowClaimEurmRaw === null) {
+      blockers.push(
+        issue(
+          "STRATEGY_BOUNDARY_MODEL_MISSING",
+          `${name} is enabled without a recorded quote-asset boundary model for S.`,
+        ),
+      );
+    }
+    if (enabled && mintsQuoteIntoPoolClaim && mintCapClaimEurmRaw === null) {
+      blockers.push(
+        issue(
+          "RESERVE_MINT_CAP_MISSING",
+          `${name} can mint quote assets into the pool without a recorded cap for S.`,
+        ),
+      );
+    }
+
+    return {
+      name,
+      address: parsed.address ?? null,
+      kind: parsed.kind ?? "unknown",
+      enabled,
+      cooldownSeconds,
+      isToken0Debt: parsed.isToken0Debt === true,
+      lastRebalance,
+      protocolFeeRecipient: parsed.protocolFeeRecipient ?? null,
+      incentives: {
+        liquiditySourceExpansionBps,
+        protocolExpansionBps,
+        liquiditySourceContractionBps,
+        protocolContractionBps,
+      },
+      maxQuoteOutflowClaimEurmRaw,
+      mintsQuoteIntoPoolClaim,
+      mintCapClaimEurmRaw,
+      reserveV2: parsed.reserveV2 ?? null,
+      authenticated: false,
+    };
+  });
+
+  const open = entries.filter((entry) => entry.kind === "open");
+  const reserve = entries.filter((entry) => entry.kind === "reserve");
+  const configurationMatches =
+    entries.length === 2 &&
+    open.length === 1 &&
+    reserve.length === 1 &&
+    matchesAddress(open[0].address, EXPECTED_OPEN_STRATEGY) &&
+    matchesAddress(reserve[0].address, EXPECTED_RESERVE_STRATEGY) &&
+    matchesAddress(reserve[0].reserveV2, EXPECTED_RESERVE_V2) &&
+    open[0].enabled &&
+    reserve[0].enabled &&
+    open[0].cooldownSeconds === 300n &&
+    reserve[0].cooldownSeconds === 300n &&
+    open[0].isToken0Debt &&
+    reserve[0].isToken0Debt &&
+    open[0].lastRebalance === 1_785_523_331n &&
+    reserve[0].lastRebalance === 0n &&
+    matchesAddress(
+      open[0].protocolFeeRecipient,
+      EXPECTED_PROTOCOL_FEE_RECIPIENT,
+    ) &&
+    matchesAddress(
+      reserve[0].protocolFeeRecipient,
+      EXPECTED_PROTOCOL_FEE_RECIPIENT,
+    ) &&
+    Object.values(open[0].incentives).every((value) => value === 0n) &&
+    Object.values(reserve[0].incentives).every((value) => value === 0n);
+
+  if (!configurationMatches) {
+    blockers.push(
+      issue(
+        "STRATEGY_CONFIGURATION_MISMATCH",
+        "The enabled Open or Reserve strategy identity, debt-token orientation, last rebalance, fee recipient, incentives, ReserveV2 source, or cooldown differs from the pinned EUROP configuration.",
+      ),
+    );
+  }
+
+  return {
+    enumerationClaim,
+    configurationMatches,
+    authenticated: false,
+    entries,
+  };
+}
+
+export function inspectEmergencyHalt(snapshot, witnessConfiguration, blockers) {
+  const halt = requiredObject(snapshot.emergencyHalt, "snapshot.emergencyHalt");
+  const proof = requiredObject(
+    halt.forkProof,
+    "snapshot.emergencyHalt.forkProof",
+  );
+  const rateDecimals = nonNegative(
+    halt.rateDecimals,
+    "emergencyHalt.rateDecimals",
+  );
+  const reportRateRaw = positive(
+    halt.reportRateRaw,
+    "emergencyHalt.reportRateRaw",
+  );
+  const expectedTradingMode = nonNegative(
+    halt.expectedTradingMode,
+    "emergencyHalt.expectedTradingMode",
+  );
+  const proofBlockNumber = positive(
+    proof.blockNumber,
+    "emergencyHalt.forkProof.blockNumber",
+  );
+  const proofBlockHashMatches =
+    hasText(proof.blockHash) &&
+    proof.blockHash.toLowerCase() === EXPECTED_PIN_BLOCK_HASH;
+  const restoredRateRaw = positive(
+    proof.restoredRateRaw,
+    "emergencyHalt.forkProof.restoredRateRaw",
+  );
+  const restoredTradingMode = nonNegative(
+    proof.restoredTradingMode,
+    "emergencyHalt.forkProof.restoredTradingMode",
+  );
+  const evidenceBlockNumber = positive(
+    requiredObject(snapshot.evidence, "snapshot.evidence").blockNumber,
+    "evidence.blockNumber",
+  );
+  const localForkClaimMatches =
+    matchesAddress(halt.controlSafe, EXPECTED_SAFE_ADDRESS) &&
+    matchesAddress(halt.sortedOracles, EXPECTED_SORTED_ORACLES) &&
+    matchesAddress(halt.breakerBox, EXPECTED_BREAKER_BOX) &&
+    matchesAddress(halt.valueDeltaBreaker, EXPECTED_VALUE_DELTA_BREAKER) &&
+    matchesAddress(halt.rateFeedId, EXPECTED_RATE_FEED) &&
+    matchesAddress(halt.lesserKey, ZERO_ADDRESS) &&
+    matchesAddress(halt.greaterKey, ZERO_ADDRESS) &&
+    rateDecimals === EXPECTED_RATE_DECIMALS &&
+    reportRateRaw === EXPECTED_HALT_RATE_RAW &&
+    expectedTradingMode === 1n &&
+    proofBlockNumber === evidenceBlockNumber &&
+    proofBlockNumber === EXPECTED_PIN_BLOCK_NUMBER &&
+    proofBlockHashMatches &&
+    witnessConfiguration?.datedPinMatches === true &&
+    witnessConfiguration?.protocolIdentityMatches === true &&
+    witnessConfiguration?.safeConfigurationMatches === true &&
+    witnessConfiguration?.rateConfigurationMatches === true &&
+    witnessConfiguration?.strategyConfigurationMatches === true &&
+    proof.haltReportSucceeded === true &&
+    proof.swapSuspended === true &&
+    proof.openRebalanceSuspended === true &&
+    proof.reserveRebalanceSuspended === true &&
+    restoredRateRaw === EXPECTED_RATE_RAW &&
+    proof.restoreReportSucceeded === true &&
+    restoredTradingMode === 0n;
+
+  if (!localForkClaimMatches) {
+    blockers.push(
+      issue(
+        "LOCAL_FORK_HALT_CLAIM_MISMATCH",
+        "The local-fork halt claim does not match the pinned diagnostic inputs or its stated halt and restore assertions.",
+      ),
+    );
+  }
+
+  return {
+    controlSafe: halt.controlSafe ?? null,
+    sortedOracles: halt.sortedOracles ?? null,
+    breakerBox: halt.breakerBox ?? null,
+    valueDeltaBreaker: halt.valueDeltaBreaker ?? null,
+    rateFeedId: halt.rateFeedId ?? null,
+    reportRateRaw,
+    expectedTradingMode,
+    proofBlockNumber,
+    proofBlockHash: proof.blockHash ?? null,
+    restoredRateRaw,
+    restoredTradingMode,
+    localForkClaimMatches,
+    localForkClaimStatus: "unattested",
+    provenance: "unattested",
+    authenticated: false,
+  };
+}
+
+export function inspectCustodyBoundary(snapshot, blockers) {
+  const boundary = requiredObject(
+    snapshot.custodyBoundary,
+    "snapshot.custodyBoundary",
+  );
+  const safe = requiredObject(
+    boundary.lpCustodySafe,
+    "custodyBoundary.lpCustodySafe",
+  );
+  const threshold = positive(
+    safe.threshold,
+    "custodyBoundary.lpCustodySafe.threshold",
+  );
+  const ownerCount = positive(
+    safe.ownerCount,
+    "custodyBoundary.lpCustodySafe.ownerCount",
+  );
+  const nonce = nonNegative(safe.nonce, "custodyBoundary.lpCustodySafe.nonce");
+  const lpBalanceRaw = nonNegative(
+    safe.lpBalanceRaw,
+    "custodyBoundary.lpCustodySafe.lpBalanceRaw",
+  );
+  const totalLpSupplyRaw = positive(
+    safe.totalLpSupplyRaw,
+    "custodyBoundary.lpCustodySafe.totalLpSupplyRaw",
+  );
+  const configurationMatches =
+    matchesAddress(safe.address, EXPECTED_LP_CUSTODY_SAFE) &&
+    threshold === 2n &&
+    ownerCount === 4n &&
+    nonce === 13n &&
+    lpBalanceRaw === EXPECTED_LP_CUSTODY_BALANCE_RAW &&
+    totalLpSupplyRaw === EXPECTED_LP_TOTAL_SUPPLY_RAW &&
+    safe.ownerSetVerifiedAtPin === true &&
+    safe.treatedAsInternalCustody === true &&
+    boundary.failClosedOnUnapprovedLpExit === true &&
+    boundary.failClosedOnControlDrift === true;
+
+  if (!configurationMatches) {
+    blockers.push(
+      issue(
+        "LP_CUSTODY_BOUNDARY_INVALID",
+        "The LP custody Safe, 2-of-4 control, pinned LP balance, internal-custody treatment, or fail-closed drift policy differs from the reviewed boundary.",
+      ),
+    );
+  }
+
+  return {
+    address: safe.address ?? null,
+    threshold,
+    ownerCount,
+    nonce,
+    lpBalanceRaw,
+    totalLpSupplyRaw,
+    configurationMatches,
+    authenticated: false,
+  };
+}

--- a/scripts/europ-operational-admission-evidence.mjs
+++ b/scripts/europ-operational-admission-evidence.mjs
@@ -1,0 +1,411 @@
+import {
+  ADDRESS_PATTERN,
+  BASIS_POINTS,
+  BLOCK_HASH_PATTERN,
+  EXPECTED_BUDGET_APPROVAL_REFERENCE,
+  EXPECTED_BUDGET_APPROVER,
+  EXPECTED_CHAIN_ID,
+  EXPECTED_MONITORED_TOKEN_ADDRESS,
+  EXPECTED_MONITORED_TOKEN_DECIMALS,
+  EXPECTED_POOL_ADDRESS,
+  EXPECTED_QUOTE_TOKEN_ADDRESS,
+  EXPECTED_QUOTE_TOKEN_DECIMALS,
+  FIXED_15,
+  MAX_BUDGET_EURM_RAW,
+  ceilDiv,
+  hasText,
+  integer,
+  issue,
+  min,
+  nonNegative,
+  optionalNonNegative,
+  positive,
+  requiredArray,
+  requiredObject,
+  timestamp,
+} from "./europ-operational-admission-contract.mjs";
+
+export function inspectEvidenceIdentity(snapshot, blockers) {
+  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
+  const pool = requiredObject(snapshot.pool, "snapshot.pool");
+  const quoteAsset = requiredObject(
+    pool.quoteAsset,
+    "snapshot.pool.quoteAsset",
+  );
+  const monitoredAsset = requiredObject(
+    pool.monitoredAsset,
+    "snapshot.pool.monitoredAsset",
+  );
+  const chainId = nonNegative(evidence.chainId, "evidence.chainId");
+  const blockNumber = positive(evidence.blockNumber, "evidence.blockNumber");
+  const quoteAssetDecimals = nonNegative(
+    quoteAsset.decimals,
+    "pool.quoteAsset.decimals",
+  );
+  const monitoredAssetDecimals = nonNegative(
+    monitoredAsset.decimals,
+    "pool.monitoredAsset.decimals",
+  );
+  const poolMonitoredAssetDecimals = nonNegative(
+    pool.monitoredAssetDecimals,
+    "pool.monitoredAssetDecimals",
+  );
+
+  const blockReferenceWellFormed =
+    hasText(evidence.blockHash) && BLOCK_HASH_PATTERN.test(evidence.blockHash);
+  if (!blockReferenceWellFormed) {
+    blockers.push(
+      issue(
+        "BLOCK_REFERENCE_INVALID",
+        "The block reference must contain a positive canonical block number and 32-byte hash.",
+      ),
+    );
+  }
+
+  const invalidProtocolFields = [];
+  for (const [field, value] of [
+    ["pool.address", pool.address],
+    ["pool.quoteAsset.address", quoteAsset.address],
+    ["pool.monitoredAsset.address", monitoredAsset.address],
+  ]) {
+    if (!hasText(value) || !ADDRESS_PATTERN.test(value))
+      invalidProtocolFields.push(field);
+  }
+  for (const [field, value] of [
+    ["evidence.asset", evidence.asset],
+    ["evidence.quoteAsset", evidence.quoteAsset],
+    ["pool.quoteAsset.symbol", quoteAsset.symbol],
+    ["pool.monitoredAsset.symbol", monitoredAsset.symbol],
+  ]) {
+    if (!hasText(value)) invalidProtocolFields.push(field);
+  }
+
+  if (invalidProtocolFields.length > 0) {
+    blockers.push(
+      issue(
+        "PROTOCOL_IDENTITY_INVALID",
+        `Protocol identity fields are malformed: ${invalidProtocolFields.join(", ")}.`,
+      ),
+    );
+  }
+
+  const mismatches = [];
+  if (chainId !== EXPECTED_CHAIN_ID) mismatches.push("chainId");
+  if (evidence.asset !== "EUROP") mismatches.push("asset");
+  if (evidence.quoteAsset !== "EURm") mismatches.push("quoteAsset");
+  if (
+    hasText(pool.address) &&
+    pool.address.toLowerCase() !== EXPECTED_POOL_ADDRESS
+  ) {
+    mismatches.push("pool.address");
+  }
+  if (
+    hasText(quoteAsset.address) &&
+    quoteAsset.address.toLowerCase() !== EXPECTED_QUOTE_TOKEN_ADDRESS
+  ) {
+    mismatches.push("pool.quoteAsset.address");
+  }
+  if (
+    hasText(monitoredAsset.address) &&
+    monitoredAsset.address.toLowerCase() !== EXPECTED_MONITORED_TOKEN_ADDRESS
+  ) {
+    mismatches.push("pool.monitoredAsset.address");
+  }
+  if (quoteAsset.symbol !== "EURm") mismatches.push("pool.quoteAsset.symbol");
+  if (monitoredAsset.symbol !== "EUROP") {
+    mismatches.push("pool.monitoredAsset.symbol");
+  }
+  if (quoteAssetDecimals !== EXPECTED_QUOTE_TOKEN_DECIMALS) {
+    mismatches.push("pool.quoteAsset.decimals");
+  }
+  if (
+    monitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS ||
+    poolMonitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS
+  ) {
+    mismatches.push("pool.monitoredAsset.decimals");
+  }
+
+  if (mismatches.length > 0) {
+    blockers.push(
+      issue(
+        "PROTOCOL_IDENTITY_MISMATCH",
+        `Snapshot identity does not match EUROP/EURm on Polygon: ${mismatches.join(", ")}.`,
+      ),
+    );
+  }
+
+  const matchesExpectedEuropPolygonIdentity =
+    invalidProtocolFields.length === 0 && mismatches.length === 0;
+  return {
+    protocolIdentity: {
+      chainId,
+      asset: evidence.asset ?? null,
+      quoteAsset: evidence.quoteAsset ?? null,
+      poolAddress: pool.address ?? null,
+      quoteAssetAddress: quoteAsset.address ?? null,
+      monitoredAssetAddress: monitoredAsset.address ?? null,
+      quoteAssetDecimals,
+      monitoredAssetDecimals,
+      matchesExpectedEuropPolygonIdentity,
+      authenticated: false,
+    },
+    blockReference: {
+      blockNumber,
+      blockHash: evidence.blockHash ?? null,
+      wellFormed: blockReferenceWellFormed,
+      authenticated: false,
+    },
+  };
+}
+
+/**
+ * Derive the durable TradingLimitsV2 capacity documented in the canonical
+ * onboarding runbook. This is a fee-adjusted monitored-token netflow envelope,
+ * not a quote-asset loss result.
+ */
+export function deriveMonotoneSwapEnvelope(input) {
+  const snapshot = requiredObject(input, "snapshot");
+  const pool = requiredObject(snapshot.pool, "snapshot.pool");
+  const responseSeconds = positive(snapshot.responseSeconds, "responseSeconds");
+  const monitoredAssetDecimals = Number(
+    nonNegative(pool.monitoredAssetDecimals, "pool.monitoredAssetDecimals"),
+  );
+  if (!Number.isSafeInteger(monitoredAssetDecimals)) {
+    throw new Error("pool.monitoredAssetDecimals must be a safe integer");
+  }
+
+  const fee = requiredObject(pool.fee, "pool.fee");
+  const totalFeeBps =
+    nonNegative(fee.lpBps, "pool.fee.lpBps") +
+    nonNegative(fee.protocolBps, "pool.fee.protocolBps");
+  if (totalFeeBps >= BASIS_POINTS) {
+    throw new Error("pool total fee must be below 10,000 bps");
+  }
+
+  const invariantViolations = [];
+  const windows = requiredArray(pool.tradingLimits, "pool.tradingLimits")
+    .map((window, index) => {
+      const parsed = requiredObject(window, `pool.tradingLimits[${index}]`);
+      const limitFixed15 = nonNegative(
+        parsed.limitFixed15,
+        `pool.tradingLimits[${index}].limitFixed15`,
+      );
+      const durationSeconds = positive(
+        parsed.durationSeconds,
+        `pool.tradingLimits[${index}].durationSeconds`,
+      );
+      const netflowFixed15 = integer(
+        parsed.netflowFixed15,
+        `pool.tradingLimits[${index}].netflowFixed15`,
+      );
+      if (limitFixed15 === 0n) return null;
+
+      const name = hasText(parsed.name) ? parsed.name : `window-${index}`;
+      const withinInvariant =
+        netflowFixed15 >= -limitFixed15 && netflowFixed15 <= limitFixed15;
+      if (!withinInvariant) {
+        invariantViolations.push(
+          issue(
+            "TRADING_LIMIT_INVARIANT_VIOLATION",
+            `${name} signed netflow is outside the enforced interval [-L, +L].`,
+          ),
+        );
+      }
+
+      const resetWindows = ceilDiv(responseSeconds, durationSeconds);
+      return {
+        name,
+        durationSeconds,
+        limitFixed15,
+        netflowFixed15,
+        withinInvariant,
+        resetWindows,
+        durableCapacityFixed15: 2n * limitFixed15 + limitFixed15 * resetWindows,
+      };
+    })
+    .filter((window) => window !== null);
+
+  if (windows.length === 0) {
+    throw new Error("at least one positive TradingLimitsV2 window is required");
+  }
+
+  const netflowCapacityFixed15 = min(
+    windows.map((window) => window.durableCapacityFixed15),
+  );
+  const grossInputFixed15 =
+    (netflowCapacityFixed15 * BASIS_POINTS) / (BASIS_POINTS - totalFeeBps);
+
+  let grossMonitoredInputRaw = null;
+  if (monitoredAssetDecimals <= 15) {
+    const fixed15PerMonitoredTokenRaw =
+      FIXED_15 / 10n ** BigInt(monitoredAssetDecimals);
+    grossMonitoredInputRaw = grossInputFixed15 / fixed15PerMonitoredTokenRaw;
+  }
+
+  return {
+    responseSeconds,
+    totalFeeBps,
+    monitoredAssetDecimals,
+    windows,
+    invariantViolations,
+    netflowCapacityFixed15,
+    grossInputFixed15,
+    grossMonitoredInputRaw,
+  };
+}
+
+export function inspectEvaluation(snapshot, blockers) {
+  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
+  const evaluation = requiredObject(snapshot.evaluation, "snapshot.evaluation");
+  const observedAt = timestamp(evidence.observedAt);
+  const evaluatedAt = timestamp(evaluation.evaluatedAt);
+  const maxEvidenceAgeSeconds = positive(
+    evaluation.maxEvidenceAgeSeconds,
+    "evaluation.maxEvidenceAgeSeconds",
+  );
+
+  if (observedAt === null) {
+    blockers.push(
+      issue(
+        "EVIDENCE_TIMESTAMP_MISSING_OR_INVALID",
+        "The pinned evidence timestamp is absent or invalid.",
+      ),
+    );
+  }
+  if (evaluatedAt === null) {
+    blockers.push(
+      issue(
+        "EVALUATION_TIMESTAMP_MISSING_OR_INVALID",
+        "The explicit evaluation timestamp is absent or invalid.",
+      ),
+    );
+  }
+
+  let evidenceAgeSeconds = null;
+  if (observedAt !== null && evaluatedAt !== null) {
+    evidenceAgeSeconds = BigInt(Math.floor((evaluatedAt - observedAt) / 1000));
+    if (evidenceAgeSeconds < 0n) {
+      blockers.push(
+        issue(
+          "EVIDENCE_FROM_FUTURE",
+          "The pinned evidence timestamp is later than the explicit evaluation time.",
+        ),
+      );
+    } else if (evidenceAgeSeconds > maxEvidenceAgeSeconds) {
+      blockers.push(
+        issue(
+          "EVIDENCE_STALE",
+          "The pinned evidence is older than the explicit maximum evidence age.",
+        ),
+      );
+    }
+  }
+
+  return {
+    observedAt: evidence.observedAt ?? null,
+    evaluatedAt: evaluation.evaluatedAt ?? null,
+    maxEvidenceAgeSeconds,
+    evidenceAgeSeconds,
+  };
+}
+
+export function deriveApprovedBudget(snapshot, blockers) {
+  const budget = requiredObject(snapshot.budget, "snapshot.budget");
+  const liquidReserveAssetsEurmRaw = optionalNonNegative(
+    budget.liquidReserveAssetsEurmRaw,
+    "budget.liquidReserveAssetsEurmRaw",
+  );
+  const approvedBudgetEurmRaw = optionalNonNegative(
+    budget.approvedBudgetEurmRaw,
+    "budget.approvedBudgetEurmRaw",
+  );
+  const approvalEvidencePresent =
+    hasText(budget.approvedBy) && hasText(budget.approvalReference);
+  const approvalEvidenceMatches =
+    budget.approvedBy === EXPECTED_BUDGET_APPROVER &&
+    budget.approvalReference === EXPECTED_BUDGET_APPROVAL_REFERENCE;
+  const policyMatches =
+    budget.rule === "fixed 100,000 EURm loss budget" &&
+    liquidReserveAssetsEurmRaw === null &&
+    approvedBudgetEurmRaw === MAX_BUDGET_EURM_RAW;
+
+  if (approvedBudgetEurmRaw === null) {
+    blockers.push(
+      issue("APPROVED_BUDGET_MISSING", "The exact numeric B is absent."),
+    );
+  } else if (approvedBudgetEurmRaw > MAX_BUDGET_EURM_RAW) {
+    blockers.push(
+      issue(
+        "APPROVED_BUDGET_ABOVE_POLICY_CEILING",
+        "The approved budget exceeds the 100,000 EURm policy ceiling.",
+      ),
+    );
+  } else if (!approvalEvidencePresent) {
+    blockers.push(
+      issue(
+        "BUDGET_APPROVAL_EVIDENCE_MISSING",
+        "The recorded B lacks its accountable approver or approval reference.",
+      ),
+    );
+  } else if (!approvalEvidenceMatches) {
+    blockers.push(
+      issue(
+        "BUDGET_APPROVAL_EVIDENCE_MISMATCH",
+        "The budget approver or issue-comment reference differs from the approved EUROP decision.",
+      ),
+    );
+  }
+
+  if (!policyMatches) {
+    blockers.push(
+      issue(
+        "APPROVED_BUDGET_POLICY_MISMATCH",
+        "The recorded policy must be the approved fixed 100,000 EURm loss budget.",
+      ),
+    );
+  }
+
+  if (liquidReserveAssetsEurmRaw === null) {
+    if (approvedBudgetEurmRaw === null) {
+      blockers.push(
+        issue(
+          "LIQUID_RESERVE_VALUE_MISSING",
+          "No approved liquid-reserve value is available to calculate B from the starter rule.",
+        ),
+      );
+    }
+    return {
+      liquidReserveAssetsEurmRaw,
+      derivedBudgetEurmRaw: null,
+      approvedBudgetEurmRaw,
+      approvalEvidencePresent,
+      approvalEvidenceMatches,
+      policyMatches,
+    };
+  }
+
+  const derivedBudgetEurmRaw = min([
+    MAX_BUDGET_EURM_RAW,
+    (liquidReserveAssetsEurmRaw * 5n) / 1000n,
+  ]);
+  if (
+    approvedBudgetEurmRaw !== null &&
+    approvedBudgetEurmRaw !== derivedBudgetEurmRaw
+  ) {
+    blockers.push(
+      issue(
+        "APPROVED_BUDGET_MISMATCH",
+        "The recorded B does not equal min(100,000 EURm, 0.5% of the approved liquid-reserve value).",
+      ),
+    );
+  }
+
+  return {
+    liquidReserveAssetsEurmRaw,
+    derivedBudgetEurmRaw,
+    approvedBudgetEurmRaw,
+    approvalEvidencePresent,
+    approvalEvidenceMatches,
+    policyMatches,
+  };
+}

--- a/scripts/europ-operational-admission-proof.sh
+++ b/scripts/europ-operational-admission-proof.sh
@@ -397,7 +397,8 @@ run_witness_scenario() {
   start_fresh_fork "witness" "$proof_witness_port"
   prepare_witness_seed
 
-  for cycle in $(seq 1 "$proof_cycles"); do
+  cycle=1
+  while [[ "$cycle" -le "$proof_cycles" ]]; do
     cycle_timestamp="$((proof_start_timestamp + (cycle - 1) * proof_cycle_seconds))"
     quote="$(read_uint "$proof_pool" 'getAmountOut(uint256,address)(uint256)' "$proof_europ_input_per_cycle" "$proof_europ")"
     [[ "$quote" == "$proof_eurm_output_per_cycle" ]] || fail "cycle $cycle quote was not exactly 1,999 EURm"
@@ -411,6 +412,7 @@ run_witness_scenario() {
     fi
     cast call --rpc-url "$proof_rpc" "$proof_reserve_strategy" 'rebalance(address)' "$proof_pool" >/dev/null
     send_unlocked_at "$rebalance_timestamp" "reserve-rebalance" "$proof_trader" "$proof_reserve_strategy" 'rebalance(address)' "$proof_pool"
+    cycle="$((cycle + 1))"
   done
 
   final_timestamp="$proof_last_timestamp"

--- a/scripts/europ-operational-admission-proof.sh
+++ b/scripts/europ-operational-admission-proof.sh
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+# Runs two localhost-only diagnostics for the EUROP admission record.
+#
+# This script never signs or broadcasts to Polygon. POLYGON_RPC_URL is only a
+# read source for Anvil; every mutation and transaction targets a fresh,
+# localhost-only Anvil process started here.
+set -Eeuo pipefail
+
+# Foundry nightly builds otherwise repeat this warning for every Cast call.
+export FOUNDRY_DISABLE_NIGHTLY_WARNING=1
+
+if [[ $# -ne 0 ]]; then
+  echo "usage: POLYGON_RPC_URL=https://... bash scripts/europ-operational-admission-proof.sh" >&2
+  exit 2
+fi
+
+if [[ -z "${POLYGON_RPC_URL:-}" ]]; then
+  echo "error: POLYGON_RPC_URL is required as the read-only Polygon fork source" >&2
+  exit 2
+fi
+
+# A second endpoint would make it ambiguous where mutations run. The runner
+# owns its execution endpoint and rejects attempts to supply one.
+if [[ -n "${EXECUTION_RPC_URL:-}" || -n "${PROOF_EXECUTION_RPC_URL:-}" ]]; then
+  echo "error: this runner owns execution on fresh localhost Anvil forks; do not set an execution RPC URL" >&2
+  exit 2
+fi
+
+if ! node -e '
+  const { isIP } = require("node:net");
+  let url;
+  try {
+    url = new URL(process.argv[1]);
+  } catch {
+    process.exit(1);
+  }
+  const hostname = url.hostname.replace(/^\[|\]$/gu, "").toLowerCase();
+  const localName =
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".lan");
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    hostname === "" ||
+    localName ||
+    isIP(hostname) !== 0
+  ) {
+    process.exit(1);
+  }
+' "$POLYGON_RPC_URL"; then
+  echo "error: POLYGON_RPC_URL must use a remote HTTPS hostname without embedded credentials" >&2
+  exit 2
+fi
+
+for proof_command in anvil cast jq node shasum nc; do
+  command -v "$proof_command" >/dev/null 2>&1 || {
+    echo "error: required command not found: $proof_command" >&2
+    exit 2
+  }
+done
+
+proof_repo_root="$(git rev-parse --show-toplevel)"
+proof_output_root="$proof_repo_root/.tmp/europ-operational-admission-proof"
+mkdir -p "$proof_output_root"
+proof_run_dir="$(mktemp -d "$proof_output_root/run.XXXXXXXX")"
+
+proof_chain_id="137"
+proof_fork_block="91830875"
+proof_fork_hash="0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25"
+proof_witness_port="8552"
+proof_halt_port="8553"
+proof_start_timestamp="1786451400"
+proof_response_seconds="21600"
+
+proof_pool="0xCd8C6811d975981F57E7fB32e59f0BeE66aF3201"
+proof_eurm="0x4D502d735B4C574B487Ed641ae87cEaE884731C7"
+proof_europ="0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51"
+proof_open_strategy="0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f"
+proof_reserve_strategy="0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B"
+proof_safe="0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458"
+proof_sorted_oracles="0x6f92C745346057a61b259579256159458a0a6A92"
+proof_breaker_box="0x9fc1E0d10fb38954Da385B8B25aB2BbaF3241722"
+proof_feed="0xc22418a83DfC262B10a1f57E25309DB83E7eA79e"
+proof_zero="0x0000000000000000000000000000000000000000"
+
+# This is Anvil's first unlocked development account. It is used only on the
+# process started by this script; no signing material is supplied to Cast.
+proof_trader="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# Storage locations were checked against the ERC-20 getters before any local
+# write. The witness seeds only this local account's EUROP balance and matching
+# total supply; it never changes pool storage.
+proof_europ_balance_slot="0x60d9306e205976af7394daf1199228fbe24704f9030af127fa8c5e3e867e5ead"
+proof_europ_total_supply_slot="0x00000000000000000000000000000000000000000000000000000000000000cb"
+proof_seed_europ="102000000000"
+proof_cycles="51"
+proof_europ_input_per_cycle="2000000000"
+proof_eurm_output_per_cycle="1999000000000000000000"
+proof_witness_model="europ-reserve-rebalance-51-cycle-v1"
+proof_mento_core_commit="07ecf3df5650a33ea6957f1ad2966e02c5082253"
+proof_expected_external_eurm="101949000000000000000000"
+proof_budget_eurm="100000000000000000000000"
+proof_cycle_seconds="301"
+
+proof_halt_rate="994000000000000000000000"
+proof_normal_rate="1000000000000000000000000"
+proof_rate_denominator="1000000000000000000000000"
+proof_trading_suspended_selector="0x4ac30c22"
+
+proof_anvil_pid=""
+proof_rpc=""
+proof_scenario_dir=""
+proof_receipts_file=""
+proof_transactions_file=""
+proof_trace_sequence="0"
+proof_last_timestamp=""
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$proof_anvil_pid" ]] && kill -0 "$proof_anvil_pid" 2>/dev/null; then
+    kill "$proof_anvil_pid" 2>/dev/null || true
+    wait "$proof_anvil_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+uint_to_bytes32() {
+  # The template expression belongs to Node, not the shell.
+  # shellcheck disable=SC2016
+  node -e 'process.stdout.write(`0x${BigInt(process.argv[1]).toString(16).padStart(64, "0")}`)' "$1"
+}
+
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+uint_greater_than() {
+  node -e 'process.exit(BigInt(process.argv[1]) > BigInt(process.argv[2]) ? 0 : 1)' "$1" "$2"
+}
+
+read_uint() {
+  cast call --rpc-url "$proof_rpc" --json "$1" "$2" "${@:3}" | jq -er '.[0] | tostring'
+}
+
+read_block_timestamp() {
+  local block_number="$1"
+  local timestamp_hex
+  timestamp_hex="$(cast rpc --rpc-url "$proof_rpc" eth_getBlockByNumber "$block_number" false | jq -er '.timestamp')"
+  cast to-dec "$timestamp_hex"
+}
+
+require_free_local_port() {
+  local port="$1"
+  if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+    fail "refusing to use occupied localhost port $port"
+  fi
+}
+
+wait_for_fork_rpc() {
+  local attempt
+  for ((attempt = 1; attempt <= 30; attempt += 1)); do
+    if ! kill -0 "$proof_anvil_pid" 2>/dev/null; then
+      wait "$proof_anvil_pid" 2>/dev/null || true
+      fail "owned Anvil process exited before its RPC became ready; see $proof_scenario_dir/anvil.log"
+    fi
+    if cast rpc --rpc-url "$proof_rpc" eth_chainId >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "Anvil did not become ready; see $proof_scenario_dir/anvil.log"
+}
+
+verify_fresh_fork() {
+  local scenario="$1"
+  local client_version
+  local chain_id
+  local latest_number_hex
+  local latest_number
+  local latest_hash
+
+  kill -0 "$proof_anvil_pid" 2>/dev/null || fail "$scenario owned Anvil process is not alive"
+  [[ "$proof_rpc" == "http://127.0.0.1:"* ]] || fail "execution endpoint is not localhost"
+  client_version="$(cast rpc --rpc-url "$proof_rpc" web3_clientVersion | jq -er 'strings')"
+  [[ "$(lowercase "$client_version")" == *anvil* ]] || fail "$scenario endpoint is not Anvil: $client_version"
+  chain_id="$(cast rpc --rpc-url "$proof_rpc" eth_chainId | jq -er 'strings')"
+  [[ "$chain_id" == "0x89" ]] || fail "$scenario fork chain id is $chain_id, expected 0x89"
+  latest_number_hex="$(cast rpc --rpc-url "$proof_rpc" eth_blockNumber | jq -er 'strings')"
+  latest_number="$(cast to-dec "$latest_number_hex")"
+  [[ "$latest_number" == "$proof_fork_block" ]] || fail "$scenario fork is not fresh at block $proof_fork_block"
+  latest_hash="$(cast rpc --rpc-url "$proof_rpc" eth_getBlockByNumber "$latest_number_hex" false | jq -er '.hash')"
+  [[ "$(lowercase "$latest_hash")" == "$proof_fork_hash" ]] || fail "$scenario fork hash does not match the pinned Polygon block"
+  kill -0 "$proof_anvil_pid" 2>/dev/null || fail "$scenario owned Anvil process exited during verification"
+}
+
+start_fresh_fork() {
+  local scenario="$1"
+  local port="$2"
+  require_free_local_port "$port"
+  proof_scenario_dir="$proof_run_dir/$scenario"
+  mkdir -p "$proof_scenario_dir"
+  proof_receipts_file="$proof_scenario_dir/receipts.jsonl"
+  proof_transactions_file="$proof_scenario_dir/transactions.jsonl"
+  : > "$proof_receipts_file"
+  : > "$proof_transactions_file"
+  proof_trace_sequence="0"
+  proof_rpc="http://127.0.0.1:$port"
+
+  anvil \
+    --quiet \
+    --fork-url "$POLYGON_RPC_URL" \
+    --fork-block-number "$proof_fork_block" \
+    --chain-id "$proof_chain_id" \
+    --host 127.0.0.1 \
+    --port "$port" \
+    >"$proof_scenario_dir/anvil.log" 2>&1 &
+  proof_anvil_pid="$!"
+  wait_for_fork_rpc
+  # This proof is the mandatory barrier before any local storage write,
+  # impersonation, time advance, or transaction.
+  verify_fresh_fork "$scenario"
+  proof_last_timestamp="$(read_block_timestamp "0x$(printf '%x' "$proof_fork_block")")"
+  [[ "$proof_start_timestamp" -gt "$proof_last_timestamp" ]] || fail "fixed proof timestamp must follow the fork block"
+}
+
+stop_fresh_fork() {
+  cleanup
+  proof_anvil_pid=""
+  proof_rpc=""
+  proof_last_timestamp=""
+}
+
+set_next_timestamp() {
+  local timestamp="$1"
+  [[ "$timestamp" -gt "$proof_last_timestamp" ]] || fail "timestamps must increase deterministically"
+  cast rpc --rpc-url "$proof_rpc" evm_setNextBlockTimestamp "$(cast to-hex "$timestamp")" >/dev/null
+}
+
+record_successful_receipt() {
+  local expected_timestamp="$1"
+  local action="$2"
+  local receipt="$3"
+  local status
+  local block_number
+  local actual_timestamp
+  local transaction_hash
+  local transaction
+  local receipt_block_hash
+  local transaction_block_hash
+  local transaction_block_number
+
+  status="$(jq -er '.status' <<<"$receipt")"
+  [[ "$status" == "0x1" ]] || fail "transaction receipt was not successful"
+  block_number="$(jq -er '.blockNumber' <<<"$receipt")"
+  actual_timestamp="$(read_block_timestamp "$block_number")"
+  [[ "$actual_timestamp" == "$expected_timestamp" ]] || fail "receipt timestamp $actual_timestamp did not equal $expected_timestamp"
+  receipt="$(jq -c --arg blockTimestamp "$(cast to-hex "$actual_timestamp")" '. + {blockTimestamp:$blockTimestamp}' <<<"$receipt")"
+  transaction_hash="$(jq -er '.transactionHash' <<<"$receipt")"
+  transaction="$(cast rpc --rpc-url "$proof_rpc" eth_getTransactionByHash "$transaction_hash")"
+  [[ "$(lowercase "$(jq -er '.hash' <<<"$transaction")")" == "$(lowercase "$transaction_hash")" ]] || fail "transaction hash did not match its receipt"
+  receipt_block_hash="$(jq -er '.blockHash' <<<"$receipt")"
+  transaction_block_hash="$(jq -er '.blockHash' <<<"$transaction")"
+  transaction_block_number="$(jq -er '.blockNumber' <<<"$transaction")"
+  [[ "$(lowercase "$transaction_block_hash")" == "$(lowercase "$receipt_block_hash")" ]] || fail "transaction block hash did not match its receipt"
+  [[ "$transaction_block_number" == "$block_number" ]] || fail "transaction block number did not match its receipt"
+  proof_last_timestamp="$actual_timestamp"
+  proof_trace_sequence="$((proof_trace_sequence + 1))"
+  jq -c '.' <<<"$receipt" >> "$proof_receipts_file"
+  jq -cn \
+    --arg sequence "$proof_trace_sequence" \
+    --arg action "$action" \
+    --arg expectedTimestamp "$expected_timestamp" \
+    --argjson transaction "$transaction" \
+    '{sequence:$sequence, action:$action, expectedTimestamp:$expectedTimestamp, transaction:{hash:$transaction.hash, from:$transaction.from, to:$transaction.to, input:$transaction.input, blockHash:$transaction.blockHash, blockNumber:$transaction.blockNumber}}' \
+    >> "$proof_transactions_file"
+}
+
+send_unlocked_at() {
+  local expected_timestamp="$1"
+  local action="$2"
+  local sender="$3"
+  shift 3
+  local receipt
+  set_next_timestamp "$expected_timestamp"
+  receipt="$(cast send --rpc-url "$proof_rpc" --unlocked --from "$sender" --gas-limit 1000000 --json "$@")"
+  record_successful_receipt "$expected_timestamp" "$action" "$receipt"
+}
+
+write_receipt_manifest() {
+  local receipt
+  local digest
+  local transaction_hash
+  local manifest="$proof_scenario_dir/receipts.sha256"
+  : > "$manifest"
+  while IFS= read -r receipt; do
+    transaction_hash="$(jq -er '.transactionHash' <<<"$receipt")"
+    digest="$(printf '%s\n' "$receipt" | shasum -a 256 | awk '{print $1}')"
+    printf '%s  %s\n' "$digest" "$transaction_hash" >> "$manifest"
+  done < "$proof_receipts_file"
+}
+
+file_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+write_artifact_manifest() {
+  local artifact
+  local digest
+  local manifest="$proof_scenario_dir/artifacts.sha256"
+  : > "$manifest"
+  for artifact in receipts.jsonl receipts.sha256 transactions.jsonl summary.json; do
+    digest="$(file_sha256 "$proof_scenario_dir/$artifact")"
+    printf '%s  %s\n' "$digest" "$artifact" >> "$manifest"
+  done
+  if [[ -f "$proof_scenario_dir/swap-revert.txt" ]]; then
+    for artifact in swap-revert.txt open-rebalance-revert.txt reserve-rebalance-revert.txt; do
+      digest="$(file_sha256 "$proof_scenario_dir/$artifact")"
+      printf '%s  %s\n' "$digest" "$artifact" >> "$manifest"
+    done
+  fi
+}
+
+prepare_witness_seed() {
+  local initial_supply
+  local seeded_supply
+  local initial_trader_europ
+  local initial_trader_eurm
+  local initial_balance_storage
+  local initial_supply_storage
+  local initial_pool_europ
+  local initial_pool_eurm
+
+  initial_supply="$(read_uint "$proof_europ" 'totalSupply()(uint256)')"
+  initial_trader_europ="$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_trader")"
+  initial_trader_eurm="$(read_uint "$proof_eurm" 'balanceOf(address)(uint256)' "$proof_trader")"
+  initial_pool_europ="$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_pool")"
+  initial_pool_eurm="$(read_uint "$proof_eurm" 'balanceOf(address)(uint256)' "$proof_pool")"
+  initial_balance_storage="$(cast storage --rpc-url "$proof_rpc" "$proof_europ" "$proof_europ_balance_slot")"
+  initial_supply_storage="$(cast storage --rpc-url "$proof_rpc" "$proof_europ" "$proof_europ_total_supply_slot")"
+
+  [[ "$initial_trader_europ" == "0" ]] || fail "local trader must start without EUROP"
+  [[ "$initial_trader_eurm" == "0" ]] || fail "local trader must start without EURm"
+  [[ "$(lowercase "$initial_balance_storage")" == "$(uint_to_bytes32 "$initial_trader_europ")" ]] || fail "EUROP balance slot does not match balanceOf getter"
+  [[ "$(lowercase "$initial_supply_storage")" == "$(uint_to_bytes32 "$initial_supply")" ]] || fail "EUROP total-supply slot does not match totalSupply getter"
+
+  seeded_supply="$(node -e 'process.stdout.write((BigInt(process.argv[1]) + BigInt(process.argv[2])).toString())' "$initial_supply" "$proof_seed_europ")"
+  cast rpc --rpc-url "$proof_rpc" anvil_setStorageAt "$proof_europ" "$proof_europ_balance_slot" "$(uint_to_bytes32 "$proof_seed_europ")" >/dev/null
+  cast rpc --rpc-url "$proof_rpc" anvil_setStorageAt "$proof_europ" "$proof_europ_total_supply_slot" "$(uint_to_bytes32 "$seeded_supply")" >/dev/null
+  cast rpc --rpc-url "$proof_rpc" evm_mine >/dev/null
+
+  [[ "$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_trader")" == "$proof_seed_europ" ]] || fail "seeded local EUROP balance did not verify"
+  [[ "$(read_uint "$proof_europ" 'totalSupply()(uint256)')" == "$seeded_supply" ]] || fail "seeded EUROP supply did not verify"
+  [[ "$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_pool")" == "$initial_pool_europ" ]] || fail "pool EUROP changed during local seed"
+
+  proof_initial_supply="$initial_supply"
+  proof_seeded_supply="$seeded_supply"
+  proof_initial_trader_eurm="$initial_trader_eurm"
+  proof_initial_pool_europ="$initial_pool_europ"
+  proof_initial_pool_eurm="$initial_pool_eurm"
+}
+
+expect_trading_suspended() {
+  local name="$1"
+  shift
+  local output_file="$proof_scenario_dir/$name-revert.txt"
+  if "$@" >"$output_file" 2>&1; then
+    fail "expected $name eth_call to revert while trading is suspended"
+  fi
+  grep -Eq "data: \"?${proof_trading_suspended_selector}\"?$" "$output_file" || fail "$name did not return exactly TradingSuspended"
+}
+
+run_witness_scenario() {
+  local cycle
+  local cycle_timestamp
+  local rebalance_timestamp
+  local quote
+  local final_eurm
+  local final_trader_europ
+  local final_pool_europ
+  local final_pool_eurm
+  local final_supply
+  local receipt_count
+  local final_timestamp
+  local elapsed
+  local receipts_sha256
+  local receipt_index_sha256
+  local transactions_sha256
+
+  start_fresh_fork "witness" "$proof_witness_port"
+  prepare_witness_seed
+
+  for cycle in $(seq 1 "$proof_cycles"); do
+    cycle_timestamp="$((proof_start_timestamp + (cycle - 1) * proof_cycle_seconds))"
+    quote="$(read_uint "$proof_pool" 'getAmountOut(uint256,address)(uint256)' "$proof_europ_input_per_cycle" "$proof_europ")"
+    [[ "$quote" == "$proof_eurm_output_per_cycle" ]] || fail "cycle $cycle quote was not exactly 1,999 EURm"
+
+    send_unlocked_at "$cycle_timestamp" "transfer" "$proof_trader" "$proof_europ" 'transfer(address,uint256)(bool)' "$proof_pool" "$proof_europ_input_per_cycle"
+    send_unlocked_at "$((cycle_timestamp + 1))" "swap" "$proof_trader" "$proof_pool" 'swap(uint256,uint256,address,bytes)' "$proof_eurm_output_per_cycle" 0 "$proof_trader" 0x
+
+    rebalance_timestamp="$((cycle_timestamp + 2))"
+    if [[ "$cycle" == "$proof_cycles" ]]; then
+      rebalance_timestamp="$((proof_start_timestamp + 15080))"
+    fi
+    cast call --rpc-url "$proof_rpc" "$proof_reserve_strategy" 'rebalance(address)' "$proof_pool" >/dev/null
+    send_unlocked_at "$rebalance_timestamp" "reserve-rebalance" "$proof_trader" "$proof_reserve_strategy" 'rebalance(address)' "$proof_pool"
+  done
+
+  final_timestamp="$proof_last_timestamp"
+  elapsed="$((final_timestamp - proof_start_timestamp))"
+  final_eurm="$(read_uint "$proof_eurm" 'balanceOf(address)(uint256)' "$proof_trader")"
+  final_trader_europ="$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_trader")"
+  final_pool_europ="$(read_uint "$proof_europ" 'balanceOf(address)(uint256)' "$proof_pool")"
+  final_pool_eurm="$(read_uint "$proof_eurm" 'balanceOf(address)(uint256)' "$proof_pool")"
+  final_supply="$(read_uint "$proof_europ" 'totalSupply()(uint256)')"
+  receipt_count="$(wc -l < "$proof_receipts_file" | tr -d ' ')"
+
+  [[ "$receipt_count" == "153" ]] || fail "witness must have exactly 153 successful receipts"
+  [[ "$elapsed" == "15080" && "$elapsed" -le "$proof_response_seconds" ]] || fail "witness elapsed time must be exactly 15,080 seconds inside S"
+  [[ "$final_eurm" == "$proof_expected_external_eurm" ]] || fail "witness external EURm result changed"
+  uint_greater_than "$final_eurm" "$proof_budget_eurm" || fail "witness did not exceed the approved EURm budget"
+  [[ "$final_trader_europ" == "0" ]] || fail "trader retains EUROP after witness"
+  [[ "$final_pool_europ" -gt "$proof_initial_pool_europ" ]] || fail "pool EUROP did not reflect witness input"
+  uint_greater_than "$final_pool_eurm" 0 || fail "pool EURm balance is invalid"
+  [[ "$final_supply" == "$proof_seeded_supply" ]] || fail "EUROP supply changed beyond the local seed"
+
+  write_receipt_manifest
+  receipts_sha256="$(file_sha256 "$proof_receipts_file")"
+  receipt_index_sha256="$(file_sha256 "$proof_scenario_dir/receipts.sha256")"
+  transactions_sha256="$(file_sha256 "$proof_transactions_file")"
+  jq -n \
+    --arg scenario "local-fork-witness" \
+    --arg modelId "$proof_witness_model" \
+    --arg mentoCoreCommit "$proof_mento_core_commit" \
+    --arg chainId "$proof_chain_id" \
+    --arg blockNumber "$proof_fork_block" \
+    --arg blockHash "$proof_fork_hash" \
+    --arg pool "$proof_pool" \
+    --arg reserveStrategy "$proof_reserve_strategy" \
+    --arg cycles "$proof_cycles" \
+    --arg transactionsPerCycle "3" \
+    --arg inputPerCycleEuropRaw "$proof_europ_input_per_cycle" \
+    --arg outputPerCycleEurmRaw "$proof_eurm_output_per_cycle" \
+    --arg receiptCount "$receipt_count" \
+    --arg successfulReserveRebalances "$proof_cycles" \
+    --arg elapsedSeconds "$elapsed" \
+    --arg externalEurmRaw "$final_eurm" \
+    --arg budgetEurmRaw "$proof_budget_eurm" \
+    --arg initialTraderEurmRaw "$proof_initial_trader_eurm" \
+    --arg finalTraderEuropRaw "$final_trader_europ" \
+    --arg initialPoolEuropRaw "$proof_initial_pool_europ" \
+    --arg poolEuropRaw "$final_pool_europ" \
+    --arg initialPoolEurmRaw "$proof_initial_pool_eurm" \
+    --arg poolEurmRaw "$final_pool_eurm" \
+    --arg initialSupplyRaw "$proof_initial_supply" \
+    --arg seededSupplyRaw "$proof_seeded_supply" \
+    --arg finalSupplyRaw "$final_supply" \
+    --arg receiptsSha256 "$receipts_sha256" \
+    --arg receiptIndexSha256 "$receipt_index_sha256" \
+    --arg transactionsSha256 "$transactions_sha256" \
+    --arg receiptManifest "receipts.sha256" \
+    --arg artifactManifest "artifacts.sha256" \
+    '{scenario:$scenario, modelId:$modelId, mentoCoreCommit:$mentoCoreCommit, chainId:$chainId, blockNumber:$blockNumber, blockHash:$blockHash, pool:$pool, reserveStrategy:$reserveStrategy, cycles:$cycles, transactionsPerCycle:$transactionsPerCycle, inputPerCycleEuropRaw:$inputPerCycleEuropRaw, outputPerCycleEurmRaw:$outputPerCycleEurmRaw, receiptCount:$receiptCount, successfulReserveRebalances:$successfulReserveRebalances, elapsedSeconds:$elapsedSeconds, externalEurmRaw:$externalEurmRaw, budgetEurmRaw:$budgetEurmRaw, initialTraderEurmRaw:$initialTraderEurmRaw, finalTraderEuropRaw:$finalTraderEuropRaw, initialPoolEuropRaw:$initialPoolEuropRaw, poolEuropRaw:$poolEuropRaw, initialPoolEurmRaw:$initialPoolEurmRaw, poolEurmRaw:$poolEurmRaw, initialSupplyRaw:$initialSupplyRaw, seededSupplyRaw:$seededSupplyRaw, finalSupplyRaw:$finalSupplyRaw, receiptsSha256:$receiptsSha256, receiptIndexSha256:$receiptIndexSha256, transactionsSha256:$transactionsSha256, receiptManifest:$receiptManifest, artifactManifest:$artifactManifest, claimStatus:"unattested", provenance:"unattested", localOnly:true, productionActivity:false}' \
+    > "$proof_scenario_dir/summary.json"
+  write_artifact_manifest
+  stop_fresh_fork
+}
+
+run_halt_scenario() {
+  local healthy_quote
+  local halt_rate_json
+  local observed_halt_rate
+  local observed_halt_denominator
+  local halted_mode
+  local restored_rate_json
+  local observed_restored_rate
+  local observed_restored_denominator
+  local restored_mode
+  local restored_quote
+  local receipt_count
+  local receipts_sha256
+  local receipt_index_sha256
+  local transactions_sha256
+
+  start_fresh_fork "halt" "$proof_halt_port"
+  healthy_quote="$(read_uint "$proof_pool" 'getAmountOut(uint256,address)(uint256)' 1000000 "$proof_europ")"
+  uint_greater_than "$healthy_quote" 0 || fail "healthy swap quote must be positive"
+  [[ "$(read_uint "$proof_breaker_box" 'rateFeedTradingMode(address)(uint8)' "$proof_feed")" == "0" ]] || fail "feed must start in normal trading mode"
+
+  cast rpc --rpc-url "$proof_rpc" anvil_impersonateAccount "$proof_safe" >/dev/null
+  cast rpc --rpc-url "$proof_rpc" anvil_setBalance "$proof_safe" 0x21e19e0c9bab2400000 >/dev/null
+  send_unlocked_at "$proof_start_timestamp" "halt-report" "$proof_safe" "$proof_sorted_oracles" 'report(address,uint256,address,address)' "$proof_feed" "$proof_halt_rate" "$proof_zero" "$proof_zero"
+
+  halt_rate_json="$(cast call --rpc-url "$proof_rpc" --json "$proof_sorted_oracles" 'medianRate(address)(uint256,uint256)' "$proof_feed")"
+  observed_halt_rate="$(printf '%s' "$halt_rate_json" | jq -er '.[0] | tostring')"
+  observed_halt_denominator="$(printf '%s' "$halt_rate_json" | jq -er '.[1] | tostring')"
+  [[ "$observed_halt_rate" == "$proof_halt_rate" ]] || fail "halt report rate did not match SortedOracles readback"
+  [[ "$observed_halt_denominator" == "$proof_rate_denominator" ]] || fail "halt report denominator did not match SortedOracles readback"
+  halted_mode="$(read_uint "$proof_breaker_box" 'rateFeedTradingMode(address)(uint8)' "$proof_feed")"
+  [[ "$halted_mode" == "1" ]] || fail "0.994 report did not halt trading"
+  # cast call sends an eth_call, so these checks cannot mutate either fork.
+  expect_trading_suspended "swap" cast call --rpc-url "$proof_rpc" "$proof_pool" 'swap(uint256,uint256,address,bytes)' 1 0 "$proof_trader" 0x
+  expect_trading_suspended "open-rebalance" cast call --rpc-url "$proof_rpc" "$proof_open_strategy" 'rebalance(address)' "$proof_pool"
+  expect_trading_suspended "reserve-rebalance" cast call --rpc-url "$proof_rpc" "$proof_reserve_strategy" 'rebalance(address)' "$proof_pool"
+
+  send_unlocked_at "$((proof_start_timestamp + 2))" "restore-report" "$proof_safe" "$proof_sorted_oracles" 'report(address,uint256,address,address)' "$proof_feed" "$proof_normal_rate" "$proof_zero" "$proof_zero"
+  restored_rate_json="$(cast call --rpc-url "$proof_rpc" --json "$proof_sorted_oracles" 'medianRate(address)(uint256,uint256)' "$proof_feed")"
+  observed_restored_rate="$(printf '%s' "$restored_rate_json" | jq -er '.[0] | tostring')"
+  observed_restored_denominator="$(printf '%s' "$restored_rate_json" | jq -er '.[1] | tostring')"
+  [[ "$observed_restored_rate" == "$proof_normal_rate" ]] || fail "restored report rate did not match SortedOracles readback"
+  [[ "$observed_restored_denominator" == "$proof_rate_denominator" ]] || fail "restored report denominator did not match SortedOracles readback"
+  restored_mode="$(read_uint "$proof_breaker_box" 'rateFeedTradingMode(address)(uint8)' "$proof_feed")"
+  restored_quote="$(read_uint "$proof_pool" 'getAmountOut(uint256,address)(uint256)' 1000000 "$proof_europ")"
+  receipt_count="$(wc -l < "$proof_receipts_file" | tr -d ' ')"
+
+  [[ "$restored_mode" == "0" ]] || fail "1.0 report did not restore normal trading mode"
+  [[ "$restored_quote" == "$healthy_quote" ]] || fail "swap quote did not restore after the cooldown"
+  [[ "$receipt_count" == "2" ]] || fail "halt proof must contain exactly two report receipts"
+
+  write_receipt_manifest
+  receipts_sha256="$(file_sha256 "$proof_receipts_file")"
+  receipt_index_sha256="$(file_sha256 "$proof_scenario_dir/receipts.sha256")"
+  transactions_sha256="$(file_sha256 "$proof_transactions_file")"
+  jq -n \
+    --arg scenario "local-fork-halt" \
+    --arg chainId "$proof_chain_id" \
+    --arg blockNumber "$proof_fork_block" \
+    --arg blockHash "$proof_fork_hash" \
+    --arg controlSafe "$proof_safe" \
+    --arg sortedOracles "$proof_sorted_oracles" \
+    --arg breakerBox "$proof_breaker_box" \
+    --arg rateFeedId "$proof_feed" \
+    --arg haltRateRaw "$observed_halt_rate" \
+    --arg haltedMode "$halted_mode" \
+    --arg restoredRateRaw "$observed_restored_rate" \
+    --arg restoredMode "$restored_mode" \
+    --arg receiptCount "$receipt_count" \
+    --arg receiptsSha256 "$receipts_sha256" \
+    --arg receiptIndexSha256 "$receipt_index_sha256" \
+    --arg transactionsSha256 "$transactions_sha256" \
+    --arg receiptManifest "receipts.sha256" \
+    --arg artifactManifest "artifacts.sha256" \
+    '{scenario:$scenario, chainId:$chainId, blockNumber:$blockNumber, blockHash:$blockHash, controlSafe:$controlSafe, sortedOracles:$sortedOracles, breakerBox:$breakerBox, rateFeedId:$rateFeedId, haltRateRaw:$haltRateRaw, haltedMode:$haltedMode, swapSuspended:true, openRebalanceSuspended:true, reserveRebalanceSuspended:true, restoredRateRaw:$restoredRateRaw, restoredMode:$restoredMode, receiptCount:$receiptCount, receiptsSha256:$receiptsSha256, receiptIndexSha256:$receiptIndexSha256, transactionsSha256:$transactionsSha256, receiptManifest:$receiptManifest, artifactManifest:$artifactManifest, claimStatus:"unattested", provenance:"unattested", localOnly:true, productionActivity:false}' \
+    > "$proof_scenario_dir/summary.json"
+  write_artifact_manifest
+  stop_fresh_fork
+}
+
+run_witness_scenario
+run_halt_scenario
+
+echo "EUROP local-fork diagnostic completed: $proof_run_dir"
+echo "- observed candidate paths are unattested local diagnostics; they do not establish fork-source or execution provenance"
+echo "- witness: $proof_run_dir/witness/summary.json"
+echo "- halt: $proof_run_dir/halt/summary.json"

--- a/scripts/europ-operational-admission-proof.test.mjs
+++ b/scripts/europ-operational-admission-proof.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const runnerPath = fileURLToPath(
+  new URL("./europ-operational-admission-proof.sh", import.meta.url),
+);
+const source = readFileSync(runnerPath, "utf8");
+
+test("EUROP proof runner is syntax-valid shell", () => {
+  const result = spawnSync("bash", ["-n", runnerPath], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("EUROP proof runner rejects missing or caller-supplied execution endpoints before starting Anvil", () => {
+  const missingSource = spawnSync("bash", [runnerPath], {
+    encoding: "utf8",
+    env: { ...process.env, POLYGON_RPC_URL: "" },
+  });
+  assert.equal(missingSource.status, 2);
+  assert.match(missingSource.stderr, /POLYGON_RPC_URL is required/u);
+
+  const callerExecutionEndpoint = spawnSync("bash", [runnerPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      POLYGON_RPC_URL: "https://polygon-rpc.example",
+      EXECUTION_RPC_URL: "https://execution.example",
+    },
+  });
+  assert.equal(callerExecutionEndpoint.status, 2);
+  assert.match(
+    callerExecutionEndpoint.stderr,
+    /do not set an execution RPC URL/u,
+  );
+
+  const credentialedSource = new URL("https://polygon-rpc.example");
+  credentialedSource.username = "u";
+  credentialedSource.password = "p";
+  for (const localSource of [
+    "http://localhost",
+    "https://localhost",
+    "https://127.0.0.1",
+    "https://[::1]",
+    "https://10.0.0.1",
+    credentialedSource.toString(),
+  ]) {
+    const result = spawnSync("bash", [runnerPath], {
+      encoding: "utf8",
+      env: { ...process.env, POLYGON_RPC_URL: localSource },
+    });
+    assert.equal(result.status, 2, localSource);
+    assert.match(result.stderr, /remote HTTPS hostname/u, localSource);
+  }
+});
+
+test("EUROP proof runner pins a fresh localhost Polygon fork before every mutation", () => {
+  assert.match(source, /proof_chain_id="137"/u);
+  assert.match(source, /proof_fork_block="91830875"/u);
+  assert.match(
+    source,
+    /proof_fork_hash="0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25"/u,
+  );
+  assert.match(source, /proof_witness_port="8552"/u);
+  assert.match(source, /proof_halt_port="8553"/u);
+  assert.match(source, /--host 127\.0\.0\.1/u);
+  assert.match(source, /--quiet/u);
+  assert.match(source, /proof_rpc="http:\/\/127\.0\.0\.1:\$port"/u);
+  assert.match(source, /--fork-url "\$POLYGON_RPC_URL"/u);
+  assert.match(source, /--fork-block-number "\$proof_fork_block"/u);
+  assert.match(source, /verify_fresh_fork "\$scenario"/u);
+  assert.match(source, /kill -0 "\$proof_anvil_pid"/u);
+  assert.match(source, /web3_clientVersion/u);
+  assert.match(source, /eth_chainId/u);
+  assert.match(source, /eth_getBlockByNumber/u);
+  const witnessBody = source.slice(
+    source.indexOf("run_witness_scenario() {"),
+    source.indexOf("run_halt_scenario() {"),
+  );
+  const haltBody = source.slice(source.indexOf("run_halt_scenario() {"));
+  assert.ok(
+    witnessBody.indexOf('start_fresh_fork "witness"') <
+      witnessBody.indexOf("prepare_witness_seed"),
+    "the witness must start and verify its fork before the local seed",
+  );
+  assert.ok(
+    haltBody.indexOf('start_fresh_fork "halt"') <
+      haltBody.indexOf("anvil_impersonateAccount"),
+    "the halt proof must start and verify its fork before Safe impersonation",
+  );
+});
+
+test("EUROP proof runner owns its execution endpoint and never embeds signing material", () => {
+  assert.match(
+    source,
+    /POLYGON_RPC_URL is required as the read-only Polygon fork source/u,
+  );
+  assert.match(source, /do not set an execution RPC URL/u);
+  assert.match(source, /--unlocked --from "\$sender"/u);
+  assert.doesNotMatch(source, /private-key/iu);
+  assert.doesNotMatch(source, /(?:PROOF_|proof_)?(?:PRIVATE|SIGNING)_KEY\s*=/u);
+  assert.doesNotMatch(
+    source,
+    /\$\{[^}]+,,\}/u,
+    "the runner must remain Bash 3.2-compatible",
+  );
+  assert.match(source, /trap cleanup EXIT INT TERM/u);
+  assert.match(source, /\.tmp\/europ-operational-admission-proof/u);
+});
+
+test("EUROP witness has fixed arithmetic, ordered local seed checks, and deterministic time", () => {
+  for (const expected of [
+    'proof_cycles="51"',
+    'proof_europ_input_per_cycle="2000000000"',
+    'proof_eurm_output_per_cycle="1999000000000000000000"',
+    'proof_expected_external_eurm="101949000000000000000000"',
+    'proof_budget_eurm="100000000000000000000000"',
+    'proof_europ_total_supply_slot="0x00000000000000000000000000000000000000000000000000000000000000cb"',
+  ]) {
+    assert.ok(
+      source.includes(expected),
+      `missing fixed proof input: ${expected}`,
+    );
+  }
+  assert.match(source, /EUROP balance slot does not match balanceOf getter/u);
+  assert.match(
+    source,
+    /EUROP total-supply slot does not match totalSupply getter/u,
+  );
+  assert.match(source, /pool EUROP changed during local seed/u);
+  assert.match(source, /anvil_setStorageAt/u);
+  assert.match(source, /evm_setNextBlockTimestamp/u);
+  assert.match(source, /receipt_count" == "153"/u);
+  assert.match(source, /elapsed" == "15080"/u);
+  assert.match(source, /write_receipt_manifest/u);
+  assert.match(source, /write_artifact_manifest/u);
+  assert.match(source, /proof_transactions_file/u);
+  assert.match(source, /eth_getTransactionByHash/u);
+  assert.match(source, /transactions\.jsonl/u);
+  assert.match(source, /transactionsSha256/u);
+  assert.match(source, /blockTimestamp/u);
+  assert.match(source, /"transfer"/u);
+  assert.match(source, /"swap"/u);
+  assert.match(source, /"reserve-rebalance"/u);
+  assert.match(source, /proof_witness_model/u);
+  assert.match(source, /proof_mento_core_commit/u);
+  assert.match(source, /productionActivity:false/u);
+  assert.match(source, /claimStatus:"unattested"/u);
+  assert.match(source, /provenance:"unattested"/u);
+  assert.match(
+    source,
+    /for artifact in swap-revert\.txt open-rebalance-revert\.txt reserve-rebalance-revert\.txt/u,
+  );
+  assert.match(source, /receiptsSha256/u);
+  assert.match(source, /initialTraderEurmRaw/u);
+  assert.match(source, /finalTraderEuropRaw/u);
+  assert.match(source, /initialPoolEurmRaw/u);
+  assert.match(source, /finalSupplyRaw/u);
+  const seedBody = source.slice(
+    source.indexOf("prepare_witness_seed() {"),
+    source.indexOf("expect_trading_suspended() {"),
+  );
+  assert.ok(
+    seedBody.indexOf("EUROP balance slot does not match balanceOf getter") <
+      seedBody.indexOf("anvil_setStorageAt"),
+    "getter/storage checks must appear before the local seed writes",
+  );
+});
+
+test("EUROP halt proof fixes the exact report, validates all halted paths, and restores quoting", () => {
+  assert.match(source, /proof_halt_rate="994000000000000000000000"/u);
+  assert.match(source, /proof_normal_rate="1000000000000000000000000"/u);
+  assert.match(source, /proof_rate_denominator="1000000000000000000000000"/u);
+  assert.match(source, /proof_trading_suspended_selector="0x4ac30c22"/u);
+  assert.match(source, /"halt-report"/u);
+  assert.match(source, /"restore-report"/u);
+  assert.match(source, /--arg controlSafe "\$proof_safe"/u);
+  assert.match(source, /--arg sortedOracles "\$proof_sorted_oracles"/u);
+  assert.match(
+    source,
+    /halt_rate_json="\$\(cast call[^\n]+medianRate\(address\)\(uint256,uint256\)[^\n]+\)"/u,
+  );
+  assert.match(source, /observed_halt_rate" == "\$proof_halt_rate"/u);
+  assert.match(
+    source,
+    /observed_halt_denominator" == "\$proof_rate_denominator"/u,
+  );
+  assert.match(
+    source,
+    /restored_rate_json="\$\(cast call[^\n]+medianRate\(address\)\(uint256,uint256\)[^\n]+\)"/u,
+  );
+  assert.match(source, /observed_restored_rate" == "\$proof_normal_rate"/u);
+  assert.match(
+    source,
+    /observed_restored_denominator" == "\$proof_rate_denominator"/u,
+  );
+  assert.match(source, /--arg haltRateRaw "\$observed_halt_rate"/u);
+  assert.match(source, /--arg restoredRateRaw "\$observed_restored_rate"/u);
+  assert.ok(
+    source.includes(
+      'grep -Eq "data: \\"?${proof_trading_suspended_selector}\\"?$"',
+    ),
+  );
+  assert.match(
+    source,
+    /expect_trading_suspended "swap" cast call[^\n]+\n?[^\n]*'swap\(uint256,uint256,address,bytes\)'/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /expect_trading_suspended "swap" cast call[^\n]+\n?[^\n]*'getAmountOut\(uint256,address\)'/u,
+  );
+  assert.match(source, /expect_trading_suspended "open-rebalance" cast call/u);
+  assert.match(
+    source,
+    /expect_trading_suspended "reserve-rebalance" cast call/u,
+  );
+  assert.match(source, /restored_quote" == "\$healthy_quote"/u);
+  assert.match(source, /receipt_count" == "2"/u);
+});
+
+test("EUROP proof runner labels its output as an unattested local diagnostic", () => {
+  assert.match(source, /EUROP local-fork diagnostic completed/u);
+  assert.match(source, /unattested local diagnostics/u);
+  assert.doesNotMatch(source, /local signature|local token/iu);
+});

--- a/scripts/europ-operational-admission-proof.test.mjs
+++ b/scripts/europ-operational-admission-proof.test.mjs
@@ -106,6 +106,16 @@ test("EUROP proof runner owns its execution endpoint and never embeds signing ma
     /\$\{[^}]+,,\}/u,
     "the runner must remain Bash 3.2-compatible",
   );
+  assert.doesNotMatch(
+    source,
+    /\bseq\b/u,
+    "the runner must not require a non-Bash sequence utility",
+  );
+  assert.match(
+    source,
+    /cycle=1\n {2}while \[\[ "\$cycle" -le "\$proof_cycles" \]\]; do/u,
+  );
+  assert.match(source, /cycle="\$\(\(cycle \+ 1\)\)"/u);
   assert.match(source, /trap cleanup EXIT INT TERM/u);
   assert.match(source, /\.tmp\/europ-operational-admission-proof/u);
 });

--- a/scripts/europ-operational-admission-witness.mjs
+++ b/scripts/europ-operational-admission-witness.mjs
@@ -1,0 +1,435 @@
+import {
+  EXPECTED_CHAIN_ID,
+  EXPECTED_EXECUTION_PROOF_REFERENCE,
+  EXPECTED_EXECUTION_SECONDS,
+  EXPECTED_ESCALATION_ROUTE,
+  EXPECTED_MENTO_CORE_COMMIT,
+  EXPECTED_MONITORED_RESERVE_RAW,
+  EXPECTED_PIN_BLOCK_HASH,
+  EXPECTED_PIN_BLOCK_NUMBER,
+  EXPECTED_POOL_ADDRESS,
+  EXPECTED_PROTOCOL_FEE_RECIPIENT,
+  EXPECTED_QUOTE_RESERVE_RAW,
+  EXPECTED_RESERVE_STRATEGY,
+  EXPECTED_SAFE_ADDRESS,
+  EXPECTED_RESPONSE_SECONDS,
+  EXPECTED_TRADING_LIMITS,
+  EXPECTED_WITNESS_MODEL,
+  hasText,
+  integer,
+  issue,
+  matchesAddress,
+  nonNegative,
+  optionalNonNegative,
+  positive,
+  requiredArray,
+  requiredObject,
+  timestamp,
+} from "./europ-operational-admission-contract.mjs";
+
+export function inspectWitnessConfigurationPin(
+  snapshot,
+  {
+    evidenceIdentity,
+    safeDiagnostics,
+    rateDiagnostics,
+    strategyDiagnostics,
+    custodyDiagnostics,
+  },
+  blockers,
+) {
+  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
+  const pool = requiredObject(snapshot.pool, "snapshot.pool");
+  const quoteAsset = requiredObject(
+    pool.quoteAsset,
+    "snapshot.pool.quoteAsset",
+  );
+  const monitoredAsset = requiredObject(
+    pool.monitoredAsset,
+    "snapshot.pool.monitoredAsset",
+  );
+  const administration = requiredObject(
+    pool.administration,
+    "snapshot.pool.administration",
+  );
+  const fee = requiredObject(pool.fee, "snapshot.pool.fee");
+  const limits = requiredArray(
+    pool.tradingLimits,
+    "snapshot.pool.tradingLimits",
+  );
+  const chainId = nonNegative(evidence.chainId, "evidence.chainId");
+  const blockNumber = positive(evidence.blockNumber, "evidence.blockNumber");
+  const quoteReserveRaw = nonNegative(
+    quoteAsset.reserveRaw,
+    "pool.quoteAsset.reserveRaw",
+  );
+  const monitoredReserveRaw = nonNegative(
+    monitoredAsset.reserveRaw,
+    "pool.monitoredAsset.reserveRaw",
+  );
+  const lpFeeBps = nonNegative(fee.lpBps, "pool.fee.lpBps");
+  const protocolFeeBps = nonNegative(fee.protocolBps, "pool.fee.protocolBps");
+  const rebalanceIncentiveBps = nonNegative(
+    pool.rebalanceIncentiveBps,
+    "pool.rebalanceIncentiveBps",
+  );
+  const rebalanceThresholdAboveBps = nonNegative(
+    pool.rebalanceThresholdAboveBps,
+    "pool.rebalanceThresholdAboveBps",
+  );
+  const rebalanceThresholdBelowBps = nonNegative(
+    pool.rebalanceThresholdBelowBps,
+    "pool.rebalanceThresholdBelowBps",
+  );
+  const datedPinMatches =
+    chainId === EXPECTED_CHAIN_ID &&
+    blockNumber === EXPECTED_PIN_BLOCK_NUMBER &&
+    hasText(evidence.blockHash) &&
+    evidence.blockHash.toLowerCase() === EXPECTED_PIN_BLOCK_HASH;
+  const tradingLimitsMatch =
+    limits.length === EXPECTED_TRADING_LIMITS.length &&
+    limits.every((value, index) => {
+      const limit = requiredObject(value, `pool.tradingLimits[${index}]`);
+      const expected = EXPECTED_TRADING_LIMITS[index];
+      return (
+        limit.name === expected.name &&
+        nonNegative(
+          limit.limitFixed15,
+          `pool.tradingLimits[${index}].limitFixed15`,
+        ) === expected.limitFixed15 &&
+        positive(
+          limit.durationSeconds,
+          `pool.tradingLimits[${index}].durationSeconds`,
+        ) === expected.durationSeconds &&
+        integer(
+          limit.netflowFixed15,
+          `pool.tradingLimits[${index}].netflowFixed15`,
+        ) === expected.netflowFixed15 &&
+        nonNegative(
+          limit.lastUpdated,
+          `pool.tradingLimits[${index}].lastUpdated`,
+        ) === expected.lastUpdated
+      );
+    });
+  const poolConfigurationMatches =
+    quoteReserveRaw === EXPECTED_QUOTE_RESERVE_RAW &&
+    monitoredReserveRaw === EXPECTED_MONITORED_RESERVE_RAW &&
+    lpFeeBps === 3n &&
+    protocolFeeBps === 2n &&
+    rebalanceIncentiveBps === 1n &&
+    rebalanceThresholdAboveBps === 5_000n &&
+    rebalanceThresholdBelowBps === 3_333n &&
+    tradingLimitsMatch;
+  const boundaryAdministrationMatches =
+    matchesAddress(administration.owner, EXPECTED_SAFE_ADDRESS) &&
+    matchesAddress(administration.feeSetter, EXPECTED_SAFE_ADDRESS) &&
+    matchesAddress(
+      administration.protocolFeeRecipient,
+      EXPECTED_PROTOCOL_FEE_RECIPIENT,
+    );
+  const protocolIdentityMatches =
+    evidenceIdentity?.protocolIdentity?.matchesExpectedEuropPolygonIdentity ===
+    true;
+  const safeConfigurationMatches =
+    safeDiagnostics?.structurallyValid === true &&
+    safeDiagnostics?.matchesExpectedControlStructure === true;
+  const rateConfigurationMatches =
+    rateDiagnostics?.configurationMatches === true;
+  const strategyConfigurationMatches =
+    strategyDiagnostics?.enumerationClaim === true &&
+    strategyDiagnostics?.configurationMatches === true;
+  const custodyConfigurationMatches =
+    custodyDiagnostics?.configurationMatches === true;
+  const applicable =
+    datedPinMatches &&
+    protocolIdentityMatches &&
+    poolConfigurationMatches &&
+    boundaryAdministrationMatches &&
+    safeConfigurationMatches &&
+    rateConfigurationMatches &&
+    strategyConfigurationMatches &&
+    custodyConfigurationMatches;
+
+  if (!applicable) {
+    blockers.push(
+      issue(
+        "LOSS_BUDGET_WITNESS_CONFIGURATION_MISMATCH",
+        "The dated fork witness does not match the exact pinned block, pool state, administration, fee recipient, Safe, rate control, enabled strategies, or reviewed custody boundary.",
+      ),
+    );
+  }
+
+  return {
+    datedPinMatches,
+    protocolIdentityMatches,
+    poolConfigurationMatches,
+    boundaryAdministrationMatches,
+    safeConfigurationMatches,
+    rateConfigurationMatches,
+    strategyConfigurationMatches,
+    custodyConfigurationMatches,
+    applicable,
+    authenticated: false,
+  };
+}
+
+export function inspectLossBudgetWitness(
+  snapshot,
+  budget,
+  witnessConfiguration,
+  blockers,
+) {
+  const witness = requiredObject(
+    snapshot.lossBudgetWitness,
+    "snapshot.lossBudgetWitness",
+  );
+  const evidenceBlockNumber = positive(
+    requiredObject(snapshot.evidence, "snapshot.evidence").blockNumber,
+    "evidence.blockNumber",
+  );
+  const responseSeconds = positive(snapshot.responseSeconds, "responseSeconds");
+  const blockNumber = positive(
+    witness.blockNumber,
+    "lossBudgetWitness.blockNumber",
+  );
+  const blockHashMatches =
+    hasText(witness.blockHash) &&
+    witness.blockHash.toLowerCase() === EXPECTED_PIN_BLOCK_HASH;
+  const cycles = positive(witness.cycles, "lossBudgetWitness.cycles");
+  const transactionsPerCycle = positive(
+    witness.transactionsPerCycle,
+    "lossBudgetWitness.transactionsPerCycle",
+  );
+  const successfulTransactions = positive(
+    witness.successfulTransactions,
+    "lossBudgetWitness.successfulTransactions",
+  );
+  const successfulReserveRebalances = positive(
+    witness.successfulReserveRebalances,
+    "lossBudgetWitness.successfulReserveRebalances",
+  );
+  const monitoredInputPerCycleRaw = positive(
+    witness.monitoredInputPerCycleRaw,
+    "lossBudgetWitness.monitoredInputPerCycleRaw",
+  );
+  const quoteOutPerCycleEurmRaw = positive(
+    witness.quoteOutPerCycleEurmRaw,
+    "lossBudgetWitness.quoteOutPerCycleEurmRaw",
+  );
+  const totalMonitoredInputRaw = positive(
+    witness.totalMonitoredInputRaw,
+    "lossBudgetWitness.totalMonitoredInputRaw",
+  );
+  const externalQuoteOutEurmRaw = positive(
+    witness.externalQuoteOutEurmRaw,
+    "lossBudgetWitness.externalQuoteOutEurmRaw",
+  );
+  const elapsedSeconds = positive(
+    witness.elapsedSeconds,
+    "lossBudgetWitness.elapsedSeconds",
+  );
+  const expectedTransactions = cycles * transactionsPerCycle;
+  const approvedBudgetEurmRaw = budget?.approvedBudgetEurmRaw ?? null;
+  const arithmeticAndConfigurationMatch =
+    witness.modelId === EXPECTED_WITNESS_MODEL &&
+    witness.mentoCoreCommit === EXPECTED_MENTO_CORE_COMMIT &&
+    matchesAddress(witness.pool, EXPECTED_POOL_ADDRESS) &&
+    matchesAddress(witness.reserveStrategy, EXPECTED_RESERVE_STRATEGY) &&
+    blockNumber === evidenceBlockNumber &&
+    blockNumber === EXPECTED_PIN_BLOCK_NUMBER &&
+    blockHashMatches &&
+    witnessConfiguration?.applicable === true &&
+    cycles === 51n &&
+    transactionsPerCycle === 3n &&
+    successfulTransactions === expectedTransactions &&
+    successfulReserveRebalances === cycles &&
+    monitoredInputPerCycleRaw === 2_000_000_000n &&
+    totalMonitoredInputRaw === cycles * monitoredInputPerCycleRaw &&
+    quoteOutPerCycleEurmRaw === 1_999_000_000_000_000_000_000n &&
+    externalQuoteOutEurmRaw === cycles * quoteOutPerCycleEurmRaw &&
+    elapsedSeconds === 15_080n &&
+    elapsedSeconds <= responseSeconds &&
+    witness.allTransactionsSucceeded === true &&
+    witness.localForkOnly === true &&
+    witness.productionActivity === false &&
+    approvedBudgetEurmRaw !== null &&
+    budget?.policyMatches === true &&
+    budget?.approvalEvidenceMatches === true &&
+    externalQuoteOutEurmRaw > approvedBudgetEurmRaw;
+
+  if (!arithmeticAndConfigurationMatch) {
+    blockers.push(
+      issue(
+        "LOCAL_FORK_WITNESS_CLAIM_MISMATCH",
+        "The local-fork witness claim does not match the pinned diagnostic inputs or its stated arithmetic.",
+      ),
+    );
+  }
+
+  return {
+    modelId: witness.modelId ?? null,
+    blockNumber,
+    blockHash: witness.blockHash ?? null,
+    cycles,
+    successfulTransactions,
+    successfulReserveRebalances,
+    monitoredInputPerCycleRaw,
+    totalMonitoredInputRaw,
+    quoteOutPerCycleEurmRaw,
+    externalQuoteOutEurmRaw,
+    elapsedSeconds,
+    localForkClaimMatches: arithmeticAndConfigurationMatch,
+    claimStatus: "unattested",
+    provenance: "unattested",
+    authenticated: false,
+  };
+}
+
+export function inspectCertificate(snapshot, evaluation, blockers) {
+  const certificate = requiredObject(
+    snapshot.certificate,
+    "snapshot.certificate",
+  );
+  const responseSeconds = positive(snapshot.responseSeconds, "responseSeconds");
+  const acceptedSafeNonce = positive(
+    certificate.acceptedSafeNonce,
+    "certificate.acceptedSafeNonce",
+  );
+  const acceptedResponseSeconds = positive(
+    certificate.acceptedResponseSeconds,
+    "certificate.acceptedResponseSeconds",
+  );
+  const executionElapsedSeconds = positive(
+    certificate.executionElapsedSeconds,
+    "certificate.executionElapsedSeconds",
+  );
+  for (const field of [
+    "signerCoverageOwner",
+    "escalationRoute",
+    "executionProof",
+    "reviewer",
+  ]) {
+    if (!hasText(certificate[field])) {
+      blockers.push(
+        issue(
+          "CERTIFICATE_FIELD_MISSING",
+          `Certificate field ${field} is missing.`,
+        ),
+      );
+    }
+  }
+
+  const expiries = {};
+  const evaluatedAt = timestamp(evaluation?.evaluatedAt);
+  for (const field of [
+    "signerCoverageExpiresAt",
+    "escalationRouteExpiresAt",
+    "executionProofExpiresAt",
+    "budgetApprovalExpiresAt",
+  ]) {
+    const expiresAt = timestamp(certificate[field]);
+    expiries[field] = certificate[field] ?? null;
+    if (!hasText(certificate[field])) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRY_MISSING",
+          `Certificate field ${field} is missing an explicit expiry.`,
+        ),
+      );
+    } else if (expiresAt === null) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRY_INVALID",
+          `Certificate field ${field} has an invalid expiry.`,
+        ),
+      );
+    } else if (evaluatedAt !== null && expiresAt <= evaluatedAt) {
+      blockers.push(
+        issue(
+          "ATTESTATION_EXPIRED",
+          `Certificate field ${field} is expired at the explicit evaluation time.`,
+        ),
+      );
+    }
+  }
+
+  const policyMatches =
+    certificate.signerCoverageOwner === "Philip Paetz" &&
+    certificate.signerCoverageBackup === "Bogdan Dumitru" &&
+    certificate.reviewer === "Philip Paetz" &&
+    certificate.escalationRoute === EXPECTED_ESCALATION_ROUTE &&
+    acceptedSafeNonce === 8n &&
+    acceptedResponseSeconds === EXPECTED_RESPONSE_SECONDS &&
+    responseSeconds === EXPECTED_RESPONSE_SECONDS &&
+    executionElapsedSeconds === EXPECTED_EXECUTION_SECONDS &&
+    executionElapsedSeconds <= acceptedResponseSeconds &&
+    certificate.executionWithinResponseTimeAccepted === true &&
+    certificate.executionProofReference === EXPECTED_EXECUTION_PROOF_REFERENCE;
+  if (!policyMatches) {
+    blockers.push(
+      issue(
+        "CERTIFICATE_POLICY_MISMATCH",
+        "The signer owner, backup, reviewer, @support-engineer route, six-hour response time, accepted Safe nonce 8 execution, or proof reference differs from the approved certificate.",
+      ),
+    );
+  }
+
+  return {
+    signerCoverageOwner: certificate.signerCoverageOwner ?? null,
+    signerCoverageBackup: certificate.signerCoverageBackup ?? null,
+    reviewer: certificate.reviewer ?? null,
+    acceptedSafeNonce,
+    acceptedResponseSeconds,
+    executionElapsedSeconds,
+    executionWithinResponseTimeAccepted:
+      certificate.executionWithinResponseTimeAccepted === true,
+    executionProofReference: certificate.executionProofReference ?? null,
+    policyMatches,
+    expiries,
+    authenticated: false,
+  };
+}
+
+export function inspectBoundaryModelClaims(snapshot, blockers) {
+  const model = requiredObject(
+    snapshot.boundaryModel,
+    "snapshot.boundaryModel",
+  );
+  const monotoneCapacityNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
+    model.monotoneCapacityNetQuoteOutflowEurmRaw,
+    "boundaryModel.monotoneCapacityNetQuoteOutflowEurmRaw",
+  );
+  const worstCaseNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
+    model.worstCaseNetQuoteOutflowEurmRaw,
+    "boundaryModel.worstCaseNetQuoteOutflowEurmRaw",
+  );
+
+  if (monotoneCapacityNetQuoteOutflowClaimEurmRaw === null) {
+    blockers.push(
+      issue(
+        "MONOTONE_CAPACITY_QUOTE_BOUND_MISSING",
+        "No EURm result is recorded for the documented monotone capacity.",
+      ),
+    );
+  }
+  if (worstCaseNetQuoteOutflowClaimEurmRaw === null) {
+    blockers.push(
+      issue(
+        "BOUNDARY_ALIGNED_LOSS_MODEL_MISSING",
+        "No worst-case net EURm-outflow result is recorded.",
+      ),
+    );
+  }
+
+  return {
+    protectedSystemBoundaryClaim: model.protectedSystemBoundary ?? null,
+    modelIdClaim: model.modelId ?? null,
+    coversBidirectionalRateTransitionsClaim:
+      model.coversBidirectionalRateTransitions === true,
+    coversAllEnabledStrategiesClaim: model.coversAllEnabledStrategies === true,
+    monotoneCapacityNetQuoteOutflowClaimEurmRaw,
+    worstCaseNetQuoteOutflowClaimEurmRaw,
+    executable: false,
+    authenticated: false,
+  };
+}

--- a/scripts/europ-operational-admission.mjs
+++ b/scripts/europ-operational-admission.mjs
@@ -1,183 +1,43 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-
-const BASIS_POINTS = 10_000n;
-const FIXED_15 = 10n ** 15n;
-const MAX_BUDGET_EURM_RAW = 100_000n * 10n ** 18n;
-const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
-const BLOCK_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
-const CANONICAL_INTEGER_PATTERN = /^(?:0|-?[1-9][0-9]*)$/u;
-const ISO_TIMESTAMP_PATTERN =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|[+-]\d{2}:\d{2})$/u;
-const EXPECTED_CHAIN_ID = 137n;
-const EXPECTED_POOL_ADDRESS = "0xcd8c6811d975981f57e7fb32e59f0bee66af3201";
-const EXPECTED_QUOTE_TOKEN_ADDRESS =
-  "0x4d502d735b4c574b487ed641ae87ceae884731c7";
-const EXPECTED_MONITORED_TOKEN_ADDRESS =
-  "0x888883b5f5d21fb10dfeb70e8f9722b9fb0e5e51";
-const EXPECTED_QUOTE_TOKEN_DECIMALS = 18n;
-const EXPECTED_MONITORED_TOKEN_DECIMALS = 6n;
-const EXPECTED_SAFE_ADDRESS = "0x58099b74f4acd642da77b4b7966b4138ec5ba458";
-const EXPECTED_SAFE_THRESHOLD = 4n;
-const EXPECTED_SAFE_OWNER_COUNT = 6n;
-
-function requiredObject(value, field) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${field} must be an object`);
-  }
-  return value;
-}
-
-function requiredArray(value, field) {
-  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
-  return value;
-}
-
-function integer(value, field) {
-  if (typeof value === "number") {
-    if (!Number.isSafeInteger(value)) {
-      throw new Error(`${field} must be a safe integer number`);
-    }
-    return BigInt(value);
-  }
-  if (typeof value === "string" && CANONICAL_INTEGER_PATTERN.test(value)) {
-    return BigInt(value);
-  }
-  throw new Error(
-    `${field} must be a canonical integer string or safe integer number`,
-  );
-}
-
-function nonNegative(value, field) {
-  const parsed = integer(value, field);
-  if (parsed < 0n) throw new Error(`${field} must be non-negative`);
-  return parsed;
-}
-
-function positive(value, field) {
-  const parsed = nonNegative(value, field);
-  if (parsed === 0n) throw new Error(`${field} must be positive`);
-  return parsed;
-}
-
-function optionalNonNegative(value, field) {
-  if (value === null || value === undefined) return null;
-  return nonNegative(value, field);
-}
-
-function ceilDiv(numerator, denominator) {
-  if (numerator < 0n || denominator <= 0n) {
-    throw new Error(
-      "ceilDiv requires a non-negative numerator and positive denominator",
-    );
-  }
-  return (numerator + denominator - 1n) / denominator;
-}
-
-function min(values) {
-  if (values.length === 0) throw new Error("cannot take minimum of no values");
-  return values.reduce((current, value) => (value < current ? value : current));
-}
-
-function issue(code, message) {
-  return { code, message };
-}
-
-function hasText(value) {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function isLeapYear(year) {
-  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-}
-
-function daysInMonth(year, month) {
-  const days = [
-    31,
-    isLeapYear(year) ? 29 : 28,
-    31,
-    30,
-    31,
-    30,
-    31,
-    31,
-    30,
-    31,
-    30,
-    31,
-  ];
-  return days[month - 1] ?? 0;
-}
-
-function timestamp(value) {
-  if (!hasText(value)) return null;
-  const match = ISO_TIMESTAMP_PATTERN.exec(value);
-  if (!match) return null;
-
-  const [
-    ,
-    yearText,
-    monthText,
-    dayText,
-    hourText,
-    minuteText,
-    secondText,
-    millisecondText,
-    offsetText,
-  ] = match;
-  const year = Number(yearText);
-  const month = Number(monthText);
-  const day = Number(dayText);
-  const hour = Number(hourText);
-  const minute = Number(minuteText);
-  const second = Number(secondText);
-  const millisecond = millisecondText ? Number(millisecondText) : 0;
-
-  if (
-    month < 1 ||
-    month > 12 ||
-    day < 1 ||
-    day > daysInMonth(year, month) ||
-    hour > 23 ||
-    minute > 59 ||
-    second > 59
-  ) {
-    return null;
-  }
-
-  let offsetMinutes = 0;
-  if (offsetText !== "Z") {
-    if (offsetText === "-00:00") return null;
-    const offsetHours = Number(offsetText.slice(1, 3));
-    const offsetMinutePart = Number(offsetText.slice(4, 6));
-    if (
-      offsetHours > 14 ||
-      offsetMinutePart > 59 ||
-      (offsetHours === 14 && offsetMinutePart !== 0)
-    ) {
-      return null;
-    }
-    offsetMinutes = offsetHours * 60 + offsetMinutePart;
-    if (offsetText.startsWith("-")) offsetMinutes = -offsetMinutes;
-  }
-
-  const wallClock = new Date(0);
-  wallClock.setUTCFullYear(year, month - 1, day);
-  wallClock.setUTCHours(hour, minute, second, millisecond);
-  const parsed = wallClock.getTime() - offsetMinutes * 60_000;
-  return Number.isFinite(parsed) ? parsed : null;
-}
+import {
+  issue,
+  requiredObject,
+} from "./europ-operational-admission-contract.mjs";
+import {
+  deriveApprovedBudget,
+  deriveMonotoneSwapEnvelope,
+  inspectEvaluation,
+  inspectEvidenceIdentity,
+} from "./europ-operational-admission-evidence.mjs";
+import {
+  inspectCustodyBoundary,
+  inspectEmergencyHalt,
+  inspectRateControl,
+  inspectSafe,
+  inspectStrategies,
+} from "./europ-operational-admission-controls.mjs";
+import {
+  inspectBoundaryModelClaims,
+  inspectCertificate,
+  inspectLossBudgetWitness,
+  inspectWitnessConfigurationPin,
+} from "./europ-operational-admission-witness.mjs";
 
 function permanentBlockers() {
   return [
     issue(
       "EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED",
-      "No executable sequential loss model authenticates state, advances every reachable transition, and calculates protected-boundary EURm outflow.",
+      "No complete authenticated sequential model maximizes every reachable protected-boundary EURm transition.",
     ),
     issue(
       "SNAPSHOT_NOT_AUTHENTICATED",
       "The checked-in snapshot is diagnostic evidence, not authenticated proof of Safe, rate, strategy, or budget state.",
+    ),
+    issue(
+      "LOCAL_FORK_PROVENANCE_UNATTESTED",
+      "Local-fork observations have no independent execution or fork-source attestation and cannot support Live admission.",
     ),
   ];
 }
@@ -193,10 +53,19 @@ function blockedResult({
   strategyDiagnostics = null,
   certificate = null,
   boundaryModelClaims = null,
+  haltDiagnostics = null,
+  custodyDiagnostics = null,
+  witnessConfiguration = null,
+  lossBudgetWitness = null,
 }) {
-  const reason =
-    "An executable authenticated sequential loss model is not implemented.";
   const approvedBudgetEurmRaw = budget?.approvedBudgetEurmRaw ?? null;
+  const unavailableReason =
+    "A complete authenticated sequential model is missing, and independent execution and fork-source attestation is missing.";
+  const worstCaseBudgetComparison = {
+    status: "not_evaluable",
+    reason: unavailableReason,
+    approvedBudgetEurmRaw,
+  };
   return {
     status: "BLOCKED",
     evidenceIdentity,
@@ -208,628 +77,25 @@ function blockedResult({
     strategyDiagnostics,
     certificate,
     boundaryModelClaims,
+    haltDiagnostics,
+    custodyDiagnostics,
+    witnessConfiguration,
+    lossBudgetWitness,
     monotoneCapacityBudgetComparison: {
       status: "not_evaluable",
-      reason,
+      reason: unavailableReason,
       approvedBudgetEurmRaw,
     },
-    worstCaseBudgetComparison: {
-      status: "not_evaluable",
-      reason,
-      approvedBudgetEurmRaw,
-    },
+    worstCaseBudgetComparison,
     blockers,
-  };
-}
-
-function inspectEvidenceIdentity(snapshot, blockers) {
-  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
-  const pool = requiredObject(snapshot.pool, "snapshot.pool");
-  const quoteAsset = requiredObject(
-    pool.quoteAsset,
-    "snapshot.pool.quoteAsset",
-  );
-  const monitoredAsset = requiredObject(
-    pool.monitoredAsset,
-    "snapshot.pool.monitoredAsset",
-  );
-  const chainId = nonNegative(evidence.chainId, "evidence.chainId");
-  const blockNumber = positive(evidence.blockNumber, "evidence.blockNumber");
-  const quoteAssetDecimals = nonNegative(
-    quoteAsset.decimals,
-    "pool.quoteAsset.decimals",
-  );
-  const monitoredAssetDecimals = nonNegative(
-    monitoredAsset.decimals,
-    "pool.monitoredAsset.decimals",
-  );
-  const poolMonitoredAssetDecimals = nonNegative(
-    pool.monitoredAssetDecimals,
-    "pool.monitoredAssetDecimals",
-  );
-
-  const blockReferenceWellFormed =
-    hasText(evidence.blockHash) && BLOCK_HASH_PATTERN.test(evidence.blockHash);
-  if (!blockReferenceWellFormed) {
-    blockers.push(
-      issue(
-        "BLOCK_REFERENCE_INVALID",
-        "The block reference must contain a positive canonical block number and 32-byte hash.",
-      ),
-    );
-  }
-
-  const invalidProtocolFields = [];
-  for (const [field, value] of [
-    ["pool.address", pool.address],
-    ["pool.quoteAsset.address", quoteAsset.address],
-    ["pool.monitoredAsset.address", monitoredAsset.address],
-  ]) {
-    if (!hasText(value) || !ADDRESS_PATTERN.test(value))
-      invalidProtocolFields.push(field);
-  }
-  for (const [field, value] of [
-    ["evidence.asset", evidence.asset],
-    ["evidence.quoteAsset", evidence.quoteAsset],
-    ["pool.quoteAsset.symbol", quoteAsset.symbol],
-    ["pool.monitoredAsset.symbol", monitoredAsset.symbol],
-  ]) {
-    if (!hasText(value)) invalidProtocolFields.push(field);
-  }
-
-  if (invalidProtocolFields.length > 0) {
-    blockers.push(
-      issue(
-        "PROTOCOL_IDENTITY_INVALID",
-        `Protocol identity fields are malformed: ${invalidProtocolFields.join(", ")}.`,
-      ),
-    );
-  }
-
-  const mismatches = [];
-  if (chainId !== EXPECTED_CHAIN_ID) mismatches.push("chainId");
-  if (evidence.asset !== "EUROP") mismatches.push("asset");
-  if (evidence.quoteAsset !== "EURm") mismatches.push("quoteAsset");
-  if (
-    hasText(pool.address) &&
-    pool.address.toLowerCase() !== EXPECTED_POOL_ADDRESS
-  ) {
-    mismatches.push("pool.address");
-  }
-  if (
-    hasText(quoteAsset.address) &&
-    quoteAsset.address.toLowerCase() !== EXPECTED_QUOTE_TOKEN_ADDRESS
-  ) {
-    mismatches.push("pool.quoteAsset.address");
-  }
-  if (
-    hasText(monitoredAsset.address) &&
-    monitoredAsset.address.toLowerCase() !== EXPECTED_MONITORED_TOKEN_ADDRESS
-  ) {
-    mismatches.push("pool.monitoredAsset.address");
-  }
-  if (quoteAsset.symbol !== "EURm") mismatches.push("pool.quoteAsset.symbol");
-  if (monitoredAsset.symbol !== "EUROP") {
-    mismatches.push("pool.monitoredAsset.symbol");
-  }
-  if (quoteAssetDecimals !== EXPECTED_QUOTE_TOKEN_DECIMALS) {
-    mismatches.push("pool.quoteAsset.decimals");
-  }
-  if (
-    monitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS ||
-    poolMonitoredAssetDecimals !== EXPECTED_MONITORED_TOKEN_DECIMALS
-  ) {
-    mismatches.push("pool.monitoredAsset.decimals");
-  }
-
-  if (mismatches.length > 0) {
-    blockers.push(
-      issue(
-        "PROTOCOL_IDENTITY_MISMATCH",
-        `Snapshot identity does not match EUROP/EURm on Polygon: ${mismatches.join(", ")}.`,
-      ),
-    );
-  }
-
-  const matchesExpectedEuropPolygonIdentity =
-    invalidProtocolFields.length === 0 && mismatches.length === 0;
-  return {
-    protocolIdentity: {
-      chainId,
-      asset: evidence.asset ?? null,
-      quoteAsset: evidence.quoteAsset ?? null,
-      poolAddress: pool.address ?? null,
-      quoteAssetAddress: quoteAsset.address ?? null,
-      monitoredAssetAddress: monitoredAsset.address ?? null,
-      quoteAssetDecimals,
-      monitoredAssetDecimals,
-      matchesExpectedEuropPolygonIdentity,
-      authenticated: false,
-    },
-    blockReference: {
-      blockNumber,
-      blockHash: evidence.blockHash ?? null,
-      wellFormed: blockReferenceWellFormed,
-      authenticated: false,
-    },
-  };
-}
-
-/**
- * Derive the durable TradingLimitsV2 capacity documented in the canonical
- * onboarding runbook. This is a fee-adjusted monitored-token netflow envelope,
- * not a quote-asset loss result.
- */
-function deriveMonotoneSwapEnvelope(input) {
-  const snapshot = requiredObject(input, "snapshot");
-  const pool = requiredObject(snapshot.pool, "snapshot.pool");
-  const responseSeconds = positive(snapshot.responseSeconds, "responseSeconds");
-  const monitoredAssetDecimals = Number(
-    nonNegative(pool.monitoredAssetDecimals, "pool.monitoredAssetDecimals"),
-  );
-  if (!Number.isSafeInteger(monitoredAssetDecimals)) {
-    throw new Error("pool.monitoredAssetDecimals must be a safe integer");
-  }
-
-  const fee = requiredObject(pool.fee, "pool.fee");
-  const totalFeeBps =
-    nonNegative(fee.lpBps, "pool.fee.lpBps") +
-    nonNegative(fee.protocolBps, "pool.fee.protocolBps");
-  if (totalFeeBps >= BASIS_POINTS) {
-    throw new Error("pool total fee must be below 10,000 bps");
-  }
-
-  const invariantViolations = [];
-  const windows = requiredArray(pool.tradingLimits, "pool.tradingLimits")
-    .map((window, index) => {
-      const parsed = requiredObject(window, `pool.tradingLimits[${index}]`);
-      const limitFixed15 = nonNegative(
-        parsed.limitFixed15,
-        `pool.tradingLimits[${index}].limitFixed15`,
-      );
-      const durationSeconds = positive(
-        parsed.durationSeconds,
-        `pool.tradingLimits[${index}].durationSeconds`,
-      );
-      const netflowFixed15 = integer(
-        parsed.netflowFixed15,
-        `pool.tradingLimits[${index}].netflowFixed15`,
-      );
-      if (limitFixed15 === 0n) return null;
-
-      const name = hasText(parsed.name) ? parsed.name : `window-${index}`;
-      const withinInvariant =
-        netflowFixed15 >= -limitFixed15 && netflowFixed15 <= limitFixed15;
-      if (!withinInvariant) {
-        invariantViolations.push(
-          issue(
-            "TRADING_LIMIT_INVARIANT_VIOLATION",
-            `${name} signed netflow is outside the enforced interval [-L, +L].`,
-          ),
-        );
-      }
-
-      const resetWindows = ceilDiv(responseSeconds, durationSeconds);
-      return {
-        name,
-        durationSeconds,
-        limitFixed15,
-        netflowFixed15,
-        withinInvariant,
-        resetWindows,
-        durableCapacityFixed15: 2n * limitFixed15 + limitFixed15 * resetWindows,
-      };
-    })
-    .filter((window) => window !== null);
-
-  if (windows.length === 0) {
-    throw new Error("at least one positive TradingLimitsV2 window is required");
-  }
-
-  const netflowCapacityFixed15 = min(
-    windows.map((window) => window.durableCapacityFixed15),
-  );
-  const grossInputFixed15 =
-    (netflowCapacityFixed15 * BASIS_POINTS) / (BASIS_POINTS - totalFeeBps);
-
-  let grossMonitoredInputRaw = null;
-  if (monitoredAssetDecimals <= 15) {
-    const fixed15PerMonitoredTokenRaw =
-      FIXED_15 / 10n ** BigInt(monitoredAssetDecimals);
-    grossMonitoredInputRaw = grossInputFixed15 / fixed15PerMonitoredTokenRaw;
-  }
-
-  return {
-    responseSeconds,
-    totalFeeBps,
-    monitoredAssetDecimals,
-    windows,
-    invariantViolations,
-    netflowCapacityFixed15,
-    grossInputFixed15,
-    grossMonitoredInputRaw,
-  };
-}
-
-function inspectEvaluation(snapshot, blockers) {
-  const evidence = requiredObject(snapshot.evidence, "snapshot.evidence");
-  const evaluation = requiredObject(snapshot.evaluation, "snapshot.evaluation");
-  const observedAt = timestamp(evidence.observedAt);
-  const evaluatedAt = timestamp(evaluation.evaluatedAt);
-  const maxEvidenceAgeSeconds = positive(
-    evaluation.maxEvidenceAgeSeconds,
-    "evaluation.maxEvidenceAgeSeconds",
-  );
-
-  if (observedAt === null) {
-    blockers.push(
-      issue(
-        "EVIDENCE_TIMESTAMP_MISSING_OR_INVALID",
-        "The pinned evidence timestamp is absent or invalid.",
-      ),
-    );
-  }
-  if (evaluatedAt === null) {
-    blockers.push(
-      issue(
-        "EVALUATION_TIMESTAMP_MISSING_OR_INVALID",
-        "The explicit evaluation timestamp is absent or invalid.",
-      ),
-    );
-  }
-
-  let evidenceAgeSeconds = null;
-  if (observedAt !== null && evaluatedAt !== null) {
-    evidenceAgeSeconds = BigInt(Math.floor((evaluatedAt - observedAt) / 1000));
-    if (evidenceAgeSeconds < 0n) {
-      blockers.push(
-        issue(
-          "EVIDENCE_FROM_FUTURE",
-          "The pinned evidence timestamp is later than the explicit evaluation time.",
-        ),
-      );
-    } else if (evidenceAgeSeconds > maxEvidenceAgeSeconds) {
-      blockers.push(
-        issue(
-          "EVIDENCE_STALE",
-          "The pinned evidence is older than the explicit maximum evidence age.",
-        ),
-      );
-    }
-  }
-
-  return {
-    observedAt: evidence.observedAt ?? null,
-    evaluatedAt: evaluation.evaluatedAt ?? null,
-    maxEvidenceAgeSeconds,
-    evidenceAgeSeconds,
-  };
-}
-
-function deriveApprovedBudget(snapshot, blockers) {
-  const budget = requiredObject(snapshot.budget, "snapshot.budget");
-  const liquidReserveAssetsEurmRaw = optionalNonNegative(
-    budget.liquidReserveAssetsEurmRaw,
-    "budget.liquidReserveAssetsEurmRaw",
-  );
-  const approvedBudgetEurmRaw = optionalNonNegative(
-    budget.approvedBudgetEurmRaw,
-    "budget.approvedBudgetEurmRaw",
-  );
-
-  if (approvedBudgetEurmRaw === null) {
-    blockers.push(
-      issue("APPROVED_BUDGET_MISSING", "The exact numeric B is absent."),
-    );
-  } else if (
-    !hasText(budget.approvedBy) ||
-    !hasText(budget.approvalReference)
-  ) {
-    blockers.push(
-      issue(
-        "BUDGET_APPROVAL_EVIDENCE_MISSING",
-        "The recorded B lacks its accountable approver or approval reference.",
-      ),
-    );
-  }
-
-  if (liquidReserveAssetsEurmRaw === null) {
-    if (approvedBudgetEurmRaw === null) {
-      blockers.push(
-        issue(
-          "LIQUID_RESERVE_VALUE_MISSING",
-          "No approved liquid-reserve value is available to calculate B from the starter rule.",
-        ),
-      );
-    }
-    return {
-      liquidReserveAssetsEurmRaw,
-      derivedBudgetEurmRaw: null,
-      approvedBudgetEurmRaw,
-    };
-  }
-
-  const derivedBudgetEurmRaw = min([
-    MAX_BUDGET_EURM_RAW,
-    (liquidReserveAssetsEurmRaw * 5n) / 1000n,
-  ]);
-  if (
-    approvedBudgetEurmRaw !== null &&
-    approvedBudgetEurmRaw !== derivedBudgetEurmRaw
-  ) {
-    blockers.push(
-      issue(
-        "APPROVED_BUDGET_MISMATCH",
-        "The recorded B does not equal min(100,000 EURm, 0.5% of the approved liquid-reserve value).",
-      ),
-    );
-  }
-
-  return {
-    liquidReserveAssetsEurmRaw,
-    derivedBudgetEurmRaw,
-    approvedBudgetEurmRaw,
-  };
-}
-
-function inspectSafe(snapshot, blockers) {
-  const controls = requiredObject(snapshot.controls, "snapshot.controls");
-  const safe = requiredObject(controls.safe, "controls.safe");
-  const address = safe.address;
-  const threshold = positive(safe.threshold, "controls.safe.threshold");
-  const ownerCount = positive(safe.ownerCount, "controls.safe.ownerCount");
-  const nonce = nonNegative(safe.nonce, "controls.safe.nonce");
-  const validAddress = hasText(address) && ADDRESS_PATTERN.test(address);
-  const ownerSetVerifiedAtPin = safe.ownerSetVerifiedAtPin === true;
-  const structurallyValid =
-    validAddress && threshold <= ownerCount && ownerSetVerifiedAtPin;
-  const matchesExpectedControlStructure =
-    validAddress &&
-    address.toLowerCase() === EXPECTED_SAFE_ADDRESS &&
-    threshold === EXPECTED_SAFE_THRESHOLD &&
-    ownerCount === EXPECTED_SAFE_OWNER_COUNT;
-
-  if (!validAddress || threshold > ownerCount) {
-    blockers.push(
-      issue(
-        "SAFE_STRUCTURE_INVALID",
-        "The Safe address, threshold, or owner count is structurally invalid.",
-      ),
-    );
-  }
-  if (!ownerSetVerifiedAtPin) {
-    blockers.push(
-      issue(
-        "SAFE_OWNER_SET_UNVERIFIED",
-        "The snapshot does not record a same-pin Safe owner-set read.",
-      ),
-    );
-  }
-  if (!matchesExpectedControlStructure) {
-    blockers.push(
-      issue(
-        "SAFE_EXPECTED_CONFIGURATION_MISMATCH",
-        "The Safe address or 4-of-6 structure does not match the expected EUROP control structure.",
-      ),
-    );
-  }
-
-  return {
-    address,
-    threshold,
-    ownerCount,
-    nonce,
-    ownerSetVerifiedAtPin,
-    structurallyValid,
-    matchesExpectedControlStructure,
-    authenticated: false,
-  };
-}
-
-function inspectRateControl(snapshot, blockers) {
-  const controls = requiredObject(snapshot.controls, "snapshot.controls");
-  const rate = requiredObject(controls.rate, "controls.rate");
-  const noChangeClaim = rate.enforcedNoChange === true;
-  const noArbitrageClaim = rate.enforcedNoArbitrage === true;
-  const maxSuccessfulTransitionsClaim = optionalNonNegative(
-    rate.maxSuccessfulTransitions,
-    "controls.rate.maxSuccessfulTransitions",
-  );
-
-  if (
-    !noChangeClaim &&
-    !noArbitrageClaim &&
-    maxSuccessfulTransitionsClaim === null
-  ) {
-    blockers.push(
-      issue(
-        "RATE_TRANSITION_BOUND_MISSING",
-        "Bidirectional manual-rate trading has no recorded no-change, no-arbitrage, or maximum-transition control for S.",
-      ),
-    );
-  }
-
-  return {
-    noChangeClaim,
-    noArbitrageClaim,
-    maxSuccessfulTransitionsClaim,
-    authenticated: false,
-  };
-}
-
-function inspectStrategies(snapshot, blockers) {
-  const controls = requiredObject(snapshot.controls, "snapshot.controls");
-  const strategies = requiredArray(controls.strategies, "controls.strategies");
-  const enumerationClaim = controls.strategiesEnumeratedThroughBlock === true;
-
-  if (!enumerationClaim) {
-    blockers.push(
-      issue(
-        "STRATEGY_ENUMERATION_UNVERIFIED",
-        "The snapshot does not record every strategy enabled through the pinned block.",
-      ),
-    );
-  }
-
-  const entries = strategies.map((strategy, index) => {
-    const parsed = requiredObject(strategy, `controls.strategies[${index}]`);
-    const name = hasText(parsed.name) ? parsed.name : `strategy-${index}`;
-    const enabled = parsed.enabled === true;
-    const cooldownSeconds = optionalNonNegative(
-      parsed.cooldownSeconds,
-      `controls.strategies[${index}].cooldownSeconds`,
-    );
-    const maxQuoteOutflowClaimEurmRaw = optionalNonNegative(
-      parsed.maxQuoteOutflowEurmRaw,
-      `controls.strategies[${index}].maxQuoteOutflowEurmRaw`,
-    );
-    const mintsQuoteIntoPoolClaim =
-      parsed.kind === "reserve" && parsed.mintsQuoteIntoPool !== false;
-    const mintCapClaimEurmRaw = mintsQuoteIntoPoolClaim
-      ? optionalNonNegative(
-          parsed.mintCapEurmRaw,
-          `controls.strategies[${index}].mintCapEurmRaw`,
-        )
-      : null;
-
-    if (enabled && maxQuoteOutflowClaimEurmRaw === null) {
-      blockers.push(
-        issue(
-          "STRATEGY_BOUNDARY_MODEL_MISSING",
-          `${name} is enabled without a recorded quote-asset boundary model for S.`,
-        ),
-      );
-    }
-    if (enabled && mintsQuoteIntoPoolClaim && mintCapClaimEurmRaw === null) {
-      blockers.push(
-        issue(
-          "RESERVE_MINT_CAP_MISSING",
-          `${name} can mint quote assets into the pool without a recorded cap for S.`,
-        ),
-      );
-    }
-
-    return {
-      name,
-      kind: parsed.kind ?? "unknown",
-      enabled,
-      cooldownSeconds,
-      maxQuoteOutflowClaimEurmRaw,
-      mintsQuoteIntoPoolClaim,
-      mintCapClaimEurmRaw,
-      authenticated: false,
-    };
-  });
-
-  return { enumerationClaim, authenticated: false, entries };
-}
-
-function inspectCertificate(snapshot, evaluation, blockers) {
-  const certificate = requiredObject(
-    snapshot.certificate,
-    "snapshot.certificate",
-  );
-  for (const field of [
-    "signerCoverageOwner",
-    "escalationRoute",
-    "executionProof",
-    "reviewer",
-  ]) {
-    if (!hasText(certificate[field])) {
-      blockers.push(
-        issue(
-          "CERTIFICATE_FIELD_MISSING",
-          `Certificate field ${field} is missing.`,
-        ),
-      );
-    }
-  }
-
-  const expiries = {};
-  const evaluatedAt = timestamp(evaluation?.evaluatedAt);
-  for (const field of [
-    "signerCoverageExpiresAt",
-    "escalationRouteExpiresAt",
-    "executionProofExpiresAt",
-    "budgetApprovalExpiresAt",
-  ]) {
-    const expiresAt = timestamp(certificate[field]);
-    expiries[field] = certificate[field] ?? null;
-    if (!hasText(certificate[field])) {
-      blockers.push(
-        issue(
-          "ATTESTATION_EXPIRY_MISSING",
-          `Certificate field ${field} is missing an explicit expiry.`,
-        ),
-      );
-    } else if (expiresAt === null) {
-      blockers.push(
-        issue(
-          "ATTESTATION_EXPIRY_INVALID",
-          `Certificate field ${field} has an invalid expiry.`,
-        ),
-      );
-    } else if (evaluatedAt !== null && expiresAt <= evaluatedAt) {
-      blockers.push(
-        issue(
-          "ATTESTATION_EXPIRED",
-          `Certificate field ${field} is expired at the explicit evaluation time.`,
-        ),
-      );
-    }
-  }
-
-  return { expiries, authenticated: false };
-}
-
-function inspectBoundaryModelClaims(snapshot, blockers) {
-  const model = requiredObject(
-    snapshot.boundaryModel,
-    "snapshot.boundaryModel",
-  );
-  const monotoneCapacityNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
-    model.monotoneCapacityNetQuoteOutflowEurmRaw,
-    "boundaryModel.monotoneCapacityNetQuoteOutflowEurmRaw",
-  );
-  const worstCaseNetQuoteOutflowClaimEurmRaw = optionalNonNegative(
-    model.worstCaseNetQuoteOutflowEurmRaw,
-    "boundaryModel.worstCaseNetQuoteOutflowEurmRaw",
-  );
-
-  if (monotoneCapacityNetQuoteOutflowClaimEurmRaw === null) {
-    blockers.push(
-      issue(
-        "MONOTONE_CAPACITY_QUOTE_BOUND_MISSING",
-        "No EURm result is recorded for the documented monotone capacity.",
-      ),
-    );
-  }
-  if (worstCaseNetQuoteOutflowClaimEurmRaw === null) {
-    blockers.push(
-      issue(
-        "BOUNDARY_ALIGNED_LOSS_MODEL_MISSING",
-        "No worst-case net EURm-outflow result is recorded.",
-      ),
-    );
-  }
-
-  return {
-    protectedSystemBoundaryClaim: model.protectedSystemBoundary ?? null,
-    modelIdClaim: model.modelId ?? null,
-    coversBidirectionalRateTransitionsClaim:
-      model.coversBidirectionalRateTransitions === true,
-    coversAllEnabledStrategiesClaim: model.coversAllEnabledStrategies === true,
-    monotoneCapacityNetQuoteOutflowClaimEurmRaw,
-    worstCaseNetQuoteOutflowClaimEurmRaw,
-    executable: false,
-    authenticated: false,
   };
 }
 
 /**
  * Fail-closed EUROP operational-admission diagnostic. This implementation
- * cannot grant readiness or Live admission. It always reports Blocked until an
- * executable authenticated sequential loss model replaces the static claims.
+ * cannot grant readiness or Live admission. Local-fork claims remain
+ * unattested diagnostics until a complete authenticated sequential model and
+ * independent execution and fork-source attestation are available.
  */
 export function evaluateOperationalAdmission(input) {
   const blockers = permanentBlockers();
@@ -844,6 +110,10 @@ export function evaluateOperationalAdmission(input) {
     strategyDiagnostics: null,
     certificate: null,
     boundaryModelClaims: null,
+    haltDiagnostics: null,
+    custodyDiagnostics: null,
+    witnessConfiguration: null,
+    lossBudgetWitness: null,
   };
 
   try {
@@ -862,6 +132,23 @@ export function evaluateOperationalAdmission(input) {
     partial.safeDiagnostics = inspectSafe(snapshot, blockers);
     partial.rateDiagnostics = inspectRateControl(snapshot, blockers);
     partial.strategyDiagnostics = inspectStrategies(snapshot, blockers);
+    partial.custodyDiagnostics = inspectCustodyBoundary(snapshot, blockers);
+    partial.witnessConfiguration = inspectWitnessConfigurationPin(
+      snapshot,
+      partial,
+      blockers,
+    );
+    partial.haltDiagnostics = inspectEmergencyHalt(
+      snapshot,
+      partial.witnessConfiguration,
+      blockers,
+    );
+    partial.lossBudgetWitness = inspectLossBudgetWitness(
+      snapshot,
+      partial.budget,
+      partial.witnessConfiguration,
+      blockers,
+    );
     partial.certificate = inspectCertificate(
       snapshot,
       partial.evaluation,
@@ -902,6 +189,7 @@ async function main(args) {
     );
   }
   const path = resolve(args[snapshotIndex + 1]);
+  const proofIndex = args.indexOf("--proof-dir");
   let snapshot;
   try {
     snapshot = JSON.parse(await readFile(path, "utf8"));
@@ -915,6 +203,19 @@ async function main(args) {
         ),
       ],
     });
+    process.stdout.write(`${JSON.stringify(jsonValue(result), null, 2)}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (proofIndex >= 0) {
+    const result = evaluateOperationalAdmission(snapshot);
+    result.blockers.push(
+      issue(
+        "LOCAL_FORK_ARTIFACT_IMPORT_UNSUPPORTED",
+        "--proof-dir is unsupported because caller-supplied local artifacts cannot attest execution or fork-source provenance.",
+      ),
+    );
     process.stdout.write(`${JSON.stringify(jsonValue(result), null, 2)}\n`);
     process.exitCode = 2;
     return;

--- a/scripts/europ-operational-admission.test.mjs
+++ b/scripts/europ-operational-admission.test.mjs
@@ -10,10 +10,10 @@ const fixtureUrl = new URL(
   "./fixtures/europ-operational-admission/2026-08-11.json",
   import.meta.url,
 );
+const fixturePath = fileURLToPath(fixtureUrl);
 const scriptPath = fileURLToPath(
   new URL("./europ-operational-admission.mjs", import.meta.url),
 );
-const fixturePath = fileURLToPath(fixtureUrl);
 
 async function currentSnapshot() {
   return JSON.parse(await readFile(fixtureUrl, "utf8"));
@@ -23,17 +23,45 @@ function blockerCodes(result) {
   return new Set(result.blockers.map((blocker) => blocker.code));
 }
 
-test("derives the canonical six-hour TradingLimitsV2 monotone capacity", async () => {
-  const result = evaluateOperationalAdmission(await currentSnapshot());
-  const envelope = result.monotoneSwapEnvelope;
-
+function assertUnattested(result) {
   assert.equal(result.status, "BLOCKED");
-  assert.equal(envelope.netflowCapacityFixed15, 750000000000000000000n);
-  assert.equal(envelope.grossInputFixed15, 750375187593796898449n);
-  assert.equal(envelope.grossMonitoredInputRaw, 750375187593n);
-  assert.deepEqual(envelope.invariantViolations, []);
+  assert.equal(result.worstCaseBudgetComparison.status, "not_evaluable");
+  assert.match(
+    result.worstCaseBudgetComparison.reason,
+    /complete authenticated sequential model/u,
+  );
+  assert.match(
+    result.worstCaseBudgetComparison.reason,
+    /independent execution and fork-source attestation/u,
+  );
+  assert.equal(result.lossBudgetWitness.claimStatus, "unattested");
+  assert.equal(result.lossBudgetWitness.provenance, "unattested");
+  assert.equal(result.haltDiagnostics.localForkClaimStatus, "unattested");
+  assert.equal(result.haltDiagnostics.provenance, "unattested");
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_PROVENANCE_UNATTESTED"));
+}
+
+test("derives canonical six-hour capacity while keeping local-fork claims unattested", async () => {
+  const result = evaluateOperationalAdmission(await currentSnapshot());
+
+  assertUnattested(result);
+  assert.equal(result.lossBudgetWitness.localForkClaimMatches, true);
+  assert.equal(result.haltDiagnostics.localForkClaimMatches, true);
+  assert.equal(result.monotoneCapacityBudgetComparison.status, "not_evaluable");
+  assert.equal(
+    result.monotoneSwapEnvelope.netflowCapacityFixed15,
+    750000000000000000000n,
+  );
+  assert.equal(
+    result.monotoneSwapEnvelope.grossInputFixed15,
+    750375187593796898449n,
+  );
+  assert.equal(
+    result.monotoneSwapEnvelope.grossMonitoredInputRaw,
+    750375187593n,
+  );
   assert.deepEqual(
-    envelope.windows.map((window) => [
+    result.monotoneSwapEnvelope.windows.map((window) => [
       window.name,
       window.resetWindows,
       window.durableCapacityFixed15,
@@ -43,75 +71,192 @@ test("derives the canonical six-hour TradingLimitsV2 monotone capacity", async (
       ["L1", 1n, 750000000000000000000n],
     ],
   );
+  assert.equal(
+    result.lossBudgetWitness.externalQuoteOutEurmRaw,
+    101949000000000000000000n,
+  );
 });
 
-test("keeps the current pinned evidence explicitly Blocked", async () => {
-  const result = evaluateOperationalAdmission(await currentSnapshot());
+test("caller-supplied claims and ignored extra arguments cannot unlock a conclusion", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.budget.liquidReserveAssetsEurmRaw = "40000000000000000000000000";
+  snapshot.controls.rate.enforcedNoChange = true;
+  snapshot.controls.strategies = snapshot.controls.strategies.map(
+    (strategy) => ({
+      ...strategy,
+      maxQuoteOutflowEurmRaw: "1",
+      mintCapEurmRaw: strategy.kind === "reserve" ? "1" : null,
+    }),
+  );
+  snapshot.boundaryModel = {
+    protectedSystemBoundary: "asserted boundary",
+    modelId: "asserted-model",
+    coversBidirectionalRateTransitions: true,
+    coversAllEnabledStrategies: true,
+    monotoneCapacityNetQuoteOutflowEurmRaw: "1",
+    worstCaseNetQuoteOutflowEurmRaw: "1",
+  };
+
+  const result = evaluateOperationalAdmission(snapshot, {});
+
+  assertUnattested(result);
+  assert.ok(blockerCodes(result).has("EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED"));
+});
+
+test("fails closed on malformed local-fork claims without a validation blocker", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.lossBudgetWitness.successfulTransactions = "152";
+  snapshot.emergencyHalt.forkProof.reserveRebalanceSuspended = false;
+
+  const result = evaluateOperationalAdmission(snapshot);
+
+  assertUnattested(result);
+  assert.equal(result.lossBudgetWitness.localForkClaimMatches, false);
+  assert.equal(result.haltDiagnostics.localForkClaimMatches, false);
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_WITNESS_CLAIM_MISMATCH"));
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_HALT_CLAIM_MISMATCH"));
+});
+
+test("fails closed on malformed snapshots", async () => {
+  const snapshot = await currentSnapshot();
+  snapshot.pool.tradingLimits[0].netflowFixed15 = "not-an-integer";
+
+  const result = evaluateOperationalAdmission(snapshot);
 
   assert.equal(result.status, "BLOCKED");
-  assert.equal(result.monotoneCapacityBudgetComparison.status, "not_evaluable");
-  assert.equal(result.worstCaseBudgetComparison.status, "not_evaluable");
-  assert.equal(
-    result.evidenceIdentity.protocolIdentity
-      .matchesExpectedEuropPolygonIdentity,
-    true,
-  );
-  assert.equal(result.evidenceIdentity.protocolIdentity.authenticated, false);
-  assert.equal(result.evidenceIdentity.blockReference.wellFormed, true);
-  assert.equal(result.evidenceIdentity.blockReference.authenticated, false);
-  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, true);
-  assert.deepEqual(
-    blockerCodes(result),
-    new Set([
-      "EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED",
-      "SNAPSHOT_NOT_AUTHENTICATED",
-      "APPROVED_BUDGET_MISSING",
-      "LIQUID_RESERVE_VALUE_MISSING",
-      "RATE_TRANSITION_BOUND_MISSING",
-      "STRATEGY_BOUNDARY_MODEL_MISSING",
-      "RESERVE_MINT_CAP_MISSING",
-      "CERTIFICATE_FIELD_MISSING",
-      "ATTESTATION_EXPIRY_MISSING",
-      "MONOTONE_CAPACITY_QUOTE_BOUND_MISSING",
-      "BOUNDARY_ALIGNED_LOSS_MODEL_MISSING",
-    ]),
-  );
+  assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_PROVENANCE_UNATTESTED"));
 });
 
-test("CLI exits 1 and prints JSON for a valid-but-Blocked snapshot", () => {
+test("CLI rejects proof-directory imports with structured blocked JSON and exit 2", () => {
   const child = spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--snapshot",
+      fixturePath,
+      "--proof-dir",
+      "/arbitrary/complete",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(child.status, 2, child.stderr);
+  assert.equal(child.stderr, "");
+  const result = JSON.parse(child.stdout);
+  assertUnattested(result);
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_ARTIFACT_IMPORT_UNSUPPORTED"));
+});
+
+test("CLI emits structured blocked JSON for snapshot-only and unreadable inputs", () => {
+  const snapshotOnly = spawnSync(
     process.execPath,
     [scriptPath, "--snapshot", fixturePath],
     { encoding: "utf8" },
   );
+  assert.equal(snapshotOnly.status, 1, snapshotOnly.stderr);
+  assertUnattested(JSON.parse(snapshotOnly.stdout));
 
-  assert.equal(child.status, 1);
-  assert.equal(child.signal, null);
-  assert.equal(child.stderr, "");
-  assert.equal(JSON.parse(child.stdout).status, "BLOCKED");
-});
-
-test("CLI preserves exit 2 and structured JSON for an unreadable snapshot", () => {
-  const child = spawnSync(
+  const unreadable = spawnSync(
     process.execPath,
     [scriptPath, "--snapshot", `${fixturePath}.missing`],
     { encoding: "utf8" },
   );
-
-  assert.equal(child.status, 2);
-  assert.equal(child.signal, null);
-  assert.equal(child.stderr, "");
-  const result = JSON.parse(child.stdout);
+  assert.equal(unreadable.status, 2, unreadable.stderr);
+  const result = JSON.parse(unreadable.stdout);
   assert.equal(result.status, "BLOCKED");
   assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_PROVENANCE_UNATTESTED"));
 });
 
-test("arbitrary complete-looking claims cannot grant readiness", async () => {
+test("reports rate, custody, strategy, and pool-state drift as diagnostics", async () => {
+  const cases = [
+    [
+      "rate",
+      (snapshot) => {
+        snapshot.controls.rate.valueDeltaBreakerBps = 49;
+      },
+      "RATE_CONTROL_CONFIGURATION_MISMATCH",
+      (result) => result.rateDiagnostics.configurationMatches,
+    ],
+    [
+      "custody",
+      (snapshot) => {
+        snapshot.custodyBoundary.lpCustodySafe.threshold = "3";
+      },
+      "LP_CUSTODY_BOUNDARY_INVALID",
+      (result) => result.custodyDiagnostics.configurationMatches,
+    ],
+    [
+      "strategy",
+      (snapshot) => {
+        snapshot.controls.strategies[0].cooldownSeconds = 299;
+      },
+      "STRATEGY_CONFIGURATION_MISMATCH",
+      (result) => result.strategyDiagnostics.configurationMatches,
+    ],
+    [
+      "pool state",
+      (snapshot) => {
+        snapshot.pool.tradingLimits[0].limitFixed15 = "50000000000000000001";
+      },
+      "LOSS_BUDGET_WITNESS_CONFIGURATION_MISMATCH",
+      (result) => result.witnessConfiguration.poolConfigurationMatches,
+    ],
+  ];
+
+  for (const [, mutate, code, matches] of cases) {
+    const snapshot = await currentSnapshot();
+    mutate(snapshot);
+    const result = evaluateOperationalAdmission(snapshot);
+    assertUnattested(result);
+    assert.equal(matches(result), false);
+    assert.ok(blockerCodes(result).has(code));
+  }
+});
+
+test("binds the diagnostic witness to the exact budget approver, reference, and ceiling", async () => {
+  const cases = [
+    [
+      (snapshot) => {
+        snapshot.budget.approvedBy = "Different reviewer";
+      },
+      "BUDGET_APPROVAL_EVIDENCE_MISMATCH",
+      "approvalEvidenceMatches",
+    ],
+    [
+      (snapshot) => {
+        snapshot.budget.approvalReference = "https://example.com/other";
+      },
+      "BUDGET_APPROVAL_EVIDENCE_MISMATCH",
+      "approvalEvidenceMatches",
+    ],
+    [
+      (snapshot) => {
+        snapshot.budget.approvedBudgetEurmRaw = "100001000000000000000000";
+      },
+      "APPROVED_BUDGET_ABOVE_POLICY_CEILING",
+      "policyMatches",
+    ],
+  ];
+
+  for (const [mutate, code, failedField] of cases) {
+    const snapshot = await currentSnapshot();
+    mutate(snapshot);
+    const result = evaluateOperationalAdmission(snapshot);
+    assertUnattested(result);
+    assert.equal(result.budget[failedField], false);
+    assert.equal(result.lossBudgetWitness.localForkClaimMatches, false);
+    assert.ok(blockerCodes(result).has(code));
+  }
+  const result = evaluateOperationalAdmission(await currentSnapshot());
+  assert.equal(result.budget.approvedBudgetEurmRaw, 100000000000000000000000n);
+  assert.equal(result.budget.approvalEvidenceMatches, true);
+});
+
+test("complete-looking snapshot claims never grant readiness", async () => {
   const snapshot = await currentSnapshot();
   snapshot.budget.liquidReserveAssetsEurmRaw = "40000000000000000000000000";
-  snapshot.budget.approvedBudgetEurmRaw = "100000000000000000000000";
-  snapshot.budget.approvedBy = "asserted treasury owner";
-  snapshot.budget.approvalReference = "asserted approval";
   snapshot.controls.rate.enforcedNoChange = true;
   snapshot.controls.strategies = snapshot.controls.strategies.map(
     (strategy) => ({
@@ -140,58 +285,46 @@ test("arbitrary complete-looking claims cannot grant readiness", async () => {
   };
 
   const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
+  assertUnattested(result);
   assert.equal(result.monotoneCapacityBudgetComparison.status, "not_evaluable");
-  assert.equal(result.worstCaseBudgetComparison.status, "not_evaluable");
   assert.ok(blockerCodes(result).has("EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED"));
   assert.ok(blockerCodes(result).has("SNAPSHOT_NOT_AUTHENTICATED"));
 });
 
-test("accepts signed netflow only inside the closed interval [-L, +L]", async () => {
+test("accepts signed netflow only within the closed TradingLimitsV2 interval", async () => {
   const base = await currentSnapshot();
   const limit = BigInt(base.pool.tradingLimits[0].limitFixed15);
-
-  for (const netflow of [limit, -limit]) {
+  for (const [netflow, invalid] of [
+    [limit, false],
+    [-limit, false],
+    [limit + 1n, true],
+    [-limit - 1n, true],
+  ]) {
     const snapshot = structuredClone(base);
     snapshot.pool.tradingLimits[0].netflowFixed15 = netflow.toString();
     const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
+    assertUnattested(result);
     assert.equal(
       blockerCodes(result).has("TRADING_LIMIT_INVARIANT_VIOLATION"),
-      false,
+      invalid,
     );
-  }
-
-  for (const netflow of [limit + 1n, -limit - 1n]) {
-    const snapshot = structuredClone(base);
-    snapshot.pool.tradingLimits[0].netflowFixed15 = netflow.toString();
-    const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
-    assert.ok(blockerCodes(result).has("TRADING_LIMIT_INVARIANT_VIOLATION"));
   }
 });
 
-test("returns structured Blocked results for malformed snapshots", async () => {
-  const malformedInteger = await currentSnapshot();
-  malformedInteger.pool.tradingLimits[0].netflowFixed15 = "not-an-integer";
-
-  for (const snapshot of [null, {}, malformedInteger]) {
+test("fails closed on malformed snapshots and ambiguous integer values", async () => {
+  const malformed = await currentSnapshot();
+  malformed.pool.tradingLimits[0].netflowFixed15 = "not-an-integer";
+  for (const snapshot of [null, {}, malformed]) {
     let result;
     assert.doesNotThrow(() => {
       result = evaluateOperationalAdmission(snapshot);
     });
     assert.equal(result.status, "BLOCKED");
     assert.ok(blockerCodes(result).has("INPUT_INVALID"));
-    assert.ok(
-      blockerCodes(result).has("EXECUTABLE_LOSS_MODEL_NOT_IMPLEMENTED"),
-    );
   }
-});
 
-test("rejects ambiguous and lossy integer representations", async () => {
   const base = await currentSnapshot();
-  const invalidIntegers = [
+  for (const value of [
     true,
     false,
     1.5,
@@ -204,30 +337,23 @@ test("rejects ambiguous and lossy integer representations", async () => {
     "1.0",
     "1e3",
     "",
-  ];
-
-  for (const value of invalidIntegers) {
+  ]) {
     const snapshot = structuredClone(base);
     snapshot.pool.tradingLimits[0].netflowFixed15 = value;
-    const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
-    assert.ok(blockerCodes(result).has("INPUT_INVALID"));
+    assert.ok(
+      blockerCodes(evaluateOperationalAdmission(snapshot)).has("INPUT_INVALID"),
+    );
   }
-});
-
-test("accepts canonical integer strings and safe integer numbers", async () => {
-  const base = await currentSnapshot();
   for (const value of ["0", "42", "-42", 0, 42, -42]) {
     const snapshot = structuredClone(base);
     snapshot.pool.tradingLimits[0].netflowFixed15 = value;
     const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
     assert.equal(blockerCodes(result).has("INPUT_INVALID"), false);
     assert.notEqual(result.monotoneSwapEnvelope, null);
   }
 });
 
-test("refuses to calculate capacity for a mismatched evidence identity", async () => {
+test("refuses capacity on identity mismatch or malformed block identity", async () => {
   const base = await currentSnapshot();
   const mutations = [
     (snapshot) => {
@@ -237,121 +363,83 @@ test("refuses to calculate capacity for a mismatched evidence identity", async (
       snapshot.evidence.asset = "USDm";
     },
     (snapshot) => {
-      snapshot.evidence.quoteAsset = "USDm";
-    },
-    (snapshot) => {
       snapshot.pool.address = "0x0000000000000000000000000000000000000001";
-    },
-    (snapshot) => {
-      snapshot.pool.quoteAsset.address =
-        "0x0000000000000000000000000000000000000002";
     },
     (snapshot) => {
       snapshot.pool.monitoredAsset.decimals = 18;
     },
   ];
-
   for (const mutate of mutations) {
     const snapshot = structuredClone(base);
     mutate(snapshot);
     const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
     assert.ok(blockerCodes(result).has("PROTOCOL_IDENTITY_MISMATCH"));
-    assert.equal(
-      result.evidenceIdentity.protocolIdentity
-        .matchesExpectedEuropPolygonIdentity,
-      false,
-    );
     assert.equal(result.monotoneSwapEnvelope, null);
   }
-});
 
-test("rejects malformed block identity before calculating capacity", async () => {
   const malformedHash = await currentSnapshot();
   malformedHash.evidence.blockHash = "0x1234";
   const hashResult = evaluateOperationalAdmission(malformedHash);
-  assert.equal(hashResult.status, "BLOCKED");
   assert.ok(blockerCodes(hashResult).has("BLOCK_REFERENCE_INVALID"));
-  assert.equal(hashResult.evidenceIdentity.blockReference.wellFormed, false);
   assert.equal(hashResult.monotoneSwapEnvelope, null);
 
-  const noncanonicalBlock = await currentSnapshot();
-  noncanonicalBlock.evidence.blockNumber = "091830875";
-  const blockResult = evaluateOperationalAdmission(noncanonicalBlock);
-  assert.equal(blockResult.status, "BLOCKED");
-  assert.ok(blockerCodes(blockResult).has("INPUT_INVALID"));
-  assert.equal(blockResult.monotoneSwapEnvelope, null);
+  const malformedNumber = await currentSnapshot();
+  malformedNumber.evidence.blockNumber = "091830875";
+  const numberResult = evaluateOperationalAdmission(malformedNumber);
+  assert.ok(blockerCodes(numberResult).has("INPUT_INVALID"));
+  assert.equal(numberResult.monotoneSwapEnvelope, null);
 });
 
-test("validates Safe structure for diagnostics without authenticating it", async () => {
-  const snapshot = await currentSnapshot();
-  snapshot.controls.safe.threshold = "7";
-
-  const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
-  assert.ok(blockerCodes(result).has("SAFE_STRUCTURE_INVALID"));
-  assert.ok(blockerCodes(result).has("SAFE_EXPECTED_CONFIGURATION_MISMATCH"));
-  assert.equal(result.safeDiagnostics.structurallyValid, false);
-  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, false);
-  assert.equal(result.safeDiagnostics.authenticated, false);
-});
-
-test("reports Safe nonce without including it in expected control structure", async () => {
-  const snapshot = await currentSnapshot();
-  snapshot.controls.safe.nonce = "10";
-
-  const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
-  assert.equal(result.safeDiagnostics.nonce, 10n);
-  assert.equal(result.safeDiagnostics.matchesExpectedControlStructure, true);
-  assert.equal(result.safeDiagnostics.authenticated, false);
+test("keeps Safe diagnostics structural and excludes nonce from expected structure", async () => {
+  const invalid = await currentSnapshot();
+  invalid.controls.safe.threshold = "7";
+  const invalidResult = evaluateOperationalAdmission(invalid);
+  assertUnattested(invalidResult);
+  assert.equal(invalidResult.safeDiagnostics.structurallyValid, false);
   assert.equal(
-    blockerCodes(result).has("SAFE_EXPECTED_CONFIGURATION_MISMATCH"),
+    invalidResult.safeDiagnostics.matchesExpectedControlStructure,
     false,
   );
-});
+  assert.equal(invalidResult.safeDiagnostics.authenticated, false);
+  assert.ok(blockerCodes(invalidResult).has("SAFE_STRUCTURE_INVALID"));
 
-test("treats an alternate valid block reference as well-formed but unauthenticated", async () => {
-  const snapshot = await currentSnapshot();
-  snapshot.evidence.blockNumber = "91830876";
-  snapshot.evidence.blockHash =
-    "0x1111111111111111111111111111111111111111111111111111111111111111";
-
-  const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
+  const nonce = await currentSnapshot();
+  nonce.controls.safe.nonce = "10";
+  const nonceResult = evaluateOperationalAdmission(nonce);
+  assert.equal(nonceResult.safeDiagnostics.nonce, 10n);
   assert.equal(
-    result.evidenceIdentity.protocolIdentity
-      .matchesExpectedEuropPolygonIdentity,
+    nonceResult.safeDiagnostics.matchesExpectedControlStructure,
     true,
   );
-  assert.equal(result.evidenceIdentity.blockReference.wellFormed, true);
-  assert.equal(result.evidenceIdentity.blockReference.authenticated, false);
-  assert.equal(result.evidenceIdentity.blockReference.blockNumber, 91830876n);
   assert.equal(
-    result.evidenceIdentity.blockReference.blockHash,
-    snapshot.evidence.blockHash,
-  );
-  assert.equal(
-    Object.hasOwn(result.evidenceIdentity, "matchesExpected"),
+    blockerCodes(nonceResult).has("SAFE_EXPECTED_CONFIGURATION_MISMATCH"),
     false,
   );
-  assert.notEqual(result.monotoneSwapEnvelope, null);
 });
 
-test("fails stale evidence against explicit evaluation time and maximum age", async () => {
+test("treats alternate valid block references as diagnostic and unattested", async () => {
   const snapshot = await currentSnapshot();
-  snapshot.evaluation.evaluatedAt = "2026-08-11T13:00:00Z";
+  snapshot.evidence.blockNumber = "91830876";
+  snapshot.evidence.blockHash = `0x${"1".repeat(64)}`;
 
   const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
-  assert.ok(blockerCodes(result).has("EVIDENCE_STALE"));
+  assertUnattested(result);
+  assert.equal(result.evidenceIdentity.blockReference.wellFormed, true);
+  assert.equal(result.evidenceIdentity.blockReference.authenticated, false);
+  assert.equal(result.monotoneSwapEnvelope === null, false);
+  assert.equal(result.witnessConfiguration.datedPinMatches, false);
+  assert.equal(result.haltDiagnostics.localForkClaimMatches, false);
+  assert.ok(blockerCodes(result).has("LOCAL_FORK_HALT_CLAIM_MISMATCH"));
 });
 
-test("requires strict ISO-8601 timestamps with an explicit UTC offset", async () => {
+test("enforces evidence freshness and strict timestamp syntax", async () => {
+  const stale = await currentSnapshot();
+  stale.evaluation.maxEvidenceAgeSeconds = "900";
+  stale.evaluation.evaluatedAt = "2026-08-11T13:00:00Z";
+  assert.ok(
+    blockerCodes(evaluateOperationalAdmission(stale)).has("EVIDENCE_STALE"),
+  );
+
   for (const observedAt of [
     "2026-08-11T12:29:00",
     "2026-02-30T12:29:00Z",
@@ -359,53 +447,66 @@ test("requires strict ISO-8601 timestamps with an explicit UTC offset", async ()
   ]) {
     const snapshot = await currentSnapshot();
     snapshot.evidence.observedAt = observedAt;
-    const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
     assert.ok(
-      blockerCodes(result).has("EVIDENCE_TIMESTAMP_MISSING_OR_INVALID"),
+      blockerCodes(evaluateOperationalAdmission(snapshot)).has(
+        "EVIDENCE_TIMESTAMP_MISSING_OR_INVALID",
+      ),
     );
   }
-
-  const explicitOffset = await currentSnapshot();
-  explicitOffset.evidence.observedAt = "2026-08-11T14:29:00+02:00";
-  explicitOffset.evaluation.evaluatedAt = "2026-08-11T14:35:00+02:00";
-  const validResult = evaluateOperationalAdmission(explicitOffset);
+  const offset = await currentSnapshot();
+  offset.evidence.observedAt = "2026-08-11T14:29:00+02:00";
+  offset.evaluation.evaluatedAt = "2026-08-11T14:35:00+02:00";
+  const result = evaluateOperationalAdmission(offset);
+  assert.equal(result.evaluation.evidenceAgeSeconds, 360n);
   assert.equal(
-    blockerCodes(validResult).has("EVIDENCE_TIMESTAMP_MISSING_OR_INVALID"),
+    blockerCodes(result).has("EVALUATION_TIMESTAMP_MISSING_OR_INVALID"),
     false,
   );
-  assert.equal(
-    blockerCodes(validResult).has("EVALUATION_TIMESTAMP_MISSING_OR_INVALID"),
-    false,
-  );
-  assert.equal(validResult.evaluation.evidenceAgeSeconds, 360n);
 });
 
-test("rejects timezone-less and normalized-invalid certificate expiries", async () => {
+test("enforces certificate expiry and the exact six-hour execution policy", async () => {
   for (const expiry of ["2027-01-01T00:00:00", "2026-02-30T00:00:00Z"]) {
     const snapshot = await currentSnapshot();
     snapshot.certificate.signerCoverageExpiresAt = expiry;
-    const result = evaluateOperationalAdmission(snapshot);
-    assert.equal(result.status, "BLOCKED");
-    assert.ok(blockerCodes(result).has("ATTESTATION_EXPIRY_INVALID"));
+    assert.ok(
+      blockerCodes(evaluateOperationalAdmission(snapshot)).has(
+        "ATTESTATION_EXPIRY_INVALID",
+      ),
+    );
   }
-});
+  const expired = await currentSnapshot();
+  for (const field of [
+    "signerCoverageExpiresAt",
+    "escalationRouteExpiresAt",
+    "executionProofExpiresAt",
+    "budgetApprovalExpiresAt",
+  ]) {
+    expired.certificate[field] = "2026-08-11T12:34:59Z";
+  }
+  assert.ok(
+    blockerCodes(evaluateOperationalAdmission(expired)).has(
+      "ATTESTATION_EXPIRED",
+    ),
+  );
 
-test("compares certificate expiry with explicit evaluation time", async () => {
-  const snapshot = await currentSnapshot();
-  snapshot.certificate = {
-    signerCoverageOwner: "Philip Paetz",
-    escalationRoute: "@support-engineer",
-    executionProof: "accepted Safe execution",
-    reviewer: "independent reviewer",
-    signerCoverageExpiresAt: "2026-08-11T12:34:59Z",
-    escalationRouteExpiresAt: "2026-08-11T12:34:59Z",
-    executionProofExpiresAt: "2026-08-11T12:34:59Z",
-    budgetApprovalExpiresAt: "2026-08-11T12:34:59Z",
-  };
-
-  const result = evaluateOperationalAdmission(snapshot);
-
-  assert.equal(result.status, "BLOCKED");
-  assert.ok(blockerCodes(result).has("ATTESTATION_EXPIRED"));
+  for (const mutate of [
+    (snapshot) => {
+      snapshot.certificate.acceptedSafeNonce = "9";
+    },
+    (snapshot) => {
+      snapshot.certificate.acceptedResponseSeconds = "21599";
+    },
+    (snapshot) => {
+      snapshot.certificate.executionElapsedSeconds = "7890";
+    },
+    (snapshot) => {
+      snapshot.certificate.executionWithinResponseTimeAccepted = false;
+    },
+  ]) {
+    const snapshot = await currentSnapshot();
+    mutate(snapshot);
+    const result = evaluateOperationalAdmission(snapshot);
+    assert.equal(result.certificate.policyMatches, false);
+    assert.ok(blockerCodes(result).has("CERTIFICATE_POLICY_MISMATCH"));
+  }
 });

--- a/scripts/fixtures/europ-operational-admission/2026-08-11.json
+++ b/scripts/fixtures/europ-operational-admission/2026-08-11.json
@@ -8,31 +8,24 @@
     "quoteAsset": "EURm"
   },
   "evaluation": {
-    "evaluatedAt": "2026-08-11T12:35:00Z",
-    "maxEvidenceAgeSeconds": "900"
+    "evaluatedAt": "2026-08-11T14:21:33Z",
+    "maxEvidenceAgeSeconds": "7200"
   },
   "responseSeconds": "21600",
   "budget": {
-    "rule": "min(100,000 EURm, 0.5% of approved current liquid reserve assets)",
+    "rule": "fixed 100,000 EURm loss budget",
     "liquidReserveAssetsEurmRaw": null,
-    "approvedBudgetEurmRaw": null,
-    "approvedBy": null,
-    "approvalReference": null,
-    "conditionalCandidate": {
-      "status": "unapproved",
-      "proposedCustodyBoundary": "registered assets held by ReserveV2 plus its listed other-reserve Safe",
-      "usdcRaw": "120812444400",
-      "usdcUsd": "0.9998",
-      "eurUsd": "1.15364",
-      "eurmValueRaw": "104701884392982212822024",
-      "candidateBudgetEurmRaw": "523509421964911064110",
-      "sameBlockInventoryOnly": true,
-      "sharedReservePool": "0x463c0d1F04bcd99A1efCF94AC2a75bc19Ea4A7E5",
-      "sharedOpenPool": "0x93e15A22fDa39FEfcCCe82D387A09cCF030EAD61"
-    }
+    "approvedBudgetEurmRaw": "100000000000000000000000",
+    "approvedBy": "Philip Paetz",
+    "approvalReference": "https://github.com/mento-protocol/monitoring-monorepo/issues/1687#issuecomment-5254428553"
   },
   "pool": {
     "address": "0xcd8c6811d975981f57e7fb32e59f0bee66af3201",
+    "administration": {
+      "owner": "0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458",
+      "feeSetter": "0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458",
+      "protocolFeeRecipient": "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a"
+    },
     "quoteAsset": {
       "address": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
       "symbol": "EURm",
@@ -80,9 +73,18 @@
     },
     "rate": {
       "manualRateFeedId": "0xc22418a83DfC262B10a1f57E25309DB83E7eA79e",
-      "manualRate": "1",
+      "oracleAdapter": "0xEB23E1339b2119c0f4a0097Cb294E990C1fA6423",
+      "sortedOracles": "0x6f92C745346057a61b259579256159458a0a6A92",
+      "breakerBox": "0x9fc1E0d10fb38954Da385B8B25aB2BbaF3241722",
+      "valueDeltaBreaker": "0xca2e7563dfC30bc94687F3deAcF682E1dBAffA13",
+      "rateDecimals": 24,
+      "manualRateRaw": "1000000000000000000000000",
       "manualRateUpdatedAt": "2026-07-16T15:19:19Z",
       "valueDeltaBreakerBps": 50,
+      "valueDeltaThresholdRaw": "5000000000000000000000",
+      "valueDeltaCooldownSeconds": 1,
+      "valueDeltaBreakerEnabled": true,
+      "currentTradingMode": 0,
       "enforcedNoChange": false,
       "enforcedNoArbitrage": false,
       "maxSuccessfulTransitions": null
@@ -94,7 +96,16 @@
         "address": "0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f",
         "kind": "open",
         "enabled": true,
+        "isToken0Debt": true,
+        "lastRebalance": "1785523331",
         "cooldownSeconds": 300,
+        "protocolFeeRecipient": "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a",
+        "incentives": {
+          "liquiditySourceExpansionBps": "0",
+          "protocolExpansionBps": "0",
+          "liquiditySourceContractionBps": "0",
+          "protocolContractionBps": "0"
+        },
         "maxQuoteOutflowEurmRaw": null
       },
       {
@@ -102,7 +113,16 @@
         "address": "0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B",
         "kind": "reserve",
         "enabled": true,
+        "isToken0Debt": true,
+        "lastRebalance": "0",
         "cooldownSeconds": 300,
+        "protocolFeeRecipient": "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a",
+        "incentives": {
+          "liquiditySourceExpansionBps": "0",
+          "protocolExpansionBps": "0",
+          "liquiditySourceContractionBps": "0",
+          "protocolContractionBps": "0"
+        },
         "mintsQuoteIntoPool": true,
         "mintCapEurmRaw": null,
         "maxQuoteOutflowEurmRaw": null,
@@ -114,21 +134,83 @@
       }
     ]
   },
+  "emergencyHalt": {
+    "controlSafe": "0x58099B74F4ACd642Da77b4B7966b4138ec5Ba458",
+    "sortedOracles": "0x6f92C745346057a61b259579256159458a0a6A92",
+    "breakerBox": "0x9fc1E0d10fb38954Da385B8B25aB2BbaF3241722",
+    "valueDeltaBreaker": "0xca2e7563dfC30bc94687F3deAcF682E1dBAffA13",
+    "rateFeedId": "0xc22418a83DfC262B10a1f57E25309DB83E7eA79e",
+    "rateDecimals": 24,
+    "reportRateRaw": "994000000000000000000000",
+    "lesserKey": "0x0000000000000000000000000000000000000000",
+    "greaterKey": "0x0000000000000000000000000000000000000000",
+    "expectedTradingMode": 1,
+    "forkProof": {
+      "blockNumber": "91830875",
+      "blockHash": "0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25",
+      "haltReportSucceeded": true,
+      "swapSuspended": true,
+      "openRebalanceSuspended": true,
+      "reserveRebalanceSuspended": true,
+      "restoredRateRaw": "1000000000000000000000000",
+      "restoreReportSucceeded": true,
+      "restoredTradingMode": 0
+    }
+  },
+  "custodyBoundary": {
+    "lpCustodySafe": {
+      "address": "0x3fac3feF4408CFB03aa190fbD94D571C42cFd1f1",
+      "threshold": "2",
+      "ownerCount": 4,
+      "nonce": "13",
+      "ownerSetVerifiedAtPin": true,
+      "lpBalanceRaw": "8659037237856031",
+      "totalLpSupplyRaw": "8660537237856031",
+      "treatedAsInternalCustody": true
+    },
+    "failClosedOnUnapprovedLpExit": true,
+    "failClosedOnControlDrift": true
+  },
+  "lossBudgetWitness": {
+    "modelId": "europ-reserve-rebalance-51-cycle-v1",
+    "mentoCoreCommit": "07ecf3df5650a33ea6957f1ad2966e02c5082253",
+    "blockNumber": "91830875",
+    "blockHash": "0x3f7cc53580045d0e9c7e862406891a9e152b7b2c47b0eeed1b73bcebe214af25",
+    "pool": "0xcd8c6811d975981f57e7fb32e59f0bee66af3201",
+    "reserveStrategy": "0xa0fB8b16ce6AF3634fF9F3f4F40E49E1C1ae4f0B",
+    "cycles": "51",
+    "transactionsPerCycle": "3",
+    "successfulTransactions": "153",
+    "successfulReserveRebalances": "51",
+    "monitoredInputPerCycleRaw": "2000000000",
+    "totalMonitoredInputRaw": "102000000000",
+    "quoteOutPerCycleEurmRaw": "1999000000000000000000",
+    "externalQuoteOutEurmRaw": "101949000000000000000000",
+    "elapsedSeconds": "15080",
+    "allTransactionsSucceeded": true,
+    "localForkOnly": true,
+    "productionActivity": false
+  },
   "certificate": {
     "signerCoverageOwner": "Philip Paetz",
     "signerCoverageBackup": "Bogdan Dumitru",
     "escalationRoute": "active @support-engineer resolved from VictorOps / Splunk On-Call",
     "executionProof": "Safe nonce 8 is accepted as proof that the threshold can execute within six hours.",
-    "reviewer": null,
-    "signerCoverageExpiresAt": null,
-    "escalationRouteExpiresAt": null,
-    "executionProofExpiresAt": null,
-    "budgetApprovalExpiresAt": null
+    "acceptedSafeNonce": "8",
+    "acceptedResponseSeconds": "21600",
+    "executionElapsedSeconds": "7889",
+    "executionWithinResponseTimeAccepted": true,
+    "executionProofReference": "https://polygonscan.com/tx/0x967535dc2f331298c2f88feb8a148e60a85fdc8a84dc1d3f83fcea547ef3b8b4",
+    "reviewer": "Philip Paetz",
+    "signerCoverageExpiresAt": "2026-11-09T14:21:33Z",
+    "escalationRouteExpiresAt": "2026-11-09T14:21:33Z",
+    "executionProofExpiresAt": "2026-11-09T14:21:33Z",
+    "budgetApprovalExpiresAt": "2026-11-09T14:21:33Z"
   },
   "boundaryModel": {
-    "implementationStatus": "not_implemented",
-    "protectedSystemBoundary": "EURm movements involving the FPMM, enabled liquidity strategies, ReserveV2, and protocol fee recipient",
-    "modelId": null,
+    "implementationStatus": "local_fork_diagnostic_unattested",
+    "protectedSystemBoundary": "EURm movements involving the FPMM, enabled liquidity strategies, ReserveV2, protocol fee recipient, and approved LP custody Safe",
+    "modelId": "europ-reserve-rebalance-51-cycle-v1",
     "coversBidirectionalRateTransitions": false,
     "coversAllEnabledStrategies": false,
     "monotoneCapacityNetQuoteOutflowEurmRaw": null,

--- a/ui-dashboard/src/lib/__tests__/browser-api-policy.test.ts
+++ b/ui-dashboard/src/lib/__tests__/browser-api-policy.test.ts
@@ -15,7 +15,8 @@ const OG_FIXTURE_PATH = "src/lib/homepage-og.ts";
 const TEST_FIXTURE_PATH = "src/lib/__tests__/browser-api-policy.test.ts";
 const SYMBOL_AWARE_RULE_ID =
   "browser-api-policy/no-unsupported-receiver-property";
-const LINT_RUNNER_TIMEOUT_MS = 30_000;
+const LINT_RUNNER_PROCESS_TIMEOUT_MS = 120_000;
+const POLICY_TEST_TIMEOUT_MS = LINT_RUNNER_PROCESS_TIMEOUT_MS + 5_000;
 const execFileAsync = promisify(execFile);
 const eslint = new ESLint({
   cwd: fileURLToPath(DASHBOARD_ROOT_URL),
@@ -52,6 +53,7 @@ const lintResultsPromise = execFileAsync(
     encoding: "utf8",
     env: { ...process.env, NODE_V8_COVERAGE: undefined },
     maxBuffer: 1024 * 1024,
+    timeout: LINT_RUNNER_PROCESS_TIMEOUT_MS,
   },
 ).then(
   ({ stdout }) => JSON.parse(stdout) as Record<LintCase, BrowserApiMessage[]>,
@@ -80,16 +82,24 @@ describe("browser runtime API policy", () => {
     expect(packageJson.browserslist).toEqual(browserApiPolicy.browsers);
   });
 
-  it("uses the exact blocked sets in the effective client config", async () => {
-    const rules = await browserApiRules(CLIENT_FIXTURE_PATH);
-    expect(rules.property).toBeUndefined();
-    expect(rules.symbolAware).toEqual([2, browserApiPolicy.restrictions]);
-  });
+  it(
+    "uses the exact blocked sets in the effective client config",
+    async () => {
+      const rules = await browserApiRules(CLIENT_FIXTURE_PATH);
+      expect(rules.property).toBeUndefined();
+      expect(rules.symbolAware).toEqual([2, browserApiPolicy.restrictions]);
+    },
+    POLICY_TEST_TIMEOUT_MS,
+  );
 
-  it("does not configure a generic property ban", async () => {
-    const rules = await browserApiRules(CLIENT_FIXTURE_PATH);
-    expect(rules.property).toBeUndefined();
-  });
+  it(
+    "does not configure a generic property ban",
+    async () => {
+      const rules = await browserApiRules(CLIENT_FIXTURE_PATH);
+      expect(rules.property).toBeUndefined();
+    },
+    POLICY_TEST_TIMEOUT_MS,
+  );
 
   it(
     "reports every blocked API with its intended rule and message",
@@ -108,7 +118,7 @@ describe("browser runtime API policy", () => {
         );
       }
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -118,7 +128,7 @@ describe("browser runtime API policy", () => {
 
       expect(rules.symbolAware).toEqual([2, browserApiPolicy.restrictions]);
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -143,7 +153,7 @@ describe("browser runtime API policy", () => {
         );
       }
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -168,7 +178,7 @@ describe("browser runtime API policy", () => {
         );
       }
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -191,7 +201,7 @@ describe("browser runtime API policy", () => {
         ).toHaveLength(restriction.property === "toSorted" ? 2 : 1);
       }
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it(
@@ -214,7 +224,7 @@ describe("browser runtime API policy", () => {
         );
       }
     },
-    LINT_RUNNER_TIMEOUT_MS,
+    POLICY_TEST_TIMEOUT_MS,
   );
 
   it("allows shadowed and custom static groupBy methods", async () => {


### PR DESCRIPTION
## The Problem

- EUROP needs a repeatable way to inspect its approved six-hour response inputs and candidate loss paths.
- A local fork cannot prove its own execution or source-chain state, so its files must never unlock a loss-budget verdict.
- EUROP must remain Blocked until authenticated evidence and a complete sequential loss model prove the approved 100,000 EURm limit.

## The Solution

- Add a fail-closed evaluator and a localhost-only fork diagnostic runner. They preserve useful engineering evidence while keeping both budget comparisons `not_evaluable`.

## Details

- Pin the approved policy inputs: Philip Paetz with Bogdan Dumitru as backup, `@support-engineer` escalation, six-hour response time, Safe nonce 8 execution reference, 100,000 EURm budget, and 90-day expiry.
- Record exact Polygon, pool, Safe, rate-breaker, strategy, custody, and block identity diagnostics.
- Derive the six-hour TradingLimitsV2 capacity and test policy/configuration drift, malformed input, stale evidence, and boundary mismatches.
- Add a self-contained runner that starts its own localhost Anvil fork, verifies the pinned chain and block, exercises 51 swap/rebalance cycles, records all 153 successful receipts, and tests halt plus restore behavior.
- Label every local-fork result `unattested`. The evaluator never imports runner output; `--proof-dir` is rejected with `LOCAL_FORK_ARTIFACT_IMPORT_UNSUPPORTED`.
- The local run observed a candidate 101,949 EURm outflow over 15,080 seconds. This is a diagnostic claim, not an authenticated budget result.
- Keep the existing browser API policy suite bounded but give its ESLint subprocess enough time under full coverage load; this repairs a current-`main` timeout found by the mandatory gate without weakening any assertion.
- No production, Safe, oracle, strategy, or Terraform state changes are included.
- Refs #1687.

## Validation

- `CI=true pnpm agent:quality-gate --run --parallel 2` — all mapped commands pass on the exact published head, including browser tests, package coverage, Terraform validation, and both EUROP suites.
- `node --test scripts/europ-operational-admission.test.mjs scripts/europ-operational-admission-proof.test.mjs` — 23/23 pass after rebasing onto current `main`.
- `pnpm agent:quality-gate:test` — pass after rebase.
- `CI=true pnpm lint:scripts` — pass after rebase.
- `node scripts/check-sentry-suites-in-ci.test.mjs` — 52/52 pass after rebase.
- `CI=true pnpm docs:index --check`, `CI=true pnpm agent:context-check`, and `CI=true pnpm docs:navigation-eval -- --check-fixtures` — pass after rebase.
- `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — 289/289 files and 4,208/4,208 tests pass; all coverage thresholds pass.
- `./tools/trunk check <changed files>` and `git diff --check origin/main...HEAD` — pass after rebase.
- Snapshot CLI exits 1 with `BLOCKED` and both budget comparisons `not_evaluable`; `--proof-dir` exits 2 with the expected rejection blocker.
- The first post-rebase mapped gate exposed a browser-policy timeout under full coverage load; the bounded test-harness repair above makes that exact command and the final whole-repository gate pass.
- Current-head sealed fresh-context autoreview and deterministic local autoreview — clean.

## Deferrals

- Authenticated execution/fork-source evidence and the complete sequential loss model required for Live admission remain tracked in https://github.com/mento-protocol/monitoring-monorepo/issues/1687.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable: this adds diagnostic and fail-closed tooling without changing production architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches peg-monitoring operational-admission governance and loss-budget evidence paths (not production on-chain config), with a large new fork runner surface area that must stay localhost-only and never unlock admission via imported artifacts.
> 
> **Overview**
> Adds **fail-closed EUROP operational-admission tooling** that keeps Live admission **Blocked** while recording richer diagnostics and optional localhost fork evidence.
> 
> The monolithic evaluator is split into shared modules (`contract`, `evidence`, `controls`, `witness`) and now always emits permanent blockers for missing authenticated loss model, unattested snapshots, and **unattested local-fork provenance**. Budget comparisons stay **`not_evaluable`**; **`--proof-dir`** is rejected with `LOCAL_FORK_ARTIFACT_IMPORT_UNSUPPORTED`.
> 
> The pinned **2026-08-11** snapshot and runbook are updated for the approved **100,000 EURm** budget, certificate expiries, LP custody boundary, emergency-halt claims, and a **51-cycle** local witness (101,949 EURm diagnostic outflow). A new **`europ-operational-admission-proof.sh`** runs witness and halt/restore scenarios on operator-supplied read-only Polygon RPC via fresh **localhost Anvil** forks only; CI runs static contract tests, not the live fork.
> 
> **CI**, agent quality-gate routing, and docs/quick-commands are wired to the new suites. **`browser-api-policy.test.ts`** gets longer ESLint subprocess timeouts to avoid flakes under coverage load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365a77b4264d966f545655b0859bfcd33c289766. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->