### PR TITLE
docs: carry PR work through production closeout

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-08-13
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -93,6 +93,23 @@ different budget. Report state changes only when something becomes actionable:
 required CI failure, merge conflict, unreplied review comment, unresolved
 thread, Codex approval missing after current-head review, all-clear, merged, or
 closed.
+
+That low-noise rule applies only to unsolicited polling updates. When the user
+asks for status, answer immediately with the PR URL or number, bound head SHA,
+latest feedback/readiness/check result and observation time, current action and
+owner, any blocker or wait, and the next action or deadline. Then keep the
+watcher running.
+
+## Multiple PRs
+
+Give each independent PR its own watcher worker or subagent. Bind every worker
+to that PR's exact repository, number, head, and an isolated worktree before it
+can edit. The lead owns user-facing status, cross-PR dependencies, patch review,
+and approval boundaries while the watchers stay active. A watcher reports an
+actionable transition promptly and either repairs it or hands it to an
+available repair worker; do not leave open feedback aging while every capable
+agent waits. Serialize only overlapping or dependent fixes. On cloud surfaces,
+keep one subscription or check-in loop per PR under the same ownership model.
 
 ## Act On Required Blockers
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ship
-description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
+description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, readiness babysitting, and required production closeout. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
 title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-08-13
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -168,7 +168,7 @@ only when the user explicitly asks for draft/PR-only handling or when required
 validation/review is intentionally still pending, and state that reason in the
 PR body and final summary.
 
-## Post-Push
+## Post-Push And Closeout
 
 Follow the operating card's Babysit and Ready-state steps: run
 `pnpm --silent pr:feedback-state` first, then `pnpm pr:ready-state`, both bound
@@ -176,5 +176,12 @@ with `--repo "$BASE_REPO"` because checkout inference can inspect the wrong
 same-number PR. `docs/notes/pr-ready-state.md` owns that contract. In a Claude
 cloud session without the capability gate the probes cannot run: use the
 `babysit-pr` skill's cloud watch loop and label its result MCP-emulated. If the
-user asked for the complete ship loop, run `babysit-pr` until the PR reaches
-all-clear, merged, closed, or a clear deadline/escalation state.
+user asked for the complete ship loop, run `babysit-pr` through current-head
+all-clear, then present the evidence and wait for the operating card's explicit,
+direct merge approval. After that approved merge, resume the loop when Done
+means includes deployment or live proof: monitor the deployment, obtain any
+separate apply or promotion approval, run the owning package's production
+checks, and verify the live acceptance criteria. Pre-merge all-clear is not
+completion while that proof remains. Stop only after required production
+closeout completes, after merge or closure when no closeout is required, or at
+a clear deadline or escalation state.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-08-13
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -93,6 +93,23 @@ different budget. Report state changes only when something becomes actionable:
 required CI failure, merge conflict, unreplied review comment, unresolved
 thread, Codex approval missing after current-head review, all-clear, merged, or
 closed.
+
+That low-noise rule applies only to unsolicited polling updates. When the user
+asks for status, answer immediately with the PR URL or number, bound head SHA,
+latest feedback/readiness/check result and observation time, current action and
+owner, any blocker or wait, and the next action or deadline. Then keep the
+watcher running.
+
+## Multiple PRs
+
+Give each independent PR its own watcher worker or subagent. Bind every worker
+to that PR's exact repository, number, head, and an isolated worktree before it
+can edit. The lead owns user-facing status, cross-PR dependencies, patch review,
+and approval boundaries while the watchers stay active. A watcher reports an
+actionable transition promptly and either repairs it or hands it to an
+available repair worker; do not leave open feedback aging while every capable
+agent waits. Serialize only overlapping or dependent fixes. On cloud surfaces,
+keep one subscription or check-in loop per PR under the same ownership model.
 
 ## Act On Required Blockers
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ship
-description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
+description: '[repo-skill] Ship monitoring-monorepo changes through the repo''s Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, readiness babysitting, and required production closeout. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.'
 title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-08-13
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -168,7 +168,7 @@ only when the user explicitly asks for draft/PR-only handling or when required
 validation/review is intentionally still pending, and state that reason in the
 PR body and final summary.
 
-## Post-Push
+## Post-Push And Closeout
 
 Follow the operating card's Babysit and Ready-state steps: run
 `pnpm --silent pr:feedback-state` first, then `pnpm pr:ready-state`, both bound
@@ -176,5 +176,12 @@ with `--repo "$BASE_REPO"` because checkout inference can inspect the wrong
 same-number PR. `docs/notes/pr-ready-state.md` owns that contract. In a Claude
 cloud session without the capability gate the probes cannot run: use the
 `babysit-pr` skill's cloud watch loop and label its result MCP-emulated. If the
-user asked for the complete ship loop, run `babysit-pr` until the PR reaches
-all-clear, merged, closed, or a clear deadline/escalation state.
+user asked for the complete ship loop, run `babysit-pr` through current-head
+all-clear, then present the evidence and wait for the operating card's explicit,
+direct merge approval. After that approved merge, resume the loop when Done
+means includes deployment or live proof: monitor the deployment, obtain any
+separate apply or promotion approval, run the owning package's production
+checks, and verify the live acceptance criteria. Pre-merge all-clear is not
+completion while that proof remains. Stop only after required production
+closeout completes, after merge or closure when no closeout is required, or at
+a clear deadline or escalation state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@ title: Monitoring Monorepo Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-13
 doc_type: agent-instructions
 scope: repo-wide
 review_interval_days: 90
@@ -18,7 +18,7 @@ live in [`SPEC.md`](SPEC.md).
 ## Operating Rule (read this before opening PRs)
 
 The full claim → implement → gate → autoreview → ship → babysit → ready-state →
-merge loop, with its non-negotiables, is one card:
+merge loop, plus production closeout when required, is one card:
 [`docs/notes/pr-operating-card.md`](docs/notes/pr-operating-card.md). Read it
 first; open the authority docs it names only when a step needs their depth.
 

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -3,7 +3,7 @@ title: Agent Issue Workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-08-13
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -42,8 +42,8 @@ State labels are mutually exclusive:
 - `agent-ready` — the issue body is enough for an agent to implement.
 - `agent-active` — an agent has claimed the issue and is working before or while
   opening a PR.
-- `in-pr` — an implementation PR is open; agents should not pick this up as new
-  work.
+- `in-pr` — an implementation PR is open, or its approved merge still needs
+  production closeout; agents should not pick this up as new work.
 
 Routing labels:
 
@@ -70,15 +70,20 @@ Routing labels:
    the Project has an `In Review` status option. With the default GitHub status
    options, it falls back to `In Progress`.
 6. On merge, GitHub closes issues referenced with closing keywords. Run
-   `pnpm issue:board sync` after merge, or on a schedule, to move closed
-   `in-pr` issues that are already on Project #12 to `Done` and clear the
-   queue label.
+   `pnpm issue:board sync` after merge, or on a schedule, to move those closed
+   `in-pr` issues on Project #12 to `Done` and clear the queue label. When Done
+   means still requires post-merge production proof, use `Refs`, keep the issue
+   open and `in-pr`, and retain its current owner through the live checks. Close
+   the issue and run board sync only after its live acceptance criteria pass.
 7. If the PR closes unmerged, run `pnpm issue:release --issue <issue>` and
    restore `agent-ready` only when the remaining work is still clear; otherwise
    run `pnpm issue:release --issue <issue> --needs-grooming`.
 
-For partial work, keep the issue open. Remove `in-pr` after merge and set
+For other partial work, keep the issue open. Remove `in-pr` after merge and set
 `agent-ready` or `needs-grooming` based on the remaining acceptance criteria.
+Do not release a production-closeout issue merely because its PR merged; retain
+`in-pr` until live proof passes or the owner explicitly releases work they
+cannot continue.
 
 If a follow-up PR fully closes an issue that is already labeled `in-pr` from an
 earlier partial PR, `pnpm issue:review` will refuse because the issue is no

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -3,7 +3,7 @@ title: PR Operating Card
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-13
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -12,13 +12,13 @@ garden_lane: operator-runbooks
 
 # PR Operating Card
 
-The one-card loop for taking an agent task from claim to merge. It replaces the
-old habit of reading the full stack of operating runbooks up front: work the
-steps here, and open an authority doc only when a specific step's decision needs
-its depth. Each step is terse on purpose and names its owning authority. Root
-[`AGENTS.md`](../../AGENTS.md) routes here first; the hard invariants below and
-in the Non-negotiables section are binding even when you never open an
-authority.
+The one-card loop for taking an agent task from claim through any required
+production closeout. It replaces the old habit of reading the full stack of
+operating runbooks up front: work the steps here, and open an authority doc only
+when a specific step's decision needs its depth. Each step is terse on purpose
+and names its owning authority. Root [`AGENTS.md`](../../AGENTS.md) routes here
+first; the hard invariants below and in the Non-negotiables section are binding
+even when you never open an authority.
 
 ## The loop
 
@@ -159,8 +159,19 @@ review` requests. Authority:
 8. **Merge hygiene.** **Never merge a PR without the user's explicit, direct
    approval of that specific merge.** Green CI, bot approvals, a READY
    ready-state, and "ship it" do not authorize a merge. Drive the PR to ready,
-   present the evidence, then stop and ask. After merge, sync the issue state
-   and workboard per [`agent-issue-workflow.md`](agent-issue-workflow.md).
+   present the evidence, then stop and ask. If the merge itself satisfies Done
+   means, sync the issue state and workboard afterward per
+   [`agent-issue-workflow.md`](agent-issue-workflow.md). If live proof remains,
+   continue to production closeout first.
+
+9. **Production closeout when required.** When Done means includes deployed or
+   live behavior, merge is an intermediate state. Monitor the owning deployment
+   to a terminal result, obtain any separate apply or promotion approval, and
+   run the owning package's production checks. Report merge, deployment, and
+   live proof as separate facts; a successful workflow alone does not prove the
+   runtime behavior. Use `Refs #N` instead of `Closes #N` when proof can happen
+   only after merge. Close the issue and run `pnpm issue:board sync` only after
+   the live acceptance criteria pass.
 
 ## Non-negotiables
 
@@ -183,10 +194,11 @@ These bind regardless of which step you are on:
 
 ## Authority map
 
-| Step                     | Authority doc                                                        |
-| ------------------------ | -------------------------------------------------------------------- |
-| Claim, defer, merge-sync | [`agent-issue-workflow.md`](agent-issue-workflow.md)                 |
-| Gate, autoreview         | [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md) |
-| Ready-state              | [`pr-ready-state.md`](pr-ready-state.md)                             |
-| Docs and drift           | [`../context-standards.md`](../context-standards.md)                 |
-| Ship, babysit            | `ship` and `babysit-pr` skills                                       |
+| Step                     | Authority doc                                                         |
+| ------------------------ | --------------------------------------------------------------------- |
+| Claim, defer, merge-sync | [`agent-issue-workflow.md`](agent-issue-workflow.md)                  |
+| Gate, autoreview         | [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md)  |
+| Ready-state              | [`pr-ready-state.md`](pr-ready-state.md)                              |
+| Docs and drift           | [`../context-standards.md`](../context-standards.md)                  |
+| Ship, babysit            | `ship` and `babysit-pr` skills                                        |
+| Production closeout      | [`../deployment.md`](../deployment.md) and the owning package runbook |


### PR DESCRIPTION
## The Problem

- The PR workflow ended at merge even when completion depended on a production deployment and live proof.
- Low-noise PR watching could delay a direct status answer, and several independent PRs had no explicit watcher ownership rule.

## The Solution

- Carry production-dependent work through live verification, answer direct status questions immediately, and assign one watcher to each independent PR.

## Details

- Keep production-dependent issues open until the owning deployment and live acceptance checks pass.
- Require direct status replies to name the PR and head, latest gate result and time, current owner, blocker, and next action.
- Give each independent PR an exact-head watcher while the lead owns dependencies, reviews, and approval boundaries.
- Keep the Codex and Claude babysitting skill mirrors byte-identical.

## Validation

- `CI=true pnpm agent:quality-gate --run` — passed all nine mapped commands.
- Fresh-context Codex autoreview — clean on the final diff against current `origin/main`.
- Deterministic local autoreview — clean.
- Autoreview bundle manifest — verified unchanged after review.
- `git diff --check` — passed.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this clarifies the existing PR workflow and approval boundaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent runbooks and skills; no application code, auth, or deployment logic changes.
> 
> **Overview**
> **Extends the agent PR loop** so tasks that need live or deployed proof do not end at merge. `AGENTS.md` and the **PR operating card** now run from claim through optional **production closeout** (new step 9): monitor deployment, get apply/promotion approval when needed, run package production checks, treat merge vs deployment vs live proof separately, prefer `Refs #N` when proof is post-merge, and sync/close issues only after acceptance criteria pass. **Merge hygiene** (step 8) defers issue sync when live proof is still required.
> 
> **Updates the `babysit-pr` skill** (`.agents` and `.claude` mirrors, kept identical): unsolicited polling stays low-noise, but a direct status ask must get an immediate answer (PR/head, latest probe result and time, owner, blocker, next action) while watching continues. Adds a **Multiple PRs** section—one bound watcher/worktree per independent PR, lead owns cross-PR coordination and approvals, repair handoffs without idle agents.
> 
> Metadata `last_verified` bumps on touched docs only; no runtime or CI behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db12ac048d1ae082de897537ed25da58f6d7786. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->