### PR TITLE
refactor(scripts): split the settings-contract checks out of the documentation checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1053,6 +1053,11 @@ jobs:
         # Behavioral coverage of scripts/context/check-agent-context.mjs's pure
         # helpers: frontmatter parsing and the last_verified staleness window.
         run: node scripts/context/check-agent-context.test.mjs
+      - name: Agent settings contract tests
+        # Behavioral coverage of the .claude/settings.json permission allowlist
+        # and the SessionEnd hook wiring for both runtimes, which the context
+        # checker runs but no longer defines.
+        run: node scripts/context/check-settings-contract.test.mjs
       - name: Agent context checker
         # Runs the actual check-agent-context.mjs enforcement pass (managed
         # frontmatter + last_verified staleness policy) — the unit tests

--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -125,7 +125,8 @@ scheduled document, for context an agent gets from the directory map in
   net, so it re-pins what the net covered: the `rootScripts` paths-filter now
   names both wrappers, because `agent-quality-gate.test.sh` copies and runs the
   diff wrapper in a stub repo, and the `.claude/settings.json` allowlist plus
-  its verbatim copy in `check-agent-context.mjs` carry the package path.
+  its verbatim copy in `context/check-settings-contract.mjs` carry the package
+  path.
 - An enumerated paths-filter fails silently rather than loudly: the job stops
   running, and the required `ci` sentinel stays green because a skipped job is
   not a failed one. Where a filter's whole file set is one module, replace the
@@ -172,7 +173,8 @@ routing, not procedure.
 5. `.trunk/trunk.yaml` pre-push hook, and `.gitattributes`.
 6. `.claude/settings.json`, `.codex/hooks.json`,
    `.claude/hooks/session-start.sh`, and the verbatim copies and invocation
-   regexes in `check-agent-context.mjs`.
+   regexes in `context/check-settings-contract.mjs`, which
+   `context/check-agent-context.mjs` runs.
 7. `.claude/skills/` and `.agents/skills/` — both mirrors.
 8. `docs/notes/quick-commands.md`.
 9. `agent-quality-gate.sh` routing arms — a literal-prefix glob such as

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3786,6 +3786,15 @@ while IFS= read -r path; do
           add_command "pnpm agent:context-check" "agent context checker changed"
           add_command "node scripts/context/check-agent-context.test.mjs" "agent context checker changed"
           ;;
+        scripts/context/check-settings-contract.mjs|scripts/context/check-settings-contract.test.mjs)
+          # The `.claude/settings.json` permission allowlist and the SessionEnd
+          # hook wiring for both runtimes. `check-agent-context.mjs` is the only
+          # caller, and its suite holds the one test of that forwarding, so a
+          # change here routes both suites plus the real enforcement pass.
+          add_command "pnpm agent:context-check" "agent settings contract changed"
+          add_command "node scripts/context/check-settings-contract.test.mjs" "agent settings contract changed"
+          add_command "node scripts/context/check-agent-context.test.mjs" "agent settings contract changed"
+          ;;
         scripts/mcp/build-upstash-mcp-runtime.mjs|scripts/mcp/render-upstash-mcp-config.mjs|scripts/mcp/upstash-mcp-config.test.mjs|scripts/mcp/upstash-mcp-launcher.mjs)
           add_command "node --test scripts/mcp/upstash-mcp-config.test.mjs" "Upstash MCP transport contract changed"
           ;;

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4526,6 +4526,20 @@ run_gate "scripts/context/check-agent-context.test.mjs"
 assert_contains "- pnpm agent:context-check (agent context checker changed)"
 assert_contains "- node scripts/context/check-agent-context.test.mjs (agent context checker changed)"
 
+# The settings/hook contract module split out of the context checker (#1887).
+# Its own suite plus the caller's wiring test plus the real enforcement pass.
+run_gate "scripts/context/check-settings-contract.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_contains "- pnpm agent:context-check (agent settings contract changed)"
+assert_contains "- node scripts/context/check-settings-contract.test.mjs (agent settings contract changed)"
+assert_contains "- node scripts/context/check-agent-context.test.mjs (agent settings contract changed)"
+
+run_gate "scripts/context/check-settings-contract.test.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_contains "- pnpm agent:context-check (agent settings contract changed)"
+assert_contains "- node scripts/context/check-settings-contract.test.mjs (agent settings contract changed)"
+assert_contains "- node scripts/context/check-agent-context.test.mjs (agent settings contract changed)"
+
 run_gate "scripts/mcp/build-upstash-mcp-runtime.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- node --test scripts/mcp/upstash-mcp-config.test.mjs (Upstash MCP transport contract changed)"

--- a/scripts/context/check-agent-context.mjs
+++ b/scripts/context/check-agent-context.mjs
@@ -19,6 +19,7 @@ import {
   trackedDocumentationFiles,
 } from "./docs-index-helpers.mjs";
 import { loadClaudeRuntimeDocumentRegistry } from "./claude-runtime-document-registry.mjs";
+import { checkSettingsContract } from "./check-settings-contract.mjs";
 
 const repoRoot = process.cwd();
 const failures = [];
@@ -53,27 +54,6 @@ function readRequired(filePath, displayPath = filePath) {
     return null;
   }
   return read(filePath);
-}
-
-function readJsonRequired(filePath, displayPath = filePath) {
-  const content = readRequired(filePath, displayPath);
-  if (content === null) return null;
-  try {
-    return JSON.parse(content);
-  } catch (error) {
-    fail(`${displayPath}: invalid JSON (${error.message})`);
-    return null;
-  }
-}
-
-function testOnlyInputPath(environmentVariable, canonicalPath) {
-  const override = process.env[environmentVariable];
-  if (!override) return canonicalPath;
-  if (process.env.NODE_ENV !== "test") {
-    fail(`${environmentVariable}: test-only override requires NODE_ENV=test`);
-    return canonicalPath;
-  }
-  return override;
 }
 
 function normalizeSkillContent(filePath, content) {
@@ -365,215 +345,14 @@ if (
   );
 }
 
-function sessionEndCommands(settings, filePath) {
-  const entries = settings?.hooks?.SessionEnd;
-  if (!Array.isArray(entries)) {
-    fail(`${filePath}: expected hooks.SessionEnd array`);
-    return [];
-  }
-  return entries.flatMap((entry) =>
-    Array.isArray(entry?.hooks)
-      ? entry.hooks
-          .filter((hook) => hook?.type === "command")
-          .map((hook) => hook.command)
-          .filter((command) => typeof command === "string")
-      : [],
-  );
-}
-
-function isCodexSessionEndCommand(command) {
-  return (
-    /^bash\s+-lc\s+['"]/.test(command) &&
-    command.includes("repo=$(git rev-parse --show-toplevel") &&
-    /&&\s+exec\s+bash\s+["']?\$repo\/scripts\/bootstrap\/agent-session-end-hook\.sh["']?/.test(
-      command,
-    )
-  );
-}
-
-function isClaudeSessionEndCommand(command) {
-  const scriptPath =
-    /["']\$\{CLAUDE_PROJECT_DIR\}\/scripts\/bootstrap\/agent-session-end-hook\.sh["']/;
-  const directInvocation = new RegExp(
-    String.raw`^bash\s+${scriptPath.source}(?:\s|$)`,
-  );
-  // Also accept a presence-guarded form: `if [ -f "${CLAUDE_PROJECT_DIR}/...sh" ]; then bash "${CLAUDE_PROJECT_DIR}/...sh"; fi`
-  // This lets a Claude session that outlives a deleted worktree skip the hook silently
-  // without swallowing real failures from the script when it does exist.
-  const guardedInvocation = new RegExp(
-    String.raw`^if\s+\[\s+-f\s+${scriptPath.source}\s+\]\s*;\s*then\s+bash\s+${scriptPath.source}\s*;\s*fi\s*$`,
-  );
-  return directInvocation.test(command) || guardedInvocation.test(command);
-}
-
-// Keep these in sync with `.claude/settings.json`. Bash permissions are an
-// exact reviewed allowlist so shell escaping or dynamic command construction
-// cannot bypass a command-specific policy check.
-const allowedClaudeBashScriptPermissions = new Set([
-  "Bash(bash scripts/agent-quality-gate.sh:*)",
-  "Bash(bash ./scripts/agent-quality-gate.sh:*)",
-  "Bash(bash scripts/agent-quality-gate.test.sh:*)",
-  "Bash(bash ./scripts/agent-quality-gate.test.sh:*)",
-  "Bash(bash scripts/bootstrap/agent-session-end-hook.sh:*)",
-  "Bash(bash ./scripts/bootstrap/agent-session-end-hook.sh:*)",
-  "Bash(node scripts/check-agent-quality-gate-package-scripts.mjs:*)",
-  "Bash(node ./scripts/check-agent-quality-gate-package-scripts.mjs:*)",
-  "Bash(bash ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
-  "Bash(bash ./ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
-  "Bash(bash ui-dashboard/scripts/check-react-doctor-score.sh:*)",
-  "Bash(bash ./ui-dashboard/scripts/check-react-doctor-score.sh:*)",
-]);
-
-// Keep this in sync with `.claude/settings.json`. Exact entries make the key
-// path part of the `sag` invocation itself; wrappers, compound commands, and
-// comments cannot satisfy the check by mentioning the canonical path elsewhere.
-const allowedClaudeSagPermissions = new Set([
-  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your feedback in the agent chat")',
-  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
-  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, the task finished and needs your attention in the agent chat")',
-]);
-
-const allowedClaudeOtherBashPermissions = new Set([
-  "Bash(terraform -chdir=terraform output:*)",
-  "Bash(terraform -chdir=terraform plan:*)",
-  "Bash(terraform -chdir=terraform validate:*)",
-  'Bash(say "hey, i need your feedback in the agent chat")',
-  'Bash(say "hey, i need your approval in the agent chat")',
-  'Bash(say "hey, the task finished and needs your attention in the agent chat")',
-  'Bash(spd-say "hey, i need your feedback in the agent chat")',
-  'Bash(spd-say "hey, i need your approval in the agent chat")',
-  'Bash(spd-say "hey, the task finished and needs your attention in the agent chat")',
-  "Bash(ESLINT_BASELINE_MAIN=* node *)",
-]);
-
-const allowedClaudeBashPermissions = new Set([
-  ...allowedClaudeBashScriptPermissions,
-  ...allowedClaudeSagPermissions,
-  ...allowedClaudeOtherBashPermissions,
-]);
-
-// Root `scripts/` and package-local `<package>/scripts/` both count: the React
-// Doctor wrappers live in `ui-dashboard/scripts/`, so a prefix-blind check
-// would route a package-local script permission into the generic branch.
-const bashScriptPermission =
-  /^Bash\(bash\s+(?:\.\/)?(?:[\w.-]+\/)?scripts\/[^)]*\)$/;
-const bashDeployScriptPermission =
-  /^Bash\(bash\s+(?:\.\/)?(?:[\w.-]+\/)?scripts\/deploy-[^)]*\)$/;
-
-function isClaudeBashScriptPermission(permission) {
-  return bashScriptPermission.test(permission);
-}
-
-function isClaudeSagPermission(permission) {
-  if (!permission.startsWith("Bash(")) return false;
-
-  const command = permission.slice(
-    "Bash(".length,
-    permission.endsWith(")") ? -1 : undefined,
-  );
-  const normalizedCommand = command
-    .replace(/\\\r?\n/g, "")
-    .replace(/[\\'"]/g, "");
-  return /(?:^|[\s;&|()'"`$])(?:[^\s;&|()'"`$]+\/)?sag(?=$|[\s:;&|()'"`$])/.test(
-    normalizedCommand,
-  );
-}
-
-function validateClaudePermissions(settings) {
-  const allow = settings?.permissions?.allow;
-  if (!Array.isArray(allow)) {
-    fail(".claude/settings.json: expected permissions.allow array");
-    return;
-  }
-
-  for (const permission of allow) {
-    if (typeof permission !== "string") continue;
-    if (!permission.startsWith("Bash(")) continue;
-
-    if (
-      isClaudeSagPermission(permission) &&
-      !allowedClaudeSagPermissions.has(permission)
-    ) {
-      fail(
-        `.claude/settings.json: sag permissions must include --api-key-file with the canonical ~/.config/elevenlabs_api_key path and match a reviewed single-command allowlist entry: ${permission}`,
-      );
-      continue;
-    }
-
-    if (/^Bash\(until\b/.test(permission)) {
-      fail(
-        `.claude/settings.json: permissions.allow must not allow shell-loop commands: ${permission}`,
-      );
-      continue;
-    }
-
-    if (allowedClaudeBashPermissions.has(permission)) continue;
-
-    if (bashDeployScriptPermission.test(permission)) {
-      fail(
-        `.claude/settings.json: must not allow deploy/promote scripts: ${permission}`,
-      );
-    } else if (isClaudeBashScriptPermission(permission)) {
-      fail(
-        `.claude/settings.json: unexpected bash scripts allow: ${permission}`,
-      );
-    } else {
-      fail(
-        `.claude/settings.json: unexpected Bash permission; add the exact reviewed entry to the context-check allowlist: ${permission}`,
-      );
-    }
-  }
-}
-
-// Test-only input overrides let the regression suite mutate disposable
-// fixtures instead of tracked runtime configuration. Fail closed if an
-// override leaks into a normal invocation.
-const codexHooks = readJsonRequired(
-  testOnlyInputPath("AGENT_CONTEXT_CODEX_HOOKS_FILE", ".codex/hooks.json"),
-  ".codex/hooks.json",
-);
-if (codexHooks) {
-  const commands = sessionEndCommands(codexHooks, ".codex/hooks.json");
-  if (commands.some((command) => command.includes("/Users/"))) {
-    fail(".codex/hooks.json: Codex hook command must not use /Users paths");
-  }
-  if (!commands.some(isCodexSessionEndCommand)) {
-    fail(
-      ".codex/hooks.json: expected SessionEnd command to execute scripts/bootstrap/agent-session-end-hook.sh via resolved repo root",
-    );
-  }
-}
-
-const claudeSettings = readJsonRequired(
-  testOnlyInputPath(
-    "AGENT_CONTEXT_CLAUDE_SETTINGS_FILE",
-    ".claude/settings.json",
-  ),
-  ".claude/settings.json",
-);
-if (claudeSettings) {
-  validateClaudePermissions(claudeSettings);
-
-  const commands = sessionEndCommands(claudeSettings, ".claude/settings.json");
-  if (commands.some((command) => command.includes("/Users/"))) {
-    fail(
-      ".claude/settings.json: Claude hook command must not use /Users paths",
-    );
-  }
-  if (!commands.some(isClaudeSessionEndCommand)) {
-    fail(
-      ".claude/settings.json: expected SessionEnd command to execute quoted ${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh with bash",
-    );
-  }
-}
-
-const sessionEndHook = readRequired(
-  "scripts/bootstrap/agent-session-end-hook.sh",
-);
-if (sessionEndHook?.includes("/Users/")) {
-  fail(
-    "scripts/bootstrap/agent-session-end-hook.sh: hook must derive the repository root instead of hardcoding a local path",
-  );
+// The `.claude/settings.json` permission allowlist and the SessionEnd hook
+// wiring for both runtimes are agent-runtime configuration, not documentation
+// metadata. They live in their own module with their own suite; this
+// entrypoint stays their only caller so `pnpm agent:context-check` and the
+// direct `node scripts/context/check-agent-context.mjs` invocations keep
+// covering both halves.
+for (const failure of checkSettingsContract({ repoRoot }).failures) {
+  fail(failure);
 }
 
 if (failures.length > 0) {

--- a/scripts/context/check-agent-context.test.mjs
+++ b/scripts/context/check-agent-context.test.mjs
@@ -9,6 +9,11 @@
  * check-agent-context-helpers.mjs directly, plus a small fixture harness for
  * README-specific metadata discovery that lives in the main script.
  *
+ * The `.claude/settings.json` permission allowlist and the SessionEnd hook
+ * wiring live in check-settings-contract.mjs and are covered by
+ * check-settings-contract.test.mjs. One end-to-end test below keeps this
+ * entrypoint's forwarding of those failures under test.
+ *
  * Run: node scripts/context/check-agent-context.test.mjs
  * CI:  .github/workflows/ci.yml  (scripts job)
  */
@@ -696,89 +701,25 @@ test("applies staleness checks to a hidden root README marker", () => {
   }
 });
 
-test("rejects direct and wrapped Claude sag permissions without the canonical key path", () => {
-  const today = isoDateWithOffset(0);
-  const permissions = [
-    'Bash(sag --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(sag -v Charlie --api-key-file ~/.config/sag/elevenlabs-api-key "hey, i need your approval in the agent chat")',
-    'Bash(sag speak --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "hey, i need your approval in the agent chat")',
-    "Bash(sag:*)",
-    'Bash(env LANG=C sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(command sag -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(echo ready && sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(/usr/bin/env LANG=C /usr/local/bin/sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
-    "Bash(command sag:*)",
-    'Bash(env LANG=C command sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(command sag --api-key-file=~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
-    'Bash(sag --api-key-file ~/.config/other-key -v Charlie "hey"; printf %s --api-key-file ~/.config/elevenlabs_api_key)',
-    String.raw`Bash(s\ag --api-key-file /tmp/other-key -v Charlie "hey")`,
-    "Bash(s''ag --api-key-file /tmp/other-key -v Charlie \"hey\")",
-  ];
+// ── settings-contract wiring ──────────────────────────────────────────────────
+//
+// The permission-allowlist and SessionEnd-hook rules moved to
+// check-settings-contract.mjs, and check-settings-contract.test.mjs owns their
+// coverage. What stays here is the wiring: this entrypoint must still run that
+// module and surface its failures, because `pnpm agent:context-check`, the four
+// bootstrap scripts, and the weekly staleness job all reach the contract only
+// through this script.
 
-  for (const permission of permissions) {
-    const root = createContextCheckFixture(
-      `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=true last_verified=${today} -->\n`,
-    );
-    try {
-      writeFixtureJson(root, ".claude/settings.json", {
-        permissions: { allow: [permission] },
-        hooks: {
-          SessionEnd: [
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command:
-                    'bash "${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh"',
-                },
-              ],
-            },
-          ],
-        },
-      });
+console.log("\nsettings-contract wiring");
 
-      try {
-        execFileSync(process.execPath, [checkerScriptPath], {
-          cwd: root,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        throw new Error(`expected context check to reject ${permission}`);
-      } catch (/** @type {unknown} */ err) {
-        const maybeError =
-          err && typeof err === "object"
-            ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
-                err
-              )
-            : {};
-        const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
-        assert(
-          output.includes(
-            "sag permissions must include --api-key-file with the canonical ~/.config/elevenlabs_api_key path",
-          ),
-          `expected wrapped sag path failure, got ${JSON.stringify(output || maybeError.message)}`,
-        );
-      }
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  }
-});
-
-test("accepts the reviewed single-command Claude sag permissions", () => {
+test("surfaces settings-contract failures from the extracted module", () => {
   const today = isoDateWithOffset(0);
   const root = createContextCheckFixture(
     `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=true last_verified=${today} -->\n`,
   );
   try {
     writeFixtureJson(root, ".claude/settings.json", {
-      permissions: {
-        allow: [
-          'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your feedback in the agent chat")',
-          'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
-          'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, the task finished and needs your attention in the agent chat")',
-        ],
-      },
+      permissions: { allow: ["Bash(echo sagacious)"] },
       hooks: {
         SessionEnd: [
           {
@@ -794,68 +735,30 @@ test("accepts the reviewed single-command Claude sag permissions", () => {
       },
     });
 
-    execFileSync(process.execPath, [checkerScriptPath], {
-      cwd: root,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    try {
+      execFileSync(process.execPath, [checkerScriptPath], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      throw new Error(
+        "expected context check to surface the settings-contract failure",
+      );
+    } catch (/** @type {unknown} */ err) {
+      const maybeError =
+        err && typeof err === "object"
+          ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
+              err
+            )
+          : {};
+      const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
+      assert(
+        output.includes("unexpected Bash permission"),
+        `expected unreviewed Bash permission failure, got ${JSON.stringify(output || maybeError.message)}`,
+      );
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test("rejects every unreviewed Claude Bash permission", () => {
-  const today = isoDateWithOffset(0);
-  const permissions = [
-    'Bash(cmd=sag; "$cmd" --api-key-file /tmp/other-key -v Charlie "hey")',
-    "Bash(echo sagacious)",
-  ];
-
-  for (const permission of permissions) {
-    const root = createContextCheckFixture(
-      `# Root README\n\n<!-- agent-context: title="Root README" status=active owner=eng canonical=true last_verified=${today} -->\n`,
-    );
-    try {
-      writeFixtureJson(root, ".claude/settings.json", {
-        permissions: { allow: [permission] },
-        hooks: {
-          SessionEnd: [
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command:
-                    'bash "${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh"',
-                },
-              ],
-            },
-          ],
-        },
-      });
-
-      try {
-        execFileSync(process.execPath, [checkerScriptPath], {
-          cwd: root,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        throw new Error(`expected context check to reject ${permission}`);
-      } catch (/** @type {unknown} */ err) {
-        const maybeError =
-          err && typeof err === "object"
-            ? /** @type {{stderr?: string, stdout?: string, message?: string}} */ (
-                err
-              )
-            : {};
-        const output = `${maybeError.stdout ?? ""}${maybeError.stderr ?? ""}`;
-        assert(
-          output.includes("unexpected Bash permission"),
-          `expected unreviewed Bash permission failure, got ${JSON.stringify(output || maybeError.message)}`,
-        );
-      }
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
   }
 });
 

--- a/scripts/context/check-settings-contract.mjs
+++ b/scripts/context/check-settings-contract.mjs
@@ -1,0 +1,296 @@
+/**
+ * Contract assertions for the two agent-runtime configuration files:
+ * `.claude/settings.json` and `.codex/hooks.json`.
+ *
+ * Two concerns live here, and both are security controls rather than
+ * documentation policy:
+ *
+ * - the SessionEnd hook wiring for both runtimes, which must invoke
+ *   `scripts/bootstrap/agent-session-end-hook.sh` through a derived repository
+ *   root instead of a machine-local path;
+ * - the verbatim copy of the `.claude/settings.json` Bash permission
+ *   allowlist, which is an exact reviewed set so shell escaping or dynamic
+ *   command construction cannot bypass a command-specific policy check.
+ *
+ * `check-agent-context.mjs` runs this module and folds the returned failures
+ * into its own, so `pnpm agent:context-check` and the direct
+ * `node scripts/context/check-agent-context.mjs` invocations in
+ * `.github/workflows/supply-chain.yml` and the four bootstrap scripts keep
+ * covering both halves. Like its caller this module stays on node builtins and
+ * siblings only, so the weekly staleness job still runs with no `pnpm install`.
+ *
+ * Tests: scripts/context/check-settings-contract.test.mjs
+ */
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+function sessionEndCommands(settings, filePath, fail) {
+  const entries = settings?.hooks?.SessionEnd;
+  if (!Array.isArray(entries)) {
+    fail(`${filePath}: expected hooks.SessionEnd array`);
+    return [];
+  }
+  return entries.flatMap((entry) =>
+    Array.isArray(entry?.hooks)
+      ? entry.hooks
+          .filter((hook) => hook?.type === "command")
+          .map((hook) => hook.command)
+          .filter((command) => typeof command === "string")
+      : [],
+  );
+}
+
+function isCodexSessionEndCommand(command) {
+  return (
+    /^bash\s+-lc\s+['"]/.test(command) &&
+    command.includes("repo=$(git rev-parse --show-toplevel") &&
+    /&&\s+exec\s+bash\s+["']?\$repo\/scripts\/bootstrap\/agent-session-end-hook\.sh["']?/.test(
+      command,
+    )
+  );
+}
+
+function isClaudeSessionEndCommand(command) {
+  const scriptPath =
+    /["']\$\{CLAUDE_PROJECT_DIR\}\/scripts\/bootstrap\/agent-session-end-hook\.sh["']/;
+  const directInvocation = new RegExp(
+    String.raw`^bash\s+${scriptPath.source}(?:\s|$)`,
+  );
+  // Also accept a presence-guarded form: `if [ -f "${CLAUDE_PROJECT_DIR}/...sh" ]; then bash "${CLAUDE_PROJECT_DIR}/...sh"; fi`
+  // This lets a Claude session that outlives a deleted worktree skip the hook silently
+  // without swallowing real failures from the script when it does exist.
+  const guardedInvocation = new RegExp(
+    String.raw`^if\s+\[\s+-f\s+${scriptPath.source}\s+\]\s*;\s*then\s+bash\s+${scriptPath.source}\s*;\s*fi\s*$`,
+  );
+  return directInvocation.test(command) || guardedInvocation.test(command);
+}
+
+// Keep these in sync with `.claude/settings.json`. Bash permissions are an
+// exact reviewed allowlist so shell escaping or dynamic command construction
+// cannot bypass a command-specific policy check.
+const allowedClaudeBashScriptPermissions = new Set([
+  "Bash(bash scripts/agent-quality-gate.sh:*)",
+  "Bash(bash ./scripts/agent-quality-gate.sh:*)",
+  "Bash(bash scripts/agent-quality-gate.test.sh:*)",
+  "Bash(bash ./scripts/agent-quality-gate.test.sh:*)",
+  "Bash(bash scripts/bootstrap/agent-session-end-hook.sh:*)",
+  "Bash(bash ./scripts/bootstrap/agent-session-end-hook.sh:*)",
+  "Bash(node scripts/check-agent-quality-gate-package-scripts.mjs:*)",
+  "Bash(node ./scripts/check-agent-quality-gate-package-scripts.mjs:*)",
+  "Bash(bash ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
+  "Bash(bash ./ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
+  "Bash(bash ui-dashboard/scripts/check-react-doctor-score.sh:*)",
+  "Bash(bash ./ui-dashboard/scripts/check-react-doctor-score.sh:*)",
+]);
+
+// Keep this in sync with `.claude/settings.json`. Exact entries make the key
+// path part of the `sag` invocation itself; wrappers, compound commands, and
+// comments cannot satisfy the check by mentioning the canonical path elsewhere.
+const allowedClaudeSagPermissions = new Set([
+  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your feedback in the agent chat")',
+  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
+  'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, the task finished and needs your attention in the agent chat")',
+]);
+
+const allowedClaudeOtherBashPermissions = new Set([
+  "Bash(terraform -chdir=terraform output:*)",
+  "Bash(terraform -chdir=terraform plan:*)",
+  "Bash(terraform -chdir=terraform validate:*)",
+  'Bash(say "hey, i need your feedback in the agent chat")',
+  'Bash(say "hey, i need your approval in the agent chat")',
+  'Bash(say "hey, the task finished and needs your attention in the agent chat")',
+  'Bash(spd-say "hey, i need your feedback in the agent chat")',
+  'Bash(spd-say "hey, i need your approval in the agent chat")',
+  'Bash(spd-say "hey, the task finished and needs your attention in the agent chat")',
+  "Bash(ESLINT_BASELINE_MAIN=* node *)",
+]);
+
+const allowedClaudeBashPermissions = new Set([
+  ...allowedClaudeBashScriptPermissions,
+  ...allowedClaudeSagPermissions,
+  ...allowedClaudeOtherBashPermissions,
+]);
+
+// Root `scripts/` and package-local `<package>/scripts/` both count: the React
+// Doctor wrappers live in `ui-dashboard/scripts/`, so a prefix-blind check
+// would route a package-local script permission into the generic branch.
+const bashScriptPermission =
+  /^Bash\(bash\s+(?:\.\/)?(?:[\w.-]+\/)?scripts\/[^)]*\)$/;
+const bashDeployScriptPermission =
+  /^Bash\(bash\s+(?:\.\/)?(?:[\w.-]+\/)?scripts\/deploy-[^)]*\)$/;
+
+function isClaudeBashScriptPermission(permission) {
+  return bashScriptPermission.test(permission);
+}
+
+function isClaudeSagPermission(permission) {
+  if (!permission.startsWith("Bash(")) return false;
+
+  const command = permission.slice(
+    "Bash(".length,
+    permission.endsWith(")") ? -1 : undefined,
+  );
+  const normalizedCommand = command
+    .replace(/\\\r?\n/g, "")
+    .replace(/[\\'"]/g, "");
+  return /(?:^|[\s;&|()'"`$])(?:[^\s;&|()'"`$]+\/)?sag(?=$|[\s:;&|()'"`$])/.test(
+    normalizedCommand,
+  );
+}
+
+function validateClaudePermissions(settings, fail) {
+  const allow = settings?.permissions?.allow;
+  if (!Array.isArray(allow)) {
+    fail(".claude/settings.json: expected permissions.allow array");
+    return;
+  }
+
+  for (const permission of allow) {
+    if (typeof permission !== "string") continue;
+    if (!permission.startsWith("Bash(")) continue;
+
+    if (
+      isClaudeSagPermission(permission) &&
+      !allowedClaudeSagPermissions.has(permission)
+    ) {
+      fail(
+        `.claude/settings.json: sag permissions must include --api-key-file with the canonical ~/.config/elevenlabs_api_key path and match a reviewed single-command allowlist entry: ${permission}`,
+      );
+      continue;
+    }
+
+    if (/^Bash\(until\b/.test(permission)) {
+      fail(
+        `.claude/settings.json: permissions.allow must not allow shell-loop commands: ${permission}`,
+      );
+      continue;
+    }
+
+    if (allowedClaudeBashPermissions.has(permission)) continue;
+
+    if (bashDeployScriptPermission.test(permission)) {
+      fail(
+        `.claude/settings.json: must not allow deploy/promote scripts: ${permission}`,
+      );
+    } else if (isClaudeBashScriptPermission(permission)) {
+      fail(
+        `.claude/settings.json: unexpected bash scripts allow: ${permission}`,
+      );
+    } else {
+      fail(
+        `.claude/settings.json: unexpected Bash permission; add the exact reviewed entry to the context-check allowlist: ${permission}`,
+      );
+    }
+  }
+}
+
+/**
+ * Assert the agent-runtime configuration contract against a repository tree.
+ *
+ * @param {{repoRoot: string, env?: NodeJS.ProcessEnv}} options
+ * @returns {{failures: string[]}} failures in the order the caller reports them
+ */
+export function checkSettingsContract({ repoRoot, env = process.env }) {
+  const failures = [];
+  const fail = (message) => failures.push(message);
+
+  const resolveInputPath = (filePath) =>
+    path.isAbsolute(filePath) ? filePath : path.join(repoRoot, filePath);
+
+  const exists = (filePath) => {
+    try {
+      statSync(resolveInputPath(filePath));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const read = (filePath) => readFileSync(resolveInputPath(filePath), "utf8");
+
+  const readRequired = (filePath, displayPath = filePath) => {
+    if (!exists(filePath)) {
+      fail(`${displayPath}: required guard input is missing`);
+      return null;
+    }
+    return read(filePath);
+  };
+
+  const readJsonRequired = (filePath, displayPath = filePath) => {
+    const content = readRequired(filePath, displayPath);
+    if (content === null) return null;
+    try {
+      return JSON.parse(content);
+    } catch (error) {
+      fail(`${displayPath}: invalid JSON (${error.message})`);
+      return null;
+    }
+  };
+
+  const testOnlyInputPath = (environmentVariable, canonicalPath) => {
+    const override = env[environmentVariable];
+    if (!override) return canonicalPath;
+    if (env.NODE_ENV !== "test") {
+      fail(`${environmentVariable}: test-only override requires NODE_ENV=test`);
+      return canonicalPath;
+    }
+    return override;
+  };
+
+  // Test-only input overrides let the regression suite mutate disposable
+  // fixtures instead of tracked runtime configuration. Fail closed if an
+  // override leaks into a normal invocation.
+  const codexHooks = readJsonRequired(
+    testOnlyInputPath("AGENT_CONTEXT_CODEX_HOOKS_FILE", ".codex/hooks.json"),
+    ".codex/hooks.json",
+  );
+  if (codexHooks) {
+    const commands = sessionEndCommands(codexHooks, ".codex/hooks.json", fail);
+    if (commands.some((command) => command.includes("/Users/"))) {
+      fail(".codex/hooks.json: Codex hook command must not use /Users paths");
+    }
+    if (!commands.some(isCodexSessionEndCommand)) {
+      fail(
+        ".codex/hooks.json: expected SessionEnd command to execute scripts/bootstrap/agent-session-end-hook.sh via resolved repo root",
+      );
+    }
+  }
+
+  const claudeSettings = readJsonRequired(
+    testOnlyInputPath(
+      "AGENT_CONTEXT_CLAUDE_SETTINGS_FILE",
+      ".claude/settings.json",
+    ),
+    ".claude/settings.json",
+  );
+  if (claudeSettings) {
+    validateClaudePermissions(claudeSettings, fail);
+
+    const commands = sessionEndCommands(
+      claudeSettings,
+      ".claude/settings.json",
+      fail,
+    );
+    if (commands.some((command) => command.includes("/Users/"))) {
+      fail(
+        ".claude/settings.json: Claude hook command must not use /Users paths",
+      );
+    }
+    if (!commands.some(isClaudeSessionEndCommand)) {
+      fail(
+        ".claude/settings.json: expected SessionEnd command to execute quoted ${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh with bash",
+      );
+    }
+  }
+
+  const sessionEndHook = readRequired(
+    "scripts/bootstrap/agent-session-end-hook.sh",
+  );
+  if (sessionEndHook?.includes("/Users/")) {
+    fail(
+      "scripts/bootstrap/agent-session-end-hook.sh: hook must derive the repository root instead of hardcoding a local path",
+    );
+  }
+
+  return { failures };
+}

--- a/scripts/context/check-settings-contract.test.mjs
+++ b/scripts/context/check-settings-contract.test.mjs
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for scripts/context/check-settings-contract.mjs.
+ *
+ * The module reads a repository tree but never exits the process, so these
+ * tests drive it directly against disposable fixture trees and assert on the
+ * returned failure list. `check-agent-context.test.mjs` keeps one end-to-end
+ * test proving its entrypoint still surfaces these failures.
+ *
+ * Run: node scripts/context/check-settings-contract.test.mjs
+ * CI:  .github/workflows/ci.yml  (scripts job)
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { checkSettingsContract } from "./check-settings-contract.mjs";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \x1b[32m✔\x1b[0m ${name}`);
+    passed++;
+  } catch (/** @type {unknown} */ err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`  \x1b[31m✖\x1b[0m ${name}`);
+    console.error(`    ${msg}`);
+    failed++;
+  }
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(msg);
+}
+
+const CLAUDE_SESSION_END_COMMAND =
+  'bash "${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh"';
+const CODEX_SESSION_END_COMMAND =
+  "bash -lc 'repo=$(git rev-parse --show-toplevel) && exec bash \"$repo/scripts/bootstrap/agent-session-end-hook.sh\"'";
+
+function sessionEndHooks(command) {
+  return { SessionEnd: [{ hooks: [{ type: "command", command }] }] };
+}
+
+function writeFixtureFile(root, filePath, content) {
+  const absolutePath = path.join(root, filePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function writeFixtureJson(root, filePath, value) {
+  writeFixtureFile(root, filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Build a disposable tree holding the three inputs the contract reads, run the
+ * module against it, and return its failures.
+ *
+ * @param {{
+ *   allow?: unknown,
+ *   claudeSettings?: unknown,
+ *   claudeSettingsRaw?: string,
+ *   codexHooks?: unknown,
+ *   codexHooksRaw?: string,
+ *   hookScript?: string,
+ *   omit?: string[],
+ *   env?: Record<string, string>,
+ * }} options
+ */
+function runContract(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "check-settings-contract-"));
+  const omit = new Set(options.omit ?? []);
+  try {
+    if (!omit.has(".codex/hooks.json")) {
+      if (options.codexHooksRaw !== undefined) {
+        writeFixtureFile(root, ".codex/hooks.json", options.codexHooksRaw);
+      } else {
+        writeFixtureJson(
+          root,
+          ".codex/hooks.json",
+          options.codexHooks ?? {
+            hooks: sessionEndHooks(CODEX_SESSION_END_COMMAND),
+          },
+        );
+      }
+    }
+    if (!omit.has(".claude/settings.json")) {
+      if (options.claudeSettingsRaw !== undefined) {
+        writeFixtureFile(
+          root,
+          ".claude/settings.json",
+          options.claudeSettingsRaw,
+        );
+      } else {
+        writeFixtureJson(
+          root,
+          ".claude/settings.json",
+          options.claudeSettings ?? {
+            permissions: { allow: options.allow ?? [] },
+            hooks: sessionEndHooks(CLAUDE_SESSION_END_COMMAND),
+          },
+        );
+      }
+    }
+    if (!omit.has("scripts/bootstrap/agent-session-end-hook.sh")) {
+      writeFixtureFile(
+        root,
+        "scripts/bootstrap/agent-session-end-hook.sh",
+        options.hookScript ?? "#!/usr/bin/env bash\n",
+      );
+    }
+    return checkSettingsContract({ repoRoot: root, env: options.env ?? {} })
+      .failures;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertFailureContains(failures, expected) {
+  assert(
+    failures.some((failure) => failure.includes(expected)),
+    `expected a failure containing ${JSON.stringify(expected)}, got ${JSON.stringify(failures)}`,
+  );
+}
+
+function assertNoFailures(failures) {
+  assert(
+    failures.length === 0,
+    `expected no failures, got ${JSON.stringify(failures)}`,
+  );
+}
+
+// ── clean contract ────────────────────────────────────────────────────────────
+
+console.log("\nclean contract");
+
+test("a conforming tree produces no failures", () => {
+  assertNoFailures(runContract());
+});
+
+test("accepts the presence-guarded Claude SessionEnd invocation", () => {
+  const guarded =
+    'if [ -f "${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh" ]; then bash "${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh"; fi';
+  assertNoFailures(
+    runContract({
+      claudeSettings: {
+        permissions: { allow: [] },
+        hooks: sessionEndHooks(guarded),
+      },
+    }),
+  );
+});
+
+// ── Claude Bash permission allowlist ──────────────────────────────────────────
+//
+// The allowlist is a security control: `.claude/settings.json` grants the
+// permissions, and this module holds the reviewed copy. A one-sided edit to
+// either must red, so every rejection branch gets a case here.
+
+console.log("\nClaude Bash permission allowlist");
+
+test("rejects direct and wrapped Claude sag permissions without the canonical key path", () => {
+  const permissions = [
+    'Bash(sag --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(sag -v Charlie --api-key-file ~/.config/sag/elevenlabs-api-key "hey, i need your approval in the agent chat")',
+    'Bash(sag speak --api-key-file ~/.config/sag/elevenlabs-api-key -v Charlie "hey, i need your approval in the agent chat")',
+    "Bash(sag:*)",
+    'Bash(env LANG=C sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(command sag -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(echo ready && sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(/usr/bin/env LANG=C /usr/local/bin/sag --api-key-file ~/.config/other-key -v Charlie "hey, i need your approval in the agent chat")',
+    "Bash(command sag:*)",
+    'Bash(env LANG=C command sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(command sag --api-key-file=~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
+    'Bash(sag --api-key-file ~/.config/other-key -v Charlie "hey"; printf %s --api-key-file ~/.config/elevenlabs_api_key)',
+    String.raw`Bash(s\ag --api-key-file /tmp/other-key -v Charlie "hey")`,
+    "Bash(s''ag --api-key-file /tmp/other-key -v Charlie \"hey\")",
+  ];
+
+  for (const permission of permissions) {
+    const failures = runContract({ allow: [permission] });
+    assert(
+      failures.some((failure) =>
+        failure.includes(
+          "sag permissions must include --api-key-file with the canonical ~/.config/elevenlabs_api_key path",
+        ),
+      ),
+      `expected wrapped sag path failure for ${permission}, got ${JSON.stringify(failures)}`,
+    );
+  }
+});
+
+test("accepts the reviewed single-command Claude sag permissions", () => {
+  assertNoFailures(
+    runContract({
+      allow: [
+        'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your feedback in the agent chat")',
+        'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, i need your approval in the agent chat")',
+        'Bash(sag --api-key-file ~/.config/elevenlabs_api_key -v Charlie "hey, the task finished and needs your attention in the agent chat")',
+      ],
+    }),
+  );
+});
+
+test("rejects every unreviewed Claude Bash permission", () => {
+  const permissions = [
+    'Bash(cmd=sag; "$cmd" --api-key-file /tmp/other-key -v Charlie "hey")',
+    "Bash(echo sagacious)",
+  ];
+
+  for (const permission of permissions) {
+    const failures = runContract({ allow: [permission] });
+    assert(
+      failures.some((failure) =>
+        failure.includes("unexpected Bash permission"),
+      ),
+      `expected unreviewed Bash permission failure for ${permission}, got ${JSON.stringify(failures)}`,
+    );
+  }
+});
+
+test("rejects shell-loop permissions", () => {
+  assertFailureContains(
+    runContract({ allow: ["Bash(until *)"] }),
+    ".claude/settings.json: permissions.allow must not allow shell-loop commands: Bash(until *)",
+  );
+});
+
+test("rejects unreviewed root and package-local bash script permissions", () => {
+  for (const permission of [
+    "Bash(bash scripts/*)",
+    "Bash(bash ./scripts/*)",
+    "Bash(bash ui-dashboard/scripts/check-react-doctor-other.sh:*)",
+  ]) {
+    assertFailureContains(
+      runContract({ allow: [permission] }),
+      `.claude/settings.json: unexpected bash scripts allow: ${permission}`,
+    );
+  }
+});
+
+test("rejects deploy and promote script permissions", () => {
+  for (const permission of [
+    "Bash(bash ./scripts/deploy-dashboard.sh:*)",
+    "Bash(bash ui-dashboard/scripts/deploy-preview.sh:*)",
+  ]) {
+    assertFailureContains(
+      runContract({ allow: [permission] }),
+      `.claude/settings.json: must not allow deploy/promote scripts: ${permission}`,
+    );
+  }
+});
+
+test("accepts every reviewed allowlist entry the settings file grants", () => {
+  assertNoFailures(
+    runContract({
+      allow: [
+        "Bash(bash scripts/agent-quality-gate.sh:*)",
+        "Bash(bash ./scripts/agent-quality-gate.sh:*)",
+        "Bash(bash scripts/agent-quality-gate.test.sh:*)",
+        "Bash(bash ./scripts/agent-quality-gate.test.sh:*)",
+        "Bash(bash scripts/bootstrap/agent-session-end-hook.sh:*)",
+        "Bash(bash ./scripts/bootstrap/agent-session-end-hook.sh:*)",
+        "Bash(node scripts/check-agent-quality-gate-package-scripts.mjs:*)",
+        "Bash(node ./scripts/check-agent-quality-gate-package-scripts.mjs:*)",
+        "Bash(bash ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
+        "Bash(bash ./ui-dashboard/scripts/check-react-doctor-diff.sh:*)",
+        "Bash(bash ui-dashboard/scripts/check-react-doctor-score.sh:*)",
+        "Bash(bash ./ui-dashboard/scripts/check-react-doctor-score.sh:*)",
+        "Bash(terraform -chdir=terraform output:*)",
+        "Bash(terraform -chdir=terraform plan:*)",
+        "Bash(terraform -chdir=terraform validate:*)",
+        'Bash(say "hey, i need your feedback in the agent chat")',
+        'Bash(say "hey, i need your approval in the agent chat")',
+        'Bash(say "hey, the task finished and needs your attention in the agent chat")',
+        'Bash(spd-say "hey, i need your feedback in the agent chat")',
+        'Bash(spd-say "hey, i need your approval in the agent chat")',
+        'Bash(spd-say "hey, the task finished and needs your attention in the agent chat")',
+        "Bash(ESLINT_BASELINE_MAIN=* node *)",
+      ],
+    }),
+  );
+});
+
+test("ignores non-Bash permissions and non-string entries", () => {
+  assertNoFailures(
+    runContract({
+      allow: ["Read(docs/**)", "WebFetch(domain:example.com)", 7],
+    }),
+  );
+});
+
+test("rejects a permissions.allow that is not an array", () => {
+  assertFailureContains(
+    runContract({
+      claudeSettings: {
+        permissions: { allow: "Bash(echo hi)" },
+        hooks: sessionEndHooks(CLAUDE_SESSION_END_COMMAND),
+      },
+    }),
+    ".claude/settings.json: expected permissions.allow array",
+  );
+});
+
+// ── SessionEnd hook wiring ────────────────────────────────────────────────────
+
+console.log("\nSessionEnd hook wiring");
+
+test("rejects a Claude SessionEnd command that does not run the hook script", () => {
+  assertFailureContains(
+    runContract({
+      claudeSettings: {
+        permissions: { allow: [] },
+        hooks: sessionEndHooks(
+          "echo ${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh",
+        ),
+      },
+    }),
+    ".claude/settings.json: expected SessionEnd command to execute quoted ${CLAUDE_PROJECT_DIR}/scripts/bootstrap/agent-session-end-hook.sh with bash",
+  );
+});
+
+test("rejects a Codex SessionEnd command that does not resolve the repo root", () => {
+  assertFailureContains(
+    runContract({
+      codexHooks: {
+        hooks: sessionEndHooks(
+          "bash -lc 'echo git rev-parse --show-toplevel && echo scripts/bootstrap/agent-session-end-hook.sh'",
+        ),
+      },
+    }),
+    ".codex/hooks.json: expected SessionEnd command to execute scripts/bootstrap/agent-session-end-hook.sh via resolved repo root",
+  );
+});
+
+test("rejects machine-local paths in either SessionEnd command", () => {
+  assertFailureContains(
+    runContract({
+      claudeSettings: {
+        permissions: { allow: [] },
+        hooks: sessionEndHooks(
+          'bash "/Users/someone/repo/scripts/bootstrap/agent-session-end-hook.sh"',
+        ),
+      },
+    }),
+    ".claude/settings.json: Claude hook command must not use /Users paths",
+  );
+  assertFailureContains(
+    runContract({
+      codexHooks: {
+        hooks: sessionEndHooks(
+          "bash -lc '/Users/someone/repo/scripts/bootstrap/agent-session-end-hook.sh'",
+        ),
+      },
+    }),
+    ".codex/hooks.json: Codex hook command must not use /Users paths",
+  );
+});
+
+test("rejects a missing hooks.SessionEnd array in either runtime file", () => {
+  assertFailureContains(
+    runContract({ codexHooks: { hooks: {} } }),
+    ".codex/hooks.json: expected hooks.SessionEnd array",
+  );
+  assertFailureContains(
+    runContract({
+      claudeSettings: { permissions: { allow: [] }, hooks: {} },
+    }),
+    ".claude/settings.json: expected hooks.SessionEnd array",
+  );
+});
+
+test("rejects a hook script that hardcodes a machine-local repository root", () => {
+  assertFailureContains(
+    runContract({
+      hookScript: "#!/usr/bin/env bash\ncd /Users/someone/repo || exit 1\n",
+    }),
+    "scripts/bootstrap/agent-session-end-hook.sh: hook must derive the repository root instead of hardcoding a local path",
+  );
+});
+
+// ── guard inputs ──────────────────────────────────────────────────────────────
+
+console.log("\nguard inputs");
+
+test("rejects a missing guard input", () => {
+  for (const file of [
+    ".codex/hooks.json",
+    ".claude/settings.json",
+    "scripts/bootstrap/agent-session-end-hook.sh",
+  ]) {
+    assertFailureContains(
+      runContract({ omit: [file] }),
+      `${file}: required guard input is missing`,
+    );
+  }
+});
+
+test("rejects invalid JSON in either runtime file", () => {
+  assertFailureContains(
+    runContract({ codexHooksRaw: "" }),
+    ".codex/hooks.json: invalid JSON",
+  );
+  assertFailureContains(
+    runContract({ claudeSettingsRaw: "{" }),
+    ".claude/settings.json: invalid JSON",
+  );
+});
+
+test("test-only input overrides require NODE_ENV=test", () => {
+  for (const variable of [
+    "AGENT_CONTEXT_CODEX_HOOKS_FILE",
+    "AGENT_CONTEXT_CLAUDE_SETTINGS_FILE",
+  ]) {
+    assertFailureContains(
+      runContract({ env: { [variable]: "/nonexistent/fixture.json" } }),
+      `${variable}: test-only override requires NODE_ENV=test`,
+    );
+  }
+});
+
+test("an unscoped override still reads the canonical path", () => {
+  // Fail closed: the override is refused, so the contract keeps grading the
+  // tracked file rather than the caller's fixture.
+  const failures = runContract({
+    allow: ["Bash(echo sagacious)"],
+    env: { AGENT_CONTEXT_CLAUDE_SETTINGS_FILE: "/nonexistent/fixture.json" },
+  });
+  assertFailureContains(
+    failures,
+    "AGENT_CONTEXT_CLAUDE_SETTINGS_FILE: test-only override requires NODE_ENV=test",
+  );
+  assertFailureContains(failures, "unexpected Bash permission");
+});
+
+test("NODE_ENV=test honours a test-only override", () => {
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "check-settings-contract-override-"),
+  );
+  try {
+    writeFixtureJson(fixtureRoot, "settings.json", {
+      permissions: { allow: ["Bash(echo sagacious)"] },
+      hooks: sessionEndHooks(CLAUDE_SESSION_END_COMMAND),
+    });
+    const failures = runContract({
+      env: {
+        NODE_ENV: "test",
+        AGENT_CONTEXT_CLAUDE_SETTINGS_FILE: path.join(
+          fixtureRoot,
+          "settings.json",
+        ),
+      },
+    });
+    assertFailureContains(failures, "unexpected Bash permission");
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ── summary ───────────────────────────────────────────────────────────────────
+
+console.log(
+  `\n${passed + failed} tests: \x1b[32m${passed} passed\x1b[0m${failed > 0 ? `, \x1b[31m${failed} failed\x1b[0m` : ""}\n`,
+);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## The Problem

- `scripts/context/check-agent-context.mjs` held two unrelated jobs behind one entrypoint: documentation frontmatter and `last_verified` staleness policy, and the agent-runtime configuration contract.
- The second job is a security control — the verbatim `.claude/settings.json` Bash permission allowlist and the SessionEnd hook wiring for Claude and Codex — reviewed inside a file everyone reads as a documentation checker.
- Phase P3 of the `scripts/` reorganization moved the file into `scripts/context/` unchanged and deferred the split, because a behaviour change must not ride a relocation.

## The Solution

- The permission allowlist, its validation, and both runtimes' SessionEnd hook assertions move to `scripts/context/check-settings-contract.mjs` with its own suite.
- `check-agent-context.mjs` imports the module and folds its failures in where the inline block used to run, so `pnpm agent:context-check` covers exactly what it covered before.

## Details

**Verbatim extraction.** Every allowlist entry, regex, comparison, and failure message moved unchanged. The only edits the file boundary forced: `fail` is threaded as a parameter instead of closing over the entrypoint's array, and the four input helpers the contract needs (`readRequired`, `readJsonRequired`, `testOnlyInputPath`, and the `exists`/`read` pair they call) are local to the module. A mechanical literal comparison between `origin/main`'s moved region and the new module reports zero missing string, template, or regex literals.

**Import, not a chained pnpm script.** The alias stays one command because three callers reach the contract without going through pnpm: the weekly context-staleness job in `supply-chain.yml` runs `node scripts/context/check-agent-context.mjs` directly with no `pnpm install`, and the four bootstrap scripts call the alias. Chaining would have needed each of those updated, and a miss is silent. The entrypoint already composes siblings this way — `claude-runtime-document-registry.mjs` takes injected inputs and returns `{ errors }` the caller folds in, and the new module returns `{ failures }` the same way. Both halves stay on node builtins and siblings only, so the weekly job still needs no install.

**Ordering.** The module runs where the inline block ran, so the reported failure order is byte-identical.

**Test split.** `check-settings-contract.test.mjs` owns the contract rules and drives the module directly against disposable fixture trees — 21 tests covering every rejection branch, including the ones only `agent-quality-gate.test.sh` reached before (shell-loop, deploy-script, package-local script, missing input, invalid JSON, both hook regexes, the fail-closed test-only override). `check-agent-context.test.mjs` keeps one end-to-end test proving the entrypoint still surfaces those failures.

**Registration.** The gate routes the new module and its suite; `agent-quality-gate.test.sh` asserts that routing; CI gains one step for the suite. No new pnpm alias, so the pinned alias map is untouched. ADR 0064's sweep checklist and its React Doctor consequence now name the contract's new home.

## Validation

Behaviour preservation, four directions. Each scenario ran against `origin/main`'s checker and against this branch's split, through `node scripts/context/check-agent-context.mjs` with the test-only fixture overrides. The two captures are byte-identical after normalising the run label.

| Direction | Scenario | Result |
| --- | --- | --- |
| (a) one-sided permission edit | five unreviewed entries appended to a `.claude/settings.json` fixture | same five named failures, same messages, exit 1 |
| (b) broken SessionEnd hook | `.claude/settings.json` command replaced with `echo …`; `.codex/hooks.json` command stripped of the repo-root resolution | same two failures, exit 1 |
| (b′) fail-closed override | `AGENT_CONTEXT_CODEX_HOOKS_FILE` without `NODE_ENV=test` | same refusal, exit 1 |
| (c) documentation metadata | `docs/context-standards.md` `last_verified` set to 2020-01-01 | same staleness failure through the doc-checker half, exit 1 |
| (d) clean tree | unmodified working tree | `Agent context check passed`, exit 0 |

Commands:

- `pnpm agent:context-check` — passed (147 managed files)
- `node scripts/context/check-settings-contract.test.mjs` — 21 tests, all passed
- `node scripts/context/check-agent-context.test.mjs` — 34 tests, all passed
- `node scripts/context/docs-index.test.mjs`, `node scripts/context/agent-context-budget.test.mjs` — passed
- `pnpm agent:quality-gate:test` — passed
- `pnpm agent:quality-gate --base origin/main` (dry run) — routes the new arm; negative control: a whitespace-only edit to `check-settings-contract.mjs` alone routes `pnpm agent:context-check`, its own suite, and the caller's suite, then reverted
- `pnpm agent:quality-gate --base origin/main --run --parallel 4 --skip-if-fresh` — passed
- `pnpm lint:scripts`, `bash -n` on both gate scripts — clean
- `pnpm docs:index --check`, `pnpm agent:context-budget --strict` — clean; `scripts/AGENTS.md` untouched at 8,915 bytes
- Allowlist parity: all 25 `Bash(` entries the tracked `.claude/settings.json` grants appear verbatim in the module's reviewed copy
- Documentation sweep: every other reference is to the unchanged `pnpm agent:context-check` alias or to the documentation-metadata half; ADR 0064 was the only file naming the contract's location

Both review engines ran pre-push.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — ADR 0064 already governs `scripts/` module boundaries; this PR updates its sweep checklist to the new home.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1887

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors security-sensitive Bash permission and SessionEnd hook enforcement; behavior is intended to be verbatim, but any wiring mistake could weaken agent-runtime guards without changing docs checks.
> 
> **Overview**
> Pulls **agent-runtime security checks** (the verbatim `.claude/settings.json` Bash allowlist, sag rules, and Claude/Codex **SessionEnd** hook wiring) out of `check-agent-context.mjs` into **`check-settings-contract.mjs`**, which exports `checkSettingsContract({ repoRoot })` and returns `{ failures }`.
> 
> **`check-agent-context.mjs`** now imports that module and folds failures in at the same point as before, so **`pnpm agent:context-check`** and direct `node` callers still run documentation policy **and** the settings contract in one pass with unchanged ordering.
> 
> **Tests:** `check-settings-contract.test.mjs` owns the moved contract cases (21 tests); `check-agent-context.test.mjs` keeps a single end-to-end test that the entrypoint still surfaces contract failures.
> 
> **Wiring:** CI adds a scripts-job step for the new suite; `agent-quality-gate.sh` routes edits to the module to `agent:context-check`, both test files, and the contract suite; ADR 0064’s sweep checklist points at the new home for the allowlist copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19e1a2618b7eb21d35121a9193e33fa27c82804. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->