### PR TITLE
fix(sentry): sweep the open-but-unselectable strand shape (#1817)

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -321,6 +321,18 @@ unselectable: it takes the one artifact the stub had and buys nothing. Removing
 open shape, which has no `sentry:needs-triage` left to remove — so **to retire a
 verdicted, unqueued stub for good, remove `sentry-triage`.**
 
+A read cannot close that window on its own, so membership is part of the
+**end state** the re-queue is judged by. `isSelectableForTriage` is the full
+Stage B selector — open, `sentry-triage`, `sentry:needs-triage` — and it is what
+every `verify-end-state` re-queue must observe before it may report success. A
+withdrawal landing after the check but during the writes therefore ends the run
+RED, naming the label that vanished, rather than recording a success for a stub
+whose verdict it just shed. The verifier repairs the other two conditions and
+never this one: re-adding `sentry-triage` would overrule the human who removed
+it. Nothing tries to unwind the shed either — a compensating re-add would
+reintroduce the two-writers race the withdrawal just ended, and loud failure is
+this pipeline's discipline for a mutation it cannot safely reverse.
+
 The two shapes differ in one more way, and the stub's own state is why. On the
 closed path every interruption lands somewhere inert: the state change goes last,
 so a stub whose shed failed is still closed and invisible to Stage B until the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -284,12 +284,14 @@ directions degrade into states something already repairs — a re-queue that rac
 the `project` job leaves a stub its `--batch` mode skips, and one that raced the
 close leaves the closed-plus-needs-triage pairing the first sweep repairs.
 
-A human working a strand withdraws it for free: any comment or label edit moves
-`updated_at`, so reading or annotating one keeps it out of the sweep for another
-day without knowing the rule exists. The same property is the sweep's one
-weakness on a public repo — a determined commenter can keep a genuine strand
-below the threshold indefinitely. That delays a repair; it can never cause one to
-happen wrongly, and the state it preserves is the one this sweep found.
+**To hold a strand while you work on it, write to it.** Only a mutation moves
+`updated_at` — a comment, a label change, a state change, a title or body edit.
+Reading one does not, so opening a stub to inspect it buys no time at all and the
+sweep can re-queue it under you. Post a comment saying you are on it, and the
+stub is yours for another day. The same property is the sweep's one weakness on a
+public repo: a determined commenter can keep a genuine strand below the threshold
+indefinitely. That delays a repair; it can never cause one to happen wrongly, and
+the state it preserves is the one this sweep found.
 
 The window between the sweep's revalidating read and its label shed stays open,
 like the one the re-queue CLI's terminal guard documents, and for the same

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -311,6 +311,16 @@ for a human to have declined it by removing the label, which the sweep would
 otherwise put straight back. A failed re-read leaves the stub stranded for the
 next run rather than recovering blind.
 
+**Both arms also require `sentry-triage` in that live re-read**, and decline
+without writing when it is gone. The snapshot cannot fail that test — it comes
+from a `labels=sentry-triage` query — so it exists for the withdrawal that lands
+in between. Stage B's selector wants `sentry-triage` AND `sentry:needs-triage`,
+so re-queuing a stub that lost the first sheds its verdict and still leaves it
+unselectable: it takes the one artifact the stub had and buys nothing. Removing
+`sentry-triage` is also the only withdrawal gesture available for a stub in the
+open shape, which has no `sentry:needs-triage` left to remove — so **to retire a
+verdicted, unqueued stub for good, remove `sentry-triage`.**
+
 The two shapes differ in one more way, and the stub's own state is why. On the
 closed path every interruption lands somewhere inert: the state change goes last,
 so a stub whose shed failed is still closed and invisible to Stage B until the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -229,27 +229,96 @@ Missing or invalid timestamps fail toward re-triage. The strict timestamp gate
 prevents Sentry's long-lived regressed substatus from causing a reopen/close
 loop.
 
-Ingest then sweeps the queue itself, independently of that run's Sentry
-results: a closed stub that still carries `sentry:needs-triage` is reopened,
-its stale verdict/projection/autofix/archive labels shed, and a fixed recovery
-note posted. That pairing is unreachable, never a resting state — Stage B
-selects open stubs only, and the regression gate above reopens a closed stub
-only on fresh Sentry events. Several stages can still write it (the archive
-leg's live-regression refusal, a crash inside ingest's own reopen sequence, a
-hand-edit), so it is repaired once here from observed state rather than guarded
-at each producer. The triage agent workflow's own close compensations no longer
-produce it: they run through the re-queue CLI, whose terminal revalidation
-declines on a stub that reads CLOSED — which is exactly what a close that landed
-and lost its response leaves behind. Declining a stub means
-removing `sentry:needs-triage`, not closing the stub while it still carries the
-label.
+Ingest then sweeps the queue itself, independently of that run's Sentry results.
+It repairs **two** unselectable shapes, both through the re-queue chokepoint, and
+counts them apart in the run record because they diagnose different failures.
 
-The sweep re-reads each stub immediately before touching it and acts only if it
-is still closed-and-needing-triage. The queue snapshot is taken before the whole
-Sentry loop runs, so by the time the sweep reaches a given stub the snapshot can
-be minutes old — long enough for a human to have declined it by removing the
-label, which the sweep would otherwise put straight back. A failed re-read
-leaves the stub stranded for the next run rather than recovering blind.
+**Closed while still queued.** A closed stub that still carries
+`sentry:needs-triage` is reopened, its stale verdict/projection/autofix/archive
+labels shed, and a fixed recovery note posted. That pairing is unreachable, never
+a resting state — Stage B selects open stubs only, and the regression gate above
+reopens a closed stub only on fresh Sentry events. Several stages can still write
+it (the archive leg's live-regression refusal, a crash inside ingest's own reopen
+sequence, a hand-edit), so it is repaired once here from observed state rather
+than guarded at each producer. The triage agent workflow's own close
+compensations no longer produce it: they run through the re-queue CLI, whose
+terminal revalidation declines on a stub that reads CLOSED — which is exactly
+what a close that landed and lost its response leaves behind. Declining a stub
+means removing `sentry:needs-triage`, not closing the stub while it still carries
+the label.
+
+**Open, verdicted, and no longer queued** (issue #1817). The verdict step swaps
+`sentry:needs-triage` off before anything closes the stub, so every failing exit
+in that window owes it a re-queue — and those exits go through the re-queue CLI,
+whose revalidating read retries within a bound and then THROWS. Under a
+persistent GitHub read outage that is the right refusal and it still leaves the
+stub open, verdict-labeled and unqueued: Stage B needs the label, the project job
+skips a stub that is not queued, and the closed-pairing sweep matches the
+opposite pairing. The archive leg's post-CAS rollback leaves the same shape
+whenever the stub it rolls back was open. So the sweep restores selectability
+through the same chokepoint, which brings the shed set and the terminal guard
+with it.
+
+That shape is also what a LIVE triage round looks like between its verdict label
+and its close, so the sweep additionally requires the stub to have been idle
+(`updated_at`) for a full day. The declared part of the window it must clear is
+small — a stub's clock starts when ITS verdict label lands, and at
+`max-parallel: 2` over a batch capped at 10 that leaves at most four further
+waves of a 10-minute job plus the `project` job's 15 minutes, roughly 55 minutes.
+The undeclared part is runner queueing, which no timeout bounds, and that is what
+the threshold actually answers: a live run reaching a day needs a 15-minute job
+queued for a day, and the triage workflow holds `concurrency:
+sentry-triage-agent` with `cancel-in-progress: false`, so a run stuck that long
+has already blocked the next scheduled run and become something someone is
+looking at. The cost is latency on a stub whose run already went red — a strand
+from the weekday 07:55 run is repaired within about thirty hours, without a
+human. The workflow's own compensation remains the fast path, in seconds.
+
+A stub with no parseable `updated_at` is left alone: no observation of idleness,
+no sweep. Three shapes are excluded outright, because they are resting or belong
+to another leg: `sentry:verdict-needs-human` (the close step leaves that bucket
+open for a human to answer), `sentry:approved-archive` (a live human approval the
+archive workflow is acting on), and `sentry:archived` (the archive leg's terminal
+marker). And the sweep does not rely on the threshold alone: both racing
+directions degrade into states something already repairs — a re-queue that raced
+the `project` job leaves a stub its `--batch` mode skips, and one that raced the
+close leaves the closed-plus-needs-triage pairing the first sweep repairs.
+
+A human working a strand withdraws it for free: any comment or label edit moves
+`updated_at`, so reading or annotating one keeps it out of the sweep for another
+day without knowing the rule exists. The same property is the sweep's one
+weakness on a public repo — a determined commenter can keep a genuine strand
+below the threshold indefinitely. That delays a repair; it can never cause one to
+happen wrongly, and the state it preserves is the one this sweep found.
+
+The window between the sweep's revalidating read and its label shed stays open,
+like the one the re-queue CLI's terminal guard documents, and for the same
+reason: closing it needs a shared concurrency group across ingest and archive,
+which this pipeline rejected on its own terms (GitHub keeps one pending run per
+group and would silently drop a second human-approved archive queued behind an
+ingest run). An approval landing inside that window is shed, the archive run its
+label event started refuses out loud on its own guard, and the human re-applies
+the label.
+
+The sweep re-reads each stub immediately before touching it and acts only if the
+SAME shape still holds — including its idleness, since a comment posted in the
+meantime moves no label and no state yet proves something is still working on the
+stub. The queue snapshot is taken before the whole Sentry loop runs, so by the
+time the sweep reaches a given stub the snapshot can be minutes old — long enough
+for a human to have declined it by removing the label, which the sweep would
+otherwise put straight back. A failed re-read leaves the stub stranded for the
+next run rather than recovering blind.
+
+The two shapes differ in one more way, and the stub's own state is why. On the
+closed path every interruption lands somewhere inert: the state change goes last,
+so a stub whose shed failed is still closed and invisible to Stage B until the
+next run retries. An open stub has no such cover — restoring `sentry:needs-triage`
+makes it selectable at once — so that path uses the chokepoint's
+`verify-end-state` policy instead, the same one the workflow compensation CLI
+uses on the same kind of stub: it re-attempts the shed against observed state and
+throws naming whatever survived. Under `--dry-run` that verification would assert
+writes the run deliberately did not make, so the dry run falls back to the abort
+policy and claims nothing.
 
 The sweep also skips any stub the regression path ATTEMPTED this run, not merely
 the ones it re-queued. A Sentry-evidence re-queue that throws half-way would
@@ -899,11 +968,29 @@ the state the stub had before settlement rather than forcing it open:
 - **closed**, when `sentry-triage-agent.yml` had already closed it. The
   reconciler deliberately does not reopen a stub this run did not close.
 
-No stage picks up either shape: ingest skips an open match, and skips a closed
-one whose `closed_at` postdates the regression; the triage agent selects on
-`sentry:needs-triage`; archive needs the approval. It waits for a human. That is
-deliberate, since the alternative ordering closes stubs over live regressions,
-but it is a stranded state, not a self-healing one.
+The OPEN one is the shape ingest's stranded sweep now recovers once it has been
+idle for a day (issue #1817): it is open, verdicted and unqueued, which is
+the same damage a failed compensation leaves, and the sweep repairs shapes rather
+than producers. Recovery restores `sentry:needs-triage` and re-triages the stub;
+it consumes nothing, since this shape carries neither the approval nor
+`sentry:archived` by definition, and it answers no question about **Sentry** —
+the run's summary line and the runbook below still own that.
+
+The archive leg's **freshness refusal** ends in the same shape and is recovered
+for the refusal's own reason. It fires because a Sentry event landed during the
+archive, so the verdict on that stub now predates a live occurrence and no stage
+would otherwise re-triage it — ingest skips an open match. The refusal asks for
+"a fresh approval rather than a full re-triage"; a day later the sweep gives the
+approver something fresher to approve. The pre-event verdict cannot settle
+that round either: the sweep posts no fence, but [the round
+binding](#the-round-binding) refuses any verdict comment that is not strictly
+newer than the one `select` recorded.
+
+The CLOSED one still waits for a human. No stage picks it up — ingest skips a
+closed stub whose `closed_at` postdates the regression, the triage agent selects
+on `sentry:needs-triage`, archive needs the approval — and nothing distinguishes
+it from an ordinary settled ledger entry, so nothing may act on it. That is
+deliberate, since the alternative ordering closes stubs over live regressions.
 The Sentry issue stays archived throughout — the next paragraph says why, and
 what that means for the re-approval the runbook asks for.
 
@@ -1216,13 +1303,15 @@ permission or the environment-secret writes 403 (`terraform/providers.tf`).
   `sentry:approved-archive` nor `sentry:archived` failed after it consumed the
   approval.** It can be **open or closed** — the rollback restores whichever
   state the stub had before settlement, so a stub `sentry-triage-agent.yml` had
-  already closed comes back closed. Both are stranded; the closed one is the
-  easier to miss, because it looks like an ordinary settled ledger entry until
-  you notice it has no `sentry:archived`. Nothing retries either on its own, and
-  no re-dispatch is possible — the guard needs the label the run spent. Only the
-  stub was rolled back, so start from the run's one summary line — and read what
-  it says about **Sentry** before assuming anything, because two dispositions
-  produce this same stub shape:
+  already closed comes back closed. The open one goes back in the triage queue by
+  itself, a day later, via ingest's stranded sweep (#1817) — that repairs
+  the QUEUE, not this failure, and no re-dispatch of the archive is possible
+  either way, because its guard needs the label the run spent. The closed one is
+  the easier to miss and the one nothing recovers, because it looks like an
+  ordinary settled ledger entry until you notice it has no `sentry:archived`.
+  Only the stub was rolled back, so start from the run's one summary line — and
+  read what it says about **Sentry** before assuming anything, because two
+  dispositions produce this same stub shape:
   - **"stays archived_until_escalating"** — the archive landed. That is by
     design, not damage: it is the outcome the approver asked for, and escalation
     undoes it automatically. Carry on with the options below.

--- a/scripts/sentry-suite-manifest.json
+++ b/scripts/sentry-suite-manifest.json
@@ -66,7 +66,7 @@
     },
     "scripts/sentry-triage-ingest.test.mjs": {
       "reporter": "count-line",
-      "floor": 110
+      "floor": 128
     },
     "scripts/sentry-triage-project.test.mjs": {
       "reporter": "count-line",

--- a/scripts/sentry-suite-manifest.json
+++ b/scripts/sentry-suite-manifest.json
@@ -66,7 +66,7 @@
     },
     "scripts/sentry-triage-ingest.test.mjs": {
       "reporter": "count-line",
-      "floor": 128
+      "floor": 130
     },
     "scripts/sentry-triage-project.test.mjs": {
       "reporter": "count-line",

--- a/scripts/sentry-suite-manifest.json
+++ b/scripts/sentry-suite-manifest.json
@@ -66,7 +66,7 @@
     },
     "scripts/sentry-triage-ingest.test.mjs": {
       "reporter": "count-line",
-      "floor": 130
+      "floor": 131
     },
     "scripts/sentry-triage-project.test.mjs": {
       "reporter": "count-line",

--- a/scripts/sentry-triage-archive.test.mjs
+++ b/scripts/sentry-triage-archive.test.mjs
@@ -1401,7 +1401,12 @@ await test("the non-requeuing refusals must NOT fence the prior verdict", () => 
   }
 });
 
-await test("isSelectableForTriage is exactly Stage B's selector pair", () => {
+await test("isSelectableForTriage is exactly Stage B's selector, all three parts", () => {
+  // `.github/workflows/sentry-triage-agent.yml` selects on
+  // `--label sentry-triage --label sentry:needs-triage --state open`. This
+  // predicate is the end-state test every verify-end-state re-queue is judged
+  // by, so anything it omits is something a re-queue can report as success while
+  // Stage B never sees the stub (#1817).
   const ok = {
     state: "OPEN",
     labels: ["sentry-triage", "sentry:needs-triage"],
@@ -1410,6 +1415,12 @@ await test("isSelectableForTriage is exactly Stage B's selector pair", () => {
   assertEqual(isSelectableForTriage({ ...ok, state: "CLOSED" }), false);
   assertEqual(
     isSelectableForTriage({ ...ok, labels: ["sentry-triage"] }),
+    false,
+  );
+  // Queue membership is the third part, and the one a human removes to retire a
+  // stub for good — a re-queue must never call that selectable.
+  assertEqual(
+    isSelectableForTriage({ ...ok, labels: ["sentry:needs-triage"] }),
     false,
   );
   assertEqual(isSelectableForTriage({}), false);

--- a/scripts/sentry-triage-archive.test.mjs
+++ b/scripts/sentry-triage-archive.test.mjs
@@ -1854,7 +1854,10 @@ await test("a genuinely failing reopen strands the stub and fails RED", async ()
   assert(errorLine.includes("STRANDED"), "says the stub is stranded");
   assert(errorLine.includes("state=CLOSED"), "names the observed state");
   assert(
-    errorLine.includes("Reopen it by hand"),
+    // The verifier is shared by three callers now (#1817), so its instruction
+    // is caller-neutral: what to restore, not which refusal produced the stub.
+    errorLine.includes("restore it by hand") &&
+      errorLine.includes("reopen it if it is closed"),
     "tells the operator what to do",
   );
 });

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -19,18 +19,25 @@ import { fileURLToPath } from "node:url";
 
 import { selectMarkedComment } from "./sentry-triage-project-core.mjs";
 import {
+  APPROVED_ARCHIVE_LABEL,
   ARCHIVED_LABEL,
   LABEL_DEFINITIONS,
+  NEEDS_HUMAN_VERDICT_LABEL,
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
   parseArchiveBaseline,
   reopenBaselineOf,
+  SETTLING_VERDICT_LABELS,
+  STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  STRAND_SHAPE_OPEN_VERDICT,
   truncateTitle,
 } from "./sentry-triage-queue-contract.mjs";
 import {
   buildStrandedRecoveryComment,
   REQUEUE_CAUSE_BOOKKEEPING,
   REQUEUE_CAUSE_SENTRY_EVIDENCE,
+  REQUEUE_ON_FAILURE_ABORT,
+  REQUEUE_ON_FAILURE_VERIFY_END_STATE,
   requeueQueueStub,
 } from "./sentry-triage-requeue.mjs";
 
@@ -51,6 +58,7 @@ export {
   FIX_PR_OPENED_LABEL,
   FIX_REFUSED_LABEL,
   LABEL_DEFINITIONS,
+  NEEDS_HUMAN_VERDICT_LABEL,
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
   parseArchiveBaseline,
@@ -58,6 +66,9 @@ export {
   reopenBaselineOf,
   REOPEN_SHED_LABELS,
   sanitizeFreeText,
+  SETTLING_VERDICT_LABELS,
+  STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  STRAND_SHAPE_OPEN_VERDICT,
   truncateTitle,
   VERDICT_LABELS,
   withArchiveBaseline,
@@ -388,6 +399,11 @@ export function buildRunRecordBody(counts, timestampIso) {
     // regression when Sentry actually escalated an archived issue.
     `- Reopened (regressed or escalating): ${counts.reopened}`,
     `- Recovered (stranded needs-triage): ${counts.recovered}`,
+    // The two strands are counted apart because they diagnose different things:
+    // the line above is a stub closed while still queued, this one a round that
+    // verdicted a stub and never settled it (issue #1817). A run recovering the
+    // second repeatedly says the triage workflow's compensations are failing.
+    `- Recovered (stranded open verdict): ${counts.recoveredOpenVerdict ?? 0}`,
     `- Errors: ${counts.errors}`,
   ].join("\n");
 }
@@ -664,8 +680,9 @@ async function ensureLabelsExist(options) {
 // PRs, `closed_at` for the regression-reopen timestamp gate, `labels` — read by
 // the archive-baseline branch to recognize a `sentry:archived` stub and by the
 // stranded-stub sweep to spot a closed one still wearing `sentry:needs-triage` —
-// and `body`, which carries that baseline) into the shape decideDedupAction and
-// isStrandedNeedsTriage expect. The REST list returns all five, so neither the
+// `updated_at`, the sweep's idleness clock for the OPEN strand shape, and
+// `body`, which carries that baseline) into the shape decideDedupAction and
+// strandedShapeOf expect. The REST list returns all six, so neither the
 // baseline read nor the sweep costs an extra request. Exported for tests.
 export function normalizeRestIssues(pages) {
   return (pages ?? [])
@@ -676,6 +693,7 @@ export function normalizeRestIssues(pages) {
       title: issue.title ?? "",
       state: String(issue.state ?? "").toUpperCase(),
       closedAt: issue.closed_at ?? null,
+      updatedAt: issue.updated_at ?? null,
       body: issue.body ?? "",
       labels: (issue.labels ?? [])
         .map((label) => (typeof label === "string" ? label : label?.name))
@@ -807,7 +825,135 @@ export function isStrandedNeedsTriage(issue) {
   );
 }
 
-/** Live state of one queue stub, for the sweep's pre-mutation revalidation. */
+/**
+ * The OTHER unselectable shape, and the mirror image of the one above: OPEN,
+ * carrying a settling `sentry:verdict-*`, and NOT carrying `sentry:needs-triage`
+ * (issue #1817).
+ *
+ * The verdict step swaps `sentry:needs-triage` off and the verdict label on
+ * before anything closes the stub, so every failing exit in that window owes the
+ * stub a re-queue. Those exits route through the chokepoint's workflow CLI,
+ * whose revalidating read has a bounded retry — but a PERSISTENT GitHub read
+ * outage still makes every attempt fail, and by design that throws before any
+ * write. The run is red and the stub is left exactly here: open, so Stage B's
+ * `--state open` + `sentry:needs-triage` selector misses it; not needs-triage,
+ * so the project job skips it and `isStrandedNeedsTriage` above is the opposite
+ * pairing. Nothing selected it until this arm existed.
+ *
+ * THE FALSE POSITIVE THIS MUST NOT MAKE. A stub mid-flight between its verdict
+ * label and its close carries exactly this shape for real, and re-queuing it
+ * would fight a live run. Three narrowings keep them apart:
+ *
+ *   - IDLENESS. `updatedAt` must be at least `minIdleMs` old. A stub a workflow
+ *     is acting on was just written to. No timestamp, or one that does not
+ *     parse, means no observation of idleness, so it FAILS CLOSED and is left
+ *     alone rather than swept blind.
+ *   - `needs-human` IS A RESTING STATE, not a strand: the close step leaves that
+ *     bucket open for a human to answer, so it is excluded (via
+ *     SETTLING_VERDICT_LABELS) and a stub wearing it is skipped outright — two
+ *     deliberately overlapping guards, because each covers a case the other only
+ *     covers by accident. The exclusion alone would admit a DOUBLE-verdicted stub
+ *     carrying `needs-human` beside a settling verdict; the skip alone would
+ *     admit a future verdict that also rests open. Removing either one keeps the
+ *     tests green; removing both reds them.
+ *   - TERMINAL AND APPROVED stubs are not this sweep's to touch. `sentry:archived`
+ *     is the archive leg's terminal marker (the same signal `isTerminalStub`
+ *     reads), and `sentry:approved-archive` is a LIVE human approval the archive
+ *     workflow — its own concurrency group — is acting on right now. Both are in
+ *     REOPEN_SHED_LABELS, so re-queuing would spend them.
+ *
+ *     The window between this read and the shed stays OPEN, and deliberately so:
+ *     it is the same window `runWorkflowRequeue`'s terminal guard documents and
+ *     declines to close, because the only thing that would close it is a shared
+ *     concurrency group across ingest and archive — which this pipeline rejected
+ *     on its own terms, since GitHub keeps one pending run per group and would
+ *     silently drop a second human-approved archive queued behind an ingest run
+ *     (see the archive races section of docs/notes/sentry-triage-pipeline.md).
+ *     An approval that lands inside the window is shed, the archive run that the
+ *     label event started then refuses out loud on its own guard, and the human
+ *     re-applies the label. Loud and recoverable, against a race the threshold
+ *     above already makes require a stub untouched for a day.
+ *
+ * ONE PRODUCER IS ADMITTED DELIBERATELY. The archive leg's freshness refusal
+ * ends in this exact shape — approval shed, verdict kept, stub left open — and
+ * `scripts/sentry-triage-archive.mjs` says it wants "a fresh approval rather
+ * than a full re-triage". Recovering it anyway is right, and for the refusal's
+ * OWN reason: it fires because a Sentry event landed during the archive, so the
+ * verdict on that stub now predates a live occurrence and no stage would ever
+ * re-triage it (ingest skips an open match). A re-triage produces a verdict for
+ * the current occurrence, which is what a human should be re-approving. The
+ * pre-event verdict cannot settle that round either — this re-queue posts no
+ * fence, but the round binding (#1717) refuses any verdict comment that is not
+ * strictly newer than the one `select` recorded. What the human loses is one
+ * triage round of delay; touching the stub at all resets the idle clock.
+ *
+ * THE THRESHOLD. A stub's clock starts when ITS verdict label lands, so the
+ * window to clear is only what can still happen to it after that. The declared
+ * part is small: the verdict matrix runs at `max-parallel: 2` over a batch
+ * capped at 10, so at most four further waves of a 10-minute job, plus the
+ * `project` job's 15 minutes — roughly 55 minutes. The undeclared part is runner
+ * queueing between those jobs, which no timeout bounds, and that is the part a
+ * threshold has to answer.
+ *
+ * A DAY answers it, where a small multiple of the declared time would not. A
+ * live run reaching this threshold needs a 15-minute job to sit queued for a
+ * full day — and the triage workflow holds `concurrency: sentry-triage-agent`
+ * with `cancel-in-progress: false`, so a run stuck that long has already blocked
+ * the next scheduled run and become an operational failure someone is looking
+ * at. It is not an unnoticed background state the sweep could quietly race.
+ *
+ * The cost is latency, and only on a stub whose run already went red: ingest
+ * runs twice a day, so a strand from the weekday 07:55 triage run becomes
+ * eligible the next morning and is repaired within about thirty hours, without a
+ * human. Set against "never", that is the right trade — the workflow's own
+ * compensation is still the fast path, in seconds, and this is the backstop for
+ * when it could not run at all.
+ *
+ * Even so the sweep does not RELY on the threshold alone: both racing directions
+ * degrade into states something already repairs. A re-queue that raced the
+ * `project` job leaves a stub that job's `--batch` mode SKIPS (it skips
+ * needs-triage stubs), and one that raced the `verdict` job's close leaves the
+ * closed-plus-needs-triage pairing the sweep arm above repairs.
+ *
+ * A HUMAN working the stub withdraws it from the sweep for free: a comment or a
+ * label edit moves `updated_at`, so anyone reading or annotating a strand keeps
+ * it out of this path for another day without knowing the rule exists.
+ */
+export const STRANDED_OPEN_VERDICT_MIN_IDLE_MS = 24 * 60 * 60 * 1000;
+
+export function isStrandedOpenVerdict(
+  issue,
+  { now = new Date(), minIdleMs = STRANDED_OPEN_VERDICT_MIN_IDLE_MS } = {},
+) {
+  if (String(issue?.state ?? "").toUpperCase() === "CLOSED") return false;
+  const labels = issue?.labels ?? [];
+  if (labels.includes(NEEDS_TRIAGE_LABEL)) return false;
+  if (labels.includes(NEEDS_HUMAN_VERDICT_LABEL)) return false;
+  if (labels.includes(ARCHIVED_LABEL)) return false;
+  if (labels.includes(APPROVED_ARCHIVE_LABEL)) return false;
+  if (!SETTLING_VERDICT_LABELS.some((name) => labels.includes(name))) {
+    return false;
+  }
+  const updatedAt = Date.parse(issue?.updatedAt ?? "");
+  if (Number.isNaN(updatedAt)) return false;
+  return now.getTime() - updatedAt >= minIdleMs;
+}
+
+/**
+ * Which stranded shape this stub is in, or null for every healthy one. The names
+ * (STRAND_SHAPE_*) live in the queue contract because the chokepoint renders a
+ * note per shape; the predicates live here, with the sweep that applies them.
+ */
+export function strandedShapeOf(issue, options = {}) {
+  if (isStrandedNeedsTriage(issue)) return STRAND_SHAPE_CLOSED_NEEDS_TRIAGE;
+  if (isStrandedOpenVerdict(issue, options)) return STRAND_SHAPE_OPEN_VERDICT;
+  return null;
+}
+
+/** Live state of one queue stub, for the sweep's pre-mutation revalidation.
+ * `updatedAt` rides along because the OPEN shape's premise INCLUDES idleness:
+ * a comment posted since the snapshot changes no label and no state, yet it is
+ * proof something is still working on the stub. */
 async function readQueueIssueState(options, issueNumber, runner) {
   const run = runner ?? ((args) => runGh(args, {}));
   const stdout = await run([
@@ -817,12 +963,13 @@ async function readQueueIssueState(options, issueNumber, runner) {
     "-R",
     options.repo,
     "--json",
-    "number,state,labels",
+    "number,state,labels,updatedAt",
   ]);
   const data = stdout && stdout.trim() ? JSON.parse(stdout) : {};
   return {
     number: data.number,
     state: String(data.state ?? "").toUpperCase(),
+    updatedAt: data.updatedAt ?? null,
     labels: (data.labels ?? [])
       .map((label) => (typeof label === "string" ? label : label?.name))
       .filter(Boolean),
@@ -833,8 +980,13 @@ async function readQueueIssueState(options, issueNumber, runner) {
  * `runGh` is injectable so the test can drive this exact sequence against a
  * stateful fake instead of re-implementing it.
  *
+ * `shape` names which strand the snapshot matched (default: the closed pairing).
+ * It selects the note and the failure policy, and the revalidating read requires
+ * the SAME shape to still hold live — a stub that changed shape since the
+ * snapshot belongs to whoever changed it.
+ *
  * Returns `{ recovered }` — false when the live re-read no longer shows the
- * stranded pairing, which is a normal no-op, not a failure.
+ * stranded shape, which is a normal no-op, not a failure.
  */
 export async function recoverStrandedQueueIssue(
   options,
@@ -842,6 +994,25 @@ export async function recoverStrandedQueueIssue(
   deps = {},
 ) {
   const run = deps.runGh ?? runGh;
+  const shape = deps.shape ?? STRAND_SHAPE_CLOSED_NEEDS_TRIAGE;
+  const isOpenShape = shape === STRAND_SHAPE_OPEN_VERDICT;
+  const shapeOptions = deps.now ? { now: deps.now() } : {};
+
+  // The open shape is verified, the closed one aborts, and the difference is the
+  // stub's own state. On the closed path every interruption lands somewhere
+  // inert: the state change goes last, so a stub whose shed failed is still
+  // CLOSED and invisible to Stage B until the next run retries. An OPEN stub has
+  // no such cover — restoring `sentry:needs-triage` makes it selectable
+  // immediately, so a failed shed would hand the next triage round a stub still
+  // wearing the previous round's markers. `verify-end-state` is what the sibling
+  // OPEN-stub caller (the workflow compensation CLI) uses for exactly this
+  // reason: it re-attempts the shed against observed state and throws naming
+  // whatever survived.
+  //
+  // Under --dry-run that verification would assert writes that deliberately did
+  // not happen, so the dry run would go red on a stub it never touched. Fall
+  // back to the abort policy, which makes no post-hoc claim.
+  const verifyEndState = isOpenShape && !options.dryRun;
 
   // BOOKKEEPING cause, declared rather than reconstructed: nothing about the
   // Sentry issue changed, so the chokepoint posts NO fence and the verdict
@@ -868,15 +1039,22 @@ export async function recoverStrandedQueueIssue(
       repo: options.repo,
       issueNumber: existingIssue.number,
       cause: REQUEUE_CAUSE_BOOKKEEPING,
-      note: buildStrandedRecoveryComment(),
+      note: buildStrandedRecoveryComment(shape),
       revalidate: {
-        check: isStrandedNeedsTriage,
+        check: (live) => strandedShapeOf(live, shapeOptions) === shape,
         declineNote: (live) =>
-          `Queue issue #${existingIssue.number} is no longer closed-and-needing-triage (state=${live.state}, labels=${live.labels.join(",") || "none"}); leaving it as the current state describes.`,
+          `Queue issue #${existingIssue.number} is no longer stranded as ${shape} (state=${live.state}, labels=${live.labels.join(",") || "none"}); leaving it as the current state describes.`,
       },
+      onFailure: verifyEndState
+        ? REQUEUE_ON_FAILURE_VERIFY_END_STATE
+        : REQUEUE_ON_FAILURE_ABORT,
+      // Only consulted by the end-state verification, and only to decide whether
+      // to attempt a reopen when a read fails. This stub was observed OPEN, so
+      // saying so is what keeps the verifier from reopening what is already open.
+      fallbackState: isOpenShape ? "OPEN" : "CLOSED",
     },
   );
-  // False when the live re-read no longer shows the stranded pairing, which is a
+  // False when the live re-read no longer shows the stranded shape, which is a
   // normal no-op, not a failure.
   return { recovered: outcome.requeued };
 }
@@ -1024,6 +1202,7 @@ export async function runIngest(options, deps = {}) {
     skippedExisting: 0,
     reopened: 0,
     recovered: 0,
+    recoveredOpenVerdict: 0,
     errors: 0,
   };
 
@@ -1119,19 +1298,35 @@ export async function runIngest(options, deps = {}) {
     }
   }
 
-  // Stranded-stub sweep (see isStrandedNeedsTriage). It runs over the QUEUE,
-  // not over this run's Sentry results: a stranded stub's Sentry issue is
-  // usually outside the firstSeen lookback and not regressed, so the loop above
-  // never visits it. Same per-item error handling as the loop — one unrecovered
-  // stub must not abort the rest, and the run still exits nonzero.
+  // Stranded-stub sweep (see strandedShapeOf, and the two predicates it calls).
+  // It runs over the QUEUE, not over this run's Sentry results: a stranded
+  // stub's Sentry issue is usually outside the firstSeen lookback and not
+  // regressed, so the loop above never visits it. Same per-item error handling
+  // as the loop — one unrecovered stub must not abort the rest, and the run
+  // still exits nonzero.
+  //
+  // One instant for the whole sweep, taken here rather than per stub, so the
+  // idleness threshold cannot mean something slightly different for the first
+  // stub than for the last.
+  const sweptAt = now();
   for (const existingIssue of existingIssues) {
     if (claimedBySentryPath.has(existingIssue.number)) continue;
-    if (!isStrandedNeedsTriage(existingIssue)) continue;
+    const shape = strandedShapeOf(existingIssue, { now: sweptAt });
+    if (!shape) continue;
     try {
       // A revalidation no-op is not a recovery; only count real ones so the run
       // record cannot read as activity that never happened.
-      const outcome = await recoverStranded(options, existingIssue);
-      if (outcome?.recovered !== false) counts.recovered += 1;
+      const outcome = await recoverStranded(options, existingIssue, {
+        shape,
+        now: () => sweptAt,
+      });
+      if (outcome?.recovered !== false) {
+        if (shape === STRAND_SHAPE_OPEN_VERDICT) {
+          counts.recoveredOpenVerdict += 1;
+        } else {
+          counts.recovered += 1;
+        }
+      }
     } catch (err) {
       counts.errors += 1;
       const message = err instanceof Error ? err.message : String(err);
@@ -1249,7 +1444,7 @@ async function main() {
     process.stdout.write(`${JSON.stringify(counts, null, 2)}\n`);
   } else {
     process.stdout.write(
-      `Sentry triage ingest: fetched=${counts.fetched} created=${counts.created} skipped-existing=${counts.skippedExisting} reopened=${counts.reopened} recovered=${counts.recovered} errors=${counts.errors}\n`,
+      `Sentry triage ingest: fetched=${counts.fetched} created=${counts.created} skipped-existing=${counts.skippedExisting} reopened=${counts.reopened} recovered=${counts.recovered} recovered-open-verdict=${counts.recoveredOpenVerdict} errors=${counts.errors}\n`,
     );
   }
   // Per-issue mutation failures are tolerated inside the loop (one bad issue

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -26,6 +26,7 @@ import {
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
   parseArchiveBaseline,
+  QUEUE_LABEL,
   reopenBaselineOf,
   SETTLING_VERDICT_LABELS,
   STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
@@ -63,6 +64,7 @@ export {
   neutralizeUntrusted,
   parseArchiveBaseline,
   PROJECTED_LABEL,
+  QUEUE_LABEL,
   reopenBaselineOf,
   REOPEN_SHED_LABELS,
   sanitizeFreeText,
@@ -184,7 +186,7 @@ export function classifyNoise(rawTitle) {
 }
 
 export function buildQueueLabels(isNoise) {
-  const labels = ["sentry-triage", NEEDS_TRIAGE_LABEL];
+  const labels = [QUEUE_LABEL, NEEDS_TRIAGE_LABEL];
   if (isNoise) labels.push("sentry:candidate-noise");
   return labels;
 }
@@ -947,8 +949,22 @@ export function isStrandedOpenVerdict(
  * Which stranded shape this stub is in, or null for every healthy one. The names
  * (STRAND_SHAPE_*) live in the queue contract because the chokepoint renders a
  * note per shape; the predicates live here, with the sweep that applies them.
+ *
+ * QUEUE MEMBERSHIP IS CHECKED FIRST, for BOTH shapes, and it is the revalidation
+ * that needs it. The snapshot cannot fail this test — it comes from a
+ * `labels=sentry-triage` query — so on that side the check is free and inert.
+ * On the live re-read it is the difference between repairing a strand and
+ * wrecking an issue somebody deliberately withdrew: Stage B's selector requires
+ * `sentry-triage` AND `sentry:needs-triage`, so re-queuing a stub that has lost
+ * the first one sheds its verdict and STILL leaves it unselectable. Strictly
+ * destructive — it takes the one artifact the stub had and buys nothing.
+ *
+ * Removing `sentry-triage` is also the only withdrawal gesture available for a
+ * stub in the open shape, which by definition has no `sentry:needs-triage` left
+ * to remove. Declining here is what makes that gesture mean something.
  */
 export function strandedShapeOf(issue, options = {}) {
+  if (!(issue?.labels ?? []).includes(QUEUE_LABEL)) return null;
   if (isStrandedNeedsTriage(issue)) return STRAND_SHAPE_CLOSED_NEEDS_TRIAGE;
   if (isStrandedOpenVerdict(issue, options)) return STRAND_SHAPE_OPEN_VERDICT;
   return null;

--- a/scripts/sentry-triage-ingest.mjs
+++ b/scripts/sentry-triage-ingest.mjs
@@ -885,7 +885,8 @@ export function isStrandedNeedsTriage(issue) {
  * pre-event verdict cannot settle that round either — this re-queue posts no
  * fence, but the round binding (#1717) refuses any verdict comment that is not
  * strictly newer than the one `select` recorded. What the human loses is one
- * triage round of delay; touching the stub at all resets the idle clock.
+ * triage round of delay, and any WRITE to the stub — a comment, a label — holds
+ * it past that (reads do not; see the idleness note below).
  *
  * THE THRESHOLD. A stub's clock starts when ITS verdict label lands, so the
  * window to clear is only what can still happen to it after that. The declared
@@ -915,9 +916,12 @@ export function isStrandedNeedsTriage(issue) {
  * needs-triage stubs), and one that raced the `verdict` job's close leaves the
  * closed-plus-needs-triage pairing the sweep arm above repairs.
  *
- * A HUMAN working the stub withdraws it from the sweep for free: a comment or a
- * label edit moves `updated_at`, so anyone reading or annotating a strand keeps
- * it out of this path for another day without knowing the rule exists.
+ * A HUMAN holds a strand by WRITING to it, and only by writing to it. GitHub
+ * moves `updated_at` on mutations — a comment, a label change, a state change, a
+ * title or body edit — and not on reads, so opening a stub to inspect it buys no
+ * time and this sweep can re-queue it mid-inspection. The runbook therefore
+ * tells an operator to post a comment rather than to "touch" the stub; see the
+ * open-verdict sweep in docs/notes/sentry-triage-pipeline.md.
  */
 export const STRANDED_OPEN_VERDICT_MIN_IDLE_MS = 24 * 60 * 60 * 1000;
 

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -2705,6 +2705,71 @@ for (const withdrawn of [
   });
 }
 
+await test("a withdrawal landing mid-write fails the run loudly, never reports success", async () => {
+  // The revalidating read cannot close this window: the operator removes
+  // `sentry-triage` AFTER the sweep decided and BEFORE the label writes land. By
+  // then the verdict is already shed, and nothing may undo that — a compensating
+  // re-add would reintroduce the two-writers race the withdrawal just settled.
+  // What must not happen is the run reporting success, which is what it did
+  // while the end-state test omitted queue membership (#1817).
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"])],
+  });
+  let views = 0;
+  const runGh = async (args, opts = {}) => {
+    const out = await fake.runGh(args, opts);
+    // The withdrawal lands the instant the revalidating read returns.
+    if (args[1] === "view" && ++views === 1) {
+      fake.get(42).labels = fake
+        .get(42)
+        .labels.filter((name) => name !== "sentry-triage");
+    }
+    return out;
+  };
+
+  const stderr = [];
+  const write = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    stderr.push(String(chunk));
+    return true;
+  };
+  let counts;
+  try {
+    counts = await runIngest(
+      { repo: REPO, trackerIssue: 1282 },
+      ingestDeps(fake, {
+        now: () => SWEEP_NOW,
+        recoverStranded: (options, issue, sweep) =>
+          recoverStrandedQueueIssue(options, issue, { ...sweep, runGh }),
+      }),
+    );
+  } finally {
+    process.stderr.write = write;
+  }
+
+  // The decisive assertion: NOT counted as a recovery, and the run goes red.
+  assertEqual(counts.recoveredOpenVerdict, 0);
+  assertEqual(counts.errors, 1);
+  // The stub is left as the withdrawal found it — nothing re-adds the queue
+  // label, because removing it is how a stub is retired.
+  const issue = fake.get(42);
+  assert(
+    !issue.labels.includes("sentry-triage"),
+    `the withdrawal must stand: ${JSON.stringify(issue.labels)}`,
+  );
+  // And the operator gets the right story, not the generic stranded one.
+  const errorLine = stderr.find((line) => line.includes("::error::"));
+  assert(errorLine, "a run that shed a verdict for nothing must be loud");
+  assert(
+    errorLine.includes("sentry-triage"),
+    `the failure must name the label that vanished: ${errorLine}`,
+  );
+  assert(
+    !/It is STRANDED/.test(errorLine),
+    `a withdrawn stub is retired, not stranded: ${errorLine}`,
+  );
+});
+
 await test("an open-verdict recovery whose shed fails is loud, not silently selectable", async () => {
   // The OPEN shape has no cover the closed one has: restoring the queue label
   // makes the stub selectable IMMEDIATELY, so a shed that never lands would hand

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -14,6 +14,7 @@ import {
   buildRequeueShedLabelArgs,
   buildRunRecordBody,
   buildStrandedRecoveryComment,
+  APPROVED_ARCHIVE_LABEL,
   ARCHIVED_LABEL,
   classifyNoise,
   defaultFetchMergedSentryIssues,
@@ -29,9 +30,11 @@ import {
   indexQueueIssuesByShortId,
   isSafeNextPageUrl,
   isStrandedNeedsTriage,
+  isStrandedOpenVerdict,
   LABEL_DEFINITIONS,
   mapSentryIssue,
   mergeSentryIssues,
+  NEEDS_HUMAN_VERDICT_LABEL,
   NEEDS_TRIAGE_LABEL,
   normalizeRestIssues,
   parseArchiveBaseline,
@@ -47,6 +50,10 @@ import {
   RUN_RECORD_MARKER,
   runIngest,
   sanitizeFreeText,
+  STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  STRAND_SHAPE_OPEN_VERDICT,
+  STRANDED_OPEN_VERDICT_MIN_IDLE_MS,
+  strandedShapeOf,
   toMetadata,
   truncateTitle,
   VERDICT_LABELS,
@@ -1163,7 +1170,7 @@ await test("ghPaginate fails loud on runaway pagination and non-array responses"
   assert(/non-array/.test(threw.message), "wrong non-array error");
 });
 
-await test("REST issue normalization flattens pages, drops PRs, uppercases state, carries closed_at + labels + body", () => {
+await test("REST issue normalization flattens pages, drops PRs, uppercases state, carries closed_at + updated_at + labels + body", () => {
   const normalized = normalizeRestIssues([
     [
       {
@@ -1177,6 +1184,9 @@ await test("REST issue normalization flattens pages, drops PRs, uppercases state
         title: "[sentry] X-2: b",
         state: "closed",
         closed_at: "2026-07-16T12:00:00Z",
+        // The sweep's idleness clock for the OPEN strand shape rides in the
+        // same list response — no extra request, and no sweep without it.
+        updated_at: "2026-07-16T12:00:00Z",
         labels: [{ name: "sentry-triage" }, { name: "sentry:archived" }],
         // The REST list already returns the body, so the archive baseline
         // costs no extra request — and lives nowhere a comment can reach.
@@ -1207,6 +1217,7 @@ await test("REST issue normalization flattens pages, drops PRs, uppercases state
       title: "[sentry] X-1: a",
       state: "OPEN",
       closedAt: null,
+      updatedAt: null,
       body: "",
       labels: ["sentry-triage", "sentry:needs-triage"],
     },
@@ -1215,6 +1226,7 @@ await test("REST issue normalization flattens pages, drops PRs, uppercases state
       title: "[sentry] X-2: b",
       state: "CLOSED",
       closedAt: "2026-07-16T12:00:00Z",
+      updatedAt: "2026-07-16T12:00:00Z",
       body: '```yaml\narchive_baseline_last_seen: "2026-07-16T11:00:00Z"\n```',
       labels: ["sentry-triage", "sentry:archived"],
     },
@@ -1223,6 +1235,7 @@ await test("REST issue normalization flattens pages, drops PRs, uppercases state
       title: "[sentry] X-4: c",
       state: "CLOSED",
       closedAt: null,
+      updatedAt: null,
       body: "",
       labels: ["sentry-triage", "sentry:needs-triage"],
     },
@@ -1282,6 +1295,12 @@ await test("run record body includes counts and the rolling-comment marker", () 
   assert(
     body.includes("Reopened (regressed or escalating): 1"),
     "missing reopened count",
+  );
+  // A counts object from before the second strand counter existed must still
+  // render a number here — an operator reading "undefined" learns nothing.
+  assert(
+    body.includes("Recovered (stranded open verdict): 0"),
+    "missing open-verdict recovery count",
   );
   assert(
     body.includes("Recovered (stranded needs-triage): 3"),
@@ -1851,6 +1870,10 @@ function makeFakeGitHub({
       issue.number,
       {
         closedAt: null,
+        // The sweep's idleness clock for the OPEN strand shape. Defaults far
+        // enough before every fixture's `now` that a test only sets it when
+        // idleness is the thing under test.
+        updatedAt: "2026-07-01T00:00:00Z",
         // Bodies only — the comments the pipeline itself writes, which keeps the
         // assertions readable. `untrustedComments` models what anyone with a
         // comment box can add on this PUBLIC repo; the read below is what
@@ -1942,6 +1965,7 @@ function makeFakeGitHub({
       return JSON.stringify({
         number: issue?.number,
         state: issue?.state,
+        updatedAt: issue?.updatedAt ?? null,
         labels: (issue?.labels ?? []).map((name) => ({ name })),
       });
     }
@@ -1965,6 +1989,7 @@ function makeFakeGitHub({
         title: issue.title,
         state: issue.state,
         closedAt: issue.closedAt,
+        updatedAt: issue.updatedAt,
         labels: [...issue.labels],
       })),
     /** Stage B's selector: `--label sentry-triage --label ... --state open`. */
@@ -1995,8 +2020,14 @@ function ingestDeps(fake, overrides = {}) {
     reopenIssue: async () => {
       throw new Error("unexpected regression reopen in this scenario");
     },
-    recoverStranded: (options, issue) =>
-      recoverStrandedQueueIssue(options, issue, { runGh: fake.runGh }),
+    // The sweep hands down the shape it matched and the instant it matched it
+    // at; forward both, or the recovery falls back to the closed-pairing policy
+    // and real wall-clock time.
+    recoverStranded: (options, issue, sweep) =>
+      recoverStrandedQueueIssue(options, issue, {
+        ...sweep,
+        runGh: fake.runGh,
+      }),
     postRunRecord: async () => {},
     now: () => new Date("2026-07-21T05:30:00.000Z"),
     ...overrides,
@@ -2317,6 +2348,381 @@ await test("a stub reopened by the regression path is not swept a second time", 
   assertEqual(counts.reopened, 1);
   assertEqual(counts.recovered, 0);
   assertEqual(fake.get(200).state, "OPEN");
+});
+
+// ---------------------------------------------------------------------------
+// The OTHER unselectable shape: OPEN + verdict + no `sentry:needs-triage`
+// (issue #1817).
+//
+// The verdict step swaps the queue label off before anything closes the stub,
+// so every failing exit in that window owes the stub a re-queue. Those exits go
+// through the chokepoint's workflow CLI, whose revalidating read retries within
+// a bound and then THROWS — right, and it leaves the stub open, verdicted and
+// unqueued when the read outage is persistent. Stage B selects open stubs that
+// carry the label; the closed-pairing sweep matches the opposite pairing. Until
+// this arm, nothing selected it.
+// ---------------------------------------------------------------------------
+
+const SWEEP_NOW = new Date("2026-07-21T05:30:00.000Z");
+/** Idle by more than the threshold, relative to SWEEP_NOW. */
+const IDLE_SINCE = "2026-07-19T00:00:00Z";
+/** Touched moments ago: a stub a workflow is still working on. */
+const JUST_TOUCHED = "2026-07-21T05:29:00Z";
+
+const strandedOpenStub = (labels, updatedAt = IDLE_SINCE) => ({
+  number: 42,
+  title: buildQueueTitle("X-42", "web", "error"),
+  state: "OPEN",
+  updatedAt,
+  labels: ["sentry-triage", ...labels],
+});
+
+await test("isStrandedOpenVerdict matches only an idle, unqueued, settling-verdict stub", () => {
+  const at = { now: SWEEP_NOW };
+  const shape = (labels, updatedAt = IDLE_SINCE) =>
+    isStrandedOpenVerdict(strandedOpenStub(labels, updatedAt), at);
+
+  assert(
+    shape(["sentry:verdict-upstream"]),
+    "open + a settling verdict + no needs-triage, idle, is the strand",
+  );
+  assert(
+    shape(["sentry:verdict-code-fix", PROJECTED_LABEL]),
+    "a projected row whose close never landed is the same strand",
+  );
+  assert(
+    !shape([NEEDS_TRIAGE_LABEL, "sentry:verdict-upstream"]),
+    "a stub still carrying the queue label is selectable, not stranded",
+  );
+  assert(
+    !shape(["sentry:candidate-noise"]),
+    "an open stub with no verdict at all is an ordinary queue member",
+  );
+  // The false positive that would matter most: `needs-human` RESTS open, by
+  // design, and re-queuing it would delete the question a human was asked.
+  assert(
+    !shape([NEEDS_HUMAN_VERDICT_LABEL]),
+    "a needs-human stub is awaiting a human, not stranded",
+  );
+  assert(
+    !shape([NEEDS_HUMAN_VERDICT_LABEL, "sentry:verdict-upstream"]),
+    "a double-verdicted stub carrying needs-human is still not this sweep's",
+  );
+  // Terminal, and a live human approval: both are in REOPEN_SHED_LABELS, so a
+  // re-queue would spend them.
+  assert(
+    !shape(["sentry:verdict-upstream", ARCHIVED_LABEL]),
+    "an archived stub must never be resurrected",
+  );
+  assert(
+    !shape(["sentry:verdict-upstream", APPROVED_ARCHIVE_LABEL]),
+    "a stub the archive workflow is acting on is not this sweep's to shed",
+  );
+  // Idleness, both directions, and the fail-closed case.
+  assert(
+    !shape(["sentry:verdict-upstream"], JUST_TOUCHED),
+    "a stub written to moments ago may still be mid-flight",
+  );
+  assert(
+    !shape(["sentry:verdict-upstream"], null),
+    "no idleness observation means no sweep",
+  );
+  assert(
+    !shape(["sentry:verdict-upstream"], "not-a-timestamp"),
+    "an unparsable timestamp is not an observation either",
+  );
+  assert(
+    !isStrandedOpenVerdict(
+      {
+        state: "CLOSED",
+        labels: ["sentry:verdict-upstream"],
+        updatedAt: IDLE_SINCE,
+      },
+      at,
+    ),
+    "a settled stub is not this shape",
+  );
+  // The threshold is a real bound, not a formality: exactly at it counts. It is
+  // pinned because it is load-bearing — a live run reaching it needs a
+  // 15-minute job queued for a full day, which the triage workflow's own
+  // concurrency group would have turned into a visible operational failure long
+  // before. Lowering it silently is what this assertion exists to stop.
+  assertEqual(STRANDED_OPEN_VERDICT_MIN_IDLE_MS, 24 * 60 * 60 * 1000);
+  assert(
+    isStrandedOpenVerdict(
+      strandedOpenStub(
+        ["sentry:verdict-upstream"],
+        new Date(
+          SWEEP_NOW.getTime() - STRANDED_OPEN_VERDICT_MIN_IDLE_MS,
+        ).toISOString(),
+      ),
+      at,
+    ),
+    "a stub idle for exactly the threshold is stranded",
+  );
+});
+
+await test("strandedShapeOf names both shapes and nothing else", () => {
+  const at = { now: SWEEP_NOW };
+  assertEqual(
+    strandedShapeOf(
+      { state: "CLOSED", labels: ["sentry-triage", NEEDS_TRIAGE_LABEL] },
+      at,
+    ),
+    STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  );
+  assertEqual(
+    strandedShapeOf(strandedOpenStub(["sentry:verdict-upstream"]), at),
+    STRAND_SHAPE_OPEN_VERDICT,
+  );
+  assertEqual(
+    strandedShapeOf(
+      { state: "OPEN", labels: ["sentry-triage", NEEDS_TRIAGE_LABEL] },
+      at,
+    ),
+    null,
+  );
+});
+
+await test("ingest recovers a stub a failed compensation left open and unqueued", async () => {
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-code-fix", PROJECTED_LABEL])],
+  });
+
+  // Invisible to Stage B: open, but without the label its selector requires.
+  assertDeepEqual(fake.selectable(), []);
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake, { now: () => SWEEP_NOW }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 1);
+  // Counted apart from the closed pairing: the two diagnose different failures.
+  assertEqual(counts.recovered, 0);
+  assertEqual(counts.errors, 0);
+  const issue = fake.get(42);
+  assertEqual(issue.state, "OPEN");
+  assertDeepEqual(issue.labels, ["sentry-triage", NEEDS_TRIAGE_LABEL]);
+  assertDeepEqual(issue.comments, [
+    buildStrandedRecoveryComment(STRAND_SHAPE_OPEN_VERDICT),
+  ]);
+  assertDeepEqual(fake.selectable(), [42]);
+  // Through the chokepoint, in its order: revalidate, restore the queue label,
+  // shed the previous round's markers, note, and VERIFY the end state. No
+  // reopen — the stub was already open, and the verifier reopens only a closed
+  // one.
+  assertDeepEqual(
+    fake.calls.map((args) => args[1]),
+    ["view", "edit", "edit", "comment", "view"],
+  );
+  assertDeepEqual(fake.calls[1], buildRequeueAddLabelArgs(42, REPO));
+  assertDeepEqual(fake.calls[2], buildRequeueShedLabelArgs(42, REPO));
+  // Fence-free, like every bookkeeping recovery: nothing in Sentry moved, so a
+  // verdict already posted for this stub stays admissible.
+  assert(
+    !issue.comments.some((body) =>
+      body.startsWith("Regressed in Sentry (last seen "),
+    ),
+    "a bookkeeping recovery must not post the staleness fence",
+  );
+});
+
+await test("the open-verdict recovery terminates: a second ingest run is a no-op", async () => {
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"])],
+  });
+  const deps = () => ingestDeps(fake, { now: () => SWEEP_NOW });
+
+  const first = await runIngest({ repo: REPO, trackerIssue: 1282 }, deps());
+  const second = await runIngest({ repo: REPO, trackerIssue: 1282 }, deps());
+
+  assertEqual(first.recoveredOpenVerdict, 1);
+  // The shed removed the verdict label, so the shape is gone and the sweep
+  // cannot cycle a stub it already fixed.
+  assertEqual(second.recoveredOpenVerdict, 0);
+  assertEqual(second.recovered, 0);
+  assertEqual(fake.get(42).comments.length, 1);
+});
+
+await test("the sweep leaves a stub still mid-flight between its verdict and its close", async () => {
+  // The shape is real here — it is what a live triage round looks like between
+  // the label swap and the close. Only idleness tells the two apart.
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"], JUST_TOUCHED)],
+  });
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake, { now: () => SWEEP_NOW }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 0);
+  assertEqual(counts.errors, 0);
+  // Not even a read: the snapshot alone settles it.
+  assertDeepEqual(fake.calls, []);
+});
+
+for (const resting of [
+  {
+    name: "a needs-human stub waiting on its human",
+    labels: [NEEDS_HUMAN_VERDICT_LABEL],
+  },
+  {
+    name: "a stub the archive workflow holds a live approval for",
+    labels: ["sentry:verdict-upstream", APPROVED_ARCHIVE_LABEL],
+  },
+  {
+    name: "a stub whose Sentry issue is already archived",
+    labels: ["sentry:verdict-upstream", ARCHIVED_LABEL],
+  },
+]) {
+  await test(`the open-verdict sweep does not touch ${resting.name}`, async () => {
+    const fake = makeFakeGitHub({ issues: [strandedOpenStub(resting.labels)] });
+
+    const counts = await runIngest(
+      { repo: REPO, trackerIssue: 1282 },
+      ingestDeps(fake, { now: () => SWEEP_NOW }),
+    );
+
+    assertEqual(counts.recoveredOpenVerdict, 0);
+    assertEqual(counts.errors, 0);
+    assertDeepEqual(fake.calls, []);
+    assertDeepEqual(fake.get(42).labels, ["sentry-triage", ...resting.labels]);
+  });
+}
+
+await test("the open-verdict sweep revalidates: a compensation that landed first wins", async () => {
+  // The snapshot is taken before the whole Sentry loop, so the compensation this
+  // arm exists to finish can complete in between. The live read must decide.
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"])],
+  });
+  const staleSnapshot = fake.snapshot();
+  fake.get(42).labels = ["sentry-triage", NEEDS_TRIAGE_LABEL];
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake, {
+      listQueueIssues: async () => staleSnapshot,
+      now: () => SWEEP_NOW,
+    }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 0);
+  assertEqual(counts.errors, 0);
+  assertDeepEqual(fake.get(42).comments, []);
+  // Read, then nothing: no write was attempted at all.
+  assertDeepEqual(
+    fake.calls.map((args) => args[1]),
+    ["view"],
+  );
+});
+
+await test("a comment posted since the snapshot withdraws the stub from the sweep", async () => {
+  // Idleness is part of the premise, so it is REVALIDATED like the rest of it.
+  // A bare comment moves no label and no state, yet it is proof something is
+  // still working on the stub.
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"])],
+  });
+  const staleSnapshot = fake.snapshot();
+  fake.get(42).updatedAt = JUST_TOUCHED;
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake, {
+      listQueueIssues: async () => staleSnapshot,
+      now: () => SWEEP_NOW,
+    }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 0);
+  assertEqual(counts.errors, 0);
+  assertDeepEqual(
+    fake.calls.map((args) => args[1]),
+    ["view"],
+  );
+});
+
+await test("an open-verdict recovery whose shed fails is loud, not silently selectable", async () => {
+  // The OPEN shape has no cover the closed one has: restoring the queue label
+  // makes the stub selectable IMMEDIATELY, so a shed that never lands would hand
+  // the next triage round a stub still wearing the previous round's markers.
+  // `verify-end-state` re-attempts the shed against observed state and then
+  // throws naming what survived — the run goes red rather than green over it.
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream", PROJECTED_LABEL])],
+    rejectOn: (args) => args.includes("--remove-label"),
+  });
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282 },
+    ingestDeps(fake, { now: () => SWEEP_NOW }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 0);
+  assertEqual(counts.errors, 1);
+  const issue = fake.get(42);
+  // Selectable again — the invariant this path owes — and the stale markers it
+  // could not shed are what the run is red about.
+  assert(issue.labels.includes(NEEDS_TRIAGE_LABEL));
+  assert(issue.labels.includes(PROJECTED_LABEL));
+  // The shed was attempted twice: once in the sequence, once against the
+  // verification read.
+  assertEqual(
+    fake.calls.filter((args) => args.includes("--remove-label")).length,
+    2,
+  );
+});
+
+await test("--dry-run reports the repair without asserting writes it never made", async () => {
+  // The end-state verification reads the stub back to prove the writes landed.
+  // Under --dry-run none of them do, so that assertion would fail a run that
+  // deliberately changed nothing. Modelled with the real runGh contract: a
+  // mutating call under dryRun resolves without touching the fake.
+  const fake = makeFakeGitHub({
+    issues: [strandedOpenStub(["sentry:verdict-upstream"])],
+  });
+  const runGh = (args, opts = {}) =>
+    opts.dryRun && opts.mutates ? Promise.resolve("") : fake.runGh(args);
+
+  const counts = await runIngest(
+    { repo: REPO, trackerIssue: 1282, dryRun: true },
+    ingestDeps(fake, {
+      now: () => SWEEP_NOW,
+      recoverStranded: (options, issue, sweep) =>
+        recoverStrandedQueueIssue(options, issue, { ...sweep, runGh }),
+    }),
+  );
+
+  assertEqual(counts.recoveredOpenVerdict, 1);
+  assertEqual(counts.errors, 0);
+  // Nothing was written, and the only real call was the revalidating read.
+  const issue = fake.get(42);
+  assertDeepEqual(issue.labels, ["sentry-triage", "sentry:verdict-upstream"]);
+  assertDeepEqual(issue.comments, []);
+  assertDeepEqual(
+    fake.calls.map((args) => args[1]),
+    ["view"],
+  );
+});
+
+await test("the run record counts the two strands apart", () => {
+  const body = buildRunRecordBody(
+    {
+      fetched: 1,
+      created: 0,
+      skippedExisting: 0,
+      reopened: 0,
+      recovered: 2,
+      recoveredOpenVerdict: 3,
+      errors: 0,
+    },
+    "2026-07-21T05:30:00.000Z",
+  );
+  assert(body.includes("Recovered (stranded needs-triage): 2"));
+  assert(body.includes("Recovered (stranded open verdict): 3"));
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry-triage-ingest.test.mjs
@@ -2645,6 +2645,66 @@ await test("a comment posted since the snapshot withdraws the stub from the swee
   );
 });
 
+// Withdrawal by removing `sentry-triage` itself. Stage B's selector wants that
+// label AND `sentry:needs-triage`, so re-queuing a stub that lost the first one
+// sheds its verdict and STILL leaves it unselectable — strictly destructive.
+// Both arms revalidate membership, and for the open shape it is the ONLY
+// withdrawal gesture available, since that shape has no `sentry:needs-triage`
+// left to remove.
+for (const withdrawn of [
+  {
+    name: "closed-and-needing-triage",
+    stub: {
+      number: 42,
+      title: buildQueueTitle("X-42", "web", "error"),
+      state: "CLOSED",
+      labels: ["sentry-triage", NEEDS_TRIAGE_LABEL],
+    },
+    survives: NEEDS_TRIAGE_LABEL,
+  },
+  {
+    name: "open-and-verdict-labeled",
+    stub: strandedOpenStub(["sentry:verdict-upstream"]),
+    survives: "sentry:verdict-upstream",
+  },
+]) {
+  await test(`a stub withdrawn from the queue is not re-enrolled (${withdrawn.name})`, async () => {
+    const fake = makeFakeGitHub({ issues: [withdrawn.stub] });
+    const staleSnapshot = fake.snapshot();
+    // The withdrawal lands after the snapshot, before the sweep reaches it.
+    fake.get(42).labels = fake
+      .get(42)
+      .labels.filter((name) => name !== "sentry-triage");
+
+    const counts = await runIngest(
+      { repo: REPO, trackerIssue: 1282 },
+      ingestDeps(fake, {
+        listQueueIssues: async () => staleSnapshot,
+        now: () => SWEEP_NOW,
+      }),
+    );
+
+    assertEqual(counts.recovered, 0);
+    assertEqual(counts.recoveredOpenVerdict, 0);
+    assertEqual(counts.errors, 0);
+    // Read, then nothing — declining costs one request and no write.
+    assertDeepEqual(
+      fake.calls.map((args) => args[1]),
+      ["view"],
+    );
+    const issue = fake.get(42);
+    assert(
+      issue.labels.includes(withdrawn.survives),
+      `the withdrawn stub must keep ${withdrawn.survives}: ${JSON.stringify(issue.labels)}`,
+    );
+    assert(
+      !issue.labels.includes("sentry-triage"),
+      "nothing may put the queue label back",
+    );
+    assertDeepEqual(issue.comments, []);
+  });
+}
+
 await test("an open-verdict recovery whose shed fails is loud, not silently selectable", async () => {
   // The OPEN shape has no cover the closed one has: restoring the queue label
   // makes the stub selectable IMMEDIATELY, so a shed that never lands would hand

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -73,6 +73,17 @@ export function truncateTitle(text, maxLen = 90) {
 // list every label inline).
 export const NEEDS_TRIAGE_LABEL = "sentry:needs-triage";
 
+// DURABLE QUEUE MEMBERSHIP. Stage B's selector requires this label AND
+// `sentry:needs-triage`, so a stub without it is invisible to triage no matter
+// what else it carries — which makes removing it the strongest withdrawal
+// gesture this namespace has, and the only one available for a stub that has no
+// `sentry:needs-triage` left to remove. Anything that re-enrolls a stub must
+// therefore check it against LIVE state first. `scripts/sentry-autofix-queue-io.mjs`
+// keeps its own `SENTRY_TRIAGE_QUEUE_LABEL` twin for its search strings, and the
+// LABEL_DEFINITIONS entry below keeps its literal because the bootstrap must
+// list every label inline.
+export const QUEUE_LABEL = "sentry-triage";
+
 // Idempotently created/updated on every run (`gh label create --force`).
 export const LABEL_DEFINITIONS = [
   {

--- a/scripts/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry-triage-queue-contract.mjs
@@ -191,6 +191,29 @@ export const VERDICT_LABELS = LABEL_DEFINITIONS.map(
   (label) => label.name,
 ).filter((name) => name.startsWith("sentry:verdict-"));
 
+// The one verdict whose stub RESTS open. `.github/workflows/sentry-triage-agent.yml`
+// closes every other bucket in its close step; `needs-human` exits that step
+// early and leaves the stub open for a human to answer. So open +
+// `sentry:verdict-needs-human` + no `sentry:needs-triage` is a resting state,
+// not a strand, and anything sweeping the open-but-unselectable shape must skip
+// it — re-queuing it would strip the question a human was asked and re-triage
+// the stub on a loop.
+export const NEEDS_HUMAN_VERDICT_LABEL = "sentry:verdict-needs-human";
+
+// The verdicts whose stub is SUPPOSED to end up closed. A stub still open on one
+// of these, with no `sentry:needs-triage`, has a round that never settled it —
+// the shape ingest's stranded sweep repairs (issue #1817).
+export const SETTLING_VERDICT_LABELS = VERDICT_LABELS.filter(
+  (name) => name !== NEEDS_HUMAN_VERDICT_LABEL,
+);
+
+// The two unselectable shapes ingest's stranded sweep repairs. The PREDICATES
+// live with the sweep (`strandedShapeOf` in scripts/sentry-triage-ingest.mjs);
+// the names live here because the re-queue chokepoint renders a note per shape
+// and must not import ingest — ingest imports it.
+export const STRAND_SHAPE_CLOSED_NEEDS_TRIAGE = "closed-needs-triage";
+export const STRAND_SHAPE_OPEN_VERDICT = "open-verdict";
+
 // Labels a re-queue must shed: the stale verdict labels, the stale
 // `sentry:projected` marker (ADR 0038), the stale autofix markers
 // (`sentry:fix-pr-opened` / `sentry:fix-refused`, ADR 0036 Phase 2b), AND the

--- a/scripts/sentry-triage-requeue.mjs
+++ b/scripts/sentry-triage-requeue.mjs
@@ -61,6 +61,8 @@ import {
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
   REOPEN_SHED_LABELS,
+  STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  STRAND_SHAPE_OPEN_VERDICT,
   truncateTitle,
 } from "./sentry-triage-queue-contract.mjs";
 import {
@@ -134,16 +136,42 @@ export function buildRegressedComment(lastSeen) {
  * keeps failing to reopen SHOULD accumulate a note per attempt, because that
  * repetition is the honest signal. So the text says what this run is doing and
  * what a failure means, and reads correctly either way.
+ *
+ * One note per stranded SHAPE. They describe different damage — a stub closed
+ * while still queued, versus one verdicted and never settled (issue #1817) — and
+ * an operator reading the stub has to be able to tell which happened. An unknown
+ * shape throws, before any I/O, for the same reason `buildRequeueNote` does: a
+ * caller that cannot name the shape has not decided anything.
  */
-export function buildStrandedRecoveryComment() {
-  return (
+const STRANDED_RECOVERY_NOTES = {
+  [STRAND_SHAPE_CLOSED_NEEDS_TRIAGE]:
     "Sentry triage ingest is recovering this queue stub: it was closed while " +
     "still carrying `sentry:needs-triage`, a pairing no pipeline stage can " +
     "see — the triage selector lists open stubs only. It is shedding the stale " +
     "verdict, projection and autofix markers, and a reopen follows this note. " +
     "If that reopen fails the stub stays closed and the next scheduled run " +
-    "retries, so this note can appear more than once."
-  );
+    "retries, so this note can appear more than once.",
+  [STRAND_SHAPE_OPEN_VERDICT]:
+    "Sentry triage ingest is recovering this queue stub: it has sat open with " +
+    "a verdict label and no `sentry:needs-triage` since a triage round applied " +
+    "that verdict and never settled it — a shape no pipeline stage can see, " +
+    "because the triage selector needs the label and every later step skips a " +
+    "stub that is not queued. It is restoring `sentry:needs-triage` and " +
+    "shedding the stale verdict, projection and autofix markers, so the next " +
+    "scheduled run re-triages it. If any of those writes does not land, the " +
+    "run goes red naming what survived, so this note can appear more than once.",
+};
+
+export function buildStrandedRecoveryComment(
+  shape = STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+) {
+  const note = STRANDED_RECOVERY_NOTES[shape];
+  if (!note) {
+    throw new Error(
+      `Unknown stranded shape ${JSON.stringify(shape)}; a recovery must name one of ${Object.keys(STRANDED_RECOVERY_NOTES).join(", ")}.`,
+    );
+  }
+  return note;
 }
 
 /**
@@ -403,10 +431,10 @@ export async function ensureSelectableForTriage(
     ? `state=${observed.state}, labels=${observed.labels.join("|")}`
     : `unreadable (${readError})`;
   process.stderr.write(
-    `::error::Queue stub #${issueNumber} could not be confirmed open and carrying ${NEEDS_TRIAGE_LABEL} after refusing to archive over a live regression (${seen}). It is STRANDED — Stage B selects only open stubs, and ingest will skip it while its closedAt postdates the regression. Reopen it by hand.\n`,
+    `::error::Queue stub #${issueNumber} could not be confirmed open and carrying ${NEEDS_TRIAGE_LABEL} while being re-queued for triage (${seen}). It is STRANDED — restore it by hand: reopen it if it is closed, add ${NEEDS_TRIAGE_LABEL}, and remove any stale marker from the previous round (${REOPEN_SHED_LABELS.join(", ")}).\n`,
   );
   throw new Error(
-    `Queue stub #${issueNumber} is not selectable for triage after a live-regression refusal (${seen}).`,
+    `Queue stub #${issueNumber} is not selectable for triage after a re-queue (${seen}).`,
   );
 }
 

--- a/scripts/sentry-triage-requeue.mjs
+++ b/scripts/sentry-triage-requeue.mjs
@@ -60,6 +60,7 @@
 import {
   NEEDS_TRIAGE_LABEL,
   neutralizeUntrusted,
+  QUEUE_LABEL,
   REOPEN_SHED_LABELS,
   STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
   STRAND_SHAPE_OPEN_VERDICT,
@@ -217,13 +218,32 @@ export function hasAdmissibleVerdict(comments) {
   return selectVerdictComment(comments ?? []).body !== null;
 }
 
-/** The pair Stage B's selector matches: `--state open` AND
- * `sentry:needs-triage`. A stub missing either is invisible to triage, and — if
- * its `closedAt` postdates the regression — to ingest as well. */
+/**
+ * Everything Stage B's selector matches, and it takes THREE things, not two:
+ * `--label sentry-triage --label sentry:needs-triage --state open`
+ * (.github/workflows/sentry-triage-agent.yml). A stub missing any of them is
+ * invisible to triage, and — if its `closedAt` postdates the regression — to
+ * ingest as well.
+ *
+ * `sentry-triage` was missing here while the docstring claimed this was the
+ * selector, which made it a predicate that could report a stub selectable when
+ * Stage B would never see it (issue #1817). It is the END-STATE test every
+ * `verify-end-state` re-queue is judged by, so the omission let a re-queue shed a
+ * stub's verdict, leave it unselectable, and still report success — the exact
+ * outcome the verification exists to catch. Every caller wanted the real
+ * selector; none wanted the pair.
+ *
+ * The verifier CORRECTS the other two — it reopens a closed stub and re-adds
+ * `sentry:needs-triage` — and deliberately does NOT correct this one. Removing
+ * `sentry-triage` is how a human retires a stub for good, so putting it back
+ * would overrule the withdrawal. Its absence is reported, never repaired.
+ */
 export function isSelectableForTriage({ state, labels } = {}) {
+  const names = Array.isArray(labels) ? labels : [];
   return (
     String(state ?? "").toUpperCase() !== "CLOSED" &&
-    (Array.isArray(labels) ? labels : []).includes(NEEDS_TRIAGE_LABEL)
+    names.includes(QUEUE_LABEL) &&
+    names.includes(NEEDS_TRIAGE_LABEL)
   );
 }
 
@@ -379,6 +399,17 @@ export async function ensureSelectableForTriage(
     const live = await observe();
     if (live && isSelectableForTriage(live)) return live;
 
+    // WITHDRAWN: stop, and write nothing more. `sentry-triage` gone from a read
+    // we actually took means a human retired this stub while the re-queue was
+    // in flight. Neither correction below can make it selectable again — only
+    // re-adding the label would, and doing that would overrule the withdrawal —
+    // so continuing would just be more writes on an issue somebody removed from
+    // the queue. Fall through to the failure below, which says what was seen.
+    // A FAILED read is different and keeps the old behaviour: `live` is null, we
+    // know nothing about membership, and correcting from `fallbackState` is
+    // still the right guess.
+    if (live && !(live.labels ?? []).includes(QUEUE_LABEL)) break;
+
     // Correct whatever is — or, with no read, may be — wrong. Both writes are
     // idempotent, so a repeat costs nothing and a lost response is harmless.
     const looksClosed = live
@@ -430,6 +461,23 @@ export async function ensureSelectableForTriage(
   const seen = observed
     ? `state=${observed.state}, labels=${observed.labels.join("|")}`
     : `unreadable (${readError})`;
+
+  // Membership gone is a DIFFERENT operator story from the rest, and telling
+  // them apart is the whole value of the message: nothing here is broken, a
+  // human retired the stub mid-re-queue and this run had already shed its
+  // previous-round markers by then. Say that, and do not ask anyone to undo the
+  // withdrawal by re-adding the label.
+  const withdrawn =
+    observed !== null && !(observed.labels ?? []).includes(QUEUE_LABEL);
+  if (withdrawn) {
+    process.stderr.write(
+      `::error::Queue stub #${issueNumber} lost ${QUEUE_LABEL} while it was being re-queued for triage (${seen}), so it is no longer in the queue and Stage B will never select it. This run had already shed its previous-round markers (${REOPEN_SHED_LABELS.join(", ")}). Nothing is re-adding ${QUEUE_LABEL} — removing it is how a stub is retired. If the removal was a mistake, re-add ${QUEUE_LABEL} and ${NEEDS_TRIAGE_LABEL} by hand.\n`,
+    );
+    throw new Error(
+      `Queue stub #${issueNumber} left the queue (${QUEUE_LABEL} removed) during a re-queue for triage (${seen}).`,
+    );
+  }
+
   process.stderr.write(
     `::error::Queue stub #${issueNumber} could not be confirmed open and carrying ${NEEDS_TRIAGE_LABEL} while being re-queued for triage (${seen}). It is STRANDED — restore it by hand: reopen it if it is closed, add ${NEEDS_TRIAGE_LABEL}, and remove any stale marker from the previous round (${REOPEN_SHED_LABELS.join(", ")}).\n`,
   );

--- a/scripts/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry-triage-requeue.test.mjs
@@ -22,7 +22,11 @@ import {
   REGRESSION_PREFIX,
   VERDICT_MARKER,
 } from "./sentry-triage-project-core.mjs";
-import { NEEDS_TRIAGE_LABEL } from "./sentry-triage-queue-contract.mjs";
+import {
+  NEEDS_TRIAGE_LABEL,
+  STRAND_SHAPE_CLOSED_NEEDS_TRIAGE,
+  STRAND_SHAPE_OPEN_VERDICT,
+} from "./sentry-triage-queue-contract.mjs";
 import {
   buildRegressedComment,
   buildRequeueAddLabelArgs,
@@ -1186,9 +1190,11 @@ await test("every note this chokepoint posts reads as intent, never as a complet
   // a write which did not land is a wrong attestation, so the wording has to be
   // true under every outcome — including the one where every write failed.
   //
-  // The stranded-recovery note is the same shape from ingest's side (its reopen
-  // follows the note), so both are pinned here rather than only the one that
-  // was flagged.
+  // The stranded-recovery notes are the same shape from ingest's side (its
+  // reopen follows the note), so all of them are pinned here rather than only
+  // the one that was flagged. There is one per stranded SHAPE (#1817), and the
+  // open-verdict note is posted while the label writes it describes can still
+  // fail, exactly like the closed one.
   const completedClaims = [
     "have been shed",
     "has been shed",
@@ -1199,7 +1205,15 @@ await test("every note this chokepoint posts reads as intent, never as a complet
   ];
   const notes = [
     ...REQUEUE_REASONS.map((reason) => [reason, buildRequeueNote(reason)]),
-    ["stranded-recovery", buildStrandedRecoveryComment()],
+    ...[STRAND_SHAPE_CLOSED_NEEDS_TRIAGE, STRAND_SHAPE_OPEN_VERDICT].map(
+      (shape) => [
+        `stranded-recovery/${shape}`,
+        buildStrandedRecoveryComment(shape),
+      ],
+    ),
+    // The default argument is the closed pairing, and a caller that names no
+    // shape must still get a real note rather than a throw.
+    ["stranded-recovery/default", buildStrandedRecoveryComment()],
   ];
   for (const [label, note] of notes) {
     for (const claim of completedClaims) {

--- a/scripts/sentry-triage-workflow-requeue.mjs
+++ b/scripts/sentry-triage-workflow-requeue.mjs
@@ -4,10 +4,16 @@
 // Every step in that workflow between the verdict label swap and the ledger
 // close runs on a stub whose `sentry:needs-triage` has already been removed. So
 // every FAILING exit in that window owes the same thing: put the stub back in
-// the queue. Nothing downstream would — the scheduled selector admits only
-// open + `sentry:needs-triage`, the project job skips a stub that is not
-// needs-triage, and ingest's regression gate only reopens CLOSED stubs — so a
-// bare exit strands an open, verdict-labeled stub with no retry path at all.
+// the queue. Nothing downstream would do it promptly — the scheduled selector
+// admits only open + `sentry:needs-triage`, the project job skips a stub that is
+// not needs-triage, and ingest's regression gate only reopens CLOSED stubs — so
+// a bare exit strands an open, verdict-labeled stub.
+//
+// Ingest's stranded sweep is the BACKSTOP for that shape, not a substitute for
+// this CLI (issue #1817): it repairs the stub only after a full day of idleness,
+// because the same shape is what a live triage round looks like between its
+// verdict label and its close. Compensating here is what keeps the stub out of
+// that window in the first place, in seconds rather than a day.
 //
 // Those exits used to open-code the label swap, one copy each (#1769 round 16
 // converted the first of them, and #1782 the rest). Open-coding is how the


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- When a triage round applies a verdict label and then fails before closing the
  stub, it compensates by putting the stub back in the queue — but that
  compensation reads GitHub first, and a read outage outlasting its retry makes
  it throw before writing anything.
- The stub is left OPEN, verdict-labeled and without `sentry:needs-triage`, and
  no sweeper selects that shape: the triage selector wants open **and**
  needs-triage, ingest's stranded sweep wants closed **and** needs-triage. The
  run is red, but the stub waits for a human to notice.
- The archive leg leaves the same shape twice over — its freshness refusal and
  its post-approval rollback — and
  `docs/notes/sentry-triage-pipeline.md` says so outright: "a stranded state,
  not a self-healing one".

## The Solution

- Ingest's queue sweep now repairs **two** shapes instead of one. The new arm
  recognises a stub that is open, carries a verdict that was supposed to settle
  it, and has lost `sentry:needs-triage` — and restores selectability through
  the same re-queue chokepoint the compensation itself uses, so it inherits that
  chokepoint's ordering, shed set and terminal guard rather than open-coding a
  label swap.
- That shape is also what a **live** triage round looks like between its verdict
  label and its close, so the sweep only claims a stub that has been idle for a
  full day, and skips the states that rest open or belong to another leg.

## Details

**The predicate** (`isStrandedOpenVerdict`, `scripts/sentry-triage-ingest.mjs`)
requires: not CLOSED, no `sentry:needs-triage`, at least one *settling*
`sentry:verdict-*`, and `updated_at` idle by at least 24 hours. No parseable
`updated_at` means no observation of idleness, so it fails closed and skips.
Three states are excluded outright:

- `sentry:verdict-needs-human` — the verdict job's close step exits early on that
  bucket and leaves the stub open for a human to answer. Re-queuing it would
  delete the question the human was asked and put the stub on a re-triage loop.
  Guarded twice on purpose (`SETTLING_VERDICT_LABELS` excludes it, and the
  predicate skips any stub wearing it): the exclusion alone admits a
  double-verdicted stub, the skip alone admits a future verdict that also rests
  open. Both mutations are proven below.
- `sentry:approved-archive` — a live human approval `sentry-triage-archive.yml`
  is acting on in its own concurrency group, and one of `REOPEN_SHED_LABELS`.
- `sentry:archived` — the archive leg's terminal marker, the same signal
  `isTerminalStub` reads. A terminal stub is never resurrected.

**Why a day, and not a small multiple of the job timeouts.** A stub's clock
starts when *its* verdict label lands, so the window to clear is only what can
still happen to it afterwards: at `max-parallel: 2` over a batch capped at 10,
at most four further waves of a 10-minute `verdict` job plus the `project` job's
15 minutes — roughly 55 minutes *declared*. The undeclared part is runner
queueing, which no timeout bounds, and that is what the threshold has to answer.
A live run reaching 24 hours needs a 15-minute job queued for a day, and the
triage workflow holds `concurrency: sentry-triage-agent` with
`cancel-in-progress: false`, so a run stuck that long has already blocked the
next scheduled run and become something someone is looking at. The cost is
latency on a stub whose run already went red: a strand from the weekday 07:55
run is repaired within ~30 hours, with no human. The workflow's own compensation
stays the fast path, in seconds.

The sweep does not rest on the threshold alone — both racing directions degrade
into states something already repairs. A re-queue that raced the `project` job
leaves a stub that job's `--batch` mode skips
(`scripts/sentry-triage-project.mjs:791`); one that raced the close leaves the
closed-plus-needs-triage pairing the existing arm repairs.

**Failure policy.** The closed arm keeps `abort`: its state change goes last, so
every interruption leaves the stub closed and invisible to Stage B until the next
run retries. An open stub has no such cover — restoring `sentry:needs-triage`
makes it selectable at once — so the open arm uses `verify-end-state`, the policy
the workflow compensation CLI already uses on the same kind of stub: it
re-attempts the shed against observed state and throws naming whatever survived.
Under `--dry-run` that verification would assert writes the run deliberately did
not make, so the dry run falls back to `abort` and claims nothing.

**Revalidation** re-reads the stub and requires the *same* shape to still hold,
idleness included — a comment posted since the queue snapshot moves no label and
no state, yet it proves something is still working on the stub. A failed read
propagates, as everywhere else in this family.

**Two behaviour changes worth naming.** The archive leg's freshness refusal ends
in this exact shape and is now recovered, for the refusal's own reason: it fires
because a Sentry event landed during the archive, so the verdict on that stub
predates a live occurrence and no stage would otherwise re-triage it (ingest
skips an open match). The refusal asks for "a fresh approval rather than a full
re-triage"; a day later the sweep gives the approver something fresher to
approve, and the pre-event verdict cannot settle that round because the round
binding (#1717) refuses a verdict comment that is not strictly newer than the one
`select` recorded. The archive's post-CAS rollback is the second: its OPEN
variant is recovered, its CLOSED variant still waits for a human, because nothing
distinguishes that one from an ordinary settled ledger entry. Both passages in
`docs/notes/sentry-triage-pipeline.md` are updated.

The shared end-state verifier's error text no longer says "after refusing to
archive over a live regression" — it has three callers now, so it names what to
restore instead of which refusal produced the stub.

The run record counts the two strands apart: a repeated open-verdict recovery
says the triage workflow's compensations are failing, which the closed-pairing
line would not.

## Validation

- `node scripts/sentry-suite-gate.mjs` — green; ingest floor re-measured
  110 → 128 (`pass=128 floor=128 lines=128`), every other suite unchanged.
- `node scripts/check-sentry-suites-in-ci.test.mjs` — 43 pass, 0 fail.
- Mutation proofs (mutation applied, suite run, mutation reverted):
  - disable the new arm in `strandedShapeOf` → **7 red**, including
    `ingest recovers a stub a failed compensation left open and unqueued` and
    the termination, revalidation, idleness-revalidation, shed-failure and
    dry-run cases;
  - disable the `needs-human` skip alone → **1 red** (the double-verdict case);
  - widen `SETTLING_VERDICT_LABELS` alone → green, which is what proves the two
    guards overlap rather than duplicate;
  - disable **both** → **2 red**, including
    `the open-verdict sweep does not touch a needs-human stub waiting on its human`.
- The shape tests that red an open-coded label swap stay green:
  `sentry-triage-requeue.test.mjs` (40) and `sentry-triage-brief.test.mjs` (58).
  This change adds no re-queue site — it names a shape and lets the chokepoint
  act.
- `gh issue view --json updatedAt` and the REST `updated_at` field both verified
  live against this repo before relying on either.
- `pnpm agent:quality-gate --run`, `./tools/trunk fmt --all`, and
  `pnpm agent:autoreview --engine codex` all clean; an extra adversarial codex
  pass over the false-positive, idleness, loop, failure-policy and authority
  surfaces drove the threshold from 3h to 24h and the caller-neutral verifier
  text.

## Adjudicated residuals (won't-fix)

Nothing here is owed future work — each is a property of the existing re-queue
chokepoint that this change inherits by routing through it rather than
open-coding around it, and each is documented in the code where a reader meets
it. They are recorded so a later reviewer sees the adjudication instead of
re-deriving it.

- **Approval TOCTOU.** A `sentry:approved-archive` applied between the
  revalidating read and the shed is shed. This is the same window
  `runWorkflowRequeue`'s terminal guard documents and declines to close: closing
  it needs a shared concurrency group across ingest and archive, which this
  pipeline rejected on its own terms (GitHub keeps one pending run per group and
  would silently drop a second human-approved archive). The archive run that the
  label event started then refuses on its own guard — loud, and the human
  re-applies the label.
- **A process kill between the label add and the shed** leaves the stub
  selectable while wearing the previous round's markers. The same exposure the
  workflow compensation CLI already carries on the same kind of stub; the next
  triage round replaces the verdict label and re-applies projection
  idempotently. Reversing the two writes would be worse — a kill after the shed
  leaves a stub with no verdict and no queue label, which nothing can see.
- **`updated_at` moves on any comment**, and this repo is public, so a determined
  commenter can hold a genuine strand below the threshold. That delays a repair
  that previously never happened; it can never cause one to happen wrongly. The
  same property is what lets an operator hold a strand while working on it — by
  WRITING to it (a comment, a label), since GitHub does not move `updated_at` on
  reads and opening a stub to inspect it buys no time.

## Deferrals

- None

Closes #1817
