### PR TITLE
feat: add peg alert history feed

### DIFF
--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -282,7 +282,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
       const query = url.searchParams;
       expect(query.get("from")).toBe(String(FROM_SECONDS));
       expect(query.get("to")).toBe(String(NOW_SECONDS));
-      expect(query.get("limit")).toBe(String(PEG_ALERTS_MAX_STATE_ROWS));
+      expect(query.get("limit")).toBe(String(PEG_ALERTS_MAX_STATE_ROWS + 1));
       expect(query.get("labels_service")).toBe("peg-monitoring");
       expect(new Headers(init?.headers).get("authorization")).toBe(
         "Bearer viewer-token",
@@ -405,6 +405,22 @@ describe("GET /api/peg-monitoring/alerts", () => {
     expect(PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES).toBeLessThan(
       PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
     );
+  });
+
+  it("fails closed when the state-history sentinel proves truncation", async () => {
+    const sentinelRows = Array.from(
+      { length: PEG_ALERTS_MAX_STATE_ROWS + 1 },
+      (_, index) => ({
+        at: FROM_SECONDS + index,
+        line: stateLine({ fingerprint: `sentinel-${index}` }),
+      }),
+    );
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json(stateFrame(sentinelRows)))
+      .mockResolvedValueOnce(json(stateFrame([])))
+      .mockResolvedValueOnce(json(policyResponse()));
+
+    expect((await GET()).status).toBe(502);
   });
 
   it("maps upstream timeouts to 504 without exposing credentials", async () => {

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -1,0 +1,423 @@
+import { NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PEG_ALERTS_WINDOW_SECONDS } from "@/lib/peg-alerts";
+import {
+  GET,
+  PEG_ALERTS_DATASOURCE_UID,
+  PEG_ALERTS_MAX_EVENTS,
+  PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES,
+  PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
+  PEG_ALERTS_UPSTREAM_TIMEOUT_MS,
+} from "../route";
+import {
+  PEG_ALERTS_MAX_STATE_ROWS,
+  PEG_ALERTS_POLICY_STEP_SECONDS,
+  policyQueryBounds,
+} from "../peg-alert-events";
+
+const NOW_SECONDS = 1_786_694_595;
+const FROM_SECONDS = NOW_SECONDS - PEG_ALERTS_WINDOW_SECONDS;
+const POLICY_BOUNDS = policyQueryBounds(FROM_SECONDS, NOW_SECONDS);
+
+type StateLine = {
+  schemaVersion: 1;
+  previous: string;
+  current: string;
+  fingerprint: string;
+  ruleTitle: string;
+  ruleUID: string;
+  labels: {
+    alertname: string;
+    asset: string;
+    policy_version: string;
+    route: "market" | "ops" | "page";
+    service: "peg-monitoring";
+    severity: "warning" | "critical";
+    source: string;
+  };
+};
+
+function stateLine(
+  overrides: Omit<Partial<StateLine>, "labels"> & {
+    labels?: Partial<StateLine["labels"]>;
+  } = {},
+): StateLine {
+  const ruleTitle =
+    overrides.ruleTitle ??
+    "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · active]";
+  return {
+    schemaVersion: 1,
+    previous: "Pending",
+    current: "Alerting",
+    fingerprint: "spread-instance",
+    ruleTitle,
+    ruleUID: "spread-rule",
+    ...overrides,
+    labels: {
+      alertname: ruleTitle,
+      asset: "europ-schuman",
+      policy_version: "europ-v1",
+      route: "market",
+      service: "peg-monitoring",
+      severity: "warning",
+      source: "bitvavo_eur",
+      ...overrides.labels,
+    },
+  };
+}
+
+function stateFrame(rows: Array<{ at: number; line: StateLine }>): object {
+  return {
+    schema: {
+      name: "states",
+      fields: [
+        { name: "time", type: "time", typeInfo: { frame: "time.Time" } },
+        { name: "line", type: "other", typeInfo: { frame: "json.RawMessage" } },
+        {
+          name: "labels",
+          type: "other",
+          typeInfo: { frame: "json.RawMessage" },
+        },
+      ],
+    },
+    data: {
+      values: [
+        rows.map(({ at }) => at * 1_000),
+        rows.map(({ line }) => line),
+        rows.map(() => ({
+          from: "state-history",
+          labels_service: "peg-monitoring",
+        })),
+      ],
+    },
+  };
+}
+
+function policyFrame(
+  policyVersion: string,
+  points: Array<{ at: number; value: number | null }>,
+  instance = "bridge-a",
+): object {
+  return {
+    schema: {
+      fields: [
+        { name: "Time", type: "time" },
+        {
+          name: "Value",
+          type: "number",
+          labels: {
+            __name__: "mento_peg_policy_version",
+            instance,
+            policy_version: policyVersion,
+          },
+        },
+      ],
+    },
+    data: {
+      values: [
+        points.map(({ at }) => at * 1_000),
+        points.map(({ value }) => value),
+      ],
+    },
+  };
+}
+
+function policyResponse(frames: object[] = []): object {
+  return { results: { P: { frames } } };
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return Response.json(body, init);
+}
+
+function successfulFetch() {
+  const raisedRows = [
+    // Ordinary evaluation churn is valid upstream data but never a feed event.
+    {
+      at: NOW_SECONDS - 1_500,
+      line: stateLine({ previous: "Pending", current: "Normal" }),
+    },
+    {
+      at: NOW_SECONDS - 1_200,
+      line: stateLine(),
+    },
+    // Grafana can repeat an Alerting row while the same instance remains open.
+    {
+      at: NOW_SECONDS - 1_140,
+      line: stateLine(),
+    },
+    {
+      at: NOW_SECONDS - 300,
+      line: stateLine({
+        fingerprint: "critical-instance",
+        ruleTitle: "Peg Deep-Venue Downside Critical [europ-schuman · active]",
+        ruleUID: "critical-rule",
+        labels: {
+          alertname:
+            "Peg Deep-Venue Downside Critical [europ-schuman · active]",
+          route: "page",
+          severity: "critical",
+          source: "bitvavo_eur",
+        },
+      }),
+    },
+  ];
+  const clearedRows = [
+    {
+      at: NOW_SECONDS - 600,
+      line: stateLine({ previous: "Alerting", current: "Normal" }),
+    },
+    // Repeated clears after the incident closes must not create per-check rows.
+    {
+      at: NOW_SECONDS - 540,
+      line: stateLine({ previous: "Alerting", current: "Normal" }),
+    },
+    // A clear without a raise in the bounded window has no honest duration.
+    {
+      at: NOW_SECONDS - 120,
+      line: stateLine({
+        previous: "Alerting",
+        current: "Normal",
+        fingerprint: "unpaired-instance",
+      }),
+    },
+  ];
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/api/ds/query") {
+      return json(
+        policyResponse([
+          // The old policy has a sample in the extra pre-window step.
+          policyFrame("europ-old", [
+            {
+              at: POLICY_BOUNDS.fromMs / 1_000,
+              value: 1,
+            },
+            { at: FROM_SECONDS, value: 1 },
+          ]),
+          policyFrame("europ-new", [{ at: NOW_SECONDS - 300, value: 1 }]),
+          // A second scrape instance must not duplicate the activation.
+          policyFrame(
+            "europ-new",
+            [{ at: NOW_SECONDS - 240, value: 1 }],
+            "bridge-b",
+          ),
+        ]),
+      );
+    }
+    return json(
+      stateFrame(
+        url.searchParams.get("current") === "Alerting"
+          ? raisedRows
+          : clearedRows,
+      ),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_SECONDS * 1_000);
+  vi.stubEnv("GRAFANA_QUERY_URL", "https://grafana.example");
+  vi.stubEnv("GRAFANA_QUERY_TOKEN", "viewer-token");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe("GET /api/peg-monitoring/alerts", () => {
+  it("pairs real transitions, collapses repeated rows, and adds policy activations", async () => {
+    const fetchMock = successfulFetch();
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      from: FROM_SECONDS,
+      to: NOW_SECONDS,
+      events: [
+        {
+          id: `policy:europ-new:${NOW_SECONDS - 300}`,
+          at: NOW_SECONDS - 300,
+          severity: "policy",
+          lead: "Policy europ-new activated",
+          detail: "First observed in Mimir; activation time is approximate.",
+        },
+        {
+          id: `state:critical-instance:raised:${NOW_SECONDS - 300}`,
+          at: NOW_SECONDS - 300,
+          severity: "page",
+          lead: "EUROP downside critical page raised",
+          detail: "Bitvavo EUR · active policy entered alerting.",
+        },
+        {
+          id: `state:spread-instance:cleared:${NOW_SECONDS - 600}`,
+          at: NOW_SECONDS - 600,
+          severity: "cleared",
+          lead: "EUROP spread warning cleared",
+          detail:
+            "Bitvavo EUR · active policy returned to normal after 10 min.",
+        },
+        {
+          id: `state:spread-instance:raised:${NOW_SECONDS - 1_200}`,
+          at: NOW_SECONDS - 1_200,
+          severity: "warning",
+          lead: "EUROP spread warning raised",
+          detail: "Bitvavo EUR · active policy entered alerting.",
+        },
+      ],
+    });
+    expect(PEG_ALERTS_MAX_EVENTS).toBe(4);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const stateCalls = fetchMock.mock.calls.filter(
+      ([input]) => new URL(String(input)).pathname === "/api/v1/rules/history",
+    );
+    expect(stateCalls).toHaveLength(2);
+    for (const [input, init] of stateCalls) {
+      const url = new URL(String(input));
+      const query = url.searchParams;
+      expect(query.get("from")).toBe(String(FROM_SECONDS));
+      expect(query.get("to")).toBe(String(NOW_SECONDS));
+      expect(query.get("limit")).toBe(String(PEG_ALERTS_MAX_STATE_ROWS));
+      expect(query.get("labels_service")).toBe("peg-monitoring");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer viewer-token",
+      );
+    }
+    expect(
+      stateCalls.some(
+        ([input]) =>
+          new URL(String(input)).searchParams.get("current") === "Alerting",
+      ),
+    ).toBe(true);
+    expect(
+      stateCalls.some(([input]) => {
+        const query = new URL(String(input)).searchParams;
+        return (
+          query.get("previous") === "Alerting" &&
+          query.get("current") === "Normal"
+        );
+      }),
+    ).toBe(true);
+
+    const policyCall = fetchMock.mock.calls.find(
+      ([input]) => new URL(String(input)).pathname === "/api/ds/query",
+    )!;
+    const policyBody = JSON.parse(String(policyCall[1]?.body)) as {
+      from: string;
+      to: string;
+      queries: Array<Record<string, unknown>>;
+    };
+    expect(policyBody.from).toBe(String(POLICY_BOUNDS.fromMs));
+    expect(policyBody.to).toBe(String(POLICY_BOUNDS.toMs));
+    expect(policyBody.queries).toEqual([
+      expect.objectContaining({
+        datasource: { type: "prometheus", uid: PEG_ALERTS_DATASOURCE_UID },
+        expr: "mento_peg_policy_version",
+        intervalMs: PEG_ALERTS_POLICY_STEP_SECONDS * 1_000,
+        range: true,
+        instant: false,
+      }),
+    ]);
+    expect(PEG_ALERTS_UPSTREAM_TIMEOUT_MS).toBeLessThan(10_000);
+  });
+
+  it("returns the real empty state when both Grafana sources are empty", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+      String(input).includes("/api/ds/query")
+        ? json(policyResponse())
+        : json(stateFrame([])),
+    );
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      from: FROM_SECONDS,
+      to: NOW_SECONDS,
+      events: [],
+    });
+  });
+
+  it("rejects missing credentials and unsafe Grafana origins before fetching", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    vi.stubEnv("GRAFANA_QUERY_TOKEN", "   ");
+    expect((await GET()).status).toBe(503);
+    vi.stubEnv("GRAFANA_QUERY_TOKEN", "viewer-token");
+    const credentialedOrigin = new URL("https://grafana.example");
+    credentialedOrigin.username = "user";
+    credentialedOrigin.password = "test";
+    const unsafeStatuses = await Promise.all(
+      [
+        "http://grafana.example",
+        "https://grafana.example/subpath",
+        credentialedOrigin.href,
+        "https://grafana.example?token=no",
+      ].map((origin) => {
+        vi.stubEnv("GRAFANA_QUERY_URL", origin);
+        return GET().then((response) => response.status);
+      }),
+    );
+    expect(unsafeStatuses).toEqual([503, 503, 503, 503]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for malformed frames, logical query errors, and oversized bodies", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json({ schema: {}, data: {} }))
+      .mockResolvedValueOnce(json(stateFrame([])))
+      .mockResolvedValueOnce(json(policyResponse()));
+    expect((await GET()).status).toBe(502);
+
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json(stateFrame([])))
+      .mockResolvedValueOnce(json(stateFrame([])))
+      .mockResolvedValueOnce(
+        json({
+          results: {
+            P: { frames: [], error: "secret query detail", status: 500 },
+          },
+        }),
+      );
+    const logical = await GET();
+    expect(logical.status).toBe(502);
+    expect(JSON.stringify(await logical.json())).not.toContain(
+      "secret query detail",
+    );
+
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("{}", {
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(PEG_ALERTS_MAX_STATE_RESPONSE_BYTES + 1),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(json(stateFrame([])))
+      .mockResolvedValueOnce(json(policyResponse()));
+    expect((await GET()).status).toBe(502);
+
+    expect(PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES).toBeLessThan(
+      PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
+    );
+  });
+
+  it("maps upstream timeouts to 504 without exposing credentials", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new DOMException("viewer-token", "TimeoutError"),
+    );
+    const response = await GET();
+    expect(response.status).toBe(504);
+    expect(JSON.stringify(await response.json())).not.toContain("viewer-token");
+  });
+
+  it("does not depend on a NextRequest or query parameters", async () => {
+    successfulFetch();
+    await expect(GET()).resolves.toBeInstanceOf(NextResponse);
+  });
+});

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -1,0 +1,432 @@
+import { z } from "zod";
+import type { PegAlertEvent } from "@/lib/peg-alerts";
+
+export const PEG_ALERTS_POLICY_STEP_SECONDS = 5 * 60;
+export const PEG_ALERTS_MAX_STATE_ROWS = 1_000;
+const PEG_ALERTS_MAX_POLICY_FRAMES = 8;
+
+export function policyQueryBounds(
+  fromSeconds: number,
+  toSeconds: number,
+): { fromMs: number; toMs: number } {
+  const stepMs = PEG_ALERTS_POLICY_STEP_SECONDS * 1_000;
+  return {
+    fromMs: Math.floor((fromSeconds * 1_000 - stepMs) / stepMs) * stepMs,
+    toMs: Math.floor((toSeconds * 1_000) / stepMs) * stepMs,
+  };
+}
+
+const label = z
+  .string()
+  .min(1)
+  .max(160)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/);
+const stateFieldSchema = z
+  .object({ name: z.string().min(1).max(32), type: z.string().min(1).max(32) })
+  .passthrough();
+const stateLineSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    previous: z.string().min(1).max(64),
+    current: z.string().min(1).max(64),
+    fingerprint: z.string().min(1).max(64),
+    ruleTitle: z.string().min(1).max(256),
+    ruleUID: z.string().min(1).max(64),
+    labels: z
+      .object({
+        alertname: z.string().min(1).max(256),
+        asset: label,
+        policy_version: label,
+        route: z.enum(["market", "ops", "page"]),
+        service: z.literal("peg-monitoring"),
+        severity: z.enum(["warning", "critical"]),
+        source: z.string().max(64),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+const stateFrameSchema = z
+  .object({
+    schema: z
+      .object({
+        name: z.literal("states"),
+        fields: z.array(stateFieldSchema).min(3).max(8),
+      })
+      .passthrough(),
+    data: z
+      .object({ values: z.array(z.array(z.unknown())).min(3).max(8) })
+      .passthrough(),
+  })
+  .passthrough();
+
+const policyFieldSchema = z
+  .object({
+    name: z.string().min(1).max(64),
+    type: z.string().min(1).max(32),
+    labels: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+const policyFrameSchema = z
+  .object({
+    schema: z
+      .object({ fields: z.array(policyFieldSchema).min(2).max(8) })
+      .passthrough(),
+    data: z
+      .object({ values: z.array(z.array(z.unknown())).min(2).max(8) })
+      .passthrough(),
+  })
+  .passthrough();
+const policyResponseSchema = z
+  .object({
+    results: z.record(
+      z.string(),
+      z
+        .object({
+          frames: z.array(policyFrameSchema).max(PEG_ALERTS_MAX_POLICY_FRAMES),
+          error: z.string().optional(),
+          status: z.number().int().optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+type StateFrame = z.infer<typeof stateFrameSchema>;
+type StateLine = z.infer<typeof stateLineSchema>;
+type PolicyFrame = z.infer<typeof policyFrameSchema>;
+
+class InvalidPegAlertsUpstreamError extends Error {}
+
+type PegStateTransition = {
+  at: number;
+  kind: "raised" | "cleared";
+  identity: string;
+  line: StateLine;
+};
+
+function onlyNamedFieldIndex(
+  fields: readonly { name: string; type: string }[],
+  name: string,
+  type: string,
+): number {
+  const indexes = fields.flatMap((field, index) =>
+    field.name === name && field.type === type ? [index] : [],
+  );
+  if (indexes.length !== 1) throw new InvalidPegAlertsUpstreamError();
+  return indexes[0]!;
+}
+
+function baseState(value: string): string {
+  return value.split(" ", 1)[0] ?? value;
+}
+
+function transitionKind(line: StateLine): PegStateTransition["kind"] | null {
+  if (baseState(line.current) === "Alerting") return "raised";
+  if (
+    baseState(line.previous) === "Alerting" &&
+    baseState(line.current) === "Normal"
+  )
+    return "cleared";
+  return null;
+}
+
+export function parseStateTransitions(
+  raw: unknown,
+  fromSeconds: number,
+  toSeconds: number,
+): PegStateTransition[] {
+  const parsed = stateFrameSchema.safeParse(raw);
+  if (!parsed.success) throw new InvalidPegAlertsUpstreamError();
+  const frame: StateFrame = parsed.data;
+  if (frame.schema.fields.length !== frame.data.values.length)
+    throw new InvalidPegAlertsUpstreamError();
+  const timeIndex = onlyNamedFieldIndex(frame.schema.fields, "time", "time");
+  const lineIndex = onlyNamedFieldIndex(frame.schema.fields, "line", "other");
+  const labelsIndex = onlyNamedFieldIndex(
+    frame.schema.fields,
+    "labels",
+    "other",
+  );
+  const times = frame.data.values[timeIndex]!;
+  const lines = frame.data.values[lineIndex]!;
+  const streamLabels = frame.data.values[labelsIndex]!;
+  if (
+    times.length !== lines.length ||
+    times.length !== streamLabels.length ||
+    times.length > PEG_ALERTS_MAX_STATE_ROWS
+  )
+    throw new InvalidPegAlertsUpstreamError();
+
+  const deduped = new Map<string, PegStateTransition>();
+  for (let index = 0; index < times.length; index += 1) {
+    const atMs = times[index];
+    const lineResult = stateLineSchema.safeParse(lines[index]);
+    const streamResult = z
+      .record(z.string(), z.string())
+      .safeParse(streamLabels[index]);
+    if (
+      typeof atMs !== "number" ||
+      !Number.isSafeInteger(atMs) ||
+      atMs < fromSeconds * 1_000 ||
+      atMs > toSeconds * 1_000 ||
+      !lineResult.success ||
+      !streamResult.success ||
+      streamResult.data.labels_service !== "peg-monitoring"
+    )
+      throw new InvalidPegAlertsUpstreamError();
+    const kind = transitionKind(lineResult.data);
+    if (kind === null) continue;
+    const transition: PegStateTransition = {
+      at: atMs / 1_000,
+      kind,
+      identity: lineResult.data.fingerprint,
+      line: lineResult.data,
+    };
+    deduped.set(
+      `${transition.identity}:${transition.at}:${transition.kind}`,
+      transition,
+    );
+  }
+  return [...deduped.values()];
+}
+
+function policyFrameFirstSample(
+  frame: PolicyFrame,
+  queryFromMs: number,
+  toMs: number,
+): { policyVersion: string; atMs: number } | null {
+  const { timeIndex, numberIndex, policyVersion } = policyFrameIdentity(frame);
+  const times = frame.data.values[timeIndex]!;
+  const values = frame.data.values[numberIndex]!;
+  if (times.length !== values.length || times.length > 2_020)
+    throw new InvalidPegAlertsUpstreamError();
+  let earliest: number | null = null;
+  for (let index = 0; index < times.length; index += 1) {
+    const atMs = positivePolicySample(
+      times[index],
+      values[index],
+      queryFromMs,
+      toMs,
+    );
+    if (atMs !== null)
+      earliest = earliest === null ? atMs : Math.min(earliest, atMs);
+  }
+  return earliest === null ? null : { policyVersion, atMs: earliest };
+}
+
+function policyFrameIdentity(frame: PolicyFrame): {
+  timeIndex: number;
+  numberIndex: number;
+  policyVersion: string;
+} {
+  if (frame.schema.fields.length !== frame.data.values.length)
+    throw new InvalidPegAlertsUpstreamError();
+  const timeIndexes = frame.schema.fields.flatMap((field, index) =>
+    field.type === "time" ? [index] : [],
+  );
+  const numberIndexes = frame.schema.fields.flatMap((field, index) =>
+    field.type === "number" ? [index] : [],
+  );
+  if (timeIndexes.length !== 1 || numberIndexes.length !== 1)
+    throw new InvalidPegAlertsUpstreamError();
+  const timeIndex = timeIndexes[0]!;
+  const numberIndex = numberIndexes[0]!;
+  const labels = frame.schema.fields[numberIndex]?.labels;
+  const policyResult = label.safeParse(labels?.policy_version);
+  if (
+    !policyResult.success ||
+    (labels?.__name__ !== undefined &&
+      labels.__name__ !== "mento_peg_policy_version")
+  )
+    throw new InvalidPegAlertsUpstreamError();
+  return { timeIndex, numberIndex, policyVersion: policyResult.data };
+}
+
+function positivePolicySample(
+  atMs: unknown,
+  value: unknown,
+  queryFromMs: number,
+  toMs: number,
+): number | null {
+  if (
+    typeof atMs !== "number" ||
+    !Number.isSafeInteger(atMs) ||
+    atMs < queryFromMs ||
+    atMs > toMs ||
+    (value !== null && (typeof value !== "number" || !Number.isFinite(value)))
+  )
+    throw new InvalidPegAlertsUpstreamError();
+  return typeof value === "number" && value > 0 ? atMs : null;
+}
+
+export function parsePolicyActivations(
+  raw: unknown,
+  fromSeconds: number,
+  toSeconds: number,
+): PegAlertEvent[] {
+  const parsed = policyResponseSchema.safeParse(raw);
+  if (!parsed.success) throw new InvalidPegAlertsUpstreamError();
+  const result = parsed.data.results.P;
+  if (
+    result === undefined ||
+    (result.error !== undefined && result.error.trim() !== "") ||
+    (result.status !== undefined &&
+      (result.status < 200 || result.status >= 300))
+  )
+    throw new InvalidPegAlertsUpstreamError();
+  const fromMs = fromSeconds * 1_000;
+  const toMs = toSeconds * 1_000;
+  const bounds = policyQueryBounds(fromSeconds, toSeconds);
+  const firstByPolicy = new Map<string, number>();
+  for (const frame of result.frames) {
+    const first = policyFrameFirstSample(frame, bounds.fromMs, bounds.toMs);
+    if (first === null) continue;
+    const existing = firstByPolicy.get(first.policyVersion);
+    firstByPolicy.set(
+      first.policyVersion,
+      existing === undefined ? first.atMs : Math.min(existing, first.atMs),
+    );
+  }
+
+  return [...firstByPolicy.entries()].flatMap(([policyVersion, atMs]) => {
+    // Scrapes expose a new policy as a new label series, not an explicit
+    // activation event. The first positive sample is therefore only an
+    // approximation. A sample in the extra pre-window step proves the series
+    // already existed and prevents a false activation at the seven-day edge.
+    if (atMs <= fromMs || atMs > toMs) return [];
+    return [
+      {
+        id: `policy:${policyVersion}:${atMs / 1_000}`,
+        at: atMs / 1_000,
+        severity: "policy" as const,
+        lead: `Policy ${policyVersion} activated`,
+        detail: "First observed in Mimir; activation time is approximate.",
+      },
+    ];
+  });
+}
+
+const alertSubject: Record<string, string> = {
+  "Blind Warning": "blindness warning",
+  "Blind While Stressed Critical": "blindness critical page",
+  "Critical Path Unreachable": "critical-path warning",
+  "Deep-Venue Downside Critical": "downside critical page",
+  "Deep-Venue Spread Warning": "spread warning",
+  "Downside Warning": "downside warning",
+  "Heartbeat Missing": "heartbeat warning",
+  "Indexed Pool Unreachable": "indexed-pool warning",
+  "Policy Rollover Stuck": "policy-rollover warning",
+  "Premium Warning": "premium warning",
+  "Registry Rot": "registry warning",
+  "Source Permanently Dead": "source warning",
+  "Source Unhealthy": "source warning",
+  "Structural Saturation Warning": "structural warning",
+};
+
+function assetName(asset: string): string {
+  return (asset.split("-", 1)[0] ?? asset).toUpperCase();
+}
+
+function sourceName(source: string): string | null {
+  if (source === "") return null;
+  const [provider, ...rest] = source.split("_");
+  if (provider === undefined) return source;
+  const providerName = `${provider.slice(0, 1).toUpperCase()}${provider.slice(1)}`;
+  return [providerName, ...rest.map((part) => part.toUpperCase())].join(" ");
+}
+
+function policySlot(ruleTitle: string): "active" | "previous" | "approved" {
+  const match = ruleTitle.match(/ · (active|previous)]$/);
+  return match?.[1] === "previous"
+    ? "previous"
+    : match?.[1] === "active"
+      ? "active"
+      : "approved";
+}
+
+function subject(line: StateLine): string {
+  const title = line.ruleTitle.match(/^Peg (.+?)(?: \[|$)/)?.[1];
+  if (title === undefined) return "alert";
+  const mapped = alertSubject[title];
+  if (mapped !== undefined) return mapped;
+  const fallback = title.toLowerCase();
+  return line.labels.route === "page" && !fallback.includes("page")
+    ? `${fallback} page`
+    : fallback;
+}
+
+function durationLabel(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3_600) return `${Math.max(1, Math.round(seconds / 60))} min`;
+  if (seconds < 86_400) return `${Math.max(1, Math.round(seconds / 3_600))} hr`;
+  const days = Math.max(1, Math.round(seconds / 86_400));
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}
+
+function phraseTransition(
+  transition: PegStateTransition,
+  raisedAt?: number,
+): PegAlertEvent {
+  const line = transition.line;
+  const asset = assetName(line.labels.asset);
+  const context = [
+    sourceName(line.labels.source),
+    `${policySlot(line.ruleTitle)} policy`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" · ");
+  const cleared = transition.kind === "cleared";
+  return {
+    id: `state:${transition.identity}:${transition.kind}:${transition.at}`,
+    at: transition.at,
+    severity: cleared
+      ? "cleared"
+      : line.labels.route === "page" || line.labels.severity === "critical"
+        ? "page"
+        : "warning",
+    lead: `${asset} ${subject(line)} ${cleared ? "cleared" : "raised"}`,
+    detail:
+      cleared && raisedAt !== undefined
+        ? `${context} returned to normal after ${durationLabel(Math.max(0, transition.at - raisedAt))}.`
+        : `${context} entered alerting.`,
+  };
+}
+
+function pairStateTransitions(
+  transitions: readonly PegStateTransition[],
+): PegAlertEvent[] {
+  const ordered = [...transitions].sort(
+    (left, right) =>
+      left.at - right.at ||
+      (left.kind === right.kind ? 0 : left.kind === "raised" ? -1 : 1) ||
+      left.identity.localeCompare(right.identity),
+  );
+  const open = new Map<string, PegStateTransition>();
+  const events: PegAlertEvent[] = [];
+  for (const transition of ordered) {
+    if (transition.kind === "raised") {
+      if (!open.has(transition.identity))
+        open.set(transition.identity, transition);
+      continue;
+    }
+    const raised = open.get(transition.identity);
+    if (raised === undefined || transition.at < raised.at) continue;
+    events.push(phraseTransition(raised));
+    events.push(phraseTransition(transition, raised.at));
+    open.delete(transition.identity);
+  }
+  for (const raised of open.values()) events.push(phraseTransition(raised));
+  return events;
+}
+
+export function combinePegAlertEvents(
+  stateTransitions: readonly PegStateTransition[],
+  policyEvents: readonly PegAlertEvent[],
+  maximumEvents: number,
+): PegAlertEvent[] {
+  return [...pairStateTransitions(stateTransitions), ...policyEvents]
+    .sort(
+      (left, right) => right.at - left.at || left.id.localeCompare(right.id),
+    )
+    .slice(0, maximumEvents);
+}

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -4,6 +4,9 @@ import {
   type PegAlertsResponse,
 } from "@/lib/peg-alerts";
 import {
+  GRAFANA_NO_STORE_HEADERS,
+  grafanaErrorResponse,
+  isGrafanaTimeout,
   readBoundedGrafanaResponse,
   resolveGrafanaEndpoint,
 } from "@/lib/server/grafana-read";
@@ -23,12 +26,6 @@ export const PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES = 512 * 1024;
 export const PEG_ALERTS_MAX_EVENTS = 4;
 export const PEG_ALERTS_DATASOURCE_UID = "grafanacloud-prom";
 
-const responseHeaders = { "Cache-Control": "no-store" } as const;
-
-function errorResponse(error: string, status: number): NextResponse {
-  return NextResponse.json({ error }, { status, headers: responseHeaders });
-}
-
 function stateHistoryUrl(
   origin: string | undefined,
   from: number,
@@ -39,7 +36,9 @@ function stateHistoryUrl(
   if (url === null) return null;
   url.searchParams.set("from", String(from));
   url.searchParams.set("to", String(to));
-  url.searchParams.set("limit", String(PEG_ALERTS_MAX_STATE_ROWS));
+  // Ask for one sentinel row beyond the parser cap so a full page proves the
+  // seven-day result was truncated instead of silently losing an incident.
+  url.searchParams.set("limit", String(PEG_ALERTS_MAX_STATE_ROWS + 1));
   url.searchParams.set("labels_service", "peg-monitoring");
   if (kind === "cleared") {
     url.searchParams.set("previous", "Alerting");
@@ -103,13 +102,6 @@ async function fetchJson(
   ) as unknown;
 }
 
-function timedOut(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.name === "TimeoutError" || error.name === "AbortError")
-  );
-}
-
 export async function GET(): Promise<NextResponse> {
   const to = Math.floor(Date.now() / 1_000);
   const from = to - PEG_ALERTS_WINDOW_SECONDS;
@@ -137,7 +129,7 @@ export async function GET(): Promise<NextResponse> {
     clearedUrl === null ||
     policyUrl === null
   )
-    return errorResponse("Peg alert history is not configured", 503);
+    return grafanaErrorResponse("Peg alert history is not configured", 503);
 
   try {
     const [raisedRaw, clearedRaw, policyRaw] = await Promise.all([
@@ -158,10 +150,13 @@ export async function GET(): Promise<NextResponse> {
       PEG_ALERTS_MAX_EVENTS,
     );
     const response: PegAlertsResponse = { from, to, events };
-    return NextResponse.json(response, { headers: responseHeaders });
+    return NextResponse.json(response, { headers: GRAFANA_NO_STORE_HEADERS });
   } catch (error) {
-    if (timedOut(error))
-      return errorResponse("Peg alert history timed out", 504);
-    return errorResponse("Peg alert history upstream response is invalid", 502);
+    if (isGrafanaTimeout(error))
+      return grafanaErrorResponse("Peg alert history timed out", 504);
+    return grafanaErrorResponse(
+      "Peg alert history upstream response is invalid",
+      502,
+    );
   }
 }

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from "next/server";
+import {
+  PEG_ALERTS_WINDOW_SECONDS,
+  type PegAlertsResponse,
+} from "@/lib/peg-alerts";
+import {
+  readBoundedGrafanaResponse,
+  resolveGrafanaEndpoint,
+} from "@/lib/server/grafana-read";
+import {
+  combinePegAlertEvents,
+  parsePolicyActivations,
+  parseStateTransitions,
+  policyQueryBounds,
+  PEG_ALERTS_MAX_STATE_ROWS,
+  PEG_ALERTS_POLICY_STEP_SECONDS,
+} from "./peg-alert-events";
+
+export const dynamic = "force-dynamic";
+export const PEG_ALERTS_UPSTREAM_TIMEOUT_MS = 8_000;
+export const PEG_ALERTS_MAX_STATE_RESPONSE_BYTES = 4 * 1024 * 1024;
+export const PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES = 512 * 1024;
+export const PEG_ALERTS_MAX_EVENTS = 4;
+export const PEG_ALERTS_DATASOURCE_UID = "grafanacloud-prom";
+
+const responseHeaders = { "Cache-Control": "no-store" } as const;
+
+function errorResponse(error: string, status: number): NextResponse {
+  return NextResponse.json({ error }, { status, headers: responseHeaders });
+}
+
+function stateHistoryUrl(
+  origin: string | undefined,
+  from: number,
+  to: number,
+  kind: "raised" | "cleared",
+): URL | null {
+  const url = resolveGrafanaEndpoint(origin, "/api/v1/rules/history");
+  if (url === null) return null;
+  url.searchParams.set("from", String(from));
+  url.searchParams.set("to", String(to));
+  url.searchParams.set("limit", String(PEG_ALERTS_MAX_STATE_ROWS));
+  url.searchParams.set("labels_service", "peg-monitoring");
+  if (kind === "cleared") {
+    url.searchParams.set("previous", "Alerting");
+    url.searchParams.set("current", "Normal");
+  } else {
+    url.searchParams.set("current", "Alerting");
+  }
+  return url;
+}
+
+function policyRequest(from: number, to: number): object {
+  const bounds = policyQueryBounds(from, to);
+  const stepMs = PEG_ALERTS_POLICY_STEP_SECONDS * 1_000;
+  return {
+    queries: [
+      {
+        refId: "P",
+        datasource: {
+          type: "prometheus",
+          uid: PEG_ALERTS_DATASOURCE_UID,
+        },
+        expr: "mento_peg_policy_version",
+        format: "time_series",
+        range: true,
+        instant: false,
+        intervalMs: stepMs,
+        maxDataPoints: (bounds.toMs - bounds.fromMs) / stepMs + 1,
+      },
+    ],
+    // One extra point distinguishes a policy that predates the visible window
+    // from a label series first observed inside it.
+    from: String(bounds.fromMs),
+    to: String(bounds.toMs),
+  };
+}
+
+async function fetchJson(
+  url: URL,
+  token: string,
+  maximumBytes: number,
+  init: Pick<RequestInit, "body" | "method"> = {},
+): Promise<unknown> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+      ...(init.body === undefined
+        ? {}
+        : { "Content-Type": "application/json" }),
+    },
+    cache: "no-store",
+    redirect: "error",
+    signal: AbortSignal.timeout(PEG_ALERTS_UPSTREAM_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error("Grafana unavailable");
+  if (!response.headers.get("content-type")?.includes("application/json"))
+    throw new Error("Grafana returned non-JSON");
+  return JSON.parse(
+    await readBoundedGrafanaResponse(response, maximumBytes),
+  ) as unknown;
+}
+
+function timedOut(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+export async function GET(): Promise<NextResponse> {
+  const to = Math.floor(Date.now() / 1_000);
+  const from = to - PEG_ALERTS_WINDOW_SECONDS;
+  const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
+  const raisedUrl = stateHistoryUrl(
+    process.env.GRAFANA_QUERY_URL,
+    from,
+    to,
+    "raised",
+  );
+  const clearedUrl = stateHistoryUrl(
+    process.env.GRAFANA_QUERY_URL,
+    from,
+    to,
+    "cleared",
+  );
+  const policyUrl = resolveGrafanaEndpoint(
+    process.env.GRAFANA_QUERY_URL,
+    "/api/ds/query",
+  );
+  if (
+    token === undefined ||
+    token === "" ||
+    raisedUrl === null ||
+    clearedUrl === null ||
+    policyUrl === null
+  )
+    return errorResponse("Peg alert history is not configured", 503);
+
+  try {
+    const [raisedRaw, clearedRaw, policyRaw] = await Promise.all([
+      fetchJson(raisedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
+      fetchJson(clearedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
+      fetchJson(policyUrl, token, PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES, {
+        method: "POST",
+        body: JSON.stringify(policyRequest(from, to)),
+      }),
+    ]);
+    const transitions = [
+      ...parseStateTransitions(raisedRaw, from, to),
+      ...parseStateTransitions(clearedRaw, from, to),
+    ];
+    const events = combinePegAlertEvents(
+      transitions,
+      parsePolicyActivations(policyRaw, from, to),
+      PEG_ALERTS_MAX_EVENTS,
+    );
+    const response: PegAlertsResponse = { from, to, events };
+    return NextResponse.json(response, { headers: responseHeaders });
+  } catch (error) {
+    if (timedOut(error))
+      return errorResponse("Peg alert history timed out", 504);
+    return errorResponse("Peg alert history upstream response is invalid", 502);
+  }
+}

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -7,6 +7,9 @@ import {
   type PegHistoryResponse,
 } from "@/lib/peg-history";
 import {
+  GRAFANA_NO_STORE_HEADERS,
+  grafanaErrorResponse,
+  isGrafanaTimeout,
   readBoundedGrafanaResponse,
   resolveGrafanaEndpoint,
 } from "@/lib/server/grafana-read";
@@ -16,7 +19,6 @@ export const PEG_HISTORY_UPSTREAM_TIMEOUT_MS = 8_000;
 export const PEG_HISTORY_MAX_RESPONSE_BYTES = 512 * 1024;
 export const PEG_HISTORY_DATASOURCE_UID = "grafanacloud-prom";
 
-const responseHeaders = { "Cache-Control": "no-store" } as const;
 const label = z
   .string()
   .min(1)
@@ -71,10 +73,6 @@ const grafanaResponseSchema = z
 type GrafanaFrame = z.infer<typeof grafanaFrameSchema>;
 
 class InvalidUpstreamResponseError extends Error {}
-
-function errorResponse(error: string, status: number): NextResponse {
-  return NextResponse.json({ error }, { status, headers: responseHeaders });
-}
 
 export function resolveGrafanaQueryEndpoint(
   raw: string | undefined,
@@ -210,23 +208,17 @@ function parseGrafanaPoints(
   return points;
 }
 
-function timedOut(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.name === "TimeoutError" || error.name === "AbortError")
-  );
-}
-
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const input = querySchema.safeParse(
     Object.fromEntries(request.nextUrl.searchParams.entries()),
   );
-  if (!input.success) return errorResponse("Invalid peg history query", 400);
+  if (!input.success)
+    return grafanaErrorResponse("Invalid peg history query", 400);
   const requestNowMs = Date.now();
   const requestedToMs =
     input.data.to === undefined ? requestNowMs : input.data.to * 1_000;
   if (requestedToMs > requestNowMs)
-    return errorResponse("Invalid peg history query", 400);
+    return grafanaErrorResponse("Invalid peg history query", 400);
   const settings = PEG_HISTORY_RANGES[input.data.range];
   const stepMs = settings.stepSeconds * 1_000;
   // Grafana aligns Prometheus range-query bounds to the requested step. Match
@@ -236,7 +228,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const endpoint = resolveGrafanaQueryEndpoint(process.env.GRAFANA_QUERY_URL);
   const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
   if (endpoint === null || !token)
-    return errorResponse("Peg history is not configured", 503);
+    return grafanaErrorResponse("Peg history is not configured", 503);
   const fromMs = toMs - settings.windowSeconds * 1_000;
   try {
     const upstream = await fetch(endpoint, {
@@ -252,7 +244,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       signal: AbortSignal.timeout(PEG_HISTORY_UPSTREAM_TIMEOUT_MS),
     });
     if (!upstream.ok)
-      return errorResponse("Peg history upstream unavailable", 502);
+      return grafanaErrorResponse("Peg history upstream unavailable", 502);
     if (!upstream.headers.get("content-type")?.includes("application/json"))
       throw new InvalidUpstreamResponseError();
     const points = parseGrafanaPoints(
@@ -273,9 +265,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       stepSeconds: settings.stepSeconds,
       points,
     };
-    return NextResponse.json(response, { headers: responseHeaders });
+    return NextResponse.json(response, { headers: GRAFANA_NO_STORE_HEADERS });
   } catch (error) {
-    if (timedOut(error)) return errorResponse("Peg history timed out", 504);
-    return errorResponse("Peg history upstream response is invalid", 502);
+    if (isGrafanaTimeout(error))
+      return grafanaErrorResponse("Peg history timed out", 504);
+    return grafanaErrorResponse(
+      "Peg history upstream response is invalid",
+      502,
+    );
   }
 }

--- a/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/history/route.ts
@@ -6,6 +6,10 @@ import {
   type PegHistoryPoint,
   type PegHistoryResponse,
 } from "@/lib/peg-history";
+import {
+  readBoundedGrafanaResponse,
+  resolveGrafanaEndpoint,
+} from "@/lib/server/grafana-read";
 
 export const dynamic = "force-dynamic";
 export const PEG_HISTORY_UPSTREAM_TIMEOUT_MS = 8_000;
@@ -75,27 +79,7 @@ function errorResponse(error: string, status: number): NextResponse {
 export function resolveGrafanaQueryEndpoint(
   raw: string | undefined,
 ): URL | null {
-  if (!raw) return null;
-  try {
-    const url = new URL(raw);
-    const localHttp =
-      process.env.NODE_ENV !== "production" &&
-      url.protocol === "http:" &&
-      ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
-    if (
-      (url.protocol !== "https:" && !localHttp) ||
-      url.username ||
-      url.password ||
-      url.search ||
-      url.hash ||
-      (url.pathname !== "" && url.pathname !== "/")
-    )
-      return null;
-    url.pathname = "/api/ds/query";
-    return url;
-  } catch {
-    return null;
-  }
+  return resolveGrafanaEndpoint(raw, "/api/ds/query");
 }
 
 function signedDeviationPromql(input: {
@@ -130,41 +114,6 @@ function buildGrafanaRequest(
     from: String(fromMs),
     to: String(toMs),
   };
-}
-
-async function readBounded(response: Response): Promise<string> {
-  const length = response.headers.get("content-length");
-  if (
-    length !== null &&
-    (!/^\d+$/.test(length) || Number(length) > PEG_HISTORY_MAX_RESPONSE_BYTES)
-  )
-    throw new InvalidUpstreamResponseError();
-  if (response.body === null) throw new InvalidUpstreamResponseError();
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- ordered streams expose one bounded chunk at a time
-    const next = await reader.read();
-    if (next.done) break;
-    total += next.value.byteLength;
-    if (total > PEG_HISTORY_MAX_RESPONSE_BYTES) {
-      void reader.cancel().catch(() => undefined);
-      throw new InvalidUpstreamResponseError();
-    }
-    chunks.push(next.value);
-  }
-  const body = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(body);
-  } catch {
-    throw new InvalidUpstreamResponseError();
-  }
 }
 
 function onlyFieldIndex(frame: GrafanaFrame, type: string): number {
@@ -307,7 +256,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!upstream.headers.get("content-type")?.includes("application/json"))
       throw new InvalidUpstreamResponseError();
     const points = parseGrafanaPoints(
-      JSON.parse(await readBounded(upstream)) as unknown,
+      JSON.parse(
+        await readBoundedGrafanaResponse(
+          upstream,
+          PEG_HISTORY_MAX_RESPONSE_BYTES,
+        ),
+      ) as unknown,
       fromMs,
       toMs,
       input.data,

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import type { PegMonitoringResult } from "@/hooks/use-peg-monitoring";
 import type { PegHistoryResult } from "@/hooks/use-peg-history";
+import type { PegAlertsResult } from "@/hooks/use-peg-alerts";
 import {
   makePegMonitoringResponse,
   PEG_FIXTURE_CHAIN_ID,
@@ -25,6 +26,11 @@ const state = vi.hoisted(() => ({
     hasError: true,
   } as PegHistoryResult,
   historyRequest: null as readonly unknown[] | null,
+  alerts: {
+    data: { from: 0, to: 0, events: [] },
+    isLoading: false,
+    hasError: false,
+  } as PegAlertsResult,
 }));
 vi.mock("@/hooks/use-peg-monitoring", () => ({
   usePegMonitoring: () => state.current,
@@ -34,6 +40,9 @@ vi.mock("@/hooks/use-peg-history", () => ({
     state.historyRequest = args;
     return state.history;
   },
+}));
+vi.mock("@/hooks/use-peg-alerts", () => ({
+  usePegAlerts: () => state.alerts,
 }));
 vi.mock("next/link", () => ({
   default: ({
@@ -62,6 +71,11 @@ beforeEach(() => {
   state.current = { data: null, isLoading: true, hasError: false };
   state.history = { data: null, isLoading: false, hasError: true };
   state.historyRequest = null;
+  state.alerts = {
+    data: { from: 0, to: 0, events: [] },
+    isLoading: false,
+    hasError: false,
+  };
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -506,7 +520,7 @@ describe("PegMonitoringPageClient board", () => {
     expect(panel.textContent).not.toContain("91%");
   });
 
-  it("keeps the recent-alerts container with its Grafana fallback", () => {
+  it("keeps the recent-alerts container with its Grafana history link", () => {
     loaded();
     render();
     const alerts = query('[data-testid="peg-recent-alerts"]')!;
@@ -517,6 +531,20 @@ describe("PegMonitoringPageClient board", () => {
         'a[href="https://clabsmento.grafana.net/alerting/list?search=Peg"]',
       ).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("keeps the current board intact when recent alerts fail", () => {
+    loaded();
+    state.alerts = {
+      data: { from: 0, to: 0, events: [] },
+      isLoading: false,
+      hasError: true,
+    };
+    render();
+    expect(query('[data-testid="peg-row-europ-schuman"]')).not.toBeNull();
+    expect(query('[data-testid="peg-recent-alerts"]')!.textContent).toContain(
+      "Recent alerts unavailable",
+    );
   });
 
   it("falls back to an error box when no package can be shown", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -2,11 +2,8 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  RecentAlerts,
-  alertTimestamp,
-  type PegAlertEvent,
-} from "../_components/recent-alerts";
+import { RecentAlerts, alertTimestamp } from "../_components/recent-alerts";
+import type { PegAlertEvent } from "@/lib/peg-alerts";
 
 const NOW_MS = Date.UTC(2026, 7, 11, 16, 30);
 let container: HTMLDivElement;
@@ -22,10 +19,6 @@ afterEach(() => {
   container.remove();
 });
 
-/**
- * The feed itself lands in a follow-up PR. These cover the entry row that PR
- * will bind data to, so the change stays data-only.
- */
 const events: PegAlertEvent[] = [
   {
     id: "kesm-warning",
@@ -58,18 +51,36 @@ describe("alertTimestamp", () => {
 });
 
 describe("RecentAlerts", () => {
-  it("falls back to the Grafana link while no feed is wired", () => {
-    act(() => root.render(<RecentAlerts nowMs={NOW_MS} />));
+  it("shows an explicit loading state", () => {
+    act(() =>
+      root.render(<RecentAlerts events={[]} nowMs={NOW_MS} state="loading" />),
+    );
     expect(container.textContent).toContain("Recent alerts");
     expect(container.textContent).toContain("· last 7 days");
-    expect(container.textContent).toContain(
-      "No alert feed is wired into this page yet",
-    );
+    expect(container.textContent).toContain("Loading recent alerts…");
     expect(container.querySelectorAll("li")).toHaveLength(0);
   });
 
+  it("keeps the Grafana escape hatch when the feed fails", () => {
+    act(() =>
+      root.render(
+        <RecentAlerts events={[]} nowMs={NOW_MS} state="unavailable" />,
+      ),
+    );
+    expect(container.textContent).toContain("Recent alerts unavailable");
+    expect(
+      container.querySelector(
+        'a[href="https://clabsmento.grafana.net/alerting/list?search=Peg"]',
+      ),
+    ).not.toBeNull();
+  });
+
   it("renders one entry per in-window transition with its severity dot and bold lead", () => {
-    act(() => root.render(<RecentAlerts nowMs={NOW_MS} events={events} />));
+    act(() =>
+      root.render(
+        <RecentAlerts nowMs={NOW_MS} events={events} state="ready" />,
+      ),
+    );
     const rows = container.querySelectorAll("li");
     // The Jul 22 policy activation predates the advertised 7-day window, so
     // the component drops it even though the feed supplied it.
@@ -96,7 +107,9 @@ describe("RecentAlerts", () => {
       at: Date.UTC(2026, 7, 10, 9, 0) / 1_000,
     };
     act(() =>
-      root.render(<RecentAlerts nowMs={NOW_MS} events={[recentPolicy]} />),
+      root.render(
+        <RecentAlerts nowMs={NOW_MS} events={[recentPolicy]} state="ready" />,
+      ),
     );
     expect(
       container.querySelector('[data-testid="peg-alert-policy"]')!.textContent,
@@ -107,7 +120,9 @@ describe("RecentAlerts", () => {
 
   it("says so when a wired feed has no events inside the window", () => {
     act(() =>
-      root.render(<RecentAlerts nowMs={NOW_MS} events={[events[2]!]} />),
+      root.render(
+        <RecentAlerts nowMs={NOW_MS} events={[events[2]!]} state="ready" />,
+      ),
     );
     expect(container.textContent).toContain("No alerts in the last 7 days.");
     expect(container.querySelectorAll("li")).toHaveLength(0);

--- a/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
@@ -1,20 +1,9 @@
 "use client";
 
 import { PEG_GRAFANA_ALERTS_URL } from "@/lib/peg-monitoring";
+import type { PegAlertEvent, PegAlertSeverity } from "@/lib/peg-alerts";
 import { PEG_COLOR } from "../_lib/peg-board-model";
 import { ExternalLink, SeverityDot } from "./board-primitives";
-
-type PegAlertSeverity = "warning" | "cleared" | "page" | "policy";
-
-export type PegAlertEvent = {
-  id: string;
-  /** Unix seconds. */
-  at: number;
-  severity: PegAlertSeverity;
-  /** Bold lead-in, e.g. "EUROP spread warning cleared". */
-  lead: string;
-  detail: string;
-};
 
 const SEVERITY_COLOR: Record<PegAlertSeverity, string> = {
   warning: PEG_COLOR.amber,
@@ -43,10 +32,6 @@ export function alertTimestamp(atSeconds: number, nowMs: number): string {
     : `${calendar.format(at)} ${clock.format(at)}`;
 }
 
-/**
- * State transitions and policy activations only. The feed itself lands in a
- * follow-up PR; the row shape is settled here so that change is data-only.
- */
 function AlertEntry({
   event,
   nowMs,
@@ -62,7 +47,7 @@ function AlertEntry({
       <span className="pt-[5px]">
         <SeverityDot size={8} color={SEVERITY_COLOR[event.severity]} />
       </span>
-      <span className="text-[11.5px]" style={{ color: PEG_COLOR.dim }}>
+      <span className="text-[11.5px]" style={{ color: PEG_COLOR.muted }}>
         {alertTimestamp(event.at, nowMs)}
       </span>
       <span className="text-[12.5px] text-[var(--peg-text-2)]">
@@ -80,14 +65,16 @@ const FUTURE_SKEW_MS = 60_000;
 export function RecentAlerts({
   events,
   nowMs,
+  state,
 }: {
-  events?: readonly PegAlertEvent[] | undefined;
+  events: readonly PegAlertEvent[];
   nowMs: number;
+  state: "loading" | "ready" | "unavailable";
 }): React.JSX.Element {
   // The header advertises "last 7 days", so the component enforces it rather
   // than trusting the feed: an older transition (or one stamped further than
   // clock skew into the future) must not render under that label.
-  const visible = events?.filter((event) => {
+  const visible = events.filter((event) => {
     const atMs = event.at * 1_000;
     return atMs >= nowMs - SEVEN_DAYS_MS && atMs <= nowMs + FUTURE_SKEW_MS;
   });
@@ -113,17 +100,19 @@ export function RecentAlerts({
           Full history in Grafana
         </ExternalLink>
       </div>
-      {visible === undefined ? (
-        <p className="border-t border-border px-[18px] py-3 text-[12px] text-muted-foreground">
-          No alert feed is wired into this page yet. Peg alert transitions and
-          policy activations are in{" "}
-          <ExternalLink
-            href={PEG_GRAFANA_ALERTS_URL}
-            className="text-[var(--primary-border)]"
-          >
-            Grafana
-          </ExternalLink>
-          .
+      {state === "loading" ? (
+        <p
+          role="status"
+          className="border-t border-border px-[18px] py-3 text-[12px] text-muted-foreground"
+        >
+          Loading recent alerts…
+        </p>
+      ) : state === "unavailable" ? (
+        <p
+          role="status"
+          className="border-t border-border px-[18px] py-3 text-[12px] text-muted-foreground"
+        >
+          Recent alerts unavailable. Full history remains available in Grafana.
         </p>
       ) : visible.length === 0 ? (
         <p className="border-t border-border px-[18px] py-3 text-[12px] text-muted-foreground">

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-page-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import { Provider as TooltipProvider } from "@radix-ui/react-tooltip";
 import { ErrorBox } from "@/components/feedback";
+import { usePegAlerts } from "@/hooks/use-peg-alerts";
 import { usePegMonitoring } from "@/hooks/use-peg-monitoring";
 import { classifyPegMonitoringState } from "@/lib/peg-monitoring";
 import { presentPegMonitoring } from "@/lib/peg-monitoring-presentation";
@@ -36,6 +37,7 @@ export function PegMonitoringPageClient(): React.JSX.Element {
   const nowMs = Math.max(now, Date.now());
   const state = classifyPegMonitoringState({ ...result, nowMs });
   const confirmed = state.kind === "current" || state.kind === "stale";
+  const alerts = usePegAlerts(confirmed);
   const usesPreviousPolicy =
     confirmed &&
     (state.data.policySlot === "previous" ||
@@ -71,7 +73,19 @@ export function PegMonitoringPageClient(): React.JSX.Element {
               ageLabel={formatAge(state.ageMs)}
               policyVersion={state.data.producedPolicyVersion}
             />
-            <RecentAlerts nowMs={nowMs} />
+            <RecentAlerts
+              events={alerts.data?.events ?? []}
+              nowMs={nowMs}
+              state={
+                alerts.hasError
+                  ? "unavailable"
+                  : alerts.data !== null
+                    ? "ready"
+                    : alerts.isLoading
+                      ? "loading"
+                      : "unavailable"
+              }
+            />
           </>
         )}
       </main>

--- a/ui-dashboard/src/hooks/__tests__/use-peg-alerts.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-peg-alerts.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rateLimitAwareRetry } from "@/lib/gql-retry";
+import {
+  PEG_ALERTS_REFRESH_MS,
+  type PegAlertsResponse,
+} from "@/lib/peg-alerts";
+import { SWR_KEY_PEG_ALERTS } from "@/lib/swr-keys";
+
+const swr = vi.hoisted(() => vi.fn());
+vi.mock("swr", () => ({ default: swr }));
+
+import { usePegAlerts } from "../use-peg-alerts";
+
+const data: PegAlertsResponse = {
+  from: 1_786_000_000,
+  to: 1_786_604_800,
+  events: [],
+};
+let enabled = true;
+let result: ReturnType<typeof usePegAlerts> | null = null;
+
+function Probe(): null {
+  result = usePegAlerts(enabled);
+  return null;
+}
+
+function render(): {
+  key: string | null;
+  fetcher: () => Promise<PegAlertsResponse>;
+  config: Record<string, unknown>;
+} {
+  const root = createRoot(document.createElement("div"));
+  act(() => root.render(createElement(Probe)));
+  act(() => root.unmount());
+  const call = swr.mock.calls[0]!;
+  return {
+    key: call[0] as string | null,
+    fetcher: call[1] as () => Promise<PegAlertsResponse>,
+    config: call[2] as Record<string, unknown>,
+  };
+}
+
+beforeEach(() => {
+  swr.mockReset();
+  swr.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
+  enabled = true;
+  result = null;
+});
+
+describe("usePegAlerts", () => {
+  it("polls the isolated same-origin feed every five minutes", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(Response.json(data));
+    const probe = render();
+    expect(probe.key).toBe(SWR_KEY_PEG_ALERTS);
+    expect(probe.config).toMatchObject({
+      refreshInterval: PEG_ALERTS_REFRESH_MS,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      onErrorRetry: rateLimitAwareRetry,
+    });
+    await expect(probe.fetcher()).resolves.toEqual(data);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/peg-monitoring/alerts");
+  });
+
+  it("does not query until the current board has a confirmed package", () => {
+    enabled = false;
+    const probe = render();
+    expect(probe.key).toBeNull();
+    expect(result).toEqual({ data: null, hasError: false, isLoading: false });
+  });
+
+  it("retains events while a refresh error marks only the strip unavailable", () => {
+    swr.mockReturnValue({ data, error: new Error("502"), isLoading: false });
+    render();
+    expect(result).toEqual({ data, hasError: true, isLoading: false });
+  });
+});

--- a/ui-dashboard/src/hooks/use-peg-alerts.ts
+++ b/ui-dashboard/src/hooks/use-peg-alerts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import useSWR from "swr";
+import { fetchJsonOrThrow } from "@/lib/fetch-json";
+import { rateLimitAwareRetry } from "@/lib/gql-retry";
+import {
+  PEG_ALERTS_REFRESH_MS,
+  type PegAlertsResponse,
+} from "@/lib/peg-alerts";
+import { SWR_KEY_PEG_ALERTS } from "@/lib/swr-keys";
+
+export type PegAlertsResult = {
+  data: PegAlertsResponse | null;
+  isLoading: boolean;
+  hasError: boolean;
+};
+
+function fetchPegAlerts(): Promise<PegAlertsResponse> {
+  return fetchJsonOrThrow<PegAlertsResponse>(
+    "/api/peg-monitoring/alerts",
+    "Peg alert history",
+    { timeoutMs: 10_000 },
+  );
+}
+
+export function usePegAlerts(enabled: boolean): PegAlertsResult {
+  const { data, error, isLoading } = useSWR<PegAlertsResponse>(
+    enabled ? SWR_KEY_PEG_ALERTS : null,
+    fetchPegAlerts,
+    {
+      refreshInterval: PEG_ALERTS_REFRESH_MS,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      onErrorRetry: rateLimitAwareRetry,
+    },
+  );
+  return {
+    data: data ?? null,
+    isLoading: enabled && isLoading,
+    hasError: enabled && error !== undefined,
+  };
+}

--- a/ui-dashboard/src/lib/peg-alerts.ts
+++ b/ui-dashboard/src/lib/peg-alerts.ts
@@ -1,0 +1,22 @@
+export const PEG_ALERTS_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+export const PEG_ALERTS_REFRESH_MS = 5 * 60 * 1_000;
+
+export type PegAlertSeverity = "warning" | "cleared" | "page" | "policy";
+
+export type PegAlertEvent = {
+  id: string;
+  /** Unix seconds. */
+  at: number;
+  severity: PegAlertSeverity;
+  /** Bold lead-in, e.g. "EUROP spread warning cleared". */
+  lead: string;
+  detail: string;
+};
+
+export type PegAlertsResponse = {
+  /** Unix seconds. */
+  from: number;
+  /** Unix seconds. */
+  to: number;
+  events: PegAlertEvent[];
+};

--- a/ui-dashboard/src/lib/server/grafana-read.ts
+++ b/ui-dashboard/src/lib/server/grafana-read.ts
@@ -1,4 +1,27 @@
+import { NextResponse } from "next/server";
+
 class InvalidGrafanaResponseError extends Error {}
+
+export const GRAFANA_NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+} as const;
+
+export function grafanaErrorResponse(
+  error: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    { error },
+    { status, headers: GRAFANA_NO_STORE_HEADERS },
+  );
+}
+
+export function isGrafanaTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
 
 export function resolveGrafanaEndpoint(
   rawOrigin: string | undefined,

--- a/ui-dashboard/src/lib/server/grafana-read.ts
+++ b/ui-dashboard/src/lib/server/grafana-read.ts
@@ -1,0 +1,67 @@
+class InvalidGrafanaResponseError extends Error {}
+
+export function resolveGrafanaEndpoint(
+  rawOrigin: string | undefined,
+  pathname: `/${string}`,
+): URL | null {
+  if (!rawOrigin || pathname.includes("?") || pathname.includes("#"))
+    return null;
+  try {
+    const url = new URL(rawOrigin);
+    const localHttp =
+      process.env.NODE_ENV !== "production" &&
+      url.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    if (
+      (url.protocol !== "https:" && !localHttp) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      (url.pathname !== "" && url.pathname !== "/")
+    )
+      return null;
+    url.pathname = pathname;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export async function readBoundedGrafanaResponse(
+  response: Response,
+  maximumBytes: number,
+): Promise<string> {
+  const length = response.headers.get("content-length");
+  if (
+    length !== null &&
+    (!/^\d+$/.test(length) || Number(length) > maximumBytes)
+  )
+    throw new InvalidGrafanaResponseError();
+  if (response.body === null) throw new InvalidGrafanaResponseError();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- ordered streams expose one bounded chunk at a time
+    const next = await reader.read();
+    if (next.done) break;
+    total += next.value.byteLength;
+    if (total > maximumBytes) {
+      void reader.cancel().catch(() => undefined);
+      throw new InvalidGrafanaResponseError();
+    }
+    chunks.push(next.value);
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw new InvalidGrafanaResponseError();
+  }
+}

--- a/ui-dashboard/src/lib/swr-keys.ts
+++ b/ui-dashboard/src/lib/swr-keys.ts
@@ -13,3 +13,4 @@ export const SWR_KEY_CDP_BORROWING_REVENUE =
 export const SWR_KEY_RESERVE_YIELD = "reserve-yield-current";
 export const SWR_KEY_RESERVE_YIELD_HISTORY = "reserve-yield-history";
 export const SWR_KEY_PEG_MONITORING = "peg-monitoring";
+export const SWR_KEY_PEG_ALERTS = "peg-alerts";

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -75,6 +75,25 @@ test("renders the status board, expands a row panel, and retains stale evidence"
       },
     });
   });
+  await page.route("**/api/peg-monitoring/alerts", async (route) => {
+    expect(route.request().method()).toBe("GET");
+    await route.fulfill({
+      json: {
+        from: now - 7 * 86_400,
+        to: now,
+        events: [
+          {
+            id: "europ-spread-cleared",
+            at: now - 120,
+            severity: "cleared",
+            lead: "EUROP spread warning cleared",
+            detail:
+              "Bitvavo EUR · active policy returned to normal after 22 min.",
+          },
+        ],
+      },
+    });
+  });
   await page.goto("/peg-monitoring");
 
   await expect(
@@ -166,6 +185,8 @@ test("renders the status board, expands a row panel, and retains stale evidence"
 
   const alerts = page.getByTestId("peg-recent-alerts");
   await expect(alerts).toContainText("Recent alerts");
+  await expect(alerts).toContainText("EUROP spread warning cleared");
+  await expect(alerts).toContainText("normal after 22 min");
   const grafanaLink = alerts.getByRole("link", {
     name: /Full history in Grafana/,
   });
@@ -205,6 +226,13 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
       body: '{"error":"history offline"}',
     });
   });
+  await page.route("**/api/peg-monitoring/alerts", async (route) => {
+    await route.fulfill({
+      status: 502,
+      contentType: "application/json",
+      body: '{"error":"alert history offline"}',
+    });
+  });
   await page.goto("/peg-monitoring");
 
   await expect(page.getByTestId("peg-row-europ-schuman")).toBeVisible();
@@ -215,6 +243,9 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
   await expect(page.getByTestId("peg-panel-europ-schuman")).toBeVisible();
   await expect(page.getByTestId("peg-panel-europ-schuman")).toContainText(
     "History unavailable",
+  );
+  await expect(page.getByTestId("peg-recent-alerts")).toContainText(
+    "Recent alerts unavailable",
   );
 
   const horizontalOverflow = await page.evaluate(


### PR DESCRIPTION
## The Problem

- Peg Monitoring showed the current decision package but no recent alert transitions.
- Operators had to leave the dashboard and reconstruct raised, cleared, and policy events in Grafana.

## The Solution

- Add a bounded seven-day alert-history route and a compact four-event Recent Alerts strip without coupling failures to the current status board.

## Details

- Read Grafana state history for real Alerting and Alerting-to-Normal transitions, pair each fingerprint into one incident, collapse repeated evaluations, and show clear duration.
- Derive policy activations from mento_peg_policy_version label-series transitions. The first Mimir sample is approximate, so the API and UI say so explicitly.
- Bound upstream time, rows, frames, response bytes, and public event count. Validate all Grafana frames fail-closed.
- Keep cached alert data from appearing current after a refresh error; the strip reports unavailability while the live status board stays usable.
- Reuse the existing Grafana read-access architecture from ADR 0063; this change does not make a new architecture decision.
- Closes #1832.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including coverage, production browser tests, lint, typecheck, Knip, dependency boundaries, size, Terraform tests, and React Doctor 100.
- Local autoreview — one valid retained-data refresh-error finding fixed; final fresh-context semantic review and deterministic review both clean.
- Live local production build against production Metrics Bridge and Grafana read data — API 200, four newest events in order, current board healthy, panel interaction intact, no horizontal overflow, and no console errors.
- Lighthouse snapshot — Recent Alerts has no contrast finding; remaining board timestamp contrast and missing meta-description findings predate this change.
- Claude Security scan: skipped because the Claude-only plugin is unavailable in Codex; the network-facing route was covered by the mapped gate and fresh-context review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New server route uses Grafana bearer credentials and parses untrusted upstream JSON, but origin checks, response caps, and generic error responses reduce exposure; UI isolation limits blast radius if the feed fails.
> 
> **Overview**
> Adds a **bounded seven-day peg alert history** path from Grafana into the Peg Monitoring **Recent Alerts** strip (up to four newest events), so operators see raised/cleared transitions and policy activations without leaving the board.
> 
> **`GET /api/peg-monitoring/alerts`** fans out to Grafana rules state history (raised + cleared) and a Prometheus range query on `mento_peg_policy_version`, then validates frames with Zod, pairs transitions by fingerprint (with dedup and clear duration), derives policy activations (with pre-window sampling to avoid false edge activations), and merges/sorts/truncates. Upstream calls are bounded (timeouts, row/frame/byte limits) and **fail closed** on bad config, unsafe origins, malformed payloads, or timeouts; errors avoid leaking tokens or query details.
> 
> Shared **`grafana-read`** helpers (`resolveGrafanaEndpoint`, `readBoundedGrafanaResponse`) are extracted and reused by the existing peg **history** route.
> 
> The UI adds **`usePegAlerts`** (SWR, five-minute poll, only after a confirmed package), shared **`@/lib/peg-alerts`** types, and **`RecentAlerts`** loading/ready/unavailable states while keeping the Grafana link. Alert strip failures do not block the live status board; refresh errors can retain cached events while marking the strip unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ae9c8373bbd0a4d036d0c5566bc42bca34a113. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->