### PR TITLE
fix(sentry): self-heal the verdict step's labels before it edits

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -839,10 +839,21 @@ jobs:
           # temp file so it stays out of this step's log; what a reader needs —
           # a create that failed, a name missing from the definitions — is a
           # stderr warning annotation.
-          node scripts/sentry-triage-project.mjs \
-            --ensure-labels "${label},${shed},sentry:needs-triage" \
-            --repo "${GITHUB_REPOSITORY}" \
-            > "${RUNNER_TEMP}/verdict-label-ensure.json"
+          #
+          # Guarded like the --parse-only call above, and for the same reason: a
+          # bare abort under set -e says nothing about which call died. It does
+          # NOT re-queue, deliberately. Nothing has been written yet — the edit
+          # below has not run — so `sentry:needs-triage` is still on the stub and
+          # it stays selectable for the next scheduled run without any
+          # compensation, exactly like the --parse-only refusal. The re-queue
+          # window opens at the edit, not here.
+          if ! node scripts/sentry-triage-project.mjs \
+              --ensure-labels "${label},${shed},sentry:needs-triage" \
+              --repo "${GITHUB_REPOSITORY}" \
+              > "${RUNNER_TEMP}/verdict-label-ensure.json"; then
+            echo "::error::Could not self-heal the label set for issue #${QUEUE_ISSUE_NUMBER} (see the log above); refusing to attempt the verdict edit against a label set that may not exist. Nothing was written, so sentry:needs-triage is still on the stub and the next scheduled run retries it."
+            exit 1
+          fi
           if ! gh issue edit "${QUEUE_ISSUE_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
             --remove-label "sentry:needs-triage,${shed}" \

--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -779,17 +779,21 @@ jobs:
             echo "::error::architecturalHold for issue #${QUEUE_ISSUE_NUMBER} is '${architectural_hold}', not true/false; leaving sentry:needs-triage in place for retry."
             exit 1
           fi
-          gh issue edit "${QUEUE_ISSUE_NUMBER}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --remove-label "sentry:needs-triage,${shed}" \
-            --add-label "${label}"
-          echo "Applied ${label} to issue #${QUEUE_ISSUE_NUMBER}."
-          # The edit above already took sentry:needs-triage OFF, so every exit
-          # below it must put the stub back in the queue first. Nothing
+          # The label edit below takes sentry:needs-triage OFF, so it and every
+          # exit after it must put the stub back in the queue first. Nothing
           # downstream would: the close step never runs, the project job skips
           # a stub that is not needs-triage, and the scheduled selector only
-          # admits sentry:needs-triage — a bare `exit 1` here would strand an
+          # admits sentry:needs-triage — a bare `exit 1` there would strand an
           # open, verdict-labeled stub with no retry path at all.
+          #
+          # Defined ABOVE the edit because the EDIT ITSELF is one of those
+          # exits. `gh` sends --add-label and --remove-label as discrete
+          # mutations and fails the whole command on a label the repo does not
+          # have; the add can therefore land while the command exits nonzero,
+          # leaving the stub carrying the verdict label AND sentry:needs-triage.
+          # Defined below the edit — as it was — `set -e` killed the step before
+          # any compensation existed to call (the run on 2026-08-13, issue
+          # #1811).
           #
           # Every compensating exit in this workflow routes through the ONE
           # re-queue chokepoint (scripts/sentry-triage-requeue.mjs, BOOKKEEPING
@@ -812,12 +816,48 @@ jobs:
               --repo "${GITHUB_REPOSITORY}" \
               --reason verdict-unsettled
           }
+          # SELF-HEAL every label the edit names — added AND shed, plus
+          # sentry:needs-triage — from Stage A's LABEL_DEFINITIONS, before the
+          # edit. Only the ingest job CREATES that label set, so a label added to
+          # the definitions is absent from the repo until ingest next runs, and
+          # `gh` errors on a repo-nonexistent name for --remove-label exactly as
+          # for --add-label. That is what broke this step on 2026-08-13:
+          # sentry:fix-scope-architectural (#1812) reached the shed list — which
+          # every non-architectural verdict carries — hours before the next
+          # ingest bootstrapped it, so the edit added the verdict label, failed
+          # on the unknown removal, and left issue #1811 double-labeled.
+          #
+          # The three other settlement paths already do this before they write
+          # labels (.github/workflows/sentry-autofix.yml via
+          # `sentry-autofix-finalize.mjs label-def`, runProjectionBatch in
+          # scripts/sentry-triage-project.mjs, ensureArchiveLabels in
+          # scripts/sentry-triage-archive.mjs); this step was the last one that
+          # did not. Best-effort per label, like theirs: the mode warns and
+          # continues on a create it cannot make, so the ensure never becomes the
+          # thing that kills settlement — a name that still does not exist fails
+          # the guarded edit below, which compensates. Its JSON summary goes to a
+          # temp file so it stays out of this step's log; what a reader needs —
+          # a create that failed, a name missing from the definitions — is a
+          # stderr warning annotation.
+          node scripts/sentry-triage-project.mjs \
+            --ensure-labels "${label},${shed},sentry:needs-triage" \
+            --repo "${GITHUB_REPOSITORY}" \
+            > "${RUNNER_TEMP}/verdict-label-ensure.json"
+          if ! gh issue edit "${QUEUE_ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --remove-label "sentry:needs-triage,${shed}" \
+            --add-label "${label}"; then
+            echo "::error::Applying ${label} to issue #${QUEUE_ISSUE_NUMBER} failed (see the gh error above); the add and the removals are discrete mutations, so the stub may hold the verdict label and sentry:needs-triage at once. Re-queuing it so the next scheduled run re-triages it from a known state."
+            requeue_for_retry
+            exit 1
+          fi
+          echo "Applied ${label} to issue #${QUEUE_ISSUE_NUMBER}."
           # Post-condition, re-read from GitHub rather than assumed: refuse to
           # hand a double-verdicted stub to the close/project/digest legs. Only
-          # >1 fails — the edit above already exits nonzero if the --add-label
-          # did not land, so zero is not reachable here. Fail CLOSED on a read
-          # failure too: an unverifiable stub is treated as a violation and
-          # re-queued, never waved through. Re-queueing is safe to replay: the
+          # >1 fails — the guarded edit above already exits nonzero if the
+          # --add-label did not land, so zero is not reachable here. Fail CLOSED
+          # on a read failure too: an unverifiable stub is treated as a violation
+          # and re-queued, never waved through. Re-queueing is safe to replay: the
           # shed makes the whole step idempotent, so the retry run applies the
           # verdict onto a stub in exactly the state this run found it in.
           labels_file="${RUNNER_TEMP}/verdict-labels.json"

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -727,7 +727,25 @@ A stub carries exactly one `sentry:verdict-*` label. The label edit adds the
 new one and removes every other verdict label in the same call, so
 re-dispatching an already-verdicted stub — the usual case after a human answers
 a `needs-human` escalation — replaces the old verdict instead of stacking a
-second one. The step then re-reads the stub and fails its own matrix job if the
+second one.
+
+**The step self-heals its label set first, and the edit itself compensates.**
+Only ingest CREATES labels, so a name added to `LABEL_DEFINITIONS` does not
+exist in the repo until ingest next runs — and `gh` fails an entire
+`issue edit` on a repo-nonexistent name, on `--remove-label` exactly as on
+`--add-label`, after applying the add. So the step runs
+`sentry-triage-project.mjs --ensure-labels` over every name its edit touches —
+the verdict label, the whole shed list, and `sentry:needs-triage` —
+immediately before the edit, `gh label create --force` from the same single
+source the three other settlement paths self-heal from
+(`sentry-autofix.yml`, `runProjectionBatch`, `ensureArchiveLabels`). The ensure
+is best-effort per label; the edit that follows is guarded, so a partial failure
+re-queues the stub rather than stranding it verdict-labeled and queued at once.
+That is the failure PR #1812 shipped: `sentry:fix-scope-architectural` entered
+the shed list of every non-architectural verdict hours before the ingest run
+that would have created it, and the whole settlement leg failed on it.
+
+The step then re-reads the stub and fails its own matrix job if the
 read fails or more than one verdict label survives — re-queuing the stub first,
 the same compensation the brief-clear, close and projection failure paths make,
 so it goes back in the queue instead of being stranded open with no retry path.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2386,7 +2386,12 @@ while IFS= read -r path; do
           add_command "pnpm sentry:archive:test" "Sentry needs-human brief helper changed"
           add_command "pnpm sentry:project:test" "Sentry needs-human brief helper changed"
           ;;
-        scripts/sentry-triage-project.mjs|scripts/sentry-triage-project-core.mjs|scripts/sentry-triage-project.test.mjs|scripts/sentry-triage-text.mjs|scripts/sentry-triage-projection.mjs|scripts/sentry-triage-escalation-contract.mjs)
+        scripts/sentry-triage-project.mjs|scripts/sentry-triage-project-core.mjs|scripts/sentry-triage-project-cli.mjs|scripts/sentry-triage-label-ensure.mjs|scripts/sentry-triage-project.test.mjs|scripts/sentry-triage-text.mjs|scripts/sentry-triage-projection.mjs|scripts/sentry-triage-escalation-contract.mjs)
+          # sentry-triage-project-cli.mjs (the argv surface) and
+          # sentry-triage-label-ensure.mjs (the settlement label self-heal) were
+          # split out of the entry module for the 1,000-line cap (#1827); both
+          # are covered by the projection suite and reached only through it, so
+          # they route exactly like the file they came from.
           add_command "pnpm sentry:project:test" "Sentry triage projection helper changed"
           # The agent's comment wrapper imports the shared marker contract from
           # sentry-triage-project-core.mjs, so its fences ride on this module.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3740,6 +3740,16 @@ assert_contains "- pnpm sentry:project:test (Sentry re-queue chokepoint changed)
 run_gate "scripts/sentry-triage-project.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 
+# The argv surface and the settlement label self-heal, split out of the entry
+# module for the 1,000-line hard cap (#1827). Both are reached only through that
+# leg, so an unrouted change to either would ship untested.
+run_gate "scripts/sentry-triage-project-cli.mjs"
+assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
+
+run_gate "scripts/sentry-triage-label-ensure.mjs"
+assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
+assert_contains "- pnpm sentry:brief:test (Sentry triage projection helper changed)"
+
 run_gate "scripts/sentry-triage-project-core.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 assert_contains "- node scripts/sentry-triage-agent-comment.test.mjs (Sentry triage projection helper changed)"

--- a/scripts/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry-triage-agent-comment.test.mjs
@@ -620,17 +620,28 @@ test("the verdict edit sheds the other verdict labels and proves it landed", () 
   assert.match(job, /if \[ "\$\{survivor_count\}" -gt 1 \]; then/);
 });
 
-/**
- * The verdict label step from the edit that takes `sentry:needs-triage` off to
- * the end of the step — the window where the stub is invisible to the selector
- * and every exit therefore owes it a re-queue.
- */
-function verdictPostConditionBlock() {
-  const job = WORKFLOW.slice(
+/** The whole `verdict` job. */
+function verdictJobBlock() {
+  return WORKFLOW.slice(
     WORKFLOW.indexOf("\n  verdict:"),
     WORKFLOW.indexOf("\n  project:"),
   );
-  const start = job.indexOf('--remove-label "sentry:needs-triage,${shed}"');
+}
+
+/** The label edit that takes `sentry:needs-triage` off — the start of the
+ * window where the stub is invisible to the selector. */
+const VERDICT_EDIT_MARKER = '--remove-label "sentry:needs-triage,${shed}"';
+
+/**
+ * The verdict label step from that edit to the end of the step — the window
+ * where every exit owes the stub a re-queue. The edit itself is INSIDE it: gh
+ * sends the add and the removals as discrete mutations and fails the command on
+ * a label the repo does not have, so a failed edit can leave the stub carrying
+ * the verdict label and `sentry:needs-triage` at once.
+ */
+function verdictPostConditionBlock() {
+  const job = verdictJobBlock();
+  const start = job.indexOf(VERDICT_EDIT_MARKER);
   // End at the brief step, NOT the close step: the brief step has its own,
   // deliberately different failure semantics (#1769 round 10 — a CLEAR failure
   // exits 1 to BLOCK the close without re-queuing). This block is the VERDICT
@@ -653,12 +664,25 @@ test("a failed verdict post-condition re-queues the stub instead of stranding it
   // because this is the one branch where a stub can be wearing more than one
   // verdict label, plus the projection, autofix and archive markers), the
   // ordering, and the terminal revalidation.
-  const open = lines.findIndex(
+  //
+  // It is DEFINED above the window rather than inside it, because the edit that
+  // opens the window is itself an exit that owes a re-queue: defined below the
+  // edit, `set -e` aborted the step before any compensation existed to call
+  // (the 2026-08-13 failure on issue #1811).
+  const job = verdictJobBlock();
+  const jobLines = job.split("\n");
+  const open = jobLines.findIndex(
     (line) => line.trim() === "requeue_for_retry() {",
   );
-  assert.ok(open >= 0, "the verdict post-condition has no re-queue helper");
-  const close = lines.findIndex((line, i) => i > open && line.trim() === "}");
-  const helper = lines.slice(open, close).join("\n");
+  assert.ok(open >= 0, "the verdict step has no re-queue helper");
+  assert.ok(
+    job.indexOf("requeue_for_retry() {") < job.indexOf(VERDICT_EDIT_MARKER),
+    "the re-queue helper must be defined before the label edit, or the edit's own failure has nothing to call",
+  );
+  const close = jobLines.findIndex(
+    (line, i) => i > open && line.trim() === "}",
+  );
+  const helper = jobLines.slice(open, close).join("\n");
   assert.match(helper, /node scripts\/sentry-triage-workflow-requeue\.mjs/);
   assert.match(helper, /--issue "\$\{QUEUE_ISSUE_NUMBER\}"/);
   assert.match(helper, /--reason verdict-unsettled/);

--- a/scripts/sentry-triage-brief.test.mjs
+++ b/scripts/sentry-triage-brief.test.mjs
@@ -1805,6 +1805,25 @@ await test("the verdict step self-heals every label its edit names, BEFORE the e
       .split(",")
       .map((name) => name.trim())
       .filter(Boolean);
+  // Guarded like the --parse-only call above it: under `set -e` an unguarded
+  // node call aborts the step with no annotation naming which call died. It
+  // deliberately does NOT re-queue — nothing has been written yet, so
+  // sentry:needs-triage is still on the stub and it stays selectable. The
+  // compensation count pinned in the next test is what holds that line.
+  assert(
+    /^\s*if ! node scripts\/sentry-triage-project\.mjs\s+--ensure-labels/.test(
+      ensureLine,
+    ),
+    `the label ensure must be guarded, got: ${ensureLine?.trim()}`,
+  );
+  const ensureFailureBranch = verdictJob.slice(
+    ensureAt,
+    verdictJob.indexOf("gh issue edit"),
+  );
+  assert(
+    /echo "::error::[^"]*#\$\{QUEUE_ISSUE_NUMBER\}/.test(ensureFailureBranch),
+    "the ensure's failure branch must name the issue in an ::error:: annotation",
+  );
   const ensured = new Set(
     splitNames(/--ensure-labels\s+"([^"]*)"/.exec(ensureLine)[1]),
   );

--- a/scripts/sentry-triage-brief.test.mjs
+++ b/scripts/sentry-triage-brief.test.mjs
@@ -1756,12 +1756,112 @@ await test("the verdict step keeps its own re-queue compensation (not reversed b
       verdictJob.includes("--reason verdict-unsettled"),
     "the verdict step's compensation must run through the re-queue chokepoint CLI",
   );
-  // Both exits below the label swap call it — the re-read failure and the
+  // Three exits call it: the label swap itself, the re-read failure and the
   // more-than-one-verdict-label refusal.
   assertEqual(
     verdictJob.split("requeue_for_retry\n").length - 1,
-    2,
-    "both post-swap exits in the verdict step must compensate",
+    3,
+    "the label swap and both post-swap exits in the verdict step must compensate",
+  );
+});
+
+await test("the verdict step self-heals every label its edit names, BEFORE the edit", () => {
+  // Only the ingest job CREATES labels, so any name added to LABEL_DEFINITIONS
+  // is absent from the repo until ingest next runs — and gh fails the whole
+  // `issue edit` on a repo-nonexistent name, on --remove-label exactly as on
+  // --add-label. `sentry:fix-scope-architectural` (#1812) reached the shed list
+  // of every non-architectural verdict hours before that bootstrap, and the
+  // settlement leg died on it (issue #1811, 2026-08-13). The other three
+  // settlement paths already self-heal from the same single source; this asserts
+  // the last one does, in the only order that helps.
+  const workflow = readRepoFile(".github/workflows/sentry-triage-agent.yml");
+  const verdictJob = workflow.slice(
+    workflow.indexOf("- name: Apply verdict label"),
+    workflow.indexOf("- name: Render or clear the needs-human brief"),
+  );
+  const ensureAt = verdictJob.indexOf("--ensure-labels");
+  const editAt = verdictJob.indexOf("gh issue edit");
+  assert(ensureAt !== -1, "expected the verdict step to ensure its labels");
+  assert(editAt !== -1, "expected the verdict label edit");
+  assert(
+    ensureAt < editAt,
+    "the label ensure must run BEFORE the edit it protects",
+  );
+  // Through the single-source helper, never a hand-rolled `gh label create`
+  // with its own color and description.
+  assert(
+    /node scripts\/sentry-triage-project\.mjs\s+--ensure-labels/.test(
+      verdictJob.replace(/\\\s*\n\s*/g, " "),
+    ),
+    "the ensure must run the shared self-heal, not an open-coded label create",
+  );
+  // Coverage, derived from the edit itself: every label the edit names — both
+  // sides — must be in the ensured set. Drop one and this reds.
+  const joined = verdictJob.replace(/\\\s*\n\s*/g, " ").split("\n");
+  const ensureLine = joined.find((line) => line.includes("--ensure-labels"));
+  const editLine = joined.find((line) => line.includes("gh issue edit"));
+  const splitNames = (raw) =>
+    raw
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean);
+  const ensured = new Set(
+    splitNames(/--ensure-labels\s+"([^"]*)"/.exec(ensureLine)[1]),
+  );
+  const referenced = new Set();
+  for (const [, segment] of editLine.matchAll(
+    /--(?:add|remove)-label\s+"([^"]*)"/g,
+  )) {
+    for (const name of splitNames(segment)) referenced.add(name);
+  }
+  assert(
+    referenced.has(NEEDS_TRIAGE_LABEL),
+    "expected the edit to shed sentry:needs-triage (scan found the wrong line)",
+  );
+  for (const name of referenced) {
+    assert(
+      ensured.has(name),
+      `the edit names ${name} but the ensure does not cover it`,
+    );
+  }
+});
+
+await test("the verdict step defines its compensation ABOVE the label edit and guards the edit with it", () => {
+  // The edit is itself an exit that owes a re-queue. `gh` sends --add-label and
+  // --remove-label as discrete mutations and fails the command on a label the
+  // repo does not have, so a failure can leave the stub carrying the verdict
+  // label AND sentry:needs-triage. With `requeue_for_retry` defined BELOW the
+  // edit, `set -e` aborted the step before any compensation existed — the
+  // 2026-08-13 failure on issue #1811. Ordering by index, not presence: a
+  // definition that drifts back below the edit reds this.
+  const workflow = readRepoFile(".github/workflows/sentry-triage-agent.yml");
+  const verdictJob = workflow.slice(
+    workflow.indexOf("- name: Apply verdict label"),
+    workflow.indexOf("- name: Render or clear the needs-human brief"),
+  );
+  const definedAt = verdictJob.indexOf("requeue_for_retry() {");
+  const editAt = verdictJob.indexOf("gh issue edit");
+  assert(definedAt !== -1, "expected the compensation to be defined");
+  assert(editAt !== -1, "expected the verdict label edit");
+  assert(
+    definedAt < editAt,
+    "requeue_for_retry must be defined before the label edit it compensates for",
+  );
+  // The edit runs in a condition, so its failure routes to the compensation
+  // instead of aborting the step under set -e.
+  const guarded = verdictJob
+    .replace(/\\\s*\n\s*/g, " ")
+    .split("\n")
+    .find((line) => line.includes("gh issue edit"));
+  assert(
+    /^\s*if ! gh issue edit\b/.test(guarded),
+    `the verdict label edit must be guarded, got: ${guarded?.trim()}`,
+  );
+  const failureBranch = verdictJob.slice(editAt);
+  assert(
+    failureBranch.indexOf("requeue_for_retry\n") <
+      failureBranch.indexOf("Applied ${label}"),
+    "the edit's failure branch must re-queue before the success log",
   );
 });
 

--- a/scripts/sentry-triage-brief.test.mjs
+++ b/scripts/sentry-triage-brief.test.mjs
@@ -2123,8 +2123,17 @@ await test("the brief leg is not a stub-body writer, and owns its marker alone",
 });
 
 await test("the pipeline's shared modules stay under the file-size hard cap", () => {
+  // scripts/ has no max-lines lint, so the 1,000-line hard cap in
+  // docs/pr-checklists/recurring-review-patterns.md is only enforced here. The
+  // projection leg is on this list because it was NOT: it drifted past the cap
+  // unnoticed and a later PR appended to it, which is the exact sequence the
+  // checklist forbids (#1827). Everything a live workflow entry point reaches
+  // belongs here — an omission is how the next one drifts.
   const oversized = [
+    "scripts/sentry-triage-project.mjs",
+    "scripts/sentry-triage-project-cli.mjs",
     "scripts/sentry-triage-project-core.mjs",
+    "scripts/sentry-triage-label-ensure.mjs",
     "scripts/sentry-triage-escalation-contract.mjs",
     "scripts/sentry-triage-text.mjs",
     "scripts/sentry-triage-brief.mjs",

--- a/scripts/sentry-triage-label-ensure.mjs
+++ b/scripts/sentry-triage-label-ensure.mjs
@@ -1,0 +1,110 @@
+/**
+ * Label self-heal for the Sentry triage pipeline's settlement paths.
+ *
+ * Only the ingest job CREATES the queue's label set, so any name added to
+ * LABEL_DEFINITIONS is absent from the repo until ingest next runs — and `gh`
+ * errors on a repo-nonexistent label, on `--remove-label` exactly as on
+ * `--add-label`. A consumer that ships ahead of that bootstrap therefore fails
+ * on a name it was right to use, which is what took the verdict step down on
+ * 2026-08-13 (`sentry:fix-scope-architectural` reached the shed list of every
+ * non-architectural verdict hours before the ingest run that would have created
+ * it). Every path that writes labels creates them from the single source first;
+ * this module is that step for the projection leg and for the workflow's
+ * settlement step, which reaches it through
+ * `sentry-triage-project.mjs --ensure-labels`.
+ *
+ * Its own I/O is injected: the caller owns the `gh` runner (and its token
+ * routing), so this file stays a pure mechanism and never imports the leg that
+ * imports it.
+ */
+
+import { LABEL_DEFINITIONS } from "./sentry-triage-ingest.mjs";
+
+/**
+ * Parse the `--ensure-labels` value: a comma list, the shape the workflow
+ * already builds for `--remove-label`. Empty segments are dropped so an empty
+ * shed list costs nothing. An EMPTY set is a wiring bug — a step that ensures
+ * nothing would silently reintroduce the failure this mode exists to prevent —
+ * so it fails loud here rather than no-opping.
+ */
+export function parseEnsureLabelNames(raw) {
+  const names = String(raw ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name !== "");
+  if (names.length === 0) {
+    throw new Error("--ensure-labels requires at least one label name");
+  }
+  return names;
+}
+
+/**
+ * SELF-HEAL a named set of labels from the single source of truth (Stage A's
+ * LABEL_DEFINITIONS), the pattern every other settlement path in this pipeline
+ * already uses before it writes labels (`.github/workflows/sentry-autofix.yml`
+ * via `sentry-autofix-finalize.mjs label-def`, `ensureArchiveLabels` in
+ * `scripts/sentry-triage-archive.mjs`, and `runProjectionBatch`).
+ *
+ * BEST-EFFORT per label: a create that fails warns and the loop continues, so
+ * the ensure never becomes the thing that kills a settlement; the write it was
+ * protecting still fails loudly, with compensation. A name absent from
+ * LABEL_DEFINITIONS is drift in the single source, so it is reported as a
+ * workflow annotation rather than silently skipped.
+ *
+ * `localRun` is the one-argument `gh` runner (no token override — these are
+ * local-repo writes under the ambient GH_TOKEN).
+ *
+ * Returns `{ ensured, unknown, failed }` — name lists, for the CLI's JSON.
+ */
+export async function ensureQueueLabels(localRun, repo, names) {
+  const result = { ensured: [], unknown: [], failed: [] };
+  for (const name of [...new Set(names)]) {
+    const def = LABEL_DEFINITIONS.find((entry) => entry.name === name);
+    if (!def) {
+      process.stderr.write(
+        `::warning::${name} is not in LABEL_DEFINITIONS, so it cannot be self-healed; the label single-source drifted.\n`,
+      );
+      result.unknown.push(name);
+      continue;
+    }
+    try {
+      await localRun([
+        "label",
+        "create",
+        def.name,
+        "--repo",
+        repo,
+        "--color",
+        def.color,
+        "--description",
+        def.description,
+        "--force",
+      ]);
+      result.ensured.push(name);
+    } catch (error) {
+      process.stderr.write(
+        `warning: could not ensure label ${name}: ${error.message}\n`,
+      );
+      result.failed.push(name);
+    }
+  }
+  return result;
+}
+
+/**
+ * `--ensure-labels` mode: the settlement step's pre-flight. The verdict step in
+ * `.github/workflows/sentry-triage-agent.yml` runs it with every label its one
+ * `gh issue edit` names — the verdict label being added, the whole shed list,
+ * and `sentry:needs-triage` — immediately before that edit.
+ *
+ * `deps.runGh` is REQUIRED: this module owns no runner of its own, so the entry
+ * script passes its `gh` wrapper and the tests pass a recorder.
+ */
+export async function runEnsureLabels(options, deps = {}) {
+  const { runGh } = deps;
+  if (typeof runGh !== "function") {
+    throw new Error("runEnsureLabels requires a gh runner (deps.runGh)");
+  }
+  const localRun = (args) => runGh(args, {});
+  return ensureQueueLabels(localRun, options.localRepo, options.ensureLabels);
+}

--- a/scripts/sentry-triage-project-cli.mjs
+++ b/scripts/sentry-triage-project-cli.mjs
@@ -1,0 +1,236 @@
+/**
+ * Argv surface of the verdict-projection leg (`sentry-triage-project.mjs`).
+ *
+ * Split out of that entry module (#1827) purely on size: it was over the
+ * 1,000-line hard cap in docs/pr-checklists/recurring-review-patterns.md and
+ * scripts/ has no `max-lines` lint to catch it. This is the cleanest seam the
+ * file has — help text and argument validation depend on nothing but the
+ * contract constants, while everything left behind is `gh` I/O and the mode
+ * drivers, so the two sides share no state and the cut needed no logic changes.
+ *
+ * The entry module re-exports `parseArgs` and `parseIssueNumbers`, so the
+ * import surface tests and consumers use is unchanged.
+ */
+
+import {
+  DEFAULT_REPO,
+  isPriorVerdictToken,
+  PRIOR_VERDICT_NONE,
+  PRIOR_VERDICT_UNKNOWN,
+  PROJECTED_LABEL,
+  VALID_VERDICTS,
+} from "./sentry-triage-project-core.mjs";
+import { parseEnsureLabelNames } from "./sentry-triage-label-ensure.mjs";
+
+export function usage() {
+  return `Usage: pnpm sentry:project --issue <queue-issue-number> [options]
+
+Deterministically projects an actionable (code-fix/config-fix) triage verdict
+for an EXTERNAL owning repo into a human-readable issue in that repo, labels the
+queue stub ${PROJECTED_LABEL}, and comments the projected issue URL. Prints a
+single-line JSON result ({"status": "...", "url": "..."}) to stdout; diagnostics
+and workflow annotations go to stderr.
+
+Statuses: projected | reused | skipped-verdict | skipped-repo | skipped-no-token
+(batch rows additionally: skipped-state | failed)
+
+Options:
+  --issue <number>     Queue issue number to project (positive int; required
+                       unless --batch).
+  --batch              Serialized batch mode (the workflow's project job):
+                       process --issues one at a time in ONE process, sharing
+                       an in-run registry so duplicate-family SHORT-IDs can
+                       never double-file while GitHub search still lags issue
+                       creation. Emits a JSON array of per-issue result rows.
+  --issues <json>      JSON array of queue-issue numbers (batch mode).
+  --repo <owner/name>  Repo the queue stub lives in (default: ${DEFAULT_REPO}).
+  --parse-only         Resolve and print the validated verdict + mapped label +
+                       projectability + shed list + architecturalHold
+                       ({"verdict","label","projectable","shed","architecturalHold"}
+                       JSON) without projecting. \`label\` is a comma list on a
+                       local code-fix + fix_scope:architectural verdict (adds
+                       sentry:fix-scope-architectural), and architecturalHold then
+                       tells the close step to leave the stub open. Used by the
+                       workflow's label step so labeling and projection share ONE
+                       parser. Fails (exit 1) on a missing, stale pre-regression,
+                       or invalid verdict comment.
+  --prior-verdicts     Print {"<issue>": "<comment-id>|${PRIOR_VERDICT_NONE}|${PRIOR_VERDICT_UNKNOWN}"} for
+                       --issues: the verdict comment already on each stub. Run
+                       by the SELECT job, before the triage agent, to record
+                       what the round started from (issue #1717).
+  --prior-verdict-comment <token>
+                       With --parse-only: the id --prior-verdicts recorded for
+                       this stub (or ${PRIOR_VERDICT_NONE} / ${PRIOR_VERDICT_UNKNOWN}). The resolution
+                       then refuses (exit 1) unless the verdict comment it
+                       selects is strictly newer, so a triage round that posted
+                       nothing cannot settle the stub on the previous round's
+                       verdict.
+  --verdict <value>    Already-validated verdict from the label step. When set,
+                       the script fails loud if its own parse of the newest
+                       verdict comment disagrees (never a silent skip).
+  --ensure-labels <names>
+                       Comma list of labels to self-heal from Stage A's
+                       LABEL_DEFINITIONS (\`gh label create --force\`) before a
+                       caller writes them. Run by the workflow's label step with
+                       every name its \`gh issue edit\` uses — added, shed, and
+                       \`sentry:needs-triage\` — because gh fails the whole edit
+                       on a label the repo does not have, on --remove-label just
+                       as on --add-label. Needs no --issue; best-effort per
+                       label, so it exits 0 even when a create fails.
+  -h, --help           Show this help.
+
+Env:
+  SENTRY_PROJECTION_TOKEN  Fine-grained PAT (Issues R/W on the three owning
+                           repos) for the cross-repo create/search. Absent ->
+                           graceful no-op (status skipped-no-token).
+  GH_TOKEN                 Ambient github.token for local queue-stub mutations.
+`;
+}
+
+/** Parse a `--issues` JSON array of positive integers (the select job's
+ * output). Fails loud on anything else. */
+export function parseIssueNumbers(raw) {
+  if (raw == null || String(raw).trim() === "") return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(String(raw));
+  } catch {
+    throw new Error(
+      `--issues must be a JSON array of issue numbers, got: ${raw}`,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("--issues must be a JSON array of issue numbers");
+  }
+  return parsed.map((value) => {
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+    }
+    return value;
+  });
+}
+
+export function parseArgs(argv, env = process.env) {
+  const options = {
+    localRepo: DEFAULT_REPO,
+    queueIssue: null,
+    queueIssues: [],
+    batch: false,
+    parseOnly: false,
+    priorVerdicts: false,
+    priorVerdictCommentId: null,
+    expectedVerdict: null,
+    ensureLabels: null,
+    help: false,
+  };
+  let issuesRaw = null;
+  const args = [...argv];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const readValue = () => {
+      const value = args[++i];
+      if (value == null) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+    switch (arg) {
+      case "--issue":
+        options.queueIssue = Number(readValue());
+        break;
+      case "--issues":
+        issuesRaw = readValue();
+        break;
+      case "--batch":
+        options.batch = true;
+        break;
+      case "--repo":
+        options.localRepo = readValue();
+        break;
+      case "--parse-only":
+        options.parseOnly = true;
+        break;
+      case "--prior-verdicts":
+        options.priorVerdicts = true;
+        break;
+      case "--prior-verdict-comment": {
+        // A bare comment id, `none`, or `unknown` — the closed set
+        // `--prior-verdicts` emits. Anything else is a wiring bug between the
+        // two jobs, and a wiring bug that silently degraded to "unbound" would
+        // remove the fence without saying so, so it fails loud here.
+        const value = readValue();
+        if (!isPriorVerdictToken(value)) {
+          throw new Error(
+            `--prior-verdict-comment must be a numeric comment id, ${PRIOR_VERDICT_NONE}, or ${PRIOR_VERDICT_UNKNOWN}, got: ${value}`,
+          );
+        }
+        options.priorVerdictCommentId = value;
+        break;
+      }
+      case "--verdict": {
+        // Comes from the label step's closed-enum output; anything else is a
+        // wiring bug — fail loud rather than carrying an invalid expectation.
+        const value = readValue();
+        if (!VALID_VERDICTS.includes(value)) {
+          throw new Error(
+            `--verdict must be one of ${VALID_VERDICTS.join(", ")}, got: ${value}`,
+          );
+        }
+        options.expectedVerdict = value;
+        break;
+      }
+      case "--ensure-labels":
+        options.ensureLabels = parseEnsureLabelNames(readValue());
+        break;
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+    }
+  }
+  if (!options.help) {
+    // Only --parse-only consumes the token. Accepting it on a projection run
+    // would silently drop the fence, which is the one failure mode the flag
+    // exists to prevent — so an unconsumed token is a wiring bug, not a no-op.
+    if (options.priorVerdictCommentId !== null && !options.parseOnly) {
+      throw new Error(
+        "--prior-verdict-comment is only consumed by --parse-only; pass both or neither",
+      );
+    }
+    // Label self-heal is its own mode: it touches no stub and resolves no
+    // verdict, so an invocation that also asks for one of those gets neither
+    // silently. The DEFAULT mode is the one to be careful about — it is not a
+    // flag at all, just `--issue` plus an optional `--verdict` cross-check — so
+    // a guard that only rejected the FLAGGED modes would let
+    // `--issue 5 --verdict code-fix --ensure-labels …` ensure the labels, skip
+    // the projection entirely, and exit 0 reporting success for a no-op. Every
+    // mode-bearing input is therefore rejected by name. The label step runs
+    // ensure and edit as separate, ordered invocations on purpose, so nothing
+    // legitimately needs both.
+    if (options.ensureLabels !== null) {
+      const alsoRequested = [
+        options.batch && "--batch",
+        options.parseOnly && "--parse-only",
+        options.priorVerdicts && "--prior-verdicts",
+        issuesRaw !== null && "--issues",
+        options.queueIssue !== null && "--issue",
+        options.expectedVerdict !== null && "--verdict",
+      ].filter(Boolean);
+      if (alsoRequested.length > 0) {
+        throw new Error(
+          `--ensure-labels is a standalone mode; run it in its own invocation (also passed: ${alsoRequested.join(", ")})`,
+        );
+      }
+    }
+    if (options.batch || options.priorVerdicts) {
+      options.queueIssues = parseIssueNumbers(issuesRaw);
+    } else if (
+      options.ensureLabels === null &&
+      (!Number.isInteger(options.queueIssue) || options.queueIssue <= 0)
+    ) {
+      throw new Error("--issue must be a positive integer");
+    }
+  }
+  options.projectionToken = (env.SENTRY_PROJECTION_TOKEN ?? "").trim();
+  return options;
+}

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -1155,17 +1155,30 @@ export function parseArgs(argv, env = process.env) {
         "--prior-verdict-comment is only consumed by --parse-only; pass both or neither",
       );
     }
-    // Label self-heal is its own mode: it touches no stub, so it takes no
-    // issue. Combining it with a resolving mode would hide which one the caller
-    // meant — and the label step runs the two as separate, ordered invocations
-    // on purpose (ensure, THEN edit), so nothing legitimately needs both.
-    if (
-      options.ensureLabels !== null &&
-      (options.batch || options.parseOnly || options.priorVerdicts)
-    ) {
-      throw new Error(
-        "--ensure-labels is a standalone mode; run it in its own invocation",
-      );
+    // Label self-heal is its own mode: it touches no stub and resolves no
+    // verdict, so an invocation that also asks for one of those gets neither
+    // silently. The DEFAULT mode is the one to be careful about — it is not a
+    // flag at all, just `--issue` plus an optional `--verdict` cross-check — so
+    // a guard that only rejected the FLAGGED modes would let
+    // `--issue 5 --verdict code-fix --ensure-labels …` ensure the labels, skip
+    // the projection entirely, and exit 0 reporting success for a no-op. Every
+    // mode-bearing input is therefore rejected by name. The label step runs
+    // ensure and edit as separate, ordered invocations on purpose, so nothing
+    // legitimately needs both.
+    if (options.ensureLabels !== null) {
+      const alsoRequested = [
+        options.batch && "--batch",
+        options.parseOnly && "--parse-only",
+        options.priorVerdicts && "--prior-verdicts",
+        issuesRaw !== null && "--issues",
+        options.queueIssue !== null && "--issue",
+        options.expectedVerdict !== null && "--verdict",
+      ].filter(Boolean);
+      if (alsoRequested.length > 0) {
+        throw new Error(
+          `--ensure-labels is a standalone mode; run it in its own invocation (also passed: ${alsoRequested.join(", ")})`,
+        );
+      }
     }
     if (options.batch || options.priorVerdicts) {
       options.queueIssues = parseIssueNumbers(issuesRaw);

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -771,6 +771,74 @@ const ACTIONABLE_LABEL_TO_VERDICT = {
 };
 
 /**
+ * SELF-HEAL a named set of labels from the single source of truth (Stage A's
+ * LABEL_DEFINITIONS), the pattern every other settlement path in this pipeline
+ * already uses before it writes labels (`.github/workflows/sentry-autofix.yml`
+ * via `sentry-autofix-finalize.mjs label-def`, `ensureArchiveLabels` in
+ * `scripts/sentry-triage-archive.mjs`, and the batch below).
+ *
+ * The reason it exists: only the ingest job CREATES the label set, so any label
+ * added to LABEL_DEFINITIONS is absent from the repo until ingest next runs —
+ * and `gh` errors on a repo-nonexistent label, on `--remove-label` exactly as on
+ * `--add-label`. A consumer that ships ahead of that bootstrap fails on a name
+ * it was right to use.
+ *
+ * BEST-EFFORT per label: a create that fails warns and the loop continues, so
+ * the ensure never becomes the thing that kills a settlement; the write it was
+ * protecting still fails loudly, with compensation. A name absent from
+ * LABEL_DEFINITIONS is drift in the single source, so it is reported as a
+ * workflow annotation rather than silently skipped.
+ *
+ * Returns `{ ensured, unknown, failed }` — name lists, for the CLI's JSON.
+ */
+async function ensureQueueLabels(localRun, repo, names) {
+  const result = { ensured: [], unknown: [], failed: [] };
+  for (const name of [...new Set(names)]) {
+    const def = LABEL_DEFINITIONS.find((entry) => entry.name === name);
+    if (!def) {
+      process.stderr.write(
+        `::warning::${name} is not in LABEL_DEFINITIONS, so it cannot be self-healed; the label single-source drifted.\n`,
+      );
+      result.unknown.push(name);
+      continue;
+    }
+    try {
+      await localRun([
+        "label",
+        "create",
+        def.name,
+        "--repo",
+        repo,
+        "--color",
+        def.color,
+        "--description",
+        def.description,
+        "--force",
+      ]);
+      result.ensured.push(name);
+    } catch (error) {
+      process.stderr.write(
+        `warning: could not ensure label ${name}: ${error.message}\n`,
+      );
+      result.failed.push(name);
+    }
+  }
+  return result;
+}
+
+/**
+ * `--ensure-labels` mode: the settlement step's pre-flight. The verdict step in
+ * `.github/workflows/sentry-triage-agent.yml` runs it with every label its one
+ * `gh issue edit` names — the verdict label being added, the whole shed list,
+ * and `sentry:needs-triage` — immediately before that edit.
+ */
+export async function runEnsureLabels(options, deps = {}) {
+  const runGh = deps.runGh ?? defaultRunGh;
+  const localRun = (args) => runGh(args, {});
+  return ensureQueueLabels(localRun, options.localRepo, options.ensureLabels);
+}
+
+/**
  * `--batch` mode: the serialized `project` job's driver. Processes the run's
  * queue issues ONE AT A TIME in a single node process, which kills the
  * same-run duplicate-family race by construction — no two projections are
@@ -800,29 +868,7 @@ export async function runProjectionBatch(options, deps = {}) {
   // both the stub labeling and the compensation removals on first activation.
   // Best-effort: if the ensure itself fails, per-row settling fails loudly
   // with compensation as before.
-  const projectedDef = LABEL_DEFINITIONS.find(
-    (def) => def.name === PROJECTED_LABEL,
-  );
-  if (projectedDef) {
-    try {
-      await localRun([
-        "label",
-        "create",
-        projectedDef.name,
-        "--repo",
-        options.localRepo,
-        "--color",
-        projectedDef.color,
-        "--description",
-        projectedDef.description,
-        "--force",
-      ]);
-    } catch (error) {
-      process.stderr.write(
-        `warning: could not ensure label ${PROJECTED_LABEL}: ${error.message}\n`,
-      );
-    }
-  }
+  await ensureQueueLabels(localRun, options.localRepo, [PROJECTED_LABEL]);
 
   for (const number of options.queueIssues) {
     let verdict = null;
@@ -967,6 +1013,15 @@ Options:
   --verdict <value>    Already-validated verdict from the label step. When set,
                        the script fails loud if its own parse of the newest
                        verdict comment disagrees (never a silent skip).
+  --ensure-labels <names>
+                       Comma list of labels to self-heal from Stage A's
+                       LABEL_DEFINITIONS (\`gh label create --force\`) before a
+                       caller writes them. Run by the workflow's label step with
+                       every name its \`gh issue edit\` uses — added, shed, and
+                       \`sentry:needs-triage\` — because gh fails the whole edit
+                       on a label the repo does not have, on --remove-label just
+                       as on --add-label. Needs no --issue; best-effort per
+                       label, so it exits 0 even when a create fails.
   -h, --help           Show this help.
 
 Env:
@@ -1010,6 +1065,7 @@ export function parseArgs(argv, env = process.env) {
     priorVerdicts: false,
     priorVerdictCommentId: null,
     expectedVerdict: null,
+    ensureLabels: null,
     help: false,
   };
   let issuesRaw = null;
@@ -1066,6 +1122,22 @@ export function parseArgs(argv, env = process.env) {
         options.expectedVerdict = value;
         break;
       }
+      case "--ensure-labels": {
+        // A comma list, the shape the workflow already builds for
+        // `--remove-label`; empty segments are dropped so an empty shed list
+        // costs nothing. An EMPTY set is a wiring bug — a step that ensures
+        // nothing would silently reintroduce the failure this mode exists to
+        // prevent — so it fails loud here rather than no-opping.
+        const names = readValue()
+          .split(",")
+          .map((name) => name.trim())
+          .filter((name) => name !== "");
+        if (names.length === 0) {
+          throw new Error("--ensure-labels requires at least one label name");
+        }
+        options.ensureLabels = names;
+        break;
+      }
       case "-h":
       case "--help":
         options.help = true;
@@ -1083,11 +1155,23 @@ export function parseArgs(argv, env = process.env) {
         "--prior-verdict-comment is only consumed by --parse-only; pass both or neither",
       );
     }
+    // Label self-heal is its own mode: it touches no stub, so it takes no
+    // issue. Combining it with a resolving mode would hide which one the caller
+    // meant — and the label step runs the two as separate, ordered invocations
+    // on purpose (ensure, THEN edit), so nothing legitimately needs both.
+    if (
+      options.ensureLabels !== null &&
+      (options.batch || options.parseOnly || options.priorVerdicts)
+    ) {
+      throw new Error(
+        "--ensure-labels is a standalone mode; run it in its own invocation",
+      );
+    }
     if (options.batch || options.priorVerdicts) {
       options.queueIssues = parseIssueNumbers(issuesRaw);
     } else if (
-      !Number.isInteger(options.queueIssue) ||
-      options.queueIssue <= 0
+      options.ensureLabels === null &&
+      (!Number.isInteger(options.queueIssue) || options.queueIssue <= 0)
     ) {
       throw new Error("--issue must be a positive integer");
     }
@@ -1103,7 +1187,9 @@ async function main() {
     return;
   }
   let result;
-  if (options.batch) {
+  if (options.ensureLabels) {
+    result = await runEnsureLabels(options);
+  } else if (options.batch) {
     result = await runProjectionBatch(options);
   } else if (options.priorVerdicts) {
     result = await runPriorVerdicts(options);

--- a/scripts/sentry-triage-project.mjs
+++ b/scripts/sentry-triage-project.mjs
@@ -50,10 +50,8 @@ import { fileURLToPath } from "node:url";
 export * from "./sentry-triage-project-core.mjs";
 
 import {
-  DEFAULT_REPO,
   extractPermalink,
   FIX_SCOPE_ARCHITECTURAL,
-  isPriorVerdictToken,
   isValidShortId,
   MAX_DUPLICATE_LOOKUPS,
   parseShortId,
@@ -64,7 +62,6 @@ import {
   PROJECTED_LABEL,
   resolveVerdict,
   selectVerdictComment,
-  VALID_VERDICTS,
   validateAffectedRepo,
   verdictCommentIdFromUrl,
 } from "./sentry-triage-project-core.mjs";
@@ -93,9 +90,27 @@ import {
 } from "./sentry-triage-projection.mjs";
 import {
   FIX_SCOPE_ARCHITECTURAL_LABEL,
-  LABEL_DEFINITIONS,
   VERDICT_LABELS,
 } from "./sentry-triage-ingest.mjs";
+// The argv surface and the label self-heal are siblings, split out of this file
+// (#1827) to bring it back under the 1,000-line hard cap. Both are re-exported
+// so the import surface tests and consumers use through this entry module is
+// unchanged, and so the leg keeps ONE implementation of each.
+export {
+  ensureQueueLabels,
+  parseEnsureLabelNames,
+  runEnsureLabels,
+} from "./sentry-triage-label-ensure.mjs";
+import {
+  ensureQueueLabels,
+  runEnsureLabels,
+} from "./sentry-triage-label-ensure.mjs";
+export {
+  parseArgs,
+  parseIssueNumbers,
+  usage,
+} from "./sentry-triage-project-cli.mjs";
+import { parseArgs, usage } from "./sentry-triage-project-cli.mjs";
 // Clear any stale needs-human brief before this job CLOSES a projected stub: a
 // stub re-triaged needs-human -> code-fix/config-fix whose brief-clear failed in
 // the matrix would otherwise be projected and closed here still showing the
@@ -771,74 +786,6 @@ const ACTIONABLE_LABEL_TO_VERDICT = {
 };
 
 /**
- * SELF-HEAL a named set of labels from the single source of truth (Stage A's
- * LABEL_DEFINITIONS), the pattern every other settlement path in this pipeline
- * already uses before it writes labels (`.github/workflows/sentry-autofix.yml`
- * via `sentry-autofix-finalize.mjs label-def`, `ensureArchiveLabels` in
- * `scripts/sentry-triage-archive.mjs`, and the batch below).
- *
- * The reason it exists: only the ingest job CREATES the label set, so any label
- * added to LABEL_DEFINITIONS is absent from the repo until ingest next runs —
- * and `gh` errors on a repo-nonexistent label, on `--remove-label` exactly as on
- * `--add-label`. A consumer that ships ahead of that bootstrap fails on a name
- * it was right to use.
- *
- * BEST-EFFORT per label: a create that fails warns and the loop continues, so
- * the ensure never becomes the thing that kills a settlement; the write it was
- * protecting still fails loudly, with compensation. A name absent from
- * LABEL_DEFINITIONS is drift in the single source, so it is reported as a
- * workflow annotation rather than silently skipped.
- *
- * Returns `{ ensured, unknown, failed }` — name lists, for the CLI's JSON.
- */
-async function ensureQueueLabels(localRun, repo, names) {
-  const result = { ensured: [], unknown: [], failed: [] };
-  for (const name of [...new Set(names)]) {
-    const def = LABEL_DEFINITIONS.find((entry) => entry.name === name);
-    if (!def) {
-      process.stderr.write(
-        `::warning::${name} is not in LABEL_DEFINITIONS, so it cannot be self-healed; the label single-source drifted.\n`,
-      );
-      result.unknown.push(name);
-      continue;
-    }
-    try {
-      await localRun([
-        "label",
-        "create",
-        def.name,
-        "--repo",
-        repo,
-        "--color",
-        def.color,
-        "--description",
-        def.description,
-        "--force",
-      ]);
-      result.ensured.push(name);
-    } catch (error) {
-      process.stderr.write(
-        `warning: could not ensure label ${name}: ${error.message}\n`,
-      );
-      result.failed.push(name);
-    }
-  }
-  return result;
-}
-
-/**
- * `--ensure-labels` mode: the settlement step's pre-flight. The verdict step in
- * `.github/workflows/sentry-triage-agent.yml` runs it with every label its one
- * `gh issue edit` names — the verdict label being added, the whole shed list,
- * and `sentry:needs-triage` — immediately before that edit.
- */
-export async function runEnsureLabels(options, deps = {}) {
-  const runGh = deps.runGh ?? defaultRunGh;
-  const localRun = (args) => runGh(args, {});
-  return ensureQueueLabels(localRun, options.localRepo, options.ensureLabels);
-}
-
-/**
  * `--batch` mode: the serialized `project` job's driver. Processes the run's
  * queue issues ONE AT A TIME in a single node process, which kills the
  * same-run duplicate-family race by construction — no two projections are
@@ -964,234 +911,9 @@ export async function runProjectionBatch(options, deps = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// CLI
+// CLI. The argv surface lives in ./sentry-triage-project-cli.mjs; this file
+// keeps the dispatch, which is the only part that needs the mode drivers above.
 // ---------------------------------------------------------------------------
-
-function usage() {
-  return `Usage: pnpm sentry:project --issue <queue-issue-number> [options]
-
-Deterministically projects an actionable (code-fix/config-fix) triage verdict
-for an EXTERNAL owning repo into a human-readable issue in that repo, labels the
-queue stub ${PROJECTED_LABEL}, and comments the projected issue URL. Prints a
-single-line JSON result ({"status": "...", "url": "..."}) to stdout; diagnostics
-and workflow annotations go to stderr.
-
-Statuses: projected | reused | skipped-verdict | skipped-repo | skipped-no-token
-(batch rows additionally: skipped-state | failed)
-
-Options:
-  --issue <number>     Queue issue number to project (positive int; required
-                       unless --batch).
-  --batch              Serialized batch mode (the workflow's project job):
-                       process --issues one at a time in ONE process, sharing
-                       an in-run registry so duplicate-family SHORT-IDs can
-                       never double-file while GitHub search still lags issue
-                       creation. Emits a JSON array of per-issue result rows.
-  --issues <json>      JSON array of queue-issue numbers (batch mode).
-  --repo <owner/name>  Repo the queue stub lives in (default: ${DEFAULT_REPO}).
-  --parse-only         Resolve and print the validated verdict + mapped label +
-                       projectability + shed list + architecturalHold
-                       ({"verdict","label","projectable","shed","architecturalHold"}
-                       JSON) without projecting. \`label\` is a comma list on a
-                       local code-fix + fix_scope:architectural verdict (adds
-                       sentry:fix-scope-architectural), and architecturalHold then
-                       tells the close step to leave the stub open. Used by the
-                       workflow's label step so labeling and projection share ONE
-                       parser. Fails (exit 1) on a missing, stale pre-regression,
-                       or invalid verdict comment.
-  --prior-verdicts     Print {"<issue>": "<comment-id>|${PRIOR_VERDICT_NONE}|${PRIOR_VERDICT_UNKNOWN}"} for
-                       --issues: the verdict comment already on each stub. Run
-                       by the SELECT job, before the triage agent, to record
-                       what the round started from (issue #1717).
-  --prior-verdict-comment <token>
-                       With --parse-only: the id --prior-verdicts recorded for
-                       this stub (or ${PRIOR_VERDICT_NONE} / ${PRIOR_VERDICT_UNKNOWN}). The resolution
-                       then refuses (exit 1) unless the verdict comment it
-                       selects is strictly newer, so a triage round that posted
-                       nothing cannot settle the stub on the previous round's
-                       verdict.
-  --verdict <value>    Already-validated verdict from the label step. When set,
-                       the script fails loud if its own parse of the newest
-                       verdict comment disagrees (never a silent skip).
-  --ensure-labels <names>
-                       Comma list of labels to self-heal from Stage A's
-                       LABEL_DEFINITIONS (\`gh label create --force\`) before a
-                       caller writes them. Run by the workflow's label step with
-                       every name its \`gh issue edit\` uses — added, shed, and
-                       \`sentry:needs-triage\` — because gh fails the whole edit
-                       on a label the repo does not have, on --remove-label just
-                       as on --add-label. Needs no --issue; best-effort per
-                       label, so it exits 0 even when a create fails.
-  -h, --help           Show this help.
-
-Env:
-  SENTRY_PROJECTION_TOKEN  Fine-grained PAT (Issues R/W on the three owning
-                           repos) for the cross-repo create/search. Absent ->
-                           graceful no-op (status skipped-no-token).
-  GH_TOKEN                 Ambient github.token for local queue-stub mutations.
-`;
-}
-
-/** Parse a `--issues` JSON array of positive integers (the select job's
- * output). Fails loud on anything else. */
-export function parseIssueNumbers(raw) {
-  if (raw == null || String(raw).trim() === "") return [];
-  let parsed;
-  try {
-    parsed = JSON.parse(String(raw));
-  } catch {
-    throw new Error(
-      `--issues must be a JSON array of issue numbers, got: ${raw}`,
-    );
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error("--issues must be a JSON array of issue numbers");
-  }
-  return parsed.map((value) => {
-    if (!Number.isInteger(value) || value <= 0) {
-      throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
-    }
-    return value;
-  });
-}
-
-export function parseArgs(argv, env = process.env) {
-  const options = {
-    localRepo: DEFAULT_REPO,
-    queueIssue: null,
-    queueIssues: [],
-    batch: false,
-    parseOnly: false,
-    priorVerdicts: false,
-    priorVerdictCommentId: null,
-    expectedVerdict: null,
-    ensureLabels: null,
-    help: false,
-  };
-  let issuesRaw = null;
-  const args = [...argv];
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    const readValue = () => {
-      const value = args[++i];
-      if (value == null) throw new Error(`${arg} requires a value`);
-      return value;
-    };
-    switch (arg) {
-      case "--issue":
-        options.queueIssue = Number(readValue());
-        break;
-      case "--issues":
-        issuesRaw = readValue();
-        break;
-      case "--batch":
-        options.batch = true;
-        break;
-      case "--repo":
-        options.localRepo = readValue();
-        break;
-      case "--parse-only":
-        options.parseOnly = true;
-        break;
-      case "--prior-verdicts":
-        options.priorVerdicts = true;
-        break;
-      case "--prior-verdict-comment": {
-        // A bare comment id, `none`, or `unknown` — the closed set
-        // `--prior-verdicts` emits. Anything else is a wiring bug between the
-        // two jobs, and a wiring bug that silently degraded to "unbound" would
-        // remove the fence without saying so, so it fails loud here.
-        const value = readValue();
-        if (!isPriorVerdictToken(value)) {
-          throw new Error(
-            `--prior-verdict-comment must be a numeric comment id, ${PRIOR_VERDICT_NONE}, or ${PRIOR_VERDICT_UNKNOWN}, got: ${value}`,
-          );
-        }
-        options.priorVerdictCommentId = value;
-        break;
-      }
-      case "--verdict": {
-        // Comes from the label step's closed-enum output; anything else is a
-        // wiring bug — fail loud rather than carrying an invalid expectation.
-        const value = readValue();
-        if (!VALID_VERDICTS.includes(value)) {
-          throw new Error(
-            `--verdict must be one of ${VALID_VERDICTS.join(", ")}, got: ${value}`,
-          );
-        }
-        options.expectedVerdict = value;
-        break;
-      }
-      case "--ensure-labels": {
-        // A comma list, the shape the workflow already builds for
-        // `--remove-label`; empty segments are dropped so an empty shed list
-        // costs nothing. An EMPTY set is a wiring bug — a step that ensures
-        // nothing would silently reintroduce the failure this mode exists to
-        // prevent — so it fails loud here rather than no-opping.
-        const names = readValue()
-          .split(",")
-          .map((name) => name.trim())
-          .filter((name) => name !== "");
-        if (names.length === 0) {
-          throw new Error("--ensure-labels requires at least one label name");
-        }
-        options.ensureLabels = names;
-        break;
-      }
-      case "-h":
-      case "--help":
-        options.help = true;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
-    }
-  }
-  if (!options.help) {
-    // Only --parse-only consumes the token. Accepting it on a projection run
-    // would silently drop the fence, which is the one failure mode the flag
-    // exists to prevent — so an unconsumed token is a wiring bug, not a no-op.
-    if (options.priorVerdictCommentId !== null && !options.parseOnly) {
-      throw new Error(
-        "--prior-verdict-comment is only consumed by --parse-only; pass both or neither",
-      );
-    }
-    // Label self-heal is its own mode: it touches no stub and resolves no
-    // verdict, so an invocation that also asks for one of those gets neither
-    // silently. The DEFAULT mode is the one to be careful about — it is not a
-    // flag at all, just `--issue` plus an optional `--verdict` cross-check — so
-    // a guard that only rejected the FLAGGED modes would let
-    // `--issue 5 --verdict code-fix --ensure-labels …` ensure the labels, skip
-    // the projection entirely, and exit 0 reporting success for a no-op. Every
-    // mode-bearing input is therefore rejected by name. The label step runs
-    // ensure and edit as separate, ordered invocations on purpose, so nothing
-    // legitimately needs both.
-    if (options.ensureLabels !== null) {
-      const alsoRequested = [
-        options.batch && "--batch",
-        options.parseOnly && "--parse-only",
-        options.priorVerdicts && "--prior-verdicts",
-        issuesRaw !== null && "--issues",
-        options.queueIssue !== null && "--issue",
-        options.expectedVerdict !== null && "--verdict",
-      ].filter(Boolean);
-      if (alsoRequested.length > 0) {
-        throw new Error(
-          `--ensure-labels is a standalone mode; run it in its own invocation (also passed: ${alsoRequested.join(", ")})`,
-        );
-      }
-    }
-    if (options.batch || options.priorVerdicts) {
-      options.queueIssues = parseIssueNumbers(issuesRaw);
-    } else if (
-      options.ensureLabels === null &&
-      (!Number.isInteger(options.queueIssue) || options.queueIssue <= 0)
-    ) {
-      throw new Error("--issue must be a positive integer");
-    }
-  }
-  options.projectionToken = (env.SENTRY_PROJECTION_TOKEN ?? "").trim();
-  return options;
-}
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -1201,7 +923,9 @@ async function main() {
   }
   let result;
   if (options.ensureLabels) {
-    result = await runEnsureLabels(options);
+    // The self-heal module owns no runner, so the leg's `gh` wrapper is handed
+    // in here rather than defaulted there.
+    result = await runEnsureLabels(options, { runGh: defaultRunGh });
   } else if (options.batch) {
     result = await runProjectionBatch(options);
   } else if (options.priorVerdicts) {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -2,6 +2,7 @@
 import { LABEL_TO_VERDICT } from "./sentry-triage-digest.mjs";
 import {
   FIX_SCOPE_ARCHITECTURAL_LABEL,
+  LABEL_DEFINITIONS,
   VERDICT_LABELS,
 } from "./sentry-triage-ingest.mjs";
 import {
@@ -31,6 +32,7 @@ import {
   parseVerdictComment,
   PROJECTED_LABEL,
   resolveVerdict,
+  runEnsureLabels,
   runParseOnly,
   runPriorVerdicts,
   runProjection,
@@ -2701,6 +2703,10 @@ await test("runParseOnly does NOT hold a LOCAL MECHANICAL code-fix: bare label, 
   assertEqual(result.label, "sentry:verdict-code-fix");
   // A re-dispatched stub whose fresh verdict flips to mechanical must un-strand:
   // the hold label lands in the SHED list so the same atomic edit removes it.
+  // Which means EVERY non-architectural verdict names that label in its edit,
+  // including the very first one after the label was introduced — the settlement
+  // step self-heals the whole edit's label set from LABEL_DEFINITIONS before it
+  // edits, which is what makes shedding a freshly-added name safe (2026-08-13).
   assert(
     result.shed.split(",").includes(FIX_SCOPE_ARCHITECTURAL_LABEL),
     `a non-held stub must shed the hold label to un-strand: ${result.shed}`,
@@ -3444,6 +3450,139 @@ await test("runProjectionBatch survives a failing label ensure", async () => {
     { runGh },
   );
   assertEqual(rows[0].status, "projected");
+});
+
+// ---------------------------------------------------------------------------
+// --ensure-labels: the settlement step's pre-flight.
+//
+// Only the ingest job CREATES the label set, so a label added to
+// LABEL_DEFINITIONS does not exist in the repo until ingest next runs — and gh
+// fails a whole `issue edit` on a repo-nonexistent name, on --remove-label
+// exactly as on --add-label. That is what took the verdict step down on
+// 2026-08-13: `sentry:fix-scope-architectural` reached the shed list (#1812)
+// before the next ingest bootstrapped it.
+// ---------------------------------------------------------------------------
+
+function recordingRunGh({ failOn = () => false } = {}) {
+  const calls = [];
+  const runGh = async (args, opts = {}) => {
+    calls.push({ args, token: opts.token ?? null });
+    if (failOn(args)) throw new Error("boom");
+    return "";
+  };
+  return { runGh, calls };
+}
+
+await test("runEnsureLabels creates every named label from LABEL_DEFINITIONS", async () => {
+  const { runGh, calls } = recordingRunGh();
+  const result = await runEnsureLabels(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      ensureLabels: [
+        "sentry:verdict-upstream",
+        FIX_SCOPE_ARCHITECTURAL_LABEL,
+        "sentry:needs-triage",
+      ],
+    },
+    { runGh },
+  );
+  assertDeepEqual(result.ensured, [
+    "sentry:verdict-upstream",
+    FIX_SCOPE_ARCHITECTURAL_LABEL,
+    "sentry:needs-triage",
+  ]);
+  assertDeepEqual(result.unknown, []);
+  assertDeepEqual(result.failed, []);
+  assertEqual(calls.length, 3);
+  for (const call of calls) {
+    assertEqual(call.args[0], "label");
+    assertEqual(call.args[1], "create");
+    assert(
+      call.args.includes("--force"),
+      "the ensure must be idempotent (--force), not a create that errors on an existing label",
+    );
+    assert(
+      call.args.includes("mento-protocol/monitoring-monorepo"),
+      "the ensure must target the queue repo",
+    );
+    assert(
+      call.token == null || call.token === "",
+      "label ensure must use the local token, never the projection PAT",
+    );
+  }
+  // Color/description come from the single source, so a repo label that drifted
+  // is corrected rather than merely made to exist.
+  const hold = calls.find((c) => c.args[2] === FIX_SCOPE_ARCHITECTURAL_LABEL);
+  const def = LABEL_DEFINITIONS.find(
+    (entry) => entry.name === FIX_SCOPE_ARCHITECTURAL_LABEL,
+  );
+  assert(
+    hold.args.includes(def.color) && hold.args.includes(def.description),
+    "label color/description must come from LABEL_DEFINITIONS",
+  );
+});
+
+await test("runEnsureLabels is best-effort: one failing create does not stop the rest", async () => {
+  // The ensure protects a write; it must never BE the thing that kills the
+  // step. The edit it guards still fails loudly, with compensation.
+  const { runGh, calls } = recordingRunGh({
+    failOn: (args) => args[2] === "sentry:verdict-code-fix",
+  });
+  const result = await runEnsureLabels(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      ensureLabels: [
+        "sentry:verdict-code-fix",
+        "sentry:needs-triage",
+        // A name the single source does not define: drift, reported rather
+        // than silently skipped, and never fatal here either.
+        "sentry:verdict-invented",
+      ],
+    },
+    { runGh },
+  );
+  assertDeepEqual(result.failed, ["sentry:verdict-code-fix"]);
+  assertDeepEqual(result.ensured, ["sentry:needs-triage"]);
+  assertDeepEqual(result.unknown, ["sentry:verdict-invented"]);
+  assertEqual(
+    calls.length,
+    2,
+    "an undefined label costs no gh call, and a failed one does not abort the loop",
+  );
+});
+
+await test("runEnsureLabels de-duplicates names", async () => {
+  const { runGh, calls } = recordingRunGh();
+  await runEnsureLabels(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      ensureLabels: ["sentry:needs-triage", "sentry:needs-triage"],
+    },
+    { runGh },
+  );
+  assertEqual(calls.length, 1);
+});
+
+await test("parseArgs takes --ensure-labels as a standalone mode", () => {
+  const options = parseArgs(
+    ["--ensure-labels", "sentry:verdict-upstream, sentry:needs-triage,"],
+    {},
+  );
+  assertDeepEqual(options.ensureLabels, [
+    "sentry:verdict-upstream",
+    "sentry:needs-triage",
+  ]);
+  // No --issue: the mode touches no stub.
+  assertEqual(options.queueIssue, null);
+  assertThrows(
+    () => parseArgs(["--ensure-labels", " , "], {}),
+    /at least one label name/,
+  );
+  assertThrows(
+    () =>
+      parseArgs(["--ensure-labels", "sentry:needs-triage", "--parse-only"], {}),
+    /standalone mode/,
+  );
 });
 
 if (failed > 0) {

--- a/scripts/sentry-triage-project.test.mjs
+++ b/scripts/sentry-triage-project.test.mjs
@@ -83,19 +83,20 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertThrows(fn, pattern) {
+function assertThrows(fn, pattern, label = "") {
+  const suffix = label ? ` (${label})` : "";
   try {
     fn();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (!pattern.test(message)) {
-      throw new Error(`expected ${message} to match ${pattern}`, {
+      throw new Error(`expected ${message} to match ${pattern}${suffix}`, {
         cause: err,
       });
     }
     return;
   }
-  throw new Error("expected function to throw");
+  throw new Error(`expected function to throw${suffix}`);
 }
 
 async function assertRejects(promise, pattern) {
@@ -3581,6 +3582,40 @@ await test("parseArgs takes --ensure-labels as a standalone mode", () => {
   assertThrows(
     () =>
       parseArgs(["--ensure-labels", "sentry:needs-triage", "--parse-only"], {}),
+    /standalone mode/,
+  );
+});
+
+await test("parseArgs refuses --ensure-labels alongside the DEFAULT projection mode", () => {
+  // The default mode carries no flag — it is `--issue`, optionally with the
+  // `--verdict` cross-check — so a guard that only rejected the FLAGGED modes
+  // would run the ensure, skip the projection entirely, and exit 0 reporting
+  // success for a no-op. Every mode-bearing input must be named.
+  for (const argv of [
+    ["--issue", "5", "--ensure-labels", "sentry:needs-triage"],
+    [
+      "--issue",
+      "5",
+      "--verdict",
+      "code-fix",
+      "--ensure-labels",
+      "sentry:needs-triage",
+    ],
+    ["--verdict", "code-fix", "--ensure-labels", "sentry:needs-triage"],
+    ["--issues", "[5]", "--ensure-labels", "sentry:needs-triage"],
+    ["--batch", "--issues", "[5]", "--ensure-labels", "sentry:needs-triage"],
+    ["--prior-verdicts", "--ensure-labels", "sentry:needs-triage"],
+  ]) {
+    assertThrows(
+      () => parseArgs(argv, {}),
+      /standalone mode/,
+      `expected \`${argv.join(" ")}\` to be refused`,
+    );
+  }
+  // A non-numeric --issue is still a requested projection, not an absent one.
+  assertThrows(
+    () =>
+      parseArgs(["--issue", "x", "--ensure-labels", "sentry:needs-triage"], {}),
     /standalone mode/,
   );
 });


### PR DESCRIPTION
## The Problem

- Today's 08:56Z triage run left queue stub #1811 carrying both `sentry:verdict-upstream` and `sentry:needs-triage`, and the `verdict` job went red before the close step ran.
- The label `sentry:fix-scope-architectural` was consumed before it was provisioned: PR #1812 added it to `LABEL_DEFINITIONS` and to the settlement step's shed list, but only the ingest job creates labels, and ingest last ran at 06:52Z. `gh issue edit` applies `--add-label`, then fails the whole command on a `--remove-label` naming a label the repo does not have — so it added the verdict label and died on the removal.
- The shed list carries that label on every non-architectural verdict, so inside that window essentially every verdict failed to settle, not just this one.

## The Solution

- The settlement step now self-heals its label set before it edits, from the same single source (`LABEL_DEFINITIONS`) the three other settlement paths already self-heal from — `sentry-autofix.yml`, `runProjectionBatch`, `ensureArchiveLabels`. The whole bug class goes with it: any future label can reach a consumer before ingest bootstraps it and settlement still works.
- The edit is now guarded, and its compensation is defined above it, so a partial failure re-queues the stub instead of killing the step with nothing to call.

## Details

- **Fix 1 — self-heal.** New standalone `--ensure-labels <names>` mode on `scripts/sentry-triage-project.mjs`, the script the verdict step already runs. It creates each named label with `gh label create --force` from `LABEL_DEFINITIONS`, so colour and description come from the single source too. The workflow calls it immediately before the edit with every name the edit touches: the verdict label being added, the whole shed list, and `sentry:needs-triage`. Removals need this exactly as much as additions do. Best-effort per label, matching the other three paths: a create that fails warns and the loop continues, so the ensure can never be the thing that kills settlement; a name that still does not exist fails the edit below, which now compensates. A name absent from `LABEL_DEFINITIONS` is single-source drift and gets a warning annotation.
- `runProjectionBatch`'s inline `sentry:projected` self-heal now calls the same helper instead of its own copy.
- **Fix 2 — recoverable edit.** `requeue_for_retry` moves above the edit and the edit runs as `if ! gh issue edit …; then requeue_for_retry; exit 1; fi`. Same single-owner re-queue contract as before — `scripts/sentry-triage-workflow-requeue.mjs --reason verdict-unsettled`, bookkeeping cause, no second requeue path, no open-coded label swap. The comment block that already assumed "every exit below the edit owes a re-queue" now says what is true: the edit itself is one of those exits.
- **Tests** go in the existing suites, no new suite file. `sentry-triage-brief.test.mjs` scans the workflow for ensure-before-edit — deriving the required label set from the edit's own `--add-label`/`--remove-label` arguments, so dropping any name reds — and for compensation-defined-before-edit plus the guard, both asserted by index within the step. `sentry-triage-agent-comment.test.mjs`'s post-condition test now finds the helper above the window and pins that ordering. `sentry-triage-project.test.mjs` covers the new mode: creation from the single source, best-effort on a failing create, drift reporting, de-duplication, and the standalone-mode argument rules. That the shed list carries `sentry:fix-scope-architectural` on every non-architectural verdict — the behaviour that triggered this — was already pinned by six tests in that suite; the pin now carries a comment saying the self-heal is what makes it safe.
- `docs/notes/sentry-triage-pipeline.md` records the self-heal and the guarded edit in the settlement section.

## Validation

- `bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main` → exit 0, all 17 mapped commands green (includes `sentry-suite-gate.mjs`: 14 suites asserted).
- Negative control by mutation, each reverted and re-verified green afterwards:

| Mutation | Suite that reds |
| --- | --- |
| Ensure runs after the edit | `sentry-triage-brief` — "self-heals every label its edit names, BEFORE the edit" |
| Ensure drops `sentry:needs-triage` from its list | same test, on the coverage assertion derived from the edit |
| `requeue_for_retry` defined below the edit again | `sentry-triage-brief` — "defines its compensation ABOVE the label edit"; `sentry-triage-agent-comment` — "a failed verdict post-condition re-queues the stub" |
| Edit unguarded (`gh issue edit` bare) | `sentry-triage-brief` — the guard test plus the three-compensating-exits count |
| `ensureQueueLabels` stops calling `gh label create` | `sentry-triage-project` — 4 tests, including the pre-existing `runProjectionBatch` self-heal test |
| `runParseOnly` stops shedding the architectural hold | `sentry-triage-project` — 6 tests, proving the shed behaviour is live-pinned |

## Deferrals

- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes critical triage settlement and queue label state; behavior is heavily tested and fail-closed with re-queue on partial failures.
> 
> **Overview**
> Fixes verdict settlement failing when a label exists in `LABEL_DEFINITIONS` but not yet in the repo (e.g. `sentry:fix-scope-architectural` on shed lists before ingest creates it). `gh issue edit` can apply `--add-label` then fail on `--remove-label` for a missing name, leaving stubs with both a verdict label and `sentry:needs-triage`.
> 
> **Pre-flight self-heal:** The verdict step now runs `sentry-triage-project.mjs --ensure-labels` immediately before the label edit, covering every name the edit touches (verdict label, full shed list, `sentry:needs-triage`). A shared `ensureQueueLabels` helper backs the new CLI mode and replaces the inline `sentry:projected` ensure in `runProjectionBatch`.
> 
> **Recoverable edit:** `requeue_for_retry` is defined above the edit; the edit runs inside `if ! gh issue edit …` and calls re-queue on failure so partial mutations do not abort the step under `set -e` without compensation.
> 
> Docs and workflow tests pin ensure-before-edit ordering, full label coverage derived from the edit, and the three compensation paths (edit failure plus the two post-condition exits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30dd2d0cfb65dcd34b78f3c9e6edcdb4b65ee1a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->