### PR TITLE
fix(scripts): resolve the remaining scanner reference shapes

### DIFF
--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -238,10 +238,17 @@ assignment cannot take; a TypeScript type annotation in `:` position whose
 union or intersection members all come from a closed twelve-word keyword
 vocabulary, so the value cannot carry a credential in any language, split
 across members or whole; and a shell command list on an `=` value whose head is
-the substitution the scanner already accepts and whose `||`/`&&` tail holds only
-words under credential length drawn from an alphabet with no `=`, `:`, quote,
-`$`, or parenthesis, so neither a second assignment nor a command argument can
-hide one. A literal in value position stays refused whatever names it: a fixture
+a command substitution read by word position — a command name of separator-split
+segments each under credential length, then arguments each bounded whole by that
+length, whether a shell reference, a flag with its optional value, or a bare
+word — followed by a `||`/`&&` tail of whole words under it, drawn from an
+alphabet with no `=`, `:`, quote, `$`, or parenthesis. A literal argument, one
+split across separators, one wearing a `--` prefix, and a second assignment in
+the tail all fail closed. So do two shapes that carry nothing: a head that is a
+call expression rather than a substitution, and an argument over that length,
+such as a deep path. Both refuse today too, so nothing regresses; they are the
+price of a rule that proves inertness from syntax alone.
+A literal in value position stays refused whatever names it: a fixture
 string is a quoted literal, and no syntax separates one from a weak credential,
 so fixtures compose the value from parts or use a documented placeholder marker
 (`fixture-token`, `example-secret`).

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -230,7 +230,21 @@ to the whole value, so a literal fused to a reference still refuses. Shell
 expansion nesting is bounded at eight levels, past which the value is not a
 reference and stays subject to the literal rules; real defaults nest one to
 three deep, and an unbounded walk lets one crafted line exhaust the scanner's
-stack.
+stack. Three more shapes pass on the same proof, and only unquoted. The scanner
+sees no file type, so each carries a syntactic discriminator: HCL iteration
+traversals (`each`, `count`, `self`, and the `rule` dynamic-block iterator) as
+bare dotted identifier paths behind a whitespace-surrounded `=`, which a shell
+assignment cannot take; a TypeScript type annotation in `:` position whose
+union or intersection members all come from a closed twelve-word keyword
+vocabulary, so the value cannot carry a credential in any language, split
+across members or whole; and a shell command list on an `=` value whose head is
+the substitution the scanner already accepts and whose `||`/`&&` tail holds only
+words under credential length drawn from an alphabet with no `=`, `:`, quote,
+`$`, or parenthesis, so neither a second assignment nor a command argument can
+hide one. A literal in value position stays refused whatever names it: a fixture
+string is a quoted literal, and no syntax separates one from a weak credential,
+so fixtures compose the value from parts or use a documented placeholder marker
+(`fixture-token`, `example-secret`).
 Evidence reads reject symlinks and verify that the opened descriptor still
 identifies the file that was inspected, closing path-swap races.
 

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -1058,6 +1058,135 @@ function unquotedCodeExpression(value, trailingComma, propertyContext = false) {
   return balancedDelimitedExpression(expression, openingIndex);
 }
 
+// The scanner reads a whole diff and has no file type, so a rule that proves
+// one language's syntax has to carry its own discriminator. A shell assignment
+// forbids whitespace around `=` — `TOKEN = value` runs the command `TOKEN` — so
+// requiring whitespace on both sides is a syntactic proof that the line is not
+// a shell assignment, and it is what separates an HCL attribute from
+// `TOKEN=each.value.<literal>` in a script.
+function spacedAssignmentOperator(operator) {
+  return /^[ \t]+=[ \t]+$/.test(operator);
+}
+
+// HCL iteration traversals name a value the plan resolves, exactly like the
+// `var`/`local`/`module`/`data` traversals `placeholderValue()` already accepts:
+// `each` and `count` are the fixed `for_each`/`count` scopes, `self` is a
+// resource's own attributes, and `rule` is the dynamic-block iterator this
+// repo's alert rules declare. The grammar is a bare dotted identifier path
+// anchored end to end, so a literal fused to a traversal
+// (`rule.value.token ghp_real`) is not one. Only the unquoted branches consult
+// it, which is what keeps a quoted traversal-shaped value a literal: in HCL a
+// quoted value is a string, and the traversal proof is the absence of quotes.
+// It reads the spaced `=` form only; the `key: value` form of the same path is
+// already a property traversal to `unquotedCodeExpression()`.
+const HCL_ITERATION_TRAVERSAL =
+  /^(?:count|each|rule|self)(?:\.[A-Za-z_][A-Za-z0-9_-]*)+$/;
+
+function hclIterationTraversal(value) {
+  return HCL_ITERATION_TRAVERSAL.test(value.trim());
+}
+
+// A TypeScript type annotation occupies type position: `token: string |
+// undefined` declares a shape and carries no value at all. The accepted set is
+// closed rather than shaped: every member of the union or intersection has to
+// be one of the built-in type keywords below, optionally suffixed with `[]`.
+// Because the whole value is then drawn from a twelve-word vocabulary, it
+// cannot carry a credential in any language — not as one member and not split
+// across several, which a shape rule measuring member length would allow. A
+// named type (`Address | undefined`) is outside the vocabulary and stays
+// subject to the literal rules; that is the fail-closed direction, and the
+// scanner has no file type with which to prove a name is a type.
+const TYPE_ANNOTATION_KEYWORDS = new Set([
+  "any",
+  "bigint",
+  "boolean",
+  "never",
+  "null",
+  "number",
+  "object",
+  "string",
+  "symbol",
+  "undefined",
+  "unknown",
+  "void",
+]);
+
+const TYPE_ANNOTATION_MEMBER = /^([A-Za-z_$][A-Za-z0-9_$]*)(?:\[\])*$/;
+
+function typeAnnotationValue(value) {
+  const members = value.trim().split(/\s*[|&]\s*/);
+  if (members.length < 2) return false;
+  return members.every((member) => {
+    const parsed = TYPE_ANNOTATION_MEMBER.exec(member);
+    return parsed !== null && TYPE_ANNOTATION_KEYWORDS.has(parsed[1]);
+  });
+}
+
+// A shell command list continues past the assignment: in
+// `access_token=$(get_access_token) || return 1` the assigned value is the
+// command substitution, resolved when the script runs, and `return 1` is a
+// separate command the operator guards. The line patterns carry no shell
+// grammar, so they capture the tail too and read the whole span as a literal.
+// The head is measured by the same call-expression rule a bare `$(cmd)` value
+// already passes, so no new value shape is admitted here — only the tail is
+// new. Its alphabet excludes `=`, `:`, quotes, `$`, and parentheses, so a
+// second assignment cannot hide in it, and every word stays under the length
+// the literal rules treat as credential-sized, so a command argument cannot
+// carry one either: `token=$(get) || SERVICE_TOKEN=<literal>` and
+// `token=$(get) || echo <literal>` both still fail closed. A real guard tail
+// (`|| return 1`, `|| exit 1`, `&& log ok`) is words of a few characters.
+// Operators are found at parenthesis depth zero so that `$(a || b)` stays one
+// substitution; quotes need no tracking because the callers' value groups
+// exclude them. It reads `=` values only — the languages that write a command
+// list into an assignment all use `=`.
+function shellControlOperatorIndex(expression) {
+  let depth = 0;
+  for (let index = 0; index < expression.length; index += 1) {
+    const character = expression[index];
+    if (character === "(") {
+      depth += 1;
+      continue;
+    }
+    if (character === ")") {
+      depth -= 1;
+      continue;
+    }
+    if (
+      depth === 0 &&
+      (character === "|" || character === "&") &&
+      expression[index + 1] === character
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function shellCommandListValue(value) {
+  const expression = value.trim();
+  const operatorIndex = shellControlOperatorIndex(expression);
+  if (operatorIndex === -1) return false;
+  if (
+    !unquotedCodeExpression(expression.slice(0, operatorIndex).trim(), false)
+  ) {
+    return false;
+  }
+  const words = expression
+    .slice(operatorIndex)
+    .replace(/^(?:\|\||&&)\s*/, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  return (
+    words.length > 0 &&
+    words.every(
+      (word) =>
+        word === "||" ||
+        word === "&&" ||
+        (word.length < 12 && /^[A-Za-z0-9_./-]+$/.test(word)),
+    )
+  );
+}
+
 function wrappedQuotedLiteral(value) {
   const expression = unwrapBalancedExpression(value);
   const quote = expression[0];
@@ -1690,15 +1819,19 @@ export function secretLikeReason(text) {
     return "literal wallet recovery phrase";
   }
   const genericTokenAssignmentPattern =
-    /^[+ -]?\s*["'`]?(token|[a-z][a-z0-9]*(?:_[a-z0-9]+)*_token)["'`]?\s*([:=])\s*(["'`]?)([^"'`\r\n]+?)\3[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*["'`]?(token|[a-z][a-z0-9]*(?:_[a-z0-9]+)*_token)["'`]?(\s*[:=]\s*)(["'`]?)([^"'`\r\n]+?)\3[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
   for (const match of text.matchAll(genericTokenAssignmentPattern)) {
     const key = match[1];
+    const operator = match[2];
     const quoted = Boolean(match[3]);
     const value = match[4].trim();
     const trailingComma = match[5] === ",";
     if (
       !quoted &&
-      unquotedCodeExpression(value, trailingComma, match[2] === ":")
+      (unquotedCodeExpression(value, trailingComma, operator.includes(":")) ||
+        (spacedAssignmentOperator(operator) && hclIterationTraversal(value)) ||
+        (operator.includes("=") && shellCommandListValue(value)) ||
+        (operator.includes(":") && typeAnnotationValue(value)))
     ) {
       continue;
     }
@@ -1774,11 +1907,15 @@ export function secretLikeReason(text) {
       return "literal registry credential assignment";
   }
   const unquotedKeyPattern =
-    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)\s*([:=])\s*([A-Za-z0-9_$+./=:@%!?~^-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)([A-Za-z0-9_$+./=:@%!?~^-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
   for (const match of text.matchAll(unquotedKeyPattern)) {
     const key = match[1];
+    const operator = match[2];
     const value = match[3].trim();
-    if (unquotedCodeExpression(value, match[4] === ",", match[2] === ":")) {
+    if (
+      unquotedCodeExpression(value, match[4] === ",", operator.includes(":")) ||
+      (spacedAssignmentOperator(operator) && hclIterationTraversal(value))
+    ) {
       continue;
     }
     if (

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -797,6 +797,13 @@ export function sensitivePathReason(rawPath) {
 // value then stays subject to the literal rules.
 const MAX_SHELL_EXPANSION_NESTING = 8;
 
+// The length at which the literal rules start treating a value as a credential.
+// Every rule that measures a value, a word, or a segment reads it from here, so
+// tuning it moves the whole scanner at once. Two line patterns mirror it as a
+// `{12,}` quantifier, where a computed bound would obscure the pattern; change
+// those with it.
+const CREDENTIAL_LITERAL_MIN_LENGTH = 12;
+
 function shellExpansionWord(word) {
   return (
     word === "" ||
@@ -1122,23 +1129,71 @@ function typeAnnotationValue(value) {
   });
 }
 
-// A shell command list continues past the assignment: in
-// `access_token=$(get_access_token) || return 1` the assigned value is the
-// command substitution, resolved when the script runs, and `return 1` is a
-// separate command the operator guards. The line patterns carry no shell
-// grammar, so they capture the tail too and read the whole span as a literal.
-// The head is measured by the same call-expression rule a bare `$(cmd)` value
-// already passes, so no new value shape is admitted here — only the tail is
-// new. Its alphabet excludes `=`, `:`, quotes, `$`, and parentheses, so a
-// second assignment cannot hide in it, and every word stays under the length
-// the literal rules treat as credential-sized, so a command argument cannot
-// carry one either: `token=$(get) || SERVICE_TOKEN=<literal>` and
-// `token=$(get) || echo <literal>` both still fail closed. A real guard tail
-// (`|| return 1`, `|| exit 1`, `&& log ok`) is words of a few characters.
+// Words inside an accepted command substitution are read by position, because
+// the two positions carry different risk. Arguments are where a literal can
+// sit, so each one is bounded whole by the length the literal rules treat as
+// credential-sized: a shell-native reference, a flag whose name and optional
+// value each stay under it, or a bare word that does. One uniform bound leaves
+// no position in which a long literal can hide, prefixed with `--` or split
+// across separators. It also refuses a long real argument such as a deep path,
+// which is the fail-closed direction and costs a line only when it sits in a
+// credential-named assignment with a control tail.
+//
+// The command word names something the shell executes, never a value, so it is
+// measured only for opaque runs — a real command or function name
+// (`get_access_token`) is short segments joined by separators. Bounding it whole
+// would refuse those names, and the position already carries whatever a bare
+// `$(cmd)` value carries today.
+const SHELL_WORD_ALPHABET = /^[A-Za-z0-9_./-]+$/;
+const SHELL_FLAG_WORD =
+  /^(--?[A-Za-z0-9][A-Za-z0-9-]*)(?:=([A-Za-z0-9_./-]*))?$/;
+
+function shellCommandWord(word) {
+  return (
+    SHELL_WORD_ALPHABET.test(word) &&
+    word
+      .split(/[-_./]/)
+      .every((segment) => segment.length < CREDENTIAL_LITERAL_MIN_LENGTH)
+  );
+}
+
+function shellArgumentWord(word) {
+  if (shellExpansionWord(word)) return true;
+  const flag = SHELL_FLAG_WORD.exec(word);
+  if (flag)
+    return (
+      flag[1].length < CREDENTIAL_LITERAL_MIN_LENGTH &&
+      (flag[2] ?? "").length < CREDENTIAL_LITERAL_MIN_LENGTH
+    );
+  return (
+    word.length < CREDENTIAL_LITERAL_MIN_LENGTH &&
+    SHELL_WORD_ALPHABET.test(word)
+  );
+}
+
+// The head of an accepted command list is a command substitution whose own
+// words are inert, so a literal argument fails closed
+// (`token=$(echo <literal>) || return 1`) even though the call-expression rule
+// that governs a bare `$(cmd)` value would take it. A backtick head, an
+// arithmetic expansion, and a plain call expression are all outside this form.
+function shellCommandSubstitution(head) {
+  if (!head.startsWith("$(") || !head.endsWith(")")) return false;
+  if (!balancedDelimitedExpression(head, 1)) return false;
+  const [command, ...args] = head
+    .slice(2, -1)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  return (
+    command !== undefined &&
+    shellCommandWord(command) &&
+    args.every(shellArgumentWord)
+  );
+}
+
 // Operators are found at parenthesis depth zero so that `$(a || b)` stays one
 // substitution; quotes need no tracking because the callers' value groups
-// exclude them. It reads `=` values only — the languages that write a command
-// list into an assignment all use `=`.
+// exclude them.
 function shellControlOperatorIndex(expression) {
   let depth = 0;
   for (let index = 0; index < expression.length; index += 1) {
@@ -1162,13 +1217,23 @@ function shellControlOperatorIndex(expression) {
   return -1;
 }
 
+// A shell command list continues past the assignment: in
+// `access_token=$(get_access_token) || return 1` the assigned value is the
+// command substitution, resolved when the script runs, and `return 1` is a
+// separate command the operator guards. The line patterns carry no shell
+// grammar, so they capture the tail too and read the whole span as a literal.
+// The tail is stricter than the substitution: whole words under credential
+// length from an alphabet with no `=`, `:`, quote, `$`, or parenthesis, so
+// neither a second assignment (`token=$(get) || SERVICE_TOKEN=<literal>`) nor a
+// command argument (`token=$(get) || echo <literal>`) can carry one, split
+// across separators or not. A real guard tail is `|| return 1`, `|| exit 1`,
+// `&& log ok`. Callers read `=` values only — the languages that write a
+// command list into an assignment all use `=`.
 function shellCommandListValue(value) {
   const expression = value.trim();
   const operatorIndex = shellControlOperatorIndex(expression);
   if (operatorIndex === -1) return false;
-  if (
-    !unquotedCodeExpression(expression.slice(0, operatorIndex).trim(), false)
-  ) {
+  if (!shellCommandSubstitution(expression.slice(0, operatorIndex).trim())) {
     return false;
   }
   const words = expression
@@ -1182,7 +1247,8 @@ function shellCommandListValue(value) {
       (word) =>
         word === "||" ||
         word === "&&" ||
-        (word.length < 12 && /^[A-Za-z0-9_./-]+$/.test(word)),
+        (word.length < CREDENTIAL_LITERAL_MIN_LENGTH &&
+          SHELL_WORD_ALPHABET.test(word)),
     )
   );
 }
@@ -1589,7 +1655,8 @@ function literalAuthorizationCredential(value) {
   const scheme = /^(?:bearer|basic|token|digest|apikey)\s+(.+)$/i.exec(trimmed);
   const credential = (scheme?.[1] ?? trimmed).trim();
   return (
-    credential.length >= (scheme ? 8 : 12) && !placeholderValue(credential)
+    credential.length >= (scheme ? 8 : CREDENTIAL_LITERAL_MIN_LENGTH) &&
+    !placeholderValue(credential)
   );
 }
 
@@ -1659,7 +1726,7 @@ export function secretLikeReason(text) {
       const value = rawValue.trim();
       if (
         sensitiveQueryNames.has(name.toLowerCase()) &&
-        value.length >= 12 &&
+        value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
         !placeholderValue(value)
       ) {
         return "secret-bearing URL";
@@ -1670,7 +1737,10 @@ export function secretLikeReason(text) {
     /^[+ -]?\s*["'`]?aws[_-]?(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|session[_-]?token)["'`]?\s*[:=]\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
   for (const match of text.matchAll(awsCredentialPattern)) {
     const value = match[1].trim();
-    if (value.length >= 12 && !placeholderValue(value)) {
+    if (
+      value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
+      !placeholderValue(value)
+    ) {
       return "literal AWS credential assignment";
     }
   }
@@ -1784,14 +1854,17 @@ export function secretLikeReason(text) {
           continue;
         }
         if (awsCredentialKey) {
-          if (value.length >= 12 && !placeholderValue(value)) {
+          if (
+            value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
+            !placeholderValue(value)
+          ) {
             return "literal AWS credential assignment";
           }
           continue;
         }
         if (directLiteral && !computed && !multilineDirectTemplate) continue;
         if (
-          value.length >= 12 &&
+          value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
           !publicTokenAddressForKey(key, value) &&
           !placeholderValue(value)
         ) {
@@ -1836,7 +1909,7 @@ export function secretLikeReason(text) {
       continue;
     }
     if (
-      value.length >= 12 &&
+      value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
       !publicTokenAddressForKey(key, value) &&
       !placeholderValue(value)
     ) {
@@ -1885,13 +1958,16 @@ export function secretLikeReason(text) {
         continue;
       }
       if (awsCredentialKey) {
-        if (value.length >= 12 && !placeholderValue(value)) {
+        if (
+          value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
+          !placeholderValue(value)
+        ) {
           return "literal AWS credential assignment";
         }
         continue;
       }
       if (
-        value.length >= 12 &&
+        value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
         !publicTokenAddressForKey(key, value) &&
         !placeholderValue(value)
       ) {
@@ -1903,7 +1979,10 @@ export function secretLikeReason(text) {
     /^[+ -]?\s*\/\/[^=\r\n]+\/?:_(?:authToken|auth|password)\s*=\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
   for (const match of text.matchAll(registryAuthPattern)) {
     const value = match[1].trim();
-    if (value.length >= 12 && !placeholderValue(value))
+    if (
+      value.length >= CREDENTIAL_LITERAL_MIN_LENGTH &&
+      !placeholderValue(value)
+    )
       return "literal registry credential assignment";
   }
   const unquotedKeyPattern =

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -846,6 +846,208 @@ assert.match(
   /literal generic token assignment/,
   "a real literal trailing an HCL reference fails the ^…$ anchor and is rejected",
 );
+// HCL iteration traversals are the same reference class: `each`/`count` are the
+// fixed for_each and count scopes, `self` is a resource's own attributes, and
+// `rule` is the dynamic-block iterator this repo's alert rules declare. Both
+// diff directions are asserted, because the scanner reads removed lines too and
+// a PR that only deletes such a line lost its bundle as well.
+for (const direction of ["+", "-"]) {
+  assert.equal(
+    secretLikeReason(`${direction}        token    = rule.value.token`),
+    null,
+    `dynamic-block iterator traversals are references (${direction} side)`,
+  );
+  assert.equal(
+    secretLikeReason(`${direction}  client_secret = each.value.secret`),
+    null,
+    `for_each iterator traversals are references (${direction} side)`,
+  );
+}
+assert.equal(
+  secretLikeReason("  auth_token = self.triggers.auth_token"),
+  null,
+  "self.* provisioner traversals are references, not literal tokens",
+);
+// Anti-bypass: the traversal has to be the whole unquoted value. A quoted value
+// is an HCL string, an unlisted scope is not a traversal, and a literal fused to
+// or trailing one fails the ^…$ anchor.
+const iterationTraversal = ["rule", "value", "token"].join(".");
+assert.match(
+  secretLikeReason(`  token = "${iterationTraversal}"`),
+  /literal (?:generic token|credential) assignment/,
+  "a quoted traversal-shaped value is an HCL string literal, not a reference",
+);
+assert.match(
+  secretLikeReason(`  auth_token = each.value.token ${genericTokenCredential}`),
+  /literal generic token assignment/,
+  "a literal trailing an iteration traversal is still rejected",
+);
+assert.match(
+  secretLikeReason(`  auth_token = iterator.value.${genericTokenCredential}`),
+  /literal generic token assignment/,
+  "an unlisted scope is not a traversal and stays subject to the literal rules",
+);
+// A TypeScript type annotation occupies type position and carries no value at
+// all, so `token: string | undefined` names a shape the compiler erases. The
+// generic pattern had no type-position awareness and read the annotation as a
+// literal, so editing or moving an interface aborted the bundle.
+for (const direction of ["+", "-"]) {
+  assert.equal(
+    secretLikeReason(`${direction}  token: string | undefined,`),
+    null,
+    `optional-token annotations are type positions (${direction} side)`,
+  );
+}
+assert.equal(
+  secretLikeReason("  refresh_token: number | undefined,"),
+  null,
+  "any union of built-in keywords is a type annotation",
+);
+assert.equal(
+  secretLikeReason("  token: string[] | undefined,"),
+  null,
+  "array type members are type annotations",
+);
+assert.equal(
+  secretLikeReason("  token: string | undefined;"),
+  null,
+  "semicolon-terminated interface members are type annotations",
+);
+// The scanner reads a whole diff and has no file type, so each rule carries its
+// own syntactic discriminator. The annotation rule accepts a closed keyword
+// vocabulary, which carries no credential in any language; the traversal rule
+// reads the spaced `=`, which a shell assignment cannot take; the command-list
+// rule reads `=` only.
+assert.match(
+  secretLikeReason("  token: Address | undefined,"),
+  /literal generic token assignment/,
+  "a named type is outside the keyword vocabulary and stays a literal",
+);
+assert.match(
+  secretLikeReason("  token=each.value.audit_token"),
+  /literal generic token assignment/,
+  "an unspaced `=` is a shell assignment, so a traversal-shaped value is literal",
+);
+assert.match(
+  secretLikeReason("  export SERVICE_TOKEN=each.value.audit_token"),
+  /literal (?:generic token|credential) assignment/,
+  "an exported shell assignment is likewise not an HCL attribute",
+);
+assert.match(
+  secretLikeReason("  token: $(get_access_token) || return 1"),
+  /literal generic token assignment/,
+  "the command-list rule reads `=` values, not `key: value` scalars",
+);
+// Anti-bypass: every member has to be one of the built-in keywords, so no
+// member can carry a credential and no credential can be split across members —
+// the bypass a per-member length bound would leave open. Quoting the same text
+// makes it a literal again.
+assert.match(
+  secretLikeReason(`  token: string | ${genericTokenCredential},`),
+  /literal generic token assignment/,
+  "a credential-sized union member is still rejected",
+);
+const splitCredential = ["abcdefghij", "klmnopqrst"].join(" | ");
+assert.match(
+  secretLikeReason(`  token: string | ${splitCredential},`),
+  /literal generic token assignment/,
+  "a literal split across short union members is still rejected",
+);
+const quotedAnnotation = ["string | ", genericTokenCredential].join("");
+assert.match(
+  secretLikeReason(`  token: "${quotedAnnotation}",`),
+  /literal (?:generic token|credential) assignment/,
+  "a quoted annotation-shaped value is a string literal, not a type",
+);
+assert.match(
+  secretLikeReason("  token = string | undefined"),
+  /literal generic token assignment/,
+  "type position is `:` only; the HCL/shell `=` form stays subject to the rules",
+);
+// A shell command list continues past the assignment: the value is the command
+// substitution, resolved when the script runs, and the operator's right side is
+// a separate command. The line patterns have no shell grammar, so they captured
+// the tail too and read the whole span as a literal.
+for (const direction of ["+", "-"]) {
+  assert.equal(
+    secretLikeReason(
+      `${direction}  access_token=$(get_access_token) || return 1`,
+    ),
+    null,
+    `command substitutions with a control tail are references (${direction} side)`,
+  );
+}
+assert.equal(
+  secretLikeReason("  refresh_token=$(mint --scope repo) && log ok"),
+  null,
+  "an && control tail is likewise a separate command",
+);
+assert.equal(
+  secretLikeReason("  access_token=$(get_access_token) || return 1 || exit 2"),
+  null,
+  "chained control operators are still a command list",
+);
+// Anti-bypass: the tail's alphabet excludes `=`, `:`, quotes, `$`, and
+// parentheses, so a second assignment cannot hide in it, and the head is
+// measured by the same call-expression rule a bare `$(cmd)` value already
+// passes — a literal head, or anything between the head and the operator, is
+// still a literal.
+assert.match(
+  secretLikeReason(
+    `  access_token=$(get) || SERVICE_TOKEN=${genericTokenCredential}`,
+  ),
+  /literal generic token assignment/,
+  "a credential assignment in the control tail is still rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(get) || SERVICE_TOKEN="${genericTokenCredential}"`,
+  ),
+  /literal (?:generic token|credential) (?:assignment|expression)/,
+  "a quoted credential assignment in the control tail is still rejected",
+);
+assert.match(
+  secretLikeReason(`  access_token=${genericTokenCredential} || return 1`),
+  /literal generic token assignment/,
+  "a literal head with a control tail is still rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(get) ${genericTokenCredential} || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a literal between the substitution and the operator is still rejected",
+);
+assert.match(
+  secretLikeReason(`  access_token=$(echo ${modernNpmToken}) || return 1`),
+  /credential-like token/,
+  "a strong credential inside the substitution is still rejected",
+);
+assert.match(
+  secretLikeReason(`  access_token=$(get) || echo ${genericTokenCredential}`),
+  /literal generic token assignment/,
+  "a credential-sized tail word is still rejected, assignment or not",
+);
+// Refused by design: a fixture literal such as
+// `ACTIONS_ID_TOKEN_REQUEST_TOKEN: "<hyphen-joined words>"` is a quoted literal
+// in value position, and no syntax distinguishes it from a real weak
+// credential — only the surrounding file says it is a fixture, and the diff
+// author picks that file's name. Fixtures compose the literal from parts, the
+// way this file does, or use a documented placeholder marker. This assertion
+// exists so a later rule cannot start accepting the shape unnoticed.
+const fixtureMarkerCredential = ["runner", "bound", "credential"].join("-");
+assert.match(
+  secretLikeReason(
+    `    ACTIONS_ID_TOKEN_REQUEST_TOKEN: "${fixtureMarkerCredential}",`,
+  ),
+  /literal generic token assignment/,
+  "a hyphen-joined fixture literal is still refused; compose it from parts",
+);
+assert.equal(
+  secretLikeReason('    ACTIONS_ID_TOKEN_REQUEST_TOKEN: "fixture-token",'),
+  null,
+  "the documented placeholder markers remain the fixture workaround",
+);
 const publicEvmTokenAddress = ["0x", "0".repeat(39), "1"].join("");
 assert.match(
   secretLikeReason(`USDC_TOKEN="${publicEvmTokenAddress}"`),

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -987,11 +987,23 @@ assert.equal(
   null,
   "chained control operators are still a command list",
 );
+assert.equal(
+  secretLikeReason(
+    "  access_token=$(vault read -field=token secret/path) || return 1",
+  ),
+  null,
+  "flags and paths are inert arguments: each part stays under credential length",
+);
+assert.match(
+  secretLikeReason("  access_token=$(cat /run/secrets/api_token) || return 1"),
+  /literal generic token assignment/,
+  "the argument bound is uniform: even a real long path fails closed",
+);
 // Anti-bypass: the tail's alphabet excludes `=`, `:`, quotes, `$`, and
-// parentheses, so a second assignment cannot hide in it, and the head is
-// measured by the same call-expression rule a bare `$(cmd)` value already
-// passes — a literal head, or anything between the head and the operator, is
-// still a literal.
+// parentheses, so a second assignment cannot hide in it, and its words are
+// bounded whole rather than by segment, so a literal split across separators
+// cannot either. A literal head, or anything between the head and the operator,
+// is still a literal.
 assert.match(
   secretLikeReason(
     `  access_token=$(get) || SERVICE_TOKEN=${genericTokenCredential}`,
@@ -1027,6 +1039,84 @@ assert.match(
   secretLikeReason(`  access_token=$(get) || echo ${genericTokenCredential}`),
   /literal generic token assignment/,
   "a credential-sized tail word is still rejected, assignment or not",
+);
+// The substitution's arguments are bounded too. A weak literal in argument
+// position carries no strong pattern, so nothing else in the scanner would
+// catch it, and a long one split across separators is measured whole.
+const separatorSplitCredential = ["correct", "horse", "battery", "staple"].join(
+  "-",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(echo ${separatorSplitCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a separator-split literal argument is rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(auth --${separatorSplitCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a flag prefix does not exempt a literal from the argument bound",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(get) || SERVICE_TOKEN=${separatorSplitCredential}`,
+  ),
+  /literal generic token assignment/,
+  "a separator-split literal in the control tail is rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(echo ${genericTokenCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a weak literal argument inside the substitution is rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(auth --token ${genericTokenCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a weak literal behind a flag is rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(auth --token=${genericTokenCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a weak literal in a flag value is rejected",
+);
+assert.match(
+  secretLikeReason(
+    `  access_token=$(auth --${genericTokenCredential}) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a weak literal wearing a flag prefix is rejected",
+);
+assert.match(
+  secretLikeReason("  token = getToken() || fallback"),
+  /literal generic token assignment/,
+  "the head has to be a command substitution, not any call expression",
+);
+// Words are split on whitespace, so a nested substitution arrives as fragments
+// carrying parentheses — outside the argument alphabet, and refused. This pins
+// the property rather than the parse: no rearrangement of `$( … )` inside the
+// substitution may reach the accept path.
+assert.match(
+  secretLikeReason(
+    `  access_token=$(echo $(printf ${genericTokenCredential})) || return 1`,
+  ),
+  /literal generic token assignment/,
+  "a literal inside a nested substitution is rejected",
+);
+// The command word is measured too: a real command name is short segments
+// joined by separators, an opaque run is not.
+assert.match(
+  secretLikeReason(`  access_token=$(${"a".repeat(32)}) || return 1`),
+  /literal generic token assignment/,
+  "an opaque run in command position is not a command name",
 );
 // Refused by design: a fixture literal such as
 // `ACTIONS_ID_TOKEN_REQUEST_TOKEN: "<hyphen-joined words>"` is a quoted literal

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6650,6 +6650,16 @@ run_sensitive_input_regressions() {
   run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
   expect_stderr_contains "refusing to include secret-like content"
 
+  # The substitution's own words are held to the same rule: a weak literal in
+  # argument position carries no strong pattern, so nothing else would catch it.
+  git -C "$review_repo" restore README.md
+  # shellcheck disable=SC2016
+  printf '%s%s%s\n' '  access_token=$(echo ' \
+    "live-argument-abcdefghijklmnopqrstuvwxyz" ') || return 1' \
+    >>"$review_repo/README.md"
+  run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  expect_stderr_contains "refusing to include secret-like content"
+
   git -C "$review_repo" restore README.md
   mkdir "$review_repo/.aws"
   {

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6607,6 +6607,49 @@ run_sensitive_input_regressions() {
   run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
   expect_stderr_contains "refusing to include secret-like content"
 
+  # An HCL iteration traversal, a TypeScript type annotation, and a shell
+  # command list all name values the diff does not carry. Each one used to abort
+  # the whole bundle. The fixture text stays single-quoted so the substitution
+  # and the union reach the scanner unexpanded.
+  git -C "$review_repo" restore README.md
+  {
+    # shellcheck disable=SC2016
+    printf '%s\n' '        token    = rule.value.token'
+    printf '%s\n' '  token: string | undefined,'
+    # shellcheck disable=SC2016
+    printf '%s\n' '  access_token=$(get_access_token) || return 1'
+  } >>"$review_repo/README.md"
+  local shapes_output="$tmp_dir/sensitive-prompt-shapes.md"
+  run_helper_in_repo "$review_repo" --mode local --engine local --bundle-output "$shapes_output" --prepare-only
+  expect_file_contains "$shapes_output" 'rule.value.token'
+  expect_file_contains "$shapes_output" 'string | undefined'
+  # shellcheck disable=SC2016
+  expect_file_contains "$shapes_output" '$(get_access_token) || return 1'
+  expect_empty_stderr
+
+  # Each accepted shape has a literal twin that still fails closed: quoting an
+  # HCL traversal makes it a string, a credential-sized union member is not a
+  # type, and the control tail cannot carry a second assignment. The literals are
+  # joined from parts so this file's own source carries none.
+  git -C "$review_repo" restore README.md
+  printf '%s%s%s\n' '  token    = "rule.value.' \
+    "live-traversal-abcdefghijklmnopqrstuvwxyz" '"' >>"$review_repo/README.md"
+  run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  expect_stderr_contains "refusing to include secret-like content"
+
+  git -C "$review_repo" restore README.md
+  printf '%s%s%s\n' '  token: string | ' \
+    "live-annotation-abcdefghijklmnopqrstuvwxyz" ',' >>"$review_repo/README.md"
+  run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  expect_stderr_contains "refusing to include secret-like content"
+
+  git -C "$review_repo" restore README.md
+  # shellcheck disable=SC2016
+  printf '%s%s\n' '  access_token=$(get) || SERVICE_TOKEN=' \
+    "live-tail-abcdefghijklmnopqrstuvwxyz" >>"$review_repo/README.md"
+  run_helper_in_repo_expect_failure "$review_repo" --mode local --engine local --bundle-output "$bundle_output" --prepare-only
+  expect_stderr_contains "refusing to include secret-like content"
+
   git -C "$review_repo" restore README.md
   mkdir "$review_repo/.aws"
   {


### PR DESCRIPTION
## The Problem

- The autoreview secret scanner refused four line shapes that carry no
  credential. Each one aborts the whole review bundle, so a PR that merely
  relocates a file containing one loses both review engines.
- Three of them are live in this repo today: an HCL iteration traversal in
  `alerts/rules/`, a TypeScript type annotation in `indexer-envio/src/usd.ts`,
  and a shell command list in `aegis/grafana-agent/entrypoint.sh`.

## The Solution

- `secretLikeReason()` accepts each of those three on an unquoted value, on a
  syntactic proof that the value names something resolved elsewhere.
- The fourth, a test-fixture string literal, stays refused. Nothing in its
  syntax separates it from a weak credential, so it keeps the workaround this
  repo's own fixtures use: compose the value from parts.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1912

## Details

The scanner reads a whole diff and has no file type, so each rule carries its
own discriminator rather than relying on the file it came from.

| Shape                                          | Verdict  | Rule                                                                                                                                                          |
| ---------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `token = rule.value.token` (HCL traversal)     | accepted | Bare dotted identifier path rooted at `each`, `count`, `self`, or `rule`, behind a whitespace-surrounded `=`. Shell forbids whitespace around `=`, so `TOKEN=each.value.<literal>` in a script is still a literal. |
| `token: string \| undefined` (type annotation) | accepted | Union or intersection whose members all come from a closed twelve-word keyword vocabulary, optionally `[]`-suffixed. No credential fits, whole or split across members. |
| `access_token=$(cmd) \|\| return 1` (command list) | accepted | `=` value whose head is a command substitution read by word position — a command name whose separator-split segments each stay under credential length, then arguments each bounded whole by it (shell reference, flag with its optional value, or bare word) — followed by a `||`/`&&` tail of whole words under it, over an alphabet with no `=`, `:`, quote, `## The Problem

- The autoreview secret scanner refused four line shapes that carry no
  credential. Each one aborts the whole review bundle, so a PR that merely
  relocates a file containing one loses both review engines.
- Three of them are live in this repo today: an HCL iteration traversal in
  `alerts/rules/`, a TypeScript type annotation in `indexer-envio/src/usd.ts`,
  and a shell command list in `aegis/grafana-agent/entrypoint.sh`.

## The Solution

- `secretLikeReason()` accepts each of those three on an unquoted value, on a
  syntactic proof that the value names something resolved elsewhere.
- The fourth, a test-fixture string literal, stays refused. Nothing in its
  syntax separates it from a weak credential, so it keeps the workaround this
  repo's own fixtures use: compose the value from parts.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1912

## Details

The scanner reads a whole diff and has no file type, so each rule carries its
own discriminator rather than relying on the file it came from.

| Shape                                          | Verdict  | Rule                                                                                                                                                          |
| ---------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `token = rule.value.token` (HCL traversal)     | accepted | Bare dotted identifier path rooted at `each`, `count`, `self`, or `rule`, behind a whitespace-surrounded `=`. Shell forbids whitespace around `=`, so `TOKEN=each.value.<literal>` in a script is still a literal. |
| `token: string \| undefined` (type annotation) | accepted | Union or intersection whose members all come from a closed twelve-word keyword vocabulary, optionally `[]`-suffixed. No credential fits, whole or split across members. |
| `access_token=$(cmd) \|\| return 1` (command list) | accepted | , or parenthesis. |
| Fixture literal with a credential-ish key      | refused  | A quoted literal in value position. See below.                                                                                                                 |

Why the fixture literal stays refused. A hyphen-joined dictionary value is
indistinguishable from a weak credential by syntax; only the surrounding file
says it is a fixture, and the diff author picks that file's name, so
fixture-path awareness is spoofable by naming a real secrets file like a
fixture. Relaxing inside `*.test.*` also removes the scanner from exactly the
place fixtures accumulate. An exact-line allowlist is auditable but is a value
allowlist rather than a syntax rule, and it would need an entry per fixture. The
workarounds already exist: compose the literal from parts, as the tests in this
PR do, or use one of the documented placeholder markers (`fixture-token`,
`example-secret`). A regression test holds the refusal in place so a later rule
cannot start accepting the shape unnoticed.

Every rule reads unquoted values only, so quoting any of the three accepted
shapes makes it a literal again. Both diff directions are covered, because the
scanner reads removed lines too.

Interaction with the pre-existing bare `secrets.<value>` acceptance the issue
notes: the traversal rule is the same class, and it is scoped tighter — the
existing clause runs on any value shape in any position, while this one runs
only behind a spaced `=` on an unquoted value. It carries the same residual: a
traversal's own path segments are identifier text, so
`token = each.value.<opaque>` reads as a reference exactly as
`token = var.<opaque>` does today. Anchoring that class to HCL files needs file
type, which this function does not have; nothing here changes it.

A repo-wide scan of every tracked line in both diff directions is the scope
evidence: 142 refused lines before, 137 after. The five that change are the
three shapes; nothing starts refusing. The remaining 137 are literal fixtures,
`.tfvars.example` placeholders, and shapes outside this issue (ternaries,
object-literal values, a GraphQL field).

## Validation

Every change to `agent-autoreview.*` boots the ~90-minute adversarial CI suite,
so all five families ran locally first.

| Check                                                         | Result                                                                              |
| ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| `node scripts/agent-autoreview-core.test.mjs`                 | passed                                                                              |
| `AUTOREVIEW_TEST_FOCUS=bundle-integrity` (owning family)      | passed                                                                              |
| `AUTOREVIEW_TEST_FOCUS=suite` (all five families)             | passed in 315s                                                                      |
| `pnpm agent:quality-gate --run --parallel 4`                  | all mapped commands passed, including `lint:scripts`, `tf:test`, and `trunk check`  |
| `./tools/trunk fmt` on the four changed files                 | no issues                                                                           |
| This PR's own diff, scanned by the patched scanner            | clean                                                                               |
| Repo-wide before/after scan                                   | 142 → 137 refused lines; five freed, none added                                     |

End to end, through the real bundle path. A scratch git repo whose working diff
carries all three shapes, reviewed by a runtime copied outside the checkout
(this PR edits the autoreview runtime, so an in-checkout self-review fails
closed on the runtime-trust gate, as designed). With the scanner from `main` the
bundle aborts with `literal generic token assignment`; with this branch's
scanner it builds and carries all three shapes.

Non-tautological: stripping each of the three rules in a scratch copy of the
scanner fails that rule's own tests with the exact refusal. Each accepted shape
is paired with a literal twin that still refuses, in both the unit tests and the
shell suite.

Engine reviews, both engines, from the trusted out-of-checkout runtime:

- Codex, round 1: one P1, that the exemptions were not scoped to a language.
  Addressed — each rule gained the discriminator described above.
- Codex, round 2: one P1, that a tail word could carry a credential
  (`... || echo <literal>`), and one P2, that a per-member length bound lets a
  literal be split across short union members. Addressed — tail words are bound
  to sub-credential length, and the annotation vocabulary was closed to keywords.
- Codex, round 3: clean, `patch is correct (0.89)`. Claude: clean,
  `patch is correct (0.72)`.
- CodeRabbit, on the pushed branch: one Major, that the head proved balanced
  call-like syntax without reading the words inside the substitution, so a weak
  literal argument (`$(echo <literal>) || return 1`) was accepted. Addressed —
  the head must now be a command substitution whose command word is
  segment-bounded and whose arguments are bounded whole.
- Codex, on that fix: one P1, that a `--` prefix and a separator split escaped
  the argument bound. Addressed — the flag name and value are bounded
  independently and the path carve-out was dropped for one uniform bound.
- Codex, on the final tree: clean, `patch is correct (0.9)`. Claude, on the
  final tree: `patch is correct (0.72)` with one P2, that the head narrowing
  costs call-expression heads and long arguments. Verified against the merge
  base instead of the intermediate rule: `token = getToken() || fallback`,
  `$(cat /run/secrets/api_token) || return 1`, and the `aws secretsmanager`
  form all refuse identically on `main` and on this branch, so nothing
  regresses. The trade is now stated in the design note.
- One Codex finding was refused: nested substitutions splitting a literal into
  fragments. Not reproducible — `$(echo $(printf <literal>))` refuses, because
  whitespace splitting leaves parentheses in the words and those are outside the
  argument alphabet. A regression test now pins it.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this narrows an existing rule set
      inside `secretLikeReason()`; the trust model is unchanged and the note in
      `docs/notes/autoreview-runtime-trust.md` records the new accept set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential-detection rules in security-sensitive bundle preparation; mitigated by closed vocabularies, syntactic discriminators, and extensive anti-bypass tests.
> 
> **Overview**
> Stops the autoreview **secret scanner** from aborting review bundles when diffs contain lines that name credentials elsewhere but carry no literal secret.
> 
> **`secretLikeReason()`** in `agent-autoreview-core.mjs` now treats three additional **unquoted** value shapes as safe references (each with a syntax discriminator because the scanner has no file type):
> 
> - **HCL iteration traversals** (`each`, `count`, `self`, `rule`) behind whitespace-surrounded `=`
> - **TypeScript type annotations** (`:` position) whose union/intersection members are only built-in type keywords
> - **Shell command lists** on `=` assignments: command substitution head plus `||`/`&&` tails limited to short, safe words
> 
> Assignment regexes capture the full `[:=]` operator (including surrounding whitespace) so spaced `=` can be distinguished from shell `TOKEN=value`. **Quoted** versions of these shapes still fail as literals; bypass cases (named types, credentials in tails, split union members, etc.) stay rejected.
> 
> **Fixture string literals** in value position remain refused; docs note composing literals from parts or using `fixture-token` / `example-secret`.
> 
> Tests in `agent-autoreview-core.test.mjs` and `agent-autoreview.test.sh` cover accept paths, anti-bypass cases, and both diff directions. `docs/notes/autoreview-runtime-trust.md` documents the expanded accept set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f38b1ad5a9af6a059554e040fa1ac8c1e855e413. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved secret scanning to recognize additional safe, non-literal expressions in HCL, TypeScript, and shell syntax.
  * Supports approved iteration references, type annotations, and constrained command substitutions while preserving assignment formatting.

* **Bug Fixes**
  * Continues rejecting quoted, malformed, fused, or unapproved credential-like values.
  * Added bounded handling for deeply nested shell expansions to fail safely.

* **Documentation**
  * Updated guidance for accepted syntax and fixture values.

* **Tests**
  * Added comprehensive regression coverage for supported expressions and credential-like literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
