### PR TITLE
fix(alerts): disable EUROP reserve balance pager

### DIFF
--- a/alerts/rules/protocol-routing-locals.tf
+++ b/alerts/rules/protocol-routing-locals.tf
@@ -423,7 +423,6 @@ locals {
         "Low USDT Reserve Balance Alert",
         "Low axlUSDC Reserve Balance Alert",
         "Empty USDC Reserve Balance Alert [Polygon]",
-        "Empty EUROP Reserve Balance Alert [Polygon]"
       ],
       slack_title_template       = "slack.reserve_balance_alert_title",
       slack_message_template     = "slack.reserve_balance_alert_message",

--- a/alerts/rules/rules-reserve-balances.tf
+++ b/alerts/rules/rules-reserve-balances.tf
@@ -97,8 +97,7 @@ resource "grafana_rule_group" "reserve_balances" {
   # tracked in #1332 rather than being guessed here.
   dynamic "rule" {
     for_each = {
-      USDC  = { metric = "USDC_balanceOf", token = "USDC" }
-      EUROP = { metric = "EUROP_balanceOf", token = "EUROP" }
+      USDC = { metric = "USDC_balanceOf", token = "USDC" }
     }
 
     content {


### PR DESCRIPTION
## The Problem

- EUROP ReserveV2 liquidity is managed by an external market maker, so its zero-balance page is not actionable for the protocol team.

## The Solution

Remove EUROP from the Polygon reserve-balance rule inputs while retaining the USDC zero-balance pager.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview --verify-bundle-dir /tmp/europ-reserve-autoreview --expected-bundle-manifest 876f2320c8ea7aa856fc392687b8354b12931f5ed7088c3b2291e26489de159c`
- Fresh-context closeout review: no findings

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only alert configuration change; reduces on-call noise with no runtime or security impact.
> 
> **Overview**
> Stops paging the protocol team when Polygon **ReserveV2 EUROP** collateral hits zero, because that liquidity is handled by an external market maker and the alert was not actionable.
> 
> The Polygon **empty reserve** Grafana rule now only generates **USDC** (`EUROP` is dropped from the dynamic `for_each`), and **`Empty EUROP Reserve Balance Alert [Polygon]`** is removed from the `low_reserve_balance` alert-name list so Slack and VictorOps no longer route that alert type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927f6727c0749cb9205d2d87d08ef3a2aa0b3cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Polygon reserve-balance alerts to monitor USDC only.
  * Removed EUROP metric monitoring and its associated low-reserve alert from the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->