### PR TITLE
fix(scripts): harden the quality gate against fail-open lock expiry and cross-worktree watchdog interference

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-12
+last_verified: 2026-08-18
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -194,6 +194,20 @@ moves `src` _inside_ an existing `dir` instead of failing, so a rename could
 never be a conditional claim there. A second run prints the holder's PID,
 host, and worktree, then waits — bounded by `--lock-wait` / `AGENT_QUALITY_GATE_LOCK_WAIT_SECONDS`,
 1800 seconds by default — and exits 2 naming that holder if the wait runs out.
+The expiry states itself on **stdout as well as stderr** (GitHub issue #1894).
+Every other outcome already did — a green run ends `All mapped commands
+passed.` — but the expiry once spoke on stderr alone, so a caller reading the
+gate's stdout saw the `waiting up to Ns` banner and then nothing. Piped, that
+became a fail-open: a pipeline reports the _reader's_ status unless the caller
+set `pipefail`, so a run that executed nothing read as a pass on the stream and
+on the status at once. The stdout verdict names the wait expiry, says no mapped
+command ran, and names the status a pipeline hides. `SIGPIPE` is ignored for
+those two writes, and they come after the stderr diagnosis: a stdout that
+closes while the verdict is being written costs the caller the stdout copy,
+never the stderr copy and never the exit status. A reader that closes _earlier_
+still kills the run on the wait banner, which is a `SIGPIPE` death — non-zero,
+so still not a pass. That is the invariant this path owes its caller: **a run
+that executed nothing never reports success, in any output mode.**
 Nothing that will not execute mapped commands ever competes for the lock: a dry
 run, a `--skip-if-fresh` cache hit, and a package-script refusal all exit
 before it. After waiting, a `--skip-if-fresh` run re-checks freshness, so the
@@ -557,6 +571,15 @@ self-test drives the gate against fixture repos from inside a gate run without
 deadlocking behind its own ancestor. The self-test exports
 `AGENT_QUALITY_GATE_LOCK=0` for the same reason: its fixture runs are not this
 machine's gate, and must neither queue behind a real one nor block it.
+
+**Every fixture process the self-test scans for carries that run's own PID in
+its name** (GitHub issue #1898). `pgrep` and `pkill` scan the whole machine, so
+a fixed fixture name is not a run's own: four worktrees running this suite at
+once each saw the others' timeout and interrupt fixtures, failed on them, and
+passed on a clean re-run — and a `pkill` cleanup would have reaped a sibling's
+live fixture. A new fixture whose liveness the suite asserts takes the same
+`$((RANDOM % 900 + 100))-$$` suffix the lock-race fixtures use, and every scan
+for it is scoped to that exact name.
 
 The pre-push hook reaches neither hatch — it runs a fixed command line and
 Trunk strips the environment those variables would arrive in — so when a hook's

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1753,6 +1753,23 @@ acquire_gate_run_lock() {
       # The pre-push hook passes a fixed command line and Trunk strips the
       # environment, so neither escape hatch is reachable from a failed push.
       echo "Pushing? Warm the stamps with 'pnpm agent:quality-gate --run' first, then push: --skip-if-fresh cache-hits and exits before this lock." >&2
+      # GitHub issue #1894. Every other outcome states itself on stdout — a green
+      # run ends "All mapped commands passed." — but this one used to speak on
+      # stderr alone, so a caller reading the gate's stdout saw the reassuring
+      # "waiting up to Ns" banner and then nothing. Pair that with a pipeline,
+      # whose status is the READER's unless the caller set `pipefail`, and a run
+      # that executed nothing reads as a pass on both signals at once. So the
+      # verdict goes to stdout too, and names the status a pipeline hides.
+      # SIGPIPE is ignored and the writes are optional because they come after
+      # the stderr diagnosis and must never displace it: a stdout that closes
+      # while this verdict is being written costs the caller the stdout copy,
+      # never the stderr copy and never the exit status. A reader that closed
+      # earlier still kills the run on the wait banner above, which is a
+      # SIGPIPE death — non-zero, so still not a pass, which is the invariant
+      # this path owes its caller.
+      trap '' PIPE
+      echo "Gate run lock wait expired after ${waited}s. No mapped command ran; this gate exits 2." 2>/dev/null || true
+      echo "Piped? A pipeline reports the reader's status: read \${PIPESTATUS[0]} or set -o pipefail." 2>/dev/null || true
       exit 2
     fi
     # Never sleep past the budget: with a wait shorter than — or not divisible

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4909,31 +4909,43 @@ STUB
   # parent exits on TERM while its child ignores TERM (PR 1492 review): the
   # watchdog must snapshot the tree before TERM and KILL the saved list, or
   # the reparented child survives the escalation.
-  cat > bin/qg-timeout-orphan <<'STUB'
+  #
+  # GitHub issue #1898: distinctive is not the same as unique. `pgrep` scans the
+  # whole machine, so a fixed name also matched a sibling worktree's fixture and
+  # four parallel suite runs failed each other's assertions — and `pkill` would
+  # have reaped a sibling's live fixture on the way out. The name therefore
+  # carries this run's own PID, and every scan below is scoped to that name.
+  # Same construction as the lock-race fixtures further down.
+  timeout_fixture_tag="$((RANDOM % 900 + 100))-$$"
+  timeout_victim="$command_timeout_repo/bin/qg-timeout-victim-$timeout_fixture_tag"
+  timeout_orphan="$command_timeout_repo/bin/qg-timeout-orphan-$timeout_fixture_tag"
+  cat > "$timeout_orphan" <<'STUB'
 #!/usr/bin/env bash
 trap '' TERM
 while :; do sleep 1; done
 STUB
-  cat > bin/qg-timeout-victim <<'STUB'
+  cat > "$timeout_victim" <<'STUB'
 #!/usr/bin/env bash
 trap 'exit 0' TERM
-qg-timeout-orphan &
+"${QG_TIMEOUT_ORPHAN:?}" &
 sleep 45 &
 wait
 STUB
   cat > bin/pnpm <<'STUB'
 #!/usr/bin/env bash
 if [[ "$*" == "agent:prewarm:test" ]]; then
-  exec qg-timeout-victim
+  exec "${QG_TIMEOUT_VICTIM:?}"
 fi
 exit 0
 STUB
-  chmod +x bin/pnpm bin/qg-timeout-victim bin/qg-timeout-orphan tools/trunk
+  chmod +x bin/pnpm "$timeout_victim" "$timeout_orphan" tools/trunk
   git add .
   git commit -qm init
   printf 'scripts/gate/agent-prewarm.mjs\n' > changed-paths.txt
   set +e
   PATH="$command_timeout_repo/bin:$PATH" \
+    QG_TIMEOUT_VICTIM="$timeout_victim" \
+    QG_TIMEOUT_ORPHAN="$timeout_orphan" \
     "$repo_root/scripts/agent-quality-gate.sh" \
       --changed-paths-file changed-paths.txt \
       --base HEAD \
@@ -4947,12 +4959,12 @@ STUB
     fail "expected the gate to fail when a mapped command exceeded --command-timeout"
   # TERM lands at ~2s; give the KILL backstop a moment, then assert no leak.
   sleep 4
-  if pgrep -f "qg-timeout-victim" >/dev/null 2>&1; then
-    pkill -KILL -f "qg-timeout-victim" 2>/dev/null || true
+  if pgrep -f "qg-timeout-victim-$timeout_fixture_tag" >/dev/null 2>&1; then
+    pkill -KILL -f "qg-timeout-victim-$timeout_fixture_tag" 2>/dev/null || true
     fail "timed-out command left a leaked background process"
   fi
-  if pgrep -f "qg-timeout-orphan" >/dev/null 2>&1; then
-    pkill -KILL -f "qg-timeout-orphan" 2>/dev/null || true
+  if pgrep -f "qg-timeout-orphan-$timeout_fixture_tag" >/dev/null 2>&1; then
+    pkill -KILL -f "qg-timeout-orphan-$timeout_fixture_tag" 2>/dev/null || true
     fail "timed-out command's TERM-ignoring child escaped the watchdog KILL pass"
   fi
 )
@@ -4977,8 +4989,13 @@ command_interrupt_repo="$(mktemp -d)"
 exit 0
 STUB
   # Ignores TERM and respawns its sleep child each second, so only the KILL
-  # escalation can reap it.
-  cat > bin/qg-interrupt-victim <<'STUB'
+  # escalation can reap it. Run-unique for the same reason as the timeout
+  # fixture above (GitHub issue #1898): this suite waits on `pgrep` to decide
+  # the victim started, so a sibling worktree's fixture would satisfy the wait
+  # before this run's victim exists.
+  interrupt_fixture_tag="$((RANDOM % 900 + 100))-$$"
+  interrupt_victim="$command_interrupt_repo/bin/qg-interrupt-victim-$interrupt_fixture_tag"
+  cat > "$interrupt_victim" <<'STUB'
 #!/usr/bin/env bash
 trap '' TERM
 while :; do sleep 1; done
@@ -4986,16 +5003,17 @@ STUB
   cat > bin/pnpm <<'STUB'
 #!/usr/bin/env bash
 if [[ "$*" == "agent:prewarm:test" ]]; then
-  exec qg-interrupt-victim
+  exec "${QG_INTERRUPT_VICTIM:?}"
 fi
 exit 0
 STUB
-  chmod +x bin/pnpm bin/qg-interrupt-victim tools/trunk
+  chmod +x bin/pnpm "$interrupt_victim" tools/trunk
   git add .
   git commit -qm init
   printf 'scripts/gate/agent-prewarm.mjs\n' > changed-paths.txt
   set +e
   PATH="$command_interrupt_repo/bin:$PATH" \
+    QG_INTERRUPT_VICTIM="$interrupt_victim" \
     "$repo_root/scripts/agent-quality-gate.sh" \
       --changed-paths-file changed-paths.txt \
       --base HEAD \
@@ -5004,12 +5022,12 @@ STUB
       > "$output_file" 2>&1 &
   gate_pid=$!
   waited=0
-  until pgrep -f "qg-interrupt-victim" >/dev/null 2>&1; do
+  until pgrep -f "qg-interrupt-victim-$interrupt_fixture_tag" >/dev/null 2>&1; do
     sleep 1
     waited=$((waited + 1))
     if [[ "$waited" -ge 20 ]]; then
       kill -KILL "$gate_pid" 2>/dev/null
-      pkill -KILL -f "qg-interrupt-victim" 2>/dev/null
+      pkill -KILL -f "qg-interrupt-victim-$interrupt_fixture_tag" 2>/dev/null
       fail "interrupt fixture never started its victim"
     fi
   done
@@ -5021,8 +5039,8 @@ STUB
     fail "expected the gate to exit nonzero when interrupted by TERM"
   # The trap teardown TERMs immediately, then KILLs after its 3s grace.
   sleep 5
-  if pgrep -f "qg-interrupt-victim" >/dev/null 2>&1; then
-    pkill -KILL -f "qg-interrupt-victim" 2>/dev/null || true
+  if pgrep -f "qg-interrupt-victim-$interrupt_fixture_tag" >/dev/null 2>&1; then
+    pkill -KILL -f "qg-interrupt-victim-$interrupt_fixture_tag" 2>/dev/null || true
     fail "interrupted gate left a SIGTERM-ignoring process running"
   fi
 )
@@ -5400,6 +5418,61 @@ STUB
   assert_contains "--skip-if-fresh cache-hits and exits before this lock"
   [[ -d "$gate_lock_root/run.lock" ]] ||
     fail "a run that never acquired the lock must not delete the holder's lock"
+
+  # GitHub issue #1894: the same expiry, read the way a piped caller reads it.
+  # Every other outcome states itself on stdout — a green run ends "All mapped
+  # commands passed." — but the expiry used to speak on stderr alone, leaving a
+  # stdout stream that ended on the reassuring "waiting up to Ns" banner. A
+  # caller that piped the gate then had two signals and both lied: that stream,
+  # and a pipeline status that belongs to the READER unless the caller set
+  # `pipefail`. So this asserts the shape that misled — stdout piped, stderr
+  # discarded — on both halves: the gate's own status, and a stdout stream that
+  # names the wait expiry and says nothing ran.
+  sleep 120 &
+  piped_holder_pid=$!
+  write_lock_owner "$piped_holder_pid"
+  set +e
+  AGENT_QUALITY_GATE_LOCK=1 \
+    AGENT_QUALITY_GATE_LOCK_HELD='' \
+    AGENT_QUALITY_GATE_LOCK_DIR="$gate_lock_root" \
+    AGENT_QUALITY_GATE_LOCK_POLL_SECONDS=1 \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+    --base HEAD --run --lock-wait 2 \
+    2>/dev/null | cat > "$output_file"
+  piped_exit="${PIPESTATUS[0]}"
+  set -e
+  kill "$piped_holder_pid" 2>/dev/null || true
+  [[ "$piped_exit" == "2" ]] ||
+    fail "expected a piped contended gate run to exit 2 after --lock-wait, got $piped_exit"
+  assert_raw_contains "Gate run lock wait expired after"
+  assert_raw_contains "No mapped command ran; this gate exits 2."
+  assert_raw_contains "read \${PIPESTATUS[0]} or set -o pipefail"
+  [[ -d "$gate_lock_root/run.lock" ]] ||
+    fail "a piped run that never acquired the lock must not delete the holder's lock"
+
+  # The same expiry against a reader that closes the pipe. Whether the run
+  # reaches the verdict (exit 2) or dies writing the wait banner (a SIGPIPE
+  # death) is a race with the reader, so what is pinned here is the invariant
+  # the whole path owes its caller rather than one of the two statuses: a run
+  # that executed nothing never reports success.
+  sleep 120 &
+  closed_pipe_holder_pid=$!
+  write_lock_owner "$closed_pipe_holder_pid"
+  set +e
+  AGENT_QUALITY_GATE_LOCK=1 \
+    AGENT_QUALITY_GATE_LOCK_HELD='' \
+    AGENT_QUALITY_GATE_LOCK_DIR="$gate_lock_root" \
+    AGENT_QUALITY_GATE_LOCK_POLL_SECONDS=1 \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+    --base HEAD --run --lock-wait 2 \
+    2> "$output_file" | head -c 1 > /dev/null
+  closed_pipe_exit="${PIPESTATUS[0]}"
+  set -e
+  kill "$closed_pipe_holder_pid" 2>/dev/null || true
+  [[ "$closed_pipe_exit" != "0" ]] ||
+    fail "a contended gate whose reader closed the pipe reported success without executing anything"
+  [[ -d "$gate_lock_root/run.lock" ]] ||
+    fail "a run killed by a closed pipe must not delete the holder's lock"
 
   # A dead holder whose record carries a token the gate would never generate
   # is waited out, never reclaimed: reclaiming would later drain by that


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The gate's lock-wait expiry told a piped caller nothing. It spoke on stderr alone, so the stdout stream ended on the reassuring `waiting up to Ns` banner — and a pipeline reports the reader's status unless the caller set `pipefail`. A run that executed nothing read as a pass on both signals at once.
- The self-test's timeout and interrupt fixtures had fixed process names, and `pgrep` scans the whole machine. Four worktrees running the suite at once each saw the others' fixtures and failed on them; a clean re-run passed. The `pkill` cleanup would have reaped a sibling's live fixture.

## The Solution

- The expiry now states itself on stdout as well as stderr: it names the wait expiry, says no mapped command ran, and names the exit status a pipeline hides. Nothing else about the lock changes.
- Each self-test fixture process name carries its own run's PID, and every `pgrep`/`pkill` is scoped to that exact name — the construction the lock-race fixtures already used.

## Details

- **Where the fail-open was.** Every other gate outcome already states itself on stdout; a green run ends `All mapped commands passed.`. The expiry was the one exception. The gate's own exit status was already 2 in every output mode — what was missing was a verdict on the stream a piped caller actually reads.
- **SIGPIPE.** The two stdout writes come after the stderr diagnosis, ignore `SIGPIPE`, and tolerate a failed write. A stdout that closes while the verdict is being written costs the caller the stdout copy, never the stderr copy and never the exit status. A reader that closes *earlier* still kills the run on the wait banner — a `SIGPIPE` death, non-zero, so still not a pass. The invariant the path owes its caller is that **a run that executed nothing never reports success, in any output mode**, and both shapes are now pinned by tests.
- **Fixture scoping.** The tagged victims are invoked by absolute path, so the tag appears in `argv` where `pgrep -f` matches it. The peer names reach the stubs through the same gate-invocation environment channel the old `PATH` lookup used (`QG_TIMEOUT_VICTIM`, `QG_TIMEOUT_ORPHAN`, `QG_INTERRUPT_VICTIM`). `$$` inside the test subshells resolves to the top-level suite PID, so two concurrent suite runs cannot collide.
- **Scope boundary.** The interrupt fixture is fixed alongside the timeout one: same defect, same family, adjacent lines, and the interrupt case additionally *waits* on `pgrep` to decide its victim started — a sibling's fixture satisfied that wait before this run's victim existed.
- **Environment note.** The suite must run where `pgrep` works. Under an agent sandbox that blocks the process list, `pgrep` exits 3 and every liveness assertion in the suite reads as "nothing found", so the watchdog cases pass vacuously. Both green runs below were taken unsandboxed.
- **One review finding not taken.** The Claude engine suggested gating the stdout verdict on `[[ -t 1 ]]` so a terminal user does not see the expiry restated. Not adopted, for two reasons. `-t 1` alone does not establish that stdout and stderr share a destination, so `gate 2>err.log` on a terminal would drop the verdict from the only stream the user is watching — precisely the caller class this PR exists for. And the block already prints three conditional recovery hints unconditionally, each prefixed by its condition (`Running the gate directly?`, `Pushing?`); `Piped?` follows that convention rather than becoming the one line in the block that branches on output mode.

## Validation

| Check | Result |
| --- | --- |
| `pnpm agent:quality-gate:test` | green twice, unsandboxed, on the final tree |
| `pnpm agent:quality-gate --run --parallel 3` | green, all 9 mapped commands |
| Pre-push hook on this branch | green — cache-hit the warm stamp (`Previous successful agent quality gate run is still fresh; skipping mapped commands.`) |
| `pnpm agent:quality-gate --dry-run` | routes `pnpm agent:quality-gate:test` for this diff |
| `bash -n` on both changed shell files | clean |
| `node scripts/repo-health/file-size-watchlist.test.mjs` | 22/22 pass on the rebased tree |
| Autoreview, Codex engine | round 1 clean `(0.94)`; round 2 on the final tree clean `(0.90)` |
| Autoreview, Claude engine | round 1 one P3 (closed-pipe path untested) — fixed, test added; round 2 one P3 (terminal output noise) — dispositioned below |

Reproductions and proofs:

- **Lock expiry, before.** Holder alive, `--lock-wait 2`, stdout piped with stderr dropped: the captured stream ended on `waiting up to 2s; interrupt to abort…` with no failure line, and a caller without `pipefail` read `0`.
- **Lock expiry, after.** Same shape: the stream ends `Gate run lock wait expired after 2s. No mapped command ran; this gate exits 2.` and the gate's own status is 2. Verified under bash 3.2 and 5.3.
- **Non-tautology.** Stripping the three added lines from a scratch copy of the gate fails three of the new case's four assertions; the fourth (exit 2) passed before the change and still does.
- **Cross-worktree interference, before.** With a sibling's `qg-timeout-victim`/`qg-timeout-orphan` alive, the old fixed-name scan fails with exactly the reported message: `timed-out command's TERM-ignoring child escaped the watchdog KILL pass`.
- **Cross-worktree interference, after.** Same sibling alive: passes. Two concurrent watchdog runs from separate scratch checkouts: both pass.
- **Positive control.** The scoped pattern finds its own live tagged fixture and does not match another run's tag, so the scan is not a dead pattern that passes by never matching anything.

## Deferrals

- The stamp-freshness issue https://github.com/mento-protocol/monitoring-monorepo/issues/1899 was diagnosed and is **not** fixed here. Its stated hypothesis is falsified: the fingerprint is byte-identical under the Trunk pre-push hook environment despite that environment stripping ~60 variables, prepending `git-core` to `PATH`, and changing `TMPDIR`, and it is identical across the hook's command line, `pnpm agent:quality-gate --run`, and `--parallel` variants. The real movers are ordinary inputs — chiefly `origin/main` advancing, which the hook's own `git fetch --quiet origin main` causes before every push. The full diagnosis with the dumps is posted on that issue, which stays open. No speculative fix shipped.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this changes no interface or contract, only what the expiry path prints and how the self-test names its fixtures.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1894
Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1898

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to lock-wait messaging, self-test isolation, and documentation; no mapped-command execution or lock acquisition logic is altered beyond clearer failure output.
> 
> **Overview**
> Fixes two ways the agent quality gate could **look successful without running mapped commands**, and stops parallel self-test runs from stepping on each other.
> 
> **Lock-wait expiry (#1894).** When `--lock-wait` times out on a contended run lock, the gate still exits **2**, but it now prints an explicit failure on **stdout** (not only stderr): wait expired, no mapped command ran, and a hint about `pipefail` / `${PIPESTATUS[0]}`. That closes a fail-open where piped callers saw only the “waiting up to Ns” banner and a pipeline exit code of **0**. Stdout writes ignore `SIGPIPE` and are best-effort so stderr diagnosis and exit status stay authoritative.
> 
> **Self-test fixtures (#1898).** Timeout and interrupt watchdog fixtures use run-unique process names (`$((RANDOM % 900 + 100))-$$`) and env vars for absolute paths, so machine-wide `pgrep`/`pkill` only touch this suite run’s processes. Docs in `agent-quality-gate-mechanics.md` record both behaviors.
> 
> New tests cover piped lock expiry (stdout verdict + exit 2) and early pipe close (must not exit 0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e81a060b4ae79a6a4c3fa0c4ac3c880e5b9181. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gate lock timeouts now clearly report failure status, including when output is piped or the receiving reader closes.
  * Timeout failures now explicitly indicate that no mapped command was executed.
  * Failure status is preserved reliably, preventing interrupted output streams from being reported as successful runs.

* **Documentation**
  * Updated verification guidance for lock-wait failures and run-scoped self-tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->