### PR TITLE
fix(scripts): let autoreview claude engine read macOS Keychain credentials

### DIFF
--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -206,6 +206,14 @@ unset it or provide a trusted external PEM bundle through snapshotted
 are released, including ordinary success and failure as well as timeout or
 interruption.
 
+The Claude engine additionally receives `USER`, because Claude Code builds its
+macOS Keychain account name from that variable and reports an expired OAuth
+session when the lookup misses. The helper derives the name from its own process
+credentials rather than the inherited value, and drops it when the name falls
+outside the portable username character set, so a hostile parent environment
+cannot steer the Keychain lookup. The Codex engine environment does not carry
+it.
+
 The narrow trusted exceptions to the repo-relative supplemental-evidence rule
 are adapter-generated feedback state and protected-main checklist copies inside
 the prepared-bundle directory. Sensitive paths, credential-like content, private

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -24,7 +24,7 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import {
@@ -2939,6 +2939,26 @@ function snapshotExternalRegularFileEnv(env, repo, snapshotRecord, key) {
   }
 }
 
+// Claude Code reads its macOS Keychain credentials with
+// `security find-generic-password -a "$USER" -s "Claude Code-credentials"`. The
+// engine environment is rebuilt from an allowlist, so an absent USER sends that
+// lookup to a different account name, no credential is found, and the CLI fails
+// in about 20ms with an expired-OAuth-session error. Derive the account name
+// from the process credentials rather than the inherited variable so a hostile
+// parent environment cannot steer the lookup, and reject anything outside the
+// portable username character set.
+const ENGINE_ACCOUNT_NAME_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+
+function trustedEngineAccountName() {
+  let username;
+  try {
+    ({ username } = userInfo());
+  } catch {
+    return null;
+  }
+  return ENGINE_ACCOUNT_NAME_PATTERN.test(username) ? username : null;
+}
+
 function safeEngineEnv(repo, engine, runtimeDir) {
   if (process.env.SSL_CERT_DIR) {
     throw new Error(
@@ -3056,6 +3076,8 @@ function safeEngineEnv(repo, engine, runtimeDir) {
     const claudeConfig = externalPath(repo, process.env.CLAUDE_CONFIG_DIR);
     if (claudeConfig) env.CLAUDE_CONFIG_DIR = claudeConfig;
     env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1";
+    const account = trustedEngineAccountName();
+    if (account) env.USER = account;
   }
   const git = resolveTrustedCommand("git", repo);
   const nodeRuntime = attestedNodeRuntime(repo);
@@ -3439,9 +3461,13 @@ async function ensureClaudeIsolationSupported(claude, repo, env, cwd) {
       label: "claude version probe",
       timeoutSeconds: 15,
     });
-  } catch {
+  } catch (error) {
+    // A failed probe proves nothing about the installed version. Report the
+    // probe failure and its cause so an operator does not chase an upgrade that
+    // is already in place.
     throw new Error(
-      "claude engine requires Claude Code >= 2.1.169 for --safe-mode",
+      `claude engine version probe failed: ${error?.message || error}`,
+      { cause: error },
     );
   }
   const version = parseVersion(

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -2600,6 +2600,10 @@ CLAUDE
   expect_file_contains "$capture.env" "AWS_ROLE_ARN=arn:aws:iam::123456789012:role/autoreview-test"
   expect_file_contains "$capture.env" "AWS_ROLE_SESSION_NAME=autoreview-session"
   expect_file_contains "$capture.env" "AWS_SDK_LOAD_CONFIG=1"
+  # Claude Code builds its macOS Keychain account name from USER. The runner
+  # above starts the helper with `env -i` and no USER, so this line can only
+  # come from the helper deriving the name from the process credentials.
+  expect_file_contains_line "$capture.env" "USER=$(id -un)"
   local key
   local snapshot_path
   local expected_source
@@ -2924,6 +2928,54 @@ CLAUDE
   fi
 }
 
+# A failed --version probe proves nothing about the installed version. The
+# reviewer used to report the too-old message for every probe failure, which
+# sent operators to upgrade a CLI that was already new enough.
+run_claude_version_probe_failure_regression() {
+  local review_repo="$tmp_dir/claude-version-probe"
+  local fake_bin="$tmp_dir/claude-version-probe-bin"
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  printf 'review me\n' >>"$review_repo/README.md"
+  mkdir "$fake_bin"
+  cat >"$fake_bin/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+cat >/dev/null
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'version probe exploded\n' >&2
+  exit 3
+fi
+exit 1
+CLAUDE
+  chmod +x "$fake_bin/claude"
+
+  run_helper_with_path_in_repo_expect_failure "$review_repo" "$fake_bin" \
+    --mode local --engine claude --no-tools
+  expect_stderr_contains "claude engine version probe failed"
+  expect_stderr_contains "version probe exploded"
+  expect_file_not_contains "$stderr" "requires Claude Code >= 2.1.169"
+  expect_stdout_not_contains "autoreview clean"
+
+  cat >"$fake_bin/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+cat >/dev/null
+if [[ "${1:-}" == "--version" ]]; then
+  printf '2.1.100\n'
+  exit 0
+fi
+exit 1
+CLAUDE
+  chmod +x "$fake_bin/claude"
+
+  run_helper_with_path_in_repo_expect_failure "$review_repo" "$fake_bin" \
+    --mode local --engine claude --no-tools
+  expect_stderr_contains \
+    "claude engine requires Claude Code >= 2.1.169 for --safe-mode"
+  expect_file_not_contains "$stderr" "version probe failed"
+  expect_stdout_not_contains "autoreview clean"
+}
+
 run_codex_isolation_regression() {
   local review_repo="$tmp_dir/codex-isolation"
   local fake_bin="$tmp_dir/fake-codex-bin"
@@ -3012,6 +3064,9 @@ CODEX
     printf 'Codex SSL_CERT_FILE snapshot survived engine cleanup\n' >&2
     exit 1
   fi
+  # USER exists for the claude engine's Keychain lookup alone; codex keeps the
+  # narrower environment it had before that fix.
+  expect_file_not_contains "$capture.env" "USER=$(id -un)"
   expect_file_not_contains "$capture.env" "UNRELATED_SECRET"
   expect_stdout_contains "autoreview clean"
   expect_empty_stderr
@@ -6630,6 +6685,7 @@ run_engine_isolation_family() {
   run_codex_binary_resolution_regression
   run_suite_family_diagnostic_regression
   run_claude_no_tools_regression
+  run_claude_version_probe_failure_regression
   run_codex_isolation_regression
   run_engine_signal_cleanup_regression
   run_stdin_epipe_regression


### PR DESCRIPTION
## The Problem

- The autoreview claude engine failed every run on macOS in about 20ms with `Failed to authenticate: OAuth session expired and could not be refreshed`, however fresh the login was.
- A failed `claude --version` probe reported `claude engine requires Claude Code >= 2.1.169 for --safe-mode`, which sent operators to upgrade a CLI that was already new enough.

## The Solution

- Give the claude engine environment a `USER` value, because Claude Code builds its macOS Keychain account name from that variable.
- Report a version-probe failure as a probe failure, with its cause, instead of as an out-of-date CLI.

## Details

Claude Code reads its macOS Keychain credentials with `security find-generic-password -a "$USER" -s "Claude Code-credentials"`. `safeEngineEnv` rebuilds the engine environment from an allowlist that never carried `USER`, so the lookup ran against a different account name, found nothing, and reported an expired OAuth session.

The root cause recorded on the issue was different, and the diff reflects the verified one. The issue attributed the failure to `/usr/bin` being absent from the engine PATH, leaving the `security` binary unreachable. `trustedToolPath` already returns `<trusted-bin>:/usr/bin:/bin:/usr/sbin:/sbin`, so `security` was always resolvable. A bisection over the engine environment isolated `USER` as the only missing input: with `PATH=/usr/bin:/bin:/usr/sbin:/sbin` and no `USER`, `claude --print` fails with the OAuth message; adding `USER` alone to the same environment authenticates. Disassembling the installed CLI confirms the mechanism — the keychain reader calls `security find-generic-password -a "${process.env.USER || os.userInfo().username}"`. Adding `security` to the trusted tool path would have changed nothing.

The helper derives the account name from its own process credentials rather than from the inherited variable, so a hostile parent environment cannot steer the Keychain lookup, and drops the value when it falls outside `^[A-Za-z0-9._-]{1,64}$`. Both failure paths fall back to the pre-change behaviour. The assignment sits in the claude branch of `safeEngineEnv` alone; the codex engine environment is unchanged, and a new assertion in the codex isolation regression holds it that way.

`ensureClaudeIsolationSupported` caught every version-probe rejection and threw the minimum-version error. A rejected launcher shim produced that message against an installed CLI 2.1.233. The catch path now throws `claude engine version probe failed: <cause>` and attaches the caught error as `cause`. The version comparison below it keeps its original message unchanged.

Tests extend the existing families rather than adding files. `run_claude_no_tools_regression` asserts the captured claude environment contains `USER=$(id -un)`; the suite launches the helper under `env -i` with no `USER`, so that line can only come from the OS-derived value. `run_codex_isolation_regression` asserts the same line is absent. A new `run_claude_version_probe_failure_regression` in the engine-isolation family drives two fake CLIs: one whose `--version` exits 3, expecting the probe-failure message and the absence of the version message; one reporting 2.1.100, expecting the version message and the absence of the probe-failure message.

`docs/notes/autoreview-runtime-trust.md` records the new environment element in the semantic-engine isolation contract.

## Validation

Before and after, same repository, same diff, same PATH, same claude CLI 2.1.233:

- Before, running the pre-change helper: `autoreview failed: ... "result":"Failed to authenticate: OAuth session expired and could not be refreshed" ... "duration_ms":20`, exit 1.
- After, running the patched helper: `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.98)`, exit 0, 11s wall clock.

Commands:

- `pnpm lint:scripts` — pass.
- `node scripts/agent-autoreview-core.test.mjs` — pass.
- `AUTOREVIEW_TEST_FOCUS=engine-isolation bash scripts/agent-autoreview.test.sh` — pass (covers the engine environment and the new version-probe regression).
- `AUTOREVIEW_TEST_FOCUS=runtime-trust bash scripts/agent-autoreview.test.sh` — pass.
- `bash -n scripts/agent-autoreview.test.sh` — pass.
- `./tools/trunk check docs/notes/autoreview-runtime-trust.md scripts/agent-autoreview.mjs scripts/agent-autoreview.test.sh` — no issues.
- `pnpm docs:index --check`, `pnpm agent:context-check`, `pnpm docs:navigation-eval -- --check-fixtures`, `pnpm tf:test` — pass.
- `pnpm agent:autoreview:test` (the full suite, about 90 minutes) defers to the required `ci` check. The two families above cover the changed code paths.

Autoreview on this branch's own diff, run through the documented external-checkout flow because the diff changes the autoreview runtime:

- `--engine claude`: clean, `patch is correct (0.85)`. This run is also the end-to-end authentication proof.
- `--engine codex`: clean, `patch is correct (0.91)`.

Neither engine raised an actionable finding. The claude pass noted two non-actionable points: the username pattern would accept a leading hyphen or dot, and the pattern-rejection branch has no test. Both stand as written — the value comes from `getpwuid`, never from inherited input, and the rejection branch reproduces the pre-change behaviour.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1880

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted autoreview runtime env and error messaging for the Claude path only, with regression tests and no auth or data-model changes.
> 
> **Overview**
> Fixes **macOS Claude autoreview** failing immediately with a false “OAuth session expired” by adding **`USER`** to the Claude-only allowlisted engine env in `safeEngineEnv`. The value comes from **`os.userInfo()`** (not inherited env), gated by a portable username pattern, so Keychain lookup matches the real account; **Codex env is unchanged**.
> 
> **`ensureClaudeIsolationSupported`** now surfaces **`claude engine version probe failed: …`** with the underlying error as `cause` when `--version` fails, instead of always blaming an outdated CLI.
> 
> Docs in **`autoreview-runtime-trust.md`** record the Claude `USER` contract. Tests assert Claude captures `USER=$(id -un)` under `env -i`, Codex does not, and a new regression covers probe-failure vs too-old version messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68449ffe1aa65ae846c99edb548ad31ed270d41e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->