### PR TITLE
feat(peg): explain alert causes across monitoring

### DIFF
--- a/alerts/rules/peg-copy-locals.tf
+++ b/alerts/rules/peg-copy-locals.tf
@@ -1,0 +1,94 @@
+# Peg alert summaries are user-facing copy. Rule names stay stable because
+# Grafana uses them as alert identity, while summaries lead with the concrete
+# cause shown in Grafana, Slack, and Splunk On-Call.
+locals {
+  peg_asset_symbol_display_names = {
+    europ = "EUROP"
+    kesm  = "KESm"
+  }
+  peg_provider_display_names = {
+    bitvavo = "Bitvavo"
+    kraken  = "Kraken"
+    valr    = "VALR"
+  }
+  peg_asset_display_names = merge(
+    {
+      for asset_id in keys(local.peg_active_assets) : asset_id => lookup(
+        local.peg_asset_symbol_display_names,
+        split("-", asset_id)[0],
+        upper(split("-", asset_id)[0]),
+      )
+    },
+    {
+      for asset_id in keys(local.peg_previous_assets) : asset_id => lookup(
+        local.peg_asset_symbol_display_names,
+        split("-", asset_id)[0],
+        upper(split("-", asset_id)[0]),
+      )
+    },
+  )
+  peg_source_display_names = merge(
+    {
+      for key, item in local.peg_active_sources : key => lookup(
+        local.peg_provider_display_names,
+        split("_", item.source_id)[0],
+        title(split("_", item.source_id)[0]),
+      )
+    },
+    {
+      for key, item in local.peg_previous_sources : key => lookup(
+        local.peg_provider_display_names,
+        split("_", item.source_id)[0],
+        title(split("_", item.source_id)[0]),
+      )
+    },
+  )
+
+  peg_source_failure_summary_template = chomp(<<-EOT
+{{ if eq (printf "%.0f" $values.Reason.Value) "1" }}__SOURCE__ is rejecting price requests because its rate limit is reached{{ if and $values.HttpStatus (gt $values.HttpStatus.Value 0.0) }} (HTTP {{ printf "%.0f" $values.HttpStatus.Value }}){{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "2" }}__SOURCE__ price request returns {{ if and $values.HttpStatus (gt $values.HttpStatus.Value 0.0) }}HTTP {{ printf "%.0f" $values.HttpStatus.Value }}{{ else }}an HTTP error{{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "3" }}__SOURCE__ price request is timing out{{ else if eq (printf "%.0f" $values.Reason.Value) "4" }}__SOURCE__ cannot be reached{{ else if eq (printf "%.0f" $values.Reason.Value) "5" }}__SOURCE__ is returning invalid price data{{ else if eq (printf "%.0f" $values.Reason.Value) "6" }}__SOURCE__ price data has stopped updating{{ else if eq (printf "%.0f" $values.Reason.Value) "7" }}__SOURCE__ is repeating old price data{{ else if eq (printf "%.0f" $values.Reason.Value) "8" }}__SOURCE__ cannot fill the monitored sell size{{ if and $values.Fill (ge $values.Fill.Value 0.0) }}; only {{ printf "%.4g" $values.Fill.Value }}% is available{{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "9" }}__SOURCE__ market is halted{{ else if eq (printf "%.0f" $values.Reason.Value) "10" }}__SOURCE__ price cannot be converted to the peg currency{{ else if eq (printf "%.0f" $values.Reason.Value) "11" }}__SOURCE__ price conversion is failing{{ else if eq (printf "%.0f" $values.Reason.Value) "16" }}Pool data does not provide the monitored sell size{{ else if eq (printf "%.0f" $values.Reason.Value) "17" }}__SOURCE__ is not supported by the monitor{{ else if eq (printf "%.0f" $values.Reason.Value) "19" }}Multiple failures are preventing a usable __SOURCE__ price{{ else if eq (printf "%.0f" $values.Reason.Value) "20" }}__SOURCE__ does not list this market{{ else }}__SOURCE__ is not providing a usable sell price{{ end }}
+EOT
+  )
+
+  peg_source_failure_resolved_summary_template = chomp(<<-EOT
+{{ if eq (printf "%.0f" $values.Reason.Value) "1" }}__SOURCE__ rejected price requests because its rate limit was reached{{ if and $values.HttpStatus (gt $values.HttpStatus.Value 0.0) }} (HTTP {{ printf "%.0f" $values.HttpStatus.Value }}){{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "2" }}__SOURCE__ price request returned {{ if and $values.HttpStatus (gt $values.HttpStatus.Value 0.0) }}HTTP {{ printf "%.0f" $values.HttpStatus.Value }}{{ else }}an HTTP error{{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "3" }}__SOURCE__ price request timed out{{ else if eq (printf "%.0f" $values.Reason.Value) "4" }}__SOURCE__ could not be reached{{ else if eq (printf "%.0f" $values.Reason.Value) "5" }}__SOURCE__ returned invalid price data{{ else if eq (printf "%.0f" $values.Reason.Value) "6" }}__SOURCE__ price data stopped updating{{ else if eq (printf "%.0f" $values.Reason.Value) "7" }}__SOURCE__ repeated old price data{{ else if eq (printf "%.0f" $values.Reason.Value) "8" }}__SOURCE__ could not fill the monitored sell size{{ if and $values.Fill (ge $values.Fill.Value 0.0) }}; only {{ printf "%.4g" $values.Fill.Value }}% was available{{ end }}{{ else if eq (printf "%.0f" $values.Reason.Value) "9" }}__SOURCE__ market was halted{{ else if eq (printf "%.0f" $values.Reason.Value) "10" }}__SOURCE__ price could not be converted to the peg currency{{ else if eq (printf "%.0f" $values.Reason.Value) "11" }}__SOURCE__ price conversion failed{{ else if eq (printf "%.0f" $values.Reason.Value) "16" }}Pool data did not provide the monitored sell size{{ else if eq (printf "%.0f" $values.Reason.Value) "17" }}__SOURCE__ was not supported by the monitor{{ else if eq (printf "%.0f" $values.Reason.Value) "19" }}Multiple failures prevented a usable __SOURCE__ price{{ else if eq (printf "%.0f" $values.Reason.Value) "20" }}__SOURCE__ did not list this market{{ else }}__SOURCE__ price data is usable again{{ end }}
+EOT
+  )
+
+  peg_active_source_failure_summaries = {
+    for key, item in local.peg_active_sources : key => replace(
+      local.peg_source_failure_summary_template,
+      "__SOURCE__",
+      local.peg_source_display_names[key],
+    )
+  }
+  peg_active_source_failure_resolved_summaries = {
+    for key, item in local.peg_active_sources : key => replace(
+      local.peg_source_failure_resolved_summary_template,
+      "__SOURCE__",
+      local.peg_source_display_names[key],
+    )
+  }
+  peg_previous_source_failure_summaries = {
+    for key, item in local.peg_previous_sources : key => replace(
+      local.peg_source_failure_summary_template,
+      "__SOURCE__",
+      local.peg_source_display_names[key],
+    )
+  }
+  peg_previous_source_failure_resolved_summaries = {
+    for key, item in local.peg_previous_sources : key => replace(
+      local.peg_source_failure_resolved_summary_template,
+      "__SOURCE__",
+      local.peg_source_display_names[key],
+    )
+  }
+
+  peg_indexed_pool_summary_template = chomp(<<-EOT
+{{ if eq (printf "%.0f" $values.Reason.Value) "12" }}__ASSET__ pool data cannot be fetched{{ else if eq (printf "%.0f" $values.Reason.Value) "13" }}__ASSET__ pool is missing from indexed data{{ else if eq (printf "%.0f" $values.Reason.Value) "14" }}__ASSET__ indexed pool does not match the registry{{ else if eq (printf "%.0f" $values.Reason.Value) "15" }}__ASSET__ pool data is invalid{{ else if eq (printf "%.0f" $values.Reason.Value) "19" }}Multiple indexed-data failures are blocking the __ASSET__ pool{{ else }}__ASSET__ pool data is unavailable{{ end }}
+EOT
+  )
+  peg_indexed_pool_resolved_summary_template = chomp(<<-EOT
+{{ if eq (printf "%.0f" $values.Reason.Value) "12" }}__ASSET__ pool data could not be fetched{{ else if eq (printf "%.0f" $values.Reason.Value) "13" }}__ASSET__ pool was missing from indexed data{{ else if eq (printf "%.0f" $values.Reason.Value) "14" }}__ASSET__ indexed pool did not match the registry{{ else if eq (printf "%.0f" $values.Reason.Value) "15" }}__ASSET__ pool data was invalid{{ else if eq (printf "%.0f" $values.Reason.Value) "19" }}Multiple indexed-data failures blocked the __ASSET__ pool{{ else }}__ASSET__ pool data is available again{{ end }}
+EOT
+  )
+}

--- a/alerts/rules/peg-message-templates.tf
+++ b/alerts/rules/peg-message-templates.tf
@@ -9,7 +9,11 @@ resource "grafana_message_template" "peg_slack_title" {
   name     = "Peg - Slack Title"
   template = <<-EOT
 {{ define "peg.slack.title" -}}
-{{ if (len .Alerts.Firing) }}{{ if eq .CommonLabels.severity "critical" }}🚨{{ else }}🟡{{ end }}{{ else }}✅{{ end }} {{ with .CommonLabels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}
+{{ if (len .Alerts.Firing) -}}
+{{ if eq .CommonLabels.severity "critical" }}🚨{{ else }}🟡{{ end }} {{ range $i, $alert := .Alerts.Firing }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.summary }}{{ . }}{{ else }}Peg monitoring needs attention{{ end }}{{ end }}
+{{- else -}}
+✅ {{ range $i, $alert := .Alerts.Resolved }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.resolved_summary }}{{ . }}{{ else }}Peg monitoring recovered{{ end }}{{ end }}
+{{- end }}
 {{- end }}
 EOT
 }
@@ -21,11 +25,12 @@ resource "grafana_message_template" "peg_slack_message" {
   template = <<-EOT
 {{ define "peg.slack.message" }}
 {{ if and (len .Alerts.Firing) (eq .CommonLabels.severity "critical") -}}
-<!subteam^${var.oncall_support_usergroup_id}> Please investigate this critical Peg alert.
+<!subteam^${var.oncall_support_usergroup_id}> Please investigate.
 {{ end -}}
 {{ range .Alerts.Firing -}}
-*FIRING: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}* — `{{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}`{{ with .Labels.source }} / `{{ . }}`{{ end }}
-{{ with .Annotations.summary }}{{ . }}{{ end }}
+{{ with .Annotations.summary }}*{{ . }}*{{ else }}*Peg monitoring needs attention*{{ end }}
+{{ with .Annotations.asset_name }}*Asset:* {{ . }}{{ end }}
+{{ with .Annotations.source_name }}*Source:* {{ . }}{{ end }}
 {{ with .Annotations.executable_price }}*Executable price:* {{ . }}{{ end }}
 {{ with .Annotations.deviation_bps }}*Downside deviation:* {{ . }} bps{{ end }}
 {{ with .Annotations.premium_bps }}*Premium:* {{ . }} bps{{ end }}
@@ -35,15 +40,15 @@ resource "grafana_message_template" "peg_slack_message" {
 {{ with .Annotations.listing_check_age }}*Listing checked:* {{ . }}{{ end }}
 {{ with .Annotations.structural_saturation }}*Structural saturation:* {{ . }}{{ end }}
 {{ with .Annotations.corroboration }}*Corroboration:* {{ . }}{{ end }}
-*Policy:* `{{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}`
 {{ with .Annotations.action }}*Action:* {{ . }}{{ end }}
 *Started:* {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
 *Alert ID:* `{{ .Fingerprint }}`
 {{ end -}}
 {{ range .Alerts.Resolved -}}
-*RESOLVED: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg monitoring{{ end }}* — `{{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}`{{ with .Labels.source }} / `{{ . }}`{{ end }}
-*Policy:* `{{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}`
-*Resolved:* {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+{{ with .Annotations.resolved_summary }}*{{ . }}*{{ else }}*Peg monitoring recovered*{{ end }}
+{{ with .Annotations.asset_name }}*Asset:* {{ . }}{{ end }}
+{{ with .Annotations.source_name }}*Source:* {{ . }}{{ end }}
+*Ended:* {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
 *Alert ID:* `{{ .Fingerprint }}`
 {{ end -}}
 {{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}No peg alerts are present in this notification.{{ end }}
@@ -58,11 +63,11 @@ resource "grafana_message_template" "peg_victorops_title" {
   template = <<-EOT
 {{ define "peg.victorops.title" -}}
 {{ if (len .Alerts.Firing) -}}
-P1 {{ range $i, $alert := .Alerts.Firing }}{{ if $i }}, {{ end }}{{ with $alert.Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}: {{ with $alert.Labels.alertname }}{{ . }}{{ else }}peg page{{ end }}{{ end }}
+P1 {{ range $i, $alert := .Alerts.Firing }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.summary }}{{ . }}{{ else }}Peg monitoring needs attention{{ end }}{{ end }}
 {{- end }}
 {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end -}}
 {{ if (len .Alerts.Resolved) -}}
-RESOLVED {{ range $i, $alert := .Alerts.Resolved }}{{ if $i }}, {{ end }}{{ with $alert.Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}: {{ with $alert.Labels.alertname }}{{ . }}{{ else }}peg page{{ end }}{{ end }}
+RESOLVED {{ range $i, $alert := .Alerts.Resolved }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.resolved_summary }}{{ . }}{{ else }}Peg monitoring recovered{{ end }}{{ end }}
 {{- end }}
 {{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}Peg status unknown{{ end }}
 {{- end }}
@@ -77,7 +82,7 @@ resource "grafana_message_template" "peg_victorops_message" {
 {{ define "peg.victorops.message" }}
 {{ range .Alerts.Firing -}}
 PROBLEM: {{ with .Annotations.summary }}{{ . }}{{ else }}A peg page is firing.{{ end }}
-POLICY: {{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}{{ with .Labels.source }} SOURCE: {{ . }}{{ end }}
+{{ with .Annotations.asset_name }}ASSET: {{ . }}{{ end }}{{ with .Annotations.source_name }} SOURCE: {{ . }}{{ end }}
 {{ with .Annotations.executable_price }}EXECUTABLE PRICE: {{ . }}{{ end }}
 {{ with .Annotations.deviation_bps }}DOWNSIDE DEVIATION: {{ . }} bps{{ end }}
 {{ with .Annotations.premium_bps }}PREMIUM: {{ . }} bps{{ end }}
@@ -92,9 +97,8 @@ Started: {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
 Alert: {{ .GeneratorURL }}
 {{ end -}}
 {{ range .Alerts.Resolved -}}
-RESOLVED: {{ with .Labels.alertname }}{{ . }}{{ else }}Peg page{{ end }} for {{ with .Labels.asset }}{{ . }}{{ else }}unknown asset{{ end }}.
-Policy: {{ with .Labels.policy_version }}{{ . }}{{ else }}unknown{{ end }}
-Resolved: {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+RESOLVED: {{ with .Annotations.resolved_summary }}{{ . }}{{ else }}Peg monitoring recovered{{ end }}
+Ended: {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
 {{ end -}}
 {{ if and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 0) }}Peg status unknown.{{ end }}
 {{ end }}

--- a/alerts/rules/peg-rule-definitions.tf
+++ b/alerts/rules/peg-rule-definitions.tf
@@ -17,7 +17,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Executable downside deviation is sustained above the warning threshold."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
         action             = "Compare the deep and secondary books, then inspect pool-flow saturation before escalating."
         notification       = local.peg_notify_market_warning
       }
@@ -38,7 +39,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Executable sell price is sustained above the premium warning threshold."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}above peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}above peg"
         action             = "Review reserve-side exposure; premium is warning-only and never pages the drain path."
         notification       = local.peg_notify_market_warning
       }
@@ -60,7 +62,8 @@ locals {
         spread_expr        = local.peg_active_spread_context_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_active_corroboration_promql[item.asset_id]
-        summary            = "The policy-designated deep venue has a sustained executable downside deviation."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
         action             = "Verify the deep book and structural flow, then follow the breaker-multisig decision runbook."
         notification       = local.peg_notify_page
       }
@@ -81,7 +84,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The deep venue spread exceeds its approved envelope."
+        summary            = "${local.peg_source_display_names[key]} buy and sell prices are {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ else }}unusually far {{ end }}apart"
+        resolved_summary   = "${local.peg_source_display_names[key]} buy and sell prices were {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ else }}unusually far {{ end }}apart"
         action             = "Check whether the book is evacuating or merely widening within a transient venue event."
         notification       = local.peg_notify_market_warning
       }
@@ -102,7 +106,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_active_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Indexed-pool directional flow is near the enforced trading-limit rate."
+        summary            = "${local.peg_asset_display_names[asset_id]} pool flow {{ if $values.Structural }}is using {{ printf \"%.4g\" $values.Structural.Value }}% of its trading limit{{ else }}is close to its trading limit{{ end }}"
+        resolved_summary   = "${local.peg_asset_display_names[asset_id]} pool flow {{ if $values.Structural }}used {{ printf \"%.4g\" $values.Structural.Value }}% of its trading limit{{ else }}was close to its trading limit{{ end }}"
         action             = "Inspect pool flow and counterparties; structural saturation alone never pages."
         notification       = local.peg_notify_market_warning
       }
@@ -123,7 +128,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_active_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "No usable uncapped price exists on the policy-designated deep venue."
+        summary            = local.peg_active_source_failure_summaries["${asset_id}/${asset.deepVenueSource}"]
+        resolved_summary   = local.peg_active_source_failure_resolved_summaries["${asset_id}/${asset.deepVenueSource}"]
         action             = "Inspect book depth and venue health; the consecutive-poll duration is derived from policy cadence."
         notification       = local.peg_notify_ops_warning
       }
@@ -145,7 +151,8 @@ locals {
         spread_expr        = local.peg_active_spread_context_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_active_structural_context_promql[asset_id]
         corroboration_expr = local.peg_active_corroboration_promql[asset_id]
-        summary            = "The deep venue is blind while an independent stress leg is active."
+        summary            = "${local.peg_active_source_failure_summaries["${asset_id}/${asset.deepVenueSource}"]} while separate market data also shows stress"
+        resolved_summary   = "${local.peg_active_source_failure_resolved_summaries["${asset_id}/${asset.deepVenueSource}"]} while separate market data also showed stress"
         action             = "Treat this as a page: verify partial-price shortfall, spread, and structural flow before breaker action."
         notification       = local.peg_notify_page
       }
@@ -167,7 +174,8 @@ locals {
         listing_age_expr   = local.peg_active_listing_age_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The producer confirms that this non-deep policy source's exact pair is absent."
+        summary            = "${local.peg_source_display_names[key]} does not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
+        resolved_summary   = "${local.peg_source_display_names[key]} did not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
         action             = "Verify the provider listing, then replace or remove the source through reviewed registry and policy cleanup."
         notification       = local.peg_notify_ops_warning
       }
@@ -189,7 +197,8 @@ locals {
         listing_age_expr   = local.peg_active_listing_age_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The producer confirms that the policy-designated deep pair is absent."
+        summary            = "${local.peg_source_display_names[key]} does not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
+        resolved_summary   = "${local.peg_source_display_names[key]} did not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
         action             = "Treat the critical path as unreachable and re-onboard a replacement deep source through reviewed policy."
         notification       = local.peg_notify_ops_warning
       }
@@ -210,7 +219,8 @@ locals {
         fill_expr          = local.peg_empty_context_promql
         structural_expr    = local.peg_active_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The registry-bound indexed pool is unreachable while the exact-version peg loop remains fresh."
+        summary            = replace(local.peg_indexed_pool_summary_template, "__ASSET__", local.peg_asset_display_names[asset_id])
+        resolved_summary   = replace(local.peg_indexed_pool_resolved_summary_template, "__ASSET__", local.peg_asset_display_names[asset_id])
         action             = "Inspect Hasura pool resolution and indexer coverage; use the heartbeat alert for a complete loop outage."
         notification       = local.peg_notify_ops_warning
       }
@@ -231,7 +241,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "A peg venue adapter is unhealthy while the isolated peg loop remains live."
+        summary            = local.peg_active_source_failure_summaries[key]
+        resolved_summary   = local.peg_active_source_failure_resolved_summaries[key]
         action             = "Inspect bounded peg error channels and venue/API status; this ops signal never pages."
         notification       = local.peg_notify_ops_warning
       }
@@ -252,7 +263,8 @@ locals {
         fill_expr          = local.peg_active_fill_promql[key]
         structural_expr    = local.peg_active_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "A non-primary peg source has remained unhealthy for the policy dead-source interval."
+        summary            = local.peg_active_source_failure_summaries[key]
+        resolved_summary   = local.peg_active_source_failure_resolved_summaries[key]
         action             = "Re-census the venue and prepare a source-controlled registry/policy cleanup if the listing is gone."
         notification       = local.peg_notify_ops_warning
       }
@@ -273,7 +285,8 @@ locals {
         fill_expr          = local.peg_empty_context_promql
         structural_expr    = local.peg_active_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The isolated peg loop has not completed an asset poll within the freshness grace."
+        summary            = "${local.peg_asset_display_names[asset_id]} monitor data has stopped updating"
+        resolved_summary   = "${local.peg_asset_display_names[asset_id]} monitor data stopped updating"
         action             = "Check metrics-bridge peg-loop logs and policy fetch health before trusting market decisions."
         notification       = local.peg_notify_ops_warning
       }
@@ -299,7 +312,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Retained-policy executable downside deviation remains above warning."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
         action             = "Evaluate this policy version independently; remove retained rules only through the reviewed JSON cleanup."
         notification       = local.peg_notify_market_warning
       }
@@ -320,7 +334,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Retained-policy executable premium remains above warning."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}above peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}above peg"
         action             = "Review reserve-side exposure under the retained policy."
         notification       = local.peg_notify_market_warning
       }
@@ -342,7 +357,8 @@ locals {
         spread_expr        = local.peg_previous_spread_context_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_previous_corroboration_promql[item.asset_id]
-        summary            = "The retained policy's deep venue has a sustained critical downside deviation."
+        summary            = "${local.peg_source_display_names[key]} sell price is {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
+        resolved_summary   = "${local.peg_source_display_names[key]} sell price was {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ end }}below peg"
         action             = "Treat this version independently until source-controlled cleanup removes it."
         notification       = local.peg_notify_page
       }
@@ -363,7 +379,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The retained policy's deep-venue spread exceeds its envelope."
+        summary            = "${local.peg_source_display_names[key]} buy and sell prices are {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ else }}unusually far {{ end }}apart"
+        resolved_summary   = "${local.peg_source_display_names[key]} buy and sell prices were {{ if $values.A }}{{ printf \"%.4g\" $values.A.Value }} bps {{ else }}unusually far {{ end }}apart"
         action             = "Inspect the retained policy's venue state."
         notification       = local.peg_notify_market_warning
       }
@@ -384,7 +401,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_previous_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "Retained-policy structural saturation remains elevated."
+        summary            = "${local.peg_asset_display_names[asset_id]} pool flow {{ if $values.Structural }}is using {{ printf \"%.4g\" $values.Structural.Value }}% of its trading limit{{ else }}is close to its trading limit{{ end }}"
+        resolved_summary   = "${local.peg_asset_display_names[asset_id]} pool flow {{ if $values.Structural }}used {{ printf \"%.4g\" $values.Structural.Value }}% of its trading limit{{ else }}was close to its trading limit{{ end }}"
         action             = "Inspect pool flow under the retained policy."
         notification       = local.peg_notify_market_warning
       }
@@ -405,7 +423,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_previous_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The retained policy has no usable deep-venue price."
+        summary            = local.peg_previous_source_failure_summaries["${asset_id}/${asset.deepVenueSource}"]
+        resolved_summary   = local.peg_previous_source_failure_resolved_summaries["${asset_id}/${asset.deepVenueSource}"]
         action             = "Inspect retained-policy venue health; do not gate this rule on the active ACK."
         notification       = local.peg_notify_ops_warning
       }
@@ -427,7 +446,8 @@ locals {
         spread_expr        = local.peg_previous_spread_context_promql["${asset_id}/${asset.deepVenueSource}"]
         structural_expr    = local.peg_previous_structural_context_promql[asset_id]
         corroboration_expr = local.peg_previous_corroboration_promql[asset_id]
-        summary            = "The retained policy is blind while an independent stress leg is active."
+        summary            = "${local.peg_previous_source_failure_summaries["${asset_id}/${asset.deepVenueSource}"]} while separate market data also shows stress"
+        resolved_summary   = "${local.peg_previous_source_failure_resolved_summaries["${asset_id}/${asset.deepVenueSource}"]} while separate market data also showed stress"
         action             = "Verify partial-price shortfall, spread, and structural flow before breaker action."
         notification       = local.peg_notify_page
       }
@@ -449,7 +469,8 @@ locals {
         listing_age_expr   = local.peg_previous_listing_age_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The producer confirms that this retained non-deep policy source's exact pair is absent."
+        summary            = "${local.peg_source_display_names[key]} does not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
+        resolved_summary   = "${local.peg_source_display_names[key]} did not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
         action             = "Verify the retained version independently; remove or replace its source only through reviewed cleanup."
         notification       = local.peg_notify_ops_warning
       }
@@ -471,7 +492,8 @@ locals {
         listing_age_expr   = local.peg_previous_listing_age_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The producer confirms that the retained policy's deep pair is absent."
+        summary            = "${local.peg_source_display_names[key]} does not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
+        resolved_summary   = "${local.peg_source_display_names[key]} did not list the ${local.peg_asset_display_names[item.asset_id]}/${upper(split("_", item.source_id)[1])} market"
         action             = "Treat this retained critical path as unreachable until reviewed policy cleanup removes or replaces it."
         notification       = local.peg_notify_ops_warning
       }
@@ -492,7 +514,8 @@ locals {
         fill_expr          = local.peg_empty_context_promql
         structural_expr    = local.peg_previous_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The retained policy's registry-bound indexed pool is unreachable while its peg loop remains fresh."
+        summary            = replace(local.peg_indexed_pool_summary_template, "__ASSET__", local.peg_asset_display_names[asset_id])
+        resolved_summary   = replace(local.peg_indexed_pool_resolved_summary_template, "__ASSET__", local.peg_asset_display_names[asset_id])
         action             = "Inspect Hasura pool resolution and retain this rule until reviewed policy cleanup removes the version."
         notification       = local.peg_notify_ops_warning
       }
@@ -513,7 +536,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "A retained-policy source is unhealthy."
+        summary            = local.peg_previous_source_failure_summaries[key]
+        resolved_summary   = local.peg_previous_source_failure_resolved_summaries[key]
         action             = "Inspect the retained policy's venue/API path."
         notification       = local.peg_notify_ops_warning
       }
@@ -534,7 +558,8 @@ locals {
         fill_expr          = local.peg_previous_fill_promql[key]
         structural_expr    = local.peg_previous_structural_context_promql[item.asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "A retained-policy non-primary source is permanently dead."
+        summary            = local.peg_previous_source_failure_summaries[key]
+        resolved_summary   = local.peg_previous_source_failure_resolved_summaries[key]
         action             = "Remove it only through reviewed retained-policy cleanup."
         notification       = local.peg_notify_ops_warning
       }
@@ -555,7 +580,8 @@ locals {
         fill_expr          = local.peg_empty_context_promql
         structural_expr    = local.peg_previous_structural_context_promql[asset_id]
         corroboration_expr = local.peg_no_corroboration_promql
-        summary            = "The retained policy has no fresh peg-loop heartbeat."
+        summary            = "${local.peg_asset_display_names[asset_id]} monitor data has stopped updating"
+        resolved_summary   = "${local.peg_asset_display_names[asset_id]} monitor data stopped updating"
         action             = "Keep retained rules live until explicit source-controlled cleanup."
         notification       = local.peg_notify_ops_warning
       }
@@ -578,7 +604,8 @@ locals {
       fill_expr          = local.peg_empty_context_promql
       structural_expr    = local.peg_empty_context_promql
       corroboration_expr = local.peg_no_corroboration_promql
-      summary            = "The producer has not acknowledged the active gated peg policy within its expected window."
+      summary            = "Peg monitor has not loaded policy ${local.peg_active_policy_version}"
+      resolved_summary   = "Peg monitor did not load policy ${local.peg_active_policy_version}"
       action             = "Check private policy fetch/auth and bridge peg-loop logs; do not remove the retained policy."
       notification       = local.peg_notify_ops_warning
     }

--- a/alerts/rules/peg-rule-definitions.tftest.hcl
+++ b/alerts/rules/peg-rule-definitions.tftest.hcl
@@ -26,6 +26,55 @@ run "peg_rule_definitions_preserve_consumer_guard_invariant" {
   }
 
   assert {
+    condition = alltrue([
+      for rule in values(local.peg_rule_definitions) :
+      trimspace(rule.summary) != "" && trimspace(rule.resolved_summary) != ""
+    ])
+    error_message = "Every Peg rule must provide cause-first firing and resolved copy."
+  }
+
+  assert {
+    condition = (
+      strcontains(local.peg_rule_definitions["active-downside-europ-schuman/bitvavo_eur"].summary, "Bitvavo sell price is") &&
+      strcontains(local.peg_rule_definitions["active-downside-europ-schuman/bitvavo_eur"].summary, "below peg") &&
+      strcontains(local.peg_rule_definitions["active-premium-europ-schuman/bitvavo_eur"].summary, "above peg") &&
+      strcontains(local.peg_rule_definitions["active-spread-europ-schuman/bitvavo_eur"].summary, "Bitvavo buy and sell prices are") &&
+      strcontains(local.peg_rule_definitions["active-structural-europ-schuman"].summary, "EUROP pool flow") &&
+      local.peg_rule_definitions["active-registry-rot-europ-schuman/kraken_usd"].summary == "Kraken does not list the EUROP/USD market"
+    )
+    error_message = "Peg market and listing rules must use the approved cause-first wording."
+  }
+
+  assert {
+    condition = (
+      local.peg_asset_symbol_display_names["kesm"] == "KESm" &&
+      local.peg_provider_display_names["valr"] == "VALR"
+    )
+    error_message = "Peg copy must preserve canonical asset and provider casing."
+  }
+
+  assert {
+    condition = (
+      strcontains(local.peg_rule_definitions["active-unhealthy-europ-schuman/bitvavo_eur"].summary, "rate limit is reached") &&
+      strcontains(local.peg_rule_definitions["active-unhealthy-europ-schuman/bitvavo_eur"].summary, "price request returns") &&
+      strcontains(local.peg_rule_definitions["active-unhealthy-europ-schuman/bitvavo_eur"].summary, "price request is timing out") &&
+      strcontains(local.peg_rule_definitions["active-unhealthy-europ-schuman/bitvavo_eur"].summary, "cannot be reached")
+    )
+    error_message = "Peg source alerts must expose bounded provider failure reasons."
+  }
+
+  assert {
+    condition = (
+      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "$alert.Annotations.summary") &&
+      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "$alert.Annotations.resolved_summary") &&
+      !strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, ".CommonLabels.alertname") &&
+      !strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "FIRING:") &&
+      !strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "*Policy:*")
+    )
+    error_message = "Peg Slack copy must lead with the cause and leave state to the title icon."
+  }
+
+  assert {
     condition = alltrue(concat(
       [
         for key, item in local.peg_active_sources :

--- a/alerts/rules/rules-peg.tf
+++ b/alerts/rules/rules-peg.tf
@@ -22,7 +22,10 @@ resource "grafana_rule_group" "peg_monitoring" {
 
       annotations = {
         summary          = rule.value.summary
+        resolved_summary = rule.value.resolved_summary
         action           = rule.value.action
+        asset_name       = rule.value.asset == "policy" ? "Peg monitor" : local.peg_asset_display_names[rule.value.asset]
+        source_name      = rule.value.source == "" ? "" : local.peg_source_display_names["${rule.value.asset}/${rule.value.source}"]
         executable_price = "{{ if and $values.Price (ge $values.Price.Value 0.0) }}{{ printf \"%.6f\" $values.Price.Value }}{{ else }}unavailable{{ end }}"
         deviation_bps = (
           startswith(rule.value.name, "Peg Downside Warning") || startswith(rule.value.name, "Peg Deep-Venue Downside Critical")
@@ -47,9 +50,9 @@ resource "grafana_rule_group" "peg_monitoring" {
           : ""
         )
         structural_saturation = "{{ if and $values.Structural (ge $values.Structural.Value 0.0) }}{{ printf \"%.1f%%\" $values.Structural.Value }}{{ else }}unavailable{{ end }}"
-        corroboration = startswith(rule.value.name, "Peg Blind While Stressed Critical") ? "blindness plus structural saturation, spread, or partial-price shortfall" : (
+        corroboration = startswith(rule.value.name, "Peg Blind While Stressed Critical") ? "separate market data also shows stress" : (
           startswith(rule.value.name, "Peg Deep-Venue Downside Critical")
-          ? "{{ if and $values.Corroboration (gt $values.Corroboration.Value 0.0) }}structural saturation or a distinct fresh uncapped venue{{ else }}none required; deep venue pages alone{{ end }}"
+          ? "{{ if and $values.Corroboration (gt $values.Corroboration.Value 0.0) }}separate pool or venue data also shows stress{{ else }}no extra confirmation required{{ end }}"
           : ""
         )
       }
@@ -157,6 +160,50 @@ resource "grafana_rule_group" "peg_monitoring" {
         model = jsonencode({
           refId   = "Corroboration"
           expr    = rule.value.corroboration_expr
+          instant = true
+        })
+      }
+
+      # These helper values are stored with each Grafana state transition.
+      # They do not participate in the alert condition or instance labels.
+      data {
+        ref_id         = "Reason"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId = "Reason"
+          expr = rule.value.source != "" ? format(
+            "max(mento_peg_source_failure_reason{asset=\"%s\",source=\"%s\",policy_version=\"%s\"}) or on() vector(0)",
+            rule.value.asset,
+            rule.value.source,
+            rule.value.policy_version,
+            ) : rule.value.asset != "policy" ? format(
+            "max(mento_peg_structural_failure_reason{asset=\"%s\",policy_version=\"%s\"}) or on() vector(0)",
+            rule.value.asset,
+            rule.value.policy_version,
+          ) : local.peg_no_corroboration_promql
+          instant = true
+        })
+      }
+
+      data {
+        ref_id         = "HttpStatus"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = max(rule.value.query_range, 60)
+          to   = 0
+        }
+        model = jsonencode({
+          refId = "HttpStatus"
+          expr = rule.value.source != "" ? format(
+            "max(mento_peg_source_failure_http_status{asset=\"%s\",source=\"%s\",policy_version=\"%s\"}) or on() vector(0)",
+            rule.value.asset,
+            rule.value.source,
+            rule.value.policy_version,
+          ) : local.peg_no_corroboration_promql
           instant = true
         })
       }

--- a/docs/adr/0045-peg-paging-semantics.md
+++ b/docs/adr/0045-peg-paging-semantics.md
@@ -3,7 +3,7 @@ title: Peg paging measures executable sell price; the deep venue pages alone
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-15
 scope: metrics-bridge / alerts
 date: 2026-07
 doc_type: adr
@@ -114,6 +114,16 @@ live-proof gates pass.
   needed, is stateful bridge-side work. Source _health_ problems are
   ops-noise tier and never page. Pager trust is a design invariant: the
   critical channel stays quiet enough to be believed.
+- **Failure explanations do not change alert identity.** The producer exposes
+  bounded numeric reason and HTTP-status gauges for source and indexed-pool
+  failures. Grafana reads them through helper queries that never participate
+  in the condition or instance labels. State history records those evaluated
+  values at each transition. The dashboard can therefore distinguish a 429,
+  an HTTP 500, a timeout, insufficient book depth, and other bounded causes
+  without parsing raw errors or changing the alert fingerprint. Resolved rows
+  reuse the fired transition's evidence. Active and retained-previous rules
+  remain independent in Grafana even when the dashboard combines matching
+  rows for display.
 
 ## Alternatives considered
 
@@ -154,6 +164,7 @@ live-proof gates pass.
 - `docs/notes/polygon-monitoring.md` (EURm/EUROP pool, MANUAL feed,
   migration-multisig breaker path)
 - `metrics-bridge/src/peg/order-book.ts`,
+  `metrics-bridge/src/peg/failure-reasons.ts`,
   `metrics-bridge/src/peg/poller.ts`, and
   `metrics-bridge/src/peg/metrics.ts` (implemented measurement semantics)
 - `metrics-bridge/src/peg/poll-cycle.ts` (version-bound decision scheduling

--- a/docs/adr/0063-dashboard-grafana-history-read-access.md
+++ b/docs/adr/0063-dashboard-grafana-history-read-access.md
@@ -3,7 +3,7 @@ title: Peg history reads Grafana Cloud through a dedicated read-only token
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-15
 scope: ui-dashboard / terraform/infra
 date: 2026-08
 doc_type: adr
@@ -95,6 +95,16 @@ History is an isolated failure domain. A Grafana outage, a revoked token, or a
 5xx from a history route must leave the current-state board rendering from the
 decision package. History routes degrade to an unavailable series and never
 block, delay, or fail the current-state fetch.
+
+For recent alert explanations, the dashboard reads the bounded `values` map
+that Grafana writes with each state transition. Peg rules include reason and
+HTTP-status helper queries for this purpose. These queries do not affect the
+condition or instance labels. The dashboard validates a fixed set of query
+keys and maps numeric reason codes to fixed product copy. It does not render
+Grafana errors, provider errors, annotations, URLs, or response bodies. A
+resolved row uses the values from its paired fired transition. The dashboard
+may combine matching active and retained-previous rows for display, but the
+underlying Grafana rule instances remain separate.
 
 ## Alternatives considered
 

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-15
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -105,6 +105,65 @@ the classified query after a representative production window before changing
 that interval; a sustained `upstream-rate-limit` signal is the trigger to
 reassess it.
 
+## Alert history explanations
+
+The dashboard `Recent alerts` list uses cause-first sentences. The state dot
+shows whether the condition is active, urgent, or resolved. Each dot also has
+an accessible state label. The sentence omits Grafana state terms, policy-slot
+terms, and internal rule names. For example, a downside transition reads
+`Bitvavo sell price is 31 bps below peg`.
+
+Grafana rule summaries and Peg notification templates use the same copy
+contract. Grafana keeps the internal rule name stable for alert identity, but
+the user-facing summary leads with the measured cause. Slack titles use the
+severity icon plus that summary. Slack bodies do not repeat `FIRING`,
+`RESOLVED`, the policy slot, or the internal rule name. Resolved notifications
+use the matching past-tense summary. Splunk On-Call uses the same summaries and
+keeps its required `P1` or `RESOLVED` state text because it has no color icon.
+Canonical display-name maps preserve asset and provider casing such as `KESm`
+and `VALR` across the dashboard, Grafana, and notifications.
+
+Grafana state history stores the evaluated query values for each transition.
+Every Peg rule therefore includes two helper queries, `Reason` and
+`HttpStatus`. The helpers do not affect the alert condition. They also stay out
+of instance labels, so a changed failure cause cannot change the alert
+fingerprint. The dashboard uses the fired transition's values for both the
+active row and its later resolved row. It never uses raw provider errors,
+response bodies, request URLs, or annotations as display text.
+
+Metrics Bridge publishes these bounded helper metrics:
+
+- `mento_peg_source_failure_reason` for source and deep-price failures;
+- `mento_peg_source_failure_http_status` for an exact provider HTTP status;
+  and
+- `mento_peg_structural_failure_reason` for indexed-pool failures.
+
+It also increments `mento_peg_failure_events_total` for frequency analysis.
+The counter labels contain a bounded reason, an exact HTTP status from 100
+through 599 or `none`, and the source-controlled asset and source IDs. For
+example, this query measures Bitvavo rate-limit failures:
+
+```promql
+sum(increase(mento_peg_failure_events_total{reason="rate_limited",http_status="429",source="bitvavo_eur"}[24h]))
+```
+
+Use the counter to decide whether the provider poll interval needs adjustment.
+Use the current-state gauges to explain a specific alert transition.
+
+Zero means no known failure. `metrics-bridge/src/peg/failure-reasons.ts` owns
+the stable numeric mapping. The mapping distinguishes rate limits, other HTTP
+errors, timeouts, network failures, invalid or stale data, repeated data,
+insufficient book depth, halted or unlisted markets, conversion failures,
+structural query or data failures, missing reference size, unsupported
+providers, unknown failures, and multiple simultaneous structural failures.
+The HTTP metric is zero when no status applies. A provider HTTP failure retains
+the exact status, such as 429 or 500.
+
+The dashboard combines matching active-policy and retained-previous rows only
+for display when they transition within 90 seconds. Grafana still evaluates,
+routes, and records both rule instances independently. The list does not infer
+policy activation from the first observed policy metric sample.
+
 ## Rule inventory
 
 For each active policy, the generated source defines:
@@ -195,6 +254,10 @@ are true:
 4. `mento_peg_last_poll`, `mento_peg_source_healthy`,
    `mento_peg_observation_at`, `mento_peg_indexed_pool_reachable`, and
    `mento_peg_blind_consecutive_polls` return the expected labelled series.
+   `mento_peg_source_failure_reason`,
+   `mento_peg_source_failure_http_status`, and
+   `mento_peg_structural_failure_reason` return zero for healthy evidence and
+   bounded codes for reproduced failures.
    Every configured source also exposes one-hot `mento_peg_listing_state`, a
    positive `mento_peg_listing_checked_at`, and
    `mento_peg_listing_absent_consecutive_checks` for the exact policy version.

--- a/metrics-bridge/src/peg/failure-reasons.ts
+++ b/metrics-bridge/src/peg/failure-reasons.ts
@@ -1,0 +1,127 @@
+export const PEG_FAILURE_REASON_CODES = {
+  rate_limited: 1,
+  provider_http_error: 2,
+  provider_timeout: 3,
+  provider_network: 4,
+  invalid_response: 5,
+  stale_data: 6,
+  repeated_data: 7,
+  insufficient_liquidity: 8,
+  market_halted: 9,
+  conversion_unavailable: 10,
+  conversion_error: 11,
+  structural_query: 12,
+  structural_missing: 13,
+  structural_binding: 14,
+  structural_data: 15,
+  reference_size_unavailable: 16,
+  unsupported_provider: 17,
+  unknown: 18,
+  multiple_failures: 19,
+  market_unlisted: 20,
+} as const;
+
+export type PegFailureReason = keyof typeof PEG_FAILURE_REASON_CODES;
+
+export interface PegFailureEvidence {
+  reason: PegFailureReason;
+  httpStatus: number | null;
+}
+
+interface MutablePegFailureState {
+  failureReason: PegFailureReason | null;
+  failureHttpStatus: number | null;
+}
+
+export function setPegFailure(
+  state: MutablePegFailureState,
+  evidence: PegFailureEvidence | null,
+): void {
+  state.failureReason = evidence?.reason ?? null;
+  state.failureHttpStatus = evidence?.httpStatus ?? null;
+}
+
+export class PegProviderRequestError extends Error {
+  readonly evidence: PegFailureEvidence;
+
+  constructor(
+    message: string,
+    evidence: PegFailureEvidence,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "PegProviderRequestError";
+    this.evidence = evidence;
+  }
+}
+
+export function providerFailureEvidence(cause: unknown): PegFailureEvidence {
+  if (cause instanceof PegProviderRequestError) return cause.evidence;
+  if (
+    cause instanceof Error &&
+    (cause.name === "AbortError" || cause.name === "TimeoutError")
+  ) {
+    return { reason: "provider_timeout", httpStatus: null };
+  }
+  if (cause instanceof TypeError) {
+    return { reason: "provider_network", httpStatus: null };
+  }
+  return { reason: "invalid_response", httpStatus: null };
+}
+
+export function pegFailureEvidence(
+  kind: string,
+  cause: unknown,
+): PegFailureEvidence {
+  if (kind === "source_fetch") return providerFailureEvidence(cause);
+  if (kind === "source_provider") {
+    return { reason: "unsupported_provider", httpStatus: null };
+  }
+  if (kind === "source_freshness") {
+    const message = cause instanceof Error ? cause.message : "";
+    return {
+      reason:
+        message.includes("replay") || message.includes("identity bound")
+          ? "repeated_data"
+          : "stale_data",
+      httpStatus: null,
+    };
+  }
+  if (kind === "conversion_unavailable") {
+    return { reason: "conversion_unavailable", httpStatus: null };
+  }
+  if (kind === "conversion") {
+    return { reason: "conversion_error", httpStatus: null };
+  }
+  const structuralReason = STRUCTURAL_FAILURE_REASONS[kind];
+  if (structuralReason !== undefined)
+    return { reason: structuralReason, httpStatus: null };
+  return { reason: "unknown", httpStatus: null };
+}
+
+const STRUCTURAL_FAILURE_REASONS: Partial<Record<string, PegFailureReason>> = {
+  structural_query: "structural_query",
+  structural_missing: "structural_missing",
+  structural_binding: "structural_binding",
+  structural_data: "structural_data",
+};
+
+export function failureHttpStatusLabel(httpStatus: number | null): string {
+  if (httpStatus === null) return "none";
+  return Number.isInteger(httpStatus) && httpStatus >= 100 && httpStatus <= 599
+    ? String(httpStatus)
+    : "none";
+}
+
+export function failureReasonCode(reason: PegFailureReason | null): number {
+  return reason === null ? 0 : PEG_FAILURE_REASON_CODES[reason];
+}
+
+export function combineFailureReasons(
+  reasons: readonly (PegFailureReason | null)[],
+): PegFailureReason | null {
+  const distinct = new Set(reasons.filter((reason) => reason !== null));
+  if (distinct.size === 0) return null;
+  if (distinct.size > 1) return "multiple_failures";
+  return distinct.values().next().value ?? null;
+}

--- a/metrics-bridge/src/peg/metrics.ts
+++ b/metrics-bridge/src/peg/metrics.ts
@@ -7,12 +7,24 @@ import {
   validateListingEvidence,
 } from "./listing-metrics.js";
 import type { MarketState, PegObservation } from "./types.js";
+import {
+  failureReasonCode,
+  PEG_FAILURE_REASON_CODES,
+  type PegFailureReason,
+} from "./failure-reasons.js";
 
 const sourceLabels = ["asset", "source", "policy_version"] as const;
 const venueStateLabels = [...sourceLabels, "state"] as const;
 const assetLabels = ["asset", "policy_version"] as const;
 const policyLabels = ["policy_version"] as const;
 const errorLabels = ["kind"] as const;
+const failureEventLabels = [
+  "kind",
+  "reason",
+  "http_status",
+  "asset",
+  "source",
+] as const;
 
 type SourceLabels = {
   asset: string;
@@ -35,6 +47,8 @@ export interface PegSourceMetricSnapshot {
   spreadBps: number | null;
   newSuccess: boolean;
   newUsableDecision: boolean;
+  failureReason?: PegFailureReason | null;
+  failureHttpStatus?: number | null;
 }
 
 export interface PegBreakerMetricSnapshot {
@@ -72,6 +86,7 @@ export interface PegAssetMetricSnapshot {
   structuralSaturation: number | null;
   structuralQuerySaturated: boolean;
   indexedPoolReachable: boolean;
+  structuralFailureReason?: PegFailureReason | null;
   counterpartyCount: number;
   monitors: PegMonitorMetricSnapshot[];
   sources: PegSourceMetricSnapshot[];
@@ -144,6 +159,18 @@ export const pegGauges = {
     labelNames: sourceLabels,
     registers: [register],
   }),
+  sourceFailureReason: new Gauge({
+    name: "mento_peg_source_failure_reason",
+    help: "Bounded numeric reason for the source's current unusable state. Zero means no known failure.",
+    labelNames: sourceLabels,
+    registers: [register],
+  }),
+  sourceFailureHttpStatus: new Gauge({
+    name: "mento_peg_source_failure_http_status",
+    help: "Provider HTTP status for the source's current failure. Zero means the failure has no HTTP status.",
+    labelNames: sourceLabels,
+    registers: [register],
+  }),
   observationAt: new Gauge({
     name: "mento_peg_observation_at",
     help: "Unix timestamp of the last authoritative venue timestamp or newly observed sequence; HTTP success alone never advances it.",
@@ -186,6 +213,12 @@ export const pegGauges = {
     labelNames: assetLabels,
     registers: [register],
   }),
+  structuralFailureReason: new Gauge({
+    name: "mento_peg_structural_failure_reason",
+    help: "Bounded numeric reason why indexed pool evidence is unavailable. Zero means no known failure.",
+    labelNames: assetLabels,
+    registers: [register],
+  }),
   counterpartyCount: new Gauge({
     name: "mento_peg_counterparty_count",
     help: "Advisory unique SwapEvent caller count in the bounded structural page; never a paging input.",
@@ -223,6 +256,12 @@ export const pegCounters = {
     name: "mento_peg_poll_errors_total",
     help: "Bounded peg-loop failures by stable error channel; peg failures never affect the primary bridge health signal.",
     labelNames: errorLabels,
+    registers: [register],
+  }),
+  failureEvents: new Counter({
+    name: "mento_peg_failure_events_total",
+    help: "Monotonic count of peg failures by bounded cause, exact bounded HTTP status, and source-controlled location.",
+    labelNames: failureEventLabels,
     registers: [register],
   }),
 } as const;
@@ -347,6 +386,26 @@ function validateSourceSnapshot(
     validateStatusOnlyHalt(source);
   }
   validateUsableDecision(source);
+  validateSourceFailureEvidence(source);
+}
+
+function validateSourceFailureEvidence(source: PegSourceMetricSnapshot): void {
+  if (
+    source.failureReason !== undefined &&
+    source.failureReason !== null &&
+    !(source.failureReason in PEG_FAILURE_REASON_CODES)
+  ) {
+    throw new Error("failureReason must be a supported bounded reason");
+  }
+  if (
+    source.failureHttpStatus !== undefined &&
+    source.failureHttpStatus !== null &&
+    (!Number.isInteger(source.failureHttpStatus) ||
+      source.failureHttpStatus < 100 ||
+      source.failureHttpStatus > 599)
+  ) {
+    throw new Error("failureHttpStatus must be an HTTP status or null");
+  }
 }
 
 function validateSnapshots(snapshots: PegAssetMetricSnapshot[]): void {
@@ -465,6 +524,11 @@ function publishSourceGauges(source: PegSourceMetricSnapshot): void {
     policy_version: source.policyVersion,
   };
   pegGauges.sourceHealthy.set(labels, source.healthy ? 1 : 0);
+  pegGauges.sourceFailureReason.set(
+    labels,
+    failureReasonCode(source.failureReason ?? null),
+  );
+  pegGauges.sourceFailureHttpStatus.set(labels, source.failureHttpStatus ?? 0);
   publishListingGauges(labels, source);
   if (source.referenceSize !== null) {
     pegGauges.referenceSize.set(labels, source.referenceSize);
@@ -506,6 +570,10 @@ function publishAsset(snapshot: PegAssetMetricSnapshot): void {
   pegGauges.indexedPoolReachable.set(
     labels,
     snapshot.indexedPoolReachable ? 1 : 0,
+  );
+  pegGauges.structuralFailureReason.set(
+    labels,
+    failureReasonCode(snapshot.structuralFailureReason ?? null),
   );
   pegGauges.counterpartyCount.set(labels, snapshot.counterpartyCount);
   pegGauges.lastPoll.set(labels, snapshot.lastPollAt);
@@ -553,5 +621,6 @@ export function _resetPegMetricsForTests(): void {
   pegCounters.pollSuccess.reset();
   pegCounters.usableDecision.reset();
   pegCounters.pollErrors.reset();
+  pegCounters.failureEvents.reset();
   activeSourceCounterLabels.clear();
 }

--- a/metrics-bridge/src/peg/order-book.ts
+++ b/metrics-bridge/src/peg/order-book.ts
@@ -6,6 +6,10 @@ import type {
   PegObservation,
   Sleep,
 } from "./types.js";
+import {
+  PegProviderRequestError,
+  providerFailureEvidence,
+} from "./failure-reasons.js";
 
 export const MAX_PROVIDER_RETRIES = 1;
 export const MAX_RETRY_DELAY_MS = 1_000;
@@ -253,11 +257,33 @@ const declaredContentLength = (response: Response) => {
   return Number.isSafeInteger(value) && value >= 0 ? value : null;
 };
 
+const readProviderBodyChunk = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+) => {
+  try {
+    return await reader.read();
+  } catch (cause) {
+    const evidence = providerFailureEvidence(cause);
+    throw new PegProviderRequestError(
+      evidence.reason === "provider_timeout"
+        ? "provider response body timed out"
+        : evidence.reason === "provider_network"
+          ? "provider response body failed during transfer"
+          : "provider returned an unreadable response body",
+      evidence,
+      { cause },
+    );
+  }
+};
+
 const readBoundedBody = async (response: Response, maxBytes: number) => {
   const declared = declaredContentLength(response);
   if (declared !== null && declared > maxBytes) {
     await response.body?.cancel();
-    throw new Error(`provider response exceeds ${maxBytes} bytes`);
+    throw new PegProviderRequestError(
+      `provider response exceeds ${maxBytes} bytes`,
+      { reason: "invalid_response", httpStatus: null },
+    );
   }
   if (response.body === null) return "";
 
@@ -265,12 +291,15 @@ const readBoundedBody = async (response: Response, maxBytes: number) => {
   const chunks: Uint8Array[] = [];
   let received = 0;
   while (true) {
-    const { done, value } = await reader.read();
+    const { done, value } = await readProviderBodyChunk(reader);
     if (done) break;
     received += value.byteLength;
     if (received > maxBytes) {
       await reader.cancel();
-      throw new Error(`provider response exceeds ${maxBytes} bytes`);
+      throw new PegProviderRequestError(
+        `provider response exceeds ${maxBytes} bytes`,
+        { reason: "invalid_response", httpStatus: null },
+      );
     }
     chunks.push(value);
   }
@@ -299,18 +328,44 @@ const fetchAttempt = async (request: BoundedJsonRequest) => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), request.timeoutMs);
   try {
-    const response = await request.fetch(request.url, {
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
+    let response: Response;
+    try {
+      response = await request.fetch(request.url, {
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch (cause) {
+      const timedOut =
+        cause instanceof Error &&
+        (cause.name === "AbortError" || cause.name === "TimeoutError");
+      throw new PegProviderRequestError(
+        timedOut
+          ? "provider request timed out"
+          : "provider network request failed",
+        {
+          reason: timedOut ? "provider_timeout" : "provider_network",
+          httpStatus: null,
+        },
+        { cause },
+      );
+    }
     if (!response.ok) {
       await response.body?.cancel();
       return { response, body: null };
     }
-    return {
-      response,
-      body: await readBoundedBody(response, request.maxResponseBytes),
-    };
+    try {
+      return {
+        response,
+        body: await readBoundedBody(response, request.maxResponseBytes),
+      };
+    } catch (cause) {
+      if (cause instanceof PegProviderRequestError) throw cause;
+      throw new PegProviderRequestError(
+        "provider returned an unreadable response",
+        { reason: "invalid_response", httpStatus: null },
+        { cause },
+      );
+    }
   } finally {
     clearTimeout(timer);
   }
@@ -326,16 +381,30 @@ export const fetchBoundedJson = async (request: BoundedJsonRequest) => {
       try {
         return JSON.parse(body) as unknown;
       } catch (error) {
-        throw new Error("provider returned invalid JSON", { cause: error });
+        throw new PegProviderRequestError(
+          "provider returned invalid JSON",
+          { reason: "invalid_response", httpStatus: null },
+          { cause: error },
+        );
       }
     }
     if (
       !isRetryableStatus(response.status) ||
       attempt === MAX_PROVIDER_RETRIES
     ) {
-      throw new Error(`provider returned HTTP ${response.status}`);
+      throw new PegProviderRequestError(
+        `provider returned HTTP ${response.status}`,
+        {
+          reason:
+            response.status === 429 ? "rate_limited" : "provider_http_error",
+          httpStatus: response.status,
+        },
+      );
     }
     await request.sleep(retryDelay(response));
   }
-  throw new Error("provider request exhausted its retry budget");
+  throw new PegProviderRequestError(
+    "provider request exhausted its retry budget",
+    { reason: "unknown", httpStatus: null },
+  );
 };

--- a/metrics-bridge/src/peg/poll-cycle.ts
+++ b/metrics-bridge/src/peg/poll-cycle.ts
@@ -6,6 +6,7 @@ import {
 import type { PegPolicyVersion } from "./policy.js";
 import type { PegRegistry } from "./registry.js";
 import type { MarketState, PegObservation } from "./types.js";
+import type { PegFailureReason } from "./failure-reasons.js";
 
 interface SinglePolicyPegPollCycleInput {
   registry: PegRegistry;
@@ -50,6 +51,8 @@ export interface PegPollSourceState {
   listingCheckedAt: number | null;
   listingAbsentConsecutiveChecks: number;
   blindConsecutivePolls: number;
+  failureReason: PegFailureReason | null;
+  failureHttpStatus: number | null;
 }
 
 export interface PegPollCycleCoordinatorDependencies {

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -834,10 +834,6 @@ async function snapshotWithoutReferenceSize(
   observationCadenceDue: boolean,
   listingCadenceDue: boolean,
 ): Promise<PegSourceMetricSnapshot | null> {
-  setPegFailure(state, {
-    reason: "reference_size_unavailable",
-    httpStatus: null,
-  });
   if (input.blindConsecutivePollLimit !== null && observationCadenceDue) {
     state.lastAttemptAt = input.context.nowSeconds;
     updateBlindConsecutivePolls(state, input.blindConsecutivePollLimit, false);
@@ -850,6 +846,16 @@ async function snapshotWithoutReferenceSize(
   if (state.referenceSize === null) {
     clearSource(state, null);
     if (!listingAvailable && state.listingState === null) return null;
+    if (
+      state.failureReason === null &&
+      state.listingState !== "absent" &&
+      state.listingState !== "halted"
+    ) {
+      setPegFailure(state, {
+        reason: "reference_size_unavailable",
+        httpStatus: null,
+      });
+    }
     return sourceSnapshot(input, state, {
       referenceSize: null,
       observation: null,

--- a/metrics-bridge/src/peg/poller.ts
+++ b/metrics-bridge/src/peg/poller.ts
@@ -62,6 +62,11 @@ import type {
   PegObservation,
   RecordListingCheck,
 } from "./types.js";
+import { pegFailureEvidence, setPegFailure } from "./failure-reasons.js";
+import {
+  createPegSourceMetricSnapshot,
+  type PegSourceSnapshotContent,
+} from "./source-snapshot.js";
 
 export const MAX_PROVIDER_CLOCK_SKEW_MS = 60_000;
 
@@ -178,6 +183,8 @@ const defaultSourceState = (): SourceState => ({
   listingCheckedAt: null,
   listingAbsentConsecutiveChecks: 0,
   blindConsecutivePolls: 0,
+  failureReason: null,
+  failureHttpStatus: null,
 });
 
 const defaultReadConversionLeg = async (
@@ -273,39 +280,6 @@ function observationIsFresh(
   );
 }
 
-function priceMovement(
-  observation: PegObservation | null,
-  target: number,
-): Pick<PegSourceMetricSnapshot, "deviationBps" | "premiumBps"> {
-  if (
-    observation === null ||
-    observation.venueState === "halted" ||
-    observation.capped ||
-    observation.vwap === null ||
-    !Number.isFinite(observation.vwap) ||
-    observation.vwap <= 0
-  ) {
-    return { deviationBps: null, premiumBps: null };
-  }
-  return {
-    deviationBps: Math.max(0, ((target - observation.vwap) / target) * 10_000),
-    premiumBps: Math.max(0, ((observation.vwap - target) / target) * 10_000),
-  };
-}
-
-function spreadBps(observation: PegObservation | null): number | null {
-  if (
-    observation === null ||
-    observation.bid === null ||
-    observation.ask === null
-  ) {
-    return null;
-  }
-  const midpoint = (observation.bid + observation.ask) / 2;
-  const spread = ((observation.ask - observation.bid) / midpoint) * 10_000;
-  return midpoint > 0 && Number.isFinite(spread) && spread >= 0 ? spread : null;
-}
-
 type PollSourceInput = {
   assetId: string;
   target: number;
@@ -316,41 +290,21 @@ type PollSourceInput = {
   context: CycleContext;
 };
 
-type SourceSnapshotContent = {
-  referenceSize: number | null;
-  observation: PegObservation | null;
-  newSuccess: boolean;
-};
-
 function sourceSnapshot(
   input: PollSourceInput,
   state: SourceState,
-  content: SourceSnapshotContent,
+  content: PegSourceSnapshotContent,
 ): PegSourceMetricSnapshot {
-  const { referenceSize, observation, newSuccess } = content;
-  const movement = priceMovement(observation, input.target);
-  return {
-    asset: input.assetId,
-    source: input.source.id,
-    policyVersion: input.context.policyVersion,
-    healthy:
-      observation !== null &&
-      observation.venueState !== "halted" &&
-      observation.observationAt !== null &&
-      observation.sequence !== null,
-    observation,
-    referenceSize,
-    listingState: state.listingState,
-    listingCheckedAt: state.listingCheckedAt,
-    listingAbsentConsecutiveChecks: state.listingAbsentConsecutiveChecks,
-    ...movement,
-    spreadBps: spreadBps(observation),
-    newSuccess,
-    newUsableDecision:
-      newSuccess &&
-      movement.deviationBps !== null &&
-      movement.premiumBps !== null,
-  };
+  return createPegSourceMetricSnapshot(
+    {
+      assetId: input.assetId,
+      target: input.target,
+      sourceId: input.source.id,
+      policyVersion: input.context.policyVersion,
+    },
+    state,
+    content,
+  );
 }
 
 function referenceSize(
@@ -444,6 +398,17 @@ function clearSource(state: SourceState, refSize: number | null): void {
   state.conversionValidUntil = null;
 }
 
+function setCachedObservationFailure(
+  state: SourceState,
+  conversionFresh: boolean,
+): void {
+  if (state.failureReason !== null) return;
+  setPegFailure(state, {
+    reason: cachedObservationFailureReason(conversionFresh),
+    httpStatus: null,
+  });
+}
+
 function cachedObservation(
   state: SourceState,
   source: PegSource,
@@ -468,10 +433,17 @@ function cachedObservation(
     !conversionFresh ||
     !observationIsFresh(state.observation, policy, context.nowMs)
   ) {
+    setCachedObservationFailure(state, conversionFresh);
     clearSource(state, state.referenceSize);
     return null;
   }
   return state.observation;
+}
+
+function cachedObservationFailureReason(
+  conversionFresh: boolean,
+): "stale_data" | "conversion_unavailable" {
+  return conversionFresh ? "stale_data" : "conversion_unavailable";
 }
 
 function unavailableSourceSnapshot(
@@ -561,6 +533,7 @@ function failSource(
     asset: input.assetId,
     source: input.source.id,
   });
+  setPegFailure(state, pegFailureEvidence(failure.kind, failure.cause));
   return unavailableSourceSnapshot(input, state, refSize);
 }
 
@@ -614,6 +587,7 @@ function acceptDueObservation(
     state.rawObservation = null;
     state.referenceSize = refSize;
     state.conversionValidUntil = null;
+    setPegFailure(state, { reason: "market_halted", httpStatus: null });
     return sourceSnapshot(input, state, {
       referenceSize: refSize,
       observation,
@@ -632,6 +606,12 @@ function acceptDueObservation(
     input.source.convertVia === undefined ? null : rawObservation;
   state.referenceSize = refSize;
   state.conversionValidUntil = converted.validUntil;
+  setPegFailure(
+    state,
+    observation.capped || observation.vwap === null
+      ? { reason: "insufficient_liquidity", httpStatus: null }
+      : null,
+  );
   // A repeated provider identity remains healthy until its provider timestamp
   // expires, but cannot create new coverage or sustain a price decision.
   return sourceSnapshot(input, state, {
@@ -680,6 +660,12 @@ async function refreshExpiredConversion(
 
   state.observation = converted.observation;
   state.conversionValidUntil = converted.validUntil;
+  setPegFailure(
+    state,
+    converted.observation.capped || converted.observation.vwap === null
+      ? { reason: "insufficient_liquidity", httpStatus: null }
+      : null,
+  );
   return sourceSnapshot(input, state, {
     referenceSize: refSize,
     observation: converted.observation,
@@ -848,6 +834,10 @@ async function snapshotWithoutReferenceSize(
   observationCadenceDue: boolean,
   listingCadenceDue: boolean,
 ): Promise<PegSourceMetricSnapshot | null> {
+  setPegFailure(state, {
+    reason: "reference_size_unavailable",
+    httpStatus: null,
+  });
   if (input.blindConsecutivePollLimit !== null && observationCadenceDue) {
     state.lastAttemptAt = input.context.nowSeconds;
     updateBlindConsecutivePolls(state, input.blindConsecutivePollLimit, false);
@@ -1011,6 +1001,7 @@ async function pollAsset(
     structuralSaturation: structural.saturation,
     structuralQuerySaturated: structural.querySaturated,
     indexedPoolReachable: structural.reachable,
+    structuralFailureReason: structural.failureReason,
     counterpartyCount: structural.counterpartyCount,
     monitors: structural.monitors,
     sources,

--- a/metrics-bridge/src/peg/runtime.ts
+++ b/metrics-bridge/src/peg/runtime.ts
@@ -5,6 +5,10 @@ import {
 } from "./compatibility.js";
 import { pegCounters } from "./metrics.js";
 import {
+  failureHttpStatusLabel,
+  pegFailureEvidence,
+} from "./failure-reasons.js";
+import {
   GcpMetadataBearerTokenProvider,
   parsePinnedGcsJsonMediaUrl,
 } from "./gcp-metadata-auth.js";
@@ -264,6 +268,14 @@ function selectCompatiblePolicies(
 
 function defaultErrorReporter(event: PegRuntimeErrorEvent): void {
   pegCounters.pollErrors.inc({ kind: event.kind });
+  const evidence = pegFailureEvidence(event.kind, event.cause);
+  pegCounters.failureEvents.inc({
+    kind: event.kind,
+    reason: evidence.reason,
+    http_status: failureHttpStatusLabel(evidence.httpStatus),
+    asset: event.asset ?? "",
+    source: event.source ?? "",
+  });
   const location = [
     event.asset === null ? null : `asset=${event.asset}`,
     event.source === null ? null : `source=${event.source}`,

--- a/metrics-bridge/src/peg/source-snapshot.ts
+++ b/metrics-bridge/src/peg/source-snapshot.ts
@@ -1,0 +1,105 @@
+import type { PegSourceMetricSnapshot } from "./metrics.js";
+import type { PegPollSourceState } from "./poll-cycle.js";
+import type { PegObservation } from "./types.js";
+import { setPegFailure, type PegFailureEvidence } from "./failure-reasons.js";
+
+interface PegSourceSnapshotInput {
+  assetId: string;
+  target: number;
+  sourceId: string;
+  policyVersion: string;
+}
+
+export interface PegSourceSnapshotContent {
+  referenceSize: number | null;
+  observation: PegObservation | null;
+  newSuccess: boolean;
+}
+
+function priceMovement(
+  observation: PegObservation | null,
+  target: number,
+): Pick<PegSourceMetricSnapshot, "deviationBps" | "premiumBps"> {
+  if (
+    observation === null ||
+    observation.venueState === "halted" ||
+    observation.capped ||
+    observation.vwap === null ||
+    !Number.isFinite(observation.vwap) ||
+    observation.vwap <= 0
+  ) {
+    return { deviationBps: null, premiumBps: null };
+  }
+  return {
+    deviationBps: Math.max(0, ((target - observation.vwap) / target) * 10_000),
+    premiumBps: Math.max(0, ((observation.vwap - target) / target) * 10_000),
+  };
+}
+
+function spreadBps(observation: PegObservation | null): number | null {
+  if (
+    observation === null ||
+    observation.bid === null ||
+    observation.ask === null
+  ) {
+    return null;
+  }
+  const midpoint = (observation.bid + observation.ask) / 2;
+  const spread = ((observation.ask - observation.bid) / midpoint) * 10_000;
+  return midpoint > 0 && Number.isFinite(spread) && spread >= 0 ? spread : null;
+}
+
+function inherentFailure(
+  state: PegPollSourceState,
+  observation: PegObservation | null,
+): PegFailureEvidence | null {
+  if (state.listingState === "absent") {
+    return { reason: "market_unlisted", httpStatus: null };
+  }
+  if (state.listingState === "halted" || observation?.venueState === "halted") {
+    return { reason: "market_halted", httpStatus: null };
+  }
+  if (observation?.capped || observation?.vwap === null) {
+    return { reason: "insufficient_liquidity", httpStatus: null };
+  }
+  return null;
+}
+
+export function createPegSourceMetricSnapshot(
+  input: PegSourceSnapshotInput,
+  state: PegPollSourceState,
+  content: PegSourceSnapshotContent,
+): PegSourceMetricSnapshot {
+  const { referenceSize, observation, newSuccess } = content;
+  const movement = priceMovement(observation, input.target);
+  const failure = inherentFailure(state, observation);
+  // Preserve a failure from the current poll. Listing and liquidity state only
+  // supply a cause when the poll did not already record a more direct one.
+  if (failure !== null && state.failureReason === null) {
+    setPegFailure(state, failure);
+  }
+  return {
+    asset: input.assetId,
+    source: input.sourceId,
+    policyVersion: input.policyVersion,
+    healthy:
+      observation !== null &&
+      observation.venueState !== "halted" &&
+      observation.observationAt !== null &&
+      observation.sequence !== null,
+    observation,
+    referenceSize,
+    listingState: state.listingState,
+    listingCheckedAt: state.listingCheckedAt,
+    listingAbsentConsecutiveChecks: state.listingAbsentConsecutiveChecks,
+    ...movement,
+    spreadBps: spreadBps(observation),
+    newSuccess,
+    newUsableDecision:
+      newSuccess &&
+      movement.deviationBps !== null &&
+      movement.premiumBps !== null,
+    failureReason: state.failureReason,
+    failureHttpStatus: state.failureHttpStatus,
+  };
+}

--- a/metrics-bridge/src/peg/structural-poller.ts
+++ b/metrics-bridge/src/peg/structural-poller.ts
@@ -15,6 +15,10 @@ import {
   FPMM_L1_WINDOW_SECONDS,
   TRADING_LIMIT_INTERNAL_DECIMALS,
 } from "./structural.js";
+import {
+  combineFailureReasons,
+  type PegFailureReason,
+} from "./failure-reasons.js";
 
 export interface PegPolledStructuralContext {
   reachable: boolean;
@@ -23,6 +27,7 @@ export interface PegPolledStructuralContext {
   counterpartyCount: number;
   limits: PegTradingLimitRow[];
   monitors: PegMonitorMetricSnapshot[];
+  failureReason: PegFailureReason | null;
 }
 
 type StructuralPollErrorKind =
@@ -52,6 +57,7 @@ interface StructuralPollContext {
 type MonitorResult = {
   snapshot: PegMonitorMetricSnapshot;
   limit: PegTradingLimitRow | null;
+  failureReason: PegFailureReason | null;
 };
 
 const poolIdFor = (monitor: PegMonitor) =>
@@ -103,6 +109,7 @@ const monitorIdentity = (monitor: PegMonitor) => ({
 
 const failedMonitor = (
   monitor: PegMonitor,
+  failureReason: PegFailureReason,
   querySaturated = false,
 ): MonitorResult => ({
   snapshot: {
@@ -114,6 +121,7 @@ const failedMonitor = (
     breaker: null,
   },
   limit: null,
+  failureReason,
 });
 
 function boundedMonitors(
@@ -150,7 +158,7 @@ async function pollMonitor(
     });
   } catch (error) {
     context.dependencies.report("structural_query", error, location);
-    return failedMonitor(monitor);
+    return failedMonitor(monitor, "structural_query");
   }
 
   if (result.status !== "ok") {
@@ -159,7 +167,7 @@ async function pollMonitor(
       new Error(`structural context status: ${result.status}`),
       location,
     );
-    return failedMonitor(monitor, result.pageSaturated);
+    return failedMonitor(monitor, "structural_missing", result.pageSaturated);
   }
   const bindingIssue = structuralBindingIssue(monitor, result);
   if (bindingIssue !== null) {
@@ -168,7 +176,7 @@ async function pollMonitor(
       new Error(bindingIssue),
       location,
     );
-    return failedMonitor(monitor, result.pageSaturated);
+    return failedMonitor(monitor, "structural_binding", result.pageSaturated);
   }
 
   try {
@@ -194,10 +202,11 @@ async function pollMonitor(
         breaker: breaker.breaker,
       },
       limit: result.tradingLimit,
+      failureReason: null,
     };
   } catch (error) {
     context.dependencies.report("structural_data", error, location);
-    return failedMonitor(monitor, result.pageSaturated);
+    return failedMonitor(monitor, "structural_data", result.pageSaturated);
   }
 }
 
@@ -234,5 +243,8 @@ export async function pollPegStructuralContext(
       ? results.flatMap(({ limit }) => (limit === null ? [] : [limit]))
       : [],
     monitors: results.map(({ snapshot }) => snapshot),
+    failureReason: combineFailureReasons(
+      results.map(({ failureReason }) => failureReason),
+    ),
   };
 }

--- a/metrics-bridge/test/peg-kraken.test.ts
+++ b/metrics-bridge/test/peg-kraken.test.ts
@@ -239,7 +239,7 @@ describe("Kraken response parsing", () => {
     });
   });
 
-  it("requires PostTrade when the listed book has no provider identity", async () => {
+  it("classifies a PostTrade network failure when an empty book has no identity", async () => {
     await expect(
       fetchKrakenObservation(request, {
         fetch: queuedFetch([
@@ -248,7 +248,10 @@ describe("Kraken response parsing", () => {
           new Error("PostTrade unavailable"),
         ]),
       }),
-    ).rejects.toThrow("PostTrade unavailable");
+    ).rejects.toMatchObject({
+      name: "PegProviderRequestError",
+      evidence: { reason: "provider_network", httpStatus: null },
+    });
   });
 
   it("rejects malformed numeric fields and oversized books", () => {
@@ -373,7 +376,8 @@ describe("Kraken transport bounds", () => {
 
     const pending = fetchKrakenObservation(request, { fetch });
     const assertion = expect(pending).rejects.toMatchObject({
-      name: "AbortError",
+      name: "PegProviderRequestError",
+      evidence: { reason: "provider_timeout", httpStatus: null },
     });
     await vi.advanceTimersByTimeAsync(KRAKEN_TIMEOUT_MS);
     await assertion;

--- a/metrics-bridge/test/peg-metrics.test.ts
+++ b/metrics-bridge/test/peg-metrics.test.ts
@@ -59,9 +59,20 @@ afterEach(() => _resetPegMetricsForTests());
 describe("Peg metrics", () => {
   it("publishes peg-loop failures through a bounded error channel", async () => {
     pegCounters.pollErrors.inc({ kind: "source_fetch" });
+    pegCounters.failureEvents.inc({
+      kind: "source_fetch",
+      reason: "rate_limited",
+      http_status: "429",
+      asset: "europ-schuman",
+      source: "bitvavo_eur",
+    });
 
-    expect(await register.metrics()).toContain(
+    const metrics = await register.metrics();
+    expect(metrics).toContain(
       'mento_peg_poll_errors_total{kind="source_fetch"} 1',
+    );
+    expect(metrics).toContain(
+      'mento_peg_failure_events_total{kind="source_fetch",reason="rate_limited",http_status="429",asset="europ-schuman",source="bitvavo_eur"} 1',
     );
   });
 
@@ -97,10 +108,48 @@ describe("Peg metrics", () => {
       'mento_peg_blind_consecutive_polls{asset="europ-schuman",policy_version="europ-v1"} 0',
     );
     expect(metrics).toContain(
+      'mento_peg_source_failure_reason{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 0',
+    );
+    expect(metrics).toContain(
+      'mento_peg_source_failure_http_status{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 0',
+    );
+    expect(metrics).toContain(
+      'mento_peg_structural_failure_reason{asset="europ-schuman",policy_version="europ-v1"} 0',
+    );
+    expect(metrics).toContain(
       'mento_peg_poll_success_total{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 1',
     );
     expect(metrics).toContain(
       'mento_peg_usable_decision_total{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 1',
+    );
+  });
+
+  it("publishes bounded source and structural failure evidence", async () => {
+    const failed = snapshot({
+      indexedPoolReachable: false,
+      structuralFailureReason: "structural_query",
+    });
+    const source = failed.sources[0]!;
+    source.healthy = false;
+    source.observation = null;
+    source.deviationBps = null;
+    source.premiumBps = null;
+    source.spreadBps = null;
+    source.newSuccess = false;
+    source.newUsableDecision = false;
+    source.failureReason = "rate_limited";
+    source.failureHttpStatus = 429;
+
+    publishPegMetrics([failed]);
+    const metrics = await register.metrics();
+    expect(metrics).toContain(
+      'mento_peg_source_failure_reason{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 1',
+    );
+    expect(metrics).toContain(
+      'mento_peg_source_failure_http_status{asset="europ-schuman",source="bitvavo_eur",policy_version="europ-v1"} 429',
+    );
+    expect(metrics).toContain(
+      'mento_peg_structural_failure_reason{asset="europ-schuman",policy_version="europ-v1"} 12',
     );
   });
 

--- a/metrics-bridge/test/peg-order-book.test.ts
+++ b/metrics-bridge/test/peg-order-book.test.ts
@@ -6,6 +6,7 @@ import {
   sortBookLevels,
 } from "../src/peg/order-book.js";
 import type { PegObservationInput } from "../src/peg/order-book.js";
+import { PegProviderRequestError } from "../src/peg/failure-reasons.js";
 
 const observationInput = (
   overrides: Partial<PegObservationInput> = {},
@@ -295,6 +296,85 @@ describe("fetchBoundedJson", () => {
     await expect(fetchBoundedJson(request(fetch))).rejects.toThrow(/HTTP 400/);
     expect(terminal.cancel).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("keeps exact bounded evidence for rate limits and HTTP errors", async () => {
+    const rateLimited = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(null, { status: 429 }));
+    await expect(
+      fetchBoundedJson(request(rateLimited)),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "rate_limited", httpStatus: 429 },
+    });
+
+    const serverError = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(null, { status: 500 }));
+    await expect(
+      fetchBoundedJson(request(serverError)),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "provider_http_error", httpStatus: 500 },
+    });
+  });
+
+  it("distinguishes provider timeouts from other network failures", async () => {
+    const timeout = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValue(new DOMException("late", "AbortError"));
+    await expect(
+      fetchBoundedJson(request(timeout)),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "provider_timeout", httpStatus: null },
+    });
+
+    const network = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValue(new TypeError("offline"));
+    await expect(
+      fetchBoundedJson(request(network)),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "provider_network", httpStatus: null },
+    });
+  });
+
+  it("classifies a timeout while reading the response body", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockImplementation(
+      async (_input, init) =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              init?.signal?.addEventListener("abort", () => {
+                controller.error(new DOMException("late body", "AbortError"));
+              });
+            },
+          }),
+        ),
+    );
+
+    await expect(
+      fetchBoundedJson({ ...request(fetch), timeoutMs: 5 }),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "provider_timeout", httpStatus: null },
+    });
+  });
+
+  it("classifies a network failure while reading the response body", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(new TypeError("connection reset"));
+          },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchBoundedJson(request(fetch)),
+    ).rejects.toMatchObject<PegProviderRequestError>({
+      evidence: { reason: "provider_network", httpStatus: null },
+    });
   });
 
   it("cancels a body whose declared content length exceeds the cap", async () => {

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -20,6 +20,7 @@ import {
 import { publishPegPollSnapshot } from "../src/peg/publisher.js";
 import { parsePegRegistry } from "../src/peg/registry.js";
 import type { PegObservation } from "../src/peg/types.js";
+import { PegProviderRequestError } from "../src/peg/failure-reasons.js";
 
 const fixed15 = (tokens: number) => (BigInt(tokens) * 10n ** 15n).toString();
 
@@ -233,6 +234,63 @@ afterEach(() => {
 });
 
 describe("peg poll cycle freshness and measurements", () => {
+  it("carries exact provider failure evidence into the source snapshot", async () => {
+    const spec = primaryAsset();
+    const input = makeInput([spec]);
+    const nowMs = 1_800_000_000_000;
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchBitvavo: vi.fn(async () => {
+        throw new PegProviderRequestError("provider returned HTTP 429", {
+          reason: "rate_limited",
+          httpStatus: 429,
+        });
+      }),
+      publish: vi.fn(),
+    });
+
+    const result = (await poller.pollCycle(input))[0]!;
+    expect(source(result)).toMatchObject({
+      healthy: false,
+      failureReason: "rate_limited",
+      failureHttpStatus: 429,
+    });
+  });
+
+  it("retains exact provider failure evidence between provider cadence slots", async () => {
+    const spec = primaryAsset();
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    const fetchBitvavo = vi.fn(async () => {
+      throw new PegProviderRequestError("provider returned HTTP 429", {
+        reason: "rate_limited",
+        httpStatus: 429,
+      });
+    });
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () =>
+        structuralContext(spec, Math.floor(nowMs / 1_000)),
+      ),
+      fetchBitvavo,
+      publish: vi.fn(),
+    });
+
+    await poller.pollCycle(input);
+    nowMs += 10_000;
+    const betweenAttempts = (await poller.pollCycle(input))[0]!;
+
+    expect(source(betweenAttempts)).toMatchObject({
+      healthy: false,
+      failureReason: "rate_limited",
+      failureHttpStatus: 429,
+    });
+    expect(fetchBitvavo).toHaveBeenCalledOnce();
+  });
+
   it("commits a successful listing lookup even when the book fetch fails", async () => {
     const spec = primaryAsset();
     const input = makeInput([spec]);
@@ -1738,6 +1796,7 @@ describe("peg poll cycle conversion and cadence", () => {
     nowMs += 61_000;
     const unavailable = (await poller.pollCycle(input))[0]!;
     expect(unavailable.indexedPoolReachable).toBe(false);
+    expect(unavailable.structuralFailureReason).toBe("structural_query");
     expect(source(unavailable, "kraken_usd")).toMatchObject({
       healthy: true,
       referenceSize: 50,
@@ -1754,6 +1813,7 @@ describe("peg poll cycle conversion and cadence", () => {
     nowMs += 1_000;
     const recovered = (await poller.pollCycle(input))[0]!;
     expect(recovered.indexedPoolReachable).toBe(true);
+    expect(recovered.structuralFailureReason).toBeNull();
     expect(source(recovered, "kraken_usd")).toMatchObject({
       healthy: true,
       referenceSize: 50,

--- a/metrics-bridge/test/peg-poller.test.ts
+++ b/metrics-bridge/test/peg-poller.test.ts
@@ -291,6 +291,40 @@ describe("peg poll cycle freshness and measurements", () => {
     expect(fetchBitvavo).toHaveBeenCalledOnce();
   });
 
+  it("retains provider failure evidence during a structural outage", async () => {
+    const spec = primaryAsset();
+    const input = makeInput([spec]);
+    let nowMs = 1_800_000_000_000;
+    let structuralAvailable = true;
+    const fetchBitvavo = vi.fn(async () => {
+      throw new PegProviderRequestError("provider returned HTTP 429", {
+        reason: "rate_limited",
+        httpStatus: 429,
+      });
+    });
+    const poller = createPegPoller({
+      nowMs: () => nowMs,
+      fetchStructuralContext: vi.fn(async () => {
+        if (!structuralAvailable) throw new Error("Hasura unavailable");
+        return structuralContext(spec, Math.floor(nowMs / 1_000));
+      }),
+      fetchBitvavo,
+      publish: vi.fn(),
+    });
+
+    await poller.pollCycle(input);
+    structuralAvailable = false;
+    nowMs += 10_000;
+    const unavailable = (await poller.pollCycle(input))[0]!;
+
+    expect(source(unavailable)).toMatchObject({
+      healthy: false,
+      failureReason: "rate_limited",
+      failureHttpStatus: 429,
+    });
+    expect(fetchBitvavo).toHaveBeenCalledOnce();
+  });
+
   it("commits a successful listing lookup even when the book fetch fails", async () => {
     const spec = primaryAsset();
     const input = makeInput([spec]);
@@ -619,6 +653,8 @@ describe("peg poll cycle freshness and measurements", () => {
       observation: null,
       listingState: "absent",
       listingAbsentConsecutiveChecks: 1,
+      failureReason: "market_unlisted",
+      failureHttpStatus: null,
     });
     nowMs += 30_000;
     const confirmed = (await poller.pollCycle(input))[0]!;
@@ -1367,6 +1403,8 @@ describe("peg poll cycle isolation", () => {
       newSuccess: false,
       newUsableDecision: false,
       observation: { vwap: 0.9, capped: false },
+      failureReason: null,
+      failureHttpStatus: null,
     });
     expect(fetchBitvavo).toHaveBeenCalledTimes(1);
     expect(fetchBitvavo.mock.calls[0]?.[0].refSize).toBe(10);
@@ -1430,6 +1468,8 @@ describe("peg poll cycle isolation", () => {
       healthy: true,
       observation: { sequence: "frozen" },
       newSuccess: false,
+      failureReason: null,
+      failureHttpStatus: null,
     });
     expect(source(recovered).deviationBps).toBeCloseTo(1_000);
     expect(recovered.blind).toBe(false);

--- a/metrics-bridge/test/peg-runtime.test.ts
+++ b/metrics-bridge/test/peg-runtime.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
+import { register } from "../src/metrics.js";
 import { assertPegPolicyRegistrySupportsPolicy } from "../src/peg/compatibility.js";
 import { GCP_METADATA_TOKEN_URL } from "../src/peg/gcp-metadata-auth.js";
 import {
@@ -8,6 +9,7 @@ import {
   type PegPolicyVersion,
 } from "../src/peg/policy.js";
 import type { PegPoller } from "../src/peg/poller.js";
+import { _resetPegMetricsForTests } from "../src/peg/metrics.js";
 import { loadPegRegistry, parsePegRegistry } from "../src/peg/registry.js";
 import {
   createPegRuntime as createProductionPegRuntime,
@@ -62,6 +64,28 @@ function poller(
 }
 
 describe("Peg runtime isolation", () => {
+  it("records a bounded cause through the default production reporter", async () => {
+    _resetPegMetricsForTests();
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      const runtime = createPegRuntime({
+        policyUrl: "not a protected URL",
+      });
+
+      await runtime.runCycle();
+
+      const metrics = await register.metrics();
+      expect(metrics).toContain(
+        'mento_peg_failure_events_total{kind="policy_config",reason="unknown",http_status="none",asset="",source=""} 1',
+      );
+    } finally {
+      errorLog.mockRestore();
+      _resetPegMetricsForTests();
+    }
+  });
+
   it("starts in dormant mode without scheduling or loading protected state", () => {
     const loadRegistry = vi.fn();
     const runtime = createPegRuntime({

--- a/scripts/alert-rules-lint.test.mjs
+++ b/scripts/alert-rules-lint.test.mjs
@@ -1178,7 +1178,7 @@ test("Peg Slack pages mention @support-engineer only while critical alerts are f
   const supportMention = "<!subteam^${var.oncall_support_usergroup_id}>";
   const guardedMention = [
     '{{ if and (len .Alerts.Firing) (eq .CommonLabels.severity "critical") -}}',
-    `${supportMention} Please investigate this critical Peg alert.`,
+    `${supportMention} Please investigate.`,
     "{{ end -}}",
   ].join("\n");
 
@@ -1193,6 +1193,59 @@ test("Peg Slack pages mention @support-engineer only while critical alerts are f
   assert(
     !victorOpsTemplates.includes("<!subteam^"),
     "the Slack usergroup mention must not enter Splunk On-Call payloads",
+  );
+});
+
+test("Peg Grafana and Slack copy leads with the concrete cause", () => {
+  const rulesDir = path.resolve(__dirname, "..", "alerts/rules");
+  const definitions = readFileSync(
+    path.join(rulesDir, "peg-rule-definitions.tf"),
+    "utf8",
+  );
+  const copyLocals = readFileSync(
+    path.join(rulesDir, "peg-copy-locals.tf"),
+    "utf8",
+  );
+  const rules = readFileSync(path.join(rulesDir, "rules-peg.tf"), "utf8");
+  const templates = readFileSync(
+    path.join(rulesDir, "peg-message-templates.tf"),
+    "utf8",
+  );
+
+  assert(
+    definitions.includes("sell price is") &&
+      definitions.includes("below peg") &&
+      definitions.includes("buy and sell prices are") &&
+      definitions.includes("pool flow") &&
+      definitions.includes("does not list the"),
+    "Peg Grafana summaries must use the approved cause-first market wording",
+  );
+  assert(
+    copyLocals.includes("rate limit is reached") &&
+      copyLocals.includes("price request returns") &&
+      copyLocals.includes("price request is timing out") &&
+      copyLocals.includes("cannot be reached") &&
+      copyLocals.includes("returning invalid price data"),
+    "Peg Grafana summaries must explain the bounded provider failure reason",
+  );
+  assert(
+    /kesm\s*=\s*"KESm"/.test(copyLocals) &&
+      /valr\s*=\s*"VALR"/.test(copyLocals),
+    "Peg Grafana summaries must preserve canonical asset and provider casing",
+  );
+  assert(
+    rules.includes("resolved_summary = rule.value.resolved_summary") &&
+      rules.includes("asset_name") &&
+      rules.includes("source_name"),
+    "Peg rules must expose the cause-first copy and plain display names",
+  );
+  assert(
+    templates.includes("$alert.Annotations.summary") &&
+      templates.includes("$alert.Annotations.resolved_summary") &&
+      !templates.includes(".CommonLabels.alertname") &&
+      !templates.includes("*FIRING:") &&
+      !templates.includes("*RESOLVED:"),
+    "Peg Slack titles and bodies must use the cause instead of internal alert state or rule names",
   );
 });
 

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -3,21 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PEG_ALERTS_WINDOW_SECONDS } from "@/lib/peg-alerts";
 import {
   GET,
-  PEG_ALERTS_DATASOURCE_UID,
   PEG_ALERTS_MAX_EVENTS,
-  PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES,
   PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
   PEG_ALERTS_UPSTREAM_TIMEOUT_MS,
 } from "../route";
 import {
+  combinePegAlertEvents,
+  parseStateTransitions,
   PEG_ALERTS_MAX_STATE_ROWS,
-  PEG_ALERTS_POLICY_STEP_SECONDS,
-  policyQueryBounds,
 } from "../peg-alert-events";
 
 const NOW_SECONDS = 1_786_694_595;
 const FROM_SECONDS = NOW_SECONDS - PEG_ALERTS_WINDOW_SECONDS;
-const POLICY_BOUNDS = policyQueryBounds(FROM_SECONDS, NOW_SECONDS);
 
 type StateLine = {
   schemaVersion: 1;
@@ -26,6 +23,7 @@ type StateLine = {
   fingerprint: string;
   ruleTitle: string;
   ruleUID: string;
+  values: Record<string, number>;
   labels: {
     alertname: string;
     asset: string;
@@ -52,6 +50,7 @@ function stateLine(
     fingerprint: "spread-instance",
     ruleTitle,
     ruleUID: "spread-rule",
+    values: { A: 34, Reason: 0, HttpStatus: 0 },
     ...overrides,
     labels: {
       alertname: ruleTitle,
@@ -93,65 +92,39 @@ function stateFrame(rows: Array<{ at: number; line: StateLine }>): object {
   };
 }
 
-function policyFrame(
-  policyVersion: string,
-  points: Array<{ at: number; value: number | null }>,
-  instance = "bridge-a",
-): object {
-  return {
-    schema: {
-      fields: [
-        { name: "Time", type: "time" },
-        {
-          name: "Value",
-          type: "number",
-          labels: {
-            __name__: "mento_peg_policy_version",
-            instance,
-            policy_version: policyVersion,
-          },
-        },
-      ],
-    },
-    data: {
-      values: [
-        points.map(({ at }) => at * 1_000),
-        points.map(({ value }) => value),
-      ],
-    },
-  };
-}
-
-function policyResponse(frames: object[] = []): object {
-  return { results: { P: { frames } } };
-}
-
 function json(body: unknown, init?: ResponseInit): Response {
   return Response.json(body, init);
 }
 
+function eventFor(overrides: Parameters<typeof stateLine>[0]): {
+  lead: string;
+  detail: string;
+} {
+  const transitions = parseStateTransitions(
+    stateFrame([{ at: NOW_SECONDS - 1, line: stateLine(overrides) }]),
+    FROM_SECONDS,
+    NOW_SECONDS,
+  );
+  const event = combinePegAlertEvents(transitions, 1)[0];
+  if (event === undefined) throw new Error("missing alert event");
+  return event;
+}
+
 function successfulFetch() {
   const raisedRows = [
-    // Ordinary evaluation churn is valid upstream data but never a feed event.
     {
       at: NOW_SECONDS - 1_500,
       line: stateLine({ previous: "Pending", current: "Normal" }),
     },
-    {
-      at: NOW_SECONDS - 1_200,
-      line: stateLine(),
-    },
-    // Grafana can repeat an Alerting row while the same instance remains open.
-    {
-      at: NOW_SECONDS - 1_140,
-      line: stateLine(),
-    },
+    { at: NOW_SECONDS - 1_200, line: stateLine() },
+    { at: NOW_SECONDS - 1_140, line: stateLine() },
     {
       at: NOW_SECONDS - 300,
       line: stateLine({
         fingerprint: "critical-instance",
         ruleTitle: "Peg Deep-Venue Downside Critical [europ-schuman · active]",
         ruleUID: "critical-rule",
+        values: { A: 52, Reason: 0, HttpStatus: 0 },
         labels: {
           alertname:
             "Peg Deep-Venue Downside Critical [europ-schuman · active]",
@@ -165,46 +138,24 @@ function successfulFetch() {
   const clearedRows = [
     {
       at: NOW_SECONDS - 600,
-      line: stateLine({ previous: "Alerting", current: "Normal" }),
+      line: stateLine({ previous: "Alerting", current: "Normal", values: {} }),
     },
-    // Repeated clears after the incident closes must not create per-check rows.
     {
       at: NOW_SECONDS - 540,
-      line: stateLine({ previous: "Alerting", current: "Normal" }),
+      line: stateLine({ previous: "Alerting", current: "Normal", values: {} }),
     },
-    // A clear without a raise in the bounded window has no honest duration.
     {
       at: NOW_SECONDS - 120,
       line: stateLine({
         previous: "Alerting",
         current: "Normal",
         fingerprint: "unpaired-instance",
+        values: {},
       }),
     },
   ];
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = new URL(String(input));
-    if (url.pathname === "/api/ds/query") {
-      return json(
-        policyResponse([
-          // The old policy has a sample in the extra pre-window step.
-          policyFrame("europ-old", [
-            {
-              at: POLICY_BOUNDS.fromMs / 1_000,
-              value: 1,
-            },
-            { at: FROM_SECONDS, value: 1 },
-          ]),
-          policyFrame("europ-new", [{ at: NOW_SECONDS - 300, value: 1 }]),
-          // A second scrape instance must not duplicate the activation.
-          policyFrame(
-            "europ-new",
-            [{ at: NOW_SECONDS - 240, value: 1 }],
-            "bridge-b",
-          ),
-        ]),
-      );
-    }
     return json(
       stateFrame(
         url.searchParams.get("current") === "Alerting"
@@ -229,7 +180,7 @@ afterEach(() => {
 });
 
 describe("GET /api/peg-monitoring/alerts", () => {
-  it("pairs real transitions, collapses repeated rows, and adds policy activations", async () => {
+  it("pairs transitions, keeps original evidence, and omits policy activations", async () => {
     const fetchMock = successfulFetch();
 
     const response = await GET();
@@ -240,46 +191,32 @@ describe("GET /api/peg-monitoring/alerts", () => {
       to: NOW_SECONDS,
       events: [
         {
-          id: `policy:europ-new:${NOW_SECONDS - 300}`,
-          at: NOW_SECONDS - 300,
-          severity: "policy",
-          lead: "Policy europ-new activated",
-          detail: "First observed in Mimir; activation time is approximate.",
-        },
-        {
           id: `state:critical-instance:raised:${NOW_SECONDS - 300}`,
           at: NOW_SECONDS - 300,
           severity: "page",
-          lead: "EUROP downside critical page raised",
-          detail: "Bitvavo EUR · active policy entered alerting.",
+          lead: "Bitvavo sell price is 52 bps below peg",
+          detail: "EUROP.",
         },
         {
           id: `state:spread-instance:cleared:${NOW_SECONDS - 600}`,
           at: NOW_SECONDS - 600,
           severity: "cleared",
-          lead: "EUROP spread warning cleared",
-          detail:
-            "Bitvavo EUR · active policy returned to normal after 10 min.",
+          lead: "Bitvavo buy and sell prices were 34 bps apart",
+          detail: "EUROP · lasted 10 min.",
         },
         {
           id: `state:spread-instance:raised:${NOW_SECONDS - 1_200}`,
           at: NOW_SECONDS - 1_200,
           severity: "warning",
-          lead: "EUROP spread warning raised",
-          detail: "Bitvavo EUR · active policy entered alerting.",
+          lead: "Bitvavo buy and sell prices are 34 bps apart",
+          detail: "EUROP.",
         },
       ],
     });
     expect(PEG_ALERTS_MAX_EVENTS).toBe(4);
-
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const stateCalls = fetchMock.mock.calls.filter(
-      ([input]) => new URL(String(input)).pathname === "/api/v1/rules/history",
-    );
-    expect(stateCalls).toHaveLength(2);
-    for (const [input, init] of stateCalls) {
-      const url = new URL(String(input));
-      const query = url.searchParams;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [input, init] of fetchMock.mock.calls) {
+      const query = new URL(String(input)).searchParams;
       expect(query.get("from")).toBe(String(FROM_SECONDS));
       expect(query.get("to")).toBe(String(NOW_SECONDS));
       expect(query.get("limit")).toBe(String(PEG_ALERTS_MAX_STATE_ROWS + 1));
@@ -288,49 +225,264 @@ describe("GET /api/peg-monitoring/alerts", () => {
         "Bearer viewer-token",
       );
     }
-    expect(
-      stateCalls.some(
-        ([input]) =>
-          new URL(String(input)).searchParams.get("current") === "Alerting",
-      ),
-    ).toBe(true);
-    expect(
-      stateCalls.some(([input]) => {
-        const query = new URL(String(input)).searchParams;
-        return (
-          query.get("previous") === "Alerting" &&
-          query.get("current") === "Normal"
-        );
-      }),
-    ).toBe(true);
-
-    const policyCall = fetchMock.mock.calls.find(
-      ([input]) => new URL(String(input)).pathname === "/api/ds/query",
-    )!;
-    const policyBody = JSON.parse(String(policyCall[1]?.body)) as {
-      from: string;
-      to: string;
-      queries: Array<Record<string, unknown>>;
-    };
-    expect(policyBody.from).toBe(String(POLICY_BOUNDS.fromMs));
-    expect(policyBody.to).toBe(String(POLICY_BOUNDS.toMs));
-    expect(policyBody.queries).toEqual([
-      expect.objectContaining({
-        datasource: { type: "prometheus", uid: PEG_ALERTS_DATASOURCE_UID },
-        expr: "mento_peg_policy_version",
-        intervalMs: PEG_ALERTS_POLICY_STEP_SECONDS * 1_000,
-        range: true,
-        instant: false,
-      }),
-    ]);
     expect(PEG_ALERTS_UPSTREAM_TIMEOUT_MS).toBeLessThan(10_000);
   });
 
-  it("returns the real empty state when both Grafana sources are empty", async () => {
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
-      String(input).includes("/api/ds/query")
-        ? json(policyResponse())
-        : json(stateFrame([])),
+  it("coalesces matching active and previous policy transitions", () => {
+    const active = stateLine({
+      fingerprint: "active",
+      values: { A: 31 },
+    });
+    const previous = stateLine({
+      fingerprint: "previous",
+      ruleTitle:
+        "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · previous]",
+      labels: {
+        alertname:
+          "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · previous]",
+        policy_version: "europ-old",
+      },
+      values: { A: 32 },
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 61, line: previous },
+        { at: NOW_SECONDS - 1, line: active },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:active:raised:${NOW_SECONDS - 1}`,
+        lead: "Bitvavo buy and sell prices are 31 bps apart",
+      }),
+    ]);
+  });
+
+  it("keeps separate alert cycles from the same policy", () => {
+    const fired = stateLine({ fingerprint: "active-cycle" });
+    const resolved = stateLine({
+      previous: "Alerting",
+      current: "Normal",
+      fingerprint: "active-cycle",
+      values: {},
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 200, line: fired },
+        { at: NOW_SECONDS - 160, line: resolved },
+        { at: NOW_SECONDS - 120, line: fired },
+        { at: NOW_SECONDS - 80, line: resolved },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4).map(({ id }) => id)).toEqual([
+      `state:active-cycle:cleared:${NOW_SECONDS - 80}`,
+      `state:active-cycle:raised:${NOW_SECONDS - 120}`,
+      `state:active-cycle:cleared:${NOW_SECONDS - 160}`,
+      `state:active-cycle:raised:${NOW_SECONDS - 200}`,
+    ]);
+  });
+
+  it("coalesces active and previous policy transitions one-to-one", () => {
+    const active = stateLine({ fingerprint: "active" });
+    const previous = (fingerprint: string) =>
+      stateLine({
+        fingerprint,
+        ruleTitle:
+          "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · previous]",
+        labels: {
+          alertname:
+            "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · previous]",
+          policy_version: "europ-old",
+        },
+      });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 120, line: previous("previous-older") },
+        { at: NOW_SECONDS - 90, line: active },
+        { at: NOW_SECONDS - 60, line: previous("previous-newer") },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4).map(({ id }) => id)).toEqual([
+      `state:active:raised:${NOW_SECONDS - 90}`,
+      `state:previous-older:raised:${NOW_SECONDS - 120}`,
+    ]);
+  });
+
+  it.each([
+    {
+      title: "Peg Downside Warning [europ-schuman/bitvavo_eur · active]",
+      values: { A: 31 },
+      lead: "Bitvavo sell price is 31 bps below peg",
+    },
+    {
+      title: "Peg Downside Warning [kesm-current/valr_zar · active]",
+      values: { A: 25 },
+      source: "valr_zar",
+      asset: "kesm-current",
+      lead: "VALR sell price is 25 bps below peg",
+    },
+    {
+      title: "Peg Premium Warning [europ-schuman/bitvavo_eur · active]",
+      values: { A: 26.4 },
+      lead: "Bitvavo sell price is 26.4 bps above peg",
+    },
+    {
+      title:
+        "Peg Deep-Venue Spread Warning [europ-schuman/bitvavo_eur · active]",
+      values: { A: 34 },
+      lead: "Bitvavo buy and sell prices are 34 bps apart",
+    },
+    {
+      title: "Peg Structural Saturation Warning [europ-schuman · active]",
+      values: { Structural: 82.5 },
+      source: "",
+      lead: "EUROP pool flow is using 82.5% of its trading limit",
+    },
+    {
+      title: "Peg Registry Rot [europ-schuman/kraken_usd · active]",
+      values: {},
+      source: "kraken_usd",
+      lead: "Kraken does not list the EUROP/USD market",
+    },
+    {
+      title: "Peg Indexed Pool Unreachable [europ-schuman · active]",
+      values: { Reason: 12 },
+      source: "",
+      lead: "EUROP pool data cannot be fetched",
+    },
+    {
+      title: "Peg Heartbeat Missing [europ-schuman · active]",
+      values: {},
+      source: "",
+      lead: "EUROP monitor data has stopped updating",
+    },
+    {
+      title: "Peg Policy Rollover Stuck",
+      values: {},
+      source: "",
+      asset: "policy",
+      lead: "Peg monitor has not loaded policy europ-v1",
+    },
+  ])(
+    "uses cause-first copy for $title",
+    ({ title, values, source, asset, lead }) => {
+      const event = eventFor({
+        ruleTitle: title,
+        values,
+        labels: {
+          alertname: title,
+          source: source ?? "bitvavo_eur",
+          asset: asset ?? "europ-schuman",
+        },
+      });
+      expect(event.lead).toBe(lead);
+      expect(event.lead).not.toMatch(
+        /warning|raised|cleared|alerting|blindness|critical page/i,
+      );
+    },
+  );
+
+  it.each([
+    [
+      1,
+      429,
+      "Bitvavo is rejecting price requests because its rate limit is reached (HTTP 429)",
+    ],
+    [2, 500, "Bitvavo price request returns HTTP 500"],
+    [3, 0, "Bitvavo price request is timing out"],
+    [4, 0, "Bitvavo cannot be reached"],
+    [5, 0, "Bitvavo is returning invalid price data"],
+    [6, 0, "Bitvavo price data has stopped updating"],
+    [7, 0, "Bitvavo is repeating old price data"],
+    [
+      8,
+      0,
+      "Bitvavo cannot fill the monitored sell size; only 42% is available",
+    ],
+    [9, 0, "Bitvavo market is halted"],
+    [10, 0, "Bitvavo price cannot be converted to the peg currency"],
+    [11, 0, "Bitvavo price conversion is failing"],
+    [16, 0, "Pool data does not provide the monitored sell size"],
+    [17, 0, "Bitvavo is not supported by the monitor"],
+    [18, 0, "Bitvavo is not providing a usable sell price"],
+    [19, 0, "Multiple failures are preventing a usable Bitvavo price"],
+    [20, 0, "Bitvavo does not list this market"],
+  ])(
+    "explains bounded source failure reason %i",
+    (reason, status, expectedLead) => {
+      const title = "Peg Source Unhealthy [europ-schuman/bitvavo_eur · active]";
+      const event = eventFor({
+        ruleTitle: title,
+        values: { Reason: reason, HttpStatus: status, Fill: 42 },
+        labels: { alertname: title },
+      });
+      expect(event).toMatchObject({
+        lead: expectedLead,
+        detail: "EUROP.",
+      });
+    },
+  );
+
+  it("keeps the fired HTTP cause when the alert resolves", () => {
+    const title = "Peg Source Unhealthy [europ-schuman/bitvavo_eur · active]";
+    const fired = stateLine({
+      fingerprint: "rate-limit-instance",
+      ruleTitle: title,
+      values: { Reason: 1, HttpStatus: 429 },
+      labels: { alertname: title },
+    });
+    const resolved = stateLine({
+      previous: "Alerting",
+      current: "Normal",
+      fingerprint: "rate-limit-instance",
+      ruleTitle: title,
+      values: {},
+      labels: { alertname: title },
+    });
+    const events = combinePegAlertEvents(
+      parseStateTransitions(
+        stateFrame([
+          { at: NOW_SECONDS - 120, line: fired },
+          { at: NOW_SECONDS - 60, line: resolved },
+        ]),
+        FROM_SECONDS,
+        NOW_SECONDS,
+      ),
+      4,
+    );
+
+    expect(events[0]).toMatchObject({
+      severity: "cleared",
+      lead: "Bitvavo rejected price requests because its rate limit was reached (HTTP 429)",
+      detail: "EUROP · lasted 1 min.",
+    });
+  });
+
+  it("adds the separate stress cause without policy jargon", () => {
+    const title = "Peg Blind While Stressed Critical [europ-schuman · active]";
+    expect(
+      eventFor({
+        ruleTitle: title,
+        values: { Reason: 8, Fill: 42 },
+        labels: { alertname: title, route: "page", severity: "critical" },
+      }).lead,
+    ).toBe(
+      "Bitvavo cannot fill the monitored sell size; only 42% is available while separate market data also shows stress",
+    );
+  });
+
+  it("returns an empty state when Grafana has no transitions", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      json(stateFrame([])),
     );
     const response = await GET();
     expect(response.status).toBe(200);
@@ -357,36 +509,18 @@ describe("GET /api/peg-monitoring/alerts", () => {
         "https://grafana.example?token=no",
       ].map((origin) => {
         vi.stubEnv("GRAFANA_QUERY_URL", origin);
-        return GET().then((response) => response.status);
+        return GET().then((result) => result.status);
       }),
     );
     expect(unsafeStatuses).toEqual([503, 503, 503, 503]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("fails closed for malformed frames, logical query errors, and oversized bodies", async () => {
+  it("fails closed for malformed frames and oversized bodies", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json({ schema: {}, data: {} }))
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(policyResponse()));
+      .mockResolvedValueOnce(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
-
-    vi.restoreAllMocks();
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(
-        json({
-          results: {
-            P: { frames: [], error: "secret query detail", status: 500 },
-          },
-        }),
-      );
-    const logical = await GET();
-    expect(logical.status).toBe(502);
-    expect(JSON.stringify(await logical.json())).not.toContain(
-      "secret query detail",
-    );
 
     vi.restoreAllMocks();
     vi.spyOn(globalThis, "fetch")
@@ -398,13 +532,8 @@ describe("GET /api/peg-monitoring/alerts", () => {
           },
         }),
       )
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(policyResponse()));
+      .mockResolvedValueOnce(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
-
-    expect(PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES).toBeLessThan(
-      PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
-    );
   });
 
   it("fails closed when the state-history sentinel proves truncation", async () => {
@@ -417,8 +546,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
     );
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json(stateFrame(sentinelRows)))
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(policyResponse()));
+      .mockResolvedValueOnce(json(stateFrame([])));
 
     expect((await GET()).status).toBe(502);
   });

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-copy.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-copy.ts
@@ -1,0 +1,318 @@
+const RULE_KINDS = [
+  "Blind Warning",
+  "Blind While Stressed Critical",
+  "Critical Path Unreachable",
+  "Deep-Venue Downside Critical",
+  "Deep-Venue Spread Warning",
+  "Downside Warning",
+  "Heartbeat Missing",
+  "Indexed Pool Unreachable",
+  "Policy Rollover Stuck",
+  "Premium Warning",
+  "Registry Rot",
+  "Source Permanently Dead",
+  "Source Unhealthy",
+  "Structural Saturation Warning",
+] as const;
+
+export type PegAlertRuleKind = (typeof RULE_KINDS)[number] | "Unknown";
+
+export interface PegAlertCopyLine {
+  ruleTitle: string;
+  values: {
+    A?: number | undefined;
+    Fill?: number | undefined;
+    Structural?: number | undefined;
+    Reason?: number | undefined;
+    HttpStatus?: number | undefined;
+  };
+  labels: {
+    asset: string;
+    source: string;
+    policy_version: string;
+  };
+}
+
+export interface PegAlertCauseCopy {
+  lead: string;
+  includesAsset: boolean;
+}
+
+const ASSET_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  europ: "EUROP",
+  kesm: "KESm",
+};
+
+const PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  bitvavo: "Bitvavo",
+  kraken: "Kraken",
+  valr: "VALR",
+};
+
+export function pegAlertRuleKind(line: PegAlertCopyLine): PegAlertRuleKind {
+  const title = line.ruleTitle.match(/^Peg (.+?)(?: \[|$)/)?.[1];
+  return RULE_KINDS.find((candidate) => candidate === title) ?? "Unknown";
+}
+
+export function pegAlertAssetName(asset: string): string {
+  const symbol = asset.split("-", 1)[0] ?? asset;
+  return ASSET_DISPLAY_NAMES[symbol] ?? symbol.toUpperCase();
+}
+
+function sourceName(source: string): string {
+  const provider = source.split("_", 1)[0] ?? source;
+  if (provider === "") return "Price source";
+  return (
+    PROVIDER_DISPLAY_NAMES[provider] ??
+    `${provider.slice(0, 1).toUpperCase()}${provider.slice(1)}`
+  );
+}
+
+function sourceCurrency(source: string): string | null {
+  const currency = source.split("_")[1];
+  return currency === undefined ? null : currency.toUpperCase();
+}
+
+function numberLabel(value: number | undefined): string | null {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return null;
+  return value.toFixed(1).replace(/\.0$/, "");
+}
+
+function withMeasurement(
+  measured: string | null,
+  precise: (value: string) => string,
+  fallback: string,
+): string {
+  return measured === null ? fallback : precise(measured);
+}
+
+function httpStatus(line: PegAlertCopyLine): number | null {
+  const value = line.values.HttpStatus;
+  return value !== undefined &&
+    Number.isInteger(value) &&
+    value >= 100 &&
+    value <= 599
+    ? value
+    : null;
+}
+
+function form(cleared: boolean, past: string, present: string): string {
+  return cleared ? past : present;
+}
+
+interface SourceFailureContext {
+  source: string;
+  cleared: boolean;
+  fill: string | null;
+  status: number | null;
+}
+
+type SourceFailureFormatter = (context: SourceFailureContext) => string;
+
+const SOURCE_FAILURE_LEADS: Partial<Record<number, SourceFailureFormatter>> = {
+  1: ({ source, cleared, status }) =>
+    `${source} ${form(cleared, "rejected", "is rejecting")} price requests because its rate limit ${form(cleared, "was", "is")} reached${status === null ? "" : ` (HTTP ${status})`}`,
+  2: ({ source, cleared, status }) =>
+    `${source} price request ${form(cleared, "returned", "returns")} ${status === null ? "an HTTP error" : `HTTP ${status}`}`,
+  3: ({ source, cleared }) =>
+    `${source} price request ${form(cleared, "timed out", "is timing out")}`,
+  4: ({ source, cleared }) =>
+    `${source} ${form(cleared, "could not be reached", "cannot be reached")}`,
+  5: ({ source, cleared }) =>
+    `${source} ${form(cleared, "returned", "is returning")} invalid price data`,
+  6: ({ source, cleared }) =>
+    `${source} price data ${form(cleared, "stopped", "has stopped")} updating`,
+  7: ({ source, cleared }) =>
+    `${source} ${form(cleared, "repeated", "is repeating")} old price data`,
+  8: ({ source, cleared, fill }) =>
+    `${source} ${form(cleared, "could not", "cannot")} fill the monitored sell size${fill === null ? "" : `; only ${fill}% ${form(cleared, "was", "is")} available`}`,
+  9: ({ source, cleared }) =>
+    `${source} market ${form(cleared, "was", "is")} halted`,
+  10: ({ source, cleared }) =>
+    `${source} price ${form(cleared, "could not", "cannot")} be converted to the peg currency`,
+  11: ({ source, cleared }) =>
+    `${source} price conversion ${form(cleared, "failed", "is failing")}`,
+  16: ({ cleared }) =>
+    `Pool data ${form(cleared, "did not provide", "does not provide")} the monitored sell size`,
+  17: ({ source, cleared }) =>
+    `${source} ${form(cleared, "was", "is")} not supported by the monitor`,
+  19: ({ source, cleared }) =>
+    `Multiple failures ${form(cleared, "prevented", "are preventing")} a usable ${source} price`,
+  20: ({ source, cleared }) =>
+    `${source} ${form(cleared, "did not list", "does not list")} this market`,
+};
+
+function sourceFailureCause(
+  line: PegAlertCopyLine,
+  cleared: boolean,
+): PegAlertCauseCopy {
+  const context: SourceFailureContext = {
+    source: sourceName(line.labels.source),
+    cleared,
+    fill: numberLabel(line.values.Fill),
+    status: httpStatus(line),
+  };
+  const formatter = SOURCE_FAILURE_LEADS[line.values.Reason ?? 0];
+  const lead =
+    formatter?.(context) ??
+    form(
+      cleared,
+      `${context.source} did not provide a usable sell price`,
+      `${context.source} is not providing a usable sell price`,
+    );
+  return { lead, includesAsset: false };
+}
+
+interface IndexedPoolContext {
+  asset: string;
+  cleared: boolean;
+}
+
+type IndexedPoolFormatter = (context: IndexedPoolContext) => string;
+
+const INDEXED_POOL_LEADS: Partial<Record<number, IndexedPoolFormatter>> = {
+  12: ({ asset, cleared }) =>
+    `${asset} pool data ${form(cleared, "could not be fetched", "cannot be fetched")}`,
+  13: ({ asset, cleared }) =>
+    `${asset} pool ${form(cleared, "was", "is")} missing from indexed data`,
+  14: ({ asset, cleared }) =>
+    `${asset} indexed pool ${form(cleared, "did not match", "does not match")} the registry`,
+  15: ({ asset, cleared }) =>
+    `${asset} pool data ${form(cleared, "was", "is")} invalid`,
+  19: ({ asset, cleared }) =>
+    `Multiple indexed-data failures ${form(cleared, "blocked", "are blocking")} the ${asset} pool`,
+};
+
+function indexedPoolCause(
+  line: PegAlertCopyLine,
+  cleared: boolean,
+): PegAlertCauseCopy {
+  const context = { asset: pegAlertAssetName(line.labels.asset), cleared };
+  const formatter = INDEXED_POOL_LEADS[line.values.Reason ?? 0];
+  return {
+    lead:
+      formatter?.(context) ??
+      `${context.asset} pool data ${form(cleared, "was", "is")} unavailable`,
+    includesAsset: true,
+  };
+}
+
+function marketListingCause(
+  line: PegAlertCopyLine,
+  cleared: boolean,
+): PegAlertCauseCopy {
+  const asset = pegAlertAssetName(line.labels.asset);
+  const source = sourceName(line.labels.source);
+  const currency = sourceCurrency(line.labels.source);
+  const market = currency === null ? asset : `${asset}/${currency}`;
+  return {
+    lead: `${source} ${form(cleared, "did not list", "does not list")} the ${market} market`,
+    includesAsset: true,
+  };
+}
+
+type CauseBuilder = (
+  line: PegAlertCopyLine,
+  cleared: boolean,
+) => PegAlertCauseCopy;
+
+const downsideCause: CauseBuilder = (line, cleared) => {
+  const source = sourceName(line.labels.source);
+  const present = form(cleared, "was", "is");
+  return {
+    lead: withMeasurement(
+      numberLabel(line.values.A),
+      (distance) => `${source} sell price ${present} ${distance} bps below peg`,
+      `${source} sell price ${present} below peg`,
+    ),
+    includesAsset: false,
+  };
+};
+
+const premiumCause: CauseBuilder = (line, cleared) => {
+  const source = sourceName(line.labels.source);
+  const present = form(cleared, "was", "is");
+  return {
+    lead: withMeasurement(
+      numberLabel(line.values.A),
+      (distance) => `${source} sell price ${present} ${distance} bps above peg`,
+      `${source} sell price ${present} above peg`,
+    ),
+    includesAsset: false,
+  };
+};
+
+const spreadCause: CauseBuilder = (line, cleared) => {
+  const source = sourceName(line.labels.source);
+  const present = form(cleared, "were", "are");
+  return {
+    lead: withMeasurement(
+      numberLabel(line.values.A),
+      (spread) =>
+        `${source} buy and sell prices ${present} ${spread} bps apart`,
+      `${source} buy and sell prices ${present} unusually far apart`,
+    ),
+    includesAsset: false,
+  };
+};
+
+const structuralCause: CauseBuilder = (line, cleared) => {
+  const asset = pegAlertAssetName(line.labels.asset);
+  return {
+    lead: withMeasurement(
+      numberLabel(line.values.Structural),
+      (used) =>
+        `${asset} pool flow ${form(cleared, "used", "is using")} ${used}% of its trading limit`,
+      `${asset} pool flow ${form(cleared, "was", "is")} close to its trading limit`,
+    ),
+    includesAsset: true,
+  };
+};
+
+const stressedSourceCause: CauseBuilder = (line, cleared) => {
+  const failure = sourceFailureCause(line, cleared);
+  return {
+    ...failure,
+    lead: `${failure.lead} while separate market data ${form(cleared, "also showed", "also shows")} stress`,
+  };
+};
+
+const heartbeatCause: CauseBuilder = (line, cleared) => ({
+  lead: `${pegAlertAssetName(line.labels.asset)} monitor data ${form(cleared, "stopped", "has stopped")} updating`,
+  includesAsset: true,
+});
+
+const rolloverCause: CauseBuilder = (line, cleared) => ({
+  lead: `Peg monitor ${form(cleared, "did not load", "has not loaded")} policy ${line.labels.policy_version}`,
+  includesAsset: true,
+});
+
+const unknownCause: CauseBuilder = (line, cleared) => ({
+  lead: `${pegAlertAssetName(line.labels.asset)} monitor ${form(cleared, "reported", "is reporting")} an unknown condition`,
+  includesAsset: true,
+});
+
+const CAUSE_BUILDERS: Record<PegAlertRuleKind, CauseBuilder> = {
+  "Blind Warning": sourceFailureCause,
+  "Blind While Stressed Critical": stressedSourceCause,
+  "Critical Path Unreachable": marketListingCause,
+  "Deep-Venue Downside Critical": downsideCause,
+  "Deep-Venue Spread Warning": spreadCause,
+  "Downside Warning": downsideCause,
+  "Heartbeat Missing": heartbeatCause,
+  "Indexed Pool Unreachable": indexedPoolCause,
+  "Policy Rollover Stuck": rolloverCause,
+  "Premium Warning": premiumCause,
+  "Registry Rot": marketListingCause,
+  "Source Permanently Dead": sourceFailureCause,
+  "Source Unhealthy": sourceFailureCause,
+  "Structural Saturation Warning": structuralCause,
+  Unknown: unknownCause,
+};
+
+export function pegAlertCauseCopy(
+  line: PegAlertCopyLine,
+  cleared: boolean,
+): PegAlertCauseCopy {
+  return CAUSE_BUILDERS[pegAlertRuleKind(line)](line, cleared);
+}

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -1,20 +1,13 @@
 import { z } from "zod";
 import type { PegAlertEvent } from "@/lib/peg-alerts";
+import {
+  pegAlertAssetName,
+  pegAlertCauseCopy,
+  pegAlertRuleKind,
+} from "./peg-alert-copy";
 
-export const PEG_ALERTS_POLICY_STEP_SECONDS = 5 * 60;
 export const PEG_ALERTS_MAX_STATE_ROWS = 1_000;
-const PEG_ALERTS_MAX_POLICY_FRAMES = 8;
-
-export function policyQueryBounds(
-  fromSeconds: number,
-  toSeconds: number,
-): { fromMs: number; toMs: number } {
-  const stepMs = PEG_ALERTS_POLICY_STEP_SECONDS * 1_000;
-  return {
-    fromMs: Math.floor((fromSeconds * 1_000 - stepMs) / stepMs) * stepMs,
-    toMs: Math.floor((toSeconds * 1_000) / stepMs) * stepMs,
-  };
-}
+const POLICY_DUPLICATE_WINDOW_SECONDS = 90;
 
 const label = z
   .string()
@@ -24,6 +17,20 @@ const label = z
 const stateFieldSchema = z
   .object({ name: z.string().min(1).max(32), type: z.string().min(1).max(32) })
   .passthrough();
+const stateValuesSchema = z
+  .object({
+    A: z.number().finite().optional(),
+    Price: z.number().finite().optional(),
+    Fill: z.number().finite().optional(),
+    ListingAge: z.number().finite().optional(),
+    Structural: z.number().finite().optional(),
+    Spread: z.number().finite().optional(),
+    Corroboration: z.number().finite().optional(),
+    Reason: z.number().finite().optional(),
+    HttpStatus: z.number().finite().optional(),
+    threshold: z.number().finite().optional(),
+  })
+  .strict();
 const stateLineSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -32,6 +39,7 @@ const stateLineSchema = z
     fingerprint: z.string().min(1).max(64),
     ruleTitle: z.string().min(1).max(256),
     ruleUID: z.string().min(1).max(64),
+    values: stateValuesSchema.optional().default({}),
     labels: z
       .object({
         alertname: z.string().min(1).max(256),
@@ -59,41 +67,8 @@ const stateFrameSchema = z
   })
   .passthrough();
 
-const policyFieldSchema = z
-  .object({
-    name: z.string().min(1).max(64),
-    type: z.string().min(1).max(32),
-    labels: z.record(z.string(), z.string()).optional(),
-  })
-  .passthrough();
-const policyFrameSchema = z
-  .object({
-    schema: z
-      .object({ fields: z.array(policyFieldSchema).min(2).max(8) })
-      .passthrough(),
-    data: z
-      .object({ values: z.array(z.array(z.unknown())).min(2).max(8) })
-      .passthrough(),
-  })
-  .passthrough();
-const policyResponseSchema = z
-  .object({
-    results: z.record(
-      z.string(),
-      z
-        .object({
-          frames: z.array(policyFrameSchema).max(PEG_ALERTS_MAX_POLICY_FRAMES),
-          error: z.string().optional(),
-          status: z.number().int().optional(),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
-
 type StateFrame = z.infer<typeof stateFrameSchema>;
 type StateLine = z.infer<typeof stateLineSchema>;
-type PolicyFrame = z.infer<typeof policyFrameSchema>;
 
 class InvalidPegAlertsUpstreamError extends Error {}
 
@@ -190,171 +165,6 @@ export function parseStateTransitions(
   return [...deduped.values()];
 }
 
-function policyFrameFirstSample(
-  frame: PolicyFrame,
-  queryFromMs: number,
-  toMs: number,
-): { policyVersion: string; atMs: number } | null {
-  const { timeIndex, numberIndex, policyVersion } = policyFrameIdentity(frame);
-  const times = frame.data.values[timeIndex]!;
-  const values = frame.data.values[numberIndex]!;
-  if (times.length !== values.length || times.length > 2_020)
-    throw new InvalidPegAlertsUpstreamError();
-  let earliest: number | null = null;
-  for (let index = 0; index < times.length; index += 1) {
-    const atMs = positivePolicySample(
-      times[index],
-      values[index],
-      queryFromMs,
-      toMs,
-    );
-    if (atMs !== null)
-      earliest = earliest === null ? atMs : Math.min(earliest, atMs);
-  }
-  return earliest === null ? null : { policyVersion, atMs: earliest };
-}
-
-function policyFrameIdentity(frame: PolicyFrame): {
-  timeIndex: number;
-  numberIndex: number;
-  policyVersion: string;
-} {
-  if (frame.schema.fields.length !== frame.data.values.length)
-    throw new InvalidPegAlertsUpstreamError();
-  const timeIndexes = frame.schema.fields.flatMap((field, index) =>
-    field.type === "time" ? [index] : [],
-  );
-  const numberIndexes = frame.schema.fields.flatMap((field, index) =>
-    field.type === "number" ? [index] : [],
-  );
-  if (timeIndexes.length !== 1 || numberIndexes.length !== 1)
-    throw new InvalidPegAlertsUpstreamError();
-  const timeIndex = timeIndexes[0]!;
-  const numberIndex = numberIndexes[0]!;
-  const labels = frame.schema.fields[numberIndex]?.labels;
-  const policyResult = label.safeParse(labels?.policy_version);
-  if (
-    !policyResult.success ||
-    (labels?.__name__ !== undefined &&
-      labels.__name__ !== "mento_peg_policy_version")
-  )
-    throw new InvalidPegAlertsUpstreamError();
-  return { timeIndex, numberIndex, policyVersion: policyResult.data };
-}
-
-function positivePolicySample(
-  atMs: unknown,
-  value: unknown,
-  queryFromMs: number,
-  toMs: number,
-): number | null {
-  if (
-    typeof atMs !== "number" ||
-    !Number.isSafeInteger(atMs) ||
-    atMs < queryFromMs ||
-    atMs > toMs ||
-    (value !== null && (typeof value !== "number" || !Number.isFinite(value)))
-  )
-    throw new InvalidPegAlertsUpstreamError();
-  return typeof value === "number" && value > 0 ? atMs : null;
-}
-
-export function parsePolicyActivations(
-  raw: unknown,
-  fromSeconds: number,
-  toSeconds: number,
-): PegAlertEvent[] {
-  const parsed = policyResponseSchema.safeParse(raw);
-  if (!parsed.success) throw new InvalidPegAlertsUpstreamError();
-  const result = parsed.data.results.P;
-  if (
-    result === undefined ||
-    (result.error !== undefined && result.error.trim() !== "") ||
-    (result.status !== undefined &&
-      (result.status < 200 || result.status >= 300))
-  )
-    throw new InvalidPegAlertsUpstreamError();
-  const fromMs = fromSeconds * 1_000;
-  const toMs = toSeconds * 1_000;
-  const bounds = policyQueryBounds(fromSeconds, toSeconds);
-  const firstByPolicy = new Map<string, number>();
-  for (const frame of result.frames) {
-    const first = policyFrameFirstSample(frame, bounds.fromMs, bounds.toMs);
-    if (first === null) continue;
-    const existing = firstByPolicy.get(first.policyVersion);
-    firstByPolicy.set(
-      first.policyVersion,
-      existing === undefined ? first.atMs : Math.min(existing, first.atMs),
-    );
-  }
-
-  return [...firstByPolicy.entries()].flatMap(([policyVersion, atMs]) => {
-    // Scrapes expose a new policy as a new label series, not an explicit
-    // activation event. The first positive sample is therefore only an
-    // approximation. A sample in the extra pre-window step proves the series
-    // already existed and prevents a false activation at the seven-day edge.
-    if (atMs <= fromMs || atMs > toMs) return [];
-    return [
-      {
-        id: `policy:${policyVersion}:${atMs / 1_000}`,
-        at: atMs / 1_000,
-        severity: "policy" as const,
-        lead: `Policy ${policyVersion} activated`,
-        detail: "First observed in Mimir; activation time is approximate.",
-      },
-    ];
-  });
-}
-
-const alertSubject: Record<string, string> = {
-  "Blind Warning": "blindness warning",
-  "Blind While Stressed Critical": "blindness critical page",
-  "Critical Path Unreachable": "critical-path warning",
-  "Deep-Venue Downside Critical": "downside critical page",
-  "Deep-Venue Spread Warning": "spread warning",
-  "Downside Warning": "downside warning",
-  "Heartbeat Missing": "heartbeat warning",
-  "Indexed Pool Unreachable": "indexed-pool warning",
-  "Policy Rollover Stuck": "policy-rollover warning",
-  "Premium Warning": "premium warning",
-  "Registry Rot": "registry warning",
-  "Source Permanently Dead": "source warning",
-  "Source Unhealthy": "source warning",
-  "Structural Saturation Warning": "structural warning",
-};
-
-function assetName(asset: string): string {
-  return (asset.split("-", 1)[0] ?? asset).toUpperCase();
-}
-
-function sourceName(source: string): string | null {
-  if (source === "") return null;
-  const [provider, ...rest] = source.split("_");
-  if (provider === undefined) return source;
-  const providerName = `${provider.slice(0, 1).toUpperCase()}${provider.slice(1)}`;
-  return [providerName, ...rest.map((part) => part.toUpperCase())].join(" ");
-}
-
-function policySlot(ruleTitle: string): "active" | "previous" | "approved" {
-  const match = ruleTitle.match(/ · (active|previous)]$/);
-  return match?.[1] === "previous"
-    ? "previous"
-    : match?.[1] === "active"
-      ? "active"
-      : "approved";
-}
-
-function subject(line: StateLine): string {
-  const title = line.ruleTitle.match(/^Peg (.+?)(?: \[|$)/)?.[1];
-  if (title === undefined) return "alert";
-  const mapped = alertSubject[title];
-  if (mapped !== undefined) return mapped;
-  const fallback = title.toLowerCase();
-  return line.labels.route === "page" && !fallback.includes("page")
-    ? `${fallback} page`
-    : fallback;
-}
-
 function durationLabel(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   if (seconds < 3_600) return `${Math.max(1, Math.round(seconds / 60))} min`;
@@ -363,38 +173,59 @@ function durationLabel(seconds: number): string {
   return `${days} ${days === 1 ? "day" : "days"}`;
 }
 
+function policySlot(line: StateLine): "active" | "previous" | "approved" {
+  const match = line.ruleTitle.match(/ · (active|previous)]$/);
+  return match?.[1] === "previous"
+    ? "previous"
+    : match?.[1] === "active"
+      ? "active"
+      : "approved";
+}
+
+type PhrasedEvent = PegAlertEvent & {
+  duplicateKey: string;
+  policySlot: ReturnType<typeof policySlot>;
+};
+
 function phraseTransition(
   transition: PegStateTransition,
-  raisedAt?: number,
-): PegAlertEvent {
-  const line = transition.line;
-  const asset = assetName(line.labels.asset);
-  const context = [
-    sourceName(line.labels.source),
-    `${policySlot(line.ruleTitle)} policy`,
+  raised?: PegStateTransition,
+): PhrasedEvent {
+  const evidence = raised?.line ?? transition.line;
+  const cleared = transition.kind === "cleared";
+  const cause = pegAlertCauseCopy(evidence, cleared);
+  const detail = [
+    cause.includesAsset ? null : pegAlertAssetName(evidence.labels.asset),
+    cleared && raised !== undefined
+      ? `lasted ${durationLabel(Math.max(0, transition.at - raised.at))}`
+      : null,
   ]
     .filter((part): part is string => part !== null)
     .join(" · ");
-  const cleared = transition.kind === "cleared";
   return {
     id: `state:${transition.identity}:${transition.kind}:${transition.at}`,
     at: transition.at,
     severity: cleared
       ? "cleared"
-      : line.labels.route === "page" || line.labels.severity === "critical"
+      : evidence.labels.route === "page" ||
+          evidence.labels.severity === "critical"
         ? "page"
         : "warning",
-    lead: `${asset} ${subject(line)} ${cleared ? "cleared" : "raised"}`,
-    detail:
-      cleared && raisedAt !== undefined
-        ? `${context} returned to normal after ${durationLabel(Math.max(0, transition.at - raisedAt))}.`
-        : `${context} entered alerting.`,
+    lead: cause.lead,
+    detail: detail === "" ? "" : `${detail}.`,
+    duplicateKey: [
+      pegAlertRuleKind(evidence),
+      evidence.labels.asset,
+      evidence.labels.source,
+      transition.kind,
+    ].join(":"),
+    policySlot: policySlot(evidence),
   };
 }
 
 function pairStateTransitions(
   transitions: readonly PegStateTransition[],
-): PegAlertEvent[] {
+): PhrasedEvent[] {
   const ordered = [...transitions].sort(
     (left, right) =>
       left.at - right.at ||
@@ -402,7 +233,7 @@ function pairStateTransitions(
       left.identity.localeCompare(right.identity),
   );
   const open = new Map<string, PegStateTransition>();
-  const events: PegAlertEvent[] = [];
+  const events: PhrasedEvent[] = [];
   for (const transition of ordered) {
     if (transition.kind === "raised") {
       if (!open.has(transition.identity))
@@ -412,19 +243,65 @@ function pairStateTransitions(
     const raised = open.get(transition.identity);
     if (raised === undefined || transition.at < raised.at) continue;
     events.push(phraseTransition(raised));
-    events.push(phraseTransition(transition, raised.at));
+    events.push(phraseTransition(transition, raised));
     open.delete(transition.identity);
   }
   for (const raised of open.values()) events.push(phraseTransition(raised));
   return events;
 }
 
+function preferPolicyEvent(
+  left: PhrasedEvent,
+  right: PhrasedEvent,
+): PhrasedEvent {
+  const rank = { active: 2, approved: 1, previous: 0 } as const;
+  return rank[right.policySlot] > rank[left.policySlot] ? right : left;
+}
+
+function complementaryPolicySlots(
+  left: PhrasedEvent,
+  right: PhrasedEvent,
+): boolean {
+  return (
+    (left.policySlot === "active" && right.policySlot === "previous") ||
+    (left.policySlot === "previous" && right.policySlot === "active")
+  );
+}
+
+function coalescePolicyDuplicates(events: PhrasedEvent[]): PegAlertEvent[] {
+  const coalesced: PhrasedEvent[] = [];
+  const unmatchedIndexByKey = new Map<string, number>();
+  for (const event of [...events].sort((left, right) => right.at - left.at)) {
+    const duplicateIndex = unmatchedIndexByKey.get(event.duplicateKey);
+    const candidate =
+      duplicateIndex === undefined ? undefined : coalesced[duplicateIndex];
+    if (
+      duplicateIndex === undefined ||
+      candidate === undefined ||
+      !complementaryPolicySlots(candidate, event) ||
+      Math.abs(candidate.at - event.at) > POLICY_DUPLICATE_WINDOW_SECONDS
+    ) {
+      coalesced.push(event);
+      unmatchedIndexByKey.set(event.duplicateKey, coalesced.length - 1);
+      continue;
+    }
+    coalesced[duplicateIndex] = preferPolicyEvent(candidate, event);
+    unmatchedIndexByKey.delete(event.duplicateKey);
+  }
+  return coalesced.map((event) => ({
+    id: event.id,
+    at: event.at,
+    severity: event.severity,
+    lead: event.lead,
+    detail: event.detail,
+  }));
+}
+
 export function combinePegAlertEvents(
   stateTransitions: readonly PegStateTransition[],
-  policyEvents: readonly PegAlertEvent[],
   maximumEvents: number,
 ): PegAlertEvent[] {
-  return [...pairStateTransitions(stateTransitions), ...policyEvents]
+  return coalescePolicyDuplicates(pairStateTransitions(stateTransitions))
     .sort(
       (left, right) => right.at - left.at || left.id.localeCompare(right.id),
     )

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -12,19 +12,14 @@ import {
 } from "@/lib/server/grafana-read";
 import {
   combinePegAlertEvents,
-  parsePolicyActivations,
   parseStateTransitions,
-  policyQueryBounds,
   PEG_ALERTS_MAX_STATE_ROWS,
-  PEG_ALERTS_POLICY_STEP_SECONDS,
 } from "./peg-alert-events";
 
 export const dynamic = "force-dynamic";
 export const PEG_ALERTS_UPSTREAM_TIMEOUT_MS = 8_000;
 export const PEG_ALERTS_MAX_STATE_RESPONSE_BYTES = 4 * 1024 * 1024;
-export const PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES = 512 * 1024;
 export const PEG_ALERTS_MAX_EVENTS = 4;
-export const PEG_ALERTS_DATASOURCE_UID = "grafanacloud-prom";
 
 function stateHistoryUrl(
   origin: string | undefined,
@@ -49,46 +44,15 @@ function stateHistoryUrl(
   return url;
 }
 
-function policyRequest(from: number, to: number): object {
-  const bounds = policyQueryBounds(from, to);
-  const stepMs = PEG_ALERTS_POLICY_STEP_SECONDS * 1_000;
-  return {
-    queries: [
-      {
-        refId: "P",
-        datasource: {
-          type: "prometheus",
-          uid: PEG_ALERTS_DATASOURCE_UID,
-        },
-        expr: "mento_peg_policy_version",
-        format: "time_series",
-        range: true,
-        instant: false,
-        intervalMs: stepMs,
-        maxDataPoints: (bounds.toMs - bounds.fromMs) / stepMs + 1,
-      },
-    ],
-    // One extra point distinguishes a policy that predates the visible window
-    // from a label series first observed inside it.
-    from: String(bounds.fromMs),
-    to: String(bounds.toMs),
-  };
-}
-
 async function fetchJson(
   url: URL,
   token: string,
   maximumBytes: number,
-  init: Pick<RequestInit, "body" | "method"> = {},
 ): Promise<unknown> {
   const response = await fetch(url, {
-    ...init,
     headers: {
       Accept: "application/json",
       Authorization: `Bearer ${token}`,
-      ...(init.body === undefined
-        ? {}
-        : { "Content-Type": "application/json" }),
     },
     cache: "no-store",
     redirect: "error",
@@ -132,23 +96,15 @@ export async function GET(): Promise<NextResponse> {
     return grafanaErrorResponse("Peg alert history is not configured", 503);
 
   try {
-    const [raisedRaw, clearedRaw, policyRaw] = await Promise.all([
+    const [raisedRaw, clearedRaw] = await Promise.all([
       fetchJson(raisedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
       fetchJson(clearedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
-      fetchJson(policyUrl, token, PEG_ALERTS_MAX_POLICY_RESPONSE_BYTES, {
-        method: "POST",
-        body: JSON.stringify(policyRequest(from, to)),
-      }),
     ]);
     const transitions = [
       ...parseStateTransitions(raisedRaw, from, to),
       ...parseStateTransitions(clearedRaw, from, to),
     ];
-    const events = combinePegAlertEvents(
-      transitions,
-      parsePolicyActivations(policyRaw, from, to),
-      PEG_ALERTS_MAX_EVENTS,
-    );
+    const events = combinePegAlertEvents(transitions, PEG_ALERTS_MAX_EVENTS);
     const response: PegAlertsResponse = { from, to, events };
     return NextResponse.json(response, { headers: GRAFANA_NO_STORE_HEADERS });
   } catch (error) {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -25,22 +25,15 @@ const events: PegAlertEvent[] = [
     id: "kesm-warning",
     at: Date.UTC(2026, 7, 11, 16, 5) / 1_000,
     severity: "warning",
-    lead: "KESm warning raised",
-    detail: "deviation ≥ 25 bps sustained 10 min on VALR. Slack notified.",
+    lead: "VALR sell price is 25 bps below peg",
+    detail: "KESm.",
   },
   {
     id: "europ-cleared",
     at: Date.UTC(2026, 7, 9, 14, 37) / 1_000,
     severity: "cleared",
-    lead: "EUROP spread warning cleared",
-    detail: "spread back under 30 bps after 22 min.",
-  },
-  {
-    id: "policy",
-    at: Date.UTC(2026, 6, 22, 9, 0) / 1_000,
-    severity: "policy",
-    lead: "Policy europ-2026-07-22-v1 activated",
-    detail: "warn −25, page −50, premium +25.",
+    lead: "Bitvavo buy and sell prices were 30 bps apart",
+    detail: "EUROP · lasted 22 min.",
   },
 ];
 
@@ -81,14 +74,9 @@ describe("RecentAlerts", () => {
       ),
     );
     const rows = container.querySelectorAll("li");
-    // The Jul 22 policy activation predates the advertised 7-day window, so
-    // the component drops it even though the feed supplied it.
     expect(rows).toHaveLength(2);
-    expect(
-      container.querySelector('[data-testid="peg-alert-policy"]'),
-    ).toBeNull();
     expect(rows[0]!.querySelector("strong")!.textContent).toBe(
-      "KESm warning raised",
+      "VALR sell price is 25 bps below peg",
     );
     // Every bold lead gets the same colour treatment; the mockup was
     // inconsistent about this.
@@ -98,29 +86,35 @@ describe("RecentAlerts", () => {
     expect(new Set(leadClasses).size).toBe(1);
     expect(container.textContent).toContain("Today 16:05");
     expect(container.textContent).toContain("Aug 9 14:37");
+    expect(
+      rows[0]!.querySelector('[role="img"]')?.getAttribute("aria-label"),
+    ).toBe("Alert active");
+    expect(
+      rows[1]!.querySelector('[role="img"]')?.getAttribute("aria-label"),
+    ).toBe("Alert resolved");
   });
 
-  it("renders an in-window policy activation with the brand-purple dot", () => {
-    const recentPolicy: PegAlertEvent = {
-      ...events[2]!,
-      at: Date.UTC(2026, 7, 10, 9, 0) / 1_000,
-    };
+  it("omits the separator when the cause needs no detail", () => {
     act(() =>
       root.render(
-        <RecentAlerts nowMs={NOW_MS} events={[recentPolicy]} state="ready" />,
+        <RecentAlerts
+          nowMs={NOW_MS}
+          events={[{ ...events[0]!, detail: "" }]}
+          state="ready"
+        />,
       ),
     );
-    expect(
-      container.querySelector('[data-testid="peg-alert-policy"]')!.textContent,
-    ).toContain(
-      "Policy europ-2026-07-22-v1 activated — warn −25, page −50, premium +25.",
-    );
+    expect(container.querySelector("li")?.textContent).not.toContain("—");
   });
 
   it("says so when a wired feed has no events inside the window", () => {
     act(() =>
       root.render(
-        <RecentAlerts nowMs={NOW_MS} events={[events[2]!]} state="ready" />,
+        <RecentAlerts
+          nowMs={NOW_MS}
+          events={[{ ...events[0]!, at: Date.UTC(2026, 6, 22, 9, 0) / 1_000 }]}
+          state="ready"
+        />,
       ),
     );
     expect(container.textContent).toContain("No alerts in the last 7 days.");

--- a/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
@@ -9,7 +9,12 @@ const SEVERITY_COLOR: Record<PegAlertSeverity, string> = {
   warning: PEG_COLOR.amber,
   cleared: PEG_COLOR.green,
   page: PEG_COLOR.red,
-  policy: PEG_COLOR.purple,
+};
+
+const SEVERITY_LABEL: Record<PegAlertSeverity, string> = {
+  warning: "Alert active",
+  cleared: "Alert resolved",
+  page: "Urgent alert active",
 };
 
 const clock = new Intl.DateTimeFormat("en-US", {
@@ -44,15 +49,19 @@ function AlertEntry({
       data-testid={`peg-alert-${event.id}`}
       className="grid grid-cols-[14px_96px_1fr] items-start gap-2.5 border-t border-border px-[18px] py-2.5"
     >
-      <span className="pt-[5px]">
+      <span
+        className="pt-[5px]"
+        role="img"
+        aria-label={SEVERITY_LABEL[event.severity]}
+      >
         <SeverityDot size={8} color={SEVERITY_COLOR[event.severity]} />
       </span>
       <span className="text-[11.5px]" style={{ color: PEG_COLOR.muted }}>
         {alertTimestamp(event.at, nowMs)}
       </span>
       <span className="text-[12.5px] text-[var(--peg-text-2)]">
-        <strong className="font-[650] text-foreground">{event.lead}</strong> —{" "}
-        {event.detail}
+        <strong className="font-[650] text-foreground">{event.lead}</strong>
+        {event.detail === "" ? null : <> — {event.detail}</>}
       </span>
     </li>
   );

--- a/ui-dashboard/src/lib/peg-alerts.ts
+++ b/ui-dashboard/src/lib/peg-alerts.ts
@@ -1,14 +1,14 @@
 export const PEG_ALERTS_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 export const PEG_ALERTS_REFRESH_MS = 5 * 60 * 1_000;
 
-export type PegAlertSeverity = "warning" | "cleared" | "page" | "policy";
+export type PegAlertSeverity = "warning" | "cleared" | "page";
 
 export type PegAlertEvent = {
   id: string;
   /** Unix seconds. */
   at: number;
   severity: PegAlertSeverity;
-  /** Bold lead-in, e.g. "EUROP spread warning cleared". */
+  /** Bold cause-first lead-in, e.g. "Bitvavo sell price is 30 bps below peg". */
   lead: string;
   detail: string;
 };

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -93,9 +93,8 @@ test("renders the status board, expands a row panel, and retains stale evidence"
             id: "europ-spread-cleared",
             at: now - 120,
             severity: "cleared",
-            lead: "EUROP spread warning cleared",
-            detail:
-              "Bitvavo EUR · active policy returned to normal after 22 min.",
+            lead: "Bitvavo buy and sell prices were 34 bps apart",
+            detail: "EUROP · lasted 22 min.",
           },
         ],
       },
@@ -209,8 +208,13 @@ test("renders the status board, expands a row panel, and retains stale evidence"
 
   const alerts = page.getByTestId("peg-recent-alerts");
   await expect(alerts).toContainText("Recent alerts");
-  await expect(alerts).toContainText("EUROP spread warning cleared");
-  await expect(alerts).toContainText("normal after 22 min");
+  await expect(alerts).toContainText(
+    "Bitvavo buy and sell prices were 34 bps apart",
+  );
+  await expect(alerts).toContainText("EUROP · lasted 22 min");
+  await expect(
+    alerts.getByRole("img", { name: "Alert resolved" }),
+  ).toBeVisible();
   const grafanaLink = alerts.getByRole("link", {
     name: /Full history in Grafana/,
   });


### PR DESCRIPTION
## The Problem

- Peg alert history used internal rule and policy terms instead of stating why the alert fired.
- Provider failures did not preserve a safe, specific cause such as HTTP 429, HTTP 500, timeout, or insufficient book depth.
- Grafana and Slack used different copy from the dashboard and repeated state text that the status marker already showed.

## The Solution

- Use one cause-first copy contract across the dashboard, Grafana summaries, Slack, and Splunk On-Call. Preserve bounded transition evidence so each active or resolved event states the measured cause in plain language.

## Details

- Publish bounded failure-reason gauges and an event counter from Metrics Bridge. Preserve exact provider HTTP status codes from 100 through 599. Never expose raw errors, response bodies, URLs, or credentials.
- Store `Reason` and `HttpStatus` as Grafana helper-query values. They do not affect the alert condition, labels, fingerprint, threshold, routing, or policy.
- Pair resolved transitions with their original fired evidence. Combine matching active-policy and retained-policy history rows one-to-one for display only. Grafana continues to evaluate both policy slots independently.
- Use active cause-first sentences such as `Bitvavo sell price is 31 bps below peg`. Use past tense for resolved transitions. Preserve canonical names such as `KESm` and `VALR`.
- Use the existing status dot and accessible label for active, urgent, or resolved state. Remove raised/cleared, warning/page, policy-slot, and internal rule-name jargon from visible dashboard copy.
- Use the same cause-first annotations in Grafana and notification templates. Slack uses its severity icon instead of repeating `FIRING` or `RESOLVED`. Splunk On-Call keeps the required `P1` and `RESOLVED` prefixes.
- Keep the existing Grafana alert names stable because they are alert identities.
- Terraform apply and production deployment remain separate post-merge steps. The normal Terraform plan and apply require explicit human approval.

Refs #1867

## Validation

- `pnpm agent:quality-gate --run` — passed all mapped checks, including the dashboard browser suite, package lint and type checks, coverage, React Doctor, Terraform tests, alert-rule lint, dependency checks, and documentation checks.
- `TF_DATA_DIR=alerts/rules/.terraform-agent-gate terraform -chdir=alerts/rules validate` — passed.
- `TF_DATA_DIR=alerts/rules/.terraform-agent-gate terraform -chdir=alerts/rules test` — 1 passed, 0 failed.
- `CI=true node --test scripts/alert-rules-lint.test.mjs` — 44 passed.
- `CI=true pnpm --filter @mento-protocol/ui-dashboard test --run src/app/api/peg-monitoring/alerts/__tests__/route.test.ts` — 37 passed.
- Fresh-context Codex autoreview — first cycle found one canonical-casing defect; fixed. Second cycle reviewed the sealed 30-file bundle with no findings. The bound manifest check passed.
- Deterministic local autoreview — clean.
- Claude Security scan: skipped because the Claude-only plugin is unavailable in this Codex session. The full gate and Codex review covered the network-facing API and bounded failure-data path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches peg alerting copy, new Prometheus series, and Grafana rule annotations across production notification paths; alert logic and fingerprints are intended to stay unchanged via non-participating helper queries.
> 
> **Overview**
> Peg alerts now explain **what went wrong** in plain language everywhere operators see them—dashboard recent alerts, Grafana summaries, Slack, and Splunk On-Call—instead of internal rule names and “raised/cleared” jargon.
> 
> **Metrics Bridge** publishes bounded failure reason and HTTP-status gauges (plus a failure-events counter) and classifies provider errors (429, 500, timeout, stale book, etc.) without exposing raw responses. **Grafana** rules gain `summary` / `resolved_summary` cause-first copy, `Reason` and `HttpStatus` helper queries that do not affect alert identity, and updated notification templates that lead with annotations. **Dashboard** history reads those transition values, maps reason codes to the same copy contract, pairs resolved rows with fired evidence, and optionally coalesces near-duplicate active vs retained-policy rows for display only.
> 
> Policy-activation events are dropped from the recent-alerts feed; the `policy` severity is removed from the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87a45e6350e7ab13c17ddc71dedddb3989cf81d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->