### PR TITLE
docs(scripts): relocate tf:test contract detail into ADR 0053 for AGENTS.md headroom (security review)

### DIFF
--- a/docs/adr/0053-explicit-deployment-source-staging.md
+++ b/docs/adr/0053-explicit-deployment-source-staging.md
@@ -3,7 +3,7 @@ title: Routine GCP deploys use explicit source-staging buckets
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-17
 scope: terraform/infra
 date: 2026-07
 doc_type: adr
@@ -165,6 +165,28 @@ approved apply.
   cmd shell preserves `#` as executable text; known Unix and PowerShell shells
   retain their native `#` comment behavior. Inert examples belong only in
   `scripts/deploy-staging-contract.test.mjs`.
+- The same contract pins the Metrics Bridge build path. Both submit callsites —
+  the GitHub deploy workflow and the direct wrapper — must pass
+  `--config=cloudbuild.yaml` exactly and must not override it with
+  `--service-account`. That config must name the dedicated builder
+  ([ADR 0058](0058-metrics-bridge-dedicated-cloud-build-executor.md)) and write
+  logs only to Cloud Logging, as the Alloy build config must. The contract also
+  proves the Terraform side of the grants above: the Cloud Build source-object
+  readers are exactly the two dedicated builders, and the App Engine uploader
+  and default AppSpot Storage Admin grants name only
+  `staging.<project>.appspot.com`.
+- The contract fixes the direct Metrics Bridge deploy's bootstrap shape. Before
+  it builds, that wrapper reconciles the builder's project roles, Artifact
+  Registry writer, developer act-as bindings, build-log reader,
+  dedicated-builder source readers, and Peg-policy bucket IAM. It targets the
+  two source readers by exact instance key, never their whole `for_each`
+  collection, so a routine deploy cannot enact the pending sibling removal
+  reserved for ADR 0058's reviewed platform apply. It fails closed on an
+  existing service whose exact name it cannot verify and does not target that
+  service. A first service create and an interrupted public-binding create each
+  run one separate `-refresh=false` saved plan accepted by
+  `check-metrics-bridge-bootstrap-plan.mjs`. Terraform state, the live service,
+  and the live public invoker binding are all verified before image rollout.
 - The original source-staging phase boundary is complete. ADR 0058 adds a
   separate applied-foundation, routing-canary, then direct-reader cleanup
   sequence for the Metrics Bridge builder. This ADR itself creates no peg-policy
@@ -174,7 +196,10 @@ approved apply.
 
 - Bucket and IAM ownership:
   [`terraform/deploy-staging.tf`](../../terraform/deploy-staging.tf)
-- Contract implementation:
+- Direct deploy wrapper and its bootstrap plan guard:
+  [`scripts/deploy-bridge.sh`](../../scripts/deploy-bridge.sh) and
+  [`scripts/check-metrics-bridge-bootstrap-plan.mjs`](../../scripts/check-metrics-bridge-bootstrap-plan.mjs)
+- Contract implementation, run by `pnpm tf:test`:
   [`scripts/deploy-staging-contract.mjs`](../../scripts/deploy-staging-contract.mjs)
   and
   [`scripts/deploy-staging-callsite-discovery.mjs`](../../scripts/deploy-staging-callsite-discovery.mjs).

--- a/docs/adr/0061-exact-plan-guard-for-manual-platform-applies.md
+++ b/docs/adr/0061-exact-plan-guard-for-manual-platform-applies.md
@@ -3,7 +3,7 @@ title: Manual platform applies use an exact private plan guard
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-17
 scope: terraform/infra
 date: 2026-08
 doc_type: adr
@@ -79,6 +79,13 @@ must still review a separate preflight plan and obtain explicit human approval
 before apply. The apply creates a fresh plan, so only the machine policy reviews
 the exact plan applied. Issue #1576 still owns broad policy coverage for every
 retained protected-stack mutation.
+
+This guard covers `pnpm tf plan/apply platform` only. The direct Metrics Bridge
+deploy holds a separate, deploy-only exception: two targeted `-refresh=false`
+bootstrap plans checked by
+[`scripts/check-metrics-bridge-bootstrap-plan.mjs`](../../scripts/check-metrics-bridge-bootstrap-plan.mjs).
+[ADR 0053](0053-explicit-deployment-source-staging.md) owns that shape and the
+contract that enforces it.
 
 ## Alternatives considered
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -129,29 +129,14 @@ in the PR that moves a file. Every surface there is mandatory.
   print, upload, or cache either plan form. The guarded first-service bootstrap
   plans below are a deploy-only exception. See
   [ADR 0061](../docs/adr/0061-exact-plan-guard-for-manual-platform-applies.md).
-- `pnpm tf:test` owns the deployment source-staging contract. It allows exactly
-  five literal checked-in `gcloud builds submit` / `gcloud app deploy` callsites
-  with their source-staging flag and value; pins both Metrics Bridge submit
-  paths to the checked-in `cloudbuild.yaml`; rejects CLI service-account
-  overrides; verifies that config's exact builder identity and logging mode;
-  limits direct Cloud Build source-object reads to the Alloy and Metrics Bridge
-  builders, excluding default Compute; and scopes the App Engine uploader and
-  default AppSpot Storage Admin grants to the service-owned
-  `staging.<project>.appspot.com` bucket. Before building, the direct Metrics
-  Bridge bootstrap must reconcile the builder's project roles, repository
-  writer, developer act-as bindings, build-log reader, dedicated-builder source
-  readers, and Peg-policy bucket IAM; target the two reader instances, never
-  their whole `for_each` collection, so a routine deploy cannot enact a pending
-  sibling removal reserved for a reviewed platform apply; fail closed on an
-  existing service whose exact name it cannot verify, and not target that
-  service; take separate no-refresh saved plans accepted by
-  `check-metrics-bridge-bootstrap-plan.mjs` for a first service create and an
-  interrupted public-binding create; and verify Terraform state, the live
-  service, and its public binding.
-  [ADR 0053](../docs/adr/0053-explicit-deployment-source-staging.md) owns the
-  supported static syntax and explicit proof limits. Keep indirect or dynamic
-  deploy forms forbidden and inert examples confined to
+- `pnpm tf:test` enforces the deployment source-staging contract: the five
+  allowed `gcloud builds submit` / `gcloud app deploy` callsites, the Metrics
+  Bridge build config, its guarded no-refresh bootstrap plans, and the staging
+  bucket IAM. Never add a callsite, an indirect or dynamic deploy form, or a CLI
+  service-account override, and keep inert examples in
   `scripts/deploy-staging-contract.test.mjs`.
+  [ADR 0053](../docs/adr/0053-explicit-deployment-source-staging.md) owns the
+  contract, its supported static syntax, and its explicit proof limits.
 
 ## Verification
 


### PR DESCRIPTION
## The Problem

- `scripts/AGENTS.md` sat at 9,088 of its 9,216-byte cap — 128 bytes free. Every
  remaining directory phase (P3, P4, P5, P8–P11) adds a row or a pin entry and
  would breach `pnpm agent:context-budget --strict`, a required CI step.
- Its longest bullet restated the `pnpm tf:test` deployment source-staging
  contract in ~1,650 bytes while naming ADR 0053 as the owner of that contract.
- `docs/context-standards.md` forbids exactly that: "Where a file already links
  an owning authority, keep at most a one-line gist. Never restate that
  authority's procedure, command block, or rule list."

## The Solution

- Move the contract detail into the ADRs that own it, and leave a short
  operative rule in `scripts/AGENTS.md`: what an agent must never do, plus the
  pointer to ADR 0053.
- Nothing is dropped. Clauses the ADRs already recorded are removed; clauses
  they did not are transplanted into ADR 0053, with one scope-clarifying
  paragraph in ADR 0061.

`scripts/AGENTS.md`: **9,088 → 8,003 bytes**, headroom **128 → 1,213**.

Tracking issue:
https://github.com/mento-protocol/monitoring-monorepo/issues/1877

## Details

This is Terraform-lane deploy-path text, so the move is presented as a
contract-preserving relocation rather than a rewrite. Every clause of the
removed bullet is dispositioned below.

### Clause disposition

| # | Clause in the removed bullet | Disposition | Where it lives now |
| - | ---------------------------- | ----------- | ------------------ |
| C1 | `pnpm tf:test` owns the deployment source-staging contract | Kept (reworded to name the enforcing check) | `scripts/AGENTS.md`; command name also added to ADR 0053 Evidence |
| C2 | Allows exactly five literal checked-in `gcloud builds submit` / `gcloud app deploy` callsites with their source-staging flag and value | Already in ADR | ADR 0053 Consequences (verbatim in substance) |
| C3 | Pins both Metrics Bridge submit paths to the checked-in `cloudbuild.yaml` | **Transplanted** | ADR 0053 Consequences |
| C4 | Rejects CLI service-account overrides | **Transplanted** | ADR 0053 Consequences |
| C5 | Verifies that config's exact builder identity and logging mode | **Transplanted** (facts were in ADR 0053/0058; the enforcement was not) | ADR 0053 Consequences |
| C6 | Limits direct Cloud Build source-object reads to the Alloy and Metrics Bridge builders, excluding default Compute | Already in ADR (enforcement sentence added) | ADR 0053 Decision + Consequences |
| C7 | Scopes App Engine uploader and default AppSpot Storage Admin grants to `staging.<project>.appspot.com` | Already in ADR (enforcement sentence added) | ADR 0053 Decision + Consequences |
| C8 | Pre-build bootstrap reconciles builder project roles, repository writer, developer act-as bindings, build-log reader, dedicated-builder source readers, Peg-policy bucket IAM | **Transplanted** | ADR 0053 Consequences |
| C9 | Target the two reader instances, never the whole `for_each` collection, so a routine deploy cannot enact a pending sibling removal | **Transplanted** (rationale already in ADR 0058; the prohibition was not recorded) | ADR 0053 Consequences, cross-referencing ADR 0058 |
| C10 | Fail closed on an existing service whose exact name it cannot verify, and do not target that service | **Transplanted** | ADR 0053 Consequences |
| C11 | Separate no-refresh saved plans accepted by `check-metrics-bridge-bootstrap-plan.mjs` for a first service create and an interrupted public-binding create | **Transplanted** | ADR 0053 Consequences; scope note + evidence link in ADR 0061 |
| C12 | Verify Terraform state, the live service, and its public binding | **Transplanted** | ADR 0053 Consequences |
| C13 | ADR 0053 owns the supported static syntax and explicit proof limits | Kept | `scripts/AGENTS.md` |
| C14 | Indirect or dynamic deploy forms forbidden; inert examples confined to `scripts/deploy-staging-contract.test.mjs` | Already in ADR; operative half kept as a prohibition | ADR 0053 Consequences; short "never add" form in `scripts/AGENTS.md` |

Transplanted clauses (C3, C4, C5, C8, C9, C10, C11, C12) were verified
against the enforcing source before being written into the ADR, not copied
from the prose: `scripts/deploy-staging-contract.mjs` lines 26–55 (bootstrap
and source-reader targets), 559–603 (config pin, `--service-account`
rejection, builder identity, logging mode), 639–704 (pre-build IAM reconcile,
`for_each` prohibition, fail-closed service probe), 706–847 (guarded
`-refresh=false` bootstrap plans and state classification), and 849–887 (live
public-binding verification before image rollout).

### Notes for the reviewer

- **C8 wording.** The removed bullet said "repository writer". The ADR says
  "Artifact Registry writer", matching the enforced target
  `google_artifact_registry_repository_iam_member.metrics_bridge_builder`.
  This is a clarification, not a scope change.
- **Dangling cross-reference.** The bullet directly above the changed one ends
  "The guarded first-service bootstrap plans below are a deploy-only
  exception." The replacement bullet still names "guarded no-refresh bootstrap
  plans", so "below" still resolves. A proof check asserts this.
- **ADR 0061 scope.** ADR 0061 states that ADR 0055's `-refresh=false` target
  is "the only target exception". That is true within its own scope
  (`pnpm tf plan/apply platform`). Since `AGENTS.md` no longer spells out the
  deploy-only bootstrap exception, ADR 0061 now says so itself and points at
  ADR 0053. Without this, two canonical files would read as contradictory.

### Scope boundary

Only three files change: `scripts/AGENTS.md` and the two ADRs. The contract
itself — `scripts/deploy-staging-contract.mjs`,
`scripts/deploy-staging-callsite-discovery.mjs`, `scripts/deploy-bridge.sh`,
`terraform/deploy-staging.tf`, `cloudbuild.yaml` — is untouched.
`last_verified` moves to 2026-08-17 on both amended ADRs. `pnpm docs:index
--check` passes without regeneration (no files added or moved).

## Validation

- `pnpm agent:context-budget --strict` — pass. `scripts/AGENTS.md` 8,003 bytes,
  86.8% of the scoped cap, **headroom 1,213** (was 9,088 / 98.6% / headroom
  128). `scripts` route 15,312 bytes, headroom 3,632.
- `pnpm tf:test` — pass, 46s: deployment source-staging contract, peg policy
  identity, production infrastructure identity/routing/refresh/security/workflow,
  Sentry provider contract, peg policy publication boundary, Metrics Bridge
  template plan. Proves the contract is unchanged.
- `pnpm agent:context-check` — pass (147 managed files).
- `pnpm docs:index --check` — pass, no catalog drift.
- `pnpm agent:quality-gate --dry-run` then `--run` — all 7 mapped commands
  pass, including `./tools/trunk check` on the three files,
  `check-adr-reminder.mjs`, and `pnpm docs:navigation-eval --check-fixtures`.
- Clause proof script: 21 positive assertions (every dropped clause is present
  in ADR 0053/0058/0061 text) plus 5 negative controls (the removed strings are
  absent from `scripts/AGENTS.md`). All 26 pass.
- `pnpm agent:autoreview -- --engine codex` — clean, "patch is correct" (0.95).
- `pnpm agent:autoreview -- --engine claude` — clean, "patch is correct" (0.90);
  it independently re-derived the clause list and confirmed all invariants
  preserved.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new decision is made. Two existing ADRs are
      amended to record rules they already governed but had not written down.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only relocation; deploy and Terraform contract scripts are untouched.
> 
> **Overview**
> Frees **~1.1KB** in `scripts/AGENTS.md` by moving the long `pnpm tf:test` deployment source-staging contract prose into the ADRs that own it, per context-standards (no restating an authority’s full rule list next to its link).
> 
> **`scripts/AGENTS.md`** replaces the ~1,650-byte bullet with a short operative rule: what agents must not do (extra callsites, indirect deploy forms, CLI `--service-account` overrides) and a pointer to **ADR 0053** for the full contract.
> 
> **ADR 0053** gains the transplanted enforcement detail: Metrics Bridge submit paths pinned to `cloudbuild.yaml`, Terraform IAM proofs for staging readers and AppSpot grants, direct `deploy-bridge.sh` bootstrap (IAM reconcile, exact `for_each` keys, fail-closed service probe, guarded `-refresh=false` plans via `check-metrics-bridge-bootstrap-plan.mjs`), plus Evidence links for the wrapper and guard script.
> 
> **ADR 0061** clarifies that its exact private plan guard applies only to `pnpm tf plan/apply platform`; deploy bootstrap plans are a separate exception owned by ADR 0053.
> 
> `last_verified` bumps to **2026-08-17** on both ADRs. **No** changes to `deploy-staging-contract.mjs`, workflows, or Terraform — behavior is documentation-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51879b1af4b2389fe613c2915c32b208859cd04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->