### PR TITLE
docs(context): cover generated instruction drift

### DIFF
--- a/docs/context-standards.md
+++ b/docs/context-standards.md
@@ -143,6 +143,10 @@ point that can still teach the old sequence. Search root and package
 rollback, and babysit scripts. Update stale ordered runbooks and stale
 file/directory descriptions in the same PR.
 
+Treat workflow-generated issue bodies and operator instructions as live entry
+points: compare their rules item by item with the canonical owner before the
+first push.
+
 Treat deploy, rollback, and babysit as one workflow family: a new promotion or
 verification gate normally belongs in each applicable path. Search for the old
 command or invariant after editing and inspect every remaining hit; a concise


### PR DESCRIPTION
## The Problem

- Workflow-generated issue bodies can repeat canonical operating guidance, but the drift audit did not name that surface explicitly.
- A generated instruction can therefore retain an incomplete rule set until review catches the mismatch.

## The Solution

- Treat generated issue bodies and operator instructions as live entry points and compare their rules item by item with the canonical owner before the first push.

## Details

- This is a four-line clarification in the canonical context standards.
- It changes no runtime behavior, workflow execution, or generated artifact.

## Validation

- `./tools/trunk fmt docs/context-standards.md` — passed.
- `pnpm agent:quality-gate --run` — all five mapped commands passed.
- Autoreview skipped: this docs-only clarification does not meet the ship contract's non-trivial closeout threshold.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification in context standards; no runtime, workflow, or generated-artifact behavior changes.
> 
> **Overview**
> Extends the **change-coupled drift audit** so workflow-generated **issue bodies** and **operator instructions** are explicitly treated as live entry points—not only static docs and scripts.
> 
> Authors must **compare those generated rules item by item** against the canonical owner **before the first push**, closing a gap where stale guidance could ship in automation output without being caught by the existing search list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5fccb0b9e55300ef43960e252c07f8a94dde2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->