### PR TITLE
fix: prevent peg board horizontal overflow

### DIFF
--- a/ui-dashboard/src/app/peg-monitoring/_components/board-row.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/board-row.tsx
@@ -12,6 +12,7 @@ import {
 } from "../_lib/peg-board-format";
 import {
   PEG_BOARD_GRID,
+  PEG_BOARD_ROW_PADDING,
   PEG_COLOR,
   distanceLabel,
   monitorStates,
@@ -76,7 +77,7 @@ export function BoardRow({
       onClick={(event) => {
         if (!isInteractiveTarget(event)) onToggle(assetId);
       }}
-      className={`grid cursor-pointer items-center border-b border-border px-[18px] py-4 ${PEG_BOARD_GRID} ${rowTint(badge.tone, open)}`}
+      className={`grid cursor-pointer items-center border-b border-border py-4 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING} ${rowTint(badge.tone, open)}`}
     >
       <div
         role="cell"
@@ -158,7 +159,7 @@ function DistanceCell({
   const label = distanceLabel(asset);
   const warning = tone !== "healthy";
   return (
-    <div role="cell" className="flex min-w-0 items-center gap-3">
+    <div role="cell" className="flex min-w-0 items-center gap-2 xl:gap-3">
       <DistanceRail
         testId={`peg-rail-${asset.asset.asset}`}
         marker={railMarker(asset.distanceBps, asset.direction)}
@@ -168,7 +169,7 @@ function DistanceCell({
         ariaLabel={`${asset.assetName} distance from target: ${label}`}
       />
       <span
-        className={`whitespace-nowrap text-[12.5px] ${warning ? "font-[650]" : ""}`}
+        className={`min-w-0 whitespace-normal text-[11.5px] leading-tight xl:whitespace-nowrap xl:text-[12.5px] ${warning ? "font-[650]" : ""}`}
         style={{ color: warning ? PEG_COLOR.amber : PEG_COLOR.muted }}
       >
         {label}

--- a/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
@@ -5,6 +5,7 @@ import type { PegMonitoringPresentation } from "@/lib/peg-monitoring-presentatio
 import {
   PEG_BOARD_GRID,
   PEG_BOARD_MIN_WIDTH,
+  PEG_BOARD_ROW_PADDING,
   sortBoardRows,
 } from "../_lib/peg-board-model";
 import { BoardRow } from "./board-row";
@@ -55,7 +56,10 @@ export function BoardTable({
       {/* `relative` contains absolutely-positioned descendants (the sr-only
           column label, rail markers) so they clip with the scroller instead of
           widening the document on narrow viewports. */}
-      <div className="relative overflow-x-auto">
+      <div
+        data-testid="peg-board-scroller"
+        className="relative overflow-x-auto"
+      >
         {/* The layout is a CSS grid, so the table semantics screen readers
             need for column/cell association are declared via ARIA roles; the
             expanded panel participates as a full-width row (aria-colspan). */}
@@ -66,7 +70,7 @@ export function BoardTable({
         >
           <div
             role="row"
-            className={`grid border-b border-border px-[18px] py-2.5 ${PEG_BOARD_GRID}`}
+            className={`grid border-b border-border py-2.5 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING}`}
           >
             {HEADERS.map((header, index) => (
               <div

--- a/ui-dashboard/src/app/peg-monitoring/_components/distance-rail.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/distance-rail.tsx
@@ -32,7 +32,7 @@ export function DistanceRail({
       role="img"
       aria-label={ariaLabel}
       data-testid={testId}
-      className="relative block h-2 w-[120px] shrink-0"
+      className="relative block h-2 w-[72px] shrink-0 xl:w-[120px]"
       style={{ background: PEG_RAIL_GRADIENT }}
     >
       <span

--- a/ui-dashboard/src/app/peg-monitoring/_components/distance-rail.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/distance-rail.tsx
@@ -94,7 +94,7 @@ function OffScaleMarker({
       <span
         aria-hidden="true"
         className={`absolute top-1/2 -translate-y-1/2 text-[11px] leading-none ${
-          below ? "-left-3.5" : "-right-3.5"
+          below ? "left-0 xl:-left-3.5" : "right-0 xl:-right-3.5"
         }`}
         style={{ color: PEG_COLOR.redText }}
       >

--- a/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
@@ -7,6 +7,7 @@ import { buildPoolDetailHref } from "@/lib/routing";
 import { formatFraction } from "../_lib/peg-board-format";
 import {
   PEG_COLOR,
+  PEG_BOARD_ROW_PADDING,
   distanceLabel,
   effectiveAssetPolicy,
   monitorStates,
@@ -86,7 +87,7 @@ export function RowPanel({
       id={`peg-panel-${asset.asset.asset}`}
       data-testid={`peg-panel-${asset.asset.asset}`}
       role="row"
-      className="border-y border-border bg-card px-[18px] pb-[22px] pt-5"
+      className={`border-y border-border bg-card pb-[22px] pt-5 ${PEG_BOARD_ROW_PADDING}`}
     >
       <div role="cell" aria-colspan={9}>
         <div className="space-y-2">

--- a/ui-dashboard/src/app/peg-monitoring/_components/supporting-markets.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/supporting-markets.tsx
@@ -142,15 +142,19 @@ function UsableCells({
       <div className="truncate text-[12.5px] text-muted-foreground">
         {formatNumber(source.executablePrice)}
       </div>
-      <div className="flex min-w-0 items-center gap-3">
+      <div
+        data-testid={`peg-supporting-distance-${source.id}`}
+        className="flex min-w-0 items-center gap-1.5 xl:gap-3"
+      >
         <DistanceRail
+          testId={`peg-supporting-rail-${source.id}`}
           marker={marker}
           tone={offScale ? "critical" : "healthy"}
           ariaLabel={`${venueLabel(source)}: ${distanceText}`}
           tooltip={railTooltip}
         />
         <span
-          className="whitespace-nowrap text-[12px]"
+          className="min-w-0 whitespace-normal text-[11.5px] leading-tight xl:whitespace-nowrap xl:text-[12px]"
           style={{
             color: offScale ? PEG_COLOR.offScale : PEG_COLOR.muted,
           }}
@@ -185,14 +189,18 @@ function UnavailableCells({
   return (
     <>
       <div className="truncate text-[12.5px] text-muted-foreground">—</div>
-      <div className="flex min-w-0 items-center gap-3">
+      <div
+        data-testid={`peg-supporting-distance-${source.id}`}
+        className="flex min-w-0 items-center gap-1.5 xl:gap-3"
+      >
         <DistanceRail
+          testId={`peg-supporting-rail-${source.id}`}
           marker={null}
           tone="healthy"
           ariaLabel={`${venueLabel(source)}: unavailable — ${reason}`}
         />
         <span
-          className="whitespace-nowrap text-[12px]"
+          className="min-w-0 whitespace-normal text-[11.5px] leading-tight xl:whitespace-nowrap xl:text-[12px]"
           style={{ color: PEG_COLOR.muted }}
         >
           Unavailable — {reason}

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
@@ -63,13 +63,10 @@ export const PEG_TONE_COLOR: Record<PegBoardTone, string> = {
 
 /** Board grid: Peg · Status · Price · Distance · Primary · Spread · Limit · Breaker · chevron. */
 export const PEG_BOARD_GRID =
-  "grid-cols-[118px_92px_94px_1fr_160px_118px_132px_96px_28px] gap-4";
-/** Sum of the fixed tracks plus gaps, so the 1fr distance column keeps its rail. */
-// Fixed columns + gaps + row padding total 1,002px, so anything at or below
-// that starves the 1fr distance column; 1,220px leaves it the ~215px the rail
-// plus an un-truncated "31.2 bps below" label need. Below this the wrapper's
-// overflow-x-auto scrolls instead of crushing cells.
-export const PEG_BOARD_MIN_WIDTH = "min-w-[1220px]";
+  "grid-cols-[96px_78px_76px_158px_128px_92px_100px_82px_28px] gap-[7px] xl:grid-cols-[118px_92px_94px_minmax(180px,1fr)_160px_118px_132px_96px_28px] xl:gap-4";
+/** Compact desktops fit the full board; narrow mobile viewports still scroll. */
+export const PEG_BOARD_MIN_WIDTH = "min-w-[900px] xl:min-w-[1220px]";
+export const PEG_BOARD_ROW_PADDING = "px-3 xl:px-[18px]";
 
 /** The row rail spans ±60 bps around target, with the target tick at 50%. */
 export const PEG_RAIL_SCALE_BPS = 60;

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
@@ -1,4 +1,8 @@
-import { PEG_BOARD_GRID, PEG_BOARD_MIN_WIDTH } from "./_lib/peg-board-model";
+import {
+  PEG_BOARD_GRID,
+  PEG_BOARD_MIN_WIDTH,
+  PEG_BOARD_ROW_PADDING,
+} from "./_lib/peg-board-model";
 
 const rows = ["first", "second"];
 const cells = [
@@ -40,7 +44,7 @@ export function PegMonitoringLoading(): React.JSX.Element {
         <div className="overflow-x-auto">
           <div className={PEG_BOARD_MIN_WIDTH}>
             <div
-              className={`grid border-b border-border px-[18px] py-2.5 ${PEG_BOARD_GRID}`}
+              className={`grid border-b border-border py-2.5 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING}`}
             >
               {cells.map(([column, width]) => (
                 <Bar key={column} className={`h-2.5 ${width}`} />
@@ -49,7 +53,7 @@ export function PegMonitoringLoading(): React.JSX.Element {
             {rows.map((row) => (
               <div
                 key={row}
-                className={`grid items-center border-b border-border px-[18px] py-4 ${PEG_BOARD_GRID}`}
+                className={`grid items-center border-b border-border py-4 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING}`}
               >
                 {cells.map(([column, width]) => (
                   <Bar key={column} className={`h-5 ${width}`} />

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -29,7 +29,7 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   page,
 }) => {
   await page.clock.install({ time: new Date(now * 1000 + 20_000) });
-  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.setViewportSize({ width: 1024, height: 900 });
   let request = 0;
   let failRefreshes = false;
   let failedRefreshes = 0;
@@ -179,6 +179,18 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   await expect(
     panel.getByRole("img", { name: /Peg history over 7d: 2 readings/ }),
   ).toBeVisible();
+  const boardScroller = page.getByTestId("peg-board-scroller");
+  const boardOverflow = await boardScroller.evaluate(
+    (element) => element.scrollWidth - element.clientWidth,
+  );
+  expect(boardOverflow).toBeLessThanOrEqual(1);
+  const thirtyDays = panel.getByRole("button", { name: "30d" });
+  await expect(thirtyDays).toBeInViewport();
+  await thirtyDays.click();
+  await expect(
+    panel.getByRole("img", { name: /Peg history over 30d: 2 readings/ }),
+  ).toBeVisible();
+  expect(historyRequests["30d"]).toBe(1);
   await panel.getByRole("button", { name: "24h" }).click();
   await expect(
     panel.getByRole("img", { name: /Peg history over 24h: 2 readings/ }),
@@ -297,6 +309,61 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
       document.documentElement.clientWidth,
   );
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
+});
+
+test("contains long distance labels inside the compact desktop column", async ({
+  page,
+}) => {
+  await page.clock.install({ time: new Date(now * 1000 + 20_000) });
+  await page.setViewportSize({ width: 1024, height: 900 });
+  const longDistancePayload = {
+    ...payload,
+    packages: payload.packages.map((item) => ({
+      ...item,
+      sources: item.sources.map((source) =>
+        source.id === item.policy.deepVenueSource
+          ? {
+              ...source,
+              executablePrice: 0.87655,
+              deviationBps: 1_234.5,
+            }
+          : source,
+      ),
+    })),
+  };
+  await page.route("**/api/peg-monitoring", async (route) => {
+    await route.fulfill({ json: longDistancePayload });
+  });
+  await page.route("**/api/peg-monitoring/alerts", async (route) => {
+    await route.fulfill({
+      json: { from: now - 7 * 86_400, to: now, events: [] },
+    });
+  });
+  await page.goto("/peg-monitoring");
+
+  const row = page.getByTestId("peg-row-europ-schuman");
+  const cells = row.getByRole("cell");
+  await expect(cells).toHaveCount(9);
+  const label = row.getByText("1,234.5 bps below", { exact: true });
+  await expect(label).toBeVisible();
+  const [labelBox, distanceBox, primaryBox] = await Promise.all([
+    label.boundingBox(),
+    cells.nth(3).boundingBox(),
+    cells.nth(4).boundingBox(),
+  ]);
+  expect(labelBox).not.toBeNull();
+  expect(distanceBox).not.toBeNull();
+  expect(primaryBox).not.toBeNull();
+  expect(labelBox!.x + labelBox!.width).toBeLessThanOrEqual(
+    distanceBox!.x + distanceBox!.width + 1,
+  );
+  expect(distanceBox!.x + distanceBox!.width).toBeLessThanOrEqual(
+    primaryBox!.x + 1,
+  );
+  const boardOverflow = await page
+    .getByTestId("peg-board-scroller")
+    .evaluate((element) => element.scrollWidth - element.clientWidth);
+  expect(boardOverflow).toBeLessThanOrEqual(1);
 });
 
 test("refreshes the board when a hidden tab resumes", async ({ page }) => {

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -321,7 +321,7 @@ test("contains long distance labels inside the compact desktop column", async ({
     packages: payload.packages.map((item) => ({
       ...item,
       sources: item.sources.map((source) =>
-        source.id === item.policy.deepVenueSource
+        source.id === item.policy.deepVenueSource || source.id === "kraken_eur"
           ? {
               ...source,
               executablePrice: 0.87655,
@@ -359,6 +359,38 @@ test("contains long distance labels inside the compact desktop column", async ({
   );
   expect(distanceBox!.x + distanceBox!.width).toBeLessThanOrEqual(
     primaryBox!.x + 1,
+  );
+  await row.getByText("EUROP / EUR", { exact: true }).click();
+  const supportingRow = page.getByTestId("peg-supporting-source-kraken_eur");
+  const supportingDistance = page.getByTestId(
+    "peg-supporting-distance-kraken_eur",
+  );
+  const supportingRail = page.getByTestId("peg-supporting-rail-kraken_eur");
+  const supportingLabel = supportingRow.getByText("1,234.5 bps below", {
+    exact: true,
+  });
+  const offScaleChevron = supportingRow.getByText("«", { exact: true });
+  const [
+    supportingLabelBox,
+    supportingDistanceBox,
+    supportingRailBox,
+    chevronBox,
+  ] = await Promise.all([
+    supportingLabel.boundingBox(),
+    supportingDistance.boundingBox(),
+    supportingRail.boundingBox(),
+    offScaleChevron.boundingBox(),
+  ]);
+  expect(supportingLabelBox).not.toBeNull();
+  expect(supportingDistanceBox).not.toBeNull();
+  expect(supportingRailBox).not.toBeNull();
+  expect(chevronBox).not.toBeNull();
+  expect(supportingLabelBox!.x + supportingLabelBox!.width).toBeLessThanOrEqual(
+    supportingDistanceBox!.x + supportingDistanceBox!.width + 1,
+  );
+  expect(chevronBox!.x).toBeGreaterThanOrEqual(supportingRailBox!.x - 1);
+  expect(chevronBox!.x + chevronBox!.width).toBeLessThanOrEqual(
+    supportingRailBox!.x + supportingRailBox!.width + 1,
   );
   const boardOverflow = await page
     .getByTestId("peg-board-scroller")


### PR DESCRIPTION
## The Problem

- The Peg Monitoring board forced a 1,220 px minimum width on compact desktop screens.
- Expanding Peg History created horizontal scrolling and could hide the 30d control.

## The Solution

- Use a compact responsive grid below the wide desktop breakpoint so the full board and chart fit without horizontal scrolling.

## Visual comparison

Route: `/peg-monitoring`, with Peg History expanded to 30d. Both screenshots use a 1024×900 viewport and the same deterministic fixture. Before is the branch base `9cbcb55b`; after is head `c5220ff1`.

| Before | After |
| --- | --- |
| <img width="920" height="629" alt="Before: Peg Monitoring at 1024 by 900 with horizontal overflow" src="https://github.com/user-attachments/assets/1e23ba70-e244-4f70-b1b1-22f3a7bb87a7" /> | <img width="920" height="609" alt="After: Peg Monitoring at 1024 by 900 without horizontal overflow" src="https://github.com/user-attachments/assets/e2ae2dcd-8587-4b5d-b8dd-9a82561e1844" /> |

## Details

- Keep the existing wide layout at the xl breakpoint.
- Reduce compact column, rail, gap, and row-padding widths.
- Wrap long distance labels so they do not overlap Primary Market.
- Keep narrow mobile containment behavior.
- Closes #1879.

## Validation

- pnpm agent:quality-gate --run — passed on head c5220ff1.
- Fresh-context Codex autoreview and deterministic local autoreview — clean on the final feedback batch.
- Chrome DevTools at 1024 px — board and page overflow are 0 px; 30d stays visible and works.
- Exact-revision screenshot fixture at 1024×900 — branch base 9cbcb55b measured 302 px overflow; head c5220ff1 measured 0 px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and layout constants for the peg monitoring UI; no API, auth, or data logic changes.
> 
> **Overview**
> Fixes **horizontal overflow** on the Peg Monitoring board at ~1024px widths by introducing a **compact layout** below the `xl` breakpoint while keeping the existing wide grid at `xl` and above.
> 
> **Layout model** (`peg-board-model`): tighter column tracks, smaller gaps, `min-w-[900px]` (vs `1220px` only at `xl`), and shared `PEG_BOARD_ROW_PADDING` (`px-3` / `xl:px-[18px]`) applied on header rows, data rows, expanded panels, and the loading skeleton.
> 
> **Distance column**: narrower distance rail (`72px` → `120px` at `xl`), wrapped/smaller distance labels on compact viewports so long values (e.g. `1,234.5 bps below`) stay inside the column and do not overlap Primary Market.
> 
> **Tests**: main browser flow runs at 1024px; asserts the board scroller (`peg-board-scroller`) has no internal overflow with an expanded row, **30d** peg history stays in viewport; adds a dedicated test for long distance labels and column containment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e75ea1efd6b0f3dbc69ca83a6382b663e7e4905. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
