### PR TITLE
fix(alerts): value-weight pool depletion shares

### DIFF
--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -243,6 +243,9 @@ locals {
     {{ if .Annotations.current_reserves -}}
     *Reserves:* {{ .Annotations.current_reserves }}
     {{ end -}}
+    {{ if .Annotations.value_composition -}}
+    *Value Share:* {{ .Annotations.value_composition }}
+    {{ end -}}
     {{ if .Annotations.breach_duration -}}
     *Breach Duration:* {{ .Annotations.breach_duration }}
     {{ end -}}
@@ -292,6 +295,7 @@ locals {
   victorops_pool_page_message = <<-EOT
     {{ range .Alerts }}{{ if .Annotations.summary }}{{ .Annotations.summary }}
     {{ end }}{{ if .Annotations.current_reserves }}Reserves: {{ .Annotations.current_reserves }}
+    {{ end }}{{ if .Annotations.value_composition }}Value share: {{ .Annotations.value_composition }}
     {{ end }}{{ if .Annotations.rebalance_reason }}Rebalance blocked: {{ .Annotations.rebalance_reason }}
     {{ end }}{{ if .Labels.pool_id }}Pool: https://monitoring.mento.org/pool/{{ .Labels.pool_id }}
     {{ end }}Alert ID: {{ .Fingerprint }}

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -264,8 +264,18 @@ locals {
   # ratio costs a swapper nothing on its own. A side running dry does: once one
   # leg is empty every swap into that leg reverts, and well before that the
   # remaining bandwidth on that side is too thin to serve normal size.
-  # `min(side share)` is that signal, read from the same reserve-share gauges
-  # the deviation annotations already render.
+  # `min(side share)` is that signal — measured by VALUE, not by token count.
+  #
+  # The count share (`mento_pool_reserve_share_token*`) is not a depletion
+  # signal on a pair that does not trade near parity: it is dominated by the
+  # exchange rate. A healthy, balanced JPYm/USDm pool reads 0.4% / 99.6% by
+  # count purely because one JPY is worth ~0.0063 USD, and the first shipped
+  # version of these rules (PR #1940) would have paged on both JPYm pools
+  # forever. `mento_pool_reserve_value_share_token*` converts each leg through
+  # the pool's own oracle reference — the same frame the FPMM contract and the
+  # indexer's `priceDifference` use, including the per-pool `invertRateFeed`
+  # orientation — so 50/50 here means "sitting on the oracle" and the floors
+  # below read as economic one-sidedness.
   #
   # `min without(token_symbol)` folds the two flat per-token gauges into one
   # series per pool. Aggregation drops `__name__`, so the result carries
@@ -274,20 +284,44 @@ locals {
   # skipped when a pool's reserves are both zero, so an unfunded pool produces
   # no series and cannot fire either tier.
   #
+  # The value gauges additionally need a live median and an on-chain-read feed
+  # orientation, so a pool with a dark feed publishes neither and both tiers
+  # evaluate NoData. `no_data_state = "OK"` on both rules makes that silence,
+  # not a page: a dark oracle is what the oracle staleness rules are for, and
+  # a depletion number derived from a stale or guessed rate would be worse
+  # than none. Today that is the Polygon EURm/EUROP pool, which has never
+  # landed a median.
+  #
   # Deliberately NOT FX-weekend gated, unlike the deviation rules above. Those
   # gate FX pairs because their signal derives from an oracle that legitimately
   # stops updating while the market is closed. Reserve share is on-chain
-  # balances only: a pool that is 95/5 on Saturday genuinely cannot serve one
-  # swap direction, and the weekend is exactly when nobody is watching. Same
-  # reasoning as the un-gated Oracle Jump rules in rules-fpmms.tf.
-  pool_min_reserve_share_promql = "min without(token_symbol) (mento_pool_reserve_share_token0 or mento_pool_reserve_share_token1)"
+  # balances only: a pool that is 95/5 by value on Saturday genuinely cannot
+  # serve one swap direction, and the weekend is exactly when nobody is
+  # watching. The rate used to weight the legs is the last median, which on a
+  # closed FX pair is Friday's — stale for pricing a trade, fine for deciding
+  # whether the two legs are worth roughly the same. Same reasoning as the
+  # un-gated Oracle Jump rules in rules-fpmms.tf.
+  pool_min_reserve_value_share_promql = "min without(token_symbol) (mento_pool_reserve_value_share_token0 or mento_pool_reserve_value_share_token1)"
+  # Rendered as percentages for the annotations, which name the thin side and
+  # the number an operator will quote back. Value shares, so the number in
+  # Slack is the same one that decided the alert.
+  pool_depletion_value_share_annotation_queries = [
+    {
+      ref_id = "V0"
+      expr   = "mento_pool_reserve_value_share_token0 * 100"
+    },
+    {
+      ref_id = "V1"
+      expr   = "mento_pool_reserve_value_share_token1 * 100"
+    },
+  ]
   # Two mutually exclusive bands, same shape as the oracle-jump tiers: a pool
   # matches the page rule or the critical rule, never both, so one depleting
   # pool never produces two notifications. The page band is open-ended
   # downward (a fully drained 0% side still pages); the critical band is
   # floored at the page share here and capped by its own Grafana evaluator.
-  pool_depletion_page_active_promql     = local.pool_min_reserve_share_promql
-  pool_depletion_critical_active_promql = "(${local.pool_min_reserve_share_promql}) >= 0.1"
+  pool_depletion_page_active_promql     = local.pool_min_reserve_value_share_promql
+  pool_depletion_critical_active_promql = "(${local.pool_min_reserve_value_share_promql}) >= 0.1"
 
   # Transition markers let resolved notifications say why an alert stopped
   # instead of listing every possible cause. Each base alert rule adds the
@@ -360,12 +394,13 @@ locals {
   #     NoData through the deviation rules and stuck them in Normal for
   #     ~9h on 2026-04-28).
   #   - `pool_depletion_summary_annotation` names the depleting side from the
-  #     same R0/R1 queries: whichever share is smaller is the leg that runs out
-  #     first, and its `token_symbol` label is the token swappers will stop
-  #     being able to buy. The `$values.A` fallback renders the aggregated min
-  #     share through `humanizePercentage` — safe here because A is a [0, 1]
-  #     fraction, nowhere near the 1e4 regime where that helper flips to
-  #     scientific notation.
+  #     V0/V1 value-share queries — not R0/R1, which are token counts and on an
+  #     off-parity pair name the wrong side. Whichever value share is smaller is
+  #     the leg that runs out first, and its `token_symbol` label is the token
+  #     swappers will stop being able to buy. The `$values.A` fallback renders
+  #     the aggregated min value share through `humanizePercentage` — safe here
+  #     because A is a [0, 1] fraction, nowhere near the 1e4 regime where that
+  #     helper flips to scientific notation.
   deviation_warning_summary_annotation = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
@@ -398,17 +433,28 @@ locals {
   # Risk" / "Pool Nearly One-Sided") carry the severity distinction, so the
   # copy only has to answer the two operator questions: which side is running
   # out, and what to check.
-  pool_depletion_summary_annotation               = <<-EOT
-    {{- if and $values.R0 $values.R1 -}}
-      {{- if lt $values.R0.Value $values.R1.Value -}}
-        {{- printf "Only %.0f%% of pool reserves are %s. Users cannot swap into %s once that side empties — check the rebalancer and %s reserve bandwidth." $values.R0.Value $values.R0.Labels.token_symbol $values.R0.Labels.token_symbol $values.R0.Labels.token_symbol -}}
+  pool_depletion_summary_annotation = <<-EOT
+    {{- if and $values.V0 $values.V1 -}}
+      {{- if lt $values.V0.Value $values.V1.Value -}}
+        {{- printf "Only %.0f%% of pool value is %s. Users cannot swap into %s once that side empties — check the rebalancer and %s reserve bandwidth." $values.V0.Value $values.V0.Labels.token_symbol $values.V0.Labels.token_symbol $values.V0.Labels.token_symbol -}}
       {{- else -}}
-        {{- printf "Only %.0f%% of pool reserves are %s. Users cannot swap into %s once that side empties — check the rebalancer and %s reserve bandwidth." $values.R1.Value $values.R1.Labels.token_symbol $values.R1.Labels.token_symbol $values.R1.Labels.token_symbol -}}
+        {{- printf "Only %.0f%% of pool value is %s. Users cannot swap into %s once that side empties — check the rebalancer and %s reserve bandwidth." $values.V1.Value $values.V1.Labels.token_symbol $values.V1.Labels.token_symbol $values.V1.Labels.token_symbol -}}
       {{- end -}}
     {{- else if $values.A -}}
-      {{- printf "Smallest pool side holds only %s of reserves. Users cannot swap into it once it empties — check the rebalancer and reserve bandwidth." (humanizePercentage $values.A.Value) -}}
+      {{- printf "Smallest pool side holds only %s of pool value. Users cannot swap into it once it empties — check the rebalancer and reserve bandwidth." (humanizePercentage $values.A.Value) -}}
     {{- else -}}
       One pool side is nearly drained. Users cannot swap into it once it empties — check the rebalancer and reserve bandwidth.
+    {{- end -}}
+  EOT
+  # Depletion-only companion to `current_reserves`. The two lines answer
+  # different questions and can look contradictory on an off-parity pair by
+  # design: a balanced JPYm/USDm pool is "0% USDm / 100% JPYm" by token count
+  # and "40% USDm / 60% JPYm" by value. The alert fires on the value line, so
+  # it says so in words rather than leaving on-call to guess which number the
+  # threshold used.
+  pool_depletion_value_composition_annotation     = <<-EOT
+    {{- if and $values.V0 $values.V1 -}}
+      {{- printf "%.0f%%" $values.V0.Value }} {{ $values.V0.Labels.token_symbol }} / {{ printf "%.0f%%" $values.V1.Value }} {{ $values.V1.Labels.token_symbol }} (value-weighted share, at the last oracle median)
     {{- end -}}
   EOT
   deviation_current_reserves_annotation           = <<-EOT

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -290,7 +290,9 @@ locals {
   # not a page: a dark oracle is what the oracle staleness rules are for, and
   # a depletion number derived from a stale or guessed rate would be worse
   # than none. Today that is the Polygon EURm/EUROP pool, which has never
-  # landed a median.
+  # landed a median; a feed that goes dark later drops out the same way,
+  # because the bridge gates on the median being live and not merely on the
+  # retained last price.
   #
   # Deliberately NOT FX-weekend gated, unlike the deviation rules above. Those
   # gate FX pairs because their signal derives from an oracle that legitimately

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -708,7 +708,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
 #
 # Neither tier fires on the 2026-08 CHFm/USDm breach that motivated ADR 0067:
 # that pool bottomed at ~22% min side, above both bands. `Rebalancer Stale`
-# covered it, correctly. On the 18 live pools replayed for PR #1941 the
+# covered it, correctly. On the 18 live pools replayed for PR #1944 the
 # thinnest value side was 26% (Monad CHFm/USDm), so neither tier fires today.
 resource "grafana_rule_group" "fpmms_depletion" {
   name             = "Pool Depletion Risk"

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -693,20 +693,23 @@ resource "grafana_rule_group" "fpmms_deviation" {
 # ── Pool depletion risk ──────────────────────────────────────────────────────
 #
 # The pageable failure on an oracle-priced FPMM is a side running dry, not a
-# wide reserve ratio. Both tiers read `min(side share)` from the same
-# reserve-share gauges the deviation annotations render; see main.tf for the
-# expression, the deliberate absence of FX-weekend gating, and why the two
-# bands are mutually exclusive.
+# wide reserve ratio. Both tiers read `min(side share)` from the value-weighted
+# reserve-share gauges — token counts converted through the pool's own oracle
+# reference. See main.tf for the expression, why the count-share gauges are the
+# wrong input (they read the exchange rate, not depletion), the NoData
+# behaviour when a feed is dark, the deliberate absence of FX-weekend gating,
+# and why the two bands are mutually exclusive.
 #
-#   critical — min side share in [10%, 20%), sustained 15m. Bandwidth on the
+#   critical — min value share in [10%, 20%), sustained 15m. Bandwidth on the
 #              thin side is thin enough that ordinary size starts failing, but
 #              the pool still serves both directions.
-#   page     — min side share < 10%. The pool is effectively one-sided;
+#   page     — min value share < 10%. The pool is effectively one-sided;
 #              swappers lose one direction outright once it empties.
 #
 # Neither tier fires on the 2026-08 CHFm/USDm breach that motivated ADR 0067:
 # that pool bottomed at ~22% min side, above both bands. `Rebalancer Stale`
-# covered it, correctly.
+# covered it, correctly. On the 18 live pools replayed for PR #1941 the
+# thinnest value side was 26% (Monad CHFm/USDm), so neither tier fires today.
 resource "grafana_rule_group" "fpmms_depletion" {
   name             = "Pool Depletion Risk"
   folder_uid       = grafana_folder.fpmms.uid
@@ -722,7 +725,7 @@ resource "grafana_rule_group" "fpmms_depletion" {
   #
   # What absorbs churn instead: the 15m dwell on the critical tier, and the
   # 10-percentage-point gap between the bands — a pool has to move a long way
-  # in side share to change tier, unlike a deviation ratio that re-derives on
+  # in value share to change tier, unlike a deviation ratio that re-derives on
   # every oracle update.
   rule {
     name      = "Pool Depletion Risk"
@@ -740,10 +743,11 @@ resource "grafana_rule_group" "fpmms_depletion" {
       # WORSE and crosses down into the `Pool Nearly One-Sided` band, so the
       # copy must not claim an improvement it cannot see. Same reason the
       # deviation rules use a neutral "Alert Stopped" resolution.
-      resolved_title   = "Pool Depletion Alert Stopped"
-      resolved_summary = "Either the thin side recovered above the depletion floor, or the pool crossed into the one-sided page band — check the reserves line."
-      current_reserves = local.deviation_current_reserves_annotation
-      rebalance_reason = local.deviation_rebalance_reason_annotation
+      resolved_title    = "Pool Depletion Alert Stopped"
+      resolved_summary  = "Either the thin side recovered above the depletion floor, or the pool crossed into the one-sided page band — check the reserves line."
+      current_reserves  = local.deviation_current_reserves_annotation
+      value_composition = local.pool_depletion_value_composition_annotation
+      rebalance_reason  = local.deviation_rebalance_reason_annotation
     }
 
     labels = {
@@ -751,7 +755,7 @@ resource "grafana_rule_group" "fpmms_depletion" {
       severity = "critical"
     }
 
-    # A = min side share, floored at the page band so a pool below 10% belongs
+    # A = min value share, floored at the page band so a pool below 10% belongs
     # to the page rule alone. The Grafana evaluator supplies the upper bound so
     # the mirrored `0.2` literal sits where the drift checker reads it.
     data {
@@ -773,6 +777,7 @@ resource "grafana_rule_group" "fpmms_depletion" {
     # see main.tf for why they sit outside the threshold condition.
     dynamic "data" {
       for_each = concat(
+        local.pool_depletion_value_share_annotation_queries,
         local.deviation_reserve_annotation_queries,
         local.deviation_rebalancer_annotation_queries,
       )
@@ -838,10 +843,11 @@ resource "grafana_rule_group" "fpmms_depletion" {
       # The page band is open-ended downward, so leaving it can only mean the
       # thin side grew. This resolution can honestly claim recovery where the
       # critical tier's cannot.
-      resolved_title   = "Pool Two-Sided Again"
-      resolved_summary = "The thin side is back above the one-sided floor."
-      current_reserves = local.deviation_current_reserves_annotation
-      rebalance_reason = local.deviation_rebalance_reason_annotation
+      resolved_title    = "Pool Two-Sided Again"
+      resolved_summary  = "The thin side is back above the one-sided floor."
+      current_reserves  = local.deviation_current_reserves_annotation
+      value_composition = local.pool_depletion_value_composition_annotation
+      rebalance_reason  = local.deviation_rebalance_reason_annotation
     }
 
     # `severity = "page"` follows the repo's page convention (trading limits,
@@ -871,6 +877,7 @@ resource "grafana_rule_group" "fpmms_depletion" {
 
     dynamic "data" {
       for_each = concat(
+        local.pool_depletion_value_share_annotation_queries,
         local.deviation_reserve_annotation_queries,
         local.deviation_rebalancer_annotation_queries,
       )
@@ -1202,7 +1209,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
   # rule a rebalancer whose corrections keep falling short is invisible until
   # either `Rebalancer Stale` fires — the actionable critical, once the
   # rebalancer stops acting altogether — or one side thins far enough to trip
-  # the `Pool Depletion Risk` side-share floors.
+  # the `Pool Depletion Risk` value-share floors.
   rule {
     name           = "Rebalance Ineffective"
     condition      = "threshold"

--- a/docs/adr/0067-pool-criticality-is-depletion-risk.md
+++ b/docs/adr/0067-pool-criticality-is-depletion-risk.md
@@ -168,7 +168,11 @@ inaction**, not when a ratio is large.
   feed orientation, which the count-share version did not. A pool missing
   either publishes no value share, and both tiers evaluate NoData → OK. Today
   that is the Polygon `EURm/EUROP` pool, which has never landed a median; its
-  dark feed is covered by the oracle liveness rules, not by silence here.
+  dark feed is covered by the oracle liveness rules, not by silence here. The
+  gate is `medianLive`, not a non-zero last price: a zero-median outage retains
+  the previous price, so a price-only check would have kept pricing reserves
+  off a rate the contract had stopped honouring. This matches
+  `hasFreshLiveMedian`, which is how the indexer decides the same question.
 - `POOL_DEPLETION_CRITICAL_SHARE` and `POOL_DEPLETION_PAGE_SHARE` join the
   Terraform mirror set. `DEVIATION_CRITICAL_RATIO` leaves it; a future editor
   who bumps it will get no drift-check failure, because there is nothing in
@@ -184,6 +188,13 @@ inaction**, not when a ratio is large.
 - Applying this stack destroys `grafana_contact_point.slack_critical_transition`
   and creates `grafana_contact_point.pool_page`. Both are Grafana-side
   resources behind the `production-infra` apply gate.
+- **Rollout order is a prerequisite, not a preference.** The depletion rules
+  read gauges the bridge publishes, so metrics-bridge must be deployed and
+  `mento_pool_reserve_value_share_token0` / `_token1` must be visible in
+  Prometheus before the `production-infra` apply. Applying first is not
+  dangerous but it is silent: with no series, both tiers sit at NoData → OK
+  and the depletion ladder looks healthy because it is not measuring anything.
+  Confirming the two gauges answer "is this actually watching the pools yet".
 - **The page tier has an empty day-one firing set.** Replayed against
   production on 2026-08-19, the thinnest value side across all 18 live pools is
   26% (Monad `CHFm/USDm`, the pool furthest outside its rebalance band at

--- a/docs/adr/0067-pool-criticality-is-depletion-risk.md
+++ b/docs/adr/0067-pool-criticality-is-depletion-risk.md
@@ -59,7 +59,7 @@ inaction**, not when a ratio is large.
 
   PR #1940 shipped this reading the raw token-count gauges
   (`mento_pool_reserve_share_token{0,1}`) instead, which is wrong on any pair
-  that does not trade near parity; PR #1941 corrected it before the production
+  that does not trade near parity; PR #1944 corrected it before the production
   apply. See the reversed alternative below.
 
   The bands partition the range at the page share with no gap and no overlap,
@@ -69,8 +69,10 @@ inaction**, not when a ratio is large.
   because the held band keeps firing while the pool crosses into its
   neighbour — in both directions. The 15m dwell and the 10-percentage-point
   gap between the bands absorb churn instead. Neither rule is FX-weekend
-  gated: reserve share is on-chain balances, not an oracle-derived quantity,
-  so a market pause does not make the signal spurious.
+  gated: the quantity is on-chain balances weighted by the last median, and a
+  market pause does not make it spurious — a rate that stopped updating on
+  Friday still says whether the two legs are worth roughly the same. The
+  weekend is exactly when nobody is watching a pool drain.
 
 - **Page delivery uses one bundled contact point.** Every `service = "fpmms"`
   rule routes through rule-level `notification_settings`, which bypasses
@@ -135,7 +137,7 @@ inaction**, not when a ratio is large.
   dwell and band separation instead. The cost is accepted: a pool oscillating
   across a band boundary can produce a fire/resolve pair per dwell period.
 - **A new metrics-bridge gauge for side share** — rejected as unnecessary in
-  PR #1940, **reversed in PR #1941**. The existing per-token reserve-share
+  PR #1940, **reversed in PR #1944**. The existing per-token reserve-share
   gauges do carry a number at the right pool fingerprint, but it is a token
   count, and token counts on the two sides of an off-parity pair are not
   comparable quantities. The correct comparison needs each leg priced through
@@ -217,7 +219,7 @@ inaction**, not when a ratio is large.
   — Part 1, noise mechanics (`keep_firing_for`, 12h repeat, incident grouping).
 - PR [#1940](https://github.com/mento-protocol/monitoring-monorepo/pull/1940)
   — Part 2, the depletion rules, shipped reading token-count shares.
-- PR [#1941](https://github.com/mento-protocol/monitoring-monorepo/pull/1941)
+- PR [#1944](https://github.com/mento-protocol/monitoring-monorepo/pull/1944)
   — the value-weighting correction, with the 18-pool production replay. Each
   pool's value split reproduces the pool's own on-chain `priceDifference` to
   within 1 bps, which is what establishes the conversion is in the same frame

--- a/docs/adr/0067-pool-criticality-is-depletion-risk.md
+++ b/docs/adr/0067-pool-criticality-is-depletion-risk.md
@@ -49,13 +49,18 @@ A pool alert is critical when it reflects **user impact** or **rebalancer
 inaction**, not when a ratio is large.
 
 - **Depletion risk becomes the pool-side critical.** Two rules in
-  `alerts/rules/rules-fpmms.tf` read `min(side share)` from the existing
-  `mento_pool_reserve_share_token{0,1}` gauges:
-  - `Pool Depletion Risk` — min side share in `[10%, 20%)`, sustained 15m,
+  `alerts/rules/rules-fpmms.tf` read `min(side share)` **measured by value**,
+  from the `mento_pool_reserve_value_share_token{0,1}` gauges:
+  - `Pool Depletion Risk` — min value share in `[10%, 20%)`, sustained 15m,
     `severity = critical`, twice-daily repeat via `notify_critical_pool_slow`.
-  - `Pool Nearly One-Sided` — min side share below 10% for 1m,
+  - `Pool Nearly One-Sided` — min value share below 10% for 1m,
     `severity = page`. Below 10% the pool is minutes from rejecting one swap
     direction outright.
+
+  PR #1940 shipped this reading the raw token-count gauges
+  (`mento_pool_reserve_share_token{0,1}`) instead, which is wrong on any pair
+  that does not trade near parity; PR #1941 corrected it before the production
+  apply. See the reversed alternative below.
 
   The bands partition the range at the page share with no gap and no overlap,
   so one depleting pool produces exactly one notification. Neither rule carries
@@ -129,9 +134,20 @@ inaction**, not when a ratio is large.
   still open. No hold placement survives both crossings, so the tiers rely on
   dwell and band separation instead. The cost is accepted: a pool oscillating
   across a band boundary can produce a fire/resolve pair per dwell period.
-- **A new metrics-bridge gauge for side share** — rejected as unnecessary. The
-  per-token reserve-share gauges already carry the value at the exact pool
-  fingerprint the alert instances use.
+- **A new metrics-bridge gauge for side share** — rejected as unnecessary in
+  PR #1940, **reversed in PR #1941**. The existing per-token reserve-share
+  gauges do carry a number at the right pool fingerprint, but it is a token
+  count, and token counts on the two sides of an off-parity pair are not
+  comparable quantities. The correct comparison needs each leg priced through
+  the pool's own oracle reference, which needs the per-pool `invertRateFeed`
+  orientation — a value PromQL has no access to and cannot infer from the
+  published series. `mento_pool_reserve_value_share_token{0,1}` therefore do
+  the conversion in the bridge, where the flag is available, the arithmetic is
+  unit-testable, and the alert expression stays a `min` over two gauges.
+  Choosing an orientation heuristically in PromQL was also considered and
+  rejected: every rule that guesses masks the catastrophic case, because a pool
+  that is genuinely drained by the square of the exchange rate reads as
+  perfectly balanced under the wrong orientation.
 
 ## Consequences
 
@@ -141,9 +157,16 @@ inaction**, not when a ratio is large.
   share, above both depletion bands, and would have been covered by
   `Rebalancer Stale` alone — which is the correct outcome.
 - Pool health now has two independent ladders that must not be conflated:
-  deviation ratio classifies drift for analytics, depletion side share measures
-  user impact and decides paging. A future change to one is not a change to the
-  other.
+  deviation ratio classifies drift for analytics, depletion value share
+  measures user impact and decides paging. A future change to one is not a
+  change to the other. They are related but not interchangeable — both derive
+  from the same reserve/oracle state, so a pool below the depletion floors is
+  necessarily far outside its rebalance band, while the converse does not hold.
+- The depletion tiers now depend on a live oracle median and an on-chain-read
+  feed orientation, which the count-share version did not. A pool missing
+  either publishes no value share, and both tiers evaluate NoData → OK. Today
+  that is the Polygon `EURm/EUROP` pool, which has never landed a median; its
+  dark feed is covered by the oracle liveness rules, not by silence here.
 - `POOL_DEPLETION_CRITICAL_SHARE` and `POOL_DEPLETION_PAGE_SHARE` join the
   Terraform mirror set. `DEVIATION_CRITICAL_RATIO` leaves it; a future editor
   who bumps it will get no drift-check failure, because there is nothing in
@@ -159,16 +182,32 @@ inaction**, not when a ratio is large.
 - Applying this stack destroys `grafana_contact_point.slack_critical_transition`
   and creates `grafana_contact_point.pool_page`. Both are Grafana-side
   resources behind the `production-infra` apply gate.
-- **The page tier has a non-empty day-one firing set.** Queried against
-  production on 2026-08-19, `min(side share)` puts both `JPYm/USDm` pools below
-  the page floor — Celo at 0.42% USDm (99.58% JPYm) and Monad at 0.67% USDm
-  (99.33% JPYm). Those are true positives: a swapper cannot buy USDm out of
-  either pool. Every other pool sits at 22% or above. Whoever approves the
-  `production-infra` apply is therefore approving two immediate Splunk On-Call
-  pages for a pre-existing condition, which is the producer-first rollout check
-  in `alerts/rules/README.md` working as intended — the condition is old, only
-  the visibility is new. Fund or rebalance the USDm leg of those two pools
-  before approving, or expect the pages.
+- **The page tier has an empty day-one firing set.** Replayed against
+  production on 2026-08-19, the thinnest value side across all 18 live pools is
+  26% (Monad `CHFm/USDm`, the pool furthest outside its rebalance band at
+  1.29× threshold). Nothing sits in either the critical `[10%, 20%)` band or
+  the page band below 10%, so approving the `production-infra` apply adds no
+  immediate notification.
+- **A count share is not a depletion signal, and the first version of this ADR
+  said otherwise.** PR #1940 read the token-count gauges and claimed the two
+  `JPYm/USDm` pools (0.42% and 0.67% "USDm") were day-one true positives that
+  should be funded before the apply. They were not. Those readings are the
+  JPY/USD rate: one JPY is worth ~0.0063 USD, so a JPYm/USDm pool holding equal
+  value on both sides holds ~160× more JPYm tokens than USDm tokens. By value
+  the Celo pool was 40.2% USDm / 59.8% JPYm and the Monad pool 48.2% / 51.8%,
+  both inside tolerance (`deviation_ratio` 0.976 and 0.149) and both shown
+  healthy on the dashboard, which has always converted through the oracle. Had
+  the apply been approved, both pools would have paged Splunk On-Call
+  indefinitely with no operator action that could clear them. The check that
+  caught it was replaying the expression against live production data before
+  the apply, not review of the expression itself — it reads plausibly.
+- **The orientation is per pool, not per pair.** `invertRateFeed` compensates
+  the pool's token ordering, which differs by chain: the Celo `JPYm/USDm` pool
+  lists USDm as token0 and inverts its feed, the Monad one lists JPYm as token0
+  and does not. Nine of the eighteen live pools invert. Any future consumer
+  that converts a pool's reserves through `mento_pool_oracle_price` must carry
+  that flag; assuming a single direction is confidently wrong on half the
+  estate.
 
 ## Evidence
 
@@ -176,9 +215,18 @@ inaction**, not when a ratio is large.
   — the alert-state history analysis and the two-PR plan.
 - PR [#1937](https://github.com/mento-protocol/monitoring-monorepo/pull/1937)
   — Part 1, noise mechanics (`keep_firing_for`, 12h repeat, incident grouping).
+- PR [#1940](https://github.com/mento-protocol/monitoring-monorepo/pull/1940)
+  — Part 2, the depletion rules, shipped reading token-count shares.
+- PR [#1941](https://github.com/mento-protocol/monitoring-monorepo/pull/1941)
+  — the value-weighting correction, with the 18-pool production replay. Each
+  pool's value split reproduces the pool's own on-chain `priceDifference` to
+  within 1 bps, which is what establishes the conversion is in the same frame
+  the FPMM contract uses.
 - Enforcing files: `alerts/rules/rules-fpmms.tf` (the two depletion rules and
-  the threshold-mirror banner), `alerts/rules/main.tf` (the min-side-share
-  locals and the un-suppressed warning expressions),
+  the threshold-mirror banner), `alerts/rules/main.tf` (the min-value-share
+  locals, the V0/V1 annotation queries, and the un-suppressed warning
+  expressions), `metrics-bridge/src/metrics.ts` (`reserveValueShares` and the
+  two gauges it publishes),
   `alerts/rules/contact-points.tf` (`grafana_contact_point.pool_page`,
   `notify_page_pool`), `shared-config/src/thresholds.ts` (the constants and
   which of them Terraform mirrors),

--- a/metrics-bridge/src/graphql.ts
+++ b/metrics-bridge/src/graphql.ts
@@ -164,9 +164,28 @@ export const BRIDGE_POOLS_VP_LIFECYCLE_DEPRECATION_QUERY = gql`
   }
 `;
 
+// Optional companion query for the pool's rate-feed orientation. Only the
+// value-weighted reserve-share gauges need it; if the column is unavailable
+// those gauges stop publishing and the depletion alerts go NoData (= OK)
+// rather than reading a share computed in the wrong direction.
+export const BRIDGE_POOLS_RATE_FEED_ORIENTATION_QUERY = gql`
+  query BridgePoolsRateFeedOrientation {
+    Pool(where: { source: { _like: "%fpmm%" } }) {
+      id
+      invertRateFeed
+      invertRateFeedKnown
+    }
+  }
+`;
+
 type OracleLineageRow = Pick<
   PoolRow,
   "id" | "prevMedianPrice" | "prevMedianAt"
+>;
+
+type RateFeedOrientationRow = Pick<
+  PoolRow,
+  "id" | "invertRateFeed" | "invertRateFeedKnown"
 >;
 
 type OpenBreachRow = Pick<
@@ -204,12 +223,22 @@ type BridgePoolsBaseResponse = {
     | "currentOpenBreachEntryThreshold"
     | "wrappedExchangeDeprecated"
     | "activeLiquidityStrategies"
+    | "invertRateFeed"
+    | "invertRateFeedKnown"
   >[];
 };
 
 const LINEAGE_DEFAULTS = {
   prevMedianPrice: "0",
   prevMedianAt: "0",
+} as const;
+
+// `invertRateFeedKnown: false` is the load-bearing default: it means "we have
+// not read the orientation", which suppresses the value-share gauges. The
+// `invertRateFeed: false` beside it is never acted on while `known` is false.
+const RATE_FEED_ORIENTATION_DEFAULTS = {
+  invertRateFeed: false,
+  invertRateFeedKnown: false,
 } as const;
 
 const OPEN_BREACH_DEFAULTS = {
@@ -231,6 +260,7 @@ const VP_FRESHNESS_DEFAULTS = {
 type BridgePoolCompanionResponses = {
   base: BridgePoolsBaseResponse;
   lineage: { Pool: OracleLineageRow[] };
+  rateFeedOrientation: { Pool: RateFeedOrientationRow[] };
   openBreach: { Pool: OpenBreachRow[] };
   oracleTx: { Pool: OracleTxRow[] };
   activeStrategies: ActiveLiquidityStrategiesResult;
@@ -262,6 +292,7 @@ function isUnknownFieldError(err: unknown): boolean {
 
 const unknownFieldWarnings = {
   oracleLineage: false,
+  rateFeedOrientation: false,
   openBreach: false,
   oracleTx: false,
   activeStrategies: false,
@@ -353,16 +384,65 @@ async function requestOptionalVpLifecycleDeprecationRows(
   }
 }
 
+// The `Pool`-shaped optional companions, split out so the top-level fan-out
+// stays readable as companion count grows. Every request is created before the
+// first await, here and at the call site, so all of them stay in flight
+// together — the nesting costs no round trip.
+async function requestOptionalPoolRowCompanions(
+  signal: AbortSignal,
+): Promise<
+  Pick<
+    BridgePoolCompanionResponses,
+    | "lineage"
+    | "rateFeedOrientation"
+    | "openBreach"
+    | "oracleTx"
+    | "vpFreshness"
+  >
+> {
+  const [lineage, rateFeedOrientation, openBreach, oracleTx, vpFreshness] =
+    await Promise.all([
+      requestOptionalPoolRows<OracleLineageRow>(
+        BRIDGE_POOLS_ORACLE_LINEAGE_QUERY,
+        signal,
+        "oracleLineage",
+        "[metrics-bridge] Hasura schema missing oracle-lineage fields; Oracle Jump previous-price annotation disabled until indexer catches up.",
+      ),
+      requestOptionalPoolRows<RateFeedOrientationRow>(
+        BRIDGE_POOLS_RATE_FEED_ORIENTATION_QUERY,
+        signal,
+        "rateFeedOrientation",
+        "[metrics-bridge] Hasura schema missing rate-feed orientation fields; value-weighted reserve share gauges and the pool depletion alerts they feed are disabled until indexer catches up.",
+      ),
+      requestOptionalPoolRows<OpenBreachRow>(
+        BRIDGE_POOLS_OPEN_BREACH_QUERY,
+        signal,
+        "openBreach",
+        "[metrics-bridge] Hasura schema missing open-breach fields; deviation critical de-escalation persistence disabled until indexer catches up.",
+      ),
+      requestOptionalPoolRows<OracleTxRow>(
+        BRIDGE_POOLS_ORACLE_TX_QUERY,
+        signal,
+        "oracleTx",
+        "[metrics-bridge] Hasura schema missing oracle tx hash field; oracle alert transaction links disabled until indexer catches up.",
+      ),
+      requestOptionalPoolRows<VpFreshnessRow>(
+        BRIDGE_POOLS_VP_FRESHNESS_QUERY,
+        signal,
+        "vpFreshness",
+        "[metrics-bridge] Hasura schema missing VP oracle freshness field; VirtualPool oracle staleness metric disabled until indexer catches up.",
+      ),
+    ]);
+  return { lineage, rateFeedOrientation, openBreach, oracleTx, vpFreshness };
+}
+
 async function requestBridgePoolCompanions(
   signal: AbortSignal,
 ): Promise<BridgePoolCompanionResponses> {
   const [
     base,
-    lineage,
-    openBreach,
-    oracleTx,
+    poolRowCompanions,
     activeStrategies,
-    vpFreshness,
     vpExchangeDeprecation,
     vpLifecycleDeprecation,
   ] = await Promise.all([
@@ -370,41 +450,15 @@ async function requestBridgePoolCompanions(
       document: BRIDGE_POOLS_QUERY,
       signal,
     }),
-    requestOptionalPoolRows<OracleLineageRow>(
-      BRIDGE_POOLS_ORACLE_LINEAGE_QUERY,
-      signal,
-      "oracleLineage",
-      "[metrics-bridge] Hasura schema missing oracle-lineage fields; Oracle Jump previous-price annotation disabled until indexer catches up.",
-    ),
-    requestOptionalPoolRows<OpenBreachRow>(
-      BRIDGE_POOLS_OPEN_BREACH_QUERY,
-      signal,
-      "openBreach",
-      "[metrics-bridge] Hasura schema missing open-breach fields; deviation critical de-escalation persistence disabled until indexer catches up.",
-    ),
-    requestOptionalPoolRows<OracleTxRow>(
-      BRIDGE_POOLS_ORACLE_TX_QUERY,
-      signal,
-      "oracleTx",
-      "[metrics-bridge] Hasura schema missing oracle tx hash field; oracle alert transaction links disabled until indexer catches up.",
-    ),
+    requestOptionalPoolRowCompanions(signal),
     requestOptionalActiveLiquidityStrategies(signal),
-    requestOptionalPoolRows<VpFreshnessRow>(
-      BRIDGE_POOLS_VP_FRESHNESS_QUERY,
-      signal,
-      "vpFreshness",
-      "[metrics-bridge] Hasura schema missing VP oracle freshness field; VirtualPool oracle staleness metric disabled until indexer catches up.",
-    ),
     requestOptionalVpExchangeDeprecationRows(signal),
     requestOptionalVpLifecycleDeprecationRows(signal),
   ]);
   return {
     base,
-    lineage,
-    openBreach,
-    oracleTx,
+    ...poolRowCompanions,
     activeStrategies,
-    vpFreshness,
     vpExchangeDeprecation,
     vpLifecycleDeprecation,
   };
@@ -413,6 +467,7 @@ async function requestBridgePoolCompanions(
 function mergeBridgePoolCompanions({
   base,
   lineage,
+  rateFeedOrientation,
   openBreach,
   oracleTx,
   activeStrategies,
@@ -421,6 +476,18 @@ function mergeBridgePoolCompanions({
   vpLifecycleDeprecation,
 }: BridgePoolCompanionResponses): BridgePoolsResponse {
   const lineageById = new Map(lineage.Pool.map((p) => [p.id, p]));
+  // Narrowed to the two fields on purpose: a companion row must never be able
+  // to overwrite base-query state, and `=== true` keeps a row that arrived
+  // without the columns from replacing the defaults with `undefined`.
+  const rateFeedOrientationById = new Map(
+    rateFeedOrientation.Pool.map((p) => [
+      p.id,
+      {
+        invertRateFeed: p.invertRateFeed === true,
+        invertRateFeedKnown: p.invertRateFeedKnown === true,
+      },
+    ]),
+  );
   const openBreachById = new Map(openBreach.Pool.map((p) => [p.id, p]));
   const oracleTxById = new Map(
     oracleTx.Pool.filter((p) => p.oracleTxHash).map((p) => [p.id, p]),
@@ -436,7 +503,9 @@ function mergeBridgePoolCompanions({
       ...VP_FRESHNESS_DEFAULTS,
       ...LINEAGE_DEFAULTS,
       ...OPEN_BREACH_DEFAULTS,
+      ...RATE_FEED_ORIENTATION_DEFAULTS,
       ...lineageById.get(p.id),
+      ...rateFeedOrientationById.get(p.id),
       ...openBreachById.get(p.id),
       ...oracleTxById.get(p.id),
       ...vpFreshnessById.get(p.id),

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -245,6 +245,23 @@ export const gauges = {
     labelNames: reserveShareLabels,
     registers: [register],
   }),
+  // Value-weighted twins of the two gauges above. These are what the pool
+  // depletion alerts read; the raw-count pair stays for the "100% USDT / 0%
+  // USDm" diagnostic line and for pools whose orientation or median is
+  // unknown. See `reserveValueShares` for the oracle-frame math and for why
+  // a raw count share is not a depletion signal on an off-parity pair.
+  reserveValueShareToken0: new Gauge({
+    name: "mento_pool_reserve_value_share_token0",
+    help: "Value-weighted share of pool reserves held in token0: r0_normalized × oracleRef / (r0_normalized × oracleRef + r1_normalized) ∈ [0, 1], where oracleRef is the price of token0 denominated in token1 (`mento_pool_oracle_price`, inverted when the pool's `invertRateFeed` says token0 is the feed's quote token). Equals the token-count share only when the pair trades near parity. Skipped when reserves are zero, the median price is absent, or the feed orientation has not been read on chain — no series rather than a wrong one. Carries the same `token_symbol` label as `mento_pool_reserve_share_token0`.",
+    labelNames: reserveShareLabels,
+    registers: [register],
+  }),
+  reserveValueShareToken1: new Gauge({
+    name: "mento_pool_reserve_value_share_token1",
+    help: "Value-weighted share of pool reserves held in token1 (mirror of mento_pool_reserve_value_share_token0): r1_normalized / (r0_normalized × oracleRef + r1_normalized). Same skip conditions and the same `token_symbol` label as its token0 twin.",
+    labelNames: reserveShareLabels,
+    registers: [register],
+  }),
   lastRebalancedAt: new Gauge({
     name: "mento_pool_last_rebalanced_at",
     help: "Unix timestamp of the last rebalance",
@@ -644,6 +661,68 @@ function recordLimitMetrics(pool: PoolRow, labels: PoolDisplayLabels): void {
   );
 }
 
+/**
+ * Value-weighted reserve shares, or `null` when they cannot be computed.
+ *
+ * A token-count share answers "how many tokens sit on each side", which is
+ * only a depletion signal when the two legs are worth roughly the same. On an
+ * off-parity pair it is dominated by the exchange rate: a healthy, balanced
+ * JPYm/USDm pool reads 0.4% / 99.6% by count purely because one JPY is worth
+ * ~0.0063 USD. What an operator needs to know — can a swapper still get out
+ * on this side — is a question about value.
+ *
+ * The conversion uses the same frame the FPMM contract and the indexer's
+ * `priceDifference` use (`indexer-envio/src/priceDifference.ts`):
+ * `reservePrice = r1_normalized / r0_normalized` is compared against
+ * `oracleRef`, the price of token0 denominated in token1. `oracleRef` is the
+ * SortedOracles median in feed direction, inverted when the pool's on-chain
+ * `invertRateFeed` flag says token0 is the feed's quote token. Weighting the
+ * legs by `(oracleRef, 1)` therefore reproduces the on-chain equilibrium:
+ * a pool sitting exactly on its oracle is 50/50 here, and the min side share
+ * is exactly the "how lopsided by value" number the depletion floors want.
+ *
+ * `invertRateFeed` is per-pool, not per-pair — token ordering differs between
+ * chains, and the flag is what compensates. Both JPYm/USDm pools carry the
+ * same feed with opposite flags because Celo lists USDm as token0 and Monad
+ * lists JPYm as token0. Assuming one orientation for all pools produces a
+ * confident wrong answer on the other half of them, so an unread flag
+ * (`invertRateFeedKnown === false`) publishes nothing at all.
+ *
+ * Price precision follows `mento_pool_oracle_price`: both go through
+ * `toHumanUnits`, so an operator can reproduce the share from the two
+ * published gauges by hand.
+ */
+export function reserveValueShares(
+  pool: Pick<
+    PoolRow,
+    | "reserves0"
+    | "reserves1"
+    | "token0Decimals"
+    | "token1Decimals"
+    | "lastMedianPrice"
+    | "invertRateFeed"
+    | "invertRateFeedKnown"
+  >,
+): { share0: number; share1: number } | null {
+  if (pool.invertRateFeedKnown !== true) return null;
+  const price = toHumanUnits(
+    BigInt(pool.lastMedianPrice),
+    SORTED_ORACLES_DECIMALS,
+  );
+  if (!Number.isFinite(price) || price <= 0) return null;
+  const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
+  const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
+  // `!(x >= 0)` rather than a finite-and-sign pair: it rejects NaN and
+  // negatives in one test, and an infinity that slips through is caught by the
+  // finite check on the total below.
+  if (!(r0 >= 0) || !(r1 >= 0)) return null;
+  const oracleRef = pool.invertRateFeed ? 1 / price : price;
+  const value0 = r0 * oracleRef;
+  const total = value0 + r1;
+  if (!Number.isFinite(total) || total <= 0) return null;
+  return { share0: value0 / total, share1: r1 / total };
+}
+
 function recordReserveShareMetrics(
   pool: PoolRow,
   labels: PoolDisplayLabels,
@@ -651,18 +730,31 @@ function recordReserveShareMetrics(
   const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
   const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
   const total = r0 + r1;
-  if (Number.isFinite(total) && total > 0) {
-    const token0Symbol = tokenSymbol(pool.chainId, pool.token0) ?? "token0";
-    const token1Symbol = tokenSymbol(pool.chainId, pool.token1) ?? "token1";
-    gauges.reserveShareToken0.set(
-      { ...labels, token_symbol: token0Symbol },
-      r0 / total,
-    );
-    gauges.reserveShareToken1.set(
-      { ...labels, token_symbol: token1Symbol },
-      r1 / total,
-    );
-  }
+  if (!Number.isFinite(total) || total <= 0) return;
+  const token0Symbol = tokenSymbol(pool.chainId, pool.token0) ?? "token0";
+  const token1Symbol = tokenSymbol(pool.chainId, pool.token1) ?? "token1";
+  gauges.reserveShareToken0.set(
+    { ...labels, token_symbol: token0Symbol },
+    r0 / total,
+  );
+  gauges.reserveShareToken1.set(
+    { ...labels, token_symbol: token1Symbol },
+    r1 / total,
+  );
+  // Value shares need the oracle on top of the reserves, so they publish on a
+  // subset of the pools the count shares cover. Absent series (dark median,
+  // unread orientation) leave the depletion rules at NoData, which they treat
+  // as OK — the dark feed itself is what the oracle staleness rules page on.
+  const valueShares = reserveValueShares(pool);
+  if (!valueShares) return;
+  gauges.reserveValueShareToken0.set(
+    { ...labels, token_symbol: token0Symbol },
+    valueShares.share0,
+  );
+  gauges.reserveValueShareToken1.set(
+    { ...labels, token_symbol: token1Symbol },
+    valueShares.share1,
+  );
 }
 
 /**

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -252,7 +252,7 @@ export const gauges = {
   // a raw count share is not a depletion signal on an off-parity pair.
   reserveValueShareToken0: new Gauge({
     name: "mento_pool_reserve_value_share_token0",
-    help: "Value-weighted share of pool reserves held in token0: r0_normalized × oracleRef / (r0_normalized × oracleRef + r1_normalized) ∈ [0, 1], where oracleRef is the price of token0 denominated in token1 (`mento_pool_oracle_price`, inverted when the pool's `invertRateFeed` says token0 is the feed's quote token). Equals the token-count share only when the pair trades near parity. Skipped when reserves are zero, the median price is absent, or the feed orientation has not been read on chain — no series rather than a wrong one. Carries the same `token_symbol` label as `mento_pool_reserve_share_token0`.",
+    help: "Value-weighted share of pool reserves held in token0: r0_normalized × oracleRef / (r0_normalized × oracleRef + r1_normalized) ∈ [0, 1], where oracleRef is the price of token0 denominated in token1 (`mento_pool_oracle_price`, inverted when the pool's `invertRateFeed` says token0 is the feed's quote token). Equals the token-count share only when the pair trades near parity. Skipped when reserves are zero, the median price is absent or no longer live (a zero-median outage retains the last price), or the feed orientation has not been read on chain — no series rather than a wrong one. Carries the same `token_symbol` label as `mento_pool_reserve_share_token0`.",
     labelNames: reserveShareLabels,
     registers: [register],
   }),
@@ -688,6 +688,15 @@ function recordLimitMetrics(pool: PoolRow, labels: PoolDisplayLabels): void {
  * confident wrong answer on the other half of them, so an unread flag
  * (`invertRateFeedKnown === false`) publishes nothing at all.
  *
+ * `medianLive` gates for the same fail-closed reason. It is false when the
+ * feed's most recent `MedianUpdated` carried a zero median, and
+ * `lastMedianPrice` deliberately RETAINS the last non-zero value across that
+ * outage — so a price check alone would keep publishing a share derived from a
+ * rate the contract itself no longer honours. `hasFreshLiveMedian` in
+ * `indexer-envio/src/priceDifference.ts` refuses to derive rebalance state
+ * under the same condition; this follows it rather than inventing a second
+ * answer to "is this feed usable".
+ *
  * Price precision follows `mento_pool_oracle_price`: both go through
  * `toHumanUnits`, so an operator can reproduce the share from the two
  * published gauges by hand.
@@ -700,11 +709,14 @@ export function reserveValueShares(
     | "token0Decimals"
     | "token1Decimals"
     | "lastMedianPrice"
+    | "medianLive"
     | "invertRateFeed"
     | "invertRateFeedKnown"
   >,
 ): { share0: number; share1: number } | null {
-  if (pool.invertRateFeedKnown !== true) return null;
+  if (pool.invertRateFeedKnown !== true || pool.medianLive !== true) {
+    return null;
+  }
   const price = toHumanUnits(
     BigInt(pool.lastMedianPrice),
     SORTED_ORACLES_DECIMALS,
@@ -712,10 +724,9 @@ export function reserveValueShares(
   if (!Number.isFinite(price) || price <= 0) return null;
   const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
   const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
-  // `!(x >= 0)` rather than a finite-and-sign pair: it rejects NaN and
-  // negatives in one test, and an infinity that slips through is caught by the
-  // finite check on the total below.
-  if (!(r0 >= 0) || !(r1 >= 0)) return null;
+  // `Math.min` rather than a check per leg: NaN propagates through it, and an
+  // infinity that slips past is caught by the finite check on the total below.
+  if (!(Math.min(r0, r1) >= 0)) return null;
   const oracleRef = pool.invertRateFeed ? 1 / price : price;
   const value0 = r0 * oracleRef;
   const total = value0 + r1;
@@ -741,10 +752,11 @@ function recordReserveShareMetrics(
     { ...labels, token_symbol: token1Symbol },
     r1 / total,
   );
-  // Value shares need the oracle on top of the reserves, so they publish on a
-  // subset of the pools the count shares cover. Absent series (dark median,
-  // unread orientation) leave the depletion rules at NoData, which they treat
-  // as OK — the dark feed itself is what the oracle staleness rules page on.
+  // Value shares need a usable oracle on top of the reserves, so they publish
+  // on a subset of the pools the count shares cover. Absent series (no median
+  // yet, a median that has gone dark, unread orientation) leave the depletion
+  // rules at NoData, which they treat as OK — the dark feed itself is what the
+  // oracle staleness rules page on.
   const valueShares = reserveValueShares(pool);
   if (!valueShares) return;
   gauges.reserveValueShareToken0.set(

--- a/metrics-bridge/src/rebalance-probe.property.test.ts
+++ b/metrics-bridge/src/rebalance-probe.property.test.ts
@@ -73,6 +73,8 @@ function eligiblePool(overrides: Partial<PoolRow> = {}): PoolRow {
     reserves1: "1000000000000000000",
     token0Decimals: 18,
     token1Decimals: 18,
+    invertRateFeed: false,
+    invertRateFeedKnown: true,
     rebalancerAddress: "0x0000000000000000000000000000000000000beef",
     wrappedExchangeId: "",
     wrappedExchangeDeprecated: false,

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -44,6 +44,16 @@ export interface PoolRow {
   reserves1: string;
   token0Decimals: number;
   token1Decimals: number;
+  // Optional companion state: which way round the pool reads its rate feed.
+  // `true` means token0 is the feed's quote token, so the pool's oracle
+  // reference is `1 / lastMedianPrice`. Mirrors the on-chain FPMM flag the
+  // indexer reads (`indexer-envio/src/priceDifference.ts`). `false` is both
+  // the real "not inverted" value and the companion-query default, so
+  // `invertRateFeedKnown` is what gates use: value-weighted reserve shares
+  // publish nothing until the orientation has actually been read, because
+  // guessing it inverts the answer on half the pools.
+  invertRateFeed: boolean;
+  invertRateFeedKnown: boolean;
   // Liquidity strategy address — needed by the metrics-bridge rebalance probe
   // to simulate `rebalance(pool)` and decode the revert reason. The
   // `Pool.rebalancerAddress` column is `String!` in the indexer schema

--- a/metrics-bridge/test/fixtures.ts
+++ b/metrics-bridge/test/fixtures.ts
@@ -46,6 +46,13 @@ export function makePool(overrides: Partial<PoolRow> = {}): PoolRow {
     reserves1: "1000000000000000000",
     token0Decimals: 18,
     token1Decimals: 18,
+    // Matches the real Celo GBPm/USDm pool this fixture models: token0 is
+    // USDm, the feed's quote token, so the pool inverts the GBP/USD median
+    // to get its oracle reference. Value-weighted shares therefore publish
+    // by default; tests that need them absent override
+    // `invertRateFeedKnown: false` or `lastMedianPrice: "0"`.
+    invertRateFeed: true,
+    invertRateFeedKnown: true,
     // Test default — real strategy address from FPMM Reserve liquidity
     // strategy on Celo mainnet. Probes hitting RPC are mocked at the
     // viem-client layer in dedicated tests.

--- a/metrics-bridge/test/graphql.test.ts
+++ b/metrics-bridge/test/graphql.test.ts
@@ -594,6 +594,72 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
     });
   });
 
+  it("falls back to an unknown rate-feed orientation when Hasura reports an unknown field", async () => {
+    // Fail closed: without the flag the bridge cannot tell which way round a
+    // pool reads its feed, so `invertRateFeedKnown: false` must survive the
+    // merge and suppress the value-weighted reserve-share gauges rather than
+    // let `invertRateFeed: false` be read as "not inverted".
+    requestSpy.mockImplementation(({ document }: { document: unknown }) => {
+      const doc = String(document);
+      if (doc.includes("BridgePoolsRateFeedOrientation")) {
+        return Promise.reject(unknownFieldError("invertRateFeed"));
+      }
+      if (doc.includes("BridgePoolsVpExchangeDeprecation")) {
+        return Promise.resolve({ BiPoolExchange: [] });
+      }
+      if (doc.includes("BridgePoolsVpLifecycleDeprecation")) {
+        return Promise.resolve({ VirtualPoolLifecycle: [] });
+      }
+      if (doc.includes("query BridgePools {")) {
+        return Promise.resolve({ Pool: [BASE_POOL] });
+      }
+      return Promise.resolve({ Pool: [] });
+    });
+
+    const res = await fetchPools();
+    expect(res.Pool[0]).toMatchObject({
+      id: BASE_POOL.id,
+      invertRateFeed: false,
+      invertRateFeedKnown: false,
+    });
+  });
+
+  it("carries the rate-feed orientation through the merge when the companion query succeeds", async () => {
+    requestSpy.mockImplementation(({ document }: { document: unknown }) => {
+      const doc = String(document);
+      if (doc.includes("BridgePoolsRateFeedOrientation")) {
+        return Promise.resolve({
+          Pool: [
+            {
+              id: BASE_POOL.id,
+              invertRateFeed: true,
+              invertRateFeedKnown: true,
+            },
+          ],
+        });
+      }
+      if (doc.includes("BridgePoolsVpExchangeDeprecation")) {
+        return Promise.resolve({ BiPoolExchange: [] });
+      }
+      if (doc.includes("BridgePoolsVpLifecycleDeprecation")) {
+        return Promise.resolve({ VirtualPoolLifecycle: [] });
+      }
+      if (doc.includes("query BridgePools {")) {
+        return Promise.resolve({ Pool: [BASE_POOL] });
+      }
+      return Promise.resolve({ Pool: [] });
+    });
+
+    const res = await fetchPools();
+    expect(res.Pool[0]).toMatchObject({
+      id: BASE_POOL.id,
+      invertRateFeed: true,
+      invertRateFeedKnown: true,
+      // Companion rows must not be able to overwrite base-query state.
+      lastMedianPrice: BASE_POOL.lastMedianPrice,
+    });
+  });
+
   it("falls back to an empty oracle tx hash when Hasura reports an unknown field", async () => {
     requestSpy.mockImplementation(({ document }: { document: unknown }) => {
       const doc = String(document);

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -1601,6 +1601,178 @@ describe("updateMetrics", () => {
     expect(r1Keys).toEqual([...(devKeys ?? []), "token_symbol"].sort());
   });
 
+  // ── Value-weighted reserve shares ────────────────────────────────────────
+  // The depletion alerts read these, not the raw-count pair. Each case below
+  // is a live production pool: the two JPYm pools carry the same JPY/USD feed
+  // with OPPOSITE `invertRateFeed` flags because their token0/token1 order
+  // differs by chain, so they pin both orientations. Expected values were
+  // replayed against indexer state and cross-checked against the pool's
+  // on-chain `priceDifference` (both reproduce it to within 1 bps).
+  it("value-weights an off-parity pool that reads its feed inverted (Celo JPYm/USDm, token0 = USDm)", async () => {
+    updateMetrics([
+      makePool({
+        id: "42220-0x9861f6d2fe392b934c86ec89d2886ceb772b2b41",
+        token0: "0x765de816845861e75a25fca122bb6898b8b1282a",
+        token1: "0xc45ecf20f3cd864b32d9794d6f76814ae8892e20",
+        reserves0: "24391461103092243011223",
+        reserves1: "5751211502393013574884561",
+        lastMedianPrice: "6310100000000000000000", // 0.0063101 USD per JPY
+        invertRateFeed: true,
+        invertRateFeedKnown: true,
+      }),
+    ]);
+    // By token count the pool reads 0.4% / 99.6% — that is the JPY/USD rate,
+    // not depletion. This exact reading is what shipped in PR #1940 and would
+    // have paged (`< 10%`) on a pool the dashboard shows as healthy.
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.0042, 4);
+    // By value the same pool is 40/60 — inside every depletion band.
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.402, 3);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token1", {
+        token_symbol: "JPYm",
+      }),
+    ).toBeCloseTo(0.598, 3);
+  });
+
+  it("value-weights the same feed the other way round (Monad JPYm/USDm, token0 = JPYm, not inverted)", async () => {
+    updateMetrics([
+      makePool({
+        id: "143-0x4df3f08977743ad95ab31b8dc203eae885ae9d32",
+        chainId: 143,
+        token0: "0x22f6a6752800eab67b84748fefc3cc658384af72",
+        token1: "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115",
+        reserves0: "4574818803667125398741438",
+        reserves1: "31017541179518163757928",
+        lastMedianPrice: "6309227876692451000000",
+        invertRateFeed: false,
+        invertRateFeedKnown: true,
+      }),
+    ]);
+    // Same rate, mirrored token order: assuming one orientation for every pool
+    // would read this side at ~0.00004 and page. Correct answer is ~48%.
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "JPYm",
+      }),
+    ).toBeCloseTo(0.482, 3);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token1", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.518, 3);
+  });
+
+  it("value share equals count share on a parity pair", async () => {
+    updateMetrics([
+      makePool({
+        id: "42220-0x0feba760d93423d127de1b6abecdb60e5253228d",
+        token0: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+        token1: "0x765de816845861e75a25fca122bb6898b8b1282a",
+        token0Decimals: 6,
+        reserves0: "30363272577",
+        reserves1: "30807414550474845359006",
+        lastMedianPrice: "999319820000000000000000",
+        invertRateFeed: false,
+        invertRateFeedKnown: true,
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "USDT",
+      }),
+    ).toBeCloseTo(0.4965, 3);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "USDT",
+      }),
+    ).toBeCloseTo(0.4964, 3);
+  });
+
+  it("value share reports a genuinely one-sided pool as one-sided", async () => {
+    // Same Celo JPYm pool, but the USDm leg has actually been drained: 1/1000
+    // of the reserves that made it 40/60 above.
+    updateMetrics([
+      makePool({
+        id: "42220-0x9861f6d2fe392b934c86ec89d2886ceb772b2b41",
+        token0: "0x765de816845861e75a25fca122bb6898b8b1282a",
+        token1: "0xc45ecf20f3cd864b32d9794d6f76814ae8892e20",
+        reserves0: "24391461103092243011",
+        reserves1: "5751211502393013574884561",
+        lastMedianPrice: "6310100000000000000000",
+        invertRateFeed: true,
+        invertRateFeedKnown: true,
+      }),
+    ]);
+    const share = await getGaugeValue(
+      register,
+      "mento_pool_reserve_value_share_token0",
+      { token_symbol: "USDm" },
+    );
+    expect(share).toBeLessThan(0.001);
+  });
+
+  it("publishes no value share when the rate-feed orientation has not been read", async () => {
+    updateMetrics([makePool({ invertRateFeedKnown: false })]);
+    // Count shares still publish — only the oracle-frame conversion is gated.
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.5);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeUndefined();
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token1", {
+        token_symbol: "GBPm",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("publishes no value share while the median feed is dark", async () => {
+    // Live case: the Polygon EURm/EUROP pool has never landed a median.
+    updateMetrics([makePool({ lastMedianPrice: "0" })]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("value-share gauges carry the same label shape as the count-share gauges", async () => {
+    updateMetrics([makePool()]);
+    const json = await register.getMetricsAsJSON();
+    type MetricEntry = {
+      name: string;
+      values?: Array<{ labels: Record<string, string> }>;
+    };
+    const labelKeysFor = (name: string): string[] | undefined => {
+      const m = json.find((x) => (x as MetricEntry).name === name) as
+        | MetricEntry
+        | undefined;
+      const sample = m?.values?.[0]?.labels;
+      return sample ? Object.keys(sample).sort() : undefined;
+    };
+    const countKeys = labelKeysFor("mento_pool_reserve_share_token0");
+    expect(countKeys).toBeDefined();
+    expect(labelKeysFor("mento_pool_reserve_value_share_token0")).toEqual(
+      countKeys,
+    );
+    expect(labelKeysFor("mento_pool_reserve_value_share_token1")).toEqual(
+      countKeys,
+    );
+  });
+
   it("token_symbol label resolves known token addresses on a real Celo pool (axlUSDC + USDm)", async () => {
     // 0x765de8…1282a is USDm on Celo (42220) per @mento-protocol/contracts.
     // 0xeb466342…5215 is axlUSDC. Confirms the gauge correctly carries the

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -1739,12 +1739,39 @@ describe("updateMetrics", () => {
     ).toBeUndefined();
   });
 
-  it("publishes no value share while the median feed is dark", async () => {
-    // Live case: the Polygon EURm/EUROP pool has never landed a median.
+  it("publishes no value share when a pool has never landed a median", async () => {
+    // Live case: the Polygon EURm/EUROP pool.
     updateMetrics([makePool({ lastMedianPrice: "0" })]);
     expect(
       await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
         token_symbol: "USDm",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("publishes no value share once a live median goes dark", async () => {
+    // A zero-median outage sets `medianLive: false` while `lastMedianPrice`
+    // RETAINS the last non-zero value, so a price check alone would keep
+    // publishing a share priced off a rate the contract no longer honours.
+    updateMetrics([
+      makePool({
+        medianLive: false,
+        lastMedianPrice: "1150000000000000000000000",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.5);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeUndefined();
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_value_share_token1", {
+        token_symbol: "GBPm",
       }),
     ).toBeUndefined();
   });

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1850,7 +1850,7 @@ test("flap-prone criticals keep incidents open across short recoveries", () => {
 
 // A token-count share is the exchange rate, not depletion: a balanced
 // JPYm/USDm pool reads 0.4% / 99.6% by count and would page forever. PR #1940
-// shipped exactly that and was corrected in #1941 before the production apply.
+// shipped exactly that and was corrected in #1944 before the production apply.
 // These assertions pin the value-weighted input so the cheaper-looking gauge
 // cannot be swapped back in, and pin the annotation to the same numbers the
 // threshold used.

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1848,6 +1848,90 @@ test("flap-prone criticals keep incidents open across short recoveries", () => {
   }
 });
 
+// A token-count share is the exchange rate, not depletion: a balanced
+// JPYm/USDm pool reads 0.4% / 99.6% by count and would page forever. PR #1940
+// shipped exactly that and was corrected in #1941 before the production apply.
+// These assertions pin the value-weighted input so the cheaper-looking gauge
+// cannot be swapped back in, and pin the annotation to the same numbers the
+// threshold used.
+test("pool depletion tiers measure value share, not token-count share", () => {
+  const main = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/main.tf"),
+    "utf8",
+  );
+  const stripped = stripComments(main);
+  const depletionExpressions = [
+    ...stripped.matchAll(
+      /\bpool_depletion_(?:page|critical)_active_promql\s*=\s*(.+)/g,
+    ),
+  ].map(([, value]) => value);
+  assert(
+    depletionExpressions.length === 2,
+    `expected both depletion band expressions, got ${depletionExpressions.length}`,
+  );
+  // Both bands resolve through the same local, so resolve it once and assert
+  // on the expression the rules actually evaluate.
+  const [, minShareExpression] = stripped.match(
+    /\bpool_min_reserve_value_share_promql\s*=\s*"([^"]+)"/,
+  ) ?? [null, null];
+  assert(
+    minShareExpression !== null,
+    "the depletion bands should read a value-weighted min-share local",
+  );
+  for (const gauge of [
+    "mento_pool_reserve_value_share_token0",
+    "mento_pool_reserve_value_share_token1",
+  ]) {
+    assert(
+      minShareExpression.includes(gauge),
+      `depletion min-share expression must read ${gauge}`,
+    );
+  }
+  assert(
+    !/mento_pool_reserve_share_token[01]/.test(minShareExpression),
+    "depletion must not read the raw token-count share gauges — on an off-parity pair they measure the exchange rate, not depletion",
+  );
+  for (const expression of depletionExpressions) {
+    assert(
+      expression.includes("pool_min_reserve_value_share_promql"),
+      `depletion band expression should resolve through the value-weighted local: ${expression}`,
+    );
+  }
+
+  // The summary names the thin side from the same value shares the threshold
+  // used. Reading R0/R1 here would name the wrong token on an off-parity pair.
+  const [, summary] = stripped.match(
+    /\bpool_depletion_summary_annotation\s*=\s*<<-EOT\n([\s\S]*?)\n\s*EOT/,
+  ) ?? [null, null];
+  assert(summary !== null, "pool_depletion_summary_annotation should exist");
+  assert(
+    summary.includes("$values.V0") && summary.includes("$values.V1"),
+    "depletion summary must read the V0/V1 value-share annotation queries",
+  );
+  assert(
+    !summary.includes("$values.R0") && !summary.includes("$values.R1"),
+    "depletion summary must not name the thin side from token-count shares",
+  );
+
+  // Every annotation ref the summary reads has to be supplied to both rules,
+  // or Grafana renders the fallback copy instead of the numbers.
+  const fpmmRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-fpmms.tf"),
+    "utf8",
+  );
+  for (const namePattern of [
+    /\bname\s*=\s*"Pool Depletion Risk"/,
+    /\bname\s*=\s*"Pool Nearly One-Sided"/,
+  ]) {
+    assert(
+      ruleBlockNamed(fpmmRules, namePattern).includes(
+        "local.pool_depletion_value_share_annotation_queries",
+      ),
+      `${namePattern} must attach the value-share annotation queries`,
+    );
+  }
+});
+
 test("long-lived pool criticals repeat twice daily, short-lived ones hourly", () => {
   const contactPoints = readFileSync(
     path.resolve(repoRoot, "alerts/rules/contact-points.tf"),

--- a/scripts/alerts/check-deviation-threshold-drift.test.mjs
+++ b/scripts/alerts/check-deviation-threshold-drift.test.mjs
@@ -41,8 +41,8 @@ export const POOL_DEPLETION_CRITICAL_SHARE = ${depletionCritical};
 export const POOL_DEPLETION_PAGE_SHARE = ${depletionPage};
 `,
     [ALERTS_MAIN_PATH]: `
-pool_min_reserve_share_promql = "min without(token_symbol) (mento_pool_reserve_share_token0 or mento_pool_reserve_share_token1)"
-pool_depletion_critical_active_promql = "(\${local.pool_min_reserve_share_promql}) >= ${bandFloor}"
+pool_min_reserve_value_share_promql = "min without(token_symbol) (mento_pool_reserve_value_share_token0 or mento_pool_reserve_value_share_token1)"
+pool_depletion_critical_active_promql = "(\${local.pool_min_reserve_value_share_promql}) >= ${bandFloor}"
 deviation_warning_summary_annotation = <<-EOT
 {{- printf "Pool %.0f%% above ${annotationTolerancePercent}%% tolerance." $values.Dev.Value -}}
 Pool above ${annotationTolerancePercent}% tolerance.

--- a/shared-config/src/thresholds.ts
+++ b/shared-config/src/thresholds.ts
@@ -9,7 +9,11 @@
 //     drives dashboard health badges, breach-history bucketing, the indexer's
 //     persisted breach accounting, and metrics-bridge probe eligibility.
 //   - Depletion side share (`POOL_DEPLETION_*_SHARE`) measures user impact:
-//     how thin the smaller side of the pool has become.
+//     how thin the smaller side of the pool has become, BY VALUE. Token counts
+//     are not comparable across an off-parity pair — a balanced JPYm/USDm pool
+//     holds 0.4% of its tokens in USDm and is perfectly healthy — so the
+//     consumers of these floors convert each leg through the pool's oracle
+//     first (`mento_pool_reserve_value_share_token*`).
 //
 // Since ADR 0067 only the second ladder pages. Deviation magnitude is an
 // analytics classification, not an alert severity.
@@ -67,11 +71,12 @@ export const DEVIATION_TOLERANCE_RATIO = 1.01;
 export const DEVIATION_CRITICAL_RATIO = 1.05;
 
 /**
- * Pool depletion CRITICAL floor, as a share of normalized reserves held by the
- * smaller side. Below it the thin leg no longer has the depth to absorb normal
- * swap size: an FPMM's quoted bandwidth in one direction is bounded by what
- * that side actually holds, so a 15/85 pool starts rejecting trades a 50/50
- * pool of the same TVL would serve.
+ * Pool depletion CRITICAL floor, as the VALUE share of reserves held by the
+ * smaller side — each leg priced through the pool's own oracle reference, not
+ * counted in tokens. Below it the thin leg no longer has the depth to absorb
+ * normal swap size: an FPMM's quoted bandwidth in one direction is bounded by
+ * what that side actually holds, so a 15/85 pool starts rejecting trades a
+ * 50/50 pool of the same TVL would serve.
  *
  * Mirrored into the `Pool Depletion Risk` Grafana evaluator in
  * `alerts/rules/rules-fpmms.tf`, and enforced by
@@ -80,7 +85,8 @@ export const DEVIATION_CRITICAL_RATIO = 1.05;
 export const POOL_DEPLETION_CRITICAL_SHARE = 0.2;
 
 /**
- * Pool depletion PAGE floor, same units as `POOL_DEPLETION_CRITICAL_SHARE`.
+ * Pool depletion PAGE floor, same units as `POOL_DEPLETION_CRITICAL_SHARE`
+ * (value share, not token count).
  * Below it the pool is effectively one-sided: bandwidth exhaustion is imminent
  * (a 95/5 pool has almost nothing left to sell of the thin token) and once that
  * side reaches zero, every swap into it reverts outright. That is direct,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The `Pool Depletion Risk` / `Pool Nearly One-Sided` rules merged in #1940 (issue #1936) alert on `min(token-count share)`. On a pair that does not trade near parity that number is the exchange rate, not depletion — so as merged, **both JPYm/USDm pools would have paged Splunk On-Call indefinitely**, with no operator action able to clear them. Caught before the production apply was approved.
- The two JPYm pools read 0.42% and 0.67% by token count. By value they are 40.2% / 59.8% and 48.2% / 51.8% — inside tolerance (`deviation_ratio` 0.98 and 0.15) and shown healthy on the dashboard, which has always converted through the oracle.
- The obvious fix — multiply one leg by `mento_pool_oracle_price` — is also wrong. `invertRateFeed` is per pool, not per pair: 9 of the 18 live pools invert. Assuming one direction reads Monad JPYm/USDm at 0.004% and pages on it instead.

## The Solution

- metrics-bridge publishes `mento_pool_reserve_value_share_token{0,1}`: each leg priced through the pool's own oracle reference, so 50/50 means "sitting on the oracle" and the floors measure economic one-sidedness. The conversion happens in the bridge because that is where the per-pool `invertRateFeed` flag is available; PromQL cannot see it.
- Both depletion bands read the value gauges instead of the count gauges. Rule names, severities, `for`, routing, the absent `keep_firing_for`, and the `0.20` / `0.10` constants are unchanged — this is an input and annotation fix.
- Annotations now name the thin side and render the number from the same value shares the threshold used, plus a new `Value Share:` line that says so in words.

## Details

**Orientation, established from source and confirmed against production.** The FPMM compares `reservePrice = r1_normalized / r0_normalized` against `oracleRef`, the price of token0 denominated in token1 (`indexer-envio/src/priceDifference.ts:reservePriceVsOracleRef`). `oracleRef` is the SortedOracles median in feed direction, inverted when `invertRateFeed` says token0 is the feed's quote token. Weighting the legs by `(oracleRef, 1)` therefore puts a pool sitting exactly on its oracle at 50/50. `invertRateFeed` compensates token ordering, which differs by chain — Celo lists USDm as token0 for JPYm/USDm and inverts; Monad lists JPYm as token0 and does not.

**The replay reproduces each pool's on-chain `priceDifference`.** That is the check that the conversion is in the FPMM's own frame rather than merely plausible: `|value1/value0 − 1| × 10000` matches the contract-derived `priceDifference` on every pool, to within 1 bps of rounding.

**Deploy ordering.** The gauges do not exist in production yet (confirmed: the value-share query returns no series today). Merging deploys metrics-bridge; the alert apply should follow, and the new gauges can be confirmed in Prometheus before approving it. Until they publish, both tiers evaluate NoData → `no_data_state = "OK"` → silence, which is the same posture as today's un-applied state.

**NoData behaviour.** The value gauges need a live median and an on-chain-read orientation, which the count gauges did not. A pool missing either publishes no value share and both tiers go NoData → OK. Today that is Polygon EURm/EUROP, which has never landed a median; its dark feed is covered by the oracle liveness rules. This is a deliberate coverage trade: a depletion number derived from a guessed rate is worse than none, and the alternative (falling back to counts) reintroduces exactly the bug this PR fixes.

**Also corrected in this PR:** ADR 0067's Consequences claimed the two JPYm pages were day-one true positives and told the approver to fund those pools first. That was wrong; the record now carries the count-vs-value lesson, the reversal of the "a new metrics-bridge gauge is unnecessary" alternative, and the empty day-one firing set. `shared-config/src/thresholds.ts` docstrings, the `alerts/rules` comments, and the drift-checker fixture now say value share. Constant values, drift-mirror literals, and lint rule-name lists are unchanged.

**New test coverage:** both feed orientations pinned by the two real JPYm pools (the same rate, mirrored token order); a parity pair where value and count agree; a genuinely drained side still reading as drained; suppression when the orientation is unread or the median is dark; label-shape parity with the count gauges; companion-query degradation; and an `alert-rules-lint` assertion that the depletion expression reads the value gauges and never the count gauges.

## Validation

**18-pool production replay** (2026-08-19). Reserves, decimals, median price, and `invertRateFeed` from the production indexer; raw shares and oracle price cross-checked against `grafanacloud-prom`. `count(min without(token_symbol) (…))` returns exactly 18 series against production, one per pool.

| chain | pair | token0/token1 | invert | oracle price | count min share | **value min share** | thin side (value) | pd replayed | pd on-chain |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| celo | axlEUROC/EURm | axlEUROC/EURm | false | 1.00021 | 0.4002 | **0.4002** | axlEUROC | 4986 | 4986 |
| celo | axlUSDC/USDm | USDm/axlUSDC | true | 0.999920 | 0.4841 | **0.4841** | axlUSDC | 617 | 616 |
| celo | CHFm/USDm | USDm/CHFm | true | 1.24952 | 0.3540 | **0.4064** | CHFm | 3154 | 3154 |
| celo | EURm/USDm | USDm/EURm | true | 1.16614 | 0.4369 | **0.3995** | USDm | 5028 | 5028 |
| celo | GBPm/USDm | USDm/GBPm | true | 1.36087 | 0.4760 | **0.4003** | USDm | 4979 | 4978 |
| celo | JPYm/USDm | USDm/JPYm | true | 0.00631062 | 0.0042 | **0.4019** | USDm | 4880 | 4879 |
| celo | USDC/USDm | USDm/USDC | true | 0.999920 | 0.4411 | **0.4411** | USDm | 2670 | 2669 |
| celo | USDT/USDm | USDT/USDm | false | 0.999551 | 0.4965 | **0.4964** | USDT | 145 | 145 |
| monad | AUSD/USDm | AUSD/USDm | false | 0.999895 | 0.4349 | **0.4349** | USDm | 2305 | 2304 |
| monad | CHFm/USDm | USDm/CHFm | true | 1.24959 | 0.2220 | **0.2628** | CHFm | 6434 | 6434 |
| monad | EURm/USDm | EURm/USDm | false | 1.16629 | 0.4619 | **0.4239** | USDm | 2641 | 2641 |
| monad | GBPm/USDm | GBPm/USDm | false | 1.36071 | 0.3899 | **0.4651** | GBPm | 1501 | 1500 |
| monad | JPYm/USDm | JPYm/USDm | false | 0.00631042 | 0.0067 | **0.4821** | JPYm | 744 | 744 |
| monad | USDC/USDm | USDC/USDm | false | 0.999920 | 0.4278 | **0.4278** | USDC | 3378 | 3377 |
| monad | USDT0/USDm | USDm/USDT0 | true | 0.999350 | 0.4059 | **0.4060** | USDm | 4628 | 4628 |
| polygon | EURm/EUROP | EURm/EUROP | true | — (no median) | 0.4000 | **n/a** | — | — | 5000 |
| polygon | EURm/USDm | EURm/USDm | false | 1.16636 | 0.4442 | **0.4824** | EURm | 729 | 728 |
| polygon | USDC/USDm | USDC/USDm | false | 0.999990 | 0.4000 | **0.4000** | USDm | 3333 | 3333 |

- Every pool with a live median yields exactly one series, in `[0.26, 0.50]`. Nothing lands in the critical `[0.10, 0.20)` band or the page band below `0.10`.
- The thinnest side is Monad CHFm/USDm at 26.3%, which is also the pool furthest outside its rebalance band (`priceDifference` 6434 bps = 1.29× threshold) — the two signals agree, as they must.
- Replayed `priceDifference` matches the pool's on-chain value on all 17 pools with a median (max delta 1 bps, rounding).
- **As merged in #1940** the count-share expression puts celo JPYm/USDm at 0.0042 and monad JPYm/USDm at 0.0067 — both below the 0.10 page floor.
- **The single-orientation shortcut** (`share_token1 × oracle_price`) would read monad JPYm/USDm at 0.00004 and polygon EURm/EUROP at 0 — two different false pages.

**Gates** (all green on the final head):

- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh` — all 27 mapped commands passed, including `terraform fmt`/`init`/`validate` on `alerts/rules`, `alerts:rules:lint`, `alerts:rules:lint:test`, `check-deviation-threshold-drift(.test)`, metrics-bridge typecheck/lint/knip/`test:coverage`, and `tf:test`.
- `pnpm --filter @mento-protocol/metrics-bridge test` — 604 passed.
- `scripts/agent-autoreview.sh --engine codex --base origin/main` — clean, no actionable findings ("patch is correct", 0.88). Remote Codex review is rate-limited; the local run substitutes per operator waiver.
- No terraform plan or apply was run locally.

**Terraform plan note:** the PR-level plan is targeted and will NOT show the `fpmms` rule groups, so a plan with no depletion diff on this PR is expected and proves nothing either way. The trusted-main plan is what decides, and it should be read after metrics-bridge has deployed and the new gauges are visible in Prometheus.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0067 is amended in this PR: the reversed "a new metrics-bridge gauge is unnecessary" alternative, the corrected Consequences, and the value-weighted decision text.

Refs #1936. Corrects #1940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmZZFrBzv1xngkMUKDyJHM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-call paging logic and introduces a metrics-bridge → alert dependency; wrong deploy order or orientation bugs could silence real depletion or reintroduce false pages, though extensive replay tests and fail-closed NoData handling mitigate this.
> 
> **Overview**
> Fixes pool depletion alerting so **economic one-sidedness** is measured by **value share** (oracle-weighted reserves), not raw token counts — which on off-parity pairs like JPYm/USDm reflected the exchange rate and would have caused **indefinite false Splunk pages** under #1940.
> 
> **metrics-bridge** adds `mento_pool_reserve_value_share_token{0,1}` via `reserveValueShares`, using per-pool `invertRateFeed` from a new Hasura companion query; missing median or unknown orientation publishes **no** value gauges (depletion rules stay NoData → OK). **Grafana** depletion PromQL, summaries, and V0/V1 annotations now use value shares; Slack/VictorOps gain a **Value Share** line. **ADR 0067** and threshold docs are corrected (empty day-one firing set, count-vs-value lesson). Lint/drift tests lock the expression to value gauges only.
> 
> Deploy **metrics-bridge before** alert apply so gauges exist in Prometheus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d7464ddc7a56af44e0ad5d9776ee1b97ef5721. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pool depletion monitoring now evaluates reserve shares by oracle-priced value instead of token counts.
  * Alerts identify the thinner side by value and can show a “Value Share” composition breakdown.
* **Bug Fixes**
  * Prevented stale or unavailable oracle data from triggering misleading depletion alerts.
  * Corrected depletion assessments for pools with inverted rate feeds.
* **Documentation**
  * Updated guidance and threshold descriptions to reflect value-based depletion monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->