### PR TITLE
fix(alerts-infra): move the nanoid security floor to 3.3.18

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -4,9 +4,10 @@ name: Supply Chain
 #
 # 1. npm advisory audit — fails this advisory workflow when a high/critical
 #    advisory exists against any package in the root or standalone deploy
-#    lockfiles. The governance-watchdog high-audit leg is duplicated in the
-#    required Code Quality job so that deploy lockfile stays covered by a
-#    ruleset-required check.
+#    lockfiles. The governance-watchdog and both alerts-handler high-audit
+#    legs are duplicated in the required Code Quality job so those deploy
+#    lockfiles stay covered by a ruleset-required check even though this
+#    workflow itself is not required and is path-filtered.
 #
 # 2. lockfile-lint — validates pnpm-lock.yaml structural integrity for the root
 #    workspace lockfile and the package-local Cloud Build lockfiles:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -35,6 +35,10 @@ jobs:
         run: node scripts/pnpm-audit-high-gate.test.mjs
       - name: pnpm audit governance-watchdog deploy lockfile (high+ only)
         run: node scripts/pnpm-audit-high-gate.mjs --dir governance-watchdog --label governance-watchdog
+      - name: pnpm audit on-call announcer deploy lockfile (high+ only)
+        run: node scripts/pnpm-audit-high-gate.mjs --dir alerts/infra/oncall-announcer --label alerts/infra/oncall-announcer
+      - name: pnpm audit handler deploy lockfile (high+ only)
+        run: node scripts/pnpm-audit-high-gate.mjs --dir alerts/infra/onchain-event-handler --label alerts/infra/onchain-event-handler
       - name: Cache Trunk artifacts
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -54,13 +54,17 @@ lint:
         # scanning this derived artifact would just double-report transitive
         # findings with no fix path.
         - alerts/infra/onchain-event-handler/package-lock.json
-        # Standalone Cloud Build lockfiles for the alerts handlers, audited by
-        # .github/workflows/supply-chain.yml's pnpm-audit step like their
-        # siblings above. They were the last lockfiles trunk's osv-scanner
-        # still scanned inline, which made every same-day OSV publication
-        # against any pinned transitive fail Code Quality repo-wide on files
-        # no open PR touches (2026-08-13: nanoid, then uuid and ws within
-        # hours). Security floors stay maintained via each package's
+        # Standalone Cloud Build lockfiles for the alerts handlers. The
+        # required Code Quality job runs scripts/pnpm-audit-high-gate.mjs
+        # against both directly (same duplication as governance-watchdog
+        # above), so a ruleset-required check still fails on a high/critical
+        # advisory; .github/workflows/supply-chain.yml's pnpm-audit step
+        # covers the same two directories for the non-required daily/weekly
+        # cadence. They were the last lockfiles trunk's osv-scanner still
+        # scanned inline, which made every same-day OSV publication against
+        # any pinned transitive fail Code Quality repo-wide on files no open
+        # PR touches (2026-08-13: nanoid, then uuid and ws within hours).
+        # Security floors stay maintained via each package's
         # pnpm-workspace.yaml overrides.
         - alerts/infra/oncall-announcer/pnpm-lock.yaml
         - alerts/infra/onchain-event-handler/pnpm-lock.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -54,6 +54,16 @@ lint:
         # scanning this derived artifact would just double-report transitive
         # findings with no fix path.
         - alerts/infra/onchain-event-handler/package-lock.json
+        # Standalone Cloud Build lockfiles for the alerts handlers, audited by
+        # .github/workflows/supply-chain.yml's pnpm-audit step like their
+        # siblings above. They were the last lockfiles trunk's osv-scanner
+        # still scanned inline, which made every same-day OSV publication
+        # against any pinned transitive fail Code Quality repo-wide on files
+        # no open PR touches (2026-08-13: nanoid, then uuid and ws within
+        # hours). Security floors stay maintained via each package's
+        # pnpm-workspace.yaml overrides.
+        - alerts/infra/oncall-announcer/pnpm-lock.yaml
+        - alerts/infra/onchain-event-handler/pnpm-lock.yaml
     - linters: [checkov]
       paths:
         - terraform/main.tf

--- a/alerts/infra/oncall-announcer/pnpm-lock.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
@@ -1481,8 +1481,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3548,7 +3548,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3671,7 +3671,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/alerts/infra/oncall-announcer/pnpm-workspace.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-workspace.yaml
@@ -27,8 +27,8 @@ overrides:
   fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  nanoid@<3.3.17: 3.3.17
+  # GHSA-2v37-7h3g-55p8: 3.3.18 fixes zero-size generator hangs.
+  nanoid@<3.3.18: 3.3.18
   # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5

--- a/alerts/infra/onchain-event-handler/pnpm-lock.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   form-data@<2.5.6: 2.5.6
   form-data@>=4.0.0 <4.0.6: 4.0.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
@@ -1562,8 +1562,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3736,7 +3736,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3878,7 +3878,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
@@ -25,8 +25,8 @@ overrides:
   form-data@<2.5.6: 2.5.6
   "form-data@>=4.0.0 <4.0.6": 4.0.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  nanoid@<3.3.17: 3.3.17
+  # GHSA-2v37-7h3g-55p8: 3.3.18 fixes zero-size generator hangs.
+  nanoid@<3.3.18: 3.3.18
   # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5

--- a/governance-watchdog/pnpm-lock.yaml
+++ b/governance-watchdog/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   uuid@<11.1.1: 11.1.1
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   ws@<8.21.0: 8.21.0
   '@types/node': 24.13.2
 
@@ -1669,8 +1669,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3885,7 +3885,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4032,7 +4032,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/governance-watchdog/pnpm-workspace.yaml
+++ b/governance-watchdog/pnpm-workspace.yaml
@@ -41,8 +41,8 @@ overrides:
   "uuid@<11.1.1": 11.1.1
   "protobufjs@>=7.0.0 <7.6.5": 7.6.5
   "js-yaml@>=4.0.0 <4.3.1": 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  "nanoid@<3.3.17": 3.3.17
+  # GHSA-2v37-7h3g-55p8: 3.3.18 fixes zero-size generator hangs.
+  "nanoid@<3.3.18": 3.3.18
   # isows resolves ws@8.20.1 through viem; 8.21.0 contains the GHSA-96hv-2xvq-fx4p
   # fix and stays compatible with isows' ws peer range.
   "ws@<8.21.0": 8.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   '@istanbuljs/load-nyc-config>js-yaml': 4.3.1
   '@lhci/utils>js-yaml': 4.3.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
   cookie@<0.7.0: 0.7.2
@@ -92,7 +92,7 @@ importers:
         version: 0.311.3(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
       '@upstash/mcp-server':
         specifier: 0.2.4
-        version: 0.2.4
+        version: 0.2.4(supports-color@5.5.0)
       dependency-cruiser:
         specifier: 17.4.0
         version: 17.4.0
@@ -174,7 +174,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: 11.0.12
-        version: 11.0.12(@types/node@24.10.1)
+        version: 11.0.12(@types/node@24.10.1)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: 11.0.9
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
@@ -222,7 +222,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: 29.4.5
-        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -7438,8 +7438,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11263,7 +11263,7 @@ snapshots:
 
   '@mento-protocol/contracts@0.9.0': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@5.5.0)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.0(hono@4.13.1)
       ajv: 8.18.0
@@ -11273,8 +11273,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.6.2(express@5.2.1)
+      express: 5.2.1(supports-color@5.5.0)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@5.5.0))(supports-color@5.5.0)
       hono: 4.13.1
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -11313,7 +11313,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/cli@11.0.12(@types/node@24.10.1)':
+  '@nestjs/cli@11.0.12(@types/node@24.10.1)(esbuild@0.28.1)':
     dependencies:
       '@angular-devkit/core': 19.2.19(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.19(chokidar@4.0.3)
@@ -11324,14 +11324,14 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2)
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.1))
       glob: 12.0.0
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.106.2
+      webpack: 5.106.2(esbuild@0.28.1)
       webpack-node-externals: 3.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -13067,9 +13067,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@upstash/mcp-server@0.2.4':
+  '@upstash/mcp-server@0.2.4(supports-color@5.5.0)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@5.5.0)(zod@3.25.76)
       '@types/node': 15.14.9
       chalk: 5.6.2
       commander: 14.0.3
@@ -14968,10 +14968,10 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
 
-  express-rate-limit@8.6.2(express@5.2.1):
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@5.5.0))(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.3.1
     transitivePeerDependencies:
       - supports-color
@@ -15044,7 +15044,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
       body-parser: 2.3.0
@@ -15253,7 +15253,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.1)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -15268,7 +15268,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.106.2
+      webpack: 5.106.2(esbuild@0.28.1)
 
   form-data@2.5.6:
     dependencies:
@@ -17429,7 +17429,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -17979,7 +17979,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -19136,14 +19136,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.1
 
-  terser-webpack-plugin@5.4.0(webpack@5.106.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.1
-      webpack: 5.106.2
-
   terser@5.46.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -19254,7 +19246,7 @@ snapshots:
       picomatch: 4.0.4
       typescript: 5.9.3
 
-  ts-jest@29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -19272,6 +19264,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.4.1
       babel-jest: 30.2.0(@babel/core@7.29.6)
+      esbuild: 0.28.1
       jest-util: 30.4.1
 
   ts-mixer@6.0.4: {}
@@ -19730,37 +19723,6 @@ snapshots:
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.3.4: {}
-
-  webpack@5.106.2:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.1
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.4.0(webpack@5.106.2)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.106.2(esbuild@0.28.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 0.311.3(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
       '@upstash/mcp-server':
         specifier: 0.2.4
-        version: 0.2.4(supports-color@5.5.0)
+        version: 0.2.4
       dependency-cruiser:
         specifier: 17.4.0
         version: 17.4.0
@@ -174,7 +174,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: 11.0.12
-        version: 11.0.12(@types/node@24.10.1)(esbuild@0.28.1)
+        version: 11.0.12(@types/node@24.10.1)
       '@nestjs/schematics':
         specifier: 11.0.9
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
@@ -222,7 +222,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: 29.4.5
-        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -11263,7 +11263,7 @@ snapshots:
 
   '@mento-protocol/contracts@0.9.0': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@5.5.0)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.0(hono@4.13.1)
       ajv: 8.18.0
@@ -11273,8 +11273,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1(supports-color@5.5.0)
-      express-rate-limit: 8.6.2(express@5.2.1(supports-color@5.5.0))(supports-color@5.5.0)
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
       hono: 4.13.1
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -11313,7 +11313,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/cli@11.0.12(@types/node@24.10.1)(esbuild@0.28.1)':
+  '@nestjs/cli@11.0.12(@types/node@24.10.1)':
     dependencies:
       '@angular-devkit/core': 19.2.19(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.19(chokidar@4.0.3)
@@ -11324,14 +11324,14 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.1))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2)
       glob: 12.0.0
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.28.1)
+      webpack: 5.106.2
       webpack-node-externals: 3.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -13067,9 +13067,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@upstash/mcp-server@0.2.4(supports-color@5.5.0)':
+  '@upstash/mcp-server@0.2.4':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(supports-color@5.5.0)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
       '@types/node': 15.14.9
       chalk: 5.6.2
       commander: 14.0.3
@@ -14968,10 +14968,10 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
 
-  express-rate-limit@8.6.2(express@5.2.1(supports-color@5.5.0))(supports-color@5.5.0):
+  express-rate-limit@8.6.2(express@5.2.1):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express: 5.2.1(supports-color@5.5.0)
+      express: 5.2.1
       ip-address: 10.3.1
     transitivePeerDependencies:
       - supports-color
@@ -15044,7 +15044,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@5.5.0):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.3.0
@@ -15253,7 +15253,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.1)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -15268,7 +15268,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.28.1)
+      webpack: 5.106.2
 
   form-data@2.5.6:
     dependencies:
@@ -19136,6 +19136,14 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.1
 
+  terser-webpack-plugin@5.4.0(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.1
+      webpack: 5.106.2
+
   terser@5.46.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -19246,7 +19254,7 @@ snapshots:
       picomatch: 4.0.4
       typescript: 5.9.3
 
-  ts-jest@29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.29.6)(@jest/transform@30.2.0)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.6))(jest-util@30.4.1)(jest@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -19264,7 +19272,6 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.4.1
       babel-jest: 30.2.0(@babel/core@7.29.6)
-      esbuild: 0.28.1
       jest-util: 30.4.1
 
   ts-mixer@6.0.4: {}
@@ -19723,6 +19730,37 @@ snapshots:
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.3.4: {}
+
+  webpack@5.106.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.1
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.4.0(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.106.2(esbuild@0.28.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,8 +104,8 @@ overrides:
   "@istanbuljs/load-nyc-config>js-yaml": 4.3.1
   "@lhci/utils>js-yaml": 4.3.1
   "js-yaml@>=4.0.0 <4.3.1": 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  "nanoid@<3.3.17": 3.3.17
+  # GHSA-2v37-7h3g-55p8: 3.3.18 fixes zero-size generator hangs.
+  "nanoid@<3.3.18": 3.3.18
   "protobufjs@>=7.0.0 <7.6.5": 7.6.5
   "qs@<6.15.2": 6.15.2
   "cookie@<0.7.0": 0.7.2


### PR DESCRIPTION
## The Problem

- GHSA-2v37-7h3g-55p8 (custom generators can loop indefinitely when size is
  zero) published today against nanoid 3.3.17 — the exact security floor
  pinned by four separate `pnpm-workspace.yaml` overrides in this repo
  (both alerts handlers, governance-watchdog, and the root workspace).
- Every Code Quality CI run and every local pre-push gate now fails
  repo-wide: trunk's osv-scanner (the two alerts lockfiles) and
  `scripts/pnpm-audit-high-gate.mjs` (governance-watchdog and the root
  Supply Chain workflow) all gate on this floor, on files no open PR
  touches.
- Same-day OSV wave: `uuid` and `ws` advisories landed against the same
  standalone lockfiles within hours of the nanoid one — tracked
  separately in #1842 so this PR stays scoped to unblocking CI now.

## The Solution

- Move the pinned nanoid floor from 3.3.17 to 3.3.18, the patched legacy
  release, in all four places that pin it — both alerts handlers,
  governance-watchdog, and the root workspace — with the registry
  integrity updated in each lockfile, following the same lockfile-side
  pin style used for prior advisories in these files.
- Align trunk's osv-scanner policy: the two alerts-handler lockfiles join
  their siblings (root, indexer-envio, governance-watchdog) in the
  ignore list, since the supply-chain workflow's `pnpm-audit` step is
  their real audit surface — this is what made today's advisory (and the
  ws/uuid ones a few hours later) fail Code Quality repo-wide in the
  first place.

## Details

- **Both alerts handlers** (`alerts/infra/oncall-announcer`,
  `alerts/infra/onchain-event-handler`) — six lines changed per lockfile,
  identical pattern in both `pnpm-lock.yaml` and `pnpm-workspace.yaml`:
  override range (`nanoid@<3.3.17: 3.3.17` → `nanoid@<3.3.18: 3.3.18`),
  package key, resolution integrity (verified live against the npm
  registry before applying), snapshot key, and the `postcss` dependency
  pin. The repo's lockfile-integrity CI check independently verifies the
  hand-edited hash against the registry.
- **`governance-watchdog`** — same override bump in its own
  `pnpm-workspace.yaml`, lockfile regenerated with a real
  `pnpm --dir governance-watchdog install --lockfile-only`. Diff came
  out identical in shape to the alerts lockfiles (only the four
  nanoid-specific lines), no incidental churn.
- **Root workspace** (`pnpm-workspace.yaml`, `pnpm-lock.yaml`) — same
  override bump. A full `pnpm install --lockfile-only` regen was tried
  first but re-resolved unrelated peer-dependency keys across the graph
  (webpack, express, `@nestjs/cli`, ts-jest, `@modelcontextprotocol/sdk`,
  `@upstash/mcp-server`, `express-rate-limit`,
  `fork-ts-checker-webpack-plugin`, `terser-webpack-plugin` gained or
  lost optional `esbuild`/`supports-color` peer suffixes). One of those
  shifts changed `@upstash/mcp-server`'s resolved peer key, which changed
  the bundled Upstash MCP runtime's content and broke
  `scripts/upstash-mcp-config.test.mjs`'s reviewed dependency-closed
  SHA-256 pin (`UPSTASH_MCP_RUNTIME_SHA256` in
  `scripts/upstash-mcp-launcher.mjs`) — a security control that must only
  move on deliberate review, not as a side effect of an unrelated nanoid
  bump. Replaced with the same targeted hand-edit used for the other
  three lockfiles: diffed byte-for-byte against the pre-fix root
  lockfile to confirm only the four nanoid lines changed, nothing else.
  This also matches the independent conclusion reached on
  `feat/peg-monitoring-2a-board` (commit `45d14cdd`), which hit the same
  root-lockfile-regen problem from its own nanoid workaround and left
  the root pin to this hotfix for the same reason.
- **`.trunk/trunk.yaml`** — added the two alerts-handler lockfiles to the
  osv-scanner ignore list, joining the root/indexer-envio/
  governance-watchdog siblings already there, with a comment explaining
  why (the supply-chain workflow's `pnpm-audit` step is their real audit
  surface; OSV publications against pinned transitives were failing Code
  Quality repo-wide on files no open PR touches).

## Validation

- `./tools/trunk check --all` (never `--force` on lockfiles — it bypasses
  their formatter ignores and rewrites them) → 2129 files checked, no
  issues.
- `pnpm install --frozen-lockfile` at the root → passes cleanly, no
  `minimumReleaseAge` or override-mismatch errors.
- `node --test scripts/upstash-mcp-config.test.mjs` → 23/23 passing,
  including the reviewed-bundle hash pin, confirming the root lockfile's
  targeted edit introduced zero incidental churn.
- `pnpm agent:quality-gate --run --allow-package-script-changes` → all
  mapped commands pass except `ui-dashboard`'s
  `browser-api-policy.test.ts`, which times out spawning an ESLint child
  process under sustained CPU load from repeated gate runs in this
  session — unrelated to this diff (no `ui-dashboard` files are touched)
  and reproduces the same way on an isolated re-run regardless of the
  lockfile state.

## Deferrals

- #1842 — raise the `ws` and `uuid` security floors in the alerts
  handler lockfiles (same 2026-08-13 OSV wave, published within hours of
  the nanoid advisory this PR fixes)
