### PR TITLE
fix(scripts): honor fresh gate stamps across untracked-file adds and de-flake the lock-race fixture

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -520,9 +520,23 @@ of them.
    the second as the first would discharge an obligation on the strength of a
    question that was never answered. A failed scan keeps the drain open exactly
    as an unverifiable process does, and fails closed at the bound with its own
-   line. Skipping an unreadable `/proc/<pid>/environ` is not that case: it means
-   another user's process, which cannot be one of ours, so it is a scope rather
-   than a swallowed error.
+   line. Skipping an unreadable `/proc/<pid>/environ` is deliberately **not**
+   that case. It happens three ways — another user's process, a process the
+   kernel will not let us read because it changed credentials, and a process
+   that exited between the directory listing and the read — and none of them can
+   be a process this run started, because everything it starts keeps this user's
+   credentials and this run's environment. Where that reasoning is stretched by
+   a credential-changing descendant, the argv-tag and marker-descriptor scans
+   still name it; neither reads the environment. Counting an unreadable
+   environment as a failed scan would instead fail every crash recovery closed
+   on any host that has one such process, which every GitHub runner does. The
+   read is wrapped in a group carrying its own `2>/dev/null`, because a
+   redirection that cannot open its target is reported by the shell itself,
+   before a `2>/dev/null` beside it applies: the bare form printed
+   `/proc/<pid>/environ: Permission denied` into every drain's output on a
+   runner (GitHub issue #1919). The `-r` test stays in front of it as a fast
+   path — this loop runs once per process on the host — but it is not the
+   guard, because permission bits are not what the kernel decides on.
 
 8. **Elapsed time comes from the clock, not from counting sleeps.** A loop that
    adds its own poll interval per iteration is measuring what it asked for. Any
@@ -531,8 +545,12 @@ of them.
    almost no time has passed. It then outlives the deadline it announced and
    reports a duration that never happened, which is worse than being late:
    every wait, drain, and watchdog budget in this path is also the evidence
-   printed when one expires. Each of those loops reads `date +%s` once before
-   it starts and subtracts at the top of every iteration.
+   printed when one expires. Each of those loops reads the clock once before it
+   starts and subtracts at the top of every iteration. The lock wait reads it in
+   milliseconds (`EPOCHREALTIME`, falling back to whole seconds on a shell
+   without it), because whole-second reads truncate at both ends: a wait that
+   begins at `X.99` and lasts 1.05s subtracts to two seconds, and `--lock-wait 1`
+   then reported a budget it had kept as an overshoot (GitHub issue #1919).
 
 Rule 4 is the one that does not depend on getting an interleaving right, and
 it is why the others are allowed to be merely careful: they keep runs from
@@ -896,6 +914,23 @@ can satisfy the `--skip-if-fresh` check.
 The whole-run stamp's signature is the same bound-input set described above;
 any change to it reruns the mapped commands immediately, while an unchanged
 stamp still expires after two hours to avoid masking drift.
+
+Validated file content is bound by each path's bytes, its worktree file mode,
+and the `git diff --summary` lines for it — minus the `create mode` lines,
+which report that a path became tracked rather than anything about what was
+validated. An untracked path is invisible to `git diff`, so before that
+exclusion a bare `git add` of a file the gate was already validating moved the
+signature and cost a warm stamp a full re-run, with the changed-path set, the
+mapped command plan, the base OID and the file's own bytes unchanged (GitHub
+issue #1899). Everything that genuinely changes validation still moves it:
+edited bytes, a changed file mode, and an add that puts a path the gate routes
+into the changed-path set — `git add -f` of an ignored file, which no
+`--exclude-standard` listing reports until it is tracked.
+
+The base commit is a bound input, so warm the stamp **after**
+`git fetch origin main`, not before: the pre-push hook fetches before it runs
+the gate, and a stamp warmed against a stale `origin/main` is invalidated by
+that fetch — correctly, because the validation base really did move.
 
 Below the whole-run stamp, `--run` also keeps per-command success stamps
 (`.tmp/agent-quality-gate/command-stamps.tsv`) so a run that was killed

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -56,8 +56,11 @@ even when you never open an authority.
 
    `--run` maps changed paths to the safe local checks (lint, typecheck, tests,
    browser suite) and stamps freshness so a later pre-push `--skip-if-fresh`
-   cache-hits. It does not run `trunk fmt` — run `./tools/trunk fmt` (the
-   checked-in launcher; a global `trunk` may not exist)
+   cache-hits. Run `git fetch origin main` first: the base commit is part of
+   that stamp, the hook fetches before it runs the gate, and a stamp warmed
+   against a stale `origin/main` is invalidated by that fetch, so the push pays
+   for the full gate a second time. It does not run `trunk fmt` — run
+   `./tools/trunk fmt` (the checked-in launcher; a global `trunk` may not exist)
    before committing so the required Code Quality CI stays green. The gate never
    deploys and never applies Terraform. It **refuses package-script,
    package-manager, or lockfile changes until their lifecycle risk is reviewed

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -693,7 +693,7 @@ gate_lock_token_pattern() {
 
 gate_run_tagged_pids() {
   local token="$1"
-  local environ pid marker found status
+  local environ environ_entries pid marker found status
   # A token read back from a lock record names processes (through this
   # pattern) and files (holder.*), and on a shared root it can be another
   # user's writing. One that does not have the gate-generated shape is never
@@ -717,13 +717,40 @@ gate_run_tagged_pids() {
   [[ -z "$found" ]] || printf '%s\n' "$found"
   if [[ -d /proc ]]; then
     for environ in /proc/[0-9]*/environ; do
-      # Unreadable here means another user's process, which cannot be one of
-      # ours: the environment of anything this run started is readable by it.
-      # So this skip is a scope, not a swallowed error.
+      # A builtin test first, because this loop runs once per process on the
+      # host: `-r` false means the read cannot succeed, and skipping there
+      # costs nothing. It is not the whole guard — `-r` answers from the
+      # permission bits, and the kernel refuses `/proc/<pid>/environ` for a
+      # process that changed credentials whatever those say.
       [[ -r "$environ" ]] || continue
+      # The redirection is inside a group with its own stderr redirect. A
+      # redirection that cannot open its target is reported by the shell
+      # itself, before the `2>/dev/null` beside it applies, so the bare form
+      # printed `/proc/<pid>/environ: Permission denied` into the output of
+      # every drain on a runner (GitHub issue 1919); the group's redirect is
+      # already in place when the inner one is attempted. NULs are translated
+      # before the capture because command substitution cannot hold them, and
+      # the exact-entry match below depends on the separators surviving.
+      environ_entries="$({ tr '\0' '\n' < "$environ"; } 2>/dev/null)" ||
+        environ_entries=""
+      if [[ -z "$environ_entries" ]]; then
+        # Past the `-r` test and still nothing: the kernel refused the read for
+        # a process that changed credentials, the process exited between the
+        # listing and the read, or its environment is genuinely empty. None can
+        # be one of ours. Anything this run started carries this user's
+        # credentials and this run's environment, so it stays readable to it —
+        # and where a credential-changing descendant stretches that, the
+        # argv-tag scan above and the marker-descriptor scan below still name
+        # it, because neither reads the environment. Deliberately NOT the
+        # scan-error sentinel: one unreadable process is ordinary — every
+        # GitHub runner has one — and counting it as a failed scan would fail
+        # every crash recovery on such a host closed, rather than only the ones
+        # with work left to do.
+        continue
+      fi
       # Exact entry, not substring: environ is NUL-separated, and a substring
       # match would let one token select an environment carrying a longer one.
-      tr '\0' '\n' < "$environ" 2>/dev/null |
+      printf '%s\n' "$environ_entries" |
         grep -qxF "AGENTQG_RUN=agentqg:${token}" || continue
       pid="${environ#/proc/}"
       printf '%s\n' "${pid%/environ}"
@@ -978,6 +1005,29 @@ gate_lock_field_from_file() {
 
 gate_lock_owner_field() {
   gate_lock_field_from_file "$1/owner" "$2"
+}
+
+# Wall-clock milliseconds. Two whole-second `date +%s` reads carry up to a
+# second of error between them, because each truncates to the second boundary it
+# landed in: a wait that starts at X.99 and lasts 1.05s reads as two seconds.
+# The lock wait then reports that measurement error as elapsed time, which is
+# how `--lock-wait 1` announced a two-second timeout on a loaded CI runner and
+# flaked the suite's budget assertion (GitHub issue 1919). EPOCHREALTIME renders
+# its fraction with the locale's decimal separator, so both forms are read; a
+# shell too old to have it degrades to whole seconds, which is exactly the
+# behaviour this replaces.
+gate_wall_millis() {
+  local now="${EPOCHREALTIME:-}"
+  local seconds fraction
+  case "$now" in
+    *[.,]*)
+      seconds="${now%%[.,]*}"
+      fraction="${now#*[.,]}000"
+      printf '%s%s\n' "$seconds" "${fraction:0:3}"
+      return 0
+      ;;
+  esac
+  printf '%s000\n' "$(date +%s)"
 }
 
 # The kernel's own start-time string for a PID, used verbatim. Comparing it as
@@ -1550,11 +1600,13 @@ release_gate_run_lock() {
 
 acquire_gate_run_lock() {
   local root lock owner_pid owner_host owner_worktree owner_token_value owner_start
-  local stale_reason nap remaining
+  local stale_reason nap remaining now_millis
   # Elapsed time comes from the clock, never from adding up requested sleeps.
   # A shell that is descheduled or SIGSTOPped sleeps far longer than it asked
   # to, and counting the request would let a run outlive the budget it printed
-  # while reporting a smaller number than it actually took.
+  # while reporting a smaller number than it actually took. Read in
+  # milliseconds and reported in whole seconds: measuring in whole seconds
+  # instead charges the wait up to a second it never spent.
   local waited=0
   local wait_started_at
   local last_beat=0
@@ -1586,10 +1638,17 @@ acquire_gate_run_lock() {
   lock="$root/run.lock"
   gate_lock_root_dir="$root"
   this_host="$(uname -n)"
-  wait_started_at="$(date +%s)"
+  wait_started_at="$(gate_wall_millis)"
 
   while :; do
-    waited=$(($(date +%s) - wait_started_at))
+    now_millis="$(gate_wall_millis)"
+    # A clock stepped backwards mid-wait — this is a wall clock, and NTP steps
+    # it — would otherwise make every later delta smaller than the budget, so
+    # the wait would outlive the budget it announced. Re-anchoring costs the
+    # step's worth of waiting and keeps the budget reachable; clamping the
+    # delta to zero would only tidy the number printed.
+    [[ "$now_millis" -ge "$wait_started_at" ]] || wait_started_at="$now_millis"
+    waited=$(((now_millis - wait_started_at) / 1000))
     if mkdir "$lock" 2>/dev/null; then
       gate_lock_test_crash after-mkdir
       gate_lock_test_delay "${AGENT_QUALITY_GATE_LOCK_CLAIM_DELAY_SECONDS:-}"
@@ -4532,6 +4591,25 @@ implementation_signature() {
   done | hash_stream
 }
 
+# The mode of a path, read from the worktree rather than from the index, so the
+# answer does not depend on whether the path is tracked yet. This is what the
+# ` create mode <mode> …` line dropped below used to carry. `-x` asks whether
+# THIS user may execute it, which is git's own rule — the owner bit — for a file
+# this user owns, and that is every file in a worktree it is working in. Where
+# the two differ (a file owned by somebody else, an execute bit set only for
+# group or other) this answer is still the same on both sides of a `git add`,
+# which is the property the freshness stamp needs from it.
+gate_worktree_filemode() {
+  local path="$1"
+  if [[ -L "$path" ]]; then
+    printf '120000'
+  elif [[ -x "$path" ]]; then
+    printf '100755'
+  else
+    printf '100644'
+  fi
+}
+
 validation_content_signature() {
   local path
 
@@ -4540,6 +4618,11 @@ validation_content_signature() {
       printf 'path %s\0' "$path"
       if [[ -f "$path" ]]; then
         printf 'file %s\0' "$(hash_file "$path")"
+        # The executable bit and symlink-ness are not in the content hash, and
+        # they are the part of the summary line below that says something about
+        # the file rather than about the index. Read from the worktree, so
+        # `git add` cannot move it.
+        printf 'mode %s\0' "$(gate_worktree_filemode "$path")"
       elif [[ -d "$path" ]]; then
         printf 'directory\0'
       elif [[ -e "$path" ]]; then
@@ -4547,7 +4630,18 @@ validation_content_signature() {
       else
         printf 'deleted\0'
       fi
-      git diff --no-ext-diff --summary "$base_ref" -- "$path" 2>/dev/null || true
+      # `create mode` lines are dropped: they appear the moment a path becomes
+      # tracked and say nothing about what was validated. An untracked path is
+      # invisible to `git diff`, so `git add` alone used to move this signature
+      # and cost a fresh stamp a full re-run — with the changed-path set, the
+      # command plan, the base OID and the file's bytes all provably unchanged
+      # (GitHub issue 1899). Deletions and mode changes are not index-state
+      # transitions in the same way — `git diff <base> -- <path>` reports both
+      # from the worktree, staged or not — so those summary lines stay.
+      # `awk` rather than `grep -v`, which exits 1 when it filters everything
+      # out and would abort the run under `set -e`.
+      git diff --no-ext-diff --summary "$base_ref" -- "$path" 2>/dev/null |
+        awk '!/^ create mode /' || true
     done < "$changed_paths_file"
   } | hash_stream
 }

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -67,6 +67,37 @@ fail() {
   exit 1
 }
 
+# A PID that is dead at the moment a fixture writes it into a lock record.
+# Spawning a real child and reaping it is what makes the number dead; asking
+# the gate's own two liveness probes about it afterwards is what keeps a
+# recycled number from being planted as a "dead" holder. Never a guessed
+# number, and never one captured once and reused: PIDs are handed out
+# sequentially, so the number just freed here is the last one the allocator
+# will return until it wraps the whole PID space — but a capture reused across
+# a family that runs for minutes gives a busy CI runner time to wrap onto it,
+# and a live runner process planted as a dead holder fails the family it was
+# written for (GitHub issue 1919). Call this immediately before each write.
+# The residual window is between the check below and the caller's write; it
+# takes a full PID-space wrap inside it to matter.
+fresh_dead_pid() {
+  local candidate
+  local attempt=0
+  while [[ "$attempt" -lt 20 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0 &
+    candidate=$!
+    wait "$candidate" 2>/dev/null || true
+    # Both probes, in the order acquire_gate_run_lock asks them: `kill -0` for
+    # the common case and `ps` for a live process this user may not signal.
+    if ! kill -0 "$candidate" 2>/dev/null &&
+      ! ps -p "$candidate" > /dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 run_gate() {
   : > "$paths_file"
   local path
@@ -3540,6 +3571,94 @@ STUB
 rm -rf "$stale_stamp_repo"
 assert_not_contains "Previous successful agent quality gate run is still fresh; skipping mapped commands."
 
+# GitHub issue #1899: staging a file the gate was already validating changes
+# nothing about what it validates. An untracked path is invisible to
+# `git diff`, so `git add` alone used to start a ` create mode` summary line
+# and cost a warm stamp a full re-run — with the changed-path set, the mapped
+# command plan, the base OID and the file's own bytes provably unchanged. The
+# three cases that must still bust the stamp are here beside it: content,
+# file mode, and an add that genuinely changes what the gate routes.
+index_state_stamp_repo="$(mktemp -d)"
+(
+  cd "$index_state_stamp_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  printf 'ignored-*\n' > .gitignore
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+counter_file="${COUNTER_FILE:?}"
+count=0
+if [[ -f "$counter_file" ]]; then
+  count="$(cat "$counter_file")"
+fi
+printf '%s\n' "$((count + 1))" > "$counter_file"
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  base_ref="$(git rev-parse --verify HEAD)"
+  counter="$index_state_stamp_repo/.tmp/agent-quality-gate/trunk-count"
+  printf 'changed\n' >> fixture.txt
+  printf 'brand new\n' > new.txt
+
+  index_state_gate() {
+    COUNTER_FILE="$counter" \
+      "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" "$@" \
+      > "$output_file" 2>&1
+  }
+
+  index_state_gate --run
+  index_state_before="$(sed -n '2s/^stamp=//p' \
+    "$index_state_stamp_repo/.tmp/agent-quality-gate/last-success.stamp")"
+
+  # Bytes untouched, tracking state changed.
+  git add new.txt
+  index_state_gate --run --skip-if-fresh
+  [[ "$(cat "$counter")" == "1" ]] ||
+    fail "staging an already-validated untracked file re-ran the mapped commands"
+  grep -Fq -- "Previous successful agent quality gate run is still fresh; skipping mapped commands." \
+    "$output_file" ||
+    fail "staging an already-validated untracked file lost the freshness stamp"
+
+  # The same transition must not have quietly frozen the signature: the stamp
+  # a skip reuses is still the one the warm run wrote.
+  index_state_after="$(sed -n '2s/^stamp=//p' \
+    "$index_state_stamp_repo/.tmp/agent-quality-gate/last-success.stamp")"
+  [[ "$index_state_after" == "$index_state_before" ]] ||
+    fail "the reused stamp is not the one the warm run wrote"
+
+  # Content still moves it.
+  printf 'edited after staging\n' >> new.txt
+  index_state_gate --run --skip-if-fresh
+  [[ "$(cat "$counter")" == "2" ]] ||
+    fail "editing a staged file reused the stamp warmed before the edit"
+
+  # So does the file mode, which the dropped summary line used to carry.
+  chmod +x new.txt
+  index_state_gate --run --skip-if-fresh
+  [[ "$(cat "$counter")" == "3" ]] ||
+    fail "making a validated file executable reused the stamp warmed before it"
+
+  # An ignored file is not routed, so creating one changes nothing …
+  printf 'hidden\n' > ignored-file.txt
+  index_state_gate --run --skip-if-fresh
+  [[ "$(cat "$counter")" == "3" ]] ||
+    fail "an ignored file the gate never routes invalidated the stamp"
+
+  # … but forcing it into the index adds a path the gate routes, and that is a
+  # different validation plan, not an index-state transition.
+  git add -f ignored-file.txt
+  index_state_gate --run --skip-if-fresh
+  [[ "$(cat "$counter")" == "4" ]] ||
+    fail "an add that changed the routed path set reused the stamp warmed before it"
+  grep -Fq -- "- ignored-file.txt" "$output_file" ||
+    fail "the forced add did not reach the gate's routed path set"
+)
+rm -rf "$index_state_stamp_repo"
+
 # Extending the reuse window must not weaken any exact-signature binding. Use
 # equal-tree base commits to isolate the base OID, then change the validation
 # path/command plan and the fixture's gate implementation independently. Every
@@ -5478,9 +5597,8 @@ STUB
   # is waited out, never reclaimed: reclaiming would later drain by that
   # token, matching processes with a value another writer chose. On a shared
   # root that record can be crafted, so fail-closed here means the timeout.
-  sleep 0 &
-  malformed_dead_pid=$!
-  wait "$malformed_dead_pid" 2>/dev/null || true
+  malformed_dead_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the malformed-token case"
   mkdir -p "$gate_lock_root/run.lock"
   {
     printf 'pid=%s\n' "$malformed_dead_pid"
@@ -5532,9 +5650,8 @@ STUB
   # A killed holder (SIGKILL leaves the directory behind, EXIT trap and all)
   # must never wedge the next run: it reclaims the lock unattended, then
   # releases its own on the way out.
-  sleep 0 &
-  dead_holder_pid=$!
-  wait "$dead_holder_pid" 2>/dev/null || true
+  dead_holder_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the stale-lock case"
   write_lock_owner "$dead_holder_pid"
   stale_exit="$(run_locked_gate)"
   [[ "$stale_exit" == "0" ]] ||
@@ -5650,9 +5767,8 @@ STUB
   # One stale lock, two waiters. The late waiter forms its verdict first, then
   # stalls past the point where the early one has already taken the lock over,
   # so its reclaim decision is obsolete when it finally acts on it.
-  sleep 0 &
-  race_dead_pid=$!
-  wait "$race_dead_pid" 2>/dev/null || true
+  race_dead_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the two-waiter case"
   mkdir -p "$gate_race_root/run.lock"
   {
     printf 'pid=%s\n' "$race_dead_pid"
@@ -5784,7 +5900,11 @@ STUB
     rm -rf "$gate_race_root/run.lock"
 
     # The budget is a promise: a wait shorter than the poll interval must not
-    # sleep past it and then report the overshoot as the elapsed time.
+    # sleep past it and then report the overshoot as the elapsed time. Capping
+    # the nap is only half of keeping that promise — the elapsed time has to be
+    # measured finer than the budget too, or a wait that begins late in a
+    # second reads a second longer than it was and reports a 1s budget as 2s.
+    # That is the arithmetic behind both CI sightings in GitHub issue #1919.
     mkdir -p "$gate_race_root/run.lock"
     {
       printf 'pid=%s\n' "$$"
@@ -5851,11 +5971,13 @@ STUB
     local tag="$1"
     local reclaim_delay="$2"
     local taken_delay="$3"
-    local pid
+    local pid dead_pid
+    dead_pid="$(fresh_dead_pid)" ||
+      fail "${tag}: could not obtain a reaped PID that reads as dead"
     rm -rf "$gate_race_root/run.lock"
     mkdir -p "$gate_race_root/run.lock"
     {
-      printf 'pid=%s\n' "$race_dead_pid"
+      printf 'pid=%s\n' "$dead_pid"
       printf 'host=%s\n' "$(uname -n)"
       printf 'started_at=%s\n' "$(date +%s)"
       printf 'worktree=%s\n' "$gate_race_repo"
@@ -5945,6 +6067,8 @@ STUB
 
     # The converse: a remnant naming a process that is gone is spent, and must
     # not keep a free lock looking occupied.
+    race_dead_pid="$(fresh_dead_pid)" ||
+      fail "could not obtain a reaped PID that reads as dead for the spent-remnant case"
     mkdir -p "$gate_race_root/run.lock"
     {
       printf 'pid=%s\n' "$race_dead_pid"
@@ -6648,6 +6772,8 @@ $(sed 's/^/      /' "$gate_race_out/$race_tag.out")"
   rm -rf "$gate_race_root/run.lock" "$gate_race_root/condemned.d"
   rm -f "$gate_race_root"/captured.*
   : > "$gate_race_log"
+  race_dead_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the unwritable-obligation case"
   mkdir -p "$gate_race_root/run.lock"
   {
     printf 'pid=%s\n' "$race_dead_pid"
@@ -6846,6 +6972,8 @@ $(sed 's/^/      /' "$gate_race_out/$race_tag.out")"
     : > "$gate_race_log"
     if [[ "$race_crash_point" == "after-take" ]]; then
       # Reached only with a record to take: plant a spent one.
+      race_dead_pid="$(fresh_dead_pid)" ||
+        fail "${race_crash_point}: could not obtain a reaped PID that reads as dead"
       mkdir -p "$gate_race_root/run.lock"
       {
         printf 'pid=%s\n' "$race_dead_pid"


### PR DESCRIPTION
## The Problem

- Staging a file the gate was already validating threw away a warm freshness
  stamp, so the next push paid for the full gate again with nothing about the
  validation changed.
- The gate's lock-race families flake on CI, and every crash recovery on a
  runner printed `/proc/<pid>/environ: Permission denied` into the output.

## The Solution

- Drop the ` create mode` lines from the validated-content signature. They
  appear the moment a path becomes tracked and say nothing about what was
  validated; the file mode they carried is now read from the worktree, where
  `git add` cannot move it.
- Measure the lock wait in milliseconds, take a freshly reaped PID for every
  fixture record that needs a dead one, and give the `/proc` read its own
  stderr redirect.

## Details

**Issue 1899 — measured before changing anything.** In a fixture repo, with a
file present but untracked and its bytes untouched across the transition:

| Stamp field      | Across a bare `git add` |
| ---------------- | ----------------------- |
| `base`           | unchanged               |
| `paths`          | unchanged               |
| `plan`           | unchanged               |
| `implementation` | unchanged               |
| `content`        | **moved**               |

The gate's whole dry-run output — changed paths and mapped commands — is
byte-identical either side of the add, and so is the raw path collection. The
only mover is `git diff --no-ext-diff --summary`, which prints nothing for an
untracked path and ` create mode 100644 new.txt` once it is staged. That is
pure waste, so those lines are excluded. Deletions and mode changes are
reported from the worktree whether or not they are staged, so those summary
lines stay, and a `mode` token bound from the worktree keeps the executable bit
and symlink-ness — the only part of a `create mode` line that describes the
file rather than the index.

The other mover named in that issue, `origin/main` advancing, is correct
behavior: the base commit is a bound input and the validation base really did
move. The hook's own `git fetch origin main` is what moves it, so the operating
card now says to fetch before warming.

**Issue 1919 — the fixture and the probe, plus what the CI logs actually
showed.** Both cited runs (PR 1881 run 32033283040, PR 1915 run 32128357896)
failed on the same assertion, and it is not a recovery one:
`a 1s budget under a 5s poll must report the budget it actually kept`. Two
`date +%s` reads truncate at each end, so a 1s wait starting at `X.99` and
lasting 1.05s subtracts to 2, and the gate reported a budget it had kept as an
overshoot. The wait now reads `EPOCHREALTIME` in milliseconds, falling back to
whole seconds where the shell has no fraction, and re-anchors rather than
clamping if the wall clock steps backwards.

The two halves the issue asked for are fixed as well, because both hazards are
real:

- The fixtures captured one reaped PID and reused it across families that run
  for minutes. PIDs are handed out sequentially, so a number just freed is safe
  — but a busy runner can wrap the whole PID space inside that window and hand
  it to a live process, which then reads as a live holder. `fresh_dead_pid()`
  reaps a real child immediately before each record is written and confirms it
  dead through both probes the gate itself uses; a recycled number is retried,
  never planted.
- The `/proc/<pid>/environ` read used a bare redirection, and a redirection
  that cannot open its target is reported by the shell before the `2>/dev/null`
  beside it applies. The read is wrapped in a group carrying its own redirect.
  An environment that cannot be read is **not** treated as a failed scan: it
  means another user's process, one the kernel refuses because it changed
  credentials, or one that exited mid-listing, and none can be a process this
  run started. Every GitHub runner has one such process, so the fail-closed
  reading would refuse every crash recovery there. The argv-tag and
  marker-descriptor scans cover the residual — neither reads the environment.

## Validation

| Check                                                                | Result                                                                                          |
| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| `pnpm agent:quality-gate:test`                                        | green ×2 (unsandboxed), plus a third inside the mapped gate run                                  |
| `pnpm agent:quality-gate --run`                                       | all 9 mapped commands passed                                                                     |
| lock + crash-recovery families, 5 consecutive runs                    | 5/5 green, 0 `Permission denied` lines                                                          |
| `bash -n` on both scripts                                             | clean                                                                                            |
| add-only transition keeps a warm stamp                                | stamp honored, mapped command not re-run                                                        |
| edited bytes after the add / `chmod +x` after the add                 | stamp busted, mapped command re-run                                                             |
| `git add -f` of an ignored file (an add that changes the routed plan) | stamp busted, `ignored-file.txt` present in the routed path set                                  |
| synthetic PID collision (record names a live process)                 | waited it out, never reclaimed, lock left in place, no stderr leak                              |
| control: verified-dead PID                                            | reclaimed, ran, released                                                                        |
| wait-budget report, launch phase swept across a second                | pre-fix 1/40 rounds reported `2s`; post-fix 0/60                                                |
| unreadable-environ read shape                                         | old form prints `Permission denied`, new form prints nothing and still matches the exact entry   |
| `pnpm agent:autoreview --engine codex`                                | clean, correctness 0.88                                                                          |
| `pnpm agent:autoreview --engine claude`                               | 4 findings across two passes, all addressed (see below)                                          |

Claude-engine findings and dispositions:

- *Worktree mode uses effective `-x`* — the premise that root sees every file
  as executable holds for `R_OK`, not `X_OK`: `access(2)` still requires an
  execute bit for the superuser, so `chmod +x` moves the token under root too.
  `-x` matches git's own owner-bit rule for files the running user owns, and
  where it diverges it diverges identically on both sides of a `git add`, which
  is the property the stamp needs. Comment tightened to say so.
- *Backwards-clock guard clamped to 0* — fixed. The wait re-anchors instead, so
  the budget stays reachable after a step.
- *Unwrapped markdown line* — fixed.
- *Dropping the `-r` fast path adds forks per PID* — fixed. `-r` is back in
  front as a fast path, and the read is a single `tr` in a redirected group
  rather than `cat | tr`, which also avoids SC2002.

Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1899
Closes https://github.com/mento-protocol/monitoring-monorepo/issues/1919

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this keeps the existing freshness
      and lock contracts, and records the reasoning in the mechanics note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches freshness fingerprinting and lock/orphan-drain behavior used on every `--run` and pre-push gate; mistakes could skip re-validation or mis-handle contention, but changes are narrowly scoped with expanded regression tests.
> 
> **Overview**
> **Freshness stamp (#1899):** The validated-content signature no longer treats `git diff --summary` `create mode` lines as a content change when only tracking state moves; worktree **mode** (executable/symlink) is hashed separately so `git add` alone does not bust a warm `--skip-if-fresh` stamp. Docs tell operators to **`git fetch origin main` before warming** so the stamp matches what the pre-push hook will use.
> 
> **Lock / drain / CI (#1919):** Lock wait elapsed time uses **`gate_wall_millis`** (`EPOCHREALTIME` with fallback) instead of paired `date +%s`, with re-anchor on clock step-back, so short budgets are not reported as overshoots. `/proc/*/environ` reads use a grouped stderr redirect and treat unreadable env as **skip-not-scan-failure** so GitHub runners do not fail every crash recovery. Tests use **`fresh_dead_pid()`** per fixture instead of reusing one reaped PID across long suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f318f21c7b948524783f6070b6524d906e6bef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->