### PR TITLE
fix(agent): accept common Claude clean reviews

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -104,15 +104,19 @@ terminal state so late feedback is not missed.
 
 ### Bounded clean-Claude protocol
 
-`pr:feedback-state` accepts a clean verdict from Claude only through a bounded
-parser over registered comment shapes. Anything ambiguous or unregistered fails
-closed: unknown prose, Markdown or HTML syntax, hedging, negation, malformed
-headings, and mixed clean/actionable items stay blocking. A small compatibility
-registry holds exact observed payloads, each bound to its Claude author, PR
-number, comment ID, head SHA, and a digest of the untrimmed raw body, so any
-body or binding change — including line endings — blocks again. The exact
-grammar and registry live in `scripts/pr-feedback-state-claude.mjs`; do not
-broaden them to accept a new title or checklist subject.
+`pr:feedback-state` keeps older exceptions in an exact compatibility registry.
+Each entry binds the raw body digest to its Claude author, PR, comment, and head.
+Reviews from the observed PR #1848 shape onward use a small prose-pattern
+library. The library requires one unhedged `Verdict: LGTM` or `Overall verdict:
+LGTM` line and an explicit no-findings or no-action conclusion. P0-P2 findings,
+P3 lines without a known no-action disposition, direct action requests,
+ambiguous verdicts, and unsupported markup stay blocking. Current-head and
+unresolved-feedback checks remain separate and mandatory.
+
+The registry and named phrase groups live in
+`scripts/pr-feedback-state-claude.mjs`. Add a phrase only with a real review
+fixture and nearby blocking mutations. The library does not try to prove the
+meaning of arbitrary English prose.
 
 ## Expected CLI contract
 

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -4,16 +4,32 @@ const COMMONMARK_ASCII_PUNCTUATION_ESCAPE =
   /\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/g;
 const CLAUDE_TASK_COMPLETION_LINE =
   /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*(?:\s+——\s+\[View\s+job\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+\))?$/i;
-const CLAUDE_TASK_COMPLETION_WITH_JOB_LINE =
-  /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*\s+——\s+\[View\s+job\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+\)$/i;
-const OVERALL_REVIEW_HEADING = /^###\s+Code Review\s+—\s+PR\s+#(\d+)$/;
-const OVERALL_CHECKLIST_ENTRY = /^-\s+\[([^\]])\]\s+(.{1,200})$/;
-const OVERALL_VERDICT = /^\*\*Overall verdict:\s+LGTM\*\*$/;
-const OVERALL_SUMMARY_HEADING = /^###\s+Summary$/;
-const OVERALL_VERIFICATION_HEADING =
-  /^###\s+Verification notes \(no issues found\)$/;
-const OVERALL_NOTE = /^([1-9]\d*)\.\s+\*\*(.{1,200})\*\*(?:\s+(.{1,4000}))?$/;
-const OVERALL_TERMINAL_CLEAN = /^No P1\/P2\/P3 findings\s+—\s+(.{1,500})$/;
+const CLAUDE_VERDICT_NAMESPACE = /^(?:\*\*)?(?:Overall\s+)?Verdict\s*:/i;
+const CLAUDE_CLEAN_VERDICT =
+  /^(?:\*\*)?(?:Overall\s+)?Verdict:\s*LGTM(?:\*\*)?\s*$/i;
+const PROSE_PATTERN_LIBRARY_START = Date.parse("2026-08-13T23:08:10Z");
+const REVIEW_NUMBER_HEADING = /^#{1,6}\s+Code Review\s+—\s+PR\s+#(\d+)$/gm;
+const REVIEW_TITLE_HEADING = /^#{1,6}\s+Review:\s+(.{1,200})$/gim;
+const CLEAN_CONCLUSION_PATTERNS = [
+  /^No\s+P1\/P2\/P3\s+findings(?:\s*[.—-]\s*(?:clean review|nothing rose above the bar for an inline comment))?[.!]?$/i,
+  /^No\s+P1\/P2\s+findings[.!]?$/i,
+  /^No\s+inline\s+(?:comments|findings)(?:\s+(?:filed|posted))?(?:\s*[.—-]\s*nothing rose to a P1\/P2\/P3 flag)?[.!]?$/i,
+  /^No\s+changes\s+requested[.!]?$/i,
+];
+const CLEAN_P3_DISPOSITION_PATTERNS = [
+  /\bno[- ]action(?:\s+requested)?\b/i,
+  /\bnone\s+blocking\b/i,
+  /\bnot\s+(?:a\s+)?blocker\b/i,
+  /\bisn['’]t\s+(?:a\s+)?blocker\b/i,
+  /\bnot\s+worth\s+(?:a\s+)?fix\b/i,
+  /\bnot\s+an?\s+(?:error|issue)\b/i,
+];
+const EXPLICIT_ACTION_LINE =
+  /^(?:\*\*)?(?:Action\s+(?:items?|required)|Changes\s+requested|Needs\s+changes|A\s+fix\s+is\s+required|.{1,160}\s+must\s+be\s+(?:addressed|changed|fixed|implemented|removed|restored|updated|validated)|(?:Please\s+)?(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)|(?:Must|Should|Needs?\s+to)\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate))\b/i;
+const INLINE_DIRECT_ACTION =
+  /\bplease\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)\b/i;
+const EXPLICIT_SEVERITY =
+  /(?:BUGBOT_BUG_ID|\b(?:Critical|High|Medium|Low)\s+Severity\b|\bSeverity\s*:\s*(?:Critical|High|Medium|Low)\b)/i;
 const CLEAN_REVIEW_COMPATIBILITY = new Map([
   [
     "039923882eee9f880165543ef85e1ca251d84b995a78647b41c2b788d02a4885",
@@ -70,6 +86,59 @@ function normalizedReviewTitle(value) {
     .toLowerCase();
 }
 
+function isClaudeAuthor(value) {
+  return /^claude(?:\[bot\])?$/i.test(String(value ?? ""));
+}
+
+function isCleanConclusion(line) {
+  const value = String(line ?? "").trim();
+  return CLEAN_CONCLUSION_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function withoutCleanReviewConclusionLines(value) {
+  return String(value ?? "")
+    .split("\n")
+    .filter((line) => !isCleanConclusion(line))
+    .join("\n");
+}
+
+function reviewLineContent(line) {
+  let value = String(line ?? "").trim();
+  for (let index = 0; index < 3; index += 1) {
+    const stripped = value.replace(
+      /^(?:[-*+]\s+|\d+[.)]\s+|#{1,6}\s+|\[[ xX-]\]\s+)/,
+      "",
+    );
+    if (stripped === value) break;
+    value = stripped;
+  }
+  return value;
+}
+
+function verdictDeclaration(line) {
+  return CLAUDE_VERDICT_NAMESPACE.test(reviewLineContent(line));
+}
+
+function priorityAtLineStart(line) {
+  return reviewLineContent(line).match(
+    /^(?:\*\*)?\[?[Pp]([0-3])\]?(?:\*\*)?(?=[^A-Za-z0-9]|$)/,
+  )?.[1];
+}
+
+function hasCleanP3Disposition(line) {
+  return CLEAN_P3_DISPOSITION_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+function hasExplicitAction(line) {
+  const content = reviewLineContent(line).replace(
+    /^(?:\*\*)?\[?[Pp][0-3]\]?(?:\*\*)?(?:\s*[^A-Za-z0-9\s]\s*|\s+)/,
+    "",
+  );
+  return (
+    EXPLICIT_ACTION_LINE.test(content) || INLINE_DIRECT_ACTION.test(content)
+  );
+}
+
 export function hasControlCharacter(value) {
   return Array.from(String(value ?? "")).some((character) => {
     const codePoint = character.codePointAt(0);
@@ -102,38 +171,10 @@ export function isClaudeTaskCompletionLine(value) {
 
 export function isClaudeLgtmReview(comment) {
   return (
-    /^claude(?:\[bot\])?$/i.test(comment?.author ?? "") &&
+    isClaudeAuthor(comment?.author) &&
     /^\s*(?:#{1,6}\s+)?(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(
       comment?.body ?? "",
     )
-  );
-}
-
-function isBoundedRepoRelativePath(value) {
-  const path = String(value ?? "");
-  return (
-    path.length > 0 &&
-    path.length <= 180 &&
-    !path.startsWith("/") &&
-    !path.endsWith("/") &&
-    !path.includes("//") &&
-    /^[A-Za-z0-9._/-]+$/.test(path) &&
-    path.split("/").every((segment) => segment !== "." && segment !== "..")
-  );
-}
-
-function isOverallReviewSubject(value) {
-  const reviewPath = String(value ?? "").match(
-    /^Review `([^`]+)` changes$/,
-  )?.[1];
-  return reviewPath !== undefined && isBoundedRepoRelativePath(reviewPath);
-}
-
-function hasStructuralMarkdown(value) {
-  const line = String(value ?? "");
-  return (
-    /(?:^|\s)(?:```|~~~)/.test(line) ||
-    /^(?:#{1,6}\s|[-+*]\s+|\d+[.)]\s+|>\s*|\|.*\|$)/.test(line)
   );
 }
 
@@ -149,102 +190,63 @@ export function matchesCleanReviewCompatibilityRegistry(comment, pr, rawBody) {
   );
 }
 
-export function isExplicitlyCleanOverallClaudeReview(comment, pr) {
-  const author = String(comment?.author ?? "").toLowerCase();
-  if (author !== "claude" && author !== "claude[bot]") return false;
-
+// Returns null for non-Claude or non-verdict comments, false for an explicitly
+// clean review, and true for an actionable or unsupported verdict comment.
+export function classifyClaudeReviewProse(comment, pr) {
+  if (!isClaudeAuthor(comment?.author)) return null;
   const body = String(comment?.body ?? "");
-  const lines = body.split(/\r?\n/);
-  if (hasMarkdownCodeBlockIndentation(lines)) return false;
-  const nonempty = lines.map((line) => line.trim()).filter(Boolean);
-  let index = 0;
+  const lines = body.split("\n");
+  const verdictLines = lines.filter(verdictDeclaration);
+  if (verdictLines.length === 0) return null;
+  const createdAt = Date.parse(comment?.createdAt ?? comment?.created_at ?? "");
+  if (!Number.isFinite(createdAt) || createdAt < PROSE_PATTERN_LIBRARY_START)
+    return true;
 
-  if (!CLAUDE_TASK_COMPLETION_WITH_JOB_LINE.test(nonempty[index] ?? ""))
-    return false;
-  index += 1;
-  if (nonempty[index] !== "---") return false;
-  index += 1;
-
-  const reviewNumber = nonempty[index]?.match(OVERALL_REVIEW_HEADING)?.[1];
-  if (!reviewNumber || reviewNumber !== String(pr?.number ?? "")) return false;
-  index += 1;
-
-  const checklist = [];
-  while (index < nonempty.length) {
-    const entry = nonempty[index].match(OVERALL_CHECKLIST_ENTRY);
-    if (!entry) break;
-    if (entry[1].toLowerCase() !== "x") return false;
-    if (hasControlCharacter(entry[2])) return false;
-    checklist.push(entry[2]);
-    index += 1;
-  }
   if (
-    checklist.length < 4 ||
-    checklist[0] !== "Gather context (read changed files, diff)" ||
-    checklist[1] !== "Understand the request (code review)" ||
-    checklist.at(-1) !== "Post findings" ||
-    !checklist.slice(2, -1).every(isOverallReviewSubject) ||
-    !OVERALL_VERDICT.test(nonempty[index] ?? "")
+    verdictLines.length !== 1 ||
+    !CLAUDE_CLEAN_VERDICT.test(reviewLineContent(verdictLines[0])) ||
+    body.includes("\r") ||
+    body.includes("\0") ||
+    body.length > 65_536 ||
+    hasMarkdownCodeBlockIndentation(lines) ||
+    /(?:^|\s)(?:```|~~~)|<!--|-->|^\s*(?:>|\|.*\|\s*$)/m.test(body)
   )
-    return false;
-  index += 1;
-  if (!OVERALL_SUMMARY_HEADING.test(nonempty[index] ?? "")) return false;
-  index += 1;
+    return true;
 
-  const summary = [];
-  while (
-    index < nonempty.length &&
-    !OVERALL_VERIFICATION_HEADING.test(nonempty[index])
-  ) {
-    summary.push(nonempty[index]);
-    index += 1;
-  }
+  const reviewNumbers = Array.from(
+    body.matchAll(REVIEW_NUMBER_HEADING),
+    ([, number]) => number,
+  );
   if (
-    summary.length === 0 ||
-    summary.some(
-      (line) => hasControlCharacter(line) || hasStructuralMarkdown(line),
-    ) ||
-    !OVERALL_VERIFICATION_HEADING.test(nonempty[index] ?? "")
+    reviewNumbers.length > 1 ||
+    (reviewNumbers.length === 1 &&
+      reviewNumbers[0] !== String(pr?.number ?? ""))
   )
-    return false;
-  index += 1;
+    return true;
 
-  const notes = [];
-  while (index < nonempty.length) {
-    const note = nonempty[index].match(OVERALL_NOTE);
-    if (!note) break;
+  const reviewTitles = Array.from(
+    body.matchAll(REVIEW_TITLE_HEADING),
+    ([, title]) => title,
+  );
+  if (
+    reviewTitles.length > 1 ||
+    (reviewTitles.length === 1 &&
+      !isOrdinaryReviewTitle(reviewTitles[0], pr?.title))
+  )
+    return true;
+
+  if (!lines.some(isCleanConclusion)) return true;
+
+  for (const line of lines) {
+    if (isCleanConclusion(line)) continue;
+    const priority = priorityAtLineStart(line);
     if (
-      Number(note[1]) !== notes.length + 1 ||
-      !note[3] ||
-      hasControlCharacter(note[2]) ||
-      hasControlCharacter(note[3]) ||
-      hasStructuralMarkdown(note[3])
+      priority !== undefined &&
+      (priority !== "3" || !hasCleanP3Disposition(line))
     )
-      return false;
-    notes.push(`${note[2]} ${note[3]}`);
-    index += 1;
+      return true;
+    if (hasExplicitAction(line) || EXPLICIT_SEVERITY.test(line)) return true;
   }
-  if (notes.length === 0) return false;
 
-  const terminal = nonempty[index]?.match(OVERALL_TERMINAL_CLEAN);
-  if (
-    !terminal ||
-    index !== nonempty.length - 1 ||
-    hasControlCharacter(terminal[1]) ||
-    hasStructuralMarkdown(terminal[1])
-  )
-    return false;
-  return matchesCleanReviewCompatibilityRegistry(comment, pr, body);
-}
-
-export function classifyOverallClaudeReview(comment, pr) {
-  const author = String(comment?.author ?? "").toLowerCase();
-  if (
-    (author !== "claude" && author !== "claude[bot]") ||
-    !/^\s*(?:(?:\*\*)?Overall verdict\s*:|#{1,6}\s+Code Review\s+—\s+PR\s+#|#{1,6}\s+Verification notes\b|No P1\/P2\/P3 findings\b)/im.test(
-      comment?.body ?? "",
-    )
-  )
-    return null;
-  return !isExplicitlyCleanOverallClaudeReview(comment, pr);
+  return false;
 }

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -106,10 +106,16 @@ function hasUnnegatedFailure(value) {
   const scrubbed = String(value ?? "").replace(NEGATED_FAILURE, "");
   return FAILURE_TERM.test(scrubbed);
 }
-function hasReviewContradiction(value) {
-  const body = String(value ?? "")
+function reviewContradictionBody(value) {
+  return String(value ?? "")
     .replace(/[*_~]/g, "")
     .replace(CLEAN_REVIEW_SUMMARY, "");
+}
+function hasReviewActionSignal(value) {
+  return REVIEW_CONTRADICTION.test(reviewContradictionBody(value));
+}
+function hasReviewContradiction(value) {
+  const body = reviewContradictionBody(value);
   return REVIEW_CONTRADICTION.test(body) || hasUnnegatedFailure(body);
 }
 function isBenignChecklistSubject(value) {
@@ -201,8 +207,6 @@ function isExplicitlyCleanClaudeReview(comment, pr) {
   const author = String(comment.author ?? "").toLowerCase();
   if (author !== "claude" && author !== "claude[bot]") return false;
   const body = String(comment.body ?? "");
-  if (claudeReview.matchesCleanReviewCompatibilityRegistry(comment, pr, body))
-    return true;
   const lines = body.split(/\r?\n/);
   if (claudeReview.hasMarkdownCodeBlockIndentation(lines)) return false;
   if (!/^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body)) return false;
@@ -227,13 +231,27 @@ function isExplicitlyCleanClaudeReview(comment, pr) {
 }
 function isActionableReviewBotComment(comment, pr) {
   if (!isReviewBotComment(comment)) return false;
-  if (claudeReview.isClaudeLgtmReview(comment))
-    return !isExplicitlyCleanClaudeReview(comment, pr);
-  const overallClaudeReview = claudeReview.classifyOverallClaudeReview(
-    comment,
-    pr,
-  );
-  if (overallClaudeReview !== null) return overallClaudeReview;
+  if (
+    claudeReview.matchesCleanReviewCompatibilityRegistry(
+      comment,
+      pr,
+      String(comment.body ?? ""),
+    )
+  )
+    return false;
+  if (
+    claudeReview.isClaudeLgtmReview(comment) &&
+    isExplicitlyCleanClaudeReview(comment, pr)
+  )
+    return false;
+  const claudeProse = claudeReview.classifyClaudeReviewProse(comment, pr);
+  if (claudeProse !== null)
+    return (
+      claudeProse ||
+      hasReviewActionSignal(
+        claudeReview.withoutCleanReviewConclusionLines(comment.body),
+      )
+    );
   if (hasReviewContradiction(comment.body)) return true;
   const actionableSignal =
     /(?:\[[Pp]3\]|\*\*[Pp]3\*\*|\b[Pp]3\s*(?::|[-—|]|Badge\b))/.test(

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -326,6 +326,49 @@ const PR_1837_CLEAN_CLAUDE_REVIEW = {
   ].join("\n"),
 };
 
+const PR_1848_HEAD = "44cbfc657ba8e2a3ed3f48927b3999678d66c13e";
+// Verbatim REST issuecomment 5287402981 from PR #1848. This common Claude
+// shape has an Overall-verdict heading and an explicit no-findings ending.
+const PR_1848_CLEAN_CLAUDE_REVIEW = {
+  id: 5287402981,
+  html_url:
+    "https://github.com/mento-protocol/monitoring-monorepo/pull/1848#issuecomment-5287402981",
+  created_at: "2026-08-13T23:08:10Z",
+  updated_at: "2026-08-13T23:11:53Z",
+  user: { login: "claude[bot]", type: "Bot" },
+  body: [
+    "**Claude finished @chapati23's task in 3m 28s** —— [View job](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/31752689248)",
+    "",
+    "---",
+    "### Code Review — PR #1848",
+    "",
+    "- [x] Gather context (PR body, diff, changed files)",
+    "- [x] Understand the request (code review)",
+    "- [x] Read `scripts/pr-feedback-state-claude.mjs` and diff",
+    "- [x] Read `scripts/pr-feedback-state.test.mjs` and diff",
+    "- [x] Check registry/fail-closed pattern against AGENTS.md conventions",
+    "- [x] Post findings",
+    "",
+    "### Overall verdict: LGTM",
+    "",
+    "This is a minimal, well-scoped addition that follows the existing `CLEAN_REVIEW_COMPATIBILITY` registry pattern exactly (4 prior entries for PRs #1544, #1595, #1600, #1825). It adds one new SHA-256-keyed entry for the frozen PR #1837 review body, gated on digest + author + PR number + comment ID + head SHA all matching simultaneously.",
+    "",
+    "I traced the actual code path to make sure the fix does what it claims:",
+    "",
+    "- `isActionableReviewBotComment` → `isClaudeLgtmReview` matches the `### Verdict: LGTM` line in the PR #1837 body → falls into `isExplicitlyCleanClaudeReview`, which checks `matchesCleanReviewCompatibilityRegistry` **first**, before any general-grammar parsing (`scripts/pr-feedback-state-core.mjs:200-205`). That's why this works even though the body's `### Review: <title>` / `### Cross-cutting notes` / `### Numbered finding roll-up` layout doesn't match the general `Findings`/`Roll up` heading grammar or the separate `isExplicitlyCleanOverallClaudeReview` \"Code Review — PR #N\" grammar. Confirmed both alternate parse paths correctly reject this layout on their own, so the registry entry is the only thing making it pass — exactly the stated intent.",
+    "- Verified the new registry hex string is a well-formed 64-char SHA-256 digest, and manually checked the `body.length` (3271) vs. `Buffer.byteLength` (3275) delta traces to the one `——` (double em-dash) occurrence in the completion line — internally consistent, not a copy-paste artifact.",
+    '- Walked through each of the 11 mutation cases (byte, line-ending, author, comment ID, PR number, head, verdict-hedge, contradictory roll-up, malformed heading, actionable-P3 roll-up, appended text) against the actual matcher logic — each one breaks the exact digest match and correctly falls through to a general-grammar path that rejects the layout, reproducing the fail-closed guarantee the PR claims. This is broader mutation coverage than the #1825 precedent (6 cases), which is a reasonable bar given this layout has more surface area (verdict line + roll-up section) than the earlier "Overall Claude Review" format.',
+    "- Scope check: the registry key is bound to one immutable historical comment (fixed ID + fixed head SHA + fixed digest), so this can't be reused to accept a *different* review body — no bypass risk introduced.",
+    '- Per `scripts/AGENTS.md`, this is a Node root script change with a focused test — `pr-feedback-state.test.mjs` covers it, satisfying the "new Node root scripts must be covered" rule. No shell scripts touched, no ADR needed (correctly marked N/A in the PR body — this extends existing registry data, not architecture).',
+    "",
+    "I could not execute `node --test` locally in this sandboxed review environment (bash tool execution was blocked), so I verified by static trace through the matcher functions rather than by running the suite. The PR body reports 37/37 and 75/75 passing, and CI was still in progress at review time (`CI` workflow: in_progress) — worth confirming it goes green before merge, but nothing in the diff suggests it wouldn't.",
+    "",
+    "### Numbered finding roll-up",
+    "",
+    "No P1/P2/P3 findings — nothing rose above the bar for an inline comment.",
+  ].join("\n"),
+};
+
 function normalizedReadyStateForClaudeReview(
   comment,
   {
@@ -1407,6 +1450,170 @@ test("accepts only the exact frozen PR #1837 no-action Claude LGTM", () => {
     assertEqual(mutatedFeedbackState.counts.blockingTopLevelBotComments, 1);
     assertEqual(mutatedFeedbackState.counts.blockingFindings > 0, true);
   }
+});
+
+test("accepts the observed PR #1848 Overall-verdict clean review", () => {
+  const normalizedReadyState = normalizedReadyStateForClaudeReview(
+    PR_1848_CLEAN_CLAUDE_REVIEW,
+    {
+      number: 1848,
+      title: "fix(agent): accept exact no-action Claude review",
+      headRefOid: PR_1848_HEAD,
+      headUpdatedAt: "2026-08-13T22:09:46Z",
+      reactionCreatedAt: "2026-08-13T23:12:00Z",
+    },
+  );
+  const feedbackState = summarizeFeedbackState(normalizedReadyState);
+
+  assertEqual(normalizedReadyState.required.ready, true);
+  assertEqual(feedbackState.ready, true);
+  assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
+  assertEqual(feedbackState.counts.blockingFindings, 0);
+});
+
+test("classifies the post-#1848 Claude prose pattern library", () => {
+  const options = {
+    number: 1848,
+    title: "fix(agent): accept exact no-action Claude review",
+    headRefOid: PR_1848_HEAD,
+    headUpdatedAt: "2026-08-13T22:09:46Z",
+    reactionCreatedAt: "2026-08-14T00:30:00Z",
+  };
+  const comment = (body, overrides = {}) => ({
+    ...PR_1848_CLEAN_CLAUDE_REVIEW,
+    id: 5287403000,
+    created_at: "2026-08-14T00:00:00Z",
+    updated_at: "2026-08-14T00:00:00Z",
+    body,
+    ...overrides,
+  });
+  const expectReady = (label, review, expected) => {
+    const readyState = normalizedReadyStateForClaudeReview(review, options);
+    const feedbackState = summarizeFeedbackState(readyState);
+    assertEqual(
+      feedbackState.ready,
+      expected,
+      `${label}: unexpected feedback-state result`,
+    );
+    assertEqual(
+      feedbackState.counts.blockingTopLevelBotComments,
+      expected ? 0 : 1,
+    );
+  };
+
+  for (const [label, body] of [
+    [
+      "plain LGTM with an explicit no-findings conclusion",
+      `### Review: ${options.title}\n\nVerdict: LGTM\n\nNo inline findings — nothing rose to a P1/P2/P3 flag.`,
+    ],
+    [
+      "no-action P3 observation",
+      `### Review: ${options.title}\n\n**Verdict: LGTM**\n\n1. [P3] None blocking: tests cover the changed paths.\n\nNo P1/P2 findings.`,
+    ],
+    [
+      "Overall verdict with no findings",
+      "### Overall verdict: LGTM\n\nNo P1/P2/P3 findings — clean review.",
+    ],
+  ]) {
+    expectReady(label, comment(body), true);
+  }
+
+  const clean = PR_1848_CLEAN_CLAUDE_REVIEW.body;
+  for (const [label, body] of [
+    [
+      "hedged verdict",
+      clean.replace(
+        "### Overall verdict: LGTM",
+        "### Overall verdict: probably LGTM",
+      ),
+    ],
+    [
+      "duplicate verdict",
+      clean.replace(
+        "### Overall verdict: LGTM",
+        "### Overall verdict: LGTM\n\nVerdict: LGTM",
+      ),
+    ],
+    [
+      "conflicting verdict",
+      clean.replace(
+        "### Overall verdict: LGTM",
+        "### Overall verdict: LGTM\n\nVerdict: CHANGES REQUESTED",
+      ),
+    ],
+    [
+      "bullet-prefixed conflicting verdict",
+      clean.replace(
+        "### Overall verdict: LGTM",
+        "### Overall verdict: LGTM\n\n- Verdict: CHANGES REQUESTED",
+      ),
+    ],
+    [
+      "task-list conflicting verdict",
+      clean.replace(
+        "### Overall verdict: LGTM",
+        "### Overall verdict: LGTM\n\n- [ ] Verdict: CHANGES REQUESTED",
+      ),
+    ],
+    [
+      "missing clean conclusion",
+      clean.replace(
+        "No P1/P2/P3 findings — nothing rose above the bar for an inline comment.",
+        "Review complete.",
+      ),
+    ],
+    [
+      "wrong PR heading",
+      clean.replace("### Code Review — PR #1848", "### Code Review — PR #1849"),
+    ],
+    ["P2 finding", `${clean}\n\n1. [P2] Restore validation.`],
+    ["P2 heading", `${clean}\n\n### [P2] Validation is missing.`],
+    ["P2 table row", `${clean}\n\n| P2 | Validation is missing |`],
+    ["P2 task item", `${clean}\n\n- [ ] [P2] Restore validation.`],
+    ["actionable P3", `${clean}\n\n1. [P3] Fix the fallback.`],
+    ["period-delimited P3", `${clean}\n\n- [ ] [P3]. Fix the fallback.`],
+    [
+      "period-delimited contradictory P3",
+      `${clean}\n\n- [ ] [P3]. Fix the fallback — not a blocker.`,
+    ],
+    ["bare imperative", `${clean}\n\nFix the fallback.`],
+    [
+      "contradictory P3 request",
+      `${clean}\n\n1. [P3] No action requested, but please fix the fallback.`,
+    ],
+    [
+      "contradictory bare P3 request",
+      `${clean}\n\n1. [P3] No action requested, but fix the fallback.`,
+    ],
+    ["action request", `${clean}\n\nAction required: restore validation.`],
+    ["direct request", `${clean}\n\nPlease fix the fallback.`],
+    ["required-fix noun", `${clean}\n\nA fix is required before merge.`],
+    [
+      "passive requirement",
+      `${clean}\n\nThe fallback must be fixed before merge.`,
+    ],
+    [
+      "action appended to clean conclusion",
+      clean.replace(
+        "No P1/P2/P3 findings — nothing rose above the bar for an inline comment.",
+        "No P1/P2 findings — Please fix the fallback before merge.",
+      ),
+    ],
+    ["CRLF transport", clean.replaceAll("\n", "\r\n")],
+    ["fenced suffix", `${clean}\n\n\`\`\`text\nexample\n\`\`\``],
+    ["HTML suffix", `${clean}\n\n<!-- review metadata -->`],
+  ]) {
+    expectReady(label, comment(body), false);
+  }
+
+  expectReady(
+    "pre-library comments still need an exact compatibility entry",
+    comment(clean, {
+      created_at: "2026-08-13T23:08:09Z",
+      updated_at: "2026-08-13T23:08:09Z",
+    }),
+    false,
+  );
 });
 
 test("fails closed on single-field PR #1544 Overall-verdict mutations", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `pr:feedback-state` falsely blocked 3 of 56 recent Claude reviews because their clean prose did not match a registered historical body.
- The previous proposed fix added a new review transport and provenance system for a 5.4% parser miss rate.

## The Solution

- Accept a small, explicit set of common clean Claude phrases while keeping unknown, ambiguous, or actionable review text blocking.

## Details

- Keep the five exact historical compatibility records and the existing strict legacy `Findings` and `Roll-up` grammar.
- For reviews at or after the observed PR #1848 shape, require exactly one `Verdict: LGTM` or `Overall verdict: LGTM` line and one complete allowlisted clean conclusion.
- Keep P0-P2 findings, P3 lines without a no-action disposition, conflicting verdicts, direct requests, unsupported markup, wrong PR metadata, and malformed transport blocking.
- Reuse the existing contradiction scan after removing only complete clean-conclusion lines.
- Add the verbatim PR #1848 review and adversarial mutations for verdicts, conclusions, priorities, task-list markers, requests, markup, line endings, and the library cutoff.
- Update the ready-state runbook. This PR does not change the Anthropic workflow, credentials, OIDC, artifacts, or review publication.
- The patch changes four files. Production parser code grows by 20 net lines; the remaining additions are tests and documentation.

## Validation

- `node scripts/pr-feedback-state.test.mjs` — 39 passed.
- `CI=true pnpm pr:ready-state:test` — 75 passed.
- `CI=true pnpm lint:scripts` — passed.
- `./tools/trunk check docs/notes/pr-ready-state.md scripts/pr-feedback-state-claude.mjs scripts/pr-feedback-state-core.mjs scripts/pr-feedback-state.test.mjs` — passed.
- `CI=true pnpm agent:quality-gate --run` — all 7 mapped commands passed.
- Fresh-context autoreview and deterministic local autoreview — no remaining findings.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This extends the existing parser and removes the proposed replacement architecture.

Closes #1567

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent merge gating logic for Claude bot feedback; mistakes could clear actionable reviews or block clean ones, though fail-closed defaults, a historical cutoff, and extensive mutation tests mitigate that.
> 
> **Overview**
> **`pr:feedback-state` stops falsely blocking common Claude “clean” top-level reviews** that never matched the old exact-body registry or the rigid “Code Review — PR #N” grammar.
> 
> For Claude comments **on or after** the PR #1848 cutoff, a new **`classifyClaudeReviewProse`** path in `pr-feedback-state-claude.mjs` accepts reviews that have exactly one unhedged `Verdict: LGTM` / `Overall verdict: LGTM`, an allowlisted no-findings conclusion, safe P3 “no-action” wording, and valid PR/title metadata—while still blocking P0–P2 lines, actionable P3, hedged or duplicate verdicts, explicit fix requests, and unsupported markup (CRLF, fences, HTML). **Older shapes** still rely on the **SHA-256 compatibility registry** and the legacy **Findings / Roll-up** grammar; the monolithic overall-review parser was removed in favor of this library.
> 
> **`isActionableReviewBotComment`** in `pr-feedback-state-core.mjs` now routes Claude verdict comments through registry → legacy structured clean → prose classifier, with a contradiction scan that strips only complete clean-conclusion lines. Docs in `pr-ready-state.md` describe the split; tests add the verbatim PR #1848 fixture plus broad accept/block mutations around the library cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f975d15adb27bc5d3f8ac82c1f266034d2b98a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->