### PR TITLE
refactor(sentry): split the handled-family lookup out of the autofix queue I/O

### DIFF
--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1155,7 +1155,7 @@ The arithmetic that sizes it: 521 (first pass) + 1 list invocation + 2×100 read
 **Fail closed on rate limiting.** Nearly every read in this leg fails SOFT toward
 MORE candidates — `readStub` and `openAutofixPrExists` in
 `scripts/sentry-autofix-candidate.mjs`, the per-id handled lookups in
-`scripts/sentry-autofix-queue-io.mjs`, the reverse probes in
+`scripts/sentry-autofix-family-handled.mjs`, the reverse probes in
 `scripts/sentry-autofix-reverse-verify.mjs`. That is the right trade for a
 transient blip (one self-terminating extra attempt), but the blockers those reads
 look for ARE the dedupe signals, so a throttled read is indistinguishable from

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2433,9 +2433,22 @@ while IFS= read -r path; do
           # production on the path the second look exists to create.
           add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix per-run cost cap changed"
           ;;
+        scripts/sentry-autofix-family-handled.mjs)
+          # The handled-FAMILY lookup, split out of sentry-autofix-queue-io.mjs
+          # for the 600-line soft cap. Its behaviour is exercised end to end by
+          # the select suite, like every other module on this leg.
+          add_command "pnpm sentry:autofix:select:test" "Sentry autofix handled-family lookup changed"
+          # It also OWNS a cap the finalize suite pins the select job's
+          # timeout-minutes against — MAX_HANDLED_ID_QUERIES, one of the terms in
+          # that suite's worst-case serial `gh` call count. Same reason
+          # sentry-autofix-select-instrument.mjs routes there: raising the cap
+          # without re-checking the timeout has to fail in the gate, not in
+          # production.
+          add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix per-run cost cap changed"
+          ;;
         scripts/sentry-autofix-queue-io.mjs|scripts/sentry-autofix-family-resolve.mjs|scripts/sentry-autofix-reverse-verify.mjs|scripts/sentry-autofix-family.mjs|scripts/sentry-autofix-candidate.mjs)
-          # The selection leg's gh I/O layer (openAutofixPrExists / isOwnHeadPr /
-          # the family-collapse reads), the live-state family resolver, the
+          # The selection leg's gh I/O layer (the window list, readStub,
+          # openAutofixPrExists / isOwnHeadPr), the live-state family resolver, the
           # reverse `in:comments` verification leg, and the pure union-find
           # family module (transitive union / project scoping / MAX_FAMILY_MEMBERS
           # / representative rule) — all consumed by the selector. Each is

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3799,6 +3799,16 @@ assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper change
 run_gate "scripts/sentry-triage-archive.test.mjs"
 assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper changed)"
 
+# The handled-family lookup, split out of sentry-autofix-queue-io.mjs for the
+# 600-line soft cap. Pinned ALONE — a module added to this leg without a routing
+# case matches nothing and its edits run zero tests, and a pin that lists several
+# paths at once lets a sibling's route mask the miss. It carries
+# MAX_HANDLED_ID_QUERIES, a term in the finalize suite's select-job timeout pin,
+# so both suites must be routed.
+run_gate "scripts/sentry-autofix-family-handled.mjs"
+assert_contains "- pnpm sentry:autofix:select:test (Sentry autofix handled-family lookup changed)"
+assert_contains "- pnpm sentry:autofix:finalize:test (Sentry autofix per-run cost cap changed)"
+
 # The self-run Sentry-suite gate (#1779, ADR 0062) asserts, at runtime, that the
 # suites actually ran. A contributor who edits the gate script, its own suite, or
 # the manifest it reconciles against must run scripts/sentry-suite-gate.test.mjs

--- a/scripts/sentry-autofix-family-handled.mjs
+++ b/scripts/sentry-autofix-family-handled.mjs
@@ -1,0 +1,197 @@
+/**
+ * The HANDLED-FAMILY lookup for the Sentry AUTOFIX selection leg: given the
+ * `duplicate_of` family ids a window declared, which of them already carry a
+ * TERMINAL autofix marker — and the per-run budget that bounds how many of them
+ * one run may ask about.
+ *
+ * Extracted from scripts/sentry-autofix-queue-io.mjs. That file was at 583 of
+ * the 600-line soft cap (docs/pr-checklists/recurring-review-patterns.md) — not
+ * over it, but with too little headroom for the next change, which is how the
+ * checklist's split-not-append rule gets hit late. This is the seam that leaves
+ * both sides room: one exported lookup plus the one constant that bounds it,
+ * with the budget / `queried` / `answered` accounting that only it reads.
+ *
+ * The dependency runs ONE WAY: this module imports the queue-stub vocabulary
+ * from `sentry-autofix-queue-io.mjs` (the queue label, the owning project and
+ * the title parser), and that module imports nothing from here — its importers
+ * come to this path directly, no re-export shim, exactly as the I/O module's own
+ * header requires of its exports. So no ESM cycle is reachable from this split.
+ *
+ * `runGh` is injectable for the same reason it is there: the select suite drives
+ * the whole flow with mocked I/O. Nothing here writes.
+ */
+
+import { parseShortId } from "./sentry-triage-project-core.mjs";
+import {
+  FIX_PR_OPENED_LABEL,
+  FIX_REFUSED_LABEL,
+} from "./sentry-triage-ingest.mjs";
+import { familyKey } from "./sentry-autofix-family.mjs";
+import {
+  LOCAL_SENTRY_PROJECT,
+  parseProject,
+  SENTRY_TRIAGE_QUEUE_LABEL,
+} from "./sentry-autofix-queue-io.mjs";
+
+/**
+ * How many distinct declared family ids one run may look up — a per-RUN budget,
+ * shared across the initial declared-id pass AND the fixpoint's re-checks of
+ * reverse-surfaced hub ids (see `resolveFamilies`). Each candidate's fan-out is
+ * already MAX_DUPLICATE_LOOKUPS-bounded, but the distinct union across a full
+ * window (plus the ids the reverse probe surfaces) could still be large; overflow
+ * ids are treated as NOT-handled — failing toward MORE candidates, the family
+ * module's documented safe direction — with a stderr note AND a run-record line
+ * (the overflow count is threaded out through the shared `budget`).
+ *
+ * This is one of the caps the finalize suite's select-job timeout pin derives
+ * its worst-case `gh` call count from, so this module routes to that suite too
+ * (scripts/agent-quality-gate.sh).
+ */
+export const MAX_HANDLED_ID_QUERIES = 40;
+
+/**
+ * Family keys that already carry a TERMINAL autofix marker
+ * (`sentry:fix-pr-opened` / `sentry:fix-refused`) — the family-collapse input
+ * `listCodeFixStubs` structurally cannot provide, because it excludes exactly
+ * these stubs from the candidate window. Without it, a refused representative
+ * strands its family: after `ANALYTICS-MENTO-ORG-2E` (#1304) was refused, its
+ * four siblings are the only members left in the window, each pointing back at a
+ * stub the selector can no longer see, so they return one per run and re-burn
+ * the cap on a root cause the leg already declined.
+ *
+ * Keyed on the DECLARED id, not a position in a recent window (PR #1810 bug C).
+ * The prior design listed both terminal-marker sets in bulk
+ * (`sort:created-desc --limit 200`) and read a candidate's siblings out of that
+ * recent slice — so a blocker sitting past row 200 (a terminal sibling deep in
+ * the ledger) was invisible and its family re-attempted forever. Here each
+ * declared id `<ID>` runs ONE query `"<ID>" in:title label:"sentry-triage"`,
+ * then the exactly-matching stub's labels decide it: keyed on the referenced id,
+ * a terminal sibling 500 stubs deep is still found, and truncation is
+ * structurally impossible at any ledger size.
+ *
+ * ONE query covers BOTH markers with no OR-label syntax: the search narrows to
+ * queue stubs of this family, and the marker check is client-side off the
+ * returned labels. The parsed-short-id + project recheck fences GitHub's
+ * tokenized search, so a fuzzy near-miss (a different suffix that tokenizes the
+ * same) is dropped.
+ */
+export async function listHandledShortIds(
+  runGh,
+  repo,
+  declaredIds,
+  options = {},
+) {
+  // `queried` (ids this pass must not re-attempt — answered, dropped OR failed)
+  // and `budget` (remaining allowance + accumulated overflow) are shared across
+  // the run's calls, so a second pass on reverse-surfaced ids neither re-queries
+  // an id nor exceeds the per-run cap. Absent (a standalone call), each defaults
+  // fresh, preserving the single-call cap-at-40 behaviour exactly.
+  //
+  // `answered` is the STRICT SUBSET of `queried` whose lookup actually came back
+  // and could be read — knowledge, where the rest of `queried` is merely spend
+  // (it deliberately absorbs ids this call never issued; see the overflow
+  // branch). Only that subset may cross into a pass with a FRESH budget. Why
+  // that matters: sentry-autofix-family-resolve.mjs § ANSWERED vs SPENT.
+  const queried = options.queried instanceof Set ? options.queried : new Set();
+  const answered =
+    options.answered instanceof Set ? options.answered : new Set();
+  const budget = options.budget ?? {
+    remaining: MAX_HANDLED_ID_QUERIES,
+    overflow: 0,
+  };
+  const ids = [
+    ...new Set(
+      (Array.isArray(declaredIds) ? declaredIds : [])
+        .map((id) => familyKey(id))
+        .filter((id) => id.length > 0),
+    ),
+  ].filter((id) => !queried.has(id));
+  const capacity = Math.max(0, budget.remaining ?? 0);
+  const queryIds = ids.slice(0, capacity);
+  const droppedIds = ids.slice(queryIds.length);
+  if (droppedIds.length > 0) {
+    budget.overflow = (budget.overflow ?? 0) + droppedIds.length;
+    // Mark the un-run ids as queried too. The budget is shared across the run's
+    // calls — the declared-id pass AND the fixpoint's rechecks — and a recheck
+    // re-surfaces the same member ids every iteration; without this, one
+    // un-runnable id would be re-counted into overflow once per iteration. The
+    // per-run overflow must reflect each DISTINCT un-runnable id once. It is also
+    // correct on its face: the budget is spent, so a later pass must not
+    // re-attempt these ids either.
+    for (const droppedId of droppedIds) queried.add(droppedId);
+    process.stderr.write(
+      // The budget is passed in, so name what is LEFT rather than the module
+      // constant: the selector's bounded second look runs this same helper on a
+      // smaller allowance, and printing MAX_HANDLED_ID_QUERIES there would point
+      // an operator at a number the pass never had.
+      `note: ${ids.length} distinct declared family ids exceed this pass's remaining handled-id lookup budget (${capacity} left, per-run cap ${MAX_HANDLED_ID_QUERIES}); ${droppedIds.length} are treated as not-handled this run (fails toward MORE candidates).\n`,
+    );
+  }
+  budget.remaining = capacity - queryIds.length;
+  const handled = new Set();
+  for (const id of queryIds) {
+    queried.add(id);
+    let stdout;
+    try {
+      stdout = await runGh([
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "all",
+        "--search",
+        `"${id}" in:title label:"${SENTRY_TRIAGE_QUEUE_LABEL}"`,
+        "--json",
+        "number,title,labels",
+        "--limit",
+        "20",
+      ]);
+    } catch (err) {
+      // Fail-SOFT per id, matching the reverse `in:comments` probe: a transient
+      // GitHub/subprocess failure on ONE lookup must not reject the whole call
+      // and abort the select job under `set -euo pipefail` — that breaks the
+      // "select ALWAYS emits a valid JSON array … never a failure" invariant the
+      // workflow header asserts. Treat THIS id as not-handled this run (it stays
+      // a candidate — fails toward MORE candidates) and continue so the other ids
+      // still resolve. The id is already marked `queried` and budget-spent above,
+      // so it is not re-attempted.
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `skip handled-id lookup for ${id}: ${message}; treated as not-handled this run (fails toward MORE candidates).\n`,
+      );
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      // A body we cannot read did not ANSWER the lookup any more than a failed
+      // read did, so this id stays out of `answered`. Behaviourally identical to
+      // the previous `parsed = []` (the loop below ran zero times either way).
+      continue;
+    }
+    // ANSWERED: the lookup ran and came back readable. Both outcomes count —
+    // "this id carries a terminal marker" and "it does not" are equally real
+    // answers, and re-asking on a later pass would only re-spend budget.
+    answered.add(id);
+    for (const issue of Array.isArray(parsed) ? parsed : []) {
+      const title = issue.title ?? "";
+      // Exact-parse fence over GitHub's tokenized search: the parsed short-id
+      // AND the parsed project must match this id exactly.
+      if (familyKey(parseShortId(title)) !== id) continue;
+      if (parseProject(title) !== LOCAL_SENTRY_PROJECT) continue;
+      const labels = (issue.labels ?? [])
+        .map((label) => (typeof label === "string" ? label : label?.name))
+        .filter(Boolean);
+      if (
+        labels.includes(FIX_PR_OPENED_LABEL) ||
+        labels.includes(FIX_REFUSED_LABEL)
+      ) {
+        handled.add(id);
+        break;
+      }
+    }
+  }
+  return [...handled];
+}

--- a/scripts/sentry-autofix-family-resolve.mjs
+++ b/scripts/sentry-autofix-family-resolve.mjs
@@ -20,9 +20,9 @@ import {
 } from "./sentry-autofix-family.mjs";
 import {
   listHandledShortIds,
-  LOCAL_SENTRY_PROJECT,
   MAX_HANDLED_ID_QUERIES,
-} from "./sentry-autofix-queue-io.mjs";
+} from "./sentry-autofix-family-handled.mjs";
+import { LOCAL_SENTRY_PROJECT } from "./sentry-autofix-queue-io.mjs";
 import {
   MAX_REVERSE_PROBE_QUERIES,
   MAX_REVERSE_VERIFY_READS,

--- a/scripts/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry-autofix-finalize.test.mjs
@@ -42,7 +42,7 @@ import {
   MAX_SECOND_LOOK_EVALUATIONS,
   SECOND_LOOK_FAMILY_BUDGETS,
 } from "./sentry-autofix-second-look.mjs";
-import { MAX_HANDLED_ID_QUERIES } from "./sentry-autofix-queue-io.mjs";
+import { MAX_HANDLED_ID_QUERIES } from "./sentry-autofix-family-handled.mjs";
 import {
   MAX_REVERSE_PROBE_QUERIES,
   MAX_REVERSE_VERIFY_READS,

--- a/scripts/sentry-autofix-queue-io.mjs
+++ b/scripts/sentry-autofix-queue-io.mjs
@@ -5,16 +5,21 @@
  * leg's family-dedupe work adds ~100 more) so the selector keeps only the pure
  * parse / evaluate / collapse-orchestration / report / CLI layers.
  *
- * Every `gh` read the selection leg issues lives here, and `runGh` is injectable
- * so tests drive the full flow with mocked I/O. Nothing here writes: the whole
- * selection step is read-only (the workflow's finalize job owns every write).
- * The exported names are stable — the selector and its tests import them
- * directly, no re-export shim.
+ * `runGh` is injectable so tests drive the full flow with mocked I/O. Nothing
+ * here writes: the whole selection step is read-only (the workflow's finalize
+ * job owns every write). The exported names are stable — the selector and its
+ * tests import them directly, no re-export shim.
+ *
+ * The handled-FAMILY lookup (`listHandledShortIds` and the per-run budget that
+ * bounds it) moved to scripts/sentry-autofix-family-handled.mjs when this file
+ * reached 583 of the 600-line soft cap. That module imports the queue-stub
+ * vocabulary below (`SENTRY_TRIAGE_QUEUE_LABEL`, `LOCAL_SENTRY_PROJECT`,
+ * `parseProject`); this one imports nothing from it, so the direction stays
+ * one-way and no re-export shim exists to close into a cycle.
  */
 
 import { spawn } from "node:child_process";
 
-import { parseShortId } from "./sentry-triage-project-core.mjs";
 import {
   ARCHIVED_LABEL,
   CODE_FIX_VERDICT_LABEL,
@@ -24,14 +29,13 @@ import {
   PROJECTED_LABEL,
 } from "./sentry-triage-ingest.mjs";
 import { autofixBranchName } from "./sentry-autofix-finalize.mjs";
-import { familyKey } from "./sentry-autofix-family.mjs";
 
 // The queue-membership label every triage stub carries (the queue contract's
-// `LABEL_DEFINITIONS` self-heals it). Both per-id lookups below narrow their
-// search to it so a random issue that merely quotes a SHORT-ID cannot match.
-// Exported so the extracted reverse-verify leg
-// (sentry-autofix-reverse-verify.mjs) narrows its `in:comments` probe the same
-// way.
+// `LABEL_DEFINITIONS` self-heals it). Both per-id lookups narrow their search to
+// it so a random issue that merely quotes a SHORT-ID cannot match. Exported so
+// the extracted handled-family lookup (sentry-autofix-family-handled.mjs) and
+// the reverse-verify leg (sentry-autofix-reverse-verify.mjs) narrow their
+// `in:title` / `in:comments` searches the same way.
 export const SENTRY_TRIAGE_QUEUE_LABEL = "sentry-triage";
 
 // The verdict label the select scans for — re-exported from the ingest's single
@@ -317,165 +321,6 @@ export async function listCodeFixStubsPage(runGh, repo, options = {}) {
 export async function listCodeFixStubs(runGh, repo, options = {}) {
   const { stubs } = await listCodeFixStubsPage(runGh, repo, options);
   return stubs;
-}
-
-/**
- * How many distinct declared family ids one run may look up — a per-RUN budget,
- * shared across the initial declared-id pass AND the fixpoint's re-checks of
- * reverse-surfaced hub ids (see `resolveFamilies`). Each candidate's fan-out is
- * already MAX_DUPLICATE_LOOKUPS-bounded, but the distinct union across a full
- * window (plus the ids the reverse probe surfaces) could still be large; overflow
- * ids are treated as NOT-handled — failing toward MORE candidates, the family
- * module's documented safe direction — with a stderr note AND a run-record line
- * (the overflow count is threaded out through the shared `budget`).
- */
-export const MAX_HANDLED_ID_QUERIES = 40;
-
-/**
- * Family keys that already carry a TERMINAL autofix marker
- * (`sentry:fix-pr-opened` / `sentry:fix-refused`) — the family-collapse input
- * `listCodeFixStubs` structurally cannot provide, because it excludes exactly
- * these stubs from the candidate window. Without it, a refused representative
- * strands its family: after `ANALYTICS-MENTO-ORG-2E` (#1304) was refused, its
- * four siblings are the only members left in the window, each pointing back at a
- * stub the selector can no longer see, so they return one per run and re-burn
- * the cap on a root cause the leg already declined.
- *
- * Keyed on the DECLARED id, not a position in a recent window (PR #1810 bug C).
- * The prior design listed both terminal-marker sets in bulk
- * (`sort:created-desc --limit 200`) and read a candidate's siblings out of that
- * recent slice — so a blocker sitting past row 200 (a terminal sibling deep in
- * the ledger) was invisible and its family re-attempted forever. Here each
- * declared id `<ID>` runs ONE query `"<ID>" in:title label:"sentry-triage"`,
- * then the exactly-matching stub's labels decide it: keyed on the referenced id,
- * a terminal sibling 500 stubs deep is still found, and truncation is
- * structurally impossible at any ledger size.
- *
- * ONE query covers BOTH markers with no OR-label syntax: the search narrows to
- * queue stubs of this family, and the marker check is client-side off the
- * returned labels. The parsed-short-id + project recheck fences GitHub's
- * tokenized search, so a fuzzy near-miss (a different suffix that tokenizes the
- * same) is dropped.
- */
-export async function listHandledShortIds(
-  runGh,
-  repo,
-  declaredIds,
-  options = {},
-) {
-  // `queried` (ids this pass must not re-attempt — answered, dropped OR failed)
-  // and `budget` (remaining allowance + accumulated overflow) are shared across
-  // the run's calls, so a second pass on reverse-surfaced ids neither re-queries
-  // an id nor exceeds the per-run cap. Absent (a standalone call), each defaults
-  // fresh, preserving the single-call cap-at-40 behaviour exactly.
-  //
-  // `answered` is the STRICT SUBSET of `queried` whose lookup actually came back
-  // and could be read — knowledge, where the rest of `queried` is merely spend
-  // (it deliberately absorbs ids this call never issued; see the overflow
-  // branch). Only that subset may cross into a pass with a FRESH budget. Why
-  // that matters: sentry-autofix-family-resolve.mjs § ANSWERED vs SPENT.
-  const queried = options.queried instanceof Set ? options.queried : new Set();
-  const answered =
-    options.answered instanceof Set ? options.answered : new Set();
-  const budget = options.budget ?? {
-    remaining: MAX_HANDLED_ID_QUERIES,
-    overflow: 0,
-  };
-  const ids = [
-    ...new Set(
-      (Array.isArray(declaredIds) ? declaredIds : [])
-        .map((id) => familyKey(id))
-        .filter((id) => id.length > 0),
-    ),
-  ].filter((id) => !queried.has(id));
-  const capacity = Math.max(0, budget.remaining ?? 0);
-  const queryIds = ids.slice(0, capacity);
-  const droppedIds = ids.slice(queryIds.length);
-  if (droppedIds.length > 0) {
-    budget.overflow = (budget.overflow ?? 0) + droppedIds.length;
-    // Mark the un-run ids as queried too. The budget is shared across the run's
-    // calls — the declared-id pass AND the fixpoint's rechecks — and a recheck
-    // re-surfaces the same member ids every iteration; without this, one
-    // un-runnable id would be re-counted into overflow once per iteration. The
-    // per-run overflow must reflect each DISTINCT un-runnable id once. It is also
-    // correct on its face: the budget is spent, so a later pass must not
-    // re-attempt these ids either.
-    for (const droppedId of droppedIds) queried.add(droppedId);
-    process.stderr.write(
-      // The budget is passed in, so name what is LEFT rather than the module
-      // constant: the selector's bounded second look runs this same helper on a
-      // smaller allowance, and printing MAX_HANDLED_ID_QUERIES there would point
-      // an operator at a number the pass never had.
-      `note: ${ids.length} distinct declared family ids exceed this pass's remaining handled-id lookup budget (${capacity} left, per-run cap ${MAX_HANDLED_ID_QUERIES}); ${droppedIds.length} are treated as not-handled this run (fails toward MORE candidates).\n`,
-    );
-  }
-  budget.remaining = capacity - queryIds.length;
-  const handled = new Set();
-  for (const id of queryIds) {
-    queried.add(id);
-    let stdout;
-    try {
-      stdout = await runGh([
-        "issue",
-        "list",
-        "--repo",
-        repo,
-        "--state",
-        "all",
-        "--search",
-        `"${id}" in:title label:"${SENTRY_TRIAGE_QUEUE_LABEL}"`,
-        "--json",
-        "number,title,labels",
-        "--limit",
-        "20",
-      ]);
-    } catch (err) {
-      // Fail-SOFT per id, matching the reverse `in:comments` probe: a transient
-      // GitHub/subprocess failure on ONE lookup must not reject the whole call
-      // and abort the select job under `set -euo pipefail` — that breaks the
-      // "select ALWAYS emits a valid JSON array … never a failure" invariant the
-      // workflow header asserts. Treat THIS id as not-handled this run (it stays
-      // a candidate — fails toward MORE candidates) and continue so the other ids
-      // still resolve. The id is already marked `queried` and budget-spent above,
-      // so it is not re-attempted.
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `skip handled-id lookup for ${id}: ${message}; treated as not-handled this run (fails toward MORE candidates).\n`,
-      );
-      continue;
-    }
-    let parsed;
-    try {
-      parsed = JSON.parse(stdout);
-    } catch {
-      // A body we cannot read did not ANSWER the lookup any more than a failed
-      // read did, so this id stays out of `answered`. Behaviourally identical to
-      // the previous `parsed = []` (the loop below ran zero times either way).
-      continue;
-    }
-    // ANSWERED: the lookup ran and came back readable. Both outcomes count —
-    // "this id carries a terminal marker" and "it does not" are equally real
-    // answers, and re-asking on a later pass would only re-spend budget.
-    answered.add(id);
-    for (const issue of Array.isArray(parsed) ? parsed : []) {
-      const title = issue.title ?? "";
-      // Exact-parse fence over GitHub's tokenized search: the parsed short-id
-      // AND the parsed project must match this id exactly.
-      if (familyKey(parseShortId(title)) !== id) continue;
-      if (parseProject(title) !== LOCAL_SENTRY_PROJECT) continue;
-      const labels = (issue.labels ?? [])
-        .map((label) => (typeof label === "string" ? label : label?.name))
-        .filter(Boolean);
-      if (
-        labels.includes(FIX_PR_OPENED_LABEL) ||
-        labels.includes(FIX_REFUSED_LABEL)
-      ) {
-        handled.add(id);
-        break;
-      }
-    }
-  }
-  return [...handled];
 }
 
 /** Read a queue stub's title/labels/comments so it can be evaluated in full. */

--- a/scripts/sentry-autofix-select.test.mjs
+++ b/scripts/sentry-autofix-select.test.mjs
@@ -24,12 +24,14 @@ import {
   ghFailureText,
   isOwnHeadPr,
   isRateLimitFailure,
-  listHandledShortIds,
   LIST_LIMIT,
   LOCAL_SENTRY_PROJECT,
-  MAX_HANDLED_ID_QUERIES,
   openAutofixPrExists,
 } from "./sentry-autofix-queue-io.mjs";
+import {
+  listHandledShortIds,
+  MAX_HANDLED_ID_QUERIES,
+} from "./sentry-autofix-family-handled.mjs";
 import {
   MAX_REVERSE_PROBE_QUERIES,
   MAX_REVERSE_VERIFY_READS,
@@ -5048,6 +5050,54 @@ await test("CLI: a DEGRADED run whose truncations report cannot be written fails
     writeReport(unwritable, {}, "truncations"),
     false,
     "writeReport reports its own failure",
+  );
+});
+
+await test("the selection leg's modules stay under the 600-line soft cap", () => {
+  // scripts/ has no max-lines lint and sits outside the file-size watchlist's
+  // package scopes (scripts/file-size-watchlist.mjs), so the 600-line soft cap in
+  // docs/pr-checklists/recurring-review-patterns.md is only enforced where a
+  // suite pins it. The triage legs pin their own in sentry-triage-brief.test.mjs;
+  // this leg had NO pin, which is how sentry-autofix-queue-io.mjs reached 583 —
+  // 17 lines of headroom — before anyone looked. Pinned HERE rather than added to
+  // that list because the gate routes every module below to THIS suite: a pin in
+  // a suite an autofix change never runs would not fire on the change that
+  // breaks it.
+  //
+  // Every module the select leg owns belongs on this list — an omission is how
+  // the next one drifts. sentry-autofix-finalize.mjs is deliberately absent: it
+  // belongs to the finalize leg, is already past this cap (the 1,000-line hard
+  // cap governs it), and appears in this suite's import closure only because
+  // queue-io reads `autofixBranchName` from it.
+  const paths = [
+    "sentry-autofix-candidate.mjs",
+    "sentry-autofix-decisions.mjs",
+    "sentry-autofix-family-handled.mjs",
+    "sentry-autofix-family-resolve.mjs",
+    "sentry-autofix-family.mjs",
+    "sentry-autofix-queue-io.mjs",
+    "sentry-autofix-reverse-verify.mjs",
+    "sentry-autofix-second-look.mjs",
+    "sentry-autofix-select-cli.mjs",
+    "sentry-autofix-select-instrument.mjs",
+    "sentry-autofix-select.mjs",
+  ];
+  // Resolved against THIS file rather than a repo root: the Sentry-suite gate
+  // runs each suite from its own snapshot of the derived import set, and every
+  // module above is in that closure, so a sibling-relative read works there and
+  // needs no `reads` declaration in scripts/sentry-suite-manifest.json.
+  const oversized = paths
+    .map((path) => [
+      path,
+      readFileSync(new URL(`./${path}`, import.meta.url), "utf8").split("\n")
+        .length,
+    ])
+    .filter(([, lines]) => lines > 600)
+    .map(([path, lines]) => `${path}:${lines}`);
+  assertEqual(
+    oversized.join(", "),
+    "",
+    "these selection-leg modules crossed the 600-line soft cap; split them",
   );
 });
 


### PR DESCRIPTION
## The Problem

- `scripts/sentry-autofix-queue-io.mjs` was 583 lines against the repo's 600-line
  soft cap. That is **not** a violation — it is 17 lines of headroom on the file
  the autofix selection leg touches most, which is how the split-not-append rule
  gets hit halfway through an unrelated change.
- Nothing enforced the cap on this leg. `scripts/` has no `max-lines` lint and
  sits outside the file-size watchlist's package scopes, and the only suite that
  pins line counts (`sentry-triage-brief.test.mjs`) lists triage modules only —
  no autofix module appears on it.

## The Solution

- Move the handled-family lookup — `listHandledShortIds` and the
  `MAX_HANDLED_ID_QUERIES` budget that bounds it — into
  `scripts/sentry-autofix-family-handled.mjs`. `sentry-autofix-queue-io.mjs`
  drops **583 → 428**; the new module is **197**. Both have real headroom, not
  a couple of lines.
- Pin the cap where it will actually run: a 600-line assertion over the
  selection leg's modules in `sentry-autofix-select.test.mjs`, the suite the
  gate routes every one of those modules to.

## Details

**The seam.** The three candidates were the stub-listing/paging layer, the
PR-ownership lookup, and the handled-family lookup. The handled-family lookup
wins on three counts:

- It is one exported function plus the one constant that bounds it, and the
  `queried` / `answered` / `budget` accounting is read by nothing else — the
  whole unit moves with no shared state left behind.
- It is the largest cohesive block, so the split leaves 172 lines of headroom
  rather than the ~95 the PR-ownership seam would have.
- The dependency runs **one way**: the new module imports the queue-stub
  vocabulary (`SENTRY_TRIAGE_QUEUE_LABEL`, `LOCAL_SENTRY_PROJECT`,
  `parseProject`) from `sentry-autofix-queue-io.mjs`, and that file imports
  nothing from the new one. Importers come to the new path directly — no
  re-export shim, matching the I/O module's own stated rule — so there is no
  surface an ESM cycle could form on.

**Sibling sizes, checked before choosing.** Nothing was parked in a file near
the cap: `sentry-autofix-select.mjs` 500, `-family.mjs` 377,
`-reverse-verify.mjs` 330, `-family-resolve.mjs` 299, `-candidate.mjs` 248,
`-select-instrument.mjs` 248, `-select-cli.mjs` 224, `-second-look.mjs` 191,
`-decisions.mjs` 69. A new module was the right home; folding 160 lines into
`-family-resolve.mjs`, the closest consumer, would have pushed it to 459 and
mixed the resolver with the I/O it drives.

**Gate routing, verified one module at a time.** The new module gets its own
case in `scripts/agent-quality-gate.sh`, dry-run **alone** to prove it matches:
it maps to `pnpm sentry:autofix:select:test` **and**
`pnpm sentry:autofix:finalize:test`. The second route closes a real gap the
split exposed — `MAX_HANDLED_ID_QUERIES` is one of the terms the finalize
suite's select-job `timeout-minutes` pin derives its worst-case `gh` call count
from, and the module that owned it before routed only to the select suite. The
route is pinned in `scripts/agent-quality-gate.test.sh`.

**No new suite.** Tests for the moved code stay in `sentry-autofix-select.test.mjs`;
no `scripts/sentry-*.test.mjs` file was added, so nothing touches the suite
manifest, `ci.yml`, or the suite gate.

`sentry-autofix-finalize.mjs` (904) is deliberately absent from the new pin: it
belongs to the finalize leg, is already past the soft cap, and the 1,000-line
hard cap governs it. It appears in this suite's import closure only because
`queue-io` reads `autofixBranchName` from it.

## Validation

**Equivalence, diffed rather than asserted.** A stub `gh` on `PATH` answering
every read the leg issues (window list, per-stub view, owner-qualified pulls
probe, handled-family `in:title` lookup, reverse `in:comments` probe) drove the
selector CLI across 10 paths: `--help`, an unknown option, a batch run against
an empty queue writing all four report files, a throttled run, a non-throttle
read failure on the first window list, a live window whose declared family id
resolves to a terminal sibling (positive hit on the moved code), the same window
with the handled lookup itself failing (the moved fail-soft catch), the
single-issue dispatch path, and both `--emit-verdict` paths. The identical
harness ran against `git archive origin/main` of the pre-split tree (confirmed
583 lines, new module absent). `diff -r` over all 50 artifacts — stdout, stderr,
exit code and every report file per scenario — is **empty**.

**Negative controls, re-proven after the move.** Each mutation reds exactly one
test and nothing else; the restored tree is green at 125 passed, 0 failed:

| Mutation | Test that reds |
| --- | --- |
| Remove the throttle latch in `instrumentRunGh` | FAIL CLOSED: the latch holds where the loop break cannot — a throttle DURING family resolution |
| Remove the first-window-list catch | FAIL CLOSED: a THROTTLED FIRST window list degrades the run instead of failing the step |
| Make that catch swallow unconditionally | FAIL CLOSED: a NON-throttle failure on those same reads still FAILS the step, unchanged |

The new file-size pin is load-bearing too: lowered to 150 it reds and names
every module including `sentry-autofix-family-handled.mjs`.

**Suites and gate.**

- `node scripts/sentry-autofix-select.test.mjs` — 125 passed, 0 failed
- `node scripts/sentry-autofix-finalize.test.mjs` — 64 passed, 0 failed
- `node scripts/sentry-suite-gate.mjs` — 14 suites ran and were asserted from
  their own output (the moved module's sibling-relative reads work inside the
  gate's snapshot, so no `reads` declaration is needed in the manifest)
- `bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main` — exit 0

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this moves existing code between
      files and changes no behaviour, contract, or dependency direction that a
      future change is constrained by.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file split with import and CI routing updates only; PR description claims behavior-equivalence via diffed CLI harness. No auth, data, or runtime contract changes beyond where caps are owned for gate purposes.
> 
> **Overview**
> **Splits the handled-family lookup** (`listHandledShortIds`, `MAX_HANDLED_ID_QUERIES`) out of `sentry-autofix-queue-io.mjs` into **`scripts/sentry-autofix-family-handled.mjs`** so queue I/O stays under the 600-line soft cap. Importers (`family-resolve`, select/finalize tests) import from the new module; queue-io documents the one-way dependency (no re-export shim).
> 
> **Quality gate:** Adds a dedicated `agent-quality-gate.sh` case for the new file—**select** tests for behavior and **finalize** tests because `MAX_HANDLED_ID_QUERIES` feeds the select-job timeout pin (previously only select was routed when this lived in queue-io). Gate tests assert both routes.
> 
> **Enforcement:** `sentry-autofix-select.test.mjs` gains a test that every selection-leg module stays ≤600 lines (including the new file), closing the gap that let queue-io reach 583 lines without a pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d4dcd04c6eaceb5ba1365eedf9203948ce511d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->