### PR TITLE
fix: improve peg history and refresh handling

### DIFF
--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -7,6 +7,7 @@ import { axe } from "vitest-axe";
 import type { PegMonitoringResult } from "@/hooks/use-peg-monitoring";
 import type { PegHistoryResult } from "@/hooks/use-peg-history";
 import type { PegAlertsResult } from "@/hooks/use-peg-alerts";
+import { PEG_GRAFANA_ALERTS_URL } from "@/lib/peg-monitoring";
 import {
   makePegMonitoringResponse,
   PEG_FIXTURE_CHAIN_ID,
@@ -526,11 +527,9 @@ describe("PegMonitoringPageClient board", () => {
     const alerts = query('[data-testid="peg-recent-alerts"]')!;
     expect(alerts.textContent).toContain("Recent alerts");
     expect(alerts.textContent).toContain("· last 7 days");
-    expect(
-      alerts.querySelectorAll(
-        'a[href="https://clabsmento.grafana.net/alerting/list?search=Peg"]',
-      ).length,
-    ).toBeGreaterThan(0);
+    expect(alerts.querySelector("a")?.getAttribute("href")).toBe(
+      PEG_GRAFANA_ALERTS_URL,
+    );
   });
 
   it("keeps the current board intact when recent alerts fail", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RecentAlerts, alertTimestamp } from "../_components/recent-alerts";
 import type { PegAlertEvent } from "@/lib/peg-alerts";
+import { PEG_GRAFANA_ALERTS_URL } from "@/lib/peg-monitoring";
 
 const NOW_MS = Date.UTC(2026, 7, 11, 16, 30);
 let container: HTMLDivElement;
@@ -68,11 +69,9 @@ describe("RecentAlerts", () => {
       ),
     );
     expect(container.textContent).toContain("Recent alerts unavailable");
-    expect(
-      container.querySelector(
-        'a[href="https://clabsmento.grafana.net/alerting/list?search=Peg"]',
-      ),
-    ).not.toBeNull();
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      PEG_GRAFANA_ALERTS_URL,
+    );
   });
 
   it("renders one entry per in-window transition with its severity dot and bold lead", () => {

--- a/ui-dashboard/src/hooks/__tests__/use-peg-monitoring.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-peg-monitoring.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PEG_MONITORING_REFRESH_MS } from "@/lib/peg-monitoring";
 import { SWR_KEY_PEG_MONITORING } from "@/lib/swr-keys";
 import { makePegMonitoringResponse } from "@/test-utils/peg-monitoring-fixture";
@@ -9,6 +9,7 @@ const swr = vi.hoisted(() => vi.fn());
 vi.mock("swr", () => ({ default: swr }));
 import { usePegMonitoring } from "../use-peg-monitoring";
 let result: ReturnType<typeof usePegMonitoring> | null = null;
+let mountedRoot: ReturnType<typeof createRoot> | null = null;
 function Probe(): null {
   result = usePegMonitoring();
   return null;
@@ -17,9 +18,8 @@ function render(): {
   fetcher: () => Promise<unknown>;
   config: Record<string, unknown>;
 } {
-  const root = createRoot(document.createElement("div"));
-  act(() => root.render(createElement(Probe)));
-  act(() => root.unmount());
+  mountedRoot = createRoot(document.createElement("div"));
+  act(() => mountedRoot?.render(createElement(Probe)));
   const call = swr.mock.calls[0]!;
   return {
     fetcher: call[1] as () => Promise<unknown>,
@@ -30,6 +30,12 @@ beforeEach(() => {
   swr.mockReset();
   swr.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
   result = null;
+});
+afterEach(() => {
+  if (mountedRoot !== null) {
+    act(() => mountedRoot?.unmount());
+    mountedRoot = null;
+  }
 });
 describe("usePegMonitoring", () => {
   it("uses the same-origin timed 30-second polling contract", async () => {
@@ -44,13 +50,41 @@ describe("usePegMonitoring", () => {
       revalidateOnReconnect: false,
       refreshWhenHidden: false,
     });
+    expect(probe.config).not.toHaveProperty("onError");
     await expect(probe.fetcher()).resolves.toEqual(makePegMonitoringResponse());
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/peg-monitoring");
   });
-  it("retains confirmed data when refresh fails", () => {
+  it("waits for two consecutive refresh failures before degrading retained data", () => {
     const data = makePegMonitoringResponse();
-    swr.mockReturnValue({ data, error: new Error("503"), isLoading: false });
-    render();
+    const error = new Error("503");
+    swr.mockReturnValue({ data, error, isLoading: false });
+    const probe = render();
+    const onErrorRetry = probe.config.onErrorRetry as (
+      cause: Error,
+      key: string,
+      config: { errorRetryCount: number },
+      revalidate: () => void,
+      options: { retryCount: number; dedupe: boolean },
+    ) => void;
+    const onSuccess = probe.config.onSuccess as (response: unknown) => void;
+    const recordFailure = () =>
+      onErrorRetry(
+        error,
+        SWR_KEY_PEG_MONITORING,
+        { errorRetryCount: 0 },
+        vi.fn(),
+        {
+          retryCount: 1,
+          dedupe: true,
+        },
+      );
+
+    expect(result).toEqual({ data, hasError: false, isLoading: false });
+    act(recordFailure);
+    expect(result).toEqual({ data, hasError: false, isLoading: false });
+    act(recordFailure);
     expect(result).toEqual({ data, hasError: true, isLoading: false });
+    act(() => onSuccess(data));
+    expect(result).toEqual({ data, hasError: false, isLoading: false });
   });
 });

--- a/ui-dashboard/src/hooks/use-peg-monitoring.ts
+++ b/ui-dashboard/src/hooks/use-peg-monitoring.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import useSWR from "swr";
 import { fetchJsonOrThrow } from "@/lib/fetch-json";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
@@ -15,6 +16,8 @@ export type PegMonitoringResult = {
   hasError: boolean;
 };
 
+const REFRESH_FAILURES_BEFORE_STALE = 2;
+
 function fetchPegMonitoring(): Promise<PegMonitoringResponse> {
   return fetchJsonOrThrow<PegMonitoringResponse>(
     "/api/peg-monitoring",
@@ -24,6 +27,8 @@ function fetchPegMonitoring(): Promise<PegMonitoringResponse> {
 }
 
 export function usePegMonitoring(): PegMonitoringResult {
+  const [consecutiveRefreshFailures, setConsecutiveRefreshFailures] =
+    useState(0);
   const { data, error, isLoading } = useSWR(
     SWR_KEY_PEG_MONITORING,
     fetchPegMonitoring,
@@ -32,8 +37,22 @@ export function usePegMonitoring(): PegMonitoringResult {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       refreshWhenHidden: false,
-      onErrorRetry: rateLimitAwareRetry,
+      onSuccess() {
+        setConsecutiveRefreshFailures(0);
+      },
+      onErrorRetry(error, key, config, revalidate, options) {
+        setConsecutiveRefreshFailures((failures) =>
+          Math.min(failures + 1, REFRESH_FAILURES_BEFORE_STALE),
+        );
+        rateLimitAwareRetry(error, key, config, revalidate, options);
+      },
     },
   );
-  return { data: data ?? null, isLoading, hasError: error !== undefined };
+  return {
+    data: data ?? null,
+    isLoading,
+    hasError:
+      error !== undefined &&
+      consecutiveRefreshFailures >= REFRESH_FAILURES_BEFORE_STALE,
+  };
 }

--- a/ui-dashboard/src/lib/peg-monitoring.ts
+++ b/ui-dashboard/src/lib/peg-monitoring.ts
@@ -4,7 +4,7 @@ export const PEG_MONITORING_REFRESH_MS = 30_000;
 export const PEG_MONITORING_STALE_AFTER_MS = 90_000;
 const MAX_FUTURE_CLOCK_SKEW_MS = 60_000;
 export const PEG_GRAFANA_ALERTS_URL =
-  "https://clabsmento.grafana.net/alerting/list?search=Peg";
+  "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser";
 export type {
   PegMonitoringResponse,
   PegAssetPackage,

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -192,7 +192,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   });
   await expect(grafanaLink).toHaveAttribute(
     "href",
-    "https://clabsmento.grafana.net/alerting/list?search=Peg",
+    "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser",
   );
   await expect(grafanaLink).toHaveAttribute("rel", /noopener/);
   await expect(

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -31,6 +31,8 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   await page.clock.install({ time: new Date(now * 1000 + 20_000) });
   await page.setViewportSize({ width: 1440, height: 900 });
   let request = 0;
+  let failRefreshes = false;
+  let failedRefreshes = 0;
   let releaseFirstResponse!: () => void;
   const firstResponseGate = new Promise<void>((resolve) => {
     releaseFirstResponse = resolve;
@@ -44,6 +46,11 @@ test("renders the status board, expands a row panel, and retains stale evidence"
       await route.fulfill({ json: payload });
       return;
     }
+    if (!failRefreshes) {
+      await route.fulfill({ json: payload });
+      return;
+    }
+    failedRefreshes += 1;
     await route.fulfill({
       status: 503,
       contentType: "application/json",
@@ -168,6 +175,23 @@ test("renders the status board, expands a row panel, and retains stale evidence"
     panel.getByRole("img", { name: /Peg history over 24h: 2 readings/ }),
   ).toBeVisible();
   expect(historyRequests["24h"]).toBe(1);
+
+  failRefreshes = true;
+  await page.clock.runFor(30_000);
+  await expect.poll(() => failedRefreshes).toBe(1);
+  await expect(aggregate).toHaveText("1 of 1 peg healthy");
+  await expect(aggregate).not.toContainText("latest data is stale");
+
+  await page.clock.runFor(30_000);
+  await expect.poll(() => failedRefreshes).toBeGreaterThanOrEqual(2);
+  await expect(aggregate).toContainText("latest data is stale");
+  await expect(page.getByTestId("peg-row-europ-schuman")).toContainText(
+    "· stale",
+  );
+  await expect(page.getByTestId("peg-panel-europ-schuman")).toContainText(
+    "Showing the last confirmed check",
+  );
+
   await page.clock.runFor(300_000);
   await expect.poll(() => historyRequests["24h"]).toBeGreaterThan(1);
   await expect(
@@ -199,14 +223,6 @@ test("renders the status board, expands a row panel, and retains stale evidence"
     page.getByRole("link", { name: "Peg Monitoring", exact: true }),
   ).toBeVisible();
 
-  await page.clock.runFor(80_000);
-  await expect(aggregate).toContainText("latest data is stale");
-  await expect(page.getByTestId("peg-row-europ-schuman")).toContainText(
-    "· stale",
-  );
-  await expect(page.getByTestId("peg-panel-europ-schuman")).toContainText(
-    "Showing the last confirmed check",
-  );
   await expect.poll(() => historyRequestEnds.at(-1)).toBe(String(now));
 });
 


### PR DESCRIPTION
## The Problem

- The Peg Monitoring history link opens a generic alert-rule list instead of the transition history for peg-monitoring.
- One transient refresh failure immediately turns retained, otherwise-fresh board data amber, which makes brief network errors look like a sustained monitoring gap.

## The Solution

- Open Grafana Alert history scoped to service=peg-monitoring for the last seven days, with every state transition included.
- Keep fresh retained data current through one failed refresh; mark it stale only after two consecutive failures, and reset the failure count after any successful refresh.

## Details

### Invariants

- Grafana receives the service label filter and a seven-day browser-timezone range.
- The URL omits STATE_FILTER_TO, preserving Alerting, Normal, Pending, and other transitions.
- The shared constant remains the application source of truth; browser coverage also pins the literal destination.
- One failed refresh does not degrade retained data while its normal age envelope is still fresh. A second consecutive failed request degrades it, and a successful request resets the count.
- A failure with no retained package remains unavailable immediately. The existing 90-second age rule can still mark retained data stale independently of the failure count.
- The hook preserves the global SWR Sentry error handler and the existing active-tab retry/backoff path.

### Degraded behavior

- The link remains visible when the dashboard alert feed is unavailable.
- After one failed refresh, the board keeps the last confirmed package without a board-wide stale warning.
- After two consecutive failed refreshes, the board shows that retained package as unconfirmed and stale until a refresh succeeds.

### Intentional non-goals

- This PR does not change the 30-second refresh interval, the 90-second package-age threshold, alert queries, alert rules, feed semantics, or Grafana configuration.
- This PR does not add upstream failure-class tags to Sentry.

## Deferrals

- #1858 tracks preserving timeout, network, invalid-payload, 429, 503, and other upstream failure classes in Sentry, then reassessing the 30-second interval from production evidence.

Closes #1854

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including full dashboard coverage, fixture browser tests, lint, typecheck, Trunk, codegen, Knip, dependency boundaries, React Doctor 100, size limit, and Terraform tests.
- Full Vitest suite — 298 files and 4,292 tests passed.
- Focused Playwright peg-monitoring suite — 2 tests passed; it proves the first failed refresh stays healthy and the second turns retained evidence stale.
- Fresh-context Codex autoreview — clean, zero findings at 0.93 confidence; deterministic autoreview also clean; bundle manifest matched before and after review.
- Chrome DevTools local verification — exact Grafana URL present; one completed 503 kept the board healthy; the second consecutive 503 changed it to unconfirmed/stale; no console errors.
- Live production sample before the change — 49 samples over 2m25s found no amber episode, package age 0–13s, and no console errors. Source inspection identified single-refresh errors as the plausible brief-flash path.
- Production observability audit — Sentry captures the peg-monitoring SWR key at most once per minute, but current events lack upstream status; Vercel had no grouped runtime error for the caught route failures. Follow-up: #1858.
