### PR TITLE
fix(dashboard): refresh peg board when a hidden tab resumes

### DIFF
--- a/ui-dashboard/src/hooks/__tests__/use-peg-monitoring.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-peg-monitoring.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
   }
 });
 describe("usePegMonitoring", () => {
-  it("uses the same-origin timed 30-second polling contract", async () => {
+  it("uses the same-origin polling and resumed-tab refresh contract", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(Response.json(makePegMonitoringResponse()));
@@ -46,7 +46,8 @@ describe("usePegMonitoring", () => {
     expect(swr.mock.calls[0]?.[0]).toBe(SWR_KEY_PEG_MONITORING);
     expect(probe.config).toMatchObject({
       refreshInterval: PEG_MONITORING_REFRESH_MS,
-      revalidateOnFocus: false,
+      revalidateOnFocus: true,
+      focusThrottleInterval: PEG_MONITORING_REFRESH_MS,
       revalidateOnReconnect: false,
       refreshWhenHidden: false,
     });

--- a/ui-dashboard/src/hooks/use-peg-monitoring.ts
+++ b/ui-dashboard/src/hooks/use-peg-monitoring.ts
@@ -34,7 +34,11 @@ export function usePegMonitoring(): PegMonitoringResult {
     fetchPegMonitoring,
     {
       refreshInterval: PEG_MONITORING_REFRESH_MS,
-      revalidateOnFocus: false,
+      // This is one same-origin board read, not a Hasura query fan-out. Refresh
+      // on resume so a hidden tab does not retain an old package until the next
+      // interval, and cap focus refreshes at the normal board cadence.
+      revalidateOnFocus: true,
+      focusThrottleInterval: PEG_MONITORING_REFRESH_MS,
       revalidateOnReconnect: false,
       refreshWhenHidden: false,
       onSuccess() {

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -271,3 +271,91 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
   );
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
+
+test("refreshes the board when a hidden tab resumes", async ({ page }) => {
+  await page.clock.install({ time: new Date(now * 1000 + 20_000) });
+  await page.addInitScript(() => {
+    let visibilityState: DocumentVisibilityState = "visible";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    (
+      window as Window & {
+        __setPegTestVisibility?: (state: DocumentVisibilityState) => void;
+      }
+    ).__setPegTestVisibility = (state) => {
+      visibilityState = state;
+      document.dispatchEvent(new Event("visibilitychange"));
+    };
+  });
+  let boardRequests = 0;
+  const resumedAt = now + 120;
+  const resumedPayload = {
+    ...payload,
+    producedAt: resumedAt,
+    packages: payload.packages.map((item) => ({
+      ...item,
+      monitors: item.monitors.map((monitor) => ({
+        ...monitor,
+        breaker:
+          monitor.breaker === null
+            ? null
+            : {
+                ...monitor.breaker,
+                lastUpdatedAt:
+                  monitor.breaker.lastUpdatedAt === null
+                    ? null
+                    : monitor.breaker.lastUpdatedAt + 120,
+                lastStatusUpdatedAt: monitor.breaker.lastStatusUpdatedAt + 120,
+              },
+      })),
+      sources: item.sources.map((source) => ({
+        ...source,
+        observationAt:
+          source.observationAt === null ? null : source.observationAt + 120,
+        fetchedAt: source.fetchedAt === null ? null : source.fetchedAt + 120,
+        lastTradeAt:
+          source.lastTradeAt === null ? null : source.lastTradeAt + 120,
+      })),
+    })),
+  };
+  await page.route("**/api/peg-monitoring", async (route) => {
+    boardRequests += 1;
+    await route.fulfill({
+      json: boardRequests === 1 ? payload : resumedPayload,
+    });
+  });
+  await page.route("**/api/peg-monitoring/alerts", async (route) => {
+    await route.fulfill({
+      json: { from: now - 7 * 86_400, to: now, events: [] },
+    });
+  });
+  await page.goto("/peg-monitoring");
+
+  const aggregate = page.getByTestId("peg-aggregate-status");
+  await expect(aggregate).toHaveText("1 of 1 peg healthy");
+  expect(boardRequests).toBe(1);
+
+  await page.evaluate(() => {
+    (
+      window as Window & {
+        __setPegTestVisibility?: (state: DocumentVisibilityState) => void;
+      }
+    ).__setPegTestVisibility?.("hidden");
+  });
+  await page.clock.runFor(100_000);
+  expect(boardRequests).toBe(1);
+
+  await page.evaluate(() => {
+    (
+      window as Window & {
+        __setPegTestVisibility?: (state: DocumentVisibilityState) => void;
+      }
+    ).__setPegTestVisibility?.("visible");
+  });
+  await page.clock.runFor(1);
+  await expect.poll(() => boardRequests).toBe(2);
+  await expect(aggregate).toHaveText("1 of 1 peg healthy");
+  await expect(aggregate).not.toContainText("latest data is stale");
+});


### PR DESCRIPTION
## The Problem

- A hidden peg-monitoring tab stops polling but keeps advancing its local freshness clock.
- The board can show `latest data is stale` after the tab resumes, even when the producer and browser requests are healthy.

## The Solution

- Refresh the peg-monitoring board when the document becomes visible or the window regains focus.
- Limit focus-triggered refreshes to the existing 30-second board cadence.

## Details

### Invariants

- Hidden tabs still do not poll.
- Reconnect revalidation stays disabled.
- The existing two-consecutive-failure guard stays unchanged.
- The exception applies only to the same-origin peg board read. Hasura polling hooks keep focus revalidation disabled.

### Degraded behavior

- A resumed refresh can still fail. SWR keeps the last package, and the board needs two consecutive refresh failures before it reports a transport error.
- The existing 90-second payload-age check still reports a genuinely stale package.

### Intentional non-goals

- This PR does not change the 90-second stale threshold or the 30-second polling interval.
- This PR does not add successful-but-stale payload telemetry. Issue #1861 remains open until production resume behavior is verified.

## Validation

- `CI=true pnpm agent:quality-gate --run` — all mapped dashboard, browser, coverage, size, dependency, React Doctor, and Terraform checks passed.
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/hooks/__tests__/use-peg-monitoring.test.ts` — 2 tests passed.
- `pnpm --filter @mento-protocol/ui-dashboard test:browser peg-monitoring.test.ts` — 3 tests passed.
- Local browser verification — a hidden tab made no board requests; the visible transition refreshed the board from request 1 to request 2; the board returned to healthy; no console errors.
- Deterministic local autoreview — clean.
- Fresh-context sealed-bundle autoreview — clean, 0.95 confidence.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This change restores an existing refresh behavior at one hook and does not constrain subsystem architecture.

Refs #1861

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one dashboard SWR hook for a same-origin read; polling and failure semantics stay the same aside from an extra refresh when the tab regains focus.
> 
> **Overview**
> Fixes peg boards that falsely showed **latest data is stale** after a tab was hidden: polling still pauses while hidden, but returning to the tab now triggers a same-origin `/api/peg-monitoring` refresh instead of sitting on an aged payload until the next interval.
> 
> `usePegMonitoring` turns on **`revalidateOnFocus`** and sets **`focusThrottleInterval`** to the existing 30s board cadence. Hidden-tab polling, reconnect revalidation, and the two-failure error guard are unchanged.
> 
> Unit expectations and a Playwright test cover the resumed-tab path (no requests while hidden, one refresh on visible, healthy aggregate without stale messaging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f144ea85ee72987691b500c2d8be948d8b61e46c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->