### PR TITLE
feat: wire peg history chart to Grafana

### DIFF
--- a/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
@@ -244,6 +244,22 @@ describe("POST /api/peg-monitoring/history", () => {
     expect((await POST(request())).status).toBe(502);
     expect((await POST(request())).status).toBe(502);
   });
+
+  it("preserves an extreme finite premium instead of hiding incident data", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      json({
+        results: {
+          A: { frames: [frame([NOW_MS], [25_000])] },
+        },
+      }),
+    );
+
+    const response = await POST(request());
+    expect(response.status).toBe(200);
+    expect((await response.json()).points).toEqual([
+      { at: NOW_MS / 1_000, bps: 25_000 },
+    ]);
+  });
 });
 
 async function postWithEmptyFetch(

--- a/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
@@ -142,7 +142,29 @@ describe("POST /api/peg-monitoring/history", () => {
     });
   });
 
-  it("rejects unbounded labels, unknown ranges, and extra parameters", async () => {
+  it("pins a retained package query to its confirmed timestamp", async () => {
+    const confirmedAt = (NOW_MS - 60_000) / 1_000;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(json({ results: { A: { frames: [] } } }));
+
+    const response = await POST(
+      request({ ...baseQuery, to: String(confirmedAt) }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      from: confirmedAt - 7 * 86_400,
+      to: confirmedAt,
+    });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body)) as {
+      from: string;
+      to: string;
+    };
+    expect(body.from).toBe(String(NOW_MS - 60_000 - 7 * 86_400_000));
+    expect(body.to).toBe(String(NOW_MS - 60_000));
+  });
+
+  it("rejects unbounded labels, unknown ranges, invalid end times, and extra parameters", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
     expect(
       (await POST(request({ ...baseQuery, asset: 'europ"} or vector(1)' })))
@@ -151,6 +173,11 @@ describe("POST /api/peg-monitoring/history", () => {
     expect((await POST(request({ ...baseQuery, range: "365d" }))).status).toBe(
       400,
     );
+    expect(
+      (await POST(request({ ...baseQuery, to: String(NOW_MS / 1_000 + 1) })))
+        .status,
+    ).toBe(400);
+    expect((await POST(request({ ...baseQuery, to: "1.5" }))).status).toBe(400);
     expect(
       (await POST(request({ ...baseQuery, unexpected: "value" }))).status,
     ).toBe(400);

--- a/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
@@ -1,0 +1,254 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  POST,
+  PEG_HISTORY_DATASOURCE_UID,
+  PEG_HISTORY_MAX_RESPONSE_BYTES,
+  PEG_HISTORY_UPSTREAM_TIMEOUT_MS,
+  resolveGrafanaQueryEndpoint,
+} from "../route";
+
+const NOW_MS = Date.UTC(2026, 7, 13, 20, 0);
+const baseQuery = {
+  asset: "europ-schuman",
+  source: "bitvavo_eur",
+  policyVersion: "europ-v1",
+  range: "7d",
+};
+const json = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...init.headers },
+  });
+const request = (query: Record<string, string> = baseQuery) =>
+  new NextRequest(
+    `http://localhost/api/peg-monitoring/history?${new URLSearchParams(query)}`,
+  );
+const seriesLabels = {
+  asset: baseQuery.asset,
+  source: baseQuery.source,
+  policy_version: baseQuery.policyVersion,
+};
+const frame = (
+  times: unknown[],
+  values: unknown[],
+  labels: Record<string, string> = seriesLabels,
+) => ({
+  schema: {
+    refId: "A",
+    fields: [
+      { name: "Time", type: "time" },
+      { name: "Value", type: "number", labels },
+    ],
+  },
+  data: { values: [times, values] },
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_MS);
+  vi.stubEnv("GRAFANA_QUERY_URL", "https://grafana.example");
+  vi.stubEnv("GRAFANA_QUERY_TOKEN", "test-viewer-token");
+});
+
+describe("POST /api/peg-monitoring/history", () => {
+  it("queries the exact policy and deep source with the bounded 7d contract", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      json({
+        results: {
+          A: {
+            frames: [
+              frame(
+                [NOW_MS - 3_600_000, NOW_MS - 1_800_000, NOW_MS],
+                [-4.5, null, 2.25],
+              ),
+            ],
+          },
+        },
+      }),
+    );
+
+    const response = await POST(request());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      ...baseQuery,
+      from: (NOW_MS - 7 * 86_400_000) / 1_000,
+      to: NOW_MS / 1_000,
+      stepSeconds: 1_800,
+      points: [
+        { at: (NOW_MS - 3_600_000) / 1_000, bps: -4.5 },
+        { at: NOW_MS / 1_000, bps: 2.25 },
+      ],
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://grafana.example/api/ds/query");
+    expect(init).toMatchObject({
+      method: "POST",
+      cache: "no-store",
+      redirect: "error",
+    });
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer test-viewer-token",
+    );
+    const body = JSON.parse(String(init?.body)) as {
+      from: string;
+      to: string;
+      queries: Array<Record<string, unknown>>;
+    };
+    expect(body.from).toBe(String(NOW_MS - 7 * 86_400_000));
+    expect(body.to).toBe(String(NOW_MS));
+    expect(body.queries).toEqual([
+      expect.objectContaining({
+        datasource: {
+          type: "prometheus",
+          uid: PEG_HISTORY_DATASOURCE_UID,
+        },
+        expr: 'mento_peg_premium_bps{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} - on(asset,source,policy_version) mento_peg_deviation_bps{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"}',
+        intervalMs: 1_800_000,
+        maxDataPoints: 337,
+        range: true,
+        instant: false,
+      }),
+    ]);
+    expect(PEG_HISTORY_UPSTREAM_TIMEOUT_MS).toBeLessThan(10_000);
+  });
+
+  it("maps every range to its reviewed window and step", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => json({ results: { A: { frames: [] } } }));
+    const cases = [
+      ["24h", 86_400_000, 300_000, 289],
+      ["7d", 7 * 86_400_000, 1_800_000, 337],
+      ["30d", 30 * 86_400_000, 7_200_000, 361],
+    ] as const;
+    const responses = await Promise.all(
+      cases.map(([range]) => POST(request({ ...baseQuery, range }))),
+    );
+    responses.forEach((response, index) => {
+      expect(response.status).toBe(200);
+      const call = fetchMock.mock.calls[index]!;
+      const body = JSON.parse(String(call[1]?.body)) as {
+        from: string;
+        queries: Array<{ intervalMs: number; maxDataPoints: number }>;
+      };
+      const [, windowMs, intervalMs, maxDataPoints] = cases[index]!;
+      expect(body.from).toBe(String(NOW_MS - windowMs));
+      expect(body.queries[0]).toMatchObject({ intervalMs, maxDataPoints });
+    });
+  });
+
+  it("rejects unbounded labels, unknown ranges, and extra parameters", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    expect(
+      (await POST(request({ ...baseQuery, asset: 'europ"} or vector(1)' })))
+        .status,
+    ).toBe(400);
+    expect((await POST(request({ ...baseQuery, range: "365d" }))).status).toBe(
+      400,
+    );
+    expect(
+      (await POST(request({ ...baseQuery, unexpected: "value" }))).status,
+    ).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing credentials and unsafe Grafana origins", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const credentialedOrigin = [
+      "https://",
+      "user",
+      ":",
+      "pass",
+      "@grafana.example",
+    ].join("");
+    for (const origin of [
+      "",
+      "http://grafana.example",
+      credentialedOrigin,
+      "https://grafana.example/subpath",
+      "https://grafana.example?token=no",
+    ]) {
+      expect(resolveGrafanaQueryEndpoint(origin)).toBeNull();
+    }
+    vi.stubEnv("GRAFANA_QUERY_URL", "https://grafana.example");
+    vi.stubEnv("GRAFANA_QUERY_TOKEN", "   ");
+    expect((await POST(request())).status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for upstream errors, timeouts, oversized bodies, and malformed frames", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json({ error: "secret" }, { status: 403 }))
+      .mockRejectedValueOnce(new DOMException("secret", "TimeoutError"))
+      .mockResolvedValueOnce(
+        new Response("{}", {
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(PEG_HISTORY_MAX_RESPONSE_BYTES + 1),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(json({ results: { A: { frames: [{}] } } }))
+      .mockResolvedValueOnce(
+        json({
+          results: {
+            A: {
+              frames: [
+                frame([NOW_MS], [-1]),
+                frame([NOW_MS - 1_800_000], [-2]),
+              ],
+            },
+          },
+        }),
+      );
+    expect((await POST(request())).status).toBe(502);
+    expect((await POST(request())).status).toBe(504);
+    expect((await POST(request())).status).toBe(502);
+    expect((await POST(request())).status).toBe(502);
+    expect((await POST(request())).status).toBe(502);
+    expect(
+      JSON.stringify(await (await postWithEmptyFetch(fetchMock)).json()),
+    ).not.toContain("test-viewer-token");
+  });
+
+  it("rejects logical query errors and series from another identity", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        json({
+          results: {
+            A: { error: "query failed", status: 500, frames: [] },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        json({
+          results: {
+            A: {
+              frames: [
+                frame([NOW_MS], [-1], {
+                  ...seriesLabels,
+                  source: "kraken_eur",
+                }),
+              ],
+            },
+          },
+        }),
+      );
+
+    expect((await POST(request())).status).toBe(502);
+    expect((await POST(request())).status).toBe(502);
+  });
+});
+
+async function postWithEmptyFetch(
+  fetchMock: ReturnType<typeof vi.spyOn>,
+): Promise<Response> {
+  fetchMock.mockResolvedValueOnce(json({ results: { A: { frames: [] } } }));
+  return POST(request());
+}

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -182,8 +182,7 @@ function parsePoint(
     atMs < fromMs ||
     atMs > toMs ||
     typeof bps !== "number" ||
-    !Number.isFinite(bps) ||
-    Math.abs(bps) > 10_000
+    !Number.isFinite(bps)
   )
     throw new InvalidUpstreamResponseError();
   return { at: atMs / 1_000, bps };

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -24,6 +24,13 @@ const querySchema = z
     source: label,
     policyVersion: label,
     range: z.enum(PEG_HISTORY_RANGE_OPTIONS),
+    /** Optional confirmed package timestamp, expressed as Unix seconds. */
+    to: z
+      .string()
+      .regex(/^[1-9]\d{0,12}$/)
+      .transform(Number)
+      .refine(Number.isSafeInteger)
+      .optional(),
   })
   .strict();
 const grafanaFieldSchema = z
@@ -266,12 +273,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     Object.fromEntries(request.nextUrl.searchParams.entries()),
   );
   if (!input.success) return errorResponse("Invalid peg history query", 400);
+  const requestNowMs = Date.now();
+  const toMs =
+    input.data.to === undefined ? requestNowMs : input.data.to * 1_000;
+  if (toMs > requestNowMs)
+    return errorResponse("Invalid peg history query", 400);
   const endpoint = resolveGrafanaQueryEndpoint(process.env.GRAFANA_QUERY_URL);
   const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
   if (endpoint === null || !token)
     return errorResponse("Peg history is not configured", 503);
   const settings = PEG_HISTORY_RANGES[input.data.range];
-  const toMs = Date.now();
   const fromMs = toMs - settings.windowSeconds * 1_000;
   try {
     const upstream = await fetch(endpoint, {

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -1,0 +1,312 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  PEG_HISTORY_RANGE_OPTIONS,
+  PEG_HISTORY_RANGES,
+  type PegHistoryPoint,
+  type PegHistoryResponse,
+} from "@/lib/peg-history";
+
+export const dynamic = "force-dynamic";
+export const PEG_HISTORY_UPSTREAM_TIMEOUT_MS = 8_000;
+export const PEG_HISTORY_MAX_RESPONSE_BYTES = 512 * 1024;
+export const PEG_HISTORY_DATASOURCE_UID = "grafanacloud-prom";
+
+const responseHeaders = { "Cache-Control": "no-store" } as const;
+const label = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/);
+const querySchema = z
+  .object({
+    asset: label,
+    source: label,
+    policyVersion: label,
+    range: z.enum(PEG_HISTORY_RANGE_OPTIONS),
+  })
+  .strict();
+const grafanaFieldSchema = z
+  .object({
+    name: z.string(),
+    type: z.string(),
+    labels: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+const grafanaFrameSchema = z
+  .object({
+    schema: z
+      .object({ fields: z.array(grafanaFieldSchema).min(1).max(8) })
+      .passthrough(),
+    data: z
+      .object({ values: z.array(z.array(z.unknown())).min(1).max(8) })
+      .passthrough(),
+  })
+  .passthrough();
+const grafanaResponseSchema = z
+  .object({
+    results: z.record(
+      z.string(),
+      z
+        .object({
+          frames: z.array(grafanaFrameSchema).max(4),
+          error: z.string().optional(),
+          status: z.number().int().optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+type GrafanaFrame = z.infer<typeof grafanaFrameSchema>;
+
+class InvalidUpstreamResponseError extends Error {}
+
+function errorResponse(error: string, status: number): NextResponse {
+  return NextResponse.json({ error }, { status, headers: responseHeaders });
+}
+
+export function resolveGrafanaQueryEndpoint(
+  raw: string | undefined,
+): URL | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const localHttp =
+      process.env.NODE_ENV !== "production" &&
+      url.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    if (
+      (url.protocol !== "https:" && !localHttp) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      (url.pathname !== "" && url.pathname !== "/")
+    )
+      return null;
+    url.pathname = "/api/ds/query";
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function signedDeviationPromql(input: {
+  asset: string;
+  source: string;
+  policyVersion: string;
+}): string {
+  const selector = `asset=${JSON.stringify(input.asset)},source=${JSON.stringify(input.source)},policy_version=${JSON.stringify(input.policyVersion)}`;
+  return `mento_peg_premium_bps{${selector}} - on(asset,source,policy_version) mento_peg_deviation_bps{${selector}}`;
+}
+
+function buildGrafanaRequest(
+  input: z.infer<typeof querySchema>,
+  fromMs: number,
+  toMs: number,
+): object {
+  const settings = PEG_HISTORY_RANGES[input.range];
+  return {
+    queries: [
+      {
+        refId: "A",
+        datasource: { type: "prometheus", uid: PEG_HISTORY_DATASOURCE_UID },
+        expr: signedDeviationPromql(input),
+        format: "time_series",
+        range: true,
+        instant: false,
+        intervalMs: settings.stepSeconds * 1_000,
+        maxDataPoints:
+          Math.ceil(settings.windowSeconds / settings.stepSeconds) + 1,
+      },
+    ],
+    from: String(fromMs),
+    to: String(toMs),
+  };
+}
+
+async function readBounded(response: Response): Promise<string> {
+  const length = response.headers.get("content-length");
+  if (
+    length !== null &&
+    (!/^\d+$/.test(length) || Number(length) > PEG_HISTORY_MAX_RESPONSE_BYTES)
+  )
+    throw new InvalidUpstreamResponseError();
+  if (response.body === null) throw new InvalidUpstreamResponseError();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- ordered streams expose one bounded chunk at a time
+    const next = await reader.read();
+    if (next.done) break;
+    total += next.value.byteLength;
+    if (total > PEG_HISTORY_MAX_RESPONSE_BYTES) {
+      void reader.cancel().catch(() => undefined);
+      throw new InvalidUpstreamResponseError();
+    }
+    chunks.push(next.value);
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw new InvalidUpstreamResponseError();
+  }
+}
+
+function onlyFieldIndex(frame: GrafanaFrame, type: string): number {
+  const indexes = frame.schema.fields.flatMap((field, index) =>
+    field.type === type ? [index] : [],
+  );
+  if (indexes.length !== 1) throw new InvalidUpstreamResponseError();
+  return indexes[0]!;
+}
+
+function parsePoint(
+  atMs: unknown,
+  bps: unknown,
+  fromMs: number,
+  toMs: number,
+): PegHistoryPoint | null {
+  if (bps === null) return null;
+  if (
+    typeof atMs !== "number" ||
+    !Number.isFinite(atMs) ||
+    !Number.isInteger(atMs) ||
+    atMs < fromMs ||
+    atMs > toMs ||
+    typeof bps !== "number" ||
+    !Number.isFinite(bps) ||
+    Math.abs(bps) > 10_000
+  )
+    throw new InvalidUpstreamResponseError();
+  return { at: atMs / 1_000, bps };
+}
+
+function parseFramePoints(
+  frame: GrafanaFrame,
+  fromMs: number,
+  toMs: number,
+  expected: z.infer<typeof querySchema>,
+): PegHistoryPoint[] {
+  const points = new Map<number, number>();
+  if (frame.schema.fields.length !== frame.data.values.length)
+    throw new InvalidUpstreamResponseError();
+  const times = frame.data.values[onlyFieldIndex(frame, "time")]!;
+  const numberIndex = onlyFieldIndex(frame, "number");
+  const labels = frame.schema.fields[numberIndex]?.labels;
+  if (
+    labels === undefined ||
+    labels.asset !== expected.asset ||
+    labels.source !== expected.source ||
+    labels.policy_version !== expected.policyVersion
+  )
+    throw new InvalidUpstreamResponseError();
+  const values = frame.data.values[numberIndex]!;
+  if (times.length !== values.length) throw new InvalidUpstreamResponseError();
+  for (let index = 0; index < times.length; index++) {
+    const point = parsePoint(times[index], values[index], fromMs, toMs);
+    if (point === null) continue;
+    const existing = points.get(point.at);
+    if (existing !== undefined && existing !== point.bps)
+      throw new InvalidUpstreamResponseError();
+    points.set(point.at, point.bps);
+  }
+  return [...points.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([at, bps]) => ({ at, bps }));
+}
+
+function parseGrafanaPoints(
+  raw: unknown,
+  fromMs: number,
+  toMs: number,
+  expected: z.infer<typeof querySchema>,
+): PegHistoryPoint[] {
+  const parsed = grafanaResponseSchema.safeParse(raw);
+  if (!parsed.success) throw new InvalidUpstreamResponseError();
+  const result = parsed.data.results.A;
+  if (result === undefined) throw new InvalidUpstreamResponseError();
+  if (
+    (result.error !== undefined && result.error.trim() !== "") ||
+    (result.status !== undefined &&
+      (result.status < 200 || result.status >= 300))
+  )
+    throw new InvalidUpstreamResponseError();
+  const populated = result.frames.reduce<PegHistoryPoint[][]>((all, frame) => {
+    const points = parseFramePoints(frame, fromMs, toMs, expected);
+    if (points.length > 0) all.push(points);
+    return all;
+  }, []);
+  if (populated.length > 1) throw new InvalidUpstreamResponseError();
+  const points = populated[0] ?? [];
+  const maximum =
+    Math.ceil(
+      PEG_HISTORY_RANGES[expected.range].windowSeconds /
+        PEG_HISTORY_RANGES[expected.range].stepSeconds,
+    ) + 1;
+  if (points.length > maximum) throw new InvalidUpstreamResponseError();
+  return points;
+}
+
+function timedOut(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const input = querySchema.safeParse(
+    Object.fromEntries(request.nextUrl.searchParams.entries()),
+  );
+  if (!input.success) return errorResponse("Invalid peg history query", 400);
+  const endpoint = resolveGrafanaQueryEndpoint(process.env.GRAFANA_QUERY_URL);
+  const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
+  if (endpoint === null || !token)
+    return errorResponse("Peg history is not configured", 503);
+  const settings = PEG_HISTORY_RANGES[input.data.range];
+  const toMs = Date.now();
+  const fromMs = toMs - settings.windowSeconds * 1_000;
+  try {
+    const upstream = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildGrafanaRequest(input.data, fromMs, toMs)),
+      cache: "no-store",
+      redirect: "error",
+      signal: AbortSignal.timeout(PEG_HISTORY_UPSTREAM_TIMEOUT_MS),
+    });
+    if (!upstream.ok)
+      return errorResponse("Peg history upstream unavailable", 502);
+    if (!upstream.headers.get("content-type")?.includes("application/json"))
+      throw new InvalidUpstreamResponseError();
+    const points = parseGrafanaPoints(
+      JSON.parse(await readBounded(upstream)) as unknown,
+      fromMs,
+      toMs,
+      input.data,
+    );
+    const response: PegHistoryResponse = {
+      ...input.data,
+      from: fromMs / 1_000,
+      to: toMs / 1_000,
+      stepSeconds: settings.stepSeconds,
+      points,
+    };
+    return NextResponse.json(response, { headers: responseHeaders });
+  } catch (error) {
+    if (timedOut(error)) return errorResponse("Peg history timed out", 504);
+    return errorResponse("Peg history upstream response is invalid", 502);
+  }
+}

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -24,12 +24,16 @@ const state = vi.hoisted(() => ({
     isLoading: false,
     hasError: true,
   } as PegHistoryResult,
+  historyRequest: null as readonly unknown[] | null,
 }));
 vi.mock("@/hooks/use-peg-monitoring", () => ({
   usePegMonitoring: () => state.current,
 }));
 vi.mock("@/hooks/use-peg-history", () => ({
-  usePegHistory: () => state.history,
+  usePegHistory: (...args: readonly unknown[]) => {
+    state.historyRequest = args;
+    return state.history;
+  },
 }));
 vi.mock("next/link", () => ({
   default: ({
@@ -57,6 +61,7 @@ beforeEach(() => {
   vi.setSystemTime(PEG_FIXTURE_PRODUCED_AT * 1000 + 20_000);
   state.current = { data: null, isLoading: true, hasError: false };
   state.history = { data: null, isLoading: false, hasError: true };
+  state.historyRequest = null;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -212,6 +217,9 @@ describe("PegMonitoringPageClient board", () => {
         .textContent,
     ).toContain("DISPLAY ONLY");
     expect(panel.querySelectorAll("[aria-pressed]")).toHaveLength(3);
+    expect(
+      panel.querySelector('figure [role="status"]')!.textContent,
+    ).toContain("Peg history over 7d unavailable");
   });
 
   it("wires validated history into the expanded asset chart", () => {
@@ -347,6 +355,7 @@ describe("PegMonitoringPageClient board", () => {
     expect(
       query('[data-testid="peg-panel-europ-schuman"]')!.textContent,
     ).toContain("Showing the last confirmed check, produced 20s ago.");
+    expect(state.historyRequest?.[2]).toBe(PEG_FIXTURE_PRODUCED_AT);
   });
 
   it("keeps a previous-policy notice in the affected row's panel", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -253,8 +253,15 @@ describe("PegMonitoringPageClient board", () => {
     state.history = {
       ...state.history,
       data: { ...state.history.data!, points: [] },
-      hasError: false,
     };
+    render();
+    expect(
+      query('[data-testid="peg-panel-europ-schuman"]')!.textContent,
+    ).toContain(
+      "History refresh failed · no last confirmed readings in this window",
+    );
+
+    state.history = { ...state.history, hasError: false };
     render();
     expect(query('[aria-label*="Peg history over 7d"]')!.textContent).toContain(
       "No readings in this window",
@@ -269,6 +276,9 @@ describe("PegMonitoringPageClient board", () => {
     };
     render();
     expect(query('[data-testid="peg-history-single-point"]')).not.toBeNull();
+    expect(
+      container.querySelectorAll('[data-testid="peg-history-axis-tick"]'),
+    ).toHaveLength(1);
   });
 
   it("pins an off-scale supporting venue at the rail edge", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import type { PegMonitoringResult } from "@/hooks/use-peg-monitoring";
+import type { PegHistoryResult } from "@/hooks/use-peg-history";
 import {
   makePegMonitoringResponse,
   PEG_FIXTURE_CHAIN_ID,
@@ -18,9 +19,17 @@ const state = vi.hoisted(() => ({
     isLoading: true,
     hasError: false,
   } as PegMonitoringResult,
+  history: {
+    data: null,
+    isLoading: false,
+    hasError: true,
+  } as PegHistoryResult,
 }));
 vi.mock("@/hooks/use-peg-monitoring", () => ({
   usePegMonitoring: () => state.current,
+}));
+vi.mock("@/hooks/use-peg-history", () => ({
+  usePegHistory: () => state.history,
 }));
 vi.mock("next/link", () => ({
   default: ({
@@ -47,6 +56,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(PEG_FIXTURE_PRODUCED_AT * 1000 + 20_000);
   state.current = { data: null, isLoading: true, hasError: false };
+  state.history = { data: null, isLoading: false, hasError: true };
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -202,6 +212,63 @@ describe("PegMonitoringPageClient board", () => {
         .textContent,
     ).toContain("DISPLAY ONLY");
     expect(panel.querySelectorAll("[aria-pressed]")).toHaveLength(3);
+  });
+
+  it("wires validated history into the expanded asset chart", () => {
+    const response = makePegMonitoringResponse();
+    const item = response.packages[0]!;
+    state.history = {
+      data: {
+        asset: item.asset,
+        source: item.policy.deepVenueSource,
+        policyVersion: response.producedPolicyVersion,
+        range: "7d",
+        from: PEG_FIXTURE_PRODUCED_AT - 7 * 86_400,
+        to: PEG_FIXTURE_PRODUCED_AT,
+        stepSeconds: 1_800,
+        points: [
+          { at: PEG_FIXTURE_PRODUCED_AT - 3_600, bps: -4 },
+          { at: PEG_FIXTURE_PRODUCED_AT, bps: 2 },
+        ],
+      },
+      isLoading: false,
+      hasError: false,
+    };
+    loaded(response);
+    render();
+    click(query('[data-testid="peg-row-europ-schuman"]'));
+    const chart = query('[aria-label*="Peg history over 7d"]')!;
+    expect(chart.getAttribute("aria-label")).toContain("2 readings");
+    expect(chart.textContent).not.toContain("History unavailable");
+
+    state.history = { ...state.history, hasError: true };
+    render();
+    expect(
+      query('[aria-label*="Peg history over 7d"]')!.getAttribute("aria-label"),
+    ).toContain("2 last confirmed readings; refresh failed");
+    expect(
+      query('[data-testid="peg-panel-europ-schuman"]')!.textContent,
+    ).toContain("History refresh failed · showing last confirmed readings");
+
+    state.history = {
+      ...state.history,
+      data: { ...state.history.data!, points: [] },
+      hasError: false,
+    };
+    render();
+    expect(query('[aria-label*="Peg history over 7d"]')!.textContent).toContain(
+      "No readings in this window",
+    );
+
+    state.history = {
+      ...state.history,
+      data: {
+        ...state.history.data!,
+        points: [{ at: PEG_FIXTURE_PRODUCED_AT, bps: -3 }],
+      },
+    };
+    render();
+    expect(query('[data-testid="peg-history-single-point"]')).not.toBeNull();
   });
 
   it("pins an off-scale supporting venue at the rail edge", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/peg-history-chart.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/peg-history-chart.test.tsx
@@ -81,4 +81,33 @@ describe("PegHistoryChart ranges", () => {
     expect(texts.some((text) => text!.endsWith("· at target"))).toBe(true);
     expect(texts.some((text) => text!.includes("0 bps above"))).toBe(false);
   });
+
+  it("breaks the line across missing sampling intervals", () => {
+    const fiveMinutes = 5 * 60_000;
+    act(() =>
+      root.render(
+        <PegHistoryChart
+          policy={policy}
+          nowBps={-3.1}
+          tone="healthy"
+          measurement="Test measurement"
+          nowMs={NOW_MS}
+          series={[
+            point(20 * fiveMinutes, -6),
+            point(19 * fiveMinutes, -5),
+            point(3 * fiveMinutes, -4),
+            point(2 * fiveMinutes, -3),
+          ]}
+        />,
+      ),
+    );
+
+    const segments = container.querySelectorAll(
+      '[data-testid="peg-history-line-segment"]',
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments[0]!.getAttribute("points")).not.toContain(
+      segments[1]!.getAttribute("points")!,
+    );
+  });
 });

--- a/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
@@ -29,6 +29,7 @@ export function BoardTable({
   stale,
   previousPolicy,
   ageLabel,
+  policyVersion,
 }: {
   presentation: PegMonitoringPresentation;
   nowMs: number;
@@ -36,6 +37,7 @@ export function BoardTable({
   stale: boolean;
   previousPolicy: boolean;
   ageLabel: string;
+  policyVersion: string;
 }): React.JSX.Element {
   const [openRows, setOpenRows] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
@@ -107,6 +109,7 @@ export function BoardTable({
                     previousPolicy={previousPolicy}
                     ageLabel={ageLabel}
                     structuralCurrent={structuralCurrent}
+                    policyVersion={policyVersion}
                   />
                 ) : null}
               </Fragment>

--- a/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart-plot.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart-plot.tsx
@@ -1,0 +1,155 @@
+import type { PegAssetPackage } from "@/lib/peg-monitoring";
+import {
+  PEG_CHART,
+  pegChartBands,
+  pegChartScale,
+  type PegHistoryPoint,
+} from "../_lib/peg-chart-scale";
+import {
+  PEG_COLOR,
+  PEG_TONE_COLOR,
+  type PegBoardTone,
+} from "../_lib/peg-board-model";
+
+const day = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+export function ChartBands({
+  policy,
+}: {
+  policy: PegAssetPackage["policy"];
+}): React.JSX.Element {
+  const scale = pegChartScale(policy);
+  const bands = pegChartBands(scale);
+  const lines: Array<{ y: number; stroke: string }> = [
+    { y: scale.y(scale.premiumWarnBps), stroke: "oklch(76.9% 0.188 70 / 0.5)" },
+    { y: scale.y(-scale.warnBps), stroke: "oklch(76.9% 0.188 70 / 0.5)" },
+    { y: scale.y(-scale.criticalBps), stroke: "oklch(54.7% 0.193 26.4 / 0.6)" },
+  ];
+  return (
+    <g>
+      {bands.map((band) => (
+        <rect
+          key={band.key}
+          x={0}
+          y={band.y}
+          width={PEG_CHART.plotWidth}
+          height={band.height}
+          fill={band.fill}
+        />
+      ))}
+      {lines.map((line) => (
+        <line
+          key={line.y}
+          x1={0}
+          x2={PEG_CHART.plotWidth}
+          y1={line.y}
+          y2={line.y}
+          stroke={line.stroke}
+          strokeWidth={1}
+          strokeDasharray="4 4"
+        />
+      ))}
+      <line
+        x1={0}
+        x2={PEG_CHART.plotWidth}
+        y1={scale.y(0)}
+        y2={scale.y(0)}
+        stroke="oklch(98% 0.0054 297.73 / 0.3)"
+        strokeWidth={1}
+      />
+    </g>
+  );
+}
+
+export function ChartSeries({
+  points,
+  xs,
+  stepSeconds,
+  scale,
+  tone,
+}: {
+  points: readonly PegHistoryPoint[];
+  xs: readonly number[];
+  stepSeconds: number;
+  scale: ReturnType<typeof pegChartScale>;
+  tone: PegBoardTone;
+}): React.JSX.Element | null {
+  if (points.length === 0) return null;
+  const segments: Array<Array<{ point: PegHistoryPoint; x: number }>> = [];
+  points.forEach((point, index) => {
+    const previous = points[index - 1];
+    if (previous === undefined || point.at - previous.at > stepSeconds * 1.5)
+      segments.push([]);
+    segments.at(-1)!.push({ point, x: xs[index]! });
+  });
+  return (
+    <g>
+      {segments.map((segment) =>
+        segment.length === 1 ? (
+          <circle
+            key={segment[0]!.point.at}
+            data-testid={
+              points.length === 1
+                ? "peg-history-single-point"
+                : "peg-history-isolated-point"
+            }
+            cx={segment[0]!.x}
+            cy={scale.y(segment[0]!.point.bps)}
+            r={3.5}
+            fill={PEG_TONE_COLOR[tone]}
+          />
+        ) : (
+          <polyline
+            key={segment[0]!.point.at}
+            data-testid="peg-history-line-segment"
+            points={segment
+              .map(({ point, x }) => `${x},${scale.y(point.bps)}`)
+              .join(" ")}
+            fill="none"
+            stroke={PEG_TONE_COLOR[tone]}
+            strokeWidth={2}
+            strokeLinejoin="round"
+          />
+        ),
+      )}
+    </g>
+  );
+}
+
+export function ChartAxis({
+  points,
+  xs,
+}: {
+  points: readonly PegHistoryPoint[];
+  xs: readonly number[];
+}): React.JSX.Element {
+  const ratios = points.length === 1 ? [0] : [0, 0.33, 0.66, 1];
+  const ticks = ratios.map((ratio) => {
+    const index = Math.min(
+      points.length - 1,
+      Math.round(ratio * (points.length - 1)),
+    );
+    return { index, ratio, x: xs[index]! };
+  });
+  return (
+    <g>
+      {ticks.map((tick) => (
+        <text
+          key={tick.ratio}
+          data-testid="peg-history-axis-tick"
+          x={Math.min(PEG_CHART.plotWidth - 12, Math.max(12, tick.x))}
+          y={PEG_CHART.axisY}
+          textAnchor="middle"
+          fontSize={10}
+          fill={PEG_COLOR.muted}
+        >
+          {day.format(points[tick.index]!.at * 1_000)}
+        </text>
+      ))}
+    </g>
+  );
+}

--- a/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
@@ -7,6 +7,7 @@ import {
   type PegHistoryResult,
 } from "@/hooks/use-peg-history";
 import type { PegAssetPackage } from "@/lib/peg-monitoring";
+import { PEG_HISTORY_RANGES } from "@/lib/peg-history";
 import {
   PEG_CHART,
   PEG_CHART_DEFAULT_RANGE,
@@ -24,6 +25,7 @@ import {
   formatDeviationBps,
   type PegBoardTone,
 } from "../_lib/peg-board-model";
+import { ChartAxis, ChartBands, ChartSeries } from "./peg-history-chart-plot";
 
 const dayTime = new Intl.DateTimeFormat("en-US", {
   month: "short",
@@ -33,12 +35,6 @@ const dayTime = new Intl.DateTimeFormat("en-US", {
   hour12: false,
   timeZone: "UTC",
 });
-const day = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  timeZone: "UTC",
-});
-
 /** "3.1 bps below target" / "at target" — matches the row's zero handling. */
 function deviationPhrase(bps: number): string {
   if (bps === 0) return "at target";
@@ -65,23 +61,51 @@ type ChartProps = {
   nowMs: number;
   series?: readonly PegHistoryPoint[] | undefined;
   historyIdentity?: PegHistoryIdentity | null | undefined;
+  /** Fixed end of a retained package's historical window, in Unix seconds. */
+  historyEndSeconds?: number | undefined;
 };
 
 type HistoryState = "loading" | "ready" | "empty" | "stale" | "unavailable";
 
+function visibleHistory(
+  points: readonly PegHistoryPoint[],
+  range: PegChartRange,
+  nowMs: number,
+): { points: readonly PegHistoryPoint[]; xs: number[] } {
+  const cutoffSeconds = (nowMs - RANGE_MS[range]) / 1_000;
+  const windowEndSeconds = nowMs / 1_000;
+  const visible = points.filter(
+    (point) => point.at >= cutoffSeconds && point.at <= windowEndSeconds,
+  );
+  return {
+    points: visible,
+    // Timestamp-derived positions preserve the real duration of missed polls.
+    xs: visible.map((point) =>
+      pointXAt(point.at, cutoffSeconds, windowEndSeconds),
+    ),
+  };
+}
+
 function resolvedHistory(
   series: readonly PegHistoryPoint[] | undefined,
   history: PegHistoryResult,
+  range: PegChartRange,
 ): {
   points: readonly PegHistoryPoint[];
   state: HistoryState;
+  stepSeconds: number;
 } {
   if (series !== undefined)
-    return { points: series, state: series.length === 0 ? "empty" : "ready" };
+    return {
+      points: series,
+      state: series.length === 0 ? "empty" : "ready",
+      stepSeconds: PEG_HISTORY_RANGES[range].stepSeconds,
+    };
   if (history.data !== null) {
     const points = history.data.points;
     return {
       points,
+      stepSeconds: history.data.stepSeconds,
       state: history.hasError
         ? "stale"
         : points.length === 0
@@ -89,10 +113,16 @@ function resolvedHistory(
           : "ready",
     };
   }
-  if (history.hasError) return { points: [], state: "unavailable" };
+  if (history.hasError)
+    return {
+      points: [],
+      state: "unavailable",
+      stepSeconds: PEG_HISTORY_RANGES[range].stepSeconds,
+    };
   return {
     points: [],
     state: history.isLoading ? "loading" : "unavailable",
+    stepSeconds: PEG_HISTORY_RANGES[range].stepSeconds,
   };
 }
 
@@ -104,21 +134,13 @@ export function PegHistoryChart({
   nowMs,
   series,
   historyIdentity = null,
+  historyEndSeconds,
 }: ChartProps): React.JSX.Element {
   const [range, setRange] = useState<PegChartRange>(PEG_CHART_DEFAULT_RANGE);
   const [hovered, setHovered] = useState<number | null>(null);
-  const history = usePegHistory(historyIdentity, range);
-  const resolved = resolvedHistory(series, history);
-  // The selected range is a promise to the reader: whatever the feed supplies,
-  // only readings inside the window may plot, feed the axis, or reach the
-  // hover/reading list.
-  const cutoffSeconds = (nowMs - RANGE_MS[range]) / 1_000;
-  const points = resolved.points.filter((point) => point.at >= cutoffSeconds);
-  // Timestamp-derived x positions: a gap between polls occupies its real
-  // share of the window instead of collapsing to one array step.
-  const pointXs = points.map((point) =>
-    pointXAt(point.at, cutoffSeconds, nowMs / 1_000),
-  );
+  const history = usePegHistory(historyIdentity, range, historyEndSeconds);
+  const resolved = resolvedHistory(series, history, range);
+  const { points, xs: pointXs } = visibleHistory(resolved.points, range, nowMs);
   const scale = pegChartScale(policy);
   const nowY = nowBps === null ? null : scale.y(nowBps);
 
@@ -132,14 +154,11 @@ export function PegHistoryChart({
           setRange(next);
         }}
       />
-      {resolved.state === "stale" ? (
-        <p role="status" className="-mt-2 mb-2 text-[11px] text-amber-700">
-          History refresh failed ·{" "}
-          {points.length === 0
-            ? "no last confirmed readings in this window"
-            : "showing last confirmed readings"}
-        </p>
-      ) : null}
+      <HistoryStatus
+        range={range}
+        count={points.length}
+        state={resolved.state}
+      />
       <div
         onPointerMove={(event) => {
           if (points.length === 0) return;
@@ -157,7 +176,13 @@ export function PegHistoryChart({
           className="block w-full"
         >
           <ChartBands policy={policy} />
-          <ChartSeries points={points} xs={pointXs} scale={scale} tone={tone} />
+          <ChartSeries
+            points={points}
+            xs={pointXs}
+            stepSeconds={resolved.stepSeconds}
+            scale={scale}
+            tone={tone}
+          />
           <ChartGutter
             policy={policy}
             nowBps={nowBps}
@@ -269,121 +294,42 @@ function emptyHistoryMessage(state: HistoryState): string {
   return "No readings in this window";
 }
 
-function ChartBands({
-  policy,
-}: {
-  policy: PegAssetPackage["policy"];
-}): React.JSX.Element {
-  const scale = pegChartScale(policy);
-  const bands = pegChartBands(scale);
-  const lines: Array<{ y: number; stroke: string }> = [
-    { y: scale.y(scale.premiumWarnBps), stroke: "oklch(76.9% 0.188 70 / 0.5)" },
-    { y: scale.y(-scale.warnBps), stroke: "oklch(76.9% 0.188 70 / 0.5)" },
-    { y: scale.y(-scale.criticalBps), stroke: "oklch(54.7% 0.193 26.4 / 0.6)" },
-  ];
-  return (
-    <g>
-      {bands.map((band) => (
-        <rect
-          key={band.key}
-          x={0}
-          y={band.y}
-          width={PEG_CHART.plotWidth}
-          height={band.height}
-          fill={band.fill}
-        />
-      ))}
-      {lines.map((line) => (
-        <line
-          key={line.y}
-          x1={0}
-          x2={PEG_CHART.plotWidth}
-          y1={line.y}
-          y2={line.y}
-          stroke={line.stroke}
-          strokeWidth={1}
-          strokeDasharray="4 4"
-        />
-      ))}
-      <line
-        x1={0}
-        x2={PEG_CHART.plotWidth}
-        y1={scale.y(0)}
-        y2={scale.y(0)}
-        stroke="oklch(98% 0.0054 297.73 / 0.3)"
-        strokeWidth={1}
-      />
-    </g>
-  );
+function historyStatusMessage(
+  range: PegChartRange,
+  count: number,
+  state: HistoryState,
+): string {
+  if (state === "loading") return `Loading peg history over ${range}`;
+  if (state === "unavailable") return `Peg history over ${range} unavailable`;
+  if (state === "stale")
+    return `History refresh failed · ${
+      count === 0
+        ? "no last confirmed readings in this window"
+        : "showing last confirmed readings"
+    }`;
+  if (state === "empty") return `No peg history readings over ${range}`;
+  return `${count} peg history readings loaded over ${range}`;
 }
 
-function ChartSeries({
-  points,
-  xs,
-  scale,
-  tone,
+function HistoryStatus({
+  range,
+  count,
+  state,
 }: {
-  points: readonly PegHistoryPoint[];
-  xs: readonly number[];
-  scale: ReturnType<typeof pegChartScale>;
-  tone: PegBoardTone;
-}): React.JSX.Element | null {
-  if (points.length === 0) return null;
-  if (points.length === 1)
-    return (
-      <circle
-        data-testid="peg-history-single-point"
-        cx={xs[0]!}
-        cy={scale.y(points[0]!.bps)}
-        r={3.5}
-        fill={PEG_TONE_COLOR[tone]}
-      />
-    );
-  const path = points
-    .map((point, index) => `${xs[index]!},${scale.y(point.bps)}`)
-    .join(" ");
-  return (
-    <polyline
-      points={path}
-      fill="none"
-      stroke={PEG_TONE_COLOR[tone]}
-      strokeWidth={2}
-      strokeLinejoin="round"
-    />
-  );
-}
-
-function ChartAxis({
-  points,
-  xs,
-}: {
-  points: readonly PegHistoryPoint[];
-  xs: readonly number[];
+  range: PegChartRange;
+  count: number;
+  state: HistoryState;
 }): React.JSX.Element {
-  const ratios = points.length === 1 ? [0] : [0, 0.33, 0.66, 1];
-  const ticks = ratios.map((ratio) => {
-    const index = Math.min(
-      points.length - 1,
-      Math.round(ratio * (points.length - 1)),
-    );
-    return { index, ratio, x: xs[index]! };
-  });
   return (
-    <g>
-      {ticks.map((tick) => (
-        <text
-          key={tick.ratio}
-          data-testid="peg-history-axis-tick"
-          x={Math.min(PEG_CHART.plotWidth - 12, Math.max(12, tick.x))}
-          y={PEG_CHART.axisY}
-          textAnchor="middle"
-          fontSize={10}
-          fill={PEG_COLOR.muted}
-        >
-          {day.format(points[tick.index]!.at * 1_000)}
-        </text>
-      ))}
-    </g>
+    <p
+      role="status"
+      aria-atomic="true"
+      className={
+        state === "stale" ? "-mt-2 mb-2 text-[11px] text-amber-700" : "sr-only"
+      }
+    >
+      {historyStatusMessage(range, count, state)}
+    </p>
   );
 }
 

--- a/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import {
+  usePegHistory,
+  type PegHistoryIdentity,
+  type PegHistoryResult,
+} from "@/hooks/use-peg-history";
 import type { PegAssetPackage } from "@/lib/peg-monitoring";
 import {
   PEG_CHART,
@@ -59,7 +64,37 @@ type ChartProps = {
   measurement: string;
   nowMs: number;
   series?: readonly PegHistoryPoint[] | undefined;
+  historyIdentity?: PegHistoryIdentity | null | undefined;
 };
+
+type HistoryState = "loading" | "ready" | "empty" | "stale" | "unavailable";
+
+function resolvedHistory(
+  series: readonly PegHistoryPoint[] | undefined,
+  history: PegHistoryResult,
+): {
+  points: readonly PegHistoryPoint[];
+  state: HistoryState;
+} {
+  if (series !== undefined)
+    return { points: series, state: series.length === 0 ? "empty" : "ready" };
+  if (history.data !== null) {
+    const points = history.data.points;
+    return {
+      points,
+      state: history.hasError
+        ? "stale"
+        : points.length === 0
+          ? "empty"
+          : "ready",
+    };
+  }
+  if (history.hasError) return { points: [], state: "unavailable" };
+  return {
+    points: [],
+    state: history.isLoading ? "loading" : "unavailable",
+  };
+}
 
 export function PegHistoryChart({
   policy,
@@ -68,14 +103,17 @@ export function PegHistoryChart({
   measurement,
   nowMs,
   series,
+  historyIdentity = null,
 }: ChartProps): React.JSX.Element {
   const [range, setRange] = useState<PegChartRange>(PEG_CHART_DEFAULT_RANGE);
   const [hovered, setHovered] = useState<number | null>(null);
+  const history = usePegHistory(historyIdentity, range);
+  const resolved = resolvedHistory(series, history);
   // The selected range is a promise to the reader: whatever the feed supplies,
   // only readings inside the window may plot, feed the axis, or reach the
   // hover/reading list.
   const cutoffSeconds = (nowMs - RANGE_MS[range]) / 1_000;
-  const points = (series ?? []).filter((point) => point.at >= cutoffSeconds);
+  const points = resolved.points.filter((point) => point.at >= cutoffSeconds);
   // Timestamp-derived x positions: a gap between polls occupies its real
   // share of the window instead of collapsing to one array step.
   const pointXs = points.map((point) =>
@@ -86,7 +124,19 @@ export function PegHistoryChart({
 
   return (
     <figure className="m-0">
-      <ChartHeader measurement={measurement} range={range} onRange={setRange} />
+      <ChartHeader
+        measurement={measurement}
+        range={range}
+        onRange={(next) => {
+          setHovered(null);
+          setRange(next);
+        }}
+      />
+      {resolved.state === "stale" ? (
+        <p role="status" className="-mt-2 mb-2 text-[11px] text-amber-700">
+          History refresh failed · showing last confirmed readings
+        </p>
+      ) : null}
       <div
         onPointerMove={(event) => {
           if (points.length === 0) return;
@@ -100,7 +150,7 @@ export function PegHistoryChart({
         <svg
           viewBox={`0 0 ${PEG_CHART.viewBoxWidth} ${PEG_CHART.viewBoxHeight}`}
           role="img"
-          aria-label={chartLabel(nowBps, range, points.length)}
+          aria-label={chartLabel(nowBps, range, points.length, resolved.state)}
           className="block w-full"
         >
           <ChartBands policy={policy} />
@@ -119,7 +169,7 @@ export function PegHistoryChart({
               fontSize={12}
               fill={PEG_COLOR.muted}
             >
-              History unavailable
+              {emptyHistoryMessage(resolved.state)}
             </text>
           ) : (
             <ChartAxis points={points} xs={pointXs} />
@@ -190,14 +240,30 @@ function chartLabel(
   nowBps: number | null,
   range: PegChartRange,
   count: number,
+  state: HistoryState,
 ): string {
   const current =
     nowBps === null
       ? "the current deviation is unavailable"
       : `now ${deviationPhrase(nowBps)}`;
-  return count === 0
-    ? `Peg history over ${range}. History is unavailable, so only the alert bands and ${current} are drawn.`
-    : `Peg history over ${range}: ${count} readings, ${current}.`;
+  if (count > 0)
+    return state === "stale"
+      ? `Peg history over ${range}: ${count} last confirmed readings; refresh failed, ${current}.`
+      : `Peg history over ${range}: ${count} readings, ${current}.`;
+  if (state === "loading")
+    return `Peg history over ${range}. History is loading, so only the alert bands and ${current} are drawn.`;
+  if (state === "unavailable")
+    return `Peg history over ${range}. History is unavailable, so only the alert bands and ${current} are drawn.`;
+  if (state === "stale")
+    return `Peg history over ${range}. The refresh failed and there are no last confirmed readings in this window, so only the alert bands and ${current} are drawn.`;
+  return `Peg history over ${range}. No readings were returned in this window, so only the alert bands and ${current} are drawn.`;
+}
+
+function emptyHistoryMessage(state: HistoryState): string {
+  if (state === "loading") return "Loading history";
+  if (state === "unavailable") return "History unavailable";
+  if (state === "stale") return "No last confirmed readings in this window";
+  return "No readings in this window";
 }
 
 function ChartBands({
@@ -260,6 +326,16 @@ function ChartSeries({
   tone: PegBoardTone;
 }): React.JSX.Element | null {
   if (points.length === 0) return null;
+  if (points.length === 1)
+    return (
+      <circle
+        data-testid="peg-history-single-point"
+        cx={xs[0]!}
+        cy={scale.y(points[0]!.bps)}
+        r={3.5}
+        fill={PEG_TONE_COLOR[tone]}
+      />
+    );
   const path = points
     .map((point, index) => `${xs[index]!},${scale.y(point.bps)}`)
     .join(" ");
@@ -286,13 +362,13 @@ function ChartAxis({
       points.length - 1,
       Math.round(ratio * (points.length - 1)),
     );
-    return { index, x: xs[index]! };
+    return { index, ratio, x: xs[index]! };
   });
   return (
     <g>
       {ticks.map((tick) => (
         <text
-          key={tick.index}
+          key={tick.ratio}
           x={Math.min(PEG_CHART.plotWidth - 12, Math.max(12, tick.x))}
           y={PEG_CHART.axisY}
           textAnchor="middle"

--- a/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/peg-history-chart.tsx
@@ -134,7 +134,10 @@ export function PegHistoryChart({
       />
       {resolved.state === "stale" ? (
         <p role="status" className="-mt-2 mb-2 text-[11px] text-amber-700">
-          History refresh failed · showing last confirmed readings
+          History refresh failed ·{" "}
+          {points.length === 0
+            ? "no last confirmed readings in this window"
+            : "showing last confirmed readings"}
         </p>
       ) : null}
       <div
@@ -357,7 +360,8 @@ function ChartAxis({
   points: readonly PegHistoryPoint[];
   xs: readonly number[];
 }): React.JSX.Element {
-  const ticks = [0, 0.33, 0.66, 1].map((ratio) => {
+  const ratios = points.length === 1 ? [0] : [0, 0.33, 0.66, 1];
+  const ticks = ratios.map((ratio) => {
     const index = Math.min(
       points.length - 1,
       Math.round(ratio * (points.length - 1)),
@@ -369,6 +373,7 @@ function ChartAxis({
       {ticks.map((tick) => (
         <text
           key={tick.ratio}
+          data-testid="peg-history-axis-tick"
           x={Math.min(PEG_CHART.plotWidth - 12, Math.max(12, tick.x))}
           y={PEG_CHART.axisY}
           textAnchor="middle"

--- a/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import type { PegHistoryIdentity } from "@/hooks/use-peg-history";
 import type { PegAssetPresentation } from "@/lib/peg-monitoring-presentation";
 import { buildPoolDetailHref } from "@/lib/routing";
 import { formatFraction } from "../_lib/peg-board-format";
@@ -35,6 +36,19 @@ const noticeTint = {
   },
 } as const;
 
+function historyIdentity(
+  asset: PegAssetPresentation,
+  policyVersion: string,
+): PegHistoryIdentity | null {
+  return asset.deepSource === null
+    ? null
+    : {
+        asset: asset.asset.asset,
+        source: asset.deepSource.id,
+        policyVersion,
+      };
+}
+
 export function RowPanel({
   asset,
   nowMs,
@@ -43,6 +57,7 @@ export function RowPanel({
   previousPolicy,
   ageLabel,
   structuralCurrent,
+  policyVersion,
 }: {
   asset: PegAssetPresentation;
   nowMs: number;
@@ -51,6 +66,7 @@ export function RowPanel({
   previousPolicy: boolean;
   ageLabel: string;
   structuralCurrent: boolean;
+  policyVersion: string;
 }): React.JSX.Element {
   const notice = panelNotice(asset, stale, previousPolicy);
   const primary = asset.deepSource;
@@ -128,6 +144,7 @@ export function RowPanel({
             }
             measurement={measurementLabel(primary)}
             nowMs={nowMs}
+            historyIdentity={historyIdentity(asset, policyVersion)}
           />
         </div>
         <p className="sr-only">{`${asset.assetName} is ${distanceLabel(asset)}.`}</p>

--- a/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
@@ -143,8 +143,9 @@ export function RowPanel({
                 : asset.thresholdTone
             }
             measurement={measurementLabel(primary)}
-            nowMs={nowMs}
+            nowMs={stale ? producedAt * 1_000 : nowMs}
             historyIdentity={historyIdentity(asset, policyVersion)}
+            historyEndSeconds={stale ? producedAt : undefined}
           />
         </div>
         <p className="sr-only">{`${asset.assetName} is ${distanceLabel(asset)}.`}</p>

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-chart-scale.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-chart-scale.ts
@@ -1,4 +1,10 @@
 import type { PegAssetPackage } from "@/lib/peg-monitoring";
+import {
+  PEG_HISTORY_RANGE_OPTIONS,
+  type PegHistoryRange,
+} from "@/lib/peg-history";
+
+export type { PegHistoryPoint } from "@/lib/peg-history";
 
 /**
  * Chart geometry, read off the 2a mockup's SVG. The plot occupies x 0–760, the
@@ -122,15 +128,6 @@ const RAIL_FILL: Record<string, string> = {
   red: "oklch(54.7% 0.193 26.4 / 0.4)",
 };
 
-export type PegHistoryPoint = {
-  /** Unix seconds. */
-  at: number;
-  /** Signed deviation from target; negative is below target. */
-  bps: number;
-  /** Alert name when a state transition fired at this reading. */
-  event?: string;
-};
-
 /**
  * X positions come from each reading's timestamp over the visible window, not
  * from its array index: with missed or irregular polls, index spacing would
@@ -164,6 +161,6 @@ export function nearestPointIndex(
   return nearest;
 }
 
-export const PEG_CHART_RANGES = ["24h", "7d", "30d"] as const;
-export type PegChartRange = (typeof PEG_CHART_RANGES)[number];
+export const PEG_CHART_RANGES = PEG_HISTORY_RANGE_OPTIONS;
+export type PegChartRange = PegHistoryRange;
 export const PEG_CHART_DEFAULT_RANGE: PegChartRange = "7d";

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -69,6 +69,7 @@ export function PegMonitoringPageClient(): React.JSX.Element {
               stale={state.kind === "stale"}
               previousPolicy={usesPreviousPolicy}
               ageLabel={formatAge(state.ageMs)}
+              policyVersion={state.data.producedPolicyVersion}
             />
             <RecentAlerts nowMs={nowMs} />
           </>

--- a/ui-dashboard/src/hooks/__tests__/use-peg-history.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-peg-history.test.ts
@@ -1,0 +1,105 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rateLimitAwareRetry } from "@/lib/gql-retry";
+import { PEG_HISTORY_RANGES, type PegHistoryResponse } from "@/lib/peg-history";
+
+const swr = vi.hoisted(() => vi.fn());
+vi.mock("swr", () => ({ default: swr }));
+
+import {
+  pegHistoryUrl,
+  usePegHistory,
+  type PegHistoryIdentity,
+} from "../use-peg-history";
+
+const identity: PegHistoryIdentity = {
+  asset: "europ-schuman",
+  source: "bitvavo_eur",
+  policyVersion: "europ-v1",
+};
+const data: PegHistoryResponse = {
+  ...identity,
+  range: "7d",
+  from: 1_786_000_000,
+  to: 1_786_604_800,
+  stepSeconds: 1_800,
+  points: [{ at: 1_786_604_800, bps: -3 }],
+};
+
+let selectedIdentity: PegHistoryIdentity | null = identity;
+let result: ReturnType<typeof usePegHistory> | null = null;
+
+function Probe(): null {
+  result = usePegHistory(selectedIdentity, "7d");
+  return null;
+}
+
+function render(): {
+  key: string | null;
+  fetcher: (url: string) => Promise<PegHistoryResponse>;
+  config: Record<string, unknown>;
+} {
+  const root = createRoot(document.createElement("div"));
+  act(() => root.render(createElement(Probe)));
+  act(() => root.unmount());
+  const call = swr.mock.calls[0]!;
+  return {
+    key: call[0] as string | null,
+    fetcher: call[1] as (url: string) => Promise<PegHistoryResponse>,
+    config: call[2] as Record<string, unknown>,
+  };
+}
+
+beforeEach(() => {
+  swr.mockReset();
+  swr.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
+  selectedIdentity = identity;
+  result = null;
+});
+
+describe("usePegHistory", () => {
+  it("uses one bounded same-origin key and the shared active-tab retry guard", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(Response.json(data));
+    const probe = render();
+    expect(probe.key).toBe(
+      "/api/peg-monitoring/history?asset=europ-schuman&source=bitvavo_eur&policyVersion=europ-v1&range=7d",
+    );
+    expect(probe.config).toMatchObject({
+      refreshInterval: PEG_HISTORY_RANGES["7d"].stepSeconds * 1_000,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      onErrorRetry: rateLimitAwareRetry,
+    });
+    await expect(probe.fetcher(probe.key!)).resolves.toEqual(data);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(probe.key);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+  });
+
+  it("does not query without a complete current-state identity", () => {
+    selectedIdentity = null;
+    const probe = render();
+    expect(probe.key).toBeNull();
+    expect(result).toEqual({ data: null, hasError: false, isLoading: false });
+  });
+
+  it("reports a revalidation error alongside retained data", () => {
+    swr.mockReturnValue({ data, error: new Error("503"), isLoading: false });
+    render();
+    expect(result).toEqual({ data, hasError: true, isLoading: false });
+  });
+
+  it("builds encoded keys instead of interpolating labels", () => {
+    expect(
+      pegHistoryUrl(
+        { ...identity, policyVersion: "version with spaces" },
+        "24h",
+      ),
+    ).toContain("policyVersion=version+with+spaces");
+  });
+});

--- a/ui-dashboard/src/hooks/__tests__/use-peg-history.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-peg-history.test.ts
@@ -30,10 +30,11 @@ const data: PegHistoryResponse = {
 };
 
 let selectedIdentity: PegHistoryIdentity | null = identity;
+let selectedToSeconds: number | undefined;
 let result: ReturnType<typeof usePegHistory> | null = null;
 
 function Probe(): null {
-  result = usePegHistory(selectedIdentity, "7d");
+  result = usePegHistory(selectedIdentity, "7d", selectedToSeconds);
   return null;
 }
 
@@ -57,6 +58,7 @@ beforeEach(() => {
   swr.mockReset();
   swr.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
   selectedIdentity = identity;
+  selectedToSeconds = undefined;
   result = null;
 });
 
@@ -86,6 +88,15 @@ describe("usePegHistory", () => {
     const probe = render();
     expect(probe.key).toBeNull();
     expect(result).toEqual({ data: null, hasError: false, isLoading: false });
+  });
+
+  it("pins retained history to a confirmed endpoint without polling it", () => {
+    selectedToSeconds = 1_786_604_800;
+    const probe = render();
+    expect(probe.key).toBe(
+      "/api/peg-monitoring/history?asset=europ-schuman&source=bitvavo_eur&policyVersion=europ-v1&range=7d&to=1786604800",
+    );
+    expect(probe.config.refreshInterval).toBe(0);
   });
 
   it("reports a revalidation error alongside retained data", () => {

--- a/ui-dashboard/src/hooks/use-peg-history.ts
+++ b/ui-dashboard/src/hooks/use-peg-history.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "@/lib/fetch-json";
+import { rateLimitAwareRetry } from "@/lib/gql-retry";
+import {
+  PEG_HISTORY_RANGES,
+  type PegHistoryRange,
+  type PegHistoryResponse,
+} from "@/lib/peg-history";
+
+export type PegHistoryIdentity = {
+  asset: string;
+  source: string;
+  policyVersion: string;
+};
+
+export type PegHistoryResult = {
+  data: PegHistoryResponse | null;
+  isLoading: boolean;
+  hasError: boolean;
+};
+
+export function pegHistoryUrl(
+  identity: PegHistoryIdentity,
+  range: PegHistoryRange,
+): string {
+  const query = new URLSearchParams({ ...identity, range });
+  return `/api/peg-monitoring/history?${query.toString()}`;
+}
+
+export function usePegHistory(
+  identity: PegHistoryIdentity | null,
+  range: PegHistoryRange,
+): PegHistoryResult {
+  const key = identity === null ? null : pegHistoryUrl(identity, range);
+  const { data, error, isLoading } = useSWR<PegHistoryResponse>(
+    key,
+    (url: string) =>
+      fetchJsonOrThrow<PegHistoryResponse>(url, "Peg history", {
+        timeoutMs: 10_000,
+        method: "POST",
+      }),
+    {
+      refreshInterval: PEG_HISTORY_RANGES[range].stepSeconds * 1_000,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      onErrorRetry: rateLimitAwareRetry,
+    },
+  );
+  return {
+    data: data ?? null,
+    isLoading: identity !== null && isLoading,
+    hasError: error !== undefined,
+  };
+}

--- a/ui-dashboard/src/hooks/use-peg-history.ts
+++ b/ui-dashboard/src/hooks/use-peg-history.ts
@@ -24,16 +24,20 @@ export type PegHistoryResult = {
 export function pegHistoryUrl(
   identity: PegHistoryIdentity,
   range: PegHistoryRange,
+  toSeconds?: number,
 ): string {
   const query = new URLSearchParams({ ...identity, range });
+  if (toSeconds !== undefined) query.set("to", String(toSeconds));
   return `/api/peg-monitoring/history?${query.toString()}`;
 }
 
 export function usePegHistory(
   identity: PegHistoryIdentity | null,
   range: PegHistoryRange,
+  toSeconds?: number,
 ): PegHistoryResult {
-  const key = identity === null ? null : pegHistoryUrl(identity, range);
+  const key =
+    identity === null ? null : pegHistoryUrl(identity, range, toSeconds);
   const { data, error, isLoading } = useSWR<PegHistoryResponse>(
     key,
     (url: string) =>
@@ -42,7 +46,12 @@ export function usePegHistory(
         method: "POST",
       }),
     {
-      refreshInterval: PEG_HISTORY_RANGES[range].stepSeconds * 1_000,
+      // A retained package pins history to its confirmed timestamp. That
+      // historical window is immutable, so only live windows need polling.
+      refreshInterval:
+        toSeconds === undefined
+          ? PEG_HISTORY_RANGES[range].stepSeconds * 1_000
+          : 0,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       refreshWhenHidden: false,

--- a/ui-dashboard/src/lib/fetch-json.ts
+++ b/ui-dashboard/src/lib/fetch-json.ts
@@ -16,10 +16,13 @@ const DEFAULT_TIMEOUT_MS = 25_000;
 export async function fetchJsonOrThrow<T>(
   url: string,
   label: string,
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; method?: "GET" | "POST" } = {},
 ): Promise<T> {
   const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const res = await fetch(url, { signal: AbortSignal.timeout(timeout) });
+  const res = await fetch(url, {
+    ...(opts.method === undefined ? {} : { method: opts.method }),
+    signal: AbortSignal.timeout(timeout),
+  });
   if (!res.ok) {
     const body = (await res.json().catch(() => null)) as {
       error?: string;

--- a/ui-dashboard/src/lib/peg-history.ts
+++ b/ui-dashboard/src/lib/peg-history.ts
@@ -1,0 +1,28 @@
+export const PEG_HISTORY_RANGES = {
+  "24h": { windowSeconds: 24 * 60 * 60, stepSeconds: 5 * 60 },
+  "7d": { windowSeconds: 7 * 24 * 60 * 60, stepSeconds: 30 * 60 },
+  "30d": { windowSeconds: 30 * 24 * 60 * 60, stepSeconds: 2 * 60 * 60 },
+} as const;
+
+export const PEG_HISTORY_RANGE_OPTIONS = ["24h", "7d", "30d"] as const;
+export type PegHistoryRange = (typeof PEG_HISTORY_RANGE_OPTIONS)[number];
+
+export type PegHistoryPoint = {
+  /** Unix seconds. */
+  at: number;
+  /** Signed deviation from target; negative is below target. */
+  bps: number;
+  /** Alert name when a later feed attaches a state transition to this reading. */
+  event?: string;
+};
+
+export type PegHistoryResponse = {
+  asset: string;
+  source: string;
+  policyVersion: string;
+  range: PegHistoryRange;
+  from: number;
+  to: number;
+  stepSeconds: number;
+  points: PegHistoryPoint[];
+};

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -36,6 +36,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
     releaseFirstResponse = resolve;
   });
   const historyRequests: Record<string, number> = {};
+  const historyRequestEnds: Array<string | null> = [];
   await page.route("**/api/peg-monitoring", async (route) => {
     request += 1;
     if (request === 1) {
@@ -53,6 +54,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
     expect(route.request().method()).toBe("POST");
     const url = new URL(route.request().url());
     const range = url.searchParams.get("range") ?? "7d";
+    historyRequestEnds.push(url.searchParams.get("to"));
     historyRequests[range] = (historyRequests[range] ?? 0) + 1;
     const windowSeconds =
       range === "24h" ? 86_400 : range === "30d" ? 30 * 86_400 : 7 * 86_400;
@@ -184,6 +186,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   await expect(page.getByTestId("peg-panel-europ-schuman")).toContainText(
     "Showing the last confirmed check",
   );
+  await expect.poll(() => historyRequestEnds.at(-1)).toBe(String(now));
 });
 
 test("keeps the board scrollable without pushing the page wider on mobile", async ({

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -35,6 +35,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   const firstResponseGate = new Promise<void>((resolve) => {
     releaseFirstResponse = resolve;
   });
+  const historyRequests: Record<string, number> = {};
   await page.route("**/api/peg-monitoring", async (route) => {
     request += 1;
     if (request === 1) {
@@ -46,6 +47,30 @@ test("renders the status board, expands a row panel, and retains stale evidence"
       status: 503,
       contentType: "application/json",
       body: '{"error":"offline"}',
+    });
+  });
+  await page.route("**/api/peg-monitoring/history?*", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    const url = new URL(route.request().url());
+    const range = url.searchParams.get("range") ?? "7d";
+    historyRequests[range] = (historyRequests[range] ?? 0) + 1;
+    const windowSeconds =
+      range === "24h" ? 86_400 : range === "30d" ? 30 * 86_400 : 7 * 86_400;
+    const stepSeconds = range === "24h" ? 300 : range === "30d" ? 7_200 : 1_800;
+    await route.fulfill({
+      json: {
+        asset: "europ-schuman",
+        source: "bitvavo_eur",
+        policyVersion: payload.producedPolicyVersion,
+        range,
+        from: now - windowSeconds,
+        to: now,
+        stepSeconds,
+        points: [
+          { at: now - Math.min(windowSeconds, 3_600), bps: -4 },
+          { at: now, bps: 1.5 },
+        ],
+      },
     });
   });
   await page.goto("/peg-monitoring");
@@ -114,7 +139,16 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   ).toHaveAttribute("aria-expanded", "true");
   await expect(panel).toContainText("Supporting Markets");
   await expect(panel).toContainText("Peg History");
-  await expect(panel).toContainText("History unavailable");
+  await expect(
+    panel.getByRole("img", { name: /Peg history over 7d: 2 readings/ }),
+  ).toBeVisible();
+  await panel.getByRole("button", { name: "24h" }).click();
+  await expect(
+    panel.getByRole("img", { name: /Peg history over 24h: 2 readings/ }),
+  ).toBeVisible();
+  expect(historyRequests["24h"]).toBe(1);
+  await page.clock.runFor(300_000);
+  await expect.poll(() => historyRequests["24h"]).toBeGreaterThan(1);
   await expect(
     panel.getByTestId("peg-supporting-source-kraken_eur"),
   ).toContainText("DEPTH ONLY");
@@ -160,6 +194,14 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
   await page.route("**/api/peg-monitoring", async (route) => {
     await route.fulfill({ json: payload });
   });
+  await page.route("**/api/peg-monitoring/history?*", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: '{"error":"history offline"}',
+    });
+  });
   await page.goto("/peg-monitoring");
 
   await expect(page.getByTestId("peg-row-europ-schuman")).toBeVisible();
@@ -168,6 +210,9 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
     .getByText("EUROP / EUR", { exact: true })
     .click();
   await expect(page.getByTestId("peg-panel-europ-schuman")).toBeVisible();
+  await expect(page.getByTestId("peg-panel-europ-schuman")).toContainText(
+    "History unavailable",
+  );
 
   const horizontalOverflow = await page.evaluate(
     () =>


### PR DESCRIPTION
## The Problem

- The peg board only showed the current decision package, so operators could not inspect 24h, 7d, or 30d deviation history per asset.
- Grafana history must remain server-only and fail independently so an unavailable history query never degrades the current peg board.

## The Solution

- Add a bounded dashboard route that reads the selected asset's deep-source series from Grafana and wire the existing Peg History chart and range controls to that route.

## Details

- Queries the exact asset, deep source, and produced policy version at 24h/5m, 7d/30m, or 30d/2h resolution.
- Reconstructs signed deviation from the premium and downside-deviation metrics, validates Grafana result status, series identity, frames, timestamps, values, and response size, and never sends the Grafana token to the browser.
- Refreshes open charts at the selected sampling cadence while disabling focus, reconnect, and hidden-tab polling.
- Keeps loading, empty, unavailable, and failed-refresh-with-last-confirmed-data states distinct. A history failure leaves current peg status and board interactions usable.
- Does not apply the Terraform from #1833 or claim production proof. That remains an explicit approval-gated closeout step for #1831.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including production Playwright, coverage, typecheck, lint, Trunk, knip, dependency checks, bundle limits, React Doctor 100, and Terraform tests.
- `pnpm --filter @mento-protocol/ui-dashboard test:browser:production tests/browser/peg-monitoring.test.ts` — 2 passed on a production build.
- Fresh-context Codex autoreview — two fix cycles accepted and resolved; final semantic pass clean at `94f42ae5`.
- Local deterministic autoreview — clean.
- Browser checks covered desktop history/range refresh, mobile 5xx isolation, no horizontal overflow, and no console errors.

Refs #1831

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new server proxy that holds Grafana credentials and parses upstream Prometheus frames; validation and fail-closed behavior are thorough, but misconfiguration or parser gaps could affect operator history views without impacting the live peg board.
> 
> **Overview**
> Adds **server-side peg deviation history** so expanded board rows can plot 24h / 7d / 30d series without exposing Grafana credentials to the browser.
> 
> A new **`POST /api/peg-monitoring/history`** route validates `asset`, deep `source`, `policyVersion`, and `range`, then queries Grafana Prometheus with bounded windows/steps, reconstructs **signed deviation** from premium minus downside metrics, and **fails closed** on bad labels, unsafe origins, upstream errors, timeouts, oversized bodies, or mismatched series identity. Responses are `no-store`; the viewer token stays on the server.
> 
> The **Peg History** chart and range controls load via **`usePegHistory`** (SWR, POST, refresh at the range’s step). The UI distinguishes **loading**, **empty**, **unavailable**, and **stale refresh with last confirmed points** (including single-point rendering and updated aria copy). **`producedPolicyVersion`** flows from the page into the row panel so history matches the current decision package’s deep venue.
> 
> Shared **`peg-history`** types/range constants replace chart-local range definitions; **`fetchJsonOrThrow`** gains optional **POST**. Unit, component, and Playwright coverage exercise the route contract, hook behavior, chart states, and range polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f42ae52ccdea7af82c606cef6ca2391f25c076. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->