### PR TITLE
fix(alerts): cut critical Slack noise from flaps, repeats, and per-pool fan-out

### DIFF
--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -252,16 +252,23 @@ locals {
   EOT
 
   # Group/repeat timings applied via notification_settings on every v3 rule.
-  # Aegis root policy uses 30s/5m/4h for catch-all; v3 shortens repeat to 1h so
-  # unacknowledged pages don't go silent overnight.
+  # Aegis root policy uses 30s/5m/4h for catch-all. v3 criticals repeat hourly by
+  # default so an unacknowledged page doesn't go silent overnight; the one
+  # exception is `notify_critical_pool_slow` below, for conditions that stay true
+  # for days at a time and where hourly repetition buries the new alerts instead
+  # of surfacing the old one.
   #
-  # Two variants:
+  # Four variants:
   #   `notify_*_pool` omits `alertname` so co-firing KPI rules on the same
   #     pool (e.g. Deviation Breach + Rebalancer Stale) collapse into one
   #     Slack thread per (chain_id, pool_id). Used by fpmms pool-level rules.
   #   `notify_*` keeps `alertname` (the pre-collapse grouping). Used by
   #     service-scoped rules (metrics-bridge) that lack pool labels —
   #     without alertname they would all merge into one folder-level group.
+  #   `notify_critical_pool_slow` is `notify_critical_pool` with a 12h repeat.
+  #   `notify_critical_incident` omits `pool_id` so a single upstream failure
+  #     that hits many pools at once collapses into one Slack message per
+  #     (chain_id, alertname). Used by the oracle-driven criticals.
   notify_critical = {
     contact_point   = grafana_contact_point.slack_critical.name
     group_by        = ["alertname", "grafana_folder", "chain_id", "pool_id"]
@@ -281,6 +288,46 @@ locals {
   notify_critical_pool = {
     contact_point   = grafana_contact_point.slack_critical.name
     group_by        = ["grafana_folder", "chain_id", "pool_id"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "1h"
+  }
+
+  # Same routing and grouping as `notify_critical_pool`, slower repeat. Split by
+  # how long the underlying condition normally lasts, not by severity:
+  #   - Oracle and trading-limit criticals describe short-lived incidents that
+  #     someone is expected to clear within the hour, so they keep the 1h repeat
+  #     above and stay on `notify_critical_pool`.
+  #   - Pool-balance criticals (deviation breach, stalled rebalancer) can stay
+  #     true for weeks while a fix is planned. CHFm/USDm sat in breach for 14.6
+  #     days and re-posted to #alerts-critical up to 24 times a day at the hourly
+  #     cadence, which buried every unrelated alert raised in that window.
+  # Twice-daily re-notification still surfaces a forgotten breach without
+  # crowding out the alerts an operator has not seen yet.
+  notify_critical_pool_slow = {
+    contact_point   = grafana_contact_point.slack_critical.name
+    group_by        = ["grafana_folder", "chain_id", "pool_id"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "12h"
+  }
+
+  # Incident-level grouping for criticals whose cause is upstream of any single
+  # pool. An oracle stall or a median jump lands on every pool reading that feed
+  # at once (observed: 9 pools in 3 minutes, 7 pools in 1 minute), and per-pool
+  # grouping turned one incident into that many separate Slack messages.
+  # Dropping `pool_id` collapses them into one message; the Slack body ranges
+  # over `.Alerts`, so every affected pool still gets its own titled block
+  # inside that message. `alertname` is retained so an oracle stall and a price
+  # jump on the same chain stay legible as two distinct incidents. The label is
+  # `chain_id`, not `chain` — protocol rules carry the former.
+  #
+  # Repeat stays at the 1h critical default: this variant changes how many
+  # messages one incident produces, not how often an unresolved one is repeated,
+  # and oracle incidents are expected to clear within the hour.
+  notify_critical_incident = {
+    contact_point   = grafana_contact_point.slack_critical.name
+    group_by        = ["alertname", "grafana_folder", "chain_id"]
     group_wait      = "30s"
     group_interval  = "5m"
     repeat_interval = "1h"

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -690,11 +690,18 @@ resource "grafana_rule_group" "fpmms_deviation" {
   # grace prevents single-eval glitches from undoing an otherwise stable
   # firing state. Same rationale on the anchored rule below.
   rule {
-    name           = "Deviation Breach Critical"
-    condition      = "threshold"
-    for            = "1m"
-    exec_err_state = "Error"
-    no_data_state  = "OK"
+    name      = "Deviation Breach Critical"
+    condition = "threshold"
+    for       = "1m"
+    # `keep_firing_for = "1h"`: `for = "1m"` smooths a single-eval glitch, but a
+    # breached pool still churned through 23 Pending→Alerting transitions in two
+    # weeks (four inside 27 minutes), and every transition re-notifies
+    # #alerts-critical. Holding the incident open across short healthy dips
+    # collapses that churn into one alert lifecycle. Same rationale as
+    # rules-trading-modes.tf.
+    keep_firing_for = "1h"
+    exec_err_state  = "Error"
+    no_data_state   = "OK"
 
     annotations = {
       summary          = local.deviation_critical_summary_annotation
@@ -836,12 +843,15 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
+    # `_slow`: a breach can stay open for weeks while a fix is planned, so this
+    # repeats twice a day instead of hourly. The oracle criticals earlier in this
+    # file stay on the 1h `notify_critical_pool`.
     notification_settings {
-      contact_point   = local.notify_critical_pool.contact_point
-      group_by        = local.notify_critical_pool.group_by
-      group_wait      = local.notify_critical_pool.group_wait
-      group_interval  = local.notify_critical_pool.group_interval
-      repeat_interval = local.notify_critical_pool.repeat_interval
+      contact_point   = local.notify_critical_pool_slow.contact_point
+      group_by        = local.notify_critical_pool_slow.group_by
+      group_wait      = local.notify_critical_pool_slow.group_wait
+      group_interval  = local.notify_critical_pool_slow.group_interval
+      repeat_interval = local.notify_critical_pool_slow.repeat_interval
     }
   }
 
@@ -861,9 +871,11 @@ resource "grafana_rule_group" "fpmms_deviation" {
     # is absent, so the annotation query set is even sparser — without
     # the 1m grace a single Mimir-ruler glitch in either Aegis reserve-
     # balance query would reset the firing state.
-    for            = "1m"
-    exec_err_state = "Error"
-    no_data_state  = "OK"
+    for = "1m"
+    # Same flap absorption as the magnitude-gated critical above.
+    keep_firing_for = "1h"
+    exec_err_state  = "Error"
+    no_data_state   = "OK"
 
     annotations = {
       summary          = "Breach active for {{ humanizeDuration $values.A.Value }} — deviation-ratio data unavailable; can't confirm magnitude."
@@ -965,12 +977,13 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
+    # `_slow`: same long-lived-breach reasoning as the magnitude-gated rule.
     notification_settings {
-      contact_point   = local.notify_critical_pool.contact_point
-      group_by        = local.notify_critical_pool.group_by
-      group_wait      = local.notify_critical_pool.group_wait
-      group_interval  = local.notify_critical_pool.group_interval
-      repeat_interval = local.notify_critical_pool.repeat_interval
+      contact_point   = local.notify_critical_pool_slow.contact_point
+      group_by        = local.notify_critical_pool_slow.group_by
+      group_wait      = local.notify_critical_pool_slow.group_wait
+      group_interval  = local.notify_critical_pool_slow.group_interval
+      repeat_interval = local.notify_critical_pool_slow.repeat_interval
     }
   }
 }
@@ -1108,11 +1121,15 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
   interval_seconds = 60
 
   rule {
-    name           = "Rebalancer Stale"
-    condition      = "threshold"
-    for            = "5m"
-    exec_err_state = "Error"
-    no_data_state  = "OK"
+    name      = "Rebalancer Stale"
+    condition = "threshold"
+    for       = "5m"
+    # A rebalancer that acts once and stalls again flips this rule in and out of
+    # Alerting, and each flip re-notifies #alerts-critical. Hold the incident
+    # open for an hour so one stalled rebalancer reads as one incident.
+    keep_firing_for = "1h"
+    exec_err_state  = "Error"
+    no_data_state   = "OK"
 
     annotations = {
       summary          = "Rebalancer hasn't acted{{ if $values.BreachAge }} despite {{ humanizeDuration $values.BreachAge.Value }} of ongoing threshold breach{{ else }} despite ongoing threshold breach{{ end }}."
@@ -1234,12 +1251,14 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       })
     }
 
+    # `_slow`: a rebalancer blocked on a reserve shortfall stays stale until the
+    # shortfall is funded, which is days rather than minutes. Repeat twice a day.
     notification_settings {
-      contact_point   = local.notify_critical_pool.contact_point
-      group_by        = local.notify_critical_pool.group_by
-      group_wait      = local.notify_critical_pool.group_wait
-      group_interval  = local.notify_critical_pool.group_interval
-      repeat_interval = local.notify_critical_pool.repeat_interval
+      contact_point   = local.notify_critical_pool_slow.contact_point
+      group_by        = local.notify_critical_pool_slow.group_by
+      group_wait      = local.notify_critical_pool_slow.group_wait
+      group_interval  = local.notify_critical_pool_slow.group_interval
+      repeat_interval = local.notify_critical_pool_slow.repeat_interval
     }
   }
 
@@ -1660,12 +1679,15 @@ resource "grafana_rule_group" "fpmms_oracle_jump" {
       })
     }
 
+    # Incident-level grouping: one oracle median jump hits every pool on that
+    # feed in the same evaluation, so group without `pool_id` and let the Slack
+    # body list the affected pools in a single message.
     notification_settings {
-      contact_point   = local.notify_critical.contact_point
-      group_by        = local.notify_critical.group_by
-      group_wait      = local.notify_critical.group_wait
-      group_interval  = local.notify_critical.group_interval
-      repeat_interval = local.notify_critical.repeat_interval
+      contact_point   = local.notify_critical_incident.contact_point
+      group_by        = local.notify_critical_incident.group_by
+      group_wait      = local.notify_critical_incident.group_wait
+      group_interval  = local.notify_critical_incident.group_interval
+      repeat_interval = local.notify_critical_incident.repeat_interval
     }
   }
 }

--- a/alerts/rules/rules-oracle-relayers.tf
+++ b/alerts/rules/rules-oracle-relayers.tf
@@ -7,11 +7,17 @@ resource "grafana_rule_group" "oracle_relayers" {
     for_each = local.chains
 
     content {
-      name           = "Oldest Report Expired [${rule.value.title}]"
-      condition      = "isExpired"
-      for            = "5m"
-      exec_err_state = "Error"
-      no_data_state  = "NoData"
+      name      = "Oldest Report Expired [${rule.value.title}]"
+      condition = "isExpired"
+      for       = "5m"
+      # A relayer that catches up for one evaluation and falls behind again
+      # resolves and re-fires this rule; Celo alone logged 30 such transitions
+      # across roughly three incidents in two weeks. Hold the incident open for
+      # 30m — long enough to absorb the catch-up cycle, short enough that a real
+      # recovery still resolves within the relayer's report cadence.
+      keep_firing_for = "30m"
+      exec_err_state  = "Error"
+      no_data_state   = "NoData"
 
       annotations = {
         summary = "{{ $labels.rateFeed }} oracle report expired on {{ $labels.chain | title }}. Swaps using this feed may revert. {{ if and (or (eq $labels.chain \"polygon\") (eq $labels.chain \"polygon-testnet\")) (eq $labels.rateFeed \"EUROPEUR\") }}Check the deployment/migration owner responsible for the fixed 1.0 SortedOracles report.{{ else }}Check whether the oracle relayer is executing and inspect errors for this feed.{{ end }}"

--- a/alerts/rules/rules-vp-oracles.tf
+++ b/alerts/rules/rules-vp-oracles.tf
@@ -71,12 +71,15 @@ resource "grafana_rule_group" "vp_oracle_staleness" {
       })
     }
 
+    # Incident-level grouping: one stale oracle feed goes stale for every
+    # VirtualPool that wraps it, so group without `pool_id` and let the Slack
+    # body list the affected pools in a single message.
     notification_settings {
-      contact_point   = local.notify_critical_pool.contact_point
-      group_by        = local.notify_critical_pool.group_by
-      group_wait      = local.notify_critical_pool.group_wait
-      group_interval  = local.notify_critical_pool.group_interval
-      repeat_interval = local.notify_critical_pool.repeat_interval
+      contact_point   = local.notify_critical_incident.contact_point
+      group_by        = local.notify_critical_incident.group_by
+      group_wait      = local.notify_critical_incident.group_wait
+      group_interval  = local.notify_critical_incident.group_interval
+      repeat_interval = local.notify_critical_incident.repeat_interval
     }
   }
 }

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1876,10 +1876,20 @@ test("long-lived pool criticals repeat twice daily, short-lived ones hourly", ()
     );
   const poolAttributes = attributesExceptRepeat(poolRoute);
   const slowAttributes = attributesExceptRepeat(slowRoute);
-  assert(
-    Object.keys(poolAttributes).length >= 4,
-    "expected to parse contact_point, group_by, group_wait and group_interval",
-  );
+  // Named-presence check and union comparison cover different failures: this
+  // catches a required attribute missing from BOTH locals (or a regex that
+  // silently parsed nothing), the loop below catches the two diverging.
+  for (const key of [
+    "contact_point",
+    "group_by",
+    "group_wait",
+    "group_interval",
+  ]) {
+    assert(
+      Object.hasOwn(poolAttributes, key) && Object.hasOwn(slowAttributes, key),
+      `both pool-critical routes should declare ${key}`,
+    );
+  }
   for (const key of new Set([
     ...Object.keys(poolAttributes),
     ...Object.keys(slowAttributes),

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1794,6 +1794,165 @@ test("trading-mode alerts keep incidents open across short flaps", () => {
   );
 });
 
+// Rule blocks are written as `rule {` directly, or as `content {` inside a
+// `dynamic "rule"` loop. Comments are stripped first so a rationale comment
+// quoting an attribute cannot satisfy an assertion.
+function ruleBlockNamed(source, namePattern) {
+  const stripped = stripComments(source);
+  const blocks = [
+    ...blocksFor(stripped, "rule {"),
+    ...blocksFor(stripped, "content {"),
+  ].filter((block) => namePattern.test(block));
+  assert(
+    blocks.length === 1,
+    `expected exactly one rule block matching ${namePattern}, got ${blocks.length}`,
+  );
+  return blocks[0];
+}
+
+test("flap-prone criticals keep incidents open across short recoveries", () => {
+  const fpmmRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-fpmms.tf"),
+    "utf8",
+  );
+  const relayerRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-oracle-relayers.tf"),
+    "utf8",
+  );
+
+  for (const [namePattern, source] of [
+    [/\bname\s*=\s*"Deviation Breach Critical"/, fpmmRules],
+    [/\bname\s*=\s*"Deviation Breach Critical \(anchored\)"/, fpmmRules],
+    [/\bname\s*=\s*"Rebalancer Stale"/, fpmmRules],
+  ]) {
+    assert(
+      /\bkeep_firing_for\s*=\s*"1h"/.test(ruleBlockNamed(source, namePattern)),
+      `${namePattern} should hold the incident open for 1h across short recoveries`,
+    );
+  }
+
+  assert(
+    /\bkeep_firing_for\s*=\s*"30m"/.test(
+      ruleBlockNamed(relayerRules, /\bname\s*=\s*"Oldest Report Expired \[/),
+    ),
+    "Oldest Report Expired should absorb relayer catch-up cycles for 30m",
+  );
+});
+
+test("long-lived pool criticals repeat twice daily, short-lived ones hourly", () => {
+  const contactPoints = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/contact-points.tf"),
+    "utf8",
+  );
+  const stripped = stripComments(contactPoints);
+  const [poolRoute] = blocksFor(stripped, "notify_critical_pool = ");
+  const [slowRoute] = blocksFor(stripped, "notify_critical_pool_slow = ");
+  assert(poolRoute, "notify_critical_pool local should exist");
+  assert(slowRoute, "notify_critical_pool_slow local should exist");
+  assert(
+    /\brepeat_interval\s*=\s*"1h"/.test(poolRoute),
+    "the shared pool-critical route must keep its hourly repeat for other consumers",
+  );
+  assert(
+    /\brepeat_interval\s*=\s*"12h"/.test(slowRoute),
+    "a weeks-long pool breach should re-notify #alerts-critical twice a day, not 24 times",
+  );
+
+  // The slow variant must differ from the shared one in repeat cadence only —
+  // same channel, same grouping, same debounce.
+  for (const attribute of ["contact_point", "group_by", "group_wait"]) {
+    const pattern = new RegExp(`\\b${attribute}\\s*=\\s*([^\\n]+)`);
+    assert(
+      pattern.exec(poolRoute)?.[1].trim() ===
+        pattern.exec(slowRoute)?.[1].trim(),
+      `notify_critical_pool_slow should differ from notify_critical_pool in repeat_interval only, but ${attribute} differs`,
+    );
+  }
+
+  // Only the long-lived pool-balance criticals take the slow cadence; the
+  // oracle and trading-limit criticals in the same file stay hourly.
+  const fpmmRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-fpmms.tf"),
+    "utf8",
+  );
+  const slowRules = [
+    /\bname\s*=\s*"Deviation Breach Critical"/,
+    /\bname\s*=\s*"Deviation Breach Critical \(anchored\)"/,
+    /\bname\s*=\s*"Rebalancer Stale"/,
+  ];
+  const hourlyRules = [
+    /\bname\s*=\s*"Oracle Contract Down"/,
+    /\bname\s*=\s*"Oracle Down"/,
+    /\bname\s*=\s*"Oracle Liveness Critical"/,
+    /\bname\s*=\s*"Trading Limit Tripped"/,
+  ];
+  for (const namePattern of slowRules) {
+    assert(
+      /\blocal\.notify_critical_pool_slow\b/.test(
+        ruleBlockNamed(fpmmRules, namePattern),
+      ),
+      `${namePattern} should notify through notify_critical_pool_slow`,
+    );
+  }
+  for (const namePattern of hourlyRules) {
+    assert(
+      /\blocal\.notify_critical_pool\b/.test(
+        ruleBlockNamed(fpmmRules, namePattern),
+      ),
+      `${namePattern} should stay on the hourly notify_critical_pool route`,
+    );
+  }
+});
+
+test("oracle-driven criticals group per incident, not per pool", () => {
+  const contactPoints = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/contact-points.tf"),
+    "utf8",
+  );
+  const stripped = stripComments(contactPoints);
+  const [incidentRoute] = blocksFor(stripped, "notify_critical_incident = ");
+  assert(incidentRoute, "notify_critical_incident local should exist");
+  assert(
+    /\bcontact_point\s*=\s*grafana_contact_point\.slack_critical\.name/.test(
+      incidentRoute,
+    ),
+    "incident-grouped criticals should still route to #alerts-critical",
+  );
+  assert(
+    /\bgroup_by\s*=\s*\[\s*"alertname"\s*,\s*"grafana_folder"\s*,\s*"chain_id"\s*\]/.test(
+      incidentRoute,
+    ),
+    "incident grouping must drop pool_id so one upstream failure sends one message",
+  );
+  assert(
+    /\brepeat_interval\s*=\s*"1h"/.test(incidentRoute),
+    "incident grouping changes message count, not the hourly critical repeat",
+  );
+
+  // Service-scoped criticals (metrics-bridge) have no pool labels; without
+  // `alertname` they would collapse into a single folder-level group.
+  const [serviceRoute] = blocksFor(stripped, "notify_critical = ");
+  assert(serviceRoute, "notify_critical local should exist");
+  assert(
+    /\bgroup_by\s*=\s*\[[^\]]*"alertname"/.test(serviceRoute),
+    "service-scoped criticals must keep alertname in group_by",
+  );
+
+  for (const [relativePath, namePattern] of [
+    ["alerts/rules/rules-vp-oracles.tf", /"VirtualPool Oracle Stale \(prod\)"/],
+    ["alerts/rules/rules-fpmms.tf", /"Oracle Jump Far Above Swap Fee"/],
+  ]) {
+    const source = readFileSync(path.resolve(repoRoot, relativePath), "utf8");
+    const block = ruleBlockNamed(source, namePattern);
+    assert(
+      /\bcontact_point\s*=\s*local\.notify_critical_incident\.contact_point/.test(
+        block,
+      ) && !/\blocal\.notify_critical_pool\b/.test(block),
+      `${relativePath} ${namePattern} should notify through notify_critical_incident`,
+    );
+  }
+});
+
 test("CLI recognizes gauges registered by the peg listing module", () => {
   const dir = mkdtempSync(join(tmpdir(), "alert-rules-lint-test-"));
   try {

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1858,14 +1858,35 @@ test("long-lived pool criticals repeat twice daily, short-lived ones hourly", ()
     "a weeks-long pool breach should re-notify #alerts-critical twice a day, not 24 times",
   );
 
-  // The slow variant must differ from the shared one in repeat cadence only —
-  // same channel, same grouping, same debounce.
-  for (const attribute of ["contact_point", "group_by", "group_wait"]) {
-    const pattern = new RegExp(`\\b${attribute}\\s*=\\s*([^\\n]+)`);
+  // The slow variant must differ from the shared one in repeat cadence only.
+  // Compare every attribute the two locals declare rather than a hand-listed
+  // subset, so an attribute added to one local and not the other is caught
+  // without anyone remembering to extend this test.
+  const attributesExceptRepeat = (block) =>
+    Object.fromEntries(
+      // Slice past the `<name> = {` header so the local's own name is not
+      // read as an attribute — the two locals have different names by design.
+      [
+        ...block
+          .slice(block.indexOf("{") + 1)
+          .matchAll(/^\s*(\w+)\s*=\s*(.+?)\s*$/gm),
+      ]
+        .map(([, key, value]) => [key, value])
+        .filter(([key]) => key !== "repeat_interval"),
+    );
+  const poolAttributes = attributesExceptRepeat(poolRoute);
+  const slowAttributes = attributesExceptRepeat(slowRoute);
+  assert(
+    Object.keys(poolAttributes).length >= 4,
+    "expected to parse contact_point, group_by, group_wait and group_interval",
+  );
+  for (const key of new Set([
+    ...Object.keys(poolAttributes),
+    ...Object.keys(slowAttributes),
+  ])) {
     assert(
-      pattern.exec(poolRoute)?.[1].trim() ===
-        pattern.exec(slowRoute)?.[1].trim(),
-      `notify_critical_pool_slow should differ from notify_critical_pool in repeat_interval only, but ${attribute} differs`,
+      poolAttributes[key] === slowAttributes[key],
+      `notify_critical_pool_slow should differ from notify_critical_pool in repeat_interval only, but ${key} differs: ${poolAttributes[key]} vs ${slowAttributes[key]}`,
     );
   }
 


### PR DESCRIPTION
## The Problem

- `#alerts-critical` floods, and a two-week review of alert state history traced it to notification mechanics rather than to the thresholds. Rules flap: one pool logged 23 `Pending → Alerting` transitions in two weeks, four of them inside 27 minutes, and `Oldest Report Expired [Celo]` logged 30 across roughly three incidents. Each transition re-notifies.
- A stuck pool re-notifies forever. CHFm/USDm sat in breach for 14.6 days and re-posted up to 24 times a day at the hourly repeat interval, burying every unrelated alert raised in that window.
- One upstream oracle incident arrives as many messages. Per-pool grouping turned a single stale feed into 9 Slack messages in 3 minutes, and a single median jump into 7 in 1 minute.

## The Solution

- Hold flap-prone incidents open across short recoveries with `keep_firing_for`, so one incident produces one alert lifecycle instead of one per dip.
- Give the pool-balance criticals — the ones whose condition legitimately stays true for days — their own notification route that repeats twice a day instead of hourly. Every other critical keeps the hourly repeat.
- Group the two oracle-driven criticals per incident rather than per pool, so one upstream failure sends one Slack message listing the affected pools.

Part 1 of #1936. Refs #1936.

## Details

**`keep_firing_for` (precedent: `alerts/rules/rules-trading-modes.tf`)**

| Rule | File | Value |
| --- | --- | --- |
| Deviation Breach Critical | `alerts/rules/rules-fpmms.tf` | `1h` |
| Deviation Breach Critical (anchored) | `alerts/rules/rules-fpmms.tf` | `1h` |
| Rebalancer Stale | `alerts/rules/rules-fpmms.tf` | `1h` |
| Oldest Report Expired `[<chain>]` | `alerts/rules/rules-oracle-relayers.tf` | `30m` |

`for` values are untouched, so time-to-first-alert is unchanged. The visible trade-off is on the other end: a resolve message now arrives up to `keep_firing_for` after the condition actually clears. Each rule carries a comment with the observed transition counts so the value is not re-tuned blind.

`Oldest Report Expired` is generated by one `dynamic "rule"` block over `local.chains`, so `keep_firing_for` applies to the testnet definitions as well as the prod ones. This matches `rules-trading-modes.tf`, which applies its `keep_firing_for = "1h"` across the same `for_each` without branching on `rule.value.env`. Flap absorption is severity-neutral, and a per-env ternary would add branching for no operational gain. Flagged here because the issue named the prod definitions specifically.

**Repeat interval — the shared local is intentionally untouched**

`local.notify_critical_pool` is consumed by 8 rules, so its `repeat_interval` stays at `1h`. Instead `alerts/rules/contact-points.tf` gains `local.notify_critical_pool_slow`, identical except for `repeat_interval = "12h"`. A test asserts the two differ in `repeat_interval` only: it parses every attribute each local declares and compares the union of their keys, so `contact_point`, `group_by`, `group_wait` and `group_interval` must all match, and an attribute added to one local and not the other also fails.

Moved to the 12h route (long-lived pool-balance conditions):

- Deviation Breach Critical
- Deviation Breach Critical (anchored)
- Rebalancer Stale

Still on the shared hourly route (short-lived incidents expected to clear within the hour):

- Oracle Contract Down
- Oracle Down
- Oracle Liveness Critical
- Trading Limit Tripped
- VirtualPool Oracle Stale (prod) — moved to the incident route below, still hourly

The split is by how long the underlying condition normally lasts, not by severity.

**Incident-level grouping**

`local.notify_critical_incident` groups by `["alertname", "grafana_folder", "chain_id"]` — the same shape as the existing criticals minus `pool_id`. The label is `chain_id`, not `chain`; protocol rules carry the former. `alertname` is retained so an oracle stall and a price jump on the same chain stay legible as two distinct incidents. Repeat stays at the `1h` critical default: this local changes how many messages one incident produces, not how often an unresolved one is repeated.

Two rules point at it, each with a comment saying why they diverge from their neighbours:

- `VirtualPool Oracle Stale (prod)` (`alerts/rules/rules-vp-oracles.tf`), previously `notify_critical_pool`
- `Oracle Jump Far Above Swap Fee` (`alerts/rules/rules-fpmms.tf`), previously `notify_critical`

Both shared locals keep their existing consumers and their existing `group_by`.

**Slack template renders grouped alerts correctly.** `local.slack_body_template` in `alerts/rules/contact-points.tf` wraps its layout in `{{ range .Alerts }}`, so every alert in a group renders its own titled block with its own pool link, summary, reserves, and fingerprint. No template change is needed. The user-visible effect is that these two alerts now produce one longer Slack message instead of several short ones.

**Scope boundaries.** No threshold or severity value changes anywhere in the diff; `shared-config/src/thresholds.ts` and `scripts/alerts/check-deviation-threshold-drift.mjs` are untouched (PR 2 owns those). The comment at `contact-points.tf` naming "Deviation Breach + Rebalancer Stale" as a grouping example is deliberately left alone for PR 2.

**Docs drift: none found.** A repo-wide sweep of `AGENTS.md`, `CLAUDE.md`, every `README.md`, `SPEC.md`, and all 116 files under `docs/**` found no prose restating repeat-interval values, `group_by` keys, per-pool grouping behaviour, or `keep_firing_for` durations. Those mechanics are documented only in the `.tf` comments this PR updates in place. `docs/adr/0045-peg-paging-semantics.md` mentions repeat-interval dedup, but for the separate peg plane, which this PR does not touch.

## Validation

- **Thresholds and severities unchanged.** The diff changes `keep_firing_for`, `notification_settings` references, and two `locals` blocks. No `for`, no PromQL, no `severity` label, and no threshold constant is modified.
- `terraform fmt` clean; `pnpm tf validate alerts-rules` → `Success! The configuration is valid.`
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh` → all 9 mapped commands passed, including `trunk check`, `terraform fmt`/`init`/`validate`, `pnpm alerts:rules:lint`, `pnpm tf:test`, `check-deviation-threshold-drift.mjs`, and `pnpm lint:scripts`.
- `pnpm alerts:rules:lint:test` → 47 tests passed, including three new invariant tests in `scripts/alerts/alert-rules-lint.test.mjs`: `keep_firing_for` on the four flap-prone rules; the 12h/1h route split with the correct rules on each side; and incident grouping dropping `pool_id` while `notify_critical` keeps `alertname`.
- **Negative controls.** Each new assertion was verified to bite by mutating the invariant and re-running the suite: weakening `keep_firing_for` on `Rebalancer Stale`, deleting it from `Oldest Report Expired`, setting `notify_critical_pool_slow` back to `1h`, setting the shared `notify_critical_pool` to `12h`, restoring `pool_id` to the incident `group_by`, and reverting each repointed rule to its old local. All seven produced the expected failure; the unmutated baseline is clean. After the review fix, five further mutations confirmed the route-equality check bites: `group_interval`, `group_wait`, `group_by`, and `contact_point` drift on the slow route, plus a new attribute added to one local only.
- `pnpm agent:autoreview` → clean, no accepted or actionable findings.
- **CI `terraform plan` is the authoritative check, and on a PR it covers only part of this diff.** Local validation proves configuration validity and static invariants, not the resulting Grafana state or runtime notification behaviour. No local apply was run and no local plan was attempted — worktrees lack `terraform.tfvars`.

  Per `.github/workflows/alerts-rules.yml`, same-repo PR plans run with placeholder tokens and `-target` only the secretless guard plus the rule groups that route through the global notification policy. Rule groups with direct `notification_settings` are deliberately excluded, because dummy secrets would produce bogus diffs. Concretely, for this PR:

  | Change | Rule group | Covered by the PR plan? |
  | --- | --- | --- |
  | `keep_firing_for = "30m"` | `oracle_relayers` | Yes — plan shows `+ keep_firing_for = "30m"` on all six `Oldest Report Expired` rules |
  | `keep_firing_for = "1h"` (deviation x2, rebalancer) | `fpmms_deviation`, `fpmms_rebalancer` | No — excluded target |
  | `notify_critical_pool_slow` repoint | `fpmms_deviation`, `fpmms_rebalancer` | No — excluded target |
  | `notify_critical_incident` repoint | `fpmms_oracle_jump`, `vp_oracle_staleness` | No — excluded target |

  The PR plan reports `Plan: 0 to add, 1 to change, 0 to destroy` for that reason, not because the other edits are no-ops. It also confirms the deviation noted above: `keep_firing_for` lands on all six chains including the testnet definitions. The excluded majority of the diff is checked on the PR only by `terraform validate` (full config shape, which passes) and gets its real plan from the trusted-main run after merge, with apply behind the `production-infra` approval gate. **Reviewers should treat the post-merge trusted-main plan as the real diff for the FPMM and VirtualPool rule groups.**

## Deferrals

- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only notification timing and grouping in Terraform; thresholds and severities are untouched, but mis-routed rules could delay repeats or over-collapse distinct pool incidents until the new lint tests and CI terraform plan validate Grafana behavior.
> 
> **Overview**
> Reduces **#alerts-critical** noise by changing how Grafana notifies, not what fires. **Flap-prone rules** get `keep_firing_for` so brief recoveries do not spawn new pages: **1h** on deviation-breach criticals (magnitude-gated and anchored) and **Rebalancer Stale**, **30m** on **Oldest Report Expired** relayer rules.
> 
> **Long-lived pool conditions** (deviation breach criticals, rebalancer stale) move to a new `notify_critical_pool_slow` route with **12h** repeat instead of hourly, while oracle and trading-limit pool criticals stay on hourly `notify_critical_pool`.
> 
> **Upstream oracle incidents** (**VirtualPool Oracle Stale**, **Oracle Jump Far Above Swap Fee**) use `notify_critical_incident`, grouping by `chain_id` and `alertname` without `pool_id` so one feed failure becomes one Slack message (multi-pool blocks still render via the existing `range .Alerts` template).
> 
> **Lint tests** lock these invariants: `keep_firing_for` on the four flap rules, slow vs hourly route assignment, and incident grouping shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffeeb60363e32b9f3c46412bc20a6733eb5f6e55. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added critical notification variants with slower repeat intervals and clearer incident-level grouping.
  - Oracle-related incidents can now be grouped into consolidated notifications by alert and chain.
- **Bug Fixes**
  - Critical alerts remain active briefly after conditions clear, improving reliability during delayed recovery or catch-up periods.
  - VirtualPool oracle staleness alerts now consolidate affected pools into a single incident notification.
- **Improvements**
  - Updated alert routing and repeat intervals to reduce duplicate notifications while preserving timely updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

