### PR TITLE
feat(scripts): widen deploy routing globs for scripts/deploy/ (D1)

### DIFF
--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -3,7 +3,7 @@ title: scripts/ may use module subdirectories; basenames and pinned paths are th
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-17
+last_verified: 2026-08-18
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -62,6 +62,27 @@ already carries the paired arm `scripts/*/sentry-*.test.mjs` next to
 all 53 `sentry-*` files wherever they land, keep the `deploy-` prefix on the
 deploy wrappers, and add the paired one-level arm whenever a literal-prefix glob
 is the routing.
+
+Both deploy arms now carry that pair, added ahead of the move rather than with
+it: `scripts/deploy-*.sh|scripts/*/deploy-*.sh` routes the root-anchor check in
+`agent-quality-gate.sh`, and the same pair routes the Terraform/Cloud Run
+checklist in `select_checklists()` in `agent-autoreview.sh`. Both stay
+shell-scoped. The check behind the first has a `deploy-*.sh` subject set, and
+the Node deploy helpers that land in the same directory drive Envio and own no
+Cloud Run surface, so neither arm is the right home for them. Widening a routing
+glob is separable from the move it protects, and doing it first means the move
+cannot be the commit that goes quiet.
+
+Because `*` matches `/`, the pair reaches a `deploy-*.sh` basename under any
+`scripts/` subdirectory rather than one fixed directory. That is deliberate on
+both arms: `collectDeployWrappers()` in `check-deploy-root-anchors.test.mjs`
+walks `scripts/` recursively, so routing pinned to a single directory would once
+again be narrower than the check it schedules. The one live path it newly
+reaches is `scripts/lib/deploy-guard.sh`, the guard every wrapper sources before
+it mutates anything, which is precisely when both the check and the Cloud Run
+checklist should run. Both suites pin it. One consequence for later edits: a
+`case` takes the first matching arm, so a new arm for a path of the shape
+`scripts/<dir>/deploy-*.sh` goes ABOVE the pair or it never runs.
 
 `scripts/sentry-suite-manifest.json` is stricter than a glob. Its keys are exact
 repo-relative paths, and `scripts/sentry-suite-gate.mjs` reconciles them against
@@ -179,7 +200,16 @@ routing, not procedure.
 8. `docs/notes/quick-commands.md`.
 9. `agent-quality-gate.sh` routing arms — a literal-prefix glob such as
    `scripts/deploy-*.sh` or `scripts/sentry-*.test.mjs` stops matching one
-   directory down. Keep the basename prefix; add the paired one-level arm. Its
+   directory down. Keep the basename prefix; add the paired one-level arm. The
+   `sentry-` and `deploy-` arms already carry theirs, so a move of those files
+   verifies the pair rather than adding it. An arm naming an exact path is a
+   literal, not a glob, and needs the same pairing for the same reason: all
+   three on the deploy leg — `scripts/deploy-indexer-logs.sh`,
+   `scripts/deploy-bridge.sh`, and the `deploy-*.sh` glob — now carry it, so a
+   moved wrapper keeps its whole command set. Leaving one unpaired below a
+   widened glob is the worst case, not the safe one: the glob catches the moved
+   path, the run still looks routed, and only the arm's extra commands go
+   missing. Its
    contract-surface arm also names `scripts/lib/*.mjs`, which sets the
    `pnpm tf:test` reason; the unconditional sweep already runs the suite. Its
    `implementation_signature()` path list is stricter than a glob: an entry it
@@ -217,9 +247,15 @@ not only the arm of the consumer that happens to fail loudest.
 - Flat-layout scale and prefix counts: `git ls-files scripts/` — 210 top-level
   files, 53 with the `sentry-` prefix, measured at P0. The count falls with each
   phase; `scripts/AGENTS.md` carries the current one.
-- Bash `case` routing: `scripts/agent-autoreview.sh` (`scripts/*` arm),
-  `scripts/agent-quality-gate.sh` (`scripts/*.sh`, `scripts/deploy-*.sh`, and
-  the paired `scripts/sentry-*.test.mjs` / `scripts/*/sentry-*.test.mjs` arms).
+- Bash `case` routing: `scripts/agent-autoreview.sh` (`scripts/*` arm, and the
+  paired `scripts/deploy-*.sh` / `scripts/*/deploy-*.sh` checklist arm),
+  `scripts/agent-quality-gate.sh` (`scripts/*.sh`, and the paired
+  `scripts/deploy-*.sh` / `scripts/*/deploy-*.sh` and
+  `scripts/sentry-*.test.mjs` / `scripts/*/sentry-*.test.mjs` arms).
+- Routing assertions for both deploy pairs, each with a negative control:
+  `scripts/agent-quality-gate.test.sh` (the `scripts/deploy/` cases beside the
+  flat ones) and `run_deploy_directory_checklist_routing_regression` in
+  `scripts/agent-autoreview.test.sh`.
 - Recursive lint: `package.json` `lint:scripts`, `eslint.config.mjs` `files`
   globs.
 - Recursive CI filter: `.github/workflows/ci.yml`, `rootScripts` filter, whose

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -6088,7 +6088,20 @@ select_checklists() {
     esac
 
     case "$path" in
-      terraform/*|aegis/terraform/*|alerts/rules/*|scripts/deploy-*.sh)
+      # `scripts/*/deploy-*.sh` is the paired one-level arm ADR 0064 requires
+      # next to a literal-prefix glob: `scripts/deploy-*.sh` stops matching a
+      # wrapper that moves into `scripts/deploy/`, and the review silently loses
+      # the Terraform/Cloud Run checklist rather than failing. `*` matches `/`
+      # in a `case` pattern, so the pair reaches every depth. Shell-only, like
+      # the set it widens: the deploy helpers written in Node (indexer perf,
+      # verify, runtime-log filter) drive Envio, own no Cloud Run or Terraform
+      # surface, and are not routed this checklist today.
+      #
+      # The pair also reaches a `deploy-*.sh` basename under any other scripts/
+      # subdirectory, today `scripts/lib/deploy-guard.sh`. Intended and pinned
+      # in the suite: that guard is what `deploy-bridge.sh` sources before it
+      # mutates Cloud Run, so a review of it is a review of that deploy path.
+      terraform/*|aegis/terraform/*|alerts/rules/*|scripts/deploy-*.sh|scripts/*/deploy-*.sh)
         candidate="$(add_checklist "$repo" "docs/pr-checklists/terraform-cloudrun.md" "$source_ref" "${checklists[@]+"${checklists[@]}"}" || true)"
         [[ -n "$candidate" ]] && checklists+=("$candidate")
         ;;

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -5247,6 +5247,115 @@ run_frozen_checklist_symlink_regression() {
   fi
 }
 
+# The Terraform/Cloud Run checklist reaches a review through a literal-prefix
+# glob, `scripts/deploy-*.sh`, which stops matching once a wrapper sits in
+# `scripts/deploy/` (ADR 0064). Nothing fails when it stops: the review just
+# runs without the checklist. Each run below changes exactly one file, so the
+# only thing that can select terraform-cloudrun.md is the deploy arm itself —
+# revert the paired glob and the nested case fails here.
+run_deploy_directory_checklist_routing_regression() {
+  local review_repo="$tmp_dir/deploy-directory-checklist-routing"
+  local flat_bundle="$tmp_dir/deploy-directory-checklist-flat-bundle"
+  local nested_bundle="$tmp_dir/deploy-directory-checklist-nested-bundle"
+  local node_bundle="$tmp_dir/deploy-directory-checklist-node-bundle"
+  local guard_bundle="$tmp_dir/deploy-directory-checklist-guard-bundle"
+  init_review_repo "$review_repo"
+  mkdir -p "$review_repo/docs/pr-checklists"
+  printf 'base\n' >"$review_repo/README.md"
+  printf 'recurring checklist\n' \
+    >"$review_repo/docs/pr-checklists/recurring-review-patterns.md"
+  printf 'exclusions checklist\n' \
+    >"$review_repo/docs/pr-checklists/review-prompt-exclusions.md"
+  printf 'code-health checklist\n' \
+    >"$review_repo/docs/pr-checklists/code-health.md"
+  printf 'terraform checklist\n' \
+    >"$review_repo/docs/pr-checklists/terraform-cloudrun.md"
+  commit_review_repo "$review_repo" "add trusted checklists"
+
+  # Control: the flat wrapper shape the arm routes today.
+  git -C "$review_repo" switch -c flat-deploy >/dev/null 2>&1
+  mkdir -p "$review_repo/scripts"
+  printf 'flat deploy wrapper\n' >"$review_repo/scripts/deploy-probe.sh"
+  commit_review_repo "$review_repo" "add flat deploy wrapper"
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$flat_bundle" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_file_contains_line \
+    "$flat_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/terraform-cloudrun.md"
+
+  # The same wrapper one directory down must select the identical checklist.
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  git -C "$review_repo" switch -c nested-deploy >/dev/null 2>&1
+  mkdir -p "$review_repo/scripts/deploy"
+  printf 'nested deploy wrapper\n' \
+    >"$review_repo/scripts/deploy/deploy-probe.sh"
+  commit_review_repo "$review_repo" "add nested deploy wrapper"
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$nested_bundle" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_file_contains_line \
+    "$nested_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/terraform-cloudrun.md"
+
+  # Shell-scoped on purpose. A Node deploy helper landing in the same directory
+  # drives Envio, owns no Cloud Run or Terraform surface, and is not routed this
+  # checklist today; it still picks up code-health through the recursive
+  # `scripts/*` arm. Pin both halves so a later widening is a decision, not a
+  # side effect.
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  git -C "$review_repo" switch -c nested-node-deploy >/dev/null 2>&1
+  mkdir -p "$review_repo/scripts/deploy"
+  printf 'nested deploy helper\n' \
+    >"$review_repo/scripts/deploy/deploy-probe.mjs"
+  commit_review_repo "$review_repo" "add nested deploy helper"
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$node_bundle" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_file_contains_line \
+    "$node_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/code-health.md"
+  expect_file_not_contains \
+    "$node_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/terraform-cloudrun.md"
+
+  # `*` matches `/`, so the pair also reaches a `deploy-*.sh` basename in any
+  # other scripts/ subdirectory — today `scripts/lib/deploy-guard.sh`, which
+  # `deploy-bridge.sh` sources before it mutates Cloud Run. Reviewing that guard
+  # against the Cloud Run checklist is the intent, so pin it rather than leave
+  # it to be rediscovered as a surprise.
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  git -C "$review_repo" switch -c deploy-guard >/dev/null 2>&1
+  mkdir -p "$review_repo/scripts/lib"
+  printf 'shared deploy guard\n' \
+    >"$review_repo/scripts/lib/deploy-guard.sh"
+  commit_review_repo "$review_repo" "add shared deploy guard"
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$guard_bundle" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_file_contains_line \
+    "$guard_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/terraform-cloudrun.md"
+  # Each checklist has its own `case` statement, so the new alternative can only
+  # add a selection, never displace one. Pin the coexistence rather than argue
+  # it: code-health still arrives through the recursive `scripts/*` arm.
+  expect_file_contains_line \
+    "$guard_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/code-health.md"
+  expect_file_contains_line \
+    "$nested_bundle/selected-checklists.txt" \
+    "docs/pr-checklists/code-health.md"
+  expect_empty_stderr
+}
+
 run_git_replace_ref_regression() {
   local review_repo="$tmp_dir/git-replace-ref"
   local bundle_dir="$tmp_dir/git-replace-ref-bundle"
@@ -6822,6 +6931,7 @@ run_bundle_integrity_family() {
   run_stage_timing_split_checkout_regression
   run_prepared_unsupported_path_regressions
   run_frozen_checklist_symlink_regression
+  run_deploy_directory_checklist_routing_regression
   run_prepared_untracked_symlink_regression
   run_feedback_runtime_aggregate_regression
   run_large_untracked_bound_regression

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3792,11 +3792,36 @@ while IFS= read -r path; do
     scripts/*.sh)
       add_surface "scripts"
       case "$path" in
-        scripts/deploy-indexer-logs.sh)
+        # Paired for the same reason as the arm below, and it has to be: this one
+        # sits FIRST, so once this wrapper moves the exact path stops matching,
+        # the widened arm below catches it instead, and the run keeps scheduling
+        # the root-anchor check while the runtime-log filter check quietly drops
+        # out. Partial routing reads as working routing, which is worse than the
+        # gap the pair exists to close.
+        scripts/deploy-indexer-logs.sh|scripts/*/deploy-indexer-logs.sh)
           add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy wrapper changed"
           add_command "node scripts/filter-envio-runtime-errors.test.mjs" "indexer runtime-log filter changed"
           ;;
-        scripts/deploy-*.sh)
+        # Paired one-level arm, the ADR 0064 remedy for a literal-prefix glob.
+        # `scripts/deploy-*.sh` is anchored on a prefix at the TOP of scripts/,
+        # so it stops matching the moment a wrapper sits one directory down —
+        # and nothing reds: the root-anchor check simply stops being scheduled.
+        # `*` matches `/` in a `case` pattern, so the paired arm reaches every
+        # depth. Shell-only on purpose: the subject set of
+        # check-deploy-root-anchors.test.mjs is `deploy-*.sh` files that source
+        # `lib/deploy-guard.sh`, and that walk is already recursive, so the
+        # check is ready for the move before the routing is.
+        #
+        # That same breadth reaches a `deploy-*.sh` basename under any scripts/
+        # subdirectory, today `scripts/lib/deploy-guard.sh` — deliberate, and
+        # pinned in the suite. Matching the check's own recursive walk is the
+        # whole point; a pattern stopping at one fixed directory would be
+        # narrower than what it schedules. The guard is the file every wrapper
+        # sources, so a change to it is exactly when the check should run.
+        # Consequence for later edits: `case` takes the FIRST matching arm, so a
+        # new arm for a path of the shape `scripts/<dir>/deploy-*.sh` belongs
+        # ABOVE this one or it never runs.
+        scripts/deploy-*.sh|scripts/*/deploy-*.sh)
           add_command "node scripts/check-deploy-root-anchors.test.mjs" "deploy wrapper changed"
           ;;
         scripts/sanitize-terraform-output.sh)
@@ -3813,7 +3838,13 @@ while IFS= read -r path; do
         scripts/repo-health/dev-janitor.sh|scripts/repo-health/dev-janitor.test.sh)
           add_command "bash scripts/repo-health/dev-janitor.test.sh" "dev janitor script changed"
           ;;
-        scripts/deploy-bridge.sh)
+        # Paired like the two arms in the case above. This is a separate `case`
+        # statement, so the widened deploy glob cannot shadow it — but an exact
+        # path stops matching after a move all the same, and these two commands
+        # are the whole Cloud Run half of this wrapper's routing. Pairing it here
+        # is what makes "a moved deploy script routes identically" true for the
+        # bridge rather than true for the root-anchor check alone.
+        scripts/deploy-bridge.sh|scripts/*/deploy-bridge.sh)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Run deploy script changed"
           add_command "pnpm agent:context-check" "Cloud Run revision suffix guard changed"
           ;;

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2519,6 +2519,59 @@ run_gate "scripts/check-deploy-root-anchors.test.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy root-anchor test changed)"
 
+# A deploy wrapper that lands under scripts/deploy/ must route the same
+# root-anchor contract the flat wrappers route today. `scripts/deploy-*.sh` is
+# anchored on a literal prefix at the TOP of scripts/, so it stops matching one
+# directory down and the check simply stops being scheduled — nothing reds.
+# ADR 0064's remedy is the paired one-level arm, and check-deploy-root-anchors
+# .test.mjs already walks scripts/ recursively, so only the routing was missing.
+# The path need not exist (see the nested Sentry suite cases below); `bash -n`
+# is skipped for a path with no file, so only the routed check is asserted.
+run_gate "scripts/deploy/deploy-indexer.sh"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+
+# The bridge carries a Cloud Run arm of its own in a later `case` statement, so
+# asserting only the root-anchor check here would record post-move under-routing
+# as the expectation. Require the full set the flat path gets above.
+run_gate "scripts/deploy/deploy-bridge.sh"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
+assert_contains "- pnpm agent:context-check (Cloud Run revision suffix guard changed)"
+
+# The wrapper with a two-command arm of its own, and the one case where the
+# widened glob is actively dangerous: its arm sits FIRST and matches an exact
+# path, so after a move the glob below would catch the path and schedule only
+# the root-anchor check. The run still looks routed while the runtime-log filter
+# check is gone. Assert BOTH commands survive the move, not just the one the
+# widened arm supplies.
+run_gate "scripts/deploy/deploy-indexer-logs.sh"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+assert_contains "- node scripts/filter-envio-runtime-errors.test.mjs (indexer runtime-log filter changed)"
+
+# `*` matches `/`, so the paired arm reaches a `deploy-*.sh` basename under ANY
+# scripts/ subdirectory, not only a future scripts/deploy/. That breadth is the
+# point: check-deploy-root-anchors.test.mjs walks scripts/ recursively too, so
+# routing that stopped at one fixed directory would again be narrower than the
+# check it schedules. The live path it newly reaches is the shared guard every
+# wrapper sources — the one file whose change can break all of them at once —
+# and the check exists to assert they still source it. Pin it so the reach is a
+# recorded decision, and so a later arm of the same shape has to be placed
+# BEFORE this one rather than being silently shadowed by it.
+run_gate "scripts/lib/deploy-guard.sh"
+assert_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+# The reach is purely additive: this live path keeps everything it routed before
+# the pair existed. Assert that too, so a future arm ordering that swallows it
+# reds here instead of quietly thinning the guard's routing.
+assert_contains "- bash -n scripts/lib/deploy-guard.sh (shell script changed)"
+
+# The arm stays shell-scoped on purpose: the check's subject set is `deploy-*.sh`
+# files that source lib/deploy-guard.sh, so a Node helper moving into the same
+# directory must NOT pick it up. Pin that, or the next widening quietly schedules
+# a shell contract for files it cannot assert anything about.
+run_gate "scripts/deploy/deploy-indexer-perf.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_not_contains "- node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)"
+
 run_gate "scripts/bootstrap/agent-session-end-hook.sh"
 assert_contains "- bash -n scripts/bootstrap/agent-session-end-hook.sh (shell script changed)"
 assert_contains "- pnpm agent:context-check (agent SessionEnd hook changed)"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Three routing arms in two trust roots match deploy scripts by a glob anchored on a literal prefix at the top of `scripts/`. All three stop matching when a wrapper moves into `scripts/deploy/`, which the scripts reorg (issue 1877) will do.
- Nothing fails when they stop. The root-anchor check and the Terraform/Cloud Run checklist just stop being scheduled, and the run still reads as green.

## The Solution

- Add the paired one-level arm ADR 0064 prescribes next to each pattern, keeping the flat pattern matching. A wrapper under `scripts/deploy/` now routes exactly what its flat counterpart routes today.
- Pin every case in both suites, each with a negative control, so a later edit that narrows the routing reds instead of going quiet.

## Details

Groundwork only. No file moves; the move is a separate PR.

Three arms changed, all additive:

| File | Arm | Now |
| --- | --- | --- |
| `agent-quality-gate.sh` | `scripts/deploy-*.sh` | `scripts/deploy-*.sh\|scripts/*/deploy-*.sh` |
| `agent-quality-gate.sh` | `scripts/deploy-indexer-logs.sh` | `…\|scripts/*/deploy-indexer-logs.sh` |
| `agent-quality-gate.sh` | `scripts/deploy-bridge.sh` | `…\|scripts/*/deploy-bridge.sh` |
| `agent-autoreview.sh` | `scripts/deploy-*.sh` in `select_checklists()` | `…\|scripts/*/deploy-*.sh` |

**Why the two exact-path arms are in scope.** Widening only the glob makes the
`deploy-indexer-logs.sh` case worse, not better: its exact-path arm sits first
in the same `case`, so after a move it stops matching, the widened glob catches
the path instead, and the run keeps scheduling the root-anchor check while the
runtime-log filter check drops out. Partial routing reads as working routing.
`deploy-bridge.sh` sits in a second `case` statement and so is not shadowed, but
it loses its Cloud Run checklist and `agent:context-check` on the same move.
Pairing both is what makes "a moved deploy script routes identically" true.

**Why both widened arms stay `.sh`-scoped.** The subject set of
`check-deploy-root-anchors.test.mjs` is `deploy-*.sh` files that source
`lib/deploy-guard.sh`; a Node helper has nothing for it to assert. The Node
deploy helpers landing in the same directory (`deploy-indexer-perf.mjs`,
`deploy-indexer-verify.mjs`, `filter-envio-runtime-errors.mjs`) drive Envio and
own no Cloud Run or Terraform surface, and are not routed the Cloud Run
checklist today. Both suites carry a Node-helper negative control pinning this.

**One live path newly reached.** `*` matches `/` in a `case` pattern, so the
pair reaches a `deploy-*.sh` basename under any `scripts/` subdirectory, today
`scripts/lib/deploy-guard.sh`. That breadth is deliberate:
`collectDeployWrappers()` in the check walks `scripts/` recursively, so routing
pinned to one fixed directory would again be narrower than the check it
schedules. The guard is the file every wrapper sources before it mutates
anything, which is exactly when both the check and the Cloud Run checklist
should run. Measured, the reach is strictly additive — the guard keeps
everything it routed before — and both suites pin that.

`scripts/AGENTS.md` needed no change and is untouched at 9,161 bytes, inside the
9,216-byte cap. ADR 0064 is updated: it named these globs as the unfixed case,
and its sweep checklist told a later move to add the pair that now exists.

## Validation

**Quality gate** — `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`, all 12 mapped commands passed:
`agent:quality-gate:test` (7m53s), `agent:autoreview:test` (4m35s, all five families),
`docs:index --check`, `agent:context-check`, `check-sentry-suites-in-ci.test.mjs`,
`docs:navigation-eval --check-fixtures`, `tf:test`, Trunk on all five files, and `bash -n` on all four shell files.

**Negative controls, both proven by reverting the widening and restoring it:**

- Gate: with `scripts/*/deploy-*.sh` removed, `agent-quality-gate.test.sh` fails —
  `expected output to contain: - node scripts/check-deploy-root-anchors.test.mjs (deploy wrapper changed)`,
  with the gate output showing `scripts/deploy/deploy-indexer.sh` mapping only Trunk and `tf:test`. Restored: suite passes.
- Autoreview: with the alternative removed, `AUTOREVIEW_TEST_FOCUS=bundle-integrity` fails —
  the nested bundle's `selected-checklists.txt` holds only `recurring-review-patterns.md`,
  `review-prompt-exclusions.md`, and `code-health.md`; `terraform-cloudrun.md` is absent. Restored: family passes.

**Shadowing check** (the review question that drove the two exact-path pairings) — routing for
`scripts/lib/deploy-guard.sh` compared with the widened alternatives present and removed: identical apart
from the added root-anchor check, so nothing was displaced. `scripts/deploy/deploy-indexer-logs.sh` keeps
both its commands, and `scripts/deploy/deploy-bridge.sh` keeps all three.

**Local autoreview, both engines clean** (review-bot substitute while both bots are down). Because this PR
changes the autoreview runtime itself, the adapter fail-closes on self-review; both runs used the runbook's
trusted-checkout procedure — a clean `origin/main` clone with an explicit `AUTOREVIEW_HELPER`, verified
byte-identical to protected main for all three runtime files.

- codex: `autoreview clean: no accepted/actionable findings reported`, `patch is correct (0.94)`
- claude: `autoreview clean: no accepted/actionable findings reported`, `patch is correct (0.75)`

Earlier rounds were not clean, and both fixes are in the diff: the claude engine flagged the undocumented
reach to `scripts/lib/deploy-guard.sh` (pinned in both suites, documented in the ADR) and then the
exact-path shadowing hazard (both arms paired, full command sets asserted). Its remaining reservations —
that the "new `scripts/<dir>/deploy-*.sh` arm goes above the pair" invariant is comment-enforced, and that
dropping the `deploy-` basename prefix would defeat both arms — it filed as non-blocking; ADR 0064 already
mandates keeping the prefix, and both belong to the move commit.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new decision; ADR 0064 is updated to match the code it governs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/review routing for deploy and Cloud Run paths; behavior is additive and heavily regression-tested, but mis-routing would fail open (skipped checks) rather than fail closed.
> 
> **Overview**
> Prepares the upcoming `scripts/deploy/` reorg by widening **deploy script routing** so checks do not silently drop when wrappers move one directory down.
> 
> **Quality gate** (`agent-quality-gate.sh`) pairs `scripts/*/deploy-*.sh` (and nested exact paths) with existing flat patterns for the deploy glob, `deploy-indexer-logs.sh`, and `deploy-bridge.sh`, preserving the full command set—including cases where a widened glob alone would shadow a more specific arm and drop checks.
> 
> **Autoreview** (`agent-autoreview.sh`) applies the same paired pattern so the Terraform/Cloud Run checklist still selects for nested `deploy-*.sh` paths.
> 
> **Tests** add nested-path coverage in `agent-quality-gate.test.sh` and `run_deploy_directory_checklist_routing_regression` in `agent-autoreview.test.sh`, including negative controls (Node helpers stay shell-scoped; `scripts/lib/deploy-guard.sh` intentionally gets deploy checks).
> 
> **ADR 0064** documents that deploy pairs land before the move and updates the sweep checklist accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3de56db7812cd01c1b3904825d9f05118414bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment script detection for nested paths.
  * Ensured deployment-related checks are correctly applied to shell wrappers while excluding unrelated helpers.

* **Tests**
  * Added regression coverage for nested deployment routing.
  * Verified Cloud Run, context, runtime-log, root-anchor, and shell syntax checks remain correctly assigned.

* **Documentation**
  * Updated architecture documentation with deployment routing rules, checklist requirements, and validation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->