### PR TITLE
chore(ci): drop the legacy trusted-validator probe path

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -52,20 +52,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Probe BOTH trusted-base locations before considering the PR's own
-          # copy. The validator moved to scripts/pr/ (issue 1877 phase P5);
-          # every PR branched before that move has a base ref that still
-          # carries it at the old flat path. Dropping the legacy probe would
-          # silently fall through to the pr-head copy for the whole in-flight
-          # backlog — "trust the PR", which is the property this job exists to
-          # deny. Retiring the legacy probe is tracked separately; it can only
-          # happen once no open PR has a pre-move base.
+          # Prefer the trusted base-ref copy over the PR's own, so a PR
+          # cannot edit the rule it is judged by. The legacy flat-path probe
+          # (pre issue-1877-P5) retired in issue 1904: the checkout above
+          # uses the base branch NAME, so trusted-base/ is always current
+          # main at job-execution time, never a snapshot pinned to when a PR
+          # branched — once main carries the validator at scripts/pr/, no
+          # PR (old, reopened, or new) can still resolve the flat path.
           if [ -f trusted-base/scripts/pr/check-pr-description.mjs ]; then
             node trusted-base/scripts/pr/check-pr-description.mjs
-          elif [ -f trusted-base/scripts/check-pr-description.mjs ]; then
-            node trusted-base/scripts/check-pr-description.mjs
           elif [ -f pr-head/scripts/pr/check-pr-description.mjs ]; then
-            echo "::warning::Trusted PR-description validator missing on the target branch at both scripts/pr/ and scripts/; using the PR copy only for the bootstrap PR that introduces the script."
+            echo "::warning::Trusted PR-description validator missing on the target branch; using the PR copy only for the bootstrap PR that introduces the script."
             node pr-head/scripts/pr/check-pr-description.mjs
           else
             echo "::error::PR-description validator is missing from both the target branch and PR head."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -58,7 +58,10 @@ jobs:
           # uses the base branch NAME, so trusted-base/ is always current
           # main at job-execution time, never a snapshot pinned to when a PR
           # branched — once main carries the validator at scripts/pr/, no
-          # PR (old, reopened, or new) can still resolve the flat path.
+          # PR (old, reopened, or new) can still resolve the flat path. This
+          # relies on the trigger above staying `branches: [main]`; widening
+          # it to other long-lived base branches needs its own dual-probe
+          # bridge until those branches carry scripts/pr/ too.
           if [ -f trusted-base/scripts/pr/check-pr-description.mjs ]; then
             node trusted-base/scripts/pr/check-pr-description.mjs
           elif [ -f pr-head/scripts/pr/check-pr-description.mjs ]; then

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -94,7 +94,11 @@ that mechanism moves with it, in the same PR.
 - **Terraform stack registry.** `terraform.stacks.json` `changedPathPatterns`
   pins exact `scripts/` paths per stack, mirrored into those filters.
 - **Trusted-validator probes.** `pr-description.yml` runs the validator from the
-  PR's base ref, so a move probes both paths. ADR 0064 has the failure mode.
+  PR's base ref via the base branch **name**, so it always resolves to the base
+  branch's current tip — never a snapshot from when a PR branched. One probe
+  path is enough once the target path is live on the base branch (issue 1904);
+  a move still needs a temporary dual probe for the commit that performs it.
+  ADR 0064 has the failure mode.
 - **Production infrastructure contract pins.**
   `production-infra-identity-contract/workflow-inventory.mjs` pins exact script
   paths for the workflows it audits.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `pr-description.yml` probes `trusted-base/scripts/pr/`, then
  `trusted-base/scripts/` (the pre-move flat path), then `pr-head/`, before
  failing closed. The flat-path `elif` was added by P5 (issue 1877) to bridge
  the validator's move to `scripts/pr/`, and was always meant to retire once no
  open PR could still need it (tracked in issue 1904).
- The trusted-base checkout (`ref: ${{ github.event.pull_request.base.ref }}`)
  uses the base **branch name**, so it always resolves to the base branch's
  current tip at job-execution time — never a snapshot pinned to when a PR
  branched. That makes the flat-path `elif` unreachable for any PR, not just
  ones with a "recent enough" base, once `main` itself carries the validator
  only at the new path.

## The Solution

- Drop the flat-path `elif` and its P5 comment block. Keep the new-path probe,
  the fail-closed error, and the `pr-head` bootstrap warning (which predates
  P5 — added in PR 746 for the original PR that introduced the validator — and
  stays reachable for any future rename or deletion of the script).
- Update the `scripts/AGENTS.md` "Trusted-validator probes" bullet to describe
  the single-path probe.

## Details

**Reachability check that proves this safe.** `git show
origin/main:scripts/check-pr-description.mjs` — missing; `git show
origin/main:scripts/pr/check-pr-description.mjs` — present. P5 (commit
`288dce35`, PR 1907) already merged. Since the checkout is a live
`ref: main` fetch (not `base.sha`, not a merge-base, not anything pinned to
the PR's own history), no PR — old, reopened, or new — can ever cause
`trusted-base/` to reflect pre-move `main` again, short of someone reverting
the move on `main` itself. That's a stronger guarantee than "the backlog has
drained": there is no backlog dependency in the first place, because the
checkout was never staled to a PR's branch point.

Also checked directly: `gh pr list --state open` returns zero PRs right now,
and the repo's branch-protection ruleset has
`strict_required_status_checks_policy: false` (branches need not be up to
date to merge) — which turns out not to matter here either, since the
checkout doesn't derive from the PR's head or merge-base at all.

Full write-up posted to the issue:
https://github.com/mento-protocol/monitoring-monorepo/issues/1904#issuecomment-5325789070

**Scope.** Only the flat-path `elif` and its comment come out. The bootstrap
`pr-head` branch and the fail-closed `else` are untouched — they're general
safety nets, not P5-specific compatibility code, and nothing in this PR
retires them.

## Validation

- `actionlint .github/workflows/pr-description.yml` — clean.
- `python3 -c "import yaml; yaml.safe_load(open(...))"` — parses.
- `node scripts/context/check-agent-context.mjs` — passed (147 managed files);
  `scripts/AGENTS.md` stays at 9,186 bytes, under its documented budget.
- Ran `scripts/pr/check-pr-description.mjs` directly against a real merged
  PR body (PR 1907's) — passes with the expected "OK" message.
- Simulated the full post-edit shell probe (`if`/`elif`/`else`) against five
  fixture shapes: new-path present (steady state) → validates and passes;
  trusted-base empty + pr-head present (bootstrap) → warns, validates, passes;
  neither side present → fails closed, exit 1; legacy flat path present alone
  (hypothetical, cannot occur on `main` today) → correctly falls to the
  bootstrap branch instead of trusting the stale copy; a rejecting PR body
  under the new-path branch → fails closed, exit 1.
- Pushed branch; `agent-quality-gate.sh` pre-push checks all passed
  (`trunk check`, action-pin check, autofix-trust check, ADR-reminder check,
  `tf:test`, Sentry-suites-in-CI check, `docs:index --check`,
  `agent:context-budget --strict`, `agent:context-check`,
  `docs:navigation-eval --check-fixtures`).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this doesn't change the
      trusted-validator contract, only retires dead code per the plan issue
      1904 itself specified (no ADR needed unless the answer changes the
      contract).

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1904

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-code removal in CI probe logic only; trusted `scripts/pr/` path and fail-closed behavior are unchanged.
> 
> **Overview**
> Removes the **P5 bridge** `elif` that ran `trusted-base/scripts/check-pr-description.mjs` from the PR description workflow. Validation now uses only `trusted-base/scripts/pr/check-pr-description.mjs`, then the existing `pr-head` bootstrap fallback, then fail-closed.
> 
> Comments and **`scripts/AGENTS.md`** are updated to explain that the trusted-base checkout tracks the base branch **name** (current tip), so the old flat path is unreachable on `main` and a single trusted probe is enough after issue 1904.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26df4ac53ee4378c485594851a0995dad44b6af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->