### PR TITLE
fix(scripts): make autoreview capture rename-aware

### DIFF
--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -27,6 +27,32 @@ The direct helper and prepared-bundle adapter enforce one cumulative input
 budget while capturing diffs, untracked files, checklists, and feedback, before
 those bytes can accumulate in memory or staging sidecars.
 
+Every Git invocation pins `-c diff.renames=false`, so no capture inherits a
+rename policy from operator configuration and each one states its own. The patch
+and stat captures pass `--find-renames` at Git's default similarity floor, which
+overrides that pin: a branch that relocates many files otherwise bundles as
+delete+add pairs and exhausts the budget before analysis runs, and a stat that
+disagreed with the patch it indexes would misreport the change. Content is
+elided only at similarity index 100%, and rename detection pairs an added path
+only with a deleted one, so a header can never stand in for content the change
+introduces. A relocation carrying edits emits its hunks, which are bundled,
+chunked, and scanned like any other change; a relocated binary is reviewable
+only while it is byte-identical, and one that also changes still fails closed.
+Those captures also own the rename candidate limit as `-l5000`, because the
+reviewed repository's own config can still set `diff.renameLimit`, and a move
+that changes a basename and edits the file needs the exhaustive pass Git skips
+past 1,000 candidates even by default. The pin stays finite: that pass runs
+before any byte reaches the capture limiter and is quadratic in candidate count,
+so a change more than twice the size of the whole tracked tree says on stderr
+that detection was skipped and falls back to delete+add pairs, rather than
+stalling in Git. Those pairs still review correctly; a large enough one fails on
+the capture budget with its own message.
+The changed-path captures keep the pin, so both sides of a move stay enumerated
+for the sensitive-path refusal and checklist routing. Rename detection works
+within one diff, so a move whose two sides are split across commits has no pair
+to find: review that branch in branch mode, where both sides sit in the same
+diff.
+
 For a real review, the helper resolves a symbolic branch base or commit target
 once to an immutable object ID. Direct `--dry-run` instead reports the requested
 ref without resolving or freezing it. Source fingerprints cover the symbolic

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -41,21 +41,27 @@ only while it is byte-identical, and one that also changes still fails closed.
 Those captures also own the rename candidate limit as `-l5000`, because the
 reviewed repository's own config can still set `diff.renameLimit`, and a move
 that changes a basename and edits the file needs the exhaustive pass Git skips
-past its default candidate count. The pin stays finite: that pass runs before
-any byte reaches the capture limiter and is quadratic in candidate count, so a
-change more than twice the size of the whole tracked tree says on stderr that
-detection was skipped and falls back to delete+add pairs, rather than stalling
-in Git. Those pairs still review correctly; a large enough one fails on the
-capture budget with its own message.
+past its default candidate count. The pin stays finite because that pass runs
+before any byte reaches the capture limiter, so no output bound can cut it
+short. What bounds it is the gate Git applies: the exhaustive pass is skipped
+once the number of unpaired sources multiplied by the number of unpaired
+destinations exceeds the square of the limit. `-l5000` therefore authorizes at
+most 25,000,000 pair comparisons, whatever the reviewed change looks like.
+Past that product Git says on stderr that detection was skipped and these
+captures fall back to delete+add pairs, rather than stalling. Those pairs still
+review correctly; a large enough one fails on the capture budget with its own
+message.
 
 This repository declares no minimum Git version, and the default the pin
 replaces has moved: `diff.renameLimit` documents 400 in older Git and 1,000
 today. Nothing here depends on which one a host ships, because the pin overrides
 both — an explicit `-l` wins over the config and over the built-in default, and
-5,000 is above either. The reasoning and the timings above were validated
-against Git 2.54.0, where 2,000 symmetric candidates pair under `-l5000` and are
-skipped without it. Git gates the pass on the candidate product rather than one
-count, so `-l5000` authorizes at most 25,000,000 pair comparisons.
+5,000 is above either. The bound above was validated against Git 2.54.0, where
+2,000 symmetric candidates pair under `-l5000` and are skipped without it. As
+one machine-specific observation rather than a guarantee: on that host, 5,000
+symmetric candidates of 50 KB blobs took about 74 seconds at the product
+ceiling, against 272 MB of restated diff with detection off. Elapsed time
+depends on hardware and blob size; the comparison count does not.
 
 The changed-path captures keep the pin, so both sides of a move stay enumerated
 for the sensitive-path refusal and checklist routing. The scope baseline splits

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -41,17 +41,30 @@ only while it is byte-identical, and one that also changes still fails closed.
 Those captures also own the rename candidate limit as `-l5000`, because the
 reviewed repository's own config can still set `diff.renameLimit`, and a move
 that changes a basename and edits the file needs the exhaustive pass Git skips
-past 1,000 candidates even by default. The pin stays finite: that pass runs
-before any byte reaches the capture limiter and is quadratic in candidate count,
-so a change more than twice the size of the whole tracked tree says on stderr
-that detection was skipped and falls back to delete+add pairs, rather than
-stalling in Git. Those pairs still review correctly; a large enough one fails on
-the capture budget with its own message.
+past its default candidate count. The pin stays finite: that pass runs before
+any byte reaches the capture limiter and is quadratic in candidate count, so a
+change more than twice the size of the whole tracked tree says on stderr that
+detection was skipped and falls back to delete+add pairs, rather than stalling
+in Git. Those pairs still review correctly; a large enough one fails on the
+capture budget with its own message.
+
+This repository declares no minimum Git version, and the default the pin
+replaces has moved: `diff.renameLimit` documents 400 in older Git and 1,000
+today. Nothing here depends on which one a host ships, because the pin overrides
+both — an explicit `-l` wins over the config and over the built-in default, and
+5,000 is above either. The reasoning and the timings above were validated
+against Git 2.54.0, where 2,000 symmetric candidates pair under `-l5000` and are
+skipped without it. Git gates the pass on the candidate product rather than one
+count, so `-l5000` authorizes at most 25,000,000 pair comparisons.
+
 The changed-path captures keep the pin, so both sides of a move stay enumerated
-for the sensitive-path refusal and checklist routing. Rename detection works
-within one diff, so a move whose two sides are split across commits has no pair
-to find: review that branch in branch mode, where both sides sit in the same
-diff.
+for the sensitive-path refusal and checklist routing. The scope baseline splits
+the difference on purpose: its changed-file count comes from that rename-blind
+enumeration and counts both sides of a move, while its non-test line count is
+rename-aware, so the prompt states how many paths a change touches beside how
+many lines it actually changes. Rename detection works within one diff, so a
+move whose two sides are split across commits has no pair to find: review that
+branch in branch mode, where both sides sit in the same diff.
 
 For a real review, the helper resolves a symbolic branch base or commit target
 once to an immutable object ID. Direct `--dry-run` instead reports the requested

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -4152,6 +4152,24 @@ function nonTestPath(relativePath) {
   );
 }
 
+// `--numstat` states a detected rename in its path column as `old => new`, or
+// as `pre/{old => new}/post` when the two paths share a prefix and a suffix.
+// Classification has to read the destination: a file moved out of a test path
+// is not test churn any more, and one moved into a test path is.
+function numstatDestinationPath(pathField) {
+  const braced = pathField.match(/^(.*)\{(.*) => (.*)\}(.*)$/);
+  if (braced) return `${braced[1]}${braced[3]}${braced[4]}`;
+  const plain = pathField.match(/^(.*) => (.*)$/);
+  if (plain) return plain[2];
+  return pathField;
+}
+
+// These carry `--find-renames -l5000` for the same reason the bundle captures
+// do: the baseline states the size of the change the bundle shows, and without
+// pairing a verbatim move reports every line of every moved file twice. The
+// changed-file count beside it still comes from the rename-blind path
+// enumeration, so it deliberately counts both sides of a move: one number is
+// paths touched, the other is lines changed.
 function numstatSources(repo, target) {
   if (target.mode === "local") {
     return [
@@ -4160,11 +4178,20 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "--find-renames",
+        "-l5000",
         "--cached",
         target.head,
         "--",
       ]),
-      runGit(repo, ["diff", "--no-ext-diff", "--no-textconv", "--numstat"]),
+      runGit(repo, [
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--numstat",
+        "--find-renames",
+        "-l5000",
+      ]),
     ];
   }
   if (target.mode === "branch") {
@@ -4174,6 +4201,8 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "--find-renames",
+        "-l5000",
         `${target.ref}...${target.head}`,
       ]),
     ];
@@ -4185,6 +4214,8 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "--find-renames",
+        "-l5000",
         `${target.ref}...${target.head}`,
       ]),
       runGit(repo, [
@@ -4192,11 +4223,20 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "--find-renames",
+        "-l5000",
         "--cached",
         target.head,
         "--",
       ]),
-      runGit(repo, ["diff", "--no-ext-diff", "--no-textconv", "--numstat"]),
+      runGit(repo, [
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--numstat",
+        "--find-renames",
+        "-l5000",
+      ]),
     ];
   }
   return [
@@ -4205,6 +4245,8 @@ function numstatSources(repo, target) {
       "--no-ext-diff",
       "--no-textconv",
       "--numstat",
+      "--find-renames",
+      "-l5000",
       "--format=",
       target.ref,
     ]),
@@ -4216,7 +4258,7 @@ function scopeBaseline(repo, target, paths) {
   for (const source of numstatSources(repo, target)) {
     for (const line of source.split("\n")) {
       const match = line.match(/^(\d+|-)\t(\d+|-)\t(.+)$/);
-      if (!match || !nonTestPath(match[3])) continue;
+      if (!match || !nonTestPath(numstatDestinationPath(match[3]))) continue;
       if (match[1] !== "-") nonTestLoc += Number.parseInt(match[1], 10);
       if (match[2] !== "-") nonTestLoc += Number.parseInt(match[2], 10);
     }

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -4152,16 +4152,36 @@ function nonTestPath(relativePath) {
   );
 }
 
-// `--numstat` states a detected rename in its path column as `old => new`, or
-// as `pre/{old => new}/post` when the two paths share a prefix and a suffix.
-// Classification has to read the destination: a file moved out of a test path
-// is not test churn any more, and one moved into a test path is.
-function numstatDestinationPath(pathField) {
-  const braced = pathField.match(/^(.*)\{(.*) => (.*)\}(.*)$/);
-  if (braced) return `${braced[1]}${braced[3]}${braced[4]}`;
-  const plain = pathField.match(/^(.*) => (.*)$/);
-  if (plain) return plain[2];
-  return pathField;
+// `--numstat -z` states one record as `added TAB deleted TAB path NUL`, and a
+// detected rename as `added TAB deleted TAB NUL preimage NUL postimage NUL` —
+// an empty path field followed by the two paths as fields of their own.
+// Reading them structurally is what makes classification correct: without `-z`
+// the same rename renders as `old => new` inside the path column, and a file
+// whose own name contains ` => ` is then indistinguishable from a rename. Such
+// a name is legal, and mis-splitting it hands the wrong half to `nonTestPath`.
+// Classification wants the postimage: a file moved out of a test path is not
+// test churn any more, and one moved into a test path is.
+function parseNumstatRecords(source) {
+  const fields = source.split("\0");
+  const records = [];
+  let index = 0;
+  while (index < fields.length) {
+    const match = fields[index].match(/^(\d+|-)\t(\d+|-)\t([\s\S]*)$/);
+    if (!match) {
+      index += 1;
+      continue;
+    }
+    if (match[3] !== "") {
+      records.push({ added: match[1], deleted: match[2], path: match[3] });
+      index += 1;
+      continue;
+    }
+    const postimage = fields[index + 2];
+    if (postimage === undefined) break;
+    records.push({ added: match[1], deleted: match[2], path: postimage });
+    index += 3;
+  }
+  return records;
 }
 
 // These carry `--find-renames -l5000` for the same reason the bundle captures
@@ -4169,7 +4189,8 @@ function numstatDestinationPath(pathField) {
 // pairing a verbatim move reports every line of every moved file twice. The
 // changed-file count beside it still comes from the rename-blind path
 // enumeration, so it deliberately counts both sides of a move: one number is
-// paths touched, the other is lines changed.
+// paths touched, the other is lines changed. This output feeds the baseline
+// only; no NUL from it reaches the review bundle or its collector.
 function numstatSources(repo, target) {
   if (target.mode === "local") {
     return [
@@ -4178,6 +4199,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
         "--cached",
@@ -4189,6 +4211,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
       ]),
@@ -4201,6 +4224,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
         `${target.ref}...${target.head}`,
@@ -4214,6 +4238,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
         `${target.ref}...${target.head}`,
@@ -4223,6 +4248,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
         "--cached",
@@ -4234,6 +4260,7 @@ function numstatSources(repo, target) {
         "--no-ext-diff",
         "--no-textconv",
         "--numstat",
+        "-z",
         "--find-renames",
         "-l5000",
       ]),
@@ -4245,6 +4272,7 @@ function numstatSources(repo, target) {
       "--no-ext-diff",
       "--no-textconv",
       "--numstat",
+      "-z",
       "--find-renames",
       "-l5000",
       "--format=",
@@ -4256,11 +4284,12 @@ function numstatSources(repo, target) {
 function scopeBaseline(repo, target, paths) {
   let nonTestLoc = 0;
   for (const source of numstatSources(repo, target)) {
-    for (const line of source.split("\n")) {
-      const match = line.match(/^(\d+|-)\t(\d+|-)\t(.+)$/);
-      if (!match || !nonTestPath(numstatDestinationPath(match[3]))) continue;
-      if (match[1] !== "-") nonTestLoc += Number.parseInt(match[1], 10);
-      if (match[2] !== "-") nonTestLoc += Number.parseInt(match[2], 10);
+    for (const record of parseNumstatRecords(source)) {
+      if (!nonTestPath(record.path)) continue;
+      if (record.added !== "-") nonTestLoc += Number.parseInt(record.added, 10);
+      if (record.deleted !== "-") {
+        nonTestLoc += Number.parseInt(record.deleted, 10);
+      }
     }
   }
   if (target.mode === "local" || target.mode === "branch-local") {

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -2268,6 +2268,17 @@ function aggregateInputLimitError(label) {
   return error;
 }
 
+// `runGitBufferResult` pins `-c diff.renames=false`, so every stat and patch
+// below overrides it with `--find-renames` at Git's default similarity floor,
+// for the reason the wrapper's capture block records: a bulk move otherwise
+// renders as delete+add pairs and deterministically exhausts the aggregate
+// limit. Git elides content only at similarity index 100%, and pairs an added
+// path only with a deleted one, so a rename header can never stand in for
+// content this branch introduces. A rename carrying edits still emits its
+// hunks, so they are bundled, chunked, and scanned exactly like any other
+// change. `-l5000` owns the rename candidate limit, finite for the reason the
+// wrapper's capture block records. `changedPaths` keeps the pin, so a move's
+// source path still reaches the sensitive-path refusal.
 function gitBundlePart(collector, label, repo, gitArgs) {
   const maxBuffer = Math.max(
     1024,
@@ -2296,6 +2307,8 @@ function appendLocalBundle(repo, target, collector) {
     "--cached",
     target.head,
     "--stat",
+    "--find-renames",
+    "-l5000",
     "--",
   ]);
   gitBundlePart(collector, "staged diff", repo, [
@@ -2305,7 +2318,8 @@ function appendLocalBundle(repo, target, collector) {
     "--cached",
     target.head,
     "--patch",
-    "--no-renames",
+    "--find-renames",
+    "-l5000",
     "--",
   ]);
   collector.add("unstaged diff heading", "# Unstaged Diff");
@@ -2314,13 +2328,16 @@ function appendLocalBundle(repo, target, collector) {
     "--no-ext-diff",
     "--no-textconv",
     "--stat",
+    "--find-renames",
+    "-l5000",
   ]);
   gitBundlePart(collector, "unstaged diff", repo, [
     "diff",
     "--no-ext-diff",
     "--no-textconv",
     "--patch",
-    "--no-renames",
+    "--find-renames",
+    "-l5000",
   ]);
   const untracked = gitPathList(repo, [
     "ls-files",
@@ -2364,6 +2381,8 @@ function appendBranchBundle(repo, target, collector) {
     "--no-ext-diff",
     "--no-textconv",
     "--stat",
+    "--find-renames",
+    "-l5000",
     `${target.ref}...${target.head}`,
     "--",
   ]);
@@ -2372,7 +2391,8 @@ function appendBranchBundle(repo, target, collector) {
     "--no-ext-diff",
     "--no-textconv",
     "--patch",
-    "--no-renames",
+    "--find-renames",
+    "-l5000",
     `${target.ref}...${target.head}`,
     "--",
   ]);
@@ -2401,6 +2421,8 @@ function commitBundle(repo, commitRef) {
     "--no-ext-diff",
     "--no-textconv",
     "--stat",
+    "--find-renames",
+    "-l5000",
     "--format=fuller",
     "--end-of-options",
     commitRef,
@@ -2411,7 +2433,8 @@ function commitBundle(repo, commitRef) {
     "--no-ext-diff",
     "--no-textconv",
     "--patch",
-    "--no-renames",
+    "--find-renames",
+    "-l5000",
     "--format=fuller",
     "--end-of-options",
     commitRef,

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -6471,6 +6471,36 @@ EOF
     exit 1
   fi
 
+  # `git_output` pins `-c diff.renames=false`, so every capture below states its
+  # own rename policy instead of inheriting one. The patch and stat captures pass
+  # `--find-renames` at Git's default similarity floor, which overrides that pin:
+  # a bulk move otherwise renders as delete+add pairs and deterministically
+  # exhausts the capture budget, and a stat that disagreed with its own patch
+  # would misreport the change. Git elides content only at similarity index 100%,
+  # a byte-identical relocation of already-reviewed content, and rename detection
+  # pairs an added path only with a deleted one, so nothing new hides behind a
+  # header. Any edit still emits its hunks, which stay reviewable and reach the
+  # helper's secret scanner. `--no-ext-diff --no-textconv` still pin the payload
+  # to Git's own plain text.
+  #
+  # `-l5000` owns the rename candidate limit, which `diff.renameLimit` in the
+  # reviewed repository's own config would otherwise set. Git's exact and
+  # basename passes ignore that limit, but a move that changes a basename and
+  # edits the file needs the exhaustive pass, which Git skips past 1,000
+  # candidates even by default; skipping it restores the delete+add blowup this
+  # block exists to prevent. The pin stays finite because that pass runs before
+  # any byte reaches the capture limiter, so it is the one stage no output bound
+  # can cut short, and it is quadratic in candidate count. 5,000 is more than
+  # twice this repository's whole tracked tree and costs about 74 seconds at its
+  # own ceiling, measured on 50 KB blobs that defeat both cheap passes; the same
+  # change without detection produces 272 MB. Past the pin, Git says on stderr
+  # that it skipped detection and these captures fall back to delete+add pairs,
+  # which review correctly and either fit the budget or fail it by its own
+  # message. Nothing here treats that stderr as a capture failure.
+  #
+  # The changed-path captures keep the `diff.renames=false` pin on purpose: they
+  # feed the sensitive-path refusal and checklist routing, which must still see
+  # the path a move leaves behind.
   case "$target_mode" in
     local)
       capture_output_file "$staging_dir/git-status.txt" "git status" 0 \
@@ -6478,13 +6508,13 @@ EOF
       capture_output_file "$staging_dir/changed-paths.txt" "changed paths" 0 \
         emit_local_changed_paths "$repo" "$frozen_head_oid"
       capture_output_file "$staging_dir/patches/staged.stat" "staged diff stat" 0 \
-        git_output "$repo" diff --cached --stat --no-ext-diff --no-textconv "$frozen_head_oid" --
+        git_output "$repo" diff --cached --stat --find-renames -l5000 --no-ext-diff --no-textconv "$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/staged.diff" "staged diff" 0 \
-        git_output "$repo" diff --cached --patch --no-renames --no-ext-diff --no-textconv "$frozen_head_oid" --
+        git_output "$repo" diff --cached --patch --find-renames -l5000 --no-ext-diff --no-textconv "$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/unstaged.stat" "unstaged diff stat" 0 \
-        git_output "$repo" diff --stat --no-ext-diff --no-textconv
+        git_output "$repo" diff --stat --find-renames -l5000 --no-ext-diff --no-textconv
       capture_output_file "$staging_dir/patches/unstaged.diff" "unstaged diff" 0 \
-        git_output "$repo" diff --patch --no-renames --no-ext-diff --no-textconv
+        git_output "$repo" diff --patch --find-renames -l5000 --no-ext-diff --no-textconv
       capture_output_file "$staging_dir/patches/untracked-paths.txt" "untracked paths" 0 \
         emit_untracked_paths "$repo"
       capture_untracked_files \
@@ -6496,9 +6526,9 @@ EOF
       capture_output_file "$staging_dir/changed-paths.txt" "changed paths" 0 \
         emit_branch_changed_paths "$repo" "$target_ref" "$frozen_head_oid"
       capture_output_file "$staging_dir/patches/branch.stat" "branch diff stat" 0 \
-        git_output "$repo" diff --stat --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
+        git_output "$repo" diff --stat --find-renames -l5000 --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/branch.diff" "branch diff" 0 \
-        git_output "$repo" diff --patch --no-renames --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
+        git_output "$repo" diff --patch --find-renames -l5000 --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
       ;;
     branch-local)
       capture_output_file "$staging_dir/git-status.txt" "git status" 0 \
@@ -6506,17 +6536,17 @@ EOF
       capture_output_file "$staging_dir/changed-paths.txt" "changed paths" 0 \
         emit_branch_local_changed_paths "$repo" "$target_ref" "$frozen_head_oid"
       capture_output_file "$staging_dir/patches/branch.stat" "branch diff stat" 0 \
-        git_output "$repo" diff --stat --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
+        git_output "$repo" diff --stat --find-renames -l5000 --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/branch.diff" "branch diff" 0 \
-        git_output "$repo" diff --patch --no-renames --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
+        git_output "$repo" diff --patch --find-renames -l5000 --no-ext-diff --no-textconv "$target_ref...$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/staged.stat" "staged diff stat" 0 \
-        git_output "$repo" diff --cached --stat --no-ext-diff --no-textconv "$frozen_head_oid" --
+        git_output "$repo" diff --cached --stat --find-renames -l5000 --no-ext-diff --no-textconv "$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/staged.diff" "staged diff" 0 \
-        git_output "$repo" diff --cached --patch --no-renames --no-ext-diff --no-textconv "$frozen_head_oid" --
+        git_output "$repo" diff --cached --patch --find-renames -l5000 --no-ext-diff --no-textconv "$frozen_head_oid" --
       capture_output_file "$staging_dir/patches/unstaged.stat" "unstaged diff stat" 0 \
-        git_output "$repo" diff --stat --no-ext-diff --no-textconv
+        git_output "$repo" diff --stat --find-renames -l5000 --no-ext-diff --no-textconv
       capture_output_file "$staging_dir/patches/unstaged.diff" "unstaged diff" 0 \
-        git_output "$repo" diff --patch --no-renames --no-ext-diff --no-textconv
+        git_output "$repo" diff --patch --find-renames -l5000 --no-ext-diff --no-textconv
       capture_output_file "$staging_dir/patches/untracked-paths.txt" "untracked paths" 0 \
         emit_untracked_paths "$repo"
       capture_untracked_files \
@@ -6528,9 +6558,9 @@ EOF
       capture_output_file "$staging_dir/changed-paths.txt" "changed paths" 0 \
         emit_commit_changed_paths "$repo" "$target_ref"
       capture_output_file "$staging_dir/patches/commit.stat" "commit diff stat" 0 \
-        git_output "$repo" show --stat --no-ext-diff --no-textconv --format=fuller "$target_ref"
+        git_output "$repo" show --stat --find-renames -l5000 --no-ext-diff --no-textconv --format=fuller "$target_ref"
       capture_output_file "$staging_dir/patches/commit.diff" "commit diff" 0 \
-        git_output "$repo" show --patch --no-renames --no-ext-diff --no-textconv --format=fuller "$target_ref"
+        git_output "$repo" show --patch --find-renames -l5000 --no-ext-diff --no-textconv --format=fuller "$target_ref"
       ;;
   esac
 

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -6490,13 +6490,14 @@ EOF
   # candidates even by default; skipping it restores the delete+add blowup this
   # block exists to prevent. The pin stays finite because that pass runs before
   # any byte reaches the capture limiter, so it is the one stage no output bound
-  # can cut short, and it is quadratic in candidate count. 5,000 is more than
-  # twice this repository's whole tracked tree and costs about 74 seconds at its
-  # own ceiling, measured on 50 KB blobs that defeat both cheap passes; the same
-  # change without detection produces 272 MB. Past the pin, Git says on stderr
-  # that it skipped detection and these captures fall back to delete+add pairs,
-  # which review correctly and either fit the budget or fail it by its own
-  # message. Nothing here treats that stderr as a capture failure.
+  # can cut short. What bounds it is Git's own gate: the exhaustive pass is
+  # skipped once unpaired sources multiplied by unpaired destinations exceeds
+  # the square of the limit, so `-l5000` authorizes at most 25,000,000 pair
+  # comparisons. 5,000 is also more than twice this repository's whole tracked
+  # tree. Past that product, Git says on stderr that it skipped detection and
+  # these captures fall back to delete+add pairs, which review correctly and
+  # either fit the budget or fail it by its own message. Nothing here treats
+  # that stderr as a capture failure.
   #
   # The changed-path captures keep the `diff.renames=false` pin on purpose: they
   # feed the sensitive-path refusal and checklist routing, which must still see

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6478,6 +6478,56 @@ run_rename_capture_regressions() {
   expect_stderr_contains "refusing binary changes"
 }
 
+run_numstat_path_parsing_regressions() {
+  local arrow_repo="$tmp_dir/numstat-path-parsing"
+  local arrow_output="$tmp_dir/numstat-path-parsing-prompt.md"
+  # A literal ` => ` in a filename is legal, and it is exactly what a rename
+  # renders as inside the textual path column. The baseline reads NUL-delimited
+  # records instead, where a rename carries its preimage and postimage as
+  # separate fields, so the two cases cannot be confused.
+  local arrow_name='report.test.mjs => summary.mjs'
+  init_review_repo "$arrow_repo"
+  mkdir "$arrow_repo/src"
+  seed_rename_capture_lines "$arrow_repo/src/$arrow_name" 20
+  seed_rename_capture_lines "$arrow_repo/src/keeper.test.mjs" 20
+  seed_rename_capture_lines "$arrow_repo/src/plain.mjs" 20
+  commit_review_repo "$arrow_repo" init
+
+  git -C "$arrow_repo" switch -c arrow >/dev/null 2>&1
+  # Edited in place. Its own name ends in a test suffix, so its line must not
+  # reach the non-test count. A textual split hands `summary.mjs` to
+  # classification and counts it.
+  printf 'edited in place\n' >>"$arrow_repo/src/$arrow_name"
+  # A test file renamed to a non-test path: the postimage decides, so this line
+  # must count. Reading the preimage instead would drop it.
+  git -C "$arrow_repo" mv src/keeper.test.mjs src/keeper.mjs
+  printf 'edited after the move\n' >>"$arrow_repo/src/keeper.mjs"
+  printf 'edited plainly\n' >>"$arrow_repo/src/plain.mjs"
+  commit_review_repo "$arrow_repo" "edit an arrow-named file and rename a test"
+
+  # Precondition: the textual form really is ambiguous here, so the control
+  # cannot pass on output that never had the problem.
+  if ! git -C "$arrow_repo" diff \
+    --numstat --find-renames -l5000 --no-ext-diff --no-textconv \
+    'main...arrow' -- |
+    grep -Fq "src/$arrow_name"; then
+    printf 'arrow-named control no longer renders an ambiguous numstat path; it stopped proving anything\n' >&2
+    exit 1
+  fi
+
+  run_helper_in_repo "$arrow_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$arrow_output"
+  expect_empty_stderr
+  # Two counted lines: the renamed test's edit and the plain file's edit. The
+  # arrow-named file is a test path and stays out. Four changed paths, because
+  # the enumeration keeps both sides of the rename.
+  expect_stdout_contains "scope_baseline: changed_files=4 non_test_loc=2"
+}
+
 run_moved_content_rescan_regressions() {
   local atomic_repo="$tmp_dir/moved-content-atomic"
   local split_repo="$tmp_dir/moved-content-split"
@@ -7364,6 +7414,7 @@ run_bundle_integrity_family() {
   run_large_untracked_bound_regression
   run_aggregate_untracked_bound_regression
   run_rename_capture_regressions
+  run_numstat_path_parsing_regressions
   run_moved_content_rescan_regressions
   run_bundle_output_deferred_regression
   run_sensitive_input_regressions

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6125,6 +6125,411 @@ run_aggregate_untracked_bound_regression() {
   fi
 }
 
+# The credential fixtures below are joined from parts so this suite's own source
+# carries no credential assignment for the scanner to reject when a diff of this
+# file is reviewed.
+rename_capture_credential_line() {
+  printf 'api_key = "%s%s"\n' "live-move-" "abcdefghijklmnopqrstuvwxyz"
+}
+
+seed_rename_capture_module() {
+  local target="$1"
+  local module="$2"
+  awk -v n="$module" 'BEGIN {
+    for (j = 0; j < 700; j += 1) {
+      printf "export const value_%02d_%03d = \"payload %02d %03d abcdefghijklmnopqrstuvwxyz0123456789\";\n", n, j, n, j
+    }
+  }' >"$target"
+}
+
+seed_rename_capture_lines() {
+  local target="$1"
+  local count="$2"
+  awk -v total="$count" 'BEGIN {
+    for (j = 0; j < total; j += 1) printf "stable %04d\n", j
+  }' >"$target"
+}
+
+run_rename_capture_regressions() {
+  local review_repo="$tmp_dir/rename-capture"
+  local bundle_dir="$tmp_dir/rename-capture-bundle"
+  local bundle_output="$tmp_dir/rename-capture-prompt.md"
+  local branch_patch="$bundle_dir/patches/branch.diff"
+  local captured_bytes
+  local index
+
+  # A bulk verbatim move used to render as delete+add pairs and exhaust the
+  # capture budget before any analysis ran. Fifty modules of roughly 57 KB
+  # exceed the budget when doubled, so this fixture fails closed without rename
+  # detection and bundles compactly with it.
+  init_review_repo "$review_repo"
+  mkdir "$review_repo/flat"
+  index=0
+  while ((index < 50)); do
+    seed_rename_capture_module "$review_repo/flat/module-$index.mjs" "$index"
+    index=$((index + 1))
+  done
+  rename_capture_credential_line >>"$review_repo/flat/module-49.mjs"
+  commit_review_repo "$review_repo" init
+
+  git -C "$review_repo" switch -c bulk-move >/dev/null 2>&1
+  mkdir "$review_repo/nested"
+  index=0
+  while ((index < 50)); do
+    git -C "$review_repo" mv \
+      "flat/module-$index.mjs" \
+      "nested/module-$index.mjs"
+    index=$((index + 1))
+  done
+  printf 'export const movedAndEdited = "edit sentinel";\n' \
+    >>"$review_repo/nested/module-0.mjs"
+  commit_review_repo "$review_repo" "move modules and edit one"
+
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$bundle_dir" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_empty_stderr
+  # Forty-nine verbatim moves carry a header and no content; the fiftieth
+  # exposes exactly its edit hunk.
+  expect_file_contains "$branch_patch" "rename from flat/module-1.mjs"
+  expect_file_contains "$branch_patch" "similarity index 100%"
+  expect_file_contains "$branch_patch" '+export const movedAndEdited'
+  expect_file_not_contains "$branch_patch" "value_01_500"
+  # A verbatim move of a file that already carried a credential-shaped line
+  # reports nothing, because the capture never restates the line.
+  expect_file_not_contains "$branch_patch" "live-move-"
+  captured_bytes="$(wc -c <"$branch_patch")"
+  captured_bytes="${captured_bytes//[[:space:]]/}"
+  if ((captured_bytes > 200000)); then
+    printf 'rename-aware branch capture is %s bytes; verbatim moves are being restated as content\n' \
+      "$captured_bytes" >&2
+    exit 1
+  fi
+
+  run_helper_in_repo "$review_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$bundle_output"
+  expect_empty_stderr
+  expect_file_contains "$bundle_output" "rename from flat/module-1.mjs"
+  expect_file_contains "$bundle_output" '+export const movedAndEdited'
+  expect_file_not_contains "$bundle_output" "value_01_500"
+  expect_file_not_contains "$bundle_output" "live-move-"
+  # The stat has its own call sites and must describe the same change as the
+  # patch it indexes, not 100 separate deletions and creations.
+  expect_file_contains "$bundle_dir/patches/branch.stat" \
+    "{flat => nested}/module-1.mjs"
+
+  # The staged and unstaged captures are separate call sites in both runtimes,
+  # reached only by a local or branch-local target. A staged move must land on
+  # them too.
+  local staged_repo="$tmp_dir/rename-capture-staged"
+  local staged_bundle="$tmp_dir/rename-capture-staged-bundle"
+  local staged_output="$tmp_dir/rename-capture-staged-prompt.md"
+  init_review_repo "$staged_repo"
+  seed_rename_capture_lines "$staged_repo/legacy.txt" 200
+  rename_capture_credential_line >>"$staged_repo/legacy.txt"
+  commit_review_repo "$staged_repo" init
+  git -C "$staged_repo" mv legacy.txt moved.txt
+  run_helper_in_repo "$staged_repo" \
+    --prepare-bundle-dir "$staged_bundle" \
+    --mode local \
+    --engine local
+  expect_empty_stderr
+  expect_file_contains "$staged_bundle/patches/staged.diff" "rename from legacy.txt"
+  expect_file_not_contains "$staged_bundle/patches/staged.diff" "live-move-"
+  expect_file_contains "$staged_bundle/patches/staged.stat" "legacy.txt => moved.txt"
+  # The changed-path capture keeps both sides, so the path a move leaves behind
+  # still reaches the sensitive-path refusal and checklist routing.
+  expect_file_contains "$staged_bundle/changed-paths.txt" "legacy.txt"
+  expect_file_contains "$staged_bundle/changed-paths.txt" "moved.txt"
+  run_helper_in_repo "$staged_repo" \
+    --mode local \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$staged_output"
+  expect_empty_stderr
+  expect_file_contains "$staged_output" "rename from legacy.txt"
+  expect_file_not_contains "$staged_output" "live-move-"
+  # The unstaged capture is deliberately unasserted for renames: its added side
+  # would have to be a worktree path Git already tracks, and a worktree move
+  # leaves the destination untracked, so no pair can form there. The run above
+  # still executes that capture, which is what catches a malformed flag.
+
+  # The branch-local arm has six capture lines of its own, reached only when a
+  # non-main branch is dirty.
+  local branch_local_bundle="$tmp_dir/rename-capture-branch-local-bundle"
+  git -C "$review_repo" mv \
+    nested/module-3.mjs \
+    nested/module-3-relocated.mjs
+  run_helper_in_repo "$review_repo" \
+    --prepare-bundle-dir "$branch_local_bundle" \
+    --mode auto \
+    --base main \
+    --engine local
+  expect_empty_stderr
+  expect_stdout_contains "autoreview target: branch-local"
+  expect_file_contains "$branch_local_bundle/patches/branch.diff" \
+    "rename from flat/module-1.mjs"
+  expect_file_not_contains "$branch_local_bundle/patches/branch.diff" "value_01_500"
+  expect_file_contains "$branch_local_bundle/patches/staged.diff" \
+    "rename from nested/module-3.mjs"
+  expect_file_not_contains "$branch_local_bundle/patches/staged.diff" "value_03_500"
+  expect_file_contains "$branch_local_bundle/patches/staged.stat" \
+    "nested/{module-3.mjs => module-3-relocated.mjs}"
+  git -C "$review_repo" mv \
+    nested/module-3-relocated.mjs \
+    nested/module-3.mjs
+
+  # Negative control: a move that also introduces a credential-shaped line must
+  # still fail closed. Rename detection may not become a smuggling channel.
+  local smuggle_repo="$tmp_dir/rename-capture-smuggle"
+  init_review_repo "$smuggle_repo"
+  seed_rename_capture_lines "$smuggle_repo/legacy.txt" 200
+  commit_review_repo "$smuggle_repo" init
+  git -C "$smuggle_repo" switch -c smuggle >/dev/null 2>&1
+  git -C "$smuggle_repo" mv legacy.txt moved.txt
+  rename_capture_credential_line >>"$smuggle_repo/moved.txt"
+  commit_review_repo "$smuggle_repo" "move and introduce a credential"
+  run_helper_in_repo_expect_failure "$smuggle_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/rename-capture-smuggle-prompt.md"
+  expect_stderr_contains "refusing to include secret-like content"
+
+  # Negative control: a verbatim move carries no content, so the content scanner
+  # has nothing to read. The path refusal is what covers a file crossing into a
+  # less trusted location, and it still sees both sides because the changed-path
+  # capture keeps the `diff.renames=false` pin.
+  local boundary_repo="$tmp_dir/rename-capture-boundary"
+  init_review_repo "$boundary_repo"
+  mkdir "$boundary_repo/private" "$boundary_repo/public"
+  rename_capture_credential_line >"$boundary_repo/private/.env.production"
+  printf 'placeholder\n' >"$boundary_repo/public/readme.txt"
+  commit_review_repo "$boundary_repo" init
+  git -C "$boundary_repo" switch -c boundary >/dev/null 2>&1
+  git -C "$boundary_repo" mv private/.env.production public/config.txt
+  commit_review_repo "$boundary_repo" "move a private file to a published path"
+  run_helper_in_repo_expect_failure "$boundary_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/rename-capture-boundary-prompt.md"
+  expect_stderr_contains "refusing to include sensitive changed paths"
+  expect_stderr_contains "private/.env.production"
+
+  # Negative control: a similarity-gamed move — thousands of identical lines
+  # plus one hostile line — pairs as a rename and must still surface that line
+  # as a reviewable, scanned hunk. The pairing is asserted first, so the control
+  # cannot pass by quietly falling back to a delete+add pair.
+  local gamed_repo="$tmp_dir/rename-capture-gamed"
+  init_review_repo "$gamed_repo"
+  seed_rename_capture_lines "$gamed_repo/legacy.txt" 4000
+  commit_review_repo "$gamed_repo" init
+  git -C "$gamed_repo" switch -c gamed >/dev/null 2>&1
+  git -C "$gamed_repo" mv legacy.txt moved.txt
+  rename_capture_credential_line >>"$gamed_repo/moved.txt"
+  commit_review_repo "$gamed_repo" "gamed move"
+  if ! git -C "$gamed_repo" diff \
+    --patch --find-renames --no-ext-diff --no-textconv \
+    'main...gamed' -- |
+    grep -q '^similarity index 99%'; then
+    printf 'similarity-gamed control no longer pairs as a rename; it stopped exercising rename capture\n' >&2
+    exit 1
+  fi
+  run_helper_in_repo_expect_failure "$gamed_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/rename-capture-gamed-prompt.md"
+  expect_stderr_contains "refusing to include secret-like content"
+
+  # The reviewed repository's own config still reaches Git, and a rename
+  # candidate limit there would skip the exhaustive pass that pairs a move which
+  # changes a basename and edits the file. `-l5000` owns it. The fixture asserts
+  # that Git really would skip without the flag, so the control cannot pass on a
+  # limit that never bites.
+  local limited_repo="$tmp_dir/rename-capture-limited"
+  local limited_output="$tmp_dir/rename-capture-limited-prompt.md"
+  init_review_repo "$limited_repo"
+  git -C "$limited_repo" config diff.renameLimit 1
+  mkdir "$limited_repo/flat"
+  index=0
+  while ((index < 6)); do
+    seed_rename_capture_lines "$limited_repo/flat/old-$index.txt" 200
+    printf 'module %s\n' "$index" >>"$limited_repo/flat/old-$index.txt"
+    index=$((index + 1))
+  done
+  commit_review_repo "$limited_repo" init
+  git -C "$limited_repo" switch -c limited >/dev/null 2>&1
+  mkdir "$limited_repo/nested"
+  index=0
+  while ((index < 6)); do
+    git -C "$limited_repo" mv \
+      "flat/old-$index.txt" \
+      "nested/renamed-$index.txt"
+    printf 'edited tail %s\n' "$index" \
+      >>"$limited_repo/nested/renamed-$index.txt"
+    index=$((index + 1))
+  done
+  commit_review_repo "$limited_repo" "rename and edit every module"
+  if git -C "$limited_repo" diff \
+    --patch --find-renames --no-ext-diff --no-textconv \
+    'main...limited' -- 2>/dev/null |
+    grep -q '^rename from '; then
+    printf 'rename-limit control no longer suppresses detection without an owned -l; it stopped proving anything\n' >&2
+    exit 1
+  fi
+  run_helper_in_repo "$limited_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$limited_output"
+  expect_empty_stderr
+  expect_file_contains "$limited_output" "rename from flat/old-3.txt"
+  local limited_bundle="$tmp_dir/rename-capture-limited-bundle"
+  run_helper_in_repo "$limited_repo" \
+    --prepare-bundle-dir "$limited_bundle" \
+    --mode branch \
+    --base main \
+    --engine local
+  expect_empty_stderr
+  expect_file_contains "$limited_bundle/patches/branch.diff" \
+    "rename from flat/old-3.txt"
+
+  # A binary move keeps the same rule: a verbatim relocation has no content to
+  # review, and a binary that actually changes still fails closed.
+  local binary_repo="$tmp_dir/rename-capture-binary"
+  init_review_repo "$binary_repo"
+  head -c 4096 /dev/urandom >"$binary_repo/blob.bin"
+  commit_review_repo "$binary_repo" init
+  git -C "$binary_repo" switch -c binary-move >/dev/null 2>&1
+  git -C "$binary_repo" mv blob.bin moved.bin
+  commit_review_repo "$binary_repo" "move a binary verbatim"
+  run_helper_in_repo "$binary_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/rename-capture-binary-prompt.md"
+  expect_empty_stderr
+  # A verbatim relocation carries no bytes to review, but a mode change is not
+  # content: Git states it on the rename header, so a binary that lands in an
+  # executable position stays visible to the reviewer.
+  local mode_repo="$tmp_dir/rename-capture-binary-mode"
+  local mode_output="$tmp_dir/rename-capture-binary-mode-prompt.md"
+  init_review_repo "$mode_repo"
+  head -c 4096 /dev/urandom >"$mode_repo/blob.bin"
+  commit_review_repo "$mode_repo" init
+  git -C "$mode_repo" switch -c binary-mode >/dev/null 2>&1
+  mkdir "$mode_repo/hooks"
+  git -C "$mode_repo" mv blob.bin hooks/blob.bin
+  chmod +x "$mode_repo/hooks/blob.bin"
+  commit_review_repo "$mode_repo" "move a binary into hooks and make it executable"
+  run_helper_in_repo "$mode_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$mode_output"
+  expect_empty_stderr
+  expect_file_contains "$mode_output" "rename to hooks/blob.bin"
+  expect_file_contains "$mode_output" "new mode 100755"
+
+  head -c 4096 /dev/urandom >>"$binary_repo/moved.bin"
+  commit_review_repo "$binary_repo" "change the binary"
+  run_helper_in_repo_expect_failure "$binary_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/rename-capture-binary-changed-prompt.md"
+  expect_stderr_contains "refusing binary changes"
+}
+
+run_moved_content_rescan_regressions() {
+  local atomic_repo="$tmp_dir/moved-content-atomic"
+  local split_repo="$tmp_dir/moved-content-split"
+
+  # A commit that moves a file carrying a credential-shaped line used to abort
+  # per-commit review: the delete side restated content the repository already
+  # held. Pairing the two sides inside the commit removes that false positive.
+  init_review_repo "$atomic_repo"
+  seed_rename_capture_lines "$atomic_repo/legacy.txt" 200
+  rename_capture_credential_line >>"$atomic_repo/legacy.txt"
+  commit_review_repo "$atomic_repo" init
+  git -C "$atomic_repo" switch -c atomic-move >/dev/null 2>&1
+  git -C "$atomic_repo" mv legacy.txt moved.txt
+  commit_review_repo "$atomic_repo" "move the file in one commit"
+  run_helper_in_repo "$atomic_repo" \
+    --mode commit \
+    --commit HEAD \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/moved-content-atomic-prompt.md"
+  expect_empty_stderr
+  expect_file_contains "$tmp_dir/moved-content-atomic-prompt.md" \
+    "rename from legacy.txt"
+  expect_file_not_contains "$tmp_dir/moved-content-atomic-prompt.md" \
+    "live-move-"
+  # The wrapper's own commit-mode captures are separate call sites from the
+  # helper's, so they get their own assertion rather than riding on the prompt.
+  local atomic_bundle="$tmp_dir/moved-content-atomic-bundle"
+  run_helper_in_repo "$atomic_repo" \
+    --prepare-bundle-dir "$atomic_bundle" \
+    --mode commit \
+    --commit HEAD \
+    --engine local
+  expect_empty_stderr
+  expect_file_contains "$atomic_bundle/patches/commit.diff" "rename from legacy.txt"
+  expect_file_not_contains "$atomic_bundle/patches/commit.diff" "live-move-"
+  expect_file_contains "$atomic_bundle/patches/commit.stat" "legacy.txt => moved.txt"
+
+  # Residue pinned by issue 1931: when the added copy landed in an earlier
+  # commit, the deleting commit holds no added path for Git to pair with, so
+  # the restated content still reaches the scanner and per-commit review of that
+  # commit still fails closed. Rename detection is per diff and cannot reach
+  # across commits. Review such a branch in branch mode, where both sides are in
+  # one diff. Assert the current behavior so a future fix has to change this
+  # test deliberately.
+  init_review_repo "$split_repo"
+  seed_rename_capture_lines "$split_repo/legacy.txt" 200
+  rename_capture_credential_line >>"$split_repo/legacy.txt"
+  commit_review_repo "$split_repo" init
+  git -C "$split_repo" switch -c split-move >/dev/null 2>&1
+  cp "$split_repo/legacy.txt" "$split_repo/moved.txt"
+  commit_review_repo "$split_repo" "add the copy at its new path"
+  git -C "$split_repo" rm -q legacy.txt
+  commit_review_repo "$split_repo" "remove the original path"
+  run_helper_in_repo_expect_failure "$split_repo" \
+    --mode commit \
+    --commit HEAD \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/moved-content-split-prompt.md"
+  expect_stderr_contains "refusing to include secret-like content"
+  run_helper_in_repo "$split_repo" \
+    --mode branch \
+    --base main \
+    --engine local \
+    --prepare-only \
+    --bundle-output "$tmp_dir/moved-content-split-branch-prompt.md"
+  expect_empty_stderr
+  expect_file_contains "$tmp_dir/moved-content-split-branch-prompt.md" \
+    "rename from legacy.txt"
+  expect_file_not_contains "$tmp_dir/moved-content-split-branch-prompt.md" \
+    "live-move-"
+}
+
 run_bundle_output_deferred_regression() {
   local review_repo="$tmp_dir/bundle-output-deferred"
   local fake_bin="$tmp_dir/bundle-output-deferred-bin"
@@ -6936,6 +7341,8 @@ run_bundle_integrity_family() {
   run_feedback_runtime_aggregate_regression
   run_large_untracked_bound_regression
   run_aggregate_untracked_bound_regression
+  run_rename_capture_regressions
+  run_moved_content_rescan_regressions
   run_bundle_output_deferred_regression
   run_sensitive_input_regressions
   run_attested_untracked_serializer_regression

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6185,6 +6185,23 @@ run_rename_capture_regressions() {
     >>"$review_repo/nested/module-0.mjs"
   commit_review_repo "$review_repo" "move modules and edit one"
 
+  # The fixture proves something only while its un-paired form really would
+  # exhaust the budget. Assert that before trusting the rename-aware result, so
+  # a later edit that shrinks the module count or size fails here instead of
+  # passing vacuously.
+  local unpaired_bytes
+  unpaired_bytes="$(
+    git -C "$review_repo" diff \
+      --patch --no-renames --no-ext-diff --no-textconv \
+      'main...bulk-move' -- | wc -c
+  )"
+  unpaired_bytes="${unpaired_bytes//[[:space:]]/}"
+  if ((unpaired_bytes <= 4096000)); then
+    printf 'bulk-move fixture is %s bytes without rename detection; it no longer exceeds the capture budget it exists to test\n' \
+      "$unpaired_bytes" >&2
+    exit 1
+  fi
+
   run_helper_in_repo "$review_repo" \
     --prepare-bundle-dir "$bundle_dir" \
     --mode branch \
@@ -6215,6 +6232,11 @@ run_rename_capture_regressions() {
     --prepare-only \
     --bundle-output "$bundle_output"
   expect_empty_stderr
+  # The baseline states the size of the change the bundle shows: one edited
+  # line, not 70,000 restated ones. The changed-file count still carries both
+  # sides of every move, because the path enumeration stays rename-blind.
+  expect_stdout_contains "scope_baseline: changed_files=100 non_test_loc=1"
+  expect_file_contains "$bundle_output" "Scope baseline: 100 changed files; 1 non-test changed lines."
   expect_file_contains "$bundle_output" "rename from flat/module-1.mjs"
   expect_file_contains "$bundle_output" '+export const movedAndEdited'
   expect_file_not_contains "$bundle_output" "value_01_500"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Autoreview could not review a branch that moved files. Every patch capture hardcoded `--no-renames`, so a bulk move rendered as full delete+add pairs and blew the 4,096,000-byte capture budget before any analysis ran.
- That is a live CI failure, not a theoretical one: PR 1930's 66-file sentry move produced a 4,361,395-byte branch diff and failed the required `ci` roll-up, because the Autoreview adapter test family bootstraps a real branch capture.
- The same restated content made the bundle secret scanner abort on credential-shaped lines the repository already held, so a move had to be reviewed commit by commit with a written exception.

## The Solution

- Pair renames during capture. A verbatim move now bundles as a compact rename header instead of a full deletion plus a full re-addition, and the same PR 1930 branch diff drops from 4,361,395 bytes to 254,479.
- Content disappears from the bundle only when the two blobs are byte-identical — content the base already held at the old path. Anything a move edits still appears as ordinary hunks, so an introduced credential is still caught.
- The scanner needed no change: a pure rename carries no lines for it to read, and an edited rename carries exactly its edit hunks.

## Details

Both runtimes already pin `-c diff.renames=false` on every Git invocation, so no capture inherits a rename policy from operator config. Each capture states its own.

| Call site | Runtime | Decision |
| --- | --- | --- |
| local staged patch + stat | `.sh` 6511-6513, `.mjs` `appendLocalBundle` | `--find-renames -l5000` — a staged `git mv` is where a local-mode move shows up |
| local unstaged patch + stat | `.sh` 6515-6517, `.mjs` `appendLocalBundle` | `--find-renames -l5000` for symmetry; renames are structurally unreachable there, because a worktree move leaves the destination untracked so no add side exists to pair |
| branch patch + stat | `.sh` 6529-6531, `.mjs` `appendBranchBundle` | `--find-renames -l5000` — the site issue 1931 reports |
| branch-local branch/staged/unstaged patch + stat | `.sh` 6539-6549 | `--find-renames -l5000` — six independent lines, the adapter's automatic mode |
| commit patch + stat | `.sh` 6561-6563, `.mjs` `commitBundle` | `--find-renames -l5000` — pairs both sides of an atomic move commit |
| scope baseline (`--numstat -z`), 7 sites | `.mjs` `numstatSources` | `--find-renames -l5000` — the baseline states the size of the change the bundle shows. Without it the bulk-move fixture reported 70,003 non-test changed lines for one edited line. `-z` makes the records structural: a rename carries its preimage and postimage as separate fields, so a filename containing a literal ` => ` cannot be mistaken for one, and classification reads the postimage |
| changed paths (`--name-only`) | `.sh` `emit_*_changed_paths`, `.mjs` `changedPaths` | **unchanged.** These feed the sensitive-path refusal and checklist routing, which must still see the path a move leaves behind. A regression proves it: moving `private/.env.production` to `public/config.txt` verbatim still fails closed on the source path |

The stat captures move with the patch ones deliberately. A stat that still listed 100 separate deletions and creations beside a patch showing 50 renames would misreport the same change to the reviewer.

`-l5000` owns the rename candidate limit, on the bundle captures and the scope baseline alike. The reviewed repository's own config still reaches Git, and a move that changes a basename **and** edits the file needs the exhaustive pass that Git skips past 1,000 candidates even by default — skipping it restores the blowup this change exists to prevent. The pin stays finite because that pass runs before any byte reaches the capture limiter, so no output bound can cut it short. What bounds it is Git's own gate: the exhaustive pass is skipped once unpaired sources multiplied by unpaired destinations exceeds the square of the limit, so `-l5000` authorizes at most 25,000,000 pair comparisons whatever the change looks like. Past that product the captures fall back to delete+add pairs, which still review correctly and fail on the capture budget when large enough. The repository tracks 2,220 files, so the pin is also more than twice a whole-tree relocation. As machine-specific observations only, on synthetic basename-changing edited moves of ~50 KB blobs that defeat both of Git's cheap passes: 3,000 candidates cost 28 s (1.1 MB, against 163 MB undetected), and 5,000 cost 74 s (1.8 MB, against 272 MB). Elapsed time depends on hardware and blob size; the comparison count does not. It also replaces a default that has moved — `diff.renameLimit` documents 400 in older Git and 1,000 today — and an explicit `-l` overrides both; the reasoning and timings were validated against Git 2.54.0.

Two behavior changes worth stating. A verbatim binary relocation is now accepted, because it changes no bytes; a binary that actually changes still fails closed, and a mode change on a rename is still emitted (`new mode 100755`), so a binary landing in an executable position stays visible. And per-commit review of a move whose delete and add sides sit in one commit no longer aborts — but a move split across commits has no pair for Git to find, and still does. That residue is pinned as a test rather than papered over; branch mode reviews such a branch cleanly, and the test asserts that too.

## Validation

Reproduced first against unfixed code, then fixed:

- Issue 1931's own failure, on the real branch: `agent-autoreview.mjs --mode commit --commit a483c8f6` refused with `credential-like token` — a `ghs_…` fixture literal in the deleted sentry test files. PR 1930's branch diff: 4,361,395 bytes with `--no-renames`, 254,479 with rename detection, 65 renames paired.
- Synthetic bulk move (60 files, 9,092,726-byte no-renames diff): the helper failed with the exact aggregate-limit error before, and builds an 18,412-byte bundle after — 59 headers at similarity index 100%, one edited move exposing exactly its edit hunk.
- New regressions in the `bundle-integrity` family. `run_rename_capture_regressions`: a 50-module bulk move under the cap with zero content from the verbatim moves and the edit hunk present; staged, branch-local, and prepared-bundle arms; a smuggling control (move plus a credential line, refused); a similarity-gamed control (99% pairing asserted **before** the refusal, so it cannot pass by degrading to delete+add); a sensitive-path boundary control; a `diff.renameLimit 1` control that first asserts Git really would skip detection without the owned `-l`; binary verbatim, mode-change, and content-change cases. `run_moved_content_rescan_regressions`: the atomic-move commit now reviews clean, and the split-across-commits residue is pinned.
- The bulk-move fixture asserts its own un-paired form still exceeds the budget (5,895,988 bytes, 1.44x the cap), so shrinking it fails instead of passing vacuously.
- `run_numstat_path_parsing_regressions` pins the structural numstat parse with a literal ` => ` filename edited in place and a test file renamed to a non-test path, asserting the ambiguous textual form is really produced first. Mutation-tested both ways: a textual split reports 3, reading the preimage reports 1, correct is 2.
- Every new assertion was mutation-tested. Reverting one `.mjs` staged patch site, the wrapper stat flags, the wrapper branch-local staged site, the branch numstat flags, either `-l5000`, or the changed-path pin each makes the suite fail.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main` — all 9 mapped commands pass, including the full autoreview suite (5 families).
- Dual-engine local autoreview from a trusted checkout at `origin/main`: Claude engine `patch is correct (0.72)`, remaining findings P3 and addressed or answered below. Codex engine reports a P1 on the capture path's lack of a wall-clock bound, deferred below.

Reviewer findings answered rather than applied:

- *Scan every renamed destination blob in full.* This would reintroduce the exact false positive issue 1931 removes, on a wider surface. 73 of this repository's 2,220 tracked files trip `secretLikeReason` on their own content, so any branch relocating one of them verbatim would abort. The scanner is an egress guard on what leaves for the review engine — eliding content sends less, not more — and the control that covers a file crossing into a less trusted location is the path refusal, which this PR deliberately keeps intact and now tests.
- *Git's rename-limit warning on stderr.* `capture_output_file` pipes stdout only and gates on exit status; nothing treats capture stderr as failure. Past the pin the captures fall back to delete+add pairs, which review correctly.
- *Factor the flag pair into a shared constant across the 22 sites.* Out of scope for a fix in a trust root, and every arm now carries its own assertion.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1933 — Git captures have no wall-clock bound, only an output bound. Predates this change; a deadline needs its own design across the wrapper's trusted spawn path, the helper's synchronous spawn, and partial-capture semantics.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this changes flags on existing captures and constrains no future work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved change detection and review results for renamed, moved, binary, and sensitive files.
  * More accurately tracks line changes and test classification when files are renamed.
  * Added safeguards for unusual filenames and content moved between files.
  * Rename analysis now uses a defined comparison limit for more predictable performance.

* **Documentation**
  * Clarified rename-detection limits, fallback behavior, and expected runtime characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->