### PR TITLE
docs: require Aegis post-apply proof

### DIFF
--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -107,6 +107,12 @@ trimmed build context:
       Admin only on the service-owned `staging.<project>.appspot.com` bucket.
       Do not widen them to project scope or the Terraform-managed source
       buckets.
+- [ ] After an approved apply changes App Engine staging IAM, dispatch the Aegis
+      App Engine workflow from clean current `main` and require success on that
+      exact head. Verify the new Aegis version serves 100% of traffic,
+      `/metrics` responds with a new `process_start_time_seconds`, and
+      `lastUpdatedAt` advances; then rerun the full platform plan and require no
+      changes.
 - [ ] Use `CLOUD_LOGGING_ONLY` unless a retained log bucket exists.
 
 ## 5. IAM ordering + dependencies


### PR DESCRIPTION
## The Problem

- An App Engine staging-IAM apply can succeed without proving that Aegis deploys and serves fresh metrics.

## The Solution

- Require exact-head deployment and runtime proof after an approved App Engine staging-IAM apply.

## Details

- Require the Aegis App Engine workflow to succeed from clean current `main`.
- Verify the new version serves 100% of traffic and `/metrics` reports a new process start with advancing `lastUpdatedAt`.
- Require a clean full platform plan after the rollout.

## Validation

- The enforced push hook ran the mapped docs and infrastructure checks; all five passed.
- Autoreview was skipped at the user's request for this mini docs PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an infra checklist; no runtime, IAM, or Terraform behavior is modified.
> 
> **Overview**
> Adds a **post-apply verification step** to the Terraform + Cloud Run checklist when an approved apply changes **App Engine staging IAM**.
> 
> Reviewers must run the **Aegis App Engine workflow** from clean current `main` on the exact head, confirm the new version gets **100% traffic**, and check **`/metrics`** for a fresh `process_start_time_seconds` and advancing `lastUpdatedAt`. A **full platform plan** must then show **no further changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622a922b21c152591bd699e9c27e9dda411b7eb3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->