### PR TITLE
fix(alerts): raise the nanoid advisory floor to 3.3.18

### DIFF
--- a/alerts/infra/oncall-announcer/pnpm-lock.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
@@ -1481,8 +1481,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3548,7 +3548,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3671,7 +3671,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/alerts/infra/oncall-announcer/pnpm-workspace.yaml
+++ b/alerts/infra/oncall-announcer/pnpm-workspace.yaml
@@ -27,8 +27,9 @@ overrides:
   fast-uri@<3.1.5: 3.1.5
   form-data@<2.5.6: 2.5.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  nanoid@<3.3.17: 3.3.17
+  # GHSA-2v37-7h3g-55p8: the 3.3.17 fix is incomplete; 3.3.18 closes the
+  # zero-size generator hang.
+  nanoid@<3.3.18: 3.3.18
   # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5

--- a/alerts/infra/onchain-event-handler/pnpm-lock.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   form-data@<2.5.6: 2.5.6
   form-data@>=4.0.0 <4.0.6: 4.0.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5
   qs@<6.15.2: 6.15.2
@@ -1562,8 +1562,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3736,7 +3736,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3878,7 +3878,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
+++ b/alerts/infra/onchain-event-handler/pnpm-workspace.yaml
@@ -25,8 +25,9 @@ overrides:
   form-data@<2.5.6: 2.5.6
   "form-data@>=4.0.0 <4.0.6": 4.0.6
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  # GHSA-2v37-7h3g-55p8: 3.3.17 fixes zero-size generator hangs.
-  nanoid@<3.3.17: 3.3.17
+  # GHSA-2v37-7h3g-55p8: the 3.3.17 fix is incomplete; 3.3.18 closes the
+  # zero-size generator hang.
+  nanoid@<3.3.18: 3.3.18
   # GHSA-fxqj-rqcc-2cmp: all releases through 8.5.22 are vulnerable.
   postcss@<8.5.23: 8.5.23
   protobufjs@>=7.0.0 <7.6.5: 7.6.5


### PR DESCRIPTION
## The Problem

`osv-scanner` inside `trunk check --all` started failing **Code Quality** on every branch and on `main`:

```
alerts/infra/oncall-announcer/pnpm-lock.yaml:14       high  nanoid GHSA-2v37-7h3g-55p8
alerts/infra/onchain-event-handler/pnpm-lock.yaml:14  high  nanoid GHSA-2v37-7h3g-55p8
✖ 2 security issues
```

The advisory now reports **3.3.17 itself as vulnerable**, and both `alerts/infra` packages pinned exactly that version. Nothing in the repo changed to cause this — the advisory's affected range widened, so it began failing runs that had previously passed.

`Code Quality` is a ruleset-required check, so this blocks **all merges** repo-wide until the floor moves. It is also the Dependabot alert GitHub has been reporting on pushes (`security/dependabot/239`).

## The Solution

Raise the override floor to `nanoid@<3.3.18: 3.3.18` in both packages and refresh their lockfiles.

Both already carried an override for this same advisory (`nanoid@<3.3.17: 3.3.17`), so this is the same shape as the `brace-expansion` entry directly above it — the earlier patch was incomplete, and the floor moves to the release that closes it. The comment now says so, to spare the next reader the same archaeology.

## Details

The overrides live in each package's `pnpm-workspace.yaml` (pnpm 11 config), **not** in `package.json`. Both packages also carry a `package.json` `overrides` block that is stale and unused — it lists neither `nanoid` nor `ws`, and pins older `postcss`/`fast-uri`/`js-yaml` versions than the lockfiles resolve. Editing it would have looked plausible and changed nothing about resolution. Left as-is here rather than expanded into an unrelated cleanup.

`nanoid@3.3.18` was published 6 days ago, comfortably past the packages' 4320-minute `minimumReleaseAge` gate, so no `minimumReleaseAgeExclude` entry is needed — unlike `postcss@8.5.23`, which required one.

The lockfiles were refreshed with `pnpm install --lockfile-only`; their diffs contain **nanoid lines only**. No other override was dropped and no unrelated dependency moved — worth stating explicitly, because regenerating a lockfile from a stale override set is exactly how a fix like this silently reintroduces other advisories.

## Validation

- `trunk check --filter=osv-scanner` on both lockfiles: **no issues** (was 2 high).
- Full agent quality gate for the changed paths: all mapped commands passed — terraform fmt/init/validate for `alerts/infra`, lint, typecheck, knip, `code-health:deps`, `tf:test`, and `test:coverage` for both packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency floor bump for a transitive ID generator; no application or auth logic changes.
> 
> **Overview**
> Unblocks **Code Quality** / `osv-scanner` failures on `alerts/infra` after **GHSA-2v37-7h3g-55p8** started treating the previously pinned `nanoid@3.3.17` as vulnerable.
> 
> In **`oncall-announcer`** and **`onchain-event-handler`**, the pnpm workspace override moves from `nanoid@<3.3.17: 3.3.17` to **`nanoid@<3.3.18: 3.3.18`**, with comments noting that 3.3.17’s fix was incomplete. Lockfiles were refreshed so resolved **`nanoid`** (including via **`postcss`**) is **3.3.18** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9464e87ee737283dc41045f989d1f0d01d2484. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->