### PR TITLE
fix(tooling): resolve the codex CLI beyond the caller's PATH

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -311,6 +311,12 @@ will execute. An engine that resolves to nothing fails with the override
 variable and the probed paths instead of a bare command-not-found exit. Set
 `AUTOREVIEW_TRACE_COMMANDS=1` to log which candidate won.
 
+A resolved codex that exits 127 is treated as unresolved rather than as a failed
+review. Launcher shims re-resolve the real CLI from `PATH`, and the reviewer
+hands its engine a sanitized environment on purpose, so such a shim can never
+work; the search drops it and continues to the next candidate. When every
+candidate behaves that way, one message names them all.
+
 Set `AUTOREVIEW_HELPER` only when intentionally testing or replacing the
 pinned repo helper with a compatible implementation of its CLI contract.
 Prepared-bundle replacements receive only the final prompt handoff and must

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -311,11 +311,13 @@ will execute. An engine that resolves to nothing fails with the override
 variable and the probed paths instead of a bare command-not-found exit. Set
 `AUTOREVIEW_TRACE_COMMANDS=1` to log which candidate won.
 
-A resolved codex that exits 127 is treated as unresolved rather than as a failed
-review. Launcher shims re-resolve the real CLI from `PATH`, and the reviewer
-hands its engine a sanitized environment on purpose, so such a shim can never
-work; the search drops it and continues to the next candidate. When every
-candidate behaves that way, one message names them all.
+A resolved codex that exits 127 **and** cannot report `--version` in the same
+isolated environment is a launcher shim, not a working engine: shims re-resolve
+the real CLI from a `PATH` the reviewer deliberately withholds, so the search
+drops that candidate and continues. An engine that answers `--version` keeps its
+own exit 127 as a review failure, and the search never silently swaps in a
+different installation behind it. When every candidate is a shim, one message
+names them and carries the engine's error.
 
 Set `AUTOREVIEW_HELPER` only when intentionally testing or replacing the
 pinned repo helper with a compatible implementation of its CLI contract.

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -316,8 +316,12 @@ isolated environment is a launcher shim, not a working engine: shims re-resolve
 the real CLI from a `PATH` the reviewer deliberately withholds, so the search
 drops that candidate and continues. An engine that answers `--version` keeps its
 own exit 127 as a review failure, and the search never silently swaps in a
-different installation behind it. When every candidate is a shim, one message
-names them and carries the engine's error.
+different installation behind it. The probe spawns through the same
+snapshot-revalidating path as every other trusted executable, captures no pipes
+a descendant could hold open, and is bounded at 15 seconds by a `SIGKILL` sweep
+of its own process group. A probe that times out counts as failed, and the
+message says so. When every candidate is a shim, one message names each with the
+reason its probe failed and carries the engine's error.
 
 Set `AUTOREVIEW_HELPER` only when intentionally testing or replacing the
 pinned repo helper with a compatible implementation of its CLI contract.

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -298,6 +298,19 @@ the adapter defaults to the helper's local deterministic engine because nested
 `codex exec` is unavailable there. An explicit engine selection through
 `--engine codex`, `--engine claude`, or `AUTOREVIEW_ENGINE` takes precedence
 and fails closed if that engine is unavailable; it never silently falls back.
+
+The helper resolves each external CLI in one order: an absolute path in
+`AUTOREVIEW_<COMMAND>_BIN` (`AUTOREVIEW_CODEX_BIN`, `AUTOREVIEW_CLAUDE_BIN`),
+then `PATH`, then the well-known install directories `/opt/homebrew/bin`,
+`/usr/local/bin`, and `~/.local/bin`. That last list keeps the reviewer working
+from agent-isolation and CI shells whose `PATH` omits the local package
+manager's bin directory; set `AUTOREVIEW_EXTRA_BIN_DIRS` to replace it, or to an
+empty value to search `PATH` alone. Every candidate still passes the same
+trusted-executable checks, so the wider search never widens what the reviewer
+will execute. An engine that resolves to nothing fails with the override
+variable and the probed paths instead of a bare command-not-found exit. Set
+`AUTOREVIEW_TRACE_COMMANDS=1` to log which candidate won.
+
 Set `AUTOREVIEW_HELPER` only when intentionally testing or replacing the
 pinned repo helper with a compatible implementation of its CLI contract.
 Prepared-bundle replacements receive only the final prompt handoff and must

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -79,7 +79,10 @@ interpreter startup-injection variables, so ambient hooks cannot run before the
 pinned helper. An explicit helper from a separate checkout remains an explicit
 trust decision. The adapter also requires the physical checkout root to match
 Git's top level, removes reviewed-repo directories from its executable search
-path, and runs bare shell utilities from the system path. Direct Git, Node,
+path, and runs bare shell utilities from the system path. The helper searches
+`AUTOREVIEW_<COMMAND>_BIN`, then that path, then well-known install directories
+so a thin caller `PATH` cannot hide an installed engine; those extra directories
+are search order only and grant no trust of their own. Direct Git, Node,
 GitHub CLI, and semantic-engine executables and every canonical ancestor must be
 owned by the current user or root and must not be group/other-writable. Node
 discovery never executes a version-manager shim: Volta is queried through a

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -1203,37 +1203,54 @@ function traceCommandResolution(command, candidate, resolved, source) {
   );
 }
 
-function unavailableCommandMessage(command) {
+function unavailableCommandMessage(command, launcherFailures = []) {
   const { candidates, overrideVariable, overrideValue } =
     trustedCommandCandidates(command);
   const probed = candidates.map(({ candidate }) => candidate).join(", ");
   const variable = commandOverrideVariable(command);
+  const skipped = launcherFailures.length
+    ? ` Skipped after exit 127, unable to find their own target: ${launcherFailures.join(", ")}.`
+    : "";
   if (overrideVariable) {
-    return `${command} CLI is not available: ${variable} does not point at a trusted absolute executable. Probed: ${probed || overrideValue}`;
+    return `${command} CLI is not available: ${variable} does not point at a trusted absolute executable. Probed: ${probed || overrideValue}.${skipped}`;
   }
-  return `${command} CLI is not available outside the reviewed repo. Install it, or set ${variable} to its absolute path. Probed: ${probed || "<no absolute search directories>"}`;
+  return `${command} CLI is not available outside the reviewed repo. Install it, or set ${variable} to its absolute path. Probed: ${probed || "<no absolute search directories>"}.${skipped}`;
 }
 
-function resolveTrustedCommand(command, rejectRoot, { required = true } = {}) {
+// Yields every trusted executable the search order offers, best first, so a
+// caller can move past one that resolves but cannot run.
+function* trustedCommandResolutions(command, rejectRoot) {
   const { candidates } = trustedCommandCandidates(command);
   const root = realpathSync(rejectRoot);
   for (const { candidate, source } of candidates) {
     if (rejectedTrustedExecutableCandidates.has(candidate)) continue;
+    let resolved;
     try {
       accessSync(candidate, fsConstants.X_OK);
-      const resolved = trustedExecutableCandidate(
+      resolved = trustedExecutableCandidate(
         candidate,
         root,
         path.basename(command) || "executable",
         { allowSnapshot: path.basename(command) !== "git" },
       );
-      traceCommandResolution(command, candidate, resolved, source);
-      return resolved;
     } catch {
       rejectedTrustedExecutableCandidates.add(candidate);
       // Keep searching a bounded, absolute search list for an external
       // executable.
+      continue;
     }
+    traceCommandResolution(command, candidate, resolved, source);
+    yield { candidate, executable: resolved };
+  }
+}
+
+function rejectResolvedCommandCandidate(candidate) {
+  rejectedTrustedExecutableCandidates.add(candidate);
+}
+
+function resolveTrustedCommand(command, rejectRoot, { required = true } = {}) {
+  for (const { executable } of trustedCommandResolutions(command, rejectRoot)) {
+    return executable;
   }
   if (required) {
     throw new Error(unavailableCommandMessage(command));
@@ -3181,11 +3198,11 @@ function runCommandWithInput(
         return;
       }
       if (code !== 0) {
-        rejectOnce(
-          new Error(
-            `${command} failed (${code ?? signal}): ${stderr || stdout}`,
-          ),
+        const failure = new Error(
+          `${command} failed (${code ?? signal}): ${stderr || stdout}`,
         );
+        failure.exitCode = code ?? null;
+        rejectOnce(failure);
         return;
       }
       if (stdinWriteError) {
@@ -3214,15 +3231,32 @@ function tomlInlineTable(values) {
 }
 
 async function runCodex(repo, args, prompt) {
-  const codex = resolveTrustedCommand("codex", repo, { required: false });
-  if (!codex) {
-    throw new Error(unavailableCommandMessage("codex"));
-  }
   if (!args.tools) {
     throw new Error(
       "--no-tools is not supported for Codex; use read-only sandbox",
     );
   }
+  const launcherFailures = [];
+  for (const { candidate, executable } of trustedCommandResolutions(
+    "codex",
+    repo,
+  )) {
+    try {
+      return await runCodexExecutable(executable, repo, args, prompt);
+    } catch (error) {
+      if (error?.exitCode !== 127) throw error;
+      // Exit 127 means this codex could not find its own target. That is a
+      // launcher shim relying on a caller PATH the reviewer deliberately does
+      // not hand to the engine, so it is an unresolved engine, not a review
+      // failure: drop it and keep searching.
+      rejectResolvedCommandCandidate(candidate);
+      launcherFailures.push(candidate);
+    }
+  }
+  throw new Error(unavailableCommandMessage("codex", launcherFailures));
+}
+
+async function runCodexExecutable(codex, repo, args, prompt) {
   const tempRoot = safeTempRoot(repo);
   const tempDir = createRegisteredEngineRuntimeDirectory(
     tempRoot,

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -113,6 +113,7 @@ const FROZEN_TARGET_MODES = new Set([
 const MAX_GIT_OUTPUT_BYTES = MAX_REVIEW_INPUT_BYTES + 12 * 1024 * 1024;
 const MAX_TRUSTED_ENGINE_FILE_BYTES = 16 * 1024 * 1024;
 const CLAUDE_SAFE_MODE_MIN_VERSION = [2, 1, 169];
+const ENGINE_VERSION_PROBE_TIMEOUT_MS = 15_000;
 const AWS_CREDENTIAL_CONFIG_KEYS = new Set([
   "AWS_CONFIG_FILE",
   "AWS_SHARED_CREDENTIALS_FILE",
@@ -1203,18 +1204,15 @@ function traceCommandResolution(command, candidate, resolved, source) {
   );
 }
 
-function unavailableCommandMessage(command, launcherFailures = []) {
+function unavailableCommandMessage(command) {
   const { candidates, overrideVariable, overrideValue } =
     trustedCommandCandidates(command);
   const probed = candidates.map(({ candidate }) => candidate).join(", ");
   const variable = commandOverrideVariable(command);
-  const skipped = launcherFailures.length
-    ? ` Skipped after exit 127, unable to find their own target: ${launcherFailures.join(", ")}.`
-    : "";
   if (overrideVariable) {
-    return `${command} CLI is not available: ${variable} does not point at a trusted absolute executable. Probed: ${probed || overrideValue}.${skipped}`;
+    return `${command} CLI is not available: ${variable} does not point at a trusted absolute executable. Probed: ${probed || overrideValue}`;
   }
-  return `${command} CLI is not available outside the reviewed repo. Install it, or set ${variable} to its absolute path. Probed: ${probed || "<no absolute search directories>"}.${skipped}`;
+  return `${command} CLI is not available outside the reviewed repo. Install it, or set ${variable} to its absolute path. Probed: ${probed || "<no absolute search directories>"}`;
 }
 
 // Yields every trusted executable the search order offers, best first, so a
@@ -3230,13 +3228,38 @@ function tomlInlineTable(values) {
     .join(", ")}}`;
 }
 
+// A launcher shim exits 127 because it re-resolves the real CLI from a PATH the
+// reviewer deliberately does not hand to its engine. A working engine can also
+// exit 127 for its own reasons, so confirm the executable cannot even report its
+// version in that same environment before calling it unusable.
+function engineExecutableRuns(executable, cwd, env) {
+  try {
+    const probe = spawnSync(executable, ["--version"], {
+      cwd,
+      encoding: "utf8",
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: ENGINE_VERSION_PROBE_TIMEOUT_MS,
+    });
+    return !probe.error && probe.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function unusableEngineLauncherMessage(command, launchers, engineError) {
+  const variable = commandOverrideVariable(command);
+  return `${command} CLI cannot run in the reviewer's isolated environment: ${launchers.join(", ")} exited 127 and could not report a version, which is how a launcher shim behaves. Point ${variable} at the real ${command} executable. Engine error: ${engineError}`;
+}
+
 async function runCodex(repo, args, prompt) {
   if (!args.tools) {
     throw new Error(
       "--no-tools is not supported for Codex; use read-only sandbox",
     );
   }
-  const launcherFailures = [];
+  const unusableLaunchers = [];
+  let firstLauncherError = null;
   for (const { candidate, executable } of trustedCommandResolutions(
     "codex",
     repo,
@@ -3244,16 +3267,24 @@ async function runCodex(repo, args, prompt) {
     try {
       return await runCodexExecutable(executable, repo, args, prompt);
     } catch (error) {
-      if (error?.exitCode !== 127) throw error;
-      // Exit 127 means this codex could not find its own target. That is a
-      // launcher shim relying on a caller PATH the reviewer deliberately does
-      // not hand to the engine, so it is an unresolved engine, not a review
-      // failure: drop it and keep searching.
+      // Every other failure, including a genuine engine exit 127, still fails
+      // the review with the engine's own error.
+      if (!error?.launcherUnusable) throw error;
       rejectResolvedCommandCandidate(candidate);
-      launcherFailures.push(candidate);
+      unusableLaunchers.push(candidate);
+      firstLauncherError ??= error;
     }
   }
-  throw new Error(unavailableCommandMessage("codex", launcherFailures));
+  if (unusableLaunchers.length > 0) {
+    throw new Error(
+      unusableEngineLauncherMessage(
+        "codex",
+        unusableLaunchers,
+        firstLauncherError.message,
+      ),
+    );
+  }
+  throw new Error(unavailableCommandMessage("codex"));
 }
 
 async function runCodexExecutable(codex, repo, args, prompt) {
@@ -3336,18 +3367,24 @@ async function runCodexExecutable(codex, repo, args, prompt) {
       codexArgs.push("-c", `model_reasoning_effort="${args.thinking}"`);
     }
     codexArgs.push("-");
-    const result = await runCommandWithInput(
-      codex,
-      codexArgs,
-      workspace,
-      prompt,
-      {
-        env: safeEngineEnv(repo, "codex", tempDir),
+    const engineEnv = safeEngineEnv(repo, "codex", tempDir);
+    let result;
+    try {
+      result = await runCommandWithInput(codex, codexArgs, workspace, prompt, {
+        env: engineEnv,
         label: "codex",
         stream: args.streamEngineOutput,
         timeoutSeconds: args.timeoutSeconds,
-      },
-    );
+      });
+    } catch (error) {
+      if (
+        error?.exitCode === 127 &&
+        !engineExecutableRuns(codex, workspace, engineEnv)
+      ) {
+        error.launcherUnusable = true;
+      }
+      throw error;
+    }
     return existsSync(outputPath)
       ? readFileSync(outputPath, "utf8")
       : result.stdout;

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -3231,25 +3231,44 @@ function tomlInlineTable(values) {
 // A launcher shim exits 127 because it re-resolves the real CLI from a PATH the
 // reviewer deliberately does not hand to its engine. A working engine can also
 // exit 127 for its own reasons, so confirm the executable cannot even report its
-// version in that same environment before calling it unusable.
-function engineExecutableRuns(executable, cwd, env) {
+// version in that same environment before calling it unusable. Returns null when
+// the probe succeeds, otherwise the reason it failed.
+function engineVersionProbeFailure(executable, cwd, env) {
+  const seconds = ENGINE_VERSION_PROBE_TIMEOUT_MS / 1000;
+  let probe;
   try {
-    const probe = spawnSync(executable, ["--version"], {
+    probe = spawnTrustedSync(executable, ["--version"], {
       cwd,
-      encoding: "utf8",
       env,
-      stdio: ["ignore", "pipe", "pipe"],
+      // No pipes: spawnSync waits for the captured stdio to close, so a
+      // descendant still holding one would outlast the timeout and wedge the
+      // review. Only the exit status matters here.
+      stdio: ["ignore", "ignore", "ignore"],
       timeout: ENGINE_VERSION_PROBE_TIMEOUT_MS,
+      // SIGKILL cannot be caught or ignored, and detached: true makes the
+      // child its own group leader so the sweep below reaches its descendants.
+      killSignal: "SIGKILL",
+      detached: true,
     });
-    return !probe.error && probe.status === 0;
-  } catch {
-    return false;
+  } catch (error) {
+    return `its --version probe could not start: ${error.message}`;
   }
+  if (probe.error?.code === "ETIMEDOUT" || probe.signal === "SIGKILL") {
+    killProcessGroup(probe.pid);
+    return `its --version probe timed out after ${seconds}s`;
+  }
+  if (probe.error) {
+    return `its --version probe failed: ${probe.error.message}`;
+  }
+  if (probe.status !== 0) {
+    return `its --version probe exited ${probe.status}`;
+  }
+  return null;
 }
 
 function unusableEngineLauncherMessage(command, launchers, engineError) {
   const variable = commandOverrideVariable(command);
-  return `${command} CLI cannot run in the reviewer's isolated environment: ${launchers.join(", ")} exited 127 and could not report a version, which is how a launcher shim behaves. Point ${variable} at the real ${command} executable. Engine error: ${engineError}`;
+  return `${command} CLI cannot run in the reviewer's isolated environment: ${launchers.join("; ")}, which is how a launcher shim behaves. Point ${variable} at the real ${command} executable. Engine error: ${engineError}`;
 }
 
 async function runCodex(repo, args, prompt) {
@@ -3271,7 +3290,9 @@ async function runCodex(repo, args, prompt) {
       // the review with the engine's own error.
       if (!error?.launcherUnusable) throw error;
       rejectResolvedCommandCandidate(candidate);
-      unusableLaunchers.push(candidate);
+      unusableLaunchers.push(
+        `${candidate} exited 127 and ${error.launcherProbeFailure}`,
+      );
       firstLauncherError ??= error;
     }
   }
@@ -3377,11 +3398,16 @@ async function runCodexExecutable(codex, repo, args, prompt) {
         timeoutSeconds: args.timeoutSeconds,
       });
     } catch (error) {
-      if (
-        error?.exitCode === 127 &&
-        !engineExecutableRuns(codex, workspace, engineEnv)
-      ) {
-        error.launcherUnusable = true;
+      if (error?.exitCode === 127) {
+        const probeFailure = engineVersionProbeFailure(
+          codex,
+          workspace,
+          engineEnv,
+        );
+        if (probeFailure) {
+          error.launcherUnusable = true;
+          error.launcherProbeFailure = probeFailure;
+        }
       }
       throw error;
     }

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -1126,33 +1126,117 @@ function trustedExecutableCandidate(
   }
 }
 
+function commandOverrideVariable(command) {
+  const name = path
+    .basename(command)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_");
+  return `AUTOREVIEW_${name}_BIN`;
+}
+
+// Agent-isolation and CI shells routinely inherit a PATH without the local
+// package manager's bin directory, which used to make an installed reviewer CLI
+// look missing. Probing these after PATH keeps the reviewer usable from any
+// shell; every candidate still passes the same trusted-executable checks, so a
+// wider search never widens what the reviewer is willing to execute.
+function wellKnownCommandDirectories() {
+  const configured = process.env.AUTOREVIEW_EXTRA_BIN_DIRS;
+  const entries =
+    configured === undefined
+      ? ["/opt/homebrew/bin", "/usr/local/bin", homeBinDirectory()]
+      : configured.split(path.delimiter);
+  return entries.filter((entry) => entry && path.isAbsolute(entry));
+}
+
+function homeBinDirectory() {
+  const home = process.env.HOME;
+  return home && path.isAbsolute(home) ? path.join(home, ".local", "bin") : "";
+}
+
+function trustedCommandCandidates(command) {
+  if (path.isAbsolute(command)) {
+    return { candidates: [{ candidate: command, source: "absolute path" }] };
+  }
+  const overrideVariable = commandOverrideVariable(command);
+  const override = process.env[overrideVariable];
+  if (override) {
+    // An explicit override is authoritative: a typo must surface as its own
+    // error rather than silently reviving whatever the caller's PATH offers.
+    return {
+      candidates: path.isAbsolute(override)
+        ? [{ candidate: override, source: overrideVariable }]
+        : [],
+      overrideVariable,
+      overrideValue: override,
+    };
+  }
+  const seen = new Set();
+  const candidates = [];
+  const searchDirectories = [
+    ...(process.env.PATH || "").split(path.delimiter).map((entry) => ({
+      directory: entry,
+      source: "PATH",
+    })),
+    ...wellKnownCommandDirectories().map((directory) => ({
+      directory,
+      source: "well-known install location",
+    })),
+  ];
+  for (const { directory, source } of searchDirectories) {
+    if (!directory || !path.isAbsolute(directory)) continue;
+    const candidate = path.join(directory, command);
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    candidates.push({ candidate, source });
+  }
+  return { candidates };
+}
+
+function traceCommandResolution(command, candidate, resolved, source) {
+  if (!process.env.AUTOREVIEW_TRACE_COMMANDS) return;
+  // Report the probed location, not just the launch target: an executable with
+  // Homebrew-style ancestry launches from a sealed snapshot, and only the
+  // probed path tells an operator which search step won.
+  const launch = resolved === candidate ? "" : ` -> ${resolved}`;
+  console.error(
+    `agent:autoreview: resolved ${command} via ${source}: ${candidate}${launch}`,
+  );
+}
+
+function unavailableCommandMessage(command) {
+  const { candidates, overrideVariable, overrideValue } =
+    trustedCommandCandidates(command);
+  const probed = candidates.map(({ candidate }) => candidate).join(", ");
+  const variable = commandOverrideVariable(command);
+  if (overrideVariable) {
+    return `${command} CLI is not available: ${variable} does not point at a trusted absolute executable. Probed: ${probed || overrideValue}`;
+  }
+  return `${command} CLI is not available outside the reviewed repo. Install it, or set ${variable} to its absolute path. Probed: ${probed || "<no absolute search directories>"}`;
+}
+
 function resolveTrustedCommand(command, rejectRoot, { required = true } = {}) {
-  const candidates = path.isAbsolute(command)
-    ? [command]
-    : (process.env.PATH || "")
-        .split(path.delimiter)
-        .filter((entry) => entry && path.isAbsolute(entry))
-        .map((entry) => path.join(entry, command));
+  const { candidates } = trustedCommandCandidates(command);
   const root = realpathSync(rejectRoot);
-  for (const candidate of candidates) {
+  for (const { candidate, source } of candidates) {
     if (rejectedTrustedExecutableCandidates.has(candidate)) continue;
     try {
       accessSync(candidate, fsConstants.X_OK);
-      return trustedExecutableCandidate(
+      const resolved = trustedExecutableCandidate(
         candidate,
         root,
         path.basename(command) || "executable",
         { allowSnapshot: path.basename(command) !== "git" },
       );
+      traceCommandResolution(command, candidate, resolved, source);
+      return resolved;
     } catch {
       rejectedTrustedExecutableCandidates.add(candidate);
-      // Keep searching a bounded, absolute PATH for an external executable.
+      // Keep searching a bounded, absolute search list for an external
+      // executable.
     }
   }
   if (required) {
-    throw new Error(
-      `${command} CLI is not available outside the reviewed repo`,
-    );
+    throw new Error(unavailableCommandMessage(command));
   }
   return null;
 }
@@ -3132,7 +3216,7 @@ function tomlInlineTable(values) {
 async function runCodex(repo, args, prompt) {
   const codex = resolveTrustedCommand("codex", repo, { required: false });
   if (!codex) {
-    throw new Error("codex CLI is not available");
+    throw new Error(unavailableCommandMessage("codex"));
   }
   if (!args.tools) {
     throw new Error(
@@ -3302,7 +3386,7 @@ async function ensureClaudeIsolationSupported(claude, repo, env, cwd) {
 async function runClaude(repo, args, prompt) {
   const claude = resolveTrustedCommand("claude", repo, { required: false });
   if (!claude) {
-    throw new Error("claude CLI is not available");
+    throw new Error(unavailableCommandMessage("claude"));
   }
   const tempRoot = safeTempRoot(repo);
   const tempDir = createRegisteredEngineRuntimeDirectory(

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -2256,6 +2256,7 @@ run_codex_binary_resolution_regression() {
   local review_repo="$tmp_dir/codex-binary-resolution"
   local fake_bin="$tmp_dir/codex-binary-resolution-bin"
   local shim_bin="$tmp_dir/codex-binary-resolution-shim"
+  local failing_bin="$tmp_dir/codex-binary-resolution-failing"
   local status=0
 
   init_review_repo "$review_repo"
@@ -2293,6 +2294,19 @@ exit 127
 CODEX
   chmod +x "$shim_bin/codex"
 
+  # A working engine that answers --version and still exits 127 on the review.
+  mkdir "$failing_bin"
+  cat >"$failing_bin/codex" <<'CODEX'
+#!/bin/bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'codex-cli 9.9.9\n'
+  exit 0
+fi
+printf 'internal helper missing\n' >&2
+exit 127
+CODEX
+  chmod +x "$failing_bin/codex"
+
   # PATH has no codex, so the configured well-known install directory decides.
   run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" \
@@ -2323,7 +2337,8 @@ CODEX
   expect_stderr_contains "resolved codex via PATH"
   expect_stderr_contains "resolved codex via well-known install location"
 
-  # When every candidate is such a shim, one message names them.
+  # When every candidate is such a shim, one message names them and keeps the
+  # engine's own error rather than claiming the CLI was never found.
   status=0
   run_codex_resolution_helper "$review_repo" "$shim_bin:$hermetic_git_bin" \
     "AUTOREVIEW_EXTRA_BIN_DIRS=" || status=$?
@@ -2331,9 +2346,23 @@ CODEX
     printf 'expected an all-shim codex search to fail\n' >&2
     exit 1
   fi
-  expect_stderr_contains "codex CLI is not available"
-  expect_stderr_contains "Skipped after exit 127"
+  expect_stderr_contains \
+    "codex CLI cannot run in the reviewer's isolated environment"
   expect_stderr_contains "codex-binary-resolution-shim/codex"
+  expect_stderr_contains "Engine error:"
+  expect_stdout_not_contains "autoreview clean"
+
+  # An engine that can report its version keeps its own exit 127 as a review
+  # failure: the search must not discard it and try a different installation.
+  status=0
+  run_codex_resolution_helper "$review_repo" "$failing_bin:$hermetic_git_bin" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected a genuine codex exit 127 to fail the review\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains "codex-binary-resolution-failing/codex failed (127)"
+  expect_stderr_contains "internal helper missing"
   expect_stdout_not_contains "autoreview clean"
 
   # An unusable override reports itself instead of exiting 127.

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -2230,14 +2230,15 @@ run_requested_codex_missing_regression() {
 
 run_codex_resolution_helper() {
   local review_repo="$1"
-  shift
+  local search_path="$2"
+  shift 2
   : >"$stdout"
   : >"$stderr"
   local status=0
   (
     cd "$review_repo"
     env -i \
-      "PATH=$hermetic_git_bin" \
+      "PATH=$search_path" \
       "HOME=$HOME" \
       "TMPDIR=${TMPDIR:-/tmp}" \
       "GIT_CONFIG_GLOBAL=/dev/null" \
@@ -2254,6 +2255,7 @@ run_codex_resolution_helper() {
 run_codex_binary_resolution_regression() {
   local review_repo="$tmp_dir/codex-binary-resolution"
   local fake_bin="$tmp_dir/codex-binary-resolution-bin"
+  local shim_bin="$tmp_dir/codex-binary-resolution-shim"
   local status=0
 
   init_review_repo "$review_repo"
@@ -2281,8 +2283,18 @@ printf '%s\n' '{"findings":[],"overall_correctness":"patch is correct","overall_
 CODEX
   chmod +x "$fake_bin/codex"
 
+  # A launcher shim: it resolves and runs, then cannot find the real codex in
+  # the sanitized environment the reviewer hands its engine.
+  mkdir "$shim_bin"
+  cat >"$shim_bin/codex" <<'CODEX'
+#!/bin/bash
+printf 'Error: codex not found in PATH\n' >&2
+exit 127
+CODEX
+  chmod +x "$shim_bin/codex"
+
   # PATH has no codex, so the configured well-known install directory decides.
-  run_codex_resolution_helper "$review_repo" \
+  run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" \
     "AUTOREVIEW_TRACE_COMMANDS=1"
   expect_stdout_contains "autoreview clean"
@@ -2290,21 +2302,43 @@ CODEX
   expect_stderr_contains "codex-binary-resolution-bin/codex"
 
   # An explicit override decides before any search directory.
-  run_codex_resolution_helper "$review_repo" \
+  run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_CODEX_BIN=$fake_bin/codex" \
     "AUTOREVIEW_TRACE_COMMANDS=1"
   expect_stdout_contains "autoreview clean"
   expect_stderr_contains "resolved codex via AUTOREVIEW_CODEX_BIN"
 
   # Resolution stays quiet unless the trace is requested.
-  run_codex_resolution_helper "$review_repo" \
+  run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_CODEX_BIN=$fake_bin/codex"
   expect_stdout_contains "autoreview clean"
   expect_empty_stderr
 
+  # A shim that exits 127 is an unresolved engine, not a review failure: the
+  # search moves on to the next candidate instead of aborting the review.
+  run_codex_resolution_helper "$review_repo" "$shim_bin:$hermetic_git_bin" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" \
+    "AUTOREVIEW_TRACE_COMMANDS=1"
+  expect_stdout_contains "autoreview clean"
+  expect_stderr_contains "resolved codex via PATH"
+  expect_stderr_contains "resolved codex via well-known install location"
+
+  # When every candidate is such a shim, one message names them.
+  status=0
+  run_codex_resolution_helper "$review_repo" "$shim_bin:$hermetic_git_bin" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected an all-shim codex search to fail\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains "codex CLI is not available"
+  expect_stderr_contains "Skipped after exit 127"
+  expect_stderr_contains "codex-binary-resolution-shim/codex"
+  expect_stdout_not_contains "autoreview clean"
+
   # An unusable override reports itself instead of exiting 127.
   status=0
-  run_codex_resolution_helper "$review_repo" \
+  run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_CODEX_BIN=$tmp_dir/absent-codex-override" || status=$?
   if [[ "$status" -eq 0 ]]; then
     printf 'expected an unusable AUTOREVIEW_CODEX_BIN override to fail\n' >&2
@@ -2321,7 +2355,7 @@ CODEX
 
   # A relative override never falls back to a search path either.
   status=0
-  run_codex_resolution_helper "$review_repo" \
+  run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_CODEX_BIN=codex" \
     "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" || status=$?
   if [[ "$status" -eq 0 ]]; then

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -2257,6 +2257,9 @@ run_codex_binary_resolution_regression() {
   local fake_bin="$tmp_dir/codex-binary-resolution-bin"
   local shim_bin="$tmp_dir/codex-binary-resolution-shim"
   local failing_bin="$tmp_dir/codex-binary-resolution-failing"
+  local hanging_bin="$tmp_dir/codex-binary-resolution-hanging"
+  local probe_started
+  local probe_elapsed
   local status=0
 
   init_review_repo "$review_repo"
@@ -2307,6 +2310,22 @@ exit 127
 CODEX
   chmod +x "$failing_bin/codex"
 
+  # A shim whose --version ignores SIGTERM and leaves a descendant running.
+  # Only a SIGKILL sweep of the whole group can bound this probe.
+  mkdir "$hanging_bin"
+  cat >"$hanging_bin/codex" <<'CODEX'
+#!/bin/bash
+if [[ "${1:-}" == "--version" ]]; then
+  trap '' TERM INT
+  sleep 90 &
+  sleep 90
+  exit 0
+fi
+printf 'Error: codex not found in PATH\n' >&2
+exit 127
+CODEX
+  chmod +x "$hanging_bin/codex"
+
   # PATH has no codex, so the configured well-known install directory decides.
   run_codex_resolution_helper "$review_repo" "$hermetic_git_bin" \
     "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" \
@@ -2348,8 +2367,29 @@ CODEX
   fi
   expect_stderr_contains \
     "codex CLI cannot run in the reviewer's isolated environment"
-  expect_stderr_contains "codex-binary-resolution-shim/codex"
+  expect_stderr_contains "codex-binary-resolution-shim/codex exited 127 and"
+  expect_stderr_contains "its --version probe exited 127"
   expect_stderr_contains "Engine error:"
+  expect_stdout_not_contains "autoreview clean"
+
+  # A probe that ignores SIGTERM and leaves a descendant behind must not wedge
+  # the review: the bounded SIGKILL sweep ends it and the timeout is named.
+  status=0
+  probe_started="$(date +%s)"
+  run_codex_resolution_helper "$review_repo" "$hanging_bin:$hermetic_git_bin" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=" || status=$?
+  probe_elapsed="$(($(date +%s) - probe_started))"
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected a hanging codex --version probe to fail the search\n' >&2
+    exit 1
+  fi
+  if [[ "$probe_elapsed" -ge 60 ]]; then
+    printf 'codex --version probe outlived its timeout: %ss\n' \
+      "$probe_elapsed" >&2
+    exit 1
+  fi
+  expect_stderr_contains "its --version probe timed out after"
+  expect_stderr_contains "codex-binary-resolution-hanging/codex"
   expect_stdout_not_contains "autoreview clean"
 
   # An engine that can report its version keeps its own exit 127 as a review
@@ -6285,6 +6325,32 @@ CODEX
   fi
 }
 
+# Sealed-snapshot revalidation is an invariant only if every synchronous spawn
+# of a resolved executable honours it. spawnTrustedSync is that chokepoint; a
+# bare spawnSync of a resolved path would execute a snapshot nobody rechecked.
+run_trusted_sync_spawn_invariant_regression() {
+  local helper_source="$repo_root/scripts/agent-autoreview.mjs"
+  local offenders
+
+  offenders="$(
+    grep -nE '(^|[^A-Za-z])spawnSync\(' "$helper_source" |
+      grep -vE '^[0-9]+:[[:space:]]*//' |
+      grep -vE '^[0-9]+:import ' |
+      grep -vE 'spawnSync\("/bin/ls"' |
+      grep -vE '^[0-9]+:[[:space:]]*return spawnSync\(command, args, options\);$' ||
+      true
+  )"
+  if [[ -n "$offenders" ]]; then
+    printf 'autoreview helper spawns a resolved executable outside spawnTrustedSync, skipping snapshot revalidation:\n%s\n' \
+      "$offenders" >&2
+    exit 1
+  fi
+  if ! grep -q 'spawnTrustedSync(executable, \["--version"\]' "$helper_source"; then
+    printf 'the engine version probe no longer spawns through spawnTrustedSync\n' >&2
+    exit 1
+  fi
+}
+
 run_privileged_shebang_startup_regression() {
   local review_repo="$tmp_dir/privileged-shebang-startup"
   local startup_payload="$tmp_dir/hostile-bash-env.sh"
@@ -6613,6 +6679,7 @@ run_runtime_trust_family() {
   run_unsafe_script_fallback_regressions
   run_privileged_shebang_startup_regression
   run_hostile_volta_environment_regression
+  run_trusted_sync_spawn_invariant_regression
 }
 
 run_bundle_integrity_family() {

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -1882,6 +1882,7 @@ run_node_helper_in_repo_expect_failure() {
       "HOME=$HOME" \
       "TMPDIR=${TMPDIR:-/tmp}" \
       "GIT_CONFIG_GLOBAL=/dev/null" \
+      "AUTOREVIEW_EXTRA_BIN_DIRS=" \
       "$node_bin" "$repo_root/scripts/agent-autoreview.mjs" \
       "$@" >"$stdout" 2>"$stderr"
   ) || status=$?
@@ -2222,6 +2223,114 @@ run_requested_codex_missing_regression() {
   run_node_helper_in_repo_expect_failure "$review_repo" --mode local --engine codex
   expect_stdout_contains "autoreview target: local"
   expect_stderr_contains "codex CLI is not available"
+  expect_stderr_contains "set AUTOREVIEW_CODEX_BIN to its absolute path"
+  expect_stderr_contains "Probed:"
+  expect_stdout_not_contains "autoreview clean"
+}
+
+run_codex_resolution_helper() {
+  local review_repo="$1"
+  shift
+  : >"$stdout"
+  : >"$stderr"
+  local status=0
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$hermetic_git_bin" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "GIT_CONFIG_GLOBAL=/dev/null" \
+      "$@" \
+      "$node_bin" "$repo_root/scripts/agent-autoreview.mjs" \
+      --mode local --engine codex >"$stdout" 2>"$stderr"
+  ) || status=$?
+  return "$status"
+}
+
+# The reviewer must resolve its engine from a shell whose PATH omits the local
+# package manager's bin directory; agent-isolation shells routinely do, and a
+# missed codex used to force a slow remote review instead.
+run_codex_binary_resolution_regression() {
+  local review_repo="$tmp_dir/codex-binary-resolution"
+  local fake_bin="$tmp_dir/codex-binary-resolution-bin"
+  local status=0
+
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  printf 'change\n' >>"$review_repo/README.md"
+
+  mkdir "$fake_bin"
+  cat >"$fake_bin/codex" <<'CODEX'
+#!/bin/bash
+output=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >/dev/null
+printf '%s\n' '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"clean","overall_confidence":0.9}' >"$output"
+CODEX
+  chmod +x "$fake_bin/codex"
+
+  # PATH has no codex, so the configured well-known install directory decides.
+  run_codex_resolution_helper "$review_repo" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" \
+    "AUTOREVIEW_TRACE_COMMANDS=1"
+  expect_stdout_contains "autoreview clean"
+  expect_stderr_contains "resolved codex via well-known install location"
+  expect_stderr_contains "codex-binary-resolution-bin/codex"
+
+  # An explicit override decides before any search directory.
+  run_codex_resolution_helper "$review_repo" \
+    "AUTOREVIEW_CODEX_BIN=$fake_bin/codex" \
+    "AUTOREVIEW_TRACE_COMMANDS=1"
+  expect_stdout_contains "autoreview clean"
+  expect_stderr_contains "resolved codex via AUTOREVIEW_CODEX_BIN"
+
+  # Resolution stays quiet unless the trace is requested.
+  run_codex_resolution_helper "$review_repo" \
+    "AUTOREVIEW_CODEX_BIN=$fake_bin/codex"
+  expect_stdout_contains "autoreview clean"
+  expect_empty_stderr
+
+  # An unusable override reports itself instead of exiting 127.
+  status=0
+  run_codex_resolution_helper "$review_repo" \
+    "AUTOREVIEW_CODEX_BIN=$tmp_dir/absent-codex-override" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected an unusable AUTOREVIEW_CODEX_BIN override to fail\n' >&2
+    exit 1
+  fi
+  if [[ "$status" -eq 127 ]]; then
+    printf 'unusable AUTOREVIEW_CODEX_BIN override exited 127 without guidance\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains \
+    "AUTOREVIEW_CODEX_BIN does not point at a trusted absolute executable"
+  expect_stderr_contains "Probed: $tmp_dir/absent-codex-override"
+  expect_stdout_not_contains "autoreview clean"
+
+  # A relative override never falls back to a search path either.
+  status=0
+  run_codex_resolution_helper "$review_repo" \
+    "AUTOREVIEW_CODEX_BIN=codex" \
+    "AUTOREVIEW_EXTRA_BIN_DIRS=$fake_bin" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected a relative AUTOREVIEW_CODEX_BIN override to fail\n' >&2
+    exit 1
+  fi
+  expect_stderr_contains \
+    "AUTOREVIEW_CODEX_BIN does not point at a trusted absolute executable"
+  expect_stderr_contains "Probed: codex"
   expect_stdout_not_contains "autoreview clean"
 }
 
@@ -6097,6 +6206,7 @@ CODEX
       "HOME=$HOME" \
       "TMPDIR=${TMPDIR:-/tmp}" \
       "GIT_CONFIG_GLOBAL=/dev/null" \
+      "AUTOREVIEW_EXTRA_BIN_DIRS=" \
       "$node_exec" "$repo_root/scripts/agent-autoreview.mjs" \
       --mode local \
       --engine codex >"$stdout" 2>"$stderr"
@@ -6388,6 +6498,7 @@ run_untrusted_cleanup_retention_regression() {
 
 run_engine_isolation_family() {
   run_requested_codex_missing_regression
+  run_codex_binary_resolution_regression
   run_suite_family_diagnostic_regression
   run_claude_no_tools_regression
   run_codex_isolation_regression


### PR DESCRIPTION
## The Problem

- A closeout autoreview died with `codex not found in PATH` (exit 127) and fell back to remote review, which lands about one finding per round and cost hours.
- The reviewer searched only the caller's `PATH`, so an agent-isolation shell without `/opt/homebrew/bin` hid a codex 0.147.0 that was installed the whole time.
- Where a `codex` did resolve, it was a launcher shim that re-resolves the real CLI from `PATH` — which the reviewer deliberately withholds from its engine — so the review died on the shim's own 127.

## The Solution

- The reviewer resolves each external CLI in a fixed order: `AUTOREVIEW_<COMMAND>_BIN`, then `PATH`, then the well-known install directories `/opt/homebrew/bin`, `/usr/local/bin`, and `~/.local/bin`.
- A codex that exits 127 and cannot report `--version` in that same isolated environment is a shim, not an engine: the search drops it and tries the next candidate.
- Nothing resolves? One message names the override variable and every probed path, instead of a bare command-not-found exit.

## Details

- Operator-directed work. No GitHub issue backs it, and none was filed.
- Resolution lands in `resolveTrustedCommand`, the one place the helper resolves `codex`, `claude`, `gh`, and `git`, so every engine gains the behavior without a second code path. Nothing else in the repo shells out to the codex CLI.
- Trust is unchanged. Every candidate still passes `trustedExecutableCandidate`: owner check, no shared-writable file or ancestry, no write-granting ACL, repo-internal paths rejected, and Homebrew-style ancestry still executed only from a sealed private snapshot. A wider search does not widen what the reviewer will execute.
- An override is authoritative and must be absolute, so a typo fails with its own message rather than silently reviving whatever `PATH` offers.
- The 127 fallthrough is deliberately narrow. The first local review of this branch flagged that a real Codex can exit 127 for its own reasons, so a candidate is dropped only when it also fails a `--version` probe in the engine's exact environment. An engine that answers `--version` keeps its exit 127 as a review failure, carrying its own error, and the search never swaps in a different installation behind it.
- The probe holds the file's own invariants. It spawns through `spawnTrustedSync`, so it revalidates sealed snapshots like every other trusted-executable spawn here. It captures no pipes, so no descendant can hold the wait open, and it bounds itself with `SIGKILL` plus a detached process group swept on timeout. A timed-out probe counts as failed and names the timeout, so no candidate is ever dropped silently.
- `AUTOREVIEW_EXTRA_BIN_DIRS` replaces the well-known list; an empty value searches `PATH` alone. The missing-CLI fixtures set it so they stay hermetic on a machine that has codex installed.
- `AUTOREVIEW_TRACE_COMMANDS=1` logs the winning candidate, and the sealed snapshot when the launch target differs. It stays off by default, so the wrapper's clean-stderr contract holds.

## Residuals

Documented, not fixed here, and not deferred work from this change:

- The adapter still resolves `node`, `git`, and `gh` from the caller's `PATH` alone. On this machine `node` comes from a version manager rather than a well-known bin directory, so the same fallback would not help; a `PATH` without `node` still fails with `agent:autoreview requires a trusted node executable`.
- `--engine claude` takes the first `claude` on `PATH`. Where that is a launcher shim, the isolation probe reads no version from it and the run fails with `claude engine requires Claude Code >= 2.1.169 for --safe-mode` even though Claude Code 2.1.229 is installed. `AUTOREVIEW_CLAUDE_BIN=$HOME/.local/bin/claude` now routes around the shim; the run then reaches real Claude Code and fails on an isolated-environment OAuth refresh. The version gate itself is untouched here.

## Validation

Before and after, same throwaway repo, same isolation-shaped shell (`PATH=$HOME/.volta/bin:/usr/bin:/bin`, no Homebrew):

- `origin/main` adapter: `autoreview failed: codex CLI is not available`, exit 1.
- this branch: `resolved codex via well-known install location: /opt/homebrew/bin/codex -> …`, then `autoreview clean`, `overall: patch is correct (0.99)`.

Strict minimal shell, `env -i HOME=… TMPDIR=… PATH=/usr/bin:/bin`, helper invoked directly: resolves `git` from `/usr/bin` and `codex` from `/opt/homebrew/bin`, and the engine runs to a clean review.

Negative control, `AUTOREVIEW_CODEX_BIN=/nonexistent`: `codex CLI is not available: AUTOREVIEW_CODEX_BIN does not point at a trusted absolute executable. Probed: /nonexistent`, exit 1 rather than 127.

Round-1 review fixes are mutation-checked, not just asserted:

- Revert the probe to a bare `spawnSync` and `run_trusted_sync_spawn_invariant_regression` fails on the skipped revalidation.
- Restore the probe's captured pipes and default kill signal, and the hanging-stub regression fails with `codex --version probe outlived its timeout: 91s` instead of finishing in about 15.

- Closeout review from the pre-change checkout with an explicit `AUTOREVIEW_HELPER`, as the runtime-change contract requires: one P2 on the first pass (over-broad 127 handling), fixed, then `autoreview clean` — re-run after the round-1 fixes, still clean, `overall: patch is correct (0.88)`.
- `pnpm agent:autoreview:test -- --jobs 1` — passed, all five families ok.
- `pnpm agent:quality-gate --run` — all 8 mapped commands green.
- `./tools/trunk fmt --all` and `./tools/trunk check` on the touched files — no issues

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.
