### PR TITLE
fix: remove xl peg board overflow

### DIFF
--- a/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/page-client.test.tsx
@@ -167,12 +167,13 @@ describe("PegMonitoringPageClient board", () => {
     ).not.toBeNull();
   });
 
-  it("toggles the panel from the row and from the chevron, and keeps rows independent", () => {
+  it("toggles the panel from the row and the peg label", () => {
     loaded();
     render();
     const row = query('[data-testid="peg-row-europ-schuman"]')!;
-    const chevron = row.querySelector("button[aria-expanded]")!;
-    expect(chevron.getAttribute("aria-expanded")).toBe("false");
+    const toggle = row.querySelector("button[aria-expanded]")!;
+    expect(toggle.textContent).toBe("EUROP / EUR");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(query('[data-testid="peg-panel-europ-schuman"]')).toBeNull();
 
     click(row);
@@ -188,11 +189,7 @@ describe("PegMonitoringPageClient board", () => {
         .getAttribute("aria-controls"),
     ).toBe("peg-panel-europ-schuman");
 
-    click(
-      query('[data-testid="peg-row-europ-schuman"]')!.querySelector(
-        "button[aria-expanded]",
-      ),
-    );
+    click(toggle);
     expect(query('[data-testid="peg-panel-europ-schuman"]')).toBeNull();
   });
 

--- a/ui-dashboard/src/app/peg-monitoring/_components/board-row.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/board-row.tsx
@@ -66,9 +66,8 @@ export function BoardRow({
   const assetId = asset.asset.asset;
   const panelId = `peg-panel-${assetId}`;
   return (
-    // The chevron button carries the accessible, focusable toggle; the row's
-    // own click handler is a pointer convenience layered on the ARIA table
-    // row, so the row itself stays out of the tab order.
+    // The peg label carries the accessible, focusable toggle. The row's click
+    // handler is a pointer convenience layered on the ARIA table row.
     // eslint-disable-next-line jsx-a11y/interactive-supports-focus, jsx-a11y/click-events-have-key-events
     <div
       data-testid={`peg-row-${assetId}`}
@@ -79,11 +78,17 @@ export function BoardRow({
       }}
       className={`grid cursor-pointer items-center border-b border-border py-4 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING} ${rowTint(badge.tone, open)}`}
     >
-      <div
-        role="cell"
-        className="truncate text-[15px] font-[650] text-foreground"
-      >
-        {pegPairLabel(asset)}
+      <div role="cell" className="min-w-0">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          aria-label={`${open ? "Collapse" : "Expand"} ${pegPairLabel(asset)} details`}
+          onClick={() => onToggle(assetId)}
+          className="block max-w-full truncate text-left text-[15px] font-[650] text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary-border)]"
+        >
+          {pegPairLabel(asset)}
+        </button>
       </div>
       <div role="cell">
         <StatusBadge
@@ -120,22 +125,6 @@ export function BoardRow({
         stale={stale}
         structuralCurrent={structuralCurrent}
       />
-      <div role="cell" className="justify-self-end">
-        <button
-          type="button"
-          aria-expanded={open}
-          aria-controls={panelId}
-          aria-label={`${open ? "Collapse" : "Expand"} ${pegPairLabel(asset)} details`}
-          onClick={() => onToggle(assetId)}
-          className={`flex size-7 items-center justify-center border text-[11px] ${
-            open
-              ? "border-[var(--border-secondary)] bg-[oklch(26.1%_0.0288_303)] text-foreground"
-              : "border-[var(--border-tertiary)] text-muted-foreground"
-          }`}
-        >
-          {open ? "▾" : "▸"}
-        </button>
-      </div>
     </div>
   );
 }

--- a/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/board-table.tsx
@@ -20,7 +20,6 @@ const HEADERS = [
   "Bid-ask spread",
   "Trading limit",
   "Breaker",
-  "",
 ];
 
 export function BoardTable({
@@ -72,19 +71,13 @@ export function BoardTable({
             role="row"
             className={`grid border-b border-border py-2.5 ${PEG_BOARD_GRID} ${PEG_BOARD_ROW_PADDING}`}
           >
-            {HEADERS.map((header, index) => (
+            {HEADERS.map((header) => (
               <div
                 role="columnheader"
-                key={header === "" ? `spacer-${index}` : header}
+                key={header}
                 className="whitespace-nowrap text-[10.5px] font-[650] uppercase tracking-[0.1em] text-muted-foreground"
               >
-                {/* axe's empty-table-header wants SR-visible text, not a
-                    label attribute, for the chevron column. */}
-                {header === "" ? (
-                  <span className="sr-only">Details</span>
-                ) : (
-                  header
-                )}
+                {header}
               </div>
             ))}
           </div>

--- a/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/row-panel.tsx
@@ -89,7 +89,7 @@ export function RowPanel({
       role="row"
       className={`border-y border-border bg-card pb-[22px] pt-5 ${PEG_BOARD_ROW_PADDING}`}
     >
-      <div role="cell" aria-colspan={9}>
+      <div role="cell" aria-colspan={8}>
         <div className="space-y-2">
           {stale ? (
             <PanelLine tone="warning" text={staleNotice(ageLabel)} />

--- a/ui-dashboard/src/app/peg-monitoring/_components/supporting-markets.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/supporting-markets.tsx
@@ -200,7 +200,7 @@ function UnavailableCells({
           ariaLabel={`${venueLabel(source)}: unavailable — ${reason}`}
         />
         <span
-          className="min-w-0 whitespace-normal text-[11.5px] leading-tight xl:whitespace-nowrap xl:text-[12px]"
+          className="min-w-0 whitespace-normal text-[11.5px] leading-tight xl:text-[12px]"
           style={{ color: PEG_COLOR.muted }}
         >
           Unavailable — {reason}

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
@@ -61,9 +61,9 @@ export const PEG_TONE_COLOR: Record<PegBoardTone, string> = {
   uncertain: PEG_COLOR.amber,
 };
 
-/** Board grid: Peg · Status · Price · Distance · Primary · Spread · Limit · Breaker · chevron. */
+/** Board grid: Peg · Status · Price · Distance · Primary · Spread · Limit · Breaker. */
 export const PEG_BOARD_GRID =
-  "grid-cols-[96px_78px_76px_158px_128px_92px_100px_82px_28px] gap-[7px] xl:grid-cols-[112px_86px_88px_minmax(190px,1fr)_150px_110px_120px_90px_24px] xl:gap-[14px]";
+  "grid-cols-[100px_80px_78px_168px_134px_96px_104px_84px] gap-[8px] xl:grid-cols-[120px_90px_92px_minmax(220px,1fr)_164px_114px_124px_96px] xl:gap-[14px]";
 /** Compact desktops fit the full board; narrow mobile viewports still scroll. */
 export const PEG_BOARD_MIN_WIDTH = "min-w-[900px] xl:min-w-full";
 export const PEG_BOARD_ROW_PADDING = "px-3 xl:px-[18px]";

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-board-model.ts
@@ -63,9 +63,9 @@ export const PEG_TONE_COLOR: Record<PegBoardTone, string> = {
 
 /** Board grid: Peg · Status · Price · Distance · Primary · Spread · Limit · Breaker · chevron. */
 export const PEG_BOARD_GRID =
-  "grid-cols-[96px_78px_76px_158px_128px_92px_100px_82px_28px] gap-[7px] xl:grid-cols-[118px_92px_94px_minmax(180px,1fr)_160px_118px_132px_96px_28px] xl:gap-4";
+  "grid-cols-[96px_78px_76px_158px_128px_92px_100px_82px_28px] gap-[7px] xl:grid-cols-[112px_86px_88px_minmax(190px,1fr)_150px_110px_120px_90px_24px] xl:gap-[14px]";
 /** Compact desktops fit the full board; narrow mobile viewports still scroll. */
-export const PEG_BOARD_MIN_WIDTH = "min-w-[900px] xl:min-w-[1220px]";
+export const PEG_BOARD_MIN_WIDTH = "min-w-[900px] xl:min-w-full";
 export const PEG_BOARD_ROW_PADDING = "px-3 xl:px-[18px]";
 
 /** The row rail spans ±60 bps around target, with the target tick at 50%. */

--- a/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/peg-monitoring-loading.tsx
@@ -14,7 +14,6 @@ const cells = [
   ["spread", "w-12"],
   ["limit", "w-10"],
   ["breaker", "w-14"],
-  ["chevron", "w-7"],
 ] as const;
 
 function Bar({ className }: { className: string }): React.JSX.Element {
@@ -24,7 +23,7 @@ function Bar({ className }: { className: string }): React.JSX.Element {
 }
 
 /**
- * Board-shaped skeleton: same header row, same nine-column grid and the same
+ * Board-shaped skeleton: same header row, same eight-column grid and the same
  * 16px row padding as the loaded table, so the first paint does not reflow.
  */
 export function PegMonitoringLoading(): React.JSX.Element {

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -311,7 +311,7 @@ test("keeps the board scrollable without pushing the page wider on mobile", asyn
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
 
-test("contains long distance labels inside the compact desktop column", async ({
+test("contains long distance labels without desktop board overflow", async ({
   page,
 }) => {
   await page.clock.install({ time: new Date(now * 1000 + 20_000) });
@@ -396,6 +396,12 @@ test("contains long distance labels inside the compact desktop column", async ({
     .getByTestId("peg-board-scroller")
     .evaluate((element) => element.scrollWidth - element.clientWidth);
   expect(boardOverflow).toBeLessThanOrEqual(1);
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  const largeBoardOverflow = await page
+    .getByTestId("peg-board-scroller")
+    .evaluate((element) => element.scrollWidth - element.clientWidth);
+  expect(largeBoardOverflow).toBeLessThanOrEqual(1);
 });
 
 test("refreshes the board when a hidden tab resumes", async ({ page }) => {

--- a/ui-dashboard/tests/browser/peg-monitoring.test.ts
+++ b/ui-dashboard/tests/browser/peg-monitoring.test.ts
@@ -156,8 +156,9 @@ test("renders the status board, expands a row panel, and retains stale evidence"
   await expect(venueLink).toHaveAttribute("target", "_blank");
 
   // Clicking a link navigates instead of toggling the panel.
-  const chevron = row.getByRole("button", { name: /Expand EUROP/ });
-  await expect(chevron).toHaveAttribute("aria-expanded", "false");
+  const rowToggle = row.getByRole("button", { name: /Expand EUROP/ });
+  await expect(rowToggle).toHaveAttribute("aria-expanded", "false");
+  await expect(rowToggle).toHaveText("EUROP / EUR");
   await row.getByRole("link", { name: "Ready" }).click();
   await expect(page).toHaveURL(new RegExp(`/pool/${poolId}\\?tab=oracle`));
   await page.goBack();
@@ -320,15 +321,29 @@ test("contains long distance labels without desktop board overflow", async ({
     ...payload,
     packages: payload.packages.map((item) => ({
       ...item,
-      sources: item.sources.map((source) =>
-        source.id === item.policy.deepVenueSource || source.id === "kraken_eur"
-          ? {
-              ...source,
-              executablePrice: 0.87655,
-              deviationBps: 1_234.5,
-            }
-          : source,
-      ),
+      sources: item.sources.map((source) => {
+        if (
+          source.id === item.policy.deepVenueSource ||
+          source.id === "kraken_eur"
+        ) {
+          return {
+            ...source,
+            executablePrice: 0.87655,
+            deviationBps: 1_234.5,
+          };
+        }
+        if (source.id === "kraken_usd") {
+          return {
+            ...source,
+            healthy: false,
+            venueState: "unavailable" as const,
+            executablePrice: null,
+            observationAt: null,
+            spreadBps: null,
+          };
+        }
+        return source;
+      }),
     })),
   };
   await page.route("**/api/peg-monitoring", async (route) => {
@@ -343,7 +358,7 @@ test("contains long distance labels without desktop board overflow", async ({
 
   const row = page.getByTestId("peg-row-europ-schuman");
   const cells = row.getByRole("cell");
-  await expect(cells).toHaveCount(9);
+  await expect(cells).toHaveCount(8);
   const label = row.getByText("1,234.5 bps below", { exact: true });
   await expect(label).toBeVisible();
   const [labelBox, distanceBox, primaryBox] = await Promise.all([
@@ -398,6 +413,31 @@ test("contains long distance labels without desktop board overflow", async ({
   expect(boardOverflow).toBeLessThanOrEqual(1);
 
   await page.setViewportSize({ width: 1920, height: 1080 });
+  const unavailableRow = page.getByTestId("peg-supporting-source-kraken_usd");
+  const unavailableDistance = page.getByTestId(
+    "peg-supporting-distance-kraken_usd",
+  );
+  const unavailableLabel = unavailableRow.getByText(
+    "Unavailable — no healthy observation",
+    { exact: true },
+  );
+  const [unavailableLabelBox, unavailableDistanceBox, unavailableAgeBox] =
+    await Promise.all([
+      unavailableLabel.boundingBox(),
+      unavailableDistance.boundingBox(),
+      unavailableRow.locator(":scope > div").nth(3).boundingBox(),
+    ]);
+  expect(unavailableLabelBox).not.toBeNull();
+  expect(unavailableDistanceBox).not.toBeNull();
+  expect(unavailableAgeBox).not.toBeNull();
+  expect(
+    unavailableLabelBox!.x + unavailableLabelBox!.width,
+  ).toBeLessThanOrEqual(
+    unavailableDistanceBox!.x + unavailableDistanceBox!.width + 1,
+  );
+  expect(
+    unavailableDistanceBox!.x + unavailableDistanceBox!.width,
+  ).toBeLessThanOrEqual(unavailableAgeBox!.x + 1);
   const largeBoardOverflow = await page
     .getByTestId("peg-board-scroller")
     .evaluate((element) => element.scrollWidth - element.clientWidth);


### PR DESCRIPTION

## The Problem

The Peg Monitoring board still shows an internal horizontal scrollbar on large viewports. The XL layout forces a 1,220px minimum width inside the 1,174px dashboard content area.

## The Solution

Fit the XL board to the dashboard content width. Rebalance the fixed columns and gaps while keeping the distance column flexible.

## Visual comparison

Route: `/peg-monitoring` · State: row expanded with an unavailable supporting market · Viewport: 1920×1080 · Source: same deterministic fixture

| Before — `a60c1031` | After — `6321af67` |
| --- | --- |
| <img width="1920" height="1080" alt="Before at a60c1031: Peg Monitoring board overflows at 1920x1080" src="https://github.com/user-attachments/assets/5389584e-3368-494c-b98d-354363843afd" /> | <img width="1920" height="1080" alt="After at 6321af67: Peg Monitoring board fits without a trailing caret and supporting-market copy stays within its column" src="https://github.com/user-attachments/assets/4b9f89a9-6ab5-4177-b3f6-a0ef759907fd" /> |

## Details

- Keep the 900px compact minimum below the XL breakpoint.
- Remove the forced 1,220px XL minimum.
- Cover compact and 1,920px desktop widths with long distance labels.
- Remove the trailing caret column and use the peg label as the accessible row toggle.
- Keep unavailable supporting-market reasons within their grid cell.
- Keep mobile and compact behavior unchanged.
- Close #1888.

## Validation

- Full mapped agent quality gate passed.
- Peg Monitoring browser suite passed: 4 tests.
- Fresh-context Codex autoreview passed with no findings.
- Deterministic local autoreview passed.
- Chrome at 1,920×1,080: internal overflow changed from 46px to 0px.
- Chrome at 1,024×900: internal overflow remained 0px.
- Chrome console: no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Peg Monitoring UI and test updates only; behavior is preserved aside from where users click to expand rows and XL layout fitting.
> 
> **Overview**
> Fixes **horizontal overflow on large viewports** by dropping the ninth chevron column and changing **`PEG_BOARD_MIN_WIDTH`** from a fixed **1,220px** XL minimum to **`xl:min-w-full`**, with **rebalanced column tracks and gaps** while keeping the distance column flexible.
> 
> **Row interaction and a11y:** detail expand/collapse moves from a trailing chevron button to the **peg pair label** (`EUROP / EUR`), which keeps **`aria-expanded` / `aria-controls`**; row clicks still toggle except on nested links/buttons. Headers, loading skeleton, expanded panel **`aria-colspan`**, and tests now assume **eight columns**.
> 
> **Supporting markets:** unavailable distance copy **drops `xl:whitespace-nowrap`** so long “Unavailable — …” text can wrap on wide layouts. Browser tests add **1920×1080** overflow checks and an unavailable supporting-venue fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6321af67eff82113cd682c9f79963ae76e4b5a20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->