### PR TITLE
feat(sentry): widen the autofix window, add a bounded second look, fail closed on throttling

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -144,15 +144,20 @@ jobs:
     #   TOTAL ≈ 782 invocations ≈ 13 min at a pessimistic ~1 s/call, ~52% of this
     #   budget, leaving room for checkout/setup and API-latency spikes.
     # In API REQUESTS — the unit the rate limiter bills, since `gh issue list`
-    # paginates at 100 rows per request — the same worst case is ~785. Do NOT
+    # paginates at 100 rows per request — the same worst case is 786. Do NOT
     # mix the two: the run record reports invocations. CI minutes are free on a
     # public repo's ubuntu-latest, so the timeout headroom itself costs nothing.
     #
-    # The timeout is NOT the only constraint. Split that ~785 by bucket against
+    # The timeout is NOT the only constraint. Split that 786 by bucket against
     # the free-plan budgets named on the rate-budget steps below (1,000 core
     # req/hr per repo, 1,000 GraphQL points/hr, both SHARED with every other
-    # workflow): ~485 GraphQL (6 list pages + 300 `issue view` + 60 `in:title` +
-    # 60 `in:comments` + 60 verify reads) and ~300 REST core (`gh api …/pulls`).
+    # workflow): 486 GraphQL (6 list pages + 300 `issue view` + 60 `in:title` +
+    # 60 `in:comments` + 60 verify reads) and 300 REST core (`gh api …/pulls`).
+    # The 6 list pages are 2 + 4: 200 rows for the first pass, 301 for the
+    # second look — its 300 plus ONE sentinel row that lands alone on a fourth
+    # page and makes its "MORE rows sit past even that" tracker line a fact
+    # instead of a guess at the boundary. Every other term is the first pass's
+    # cap plus the second look's half (200+100 stub reads, 40+20 per budget).
     # One worst-case run is therefore ~49% of the repo's hourly GraphQL budget
     # and ~30% of core, inside 13 minutes, while `agent` and `finalize` do their
     # own `gh` work in the same hour. That is a ~2x margin, not a non-issue —

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -118,7 +118,14 @@ jobs:
   # DUPLICATE fix PRs while looking green. On a rate-limit-shaped failure the
   # selector emits ZERO entries and the disposition becomes
   # `degraded-rate-limited`. It still emits a valid JSON array and still exits 0:
-  # the always-emits-an-array contract above is not negotiable.
+  # the always-emits-an-array contract above is not negotiable. Closed at the
+  # TOKEN level too — the first such failure latches, and every later read this
+  # run would have made is refused without issuing it, so a throttled run stops
+  # feeding an active secondary limit instead of firing ~400 more requests into
+  # it. The ONE exception to the exit-0 rule: if the run was degraded and the
+  # truncations report could not be written, the step fails, because that file is
+  # the only channel the disposition flip rides and a lost signal would render a
+  # suppressed run as a healthy idle one.
   # ---------------------------------------------------------------------------
   select:
     runs-on: ubuntu-latest
@@ -128,15 +135,31 @@ jobs:
     # second look past that ceiling. Every leg is still capped
     # (MAX_CANDIDATE_EVALUATIONS, MAX_HANDLED_ID_QUERIES,
     # MAX_REVERSE_PROBE_QUERIES, MAX_REVERSE_VERIFY_READS, and the second look's
-    # own MAX_SECOND_LOOK_EVALUATIONS + halved family budgets), so the worst case
-    # is arithmetic, not hope: 2 list pages + 2×200 per-stub reads + 120 family
-    # budget = 522 for the first pass, + 4 list pages + 2×100 + 60 = 264 for the
-    # second look → ~786 SERIAL `gh` calls (no Promise.all anywhere in this leg).
-    # At a pessimistic ~1 s/call that is ~13 min, ~52% of this budget, leaving
-    # room for checkout/setup and API-latency spikes. The timeout — not any rate
-    # limit — is the binding constraint here, and CI minutes are free on a public
-    # repo's ubuntu-latest, so the headroom costs nothing. See the pipeline note
-    # § "Cost bound".
+    # own MAX_SECOND_LOOK_EVALUATIONS + matching row cap and halved family
+    # budgets), so the worst case is arithmetic, not hope. Count it in the unit
+    # this timeout is actually spent in — SERIAL `gh` INVOCATIONS, one
+    # subprocess each, no Promise.all anywhere in this leg:
+    #   first pass  = 1 window list + 2×200 per-stub reads + 120 family = 521
+    #   second look = 1 list + 2×100 per-stub reads + 60 family        = 261
+    #   TOTAL ≈ 782 invocations ≈ 13 min at a pessimistic ~1 s/call, ~52% of this
+    #   budget, leaving room for checkout/setup and API-latency spikes.
+    # In API REQUESTS — the unit the rate limiter bills, since `gh issue list`
+    # paginates at 100 rows per request — the same worst case is ~785. Do NOT
+    # mix the two: the run record reports invocations. CI minutes are free on a
+    # public repo's ubuntu-latest, so the timeout headroom itself costs nothing.
+    #
+    # The timeout is NOT the only constraint. Split that ~785 by bucket against
+    # the free-plan budgets named on the rate-budget steps below (1,000 core
+    # req/hr per repo, 1,000 GraphQL points/hr, both SHARED with every other
+    # workflow): ~485 GraphQL (6 list pages + 300 `issue view` + 60 `in:title` +
+    # 60 `in:comments` + 60 verify reads) and ~300 REST core (`gh api …/pulls`).
+    # One worst-case run is therefore ~49% of the repo's hourly GraphQL budget
+    # and ~30% of core, inside 13 minutes, while `agent` and `finalize` do their
+    # own `gh` work in the same hour. That is a ~2x margin, not a non-issue —
+    # which is why the rate-budget steps below MEASURE it rather than assert it,
+    # and why a single throttle event now latches the run closed instead of
+    # spending the rest of the budget into an active limit. See the pipeline
+    # note § "Cost bound".
     timeout-minutes: 25
     # sentry-pipeline Environment (issue #1289): AUTOFIX_APP_PRIVATE_KEY is now an
     # environment secret, so this job MUST declare the environment for its
@@ -183,6 +206,16 @@ jobs:
       second_look: ${{ steps.select.outputs.second_look }}
       second_look_total: ${{ steps.select.outputs.second_look_total }}
       second_look_evaluated: ${{ steps.select.outputs.second_look_evaluated }}
+      # Whether MORE rows still sat past even the second look. This — not the
+      # counts beside it — is the standing tripwire for queue regrowth: the
+      # second look's own row cap clamps `second_look_total`, so the counts read
+      # identically whether 100 or 5,000 stubs sit past the ceiling.
+      second_look_full: ${{ steps.select.outputs.second_look_full }}
+      # Whether the second look's own list read FAILED. It is the one gh call in
+      # this leg with no fail-soft handler under it, and it sits on the frequent
+      # path, so it is caught rather than allowed to kill the step — which makes
+      # it something the run record has to say out loud.
+      second_look_failed: ${{ steps.select.outputs.second_look_failed }}
       # Measured `gh` invocations for the run. The per-run ceiling used to be
       # arithmetic over caps that nothing counted; this makes it a tracked number
       # so drift surfaces before a timeout does.
@@ -297,10 +330,19 @@ jobs:
             # Reject anything that isn't a bare integer before it reaches the
             # selector / matrix.
             if [[ "${DISPATCH_ISSUE}" =~ ^[0-9]+$ ]]; then
+              # `--truncations-out` on this path too, NOT just the batch one:
+              # the dispatch dedupes on the same open-PR read, so it fails closed
+              # in the selector — but without the report the `rate_limited` read
+              # below stays 0, the disposition never flips, and a THROTTLED
+              # dispatch renders as `State: active, Candidates selected: 0`,
+              # byte-identical to "the named issue was ineligible". The dispatch
+              # is the documented remedy for a stalled leg; a silent remedy for a
+              # silent stall is exactly how #1758 stayed undiagnosed.
               entries=$(node scripts/sentry-autofix-select.mjs \
                 --repo "${GITHUB_REPOSITORY}" \
                 --issue "${DISPATCH_ISSUE}" \
-                --skipped-out "${skipped_report}")
+                --skipped-out "${skipped_report}" \
+                --truncations-out "${truncations_report}")
             else
               echo "::error::workflow_dispatch input issue_number must be a plain integer"
               exit 1
@@ -336,6 +378,8 @@ jobs:
           second_look=$(jq -r 'if (.secondLook // false) then "true" else "false" end' "${window_report}")
           second_look_total=$(jq -r '(.secondLookTotal // 0) | floor' "${window_report}")
           second_look_evaluated=$(jq -r '(.secondLookEvaluated // 0) | floor' "${window_report}")
+          second_look_full=$(jq -r 'if (.secondLookFull // false) then "true" else "false" end' "${window_report}")
+          second_look_failed=$(jq -r 'if (.secondLookFailed // false) then "true" else "false" end' "${window_report}")
           gh_calls=$(jq -r '(.ghCalls // 0) | floor' "${window_report}")
           # Cost-budget truncations: the handled-id overflow COUNT plus two
           # boolean flags, normalized here so the record-job contract stays
@@ -365,6 +409,8 @@ jobs:
             echo "second_look=${second_look}"
             echo "second_look_total=${second_look_total}"
             echo "second_look_evaluated=${second_look_evaluated}"
+            echo "second_look_full=${second_look_full}"
+            echo "second_look_failed=${second_look_failed}"
             echo "gh_calls=${gh_calls}"
             echo "handled_overflow=${handled_overflow}"
             echo "reverse_truncated=${reverse_truncated}"
@@ -372,7 +418,7 @@ jobs:
             echo "rate_limited=${rate_limited}"
             echo "disposition=${disposition}"
           } >> "${GITHUB_OUTPUT}"
-          echo "Selected ${count} candidate(s), deferred ${deferred}, skipped ${skipped}, window ${window_evaluated}/${window_total}, second-look ${second_look} ${second_look_evaluated}/${second_look_total}, gh-calls ${gh_calls}, rate-limited ${rate_limited} [${disposition}]: ${entries}"
+          echo "Selected ${count} candidate(s), deferred ${deferred}, skipped ${skipped}, window ${window_evaluated}/${window_total}, second-look ${second_look} ${second_look_evaluated}/${second_look_total} (more-past=${second_look_full} failed=${second_look_failed}), gh-invocations ${gh_calls}, rate-limited ${rate_limited} [${disposition}]: ${entries}"
 
       # After, so the pair brackets exactly this leg's spend and the delta is a
       # tracked number. `always()` — a degraded or failed select is precisely
@@ -1284,6 +1330,8 @@ jobs:
           SECOND_LOOK: ${{ needs.select.outputs.second_look }}
           SECOND_LOOK_TOTAL: ${{ needs.select.outputs.second_look_total }}
           SECOND_LOOK_EVALUATED: ${{ needs.select.outputs.second_look_evaluated }}
+          SECOND_LOOK_FULL: ${{ needs.select.outputs.second_look_full }}
+          SECOND_LOOK_FAILED: ${{ needs.select.outputs.second_look_failed }}
           GH_CALLS: ${{ needs.select.outputs.gh_calls }}
           RATE_LIMITED: ${{ needs.select.outputs.rate_limited }}
           HANDLED_OVERFLOW: ${{ needs.select.outputs.handled_overflow }}
@@ -1307,6 +1355,8 @@ jobs:
           second_look="${SECOND_LOOK:-false}"
           second_look_total="${SECOND_LOOK_TOTAL:-0}"
           second_look_evaluated="${SECOND_LOOK_EVALUATED:-0}"
+          second_look_full="${SECOND_LOOK_FULL:-false}"
+          second_look_failed="${SECOND_LOOK_FAILED:-false}"
           gh_calls="${GH_CALLS:-0}"
           rate_limited="${RATE_LIMITED:-0}"
           handled_overflow="${HANDLED_OVERFLOW:-0}"
@@ -1326,6 +1376,8 @@ jobs:
             second_look=false
             second_look_total=0
             second_look_evaluated=0
+            second_look_full=false
+            second_look_failed=false
             gh_calls=0
             rate_limited=0
             handled_overflow=0
@@ -1377,6 +1429,8 @@ jobs:
             --second-look "${second_look}" \
             --second-look-total "${second_look_total}" \
             --second-look-evaluated "${second_look_evaluated}" \
+            --second-look-full "${second_look_full}" \
+            --second-look-failed "${second_look_failed}" \
             --gh-calls "${gh_calls}" \
             --rate-limited "${rate_limited}" \
             --handled-overflow "${handled_overflow}" \

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -103,19 +103,41 @@ jobs:
   # excludes it too. This job emits both stand-down counts and their issue
   # numbers — the record job is the only durable trace of a suppressed queue,
   # and without them "everything stood down" reads exactly like "nothing queued".
+  #
+  # SECOND LOOK: when the first pass selects NOTHING and the list came back FULL,
+  # the selector takes ONE bounded pass over the rows past the list ceiling. That
+  # is the only escape from the starvation shape where a whole window is deferred
+  # family members: deferral writes nothing, so the same window returns forever
+  # and a selectable stub one row past it is never evaluated at all. It has its
+  # own evaluation ceiling and its own family budgets, costs NOTHING on a run
+  # that selected anything, and reports both that it ran and any truncation.
+  #
+  # FAIL CLOSED ON THROTTLING: every read this leg issues is a dedupe/blocker
+  # signal, and every one fails SOFT toward MORE candidates — so a 403/429 is
+  # indistinguishable from "no blocker found" and a throttled run could open
+  # DUPLICATE fix PRs while looking green. On a rate-limit-shaped failure the
+  # selector emits ZERO entries and the disposition becomes
+  # `degraded-rate-limited`. It still emits a valid JSON array and still exits 0:
+  # the always-emits-an-array contract above is not negotiable.
   # ---------------------------------------------------------------------------
   select:
     runs-on: ubuntu-latest
-    # 10, not 5 (PR #1810): the per-declared-id handled lookups and the reverse
-    # family search add bounded `gh` volume on top of the per-candidate reads.
-    # Every leg is capped (MAX_CANDIDATE_EVALUATIONS, MAX_HANDLED_ID_QUERIES,
-    # MAX_REVERSE_PROBE_QUERIES, and MAX_REVERSE_VERIFY_READS — the reverse
-    # in:comments searches each page up to REVERSE_SEARCH_LIMIT hits, and every
-    # unseen hit costs one verdict re-read, so that leg needs its own read cap),
-    # so the hard ceiling is ~221 serial subprocesses (documented in the pipeline
-    # note § "Cost bound"); 10 leaves headroom for checkout/setup and API-latency
-    # spikes instead of sizing to hope.
-    timeout-minutes: 10
+    # 25, not 10: MAX_CANDIDATE_EVALUATIONS is now 200 (the real LIST_LIMIT
+    # ceiling, which the API applies first — a smaller value just left rows
+    # unread), and a run that selects nothing off a FULL page takes ONE bounded
+    # second look past that ceiling. Every leg is still capped
+    # (MAX_CANDIDATE_EVALUATIONS, MAX_HANDLED_ID_QUERIES,
+    # MAX_REVERSE_PROBE_QUERIES, MAX_REVERSE_VERIFY_READS, and the second look's
+    # own MAX_SECOND_LOOK_EVALUATIONS + halved family budgets), so the worst case
+    # is arithmetic, not hope: 2 list pages + 2×200 per-stub reads + 120 family
+    # budget = 522 for the first pass, + 4 list pages + 2×100 + 60 = 264 for the
+    # second look → ~786 SERIAL `gh` calls (no Promise.all anywhere in this leg).
+    # At a pessimistic ~1 s/call that is ~13 min, ~52% of this budget, leaving
+    # room for checkout/setup and API-latency spikes. The timeout — not any rate
+    # limit — is the binding constraint here, and CI minutes are free on a public
+    # repo's ubuntu-latest, so the headroom costs nothing. See the pipeline note
+    # § "Cost bound".
+    timeout-minutes: 25
     # sentry-pipeline Environment (issue #1289): AUTOFIX_APP_PRIVATE_KEY is now an
     # environment secret, so this job MUST declare the environment for its
     # presence check to see it; the main-only deployment-branch policy also
@@ -152,6 +174,25 @@ jobs:
       # on the tracker weeks ahead of a silent truncation.
       window_total: ${{ steps.select.outputs.window_total }}
       window_evaluated: ${{ steps.select.outputs.window_evaluated }}
+      # The bounded SECOND LOOK: whether it ran, and how far it got. It fires
+      # only when the first pass selected NOTHING off a FULL list page — the
+      # starvation state where selectable stubs sit past the list ceiling and no
+      # run would otherwise ever reach them. It is extra `gh` spend and it has an
+      # evaluation ceiling of its own, so both facts are recorded: never a silent
+      # extra cost, never a silent truncation.
+      second_look: ${{ steps.select.outputs.second_look }}
+      second_look_total: ${{ steps.select.outputs.second_look_total }}
+      second_look_evaluated: ${{ steps.select.outputs.second_look_evaluated }}
+      # Measured `gh` invocations for the run. The per-run ceiling used to be
+      # arithmetic over caps that nothing counted; this makes it a tracked number
+      # so drift surfaces before a timeout does.
+      gh_calls: ${{ steps.select.outputs.gh_calls }}
+      # Rate-limit-shaped read failures. Nonzero means the run FAILED CLOSED:
+      # every dedupe read fails soft toward MORE candidates, so a throttled run
+      # cannot tell "no prior fix PR" from "GitHub refused to answer" and would
+      # open DUPLICATE autofix PRs looking green. The selector emits `[]` instead
+      # (never a step failure — the always-emits-an-array contract holds).
+      rate_limited: ${{ steps.select.outputs.rate_limited }}
       # Cost-budget truncations (PR #1810 follow-up): the handled-id overflow
       # count and the reverse-probe / non-convergence flags. Each marks a family
       # that should have stood down but a per-run budget capped its lookup, so it
@@ -171,6 +212,23 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
+
+      # The repo's REAL remaining GITHUB_TOKEN budget at the moment this leg
+      # runs, before and after. The org is on the free plan (1,000 core req/hr
+      # per repo and 1,000 GraphQL points/hr, SHARED with every other workflow),
+      # and this leg's window is now 200 wide — so "how much budget was actually
+      # left at 08:30 UTC" stopped being a thing to reason about and became a
+      # thing to measure. One greppable line each, and never a job failure: a
+      # metering read must not be able to break the leg it meters.
+      - name: Rate budget before select
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          gh api rate_limit --jq \
+            '"rate-budget before core=\(.resources.core.remaining)/\(.resources.core.limit) graphql=\(.resources.graphql.remaining)/\(.resources.graphql.limit) search=\(.resources.search.remaining)/\(.resources.search.limit) core_reset=\(.resources.core.reset)"' \
+            || echo "rate-budget before unavailable"
 
       - name: Select autofix candidates (kill-switch + App guarded)
         id: select
@@ -273,12 +331,28 @@ jobs:
           # keep the record-job contract integer-only).
           window_total=$(jq -r '(.total // 0) | floor' "${window_report}")
           window_evaluated=$(jq -r '(.evaluated // 0) | floor' "${window_report}")
+          # The bounded second look and the measured gh volume ride the same
+          # report file, normalized to the record job's integer/boolean contract.
+          second_look=$(jq -r 'if (.secondLook // false) then "true" else "false" end' "${window_report}")
+          second_look_total=$(jq -r '(.secondLookTotal // 0) | floor' "${window_report}")
+          second_look_evaluated=$(jq -r '(.secondLookEvaluated // 0) | floor' "${window_report}")
+          gh_calls=$(jq -r '(.ghCalls // 0) | floor' "${window_report}")
           # Cost-budget truncations: the handled-id overflow COUNT plus two
           # boolean flags, normalized here so the record-job contract stays
           # integer/^(true|false)$-only (our own JSON, but keep it strict).
           handled_overflow=$(jq -r '(.handledOverflow // 0) | floor' "${truncations_report}")
           reverse_truncated=$(jq -r 'if (.reverseBudget // false) then "true" else "false" end' "${truncations_report}")
           reverse_nonconvergent=$(jq -r 'if (.reverseNonconvergent // false) then "true" else "false" end' "${truncations_report}")
+          # Rate-limit-shaped read failures. The selector already emitted `[]`
+          # (fail CLOSED — see the job header), so this only has to make the
+          # reason loud: flip the disposition so the tracker's `State:` line says
+          # it outright instead of rendering a suppressed run as a healthy idle
+          # one, which is the #1758 misdiagnosis this leg exists to prevent.
+          rate_limited=$(jq -r '(.rateLimited // 0) | floor' "${truncations_report}")
+          if [ "${rate_limited}" != "0" ] && [ "${disposition}" = "active" ]; then
+            disposition='degraded-rate-limited'
+            echo "::error::Selection degraded: ${rate_limited} rate-limit-shaped gh read failure(s); emitted 0 candidates rather than selecting on unreliable dedupe data."
+          fi
           {
             echo "entries=${entries}"
             echo "count=${count}"
@@ -288,12 +362,31 @@ jobs:
             echo "skipped_issues=${skipped_issues}"
             echo "window_total=${window_total}"
             echo "window_evaluated=${window_evaluated}"
+            echo "second_look=${second_look}"
+            echo "second_look_total=${second_look_total}"
+            echo "second_look_evaluated=${second_look_evaluated}"
+            echo "gh_calls=${gh_calls}"
             echo "handled_overflow=${handled_overflow}"
             echo "reverse_truncated=${reverse_truncated}"
             echo "reverse_nonconvergent=${reverse_nonconvergent}"
+            echo "rate_limited=${rate_limited}"
             echo "disposition=${disposition}"
           } >> "${GITHUB_OUTPUT}"
-          echo "Selected ${count} candidate(s), deferred ${deferred}, skipped ${skipped}, window ${window_evaluated}/${window_total} [${disposition}]: ${entries}"
+          echo "Selected ${count} candidate(s), deferred ${deferred}, skipped ${skipped}, window ${window_evaluated}/${window_total}, second-look ${second_look} ${second_look_evaluated}/${second_look_total}, gh-calls ${gh_calls}, rate-limited ${rate_limited} [${disposition}]: ${entries}"
+
+      # After, so the pair brackets exactly this leg's spend and the delta is a
+      # tracked number. `always()` — a degraded or failed select is precisely
+      # when the remaining budget matters most.
+      - name: Rate budget after select
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          gh api rate_limit --jq \
+            '"rate-budget after core=\(.resources.core.remaining)/\(.resources.core.limit) graphql=\(.resources.graphql.remaining)/\(.resources.graphql.limit) search=\(.resources.search.remaining)/\(.resources.search.limit) core_reset=\(.resources.core.reset)"' \
+            || echo "rate-budget after unavailable"
 
   # ---------------------------------------------------------------------------
   # autofix: one claude-code-action fix + deterministic PR per selected stub.
@@ -1188,6 +1281,11 @@ jobs:
           SKIPPED_ISSUES: ${{ needs.select.outputs.skipped_issues }}
           WINDOW_TOTAL: ${{ needs.select.outputs.window_total }}
           WINDOW_EVALUATED: ${{ needs.select.outputs.window_evaluated }}
+          SECOND_LOOK: ${{ needs.select.outputs.second_look }}
+          SECOND_LOOK_TOTAL: ${{ needs.select.outputs.second_look_total }}
+          SECOND_LOOK_EVALUATED: ${{ needs.select.outputs.second_look_evaluated }}
+          GH_CALLS: ${{ needs.select.outputs.gh_calls }}
+          RATE_LIMITED: ${{ needs.select.outputs.rate_limited }}
           HANDLED_OVERFLOW: ${{ needs.select.outputs.handled_overflow }}
           REVERSE_TRUNCATED: ${{ needs.select.outputs.reverse_truncated }}
           REVERSE_NONCONVERGENT: ${{ needs.select.outputs.reverse_nonconvergent }}
@@ -1206,6 +1304,11 @@ jobs:
           skipped_issues="${SKIPPED_ISSUES:-}"
           window_total="${WINDOW_TOTAL:-0}"
           window_evaluated="${WINDOW_EVALUATED:-0}"
+          second_look="${SECOND_LOOK:-false}"
+          second_look_total="${SECOND_LOOK_TOTAL:-0}"
+          second_look_evaluated="${SECOND_LOOK_EVALUATED:-0}"
+          gh_calls="${GH_CALLS:-0}"
+          rate_limited="${RATE_LIMITED:-0}"
           handled_overflow="${HANDLED_OVERFLOW:-0}"
           reverse_truncated="${REVERSE_TRUNCATED:-false}"
           reverse_nonconvergent="${REVERSE_NONCONVERGENT:-false}"
@@ -1220,6 +1323,11 @@ jobs:
             skipped_issues=""
             window_total=0
             window_evaluated=0
+            second_look=false
+            second_look_total=0
+            second_look_evaluated=0
+            gh_calls=0
+            rate_limited=0
             handled_overflow=0
             reverse_truncated=false
             reverse_nonconvergent=false
@@ -1266,6 +1374,11 @@ jobs:
             --skipped-issues "${skipped_issues}" \
             --window-total "${window_total}" \
             --window-evaluated "${window_evaluated}" \
+            --second-look "${second_look}" \
+            --second-look-total "${second_look_total}" \
+            --second-look-evaluated "${second_look_evaluated}" \
+            --gh-calls "${gh_calls}" \
+            --rate-limited "${rate_limited}" \
             --handled-overflow "${handled_overflow}" \
             --reverse-truncated "${reverse_truncated}" \
             --reverse-nonconvergent "${reverse_nonconvergent}")
@@ -1325,6 +1438,9 @@ jobs:
           # Only when the select job actually ran and reported architectural
           # skips: a failed/off-main/disabled select reports nothing, so there is
           # nothing to backfill and no reason to touch the label at all.
+          # `degraded-rate-limited` is deliberately covered by the `!= active`
+          # test: a throttled run's skip list was computed off reads that may not
+          # have answered, so it must not drive a label WRITE either.
           if [ "${SELECT_RESULT}" != "success" ] || [ "${DISPOSITION:-}" != "active" ]; then
             echo "select was ${SELECT_RESULT}/${DISPOSITION:-unknown}; no architectural backfill this run."
             exit 0

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1055,6 +1055,23 @@ every budget here fails OPEN toward MORE candidates, so a family whose terminal
 sibling the first pass found at probe 25 would be unreachable at 20 — and the
 second look would select a stub the same run had just stood down.
 
+The seed carries **answered** work only, and that distinction is load-bearing in
+both directions. Each of the resolver's dedupe structures has a wider in-pass
+twin that also absorbs ids the pass **dropped** for budget, **failed** to read,
+or left half-read: `listHandledShortIds` folds every overflowed id into its
+re-attempt guard so the per-run overflow counts each distinct un-runnable id once
+rather than once per fixpoint iteration; a probe id is recorded before its search
+runs; a thrown stub read is negative-cached as `null`. All three are right within
+one pass, where a budget only shrinks — and wrong the moment a pass with a FRESH
+budget inherits them, because they then claim work nobody completed was
+resolved. The second look would spend none of its new allowance on those ids and
+select a stub whose sibling carries a terminal marker no read ever looked at: a
+duplicate autofix PR reached from the opposite side to the throttle case. So the
+resolver returns only the answered subsets, and the in-pass guards start from
+them. Seed too little and the second look re-derives proven blockers on half a
+budget; seed too much and it skips work nobody did. Both land on the same
+duplicate PR.
+
 `SECOND_LOOK_LIST_ROWS` **equals** `MAX_SECOND_LOOK_EVALUATIONS`, bound by the same
 no-op invariant as `MAX_CANDIDATE_EVALUATIONS`/`LIST_LIMIT` (the row cap is applied
 first, so raising the evaluation cap alone would read the same rows and say

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -955,7 +955,7 @@ is how a drift detector ends up compared against a ceiling it can never reach:
 | unit                 | what it is                                                                         | worst case, first pass | + second look |
 | -------------------- | ---------------------------------------------------------------------------------- | ---------------------- | ------------- |
 | `gh` **invocations** | serial subprocesses; ≈ 1 s each, so this is what the job **timeout** is spent in   | 521                    | **782**       |
-| API **requests**     | what the rate limiter **bills**; `gh issue list` paginates at 100 rows per request | 522                    | **785**       |
+| API **requests**     | what the rate limiter **bills**; `gh issue list` paginates at 100 rows per request | 522                    | **786**       |
 
 The first pass: one window list invocation (2 requests at 200 rows) +
 `MAX_CANDIDATE_EVALUATIONS` (200) × 2 reads (issue view + PR list) +
@@ -994,14 +994,19 @@ the ~782-invocation worst case fits at ~52% of the budget with room for checkout
 setup, and API-latency spikes rather than being sized to hope. CI minutes are free
 on this public repo's `ubuntu-latest`, so that headroom costs nothing.
 
-**The timeout is not the only constraint.** Split the ~785 requests by bucket
+**The timeout is not the only constraint.** Split the ~786 requests by bucket
 against the free-plan budgets (1,000 core req/hr per repo, 1,000 GraphQL points/hr,
 both SHARED with every other workflow in this repo):
 
-- **GraphQL ≈ 485** — 6 list pages + 300 `issue view` + 60 `in:title` searches +
+- **GraphQL = 486** — 6 list pages + 300 `issue view` + 60 `in:title` searches +
   60 `in:comments` probes + 60 verify reads. `gh issue list --search` routes to
-  GraphQL, not the REST search bucket.
-- **REST core = 300** — one `gh api repos/…/pulls` per evaluated stub.
+  GraphQL, not the REST search bucket. The 6 pages are **2 + 4**: the first
+  pass asks for 200 rows (2 pages at 100 rows/request) and the second look for
+  301 (3 full pages plus a fourth holding only its sentinel row — see "Bounded
+  second look"). The 300 `issue view` are the per-stub verdict reads, 200 in the
+  first pass and 100 in the second; each family term is likewise its first-pass
+  cap plus the second look's half (40+20).
+- **REST core = 300** — one `gh api repos/…/pulls` per evaluated stub (200 + 100).
 
 So one worst-case run burns **~49% of the repo's hourly GraphQL budget and ~30% of
 core in 13 minutes**, while `agent` (30 min) and `finalize` (15 min) do their own
@@ -1036,9 +1041,10 @@ run — and a selectable stub sitting one row past the list ceiling is never
 evaluated, at any point, ever. When the first pass yields **zero** selectable
 entries **and** the list came back **full** (`rawCount >= LIST_LIMIT`, so more may
 exist), the selector takes ONE bounded pass over the rows beyond that ceiling: a
-single `gh issue list --limit <skip> + SECOND_LOOK_LIST_ROWS` with the first
+single `gh issue list --limit <skip> + SECOND_LOOK_LIST_ROWS + 1` with the first
 `<skip>` **raw** rows dropped client-side (raw, because `--limit` is applied
-server-side before the project filter, so a filtered-row skip would not line up).
+server-side before the project filter, so a filtered-row skip would not line up)
+and the trailing `+ 1` **sentinel** row dropped before anything reads it.
 It evaluates at most `MAX_SECOND_LOOK_EVALUATIONS` (100) of them and resolves
 families over them on its OWN halved budgets (20 handled-id / 20 reverse probe /
 20 verify read) — the first pass has already spent the per-run ones — but over the
@@ -1072,13 +1078,40 @@ list read FAILED`** when it could not read at all. That `full` flag, not the cou
 is the standing tripwire for queue regrowth: `N` is clamped by the row cap, so the
 counts alone read identically whether 100 stubs or 5,000 sit past the ceiling.
 
-Its list read is the one `gh` call in this leg with no fail-soft handler under it,
-and the second look put it on the frequent path — once the queue is ≥ `LIST_LIMIT`
-rows, EVERY no-selection run depends on it. It is caught rather than allowed to
-propagate: an uncaught rejection would exit 1 and kill the step under `set -euo
-pipefail`, destroying the whole run record including the DEGRADED line a throttled
-run needs most. The first pass selected nothing by precondition, so nothing is lost
-by standing on its result.
+That is why the second look's `full` is a **sentinel** read rather than the first
+pass's `rawCount >= limit` form. The two differ at exactly one queue size — when
+`skip + SECOND_LOOK_LIST_ROWS` raw rows exist and nothing is past them — and there
+the weaker form states on the tracker that more rows remain and the queue is
+outgrowing one run's reach, which is false. So the second look asks for one row
+past its ceiling, never evaluates it, and raises `full` only when it comes back.
+The **cost delta is one API request per second look** (301 rows is four 100-row
+pages instead of three), no extra `gh` invocation and no extra per-stub read; it
+is the whole difference between the 785 this leg would otherwise bill and the 786
+above. The first pass keeps the cheaper form on purpose: its `full` only decides
+whether to run this pass, and over-firing costs one list call on a run that
+already selected nothing — far less than an extra request on **every** run.
+
+Three `gh` calls in this leg have no fail-soft handler under them: the first
+pass's window list, the single-issue dispatch's `readStub`, and the second look's
+own list — which this pass put on the frequent path, since once the queue is ≥
+`LIST_LIMIT` rows EVERY no-selection run depends on it. All three are caught, and
+all three split the same way:
+
+- A **rate-limit-shaped** failure DEGRADES the run — `[]`, `rateLimited`, the
+  `::error::` line, exit 0. `instrumentRunGh` records the throttle and rethrows
+  (so every fail-soft handler downstream keeps its exact behaviour), so without
+  the catch the rejection reaches `main`, exits 1 and kills the step under `set
+-euo pipefail` — destroying the whole run record including the DEGRADED line a
+  throttled run needs most. The second look's own failure additionally reports
+  `secondLookFailed` and stands on the first pass's result, which by precondition
+  selected nothing, so nothing is lost.
+- **Any other** failure still propagates and fails the step, unchanged. A
+  malformed body, a dead token or a missing `gh` means the run cannot see its
+  queue at all; there is no window to report on, nothing can be wrongly selected
+  from a read that never happened, and a failed step is the louder signal. The
+  fail-closed work deliberately did not touch it. (The second look is the one
+  exception, and only because the first pass's report is already complete and
+  valid: its non-throttle failure is a `::warning::` plus `secondLookFailed`.)
 
 The arithmetic that sizes it: 521 (first pass) + 1 list invocation + 2×100 reads +
 60 family budget = **782** serial invocations, ~13 min at 1.0 s/call, ~52% of the

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -861,8 +861,8 @@ that still fire via the normal ingest path (`REOPEN_SHED_LABELS` sheds the hold
 so the fresh round re-decides scope). This closes issue #1813: the architectural
 class no longer fills the selector's read window. With the window now equal to
 `LIST_LIMIT`, the standing tripwire for regrowth is the bounded second look's
-`Second look: …` run-record line — a full window that selects nothing is exactly
-what fires it.
+`Second look: …` run-record line, and specifically its `and MORE rows sit past even
+that` clause — a full window that selects nothing is exactly what fires it.
 
 A residue this design does NOT drain, stated not hidden: a stub with no parseable
 SHORT-ID, an unparsable verdict, a verdict that is not `code-fix`, or a
@@ -947,14 +947,24 @@ projected, archived, and external-project stubs are all excluded server-side
 before `--limit` applies, so the eligible window stays single-digit at steady
 state and the leg's `gh` volume no longer scales with the list ceiling. Every leg
 of the per-run `gh` cost is bounded by a named cap, so the ceiling is a real
-bound, not an average: one window list (2 API pages at 200 rows) +
+bound, not an average.
+
+Count it in **two units**, because they are different numbers and conflating them
+is how a drift detector ends up compared against a ceiling it can never reach:
+
+| unit                 | what it is                                                                         | worst case, first pass | + second look |
+| -------------------- | ---------------------------------------------------------------------------------- | ---------------------- | ------------- |
+| `gh` **invocations** | serial subprocesses; ≈ 1 s each, so this is what the job **timeout** is spent in   | 521                    | **782**       |
+| API **requests**     | what the rate limiter **bills**; `gh issue list` paginates at 100 rows per request | 522                    | **785**       |
+
+The first pass: one window list invocation (2 requests at 200 rows) +
 `MAX_CANDIDATE_EVALUATIONS` (200) × 2 reads (issue view + PR list) +
 `MAX_HANDLED_ID_QUERIES` (40) per-declared-id lookups + `MAX_REVERSE_PROBE_QUERIES`
 (40) reverse `in:comments` searches + `MAX_REVERSE_VERIFY_READS` (40) cached verify
-reads — **≈ 522** serial subprocesses worst case for the first pass, and **≈ 786**
-if the bounded second look also runs (below). Every call is serial — there is no
-`Promise.all` anywhere in this leg — so at a pessimistic ~1 s/call that worst case
-is ~13 minutes. Two of those legs are the bug-B
+reads. Every call is serial — there is no `Promise.all` anywhere in this leg — so at
+a pessimistic ~1 s/call that worst case is ~13 minutes. The run record reports
+**invocations** (`gh invocations: N`), and the suite pins invocations; the
+per-bucket rate arithmetic below runs in **requests**. Two of those legs are the bug-B
 mirror of the handled-id one. `probeIds` is the union of a cap-2 finalist set's
 family members, and a family can hold up to `MAX_FAMILY_MEMBERS` (40) ids, so
 without the search budget a run could fan out to ~80 secondary-rate-limited SEARCH
@@ -980,15 +990,30 @@ is what keeps the eligible window small, and the second look below is what cover
 the case where 200 rows are not enough.
 
 The select job's `timeout-minutes` is **25** (raised from 10 with the window), so
-the ~786-call worst case fits at ~52% of the budget with room for checkout, setup,
-and API-latency spikes rather than being sized to hope. The timeout, not any rate
-limit, is the binding constraint: `gh issue list --search` routes to GraphQL and
-the raise adds only `issue view` + `gh api …/pulls` volume, and CI minutes are free
-on this public repo's `ubuntu-latest`. What the run's real budget consumption looks
-like is now measured rather than assumed — the job echoes `gh api rate_limit`
-immediately before and after the select step (`rate-budget before …` /
-`rate-budget after …`, one greppable line each), and the selector counts its own
-`gh` invocations and reports them as `gh reads: N` on the tracker.
+the ~782-invocation worst case fits at ~52% of the budget with room for checkout,
+setup, and API-latency spikes rather than being sized to hope. CI minutes are free
+on this public repo's `ubuntu-latest`, so that headroom costs nothing.
+
+**The timeout is not the only constraint.** Split the ~785 requests by bucket
+against the free-plan budgets (1,000 core req/hr per repo, 1,000 GraphQL points/hr,
+both SHARED with every other workflow in this repo):
+
+- **GraphQL ≈ 485** — 6 list pages + 300 `issue view` + 60 `in:title` searches +
+  60 `in:comments` probes + 60 verify reads. `gh issue list --search` routes to
+  GraphQL, not the REST search bucket.
+- **REST core = 300** — one `gh api repos/…/pulls` per evaluated stub.
+
+So one worst-case run burns **~49% of the repo's hourly GraphQL budget and ~30% of
+core in 13 minutes**, while `agent` (30 min) and `finalize` (15 min) do their own
+`gh` work inside the same hour. That is a ~2x margin, not a non-issue, and it is
+~3x what the leg spent before the window went to 200. It is therefore MEASURED, not
+asserted: the job echoes `gh api rate_limit` immediately before and after the select
+step (`rate-budget before …` / `rate-budget after …`, one greppable line each), and
+the selector counts its own `gh` invocations and reports them as `gh invocations: N`
+on the tracker. The mitigation on the other side is the latch described under "Fail
+closed on rate limiting" — the first throttle-shaped failure stops the run from
+issuing any further read, so a run that hits the wall stops pushing on it rather
+than spending its remaining ~400 requests into an active secondary limit.
 
 The read budget truncates the window's **newest** tail (it is oldest-first). Each
 reverse
@@ -1011,20 +1036,53 @@ run — and a selectable stub sitting one row past the list ceiling is never
 evaluated, at any point, ever. When the first pass yields **zero** selectable
 entries **and** the list came back **full** (`rawCount >= LIST_LIMIT`, so more may
 exist), the selector takes ONE bounded pass over the rows beyond that ceiling: a
-single `gh issue list --limit LIST_LIMIT + SECOND_LOOK_LIST_ROWS` with the first
-`LIST_LIMIT` **raw** rows dropped client-side (raw, because `--limit` is applied
+single `gh issue list --limit <skip> + SECOND_LOOK_LIST_ROWS` with the first
+`<skip>` **raw** rows dropped client-side (raw, because `--limit` is applied
 server-side before the project filter, so a filtered-row skip would not line up).
 It evaluates at most `MAX_SECOND_LOOK_EVALUATIONS` (100) of them and resolves
 families over them on its OWN halved budgets (20 handled-id / 20 reverse probe /
-20 verify read) — the first pass has already spent the per-run ones.
+20 verify read) — the first pass has already spent the per-run ones — but over the
+first pass's **findings**: the blockers, edges, probed ids and cached stubs it
+resolved are seeded in. Fresh budgets, inherited knowledge. Without the seed the
+smaller budget would have to re-derive blockers the run had already proven, and
+every budget here fails OPEN toward MORE candidates, so a family whose terminal
+sibling the first pass found at probe 25 would be unreachable at 20 — and the
+second look would select a stub the same run had just stood down.
+
+`SECOND_LOOK_LIST_ROWS` **equals** `MAX_SECOND_LOOK_EVALUATIONS`, bound by the same
+no-op invariant as `MAX_CANDIDATE_EVALUATIONS`/`LIST_LIMIT` (the row cap is applied
+first, so raising the evaluation cap alone would read the same rows and say
+nothing); `secondLookCeilingWarning` re-checks the pair at run time and a suite test
+pins it. The skip offset is `min(MAX_CANDIDATE_EVALUATIONS, LIST_LIMIT)` rather than
+`LIST_LIMIT`: the two are equal today, but under a LOWER eval cap a `LIST_LIMIT`
+skip would leave the rows between the two read by neither pass — a permanent hole
+in the middle of the window, the exact starvation this pass exists to close.
 
 It costs a healthy run **nothing**: anything selected in the first pass and the
-second look never fires. Both facts reach the tracker — `Second look: N further
-stubs past the window, evaluated M`, with `(capped by
-MAX_SECOND_LOOK_EVALUATIONS)` when it truncated — so the extra spend is never
-silent and neither is a truncation of its own. The arithmetic that sizes it: 522
-(first pass) + 4 list pages + 2×100 reads + 60 family budget = **786** serial
-calls, ~13 min at 1.0 s/call, ~52% of the 25-minute job budget.
+second look never fires. Stated plainly, though: the ~782 figure is a worst case
+for the timeout, not a rare one for the budget. The fire condition is zero entries
+off a full RAW page, and the residue class below (unparsable verdicts, foreign
+`affected_repo`) selects nothing while still filling the page — so once the queue
+passes `LIST_LIMIT` raw rows in that state, a run pays close to the full bill every
+weekday and still selects nothing. The `and MORE rows sit past even that` clause is
+what makes that state visible on the tracker instead of inferable from a bill. Every fact reaches the tracker on one line — `Second look:
+N further stubs past the window, evaluated M`, plus **`— and MORE rows sit past even
+that`** when the second look's own page came back full, or **`the second look's own
+list read FAILED`** when it could not read at all. That `full` flag, not the counts,
+is the standing tripwire for queue regrowth: `N` is clamped by the row cap, so the
+counts alone read identically whether 100 stubs or 5,000 sit past the ceiling.
+
+Its list read is the one `gh` call in this leg with no fail-soft handler under it,
+and the second look put it on the frequent path — once the queue is ≥ `LIST_LIMIT`
+rows, EVERY no-selection run depends on it. It is caught rather than allowed to
+propagate: an uncaught rejection would exit 1 and kill the step under `set -euo
+pipefail`, destroying the whole run record including the DEGRADED line a throttled
+run needs most. The first pass selected nothing by precondition, so nothing is lost
+by standing on its result.
+
+The arithmetic that sizes it: 521 (first pass) + 1 list invocation + 2×100 reads +
+60 family budget = **782** serial invocations, ~13 min at 1.0 s/call, ~52% of the
+25-minute job budget.
 
 **Fail closed on rate limiting.** Nearly every read in this leg fails SOFT toward
 MORE candidates — `readStub` and `openAutofixPrExists` in

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -859,8 +859,10 @@ was CLOSED at verdict time; the record-run backfill only adds the
 window-exclusion label at up to 50/run, never reopens. A regression reopens any
 that still fire via the normal ingest path (`REOPEN_SHED_LABELS` sheds the hold
 so the fresh round re-decides scope). This closes issue #1813: the architectural
-class no longer fills the selector's read window, and the `Window: N stubs,
-evaluated M` line (below) is the standing tripwire for any regrowth.
+class no longer fills the selector's read window. With the window now equal to
+`LIST_LIMIT`, the standing tripwire for regrowth is the bounded second look's
+`Second look: …` run-record line — a full window that selects nothing is exactly
+what fires it.
 
 A residue this design does NOT drain, stated not hidden: a stub with no parseable
 SHORT-ID, an unparsable verdict, a verdict that is not `code-fix`, or a
@@ -869,7 +871,9 @@ foreign/unrecognized `affected_repo` is dropped by `evaluateCandidate` (returns
 yet it keeps its `verdict-code-fix` + `autofix-select` labels and the oldest-first
 query returns it every run. A pile of these can occupy the whole
 `MAX_CANDIDATE_EVALUATIONS` slice while the run record names no reason; the only
-signal is the select step's stderr `skip #N:` note. It is not the architectural
+signal is the select step's stderr `skip #N:` note. A pile large enough to fill
+the whole window does at least surface indirectly now — it makes the run take a
+bounded second look, which the run record names. It is not the architectural
 class and gets no hold label — a triage error whose fix does not live here. A
 run-record reporting path for this residue is a deliberate follow-up if real
 starvation is observed: it would have to thread these heterogeneous skip reasons
@@ -938,15 +942,19 @@ operator who sees a standing deferred count overrides it with the single-issue
 explicit human intent that beats a heuristic signal. Selection itself stays
 read-only and never re-queues anything.
 
-**Cost bound** (PR #1810). Terminal, projected, archived, and external-project
-stubs are all excluded server-side before `--limit` applies, so the eligible
-window stays single-digit at steady state and the leg's `gh` volume no longer
-scales with the list ceiling. Every leg of the per-run `gh` cost is now bounded by
-a named cap, so the ceiling is a real bound, not an average: one window list +
-`MAX_CANDIDATE_EVALUATIONS` (50) × 2 reads (issue view + PR list) +
+**Cost bound** (PR #1810, re-sized when the window went to 200). Terminal,
+projected, archived, and external-project stubs are all excluded server-side
+before `--limit` applies, so the eligible window stays single-digit at steady
+state and the leg's `gh` volume no longer scales with the list ceiling. Every leg
+of the per-run `gh` cost is bounded by a named cap, so the ceiling is a real
+bound, not an average: one window list (2 API pages at 200 rows) +
+`MAX_CANDIDATE_EVALUATIONS` (200) × 2 reads (issue view + PR list) +
 `MAX_HANDLED_ID_QUERIES` (40) per-declared-id lookups + `MAX_REVERSE_PROBE_QUERIES`
 (40) reverse `in:comments` searches + `MAX_REVERSE_VERIFY_READS` (40) cached verify
-reads — ≈ 221 serial subprocesses worst case. Two of those legs are the bug-B
+reads — **≈ 522** serial subprocesses worst case for the first pass, and **≈ 786**
+if the bounded second look also runs (below). Every call is serial — there is no
+`Promise.all` anywhere in this leg — so at a pessimistic ~1 s/call that worst case
+is ~13 minutes. Two of those legs are the bug-B
 mirror of the handled-id one. `probeIds` is the union of a cap-2 finalist set's
 family members, and a family can hold up to `MAX_FAMILY_MEMBERS` (40) ids, so
 without the search budget a run could fan out to ~80 secondary-rate-limited SEARCH
@@ -957,13 +965,33 @@ so without the verify-read budget the admit leg fans out to
 `MAX_REVERSE_PROBE_QUERIES` × `REVERSE_SEARCH_LIMIT` (4000) `gh issue view`
 subprocesses — `MAX_REVERSE_VERIFY_READS` bounds the distinct cache-miss reads
 across the whole fixpoint so the "cached verify reads" term is a real cap, not an
-average. `LIST_LIMIT` (200) is a
-**safety ceiling, not the throttle**; the throttle is the exclusion set plus
-`MAX_CANDIDATE_EVALUATIONS`. The select job's `timeout-minutes` is **10** (raised
-from 5) so that ceiling keeps headroom for checkout, setup, and API-latency spikes
-rather than being sized to hope. The read budget truncates the window's **newest**
-tail (it is oldest-first), and any approach toward the eval cap is surfaced on the
-tracker as `Window: N stubs, evaluated M` in the run record. Each reverse
+average.
+
+`LIST_LIMIT` (200) is the **hard upper bound on the window**, not a decoration:
+`--limit` caps what the API RETURNS, and that happens BEFORE
+`MAX_CANDIDATE_EVALUATIONS` slices the rows. Raising the evaluation cap above the
+list limit is therefore a strict **no-op** — the run reads exactly `LIST_LIMIT`
+rows either way and nothing says so. **The two must move together.** A suite test
+pins `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT` and `windowCeilingWarning` re-checks
+the pair at run time (it warns, it does not throw — a static config mistake must
+not break the always-emits-an-array contract). They are equal today, at 200, which
+is why the `Window: N stubs, evaluated M` line no longer fires: the exclusion set
+is what keeps the eligible window small, and the second look below is what covers
+the case where 200 rows are not enough.
+
+The select job's `timeout-minutes` is **25** (raised from 10 with the window), so
+the ~786-call worst case fits at ~52% of the budget with room for checkout, setup,
+and API-latency spikes rather than being sized to hope. The timeout, not any rate
+limit, is the binding constraint: `gh issue list --search` routes to GraphQL and
+the raise adds only `issue view` + `gh api …/pulls` volume, and CI minutes are free
+on this public repo's `ubuntu-latest`. What the run's real budget consumption looks
+like is now measured rather than assumed — the job echoes `gh api rate_limit`
+immediately before and after the select step (`rate-budget before …` /
+`rate-budget after …`, one greppable line each), and the selector counts its own
+`gh` invocations and reports them as `gh reads: N` on the tracker.
+
+The read budget truncates the window's **newest** tail (it is oldest-first). Each
+reverse
 `in:comments` search itself reads a bounded page — `REVERSE_SEARCH_LIMIT` (100),
 5x headroom over the queue scale — rather than paginating to exhaustion (PR #1810
 follow-up); a search that comes back a full page deep flags the same reverse
@@ -976,6 +1004,56 @@ re-attempted, never wrongly closed), and each truncation is surfaced too —
 page can each raise it), or `Reverse family verification did not converge …` — so
 a bounded re-attempt is never the silent, healthy-looking one the Window line
 exists to eliminate.
+
+**Bounded second look** (the starvation fix). Family deferral writes nothing, so
+a window whose every stub is a deferred family member returns byte-identical next
+run — and a selectable stub sitting one row past the list ceiling is never
+evaluated, at any point, ever. When the first pass yields **zero** selectable
+entries **and** the list came back **full** (`rawCount >= LIST_LIMIT`, so more may
+exist), the selector takes ONE bounded pass over the rows beyond that ceiling: a
+single `gh issue list --limit LIST_LIMIT + SECOND_LOOK_LIST_ROWS` with the first
+`LIST_LIMIT` **raw** rows dropped client-side (raw, because `--limit` is applied
+server-side before the project filter, so a filtered-row skip would not line up).
+It evaluates at most `MAX_SECOND_LOOK_EVALUATIONS` (100) of them and resolves
+families over them on its OWN halved budgets (20 handled-id / 20 reverse probe /
+20 verify read) — the first pass has already spent the per-run ones.
+
+It costs a healthy run **nothing**: anything selected in the first pass and the
+second look never fires. Both facts reach the tracker — `Second look: N further
+stubs past the window, evaluated M`, with `(capped by
+MAX_SECOND_LOOK_EVALUATIONS)` when it truncated — so the extra spend is never
+silent and neither is a truncation of its own. The arithmetic that sizes it: 522
+(first pass) + 4 list pages + 2×100 reads + 60 family budget = **786** serial
+calls, ~13 min at 1.0 s/call, ~52% of the 25-minute job budget.
+
+**Fail closed on rate limiting.** Nearly every read in this leg fails SOFT toward
+MORE candidates — `readStub` and `openAutofixPrExists` in
+`scripts/sentry-autofix-candidate.mjs`, the per-id handled lookups in
+`scripts/sentry-autofix-queue-io.mjs`, the reverse probes in
+`scripts/sentry-autofix-reverse-verify.mjs`. That is the right trade for a
+transient blip (one self-terminating extra attempt), but the blockers those reads
+look for ARE the dedupe signals, so a throttled read is indistinguishable from
+"no blocker found" — and a rate-limited run can open **duplicate** autofix PRs
+and still look green. A 200-wide window raises that probability.
+
+So the run's `gh` driver is wrapped once, and a rate-limit-shaped rejection marks
+the whole run DEGRADED. The shapes are what `gh` actually prints, folded into its
+rejection message: `HTTP 403: API rate limit exceeded …`, `HTTP 403: You have
+exceeded a secondary rate limit …`, `HTTP 429 Too Many Requests`, `GraphQL: API
+rate limit exceeded … (rateLimitExceeded)`, and `You have triggered an abuse
+detection mechanism`. A bare `HTTP 403` permissions failure matches too, on
+purpose: both mean the read did not answer the dedupe question, and both warrant
+the same action.
+
+A degraded run emits **zero** matrix entries and says so loudly — the select job's
+disposition becomes `degraded-rate-limited` and the run record carries a
+`**DEGRADED (rate limited):** N gh read(s) …` line. It does **not** throw: the
+select step must ALWAYS emit a valid JSON array and never fail the step (it runs
+under `set -euo pipefail` and the matrix consumes its stdout), so fail-closed here
+means `[]` plus a loud report. The degraded disposition also suppresses the
+architectural label backfill, since that write would be driven by skips computed
+off reads that may never have answered. Non-rate-limit transients keep their
+existing per-read fail-soft behaviour, unchanged.
 
 The selector reads only PRs whose head branch is in **this** repo. A branch-name
 match returns fork PRs too — they carry the same head branch — so on a public

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2406,6 +2406,28 @@ while IFS= read -r path; do
         scripts/sentry-autofix-select.mjs|scripts/sentry-autofix-select.test.mjs)
           add_command "pnpm sentry:autofix:select:test" "Sentry autofix select helper changed"
           ;;
+        scripts/sentry-autofix-select-cli.mjs|scripts/sentry-autofix-decisions.mjs)
+          # The selector's CLI surface (option contract, help text, the report
+          # files the tracker reads back, --emit-verdict) and the decision ->
+          # report classifier both passes share. Neither owns a cost cap; both
+          # are exercised end to end by the select suite, which drives the CLI
+          # layer through writeRunReports and the classifier through the family
+          # collapse.
+          add_command "pnpm sentry:autofix:select:test" "Sentry autofix selection helper changed"
+          ;;
+        scripts/sentry-autofix-select-instrument.mjs|scripts/sentry-autofix-second-look.mjs)
+          # The selector's budget + instrumentation layer (the per-run read cap
+          # and its no-op guard, the gh counter, the throttle latch, the DEGRADED
+          # and summary lines) and the bounded second look.
+          add_command "pnpm sentry:autofix:select:test" "Sentry autofix selection helper changed"
+          # These two OWN caps the finalize suite pins the select job's
+          # timeout-minutes against — MAX_CANDIDATE_EVALUATIONS here,
+          # MAX_SECOND_LOOK_EVALUATIONS + SECOND_LOOK_FAMILY_BUDGETS there. That
+          # pin derives the budget from the LIVE constants, so raising one
+          # without re-checking the timeout has to fail in the gate, not in
+          # production on the path the second look exists to create.
+          add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix per-run cost cap changed"
+          ;;
         scripts/sentry-autofix-queue-io.mjs|scripts/sentry-autofix-family-resolve.mjs|scripts/sentry-autofix-reverse-verify.mjs|scripts/sentry-autofix-family.mjs|scripts/sentry-autofix-candidate.mjs)
           # The selection leg's gh I/O layer (openAutofixPrExists / isOwnHeadPr /
           # the family-collapse reads), the live-state family resolver, the

--- a/scripts/sentry-autofix-decisions.mjs
+++ b/scripts/sentry-autofix-decisions.mjs
@@ -1,0 +1,69 @@
+/**
+ * Decision → report classification for the Sentry AUTOFIX selector
+ * (scripts/sentry-autofix-select.mjs). Extracted so the selector stays under the
+ * 600-line soft cap: it owns the window, the family orchestration and the CLI,
+ * and this module owns the one question "what does each family decision MEAN to
+ * an operator reading the tracker?".
+ *
+ * Both the first pass and the bounded second look run through it, which is the
+ * point: a second look that reported a family DEFERRAL as a fix_scope SKIP would
+ * send an operator to the wrong remedy — a deferral lifts when a sibling's
+ * marker goes away, a skip only when a re-triage supplies a new verdict.
+ *
+ * PURE except for the stderr diagnostics, which are the deferral's only live
+ * trace inside a workflow log (the durable one is the run record the caller
+ * builds from these arrays).
+ */
+
+import {
+  DEFER_FAMILY_DUPLICATE,
+  DEFER_FAMILY_HANDLED,
+  DEFER_FAMILY_RECONCILING,
+} from "./sentry-autofix-family.mjs";
+import { safeShortId } from "./sentry-autofix-candidate.mjs";
+
+/** One note per deferral reason, keyed by the collapse's own constants so a
+ * reason added there cannot silently inherit another's wording. An unmapped
+ * reason still prints — as itself, not as somebody else's explanation. */
+const DEFER_NOTES = {
+  [DEFER_FAMILY_DUPLICATE]: (decision) =>
+    `same duplicate_of family as ${safeShortId(decision.representative)}, which represents the family this run`,
+  [DEFER_FAMILY_HANDLED]: (decision) =>
+    `its duplicate_of family already has an autofix attempt on ${safeShortId(decision.representative)} (a regression sheds that marker)`,
+  [DEFER_FAMILY_RECONCILING]: () =>
+    "its duplicate_of family already has an open autofix PR being reconciled this run",
+};
+
+/** Split one resolve pass's decisions into the three reported halves:
+ * `{ entries, deferred, skipped }`. */
+export function partitionDecisions(decisions, cap) {
+  const entries = [];
+  const deferred = [];
+  const skipped = [];
+  for (const decision of decisions) {
+    const number = decision.candidate.issue;
+    // Ruled out before the collapse ran (fix_scope). It joined the union so its
+    // family edges survived, but it is not a family deferral and must not be
+    // reported as one: the two lift on different events.
+    if (decision.candidate.eligible === false) {
+      skipped.push({ issue: number, reason: decision.candidate.skipReason });
+      continue;
+    }
+    if (!decision.selected) {
+      // Deferral writes NOTHING to the queue — no label, no comment, no marker.
+      // The member stays exactly as selectable as its live state makes it on the
+      // next run, which is what lets a genuine regression (ingest sheds the
+      // sibling's autofix marker) bring the family straight back. It IS reported
+      // out, though: the run record carries the count and the issue numbers so
+      // "everything suppressed" never reads as "nothing queued".
+      process.stderr.write(
+        `defer #${number}: ${DEFER_NOTES[decision.reason]?.(decision) ?? `deferred (${decision.reason})`}; not marked, re-evaluated next run.\n`,
+      );
+      deferred.push({ issue: number, reason: decision.reason });
+      continue;
+    }
+    if (entries.length >= cap) continue;
+    entries.push(decision.candidate.entry);
+  }
+  return { entries, deferred, skipped };
+}

--- a/scripts/sentry-autofix-family-resolve.mjs
+++ b/scripts/sentry-autofix-family-resolve.mjs
@@ -55,8 +55,28 @@ const MAX_REVERSE_ITERATIONS = 4;
  * Returns `{ decisions, truncations }` — `truncations` carries the handled-id
  * overflow count and the reverse-probe / non-convergence flags for the run
  * record, so a bounded re-attempt is never silent.
+ *
+ * `options.budgets` ({ handled, probe, verify }) overrides the three per-RUN
+ * caps for ONE call. The selector's bounded second look needs it: the first
+ * pass has already SPENT the module defaults, so a second pass reusing them
+ * would double the run's worst-case `gh` volume. Absent, the defaults apply and
+ * behaviour is byte-identical to before the option existed.
  */
-export async function resolveFamilies(runGh, repo, candidates, cap) {
+export async function resolveFamilies(
+  runGh,
+  repo,
+  candidates,
+  cap,
+  options = {},
+) {
+  const budgets = options.budgets ?? {};
+  const handledCap = Number.isInteger(budgets.handled)
+    ? budgets.handled
+    : MAX_HANDLED_ID_QUERIES;
+  const verifyCap = Number.isInteger(budgets.verify)
+    ? budgets.verify
+    : MAX_REVERSE_VERIFY_READS;
+  const probeCap = Number.isInteger(budgets.probe) ? budgets.probe : undefined;
   const project = LOCAL_SENTRY_PROJECT;
   const candidateKeys = new Set(
     candidates.map((candidate) => familyKey(candidate.shortId)),
@@ -77,14 +97,14 @@ export async function resolveFamilies(runGh, repo, candidates, cap) {
   // fixpoint's re-checks of reverse-surfaced hub ids, so the total stays bounded
   // and its overflow surfaces on the tracker.
   const handledQueried = new Set();
-  const handledBudget = { remaining: MAX_HANDLED_ID_QUERIES, overflow: 0 };
+  const handledBudget = { remaining: handledCap, overflow: 0 };
   const stubCache = new Map();
   const alreadyProbed = new Set();
   // One per-RUN verify-read budget for the reverse leg, shared across the fixpoint
   // so the total `gh issue view` fan-out over hit-verification is bounded (the
   // bug-B mirror of the probe-search cap: each search returns up to
   // REVERSE_SEARCH_LIMIT rows and every unseen row costs a verdict re-read).
-  const reverseVerifyBudget = { remaining: MAX_REVERSE_VERIFY_READS };
+  const reverseVerifyBudget = { remaining: verifyCap };
   let reverseBudgetTruncated = false;
   let reverseNonconvergent = false;
 
@@ -167,6 +187,7 @@ export async function resolveFamilies(runGh, repo, candidates, cap) {
         stubCache,
         alreadyProbed,
         verifyBudget: reverseVerifyBudget,
+        maxProbes: probeCap,
       });
       edges = result.edges;
       blockers = result.blockers;

--- a/scripts/sentry-autofix-family-resolve.mjs
+++ b/scripts/sentry-autofix-family-resolve.mjs
@@ -24,6 +24,7 @@ import {
   MAX_HANDLED_ID_QUERIES,
 } from "./sentry-autofix-queue-io.mjs";
 import {
+  MAX_REVERSE_PROBE_QUERIES,
   MAX_REVERSE_VERIFY_READS,
   reverseVerifyFamilies,
 } from "./sentry-autofix-reverse-verify.mjs";
@@ -61,6 +62,21 @@ const MAX_REVERSE_ITERATIONS = 4;
  * pass has already SPENT the module defaults, so a second pass reusing them
  * would double the run's worst-case `gh` volume. Absent, the defaults apply and
  * behaviour is byte-identical to before the option existed.
+ *
+ * `options.seed` carries a PRIOR pass's resolved state into this one — the
+ * `resolved` object this function returns. Only the selector's second look uses
+ * it, and it is what keeps that pass from being strictly weaker than the pass it
+ * follows. The precondition for a second look is that the first pass found a
+ * blocker for EVERYTHING, so the run has already PROVEN those blockers exist;
+ * without the seed the second look throws that proof away and asks a half-sized
+ * budget to re-derive it from scratch, and every budget here fails OPEN toward
+ * MORE candidates — so a family whose terminal sibling the first pass surfaced at
+ * probe 25 is unreachable at 20 probes, and the second look selects a stub whose
+ * family the same run just stood down. That is a duplicate autofix PR with no
+ * rate limit involved. Seeding is also strictly cheaper: `handledQueried`,
+ * `alreadyProbed` and `stubCache` make the second look skip reads the first pass
+ * already paid for. Budgets are NOT seeded — they are fresh allowances for the
+ * ids this pass is the first to see.
  */
 export async function resolveFamilies(
   runGh,
@@ -76,7 +92,10 @@ export async function resolveFamilies(
   const verifyCap = Number.isInteger(budgets.verify)
     ? budgets.verify
     : MAX_REVERSE_VERIFY_READS;
-  const probeCap = Number.isInteger(budgets.probe) ? budgets.probe : undefined;
+  const probeCap = Number.isInteger(budgets.probe)
+    ? budgets.probe
+    : MAX_REVERSE_PROBE_QUERIES;
+  const seed = options.seed ?? {};
   const project = LOCAL_SENTRY_PROJECT;
   const candidateKeys = new Set(
     candidates.map((candidate) => familyKey(candidate.shortId)),
@@ -96,10 +115,14 @@ export async function resolveFamilies(
   // One per-RUN handled-id budget, shared by the initial declared-id pass and the
   // fixpoint's re-checks of reverse-surfaced hub ids, so the total stays bounded
   // and its overflow surfaces on the tracker.
-  const handledQueried = new Set();
+  // Seeded from a prior pass where one exists (see `options.seed`), fresh
+  // otherwise. The BUDGETS below are always fresh: the seed carries knowledge,
+  // never spend.
+  const handledQueried = new Set(seed.handledQueried ?? []);
   const handledBudget = { remaining: handledCap, overflow: 0 };
-  const stubCache = new Map();
-  const alreadyProbed = new Set();
+  const probeBudget = { remaining: probeCap };
+  const stubCache = seed.stubCache instanceof Map ? seed.stubCache : new Map();
+  const alreadyProbed = new Set(seed.alreadyProbed ?? []);
   // One per-RUN verify-read budget for the reverse leg, shared across the fixpoint
   // so the total `gh issue view` fan-out over hit-verification is bounded (the
   // bug-B mirror of the probe-search cap: each search returns up to
@@ -108,13 +131,20 @@ export async function resolveFamilies(
   let reverseBudgetTruncated = false;
   let reverseNonconvergent = false;
 
-  let handledShortIds = declaredIds.length
-    ? await listHandledShortIds(runGh, repo, declaredIds, {
-        queried: handledQueried,
-        budget: handledBudget,
-      })
-    : [];
-  const handledEdges = [];
+  // The seeded blockers/edges are the prior pass's PROVEN findings, folded in
+  // before the first collapse so this pass never has to re-derive them (and, on
+  // a smaller budget, fail to).
+  let handledShortIds = [...new Set(seed.handledShortIds ?? [])];
+  if (declaredIds.length) {
+    const found = await listHandledShortIds(runGh, repo, declaredIds, {
+      queried: handledQueried,
+      budget: handledBudget,
+    });
+    handledShortIds = [...new Set([...handledShortIds, ...found])];
+  }
+  const handledEdges = [
+    ...(Array.isArray(seed.handledEdges) ? seed.handledEdges : []),
+  ];
 
   // Family ids are agent-authored free text. Scoping every joiner AND every
   // blocker to this project is what stops a foreign-project id — or the bare
@@ -187,6 +217,7 @@ export async function resolveFamilies(
         stubCache,
         alreadyProbed,
         verifyBudget: reverseVerifyBudget,
+        probeBudget,
         maxProbes: probeCap,
       });
       edges = result.edges;
@@ -219,6 +250,16 @@ export async function resolveFamilies(
       handledOverflow: handledBudget.overflow,
       reverseBudget: reverseBudgetTruncated,
       reverseNonconvergent,
+    },
+    // Everything this pass LEARNED, in the shape `options.seed` accepts. The
+    // selector hands it to the second look so that pass starts from this one's
+    // blockers and edges instead of re-deriving them on a smaller budget.
+    resolved: {
+      handledShortIds,
+      handledEdges,
+      handledQueried,
+      stubCache,
+      alreadyProbed,
     },
   };
 }

--- a/scripts/sentry-autofix-family-resolve.mjs
+++ b/scripts/sentry-autofix-family-resolve.mjs
@@ -73,10 +73,16 @@ const MAX_REVERSE_ITERATIONS = 4;
  * MORE candidates — so a family whose terminal sibling the first pass surfaced at
  * probe 25 is unreachable at 20 probes, and the second look selects a stub whose
  * family the same run just stood down. That is a duplicate autofix PR with no
- * rate limit involved. Seeding is also strictly cheaper: `handledQueried`,
- * `alreadyProbed` and `stubCache` make the second look skip reads the first pass
+ * rate limit involved. Seeding is also strictly cheaper: `handledAnswered`,
+ * `probesAnswered` and `stubCache` make the second look skip reads the first pass
  * already paid for. Budgets are NOT seeded — they are fresh allowances for the
  * ids this pass is the first to see.
+ *
+ * The seed carries ANSWERED work only. Every set here has a wider in-pass twin
+ * that also suppresses ids the pass DROPPED for budget or FAILED to read; those
+ * twins never leave the pass. Seeding spend as if it were knowledge is the
+ * inverse of the bug seeding exists to fix, and lands in the same place — a
+ * duplicate autofix PR — from the other direction.
  */
 export async function resolveFamilies(
   runGh,
@@ -112,17 +118,33 @@ export async function resolveFamilies(
       ),
     ),
   ];
-  // One per-RUN handled-id budget, shared by the initial declared-id pass and the
-  // fixpoint's re-checks of reverse-surfaced hub ids, so the total stays bounded
-  // and its overflow surfaces on the tracker.
-  // Seeded from a prior pass where one exists (see `options.seed`), fresh
-  // otherwise. The BUDGETS below are always fresh: the seed carries knowledge,
-  // never spend.
-  const handledQueried = new Set(seed.handledQueried ?? []);
+  // ANSWERED vs SPENT. Each pair below is the same distinction: the first member
+  // is what this pass may not re-attempt (answered, dropped for budget, or
+  // failed), the second is the strict subset that was actually ANSWERED and is
+  // therefore knowledge a later pass may inherit. Only the answered halves reach
+  // `resolved`, and each within-pass set STARTS from the seeded answered one —
+  // so a fresh budget retries exactly what nobody ever read.
+  //
+  // Getting this wrong is a duplicate autofix PR. `listHandledShortIds` folds
+  // every OVERFLOWED id into `queried` on purpose, so the per-run overflow counts
+  // each distinct un-runnable id once instead of once per fixpoint iteration —
+  // correct while a budget only shrinks within one pass, and silently wrong the
+  // moment a pass with a FRESH budget inherits it: the second look would treat
+  // never-read ids as resolved, spend none of its new allowance on them, and
+  // select a stub whose sibling carries a terminal marker nobody ever looked at.
+  const handledAnswered = new Set(seed.handledAnswered ?? []);
+  const handledQueried = new Set(handledAnswered);
   const handledBudget = { remaining: handledCap, overflow: 0 };
   const probeBudget = { remaining: probeCap };
-  const stubCache = seed.stubCache instanceof Map ? seed.stubCache : new Map();
-  const alreadyProbed = new Set(seed.alreadyProbed ?? []);
+  // The stub cache negative-caches a FAILED read as `null` so one broken stub is
+  // not re-read once per fixpoint iteration. That null is spend; `failedStubReads`
+  // records which keys it covers so they can be dropped from the seed while the
+  // in-pass cache keeps its bound.
+  const failedStubReads = new Set();
+  const stubCache =
+    seed.stubCache instanceof Map ? new Map(seed.stubCache) : new Map();
+  const probesAnswered = new Set(seed.probesAnswered ?? []);
+  const alreadyProbed = new Set(probesAnswered);
   // One per-RUN verify-read budget for the reverse leg, shared across the fixpoint
   // so the total `gh issue view` fan-out over hit-verification is bounded (the
   // bug-B mirror of the probe-search cap: each search returns up to
@@ -138,6 +160,7 @@ export async function resolveFamilies(
   if (declaredIds.length) {
     const found = await listHandledShortIds(runGh, repo, declaredIds, {
       queried: handledQueried,
+      answered: handledAnswered,
       budget: handledBudget,
     });
     handledShortIds = [...new Set([...handledShortIds, ...found])];
@@ -204,6 +227,7 @@ export async function resolveFamilies(
       recheckIds.length > 0
         ? await listHandledShortIds(runGh, repo, recheckIds, {
             queried: handledQueried,
+            answered: handledAnswered,
             budget: handledBudget,
           })
         : [];
@@ -216,6 +240,8 @@ export async function resolveFamilies(
         project,
         stubCache,
         alreadyProbed,
+        answeredProbes: probesAnswered,
+        failedStubReads,
         verifyBudget: reverseVerifyBudget,
         probeBudget,
         maxProbes: probeCap,
@@ -251,15 +277,23 @@ export async function resolveFamilies(
       reverseBudget: reverseBudgetTruncated,
       reverseNonconvergent,
     },
-    // Everything this pass LEARNED, in the shape `options.seed` accepts. The
-    // selector hands it to the second look so that pass starts from this one's
-    // blockers and edges instead of re-deriving them on a smaller budget.
+    // Everything this pass LEARNED — and ONLY that — in the shape `options.seed`
+    // accepts. The selector hands it to the second look so that pass starts from
+    // this one's blockers and edges instead of re-deriving them on a smaller
+    // budget. Deliberately absent: every id this pass dropped for budget, every
+    // lookup and probe that failed, and every stub read that threw. Those are
+    // spend, and the second look's budgets are FRESH, so it must be free to
+    // retry exactly the work this pass could not afford. Carrying them would
+    // read as "already resolved" and let a stub whose sibling holds a terminal
+    // marker through as a duplicate fix PR.
     resolved: {
       handledShortIds,
       handledEdges,
-      handledQueried,
-      stubCache,
-      alreadyProbed,
+      handledAnswered,
+      probesAnswered,
+      stubCache: new Map(
+        [...stubCache].filter(([key]) => !failedStubReads.has(key)),
+      ),
     },
   };
 }

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -682,7 +682,8 @@ Commands:
              [--deferred <n>] [--deferred-issues "<n n …>"] \\
              [--window-total <n>] [--window-evaluated <n>] \\
              [--second-look <bool>] [--second-look-total <n>] \\
-             [--second-look-evaluated <n>] [--gh-calls <n>] \\
+             [--second-look-evaluated <n>] [--second-look-full <bool>] \\
+             [--second-look-failed <bool>] [--gh-calls <n>] \\
              [--rate-limited <n>] \\
              [--handled-overflow <n>] [--reverse-truncated <bool>] \\
              [--reverse-nonconvergent <bool>]
@@ -835,6 +836,8 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
           secondLook: readFlag(args, "--second-look"),
           secondLookTotal: readFlag(args, "--second-look-total"),
           secondLookEvaluated: readFlag(args, "--second-look-evaluated"),
+          secondLookFull: readFlag(args, "--second-look-full"),
+          secondLookFailed: readFlag(args, "--second-look-failed"),
           ghCalls: readFlag(args, "--gh-calls"),
           rateLimited: readFlag(args, "--rate-limited"),
           handledOverflow: readFlag(args, "--handled-overflow"),

--- a/scripts/sentry-autofix-finalize.mjs
+++ b/scripts/sentry-autofix-finalize.mjs
@@ -681,11 +681,16 @@ Commands:
              --candidates <n> --opened <n> --refused <n> --incomplete <n> \\
              [--deferred <n>] [--deferred-issues "<n n …>"] \\
              [--window-total <n>] [--window-evaluated <n>] \\
+             [--second-look <bool>] [--second-look-total <n>] \\
+             [--second-look-evaluated <n>] [--gh-calls <n>] \\
+             [--rate-limited <n>] \\
              [--handled-overflow <n>] [--reverse-truncated <bool>] \\
              [--reverse-nonconvergent <bool>]
       Print the tracker run-record comment body (rolling comment, marker-keyed).
       The Window line renders only when --window-total exceeds --window-evaluated;
-      each truncation line renders only when its budget was actually hit.
+      the Second look line only when the bounded second look actually ran; the
+      DEGRADED line only when --rate-limited is nonzero; each truncation line
+      only when its budget was actually hit.
   select-run-record-id --comments-file <path>
       Print the numeric id of the tracker issue's existing rolling run-record
       comment (trusted-author + prefix-anchored, selectMarkedComment),
@@ -827,6 +832,11 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
           skippedIssues: readFlag(args, "--skipped-issues"),
           windowTotal: readFlag(args, "--window-total"),
           windowEvaluated: readFlag(args, "--window-evaluated"),
+          secondLook: readFlag(args, "--second-look"),
+          secondLookTotal: readFlag(args, "--second-look-total"),
+          secondLookEvaluated: readFlag(args, "--second-look-evaluated"),
+          ghCalls: readFlag(args, "--gh-calls"),
+          rateLimited: readFlag(args, "--rate-limited"),
           handledOverflow: readFlag(args, "--handled-overflow"),
           reverseTruncated: readFlag(args, "--reverse-truncated"),
           reverseNonconvergent: readFlag(args, "--reverse-nonconvergent"),

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -34,6 +34,19 @@ import {
 // the body); the marker is used here to test the CLI's rolling-comment upsert
 // and the untrusted-author selection fence.
 import { AUTOFIX_RUN_RECORD_MARKER } from "./sentry-autofix-run-record.mjs";
+// The select leg's per-run cost caps. This suite already reads the autofix
+// workflow, so it is where the job budget those caps are sized against can be
+// pinned against the caps themselves — see the timeout test at the end.
+import { MAX_CANDIDATE_EVALUATIONS } from "./sentry-autofix-select.mjs";
+import {
+  MAX_SECOND_LOOK_EVALUATIONS,
+  SECOND_LOOK_FAMILY_BUDGETS,
+} from "./sentry-autofix-second-look.mjs";
+import { MAX_HANDLED_ID_QUERIES } from "./sentry-autofix-queue-io.mjs";
+import {
+  MAX_REVERSE_PROBE_QUERIES,
+  MAX_REVERSE_VERIFY_READS,
+} from "./sentry-autofix-reverse-verify.mjs";
 import { AUTOFIX_COMMENT_PREFIX } from "./sentry-triage-digest.mjs";
 import {
   FIX_SCOPE_MECHANICAL,
@@ -1783,6 +1796,45 @@ await test("fork-fence negative control: the pre-fix bare jq TRUSTS the fork PR"
       "the shipped fence must not be the bare, fork-trusting read",
     );
   }
+});
+
+await test("the select job's timeout-minutes is pinned to the selection caps it is sized against", () => {
+  // The one change in the window/second-look work with no test at all: a bare
+  // YAML scalar. `timeout-minutes` is the REAL binding constraint on this leg —
+  // every gh call it makes is serial, so the worst case is wall clock, not a
+  // rate limit — and the caps below are what make that worst case finite. The
+  // two are a pair, and nothing connected them: reverting the timeout to its old
+  // 10 would ship past every suite and then kill the job on precisely the path
+  // the second look exists to create (a full window that selects nothing).
+  //
+  // Derived from the LIVE constants rather than restating 782, so raising a cap
+  // without re-checking the budget fails here instead of in production.
+  const perRunGhCalls =
+    1 + // window list
+    2 * MAX_CANDIDATE_EVALUATIONS + // issue view + pulls, per stub
+    MAX_HANDLED_ID_QUERIES +
+    MAX_REVERSE_PROBE_QUERIES +
+    MAX_REVERSE_VERIFY_READS +
+    1 + // the second look's own list
+    2 * MAX_SECOND_LOOK_EVALUATIONS +
+    SECOND_LOOK_FAMILY_BUDGETS.handled +
+    SECOND_LOOK_FAMILY_BUDGETS.probe +
+    SECOND_LOOK_FAMILY_BUDGETS.verify;
+  // A pessimistic 1.0 s per serial call, and the documented rule that the leg
+  // must fit inside 60% of the job budget so checkout, setup and latency spikes
+  // have room.
+  const requiredMinutes = perRunGhCalls / 60 / 0.6;
+
+  const selectJob = /\n {2}select:\n([\s\S]*?)\n {2}[a-z][\w-]*:\n/.exec(
+    `${AUTOFIX_WORKFLOW}\n  zzz:\n`,
+  );
+  assert(selectJob, "the select job must be locatable in the workflow");
+  const timeout = /^\s{4}timeout-minutes:\s*(\d+)\s*$/m.exec(selectJob[1]);
+  assert(timeout, "the select job must declare a timeout-minutes");
+  assert(
+    Number(timeout[1]) >= requiredMinutes,
+    `select timeout-minutes is ${timeout[1]}, but the capped worst case is ${perRunGhCalls} serial gh calls = ${(perRunGhCalls / 60).toFixed(1)} min, which needs at least ${Math.ceil(requiredMinutes)} to stay under 60% of the budget`,
+  );
 });
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);

--- a/scripts/sentry-autofix-queue-io.mjs
+++ b/scripts/sentry-autofix-queue-io.mjs
@@ -363,12 +363,20 @@ export async function listHandledShortIds(
   declaredIds,
   options = {},
 ) {
-  // `queried` (already-looked-up ids) and `budget` (remaining allowance +
-  // accumulated overflow) are shared across the run's calls, so a second pass on
-  // reverse-surfaced ids neither re-queries an id nor exceeds the per-run cap.
-  // Absent (a standalone call), each defaults fresh, preserving the single-call
-  // cap-at-40 behaviour exactly.
+  // `queried` (ids this pass must not re-attempt — answered, dropped OR failed)
+  // and `budget` (remaining allowance + accumulated overflow) are shared across
+  // the run's calls, so a second pass on reverse-surfaced ids neither re-queries
+  // an id nor exceeds the per-run cap. Absent (a standalone call), each defaults
+  // fresh, preserving the single-call cap-at-40 behaviour exactly.
+  //
+  // `answered` is the STRICT SUBSET of `queried` whose lookup actually came back
+  // and could be read — knowledge, where the rest of `queried` is merely spend
+  // (it deliberately absorbs ids this call never issued; see the overflow
+  // branch). Only that subset may cross into a pass with a FRESH budget. Why
+  // that matters: sentry-autofix-family-resolve.mjs § ANSWERED vs SPENT.
   const queried = options.queried instanceof Set ? options.queried : new Set();
+  const answered =
+    options.answered instanceof Set ? options.answered : new Set();
   const budget = options.budget ?? {
     remaining: MAX_HANDLED_ID_QUERIES,
     overflow: 0,
@@ -440,8 +448,15 @@ export async function listHandledShortIds(
     try {
       parsed = JSON.parse(stdout);
     } catch {
-      parsed = [];
+      // A body we cannot read did not ANSWER the lookup any more than a failed
+      // read did, so this id stays out of `answered`. Behaviourally identical to
+      // the previous `parsed = []` (the loop below ran zero times either way).
+      continue;
     }
+    // ANSWERED: the lookup ran and came back readable. Both outcomes count —
+    // "this id carries a terminal marker" and "it does not" are equally real
+    // answers, and re-asking on a later pass would only re-spend budget.
+    answered.add(id);
     for (const issue of Array.isArray(parsed) ? parsed : []) {
       const title = issue.title ?? "";
       // Exact-parse fence over GitHub's tokenized search: the parsed short-id

--- a/scripts/sentry-autofix-queue-io.mjs
+++ b/scripts/sentry-autofix-queue-io.mjs
@@ -65,7 +65,57 @@ export function parseProject(title) {
 // pre-filter above, the eligible-and-unfixed local set stays tiny, so this is
 // only a safety ceiling — not the throttle. Oldest-first, so genuinely old
 // candidates are never starved by newer ones.
-const LIST_LIMIT = 200;
+//
+// It is also the HARD upper bound on the selector's evaluation window. `--limit`
+// caps what the API RETURNS, and that happens BEFORE
+// `MAX_CANDIDATE_EVALUATIONS` (sentry-autofix-select.mjs) slices the returned
+// rows — so raising that constant above this one is a strict NO-OP, and the two
+// must move together. The invariant is pinned by a test
+// (`MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT` in sentry-autofix-select.test.mjs)
+// and re-checked at run time by `windowCeilingWarning`, because a silent no-op
+// is exactly the failure a "we raised the window" change must not ship as.
+// Exported for both.
+export const LIST_LIMIT = 200;
+
+// Rate-limit-shaped `gh` failure text. EVERY read the select leg issues is a
+// dedupe/blocker signal (a prior fix PR, a terminal sibling's marker, a verdict),
+// and every one of them fails SOFT toward MORE candidates — so a rejection the
+// caller cannot tell apart from "no blocker found" makes a throttled run open
+// DUPLICATE autofix PRs and still look green. These patterns are what `gh`
+// actually prints on the wire:
+//   - `gh api` surfaces the HTTP status verbatim: `HTTP 403: API rate limit
+//     exceeded for user ID 1234. (https://api.github.com/…)`, and
+//     `HTTP 403: You have exceeded a secondary rate limit and have been
+//     temporarily blocked from content creation.` GitHub also serves plain
+//     `HTTP 429 Too Many Requests` on some abuse paths.
+//   - `gh issue list --search` routes to GraphQL, whose throttle body reads
+//     `GraphQL: API rate limit exceeded for user ID 1234. (rateLimitExceeded)`.
+//   - Older/abuse-detection responses read `You have triggered an abuse
+//     detection mechanism`.
+// `defaultRunGh` puts gh's whole stderr into the rejection message, so matching
+// the message text covers all of them.
+//
+// A bare `HTTP 403` that is really a PERMISSIONS failure matches too. That is
+// deliberate: both mean "this read did not answer the dedupe question", and the
+// only action either warrants is the same one — stop selecting on unreliable
+// data. Fail closed, not clever.
+const RATE_LIMIT_PATTERNS = [
+  /\bHTTP 403\b/,
+  /\bHTTP 429\b/,
+  /rate limit/i,
+  /rateLimitExceeded/i,
+  /abuse detection/i,
+  /too many requests/i,
+];
+
+/** True when a `gh` failure message is rate-limit / throttle shaped — i.e. the
+ * read did NOT answer the dedupe question it was issued for, as opposed to
+ * answering "no blocker". Pure and exported so the selector can classify a
+ * rejection from ANY read without each call site re-implementing the match. */
+export function isRateLimitFailure(message) {
+  const text = String(message ?? "");
+  return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(text));
+}
 
 export function defaultRunGh(args) {
   return new Promise((resolve, reject) => {
@@ -107,8 +157,28 @@ export function defaultRunGh(args) {
  *     the returned title) drops EXTERNAL-repo code-fix stubs before their
  *     verdict is ever read.
  * Oldest-first via `sort:created-asc`, capped at LIST_LIMIT as a safety ceiling.
+ *
+ * `options.limit` widens that ceiling and `options.skip` drops the oldest N RAW
+ * rows before the client-side project filter — the pair the selector's bounded
+ * SECOND LOOK uses to reach rows past the first window when the first window
+ * selected nothing (see MAX_SECOND_LOOK_EVALUATIONS). `skip` counts RAW rows on
+ * purpose: it must line up with the first pass's own `--limit`, which the API
+ * applies before any client-side filter, so counting filtered rows would
+ * re-read or skip stubs depending on how many the project filter dropped.
+ *
+ * Returns `{ stubs, rawCount, full }` — `full` (rawCount >= limit) is the
+ * "there may be more" signal, taken off the RAW row count for the same reason.
+ * The filtered `stubs` length cannot carry it: the project filter can drop rows,
+ * so a genuinely full page can come back short and a second look that keyed on
+ * it would never fire.
  */
-export async function listCodeFixStubs(runGh, repo) {
+export async function listCodeFixStubsPage(runGh, repo, options = {}) {
+  const limit =
+    Number.isInteger(options.limit) && options.limit > 0
+      ? options.limit
+      : LIST_LIMIT;
+  const skip =
+    Number.isInteger(options.skip) && options.skip > 0 ? options.skip : 0;
   const stdout = await runGh([
     "issue",
     "list",
@@ -160,28 +230,36 @@ export async function listCodeFixStubs(runGh, repo) {
     "--json",
     "number,title,labels,createdAt",
     "--limit",
-    String(LIST_LIMIT),
+    String(limit),
   ]);
   const parsed = JSON.parse(stdout);
   const list = Array.isArray(parsed) ? parsed : [];
-  return (
-    list
-      .map((issue) => ({
-        number: issue.number,
-        title: issue.title ?? "",
-        createdAt: issue.createdAt ?? "",
-        labels: (issue.labels ?? [])
-          .map((label) => (typeof label === "string" ? label : label?.name))
-          .filter(Boolean),
-      }))
-      // Exact owning-project gate — the server-side `<slug> in:title` filter
-      // keeps the WINDOW local (tokenized, so approximate); this parses the
-      // exact project out of the title and drops any tokenized false-positive.
-      .filter((issue) => parseProject(issue.title) === LOCAL_SENTRY_PROJECT)
-      // `--search sort:created-asc` returns oldest-first, but keep the client-side
-      // sort as defense-in-depth (same pattern as the triage select job).
-      .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))
-  );
+  const stubs = list
+    .slice(skip)
+    .map((issue) => ({
+      number: issue.number,
+      title: issue.title ?? "",
+      createdAt: issue.createdAt ?? "",
+      labels: (issue.labels ?? [])
+        .map((label) => (typeof label === "string" ? label : label?.name))
+        .filter(Boolean),
+    }))
+    // Exact owning-project gate — the server-side `<slug> in:title` filter
+    // keeps the WINDOW local (tokenized, so approximate); this parses the
+    // exact project out of the title and drops any tokenized false-positive.
+    .filter((issue) => parseProject(issue.title) === LOCAL_SENTRY_PROJECT)
+    // `--search sort:created-asc` returns oldest-first, but keep the client-side
+    // sort as defense-in-depth (same pattern as the triage select job).
+    .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
+  return { stubs, rawCount: list.length, full: list.length >= limit };
+}
+
+/** The filtered window only — the shape every caller but the second look wants.
+ * Thin wrapper over `listCodeFixStubsPage`, kept because it is the name the
+ * selector and the suites have always imported. */
+export async function listCodeFixStubs(runGh, repo, options = {}) {
+  const { stubs } = await listCodeFixStubsPage(runGh, repo, options);
+  return stubs;
 }
 
 /**
@@ -259,7 +337,11 @@ export async function listHandledShortIds(
     // re-attempt these ids either.
     for (const droppedId of droppedIds) queried.add(droppedId);
     process.stderr.write(
-      `note: ${ids.length} distinct declared family ids exceed the per-run MAX_HANDLED_ID_QUERIES budget (${MAX_HANDLED_ID_QUERIES}); ${droppedIds.length} are treated as not-handled this run (fails toward MORE candidates).\n`,
+      // The budget is passed in, so name what is LEFT rather than the module
+      // constant: the selector's bounded second look runs this same helper on a
+      // smaller allowance, and printing MAX_HANDLED_ID_QUERIES there would point
+      // an operator at a number the pass never had.
+      `note: ${ids.length} distinct declared family ids exceed this pass's remaining handled-id lookup budget (${capacity} left, per-run cap ${MAX_HANDLED_ID_QUERIES}); ${droppedIds.length} are treated as not-handled this run (fails toward MORE candidates).\n`,
     );
   }
   budget.remaining = capacity - queryIds.length;

--- a/scripts/sentry-autofix-queue-io.mjs
+++ b/scripts/sentry-autofix-queue-io.mjs
@@ -92,8 +92,8 @@ export const LIST_LIMIT = 200;
 //     `GraphQL: API rate limit exceeded for user ID 1234. (rateLimitExceeded)`.
 //   - Older/abuse-detection responses read `You have triggered an abuse
 //     detection mechanism`.
-// `defaultRunGh` puts gh's whole stderr into the rejection message, so matching
-// the message text covers all of them.
+// Match these against gh's STDERR only, never the rejection message as a whole —
+// see `ghFailureText`.
 //
 // A bare `HTTP 403` that is really a PERMISSIONS failure matches too. That is
 // deliberate: both mean "this read did not answer the dedupe question", and the
@@ -117,6 +117,28 @@ export function isRateLimitFailure(message) {
   return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(text));
 }
 
+/**
+ * The text a `gh` rejection should be CLASSIFIED on: gh's own stderr when the
+ * rejection carries it, the whole message otherwise.
+ *
+ * `defaultRunGh` builds its message as `gh <argv> failed with exit N:\n<stderr>`,
+ * so classifying the message directly matches the ARGV too — and argv carries
+ * agent-authored text. Family ids come from an LLM's `duplicate_of` (charset
+ * `[A-Za-z0-9._-]`, so `RATELIMITEXCEEDED` is a legal id) and are interpolated
+ * into the `in:title` / `in:comments` searches. A stub declaring such an id would
+ * turn ANY unrelated failure of its own probe — 404, 502, ECONNRESET — into a
+ * whole-run stand-down. Scoping the match to the stderr half closes that: the
+ * rejection carries the raw stderr on `ghStderr`, and only that is classified.
+ * Rejections without the property (a spawn error, or a test double throwing a
+ * plain Error) fall back to the message, so existing behaviour is unchanged
+ * wherever there is no argv to confuse it with.
+ */
+export function ghFailureText(err) {
+  const stderr = err?.ghStderr;
+  if (typeof stderr === "string") return stderr;
+  return err instanceof Error ? err.message : String(err ?? "");
+}
+
 export function defaultRunGh(args) {
   return new Promise((resolve, reject) => {
     const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] });
@@ -135,11 +157,15 @@ export function defaultRunGh(args) {
     });
     child.on("close", (status) => {
       if (status !== 0) {
-        reject(
-          new Error(
-            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
-          ),
+        const err = new Error(
+          `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
         );
+        // The message keeps the argv (an operator reading the log needs to know
+        // WHICH read failed); `ghStderr` carries gh's half alone, because that
+        // is the only half `isRateLimitFailure` may be run against. See
+        // `ghFailureText`.
+        err.ghStderr = stderr;
+        reject(err);
         return;
       }
       resolve(stdout);

--- a/scripts/sentry-autofix-queue-io.mjs
+++ b/scripts/sentry-autofix-queue-io.mjs
@@ -192,11 +192,29 @@ export function defaultRunGh(args) {
  * applies before any client-side filter, so counting filtered rows would
  * re-read or skip stubs depending on how many the project filter dropped.
  *
- * Returns `{ stubs, rawCount, full }` — `full` (rawCount >= limit) is the
- * "there may be more" signal, taken off the RAW row count for the same reason.
- * The filtered `stubs` length cannot carry it: the project filter can drop rows,
- * so a genuinely full page can come back short and a second look that keyed on
- * it would never fire.
+ * Returns `{ stubs, rawCount, full }` — `full` is the "is there anything past
+ * this page?" signal, taken off the RAW row count. The filtered `stubs` length
+ * cannot carry it: the project filter can drop rows, so a genuinely full page
+ * can come back short and a second look that keyed on it would never fire.
+ *
+ * `full` has TWO strengths, and the caller picks by what it does with the answer.
+ * By default it is `rawCount >= limit` — "the page came back full, so rows MAY
+ * sit past it". That is right for a TRIGGER (being wrong costs one extra list
+ * call) and wrong for a CLAIM: at EXACTLY `limit` rows it asserts more remain
+ * when nothing does.
+ *
+ * `options.sentinel` buys the definite answer. The query asks for ONE row past
+ * the ceiling, that row is dropped before anything reads or counts it, and
+ * `full` becomes "a row beyond the ceiling really did come back". Cost: ONE
+ * extra API REQUEST on the calls that opt in, and zero extra `gh` invocations
+ * and zero extra per-stub reads — `gh issue list` paginates at 100 rows per
+ * request, so a 300-row ask (3 requests) becomes a 301-row ask (4, the last
+ * holding just the sentinel). Opt-in for exactly that reason: the second look
+ * PUBLISHES its `full` on the operator-facing tracker as the standing regrowth
+ * tripwire, so it pays; the first pass only uses `full` to decide whether to
+ * take a second look at all, and being conservative there costs one extra list
+ * call on a run that already selected nothing — cheaper than the extra request
+ * on EVERY run.
  */
 export async function listCodeFixStubsPage(runGh, repo, options = {}) {
   const limit =
@@ -205,6 +223,7 @@ export async function listCodeFixStubsPage(runGh, repo, options = {}) {
       : LIST_LIMIT;
   const skip =
     Number.isInteger(options.skip) && options.skip > 0 ? options.skip : 0;
+  const sentinel = options.sentinel === true;
   const stdout = await runGh([
     "issue",
     "list",
@@ -256,10 +275,16 @@ export async function listCodeFixStubsPage(runGh, repo, options = {}) {
     "--json",
     "number,title,labels,createdAt",
     "--limit",
-    String(limit),
+    String(sentinel ? limit + 1 : limit),
   ]);
   const parsed = JSON.parse(stdout);
-  const list = Array.isArray(parsed) ? parsed : [];
+  const returned = Array.isArray(parsed) ? parsed : [];
+  // The sentinel is COUNTED, never used. Trimming it here — before the skip, the
+  // project filter and the sort — is what keeps `limit` an honest ceiling: the
+  // page still delivers at most `limit` raw rows, so `rawCount`, the evaluable
+  // stubs and every per-stub read budget downstream are byte-identical to the
+  // same call without it.
+  const list = sentinel ? returned.slice(0, limit) : returned;
   const stubs = list
     .slice(skip)
     .map((issue) => ({
@@ -277,7 +302,13 @@ export async function listCodeFixStubsPage(runGh, repo, options = {}) {
     // `--search sort:created-asc` returns oldest-first, but keep the client-side
     // sort as defense-in-depth (same pattern as the triage select job).
     .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
-  return { stubs, rawCount: list.length, full: list.length >= limit };
+  return {
+    stubs,
+    rawCount: list.length,
+    // With the sentinel, `full` is a fact: a row past the ceiling came back.
+    // Without it, it is the weaker "the page filled up, so more MAY exist".
+    full: sentinel ? returned.length > limit : list.length >= limit,
+  };
 }
 
 /** The filtered window only — the shape every caller but the second look wants.

--- a/scripts/sentry-autofix-record-labels.mjs
+++ b/scripts/sentry-autofix-record-labels.mjs
@@ -60,11 +60,15 @@ import {
 // label.
 export const SKIP_FIX_SCOPE_ARCHITECTURAL = "fix-scope-architectural";
 
-// One run may backfill at most this many labels. The skip report can never hold
-// more than the selector's MAX_CANDIDATE_EVALUATIONS (50) entries, so this is a
-// belt-and-braces bound that keeps the write volume aligned with the documented
-// cost ceiling; overflow ids are simply labeled on a later run (they re-enter the
-// skip report until labeled). Oldest-first order is preserved from the report.
+// One run may backfill at most this many labels. The skip report can now hold up
+// to MAX_CANDIDATE_EVALUATIONS (200) entries plus MAX_SECOND_LOOK_EVALUATIONS
+// (100) from a second look, so this is a REAL throttle on the write volume, not
+// the belt-and-braces bound it was when the window was 50 — deliberately left at
+// 50 because each backfilled stub costs three-to-four `gh` calls (below) and the
+// record job runs on a 5-minute timeout. Overflow ids are simply labeled on a
+// later run (they re-enter the skip report until labeled), and a full window of
+// architectural stubs drains at 50/run. Oldest-first order is preserved from the
+// report, so the queue's oldest stragglers are always the ones that drain first.
 // Each backfilled stub now costs read + write + read (the pre- and post-write
 // halves of the TOCTOU guard below), plus one more write when the post-check
 // forces a compensating removal — so this bound governs three-to-four gh calls

--- a/scripts/sentry-autofix-reverse-verify.mjs
+++ b/scripts/sentry-autofix-reverse-verify.mjs
@@ -158,6 +158,12 @@ export async function reverseVerifyFamilies(
   const verifyBudget = options.verifyBudget ?? {
     remaining: MAX_REVERSE_VERIFY_READS,
   };
+  // `maxProbes` overrides the per-run probe cap for ONE resolve pass — the
+  // selector's bounded second look runs on a smaller allowance because the first
+  // pass already spent the module default. Absent, the default applies.
+  const maxProbes = Number.isInteger(options.maxProbes)
+    ? options.maxProbes
+    : MAX_REVERSE_PROBE_QUERIES;
   const edges = [];
   const blockers = new Set();
   let truncated = false;
@@ -171,7 +177,7 @@ export async function reverseVerifyFamilies(
     // Per-run probe budget (counts distinct LOCAL probes across the fixpoint via
     // the shared `probed` set). At the ceiling, stop probing and treat the rest
     // as not-probed — fewer blockers, MORE candidates, the safe direction.
-    if (probed.size >= MAX_REVERSE_PROBE_QUERIES) {
+    if (probed.size >= maxProbes) {
       truncated = true;
       break;
     }
@@ -268,7 +274,7 @@ export async function reverseVerifyFamilies(
   }
   if (truncated) {
     process.stderr.write(
-      `note: reverse family verification was truncated this run — the per-run probe budget (${MAX_REVERSE_PROBE_QUERIES}) or verify-read budget (${MAX_REVERSE_VERIFY_READS}) was reached, or a probe returned a full page; the unreached hits/probes are treated as not-admitted (fails toward MORE candidates).\n`,
+      `note: reverse family verification was truncated this pass — the probe budget (${maxProbes}) or verify-read budget was reached, or a probe returned a full page; the unreached hits/probes are treated as not-admitted (fails toward MORE candidates).\n`,
     );
   }
   return { edges, blockers: [...blockers], truncated };

--- a/scripts/sentry-autofix-reverse-verify.mjs
+++ b/scripts/sentry-autofix-reverse-verify.mjs
@@ -37,7 +37,7 @@ import {
  * parsed verdict, or `null` when the stub cannot be read or carries no usable
  * fenced verdict (a comment mention that is not a real verdict). Never throws.
  */
-async function readVerdictCached(runGh, repo, number, cache) {
+async function readVerdictCached(runGh, repo, number, cache, failedReads) {
   const key = String(number);
   if (cache.has(key)) return cache.get(key);
   let parsed;
@@ -46,6 +46,12 @@ async function readVerdictCached(runGh, repo, number, cache) {
     parsed = resolveVerdict(full, number).parsed;
   } catch {
     parsed = null;
+    // A FAILED read is cached as `null` so one broken stub cannot be re-read once
+    // per fixpoint iteration — but that null is spend, not knowledge, and it is
+    // indistinguishable from the legitimate "read fine, carries no fenced
+    // verdict". Recording the key here is what lets the caller keep the negative
+    // cache inside this pass and refuse to SEED it into the next one.
+    failedReads?.add(key);
   }
   cache.set(key, parsed);
   return parsed;
@@ -154,6 +160,15 @@ export async function reverseVerifyFamilies(
   const project = options.project;
   const stubCache = options.stubCache ?? new Map();
   const probed = options.alreadyProbed ?? new Set();
+  // The ANSWERED subset of `probed`: probes whose search came back AND whose
+  // every hit was verified within budget. `probed` alone is a re-attempt guard
+  // and absorbs probes that failed or were left half-read — spend, not
+  // knowledge — so only this set may be seeded into a pass with a fresh budget.
+  // (A probe cut off by the PROBE budget never reaches `probed` at all: the
+  // ceiling check breaks before the add.) Optional: a standalone call keeps its
+  // previous behaviour exactly.
+  const answeredProbes = options.answeredProbes ?? null;
+  const failedStubReads = options.failedStubReads ?? new Set();
   // Shared across the caller's fixpoint iterations (like `probed`), so the
   // per-run verify-read cap bounds the whole reverse leg, not one call. Absent
   // (a standalone call), it defaults fresh, preserving cap-at-N per call.
@@ -225,6 +240,16 @@ export async function reverseVerifyFamilies(
     if (Array.isArray(hits) && hits.length >= REVERSE_SEARCH_LIMIT) {
       truncated = true;
     }
+    // Whether THIS probe left any hit unresolved — starved of verify budget, or
+    // read and thrown. Either way the probe's own answer is incomplete: the hit
+    // it could not read may be the terminal sibling, and only re-probing on a
+    // fresh budget can reach it.
+    //
+    // A full page above does NOT count. That truncation is structural — the API
+    // returned `--limit` rows and page 2 is unreachable by design — so a re-probe
+    // would return the identical page and learn nothing; spending a fresh
+    // budget on it would be pure waste.
+    let hitUnresolved = false;
     for (const hit of Array.isArray(hits) ? hits : []) {
       const hitShortId = parseShortId(hit.title ?? "");
       if (!isValidShortId(hitShortId)) continue;
@@ -239,6 +264,7 @@ export async function reverseVerifyFamilies(
       if (!stubCache.has(String(hit.number))) {
         if (verifyBudget.remaining <= 0) {
           truncated = true;
+          hitUnresolved = true;
           continue;
         }
         verifyBudget.remaining -= 1;
@@ -248,7 +274,14 @@ export async function reverseVerifyFamilies(
         repo,
         hit.number,
         stubCache,
+        failedStubReads,
       );
+      // A THROWN read leaves this hit unresolved too — and unlike a hit that
+      // read fine and simply carries no fenced verdict (also `parsed == null`,
+      // and a real answer), it is worth retrying. Checked on the shared set, so
+      // a hit whose read failed in an earlier iteration and now returns from the
+      // negative cache still marks THIS probe incomplete.
+      if (failedStubReads.has(String(hit.number))) hitUnresolved = true;
       if (!parsed) continue;
       // The hub's WHOLE declared local family (project-scoped, self-excluded,
       // MAX_DUPLICATE_LOOKUPS-bounded — the forward path's exact rule). The probe
@@ -283,6 +316,10 @@ export async function reverseVerifyFamilies(
         blockers.add(hitKey);
       }
     }
+    // The probe is ANSWERED only now: its search returned AND every hit it
+    // surfaced was resolved. A `continue` on search failure above never reaches
+    // this line, which is the point.
+    if (!hitUnresolved) answeredProbes?.add(probeId);
   }
   if (truncated) {
     process.stderr.write(

--- a/scripts/sentry-autofix-reverse-verify.mjs
+++ b/scripts/sentry-autofix-reverse-verify.mjs
@@ -130,8 +130,10 @@ export const MAX_REVERSE_VERIFY_READS = 40;
  * Fail-SOFT, same direction as `openAutofixPrExists`: a `gh` failure on one
  * probe skips that probe this run (at worst one self-terminating extra attempt),
  * never rejecting out of selection. `alreadyProbed` carries across the caller's
- * fixpoint iterations so no id is queried twice AND so the per-run
- * MAX_REVERSE_PROBE_QUERIES budget bounds the whole fixpoint, not one call;
+ * fixpoint iterations (and, for the selector's second look, across PASSES) so no
+ * id is queried twice; the separate `probeBudget` counter is what bounds the
+ * per-run MAX_REVERSE_PROBE_QUERIES spend across the whole fixpoint, kept apart
+ * from the dedupe set so a seeded set cannot read as a spent budget;
  * `verifyBudget` likewise carries across iterations so the per-run
  * MAX_REVERSE_VERIFY_READS cap bounds the hit-verification reads across the whole
  * fixpoint, not one probe. Returns
@@ -164,6 +166,15 @@ export async function reverseVerifyFamilies(
   const maxProbes = Number.isInteger(options.maxProbes)
     ? options.maxProbes
     : MAX_REVERSE_PROBE_QUERIES;
+  // The budget is a COUNTER, not `probed.size`. The two were the same while
+  // `alreadyProbed` started empty on every resolve pass, but the selector's
+  // second look now SEEDS it with the first pass's probed ids (so it does not
+  // re-issue searches the run already paid for) — and with `probed.size` as the
+  // meter, a seeded set of 40 would read as "budget already spent" and the
+  // second look would probe NOTHING while reporting `truncated`. Shared across
+  // the caller's fixpoint iterations exactly like `verifyBudget`, so the per-run
+  // cap still bounds the whole reverse leg rather than one call.
+  const probeBudget = options.probeBudget ?? { remaining: maxProbes };
   const edges = [];
   const blockers = new Set();
   let truncated = false;
@@ -174,13 +185,14 @@ export async function reverseVerifyFamilies(
     // note below, where a newline would inject a workflow command.
     if (!isLocalFamilyId(probeId, project)) continue;
     if (probed.has(probeId)) continue;
-    // Per-run probe budget (counts distinct LOCAL probes across the fixpoint via
-    // the shared `probed` set). At the ceiling, stop probing and treat the rest
-    // as not-probed — fewer blockers, MORE candidates, the safe direction.
-    if (probed.size >= maxProbes) {
+    // Per-run probe budget (counts distinct LOCAL probes ISSUED across the
+    // fixpoint). At the ceiling, stop probing and treat the rest as not-probed —
+    // fewer blockers, MORE candidates, the safe direction.
+    if (probeBudget.remaining <= 0) {
       truncated = true;
       break;
     }
+    probeBudget.remaining -= 1;
     probed.add(probeId);
     let hits;
     try {

--- a/scripts/sentry-autofix-run-record.mjs
+++ b/scripts/sentry-autofix-run-record.mjs
@@ -99,6 +99,8 @@ export function buildAutofixRunRecordBody({
   secondLook,
   secondLookTotal,
   secondLookEvaluated,
+  secondLookFull,
+  secondLookFailed,
   ghCalls,
   rateLimited,
   handledOverflow,
@@ -149,25 +151,39 @@ export function buildAutofixRunRecordBody({
   // The bounded SECOND LOOK (this leg's starvation fix). It fires only when the
   // first pass selected NOTHING from a FULL list page — i.e. selectable stubs may
   // sit past the list ceiling that no run would otherwise ever reach. It is extra
-  // `gh` spend, so it is never silent; and it carries its own evaluation ceiling,
-  // so `evaluated < total` on this line is its own truncation, reported exactly
-  // like the Window tripwire.
+  // `gh` spend, so it is never silent.
+  //
+  // This is also the standing tripwire for queue REGROWTH, now that the eval cap
+  // equals the list ceiling and the Window line above is inert. That job needs
+  // `secondLookFull`, not the counts: the second look's row cap clamps
+  // `secondLookTotal` by construction, so the counts alone read identically
+  // whether 100 stubs or 5,000 sit past the ceiling. `full` is what separates
+  // "the run reached the end of the queue" from "the queue is growing past what
+  // one run can see", and it is the second look's own truncation signal —
+  // `evaluated < total` is the strictly weaker one it replaces.
   if (secondLook === true || secondLook === "true") {
     const secondTotalN = nonNegativeInt(secondLookTotal);
     const secondEvaluatedN = nonNegativeInt(secondLookEvaluated);
+    const suffix =
+      secondLookFailed === true || secondLookFailed === "true"
+        ? " — the second look's own list read FAILED, so nothing past the window was seen this run"
+        : secondLookFull === true || secondLookFull === "true"
+          ? " — and MORE rows sit past even that (the queue is outgrowing one run's reach)"
+          : secondTotalN > secondEvaluatedN
+            ? " (capped by MAX_SECOND_LOOK_EVALUATIONS)"
+            : "";
     lines.push(
-      `- Second look: ${secondTotalN} further stubs past the window, evaluated ${secondEvaluatedN}${
-        secondTotalN > secondEvaluatedN
-          ? " (capped by MAX_SECOND_LOOK_EVALUATIONS)"
-          : ""
-      }`,
+      `- Second look: ${secondTotalN} further stubs past the window, evaluated ${secondEvaluatedN}${suffix}`,
     );
   }
-  // Measured `gh` invocations. The per-run cost ceiling was arithmetic over caps
-  // that nothing ever counted; this makes it an observed number, so drift shows
-  // up on the tracker before it shows up as a timed-out job.
+  // Measured `gh` INVOCATIONS — serial subprocesses, the unit the job timeout is
+  // sized in. Deliberately not "requests": one `gh issue list --limit 200` is a
+  // single invocation but two API requests, so the rate-limit arithmetic in
+  // docs/notes/sentry-triage-pipeline.md § "Cost bound" runs in the other unit.
+  // Naming the unit here is what keeps this a drift detector rather than a number
+  // compared against a ceiling it can never reach.
   const ghCallsN = nonNegativeInt(ghCalls);
-  if (ghCallsN > 0) lines.push(`- gh reads: ${ghCallsN}`);
+  if (ghCallsN > 0) lines.push(`- gh invocations: ${ghCallsN}`);
   // Cost-budget truncations (PR #1810 follow-up): a family-dedupe lookup a per-run
   // budget capped, so a stub that SHOULD have stood down may re-attempt this run.
   // Each fails toward MORE candidates (never a wrong close), but the re-attempt

--- a/scripts/sentry-autofix-run-record.mjs
+++ b/scripts/sentry-autofix-run-record.mjs
@@ -96,6 +96,11 @@ export function buildAutofixRunRecordBody({
   skippedIssues,
   windowTotal,
   windowEvaluated,
+  secondLook,
+  secondLookTotal,
+  secondLookEvaluated,
+  ghCalls,
+  rateLimited,
   handledOverflow,
   reverseTruncated,
   reverseNonconvergent,
@@ -115,11 +120,12 @@ export function buildAutofixRunRecordBody({
     `- Skipped (fix_scope: architectural): ${nonNegativeInt(skipped)}${renderDeferredIssues(skippedIssues)}`,
   ];
   // Window tripwire (PR #1810): rendered ONLY when the list window exceeded the
-  // evaluation cap (total > evaluated). The selector bounds the READ at
-  // MAX_CANDIDATE_EVALUATIONS, so a growing window would otherwise truncate its
-  // newest tail silently; this line surfaces the approach on the tracker weeks
-  // ahead of the cap, which is #1813's fallback remedy shipped alongside the
-  // fix. When the window fits (the steady state), the line is absent.
+  // evaluation cap (total > evaluated). Kept as a guard rather than deleted:
+  // MAX_CANDIDATE_EVALUATIONS now EQUALS LIST_LIMIT, so the API truncates before
+  // the eval slice can and this line is inert in practice — but it fires again
+  // the moment the eval cap is lowered below the list ceiling, which is exactly
+  // when a silent newest-tail truncation would return. The live tripwire for a
+  // window that cannot hold the queue is the Second look line below.
   const windowTotalN = nonNegativeInt(windowTotal);
   const windowEvaluatedN = nonNegativeInt(windowEvaluated);
   if (windowTotalN > windowEvaluatedN) {
@@ -127,6 +133,41 @@ export function buildAutofixRunRecordBody({
       `- Window: ${windowTotalN} stubs, evaluated ${windowEvaluatedN}`,
     );
   }
+  // DEGRADED run. Every read the select leg issues answers a dedupe/blocker
+  // question and every one of them fails SOFT toward MORE candidates, so a
+  // throttled run cannot tell "no prior fix PR" from "GitHub refused to answer"
+  // — and would open a DUPLICATE autofix PR while rendering as a clean
+  // `Candidates selected: N`. The leg therefore emits ZERO entries and says so
+  // HERE, loudly: without this line a fail-closed run is byte-identical to an
+  // idle one, which is the #1758 misdiagnosis wearing a different hat.
+  const rateLimitedN = nonNegativeInt(rateLimited);
+  if (rateLimitedN > 0) {
+    lines.push(
+      `- **DEGRADED (rate limited):** ${rateLimitedN} gh read(s) failed rate-limit-shaped; selection was suppressed (0 entries emitted) rather than run on unreliable dedupe data`,
+    );
+  }
+  // The bounded SECOND LOOK (this leg's starvation fix). It fires only when the
+  // first pass selected NOTHING from a FULL list page — i.e. selectable stubs may
+  // sit past the list ceiling that no run would otherwise ever reach. It is extra
+  // `gh` spend, so it is never silent; and it carries its own evaluation ceiling,
+  // so `evaluated < total` on this line is its own truncation, reported exactly
+  // like the Window tripwire.
+  if (secondLook === true || secondLook === "true") {
+    const secondTotalN = nonNegativeInt(secondLookTotal);
+    const secondEvaluatedN = nonNegativeInt(secondLookEvaluated);
+    lines.push(
+      `- Second look: ${secondTotalN} further stubs past the window, evaluated ${secondEvaluatedN}${
+        secondTotalN > secondEvaluatedN
+          ? " (capped by MAX_SECOND_LOOK_EVALUATIONS)"
+          : ""
+      }`,
+    );
+  }
+  // Measured `gh` invocations. The per-run cost ceiling was arithmetic over caps
+  // that nothing ever counted; this makes it an observed number, so drift shows
+  // up on the tracker before it shows up as a timed-out job.
+  const ghCallsN = nonNegativeInt(ghCalls);
+  if (ghCallsN > 0) lines.push(`- gh reads: ${ghCallsN}`);
   // Cost-budget truncations (PR #1810 follow-up): a family-dedupe lookup a per-run
   // budget capped, so a stub that SHOULD have stood down may re-attempt this run.
   // Each fails toward MORE candidates (never a wrong close), but the re-attempt

--- a/scripts/sentry-autofix-run-record.test.mjs
+++ b/scripts/sentry-autofix-run-record.test.mjs
@@ -343,5 +343,117 @@ await test("run record renders each cost-budget truncation only when its budget 
   );
 });
 
+await test("run record renders the bounded second look only when it actually ran", () => {
+  // The second look is extra `gh` spend on a run that already found nothing, so
+  // it must never be silent — and it carries an evaluation ceiling of its own,
+  // so `evaluated < total` on the same line is its own truncation report.
+  //
+  // NEGATIVE CONTROL: drop the `if (secondLook === true …)` guard in
+  // buildAutofixRunRecordBody and the steady-state assertion below (no line when
+  // it did not run) fails.
+  const idle = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 0,
+  });
+  assert(
+    !idle.includes("Second look"),
+    "no second-look line when it did not run",
+  );
+  const ran = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 1,
+    secondLook: "true",
+    secondLookTotal: 7,
+    secondLookEvaluated: 7,
+  });
+  assert(
+    ran.includes("- Second look: 7 further stubs past the window, evaluated 7"),
+    `second-look line renders, got: ${ran}`,
+  );
+  assert(
+    !ran.includes("MAX_SECOND_LOOK_EVALUATIONS"),
+    "an untruncated second look must not claim a cap it never hit",
+  );
+  const capped = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 1,
+    secondLook: true,
+    secondLookTotal: 105,
+    secondLookEvaluated: 100,
+  });
+  assert(
+    capped.includes(
+      "- Second look: 105 further stubs past the window, evaluated 100 (capped by MAX_SECOND_LOOK_EVALUATIONS)",
+    ),
+    `a truncated second look names its cap, got: ${capped}`,
+  );
+});
+
+await test("run record renders the measured gh read count when there is one", () => {
+  // The per-run cost ceiling was arithmetic nothing ever counted; this is the
+  // observed number, so drift lands on the tracker before it lands as a timeout.
+  const measured = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 2,
+    ghCalls: 522,
+  });
+  assert(measured.includes("- gh reads: 522"), `got: ${measured}`);
+  const none = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "off-main",
+    candidates: 0,
+  });
+  assert(
+    !none.includes("gh reads"),
+    "a leg that issued no reads carries no count line",
+  );
+});
+
+await test("run record renders a LOUD degraded line when reads were rate limited", () => {
+  // Fail-closed's whole point is that the suppression is visible: a run that
+  // emitted zero entries because GitHub throttled it must not render identically
+  // to an idle one — that is the #1758 misdiagnosis in a new costume, and here it
+  // would be hiding a state in which a duplicate PR was NARROWLY avoided.
+  //
+  // NEGATIVE CONTROL: drop the `rateLimitedN > 0` push and the assertion below
+  // fails while every other line still renders — proving this line is the only
+  // durable trace of the degradation.
+  const degraded = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "degraded-rate-limited",
+    candidates: 0,
+    rateLimited: 3,
+  });
+  assert(
+    degraded.includes("**DEGRADED (rate limited):** 3 gh read(s)"),
+    `degraded line renders with its count, got: ${degraded}`,
+  );
+  assert(
+    degraded.includes("0 entries emitted"),
+    "the degraded line must state that selection was suppressed",
+  );
+  const clean = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 2,
+    rateLimited: 0,
+  });
+  assert(
+    !clean.includes("DEGRADED"),
+    "the steady state carries no degraded line",
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exitCode = 1;

--- a/scripts/sentry-autofix-run-record.test.mjs
+++ b/scripts/sentry-autofix-run-record.test.mjs
@@ -395,17 +395,69 @@ await test("run record renders the bounded second look only when it actually ran
   );
 });
 
-await test("run record renders the measured gh read count when there is one", () => {
+await test("run record: the second look's REGROWTH tripwire is `full`, which the counts cannot carry", () => {
+  // With the eval cap equal to the list ceiling the Window line above is inert,
+  // and the pipeline note names this line the standing tripwire for queue
+  // regrowth. The COUNTS cannot do that job: the second look's own row cap
+  // clamps `secondLookTotal`, so `100 further stubs, evaluated 100` reads
+  // identically whether 100 or 5,000 stubs sit past the ceiling — a tripwire
+  // that cannot distinguish bounded from unbounded. `secondLookFull` is the
+  // signal that can.
+  //
+  // NEGATIVE CONTROL: drop the `secondLookFull` branch from the suffix in
+  // buildAutofixRunRecordBody and the first assertion below fails while the
+  // saturated counts still render exactly as before.
+  const base = {
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 0,
+    secondLook: true,
+    secondLookTotal: 100,
+    secondLookEvaluated: 100,
+  };
+  const more = buildAutofixRunRecordBody({ ...base, secondLookFull: "true" });
+  assert(
+    more.includes("and MORE rows sit past even that"),
+    `a full second-look page must say the queue is outgrowing one run, got: ${more}`,
+  );
+  const drained = buildAutofixRunRecordBody({ ...base, secondLookFull: false });
+  assert(
+    !drained.includes("MORE rows sit past"),
+    "a second look that reached the end of the queue must not claim regrowth",
+  );
+  // A FAILED second look outranks both: it saw nothing at all, so the zeros
+  // beside it mean "unknown", not "empty".
+  const failed = buildAutofixRunRecordBody({
+    ...base,
+    secondLookTotal: 0,
+    secondLookEvaluated: 0,
+    secondLookFull: false,
+    secondLookFailed: "true",
+  });
+  assert(
+    failed.includes("the second look's own list read FAILED"),
+    `a failed second look must say so, got: ${failed}`,
+  );
+});
+
+await test("run record names the UNIT of the measured gh count, because two units are in play", () => {
   // The per-run cost ceiling was arithmetic nothing ever counted; this is the
   // observed number, so drift lands on the tracker before it lands as a timeout.
+  // The counter counts INVOCATIONS (serial subprocesses — the unit the job
+  // timeout is spent in), while the rate-budget arithmetic in the pipeline note
+  // counts API REQUESTS, and one `gh issue list --limit 200` is one invocation
+  // but two requests. Labelled "gh reads" the number was silently compared
+  // against a ceiling in the other unit, which is a drift detector that cannot
+  // detect drift.
   const measured = buildAutofixRunRecordBody({
     timestampIso: "2026-07-19T08:30:00Z",
     trigger: "schedule",
     disposition: "active",
     candidates: 2,
-    ghCalls: 522,
+    ghCalls: 521,
   });
-  assert(measured.includes("- gh reads: 522"), `got: ${measured}`);
+  assert(measured.includes("- gh invocations: 521"), `got: ${measured}`);
   const none = buildAutofixRunRecordBody({
     timestampIso: "2026-07-19T08:30:00Z",
     trigger: "schedule",
@@ -413,7 +465,7 @@ await test("run record renders the measured gh read count when there is one", ()
     candidates: 0,
   });
   assert(
-    !none.includes("gh reads"),
+    !none.includes("gh invocations"),
     "a leg that issued no reads carries no count line",
   );
 });

--- a/scripts/sentry-autofix-second-look.mjs
+++ b/scripts/sentry-autofix-second-look.mjs
@@ -30,11 +30,14 @@
  *   first pass  = 1 list invocation (2 requests, 200 rows) + 2 × 200 per-stub
  *                 reads + 120 family budget (40 handled-id + 40 reverse probe +
  *                 40 verify read) = 521 invocations / 522 requests
- *   second look = 1 list invocation (3 requests: 300 rows) + 2 × 100 per-stub
- *                 reads + 60 family budget (20 each) = 261 invocations /
- *                 263 requests
+ *   second look = 1 list invocation (4 requests: 301 rows — the 300 it reads
+ *                 plus ONE sentinel row, which lands alone on a fourth page and
+ *                 is counted, never evaluated) + 2 × 100 per-stub reads + 60
+ *                 family budget (20 each) = 261 invocations / 264 requests
  *   TOTAL       = 782 invocations ≈ 13.0 min at a pessimistic 1.0 s/call = 52%
- *                 of the 25-minute select timeout; 785 API requests.
+ *                 of the 25-minute select timeout; 786 API requests.
+ * The sentinel is the whole delta between 785 and 786, and it buys `full` the
+ * difference between "the page filled up" and "a row really does sit past this".
  * Raising any constant here re-opens BOTH sums — the timeout above and
  * the per-bucket rate budget in docs/notes/sentry-triage-pipeline.md § "Cost
  * bound". The select suite pins the invocation total against
@@ -123,11 +126,19 @@ export const SECOND_LOOK_FAMILY_BUDGETS = {
  * already proven rather than re-deriving them on a smaller budget.
  *
  * `full` is the "there is MORE past even this" signal, taken off the raw row
- * count exactly like the first pass's. It is the honest replacement for the
- * `total > evaluated` truncation this pass used to report: `total` is clamped by
- * SECOND_LOOK_LIST_ROWS by construction, so it reads the same whether 100 or
- * 5,000 stubs sit past the ceiling, whereas `full` distinguishes "we reached the
- * end of the queue" from "the queue is growing past what one run can see".
+ * count. It is the honest replacement for the `total > evaluated` truncation
+ * this pass used to report: `total` is clamped by SECOND_LOOK_LIST_ROWS by
+ * construction, so it reads the same whether 100 or 5,000 stubs sit past the
+ * ceiling, whereas `full` distinguishes "we reached the end of the queue" from
+ * "the queue is growing past what one run can see".
+ *
+ * It is a SENTINEL read, not the first pass's `rawCount >= limit` form. The two
+ * differ at exactly one point — a queue holding precisely `skipRawRows +
+ * SECOND_LOOK_LIST_ROWS` raw rows — and that point is where the weaker form is
+ * simply wrong: nothing sits past the second look, yet the tracker states that
+ * more rows remain and the queue is outgrowing one run's reach. The first pass
+ * can afford the guess (its `full` only decides whether to run this pass); a
+ * line an operator reads as a standing regrowth tripwire cannot.
  */
 export async function resolveSecondLook(runGh, repo, cap, options = {}) {
   const skipRawRows =
@@ -137,6 +148,16 @@ export async function resolveSecondLook(runGh, repo, cap, options = {}) {
   const beyond = await listCodeFixStubsPage(runGh, repo, {
     limit: skipRawRows + SECOND_LOOK_LIST_ROWS,
     skip: skipRawRows,
+    // Ask for ONE row past the ceiling so `full` is a FACT, not a guess. This
+    // pass PUBLISHES `full` on the tracker as "and MORE rows sit past even
+    // that" — a definite claim about the queue — and the default
+    // `rawCount >= limit` form asserts exactly that at the boundary where it is
+    // false: a queue holding precisely `skipRawRows + SECOND_LOOK_LIST_ROWS`
+    // raw rows has NOTHING past the second look, yet reads as outgrowing one
+    // run's reach forever. The sentinel row is dropped before anything reads or
+    // counts it, so the evaluated set and every per-stub budget are unchanged;
+    // it costs ONE extra API request per second look (see § COST ARITHMETIC).
+    sentinel: true,
   });
   const evaluable = beyond.stubs.slice(0, MAX_SECOND_LOOK_EVALUATIONS);
   if (beyond.stubs.length > evaluable.length) {

--- a/scripts/sentry-autofix-second-look.mjs
+++ b/scripts/sentry-autofix-second-look.mjs
@@ -18,38 +18,74 @@
  * hands the caller everything needed to report that it ran AND any truncation of
  * its own.
  *
- * COST ARITHMETIC (the constraint: first pass + second look must stay under
- * ~60% of the 25-minute select timeout at a pessimistic 1.0 s/call — every `gh`
- * call in this leg is serial, no `Promise.all` anywhere, so ~900 calls is the
- * wall):
- *   first pass  = 2 list pages + 2 × 200 per-stub reads + 120 family budget
- *                 (40 handled-id + 40 reverse probe + 40 verify read) = 522
- *   second look = 4 list pages (one `--limit 400` call, 100 rows per page)
- *               + 2 × 100 per-stub reads + 60 family budget (20 each) = 264
- *   TOTAL       = 786 calls ≈ 13.1 min at 1.0 s/call = 52% of 25 min. Under the
- *                 15-minute (≈900-call) wall with ~2 minutes of slack.
- * Raising any constant here re-opens that arithmetic; the select suite pins the
- * total against DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK.
+ * COST ARITHMETIC. Two units, and they are not the same number — conflating them
+ * is how a "drift detector" ends up measured against a ceiling it cannot reach:
+ *   - `gh` INVOCATIONS: what `state.ghCalls` counts and what the run record
+ *     reports. One invocation = one serial subprocess ≈ one second of wall
+ *     clock, so this is the unit the TIMEOUT is sized in.
+ *   - API REQUESTS: what the rate limiter bills. A `gh issue list --limit N`
+ *     paginates internally at 100 rows per request, so ONE invocation of it can
+ *     be several requests.
+ * Worst case, per run:
+ *   first pass  = 1 list invocation (2 requests, 200 rows) + 2 × 200 per-stub
+ *                 reads + 120 family budget (40 handled-id + 40 reverse probe +
+ *                 40 verify read) = 521 invocations / 522 requests
+ *   second look = 1 list invocation (3 requests: 300 rows) + 2 × 100 per-stub
+ *                 reads + 60 family budget (20 each) = 261 invocations /
+ *                 263 requests
+ *   TOTAL       = 782 invocations ≈ 13.0 min at a pessimistic 1.0 s/call = 52%
+ *                 of the 25-minute select timeout; 785 API requests.
+ * Raising any constant here re-opens BOTH sums — the timeout above and
+ * the per-bucket rate budget in docs/notes/sentry-triage-pipeline.md § "Cost
+ * bound". The select suite pins the invocation total against
+ * DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK and pins the list `--limit` this module
+ * asks for, which is the only term that makes the two units differ.
  */
 
 import { evaluateCandidate } from "./sentry-autofix-candidate.mjs";
 import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
-import {
-  listCodeFixStubsPage,
-  LIST_LIMIT,
-} from "./sentry-autofix-queue-io.mjs";
+import { listCodeFixStubsPage } from "./sentry-autofix-queue-io.mjs";
 
 /** How many stubs past the first window ONE second look may evaluate. Its own
  * hard ceiling, separate from MAX_CANDIDATE_EVALUATIONS, because this pass is
  * additive to a run that has already spent the first pass's whole budget. */
 export const MAX_SECOND_LOOK_EVALUATIONS = 100;
 
-/** How many RAW rows past the first window the second look asks for. The list is
- * issued as ONE `gh issue list --limit LIST_LIMIT + this`, with the first
- * LIST_LIMIT raw rows dropped client-side — `gh issue list` has no offset flag,
- * and a raw-row skip is what lines up with the first pass's own `--limit`
- * (applied server-side, before any client filter). */
-export const SECOND_LOOK_LIST_ROWS = 200;
+/**
+ * How many RAW rows past the first window the second look asks for. The list is
+ * issued as ONE `gh issue list --limit <skip> + this`, with the first `<skip>`
+ * raw rows dropped client-side — `gh issue list` has no offset flag, and a
+ * raw-row skip is what lines up with the first pass's own `--limit` (applied
+ * server-side, before any client filter).
+ *
+ * EQUAL to MAX_SECOND_LOOK_EVALUATIONS, and the same no-op invariant binds the
+ * pair as binds MAX_CANDIDATE_EVALUATIONS / LIST_LIMIT: the row cap is applied
+ * FIRST, so raising the evaluation cap above it reads exactly this many rows and
+ * nothing says the raise did nothing. `secondLookCeilingWarning` re-checks the
+ * pair at run time and a suite test pins it.
+ *
+ * It used to be 200 against an evaluation cap of 100 — 100 rows fetched on every
+ * second look that were structurally unreachable, presented in this header as
+ * part of the necessary cost of reaching 100 stubs. The truncation signal that
+ * over-fetch bought (`total > evaluated`) saturated anyway: it read the same at
+ * 200 further stubs and at 5,000. `full` below is that signal done properly.
+ */
+export const SECOND_LOOK_LIST_ROWS = 100;
+
+/**
+ * A run-time note when the second look's evaluation cap is configured above the
+ * row cap that is applied first — the same silent-no-op shape
+ * `windowCeilingWarning` guards for the first pass, on the pair this module
+ * added. Generic invariant, so it gets a guard of its own rather than the
+ * first pass's guard and a hope. Pure; returns the note, or null.
+ */
+export function secondLookCeilingWarning(
+  evaluations = MAX_SECOND_LOOK_EVALUATIONS,
+  listRows = SECOND_LOOK_LIST_ROWS,
+) {
+  if (!(evaluations > listRows)) return null;
+  return `warn: MAX_SECOND_LOOK_EVALUATIONS (${evaluations}) exceeds SECOND_LOOK_LIST_ROWS (${listRows}), which the API applies FIRST — the second look really reads ${listRows} rows and raising the evaluation cap alone does nothing. Raise SECOND_LOOK_LIST_ROWS too.\n`;
+}
 
 /** The second look's OWN family budgets. The first pass's per-run budgets are
  * spent by the time it runs, so it cannot reuse them; half of each keeps the
@@ -62,19 +98,45 @@ export const SECOND_LOOK_FAMILY_BUDGETS = {
 
 /**
  * Read and resolve the rows past the first window. Returns
- * `{ decisions, truncations, total, evaluated }` — RAW decisions, not reports:
- * the caller partitions them through the same classifier its first pass uses, so
- * a second-look family deferral can never be reported as a fix_scope skip (the
- * two lift on different events and send an operator to different remedies).
+ * `{ decisions, truncations, total, evaluated, full }` — RAW decisions, not
+ * reports: the caller partitions them through the same classifier its first pass
+ * uses, so a second-look family deferral can never be reported as a fix_scope
+ * skip (the two lift on different events and send an operator to different
+ * remedies).
  *
- * `total` vs `evaluated` is the second look's own truncation signal, surfaced by
- * the caller exactly like the Window tripwire — this pass must not silently stop
- * short either.
+ * `options.skipRawRows` is how many RAW rows the FIRST pass consumed — the
+ * offset this pass starts at. It is a parameter rather than `LIST_LIMIT` because
+ * the two coincide only while `MAX_CANDIDATE_EVALUATIONS === LIST_LIMIT`. The
+ * moment the evaluation cap is lowered below the list ceiling (which the pin
+ * permits, and which the Window tripwire is deliberately kept alive for), rows
+ * between the eval cap and the list ceiling would be sliced away by the first
+ * pass AND jumped over by a `LIST_LIMIT` skip here — a permanent hole in the
+ * middle of the window, which is the exact starvation this module exists to
+ * close. The caller passes `min(MAX_CANDIDATE_EVALUATIONS, LIST_LIMIT)`: since
+ * filtered stubs are never more numerous than the raw rows they came from, N
+ * evaluated stubs span at LEAST N raw rows, so this offset can only OVERLAP the
+ * first pass, never skip past it. Overlap costs a re-read; a hole loses a stub
+ * forever.
+ *
+ * `options.seed` is the first pass's resolved family state (see
+ * `resolveFamilies`) — this pass starts from the blockers and edges the run has
+ * already proven rather than re-deriving them on a smaller budget.
+ *
+ * `full` is the "there is MORE past even this" signal, taken off the raw row
+ * count exactly like the first pass's. It is the honest replacement for the
+ * `total > evaluated` truncation this pass used to report: `total` is clamped by
+ * SECOND_LOOK_LIST_ROWS by construction, so it reads the same whether 100 or
+ * 5,000 stubs sit past the ceiling, whereas `full` distinguishes "we reached the
+ * end of the queue" from "the queue is growing past what one run can see".
  */
-export async function resolveSecondLook(runGh, repo, cap) {
+export async function resolveSecondLook(runGh, repo, cap, options = {}) {
+  const skipRawRows =
+    Number.isInteger(options.skipRawRows) && options.skipRawRows > 0
+      ? options.skipRawRows
+      : 0;
   const beyond = await listCodeFixStubsPage(runGh, repo, {
-    limit: LIST_LIMIT + SECOND_LOOK_LIST_ROWS,
-    skip: LIST_LIMIT,
+    limit: skipRawRows + SECOND_LOOK_LIST_ROWS,
+    skip: skipRawRows,
   });
   const evaluable = beyond.stubs.slice(0, MAX_SECOND_LOOK_EVALUATIONS);
   if (beyond.stubs.length > evaluable.length) {
@@ -89,18 +151,20 @@ export async function resolveSecondLook(runGh, repo, cap) {
     if (candidate) candidates.push(candidate);
   }
   // Its OWN family budgets: the first pass spent the per-run ones, so reusing
-  // them would silently double the run's worst-case volume.
+  // them would silently double the run's worst-case volume. Its own budgets over
+  // the first pass's KNOWLEDGE, though — see the `seed` note above.
   const { decisions, truncations } = await resolveFamilies(
     runGh,
     repo,
     candidates,
     cap,
-    { budgets: SECOND_LOOK_FAMILY_BUDGETS },
+    { budgets: SECOND_LOOK_FAMILY_BUDGETS, seed: options.seed },
   );
   return {
     decisions,
     truncations,
     total: beyond.stubs.length,
     evaluated: evaluable.length,
+    full: beyond.full,
   };
 }

--- a/scripts/sentry-autofix-second-look.mjs
+++ b/scripts/sentry-autofix-second-look.mjs
@@ -1,0 +1,106 @@
+/**
+ * The bounded SECOND LOOK for the Sentry AUTOFIX selector
+ * (scripts/sentry-autofix-select.mjs). Extracted so the selector stays under the
+ * 600-line soft cap: the selector keeps the window, the family orchestration,
+ * the reporting and its CLI, and this module owns the one question "the first
+ * pass found nothing and the list was full — what is past the ceiling?".
+ *
+ * The starvation it exists to break: every stub inside the window is a deferred
+ * family member (or a fix_scope skip), so the run selects NOTHING and writes
+ * NOTHING, and the next run reads the SAME window and repeats — forever.
+ * Deferral is state-free by design, so nothing ages out; a selectable stub
+ * sitting one row past the window is never evaluated, at any point, ever.
+ *
+ * It fires ONLY on that exact signature: zero matrix entries AND a FULL list
+ * page (`rawCount >= LIST_LIMIT`, so rows beyond it may exist). A healthy run —
+ * anything selected — never reaches it and pays nothing. It is not a retry and
+ * not a widening: it reads the NEXT rows once, with its own hard ceilings, and
+ * hands the caller everything needed to report that it ran AND any truncation of
+ * its own.
+ *
+ * COST ARITHMETIC (the constraint: first pass + second look must stay under
+ * ~60% of the 25-minute select timeout at a pessimistic 1.0 s/call — every `gh`
+ * call in this leg is serial, no `Promise.all` anywhere, so ~900 calls is the
+ * wall):
+ *   first pass  = 2 list pages + 2 × 200 per-stub reads + 120 family budget
+ *                 (40 handled-id + 40 reverse probe + 40 verify read) = 522
+ *   second look = 4 list pages (one `--limit 400` call, 100 rows per page)
+ *               + 2 × 100 per-stub reads + 60 family budget (20 each) = 264
+ *   TOTAL       = 786 calls ≈ 13.1 min at 1.0 s/call = 52% of 25 min. Under the
+ *                 15-minute (≈900-call) wall with ~2 minutes of slack.
+ * Raising any constant here re-opens that arithmetic; the select suite pins the
+ * total against DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK.
+ */
+
+import { evaluateCandidate } from "./sentry-autofix-candidate.mjs";
+import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
+import {
+  listCodeFixStubsPage,
+  LIST_LIMIT,
+} from "./sentry-autofix-queue-io.mjs";
+
+/** How many stubs past the first window ONE second look may evaluate. Its own
+ * hard ceiling, separate from MAX_CANDIDATE_EVALUATIONS, because this pass is
+ * additive to a run that has already spent the first pass's whole budget. */
+export const MAX_SECOND_LOOK_EVALUATIONS = 100;
+
+/** How many RAW rows past the first window the second look asks for. The list is
+ * issued as ONE `gh issue list --limit LIST_LIMIT + this`, with the first
+ * LIST_LIMIT raw rows dropped client-side — `gh issue list` has no offset flag,
+ * and a raw-row skip is what lines up with the first pass's own `--limit`
+ * (applied server-side, before any client filter). */
+export const SECOND_LOOK_LIST_ROWS = 200;
+
+/** The second look's OWN family budgets. The first pass's per-run budgets are
+ * spent by the time it runs, so it cannot reuse them; half of each keeps the
+ * total inside the arithmetic above while still letting a real family resolve. */
+export const SECOND_LOOK_FAMILY_BUDGETS = {
+  handled: 20,
+  probe: 20,
+  verify: 20,
+};
+
+/**
+ * Read and resolve the rows past the first window. Returns
+ * `{ decisions, truncations, total, evaluated }` — RAW decisions, not reports:
+ * the caller partitions them through the same classifier its first pass uses, so
+ * a second-look family deferral can never be reported as a fix_scope skip (the
+ * two lift on different events and send an operator to different remedies).
+ *
+ * `total` vs `evaluated` is the second look's own truncation signal, surfaced by
+ * the caller exactly like the Window tripwire — this pass must not silently stop
+ * short either.
+ */
+export async function resolveSecondLook(runGh, repo, cap) {
+  const beyond = await listCodeFixStubsPage(runGh, repo, {
+    limit: LIST_LIMIT + SECOND_LOOK_LIST_ROWS,
+    skip: LIST_LIMIT,
+  });
+  const evaluable = beyond.stubs.slice(0, MAX_SECOND_LOOK_EVALUATIONS);
+  if (beyond.stubs.length > evaluable.length) {
+    process.stderr.write(
+      `note: second look saw ${beyond.stubs.length} further stubs; evaluating the oldest ${evaluable.length} (MAX_SECOND_LOOK_EVALUATIONS).\n`,
+    );
+  }
+
+  const candidates = [];
+  for (const stub of evaluable) {
+    const candidate = await evaluateCandidate(runGh, repo, stub);
+    if (candidate) candidates.push(candidate);
+  }
+  // Its OWN family budgets: the first pass spent the per-run ones, so reusing
+  // them would silently double the run's worst-case volume.
+  const { decisions, truncations } = await resolveFamilies(
+    runGh,
+    repo,
+    candidates,
+    cap,
+    { budgets: SECOND_LOOK_FAMILY_BUDGETS },
+  );
+  return {
+    decisions,
+    truncations,
+    total: beyond.stubs.length,
+    evaluated: evaluable.length,
+  };
+}

--- a/scripts/sentry-autofix-select-cli.mjs
+++ b/scripts/sentry-autofix-select-cli.mjs
@@ -1,0 +1,224 @@
+/**
+ * The CLI SURFACE of the Sentry AUTOFIX selector
+ * (scripts/sentry-autofix-select.mjs): the option contract the workflow invokes
+ * it with, the help text that documents it, the report files it writes for the
+ * tracker to read back, and the `--emit-verdict` subcommand. Extracted so the
+ * selector keeps the window, the family orchestration and the decisions.
+ *
+ * One concern: everything here is about the BOUNDARY between the selection run
+ * and the workflow around it. Nothing here decides whether a stub is selectable,
+ * and nothing here issues a `gh` read except the one `--emit-verdict` snapshot.
+ *
+ * A LEAF by construction — it imports nothing from the selector, so the
+ * selector can import and re-export it without an ESM cycle. `main` stays in the
+ * selector for the same reason: it is the one function that needs both halves,
+ * and the workflow invokes `scripts/sentry-autofix-select.mjs` directly (three
+ * call sites in .github/workflows/sentry-autofix.yml), so that file must remain
+ * the executable entry point.
+ */
+
+import { writeFileSync } from "node:fs";
+
+import {
+  DEFAULT_REPO,
+  selectVerdictComment,
+} from "./sentry-triage-project-core.mjs";
+import { defaultRunGh, readStub } from "./sentry-autofix-queue-io.mjs";
+
+/** Max CANDIDATES one run may select. Lives here because the CLI's `--cap`
+ * parse and its help text are its two closest readers; the selector imports it
+ * for the default and re-exports it as part of the selection contract. */
+export const DEFAULT_CAP = 2;
+
+export function usage() {
+  return `Usage: pnpm sentry:autofix:select [--repo <owner/name>] [--cap <n>]
+
+Prints a JSON array of { "issue": <number>, "shortId": "<SHORT-ID>" } matrix
+entries — the oldest capped batch of code-fix queue stubs owned by this repo
+that claim \`fix_scope: mechanical\` and do not yet have a fix PR, collapsed to
+ONE candidate per \`duplicate_of\` family. Diagnostics go to stderr.
+
+Options:
+  --repo <owner/name>  Repo the queue stubs live in (default: ${DEFAULT_REPO}).
+  --cap <n>            Max CANDIDATES to select per run — one duplicate_of family
+                       counts once, however many stubs it spans (positive int;
+                       default ${DEFAULT_CAP}).
+  --issue <n>          Single-issue live run: evaluate ONLY this issue through the
+                       same filters (the workflow_dispatch path). Opens a real
+                       fix PR if the issue is eligible. Overrides --cap.
+  --deferred-out <p>   Write the duplicate_of DEFERRAL report — a JSON array of
+                       { "issue": <number>, "reason": "<enum>" } — to this path,
+                       so the run record can distinguish an empty queue from one
+                       whose candidates were all stood down. Stdout is unchanged.
+  --skipped-out <p>    Write the fix_scope SKIP report, same shape, to this path.
+                       An architectural verdict writes nothing to the queue, so
+                       without it a window standing entirely down on scope is
+                       indistinguishable from an empty one. Stdout is unchanged.
+  --window-out <p>     Write the Window tripwire — { "total": <n>, "evaluated":
+                       <n>, "secondLook": <bool>, "secondLookTotal": <n>,
+                       "secondLookEvaluated": <n>, "secondLookFull": <bool>,
+                       "secondLookFailed": <bool>, "ghCalls": <n> } — to this
+                       path, so the run record can surface a list window that
+                       exceeded the eval cap, a bounded second look (that it ran,
+                       whether MORE rows still sat past even it, and whether its
+                       own read failed), and the run's measured \`gh\` invocation
+                       count. Stdout is unchanged.
+  --truncations-out <p> Write the cost-budget truncations — { "handledOverflow":
+                       <n>, "reverseBudget": <bool>, "reverseNonconvergent":
+                       <bool>, "rateLimited": <n> } — to this path, so the run
+                       record can surface a bounded re-attempt (a family that
+                       should have stood down but a budget capped its lookup) and
+                       a DEGRADED run (rate-limit-shaped gh failures, which force
+                       zero entries). Stdout is unchanged.
+  --emit-verdict       With --issue: print the trusted (fence-selected) verdict
+                       comment body for that issue and exit (the workflow
+                       snapshots it to a file the fix agent reads, so the agent
+                       needs no gh tool or token).
+  -h, --help           Show this help.
+`;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    repo: DEFAULT_REPO,
+    cap: DEFAULT_CAP,
+    issue: null,
+    emitVerdict: false,
+    deferredOut: null,
+    skippedOut: null,
+    windowOut: null,
+    truncationsOut: null,
+    help: false,
+  };
+  const args = [...argv];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const readValue = () => {
+      const value = args[++i];
+      if (value == null) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+    switch (arg) {
+      case "--repo":
+        options.repo = readValue();
+        break;
+      case "--cap": {
+        const value = Number(readValue());
+        if (!Number.isInteger(value) || value <= 0) {
+          throw new Error("--cap must be a positive integer");
+        }
+        options.cap = value;
+        break;
+      }
+      case "--issue": {
+        const value = Number(readValue());
+        if (!Number.isInteger(value) || value <= 0) {
+          throw new Error("--issue must be a positive integer");
+        }
+        options.issue = value;
+        break;
+      }
+      case "--emit-verdict":
+        options.emitVerdict = true;
+        break;
+      case "--deferred-out":
+        options.deferredOut = readValue();
+        break;
+      case "--skipped-out":
+        options.skippedOut = readValue();
+        break;
+      case "--window-out":
+        options.windowOut = readValue();
+        break;
+      case "--truncations-out":
+        options.truncationsOut = readValue();
+        break;
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+    }
+  }
+  return options;
+}
+
+/** Best-effort JSON report write. A failed write degrades ONE counter on the
+ * run record; it must never fail the select step, whose whole contract is that
+ * it always emits a valid array. Returns whether the file was written — one
+ * caller (the degraded signal) has to know. Exported because `main` is the only
+ * bridge between the selector's return value and the `jq` reads the workflow
+ * builds the tracker record from, and a key-name or serialization bug here is
+ * invisible to every test that exercises `selectAutofixRun` alone. */
+export function writeReport(path, report, label) {
+  if (!path) return true;
+  try {
+    writeFileSync(path, `${JSON.stringify(report ?? [])}\n`);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `warn: could not write the ${label} report: ${message}\n`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Write every report file the workflow reads, and answer the one question the
+ * caller must act on: was a DEGRADED run's signal lost?
+ *
+ * `rateLimited` reaches the workflow through exactly one channel — the
+ * truncations file — and the workflow flips `disposition` to
+ * `degraded-rate-limited` off it. Every OTHER field on these files is a
+ * nice-to-have that degrades to "0" or a missing line. This one is the safety
+ * signal: lose it and `rate_limited` reads 0, the disposition stays `active`,
+ * the tracker renders a suppressed run as a healthy idle one — the #1758
+ * misdiagnosis — and the record job's label backfill gate opens on reads the run
+ * itself declared unreliable. So a best-effort write is the wrong contract for
+ * that one case, and the caller fails the step instead. Exported for the same
+ * reason `writeReport` is.
+ */
+export function writeRunReports(options, run) {
+  // Report BEFORE stdout: the workflow captures stdout into a shell variable, so
+  // a failed report write must not be able to lose the entries too. All are
+  // best-effort — the run record degrades to "0" / no Window line / no
+  // truncation line, never to a dead leg.
+  writeReport(options.deferredOut, run.deferred, "deferral");
+  writeReport(options.skippedOut, run.skipped, "fix_scope skip");
+  writeReport(options.windowOut, run.window ?? {}, "window");
+  const truncations = run.truncations ?? {};
+  const wroteTruncations = writeReport(
+    options.truncationsOut,
+    truncations,
+    "truncations",
+  );
+  return {
+    lostDegradedSignal:
+      Number(truncations.rateLimited ?? 0) > 0 && !wroteTruncations,
+  };
+}
+
+/**
+ * Emit the trusted, fence-selected verdict comment body for one issue, so the
+ * workflow can snapshot it to a file the fix agent reads — instead of giving the
+ * agent a `gh` tool + GitHub token (which a prompt-injected agent could try to
+ * exfiltrate from its process env). Uses the SAME authorship/regression fence
+ * as the label + projection steps. Throws if there is no usable verdict.
+ */
+export async function emitVerdict(options, deps = {}) {
+  const runGh = deps.runGh ?? defaultRunGh;
+  const stub = await readStub(
+    runGh,
+    options.repo ?? DEFAULT_REPO,
+    options.issue,
+  );
+  const selected = selectVerdictComment(stub.comments);
+  if (!selected.body) {
+    throw new Error(
+      `No usable verdict comment on issue #${options.issue} (${selected.reason}).`,
+    );
+  }
+  return selected.body;
+}

--- a/scripts/sentry-autofix-select-instrument.mjs
+++ b/scripts/sentry-autofix-select-instrument.mjs
@@ -1,0 +1,248 @@
+/**
+ * The BUDGET and INSTRUMENTATION of one Sentry AUTOFIX selection run
+ * (scripts/sentry-autofix-select.mjs): what bounds a run's spend, what measures
+ * it, what latches it shut when GitHub throttles it, and how it reports itself
+ * when it stands down. Extracted so the selector keeps the window, the family
+ * orchestration, the decisions and its CLI, and this module owns everything that
+ * BOUNDS or OBSERVES a run rather than deciding one.
+ *
+ * One subject seen from both sides, which is why the read cap sits beside the
+ * call counter: `MAX_CANDIDATE_EVALUATIONS` is the PREDICTED per-run spend (the
+ * whole 782-invocation arithmetic in the pipeline note's § "Cost bound" starts
+ * from `2 ×` it), `state.ghCalls` is the MEASURED one, and
+ * `windowCeilingWarning` is the guard that the prediction is real rather than a
+ * silent no-op above `LIST_LIMIT`. It also puts the first pass's cap/guard pair
+ * in the same shape as the second look's, which already lives outside the
+ * selector in sentry-autofix-second-look.mjs; the selector re-exports both.
+ *
+ * Six pieces, none of which decides whether a stub is selectable:
+ *   - `MAX_CANDIDATE_EVALUATIONS` / `windowCeilingWarning` — the per-run read
+ *     bound and the run-time check that it is not a no-op;
+ *   - `newRunState` — the two counters, defined once beside everything that
+ *     touches them;
+ *   - `instrumentRunGh` — the counter and the throttle latch, on every `gh` call
+ *     the leg makes;
+ *   - `emptyWindow` / `noTruncations` — the zero-state record shapes a run
+ *     returns when it never got far enough to fill them;
+ *   - `degradeReport` / `summarizeRun` — the only two things a run says about
+ *     itself on stderr.
+ *
+ * FAIL CLOSED is the contract this module carries, and it has two halves that
+ * are easy to conflate. `instrumentRunGh` RETHROWS — deliberately, so every
+ * fail-soft handler downstream runs its normal path unchanged — which means the
+ * standing-down is the CALLER's job: it checks `state.rateLimited` and returns
+ * `degradeReport(state, …)` rather than selecting on data it knows is
+ * unreliable. A read with no fail-soft handler under it must therefore be
+ * wrapped by its caller, or the rethrow escapes and kills the select step under
+ * `set -euo pipefail` — taking the degradation report with it. The selector
+ * wraps all three such reads; see its `selectAutofixRun`.
+ */
+
+import {
+  ghFailureText,
+  isRateLimitFailure,
+  LIST_LIMIT,
+} from "./sentry-autofix-queue-io.mjs";
+
+// How many window stubs one run may READ. The family union is transitive, so
+// selection can no longer stop at the first `cap` stubs — but "evaluate the
+// whole window" makes the run's `gh` cost scale with LIST_LIMIT (one `issue
+// view` plus one `pr list` each, ~400 sequential subprocesses at the ceiling)
+// inside the select job's `timeout-minutes` budget, and family deferral writes
+// nothing, so a collapsed family of K leaves K-1 PERMANENT window residents that
+// are re-read every run. That is monotonic growth driven from outside: every new
+// error fingerprint an unauthenticated dashboard visitor produces can add one.
+//
+// Bound the READ instead of the selection. The window is oldest-first, so this
+// truncates the NEWEST tail — the oldest candidates, the ones `sort:created-asc`
+// exists to protect, are always inside the budget. A truncated family is the
+// same situation MAX_DUPLICATE_LOOKUPS already creates (a member the run cannot
+// see), and it fails toward MORE candidates, never fewer.
+//
+// `LIST_LIMIT` (sentry-autofix-queue-io.mjs, 200) is the HARD upper bound on
+// this constant. `gh issue list --limit` caps what the API RETURNS, and that
+// happens BEFORE the slice below runs, so raising this value above LIST_LIMIT is
+// a strict NO-OP — the run reads exactly LIST_LIMIT rows either way, the Window
+// tripwire reports `total == evaluated`, and nothing anywhere says the raise did
+// nothing. THE TWO MUST MOVE TOGETHER. `windowCeilingWarning` re-checks the pair
+// at run time and a suite test pins `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT`,
+// because a silent no-op is precisely the failure a "we widened the window"
+// change must not ship as.
+//
+// 200, not 50: 50 left 150 rows of a full window unread every run, which —
+// combined with family deferral writing nothing — is the starvation
+// sentry-autofix-second-look.mjs exists to break. The cost is bounded and paid
+// for: the select job's `timeout-minutes` is 25, and 1 list + 2×200 + 120 = 521
+// serial `gh` INVOCATIONS at a pessimistic ~1 s/call is ~9 minutes. (522 API
+// REQUESTS — the list invocation paginates at 100 rows. The two units are
+// tracked separately; see sentry-autofix-second-look.mjs § COST ARITHMETIC.)
+export const MAX_CANDIDATE_EVALUATIONS = 200;
+
+/**
+ * A run-time note when the evaluation window is configured above the list
+ * ceiling that is applied first — the mismatch that makes a raise a silent
+ * no-op. Pure (and exported) so the check is a real, testable behaviour rather
+ * than an assertion nobody can exercise: a THROW here would break the select
+ * step's "always emits a valid JSON array, never fails" invariant over a static
+ * config mistake, so this is loud, not fatal. Returns the note, or null.
+ */
+export function windowCeilingWarning(
+  evaluations = MAX_CANDIDATE_EVALUATIONS,
+  listLimit = LIST_LIMIT,
+) {
+  if (!(evaluations > listLimit)) return null;
+  return `warn: MAX_CANDIDATE_EVALUATIONS (${evaluations}) exceeds LIST_LIMIT (${listLimit}), which the API applies FIRST — the window is really ${listLimit} and raising the evaluation cap alone does nothing. Raise LIST_LIMIT too.\n`;
+}
+
+/**
+ * The per-run counters every function here reads or writes. One factory rather
+ * than an object literal at the call site: the shape is shared across this whole
+ * module and the selector's stand-down checks, so a key defined in one place and
+ * read in five is exactly the drift `emptyWindow` exists to prevent.
+ *
+ * `ghCalls` counts REAL invocations (it is the drift detector for the timeout
+ * arithmetic) and `rateLimited` counts REAL throttle events — never loop
+ * iterations after the first latch.
+ */
+export function newRunState() {
+  return { ghCalls: 0, rateLimited: 0 };
+}
+
+/**
+ * Wrap the run's `gh` driver so ONE place sees every invocation the select leg
+ * makes. Three jobs, all otherwise unmeasurable:
+ *
+ * 1. COUNT. The per-run `gh` volume is a documented ceiling that nothing
+ *    actually measured — every cost claim in the pipeline note was arithmetic
+ *    over caps. `state.ghCalls` makes it an observed number on the run record,
+ *    so drift shows up before a timeout does.
+ *
+ * 2. FAIL CLOSED ON THROTTLING. Nearly every read in this leg fails SOFT toward
+ *    MORE candidates — `readStub`, `openAutofixPrExists`, the handled-id
+ *    lookups, the reverse probes all treat a rejection as "no blocker found".
+ *    But the blockers they look for ARE the dedupe signals, so a rate-limited
+ *    read is indistinguishable from a clean one, and a throttled run can open
+ *    DUPLICATE autofix PRs while looking perfectly green. Intercepting here
+ *    catches EVERY read — including ones added later — without threading a sink
+ *    through four modules, and it re-throws so each existing fail-soft path
+ *    behaves exactly as before locally; the caller then refuses to SELECT on the
+ *    data those paths produced.
+ *
+ * 3. STOP SPENDING ONCE THROTTLED. The decision in (2) is taken at pass
+ *    boundaries, but the loops that reach them are long: the per-stub loop alone
+ *    is 2 × MAX_CANDIDATE_EVALUATIONS calls. Without this, one 403 at the head
+ *    of the window is followed by ~400 more requests fired into an ACTIVE
+ *    throttle before the run stands down — and GitHub's secondary limits EXTEND
+ *    on continued requests and escalate to abuse detection, on a repo-shared
+ *    free-plan `GITHUB_TOKEN` every other workflow draws from. "Fail closed"
+ *    that spends 400 more requests is not closed at the token level. So the
+ *    first rate-limit-shaped failure latches, and every later call rejects
+ *    IMMEDIATELY without spawning `gh`. The same one place, for the same reason
+ *    it is one place: it covers reads added later, for free.
+ *
+ *    It is a rejection, not a silent empty result, precisely so every existing
+ *    fail-soft handler runs its normal path — and the run stands down anyway,
+ *    because `state.rateLimited` is already nonzero by then. Latched calls are
+ *    NOT counted: `ghCalls` must stay a count of real invocations (it is the
+ *    drift detector for the timeout arithmetic), and `rateLimited` must stay a
+ *    count of real throttle events, not of loop iterations after the first.
+ *
+ * Non-rate-limit transients keep their existing fail-soft behaviour untouched:
+ * only `isRateLimitFailure` text degrades the run.
+ */
+export function instrumentRunGh(baseRunGh, state) {
+  return async (args) => {
+    if (state.rateLimited > 0) {
+      // Deliberately argv-free and rate-limit-shape-free: this text reaches
+      // `ghFailureText`, and a message that matched `isRateLimitFailure` would
+      // inflate the throttle count with one entry per latched call.
+      throw new Error(
+        "selection stood down: an earlier gh read failed rate-limit-shaped, so this read was not issued",
+      );
+    }
+    state.ghCalls += 1;
+    try {
+      return await baseRunGh(args);
+    } catch (err) {
+      // Classify gh's STDERR, not the whole rejection message: the message
+      // carries the argv, and argv carries agent-authored family ids.
+      const text = ghFailureText(err);
+      if (isRateLimitFailure(text)) {
+        state.rateLimited += 1;
+        if (state.rateLimited === 1) {
+          process.stderr.write(
+            `::error::rate-limit-shaped gh failure during selection: ${text.split("\n")[0]}; no further gh reads will be issued this run.\n`,
+          );
+        }
+      }
+      throw err;
+    }
+  };
+}
+
+/** The Window tripwire record at its zero state — every field the workflow's
+ * `jq` reads, before anything has been counted. One source rather than a literal
+ * per return path: the workflow reads these key names, so a typo in one copy
+ * silently zeroes a line of the run record and no test that asserts the returned
+ * OBJECT would see it. */
+export const emptyWindow = () => ({
+  total: 0,
+  evaluated: 0,
+  secondLook: false,
+  secondLookTotal: 0,
+  secondLookEvaluated: 0,
+  secondLookFull: false,
+  secondLookFailed: false,
+  ghCalls: 0,
+});
+
+/** The truncation record with nothing cut — the baseline the paths that never
+ * reach the family resolver return. Same reason as `emptyWindow`: `rateLimited`
+ * in particular is the one key the degraded disposition rides on. */
+export const noTruncations = () => ({
+  handledOverflow: 0,
+  reverseBudget: false,
+  reverseNonconvergent: false,
+  rateLimited: 0,
+});
+
+/**
+ * Fail CLOSED on throttling. Every read this leg issues answers a dedupe or
+ * blocker question, and every one of them fails SOFT toward MORE candidates, so
+ * a rate-limited run cannot tell "no prior PR" from "GitHub refused to tell me"
+ * — and would open a DUPLICATE autofix PR looking green. So the run does not
+ * SELECT on data it knows is unreliable.
+ *
+ * "Fail closed" here means ZERO matrix entries plus a loud report, NOT a throw:
+ * the workflow's select step asserts it always emits a valid JSON array and
+ * never fails (the leg runs under `set -euo pipefail`), so throwing would break
+ * the contract this whole job is built around. The stand-down reports are still
+ * returned — they cost nothing and an operator reading the tracker needs the
+ * whole picture — but the degraded line dominates them.
+ */
+export function degradeReport(state, report) {
+  process.stderr.write(
+    `::error::selection DEGRADED: ${state.rateLimited} rate-limit-shaped gh read failure(s); emitting ZERO entries rather than selecting on unreliable dedupe data.\n`,
+  );
+  return {
+    ...report,
+    entries: [],
+    truncations: { ...report.truncations, rateLimited: state.rateLimited },
+  };
+}
+
+/**
+ * The single greppable operator line for the run. It takes the emitted count as
+ * an ARGUMENT rather than reading it off a report, because `degradeReport`
+ * replaces `entries` with `[]` only when it runs: a line built from the
+ * pre-degradation report said `entries=2` on runs that emitted zero — on exactly
+ * the fail-closed path, the one an operator greps this line to understand.
+ */
+export function summarizeRun(state, window, emitted) {
+  const secondLook = window.secondLook
+    ? `${window.secondLookEvaluated}/${window.secondLookTotal}${window.secondLookFull ? "+" : ""}${window.secondLookFailed ? " (failed)" : ""}`
+    : "no";
+  process.stderr.write(
+    `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${secondLook} entries=${emitted}\n`,
+  );
+}

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -51,12 +51,18 @@ import {
   DEFAULT_REPO,
   selectVerdictComment,
 } from "./sentry-triage-project-core.mjs";
-import {
-  DEFER_FAMILY_DUPLICATE,
-  DEFER_FAMILY_HANDLED,
-  DEFER_FAMILY_RECONCILING,
-} from "./sentry-autofix-family.mjs";
+// The decision -> report classifier, shared by the first pass and the second
+// look so both label a stand-down identically (a deferral and a fix_scope skip
+// lift on different events, and send an operator to different remedies).
+import { partitionDecisions } from "./sentry-autofix-decisions.mjs";
 import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
+// The bounded second look, extracted so this module stays under the 600-line
+// soft cap: it owns the "the first pass found nothing off a FULL page — what is
+// past the ceiling?" pass, its own ceilings, and the cost arithmetic behind them.
+import {
+  resolveSecondLook,
+  SECOND_LOOK_LIST_ROWS,
+} from "./sentry-autofix-second-look.mjs";
 import {
   defaultRunGh,
   isRateLimitFailure,
@@ -67,17 +73,27 @@ import {
 // The per-stub eligibility layer, extracted so this module stays under the
 // 600-line soft cap: every filter that decides whether ONE stub may start a fix
 // attempt lives there, this module owns the window and the family collapse.
-import { evaluateCandidate, safeShortId } from "./sentry-autofix-candidate.mjs";
+import { evaluateCandidate } from "./sentry-autofix-candidate.mjs";
 
 // The queue-scoping label (AUTOFIX_SELECT_LABEL) lives in the I/O layer beside
 // the queries that use it; the family-collapse project scope
 // (LOCAL_SENTRY_PROJECT) is owned by the extracted resolver
 // (sentry-autofix-family-resolve.mjs); the per-stub filters and the skip reason
-// are owned by sentry-autofix-candidate.mjs.
+// are owned by sentry-autofix-candidate.mjs; the deferral wording and the
+// decision -> report split are owned by sentry-autofix-decisions.mjs.
 
 /** Re-exported from the candidate layer: the selector is still the module the
  * workflow and the suites import this contract from. */
 export { SKIP_FIX_SCOPE_ARCHITECTURAL } from "./sentry-autofix-candidate.mjs";
+
+/** Re-exported from the extracted second-look layer, same reason: the bounded
+ * second look is part of the SELECTION contract and the suite reads its ceilings
+ * from here. Its mechanics live in sentry-autofix-second-look.mjs. */
+export {
+  MAX_SECOND_LOOK_EVALUATIONS,
+  SECOND_LOOK_FAMILY_BUDGETS,
+  SECOND_LOOK_LIST_ROWS,
+} from "./sentry-autofix-second-look.mjs";
 
 export const DEFAULT_CAP = 2;
 
@@ -106,11 +122,11 @@ export const DEFAULT_CAP = 2;
 // because a silent no-op is precisely the failure a "we widened the window"
 // change must not ship as.
 //
-// 200, not 50 (this PR): 50 left 150 rows of a full window unread every run,
-// which — combined with family deferral writing nothing — is the starvation the
-// second look below exists to break. The cost is bounded and paid for: the
-// select job's `timeout-minutes` is 25, and 2 + 2×200 + 120 ≈ 522 serial `gh`
-// calls at a pessimistic ~1 s/call is ~9 minutes.
+// 200, not 50: 50 left 150 rows of a full window unread every run, which —
+// combined with family deferral writing nothing — is the starvation
+// sentry-autofix-second-look.mjs exists to break. The cost is bounded and paid
+// for: the select job's `timeout-minutes` is 25, and 2 + 2×200 + 120 ≈ 522
+// serial `gh` calls at a pessimistic ~1 s/call is ~9 minutes.
 export const MAX_CANDIDATE_EVALUATIONS = 200;
 
 /**
@@ -128,64 +144,6 @@ export function windowCeilingWarning(
   if (!(evaluations > listLimit)) return null;
   return `warn: MAX_CANDIDATE_EVALUATIONS (${evaluations}) exceeds LIST_LIMIT (${listLimit}), which the API applies FIRST — the window is really ${listLimit} and raising the evaluation cap alone does nothing. Raise LIST_LIMIT too.\n`;
 }
-
-// ---------------------------------------------------------------------------
-// Bounded second look
-// ---------------------------------------------------------------------------
-//
-// The starvation this exists to break: every stub inside the window is a
-// deferred family member, so the run selects NOTHING, writes NOTHING, and the
-// next run reads the SAME window and repeats — forever. Deferral is by design
-// state-free, so nothing ages out; a selectable stub sitting one row past the
-// window is never evaluated, at any point, ever.
-//
-// The second look fires ONLY on that exact signature: the first pass produced
-// zero matrix entries AND the list came back FULL (rawCount >= LIST_LIMIT, so
-// rows beyond it may exist). A healthy run — anything selected — never reaches
-// it and pays nothing. It is not a retry and not a widening: it reads the NEXT
-// rows once, with its own hard ceilings, and reports both that it ran and any
-// truncation of its own.
-//
-// COST ARITHMETIC (the constraint: first pass + second look must stay under
-// ~60% of the 25-minute select timeout at a pessimistic 1.0 s/call — every `gh`
-// call in this leg is serial, so ~900 calls is the wall):
-//   first pass  = 2 list pages + 2 × 200 per-stub reads + 120 family budget
-//                 (40 handled-id + 40 reverse probe + 40 verify read) = 522
-//   second look = 4 list pages (one `--limit 400` call, 100 rows per page)
-//               + 2 × 100 per-stub reads + 60 family budget (20 each) = 264
-//   TOTAL       = 786 calls ≈ 13.1 min at 1.0 s/call = 52% of 25 min. Under the
-//                 15-minute (≈900-call) wall with ~2 minutes of slack.
-// Raising any constant below re-opens this arithmetic; the suite pins the total
-// against DOCUMENTED_GH_CEILING.
-export const MAX_SECOND_LOOK_EVALUATIONS = 100;
-
-/** How many RAW rows past the first window the second look asks for. The list
- * is issued as ONE `gh issue list --limit LIST_LIMIT + this`, with the first
- * LIST_LIMIT raw rows dropped client-side — `gh issue list` has no offset flag,
- * and a raw-row skip is what lines up with the first pass's own `--limit`
- * (applied server-side, before any client filter). */
-export const SECOND_LOOK_LIST_ROWS = 200;
-
-/** The second look's OWN family budgets. The first pass's per-run budgets are
- * spent by the time it runs, so it cannot reuse them; half of each keeps the
- * total inside the arithmetic above while still letting a real family resolve. */
-export const SECOND_LOOK_FAMILY_BUDGETS = {
-  handled: 20,
-  probe: 20,
-  verify: 20,
-};
-
-/** One note per deferral reason, keyed by the collapse's own constants so a
- * reason added there cannot silently inherit another's wording. An unmapped
- * reason still prints — as itself, not as somebody else's explanation. */
-const DEFER_NOTES = {
-  [DEFER_FAMILY_DUPLICATE]: (decision) =>
-    `same duplicate_of family as ${safeShortId(decision.representative)}, which represents the family this run`,
-  [DEFER_FAMILY_HANDLED]: (decision) =>
-    `its duplicate_of family already has an autofix attempt on ${safeShortId(decision.representative)} (a regression sheds that marker)`,
-  [DEFER_FAMILY_RECONCILING]: () =>
-    "its duplicate_of family already has an open autofix PR being reconciled this run",
-};
 
 /**
  * Wrap the run's `gh` driver so ONE place sees every invocation the select leg
@@ -228,42 +186,6 @@ function instrumentRunGh(baseRunGh, state) {
       throw err;
     }
   };
-}
-
-/** Split one resolve pass's decisions into the three reported halves. Shared by
- * the first pass and the second look so both classify identically — a second
- * look that reported a family deferral as a fix_scope skip would send an
- * operator to the wrong remedy. */
-function partitionDecisions(decisions, cap) {
-  const entries = [];
-  const deferred = [];
-  const skipped = [];
-  for (const decision of decisions) {
-    const number = decision.candidate.issue;
-    // Ruled out before the collapse ran (fix_scope). It joined the union so its
-    // family edges survived, but it is not a family deferral and must not be
-    // reported as one: the two lift on different events.
-    if (decision.candidate.eligible === false) {
-      skipped.push({ issue: number, reason: decision.candidate.skipReason });
-      continue;
-    }
-    if (!decision.selected) {
-      // Deferral writes NOTHING to the queue — no label, no comment, no marker.
-      // The member stays exactly as selectable as its live state makes it on the
-      // next run, which is what lets a genuine regression (ingest sheds the
-      // sibling's autofix marker) bring the family straight back. It IS reported
-      // out, though: the run record carries the count and the issue numbers so
-      // "everything suppressed" never reads as "nothing queued".
-      process.stderr.write(
-        `defer #${number}: ${DEFER_NOTES[decision.reason]?.(decision) ?? `deferred (${decision.reason})`}; not marked, re-evaluated next run.\n`,
-      );
-      deferred.push({ issue: number, reason: decision.reason });
-      continue;
-    }
-    if (entries.length >= cap) continue;
-    entries.push(decision.candidate.entry);
-  }
-  return { entries, deferred, skipped };
 }
 
 /**
@@ -455,31 +377,13 @@ export async function selectAutofixRun(options, deps = {}) {
     process.stderr.write(
       `note: first pass selected nothing from a FULL list page (${page.rawCount} rows); taking ONE bounded second look at the next ${SECOND_LOOK_LIST_ROWS} rows.\n`,
     );
-    const beyond = await listCodeFixStubsPage(runGh, repo, {
-      limit: LIST_LIMIT + SECOND_LOOK_LIST_ROWS,
-      skip: LIST_LIMIT,
-    });
-    const furtherEvaluable = beyond.stubs.slice(0, MAX_SECOND_LOOK_EVALUATIONS);
-    window.secondLookTotal = beyond.stubs.length;
-    window.secondLookEvaluated = furtherEvaluable.length;
-    if (beyond.stubs.length > furtherEvaluable.length) {
-      // The second look's OWN truncation, surfaced exactly like the Window
-      // tripwire: it must never silently stop short either.
-      process.stderr.write(
-        `note: second look saw ${beyond.stubs.length} further stubs; evaluating the oldest ${furtherEvaluable.length} (MAX_SECOND_LOOK_EVALUATIONS).\n`,
-      );
-    }
-
-    const furtherCandidates = [];
-    for (const stub of furtherEvaluable) {
-      const candidate = await evaluateCandidate(runGh, repo, stub);
-      if (candidate) furtherCandidates.push(candidate);
-    }
-    // Its OWN family budgets: the first pass spent the per-run ones, so reusing
-    // them would silently double the run's worst-case volume.
-    const second = await resolveFamilies(runGh, repo, furtherCandidates, cap, {
-      budgets: SECOND_LOOK_FAMILY_BUDGETS,
-    });
+    const second = await resolveSecondLook(runGh, repo, cap);
+    // Its own total-vs-evaluated is its own truncation, surfaced exactly like
+    // the Window tripwire: this pass must never silently stop short either.
+    window.secondLookTotal = second.total;
+    window.secondLookEvaluated = second.evaluated;
+    // Partitioned through the SAME classifier the first pass used, so a
+    // second-look family deferral is never reported as a fix_scope skip.
     const secondParts = partitionDecisions(second.decisions, cap);
     entries.push(...secondParts.entries);
     deferred.push(...secondParts.deferred);

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -222,6 +222,32 @@ function instrumentRunGh(baseRunGh, state) {
   };
 }
 
+/** The Window tripwire record at its zero state — every field the workflow's
+ * `jq` reads, before anything has been counted. One source rather than a literal
+ * per return path: the workflow reads these key names, so a typo in one copy
+ * silently zeroes a line of the run record and no test that asserts the returned
+ * OBJECT would see it. */
+const emptyWindow = () => ({
+  total: 0,
+  evaluated: 0,
+  secondLook: false,
+  secondLookTotal: 0,
+  secondLookEvaluated: 0,
+  secondLookFull: false,
+  secondLookFailed: false,
+  ghCalls: 0,
+});
+
+/** The truncation record with nothing cut — the baseline the paths that never
+ * reach the family resolver return. Same reason as `emptyWindow`: `rateLimited`
+ * in particular is the one key the degraded disposition rides on. */
+const noTruncations = () => ({
+  handledOverflow: 0,
+  reverseBudget: false,
+  reverseNonconvergent: false,
+  rateLimited: 0,
+});
+
 /**
  * Run the selection and report EVERY half of its outcome: the matrix entries,
  * every candidate the family collapse stood down, and every stub the `fix_scope`
@@ -300,7 +326,42 @@ export async function selectAutofixRun(options, deps = {}) {
   // leg is itself silent, and an operator who dispatches an architectural stub
   // sees the same empty array as for an ineligible one.
   if (options.issue != null) {
-    const stub = await readStub(runGh, repo, options.issue);
+    let stub;
+    try {
+      stub = await readStub(runGh, repo, options.issue);
+    } catch (err) {
+      // THROTTLE ONLY, and this is the distinction the scope turns on.
+      //
+      // A RATE-LIMIT-shaped failure must DEGRADE. `instrumentRunGh` records the
+      // throttle and RETHROWS by design — so every fail-soft handler downstream
+      // keeps behaving exactly as it did — but this read has no handler under
+      // it, so the rejection would leave `selectAutofixRun`, reach `main`, set
+      // exit 1, and kill the step under `set -euo pipefail`. That destroys the
+      // `::error::` line, the `rateLimited` truncation and the disposition flip
+      // that ARE the fail-closed contract, on precisely the run they exist for.
+      // Degrade instead: zero entries, the loud report, exit 0.
+      //
+      // Any OTHER failure still rejects, unchanged. A missing issue, malformed
+      // JSON or a broken `gh` is not the hazard this leg fails closed against —
+      // nothing was read, so nothing can be wrongly SELECTED — and a dispatch
+      // that names an unreadable issue is an operator error whose loudest,
+      // most useful signal is a failed step. That is the behaviour on `main`
+      // and this round deliberately leaves it alone.
+      if (state.rateLimited === 0) throw err;
+      return degraded({
+        entries: [],
+        deferred: [],
+        skipped: [],
+        window: {
+          ...emptyWindow(),
+          // One issue was named, none was evaluated. Never `evaluated: 1`: the
+          // read that would have evaluated it is exactly what failed.
+          total: 1,
+          ghCalls: state.ghCalls,
+        },
+        truncations: noTruncations(),
+      });
+    }
     const candidate = await evaluateCandidate(runGh, repo, {
       number: stub.number,
       title: stub.title,
@@ -323,21 +384,12 @@ export async function selectAutofixRun(options, deps = {}) {
           ? []
           : [{ issue: candidate.issue, reason: candidate.skipReason }],
       window: {
+        ...emptyWindow(),
         total: 1,
         evaluated: 1,
-        secondLook: false,
-        secondLookTotal: 0,
-        secondLookEvaluated: 0,
-        secondLookFull: false,
-        secondLookFailed: false,
         ghCalls: state.ghCalls,
       },
-      truncations: {
-        handledOverflow: 0,
-        reverseBudget: false,
-        reverseNonconvergent: false,
-        rateLimited: 0,
-      },
+      truncations: noTruncations(),
     };
     // A dispatch dedupes on the SAME open-PR read the batch path does, so a
     // throttled one can open a duplicate just as easily.
@@ -348,7 +400,55 @@ export async function selectAutofixRun(options, deps = {}) {
     Number.isInteger(options.cap) && options.cap > 0
       ? options.cap
       : DEFAULT_CAP;
-  const page = await listCodeFixStubsPage(runGh, repo);
+  // The Window tripwire (PR #1810 cost bound): the record job renders "Window: N
+  // stubs, evaluated M" when N>M, so any approach toward the eval cap is
+  // reported on the tracker weeks ahead — never a silent truncation. Built
+  // BEFORE the window list, so a list read that never answers still has a report
+  // to degrade onto instead of taking the whole run record down with it.
+  const window = emptyWindow();
+
+  // The single greppable operator line for the run. It is emitted by the CALLER
+  // with the count that was actually emitted, not built inside `finish()`:
+  // `degraded()` replaces `entries` with `[]` AFTER `finish()` returns, so a
+  // line built there reported `entries=2` on runs that emitted zero — on exactly
+  // the fail-closed path, the one an operator greps this line to understand.
+  const summarize = (emitted) => {
+    process.stderr.write(
+      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}${window.secondLookFull ? "+" : ""}${window.secondLookFailed ? " (failed)" : ""}` : "no"} entries=${emitted}\n`,
+    );
+  };
+
+  // The FIRST window list, and — like the dispatch `readStub` above and the
+  // second look's own list below — a `gh` call with no fail-soft handler under
+  // it. Same split, for the same reason:
+  //
+  //   THROTTLE -> DEGRADE. `instrumentRunGh` rethrows, so an uncaught rejection
+  //   here exits 1 and kills the step under `set -euo pipefail` — losing the
+  //   `::error::` line, `truncations.rateLimited` and the `degraded-rate-limited`
+  //   disposition on the one run that needs them. A throttled window read also
+  //   answers NOTHING about the queue, so `[]` is the only honest emission.
+  //
+  //   ANYTHING ELSE -> THROW, unchanged. A malformed JSON body, a dead token, a
+  //   missing `gh`: the run cannot see its queue at all, there is no window to
+  //   report on, and a failed step is the louder and more actionable signal than
+  //   a green run rendering as an idle one. That is `main`'s behaviour today and
+  //   the harden round leaves it exactly as it is.
+  let page;
+  try {
+    page = await listCodeFixStubsPage(runGh, repo);
+  } catch (err) {
+    if (state.rateLimited === 0) throw err;
+    window.ghCalls = state.ghCalls;
+    const report = degraded({
+      entries: [],
+      deferred: [],
+      skipped: [],
+      window,
+      truncations: noTruncations(),
+    });
+    summarize(report.entries.length);
+    return report;
+  }
   const stubs = page.stubs;
 
   // Evaluate the window before choosing, not just the first `cap`: the family
@@ -364,19 +464,8 @@ export async function selectAutofixRun(options, deps = {}) {
       `note: window has ${stubs.length} stubs; evaluating the oldest ${evaluable.length} (MAX_CANDIDATE_EVALUATIONS).\n`,
     );
   }
-  // The Window tripwire (PR #1810 cost bound): the record job renders "Window: N
-  // stubs, evaluated M" when N>M, so any approach toward the eval cap is
-  // reported on the tracker weeks ahead — never a silent truncation.
-  const window = {
-    total: stubs.length,
-    evaluated: evaluable.length,
-    secondLook: false,
-    secondLookTotal: 0,
-    secondLookEvaluated: 0,
-    secondLookFull: false,
-    secondLookFailed: false,
-    ghCalls: 0,
-  };
+  window.total = stubs.length;
+  window.evaluated = evaluable.length;
 
   const candidates = [];
   for (const stub of evaluable) {
@@ -406,17 +495,6 @@ export async function selectAutofixRun(options, deps = {}) {
   const deferred = first.deferred;
   const skipped = first.skipped;
   const runTruncations = { ...truncations, rateLimited: 0 };
-
-  // The single greppable operator line for the run. It is emitted by the CALLER
-  // with the count that was actually emitted, not built inside `finish()`:
-  // `degraded()` replaces `entries` with `[]` AFTER `finish()` returns, so a
-  // line built there reported `entries=2` on runs that emitted zero — on exactly
-  // the fail-closed path, the one an operator greps this line to understand.
-  const summarize = (emitted) => {
-    process.stderr.write(
-      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}${window.secondLookFull ? "+" : ""}${window.secondLookFailed ? " (failed)" : ""}` : "no"} entries=${emitted}\n`,
-    );
-  };
 
   const finish = () => {
     window.ghCalls = state.ghCalls;

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -61,10 +61,12 @@ import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
 // past the ceiling?" pass, its own ceilings, and the cost arithmetic behind them.
 import {
   resolveSecondLook,
+  secondLookCeilingWarning,
   SECOND_LOOK_LIST_ROWS,
 } from "./sentry-autofix-second-look.mjs";
 import {
   defaultRunGh,
+  ghFailureText,
   isRateLimitFailure,
   listCodeFixStubsPage,
   LIST_LIMIT,
@@ -91,6 +93,7 @@ export { SKIP_FIX_SCOPE_ARCHITECTURAL } from "./sentry-autofix-candidate.mjs";
  * from here. Its mechanics live in sentry-autofix-second-look.mjs. */
 export {
   MAX_SECOND_LOOK_EVALUATIONS,
+  secondLookCeilingWarning,
   SECOND_LOOK_FAMILY_BUDGETS,
   SECOND_LOOK_LIST_ROWS,
 } from "./sentry-autofix-second-look.mjs";
@@ -101,10 +104,10 @@ export const DEFAULT_CAP = 2;
 // selection can no longer stop at the first `cap` stubs — but "evaluate the
 // whole window" makes the run's `gh` cost scale with LIST_LIMIT (one `issue
 // view` plus one `pr list` each, ~400 sequential subprocesses at the ceiling)
-// inside a `timeout-minutes: 5` job, and family deferral writes nothing, so a
-// collapsed family of K leaves K-1 PERMANENT window residents that are re-read
-// every run. That is monotonic growth driven from outside: every new error
-// fingerprint an unauthenticated dashboard visitor produces can add one.
+// inside the select job's `timeout-minutes` budget, and family deferral writes
+// nothing, so a collapsed family of K leaves K-1 PERMANENT window residents that
+// are re-read every run. That is monotonic growth driven from outside: every new
+// error fingerprint an unauthenticated dashboard visitor produces can add one.
 //
 // Bound the READ instead of the selection. The window is oldest-first, so this
 // truncates the NEWEST tail — the oldest candidates, the ones `sort:created-asc`
@@ -125,8 +128,10 @@ export const DEFAULT_CAP = 2;
 // 200, not 50: 50 left 150 rows of a full window unread every run, which —
 // combined with family deferral writing nothing — is the starvation
 // sentry-autofix-second-look.mjs exists to break. The cost is bounded and paid
-// for: the select job's `timeout-minutes` is 25, and 2 + 2×200 + 120 ≈ 522
-// serial `gh` calls at a pessimistic ~1 s/call is ~9 minutes.
+// for: the select job's `timeout-minutes` is 25, and 1 list + 2×200 + 120 = 521
+// serial `gh` INVOCATIONS at a pessimistic ~1 s/call is ~9 minutes. (522 API
+// REQUESTS — the list invocation paginates at 100 rows. The two units are
+// tracked separately; see sentry-autofix-second-look.mjs § COST ARITHMETIC.)
 export const MAX_CANDIDATE_EVALUATIONS = 200;
 
 /**
@@ -147,7 +152,7 @@ export function windowCeilingWarning(
 
 /**
  * Wrap the run's `gh` driver so ONE place sees every invocation the select leg
- * makes. Two jobs, both otherwise unmeasurable:
+ * makes. Three jobs, all otherwise unmeasurable:
  *
  * 1. COUNT. The per-run `gh` volume is a documented ceiling that nothing
  *    actually measured — every cost claim in the pipeline note was arithmetic
@@ -165,21 +170,50 @@ export function windowCeilingWarning(
  *    behaves exactly as before locally; the caller then refuses to SELECT on the
  *    data those paths produced.
  *
+ * 3. STOP SPENDING ONCE THROTTLED. The decision in (2) is taken at pass
+ *    boundaries, but the loops that reach them are long: the per-stub loop alone
+ *    is 2 × MAX_CANDIDATE_EVALUATIONS calls. Without this, one 403 at the head
+ *    of the window is followed by ~400 more requests fired into an ACTIVE
+ *    throttle before the run stands down — and GitHub's secondary limits EXTEND
+ *    on continued requests and escalate to abuse detection, on a repo-shared
+ *    free-plan `GITHUB_TOKEN` every other workflow draws from. "Fail closed"
+ *    that spends 400 more requests is not closed at the token level. So the
+ *    first rate-limit-shaped failure latches, and every later call rejects
+ *    IMMEDIATELY without spawning `gh`. The same one place, for the same reason
+ *    it is one place: it covers reads added later, for free.
+ *
+ *    It is a rejection, not a silent empty result, precisely so every existing
+ *    fail-soft handler runs its normal path — and the run stands down anyway,
+ *    because `state.rateLimited` is already nonzero by then. Latched calls are
+ *    NOT counted: `ghCalls` must stay a count of real invocations (it is the
+ *    drift detector for the timeout arithmetic), and `rateLimited` must stay a
+ *    count of real throttle events, not of loop iterations after the first.
+ *
  * Non-rate-limit transients keep their existing fail-soft behaviour untouched:
  * only `isRateLimitFailure` text degrades the run.
  */
 function instrumentRunGh(baseRunGh, state) {
   return async (args) => {
+    if (state.rateLimited > 0) {
+      // Deliberately argv-free and rate-limit-shape-free: this text reaches
+      // `ghFailureText`, and a message that matched `isRateLimitFailure` would
+      // inflate the throttle count with one entry per latched call.
+      throw new Error(
+        "selection stood down: an earlier gh read failed rate-limit-shaped, so this read was not issued",
+      );
+    }
     state.ghCalls += 1;
     try {
       return await baseRunGh(args);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (isRateLimitFailure(message)) {
+      // Classify gh's STDERR, not the whole rejection message: the message
+      // carries the argv, and argv carries agent-authored family ids.
+      const text = ghFailureText(err);
+      if (isRateLimitFailure(text)) {
         state.rateLimited += 1;
         if (state.rateLimited === 1) {
           process.stderr.write(
-            `::error::rate-limit-shaped gh failure during selection: ${message.split("\n")[0]}\n`,
+            `::error::rate-limit-shaped gh failure during selection: ${text.split("\n")[0]}; no further gh reads will be issued this run.\n`,
           );
         }
       }
@@ -232,6 +266,8 @@ export async function selectAutofixRun(options, deps = {}) {
 
   const ceilingWarning = windowCeilingWarning();
   if (ceilingWarning) process.stderr.write(ceilingWarning);
+  const secondLookWarning = secondLookCeilingWarning();
+  if (secondLookWarning) process.stderr.write(secondLookWarning);
 
   /**
    * Fail CLOSED on throttling. Every read this leg issues answers a dedupe or
@@ -292,6 +328,8 @@ export async function selectAutofixRun(options, deps = {}) {
         secondLook: false,
         secondLookTotal: 0,
         secondLookEvaluated: 0,
+        secondLookFull: false,
+        secondLookFailed: false,
         ghCalls: state.ghCalls,
       },
       truncations: {
@@ -335,16 +373,29 @@ export async function selectAutofixRun(options, deps = {}) {
     secondLook: false,
     secondLookTotal: 0,
     secondLookEvaluated: 0,
+    secondLookFull: false,
+    secondLookFailed: false,
     ghCalls: 0,
   };
 
   const candidates = [];
   for (const stub of evaluable) {
+    // Stop the moment the run is throttled. `instrumentRunGh` already latches
+    // every later read into an immediate rejection, so this is not what makes
+    // the spend stop — but the evaluation loop would still grind through the
+    // remaining ~200 stubs printing a skip line each, and the run has already
+    // decided it will emit nothing. Leave loudly instead.
+    if (state.rateLimited > 0) {
+      process.stderr.write(
+        `note: stopping the window evaluation at ${candidates.length} candidate(s) — the run is rate limited and will emit zero entries.\n`,
+      );
+      break;
+    }
     const candidate = await evaluateCandidate(runGh, repo, stub);
     if (candidate) candidates.push(candidate);
   }
 
-  const { decisions, truncations } = await resolveFamilies(
+  const { decisions, truncations, resolved } = await resolveFamilies(
     runGh,
     repo,
     candidates,
@@ -356,17 +407,30 @@ export async function selectAutofixRun(options, deps = {}) {
   const skipped = first.skipped;
   const runTruncations = { ...truncations, rateLimited: 0 };
 
+  // The single greppable operator line for the run. It is emitted by the CALLER
+  // with the count that was actually emitted, not built inside `finish()`:
+  // `degraded()` replaces `entries` with `[]` AFTER `finish()` returns, so a
+  // line built there reported `entries=2` on runs that emitted zero — on exactly
+  // the fail-closed path, the one an operator greps this line to understand.
+  const summarize = (emitted) => {
+    process.stderr.write(
+      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}${window.secondLookFull ? "+" : ""}${window.secondLookFailed ? " (failed)" : ""}` : "no"} entries=${emitted}\n`,
+    );
+  };
+
   const finish = () => {
     window.ghCalls = state.ghCalls;
-    process.stderr.write(
-      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}` : "no"} entries=${entries.length}\n`,
-    );
     return { entries, deferred, skipped, window, truncations: runTruncations };
+  };
+  const finishDegraded = () => {
+    const report = degraded(finish());
+    summarize(report.entries.length);
+    return report;
   };
 
   // Bail before spending anything more: the first pass's dedupe reads are
   // already untrustworthy, so a second look would only widen the blast radius.
-  if (state.rateLimited > 0) return degraded(finish());
+  if (state.rateLimited > 0) return finishDegraded();
 
   // The bounded SECOND LOOK. Fires only on the starvation signature — nothing
   // selectable in the whole window AND a FULL list page, so selectable rows may
@@ -377,28 +441,70 @@ export async function selectAutofixRun(options, deps = {}) {
     process.stderr.write(
       `note: first pass selected nothing from a FULL list page (${page.rawCount} rows); taking ONE bounded second look at the next ${SECOND_LOOK_LIST_ROWS} rows.\n`,
     );
-    const second = await resolveSecondLook(runGh, repo, cap);
-    // Its own total-vs-evaluated is its own truncation, surfaced exactly like
-    // the Window tripwire: this pass must never silently stop short either.
-    window.secondLookTotal = second.total;
-    window.secondLookEvaluated = second.evaluated;
-    // Partitioned through the SAME classifier the first pass used, so a
-    // second-look family deferral is never reported as a fix_scope skip.
-    const secondParts = partitionDecisions(second.decisions, cap);
-    entries.push(...secondParts.entries);
-    deferred.push(...secondParts.deferred);
-    skipped.push(...secondParts.skipped);
-    runTruncations.handledOverflow += second.truncations.handledOverflow ?? 0;
-    runTruncations.reverseBudget =
-      runTruncations.reverseBudget || second.truncations.reverseBudget;
-    runTruncations.reverseNonconvergent =
-      runTruncations.reverseNonconvergent ||
-      second.truncations.reverseNonconvergent;
+    let second = null;
+    try {
+      second = await resolveSecondLook(runGh, repo, cap, {
+        // The RAW offset the first pass consumed, NOT LIST_LIMIT: the two are
+        // equal only while MAX_CANDIDATE_EVALUATIONS === LIST_LIMIT, and a
+        // LIST_LIMIT skip under a LOWER eval cap would leave the rows between
+        // them read by neither pass — a permanent hole in the middle of the
+        // window. `min` because the API applies LIST_LIMIT first, so the first
+        // pass can never have consumed more raw rows than that; and because N
+        // filtered stubs span at least N raw rows, this can only overlap the
+        // first pass, never jump past it.
+        skipRawRows: Math.min(MAX_CANDIDATE_EVALUATIONS, LIST_LIMIT),
+        // Start from what the first pass PROVED rather than re-deriving it on
+        // half the budget — see resolveFamilies' `options.seed`. Without this
+        // the second look can select a stub whose family this same run already
+        // stood down, which is a duplicate autofix PR with no rate limit
+        // anywhere in the story.
+        seed: resolved,
+      });
+    } catch (err) {
+      // The second look's list read is the ONE `gh` call in this leg with no
+      // fail-soft handler under it, and this PR put it on the frequent path:
+      // once the queue is >= LIST_LIMIT rows, EVERY no-selection run depends on
+      // it. Unhandled, a rejection propagates to `main`, sets exit 1, and kills
+      // the step under `set -euo pipefail` — taking the whole run record with
+      // it, including the DEGRADED line a throttled run needs most. So it is
+      // caught: the FIRST pass completed and its report is valid and complete
+      // (it selected nothing by precondition, so no entry is lost), and the
+      // only thing missing is the look past the ceiling. Say so, and let the
+      // rate-limit check below degrade the run if that is why it failed.
+      const message = err instanceof Error ? err.message : String(err);
+      window.secondLookFailed = true;
+      process.stderr.write(
+        `::warning::the bounded second look could not read past the list ceiling: ${message.split("\n")[0]}; the first pass's result stands.\n`,
+      );
+    }
+    if (second) {
+      window.secondLookTotal = second.total;
+      window.secondLookEvaluated = second.evaluated;
+      // The honest "there is MORE past even this" signal, taken off the raw row
+      // count. `total` saturates at SECOND_LOOK_LIST_ROWS by construction, so on
+      // its own it reads the same at 100 further stubs and at 5,000 — and the
+      // pipeline note names this line the standing tripwire for queue regrowth.
+      window.secondLookFull = second.full === true;
+      // Partitioned through the SAME classifier the first pass used, so a
+      // second-look family deferral is never reported as a fix_scope skip.
+      const secondParts = partitionDecisions(second.decisions, cap);
+      entries.push(...secondParts.entries);
+      deferred.push(...secondParts.deferred);
+      skipped.push(...secondParts.skipped);
+      runTruncations.handledOverflow += second.truncations.handledOverflow ?? 0;
+      runTruncations.reverseBudget =
+        runTruncations.reverseBudget || second.truncations.reverseBudget;
+      runTruncations.reverseNonconvergent =
+        runTruncations.reverseNonconvergent ||
+        second.truncations.reverseNonconvergent;
+    }
 
-    if (state.rateLimited > 0) return degraded(finish());
+    if (state.rateLimited > 0) return finishDegraded();
   }
 
-  return finish();
+  const report = finish();
+  summarize(report.entries.length);
+  return report;
 }
 
 /** Matrix entries only — the emitted contract, unchanged. `selectAutofixRun`
@@ -462,11 +568,13 @@ Options:
                        indistinguishable from an empty one. Stdout is unchanged.
   --window-out <p>     Write the Window tripwire — { "total": <n>, "evaluated":
                        <n>, "secondLook": <bool>, "secondLookTotal": <n>,
-                       "secondLookEvaluated": <n>, "ghCalls": <n> } — to this
+                       "secondLookEvaluated": <n>, "secondLookFull": <bool>,
+                       "secondLookFailed": <bool>, "ghCalls": <n> } — to this
                        path, so the run record can surface a list window that
-                       exceeded the eval cap, a bounded second look (that it ran
-                       AND whether it truncated), and the run's measured \`gh\`
-                       volume. Stdout is unchanged.
+                       exceeded the eval cap, a bounded second look (that it ran,
+                       whether MORE rows still sat past even it, and whether its
+                       own read failed), and the run's measured \`gh\` invocation
+                       count. Stdout is unchanged.
   --truncations-out <p> Write the cost-budget truncations — { "handledOverflow":
                        <n>, "reverseBudget": <bool>, "reverseNonconvergent":
                        <bool>, "rateLimited": <n> } — to this path, so the run
@@ -550,17 +658,58 @@ export function parseArgs(argv) {
 
 /** Best-effort JSON report write. A failed write degrades ONE counter on the
  * run record; it must never fail the select step, whose whole contract is that
- * it always emits a valid array. */
-function writeReport(path, report, label) {
-  if (!path) return;
+ * it always emits a valid array. Returns whether the file was written — one
+ * caller (the degraded signal) has to know. Exported because `main` is the only
+ * bridge between the selector's return value and the `jq` reads the workflow
+ * builds the tracker record from, and a key-name or serialization bug here is
+ * invisible to every test that exercises `selectAutofixRun` alone. */
+export function writeReport(path, report, label) {
+  if (!path) return true;
   try {
     writeFileSync(path, `${JSON.stringify(report ?? [])}\n`);
+    return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(
       `warn: could not write the ${label} report: ${message}\n`,
     );
+    return false;
   }
+}
+
+/**
+ * Write every report file the workflow reads, and answer the one question the
+ * caller must act on: was a DEGRADED run's signal lost?
+ *
+ * `rateLimited` reaches the workflow through exactly one channel — the
+ * truncations file — and the workflow flips `disposition` to
+ * `degraded-rate-limited` off it. Every OTHER field on these files is a
+ * nice-to-have that degrades to "0" or a missing line. This one is the safety
+ * signal: lose it and `rate_limited` reads 0, the disposition stays `active`,
+ * the tracker renders a suppressed run as a healthy idle one — the #1758
+ * misdiagnosis — and the record job's label backfill gate opens on reads the run
+ * itself declared unreliable. So a best-effort write is the wrong contract for
+ * that one case, and the caller fails the step instead. Exported for the same
+ * reason `writeReport` is.
+ */
+export function writeRunReports(options, run) {
+  // Report BEFORE stdout: the workflow captures stdout into a shell variable, so
+  // a failed report write must not be able to lose the entries too. All are
+  // best-effort — the run record degrades to "0" / no Window line / no
+  // truncation line, never to a dead leg.
+  writeReport(options.deferredOut, run.deferred, "deferral");
+  writeReport(options.skippedOut, run.skipped, "fix_scope skip");
+  writeReport(options.windowOut, run.window ?? {}, "window");
+  const truncations = run.truncations ?? {};
+  const wroteTruncations = writeReport(
+    options.truncationsOut,
+    truncations,
+    "truncations",
+  );
+  return {
+    lostDegradedSignal:
+      Number(truncations.rateLimited ?? 0) > 0 && !wroteTruncations,
+  };
 }
 
 async function main() {
@@ -576,17 +725,20 @@ async function main() {
     process.stdout.write(await emitVerdict(options));
     return;
   }
-  const { entries, deferred, skipped, window, truncations } =
-    await selectAutofixRun(options);
-  // Report BEFORE stdout: the workflow captures stdout into a shell variable, so
-  // a failed report write must not be able to lose the entries too. All are
-  // best-effort — the run record degrades to "0" / no Window line / no
-  // truncation line, never to a dead leg.
-  writeReport(options.deferredOut, deferred, "deferral");
-  writeReport(options.skippedOut, skipped, "fix_scope skip");
-  writeReport(options.windowOut, window ?? {}, "window");
-  writeReport(options.truncationsOut, truncations ?? {}, "truncations");
-  process.stdout.write(`${JSON.stringify(entries)}\n`);
+  const run = await selectAutofixRun(options);
+  const { lostDegradedSignal } = writeRunReports(options, run);
+  process.stdout.write(`${JSON.stringify(run.entries)}\n`);
+  if (lostDegradedSignal) {
+    // The array contract still held — it was written above, and it is `[]`, so
+    // no PR can be opened from this run either way. What cannot hold is silence:
+    // failing the step is the only remaining way to say "this run stood down"
+    // once the file that says it is gone. Loud beats a green tracker line that
+    // is not true.
+    process.stderr.write(
+      "::error::selection was DEGRADED but the truncations report could not be written, so the run would render as a healthy idle one; failing the step instead.\n",
+    );
+    process.exitCode = 1;
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -59,7 +59,9 @@ import {
 import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
 import {
   defaultRunGh,
-  listCodeFixStubs,
+  isRateLimitFailure,
+  listCodeFixStubsPage,
+  LIST_LIMIT,
   readStub,
 } from "./sentry-autofix-queue-io.mjs";
 // The per-stub eligibility layer, extracted so this module stays under the
@@ -93,7 +95,85 @@ export const DEFAULT_CAP = 2;
 // exists to protect, are always inside the budget. A truncated family is the
 // same situation MAX_DUPLICATE_LOOKUPS already creates (a member the run cannot
 // see), and it fails toward MORE candidates, never fewer.
-export const MAX_CANDIDATE_EVALUATIONS = 50;
+//
+// `LIST_LIMIT` (sentry-autofix-queue-io.mjs, 200) is the HARD upper bound on
+// this constant. `gh issue list --limit` caps what the API RETURNS, and that
+// happens BEFORE the slice below runs, so raising this value above LIST_LIMIT is
+// a strict NO-OP — the run reads exactly LIST_LIMIT rows either way, the Window
+// tripwire reports `total == evaluated`, and nothing anywhere says the raise did
+// nothing. THE TWO MUST MOVE TOGETHER. `windowCeilingWarning` re-checks the pair
+// at run time and a suite test pins `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT`,
+// because a silent no-op is precisely the failure a "we widened the window"
+// change must not ship as.
+//
+// 200, not 50 (this PR): 50 left 150 rows of a full window unread every run,
+// which — combined with family deferral writing nothing — is the starvation the
+// second look below exists to break. The cost is bounded and paid for: the
+// select job's `timeout-minutes` is 25, and 2 + 2×200 + 120 ≈ 522 serial `gh`
+// calls at a pessimistic ~1 s/call is ~9 minutes.
+export const MAX_CANDIDATE_EVALUATIONS = 200;
+
+/**
+ * A run-time note when the evaluation window is configured above the list
+ * ceiling that is applied first — the mismatch that makes a raise a silent
+ * no-op. Pure (and exported) so the check is a real, testable behaviour rather
+ * than an assertion nobody can exercise: a THROW here would break the select
+ * step's "always emits a valid JSON array, never fails" invariant over a static
+ * config mistake, so this is loud, not fatal. Returns the note, or null.
+ */
+export function windowCeilingWarning(
+  evaluations = MAX_CANDIDATE_EVALUATIONS,
+  listLimit = LIST_LIMIT,
+) {
+  if (!(evaluations > listLimit)) return null;
+  return `warn: MAX_CANDIDATE_EVALUATIONS (${evaluations}) exceeds LIST_LIMIT (${listLimit}), which the API applies FIRST — the window is really ${listLimit} and raising the evaluation cap alone does nothing. Raise LIST_LIMIT too.\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Bounded second look
+// ---------------------------------------------------------------------------
+//
+// The starvation this exists to break: every stub inside the window is a
+// deferred family member, so the run selects NOTHING, writes NOTHING, and the
+// next run reads the SAME window and repeats — forever. Deferral is by design
+// state-free, so nothing ages out; a selectable stub sitting one row past the
+// window is never evaluated, at any point, ever.
+//
+// The second look fires ONLY on that exact signature: the first pass produced
+// zero matrix entries AND the list came back FULL (rawCount >= LIST_LIMIT, so
+// rows beyond it may exist). A healthy run — anything selected — never reaches
+// it and pays nothing. It is not a retry and not a widening: it reads the NEXT
+// rows once, with its own hard ceilings, and reports both that it ran and any
+// truncation of its own.
+//
+// COST ARITHMETIC (the constraint: first pass + second look must stay under
+// ~60% of the 25-minute select timeout at a pessimistic 1.0 s/call — every `gh`
+// call in this leg is serial, so ~900 calls is the wall):
+//   first pass  = 2 list pages + 2 × 200 per-stub reads + 120 family budget
+//                 (40 handled-id + 40 reverse probe + 40 verify read) = 522
+//   second look = 4 list pages (one `--limit 400` call, 100 rows per page)
+//               + 2 × 100 per-stub reads + 60 family budget (20 each) = 264
+//   TOTAL       = 786 calls ≈ 13.1 min at 1.0 s/call = 52% of 25 min. Under the
+//                 15-minute (≈900-call) wall with ~2 minutes of slack.
+// Raising any constant below re-opens this arithmetic; the suite pins the total
+// against DOCUMENTED_GH_CEILING.
+export const MAX_SECOND_LOOK_EVALUATIONS = 100;
+
+/** How many RAW rows past the first window the second look asks for. The list
+ * is issued as ONE `gh issue list --limit LIST_LIMIT + this`, with the first
+ * LIST_LIMIT raw rows dropped client-side — `gh issue list` has no offset flag,
+ * and a raw-row skip is what lines up with the first pass's own `--limit`
+ * (applied server-side, before any client filter). */
+export const SECOND_LOOK_LIST_ROWS = 200;
+
+/** The second look's OWN family budgets. The first pass's per-run budgets are
+ * spent by the time it runs, so it cannot reuse them; half of each keeps the
+ * total inside the arithmetic above while still letting a real family resolve. */
+export const SECOND_LOOK_FAMILY_BUDGETS = {
+  handled: 20,
+  probe: 20,
+  verify: 20,
+};
 
 /** One note per deferral reason, keyed by the collapse's own constants so a
  * reason added there cannot silently inherit another's wording. An unmapped
@@ -106,6 +186,85 @@ const DEFER_NOTES = {
   [DEFER_FAMILY_RECONCILING]: () =>
     "its duplicate_of family already has an open autofix PR being reconciled this run",
 };
+
+/**
+ * Wrap the run's `gh` driver so ONE place sees every invocation the select leg
+ * makes. Two jobs, both otherwise unmeasurable:
+ *
+ * 1. COUNT. The per-run `gh` volume is a documented ceiling that nothing
+ *    actually measured — every cost claim in the pipeline note was arithmetic
+ *    over caps. `state.ghCalls` makes it an observed number on the run record,
+ *    so drift shows up before a timeout does.
+ *
+ * 2. FAIL CLOSED ON THROTTLING. Nearly every read in this leg fails SOFT toward
+ *    MORE candidates — `readStub`, `openAutofixPrExists`, the handled-id
+ *    lookups, the reverse probes all treat a rejection as "no blocker found".
+ *    But the blockers they look for ARE the dedupe signals, so a rate-limited
+ *    read is indistinguishable from a clean one, and a throttled run can open
+ *    DUPLICATE autofix PRs while looking perfectly green. Intercepting here
+ *    catches EVERY read — including ones added later — without threading a sink
+ *    through four modules, and it re-throws so each existing fail-soft path
+ *    behaves exactly as before locally; the caller then refuses to SELECT on the
+ *    data those paths produced.
+ *
+ * Non-rate-limit transients keep their existing fail-soft behaviour untouched:
+ * only `isRateLimitFailure` text degrades the run.
+ */
+function instrumentRunGh(baseRunGh, state) {
+  return async (args) => {
+    state.ghCalls += 1;
+    try {
+      return await baseRunGh(args);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (isRateLimitFailure(message)) {
+        state.rateLimited += 1;
+        if (state.rateLimited === 1) {
+          process.stderr.write(
+            `::error::rate-limit-shaped gh failure during selection: ${message.split("\n")[0]}\n`,
+          );
+        }
+      }
+      throw err;
+    }
+  };
+}
+
+/** Split one resolve pass's decisions into the three reported halves. Shared by
+ * the first pass and the second look so both classify identically — a second
+ * look that reported a family deferral as a fix_scope skip would send an
+ * operator to the wrong remedy. */
+function partitionDecisions(decisions, cap) {
+  const entries = [];
+  const deferred = [];
+  const skipped = [];
+  for (const decision of decisions) {
+    const number = decision.candidate.issue;
+    // Ruled out before the collapse ran (fix_scope). It joined the union so its
+    // family edges survived, but it is not a family deferral and must not be
+    // reported as one: the two lift on different events.
+    if (decision.candidate.eligible === false) {
+      skipped.push({ issue: number, reason: decision.candidate.skipReason });
+      continue;
+    }
+    if (!decision.selected) {
+      // Deferral writes NOTHING to the queue — no label, no comment, no marker.
+      // The member stays exactly as selectable as its live state makes it on the
+      // next run, which is what lets a genuine regression (ingest sheds the
+      // sibling's autofix marker) bring the family straight back. It IS reported
+      // out, though: the run record carries the count and the issue numbers so
+      // "everything suppressed" never reads as "nothing queued".
+      process.stderr.write(
+        `defer #${number}: ${DEFER_NOTES[decision.reason]?.(decision) ?? `deferred (${decision.reason})`}; not marked, re-evaluated next run.\n`,
+      );
+      deferred.push({ issue: number, reason: decision.reason });
+      continue;
+    }
+    if (entries.length >= cap) continue;
+    entries.push(decision.candidate.entry);
+  }
+  return { entries, deferred, skipped };
+}
 
 /**
  * Run the selection and report EVERY half of its outcome: the matrix entries,
@@ -145,8 +304,37 @@ const DEFER_NOTES = {
  * family SIGNAL, not a confirmed duplicate, so the explicit request wins.
  */
 export async function selectAutofixRun(options, deps = {}) {
-  const runGh = deps.runGh ?? defaultRunGh;
+  const state = { ghCalls: 0, rateLimited: 0 };
+  const runGh = instrumentRunGh(deps.runGh ?? defaultRunGh, state);
   const repo = options.repo ?? DEFAULT_REPO;
+
+  const ceilingWarning = windowCeilingWarning();
+  if (ceilingWarning) process.stderr.write(ceilingWarning);
+
+  /**
+   * Fail CLOSED on throttling. Every read this leg issues answers a dedupe or
+   * blocker question, and every one of them fails SOFT toward MORE candidates,
+   * so a rate-limited run cannot tell "no prior PR" from "GitHub refused to
+   * tell me" — and would open a DUPLICATE autofix PR looking green. So the run
+   * does not SELECT on data it knows is unreliable.
+   *
+   * "Fail closed" here means ZERO matrix entries plus a loud report, NOT a
+   * throw: the workflow's select step asserts it always emits a valid JSON
+   * array and never fails (the leg runs under `set -euo pipefail`), so throwing
+   * would break the contract this whole job is built around. The stand-down
+   * reports are still returned — they cost nothing and an operator reading the
+   * tracker needs the whole picture — but the degraded line dominates them.
+   */
+  const degraded = (report) => {
+    process.stderr.write(
+      `::error::selection DEGRADED: ${state.rateLimited} rate-limit-shaped gh read failure(s); emitting ZERO entries rather than selecting on unreliable dedupe data.\n`,
+    );
+    return {
+      ...report,
+      entries: [],
+      truncations: { ...report.truncations, rateLimited: state.rateLimited },
+    };
+  };
 
   // Single-issue live run: evaluate exactly the requested issue. A dispatch
   // cannot override the fix_scope gate (that is the point of the gate), so the
@@ -161,13 +349,14 @@ export async function selectAutofixRun(options, deps = {}) {
       labels: stub.labels,
     });
     // No list window in single-issue mode: one stub considered, one evaluated,
-    // so the Window tripwire never fires (total == evaluated), and the family
-    // collapse is skipped entirely, so no cost budget can truncate. A dispatch
-    // cannot override the fix_scope gate, so an architectural stub is reported
-    // through `skipped` here too (the documented remedy for a stalled leg must
-    // not itself be silent).
+    // so the Window tripwire never fires (total == evaluated), the second look
+    // never applies (there is no list to be full), and the family collapse is
+    // skipped entirely, so no cost budget can truncate. A dispatch cannot
+    // override the fix_scope gate, so an architectural stub is reported through
+    // `skipped` here too (the documented remedy for a stalled leg must not
+    // itself be silent).
     const selectable = candidate != null && candidate.eligible !== false;
-    return {
+    const report = {
       entries: selectable ? [candidate.entry] : [],
       deferred: [],
       skipped: selectable
@@ -175,28 +364,40 @@ export async function selectAutofixRun(options, deps = {}) {
         : candidate == null
           ? []
           : [{ issue: candidate.issue, reason: candidate.skipReason }],
-      window: { total: 1, evaluated: 1 },
+      window: {
+        total: 1,
+        evaluated: 1,
+        secondLook: false,
+        secondLookTotal: 0,
+        secondLookEvaluated: 0,
+        ghCalls: state.ghCalls,
+      },
       truncations: {
         handledOverflow: 0,
         reverseBudget: false,
         reverseNonconvergent: false,
+        rateLimited: 0,
       },
     };
+    // A dispatch dedupes on the SAME open-PR read the batch path does, so a
+    // throttled one can open a duplicate just as easily.
+    return state.rateLimited > 0 ? degraded(report) : report;
   }
 
   const cap =
     Number.isInteger(options.cap) && options.cap > 0
       ? options.cap
       : DEFAULT_CAP;
-  const stubs = await listCodeFixStubs(runGh, repo);
+  const page = await listCodeFixStubsPage(runGh, repo);
+  const stubs = page.stubs;
 
   // Evaluate the window before choosing, not just the first `cap`: the family
   // union is transitive, so a stub further down the window can join two earlier
   // ones (or attach to a family through an id that is not itself a candidate),
   // and a decision taken before that stub is read can be wrong. Bounded by
   // MAX_CANDIDATE_EVALUATIONS (oldest-first, so the budget only ever drops the
-  // newest tail) rather than by LIST_LIMIT, so the run's `gh` cost cannot grow
-  // with a window that has no mechanism to shrink.
+  // newest tail), which now equals LIST_LIMIT — see the constant's note: the
+  // list ceiling is applied first, so it is the real bound either way.
   const evaluable = stubs.slice(0, MAX_CANDIDATE_EVALUATIONS);
   if (stubs.length > evaluable.length) {
     process.stderr.write(
@@ -206,7 +407,14 @@ export async function selectAutofixRun(options, deps = {}) {
   // The Window tripwire (PR #1810 cost bound): the record job renders "Window: N
   // stubs, evaluated M" when N>M, so any approach toward the eval cap is
   // reported on the tracker weeks ahead — never a silent truncation.
-  const window = { total: stubs.length, evaluated: evaluable.length };
+  const window = {
+    total: stubs.length,
+    evaluated: evaluable.length,
+    secondLook: false,
+    secondLookTotal: 0,
+    secondLookEvaluated: 0,
+    ghCalls: 0,
+  };
 
   const candidates = [];
   for (const stub of evaluable) {
@@ -220,35 +428,73 @@ export async function selectAutofixRun(options, deps = {}) {
     candidates,
     cap,
   );
-  const entries = [];
-  const deferred = [];
-  const skipped = [];
-  for (const decision of decisions) {
-    const number = decision.candidate.issue;
-    // Ruled out before the collapse ran (fix_scope). It joined the union so its
-    // family edges survived, but it is not a family deferral and must not be
-    // reported as one: the two lift on different events.
-    if (decision.candidate.eligible === false) {
-      skipped.push({ issue: number, reason: decision.candidate.skipReason });
-      continue;
-    }
-    if (!decision.selected) {
-      // Deferral writes NOTHING to the queue — no label, no comment, no marker.
-      // The member stays exactly as selectable as its live state makes it on the
-      // next run, which is what lets a genuine regression (ingest sheds the
-      // sibling's autofix marker) bring the family straight back. It IS reported
-      // out, though: the run record carries the count and the issue numbers so
-      // "everything suppressed" never reads as "nothing queued".
+  const first = partitionDecisions(decisions, cap);
+  const entries = first.entries;
+  const deferred = first.deferred;
+  const skipped = first.skipped;
+  const runTruncations = { ...truncations, rateLimited: 0 };
+
+  const finish = () => {
+    window.ghCalls = state.ghCalls;
+    process.stderr.write(
+      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}` : "no"} entries=${entries.length}\n`,
+    );
+    return { entries, deferred, skipped, window, truncations: runTruncations };
+  };
+
+  // Bail before spending anything more: the first pass's dedupe reads are
+  // already untrustworthy, so a second look would only widen the blast radius.
+  if (state.rateLimited > 0) return degraded(finish());
+
+  // The bounded SECOND LOOK. Fires only on the starvation signature — nothing
+  // selectable in the whole window AND a FULL list page, so selectable rows may
+  // sit just past it that no run will ever otherwise reach. A run that selected
+  // anything skips this entirely and pays zero extra calls.
+  if (entries.length === 0 && page.full) {
+    window.secondLook = true;
+    process.stderr.write(
+      `note: first pass selected nothing from a FULL list page (${page.rawCount} rows); taking ONE bounded second look at the next ${SECOND_LOOK_LIST_ROWS} rows.\n`,
+    );
+    const beyond = await listCodeFixStubsPage(runGh, repo, {
+      limit: LIST_LIMIT + SECOND_LOOK_LIST_ROWS,
+      skip: LIST_LIMIT,
+    });
+    const furtherEvaluable = beyond.stubs.slice(0, MAX_SECOND_LOOK_EVALUATIONS);
+    window.secondLookTotal = beyond.stubs.length;
+    window.secondLookEvaluated = furtherEvaluable.length;
+    if (beyond.stubs.length > furtherEvaluable.length) {
+      // The second look's OWN truncation, surfaced exactly like the Window
+      // tripwire: it must never silently stop short either.
       process.stderr.write(
-        `defer #${number}: ${DEFER_NOTES[decision.reason]?.(decision) ?? `deferred (${decision.reason})`}; not marked, re-evaluated next run.\n`,
+        `note: second look saw ${beyond.stubs.length} further stubs; evaluating the oldest ${furtherEvaluable.length} (MAX_SECOND_LOOK_EVALUATIONS).\n`,
       );
-      deferred.push({ issue: number, reason: decision.reason });
-      continue;
     }
-    if (entries.length >= cap) continue;
-    entries.push(decision.candidate.entry);
+
+    const furtherCandidates = [];
+    for (const stub of furtherEvaluable) {
+      const candidate = await evaluateCandidate(runGh, repo, stub);
+      if (candidate) furtherCandidates.push(candidate);
+    }
+    // Its OWN family budgets: the first pass spent the per-run ones, so reusing
+    // them would silently double the run's worst-case volume.
+    const second = await resolveFamilies(runGh, repo, furtherCandidates, cap, {
+      budgets: SECOND_LOOK_FAMILY_BUDGETS,
+    });
+    const secondParts = partitionDecisions(second.decisions, cap);
+    entries.push(...secondParts.entries);
+    deferred.push(...secondParts.deferred);
+    skipped.push(...secondParts.skipped);
+    runTruncations.handledOverflow += second.truncations.handledOverflow ?? 0;
+    runTruncations.reverseBudget =
+      runTruncations.reverseBudget || second.truncations.reverseBudget;
+    runTruncations.reverseNonconvergent =
+      runTruncations.reverseNonconvergent ||
+      second.truncations.reverseNonconvergent;
+
+    if (state.rateLimited > 0) return degraded(finish());
   }
-  return { entries, deferred, skipped, window, truncations };
+
+  return finish();
 }
 
 /** Matrix entries only — the emitted contract, unchanged. `selectAutofixRun`
@@ -311,13 +557,19 @@ Options:
                        without it a window standing entirely down on scope is
                        indistinguishable from an empty one. Stdout is unchanged.
   --window-out <p>     Write the Window tripwire — { "total": <n>, "evaluated":
-                       <n> } — to this path, so the run record can surface a list
-                       window that exceeded the eval cap. Stdout is unchanged.
+                       <n>, "secondLook": <bool>, "secondLookTotal": <n>,
+                       "secondLookEvaluated": <n>, "ghCalls": <n> } — to this
+                       path, so the run record can surface a list window that
+                       exceeded the eval cap, a bounded second look (that it ran
+                       AND whether it truncated), and the run's measured \`gh\`
+                       volume. Stdout is unchanged.
   --truncations-out <p> Write the cost-budget truncations — { "handledOverflow":
                        <n>, "reverseBudget": <bool>, "reverseNonconvergent":
-                       <bool> } — to this path, so the run record can surface a
-                       bounded re-attempt (a family that should have stood down
-                       but a budget capped its lookup). Stdout is unchanged.
+                       <bool>, "rateLimited": <n> } — to this path, so the run
+                       record can surface a bounded re-attempt (a family that
+                       should have stood down but a budget capped its lookup) and
+                       a DEGRADED run (rate-limit-shaped gh failures, which force
+                       zero entries). Stdout is unchanged.
   --emit-verdict       With --issue: print the trusted (fence-selected) verdict
                        comment body for that issue and exit (the workflow
                        snapshots it to a file the fix agent reads, so the agent

--- a/scripts/sentry-autofix-select.mjs
+++ b/scripts/sentry-autofix-select.mjs
@@ -44,13 +44,9 @@
  * stdout (diagnostics on stderr).
  */
 
-import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import {
-  DEFAULT_REPO,
-  selectVerdictComment,
-} from "./sentry-triage-project-core.mjs";
+import { DEFAULT_REPO } from "./sentry-triage-project-core.mjs";
 // The decision -> report classifier, shared by the first pass and the second
 // look so both label a stand-down identically (a deferral and a fix_scope skip
 // lift on different events, and send an operator to different remedies).
@@ -66,12 +62,35 @@ import {
 } from "./sentry-autofix-second-look.mjs";
 import {
   defaultRunGh,
-  ghFailureText,
-  isRateLimitFailure,
   listCodeFixStubsPage,
   LIST_LIMIT,
   readStub,
 } from "./sentry-autofix-queue-io.mjs";
+// The run's budget and instrumentation, extracted so this module stays under the
+// 600-line soft cap: the per-run read bound and its no-op guard, the `gh`
+// counter, the throttle latch, the zero-state record shapes and the two lines a
+// run writes about itself. This module owns what a run DECIDES; that one owns
+// what bounds it, measures it, and stands it down.
+import {
+  degradeReport,
+  emptyWindow,
+  instrumentRunGh,
+  MAX_CANDIDATE_EVALUATIONS,
+  newRunState,
+  noTruncations,
+  summarizeRun,
+  windowCeilingWarning,
+} from "./sentry-autofix-select-instrument.mjs";
+// The CLI surface, extracted for the same reason: the option contract, the help
+// text, the report files the tracker reads back, and `--emit-verdict`. A leaf —
+// it imports nothing from here — so the re-exports below cannot form a cycle.
+import {
+  DEFAULT_CAP,
+  emitVerdict,
+  parseArgs,
+  usage,
+  writeRunReports,
+} from "./sentry-autofix-select-cli.mjs";
 // The per-stub eligibility layer, extracted so this module stays under the
 // 600-line soft cap: every filter that decides whether ONE stub may start a fix
 // attempt lives there, this module owns the window and the family collapse.
@@ -98,155 +117,25 @@ export {
   SECOND_LOOK_LIST_ROWS,
 } from "./sentry-autofix-second-look.mjs";
 
-export const DEFAULT_CAP = 2;
+/** Re-exported from the extracted CLI layer, same reason again: the workflow
+ * runs this file and the suites import these names from it, so the module
+ * boundary is an internal detail and must stay one. */
+export {
+  DEFAULT_CAP,
+  emitVerdict,
+  parseArgs,
+  writeReport,
+  writeRunReports,
+} from "./sentry-autofix-select-cli.mjs";
 
-// How many window stubs one run may READ. The family union is transitive, so
-// selection can no longer stop at the first `cap` stubs — but "evaluate the
-// whole window" makes the run's `gh` cost scale with LIST_LIMIT (one `issue
-// view` plus one `pr list` each, ~400 sequential subprocesses at the ceiling)
-// inside the select job's `timeout-minutes` budget, and family deferral writes
-// nothing, so a collapsed family of K leaves K-1 PERMANENT window residents that
-// are re-read every run. That is monotonic growth driven from outside: every new
-// error fingerprint an unauthenticated dashboard visitor produces can add one.
-//
-// Bound the READ instead of the selection. The window is oldest-first, so this
-// truncates the NEWEST tail — the oldest candidates, the ones `sort:created-asc`
-// exists to protect, are always inside the budget. A truncated family is the
-// same situation MAX_DUPLICATE_LOOKUPS already creates (a member the run cannot
-// see), and it fails toward MORE candidates, never fewer.
-//
-// `LIST_LIMIT` (sentry-autofix-queue-io.mjs, 200) is the HARD upper bound on
-// this constant. `gh issue list --limit` caps what the API RETURNS, and that
-// happens BEFORE the slice below runs, so raising this value above LIST_LIMIT is
-// a strict NO-OP — the run reads exactly LIST_LIMIT rows either way, the Window
-// tripwire reports `total == evaluated`, and nothing anywhere says the raise did
-// nothing. THE TWO MUST MOVE TOGETHER. `windowCeilingWarning` re-checks the pair
-// at run time and a suite test pins `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT`,
-// because a silent no-op is precisely the failure a "we widened the window"
-// change must not ship as.
-//
-// 200, not 50: 50 left 150 rows of a full window unread every run, which —
-// combined with family deferral writing nothing — is the starvation
-// sentry-autofix-second-look.mjs exists to break. The cost is bounded and paid
-// for: the select job's `timeout-minutes` is 25, and 1 list + 2×200 + 120 = 521
-// serial `gh` INVOCATIONS at a pessimistic ~1 s/call is ~9 minutes. (522 API
-// REQUESTS — the list invocation paginates at 100 rows. The two units are
-// tracked separately; see sentry-autofix-second-look.mjs § COST ARITHMETIC.)
-export const MAX_CANDIDATE_EVALUATIONS = 200;
-
-/**
- * A run-time note when the evaluation window is configured above the list
- * ceiling that is applied first — the mismatch that makes a raise a silent
- * no-op. Pure (and exported) so the check is a real, testable behaviour rather
- * than an assertion nobody can exercise: a THROW here would break the select
- * step's "always emits a valid JSON array, never fails" invariant over a static
- * config mistake, so this is loud, not fatal. Returns the note, or null.
- */
-export function windowCeilingWarning(
-  evaluations = MAX_CANDIDATE_EVALUATIONS,
-  listLimit = LIST_LIMIT,
-) {
-  if (!(evaluations > listLimit)) return null;
-  return `warn: MAX_CANDIDATE_EVALUATIONS (${evaluations}) exceeds LIST_LIMIT (${listLimit}), which the API applies FIRST — the window is really ${listLimit} and raising the evaluation cap alone does nothing. Raise LIST_LIMIT too.\n`;
-}
-
-/**
- * Wrap the run's `gh` driver so ONE place sees every invocation the select leg
- * makes. Three jobs, all otherwise unmeasurable:
- *
- * 1. COUNT. The per-run `gh` volume is a documented ceiling that nothing
- *    actually measured — every cost claim in the pipeline note was arithmetic
- *    over caps. `state.ghCalls` makes it an observed number on the run record,
- *    so drift shows up before a timeout does.
- *
- * 2. FAIL CLOSED ON THROTTLING. Nearly every read in this leg fails SOFT toward
- *    MORE candidates — `readStub`, `openAutofixPrExists`, the handled-id
- *    lookups, the reverse probes all treat a rejection as "no blocker found".
- *    But the blockers they look for ARE the dedupe signals, so a rate-limited
- *    read is indistinguishable from a clean one, and a throttled run can open
- *    DUPLICATE autofix PRs while looking perfectly green. Intercepting here
- *    catches EVERY read — including ones added later — without threading a sink
- *    through four modules, and it re-throws so each existing fail-soft path
- *    behaves exactly as before locally; the caller then refuses to SELECT on the
- *    data those paths produced.
- *
- * 3. STOP SPENDING ONCE THROTTLED. The decision in (2) is taken at pass
- *    boundaries, but the loops that reach them are long: the per-stub loop alone
- *    is 2 × MAX_CANDIDATE_EVALUATIONS calls. Without this, one 403 at the head
- *    of the window is followed by ~400 more requests fired into an ACTIVE
- *    throttle before the run stands down — and GitHub's secondary limits EXTEND
- *    on continued requests and escalate to abuse detection, on a repo-shared
- *    free-plan `GITHUB_TOKEN` every other workflow draws from. "Fail closed"
- *    that spends 400 more requests is not closed at the token level. So the
- *    first rate-limit-shaped failure latches, and every later call rejects
- *    IMMEDIATELY without spawning `gh`. The same one place, for the same reason
- *    it is one place: it covers reads added later, for free.
- *
- *    It is a rejection, not a silent empty result, precisely so every existing
- *    fail-soft handler runs its normal path — and the run stands down anyway,
- *    because `state.rateLimited` is already nonzero by then. Latched calls are
- *    NOT counted: `ghCalls` must stay a count of real invocations (it is the
- *    drift detector for the timeout arithmetic), and `rateLimited` must stay a
- *    count of real throttle events, not of loop iterations after the first.
- *
- * Non-rate-limit transients keep their existing fail-soft behaviour untouched:
- * only `isRateLimitFailure` text degrades the run.
- */
-function instrumentRunGh(baseRunGh, state) {
-  return async (args) => {
-    if (state.rateLimited > 0) {
-      // Deliberately argv-free and rate-limit-shape-free: this text reaches
-      // `ghFailureText`, and a message that matched `isRateLimitFailure` would
-      // inflate the throttle count with one entry per latched call.
-      throw new Error(
-        "selection stood down: an earlier gh read failed rate-limit-shaped, so this read was not issued",
-      );
-    }
-    state.ghCalls += 1;
-    try {
-      return await baseRunGh(args);
-    } catch (err) {
-      // Classify gh's STDERR, not the whole rejection message: the message
-      // carries the argv, and argv carries agent-authored family ids.
-      const text = ghFailureText(err);
-      if (isRateLimitFailure(text)) {
-        state.rateLimited += 1;
-        if (state.rateLimited === 1) {
-          process.stderr.write(
-            `::error::rate-limit-shaped gh failure during selection: ${text.split("\n")[0]}; no further gh reads will be issued this run.\n`,
-          );
-        }
-      }
-      throw err;
-    }
-  };
-}
-
-/** The Window tripwire record at its zero state — every field the workflow's
- * `jq` reads, before anything has been counted. One source rather than a literal
- * per return path: the workflow reads these key names, so a typo in one copy
- * silently zeroes a line of the run record and no test that asserts the returned
- * OBJECT would see it. */
-const emptyWindow = () => ({
-  total: 0,
-  evaluated: 0,
-  secondLook: false,
-  secondLookTotal: 0,
-  secondLookEvaluated: 0,
-  secondLookFull: false,
-  secondLookFailed: false,
-  ghCalls: 0,
-});
-
-/** The truncation record with nothing cut — the baseline the paths that never
- * reach the family resolver return. Same reason as `emptyWindow`: `rateLimited`
- * in particular is the one key the degraded disposition rides on. */
-const noTruncations = () => ({
-  handledOverflow: 0,
-  reverseBudget: false,
-  reverseNonconvergent: false,
-  rateLimited: 0,
-});
+/** Re-exported from the extracted budget/instrumentation layer. The window's
+ * read cap and its no-op guard are part of the SELECTION contract — the select
+ * suite pins `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT` and the finalize suite
+ * derives the timeout arithmetic from it — so both keep reading them here. */
+export {
+  MAX_CANDIDATE_EVALUATIONS,
+  windowCeilingWarning,
+} from "./sentry-autofix-select-instrument.mjs";
 
 /**
  * Run the selection and report EVERY half of its outcome: the matrix entries,
@@ -286,7 +175,7 @@ const noTruncations = () => ({
  * family SIGNAL, not a confirmed duplicate, so the explicit request wins.
  */
 export async function selectAutofixRun(options, deps = {}) {
-  const state = { ghCalls: 0, rateLimited: 0 };
+  const state = newRunState();
   const runGh = instrumentRunGh(deps.runGh ?? defaultRunGh, state);
   const repo = options.repo ?? DEFAULT_REPO;
 
@@ -295,30 +184,9 @@ export async function selectAutofixRun(options, deps = {}) {
   const secondLookWarning = secondLookCeilingWarning();
   if (secondLookWarning) process.stderr.write(secondLookWarning);
 
-  /**
-   * Fail CLOSED on throttling. Every read this leg issues answers a dedupe or
-   * blocker question, and every one of them fails SOFT toward MORE candidates,
-   * so a rate-limited run cannot tell "no prior PR" from "GitHub refused to
-   * tell me" — and would open a DUPLICATE autofix PR looking green. So the run
-   * does not SELECT on data it knows is unreliable.
-   *
-   * "Fail closed" here means ZERO matrix entries plus a loud report, NOT a
-   * throw: the workflow's select step asserts it always emits a valid JSON
-   * array and never fails (the leg runs under `set -euo pipefail`), so throwing
-   * would break the contract this whole job is built around. The stand-down
-   * reports are still returned — they cost nothing and an operator reading the
-   * tracker needs the whole picture — but the degraded line dominates them.
-   */
-  const degraded = (report) => {
-    process.stderr.write(
-      `::error::selection DEGRADED: ${state.rateLimited} rate-limit-shaped gh read failure(s); emitting ZERO entries rather than selecting on unreliable dedupe data.\n`,
-    );
-    return {
-      ...report,
-      entries: [],
-      truncations: { ...report.truncations, rateLimited: state.rateLimited },
-    };
-  };
+  // Fail CLOSED: zero matrix entries plus a loud report, never a throw. Bound to
+  // this run's `state` so the call sites below read as the decision they are.
+  const degraded = (report) => degradeReport(state, report);
 
   // Single-issue live run: evaluate exactly the requested issue. A dispatch
   // cannot override the fix_scope gate (that is the point of the gate), so the
@@ -407,16 +275,9 @@ export async function selectAutofixRun(options, deps = {}) {
   // to degrade onto instead of taking the whole run record down with it.
   const window = emptyWindow();
 
-  // The single greppable operator line for the run. It is emitted by the CALLER
-  // with the count that was actually emitted, not built inside `finish()`:
-  // `degraded()` replaces `entries` with `[]` AFTER `finish()` returns, so a
-  // line built there reported `entries=2` on runs that emitted zero — on exactly
-  // the fail-closed path, the one an operator greps this line to understand.
-  const summarize = (emitted) => {
-    process.stderr.write(
-      `gh-calls=${state.ghCalls} window=${window.evaluated}/${window.total} second-look=${window.secondLook ? `${window.secondLookEvaluated}/${window.secondLookTotal}${window.secondLookFull ? "+" : ""}${window.secondLookFailed ? " (failed)" : ""}` : "no"} entries=${emitted}\n`,
-    );
-  };
+  // The run's one greppable operator line. Takes the count actually EMITTED, so
+  // a degraded run cannot report the entries it computed before standing down.
+  const summarize = (emitted) => summarizeRun(state, window, emitted);
 
   // The FIRST window list, and — like the dispatch `readStub` above and the
   // second look's own list below — a `gh` call with no fail-soft handler under
@@ -593,202 +454,13 @@ export async function selectAutofixCandidates(options, deps = {}) {
   return entries;
 }
 
-/**
- * Emit the trusted, fence-selected verdict comment body for one issue, so the
- * workflow can snapshot it to a file the fix agent reads — instead of giving the
- * agent a `gh` tool + GitHub token (which a prompt-injected agent could try to
- * exfiltrate from its process env). Uses the SAME authorship/regression fence
- * as the label + projection steps. Throws if there is no usable verdict.
- */
-export async function emitVerdict(options, deps = {}) {
-  const runGh = deps.runGh ?? defaultRunGh;
-  const stub = await readStub(
-    runGh,
-    options.repo ?? DEFAULT_REPO,
-    options.issue,
-  );
-  const selected = selectVerdictComment(stub.comments);
-  if (!selected.body) {
-    throw new Error(
-      `No usable verdict comment on issue #${options.issue} (${selected.reason}).`,
-    );
-  }
-  return selected.body;
-}
-
 // ---------------------------------------------------------------------------
-// CLI
+// CLI ENTRY. The option contract, the help text, the report writers and
+// `--emit-verdict` live in sentry-autofix-select-cli.mjs; `main` stays here
+// because it is the one function that needs both halves, and because the
+// workflow invokes THIS file (three call sites in .github/workflows/
+// sentry-autofix.yml) — the executable entry point must not move.
 // ---------------------------------------------------------------------------
-
-function usage() {
-  return `Usage: pnpm sentry:autofix:select [--repo <owner/name>] [--cap <n>]
-
-Prints a JSON array of { "issue": <number>, "shortId": "<SHORT-ID>" } matrix
-entries — the oldest capped batch of code-fix queue stubs owned by this repo
-that claim \`fix_scope: mechanical\` and do not yet have a fix PR, collapsed to
-ONE candidate per \`duplicate_of\` family. Diagnostics go to stderr.
-
-Options:
-  --repo <owner/name>  Repo the queue stubs live in (default: ${DEFAULT_REPO}).
-  --cap <n>            Max CANDIDATES to select per run — one duplicate_of family
-                       counts once, however many stubs it spans (positive int;
-                       default ${DEFAULT_CAP}).
-  --issue <n>          Single-issue live run: evaluate ONLY this issue through the
-                       same filters (the workflow_dispatch path). Opens a real
-                       fix PR if the issue is eligible. Overrides --cap.
-  --deferred-out <p>   Write the duplicate_of DEFERRAL report — a JSON array of
-                       { "issue": <number>, "reason": "<enum>" } — to this path,
-                       so the run record can distinguish an empty queue from one
-                       whose candidates were all stood down. Stdout is unchanged.
-  --skipped-out <p>    Write the fix_scope SKIP report, same shape, to this path.
-                       An architectural verdict writes nothing to the queue, so
-                       without it a window standing entirely down on scope is
-                       indistinguishable from an empty one. Stdout is unchanged.
-  --window-out <p>     Write the Window tripwire — { "total": <n>, "evaluated":
-                       <n>, "secondLook": <bool>, "secondLookTotal": <n>,
-                       "secondLookEvaluated": <n>, "secondLookFull": <bool>,
-                       "secondLookFailed": <bool>, "ghCalls": <n> } — to this
-                       path, so the run record can surface a list window that
-                       exceeded the eval cap, a bounded second look (that it ran,
-                       whether MORE rows still sat past even it, and whether its
-                       own read failed), and the run's measured \`gh\` invocation
-                       count. Stdout is unchanged.
-  --truncations-out <p> Write the cost-budget truncations — { "handledOverflow":
-                       <n>, "reverseBudget": <bool>, "reverseNonconvergent":
-                       <bool>, "rateLimited": <n> } — to this path, so the run
-                       record can surface a bounded re-attempt (a family that
-                       should have stood down but a budget capped its lookup) and
-                       a DEGRADED run (rate-limit-shaped gh failures, which force
-                       zero entries). Stdout is unchanged.
-  --emit-verdict       With --issue: print the trusted (fence-selected) verdict
-                       comment body for that issue and exit (the workflow
-                       snapshots it to a file the fix agent reads, so the agent
-                       needs no gh tool or token).
-  -h, --help           Show this help.
-`;
-}
-
-export function parseArgs(argv) {
-  const options = {
-    repo: DEFAULT_REPO,
-    cap: DEFAULT_CAP,
-    issue: null,
-    emitVerdict: false,
-    deferredOut: null,
-    skippedOut: null,
-    windowOut: null,
-    truncationsOut: null,
-    help: false,
-  };
-  const args = [...argv];
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    const readValue = () => {
-      const value = args[++i];
-      if (value == null) throw new Error(`${arg} requires a value`);
-      return value;
-    };
-    switch (arg) {
-      case "--repo":
-        options.repo = readValue();
-        break;
-      case "--cap": {
-        const value = Number(readValue());
-        if (!Number.isInteger(value) || value <= 0) {
-          throw new Error("--cap must be a positive integer");
-        }
-        options.cap = value;
-        break;
-      }
-      case "--issue": {
-        const value = Number(readValue());
-        if (!Number.isInteger(value) || value <= 0) {
-          throw new Error("--issue must be a positive integer");
-        }
-        options.issue = value;
-        break;
-      }
-      case "--emit-verdict":
-        options.emitVerdict = true;
-        break;
-      case "--deferred-out":
-        options.deferredOut = readValue();
-        break;
-      case "--skipped-out":
-        options.skippedOut = readValue();
-        break;
-      case "--window-out":
-        options.windowOut = readValue();
-        break;
-      case "--truncations-out":
-        options.truncationsOut = readValue();
-        break;
-      case "-h":
-      case "--help":
-        options.help = true;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
-    }
-  }
-  return options;
-}
-
-/** Best-effort JSON report write. A failed write degrades ONE counter on the
- * run record; it must never fail the select step, whose whole contract is that
- * it always emits a valid array. Returns whether the file was written — one
- * caller (the degraded signal) has to know. Exported because `main` is the only
- * bridge between the selector's return value and the `jq` reads the workflow
- * builds the tracker record from, and a key-name or serialization bug here is
- * invisible to every test that exercises `selectAutofixRun` alone. */
-export function writeReport(path, report, label) {
-  if (!path) return true;
-  try {
-    writeFileSync(path, `${JSON.stringify(report ?? [])}\n`);
-    return true;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(
-      `warn: could not write the ${label} report: ${message}\n`,
-    );
-    return false;
-  }
-}
-
-/**
- * Write every report file the workflow reads, and answer the one question the
- * caller must act on: was a DEGRADED run's signal lost?
- *
- * `rateLimited` reaches the workflow through exactly one channel — the
- * truncations file — and the workflow flips `disposition` to
- * `degraded-rate-limited` off it. Every OTHER field on these files is a
- * nice-to-have that degrades to "0" or a missing line. This one is the safety
- * signal: lose it and `rate_limited` reads 0, the disposition stays `active`,
- * the tracker renders a suppressed run as a healthy idle one — the #1758
- * misdiagnosis — and the record job's label backfill gate opens on reads the run
- * itself declared unreliable. So a best-effort write is the wrong contract for
- * that one case, and the caller fails the step instead. Exported for the same
- * reason `writeReport` is.
- */
-export function writeRunReports(options, run) {
-  // Report BEFORE stdout: the workflow captures stdout into a shell variable, so
-  // a failed report write must not be able to lose the entries too. All are
-  // best-effort — the run record degrades to "0" / no Window line / no
-  // truncation line, never to a dead leg.
-  writeReport(options.deferredOut, run.deferred, "deferral");
-  writeReport(options.skippedOut, run.skipped, "fix_scope skip");
-  writeReport(options.windowOut, run.window ?? {}, "window");
-  const truncations = run.truncations ?? {};
-  const wroteTruncations = writeReport(
-    options.truncationsOut,
-    truncations,
-    "truncations",
-  );
-  return {
-    lostDegradedSignal:
-      Number(truncations.rateLimited ?? 0) > 0 && !wroteTruncations,
-  };
-}
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import {
   DEFAULT_CAP,
   emitVerdict,
@@ -6,13 +10,18 @@ import {
   MAX_SECOND_LOOK_EVALUATIONS,
   parseArgs,
   SECOND_LOOK_FAMILY_BUDGETS,
+  SECOND_LOOK_LIST_ROWS,
+  secondLookCeilingWarning,
   selectAutofixCandidates,
   selectAutofixRun,
   SKIP_FIX_SCOPE_ARCHITECTURAL,
   windowCeilingWarning,
+  writeReport,
+  writeRunReports,
 } from "./sentry-autofix-select.mjs";
 import {
   AUTOFIX_SELECT_LABEL,
+  ghFailureText,
   isOwnHeadPr,
   isRateLimitFailure,
   listHandledShortIds,
@@ -3488,24 +3497,111 @@ await test("SECOND LOOK: a window that is NOT full never fires it (there is noth
   assertEqual(windowListCount(calls), 1);
 });
 
-await test("SECOND LOOK: its OWN truncation is reported, never silent", async () => {
-  // The second look has a hard evaluation ceiling of its own, so it can truncate
-  // exactly like the first window — and must say so on the same surface.
-  const stubs = starvedWindowStubs({
-    further: MAX_SECOND_LOOK_EVALUATIONS + 5,
-  });
-  const { runGh } = makeRunGh({ stubs });
-  const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
-  assertEqual(window.secondLook, true);
-  assertEqual(window.secondLookTotal, MAX_SECOND_LOOK_EVALUATIONS + 5);
-  assertEqual(
-    window.secondLookEvaluated,
-    MAX_SECOND_LOOK_EVALUATIONS,
-    "the second look stops at its own ceiling",
+await test("SECOND LOOK: its OWN shortfall is reported through `full`, which does NOT saturate", async () => {
+  // The second look stops at its own row ceiling, so it can leave stubs unread
+  // exactly like the first window — and must say so on the same surface. The
+  // counts CANNOT carry that: `secondLookTotal` is clamped by
+  // SECOND_LOOK_LIST_ROWS by construction, so it reads identically whether 5 or
+  // 5,000 further stubs sit past the ceiling. `full` (raw rows >= the row cap)
+  // is the signal that distinguishes them, and the run record's regrowth
+  // tripwire is built on it.
+  //
+  // NEGATIVE CONTROL: stop returning `full` from resolveSecondLook (or drop
+  // `window.secondLookFull = second.full === true`) and the first assertion goes
+  // false — the tracker then reads "reached the end of the queue" on the run
+  // with the most hidden behind it.
+  const many = starvedWindowStubs({ further: SECOND_LOOK_LIST_ROWS + 5 });
+  const { window: deep } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh: makeRunGh({ stubs: many }).runGh },
   );
+  assertEqual(deep.secondLook, true);
+  assertEqual(
+    deep.secondLookTotal,
+    SECOND_LOOK_LIST_ROWS,
+    "the second look reads at most its own row cap",
+  );
+  assertEqual(
+    deep.secondLookFull,
+    true,
+    "more rows sit past even the second look",
+  );
+
+  // The contrast that makes the flag mean something: a second look that reached
+  // the actual end of the queue must NOT raise it.
+  const few = starvedWindowStubs({ further: 3 });
+  const { window: shallow } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh: makeRunGh({ stubs: few }).runGh },
+  );
+  assertEqual(shallow.secondLook, true);
+  assertEqual(
+    shallow.secondLookFull,
+    false,
+    "a short second-look page means the run really did reach the end",
+  );
+});
+
+await test("PIN: MAX_SECOND_LOOK_EVALUATIONS may never exceed SECOND_LOOK_LIST_ROWS (the same no-op trap, on the pass this leg added)", () => {
+  // The invariant that `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT` pins is
+  // GENERIC — the row cap is applied server-side BEFORE the evaluation slice —
+  // but the guard for it was not: the second look shipped its own row cap with
+  // no pin and no run-time check, so raising its evaluation cap to 300 would
+  // silently read the same rows. That is precisely the failure mode this whole
+  // change exists to make impossible, reintroduced in the module it added.
   assert(
-    window.secondLookTotal > window.secondLookEvaluated,
-    "total > evaluated is what the run record renders as its truncation",
+    MAX_SECOND_LOOK_EVALUATIONS <= SECOND_LOOK_LIST_ROWS,
+    `MAX_SECOND_LOOK_EVALUATIONS (${MAX_SECOND_LOOK_EVALUATIONS}) must not exceed SECOND_LOOK_LIST_ROWS (${SECOND_LOOK_LIST_ROWS}) — raise the row cap too or the raise is a no-op`,
+  );
+  assertEqual(
+    secondLookCeilingWarning(),
+    null,
+    "the shipped pair is consistent",
+  );
+  assertEqual(secondLookCeilingWarning(100, 100), null, "equal is fine");
+  const warning = secondLookCeilingWarning(300, 100);
+  assert(
+    typeof warning === "string" &&
+      warning.includes("300") &&
+      warning.includes("100"),
+    `a raise above the row cap must warn and name both numbers, got: ${warning}`,
+  );
+});
+
+await test("SECOND LOOK: the list it issues asks for exactly the rows past what the FIRST pass consumed", async () => {
+  // Two things no assertion on `calls.length` can see, because the mock returns
+  // a whole array from one call and `calls.length` is structurally invariant to
+  // `--limit`:
+  //   1. the `--limit` is the only term that makes gh INVOCATIONS and API
+  //      REQUESTS differ, so the cost pin below is blind to it;
+  //   2. the offset must derive from what the first pass actually consumed, not
+  //      from LIST_LIMIT. They are equal today, but under a LOWER eval cap a
+  //      LIST_LIMIT skip would jump the rows between the two — read by neither
+  //      pass, a permanent hole in the middle of the window.
+  //
+  // NEGATIVE CONTROL: change `skipRawRows` back to `LIST_LIMIT` while lowering
+  // MAX_CANDIDATE_EVALUATIONS, or drop `skipRawRows` so the second look re-reads
+  // from row 0, and the offset assertion below fails.
+  const stubs = starvedWindowStubs({ further: 3 });
+  const { runGh, calls } = makeRunGh({ stubs });
+  await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
+  const windowLists = calls.filter(
+    (c) =>
+      c[0] === "issue" &&
+      c[1] === "list" &&
+      /sort:created-asc/.test(String(c[c.indexOf("--search") + 1] ?? "")),
+  );
+  assertEqual(windowLists.length, 2, "one first-pass list, one second look");
+  const expectedSkip = Math.min(MAX_CANDIDATE_EVALUATIONS, LIST_LIMIT);
+  assertEqual(
+    windowLimit(windowLists[0]),
+    LIST_LIMIT,
+    "the first pass asks for the list ceiling",
+  );
+  assertEqual(
+    windowLimit(windowLists[1]),
+    expectedSkip + SECOND_LOOK_LIST_ROWS,
+    "the second look asks for the first pass's offset PLUS its own row cap",
   );
 });
 
@@ -3717,6 +3813,607 @@ await test("FAIL CLOSED: a degraded first pass never spends a second look", asyn
     windowListCount(calls),
     1,
     "no second window list is issued once the run is degraded",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Hardening round: the second look's throw site, the throttle latch, the
+// knowledge it inherits, and the CLI layer that carries the degraded signal.
+// ---------------------------------------------------------------------------
+
+function isWindowListArgs(args) {
+  return (
+    args[0] === "issue" &&
+    args[1] === "list" &&
+    /sort:created-asc/.test(String(args[args.indexOf("--search") + 1] ?? ""))
+  );
+}
+
+/**
+ * A FULL, entirely-unselectable first window whose head stub declares BLK (a
+ * sibling that already carries a TERMINAL marker), plus five selectable stubs
+ * past the ceiling. The LAST of those five also declares BLK — so it is a member
+ * of a family this same run has already proven is handled.
+ *
+ * The four before it exist to spend the second look's whole handled-id budget
+ * (MAX_DUPLICATE_LOOKUPS = 5 declared ids each × 4 = 20 =
+ * SECOND_LOOK_FAMILY_BUDGETS.handled), which is what makes BLK unreachable to a
+ * second look that has to re-derive it from scratch.
+ */
+function inheritedBlockerFixture() {
+  const stubs = [];
+  for (let i = 0; i < LIST_LIMIT; i += 1) {
+    stubs.push(
+      familyStub(
+        7100 + i,
+        `ANALYTICS-MENTO-ORG-B${i}`,
+        orderedCreatedAt(i),
+        i === 0 ? ["ANALYTICS-MENTO-ORG-BLK"] : [],
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  for (let i = 0; i < 4; i += 1) {
+    stubs.push(
+      familyStub(
+        7600 + i,
+        `ANALYTICS-MENTO-ORG-G${i}`,
+        orderedCreatedAt(LIST_LIMIT + i),
+        Array.from(
+          { length: MAX_DUPLICATE_LOOKUPS },
+          (_, j) => `ANALYTICS-MENTO-ORG-GH${i}X${j}`,
+        ),
+      ),
+    );
+  }
+  stubs.push(
+    familyStub(
+      7699,
+      "ANALYTICS-MENTO-ORG-GZ",
+      orderedCreatedAt(LIST_LIMIT + 4),
+      ["ANALYTICS-MENTO-ORG-BLK"],
+    ),
+  );
+  return makeRunGh({
+    stubs,
+    handled: [{ shortId: "ANALYTICS-MENTO-ORG-BLK", label: FIX_REFUSED_LABEL }],
+  });
+}
+
+await test("SECOND LOOK: it inherits the first pass's proven blockers instead of re-deriving them on half the budget", async () => {
+  // The precondition for a second look is that the first pass found a blocker
+  // for EVERYTHING — so the run has already PROVEN those blockers exist. Handing
+  // a smaller budget the same work from scratch is strictly weaker, and every
+  // budget in the family resolver fails OPEN toward MORE candidates: a blocker it
+  // cannot afford to look up is reported as "not handled". Here BLK is the 21st
+  // declared id the second look would have to query on a budget of 20, so without
+  // the seed #7699 is selected — a second autofix PR for a family whose sibling
+  // this same run just read a REFUSED marker off. No rate limit, no transient,
+  // and no way to see it afterwards except a truncation flag on the run record,
+  // rendered after the PR is already open.
+  //
+  // NEGATIVE CONTROL: drop `seed: resolved` from the resolveSecondLook call in
+  // selectAutofixRun (or stop returning `resolved` from resolveFamilies) and
+  // #7699 appears in `entries` — the duplicate.
+  const { runGh } = inheritedBlockerFixture();
+  const { entries, deferred } = await selectAutofixRun(
+    { repo: "o/r", cap: 6 },
+    { runGh },
+  );
+  const selectedIssues = entries.map((e) => e.issue);
+  assertDeepEqual(
+    selectedIssues,
+    [7600, 7601, 7602, 7603],
+    "the four unblocked further stubs are selected",
+  );
+  assert(
+    !selectedIssues.includes(7699),
+    "a stub whose family the FIRST pass proved handled must never be selected by the second look",
+  );
+  assert(
+    deferred.some((d) => d.issue === 7699),
+    `the inherited blocker must be reported as a deferral, got: ${JSON.stringify(deferred)}`,
+  );
+});
+
+/**
+ * The starvation shape that ALSO exercises the reverse leg: a first pass with
+ * real finalists whose families the reverse `in:comments` probe then stands
+ * ENTIRELY down, so the run selects nothing off a page that is full of RAW rows
+ * (mostly foreign-project ones the client filter drops). That is the only way to
+ * reach a second look with a populated `alreadyProbed` set — which is exactly
+ * the state the seed creates.
+ */
+function reverseStoodDownFixture({ locals = 6, further = 5 } = {}) {
+  const stubs = [];
+  const handled = [];
+  for (let i = 0; i < locals; i += 1) {
+    stubs.push(
+      familyStub(
+        7200 + i,
+        `ANALYTICS-MENTO-ORG-R${i}`,
+        orderedCreatedAt(i),
+        Array.from(
+          { length: MAX_DUPLICATE_LOOKUPS },
+          (_, j) => `ANALYTICS-MENTO-ORG-RH${i}X${j}`,
+        ),
+      ),
+    );
+    // A TERMINAL sibling reachable only through the reverse probe: it names the
+    // family's first hub in its own verdict, so the probe admits the edge and
+    // its refusal marker stands the whole family down.
+    handled.push({
+      shortId: `ANALYTICS-MENTO-ORG-RT${i}`,
+      label: FIX_REFUSED_LABEL,
+      declares: [`ANALYTICS-MENTO-ORG-RH${i}X0`],
+    });
+  }
+  // Foreign-project rows: the server returns them (they match the tokenized
+  // `<slug> in:title` filter), the exact project gate drops them. They are what
+  // makes the page RAW-full without adding candidates.
+  for (let i = 0; stubs.length < LIST_LIMIT; i += 1) {
+    stubs.push({
+      number: 7300 + i,
+      shortId: `APP-MENTO-ORG-R${i}`,
+      title: `[sentry] APP-MENTO-ORG-R${i} (app-mento-org, error)`,
+      labels: [AUTOFIX_SELECT_LABEL, "sentry-triage"],
+      createdAt: orderedCreatedAt(locals + i),
+      comments: [verdictComment()],
+    });
+  }
+  for (let i = 0; i < further; i += 1) {
+    stubs.push(
+      familyStub(
+        7400 + i,
+        `ANALYTICS-MENTO-ORG-S${i}`,
+        orderedCreatedAt(LIST_LIMIT + i),
+        Array.from(
+          { length: MAX_DUPLICATE_LOOKUPS },
+          (_, j) => `ANALYTICS-MENTO-ORG-SH${i}X${j}`,
+        ),
+      ),
+    );
+  }
+  return makeRunGh({ stubs, handled });
+}
+
+await test("SECOND LOOK: the ids the first pass PROBED are skipped, but its probe SPEND is not charged to the second look", async () => {
+  // The seed carries knowledge, never spend. `alreadyProbed` is a dedupe set —
+  // seeding it is what stops the second look re-issuing searches the run already
+  // paid for — but the probe budget used to be metered as `alreadyProbed.size`,
+  // so a seeded set larger than the second look's cap reads as "budget already
+  // spent" and the pass probes NOTHING while reporting itself truncated. That
+  // turns the seed, whose whole purpose is to make this pass stronger, into the
+  // thing that blinds it.
+  //
+  // NEGATIVE CONTROL: change the budget check in reverseVerifyFamilies back to
+  // `probed.size >= maxProbes` and the second look's probe count below drops to
+  // 0 while the first pass's stays exactly the same.
+  const { runGh, calls } = reverseStoodDownFixture();
+  const { entries, window } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertEqual(window.secondLook, true, "this pin must take a second look");
+  const secondListAt = calls.findIndex(
+    (c, i) => isWindowListArgs(c) && calls.slice(0, i).some(isWindowListArgs),
+  );
+  assert(secondListAt > 0, "the second look's own list must be locatable");
+  const firstPassProbes = reverseSearchCount(calls.slice(0, secondListAt));
+  const secondLookProbes = reverseSearchCount(calls.slice(secondListAt));
+  assert(
+    firstPassProbes > SECOND_LOOK_FAMILY_BUDGETS.probe,
+    `the first pass must probe MORE ids than the second look's whole budget, or this proves nothing (got ${firstPassProbes})`,
+  );
+  assert(
+    secondLookProbes > 0,
+    "the second look must get its own probe allowance despite the seeded set",
+  );
+  assertDeepEqual(
+    entries.map((e) => e.issue),
+    [7400, 7401],
+    "and it still reaches the selectable stubs past the ceiling",
+  );
+});
+
+await test("SECOND LOOK: a failing list read does NOT fail the step — the first pass's result stands", async () => {
+  // The second look's list is the ONE gh call in this leg with no fail-soft
+  // handler under it, and this leg put it on the FREQUENT path: once the queue
+  // is >= LIST_LIMIT rows, every no-selection run depends on it. Unhandled, its
+  // rejection reaches main(), sets exit 1, and kills the select step under
+  // `set -euo pipefail` — destroying the whole run record, the deferral and skip
+  // reports, and the DEGRADED line, on a run that before this change exited 0
+  // with a clean `[]`.
+  //
+  // NEGATIVE CONTROL: remove the try/catch around resolveSecondLook in
+  // selectAutofixRun and this test throws instead of returning.
+  const { runGh: base } = makeRunGh({
+    stubs: starvedWindowStubs({ further: 3 }),
+  });
+  let windowLists = 0;
+  const runGh = async (args) => {
+    if (isWindowListArgs(args)) {
+      windowLists += 1;
+      if (windowLists === 2) {
+        throw new Error("gh issue list failed with exit 1:\nread ECONNRESET");
+      }
+    }
+    return base(args);
+  };
+  const { entries, skipped, window, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, [], "nothing was selectable, and nothing throws");
+  assertEqual(
+    skipped.length,
+    LIST_LIMIT,
+    "the first pass's report survives the second look's failure intact",
+  );
+  assertEqual(window.secondLook, true, "the attempt is still recorded");
+  assertEqual(
+    window.secondLookFailed,
+    true,
+    "and so is the fact that it could not read — never a silent zero",
+  );
+  assertEqual(
+    truncations.rateLimited,
+    0,
+    "an ordinary transient here is not a throttle",
+  );
+});
+
+await test("SECOND LOOK: a RATE-LIMITED list read degrades the run instead of failing the step", async () => {
+  // The worse half of the same throw site: a 403 there propagated out of
+  // selectAutofixRun before `degraded()` could ever run, so the step died and
+  // `rate_limited` / the DEGRADED run-record line never rendered — the run went
+  // out as a select failure with no record of WHY.
+  const { runGh: base } = makeRunGh({
+    stubs: starvedWindowStubs({ further: 3 }),
+  });
+  let windowLists = 0;
+  const runGh = async (args) => {
+    if (isWindowListArgs(args)) {
+      windowLists += 1;
+      if (windowLists === 2) {
+        const err = new Error("gh issue list failed with exit 1");
+        err.ghStderr = "HTTP 403: API rate limit exceeded for user ID 1234.";
+        throw err;
+      }
+    }
+    return base(args);
+  };
+  const { entries, window, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assert(Array.isArray(entries), "the always-emits-an-array contract holds");
+  assertDeepEqual(entries, []);
+  assertEqual(window.secondLookFailed, true);
+  assert(
+    truncations.rateLimited > 0,
+    "the throttle must reach the disposition flip, not die with the step",
+  );
+});
+
+await test("FAIL CLOSED: a throttled run stops ISSUING reads, it does not spend the rest of the window into an active limit", async () => {
+  // Fail-closed at the token level, not only at the selection. GitHub's
+  // secondary limits EXTEND on continued requests and escalate to abuse
+  // detection, and this is the repo-shared free-plan GITHUB_TOKEN. Before the
+  // latch, one 403 at the head of a 200-wide window was followed by ~400 more
+  // subprocesses before the run stood down.
+  //
+  // NEGATIVE CONTROL: remove the `state.rateLimited > 0` short-circuit at the
+  // top of instrumentRunGh (and the matching break in the evaluation loop) and
+  // the call count jumps to the full window's ~400.
+  const { runGh, calls } = makeRunGh({
+    stubs: starvedWindowStubs({ further: 3 }),
+    openPrError:
+      "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234.",
+  });
+  const { entries, window, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, []);
+  assertEqual(truncations.rateLimited, 1, "exactly ONE real throttle event");
+  assert(
+    calls.length <= 5,
+    `a throttled run must stop issuing reads, got ${calls.length} (unlatched it made 2 x ${MAX_CANDIDATE_EVALUATIONS} + more)`,
+  );
+  assertEqual(
+    window.ghCalls,
+    calls.length,
+    "latched (never issued) reads must not inflate the measured invocation count",
+  );
+});
+
+await test("FAIL CLOSED: the latch holds where the loop break cannot — a throttle DURING family resolution", async () => {
+  // The two mechanisms are not interchangeable, and this is the half only the
+  // latch covers. The evaluation loop has already finished here; what remains is
+  // the family budget, up to MAX_HANDLED_ID_QUERIES in:title searches plus the
+  // reverse probes and verify reads on top. Breaking a loop the run has left
+  // does nothing for that, and every one of those reads is separately
+  // try/caught, so without the latch each simply fails soft and the next one
+  // fires into the same active limit.
+  //
+  // NEGATIVE CONTROL: remove the `state.rateLimited > 0` short-circuit at the
+  // top of instrumentRunGh and the in:title count below jumps from 1 to
+  // MAX_HANDLED_ID_QUERIES.
+  const stubs = [];
+  const hubIds = [];
+  for (let i = 0; i < 30; i += 1) {
+    const hubs = Array.from(
+      { length: MAX_DUPLICATE_LOOKUPS },
+      (_, j) => `ANALYTICS-MENTO-ORG-LH${i}X${j}`,
+    );
+    hubIds.push(...hubs);
+    stubs.push(
+      familyStub(
+        7900 + i,
+        `ANALYTICS-MENTO-ORG-L${i}`,
+        orderedCreatedAt(i),
+        hubs,
+      ),
+    );
+  }
+  const { runGh, calls } = makeRunGh({
+    stubs,
+    handledLookupErrorIds: hubIds,
+    handledLookupErrorMessage:
+      "gh issue list failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234.",
+  });
+  const { entries, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, [], "the run still fails closed");
+  assertEqual(truncations.rateLimited, 1, "exactly ONE real throttle event");
+  assertEqual(
+    titleSearchCount(calls),
+    1,
+    `the throttled family pass must issue no further lookups, got ${titleSearchCount(calls)} of a ${MAX_HANDLED_ID_QUERIES} budget`,
+  );
+  assertEqual(
+    reverseSearchCount(calls),
+    0,
+    "and no reverse probe may fire after the limit is known",
+  );
+});
+
+await test("FAIL CLOSED: the throttled window evaluation LEAVES, it does not grind out a skip line per remaining stub", async () => {
+  // The latch makes the remaining reads free, so this is legibility rather than
+  // spend — but 200 `skip #N` lines burying the one `::error::` that explains
+  // the run is its own failure to communicate, on the surface an operator reads
+  // when the tracker says DEGRADED.
+  //
+  // NEGATIVE CONTROL: remove the `state.rateLimited > 0` break from the window
+  // evaluation loop in selectAutofixRun and the skip-line count below goes to
+  // the whole window's ${LIST_LIMIT}.
+  const { runGh } = makeRunGh({
+    stubs: starvedWindowStubs({ further: 3 }),
+    openPrError:
+      "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234.",
+  });
+  const { stderr } = await captureStderr(() =>
+    selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh }),
+  );
+  const skipLines = stderr
+    .split("\n")
+    .filter((line) => line.startsWith("skip #")).length;
+  assert(
+    skipLines <= 2,
+    `a throttled run must leave the window loop, got ${skipLines} skip lines`,
+  );
+  assert(
+    stderr.includes("stopping the window evaluation"),
+    "and it must say why it left",
+  );
+});
+
+await test("INSTRUMENTATION: the operator summary line reports the count actually EMITTED, not the pre-degradation one", async () => {
+  // `finish()` is passed AS THE ARGUMENT to `degraded()`, which only then
+  // replaces `entries` with []. A summary built inside `finish()` therefore said
+  // `entries=2` on a run that emitted zero — on exactly the fail-closed path,
+  // the one an operator greps this line to understand.
+  //
+  // NEGATIVE CONTROL: move the `summarize(...)` call back inside `finish()` (so
+  // it reads `entries.length` before degradation) and the assertion below sees
+  // a nonzero count.
+  const { runGh } = dedupeBlockedFixture(
+    "gh issue list failed with exit 1:\nHTTP 403: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.",
+  );
+  const { result, stderr } = await captureStderr(() =>
+    selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh }),
+  );
+  assertDeepEqual(result.entries, []);
+  const summary = stderr
+    .split("\n")
+    .filter((line) => line.startsWith("gh-calls="));
+  assertEqual(summary.length, 1, `exactly one summary line, got: ${summary}`);
+  assert(
+    /\bentries=0$/.test(summary[0]),
+    `the summary must report the emitted count, got: ${summary[0]}`,
+  );
+});
+
+await test("isRateLimitFailure: the bare HTTP 403 permissions branch is load-bearing on its own", async () => {
+  // Every other positive case in this suite that contains "HTTP 403" ALSO
+  // contains "rate limit" wording, so deleting the `/\bHTTP 403\b/` pattern left
+  // the whole suite green — while a real `HTTP 403: Bad credentials` (an App
+  // token that lost its installation, the shape this leg is most likely to meet)
+  // would stop degrading the run. Matching it is a deliberate trade: a
+  // permissions failure and a throttle both mean "this read did not answer the
+  // dedupe question", and the only safe action for either is the same one.
+  //
+  // NEGATIVE CONTROL: delete `/\bHTTP 403\b/` from RATE_LIMIT_PATTERNS and this
+  // test reds while every other test in the suite stays green.
+  assert(
+    isRateLimitFailure("HTTP 403: Bad credentials"),
+    "a bare 403 with no throttle wording must still stand the run down",
+  );
+  assert(
+    isRateLimitFailure("HTTP 403: Resource not accessible by integration"),
+    "the App-permissions shape must too",
+  );
+  assert(
+    !isRateLimitFailure("HTTP 401: Bad credentials"),
+    "and it must be the 403 specifically, not any auth-shaped error",
+  );
+});
+
+await test("isRateLimitFailure is classified on gh's STDERR, never on the argv the message also carries", async () => {
+  // `defaultRunGh` builds `gh <argv> failed with exit N:\n<stderr>`, and argv
+  // carries AGENT-authored text: family ids come from an LLM's `duplicate_of`
+  // and are interpolated into the `in:title` / `in:comments` searches, with a
+  // charset (`[A-Za-z0-9._-]`) that admits `RATELIMITEXCEEDED` as a legal id.
+  // Classified against the whole message, any unrelated failure of that one
+  // probe — 404, 502, ECONNRESET — would stand the entire run down.
+  //
+  // NEGATIVE CONTROL: make ghFailureText return `err.message` and the first
+  // assertion below flips.
+  const err = new Error(
+    'gh issue list --repo o/r --search "ANALYTICS-MENTO-ORG-RATELIMITEXCEEDED" in:title failed with exit 1:\nHTTP 404: Not Found',
+  );
+  err.ghStderr = "HTTP 404: Not Found";
+  assert(
+    !isRateLimitFailure(ghFailureText(err)),
+    "an unrelated 404 on a probe for an awkwardly-named family id is not a throttle",
+  );
+  assert(
+    isRateLimitFailure(err.message),
+    "the hazard is real: the same message classified WHOLE does match",
+  );
+  // Rejections with no captured stderr (a spawn error, or a test double) keep
+  // the old behaviour exactly.
+  const plain = new Error(
+    "gh api failed with exit 1:\nHTTP 429 Too Many Requests",
+  );
+  assert(
+    isRateLimitFailure(ghFailureText(plain)),
+    "a rejection without ghStderr still classifies on its message",
+  );
+});
+
+await test("CLI: --truncations-out round-trips, and the files it writes carry the exact keys the workflow's jq reads", async () => {
+  // The file layer is the ACTUAL bridge between the selector's return value and
+  // the tracker: the workflow reads `.rateLimited`, `.secondLookFull` and the
+  // rest with jq. Every other test here asserts the returned OBJECT, so a
+  // key-name or serialization bug in this layer would pass all of them and
+  // silently zero the whole run record. `--truncations-out` in particular had no
+  // test presence at all, and it is the flag the degraded disposition rides on.
+  const parsed = parseArgs([
+    "--repo",
+    "o/r",
+    "--truncations-out",
+    "/tmp/t.json",
+    "--window-out",
+    "/tmp/w.json",
+  ]);
+  assertEqual(parsed.truncationsOut, "/tmp/t.json");
+  assertEqual(parsed.windowOut, "/tmp/w.json");
+
+  const dir = mkdtempSync(join(tmpdir(), "autofix-select-"));
+  try {
+    const windowOut = join(dir, "window.json");
+    const truncationsOut = join(dir, "truncations.json");
+    const deferredOut = join(dir, "deferred.json");
+    const { lostDegradedSignal } = writeRunReports(
+      {
+        deferredOut,
+        skippedOut: join(dir, "skipped.json"),
+        windowOut,
+        truncationsOut,
+      },
+      {
+        entries: [],
+        deferred: [{ issue: 12, reason: DEFER_FAMILY_HANDLED }],
+        skipped: [],
+        window: {
+          total: 200,
+          evaluated: 200,
+          secondLook: true,
+          secondLookTotal: 100,
+          secondLookEvaluated: 100,
+          secondLookFull: true,
+          secondLookFailed: false,
+          ghCalls: 782,
+        },
+        truncations: {
+          handledOverflow: 0,
+          reverseBudget: false,
+          reverseNonconvergent: false,
+          rateLimited: 0,
+        },
+      },
+    );
+    assertEqual(lostDegradedSignal, false, "a clean write loses nothing");
+    const written = JSON.parse(readFileSync(windowOut, "utf8"));
+    assertEqual(written.secondLookFull, true);
+    assertEqual(written.secondLookFailed, false);
+    assertEqual(written.ghCalls, 782);
+    assertEqual(
+      JSON.parse(readFileSync(truncationsOut, "utf8")).rateLimited,
+      0,
+    );
+    assertDeepEqual(JSON.parse(readFileSync(deferredOut, "utf8")), [
+      { issue: 12, reason: DEFER_FAMILY_HANDLED },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test("CLI: a DEGRADED run whose truncations report cannot be written fails LOUD rather than rendering as idle", async () => {
+  // `rateLimited` reaches the workflow through exactly one channel — this file —
+  // and the disposition flip to `degraded-rate-limited` rides on it. Every other
+  // field degrades to "0" or a missing line; this one is the safety signal. Lose
+  // it and the tracker says `State: active, Candidates selected: 0`, the #1758
+  // misreading, AND the record job's label backfill gate opens on reads the run
+  // itself declared unreliable. So this one write is not best-effort: the step
+  // fails instead. The array contract still held — it is written, and it is `[]`,
+  // so no PR can come out of the run either way.
+  //
+  // NEGATIVE CONTROL: make writeRunReports always report
+  // `lostDegradedSignal: false` and the first assertion below flips.
+  const unwritable = join(tmpdir(), "autofix-select-missing-dir", "t.json");
+  const degradedRun = {
+    entries: [],
+    deferred: [],
+    skipped: [],
+    window: {},
+    truncations: { rateLimited: 3 },
+  };
+  const { result, stderr } = await captureStderr(() =>
+    writeRunReports({ truncationsOut: unwritable }, degradedRun),
+  );
+  assertEqual(
+    result.lostDegradedSignal,
+    true,
+    "a lost degraded signal must be reported to the caller",
+  );
+  assert(
+    /could not write the truncations report/.test(stderr),
+    `the write failure must still be logged, got: ${stderr}`,
+  );
+  // A HEALTHY run losing the same file is NOT fatal: there is no signal to lose,
+  // and the always-emits-an-array-and-exit-0 contract stays absolute everywhere
+  // else.
+  const healthy = await captureStderr(() =>
+    writeRunReports(
+      { truncationsOut: unwritable },
+      { ...degradedRun, truncations: { rateLimited: 0 } },
+    ),
+  );
+  assertEqual(
+    healthy.result.lostDegradedSignal,
+    false,
+    "a healthy run's lost report must never fail the step",
+  );
+  assertEqual(
+    writeReport(unwritable, {}, "truncations"),
+    false,
+    "writeReport reports its own failure",
   );
 });
 

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -3542,6 +3542,68 @@ await test("SECOND LOOK: its OWN shortfall is reported through `full`, which doe
   );
 });
 
+await test("SECOND LOOK: `full` is a SENTINEL fact — a queue EXACTLY at the ceiling is not 'more remains'", async () => {
+  // The boundary the plain `rawCount >= limit` form gets wrong, and the whole
+  // reason this pass reads ONE row past its own ceiling. `full` is published on
+  // the tracker as `— and MORE rows sit past even that`, the standing regrowth
+  // tripwire: a definite claim that the queue is outgrowing one run's reach.
+  // At EXACTLY `skip + SECOND_LOOK_LIST_ROWS` raw rows nothing sits past the
+  // second look, so the claim is false — and false PERMANENTLY, because that
+  // state is stable: the operator is told to act on growth that is not there.
+  //
+  // NEGATIVE CONTROL: drop `sentinel: true` from resolveSecondLook's list call,
+  // or revert `full` in listCodeFixStubsPage to `list.length >= limit`, and the
+  // exactly-at-the-ceiling assertion below flips to true while the one-row-past
+  // assertion stays true — the flag stops distinguishing the two states at all.
+  const skip = Math.min(MAX_CANDIDATE_EVALUATIONS, LIST_LIMIT);
+  assertEqual(
+    skip,
+    LIST_LIMIT,
+    "starvedWindowStubs fills exactly LIST_LIMIT window rows, so the offset must be that",
+  );
+
+  // Exactly at the ceiling: skip + SECOND_LOOK_LIST_ROWS raw rows, none beyond.
+  const { window: exact } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    {
+      runGh: makeRunGh({
+        stubs: starvedWindowStubs({ further: SECOND_LOOK_LIST_ROWS }),
+      }).runGh,
+    },
+  );
+  assertEqual(exact.secondLook, true, "the second look must have run");
+  assertEqual(
+    exact.secondLookTotal,
+    SECOND_LOOK_LIST_ROWS,
+    "and it must have read its whole row cap, or the boundary is not exercised",
+  );
+  assertEqual(
+    exact.secondLookFull,
+    false,
+    "a queue that ENDS at the ceiling must not be reported as having more past it",
+  );
+
+  // One row beyond: the sentinel comes back, and the claim becomes true.
+  const { window: past } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    {
+      runGh: makeRunGh({
+        stubs: starvedWindowStubs({ further: SECOND_LOOK_LIST_ROWS + 1 }),
+      }).runGh,
+    },
+  );
+  assertEqual(
+    past.secondLookTotal,
+    SECOND_LOOK_LIST_ROWS,
+    "the counts are identical either side of the boundary — only `full` moves",
+  );
+  assertEqual(
+    past.secondLookFull,
+    true,
+    "ONE row past the ceiling must be reported as more remaining",
+  );
+});
+
 await test("PIN: MAX_SECOND_LOOK_EVALUATIONS may never exceed SECOND_LOOK_LIST_ROWS (the same no-op trap, on the pass this leg added)", () => {
   // The invariant that `MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT` pins is
   // GENERIC — the row cap is applied server-side BEFORE the evaluation slice —
@@ -3578,10 +3640,14 @@ await test("SECOND LOOK: the list it issues asks for exactly the rows past what 
   //      from LIST_LIMIT. They are equal today, but under a LOWER eval cap a
   //      LIST_LIMIT skip would jump the rows between the two — read by neither
   //      pass, a permanent hole in the middle of the window.
+  //   3. the trailing `+ 1` is the SENTINEL row that makes `full` a fact rather
+  //      than a guess, and it is the entire API-request delta the cost bound
+  //      documents (301 rows = 4 pages, not 3).
   //
   // NEGATIVE CONTROL: change `skipRawRows` back to `LIST_LIMIT` while lowering
   // MAX_CANDIDATE_EVALUATIONS, or drop `skipRawRows` so the second look re-reads
-  // from row 0, and the offset assertion below fails.
+  // from row 0, and the offset assertion below fails; drop `sentinel: true` and
+  // the same assertion fails on the `+ 1`.
   const stubs = starvedWindowStubs({ further: 3 });
   const { runGh, calls } = makeRunGh({ stubs });
   await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
@@ -3600,8 +3666,8 @@ await test("SECOND LOOK: the list it issues asks for exactly the rows past what 
   );
   assertEqual(
     windowLimit(windowLists[1]),
-    expectedSkip + SECOND_LOOK_LIST_ROWS,
-    "the second look asks for the first pass's offset PLUS its own row cap",
+    expectedSkip + SECOND_LOOK_LIST_ROWS + 1,
+    "the second look asks for the first pass's offset PLUS its own row cap PLUS the sentinel row",
   );
 });
 
@@ -4093,6 +4159,192 @@ await test("SECOND LOOK: a RATE-LIMITED list read degrades the run instead of fa
   assert(
     truncations.rateLimited > 0,
     "the throttle must reach the disposition flip, not die with the step",
+  );
+});
+
+/** A rejection shaped like the one `defaultRunGh` builds for a throttled call:
+ * the argv-carrying message plus gh's own stderr on `ghStderr`, which is the
+ * only half `isRateLimitFailure` may be run against. */
+function throttleError(argv = "gh issue list --repo o/r") {
+  const err = new Error(`${argv} failed with exit 1`);
+  err.ghStderr = "HTTP 403: API rate limit exceeded for user ID 1234.";
+  return err;
+}
+
+/** Round-trip a run through the report writer the CLI uses, so a fail-closed
+ * assertion covers the channel the disposition flip ACTUALLY rides — the
+ * truncations file — instead of only the returned object. Returns the parsed
+ * file plus whether the degraded signal survived. */
+function writeAndReadTruncations(run) {
+  const dir = mkdtempSync(join(tmpdir(), "autofix-select-failclosed-"));
+  try {
+    const truncationsOut = join(dir, "truncations.json");
+    const { lostDegradedSignal } = writeRunReports({ truncationsOut }, run);
+    return {
+      lostDegradedSignal,
+      written: JSON.parse(readFileSync(truncationsOut, "utf8")),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+await test("FAIL CLOSED: a THROTTLED FIRST window list degrades the run instead of failing the step", async () => {
+  // The third and last unhandled throw site, and the one on the most common
+  // path: the batch run's very FIRST read. `instrumentRunGh` counts the throttle
+  // and RETHROWS by design (so every fail-soft handler downstream keeps its
+  // exact behaviour), so the rejection left `selectAutofixRun` untouched, `main`
+  // set exit 1, and the step died under `set -euo pipefail` — taking the JSON
+  // array, the `::error::` line, `truncations.rateLimited` and the
+  // `degraded-rate-limited` disposition with it. The run went out as a select
+  // FAILURE with no record of why, which is the exact inverse of the contract
+  // this leg is built on. The second look's list was already wrapped for this
+  // reason; this one and the dispatch read were missed.
+  //
+  // NEGATIVE CONTROL: remove the try/catch around `listCodeFixStubsPage` in
+  // selectAutofixRun and this test throws instead of returning.
+  const { runGh: base } = makeRunGh({
+    stubs: starvedWindowStubs({ further: 3 }),
+  });
+  const runGh = async (args) => {
+    if (isWindowListArgs(args)) throw throttleError();
+    return base(args);
+  };
+  const { result, stderr } = await captureStderr(() =>
+    selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh }),
+  );
+  // The invariant the workflow header asserts: ALWAYS a valid array, NEVER a
+  // throw. Reaching this line at all is half the assertion.
+  assert(
+    Array.isArray(result.entries),
+    "the leg must still emit a valid array",
+  );
+  assertDeepEqual(result.entries, []);
+  assert(
+    result.truncations.rateLimited > 0,
+    "the degradation must be reported, not silent",
+  );
+  assertEqual(
+    result.window.total,
+    0,
+    "a window that was never read must not claim stubs it did not see",
+  );
+  assertEqual(result.window.evaluated, 0);
+  assertEqual(result.window.ghCalls, 1, "and the one issued read is counted");
+  assert(
+    stderr.includes("::error::selection DEGRADED"),
+    `the loud report must still be written, got: ${stderr}`,
+  );
+  // exit 0: `main` fails the step only when the degraded signal is LOST, so the
+  // report has to survive the file layer too — that is the channel the
+  // disposition flip rides.
+  const { lostDegradedSignal, written } = writeAndReadTruncations(result);
+  assertEqual(lostDegradedSignal, false, "the degraded run still exits 0");
+  assert(
+    written.rateLimited > 0,
+    `the truncations file must carry the throttle, got: ${JSON.stringify(written)}`,
+  );
+});
+
+await test("FAIL CLOSED: a THROTTLED dispatch readStub degrades the run instead of failing the step", async () => {
+  // The dispatch path's first read, same shape and the same stakes: the
+  // documented remedy for a stalled leg must not be the one path that turns a
+  // throttle into a dead step with no run record.
+  //
+  // NEGATIVE CONTROL: remove the try/catch around `readStub` in the
+  // `options.issue != null` branch and this test throws instead of returning.
+  const { runGh: base } = makeRunGh({
+    stubs: [stub({ number: 8400, shortId: "ANALYTICS-MENTO-ORG-DR" })],
+  });
+  const runGh = async (args) => {
+    if (args[0] === "issue" && args[1] === "view") {
+      throw throttleError("gh issue view 8400 --repo o/r");
+    }
+    return base(args);
+  };
+  const { result, stderr } = await captureStderr(() =>
+    selectAutofixRun({ repo: "o/r", issue: 8400 }, { runGh }),
+  );
+  assert(
+    Array.isArray(result.entries),
+    "the leg must still emit a valid array",
+  );
+  assertDeepEqual(result.entries, []);
+  assert(result.truncations.rateLimited > 0, "the degradation is reported");
+  assertEqual(
+    result.window.evaluated,
+    0,
+    "the stub was never read, so it was never evaluated",
+  );
+  assert(
+    stderr.includes("::error::selection DEGRADED"),
+    `the loud report must still be written, got: ${stderr}`,
+  );
+  const { lostDegradedSignal, written } = writeAndReadTruncations(result);
+  assertEqual(lostDegradedSignal, false, "the degraded run still exits 0");
+  assert(written.rateLimited > 0, "the truncations file carries the throttle");
+});
+
+await test("FAIL CLOSED: a NON-throttle failure on those same reads still FAILS the step, unchanged", async () => {
+  // The scoping half, and the reason the two catches above test
+  // `state.rateLimited` rather than swallowing everything. A rate limit is the
+  // dedupe hazard this leg fails closed against — the read did not answer, and
+  // selecting on that opens duplicate PRs — so it degrades and reports. A
+  // TOTAL failure of the same read (transport gone, malformed body, dead token)
+  // is a different thing: nothing was read, so nothing can be wrongly selected,
+  // there is no window to report on, and a dead step is the louder and more
+  // actionable signal than a green run rendering as an idle queue. That is the
+  // behaviour on main and this round deliberately preserves it.
+  //
+  // NEGATIVE CONTROL: change either new catch to swallow unconditionally (drop
+  // its `if (state.rateLimited === 0) throw err;`) and every assertion below
+  // flips — each call resolves to a clean `[]` and the failure goes silent.
+  const stubs = starvedWindowStubs({ further: 3 });
+  const rejects = async (runGh, options, what) => {
+    let threw = false;
+    try {
+      await selectAutofixRun(options, { runGh });
+    } catch {
+      threw = true;
+    }
+    assert(threw, `${what} must still reject`);
+  };
+
+  // Transport failure on the first window list.
+  const { runGh: listBase } = makeRunGh({ stubs });
+  await rejects(
+    async (args) => {
+      if (isWindowListArgs(args)) {
+        throw new Error("gh issue list failed with exit 1:\nread ECONNRESET");
+      }
+      return listBase(args);
+    },
+    { repo: "o/r", cap: 2 },
+    "a transport failure on the window list",
+  );
+
+  // Malformed body on the same read: never a `gh` rejection at all, so the
+  // throttle latch cannot have fired and the JSON.parse throw must propagate.
+  const { runGh: jsonBase } = makeRunGh({ stubs });
+  await rejects(
+    async (args) => (isWindowListArgs(args) ? "not json" : jsonBase(args)),
+    { repo: "o/r", cap: 2 },
+    "a malformed window list body",
+  );
+
+  // And the dispatch read.
+  const { runGh: dispatchBase } = makeRunGh({
+    stubs: [stub({ number: 8401, shortId: "ANALYTICS-MENTO-ORG-DQ" })],
+  });
+  await rejects(
+    async (args) => {
+      if (args[0] === "issue" && args[1] === "view") {
+        throw new Error("gh issue view 8401 failed with exit 1:\nHTTP 404");
+      }
+      return dispatchBase(args);
+    },
+    { repo: "o/r", issue: 8401 },
+    "a 404 on the dispatch stub read",
   );
 });
 

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -3,15 +3,20 @@ import {
   DEFAULT_CAP,
   emitVerdict,
   MAX_CANDIDATE_EVALUATIONS,
+  MAX_SECOND_LOOK_EVALUATIONS,
   parseArgs,
+  SECOND_LOOK_FAMILY_BUDGETS,
   selectAutofixCandidates,
   selectAutofixRun,
   SKIP_FIX_SCOPE_ARCHITECTURAL,
+  windowCeilingWarning,
 } from "./sentry-autofix-select.mjs";
 import {
   AUTOFIX_SELECT_LABEL,
   isOwnHeadPr,
+  isRateLimitFailure,
   listHandledShortIds,
+  LIST_LIMIT,
   LOCAL_SENTRY_PROJECT,
   MAX_HANDLED_ID_QUERIES,
   openAutofixPrExists,
@@ -75,6 +80,25 @@ function assertEqual(actual, expected, message) {
 }
 
 const BOT = { login: "github-actions" };
+
+/** The `--limit` a window query carried. Both mocks apply it to the rows they
+ * return, exactly as the API does — before any client-side filter. */
+function windowLimit(args) {
+  const i = args.indexOf("--limit");
+  return i === -1 ? Infinity : Number(args[i + 1]);
+}
+
+/** A `createdAt` for the i-th fixture stub that sorts LEXICOGRAPHICALLY in `i`.
+ * The selector sorts the window with `localeCompare`, so the older
+ * `00:${i}:00Z` form broke once a fixture passed 60 items (`00:100:00Z` sorts
+ * before `00:87:00Z`) — and the window is now MAX_CANDIDATE_EVALUATIONS = 200
+ * wide, so every whole-window fixture is past that. Minutes + seconds keep it a
+ * real timestamp and correctly ordered up to 3600 stubs. */
+function orderedCreatedAt(i, day = "18") {
+  const minutes = String(Math.floor(i / 60)).padStart(2, "0");
+  const seconds = String(i % 60).padStart(2, "0");
+  return `2026-07-${day}T00:${minutes}:${seconds}Z`;
+}
 
 /** Build a bot-authored verdict comment for a code-fix stub. `duplicates`
  * renders in the SAME shape the live #1304-family verdicts carry — an inline
@@ -175,6 +199,10 @@ function makeRunGh({
   repo = "o/r",
   openPrError = null,
   handledLookupErrorIds = [],
+  // What a failing per-id lookup THROWS. The text is load-bearing now: a
+  // rate-limit-shaped message must degrade the run (fail closed), while an
+  // ordinary transient must keep its fail-soft behaviour untouched.
+  handledLookupErrorMessage = "gh issue list failed with exit 1: API rate limit exceeded",
 } = {}) {
   const owner = repo.split("/")[0];
   const calls = [];
@@ -263,9 +291,7 @@ function makeRunGh({
             .map((x) => String(x).toUpperCase())
             .includes(qid)
         ) {
-          throw new Error(
-            `gh issue list "${qid}" in:title failed with exit 1: API rate limit exceeded`,
-          );
+          throw new Error(handledLookupErrorMessage);
         }
         return JSON.stringify(
           handledStubs
@@ -279,9 +305,12 @@ function makeRunGh({
             })),
         );
       }
-      // Candidate window (`sort:created-asc … <slug> in:title`).
+      // Candidate window (`sort:created-asc … <slug> in:title`). `--limit` caps
+      // what the API RETURNS, before any client-side filter — model that, or a
+      // suite can never reproduce the truncation LIST_LIMIT actually imposes,
+      // nor the "full page, there may be more" signal the second look keys on.
       return JSON.stringify(
-        stubs.map((s) => ({
+        stubs.slice(0, windowLimit(args)).map((s) => ({
           number: s.number,
           title: s.title,
           createdAt: s.createdAt,
@@ -706,14 +735,26 @@ await test("a transient open-PR read failure skips ONE stub, never the whole leg
   // read, so one `gh` rejection rejected out of the selector, exited nonzero and
   // failed the select step under `set -euo pipefail` — breaking the workflow
   // header's "ALWAYS emits a valid JSON array … never a failure" invariant.
+  //
+  // The message is deliberately NOT rate-limit shaped: a throttled read is a
+  // different failure class that must fail CLOSED for the whole run (see the
+  // degraded-run tests below), and this one pins that ordinary transients keep
+  // their per-stub fail-soft behaviour.
   const stubs = [stub({ number: 42, shortId: "APP-MENTO-ORG-2B" })];
   const { runGh } = makeRunGh({
     stubs,
-    openPrError:
-      "gh api repos/o/r/pulls failed with exit 1: API rate limit exceeded",
+    openPrError: "gh api repos/o/r/pulls failed with exit 1: read ECONNRESET",
   });
-  const selected = await selectAutofixCandidates({ repo: "o/r" }, { runGh });
-  assertDeepEqual(selected, []);
+  const { entries, truncations } = await selectAutofixRun(
+    { repo: "o/r" },
+    { runGh },
+  );
+  assertDeepEqual(entries, []);
+  assertEqual(
+    truncations.rateLimited,
+    0,
+    "an ordinary transient must NOT degrade the run",
+  );
 });
 
 await test("a normal (non-orphan) selection carries no reconcile flag", async () => {
@@ -1114,7 +1155,7 @@ await test("the per-run read budget bounds the window, keeping the OLDEST stubs"
       stub({
         number: 3000 + i,
         shortId: `APP-MENTO-ORG-${i}`,
-        createdAt: `2026-07-18T00:${String(i).padStart(2, "0")}:00Z`,
+        createdAt: orderedCreatedAt(i),
       }),
     );
   }
@@ -1781,27 +1822,35 @@ await test("bug C exact-parse fence: a tokenized near-miss title does not block"
 });
 
 // The documented per-run gh ceiling (docs/notes/sentry-triage-pipeline.md
-// § "Cost bound"): 1 window list + MAX_CANDIDATE_EVALUATIONS × 2 reads +
-// MAX_HANDLED_ID_QUERIES + MAX_REVERSE_PROBE_QUERIES + MAX_REVERSE_VERIFY_READS
-// cached verify reads ≈ 221. Load-bearing: the worst-case tests below drive EVERY
-// leg to its cap, so removing a cap breaches this number. The verify-read leg is
-// the one an empty-`handled` window leaves at zero — its own saturating pin lives
-// in "cost pin: the reverse verify-read fan-out is capped" below.
-const DOCUMENTED_GH_CEILING = 225;
+// § "Cost bound"): 1 window list + MAX_CANDIDATE_EVALUATIONS (200) × 2 reads +
+// MAX_HANDLED_ID_QUERIES (40) + MAX_REVERSE_PROBE_QUERIES (40) +
+// MAX_REVERSE_VERIFY_READS (40) cached verify reads = 521, with a little slack.
+// Load-bearing: the worst-case tests below drive EVERY leg to its cap, so
+// removing a cap breaches this number. The verify-read leg is the one an
+// empty-`handled` window leaves at zero — its own saturating pin lives in
+// "cost pin: the reverse verify-read fan-out is capped" below.
+const DOCUMENTED_GH_CEILING = 525;
 
-await test("cost pin: an EMPTY-family 50-stub window issues no per-id or reverse work", async () => {
+// The same ceiling for a run that ALSO takes the bounded second look: + 1 list
+// + MAX_SECOND_LOOK_EVALUATIONS (100) × 2 reads + 60 second-look family budget
+// = 782. This is the number the 25-minute select timeout is sized against — at
+// a pessimistic 1.0 s/call it is ~13 minutes, ~52% of the job budget. A change
+// that breaches it has re-opened the timeout arithmetic.
+const DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK = 790;
+
+await test("cost pin: an EMPTY-family full window issues no per-id or reverse work", async () => {
   // Baseline only: default stubs declare nothing, so declaredIds is empty (zero
   // in:title lookups) and every family is a singleton (each finalist's members =
-  // its own id). This pins the empty-window profile — ~1 window + 50 views + 50
-  // pr lists — but it CANNOT exercise the per-id or reverse loops, so it is not
-  // the regression guard for their caps; the worst-case window below is.
+  // its own id). This pins the empty-window profile — ~1 window + 200 views +
+  // 200 pr lists — but it CANNOT exercise the per-id or reverse loops, so it is
+  // not the regression guard for their caps; the worst-case window below is.
   const stubs = [];
   for (let i = 0; i < MAX_CANDIDATE_EVALUATIONS; i += 1) {
     stubs.push(
       stub({
         number: 4000 + i,
         shortId: `ANALYTICS-MENTO-ORG-C${i}`,
-        createdAt: `2026-07-18T00:${String(i).padStart(2, "0")}:00Z`,
+        createdAt: orderedCreatedAt(i),
       }),
     );
   }
@@ -1823,7 +1872,7 @@ await test("cost pin: an EMPTY-family 50-stub window issues no per-id or reverse
 function worstCaseWindow() {
   const stubs = [];
   let created = 0;
-  const at = () => `2026-07-18T00:${String(created++).padStart(2, "0")}:00Z`;
+  const at = () => orderedCreatedAt(created++);
   // A big family: `n` candidates each declaring a SHARED common id (so they all
   // union into one family) plus 4 unique hubs — MAX_DUPLICATE_LOOKUPS (5) ids
   // each. Members = n candidates + 1 common + 4n hubs; n=7 -> 36, under
@@ -1875,12 +1924,23 @@ function budgetFillerStubs(n) {
       familyStub(
         600 + i,
         `ANALYTICS-MENTO-ORG-BC${i}`,
-        `2026-07-05T00:${String(i).padStart(2, "0")}:00Z`,
+        orderedCreatedAt(i, "05"),
         declares,
       ),
     );
   }
   return stubs;
+}
+
+/** Candidate-window list calls only (`sort:created-asc …`), never the per-id
+ * family probes, which are also `issue list`. */
+function windowListCount(calls) {
+  return calls.filter(
+    (c) =>
+      c[0] === "issue" &&
+      c[1] === "list" &&
+      /sort:created-asc/.test(String(c[c.indexOf("--search") + 1] ?? "")),
+  ).length;
 }
 
 function reverseSearchCount(calls) {
@@ -2182,6 +2242,7 @@ await test("run record truncations are all-clear on an empty-family window and t
     handledOverflow: 0,
     reverseBudget: false,
     reverseNonconvergent: false,
+    rateLimited: 0,
   });
   const dispatch = await selectAutofixRun(
     { repo: "o/r", issue: 810 },
@@ -2191,26 +2252,34 @@ await test("run record truncations are all-clear on an empty-family window and t
     handledOverflow: 0,
     reverseBudget: false,
     reverseNonconvergent: false,
+    rateLimited: 0,
   });
 });
 
-await test("window report: a run surfaces total and evaluated when the window exceeds the eval cap", async () => {
+await test("window report: a full, selecting window reports total/evaluated, no second look, and a measured gh count", async () => {
   const stubs = [];
   for (let i = 0; i < MAX_CANDIDATE_EVALUATIONS + 1; i += 1) {
     stubs.push(
       stub({
         number: 5000 + i,
         shortId: `ANALYTICS-MENTO-ORG-W${i}`,
-        createdAt: `2026-07-18T00:${String(i).padStart(2, "0")}:00Z`,
+        createdAt: orderedCreatedAt(i),
       }),
     );
   }
   const { runGh } = makeRunGh({ stubs });
   const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
-  assertDeepEqual(window, {
-    total: MAX_CANDIDATE_EVALUATIONS + 1,
-    evaluated: MAX_CANDIDATE_EVALUATIONS,
-  });
+  // LIST_LIMIT is applied by the API BEFORE the eval slice, so the 201st stub
+  // never reaches the client: total == evaluated == the ceiling. This is why
+  // MAX_CANDIDATE_EVALUATIONS may not exceed LIST_LIMIT — see the pin below.
+  assertEqual(window.total, MAX_CANDIDATE_EVALUATIONS);
+  assertEqual(window.evaluated, MAX_CANDIDATE_EVALUATIONS);
+  // This run SELECTED, so the second look must not fire — it costs nothing on a
+  // healthy run, which is the whole condition on adding it.
+  assertEqual(window.secondLook, false, "a selecting run takes no second look");
+  assertEqual(window.secondLookTotal, 0);
+  assertEqual(window.secondLookEvaluated, 0);
+  assert(window.ghCalls > 0, "the run must report a measured gh call count");
 });
 
 await test("over-collapse invariant: foreign ids in options.handledEdges stay inert", () => {
@@ -2578,9 +2647,9 @@ function makeNegationInterpretingRunGh({
       if (dropArchitecturalNegation) {
         negated = negated.filter((n) => n !== FIX_SCOPE_ARCHITECTURAL_LABEL);
       }
-      const rows = stubs.filter(
-        (s) => !negated.some((neg) => s.labels.includes(neg)),
-      );
+      const rows = stubs
+        .filter((s) => !negated.some((neg) => s.labels.includes(neg)))
+        .slice(0, windowLimit(args));
       return JSON.stringify(
         rows.map((s) => ({
           number: s.number,
@@ -2609,12 +2678,13 @@ function makeNegationInterpretingRunGh({
   return { runGh, calls };
 }
 
-/** 50 OLDER labeled-architectural stubs + 1 NEWER mechanical stub. Oldest-first,
- * the architectural 50 fill the whole MAX_CANDIDATE_EVALUATIONS window ahead of
- * the mechanical one — the exact #1813 starvation shape. */
+/** MAX_CANDIDATE_EVALUATIONS OLDER labeled-architectural stubs + 1 NEWER
+ * mechanical stub. Oldest-first, the architectural block fills the whole window
+ * ahead of the mechanical one — the exact #1813 starvation shape. Sized to the
+ * eval cap, not a literal 50, so the shape survives a window raise. */
 function starvationStubs() {
   const arch = [];
-  for (let i = 0; i < 50; i += 1) {
+  for (let i = 0; i < MAX_CANDIDATE_EVALUATIONS; i += 1) {
     const n = 200 + i;
     arch.push(
       stub({
@@ -2640,7 +2710,7 @@ function starvationStubs() {
   return { arch, all: [...arch, mechanical] };
 }
 
-await test("STARVATION REPRO: the label negation keeps 50 architectural stubs out of the window; only the mechanical selects, zero views on the 50 (#1812/#1813)", async () => {
+await test("STARVATION REPRO: the label negation keeps a full window of architectural stubs out; only the mechanical selects, zero views on them (#1812/#1813)", async () => {
   const { arch, all } = starvationStubs();
   const { runGh, calls } = makeNegationInterpretingRunGh({ stubs: all });
   const { entries } = await selectAutofixRun(
@@ -2648,7 +2718,7 @@ await test("STARVATION REPRO: the label negation keeps 50 architectural stubs ou
     { runGh },
   );
   assertDeepEqual(entries, [{ issue: 999, shortId: "ANALYTICS-MENTO-ORG-M1" }]);
-  // The 50 architectural stubs never enter the window, so not one is READ.
+  // The architectural block never enters the window, so not one is READ.
   const archNumbers = new Set(arch.map((s) => String(s.number)));
   const viewedArch = calls.filter(
     (c) => c[0] === "issue" && c[1] === "view" && archNumbers.has(String(c[2])),
@@ -2660,21 +2730,52 @@ await test("STARVATION REPRO: the label negation keeps 50 architectural stubs ou
   );
 });
 
-await test("CONTROL: dropping the architectural negation lets the 50 refill the window and starve the mechanical -> [] (reproduces #1813)", async () => {
-  const { all } = starvationStubs();
+await test("CONTROL: dropping the architectural negation refills the window and starves the mechanical out of the FIRST pass; only the second look reaches it (#1813)", async () => {
+  const { arch, all } = starvationStubs();
   // The ONLY change: the query no longer excludes the architectural label.
-  const { runGh } = makeNegationInterpretingRunGh({
+  const { runGh, calls } = makeNegationInterpretingRunGh({
     stubs: all,
     dropArchitecturalNegation: true,
   });
-  const { entries } = await selectAutofixRun(
+  const { entries, window, skipped } = await selectAutofixRun(
     { repo: "o/r", cap: 2 },
     { runGh },
   );
-  // Oldest-first, the 50 architectural stubs fill MAX_CANDIDATE_EVALUATIONS and
-  // are all skipped on scope; the newer mechanical stub is truncated out of the
-  // eval window entirely. Nothing selects — the exact starvation #1812 removes.
-  assertDeepEqual(entries, []);
+  // Oldest-first, the architectural block fills the WHOLE list ceiling and every
+  // member is skipped on scope; the newer mechanical stub is past `--limit`, so
+  // the first pass literally cannot see it. Before the bounded second look
+  // existed this run selected NOTHING — forever, every run, since deferral and
+  // scope skips both write nothing. That is #1813's starvation.
+  assertEqual(
+    skipped.length,
+    MAX_CANDIDATE_EVALUATIONS,
+    "the whole window is skipped on scope",
+  );
+  assertEqual(window.evaluated, MAX_CANDIDATE_EVALUATIONS);
+  // What recovers it is the second look, and it says so.
+  assertEqual(
+    window.secondLook,
+    true,
+    "a zero-selection FULL window takes a second look",
+  );
+  assertEqual(window.secondLookEvaluated, 1, "exactly the one further stub");
+  assertDeepEqual(entries, [{ issue: 999, shortId: "ANALYTICS-MENTO-ORG-M1" }]);
+  // The mechanical stub is read ONLY after the second look's own list call, so
+  // the recovery genuinely comes from there and not from a wider first window.
+  assertEqual(
+    windowListCount(calls),
+    2,
+    "one first-pass window list + one second-look window list",
+  );
+  const archNumbers = new Set(arch.map((st) => String(st.number)));
+  const viewOrder = calls
+    .filter((c) => c[0] === "issue" && c[1] === "view")
+    .map((c) => String(c[2]));
+  assertEqual(
+    viewOrder.indexOf("999"),
+    archNumbers.size,
+    "the mechanical stub is read only after the whole first-pass window",
+  );
 });
 
 await test("BACKSTOP: a window stub with the hold label hand-removed but an architectural verdict is still skipped, never selected (#1812)", async () => {
@@ -3158,6 +3259,404 @@ await test("parseArgs accepts --skipped-out beside --deferred-out", async () => 
   assertEqual(options.skippedOut, "/tmp/s.json");
   // Absent by default: a caller that does not ask for the report gets no file.
   assertEqual(parseArgs([]).skippedOut, null);
+});
+
+// ---------------------------------------------------------------------------
+// The window ceiling, the bounded second look, the gh-call instrumentation, and
+// failing CLOSED on throttling.
+// ---------------------------------------------------------------------------
+
+await test("PIN: MAX_CANDIDATE_EVALUATIONS may never exceed LIST_LIMIT (a raise above it is a strict no-op)", () => {
+  // `gh issue list --limit LIST_LIMIT` caps what the API RETURNS, and that
+  // happens BEFORE the eval slice. So a window raised above the list ceiling
+  // reads exactly LIST_LIMIT rows, reports `total == evaluated`, and NOTHING
+  // says the raise did nothing — the silent no-op this pin exists to prevent.
+  // The two constants must move together.
+  assert(
+    MAX_CANDIDATE_EVALUATIONS <= LIST_LIMIT,
+    `MAX_CANDIDATE_EVALUATIONS (${MAX_CANDIDATE_EVALUATIONS}) must not exceed LIST_LIMIT (${LIST_LIMIT}) — raise LIST_LIMIT too or the window raise is a no-op`,
+  );
+});
+
+await test("windowCeilingWarning is silent at the shipped pair and LOUD on a mismatch", () => {
+  // The run-time half of the pin above. It warns rather than throws: the select
+  // step's contract is that it always emits a valid JSON array and never fails,
+  // so a static config mistake must not be able to break the leg.
+  assertEqual(windowCeilingWarning(), null, "the shipped pair is consistent");
+  assertEqual(windowCeilingWarning(200, 200), null, "equal is fine");
+  const warning = windowCeilingWarning(400, 200);
+  assert(warning != null, "a window above the list ceiling must warn");
+  assert(
+    warning.includes("400") && warning.includes("200"),
+    `the warning must name BOTH numbers, got: ${warning}`,
+  );
+});
+
+/**
+ * A FULL first window in which NOTHING is selectable (every stub is skipped on
+ * fix_scope), plus `further` selectable stubs sitting PAST the list ceiling.
+ * This is the starvation signature exactly: the run selects nothing, writes
+ * nothing, and the next run reads the same window — so without a second look the
+ * further stubs are never evaluated, at any point, ever.
+ *
+ * `hubsPerWindowStub` gives the blocked window stubs declared family ids, which
+ * is what drives the first pass's handled-id budget (an architectural stub still
+ * contributes its family edges).
+ */
+function starvedWindowStubs({
+  further = 1,
+  hubsPerWindowStub = 0,
+  hubsPerFurtherStub = 0,
+} = {}) {
+  const stubs = [];
+  for (let i = 0; i < LIST_LIMIT; i += 1) {
+    const hubs = Array.from(
+      { length: hubsPerWindowStub },
+      (_, j) => `ANALYTICS-MENTO-ORG-WH${i}X${j}`,
+    );
+    stubs.push(
+      familyStub(
+        7000 + i,
+        `ANALYTICS-MENTO-ORG-Z${i}`,
+        orderedCreatedAt(i),
+        hubs,
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  for (let i = 0; i < further; i += 1) {
+    const hubs = Array.from(
+      { length: hubsPerFurtherStub },
+      (_, j) => `ANALYTICS-MENTO-ORG-FH${i}X${j}`,
+    );
+    stubs.push(
+      familyStub(
+        7500 + i,
+        `ANALYTICS-MENTO-ORG-Y${i}`,
+        orderedCreatedAt(LIST_LIMIT + i),
+        hubs,
+      ),
+    );
+  }
+  return stubs;
+}
+
+await test("SECOND LOOK: a zero-selection FULL window reaches past the list ceiling and selects", async () => {
+  // NEGATIVE CONTROL: change the fire condition in selectAutofixRun from
+  // `entries.length === 0 && page.full` to `false` (or drop `page.full`'s
+  // `rawCount >= limit` in listCodeFixStubsPage) and this returns [] — the
+  // permanent starvation the second look exists to break.
+  const stubs = starvedWindowStubs({ further: 3 });
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { entries, window, skipped } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertEqual(
+    skipped.length,
+    LIST_LIMIT,
+    "the whole first window stands down on scope",
+  );
+  assertEqual(window.secondLook, true, "the second look must have run");
+  assertEqual(window.secondLookTotal, 3);
+  assertEqual(window.secondLookEvaluated, 3);
+  assertDeepEqual(entries, [
+    { issue: 7500, shortId: "ANALYTICS-MENTO-ORG-Y0" },
+    { issue: 7501, shortId: "ANALYTICS-MENTO-ORG-Y1" },
+  ]);
+  assertEqual(
+    windowListCount(calls),
+    2,
+    "exactly ONE extra window list — the second look is not a retry loop",
+  );
+});
+
+await test("SECOND LOOK: a healthy run that selected anything never fires it (it must cost nothing)", async () => {
+  // The whole licence for adding a second pass is that a normal run pays zero
+  // for it. One selectable stub at the head of the window is enough.
+  const stubs = starvedWindowStubs({ further: 3 });
+  stubs.unshift(
+    stub({
+      number: 6999,
+      shortId: "ANALYTICS-MENTO-ORG-OK",
+      createdAt: "2026-07-01T00:00:00Z",
+    }),
+  );
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { entries, window } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, [
+    { issue: 6999, shortId: "ANALYTICS-MENTO-ORG-OK" },
+  ]);
+  assertEqual(window.secondLook, false, "a selecting run takes no second look");
+  assertEqual(
+    windowListCount(calls),
+    1,
+    "no second window list is issued on a healthy run",
+  );
+});
+
+await test("SECOND LOOK: a window that is NOT full never fires it (there is nothing past the ceiling)", async () => {
+  // Zero selections alone is not the signature — a SHORT page means the run
+  // already saw every stub there is, so a second look could only re-read them.
+  const stubs = [];
+  for (let i = 0; i < 5; i += 1) {
+    stubs.push(
+      familyStub(
+        7800 + i,
+        `ANALYTICS-MENTO-ORG-N${i}`,
+        orderedCreatedAt(i),
+        [],
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { entries, window } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, []);
+  assertEqual(
+    window.secondLook,
+    false,
+    "a short page cannot hide further stubs",
+  );
+  assertEqual(windowListCount(calls), 1);
+});
+
+await test("SECOND LOOK: its OWN truncation is reported, never silent", async () => {
+  // The second look has a hard evaluation ceiling of its own, so it can truncate
+  // exactly like the first window — and must say so on the same surface.
+  const stubs = starvedWindowStubs({
+    further: MAX_SECOND_LOOK_EVALUATIONS + 5,
+  });
+  const { runGh } = makeRunGh({ stubs });
+  const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
+  assertEqual(window.secondLook, true);
+  assertEqual(window.secondLookTotal, MAX_SECOND_LOOK_EVALUATIONS + 5);
+  assertEqual(
+    window.secondLookEvaluated,
+    MAX_SECOND_LOOK_EVALUATIONS,
+    "the second look stops at its own ceiling",
+  );
+  assert(
+    window.secondLookTotal > window.secondLookEvaluated,
+    "total > evaluated is what the run record renders as its truncation",
+  );
+});
+
+await test("SECOND LOOK: it runs on its OWN family budgets, not the first pass's", async () => {
+  // The first pass has SPENT the per-run budgets by the time this runs, so
+  // reusing them would silently double the run's worst-case gh volume — the
+  // exact thing the timeout arithmetic is sized against.
+  //
+  // NEGATIVE CONTROL: drop the `budgets: SECOND_LOOK_FAMILY_BUDGETS` argument in
+  // selectAutofixRun's second-look `resolveFamilies` call and the handled
+  // in:title count jumps from 20 to MAX_HANDLED_ID_QUERIES (40), failing the
+  // assertion below.
+  const stubs = starvedWindowStubs({
+    further: MAX_SECOND_LOOK_EVALUATIONS,
+    hubsPerFurtherStub: 5,
+  });
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
+  assertEqual(window.secondLook, true);
+  // The window stubs declare nothing, so every in:title search below belongs to
+  // the second look.
+  assertEqual(
+    titleSearchCount(calls),
+    SECOND_LOOK_FAMILY_BUDGETS.handled,
+    `the second look must saturate AND stop at its own handled budget (${SECOND_LOOK_FAMILY_BUDGETS.handled}), got ${titleSearchCount(calls)}`,
+  );
+  assert(
+    SECOND_LOOK_FAMILY_BUDGETS.handled < MAX_HANDLED_ID_QUERIES,
+    "the second-look budget must be strictly smaller, or this proves nothing",
+  );
+});
+
+await test("cost pin: a full first pass PLUS a second look stays under the 25-minute timeout arithmetic", async () => {
+  // The constraint the second look was sized against: first pass + second look
+  // worst case must fit well inside `timeout-minutes: 25` at a pessimistic
+  // ~1 s/call, every call being serial. The first pass here saturates its
+  // handled-id budget (each blocked window stub declares 5 hubs) and the second
+  // look saturates its own.
+  const stubs = starvedWindowStubs({
+    further: MAX_SECOND_LOOK_EVALUATIONS,
+    hubsPerWindowStub: 5,
+    hubsPerFurtherStub: 5,
+  });
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
+  assertEqual(
+    window.secondLook,
+    true,
+    "this pin must actually take a second look",
+  );
+  assert(
+    calls.length > DOCUMENTED_GH_CEILING,
+    `the second look must genuinely add spend, or the pin is vacuous (got ${calls.length})`,
+  );
+  assert(
+    calls.length <= DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK,
+    `first pass + second look must stay under ${DOCUMENTED_GH_CEILING_WITH_SECOND_LOOK} serial gh calls, got ${calls.length}`,
+  );
+});
+
+await test("INSTRUMENTATION: the run reports the gh invocation count it actually made", async () => {
+  // The per-run gh ceiling was arithmetic over caps that nothing measured. This
+  // makes it an observed number on the run record, so drift shows up before a
+  // timeout does.
+  //
+  // NEGATIVE CONTROL: drop `state.ghCalls += 1` from instrumentRunGh and this
+  // reports 0 against a nonzero real count.
+  const stubs = [
+    stub({ number: 8100, shortId: "ANALYTICS-MENTO-ORG-I1" }),
+    stub({ number: 8101, shortId: "ANALYTICS-MENTO-ORG-I2" }),
+  ];
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { window } = await selectAutofixRun({ repo: "o/r", cap: 2 }, { runGh });
+  assert(calls.length > 0, "the fixture must issue real calls");
+  assertEqual(
+    window.ghCalls,
+    calls.length,
+    "the reported count must equal the invocations actually made",
+  );
+});
+
+await test("isRateLimitFailure matches what gh actually prints, and nothing else", () => {
+  // gh puts the whole HTTP/GraphQL error body into its stderr, which
+  // defaultRunGh folds into the rejection message.
+  for (const message of [
+    "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234. (https://api.github.com/rate_limit)",
+    "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.",
+    "gh issue list failed with exit 1:\nHTTP 429 Too Many Requests",
+    "gh issue list failed with exit 1:\nGraphQL: API rate limit exceeded for user ID 1234. (rateLimitExceeded)",
+    "gh api failed with exit 1:\nYou have triggered an abuse detection mechanism.",
+  ]) {
+    assert(isRateLimitFailure(message), `must match: ${message}`);
+  }
+  for (const message of [
+    "gh api repos/o/r/pulls failed with exit 1: read ECONNRESET",
+    "gh issue view 5 failed with exit 1:\nHTTP 404: Not Found",
+    "gh issue list failed with exit 1:\nHTTP 502 Bad Gateway",
+    "gh: command not found",
+    "",
+  ]) {
+    assert(
+      !isRateLimitFailure(message),
+      `must NOT match (it would degrade ordinary transients): ${message}`,
+    );
+  }
+});
+
+/** A candidate whose family sibling already carries a TERMINAL marker — so the
+ * ONLY thing standing between this run and a duplicate autofix PR is the
+ * handled-id lookup that finds the sibling. */
+function dedupeBlockedFixture(handledLookupErrorMessage) {
+  const candidate = familyStub(
+    8200,
+    "ANALYTICS-MENTO-ORG-DL",
+    "2026-07-10T00:00:00Z",
+    ["ANALYTICS-MENTO-ORG-DS"],
+  );
+  return makeRunGh({
+    stubs: [candidate],
+    handled: [{ shortId: "ANALYTICS-MENTO-ORG-DS", label: FIX_REFUSED_LABEL }],
+    handledLookupErrorIds: ["ANALYTICS-MENTO-ORG-DS"],
+    handledLookupErrorMessage,
+  });
+}
+
+await test("DANGER CONTROL: a fail-soft dedupe read that returns nothing SELECTS the stub (this is the duplicate-PR path)", async () => {
+  // Establishes the hazard the fail-closed change exists for: every dedupe read
+  // fails soft toward MORE candidates, so a read that does not answer looks
+  // exactly like "no blocker". With an ordinary transient that is the right
+  // trade (one self-terminating extra attempt) and stays unchanged.
+  const { runGh } = dedupeBlockedFixture(
+    "gh issue list failed with exit 1: read ECONNRESET",
+  );
+  const { entries, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, [
+    { issue: 8200, shortId: "ANALYTICS-MENTO-ORG-DL" },
+  ]);
+  assertEqual(
+    truncations.rateLimited,
+    0,
+    "an ordinary transient is not a degradation",
+  );
+});
+
+await test("FAIL CLOSED: the SAME read failing with a rate limit emits ZERO entries and reports the degradation", async () => {
+  // Identical topology, identical fail-soft plumbing — only the failure TEXT
+  // differs. A throttled run cannot tell "no prior PR / no terminal sibling"
+  // from "GitHub refused to answer", so it must not select at all; otherwise it
+  // opens a duplicate autofix PR and still looks green.
+  //
+  // NEGATIVE CONTROL: drop the `isRateLimitFailure` branch in instrumentRunGh
+  // (or the `state.rateLimited > 0` bail in selectAutofixRun) and this returns
+  // the SAME entry the control above does — the duplicate.
+  const { runGh } = dedupeBlockedFixture(
+    "gh issue list failed with exit 1:\nHTTP 403: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.",
+  );
+  const { entries, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  // The invariant the workflow header asserts: ALWAYS a valid array, NEVER a
+  // throw. "Fail closed" here is an empty array plus a loud report.
+  assert(Array.isArray(entries), "the leg must still emit a valid array");
+  assertDeepEqual(entries, []);
+  assert(
+    truncations.rateLimited > 0,
+    "the degradation must be reported, not silent",
+  );
+});
+
+await test("FAIL CLOSED: a rate-limited single-issue dispatch emits ZERO entries too", async () => {
+  // The dispatch path dedupes on the SAME open-PR read, so a throttled one can
+  // open a duplicate just as easily. The documented remedy for a stalled leg
+  // must not become the way a duplicate gets in.
+  const stubs = [stub({ number: 8300, shortId: "ANALYTICS-MENTO-ORG-DP" })];
+  const { runGh } = makeRunGh({
+    stubs,
+    openPrError:
+      "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234.",
+  });
+  const { entries, truncations } = await selectAutofixRun(
+    { repo: "o/r", issue: 8300 },
+    { runGh },
+  );
+  assertDeepEqual(entries, []);
+  assert(truncations.rateLimited > 0, "the dispatch degradation is reported");
+});
+
+await test("FAIL CLOSED: a degraded first pass never spends a second look", async () => {
+  // The first pass's dedupe reads are already untrustworthy; a second look could
+  // only widen the blast radius while burning the budget that made the raise
+  // affordable.
+  const stubs = starvedWindowStubs({ further: 3 });
+  const { runGh, calls } = makeRunGh({
+    stubs,
+    openPrError:
+      "gh api repos/o/r/pulls failed with exit 1:\nHTTP 403: API rate limit exceeded for user ID 1234.",
+  });
+  const { entries, window } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertDeepEqual(entries, []);
+  assertEqual(window.secondLook, false, "a degraded run takes no second look");
+  assertEqual(
+    windowListCount(calls),
+    1,
+    "no second window list is issued once the run is degraded",
+  );
 });
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -3371,6 +3371,67 @@ await test("SECOND LOOK: a zero-selection FULL window reaches past the list ceil
   );
 });
 
+await test("SECOND LOOK: the FULL-page signal is taken off RAW rows, not the project-filtered ones", async () => {
+  // `--limit` is applied server-side, BEFORE the client-side
+  // `parseProject === LOCAL_SENTRY_PROJECT` gate. So a genuinely full page can
+  // come back short once foreign-project rows are dropped, and a `full` signal
+  // keyed on the filtered length would read "there is nothing more" on exactly
+  // the window that has the most hidden behind it.
+  //
+  // NEGATIVE CONTROL: change `full` in listCodeFixStubsPage from
+  // `list.length >= limit` to `stubs.length >= limit` and this returns [] — the
+  // starvation survives untouched, and NO other test notices.
+  const stubs = [];
+  for (let i = 0; i < LIST_LIMIT - 5; i += 1) {
+    stubs.push(
+      familyStub(
+        8300 + i,
+        `ANALYTICS-MENTO-ORG-P${i}`,
+        orderedCreatedAt(i),
+        [],
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  // Five rows the server returns (they match the tokenized `<slug> in:title`
+  // filter) but the exact project gate drops.
+  for (let i = 0; i < 5; i += 1) {
+    stubs.push({
+      number: 8000 + i,
+      shortId: `APP-MENTO-ORG-X${i}`,
+      title: `[sentry] APP-MENTO-ORG-X${i} (app-mento-org, error)`,
+      labels: [AUTOFIX_SELECT_LABEL, "sentry-triage"],
+      createdAt: orderedCreatedAt(LIST_LIMIT - 5 + i),
+      comments: [verdictComment()],
+    });
+  }
+  stubs.push(
+    stub({
+      number: 8999,
+      shortId: "ANALYTICS-MENTO-ORG-PZ",
+      createdAt: orderedCreatedAt(LIST_LIMIT + 1),
+    }),
+  );
+  const { runGh } = makeRunGh({ stubs });
+  const { entries, window } = await selectAutofixRun(
+    { repo: "o/r", cap: 2 },
+    { runGh },
+  );
+  assertEqual(
+    window.total,
+    LIST_LIMIT - 5,
+    "the project gate really did shorten the page",
+  );
+  assertEqual(
+    window.secondLook,
+    true,
+    "a RAW-full page still takes a second look",
+  );
+  assertDeepEqual(entries, [
+    { issue: 8999, shortId: "ANALYTICS-MENTO-ORG-PZ" },
+  ]);
+});
+
 await test("SECOND LOOK: a healthy run that selected anything never fires it (it must cost nothing)", async () => {
   // The whole licence for adding a second pass is that a normal run pays zero
   // for it. One selectable stub at the head of the window is enough.

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -34,6 +34,7 @@ import {
   MAX_REVERSE_PROBE_QUERIES,
   MAX_REVERSE_VERIFY_READS,
   REVERSE_SEARCH_LIMIT,
+  reverseVerifyFamilies,
 } from "./sentry-autofix-reverse-verify.mjs";
 import {
   FIX_SCOPE_ARCHITECTURAL,
@@ -49,6 +50,7 @@ import {
   DEFER_FAMILY_HANDLED,
   MAX_FAMILY_MEMBERS,
 } from "./sentry-autofix-family.mjs";
+import { resolveFamilies } from "./sentry-autofix-family-resolve.mjs";
 import {
   FIX_PR_OPENED_LABEL,
   FIX_REFUSED_LABEL,
@@ -4042,6 +4044,386 @@ function reverseStoodDownFixture({ locals = 6, further = 5 } = {}) {
   }
   return makeRunGh({ stubs, handled });
 }
+
+/** `in:title` handled lookups issued for ONE specific family id. The bare
+ * `titleSearchCount` cannot tell which id a search was for, and the seed bugs
+ * below are entirely about WHICH ids get re-asked across a budget boundary. */
+function titleSearchCountFor(calls, id) {
+  return calls.filter(
+    (c) =>
+      c[0] === "issue" &&
+      c[1] === "list" &&
+      String(c[c.indexOf("--search") + 1] ?? "").includes(`"${id}" in:title`),
+  ).length;
+}
+
+/** The index of the SECOND candidate-window list — i.e. where the second look
+ * begins. Everything before it is the first pass. */
+function secondLookStartsAt(calls) {
+  return calls.findIndex(
+    (c, i) => isWindowListArgs(c) && calls.slice(0, i).some(isWindowListArgs),
+  );
+}
+
+// The id the first pass drops for budget. Window stub 150's first hub: the
+// declared-id order is window order, so the 40-lookup budget is spent long
+// before this one, and it is never read by the first pass.
+const DROPPED_HUB_ID = "ANALYTICS-MENTO-ORG-DH150X0";
+
+/**
+ * A FULL, entirely-unselectable window whose stubs declare FAR more distinct
+ * family ids than MAX_HANDLED_ID_QUERIES (200 × 5 = 1000 against a budget of
+ * 40), so 960 of them are dropped unread. Past the ceiling sits one selectable
+ * stub declaring one of those DROPPED ids — and that id's sibling carries a
+ * TERMINAL marker, so the only thing standing between this run and a second
+ * autofix PR for an already-refused family is a lookup the first pass could not
+ * afford and the second look must therefore still make.
+ */
+function droppedIdBlockerFixture() {
+  const stubs = [];
+  for (let i = 0; i < LIST_LIMIT; i += 1) {
+    stubs.push(
+      familyStub(
+        7100 + i,
+        `ANALYTICS-MENTO-ORG-D${i}`,
+        orderedCreatedAt(i),
+        Array.from(
+          { length: MAX_DUPLICATE_LOOKUPS },
+          (_, j) => `ANALYTICS-MENTO-ORG-DH${i}X${j}`,
+        ),
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  stubs.push(
+    familyStub(7699, "ANALYTICS-MENTO-ORG-DZ", orderedCreatedAt(LIST_LIMIT), [
+      DROPPED_HUB_ID,
+    ]),
+  );
+  return makeRunGh({
+    stubs,
+    handled: [{ shortId: DROPPED_HUB_ID, label: FIX_REFUSED_LABEL }],
+  });
+}
+
+await test("SEED: an id the first pass DROPPED for budget is re-lookable by the second look, so no duplicate slips through", async () => {
+  // The interaction bug between two individually-correct changes. To keep the
+  // per-run overflow counting each distinct un-runnable id ONCE rather than once
+  // per fixpoint iteration, `listHandledShortIds` folds every DROPPED id into its
+  // re-attempt guard — correct while a budget only shrinks within one pass. The
+  // second look then began SEEDING that guard while running on FRESH budgets, so
+  // never-read ids arrived labelled "already resolved": the pass spent none of
+  // its new allowance on them and selected a stub whose sibling holds a terminal
+  // refusal. A duplicate autofix PR, with no rate limit anywhere in the story —
+  // the exact hazard the fail-closed work exists to prevent, reached from the
+  // other side.
+  //
+  // NEGATIVE CONTROL: seed the wider set again — `new Set(seed.handledQueried)`
+  // in resolveFamilies, i.e. carry dropped ids across the pass boundary — and
+  // #7699 appears in `entries` with zero second-look lookups for its hub.
+  const { runGh, calls } = droppedIdBlockerFixture();
+  const { entries, deferred, truncations } = await selectAutofixRun(
+    { repo: "o/r", cap: 6 },
+    { runGh },
+  );
+
+  // The fixture must actually starve the first pass, or this proves nothing.
+  assert(
+    truncations.handledOverflow > 0,
+    "the first pass must overflow its handled budget for this to be the dropped-id path",
+  );
+  const secondListAt = secondLookStartsAt(calls);
+  assert(secondListAt > 0, "the second look must have run");
+  assertEqual(
+    titleSearchCountFor(calls.slice(0, secondListAt), DROPPED_HUB_ID),
+    0,
+    "the first pass must never have read this id — it was dropped for budget",
+  );
+
+  // The fix: a fresh budget retries exactly the work the first pass could not
+  // afford, so the terminal sibling is found.
+  assertEqual(
+    titleSearchCountFor(calls.slice(secondListAt), DROPPED_HUB_ID),
+    1,
+    "the second look must spend its OWN budget looking up the id nobody read",
+  );
+  assert(
+    !entries.some((e) => e.issue === 7699),
+    `a stub whose family carries a terminal refusal must never be selected, got: ${JSON.stringify(entries)}`,
+  );
+  assert(
+    deferred.some((d) => d.issue === 7699),
+    `and the stand-down must be reported, got: ${JSON.stringify(deferred)}`,
+  );
+});
+
+await test("SEED REGRESSION: a dropped id is counted into overflow ONCE per run, however many passes re-surface it", async () => {
+  // The invariant the seeded set was introduced to protect, pinned directly on
+  // the helper so it cannot regress behind a fixture. The fixpoint re-surfaces
+  // the same recheck ids every iteration; without the dropped ids in the
+  // re-attempt guard, each one is counted into `overflow` once per pass and the
+  // run record reports a multiple of the real number. Splitting `answered` out
+  // must NOT weaken this: the guard still absorbs dropped ids, only the SEED is
+  // narrowed.
+  //
+  // NEGATIVE CONTROL: drop the `for (const droppedId of droppedIds)
+  // queried.add(droppedId);` loop in listHandledShortIds and overflow doubles to
+  // 4 — or make the re-attempt filter read `answered` instead of `queried`, the
+  // plausible wrong shape of this round's fix, and it doubles the same way.
+  const ids = ["ANALYTICS-MENTO-ORG-OA", "ANALYTICS-MENTO-ORG-OB"];
+  const { runGh, calls } = makeRunGh({ stubs: [] });
+  const queried = new Set();
+  const answered = new Set();
+  const budget = { remaining: 0, overflow: 0 };
+  for (let pass = 0; pass < 2; pass += 1) {
+    await listHandledShortIds(runGh, "o/r", ids, {
+      queried,
+      answered,
+      budget,
+    });
+  }
+  assertEqual(
+    budget.overflow,
+    ids.length,
+    "each DISTINCT un-runnable id must count exactly once per run",
+  );
+  assertEqual(calls.length, 0, "and no lookup may be issued at zero capacity");
+  assertEqual(
+    answered.size,
+    0,
+    "nothing was answered — a dropped id is spend, never knowledge",
+  );
+});
+
+await test("SEED: an id the first pass ANSWERED is NOT re-read by the second look (seeding still pays)", async () => {
+  // The other half of the same boundary, and the reason the fix narrows the seed
+  // instead of deleting it. An id whose lookup actually came back is real
+  // knowledge: re-asking costs the second look budget it needs for the ids
+  // nobody has read yet. Here the whole window shares ONE declared hub, so the
+  // first pass answers it well inside its budget, and the stub past the ceiling
+  // declares the same hub.
+  //
+  // NEGATIVE CONTROL: stop seeding the answered set — `const handledQueried =
+  // new Set()` in resolveFamilies — and the count below goes to 2.
+  const SEEDED_HUB_ID = "ANALYTICS-MENTO-ORG-SEEDEDHUB";
+  const stubs = [];
+  for (let i = 0; i < LIST_LIMIT; i += 1) {
+    stubs.push(
+      familyStub(
+        7800 + i,
+        `ANALYTICS-MENTO-ORG-E${i}`,
+        orderedCreatedAt(i),
+        [SEEDED_HUB_ID],
+        FIX_SCOPE_ARCHITECTURAL,
+      ),
+    );
+  }
+  stubs.push(
+    familyStub(8399, "ANALYTICS-MENTO-ORG-EZ", orderedCreatedAt(LIST_LIMIT), [
+      SEEDED_HUB_ID,
+    ]),
+  );
+  // No `handled` entry: the hub exists and answers "no terminal marker".
+  const { runGh, calls } = makeRunGh({ stubs });
+  const { entries } = await selectAutofixRun(
+    { repo: "o/r", cap: 6 },
+    { runGh },
+  );
+  assert(secondLookStartsAt(calls) > 0, "the second look must have run");
+  assertEqual(
+    titleSearchCountFor(calls, SEEDED_HUB_ID),
+    1,
+    "an answered id must be looked up ONCE per run, not once per pass",
+  );
+  assert(
+    entries.some((e) => e.issue === 8399),
+    "and nothing blocks it, so the stub past the ceiling is still selected",
+  );
+});
+
+await test("SEED: a probe that FAILED or was left half-read is guarded but never seeded (the same bug, other hats)", async () => {
+  // The reverse leg carries the identical hazard on two more structures. A
+  // probe id enters `alreadyProbed` BEFORE its search runs, and a hit's stub
+  // read is negative-cached as `null` on failure — both right as within-pass
+  // re-attempt guards, both spend rather than knowledge. Seeded into a pass with
+  // fresh budgets they say "already resolved" about work nobody completed, and a
+  // terminal sibling behind an unread hit lets a duplicate fix PR through
+  // exactly as the handled-id case does.
+  //
+  // (The PROBE budget is already safe: its ceiling check breaks BEFORE the add,
+  // so a probe it refuses never enters the guard at all. Pinned below.)
+  //
+  // NEGATIVE CONTROL: seed the wide sets — `answeredProbes` fed from `probed`,
+  // or `resolved.stubCache` unfiltered — and the assertions below flip: the
+  // failed, starved and unread-hit probes all read as answered.
+  const hub = (n, shortId) => ({
+    number: n,
+    title: `[sentry] ${shortId} (analytics-mento-org, error)`,
+    labels: [],
+  });
+  const runGh = async (args) => {
+    const search = String(args[args.indexOf("--search") + 1] ?? "");
+    if (args[1] === "view") {
+      // The hit surfaced by STARVE2 cannot be read.
+      if (String(args[2]) === "9200") {
+        throw new Error("gh issue view 9200 failed with exit 1:\nHTTP 502");
+      }
+      return JSON.stringify({
+        number: Number(args[2]),
+        title: "[sentry] ANALYTICS-MENTO-ORG-HUBX (analytics-mento-org, error)",
+        body: "",
+        labels: [],
+        comments: [verdictComment({ duplicates: [] })],
+      });
+    }
+    if (/PROBEBAD/.test(search)) {
+      throw new Error("gh issue list failed with exit 1:\nread ECONNRESET");
+    }
+    if (/PROBESTARVE/.test(search)) {
+      return JSON.stringify([hub(9100, "ANALYTICS-MENTO-ORG-HUB1")]);
+    }
+    if (/PROBEREAD/.test(search)) {
+      return JSON.stringify([hub(9200, "ANALYTICS-MENTO-ORG-HUB2")]);
+    }
+    return JSON.stringify([]);
+  };
+
+  const ids = [
+    "ANALYTICS-MENTO-ORG-PROBEOK",
+    "ANALYTICS-MENTO-ORG-PROBEBAD",
+    "ANALYTICS-MENTO-ORG-PROBEREAD",
+  ];
+  const probed = new Set();
+  const answeredProbes = new Set();
+  const failedStubReads = new Set();
+  await reverseVerifyFamilies(runGh, "o/r", ids, {
+    project: LOCAL_SENTRY_PROJECT,
+    alreadyProbed: probed,
+    answeredProbes,
+    failedStubReads,
+    probeBudget: { remaining: 10 },
+    verifyBudget: { remaining: 10 },
+  });
+  assertEqual(probed.size, 3, "all three are guarded against re-attempt");
+  assertDeepEqual(
+    [...answeredProbes],
+    ["ANALYTICS-MENTO-ORG-PROBEOK"],
+    "only the probe that searched AND resolved every hit is seed-worthy",
+  );
+  assert(
+    failedStubReads.has("9200"),
+    "the thrown hit read is recorded so its null cache entry is not seeded",
+  );
+
+  // Verify-budget starvation, on its own: the search returns a hit the pass
+  // cannot afford to read.
+  const starvedProbed = new Set();
+  const starvedAnswered = new Set();
+  await reverseVerifyFamilies(
+    runGh,
+    "o/r",
+    ["ANALYTICS-MENTO-ORG-PROBESTARVE"],
+    {
+      project: LOCAL_SENTRY_PROJECT,
+      alreadyProbed: starvedProbed,
+      answeredProbes: starvedAnswered,
+      probeBudget: { remaining: 10 },
+      verifyBudget: { remaining: 0 },
+    },
+  );
+  assertEqual(starvedProbed.size, 1, "still guarded within the pass");
+  assertEqual(
+    starvedAnswered.size,
+    0,
+    "a probe whose hit went unread for want of budget is not an answer",
+  );
+
+  // And the PROBE ceiling, which was already correct: a probe it refuses never
+  // enters the guard, so nothing has to un-record it.
+  const cappedProbed = new Set();
+  const cappedAnswered = new Set();
+  await reverseVerifyFamilies(runGh, "o/r", ids, {
+    project: LOCAL_SENTRY_PROJECT,
+    alreadyProbed: cappedProbed,
+    answeredProbes: cappedAnswered,
+    probeBudget: { remaining: 0 },
+    verifyBudget: { remaining: 10 },
+  });
+  assertEqual(
+    cappedProbed.size,
+    0,
+    "a probe refused by the ceiling is never recorded as probed at all",
+  );
+});
+
+await test("SEED: a stub read that THREW is not carried into the next pass's cache", async () => {
+  // The last hat, and the one that makes the probe fix worth anything. Re-probing
+  // an unresolved id on a fresh budget only helps if the hit it could not read is
+  // actually re-readable — and `readVerdictCached` negative-caches a THROWN read
+  // as `null`, indistinguishable from the legitimate "read fine, no fenced
+  // verdict". Seed that null and the second look re-probes, finds the same hit,
+  // pays no verify budget for it (the cache claims a hit), and re-derives
+  // "not admitted" from a read that never happened.
+  //
+  // NEGATIVE CONTROL: return `stubCache` unfiltered from resolveFamilies and the
+  // first assertion below flips.
+  const runGh = async (args) => {
+    if (args[0] === "issue" && args[1] === "view") {
+      if (String(args[2]) === "9200") {
+        throw new Error("gh issue view 9200 failed with exit 1:\nHTTP 502");
+      }
+      return JSON.stringify({
+        number: Number(args[2]),
+        title:
+          "[sentry] ANALYTICS-MENTO-ORG-HUBOK (analytics-mento-org, error)",
+        body: "",
+        labels: [],
+        comments: [verdictComment({ duplicates: ["ANALYTICS-MENTO-ORG-CA"] })],
+      });
+    }
+    const search = String(args[args.indexOf("--search") + 1] ?? "");
+    if (/in:comments/.test(search)) {
+      return JSON.stringify([
+        {
+          number: 9200,
+          title:
+            "[sentry] ANALYTICS-MENTO-ORG-HUBBAD (analytics-mento-org, error)",
+          labels: [],
+        },
+        {
+          number: 9300,
+          title:
+            "[sentry] ANALYTICS-MENTO-ORG-HUBOK (analytics-mento-org, error)",
+          labels: [],
+        },
+      ]);
+    }
+    return JSON.stringify([]);
+  };
+  const candidates = [
+    {
+      entry: { issue: 500, shortId: "ANALYTICS-MENTO-ORG-CA" },
+      issue: 500,
+      shortId: "ANALYTICS-MENTO-ORG-CA",
+      duplicateOf: [],
+      reconcile: false,
+    },
+  ];
+  const { resolved } = await resolveFamilies(runGh, "o/r", candidates, 2);
+  assert(
+    !resolved.stubCache.has("9200"),
+    "a read that threw is spend, not knowledge — it must not reach the seed",
+  );
+  assert(
+    resolved.stubCache.has("9300"),
+    "a read that succeeded IS knowledge and must still be carried",
+  );
+  assertEqual(
+    resolved.probesAnswered.size,
+    0,
+    "and the probe that surfaced the unread hit is not answered either",
+  );
+});
 
 await test("SECOND LOOK: the ids the first pass PROBED are skipped, but its probe SPEND is not charged to the second look", async () => {
   // The seed carries knowledge, never spend. `alreadyProbed` is a dedupe set —


### PR DESCRIPTION
## The Problem

The autofix selector evaluates only the oldest 50 queue stubs (`MAX_CANDIDATE_EVALUATIONS`), and family deferral deliberately writes no marker so a genuine regression brings a family straight back. Together those starve the queue: with up to 40 members per family, ~2 old handled/reconciling families can permanently fill the window. The same stubs are re-read and re-deferred every run, stub 51 is never evaluated, and the tracker reports the starvation without advancing anything.

Raising the window alone does not fix it — a window full of deferred families still selects nothing — and the cap could not be raised responsibly without knowing what it actually costs.

Measurement changed the picture. The window governs how many stubs are *evaluated*; a separate `--cap 2` governs how many are *fixed*, and only the fix step invokes an agent. So the window is decoupled from model spend. CI minutes are free here (public repo, `ubuntu-latest`). The real bounds are the select job's `timeout-minutes` against strictly serial `gh` calls, and `LIST_LIMIT = 200`, a server-side row cap applied *before* the window slice — which made any raise above 200 a silent no-op that no docstring mentioned.

## The Solution

- **Window 50 → 200**, matching `LIST_LIMIT` so the raise is effective. Both constants now document that the other exists and that they must move together, and a run-time `windowCeilingWarning` makes a future mismatch loud instead of silently inert.
- **Bounded second look**: when the first pass selects nothing *and* the stub page came back full, one further bounded pass reads past the window and evaluates up to 100 more stubs on fresh family budgets, seeded with the first pass's proven blockers. It cannot fire on a healthy run, so it costs nothing in the steady state.
- **`timeout-minutes` 10 → 25** on the select job only. This — not any rate limit — is what the call count actually spends, and minutes are free on this repo.
- **Instrumentation**: a `gh` invocation counter in the run record, and a rate-budget echo before and after the select step, so per-call latency and remaining repo budget stop being extrapolations.
- **Fail closed on throttling**: rate-limit-shaped failures now stand the run down (zero entries, loud degraded report) instead of failing soft. Every dedupe read previously treated a 403 as "no blocker found" — and those reads *are* the dedupe signal, so a throttled run could open duplicate fix PRs and still look green. A wider window raises that probability, so it is fixed here rather than left as a follow-up.

## Details

**Cost, per worst-case run** (serial, no `Promise.all` in this leg): first pass 521 invocations, 782 with a second look ≈ 13 min at a pessimistic 1 s/call, ~52% of the raised timeout. Against the repo's hourly `GITHUB_TOKEN` budget that is ~485 GraphQL and ~300 REST core, roughly 49% and 30% — a ~2x margin, on a cron that fires once per weekday. Model spend is unchanged at ≤2 agent runs regardless of window size.

Two honest notes rather than favourable framing. The expensive path is the *steady state*, not the worst case: once the queue exceeds `LIST_LIMIT` raw rows in the residue condition, a run pays close to the full bill every weekday and still selects nothing — the new `full` clause in the run record is what makes that visible. And with the window now equal to `LIST_LIMIT`, the old `Window: N stubs, evaluated M` tripwire is inert, since the API truncates before the slice can; the second-look line is the live tripwire now, and the code says so.

Throttling is latched at the `gh` driver, so the first rate-limit failure short-circuits every later call in the run — a throttled run costs ~3 invocations instead of ~400, which is what keeps fail-closed from turning one 403 into an expensive no-op.

The selector crossed the 600-line soft cap during this work and was split into `sentry-autofix-second-look.mjs` and `sentry-autofix-decisions.mjs` in the same PR, per the recurring-review checklist. No new `scripts/sentry-*.test.mjs` file was added, so the suite-registration surface is unchanged.

## Validation

`bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main` → exit 0, all mapped commands green, no bypass.

Every new behaviour carries a test whose negative control was proven by mutation — the implementation was broken, the specific test observed to red, then restored and re-verified green. That includes the throw-site guard, the throttle latch (measured: 401 calls after the first 403 before the fix, 3 after), the seeded second look, the derived raw-row offset, the `full` signal, the degraded-signal write, and a pin that the window may never exceed `LIST_LIMIT`. A danger control pins that non-throttle transients still fail soft exactly as before, so the fail-closed change is scoped to throttling only.

The branch was reviewed by three independent adversarial passes before this PR was opened; every finding was fixed rather than argued away, including two that would have failed the step in production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes dedupe-critical GitHub reads, queue starvation recovery, and throttling behavior for an automated fix PR pipeline; misclassification could either duplicate PRs or over-suppress selection, and the wider window materially increases API load per run.
> 
> **Overview**
> Widens **Sentry autofix selection** so a full oldest-first window (50 → **200**, aligned with `LIST_LIMIT`) can actually be read, and adds a **bounded second look** when the first pass selects nothing off a **full** list page—one extra paginated fetch (up to 100 stubs) with halved family budgets and **seeded** first-pass blockers so deferred families cannot hide selectable stubs forever.
> 
> The select job **timeout goes 10 → 25 minutes**, with **rate-budget** echoes before/after selection and **`gh` invocation** counts on the tracker. **Rate-limit-shaped `gh` failures** now **latch** (no further API calls), emit **zero** candidates, set disposition **`degraded-rate-limited`**, and surface a **DEGRADED** run-record line; dispatch paths get **`--truncations-out`** too, and a failed truncations write **fails the step** so suppression is not silent. **`degraded-rate-limited`** also blocks architectural label backfill.
> 
> Refactors split **`sentry-autofix-second-look.mjs`**, **`sentry-autofix-decisions.mjs`**, extends **`listCodeFixStubsPage`** (`skip`/`full`), **`resolveFamilies`** (`budgets`/`seed`), probe budgeting in reverse verify, plus docs and extensive tests (including workflow timeout pin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f38a8b4f19c380e507f0e0924cab28f4f6e3620. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->