### PR TITLE
fix(dashboard): classify peg refresh failures

### DIFF
--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -78,6 +78,33 @@ The live listing-confirmation producer and consumer source includes
 application and Grafana query evidence remain separate gates. Listing state
 must never be inferred from source health.
 
+## Dashboard refresh diagnostics
+
+The dashboard reports failed `/api/peg-monitoring` SWR reads to the
+`analytics-mento-org` Sentry project with safe `api_route`, `failure_class`,
+`http_status`, and, when the bridge returned an HTTP response,
+`upstream_status` tags. The API response and Sentry event omit upstream bodies,
+request query strings, credentials, and full URLs.
+
+Use this production query to find bridge rate limits:
+
+```text
+environment:production source:swr api_route:"/api/peg-monitoring" failure_class:upstream-rate-limit upstream_status:429
+```
+
+Sentry captures at most one event per normalized SWR key and root-cause
+fingerprint per client runtime per minute. Event counts therefore measure
+sampled client-runtime minutes rather than raw failed requests, unique clients,
+or unique wall-clock minutes. Remove the `failure_class` and `upstream_status`
+terms to inspect all refresh root causes, then group the results by those tags.
+
+The seven days ending 2026-08-14 contained one client-side peg-monitoring fetch
+failure and no preserved upstream status. That evidence does not support a
+cadence change, so the dashboard retains its 30-second refresh interval. Use
+the classified query after a representative production window before changing
+that interval; a sustained `upstream-rate-limit` signal is the trigger to
+reassess it.
+
 ## Rule inventory
 
 For each active policy, the generated source defines:

--- a/ui-dashboard/src/app/api/peg-monitoring/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/__tests__/route.test.ts
@@ -169,18 +169,19 @@ describe("GET /api/peg-monitoring", () => {
     });
   });
   it.each([
-    [429, 502, "upstream-rate-limit"],
-    [503, 503, "upstream-unavailable"],
-    [418, 502, "upstream-http"],
+    [429, 502, "upstream-rate-limit", "Peg monitoring upstream rate limited"],
+    [503, 503, "upstream-unavailable", "peg decision packages unavailable"],
+    [418, 502, "upstream-http", "Peg monitoring upstream unavailable"],
   ])(
     "preserves upstream HTTP %i as %s with %s metadata",
-    async (upstreamStatus, localStatus, failureClass) => {
+    async (upstreamStatus, localStatus, failureClass, error) => {
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
         json({ ignored: "body" }, { status: upstreamStatus }),
       );
       const response = await GET();
       expect(response.status).toBe(localStatus);
       expect(await response.json()).toMatchObject({
+        error,
         failureClass,
         upstreamStatus,
       });

--- a/ui-dashboard/src/app/api/peg-monitoring/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/__tests__/route.test.ts
@@ -101,11 +101,100 @@ describe("GET /api/peg-monitoring", () => {
           ],
         }),
       );
+    const oversized = await GET();
+    expect(oversized.status).toBe(502);
+    expect(await oversized.json()).toEqual({
+      error: "Peg monitoring upstream response is invalid",
+      failureClass: "invalid-payload",
+    });
     expect((await GET()).status).toBe(502);
     expect((await GET()).status).toBe(502);
     expect((await GET()).status).toBe(502);
     expect((await GET()).status).toBe(502);
     expect((await GET()).status).toBe(502);
-    expect((await GET()).status).toBe(502);
+  });
+  it("classifies timeout and network failures without forwarding details", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock.mockRejectedValueOnce(
+      new DOMException("request timed out", "TimeoutError"),
+    );
+    const timeout = await GET();
+    expect(timeout.status).toBe(504);
+    expect(await timeout.json()).toEqual({
+      error: "Peg monitoring upstream timed out",
+      failureClass: "timeout",
+    });
+    fetchMock.mockRejectedValueOnce(new TypeError("connection failed"));
+    const network = await GET();
+    expect(network.status).toBe(502);
+    expect(await network.json()).toEqual({
+      error: "Peg monitoring upstream request failed",
+      failureClass: "network",
+    });
+  });
+  it("keeps a response-body stream timeout distinct from invalid payloads", async () => {
+    const body = new ReadableStream({
+      pull(controller) {
+        controller.error(new DOMException("body stalled", "TimeoutError"));
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(body, {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const response = await GET();
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual({
+      error: "Peg monitoring upstream timed out",
+      failureClass: "timeout",
+    });
+  });
+  it("keeps a response-body stream failure distinct from invalid payloads", async () => {
+    const body = new ReadableStream({
+      pull(controller) {
+        controller.error(new TypeError("body connection failed"));
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(body, {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const response = await GET();
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: "Peg monitoring upstream request failed",
+      failureClass: "network",
+    });
+  });
+  it.each([
+    [429, 502, "upstream-rate-limit"],
+    [503, 503, "upstream-unavailable"],
+    [418, 502, "upstream-http"],
+  ])(
+    "preserves upstream HTTP %i as %s with %s metadata",
+    async (upstreamStatus, localStatus, failureClass) => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        json({ ignored: "body" }, { status: upstreamStatus }),
+      );
+      const response = await GET();
+      expect(response.status).toBe(localStatus);
+      expect(await response.json()).toMatchObject({
+        failureClass,
+        upstreamStatus,
+      });
+    },
+  );
+  it("classifies missing configuration without starting a request", async () => {
+    vi.stubEnv("METRICS_BRIDGE_URL", "");
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const response = await GET();
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Peg monitoring upstream is not configured",
+      failureClass: "configuration",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/ui-dashboard/src/app/api/peg-monitoring/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/route.ts
@@ -119,7 +119,7 @@ export async function GET(): Promise<NextResponse> {
   }
   if (upstream.status === 429)
     return errorResponse(
-      "Peg monitoring upstream unavailable",
+      "Peg monitoring upstream rate limited",
       502,
       "upstream-rate-limit",
       upstream.status,

--- a/ui-dashboard/src/app/api/peg-monitoring/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { type ApiErrorBody, type ApiFailureClass } from "@/lib/api-failure";
 import { PegMonitoringResponseSchema } from "@/lib/peg-monitoring-schema";
 
 export const dynamic = "force-dynamic";
@@ -8,8 +9,18 @@ const headers = { "Cache-Control": "no-store" } as const;
 
 class InvalidUpstreamResponseError extends Error {}
 
-function errorResponse(error: string, status: number): NextResponse {
-  return NextResponse.json({ error }, { status, headers });
+function errorResponse(
+  error: string,
+  status: number,
+  failureClass: ApiFailureClass,
+  upstreamStatus?: number,
+): NextResponse {
+  const body: ApiErrorBody = {
+    error,
+    failureClass,
+    ...(upstreamStatus === undefined ? {} : { upstreamStatus }),
+  };
+  return NextResponse.json(body, { status, headers });
 }
 
 export function resolvePegMonitoringEndpoint(
@@ -84,18 +95,50 @@ function timedOut(error: unknown): boolean {
 export async function GET(): Promise<NextResponse> {
   const endpoint = resolvePegMonitoringEndpoint(process.env.METRICS_BRIDGE_URL);
   if (endpoint === null)
-    return errorResponse("Peg monitoring upstream is not configured", 503);
+    return errorResponse(
+      "Peg monitoring upstream is not configured",
+      503,
+      "configuration",
+    );
+  let upstream: Response;
   try {
-    const upstream = await fetch(endpoint, {
+    upstream = await fetch(endpoint, {
       headers: { Accept: "application/json" },
       cache: "no-store",
       redirect: "error",
       signal: AbortSignal.timeout(PEG_MONITORING_UPSTREAM_TIMEOUT_MS),
     });
-    if (upstream.status === 503)
-      return errorResponse("peg decision packages unavailable", 503);
-    if (!upstream.ok)
-      return errorResponse("Peg monitoring upstream unavailable", 502);
+  } catch (error) {
+    if (timedOut(error))
+      return errorResponse("Peg monitoring upstream timed out", 504, "timeout");
+    return errorResponse(
+      "Peg monitoring upstream request failed",
+      502,
+      "network",
+    );
+  }
+  if (upstream.status === 429)
+    return errorResponse(
+      "Peg monitoring upstream unavailable",
+      502,
+      "upstream-rate-limit",
+      upstream.status,
+    );
+  if (upstream.status === 503)
+    return errorResponse(
+      "peg decision packages unavailable",
+      503,
+      "upstream-unavailable",
+      upstream.status,
+    );
+  if (!upstream.ok)
+    return errorResponse(
+      "Peg monitoring upstream unavailable",
+      502,
+      "upstream-http",
+      upstream.status,
+    );
+  try {
     if (!upstream.headers.get("content-type")?.includes("application/json"))
       throw new InvalidUpstreamResponseError();
     const parsed = PegMonitoringResponseSchema.safeParse(
@@ -105,7 +148,17 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json(parsed.data, { headers });
   } catch (error) {
     if (timedOut(error))
-      return errorResponse("Peg monitoring upstream timed out", 504);
-    return errorResponse("Peg monitoring upstream response is invalid", 502);
+      return errorResponse("Peg monitoring upstream timed out", 504, "timeout");
+    if (error instanceof TypeError)
+      return errorResponse(
+        "Peg monitoring upstream request failed",
+        502,
+        "network",
+      );
+    return errorResponse(
+      "Peg monitoring upstream response is invalid",
+      502,
+      "invalid-payload",
+    );
   }
 }

--- a/ui-dashboard/src/components/__tests__/swr-provider.test.tsx
+++ b/ui-dashboard/src/components/__tests__/swr-provider.test.tsx
@@ -3,6 +3,7 @@
 import { act, StrictMode } from "react";
 import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
+import * as Sentry from "@sentry/nextjs";
 import useSWR, {
   preload,
   SWRConfig,
@@ -16,6 +17,7 @@ import {
   SwrProvider,
 } from "@/components/swr-provider";
 import type { TradingLimitsQuery } from "@/lib/__generated__/graphql";
+import { FetchJsonError } from "@/lib/fetch-json";
 import { TRADING_LIMITS } from "@/lib/queries";
 import {
   createPersistedSWRCache,
@@ -127,6 +129,24 @@ function FallbackDataProbe({ triggerRef }: { triggerRef: TriggerRef }) {
   );
 }
 
+function GlobalFailureProbe({
+  error,
+  triggerRef,
+}: {
+  error: Error;
+  triggerRef: TriggerRef;
+}) {
+  const { mutate } = useSWR(
+    "peg-monitoring-observability-test",
+    async () => {
+      throw error;
+    },
+    { revalidateOnMount: false, shouldRetryOnError: false },
+  );
+  triggerRef.current = () => mutate();
+  return null;
+}
+
 function CustomSuccessProbe({
   onSuccess,
   triggerRef,
@@ -207,6 +227,7 @@ function ImmediateFailureTradingLimitsProbe({
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
@@ -226,6 +247,75 @@ afterEach(() => {
 });
 
 describe("SwrProvider freshness tracking", () => {
+  it("captures safe fetch metadata at most once per key per minute", async () => {
+    const triggerRef: TriggerRef = { current: null };
+    const error = new FetchJsonError("upstream unavailable", {
+      failureClass: "upstream-rate-limit",
+      requestPath: "/api/peg-monitoring",
+      status: 502,
+      upstreamStatus: 429,
+    });
+
+    act(() => {
+      root.render(
+        <SwrProvider>
+          <GlobalFailureProbe error={error} triggerRef={triggerRef} />
+        </SwrProvider>,
+      );
+    });
+
+    await act(async () => {
+      await triggerRef.current?.().catch(() => undefined);
+    });
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      tags: {
+        api_route: "/api/peg-monitoring",
+        failure_class: "upstream-rate-limit",
+        http_status: "502",
+        source: "swr",
+        upstream_status: "429",
+      },
+      extra: { swrKey: "peg-monitoring-observability-test" },
+    });
+
+    await act(async () => {
+      await triggerRef.current?.().catch(() => undefined);
+    });
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+
+    const timeoutError = new FetchJsonError("request timed out", {
+      failureClass: "timeout",
+      requestPath: "/api/peg-monitoring",
+      status: 504,
+    });
+    act(() => {
+      root.render(
+        <SwrProvider>
+          <GlobalFailureProbe error={timeoutError} triggerRef={triggerRef} />
+        </SwrProvider>,
+      );
+    });
+    await act(async () => {
+      await triggerRef.current?.().catch(() => undefined);
+    });
+    expect(Sentry.captureException).toHaveBeenLastCalledWith(timeoutError, {
+      tags: {
+        api_route: "/api/peg-monitoring",
+        failure_class: "timeout",
+        http_status: "504",
+        source: "swr",
+      },
+      extra: { swrKey: "peg-monitoring-observability-test" },
+    });
+    expect(Sentry.captureException).toHaveBeenCalledTimes(2);
+
+    vi.setSystemTime(NOW + 60_000);
+    await act(async () => {
+      await triggerRef.current?.().catch(() => undefined);
+    });
+    expect(Sentry.captureException).toHaveBeenCalledTimes(3);
+  });
+
   it("seeds fallback data as last-good data before the first refresh fails", async () => {
     const triggerRef: TriggerRef = { current: null };
 

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -21,6 +21,7 @@ import {
   createPersistedSWRCache,
   type PersistedSWRCacheController,
 } from "@/lib/swr-persisted-cache";
+import { FetchJsonError } from "@/lib/fetch-json";
 
 // Global SWR onError handler: funnel every fetch failure to Sentry with the
 // SWR cache key attached as extra data. Without this, caught errors surface
@@ -43,9 +44,25 @@ function shouldCapture(normalized: string): boolean {
 
 function captureSWRError(err: unknown, key: unknown) {
   const normalized = normalizeSWRFreshnessKey(key);
-  if (!shouldCapture(normalized)) return;
+  const captureFingerprint =
+    err instanceof FetchJsonError
+      ? JSON.stringify([
+          normalized,
+          err.failureClass,
+          err.upstreamStatus ?? err.status,
+        ])
+      : normalized;
+  if (!shouldCapture(captureFingerprint)) return;
+  const tags: Record<string, string> = { source: "swr" };
+  if (err instanceof FetchJsonError) {
+    tags.failure_class = err.failureClass;
+    if (err.requestPath !== null) tags.api_route = err.requestPath;
+    if (err.status !== null) tags.http_status = String(err.status);
+    if (err.upstreamStatus !== null)
+      tags.upstream_status = String(err.upstreamStatus);
+  }
   Sentry.captureException(err, {
-    tags: { source: "swr" },
+    tags,
     extra: { swrKey: normalized },
   });
 }

--- a/ui-dashboard/src/lib/__tests__/fetch-json.test.ts
+++ b/ui-dashboard/src/lib/__tests__/fetch-json.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchJsonOr404, fetchJsonOrThrow } from "@/lib/fetch-json";
+import {
+  FetchJsonError,
+  fetchJsonOr404,
+  fetchJsonOrThrow,
+} from "@/lib/fetch-json";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -53,6 +57,122 @@ describe("fetchJsonOrThrow", () => {
       fetchJsonOrThrow("http://test/api", "test label"),
     ).rejects.toThrow("test label failed (HTTP 500)");
   });
+
+  it("preserves safe route and upstream failure metadata", async () => {
+    const urlWithPrivateParts = new URL(
+      "https://example.com/api/peg-monitoring?view=details#fragment",
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: "Peg monitoring upstream unavailable",
+          failureClass: "upstream-rate-limit",
+          upstreamStatus: 429,
+        }),
+        { status: 502 },
+      ),
+    );
+    await expect(
+      fetchJsonOrThrow(urlWithPrivateParts.href, "Peg monitoring"),
+    ).rejects.toMatchObject({
+      failureClass: "upstream-rate-limit",
+      message: "Peg monitoring upstream unavailable",
+      name: "FetchJsonError",
+      requestPath: "/api/peg-monitoring",
+      status: 502,
+      upstreamStatus: 429,
+    } satisfies Partial<FetchJsonError>);
+  });
+
+  it("rejects untrusted error metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: "Bad gateway",
+          failureClass: "unknown-category",
+          upstreamStatus: 999,
+        }),
+        { status: 502 },
+      ),
+    );
+    await expect(
+      fetchJsonOrThrow("/api/peg-monitoring", "Peg monitoring"),
+    ).rejects.toMatchObject({
+      failureClass: "http",
+      requestPath: "/api/peg-monitoring",
+      status: 502,
+      upstreamStatus: null,
+    } satisfies Partial<FetchJsonError>);
+  });
+
+  it.each([
+    ["TimeoutError", "timeout"],
+    ["TypeError", "network"],
+  ])("classifies rejected %s fetches as %s", async (name, failureClass) => {
+    const error = new Error("request failed");
+    error.name = name;
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(error);
+    await expect(
+      fetchJsonOrThrow("/api/peg-monitoring", "Peg monitoring"),
+    ).rejects.toMatchObject({
+      failureClass,
+      message:
+        failureClass === "timeout"
+          ? "Peg monitoring request timed out"
+          : "Peg monitoring request failed",
+      requestPath: "/api/peg-monitoring",
+      status: null,
+      upstreamStatus: null,
+    });
+  });
+
+  it("classifies invalid successful JSON without retaining its body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("not-json", { status: 200 }),
+    );
+    await expect(
+      fetchJsonOrThrow("/api/peg-monitoring?view=details", "Peg monitoring"),
+    ).rejects.toMatchObject({
+      failureClass: "invalid-payload",
+      message: "Peg monitoring returned invalid JSON",
+      requestPath: "/api/peg-monitoring",
+      status: 200,
+    } satisfies Partial<FetchJsonError>);
+  });
+
+  it.each([
+    [200, "TimeoutError", "timeout"],
+    [502, "TimeoutError", "timeout"],
+    [200, "TypeError", "network"],
+    [502, "TypeError", "network"],
+  ])(
+    "classifies HTTP %i body-read %s failures as %s",
+    async (status, errorName, failureClass) => {
+      const body = new ReadableStream({
+        pull(controller) {
+          controller.error(
+            errorName === "TimeoutError"
+              ? new DOMException("body stalled", "TimeoutError")
+              : new TypeError("body connection failed"),
+          );
+        },
+      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(body, { status }),
+      );
+      await expect(
+        fetchJsonOrThrow("/api/peg-monitoring", "Peg monitoring"),
+      ).rejects.toMatchObject({
+        failureClass,
+        message:
+          failureClass === "timeout"
+            ? "Peg monitoring request timed out"
+            : "Peg monitoring request failed",
+        requestPath: "/api/peg-monitoring",
+        status,
+      });
+    },
+  );
 });
 
 describe("fetchJsonOr404", () => {

--- a/ui-dashboard/src/lib/api-failure.ts
+++ b/ui-dashboard/src/lib/api-failure.ts
@@ -1,0 +1,31 @@
+const API_FAILURE_CLASSES = [
+  "configuration",
+  "http",
+  "invalid-payload",
+  "network",
+  "timeout",
+  "upstream-http",
+  "upstream-rate-limit",
+  "upstream-unavailable",
+] as const;
+
+export type ApiFailureClass = (typeof API_FAILURE_CLASSES)[number];
+
+export type ApiErrorBody = {
+  error: string;
+  failureClass: ApiFailureClass;
+  upstreamStatus?: number;
+};
+
+export function isApiFailureClass(value: unknown): value is ApiFailureClass {
+  return API_FAILURE_CLASSES.some((failureClass) => failureClass === value);
+}
+
+export function isHttpStatus(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 100 &&
+    value <= 599
+  );
+}

--- a/ui-dashboard/src/lib/fetch-json.ts
+++ b/ui-dashboard/src/lib/fetch-json.ts
@@ -6,6 +6,13 @@
  * so SWR's `error` field surfaces something the user can read.
  */
 
+import {
+  isApiFailureClass,
+  isHttpStatus,
+  type ApiErrorBody,
+  type ApiFailureClass,
+} from "@/lib/api-failure";
+
 /** Default per-request deadline. SWR polling hooks revalidate on cadences
  *  starting at 30s, and the polling-Hasura PR checklist requires a
  *  deadline below the refresh interval — otherwise a wedged route can
@@ -13,23 +20,146 @@
  *  Callers can override per-call via `opts.timeoutMs`. */
 const DEFAULT_TIMEOUT_MS = 25_000;
 
+function requestPath(url: string): string | null {
+  try {
+    const path = new URL(url, "http://dashboard.local").pathname;
+    return path.startsWith("/api/") ? path : null;
+  } catch {
+    return null;
+  }
+}
+
+function rejectedFetchFailure(error: unknown): ApiFailureClass {
+  return error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+    ? "timeout"
+    : "network";
+}
+
+function responseBodyReadError(
+  error: unknown,
+  url: string,
+  label: string,
+  status: number,
+): FetchJsonError | null {
+  if (error instanceof SyntaxError) return null;
+  const failureClass = rejectedFetchFailure(error);
+  return new FetchJsonError(
+    failureClass === "timeout"
+      ? `${label} request timed out`
+      : `${label} request failed`,
+    {
+      failureClass,
+      requestPath: requestPath(url),
+      status,
+    },
+  );
+}
+
+export class FetchJsonError extends Error {
+  readonly failureClass: ApiFailureClass;
+  readonly requestPath: string | null;
+  readonly status: number | null;
+  readonly upstreamStatus: number | null;
+
+  constructor(
+    message: string,
+    details: {
+      failureClass: ApiFailureClass;
+      requestPath: string | null;
+      status?: number;
+      upstreamStatus?: number;
+    },
+  ) {
+    super(message);
+    this.name = "FetchJsonError";
+    this.failureClass = details.failureClass;
+    this.requestPath = details.requestPath;
+    this.status = details.status ?? null;
+    this.upstreamStatus = details.upstreamStatus ?? null;
+  }
+}
+
+async function fetchResponse(
+  url: string,
+  label: string,
+  opts: { timeoutMs?: number; method?: "GET" | "POST" },
+): Promise<Response> {
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  try {
+    return await fetch(url, {
+      ...(opts.method === undefined ? {} : { method: opts.method }),
+      signal: AbortSignal.timeout(timeout),
+    });
+  } catch (error) {
+    const failureClass = rejectedFetchFailure(error);
+    throw new FetchJsonError(
+      failureClass === "timeout"
+        ? `${label} request timed out`
+        : `${label} request failed`,
+      {
+        failureClass,
+        requestPath: requestPath(url),
+      },
+    );
+  }
+}
+
+async function parseSuccessJson<T>(
+  response: Response,
+  url: string,
+  label: string,
+): Promise<T> {
+  try {
+    return (await response.json()) as T;
+  } catch (error) {
+    const readError = responseBodyReadError(error, url, label, response.status);
+    if (readError !== null) throw readError;
+    throw new FetchJsonError(`${label} returned invalid JSON`, {
+      failureClass: "invalid-payload",
+      requestPath: requestPath(url),
+      status: response.status,
+    });
+  }
+}
+
+async function responseError(
+  response: Response,
+  url: string,
+  label: string,
+): Promise<FetchJsonError> {
+  let body: Partial<ApiErrorBody> | null = null;
+  try {
+    body = (await response.json()) as Partial<ApiErrorBody>;
+  } catch (error) {
+    const readError = responseBodyReadError(error, url, label, response.status);
+    if (readError !== null) throw readError;
+  }
+  return new FetchJsonError(
+    typeof body?.error === "string"
+      ? body.error
+      : `${label} failed (HTTP ${response.status})`,
+    {
+      failureClass: isApiFailureClass(body?.failureClass)
+        ? body.failureClass
+        : "http",
+      requestPath: requestPath(url),
+      status: response.status,
+      ...(isHttpStatus(body?.upstreamStatus)
+        ? { upstreamStatus: body.upstreamStatus }
+        : {}),
+    },
+  );
+}
+
 export async function fetchJsonOrThrow<T>(
   url: string,
   label: string,
   opts: { timeoutMs?: number; method?: "GET" | "POST" } = {},
 ): Promise<T> {
-  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const res = await fetch(url, {
-    ...(opts.method === undefined ? {} : { method: opts.method }),
-    signal: AbortSignal.timeout(timeout),
-  });
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `${label} failed (HTTP ${res.status})`);
-  }
-  return (await res.json()) as T;
+  const res = await fetchResponse(url, label, opts);
+  if (!res.ok) throw await responseError(res, url, label);
+  return parseSuccessJson<T>(res, url, label);
 }
 
 /**
@@ -45,14 +175,8 @@ export async function fetchJsonOr404<T>(
   label: string,
   opts: { timeoutMs?: number } = {},
 ): Promise<T | null> {
-  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const res = await fetch(url, { signal: AbortSignal.timeout(timeout) });
+  const res = await fetchResponse(url, label, opts);
   if (res.status === 404) return null;
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `${label} failed (HTTP ${res.status})`);
-  }
-  return (await res.json()) as T;
+  if (!res.ok) throw await responseError(res, url, label);
+  return parseSuccessJson<T>(res, url, label);
 }

--- a/ui-dashboard/src/lib/peg-monitoring.ts
+++ b/ui-dashboard/src/lib/peg-monitoring.ts
@@ -4,7 +4,7 @@ export const PEG_MONITORING_REFRESH_MS = 30_000;
 export const PEG_MONITORING_STALE_AFTER_MS = 90_000;
 const MAX_FUTURE_CLOCK_SKEW_MS = 60_000;
 export const PEG_GRAFANA_ALERTS_URL =
-  "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser";
+  "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser&var-STATE_FILTER_TO=Alerting";
 export type {
   PegMonitoringResponse,
   PegAssetPackage,

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -216,7 +216,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   });
   await expect(grafanaLink).toHaveAttribute(
     "href",
-    "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser",
+    "https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser&var-STATE_FILTER_TO=Alerting",
   );
   await expect(grafanaLink).toHaveAttribute("rel", /noopener/);
   await expect(


### PR DESCRIPTION
## The Problem

- Peg-monitoring refresh failures did not show whether the cause was a timeout, network error, invalid payload, rate limit, or upstream outage.
- Sentry events lacked safe fields for the API route and upstream status. This blocked an evidence-based review of the 30-second refresh interval.
- The Grafana history link included all state transitions and produced too much noise.

## The Solution

- Classify peg-monitoring failures across the API route, browser fetcher, and Sentry capture path.
- Add safe Sentry tags for the API route, failure class, local HTTP status, and upstream HTTP status. Keep one event per distinct failure fingerprint per client runtime per minute.
- Link to Alerting transitions for the `peg-monitoring` service during the last seven days.

## Details

- Maps upstream HTTP 429 to `upstream-rate-limit`, HTTP 503 to `upstream-unavailable`, and other upstream failures to `upstream-http`.
- Separates request and response-body timeouts, network errors, invalid payloads, and missing configuration.
- Excludes response bodies, credentials, query strings, and full URLs from telemetry.
- Documents a saved Sentry query for upstream 429 evidence. The current production evidence does not justify a change to the 30-second refresh interval.
- Uses this Grafana URL: `https://clabsmento.grafana.net/alerting/history?var-LABELS_FILTER=service%3Dpeg-monitoring&from=now-7d&to=now&timezone=browser&var-STATE_FILTER_TO=Alerting`.
- No ADR is needed. This change extends the existing dashboard observability contract and does not add a new architecture decision.
- Claude Security was not run because that review engine was not available in this Codex session. Local autoreview and the repository quality gate covered the change.

## Validation

- `pnpm agent:quality-gate --run --parallel 4` — passed all mapped commands, including browser tests, dashboard coverage, React Doctor 100/100, size limits, docs checks, and Terraform tests.
- Local browser check — confirmed the exact Grafana URL, `_blank`, `noopener noreferrer`, the peg-monitoring board, and no console errors.
- Local API check — confirmed a missing bridge configuration returns HTTP 503 with `failureClass: configuration` and `Cache-Control: no-store`.
- Local Codex autoreview — clean after fixes for response-body classification, safe telemetry, and cause-aware throttling. The final fresh-context agent retry could not start because the agent service could not refresh its login token. The current session completed the final semantic pass against the verified review bundle.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #1858

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shape changes on a dashboard API path; no auth, payment, or data-model changes, with broad test coverage.
> 
> **Overview**
> Adds a shared **`failureClass`** contract from `/api/peg-monitoring` through the browser **`fetchJson`** layer into Sentry, so peg refresh outages can be diagnosed without logging bodies, query strings, or full URLs.
> 
> The API route now returns structured errors for configuration gaps, timeouts, network failures, invalid payloads, and upstream HTTP (including **429** as `upstream-rate-limit` and **503** as `upstream-unavailable`) with optional **`upstreamStatus`**. **`FetchJsonError`** carries safe **`requestPath`** (pathname only) and validated metadata; the global SWR **`onError`** handler tags Sentry with `api_route`, `failure_class`, `http_status`, and `upstream_status`, throttled once per SWR key + root-cause fingerprint per minute.
> 
> The peg-monitoring runbook documents a production Sentry query for rate limits and notes the 30s refresh interval is unchanged pending stronger evidence. The Grafana “full history” link filters to **Alerting** transitions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2336ef7e3dd49ffa28c77d5585256fc64ced14b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->