### PR TITLE
fix(scripts): stop the autoreview bundle scanner refusing inert reference patterns

### DIFF
--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -220,8 +220,15 @@ the prepared-bundle directory. Sensitive paths, credential-like content, private
 keys, wallet recovery phrases, Stripe live keys, common Slack/Discord/Telegram
 webhook URLs, and secret-bearing URL query parameters fail closed before any
 prepared-bundle artifact is published or review input is sent to a semantic
-engine. Evidence reads reject symlinks and verify that the opened descriptor
-still identifies the file that was inspected, closing path-swap races.
+engine. A value that only names a credential is a reference, not a literal, and
+passes: environment and `process.env` reads, GitHub Actions `${{ … }}` context
+expressions, Terraform `var`/`local`/`module`/`data` traversals, and shell
+parameter expansions such as `${GH_TOKEN:-${GITHUB_TOKEN:-}}` whose default,
+assign, or alternate word is empty or itself a shell-native reference. Every one
+of those is anchored to the whole value, so a literal fused to a reference still
+refuses.
+Evidence reads reject symlinks and verify that the opened descriptor still
+identifies the file that was inspected, closing path-swap races.
 
 ## Explicit helper attestation
 

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -223,10 +223,14 @@ prepared-bundle artifact is published or review input is sent to a semantic
 engine. A value that only names a credential is a reference, not a literal, and
 passes: environment and `process.env` reads, GitHub Actions `${{ … }}` context
 expressions, Terraform `var`/`local`/`module`/`data` traversals, and shell
-parameter expansions such as `${GH_TOKEN:-${GITHUB_TOKEN:-}}` whose default,
-assign, or alternate word is empty or itself a shell-native reference. Every one
-of those is anchored to the whole value, so a literal fused to a reference still
-refuses.
+parameter expansions such as `${GH_TOKEN:-${GITHUB_TOKEN:-}}` whose default
+(`:-`, `-`), assign (`:=`, `=`), alternate (`:+`, `+`), or error (`:?`, `?`)
+word is empty or itself a shell-native reference. Every one of those is anchored
+to the whole value, so a literal fused to a reference still refuses. Shell
+expansion nesting is bounded at eight levels, past which the value is not a
+reference and stays subject to the literal rules; real defaults nest one to
+three deep, and an unbounded walk lets one crafted line exhaust the scanner's
+stack.
 Evidence reads reject symlinks and verify that the opened descriptor still
 identifies the file that was inspected, closing path-swap races.
 

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -769,6 +769,52 @@ export function sensitivePathReason(rawPath) {
   return null;
 }
 
+// A shell parameter expansion carrying a default, assign, alternate, or error
+// operator resolves at runtime exactly the way a bare `${VAR}` does, so
+// `GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"` names values it does not
+// carry. The word after `:-`, `-`, `:=`, `=`, `:+`, `+`, `:?`, or `?` is
+// accepted only when it is empty or itself a shell-native reference, because a
+// default can inline a real credential (`${GH_TOKEN:-ghp_real}`) and that must
+// still fail closed. The word is deliberately not measured against the whole
+// placeholder grammar: under shell semantics a word such as `secrets.ghp_real`
+// is a plain literal, not a reference, so the broader grammar would let one
+// through. Nesting is parsed rather than pattern-matched, and the brace closing
+// the leading `${` has to be the last character, so a literal fused to an
+// expansion (`${VAR:-}ghp_real`) is not a reference either. Any other expansion
+// form — `${VAR#prefix}`, `${VAR/a/b}` — leaves a non-empty, non-reference word
+// and stays subject to the literal rules.
+function shellExpansionWord(word) {
+  return (
+    word === "" ||
+    /^\$(?:[A-Za-z_][A-Za-z0-9_]*|[0-9])$/.test(word) ||
+    shellExpansionReference(word)
+  );
+}
+
+function shellExpansionReference(expression) {
+  const head = /^\$\{(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+)(?::?[-=+?])?/.exec(
+    expression,
+  );
+  if (!head) return false;
+  let depth = 0;
+  let closing = -1;
+  for (let index = 0; index < expression.length; index += 1) {
+    if (expression[index] === "$" && expression[index + 1] === "{") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (expression[index] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) {
+      closing = index;
+      break;
+    }
+  }
+  if (closing !== expression.length - 1) return false;
+  return shellExpansionWord(expression.slice(head[0].length, closing).trim());
+}
+
 // A value is a placeholder (never a committed literal secret) when it is an
 // env/context REFERENCE rather than an inline value. The `${{ <context>.path }}`
 // clause covers GitHub Actions expressions: their contents resolve at runtime,
@@ -790,6 +836,7 @@ export function sensitivePathReason(rawPath) {
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
+    shellExpansionReference(trimmed) ||
     /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
     ) ||

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -773,9 +773,11 @@ export function sensitivePathReason(rawPath) {
 // operator resolves at runtime exactly the way a bare `${VAR}` does, so
 // `GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"` names values it does not
 // carry. The word after `:-`, `-`, `:=`, `=`, `:+`, `+`, `:?`, or `?` is
-// accepted only when it is empty or itself a shell-native reference, because a
-// default can inline a real credential (`${GH_TOKEN:-ghp_real}`) and that must
-// still fail closed. The word is deliberately not measured against the whole
+// accepted only when it is empty, an exactly-empty quoted word, or itself a
+// shell-native reference, because a default can inline a real credential
+// (`${GH_TOKEN:-ghp_real}`) and that must still fail closed — a quoted word with
+// anything in it stays subject to the literal rules. The word is deliberately
+// not measured against the whole
 // placeholder grammar: under shell semantics a word such as `secrets.ghp_real`
 // is a plain literal, not a reference, so the broader grammar would let one
 // through. Nesting is parsed rather than pattern-matched, and the brace closing
@@ -783,9 +785,23 @@ export function sensitivePathReason(rawPath) {
 // expansion (`${VAR:-}ghp_real`) is not a reference either. Any other expansion
 // form — `${VAR#prefix}`, `${VAR/a/b}` — leaves a non-empty, non-reference word
 // and stays subject to the literal rules.
+//
+// Nesting is bounded because each level recurses and rescans its own substring.
+// A single diff line of deeply nested reference-only expansions otherwise costs
+// quadratic time and one stack frame per level. Measured on this scanner before
+// the bound: 20,000 levels took 8.9s, and 100,000 levels ran 38s and then threw
+// `RangeError: Maximum call stack size exceeded` out of the scan, aborting
+// bundle preparation instead of returning a verdict. Bounded, the same
+// 100,000-level line returns a refusal in 118ms. Real shell defaults nest one to three deep, so anything past the
+// bound is treated as not a reference — the fail-closed direction, since the
+// value then stays subject to the literal rules.
+const MAX_SHELL_EXPANSION_NESTING = 8;
+
 function shellExpansionWord(word) {
   return (
     word === "" ||
+    word === "''" ||
+    word === '""' ||
     /^\$(?:[A-Za-z_][A-Za-z0-9_]*|[0-9])$/.test(word) ||
     shellExpansionReference(word)
   );
@@ -801,6 +817,7 @@ function shellExpansionReference(expression) {
   for (let index = 0; index < expression.length; index += 1) {
     if (expression[index] === "$" && expression[index + 1] === "{") {
       depth += 1;
+      if (depth > MAX_SHELL_EXPANSION_NESTING) return false;
       index += 1;
       continue;
     }

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -604,6 +604,91 @@ assert.equal(
   null,
   "service token placeholders remain allowed",
 );
+// A shell parameter expansion carrying a default, assign, or alternate operator
+// resolves at runtime the way a bare `${VAR}` does, so the diff carries no
+// literal. Before this, a PR that merely moved a shell file containing one
+// aborted the whole bundle, because the scanner read the expansion as a
+// credential and scans removed lines too.
+assert.equal(
+  secretLikeReason('GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"'),
+  null,
+  "nested shell default expansions are references, not literal tokens",
+);
+assert.equal(
+  secretLikeReason('SERVICE_TOKEN="${SERVICE_TOKEN-}"'),
+  null,
+  "unset-only shell default expansions are references",
+);
+assert.equal(
+  secretLikeReason('API_TOKEN="${API_TOKEN:=${FALLBACK_TOKEN}}"'),
+  null,
+  "assign-default shell expansions are references",
+);
+assert.equal(
+  secretLikeReason('API_TOKEN="${CI:+${GITHUB_TOKEN}}"'),
+  null,
+  "alternate shell expansions whose word is a reference are references",
+);
+assert.equal(
+  secretLikeReason('API_KEY="${3:-${QUICKNODE_API_KEY-}}"'),
+  null,
+  "positional-parameter shell expansions are references",
+);
+// Anti-bypass: the word after the operator is the one place a literal can hide,
+// and the brace that closes the expansion has to end the value. Each fixture is
+// joined from parts so this file's own source carries no credential-key
+// assignment for the scanner to reject when the diff is reviewed.
+const tokenAssignment = (value) =>
+  ["GH_API_TOKEN", "=", '"', value, '"'].join("");
+assert.match(
+  secretLikeReason(
+    tokenAssignment(["${GH_TOKEN:-", genericTokenCredential, "}"].join("")),
+  ),
+  /literal generic token assignment/,
+  "a literal default inside a shell expansion is still rejected",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(["${GH_TOKEN:+", genericTokenCredential, "}"].join("")),
+  ),
+  /literal generic token assignment/,
+  "a literal alternate inside a shell expansion is still rejected",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(["${GH_TOKEN:-}", genericTokenCredential].join("")),
+  ),
+  /literal generic token assignment/,
+  "a literal fused to a shell expansion fails the ^…$ anchor and is rejected",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(
+      ["${GH_TOKEN:-${A:-", genericTokenCredential, "}}"].join(""),
+    ),
+  ),
+  /literal generic token assignment/,
+  "a literal nested one level deeper in a default is still rejected",
+);
+// The word is measured against shell-native reference forms only. Under shell
+// semantics a `secrets.…`/`var.…` word is a plain literal, so the broader
+// placeholder grammar would otherwise carry a credential through a default.
+for (const scope of ["secrets", "var", "local"]) {
+  assert.match(
+    secretLikeReason(
+      tokenAssignment(
+        ["${GH_TOKEN:-", scope, ".", genericTokenCredential, "}"].join(""),
+      ),
+    ),
+    /literal generic token assignment/,
+    `a ${scope}.* word inside a shell default is a literal, not a reference`,
+  );
+}
+assert.equal(
+  secretLikeReason('GH_API_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"'),
+  null,
+  "a bare $VAR word inside a shell default is a reference",
+);
 assert.equal(
   secretLikeReason("GH_TOKEN: ${{ github.token }}"),
   null,

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -604,9 +604,9 @@ assert.equal(
   null,
   "service token placeholders remain allowed",
 );
-// A shell parameter expansion carrying a default, assign, or alternate operator
-// resolves at runtime the way a bare `${VAR}` does, so the diff carries no
-// literal. Before this, a PR that merely moved a shell file containing one
+// A shell parameter expansion carrying a default, assign, alternate, or error
+// operator resolves at runtime the way a bare `${VAR}` does, so the diff carries
+// no literal. Before this, a PR that merely moved a shell file containing one
 // aborted the whole bundle, because the scanner read the expansion as a
 // credential and scans removed lines too.
 assert.equal(
@@ -633,6 +633,16 @@ assert.equal(
   secretLikeReason('API_KEY="${3:-${QUICKNODE_API_KEY-}}"'),
   null,
   "positional-parameter shell expansions are references",
+);
+assert.equal(
+  secretLikeReason('SERVICE_TOKEN="${SERVICE_TOKEN:?}"'),
+  null,
+  "colon-error shell expansions are references",
+);
+assert.equal(
+  secretLikeReason('SERVICE_TOKEN="${SERVICE_TOKEN?$FALLBACK_TOKEN}"'),
+  null,
+  "unset-error shell expansions whose word is a reference are references",
 );
 // Anti-bypass: the word after the operator is the one place a literal can hide,
 // and the brace that closes the expansion has to end the value. Each fixture is
@@ -688,6 +698,59 @@ assert.equal(
   secretLikeReason('GH_API_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"'),
   null,
   "a bare $VAR word inside a shell default is a reference",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(["${GH_TOKEN:?", genericTokenCredential, "}"].join("")),
+  ),
+  /literal generic token assignment/,
+  "a literal in a shell error-operator word is still rejected",
+);
+// An exactly-empty quoted default expands to the empty string, so it is inert.
+// Anything inside those quotes is a literal and stays subject to the rules.
+assert.equal(
+  secretLikeReason(tokenAssignment("${GH_TOKEN:-''}")),
+  null,
+  "an exactly-empty quoted word inside a shell default is a reference",
+);
+assert.equal(
+  secretLikeReason(["GH_API_TOKEN", "=", "'", '${GH_TOKEN:-""}', "'"].join("")),
+  null,
+  "the double-quoted empty word is likewise a reference",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(["${GH_TOKEN:-'", genericTokenCredential, "'}"].join("")),
+  ),
+  /literal credential (?:assignment|expression)/,
+  "a quoted non-empty word inside a shell default is still rejected",
+);
+// Nesting is bounded: each level recurses and rescans its own substring, so an
+// unbounded one costs quadratic time and a stack frame per level. Past the bound
+// the value is not a reference, which leaves it subject to the literal rules —
+// the fail-closed direction.
+const nestedShellExpansion = (depth) =>
+  "${A:-".repeat(depth) + "}".repeat(depth);
+assert.equal(
+  secretLikeReason(tokenAssignment(nestedShellExpansion(8))),
+  null,
+  "shell expansions nested to the bound are still references",
+);
+assert.match(
+  secretLikeReason(tokenAssignment(nestedShellExpansion(9))),
+  /literal generic token assignment/,
+  "shell expansions nested past the bound are not references",
+);
+// The adversarial input the bound exists for: unbounded, 100,000 levels threw
+// `RangeError: Maximum call stack size exceeded` out of the scanner and aborted
+// bundle preparation instead of returning a verdict. Returning a verdict at all
+// is the whole property; wall-clock is not asserted, because the fixture also
+// runs every other rule in the scanner and a time budget would only measure the
+// machine.
+assert.match(
+  secretLikeReason(tokenAssignment(nestedShellExpansion(100_000))),
+  /literal generic token assignment/,
+  "a deeply nested shell expansion returns a verdict instead of overflowing",
 );
 assert.equal(
   secretLikeReason("GH_TOKEN: ${{ github.token }}"),

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6582,6 +6582,31 @@ run_sensitive_input_regressions() {
     exit 1
   fi
 
+  # A shell default expansion names values it does not carry, so a diff that
+  # moves or edits one builds a bundle instead of losing both review engines.
+  # The expansions below are the reviewed fixture text, so they must stay
+  # single-quoted and unexpanded.
+  git -C "$review_repo" restore README.md
+  # shellcheck disable=SC2016
+  printf '%s\n' 'GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"' \
+    >>"$review_repo/README.md"
+  run_helper_in_repo "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  # shellcheck disable=SC2016
+  expect_file_contains "$bundle_output" 'GH_API_TOKEN="${GH_TOKEN:-'
+  expect_empty_stderr
+
+  # The default is the one place a literal can hide, and it still fails closed.
+  # The head is a variable so this file's own source carries no credential-key
+  # assignment for the scanner to reject when the diff is reviewed.
+  local expansion_head
+  # shellcheck disable=SC2016
+  expansion_head='GH_API_TOKEN="${GH_TOKEN:-'
+  git -C "$review_repo" restore README.md
+  printf '%s%s%s%s\n' "$expansion_head" "live-default-" \
+    "abcdefghijklmnopqrstuvwxyz" '}"' >>"$review_repo/README.md"
+  run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  expect_stderr_contains "refusing to include secret-like content"
+
   git -C "$review_repo" restore README.md
   mkdir "$review_repo/.aws"
   {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The autoreview bundle's secret scanner read a shell default expansion —
  `GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"` — as a committed credential and
  aborted the whole run, so any PR that moved a shell file containing one lost
  both review engines and had to be reviewed outside the bundle.
- The bundle scans removed lines too, so deleting the offending line in the same
  PR did not clear it: the deletion is itself scanned.

## The Solution

- Teach `placeholderValue()` that a whole-value shell parameter expansion is a
  reference, the same way it already treats `${VAR}`, `process.env.X`,
  `${{ github.token }}`, and Terraform `var`/`local` traversals.

## Details

`shellExpansionReference()` accepts `${NAME…}` and `${N…}` with a default,
assign, alternate, or error operator (`:-`, `-`, `:=`, `=`, `:+`, `+`, `:?`,
`?`). Three properties keep it from weakening detection:

- **The word is the only place a literal can hide, and it must be inert.** It is
  accepted when empty, a bare `$VAR`/`$N`, or itself such an expansion.
  `${GH_TOKEN:-<real-key>}`, a literal alternate, and a literal nested one level
  deeper all still refuse.
- **The word is measured against shell-native reference forms only**, not the
  whole placeholder grammar. Under shell semantics a word like
  `secrets.<real-key>` is a plain literal, so routing it through
  `placeholderValue()` would have carried a credential through a default. The
  Claude engine caught this on the first draft; the narrowed check is what
  landed, with a rejection test for `secrets.*`, `var.*`, and `local.*` words.
- **Nesting is parsed, not pattern-matched**, and the brace that closes the
  leading `${` has to be the last character. `${VAR:-}<real-key>` — a literal
  fused to an expansion — is not a reference. Any other expansion form
  (`${VAR#prefix}`, `${VAR/a/b}`, `${VAR:0:4}`) leaves a non-empty,
  non-reference word and stays subject to the literal rules.

No module was added or renamed, so the wrapper's Perl copy list and the 2 MB
aggregate runtime cap are untouched. The two new regressions live in
`run_sensitive_input_regressions`, already owned by the `bundle-integrity`
family, so `verify_canonical_family_partition` needs no new entry.

The new fixtures are joined from parts, and the shell one keeps its expansion
head in a variable, so this PR's own diff carries no credential-key assignment
for the scanner to reject. That is what makes the in-bundle path usable on it.

## Validation

**Reproduction, from the merged phase that hit this.** Scanning P2's squashed
diff (`1f7fec89`, https://github.com/mento-protocol/monitoring-monorepo/pull/1892)
the way the bundle does — `git diff --no-ext-diff --no-renames`, because
difftastic is the configured differ and `--no-renames` is what turns a move into
a full delete plus a full add:

| Scanner        | Verdict on P2's diff                                                                     |
| -------------- | ---------------------------------------------------------------------------------------- |
| `origin/main`  | `literal generic token assignment` on `-GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"` |
| this branch    | `null`                                                                                     |

**End-to-end through the real wrapper.** A scratch repo whose only change is a
bootstrap script carrying that assignment, reviewed with the wrapper and helper
pinned outside the reviewed checkout:

- Runtime built from `origin/main`: `autoreview failed: refusing to include
  secret-like content in review bundle (literal generic token assignment)`,
  exit 1.
- Runtime built from this branch, `--engine codex`: bundle 517 bytes, one review
  pass, `autoreview clean: no accepted/actionable findings reported`.

**This PR's own diff.** `pnpm agent:autoreview` in the owning checkout still
refuses — `executable autoreview runtime differs from its trusted pre-change
snapshot` — which is the runtime-trust boundary working as designed, not the
scanner. The pre-change runtime the runbook would use also refuses, on the very
lines this change teaches it to accept, so this fix is its own bootstrap case.
With this branch's runtime materialized outside the checkout the bundle builds:
4 changed files, 8,874 bytes, one pass, no secret-scan refusal.

**Both directions, non-tautological.**

- `node scripts/agent-autoreview-core.test.mjs` — green; adds five reference
  shapes and seven rejection shapes.
- `AUTOREVIEW_TEST_FOCUS=bundle-integrity bash scripts/agent-autoreview.test.sh`
  — green; `run_sensitive_input_regressions` now builds a bundle for the
  expansion and still refuses its literal-default twin.
- Negative control, unit: the fix stripped from a scratch copy of the core fails
  at `nested shell default expansions are references, not literal tokens`.
- Negative control, suite: the fix stripped from the working-tree core the suite
  copies fails at `run_sensitive_input_regressions`.
- True positives spot-checked unchanged: a `ghp_` key, a PEM header, a modern
  npm token, a plain literal token assignment, an API-key literal.

**Gate and lint.**

- `bash scripts/agent-quality-gate.sh --run --parallel 4 --skip-if-fresh --base
  origin/main` — every mapped command green, including all five autoreview
  families (`engine-isolation`, `target-selection`, `runtime-trust`,
  `bundle-integrity`, `adapter`).
- `bash -n scripts/agent-autoreview.test.sh`, `pnpm lint:scripts`,
  `./tools/trunk check` on all four touched files, `pnpm docs:index --check`,
  `pnpm agent:context-check`, `pnpm docs:navigation-eval -- --check-fixtures` —
  all green.

**Engine reviews.** Codex: clean, `patch is correct (0.99)`. Claude: one P3 —
the shell default word accepted Terraform-style traversals that are literals
under shell semantics — fixed in this branch by narrowing the word check to
shell-native forms, with a rejection test.

CI will run the full adversarial autoreview suite, roughly 90 minutes, because
this touches `agent-autoreview.*`.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1912 — four other
  inert line shapes the scanner still refuses (test-fixture literal, HCL
  iteration traversal, TypeScript type annotation, shell command substitution).
  None is provably inert from its syntax the way a `${VAR:-…}` expansion is, so
  each needs its own safety argument rather than a widened rule here.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1886

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this narrows one existing
      predicate inside the established scanner design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential-detection logic on the autoreview bundle path; the implementation adds explicit anti-bypass checks, but any scanner tweak warrants careful review for false negatives.
> 
> **Overview**
> Fixes **false-positive bundle refusals** when a diff contains shell assignments whose value is only a parameter expansion (e.g. nested defaults like `"${GH_TOKEN:-${GITHUB_TOKEN:-}}"`). Those lines were scanned as literal token assignments and blocked the entire autoreview run, including on **removed** lines in the same PR.
> 
> **`placeholderValue()`** in `agent-autoreview-core.mjs` now recognizes **whole-value** shell expansions with default, assign, alternate, or error operators via new **`shellExpansionReference()`** / **`shellExpansionWord()`** helpers. Accepted operator words must be empty, a bare `$VAR`, or another such expansion; literals in the word, fused suffixes, and non-reference forms like `${VAR#prefix}` still fail closed. Default words are **not** treated as Terraform-style `secrets.*` / `var.*` references.
> 
> **`docs/notes/autoreview-runtime-trust.md`** documents shell expansions alongside existing reference types. **Unit and bundle-integrity integration tests** cover allowed shapes and bypass cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d008d79ac644d03ffe870e9dd269d99f87ad68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret scanning recognizes runtime credential references in environment variables, GitHub Actions expressions, Terraform traversals, and supported shell expansions.
  * Valid nested shell defaults and related expansion forms are accepted, with bounded nesting for reliable processing.

* **Bug Fixes**
  * Literal, malformed, fused, or overly nested credential values continue to be rejected.
  * File evidence checks reject symlinks and verify the inspected file’s identity.

* **Tests**
  * Added regression coverage for valid, invalid, and deeply nested shell expansion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->