### PR TITLE
fix(peg): finish the active-only policy cutover

### DIFF
--- a/docs/adr/0044-peg-thresholds-gated-rules-plane.md
+++ b/docs/adr/0044-peg-thresholds-gated-rules-plane.md
@@ -3,7 +3,7 @@ title: Peg alert thresholds stay in the gated alerts-rules plane, read from one 
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-13
 scope: alerts
 date: 2026-07
 doc_type: adr
@@ -23,6 +23,8 @@ gates tracked by
 [`docs/notes/peg-monitoring.md`](../notes/peg-monitoring.md).
 ADR 0057 narrows this record's observation-advancement rule without changing
 the gated-policy ownership or rollover contract.
+The first-rollover parser exception recorded below is retired by the amendment
+in this record.
 **Scope:** alerts
 
 ## Context
@@ -151,6 +153,18 @@ Phase 3 must implement the following protected artifact and rules contract:
     threshold.
   - Severity and routing stay per-rule: warn → Slack, critical → page, each
     with its own contact-point wiring.
+
+## Amendment — first-rollover parser exception retired
+
+The protected platform apply attached active-only generation
+`1786443055965590`, and live proof confirmed current producer/API packages, no
+legacy-version metric labels, and all 17 Peg Grafana rules with health `ok`,
+unpaused, and Normal. With that one-time transition complete,
+[#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
+removed the exact-version default described above. Every active or
+retained-previous source must now declare
+`listingAbsentConsecutiveChecks`; omission rejects the policy. This amendment
+does not change the gated-policy ownership or two-phase rollover contract.
 
 ## Alternatives considered
 

--- a/docs/adr/0057-peg-observation-advancement.md
+++ b/docs/adr/0057-peg-observation-advancement.md
@@ -3,7 +3,7 @@ title: Repeated Peg provider observations retain bounded health, never sample au
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-13
 scope: metrics-bridge / alerts
 date: 2026-08
 doc_type: adr
@@ -15,6 +15,9 @@ garden_lane: adrs-architecture
 
 **Status:** Accepted (Aug 2026), in force. This record narrows the
 observation-advancement clause in [ADR 0044](0044-peg-thresholds-gated-rules-plane.md).
+The predecessor cleanup named in the consequences later completed; the current
+active-only proof is recorded in
+[`docs/notes/peg-monitoring.md`](../notes/peg-monitoring.md).
 **Scope:** metrics-bridge / alerts
 
 ## Context

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@ title: Deployment Guide
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-13
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -311,10 +311,12 @@ complete. The first protected publication created
 `mento-monitoring-peg-policy/peg-policy/current.json` generation
 `1785276001213660`; its runtime attachment minted
 `metrics-bridge-r-47264e8-30405040839`. The later protected publication created
-generation `1786443055965590`. The reviewed runtime rollout selects that
-published generation in source, but it is not attached to Cloud Run until the
-approved platform apply and runtime proof complete. The canonical recovery
-procedure is in [`docs/terraform.md`](terraform.md) and
+generation `1786443055965590`. The approved runtime rollout attached that
+active-only generation to Cloud Run revision `metrics-bridge-00196-6hg`.
+Post-apply proof confirmed current producer and API packages, exactly one
+policy-version metric, no legacy policy labels, and all 17 Peg Grafana rules
+with health `ok`, unpaused, and Normal. The canonical recovery procedure is in
+[`docs/terraform.md`](terraform.md) and
 [ADR 0055](adr/0055-peg-policy-bucket-controller-recovery.md). Audit effective
 readers, writers, and IAM administrators after future applies and before runtime
 rollovers.

--- a/docs/notes/peg-monitoring-onboarding.md
+++ b/docs/notes/peg-monitoring-onboarding.md
@@ -273,14 +273,10 @@ Only an authoritative response advances `mento_peg_listing_checked_at`.
 Unknown, missing, or stale evidence is not delisting. Listing confirmation can
 still succeed when the later book fetch fails, so listing alerts do not gate
 on source health, observation time, or the asset heartbeat. Source validators
-require every policy source to declare its bounded listing-confirmation
-threshold. During the production transition only, Metrics Bridge accepts the
-omission from the exact legacy retained version
-`europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f` and normalizes it to
-`2` in decision packages. Remove that runtime shim in a follow-up PR after the
-`previous: null` generation is published, pinned, and live-verified;
-[#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750)
-tracks that removal.
+and Metrics Bridge require every active or retained-previous policy source to
+declare an integer `listingAbsentConsecutiveChecks` value from 2 through 1000.
+A missing value rejects the policy instead of receiving a runtime default. The
+current production policy is active-only, with `previous: null`.
 
 A source restoration is not enough by itself. Repeat the executable-depth and
 coverage gates before restoring alert authority.

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-12
+last_verified: 2026-08-13
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -39,11 +39,14 @@ are live in Grafana for the policy version published at that time
 recovery and bootstrap-grant removal are complete.
 The first protected `Peg Policy Publication` root created
 `mento-monitoring-peg-policy/peg-policy/current.json` generation
-`1785276001213660`. Authenticated, generation-pinned delivery and live producer
-telemetry for that attachment are proven on
-`metrics-bridge-r-47264e8-30405040839`, which serves active policy
-`europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`. The production dashboard
-prerequisite is also proven at
+`1785276001213660`. The later protected publication created active-only
+generation `1786443055965590`, with `previous: null`. The approved platform
+apply attached that exact generation to Metrics Bridge revision
+`metrics-bridge-00196-6hg`. Post-apply proof confirmed active policy
+`europ-2026-07-22-v1-f6cdaa2681ab92ce9d90572a4d29d32f`, current producer and API
+packages, exactly one policy-version metric, no legacy-version labels, and all
+17 Peg Grafana rules with health `ok`, unpaused, and Normal. The production
+dashboard is also proven at
 `https://monitoring.mento.org/peg-monitoring`: the live current package renders
 without console errors. The reviewed source activation sets the
 source-controlled `local.peg_alerts_enabled` switch to the literal `true`. That
@@ -52,25 +55,12 @@ rule group; it is not a workflow, variable, or policy-artifact switch. This
 source change does not prove the consumers exist in Grafana or that their
 queries have live data.
 
-The later protected publication created the active-only `previous: null` object
-at generation `1786443055965590`. This reviewed platform rollout changes the
-source-controlled runtime pin to that generation, sets
-`metrics_bridge_template_rollout_active` to `true`, and removes the generated
-revision-name ignore. It does not attach the new generation to Metrics Bridge.
-Do not claim active-only production operation until the approved platform apply
-and post-change producer/Grafana proof complete.
-
-Source validators now require every policy source to declare
-`listingAbsentConsecutiveChecks`, and the published policy has `previous` as
-`null`. Metrics Bridge retains a runtime-only compatibility shim for the exact
-legacy previous version
-`europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f`, which defaults the
-missing threshold to `2` while the active-only runtime generation awaits its
-approved attachment and live proof. The bridge normalizes the value into decision
-packages, so the dashboard schema remains strict. Remove the shim in a follow-up
-PR after the `previous: null` generation is attached and live-verified;
-[#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750) tracks
-that removal.
+Source validators require every policy source to declare an integer
+`listingAbsentConsecutiveChecks` value from 2 through 1000. Metrics Bridge
+applies the same strict requirement to active and retained-previous policy
+sources; it has no legacy-version default. The published and attached policy
+has `previous: null`, so production currently emits active-only policy and
+decision-package data.
 
 The production identity bootstrap in
 [#1566](https://github.com/mento-protocol/monitoring-monorepo/pull/1566) is
@@ -164,30 +154,6 @@ secret-backed contact-point dependencies. The first complete remote diff is
 therefore the trusted-main plan after merge. Keep its `production-infra` apply
 blocked, inspect the full plan, and do not treat a targeted PR plan as proof of
 the peg rule resources.
-
-## Predecessor cleanup deployment proof
-
-After this source change merges, keep the policy predecessor cleanup in the
-following order:
-
-1. Let the automatic Metrics Bridge workflow deploy the compatibility-retaining
-   revision from `main`. Verify it still loads the pinned legacy generation and
-   continues publishing current Peg polls and decision packages.
-2. Inspect the trusted-main `alerts-rules` plan, then explicitly approve its
-   `production-infra` apply. Confirm retained-previous rules are removed and
-   active rules remain evaluable in Grafana. Removing consumers before their
-   producer series follows the rollback dependency order.
-3. Inspect the trusted-main publication plan, then explicitly approve its
-   `production-infra` apply to publish the `previous: null` artifact.
-4. Review the platform change that pins Metrics Bridge to that exact positive
-   generation, apply it through its owning approved path, and verify the
-   producer reports only the active policy.
-5. After active-only production is live-verified, remove the exact legacy
-   runtime shim through [#1750](https://github.com/mento-protocol/monitoring-monorepo/issues/1750).
-
-Never run these applies from an agent session. A merged source change, a policy
-publication, or a runtime attachment alone is insufficient proof of
-active-only operation.
 
 ## Production activation preconditions
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@ title: Terraform Stacks
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-13
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -90,13 +90,15 @@ including `--force-local-apply`. Controller recovery and the first protected
 publication are complete: it created
 `mento-monitoring-peg-policy/peg-policy/current.json` generation
 `1785276001213660`, which the first runtime attachment used. The later protected
-publication produced generation `1786443055965590`. This reviewed platform
-rollout selects that published generation for the runtime; publication alone
-does not attach it to Cloud Run. An approved platform apply and runtime proof
-remain required. For a future publication, dispatch `Peg Policy Publication`
-from `main`, inspect its read-only plan, then choose `apply` and approve the
-`production-infra` Environment. Its output feeds a separately reviewed runtime
-rollover.
+publication produced generation `1786443055965590`. The approved platform apply
+attached that active-only generation to Metrics Bridge revision
+`metrics-bridge-00196-6hg`. Post-apply proof confirmed current producer/API
+packages, exactly one policy-version metric, no legacy policy labels, and all
+17 Peg Grafana rules with health `ok`, unpaused, and Normal. Publication alone
+never attaches a generation to Cloud Run. For a future publication, dispatch
+`Peg Policy Publication` from `main`, inspect its read-only plan, then choose
+`apply` and approve the `production-infra` Environment. Its output feeds a
+separately reviewed runtime rollover.
 
 ## CI Model
 
@@ -183,11 +185,13 @@ owns private buckets and identities; protected `peg-policy-publication` writes
 the policy object.
 Metrics Bridge uses the dedicated runtime identity. The first runtime attachment
 pinned generation `1785276001213660` through paired `PEG_POLICY_*` values; the
-current reviewed rollout changes the source literal to published generation
-`1786443055965590`. Publication itself attaches neither Cloud Run nor Grafana
-consumers. The approved platform apply and runtime proof attach the new pin; the
-separate alerts-rules source change and approved apply activate Grafana.
+current runtime pins active-only generation `1786443055965590` through the same
+paired values. Publication itself attaches neither Cloud Run nor Grafana
+consumers. The approved platform apply attached the current pin; the separate
+alerts-rules source change and approved apply activate Grafana.
 Terraform derives the pinned URL and `gcp-metadata` mode from that literal.
+The checked-in platform source is back in steady state: the template-rollout
+marker is `false`, and Terraform ignores the generated revision name.
 Metrics Bridge ignores `template[0].revision` in steady state so routine plans
 do not clear the generated name stamped by deploys. Any Terraform-owned
 template change, including a policy-generation handoff, sets

--- a/metrics-bridge/src/peg/decision-packages.ts
+++ b/metrics-bridge/src/peg/decision-packages.ts
@@ -7,7 +7,6 @@ import type {
 } from "./metrics.js";
 import {
   PEG_POLICY_MAX_ASSETS,
-  effectiveListingAbsentConsecutiveChecks,
   type PegAssetPolicy,
   type PegPolicyVersion,
   type PegSourcePolicy,
@@ -71,11 +70,9 @@ export interface PegDecisionPackageSource {
   registryRole: PegSourceRole;
   authority: PegSourcePolicy["authority"];
   convertVia: PegConversion | null;
-  // Live streak state stays in Prometheus; this policy threshold gives readers
-  // complete decision context, including the retained legacy default.
-  policy: Omit<PegSourcePolicy, "authority"> & {
-    listingAbsentConsecutiveChecks: number;
-  };
+  // Live streak state stays in Prometheus; the policy gives readers the
+  // threshold needed to interpret it.
+  policy: Omit<PegSourcePolicy, "authority">;
   listingState: MarketState | null;
   listingCheckedAt: number | null;
   healthy: boolean;
@@ -324,8 +321,7 @@ function sourceEvidence(
       referenceSizeCap: policy.referenceSizeCap,
       pollIntervalSeconds: policy.pollIntervalSeconds,
       staleAfterSeconds: policy.staleAfterSeconds,
-      listingAbsentConsecutiveChecks:
-        effectiveListingAbsentConsecutiveChecks(policy),
+      listingAbsentConsecutiveChecks: policy.listingAbsentConsecutiveChecks,
       spreadEnvelopeBps: policy.spreadEnvelopeBps,
       conversionErrorBps: policy.conversionErrorBps,
     },

--- a/metrics-bridge/src/peg/policy.ts
+++ b/metrics-bridge/src/peg/policy.ts
@@ -53,23 +53,6 @@ export const PEG_POLICY_MAX_ASSETS = 32;
 export const PEG_POLICY_MAX_SOURCES_PER_ASSET = 16;
 export const PEG_POLICY_MAX_BLIND_CONSECUTIVE_POLLS = 1_000;
 export const PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS = 1_000;
-export const PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS = 2;
-export const PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION =
-  "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f";
-
-/**
- * The runtime may read the exact retained pre-streak production policy until
- * the checked-in `previous: null` generation is published, pinned, and live
- * verified. Source-controlled policy remains strict.
- */
-export function effectiveListingAbsentConsecutiveChecks(source: {
-  listingAbsentConsecutiveChecks?: number | undefined;
-}): number {
-  return (
-    source.listingAbsentConsecutiveChecks ??
-    PEG_POLICY_INITIAL_LISTING_ABSENT_CONSECUTIVE_CHECKS
-  );
-}
 
 export const PegSourcePolicySchema = z
   .object({
@@ -81,8 +64,7 @@ export const PegSourcePolicySchema = z
       .number()
       .int()
       .min(2)
-      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS)
-      .optional(),
+      .max(PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS),
     spreadEnvelopeBps: z.number().finite().nonnegative().max(10_000),
     conversionErrorBps: z.number().finite().nonnegative().max(10_000),
   })
@@ -90,8 +72,7 @@ export const PegSourcePolicySchema = z
   .superRefine((source, context) => {
     if (
       source.staleAfterSeconds <
-      source.pollIntervalSeconds *
-        effectiveListingAbsentConsecutiveChecks(source)
+      source.pollIntervalSeconds * source.listingAbsentConsecutiveChecks
     ) {
       context.addIssue({
         code: "custom",
@@ -235,44 +216,6 @@ export const PegPolicyVersionSchema = z
     }
   });
 
-function requireListingThresholds(
-  policy: z.infer<typeof PegPolicyVersionSchema>,
-  slot: "active" | "previous",
-  context: z.RefinementCtx,
-): void {
-  if (
-    slot === "previous" &&
-    policy.version ===
-      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION
-  ) {
-    return;
-  }
-  const missing = Object.entries(policy.assets).flatMap(([assetId, asset]) =>
-    Object.entries(asset.sources)
-      .filter(
-        ([, source]) => source.listingAbsentConsecutiveChecks === undefined,
-      )
-      .map(([sourceId]) => ({ assetId, sourceId })),
-  );
-  for (const { assetId, sourceId } of missing) {
-    context.addIssue({
-      code: "custom",
-      path: [
-        slot,
-        "assets",
-        assetId,
-        "sources",
-        sourceId,
-        "listingAbsentConsecutiveChecks",
-      ],
-      message:
-        slot === "active"
-          ? "must be declared by the active policy"
-          : "may be omitted only by the exact pre-streak retained predecessor",
-    });
-  }
-}
-
 export const PegPolicyBundleSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -287,10 +230,6 @@ export const PegPolicyBundleSchema = z
         path: ["previous", "version"],
         message: "must differ from the active version",
       });
-    }
-    requireListingThresholds(bundle.active, "active", context);
-    if (bundle.previous !== null) {
-      requireListingThresholds(bundle.previous, "previous", context);
     }
   });
 

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -44,7 +44,6 @@ import type {
 } from "./policy.js";
 import {
   PEG_POLICY_MAX_ASSETS,
-  effectiveListingAbsentConsecutiveChecks,
   PEG_POLICY_MAX_SOURCES_PER_ASSET,
 } from "./policy.js";
 import type {
@@ -700,9 +699,8 @@ async function pollListingOnly(
     nowSeconds: input.context.nowSeconds,
     listingCadenceIsDue: listingCadenceDue,
     request,
-    listingAbsentConsecutiveCheckLimit: effectiveListingAbsentConsecutiveChecks(
-      input.policy,
-    ),
+    listingAbsentConsecutiveCheckLimit:
+      input.policy.listingAbsentConsecutiveChecks,
     report: (cause) =>
       input.context.dependencies.report("source_fetch", cause, {
         asset: input.assetId,
@@ -727,7 +725,7 @@ async function pollDueSource(
     const listingError = acceptRecordedListingCheck(
       state,
       listingChecks,
-      effectiveListingAbsentConsecutiveChecks(input.policy),
+      input.policy.listingAbsentConsecutiveChecks,
       listingCadenceDue,
     );
     const supported =
@@ -740,7 +738,7 @@ async function pollDueSource(
   const listingError = acceptRecordedListingCheck(
     state,
     listingChecks,
-    effectiveListingAbsentConsecutiveChecks(input.policy),
+    input.policy.listingAbsentConsecutiveChecks,
     listingCadenceDue,
   );
   if (listingError !== null) {

--- a/metrics-bridge/test/peg-decision-packages.test.ts
+++ b/metrics-bridge/test/peg-decision-packages.test.ts
@@ -18,10 +18,7 @@ import {
   type PegPollCycleContext,
   type PegPollSourceState,
 } from "../src/peg/poll-cycle.js";
-import {
-  PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
-  type PegPolicyVersion,
-} from "../src/peg/policy.js";
+import { type PegPolicyVersion } from "../src/peg/policy.js";
 import { publishPegPollSnapshot } from "../src/peg/publisher.js";
 import { parsePegRegistry } from "../src/peg/registry.js";
 
@@ -293,22 +290,25 @@ describe("peg decision-package producer", () => {
     );
   });
 
-  it("normalizes the exact legacy retained previous in the active-incomplete fallback", () => {
-    const legacyPrevious = policy(
-      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
-    );
-    delete legacyPrevious.assets["asset-one"]!.sources.deep_eur!
-      .listingAbsentConsecutiveChecks;
+  it("serializes the previous policy's explicit threshold in the active-incomplete fallback", () => {
+    const retainedPrevious = policy("previous-v2");
+    retainedPrevious.assets[
+      "asset-one"
+    ]!.sources.deep_eur!.listingAbsentConsecutiveChecks = 3;
     const prepared = preparePegDecisionPackages(
-      [snapshot(legacyPrevious.version)],
-      context([active, legacyPrevious], active.version, legacyPrevious.version),
+      [snapshot(retainedPrevious.version)],
+      context(
+        [active, retainedPrevious],
+        active.version,
+        retainedPrevious.version,
+      ),
     )!;
-    expect(prepared.model.producedPolicyVersion).toBe(legacyPrevious.version);
+    expect(prepared.model.producedPolicyVersion).toBe(retainedPrevious.version);
     expect(prepared.model.policySlot).toBe("previous");
     expect(
       prepared.model.packages[0]?.sources[0]?.policy
         .listingAbsentConsecutiveChecks,
-    ).toBe(2);
+    ).toBe(3);
   });
 
   it("keeps unobserved listing evidence paired null", () => {

--- a/metrics-bridge/test/peg-policy.test.ts
+++ b/metrics-bridge/test/peg-policy.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parsePegPolicyBundle,
   PEG_POLICY_MAX_ASSETS,
-  PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
   PEG_POLICY_MAX_LISTING_ABSENT_CONSECUTIVE_CHECKS,
-  effectiveListingAbsentConsecutiveChecks,
   PEG_POLICY_MAX_SOURCES_PER_ASSET,
   pegPolicyContentDigest,
   pegPolicyVersionForContent,
@@ -31,18 +29,6 @@ function versioned(
     ...candidate,
     version: pegPolicyVersionForContent(prefix, candidate),
   };
-}
-
-function legacyPrevious(policy: PegPolicyBundle): PegPolicyBundle["active"] {
-  const previous = structuredClone(policy.active);
-  previous.version =
-    PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION;
-  for (const asset of Object.values(previous.assets)) {
-    for (const source of Object.values(asset.sources)) {
-      delete source.listingAbsentConsecutiveChecks;
-    }
-  }
-  return previous;
 }
 
 describe("Peg policy", () => {
@@ -196,12 +182,11 @@ describe("Peg policy", () => {
     ).toThrow(/>=2/);
   });
 
-  it("accepts and normalizes the exact legacy retained predecessor only", async () => {
+  it("requires an explicit listing-absence threshold in every policy slot", async () => {
     const policy = await productionPolicy();
     const asset = policy.active.assets["europ-schuman"]!;
-    const source = asset.sources.bitvavo_eur!;
-    const withoutThreshold = { ...source };
-    delete withoutThreshold.listingAbsentConsecutiveChecks;
+    const withoutThreshold = { ...asset.sources.bitvavo_eur! };
+    Reflect.deleteProperty(withoutThreshold, "listingAbsentConsecutiveChecks");
 
     expect(() =>
       parsePegPolicyBundle({
@@ -220,24 +205,11 @@ describe("Peg policy", () => {
           },
         },
       }),
-    ).toThrow(/must be declared by the active policy/);
+    ).toThrow(/listingAbsentConsecutiveChecks/);
 
-    const exactLegacyPrevious = legacyPrevious(policy);
-    const parsed = parsePegPolicyBundle({
-      ...policy,
-      previous: exactLegacyPrevious,
-    });
-    expect(parsed.previous?.version).toBe(
-      PEG_POLICY_LEGACY_LISTING_ABSENT_CONSECUTIVE_CHECKS_VERSION,
-    );
-    expect(
-      effectiveListingAbsentConsecutiveChecks(
-        parsed.previous!.assets["europ-schuman"]!.sources.bitvavo_eur!,
-      ),
-    ).toBe(2);
-
-    const otherPreviousWithoutThreshold = versioned("europ-2026-07-22-v0", {
+    const retiredPreviousWithoutThreshold = {
       ...policy.active,
+      version: "europ-2026-07-22-v1-a69b99aad61649957a2639dc8348b05f",
       assets: {
         ...policy.active.assets,
         "europ-schuman": {
@@ -248,14 +220,37 @@ describe("Peg policy", () => {
           },
         },
       },
-    });
+    };
     expect(() =>
       parsePegPolicyBundle({
         ...policy,
-        previous: otherPreviousWithoutThreshold,
+        previous: retiredPreviousWithoutThreshold,
       }),
-    ).toThrow(
-      /may be omitted only by the exact pre-streak retained predecessor/,
+    ).toThrow(/listingAbsentConsecutiveChecks/);
+  });
+
+  it("rejects a listing-absence threshold changed without a new version", async () => {
+    const policy = await productionPolicy();
+    const asset = policy.active.assets["europ-schuman"]!;
+    const tampered = {
+      ...policy.active,
+      assets: {
+        ...policy.active.assets,
+        "europ-schuman": {
+          ...asset,
+          sources: {
+            ...asset.sources,
+            bitvavo_eur: {
+              ...asset.sources.bitvavo_eur!,
+              listingAbsentConsecutiveChecks: 3,
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => parsePegPolicyBundle({ ...policy, active: tampered })).toThrow(
+      /policy content digest/,
     );
   });
 

--- a/metrics-bridge/test/peg-runtime.test.ts
+++ b/metrics-bridge/test/peg-runtime.test.ts
@@ -34,12 +34,9 @@ function createPegRuntime(options: PegRuntimeOptions) {
 }
 
 async function policy() {
-  const parsed = parsePegPolicyBundle(
+  return parsePegPolicyBundle(
     JSON.parse(await readFile(POLICY_PATH, "utf8")) as unknown,
   );
-  // Most runtime cases exercise a steady-state policy. The checked-in bundle
-  // retains the exact pre-streak predecessor for this one rollout.
-  return { ...parsed, previous: null };
 }
 
 function policyResponse(value: Awaited<ReturnType<typeof policy>>): Response {

--- a/terraform/metrics-bridge.tf
+++ b/terraform/metrics-bridge.tf
@@ -81,7 +81,7 @@ locals {
   # apply and runtime proof, a separate stabilization change restores false and
   # the ignore so routine platform applies do not mint duplicate revisions.
   # Pause unrelated platform applies while this marker is true.
-  metrics_bridge_template_rollout_active = true
+  metrics_bridge_template_rollout_active = false
 }
 
 resource "google_cloud_run_v2_service" "metrics_bridge" {
@@ -188,6 +188,7 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
     # managed in both phases.
     ignore_changes = [
       template[0].containers[0].image,
+      template[0].revision,
       client,
       client_version,
       scaling[0].manual_instance_count,


### PR DESCRIPTION
## The Problem

- Metrics Bridge still accepted one retired Peg policy version without an explicit listing-confirmation threshold, even though production now serves only the active policy.
- Terraform remained in temporary Cloud Run rollout mode after the approved generation change completed.
- Current runbooks still described the finished predecessor cutover as pending work.

## The Solution

- Require every active or retained-previous policy source to declare its listing-confirmation threshold, return Metrics Bridge to normal Terraform revision handling, and update current documentation to the verified active-only state.

## Details

- Removes the exact legacy-version constant, default value, optional parser field, and bundle exception.
- Reads `listingAbsentConsecutiveChecks` directly in polling and decision-package output; accepted values remain integers from 2 through 1000.
- Replaces compatibility coverage with strict rejection tests for missing active and previous-policy thresholds, plus version-tamper coverage.
- Restores `metrics_bridge_template_rollout_active = false` and the generated revision-name lifecycle ignore. This source-only stabilization requires no apply.
- Preserves ADR history and adds concise completion amendments while removing obsolete rollout instructions from current runbooks.
- The protected platform apply completed before this change: `0 add / 1 change / 0 destroy`, attaching generation `1786443055965590` to revision `metrics-bridge-00196-6hg`.
- Post-apply proof showed 100% traffic on the Ready revision, advancing active-only producer data, no legacy policy labels, healthy public API/dashboard responses, and all 17 Grafana Peg rules healthy, unpaused, Normal, and not firing.

Closes #1750
Refs #1444

## Validation

- `pnpm agent:quality-gate --run` — all mapped checks passed in the pre-push hook, including Terraform init/validate, Metrics Bridge coverage, docs checks, Trunk, dependency boundaries, and the full Terraform contract suite.
- Metrics Bridge coverage — 27 files and 586 tests passed; 91.58% statements, 86.75% branches, 95.66% functions, and 92.89% lines.
- `pnpm --filter @mento-protocol/metrics-bridge lint` — passed.
- `pnpm --filter @mento-protocol/metrics-bridge typecheck` — passed.
- `pnpm --filter @mento-protocol/metrics-bridge build` — passed.
- `pnpm agent:context-budget --strict` — passed.
- Fresh-context Codex autoreview — complete 13-file semantic pass, no findings, reviewed head `5ce1cad0371551aff0e8b68867a29bb5d2736bf4`.
- Deterministic local autoreview — no findings.
- Prepared review bundle manifest verified before and after semantic review.

Claude Security scan: skipped (Codex session; plugin unavailable). Security-sensitive rollout behavior remains covered by the exact-plan guard, Terraform contract tests, source review, and live runtime proof.

## Deferrals

- #1826 tracks the feedback parser's false-positive classification of Claude's clean LGTM layout. It does not affect this PR's source or runtime behavior.
