### PR TITLE
fix(peg): restore alert history availability

### DIFF
--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -126,12 +126,16 @@ Canonical display-name maps preserve asset and provider casing such as `KESm`
 and `VALR` across the dashboard, Grafana, and notifications.
 
 Each dashboard alert row has a collapsed `Details` disclosure. The disclosure
-explains the fixed condition and its actual Pending-to-Alerting wait. It reads a
-threshold from the decision package only when the event and package use the
-same policy version. Older events without cause telemetry say that the exact
-cause was not recorded. The history backend reads one extra seven-day context
-window to pair transitions that began before the displayed window. It emits
-only alerts that fired or cleared during the displayed seven days.
+explains the fixed condition and its configured wait. It reads thresholds from
+the decision package only when the event and package use the same policy
+version. Older events without cause telemetry say that the exact cause was not
+recorded. The history backend reads only fired and resolved transitions from
+the displayed seven days. It does not read Pending or canceled transitions.
+When a matching fired transition is available, a resolved row keeps its cause
+and shows how long the alert stayed active. A resolution remains visible
+without that active time when the alert fired before the displayed window. Its
+details can still show the configured wait when the event and current policy
+versions match.
 
 Grafana state history stores the evaluated query values for each transition.
 Every Peg rule therefore includes two helper queries, `Reason` and

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@/lib/peg-alerts";
 import {
   GET,
-  PEG_ALERTS_CONTEXT_LEAD_IN_SECONDS,
   PEG_ALERTS_MAX_EVENTS,
   PEG_ALERTS_MAX_STATE_RESPONSE_BYTES,
   PEG_ALERTS_UPSTREAM_TIMEOUT_MS,
@@ -19,7 +18,6 @@ import {
 
 const NOW_SECONDS = 1_786_694_595;
 const FROM_SECONDS = NOW_SECONDS - PEG_ALERTS_WINDOW_SECONDS;
-const CONTEXT_FROM_SECONDS = FROM_SECONDS - PEG_ALERTS_CONTEXT_LEAD_IN_SECONDS;
 
 type StateLine = {
   schemaVersion: 1;
@@ -113,12 +111,6 @@ function eventFor(overrides: Parameters<typeof stateLine>[0]): PegAlertEvent {
 }
 
 function successfulFetch() {
-  const pendingRows = [
-    {
-      at: NOW_SECONDS - 1_800,
-      line: stateLine({ previous: "Normal", current: "Pending" }),
-    },
-  ];
   const raisedRows = [
     { at: NOW_SECONDS - 1_200, line: stateLine() },
     { at: NOW_SECONDS - 1_140, line: stateLine() },
@@ -164,13 +156,11 @@ function successfulFetch() {
     const previous = url.searchParams.get("previous");
     return json(
       stateFrame(
-        current === "Pending"
-          ? pendingRows
-          : current === "Alerting"
-            ? raisedRows
-            : previous === "Alerting"
-              ? normalRows
-              : [],
+        current === "Alerting"
+          ? raisedRows
+          : previous === "Alerting"
+            ? normalRows
+            : [],
       ),
     );
   });
@@ -201,6 +191,23 @@ describe("GET /api/peg-monitoring/alerts", () => {
       to: NOW_SECONDS,
       events: [
         {
+          id: `state:unpaired-instance:cleared:${NOW_SECONDS - 120}`,
+          at: NOW_SECONDS - 120,
+          severity: "cleared",
+          lead: "Bitvavo buy and sell prices were unusually far apart",
+          detail: "EUROP.",
+          evidence: {
+            rule: "Deep-Venue Spread Warning",
+            assetId: "europ-schuman",
+            assetName: "EUROP",
+            sourceId: "bitvavo_eur",
+            sourceName: "Bitvavo",
+            quoteCurrency: "EUR",
+            policyVersion: "europ-v1",
+            failureReason: null,
+          },
+        },
+        {
           id: `state:critical-instance:raised:${NOW_SECONDS - 300}`,
           at: NOW_SECONDS - 300,
           severity: "page",
@@ -215,7 +222,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
             quoteCurrency: "EUR",
             policyVersion: "europ-v1",
             failureReason: null,
-            pendingSeconds: null,
           },
         },
         {
@@ -233,7 +239,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
             quoteCurrency: "EUR",
             policyVersion: "europ-v1",
             failureReason: null,
-            pendingSeconds: 600,
           },
         },
         {
@@ -251,26 +256,25 @@ describe("GET /api/peg-monitoring/alerts", () => {
             quoteCurrency: "EUR",
             policyVersion: "europ-v1",
             failureReason: null,
-            pendingSeconds: 600,
           },
         },
       ],
     });
     expect(PEG_ALERTS_MAX_EVENTS).toBe(4);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("current"),
       ),
-    ).toEqual(["Pending", "Alerting", "Normal", "Normal"]);
+    ).toEqual(["Alerting", "Normal"]);
     expect(
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("previous"),
       ),
-    ).toEqual([null, null, "Alerting", "Pending"]);
+    ).toEqual([null, "Alerting"]);
     for (const [input, init] of fetchMock.mock.calls) {
       const query = new URL(String(input)).searchParams;
-      expect(query.get("from")).toBe(String(CONTEXT_FROM_SECONDS));
+      expect(query.get("from")).toBe(String(FROM_SECONDS));
       expect(query.get("to")).toBe(String(NOW_SECONDS));
       expect(query.get("limit")).toBe(String(PEG_ALERTS_MAX_STATE_ROWS + 1));
       expect(query.get("labels_service")).toBe("peg-monitoring");
@@ -281,37 +285,27 @@ describe("GET /api/peg-monitoring/alerts", () => {
     expect(PEG_ALERTS_UPSTREAM_TIMEOUT_MS).toBeLessThan(10_000);
   });
 
-  it("keeps a Pending transition just before the display window", async () => {
-    const pending = stateLine({
-      previous: "Normal",
-      current: "Pending",
-      fingerprint: "boundary-instance",
-    });
-    const raised = stateLine({ fingerprint: "boundary-instance" });
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = new URL(String(input));
-      const current = url.searchParams.get("current");
-      return json(
-        stateFrame(
-          current === "Pending"
-            ? [{ at: FROM_SECONDS - 60, line: pending }]
-            : current === "Alerting"
-              ? [{ at: FROM_SECONDS + 60, line: raised }]
-              : [],
-        ),
-      );
-    });
+  it("does not read high-cardinality Pending state history", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const query = new URL(String(input)).searchParams;
+        if (
+          query.get("current") === "Pending" ||
+          query.get("previous") === "Pending"
+        )
+          throw new Error("Pending state history exceeded 1,000 rows");
+        return json(stateFrame([]));
+      });
 
     const response = await GET();
+
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toEqual({
       from: FROM_SECONDS,
-      events: [
-        {
-          at: FROM_SECONDS + 60,
-          evidence: { pendingSeconds: 120 },
-        },
-      ],
+      to: NOW_SECONDS,
+      events: [],
     });
   });
 
@@ -375,7 +369,39 @@ describe("GET /api/peg-monitoring/alerts", () => {
     ]);
   });
 
-  it("does not attach a canceled pending cycle to a later alert", () => {
+  it("keeps only the latest resolution when its fire predates the window", () => {
+    const firstResolved = stateLine({
+      previous: "Alerting",
+      current: "Normal",
+      fingerprint: "boundary-resolution",
+      values: {},
+    });
+    const latestResolved = stateLine({
+      previous: "Alerting",
+      current: "Normal",
+      fingerprint: "boundary-resolution",
+      values: {},
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 100, line: firstResolved },
+        { at: NOW_SECONDS - 80, line: latestResolved },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:boundary-resolution:cleared:${NOW_SECONDS - 80}`,
+        severity: "cleared",
+        lead: "Bitvavo buy and sell prices were unusually far apart",
+        detail: "EUROP.",
+      }),
+    ]);
+  });
+
+  it("ignores transitions that never fired", () => {
     const pending = stateLine({
       previous: "Normal",
       current: "Pending",
@@ -387,20 +413,15 @@ describe("GET /api/peg-monitoring/alerts", () => {
       fingerprint: "canceled-pending",
       values: {},
     });
-    const fired = stateLine({ fingerprint: "canceled-pending" });
     const transitions = parseStateTransitions(
       stateFrame([
         { at: NOW_SECONDS - 200, line: pending },
         { at: NOW_SECONDS - 150, line: canceled },
-        { at: NOW_SECONDS - 100, line: fired },
       ]),
       FROM_SECONDS,
       NOW_SECONDS,
     );
-
-    expect(
-      combinePegAlertEvents(transitions, 4)[0]?.evidence.pendingSeconds,
-    ).toBeNull();
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([]);
   });
 
   it("coalesces active and previous policy transitions one-to-one", () => {
@@ -584,14 +605,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
 
   it("uses positive recovery wording for stale and unclassified prices", () => {
     const title = "Peg Source Unhealthy [europ-schuman/kraken_eur · active]";
-    const pending = stateLine({
-      previous: "Normal",
-      current: "Pending",
-      fingerprint: "stale-instance",
-      ruleTitle: title,
-      values: { Reason: 6 },
-      labels: { alertname: title, source: "kraken_eur" },
-    });
     const fired = stateLine({
       fingerprint: "stale-instance",
       ruleTitle: title,
@@ -609,7 +622,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
     const events = combinePegAlertEvents(
       parseStateTransitions(
         stateFrame([
-          { at: NOW_SECONDS - 1_920, line: pending },
           { at: NOW_SECONDS - 120, line: fired },
           { at: NOW_SECONDS - 60, line: resolved },
         ]),
@@ -625,7 +637,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
         lead: "Kraken price data is fresh again",
         evidence: expect.objectContaining({
           failureReason: 6,
-          pendingSeconds: 1_800,
         }),
       }),
       expect.objectContaining({
@@ -633,7 +644,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
         lead: "Kraken price data is too old",
         evidence: expect.objectContaining({
           failureReason: 6,
-          pendingSeconds: 1_800,
         }),
       }),
     ]);
@@ -699,8 +709,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
   it("fails closed for malformed frames and oversized bodies", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json({ schema: {}, data: {} }))
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(stateFrame([])))
       .mockResolvedValueOnce(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
 
@@ -714,8 +722,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
           },
         }),
       )
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(stateFrame([])))
       .mockResolvedValueOnce(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
   });
@@ -730,8 +736,6 @@ describe("GET /api/peg-monitoring/alerts", () => {
     );
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json(stateFrame(sentinelRows)))
-      .mockResolvedValueOnce(json(stateFrame([])))
-      .mockResolvedValueOnce(json(stateFrame([])))
       .mockResolvedValueOnce(json(stateFrame([])));
 
     expect((await GET()).status).toBe(502);

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -76,7 +76,7 @@ class InvalidPegAlertsUpstreamError extends Error {}
 
 type PegStateTransition = {
   at: number;
-  kind: "pending" | "raised" | "cleared" | "normal";
+  kind: "raised" | "cleared";
   identity: string;
   line: StateLine;
 };
@@ -98,18 +98,12 @@ function baseState(value: string): string {
 }
 
 function transitionKind(line: StateLine): PegStateTransition["kind"] | null {
-  if (baseState(line.current) === "Pending") return "pending";
   if (baseState(line.current) === "Alerting") return "raised";
   if (
     baseState(line.previous) === "Alerting" &&
     baseState(line.current) === "Normal"
   )
     return "cleared";
-  if (
-    baseState(line.previous) === "Pending" &&
-    baseState(line.current) === "Normal"
-  )
-    return "normal";
   return null;
 }
 
@@ -198,7 +192,6 @@ type PhrasedEvent = PegAlertEvent & {
 function phraseTransition(
   transition: PegStateTransition,
   raised?: PegStateTransition,
-  pending?: PegStateTransition,
 ): PhrasedEvent {
   const evidence = raised?.line ?? transition.line;
   const cleared = transition.kind === "cleared";
@@ -231,10 +224,6 @@ function phraseTransition(
       quoteCurrency: pegAlertSourceCurrency(evidence.labels.source),
       policyVersion: evidence.labels.policy_version,
       failureReason: normalizedFailureReason(evidence.values.Reason),
-      pendingSeconds:
-        pending === undefined || raised === undefined
-          ? null
-          : Math.max(0, raised.at - pending.at),
     },
     duplicateKey: [
       pegAlertRuleKind(evidence),
@@ -258,53 +247,42 @@ function normalizedFailureReason(reason: number | undefined): number | null {
 function pairStateTransitions(
   transitions: readonly PegStateTransition[],
 ): PhrasedEvent[] {
-  const kindRank: Record<PegStateTransition["kind"], number> = {
-    pending: 0,
-    raised: 1,
-    normal: 2,
-    cleared: 3,
-  };
   const ordered = [...transitions].sort(
     (left, right) =>
       left.at - right.at ||
-      kindRank[left.kind] - kindRank[right.kind] ||
+      (left.kind === right.kind ? 0 : left.kind === "raised" ? -1 : 1) ||
       left.identity.localeCompare(right.identity),
   );
-  const pending = new Map<string, PegStateTransition>();
-  const open = new Map<
-    string,
-    { raised: PegStateTransition; pending?: PegStateTransition }
-  >();
+  const open = new Map<string, PegStateTransition>();
+  const observedRaised = new Set<string>();
+  const unpairedCleared = new Map<string, PegStateTransition>();
   const events: PhrasedEvent[] = [];
   for (const transition of ordered) {
-    if (transition.kind === "pending") {
-      pending.set(transition.identity, transition);
-      continue;
-    }
-    if (transition.kind === "normal") {
-      pending.delete(transition.identity);
-      continue;
-    }
     if (transition.kind === "raised") {
+      const boundaryResolution = unpairedCleared.get(transition.identity);
+      if (boundaryResolution !== undefined) {
+        events.push(phraseTransition(boundaryResolution));
+        unpairedCleared.delete(transition.identity);
+      }
+      observedRaised.add(transition.identity);
       if (!open.has(transition.identity))
-        open.set(transition.identity, {
-          raised: transition,
-          ...(pending.has(transition.identity)
-            ? { pending: pending.get(transition.identity)! }
-            : {}),
-        });
-      pending.delete(transition.identity);
+        open.set(transition.identity, transition);
       continue;
     }
-    const cycle = open.get(transition.identity);
-    if (cycle === undefined || transition.at < cycle.raised.at) continue;
-    events.push(phraseTransition(cycle.raised, cycle.raised, cycle.pending));
-    events.push(phraseTransition(transition, cycle.raised, cycle.pending));
+    const raised = open.get(transition.identity);
+    if (raised === undefined) {
+      if (!observedRaised.has(transition.identity))
+        unpairedCleared.set(transition.identity, transition);
+      continue;
+    }
+    if (transition.at < raised.at) continue;
+    events.push(phraseTransition(raised, raised));
+    events.push(phraseTransition(transition, raised));
     open.delete(transition.identity);
   }
-  for (const cycle of open.values()) {
-    events.push(phraseTransition(cycle.raised, cycle.raised, cycle.pending));
-  }
+  for (const cleared of unpairedCleared.values())
+    events.push(phraseTransition(cleared));
+  for (const raised of open.values()) events.push(phraseTransition(raised));
   return events;
 }
 
@@ -359,12 +337,10 @@ function coalescePolicyDuplicates(events: PhrasedEvent[]): PegAlertEvent[] {
 export function combinePegAlertEvents(
   stateTransitions: readonly PegStateTransition[],
   maximumEvents: number,
-  minimumEventAt = Number.NEGATIVE_INFINITY,
 ): PegAlertEvent[] {
   return coalescePolicyDuplicates(pairStateTransitions(stateTransitions))
     .sort(
       (left, right) => right.at - left.at || left.id.localeCompare(right.id),
     )
-    .filter((event) => event.at >= minimumEventAt)
     .slice(0, maximumEvents);
 }

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -20,13 +20,12 @@ export const dynamic = "force-dynamic";
 export const PEG_ALERTS_UPSTREAM_TIMEOUT_MS = 8_000;
 export const PEG_ALERTS_MAX_STATE_RESPONSE_BYTES = 4 * 1024 * 1024;
 export const PEG_ALERTS_MAX_EVENTS = 4;
-export const PEG_ALERTS_CONTEXT_LEAD_IN_SECONDS = PEG_ALERTS_WINDOW_SECONDS;
 
 function stateHistoryUrl(
   origin: string | undefined,
   from: number,
   to: number,
-  kind: "pending" | "raised" | "cleared" | "canceled",
+  kind: "raised" | "cleared",
 ): URL | null {
   const url = resolveGrafanaEndpoint(origin, "/api/v1/rules/history");
   if (url === null) return null;
@@ -36,12 +35,8 @@ function stateHistoryUrl(
   // seven-day result was truncated instead of silently losing an incident.
   url.searchParams.set("limit", String(PEG_ALERTS_MAX_STATE_ROWS + 1));
   url.searchParams.set("labels_service", "peg-monitoring");
-  url.searchParams.set(
-    "current",
-    kind === "raised" ? "Alerting" : kind === "pending" ? "Pending" : "Normal",
-  );
+  url.searchParams.set("current", kind === "raised" ? "Alerting" : "Normal");
   if (kind === "cleared") url.searchParams.set("previous", "Alerting");
-  if (kind === "canceled") url.searchParams.set("previous", "Pending");
   return url;
 }
 
@@ -70,19 +65,16 @@ async function fetchJson(
 export async function GET(): Promise<NextResponse> {
   const to = Math.floor(Date.now() / 1_000);
   const from = to - PEG_ALERTS_WINDOW_SECONDS;
-  // Fetch one extra display window so alerts that start before `from` retain
-  // their Pending wait and fired evidence. Emitted rows remain within `from`.
-  const contextFrom = from - PEG_ALERTS_CONTEXT_LEAD_IN_SECONDS;
   const token = process.env.GRAFANA_QUERY_TOKEN?.trim();
   const raisedUrl = stateHistoryUrl(
     process.env.GRAFANA_QUERY_URL,
-    contextFrom,
+    from,
     to,
     "raised",
   );
   const clearedUrl = stateHistoryUrl(
     process.env.GRAFANA_QUERY_URL,
-    contextFrom,
+    from,
     to,
     "cleared",
   );
@@ -98,39 +90,16 @@ export async function GET(): Promise<NextResponse> {
     policyUrl === null
   )
     return grafanaErrorResponse("Peg alert history is not configured", 503);
-  const pendingUrl = stateHistoryUrl(
-    process.env.GRAFANA_QUERY_URL,
-    contextFrom,
-    to,
-    "pending",
-  );
-  const canceledUrl = stateHistoryUrl(
-    process.env.GRAFANA_QUERY_URL,
-    contextFrom,
-    to,
-    "canceled",
-  );
-  if (pendingUrl === null || canceledUrl === null)
-    return grafanaErrorResponse("Peg alert history is not configured", 503);
-
   try {
-    const [pendingRaw, raisedRaw, clearedRaw, canceledRaw] = await Promise.all([
-      fetchJson(pendingUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
+    const [raisedRaw, clearedRaw] = await Promise.all([
       fetchJson(raisedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
       fetchJson(clearedUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
-      fetchJson(canceledUrl, token, PEG_ALERTS_MAX_STATE_RESPONSE_BYTES),
     ]);
     const transitions = [
-      ...parseStateTransitions(pendingRaw, contextFrom, to),
-      ...parseStateTransitions(raisedRaw, contextFrom, to),
-      ...parseStateTransitions(clearedRaw, contextFrom, to),
-      ...parseStateTransitions(canceledRaw, contextFrom, to),
+      ...parseStateTransitions(raisedRaw, from, to),
+      ...parseStateTransitions(clearedRaw, from, to),
     ];
-    const events = combinePegAlertEvents(
-      transitions,
-      PEG_ALERTS_MAX_EVENTS,
-      from,
-    );
+    const events = combinePegAlertEvents(transitions, PEG_ALERTS_MAX_EVENTS);
     const response: PegAlertsResponse = { from, to, events };
     return NextResponse.json(response, { headers: GRAFANA_NO_STORE_HEADERS });
   } catch (error) {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -39,7 +39,6 @@ const events: PegAlertEvent[] = [
       quoteCurrency: "ZAR",
       policyVersion: "kesm-v1",
       failureReason: null,
-      pendingSeconds: null,
     },
   },
   {
@@ -57,7 +56,6 @@ const events: PegAlertEvent[] = [
       quoteCurrency: "EUR",
       policyVersion: monitoring.producedPolicyVersion,
       failureReason: null,
-      pendingSeconds: 600,
     },
   },
 ];
@@ -155,7 +153,7 @@ describe("RecentAlerts", () => {
       "The gap between the best available buy and sell prices exceeded the allowed spread.",
     );
     expect(details.textContent).toContain(
-      "The alert fired after the condition continued for 10 minutes.",
+      "The alert fires after the gap remains too wide for 10 minutes.",
     );
   });
 
@@ -190,14 +188,9 @@ describe("RecentAlerts", () => {
 });
 
 describe("pegAlertExplanation", () => {
-  it("shows the measured alert wait when the event policy is not current", () => {
-    const event: PegAlertEvent = {
-      ...events[0]!,
-      evidence: { ...events[0]!.evidence, pendingSeconds: 420 },
-    };
-
-    expect(pegAlertExplanation(event, monitoring)).toBe(
-      "The monitor uses the average price available when selling the monitored amount, not the midpoint between buy and sell prices. The alert fired after the condition continued for 7 minutes.",
+  it("does not apply current thresholds to a historical policy", () => {
+    expect(pegAlertExplanation(events[0]!, monitoring)).toBe(
+      "The monitor uses the average price available when selling the monitored amount, not the midpoint between buy and sell prices.",
     );
   });
 
@@ -217,12 +210,11 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: "EUR",
         policyVersion: monitoring.producedPolicyVersion,
         failureReason: 6,
-        pendingSeconds: 1_800,
       },
     };
 
     expect(pegAlertExplanation(staleEvent, monitoring)).toBe(
-      "The latest Kraken EUROP/EUR price was more than 5 minutes old. The alert fired after the data remained too old for 30 minutes.",
+      "The latest Kraken EUROP/EUR price was more than 5 minutes old. The alert fires after the data remains too old for 30 minutes.",
     );
     expect(
       pegAlertExplanation(
@@ -234,7 +226,7 @@ describe("pegAlertExplanation", () => {
         monitoring,
       ),
     ).toBe(
-      "A fresh Kraken EUROP/EUR price arrived, so the alert cleared. The data had remained too old for 30 minutes before the alert fired.",
+      "A fresh Kraken EUROP/EUR price arrived, so the alert cleared. The alert fires after the data remains too old for 30 minutes.",
     );
   });
 
@@ -254,7 +246,6 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: "EUR",
         policyVersion: monitoring.producedPolicyVersion,
         failureReason: null,
-        pendingSeconds: null,
       },
     };
 
@@ -295,7 +286,6 @@ describe("pegAlertExplanation", () => {
           quoteCurrency: "EUR",
           policyVersion: monitoring.producedPolicyVersion,
           failureReason: 1,
-          pendingSeconds: null,
         },
       };
 
@@ -321,7 +311,6 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: "EUR",
         policyVersion: monitoring.producedPolicyVersion,
         failureReason: 6,
-        pendingSeconds: null,
       },
     };
 
@@ -346,12 +335,11 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: "EUR",
         policyVersion: monitoring.producedPolicyVersion,
         failureReason: 18,
-        pendingSeconds: 300,
       },
     };
 
     expect(pegAlertExplanation(event, monitoring)).toBe(
-      "The monitor could not calculate a current Bitvavo sell price for the monitored amount. The alert fired after the condition continued for 5 minutes. The monitor did not classify the cause.",
+      "The monitor could not calculate a current Bitvavo sell price for the monitored amount. The alert fires after the problem continues for 1 minute. The monitor did not classify the cause.",
     );
   });
 
@@ -371,7 +359,6 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: null,
         policyVersion: monitoring.approvedActivePolicyVersion,
         failureReason: null,
-        pendingSeconds: null,
       },
     };
 
@@ -407,12 +394,11 @@ describe("pegAlertExplanation", () => {
         quoteCurrency: "EUR",
         policyVersion: monitoring.producedPolicyVersion,
         failureReason: 17,
-        pendingSeconds: null,
       },
     };
 
     expect(pegAlertExplanation(event, monitoring)).toBe(
-      "The Peg monitor supports Bitvavo again.",
+      "The Peg monitor supports Bitvavo again. The alert fires after the problem continues for 1 minute.",
     );
     expect(
       pegAlertExplanation(
@@ -422,7 +408,9 @@ describe("pegAlertExplanation", () => {
         },
         monitoring,
       ),
-    ).toBe("Bitvavo now reports that it lists the EUROP/EUR market.");
+    ).toBe(
+      "Bitvavo now reports that it lists the EUROP/EUR market. The alert fires after the problem continues for 1 minute.",
+    );
     expect(
       pegAlertExplanation(
         {

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
@@ -10,6 +10,8 @@ type ExactPolicyContext = {
   source: PegSource | null;
 };
 
+const SECONDARY_SOURCE_UNHEALTHY_SECONDS = 30 * 60;
+
 function durationWords(seconds: number): string {
   if (seconds < 60) return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
   if (seconds < 3_600) {
@@ -51,14 +53,49 @@ function marketName(event: PegAlertEvent): string {
     : `${event.evidence.assetName}/${quote}`;
 }
 
-function pendingSentence(
+function configuredWaitSeconds(
   event: PegAlertEvent,
-  condition = "the condition continued",
+  policy: ExactPolicyContext | null,
+): number | null {
+  if (policy === null) return null;
+  if (event.evidence.rule === "Source Permanently Dead")
+    return policy.asset.policy.permanentlyDeadSeconds;
+  if (event.evidence.rule === "Source Unhealthy") {
+    if (policy.source === null) return null;
+    return policy.source.authority === "secondary"
+      ? SECONDARY_SOURCE_UNHEALTHY_SECONDS
+      : policy.source.policy.pollIntervalSeconds * 2;
+  }
+  if (
+    event.evidence.rule === "Deep-Venue Spread Warning" ||
+    event.evidence.rule === "Structural Saturation Warning"
+  )
+    return policy.asset.policy.warnSustainSeconds;
+  return null;
+}
+
+function configuredWaitSentence(
+  event: PegAlertEvent,
+  policy: ExactPolicyContext | null,
+  condition: string,
 ): string {
-  const seconds = event.evidence.pendingSeconds;
+  const seconds = configuredWaitSeconds(event, policy);
   return seconds === null || seconds <= 0
     ? ""
-    : ` The alert fired after ${condition} for ${durationWords(seconds)}.`;
+    : ` The alert fires after ${condition} for ${durationWords(seconds)}.`;
+}
+
+function sourceWaitSentence(
+  event: PegAlertEvent,
+  policy: ExactPolicyContext | null,
+): string {
+  return configuredWaitSentence(
+    event,
+    policy,
+    event.evidence.rule === "Source Permanently Dead"
+      ? "the source remains unhealthy"
+      : "the problem continues",
+  );
 }
 
 function blindThresholdSentence(
@@ -91,7 +128,7 @@ function unknownSellPriceExplanation(
     event.evidence.failureReason === 18
       ? " The monitor did not classify the cause."
       : " The exact cause was not recorded.";
-  return `${opening}${blindThresholdSentence(event, policy)}${pendingSentence(event)}${causeGap}`;
+  return `${opening}${blindThresholdSentence(event, policy)}${sourceWaitSentence(event, policy)}${causeGap}`;
 }
 
 function stalePriceExplanation(
@@ -102,19 +139,19 @@ function stalePriceExplanation(
   const market = marketName(event);
   const staleAfter = policy?.source?.policy.staleAfterSeconds;
   const blindThreshold = blindThresholdSentence(event, policy);
+  const alertWait = configuredWaitSentence(
+    event,
+    policy,
+    "the data remains too old",
+  );
   if (event.severity === "cleared") {
-    const wait = event.evidence.pendingSeconds;
-    return `A fresh ${source} ${market} price arrived, so the alert cleared.${blindThreshold}${
-      wait === null || wait <= 0
-        ? ""
-        : ` The data had remained too old for ${durationWords(wait)} before the alert fired.`
-    }`;
+    return `A fresh ${source} ${market} price arrived, so the alert cleared.${blindThreshold}${alertWait}`;
   }
   const age =
     staleAfter === undefined
       ? "older than the allowed age"
       : `more than ${durationWords(staleAfter)} old`;
-  return `The latest ${source} ${market} price was ${age}.${blindThreshold}${pendingSentence(event, "the data remained too old")}`;
+  return `The latest ${source} ${market} price was ${age}.${blindThreshold}${alertWait}`;
 }
 
 function sourceFailureExplanation(
@@ -130,7 +167,7 @@ function sourceFailureExplanation(
     SOURCE_FAILURE_EXPLANATIONS[event.evidence.failureReason ?? 0];
   return explanation === undefined
     ? unknownSellPriceExplanation(event, policy)
-    : `${explanation(source, market, event.severity === "cleared")}${blindThresholdSentence(event, policy)}${pendingSentence(event)}`;
+    : `${explanation(source, market, event.severity === "cleared")}${blindThresholdSentence(event, policy)}${sourceWaitSentence(event, policy)}`;
 }
 
 type SourceFailureExplanation = (
@@ -186,13 +223,13 @@ function listingExplanation(
       checks === undefined
         ? ""
         : ` The original alert fired after ${checks} consecutive listing checks reported the market missing.`;
-    return `${event.evidence.sourceName} now reports that it lists the ${marketName(event)} market.${originalWait}${pendingSentence(event)}`;
+    return `${event.evidence.sourceName} now reports that it lists the ${marketName(event)} market.${originalWait}`;
   }
   const confirmation =
     checks === undefined
       ? ""
       : ` The monitor confirmed this across ${checks} consecutive listing checks.`;
-  return `${event.evidence.sourceName} reported that it does not list the ${marketName(event)} market.${confirmation}${pendingSentence(event)}`;
+  return `${event.evidence.sourceName} reported that it does not list the ${marketName(event)} market.${confirmation}`;
 }
 
 function movementExplanation(
@@ -207,7 +244,7 @@ function movementExplanation(
     seconds === undefined
       ? ""
       : ` The rule evaluates new sell-price decisions across a ${durationWords(seconds)} window.`;
-  return `The monitor uses the average price available when selling the monitored amount, not the midpoint between buy and sell prices.${window}${pendingSentence(event)}`;
+  return `The monitor uses the average price available when selling the monitored amount, not the midpoint between buy and sell prices.${window}`;
 }
 
 type RuleExplanation = (
@@ -226,28 +263,28 @@ const RULE_EXPLANATIONS: Record<PegAlertRuleKind, RuleExplanation> = {
   "Deep-Venue Downside Critical": movementExplanation,
   "Downside Warning": movementExplanation,
   "Premium Warning": movementExplanation,
-  "Deep-Venue Spread Warning": (event) =>
-    `The gap between the best available buy and sell prices exceeded the allowed spread.${pendingSentence(event)}`,
-  "Structural Saturation Warning": (event) =>
-    `Pool flow stayed close to the trading limit.${pendingSentence(event)}`,
-  "Heartbeat Missing": (event, policy) => {
+  "Deep-Venue Spread Warning": (event, policy) =>
+    `The gap between the best available buy and sell prices exceeded the allowed spread.${configuredWaitSentence(event, policy, "the gap remains too wide")}`,
+  "Structural Saturation Warning": (event, policy) =>
+    `Pool flow stayed close to the trading limit.${configuredWaitSentence(event, policy, "pool flow remains close to the trading limit")}`,
+  "Heartbeat Missing": (_event, policy) => {
     const freshness = policy?.asset.policy.freshnessGraceSeconds;
     const condition =
       freshness === undefined
         ? "The Peg monitor did not complete a new poll within its allowed delay."
         : `The Peg monitor did not complete a new poll within ${durationWords(freshness)}.`;
-    return `${condition}${pendingSentence(event)}`;
+    return condition;
   },
-  "Indexed Pool Unreachable": (event) =>
-    `The monitor could not verify the indexed pool that supplies trading-limit and flow data. Current market prices remain separate.${pendingSentence(event)}`,
+  "Indexed Pool Unreachable": () =>
+    "The monitor could not verify the indexed pool that supplies trading-limit and flow data. Current market prices remain separate.",
   "Policy Rollover Stuck": (event, _policy, monitoring) =>
     `${
       event.evidence.policyVersion === monitoring.approvedActivePolicyVersion
         ? `The Peg monitor did not load the approved policy within ${durationWords(monitoring.rolloverAckExpectedSeconds)}.`
         : "The Peg monitor did not load the approved policy within the allowed time."
-    }${pendingSentence(event)}`,
-  Unknown: (event) =>
-    `The alert history did not contain a recognized Peg rule or a precise cause.${pendingSentence(event)}`,
+    }`,
+  Unknown: () =>
+    "The alert history did not contain a recognized Peg rule or a precise cause.",
 };
 
 export function pegAlertExplanation(

--- a/ui-dashboard/src/lib/peg-alerts.ts
+++ b/ui-dashboard/src/lib/peg-alerts.ts
@@ -33,7 +33,6 @@ type PegAlertEvidence = {
   quoteCurrency: string | null;
   policyVersion: string;
   failureReason: number | null;
-  pendingSeconds: number | null;
 };
 
 export type PegAlertEvent = {

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -104,7 +104,6 @@ test("renders the status board, expands a row panel, and retains stale evidence"
               quoteCurrency: "EUR",
               policyVersion: payload.producedPolicyVersion,
               failureReason: null,
-              pendingSeconds: 600,
             },
           },
         ],
@@ -235,7 +234,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   await alertDetails.getByText("Details", { exact: true }).click();
   await expect(
     alertDetails.getByText(
-      "The alert fired after the condition continued for 10 minutes.",
+      "The alert fires after the gap remains too wide for 10 minutes.",
       { exact: false },
     ),
   ).toBeVisible();


### PR DESCRIPTION
## The Problem

- Peg alert history returns HTTP 502 because Pending and canceled state-history queries exceed the bounded parser limit.
- Optional timing data hides every fired and resolved alert.

## The Solution

- Query only fired and resolved transitions for the seven-day alert list.
- Explain each alert's configured wait from the matching policy instead of reading Pending history.

## Details

- The API makes two Grafana state-history requests: `Alerting` and `Alerting -> Normal`.
- A resolved row keeps its original cause and active time when its fired transition is available.
- A resolution remains visible without its active time when the fire predates the seven-day window.
- Repeated standalone resolutions for one alert identity collapse to the newest transition.
- Fired and resolved history still fails closed when its own response is malformed, truncated, or unavailable.
- Pending and canceled transitions are not alert rows and are intentionally outside this endpoint.
- Claude Security scan: skipped because this is a Codex session. The network-facing handler passed the mapped gate and local Codex autoreview.
- Refs #1874.

## Validation

- `pnpm agent:quality-gate --run` — passed all mapped commands.
- Local Codex autoreview — clear on manifest `b73992fb1f0eb1c9920530c22e640dacb52c08c6faa5a5b2ab8ac07a15309de7`.
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/app/api/peg-monitoring/alerts/__tests__/route.test.ts src/app/peg-monitoring/__tests__/recent-alerts.test.tsx` — 57 tests passed.
- Chrome DevTools at commit `1f5b4e9ab656bae002dcb1c6285d15bbf22f3c2e` — overflow fixture returned HTTP 200 with three alert rows and no console errors.
- Exact base `fdb9349895fd15a9cbddd93699c7419372cab72a` returned HTTP 502 against the same overflow fixture.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This restores the intended alert-history boundary without changing the subsystem architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a user-facing API and dashboard copy for alert history; behavior is narrower (no Pending rows) but restores availability and is covered by route, UI, and browser tests.
> 
> **Overview**
> Fixes Peg **Recent alerts** returning HTTP 502 when Grafana Pending/canceled state history exceeded the bounded row cap.
> 
> The alerts API now issues **two** state-history calls for the displayed seven days—**Alerting** and **Alerting → Normal**—instead of four queries that included Pending and canceled transitions plus a lead-in window. Pairing logic only treats **raised** and **cleared** transitions; resolutions without a fire in-window still appear (latest per identity), and paired clears keep **lasted** duration when the fire is in-window.
> 
> **`pendingSeconds`** is removed from alert evidence. Detail copy uses the **configured wait** from the decision package when the event’s policy version matches the current package (e.g. “The alert fires after the gap remains too wide for 10 minutes”), not measured Pending→Alerting time. Runbook notes in `peg-monitoring.md` match this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5b4e9ab656bae002dcb1c6285d15bbf22f3c2e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->