### PR TITLE
fix(alerts): schedule on-call reconciliation after handover

### DIFF
--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -176,7 +176,7 @@ chain key.
 
 ### On-call Announcer
 
-- Runs from Cloud Scheduler every 15 minutes by default
+- Runs from Cloud Scheduler at 10:05 and 10:20 every Sunday in `Europe/Berlin`
 - Polls Splunk On-Call `/api-public/v1/oncall/current`
 - Resolves the current Splunk On-Call user email to a Slack user ID with `users.lookupByEmail`
 - Posts one Slack message to `#eng` only when the on-call username changes

--- a/alerts/infra/oncall-announcer/README.md
+++ b/alerts/infra/oncall-announcer/README.md
@@ -19,9 +19,10 @@ Slack.
 4. Reconciles the `@support-engineer` Slack usergroup to exactly one member on
    every run.
 
-The default schedule is every 15 minutes. State dedupe prevents duplicate Slack
-messages when the rotation has not changed, and the stable Slack
-`client_msg_id` lets Cloud Scheduler retries dedupe an accepted
+The default schedule checks at 10:05 and 10:20 every Sunday in
+`Europe/Berlin`, shortly after the observed 10:00 weekly handover. State dedupe
+prevents duplicate Slack messages when the rotation has not changed, and the
+stable Slack `client_msg_id` lets Cloud Scheduler retries dedupe an accepted
 `chat.postMessage` call if the state write fails after Slack accepts the
 announcement.
 

--- a/alerts/infra/oncall-announcer/locals.tf
+++ b/alerts/infra/oncall-announcer/locals.tf
@@ -12,7 +12,6 @@ locals {
   ]
   runtime_config_hash = md5(jsonencode({
     announce_on_first_run                 = var.announce_on_first_run
-    schedule                              = var.schedule
     slack_channel_id                      = var.slack_channel_id
     slack_support_usergroup_id            = var.slack_support_usergroup_id
     splunk_on_call_api_base_url           = var.splunk_on_call_api_base_url

--- a/alerts/infra/oncall-announcer/variables.tf
+++ b/alerts/infra/oncall-announcer/variables.tf
@@ -62,9 +62,9 @@ variable "runtime" {
 }
 
 variable "schedule" {
-  description = "Cloud Scheduler cron expression for polling Splunk On-Call. State dedupe prevents duplicate announcements when this runs more often than the rotation cadence."
+  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Sunday 10:00 Europe/Berlin handover."
   type        = string
-  default     = "*/15 * * * *"
+  default     = "5,20 10 * * 0"
 }
 
 variable "scheduler_name" {

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -63,9 +63,9 @@ oncall_slack_channel_id = "C0123ABC456"
 # enabled. Create the usergroup in Slack once, then paste its ID here.
 oncall_support_usergroup_id = "S0123ABC456"
 
-# Optional: poll every 15 minutes by default; state dedupe means only rotations
-# post Slack messages.
-# oncall_rotation_check_schedule = "*/15 * * * *"
+# Optional: poll at 10:05 and 10:20 every Sunday in Europe/Berlin by default,
+# shortly after the observed 10:00 weekly handover.
+# oncall_rotation_check_schedule = "5,20 10 * * 0"
 
 #####################
 # Google Cloud Configuration

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -101,9 +101,9 @@ variable "oncall_announce_on_first_run" {
 }
 
 variable "oncall_rotation_check_schedule" {
-  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The function stores last-seen state and only posts when the on-call username changes."
+  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Sunday 10:00 Europe/Berlin handover; the function stores last-seen state and only posts when the on-call username changes."
   type        = string
-  default     = "*/15 * * * *"
+  default     = "5,20 10 * * 0"
 }
 
 variable "oncall_slack_channel_id" {

--- a/scripts/production-infra-identity-contract/provenance.mjs
+++ b/scripts/production-infra-identity-contract/provenance.mjs
@@ -27,7 +27,7 @@ const SOURCE_BLOCK_SHAPE_SPECIFICATIONS = [
   "alerts/infra:variable.debug_mode|f52b2ce0bd99f8f263fda1fbc5aac0e9b5bce445d603fc45a4d5ec0ac4f472ce",
   "alerts/infra:variable.multisigs|bc6efbb0d5eb414139081182fac6f93647f32b822e9bbd08bc2c17209bce2f29",
   "alerts/infra:variable.oncall_announce_on_first_run|e36344bd00f1f50834bd9243d1c4e059bdb52da9c090c5f1f3876ca6950557bb",
-  "alerts/infra:variable.oncall_rotation_check_schedule|0019df3ba1482127d81c064fe39e4b8d01f1217602baca2aa6e3e0aaed40a916",
+  "alerts/infra:variable.oncall_rotation_check_schedule|5bc5eda526ec49fbc7534bda52cf242fcbc0b32c19dfc62ebf5ad60a0d895c5d",
   "alerts/infra:variable.oncall_slack_channel_id|de5843b9c72d3b4400b1df21867ca03b969020399514940324fd68c750bc89a6",
   "alerts/infra:variable.oncall_support_usergroup_id|c65531b6a19f26ea2c0efb6196481a8ea9cf0949f219a147fb8a2398b2777903",
   "alerts/infra:variable.org_id|9f4baa3184507cb57b60f341f8a8bd31877289b78cc638e67709406c677f6602",


### PR DESCRIPTION
## The Problem

- On-call reconciliation polls every 15 minutes despite the observed Sunday 10:00 Europe/Berlin handover.
- A scheduler-only change currently risks an unnecessary function redeploy.

## The Solution

- Check at 10:05 and 10:20 each Sunday, shortly after handover, without changing the function runtime configuration.

## Details

- Update the Terraform defaults, operator documentation, and the production-infrastructure provenance hash.
- Removing the schedule from the runtime hash updates Cloud Scheduler without redeploying Cloud Run or changing invocation access.

## Validation

- CI Terraform plan, registry validation, cloud-function quality checks, production-infrastructure contract, and Sentry suites passed.
- The root-script suite is rerunning after its previous 15-minute runner cutoff.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision: not applicable.