### PR TITLE
docs: add shared grid parity check

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -174,6 +174,11 @@ For each non-happy path, decide the behavior explicitly.
       Verify by diffing skeleton-phase vs loaded-phase section rects; the
       browser recipe (GraphQL-delay init script + rect sampler) is embedded in
       issue #1218 and its sibling skeleton-parity issues (#1219–#1223).
+- [ ] shared table/grid parity: when a shared column template or column count
+      changes, update every structural consumer in the same patch: headers,
+      loaded rows, loading skeletons, expanded-row `aria-colspan`, nested/detail
+      rows, and tests that assert cell count or overflow. Verify the longest
+      real labels and unavailable states at narrow and wide supported viewports.
 - [ ] **SSR-prefetch / `fallbackData` of safety-critical or clock-dependent
       data ships the full staleness envelope.** Painting SSR-cached
       operator-safety state (breaker/market-hours config, halt status) on first


### PR DESCRIPTION
## The Problem

- Shared table and grid changes can leave stale skeleton cells, ARIA spans, or nested-row layouts.

## The Solution

- Add one checklist item that requires every structural consumer to stay aligned when a shared column definition changes.

## Details

- Cover headers, loaded rows, loading skeletons, expanded-row `aria-colspan`, nested rows, and related cell-count or overflow tests.
- Require checks with long real labels and unavailable states at narrow and wide supported viewports.

## Validation

- Quality gate and autoreview skipped with explicit user approval for this documentation-only mini PR.
- The commit-time file check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the stateful data/UI PR checklist; no application code or runtime behavior is modified.
> 
> **Overview**
> Adds a **degraded-mode checklist** item in `docs/pr-checklists/stateful-data-ui.md` so PRs that change a shared column template or column count must update **all structural consumers in the same patch**—headers, loaded rows, loading skeletons, expanded-row `aria-colspan`, nested/detail rows, and tests for cell count or overflow.
> 
> It also requires verifying **long real labels** and **unavailable states** at **narrow and wide** supported viewports, complementing the existing skeleton-parity bullet without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a3010b253d3460fe8f2b17885d88277660cf67. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->