### PR TITLE
fix: align peg history queries to Grafana steps

### DIFF
--- a/docs/adr/0063-dashboard-grafana-history-read-access.md
+++ b/docs/adr/0063-dashboard-grafana-history-read-access.md
@@ -15,9 +15,9 @@ garden_lane: adrs-architecture
 
 **Status:** Accepted (Aug 2026). Amends
 [ADR 0049](0049-peg-decision-package-read-model.md), which stays in force for
-current-state evidence. The Terraform is checked in and unapplied; a
-human-approved platform apply activates the identity and the dashboard
-environment. **Scope:** ui-dashboard / terraform/infra
+current-state evidence. The Terraform was applied on 2026-08-14, and the
+dashboard environment now uses the dedicated read identity. **Scope:**
+ui-dashboard / terraform/infra
 
 ## Context
 

--- a/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/__tests__/route.test.ts
@@ -8,7 +8,7 @@ import {
   resolveGrafanaQueryEndpoint,
 } from "../route";
 
-const NOW_MS = Date.UTC(2026, 7, 13, 20, 0);
+const NOW_MS = Date.UTC(2026, 7, 13, 20, 17);
 const baseQuery = {
   asset: "europ-schuman",
   source: "bitvavo_eur",
@@ -29,6 +29,9 @@ const seriesLabels = {
   source: baseQuery.source,
   policy_version: baseQuery.policyVersion,
 };
+const alignToStep = (valueMs: number, stepMs: number) =>
+  Math.floor(valueMs / stepMs) * stepMs;
+const BASE_TO_MS = alignToStep(NOW_MS, 1_800_000);
 const frame = (
   times: unknown[],
   values: unknown[],
@@ -61,7 +64,7 @@ describe("POST /api/peg-monitoring/history", () => {
           A: {
             frames: [
               frame(
-                [NOW_MS - 3_600_000, NOW_MS - 1_800_000, NOW_MS],
+                [BASE_TO_MS - 3_600_000, BASE_TO_MS - 1_800_000, BASE_TO_MS],
                 [-4.5, null, 2.25],
               ),
             ],
@@ -75,12 +78,12 @@ describe("POST /api/peg-monitoring/history", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(await response.json()).toEqual({
       ...baseQuery,
-      from: (NOW_MS - 7 * 86_400_000) / 1_000,
-      to: NOW_MS / 1_000,
+      from: (BASE_TO_MS - 7 * 86_400_000) / 1_000,
+      to: BASE_TO_MS / 1_000,
       stepSeconds: 1_800,
       points: [
-        { at: (NOW_MS - 3_600_000) / 1_000, bps: -4.5 },
-        { at: NOW_MS / 1_000, bps: 2.25 },
+        { at: (BASE_TO_MS - 3_600_000) / 1_000, bps: -4.5 },
+        { at: BASE_TO_MS / 1_000, bps: 2.25 },
       ],
     });
 
@@ -99,8 +102,8 @@ describe("POST /api/peg-monitoring/history", () => {
       to: string;
       queries: Array<Record<string, unknown>>;
     };
-    expect(body.from).toBe(String(NOW_MS - 7 * 86_400_000));
-    expect(body.to).toBe(String(NOW_MS));
+    expect(body.from).toBe(String(BASE_TO_MS - 7 * 86_400_000));
+    expect(body.to).toBe(String(BASE_TO_MS));
     expect(body.queries).toEqual([
       expect.objectContaining({
         datasource: {
@@ -134,10 +137,13 @@ describe("POST /api/peg-monitoring/history", () => {
       const call = fetchMock.mock.calls[index]!;
       const body = JSON.parse(String(call[1]?.body)) as {
         from: string;
+        to: string;
         queries: Array<{ intervalMs: number; maxDataPoints: number }>;
       };
       const [, windowMs, intervalMs, maxDataPoints] = cases[index]!;
-      expect(body.from).toBe(String(NOW_MS - windowMs));
+      const alignedToMs = alignToStep(NOW_MS, intervalMs);
+      expect(body.from).toBe(String(alignedToMs - windowMs));
+      expect(body.to).toBe(String(alignedToMs));
       expect(body.queries[0]).toMatchObject({ intervalMs, maxDataPoints });
     });
   });
@@ -152,16 +158,17 @@ describe("POST /api/peg-monitoring/history", () => {
       request({ ...baseQuery, to: String(confirmedAt) }),
     );
     expect(response.status).toBe(200);
+    const alignedConfirmedAtMs = alignToStep(confirmedAt * 1_000, 1_800_000);
     expect(await response.json()).toMatchObject({
-      from: confirmedAt - 7 * 86_400,
-      to: confirmedAt,
+      from: alignedConfirmedAtMs / 1_000 - 7 * 86_400,
+      to: alignedConfirmedAtMs / 1_000,
     });
     const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body)) as {
       from: string;
       to: string;
     };
-    expect(body.from).toBe(String(NOW_MS - 60_000 - 7 * 86_400_000));
-    expect(body.to).toBe(String(NOW_MS - 60_000));
+    expect(body.from).toBe(String(alignedConfirmedAtMs - 7 * 86_400_000));
+    expect(body.to).toBe(String(alignedConfirmedAtMs));
   });
 
   it("rejects unbounded labels, unknown ranges, invalid end times, and extra parameters", async () => {
@@ -227,8 +234,8 @@ describe("POST /api/peg-monitoring/history", () => {
           results: {
             A: {
               frames: [
-                frame([NOW_MS], [-1]),
-                frame([NOW_MS - 1_800_000], [-2]),
+                frame([BASE_TO_MS], [-1]),
+                frame([BASE_TO_MS - 1_800_000], [-2]),
               ],
             },
           },
@@ -258,7 +265,7 @@ describe("POST /api/peg-monitoring/history", () => {
           results: {
             A: {
               frames: [
-                frame([NOW_MS], [-1], {
+                frame([BASE_TO_MS], [-1], {
                   ...seriesLabels,
                   source: "kraken_eur",
                 }),
@@ -276,7 +283,7 @@ describe("POST /api/peg-monitoring/history", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       json({
         results: {
-          A: { frames: [frame([NOW_MS], [25_000])] },
+          A: { frames: [frame([BASE_TO_MS], [25_000])] },
         },
       }),
     );
@@ -284,7 +291,7 @@ describe("POST /api/peg-monitoring/history", () => {
     const response = await POST(request());
     expect(response.status).toBe(200);
     expect((await response.json()).points).toEqual([
-      { at: NOW_MS / 1_000, bps: 25_000 },
+      { at: BASE_TO_MS / 1_000, bps: 25_000 },
     ]);
   });
 });

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -274,15 +274,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   );
   if (!input.success) return errorResponse("Invalid peg history query", 400);
   const requestNowMs = Date.now();
-  const toMs =
+  const requestedToMs =
     input.data.to === undefined ? requestNowMs : input.data.to * 1_000;
-  if (toMs > requestNowMs)
+  if (requestedToMs > requestNowMs)
     return errorResponse("Invalid peg history query", 400);
+  const settings = PEG_HISTORY_RANGES[input.data.range];
+  const stepMs = settings.stepSeconds * 1_000;
+  // Grafana aligns Prometheus range-query bounds to the requested step. Match
+  // those bounds here so valid boundary points are not rejected as upstream
+  // data outside an unaligned browser-time window.
+  const toMs = Math.floor(requestedToMs / stepMs) * stepMs;
   const endpoint = resolveGrafanaQueryEndpoint(process.env.GRAFANA_QUERY_URL);
   const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
   if (endpoint === null || !token)
     return errorResponse("Peg history is not configured", 503);
-  const settings = PEG_HISTORY_RANGES[input.data.range];
   const fromMs = toMs - settings.windowSeconds * 1_000;
   try {
     const upstream = await fetch(endpoint, {


### PR DESCRIPTION
## The Problem

- Live proof after the Grafana credential rollout returned HTTP 502 for the `24h` and `7d` peg-history ranges, while `30d` succeeded.
- Grafana aligns Prometheus range-query bounds to the selected step, but the route rejected those valid boundary points against the unaligned browser timestamp.

## The Solution

- Floor the query end to the selected range step, then derive the start from that same bound so the request, parser, and response share one exact window.
- Run every range test with an unaligned clock and cover retained-package timestamps so the production failure cannot hide behind step-aligned fixtures again.

## Details

### Invariants

- The requested asset, deep source, and policy version remain exact selectors.
- Each range keeps its reviewed window, step, point cap, timeout, and response-size limit.
- The aligned query end never exceeds the live request time or retained package timestamp.
- Grafana history remains isolated from the current-state decision package and board.

### Degraded behavior

- Grafana errors and invalid frames still fail closed through the existing history-unavailable state.
- A history failure still cannot block or replace the current-state peg board.

### Intentional non-goals

- No credential, datasource, PromQL selector, range, chart, or current-state behavior changes.
- Production API and browser proof remain a post-merge redeploy step for issue #1831.

## Validation

- Live reproduction before the fix: unaligned `24h` and `7d` requests returned 502; step-aligned requests returned 200; `30d` returned 200 with 196 points.
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/app/api/peg-monitoring/history/__tests__/route.test.ts` — 296 files and 4,280 tests passed.
- `pnpm agent:quality-gate --run` — all mapped commands passed, including production browser fixtures, coverage, lint, typecheck, Trunk, knip, dependency checks, React Doctor, bundle size, Terraform contracts, and documentation checks.
- Exact post-commit gate for `30ff0dd2` passed with the same mapped command set.
- Local autoreview deterministic guard: clean.
- Fresh-context Codex semantic autoreview: clean, no findings.
- Claude Security scan: skipped because the plugin is unavailable in Codex.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this PR preserves ADR 0063 and updates its applied-state note.

Follow-up for #1831.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bugfix to time-window alignment on an isolated history route; selectors, ranges, and fail-closed behavior unchanged.
> 
> **Overview**
> Fixes **502s on `24h`/`7d` peg history** after Grafana rollout by matching Grafana’s step-aligned Prometheus window instead of using raw browser time.
> 
> The history route now **floors the query end** (`to`) to the selected range’s step, derives `from` from that bound, and uses the same window for the upstream request, response metadata, and point validation so step-aligned boundary samples are not rejected as out of range. **ADR 0063** is updated to record that the Grafana read identity Terraform was applied on 2026-08-14.
> 
> Tests use an **unaligned clock** and assert aligned `from`/`to` for all ranges and retained-package `to` timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ff0dd2ddfc635ad9b94d21d1fa8e81fc5e64f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->