### PR TITLE
fix(scripts): close six pre-existing fail-open gaps in the sentry tooling

### DIFF
--- a/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
@@ -23,13 +23,32 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 await test("run record body carries the marker, trigger, state, and tallies", () => {
   const body = buildAutofixRunRecordBody({

--- a/scripts/sentry/broker/sentry-mcp-broker.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.mjs
@@ -244,6 +244,27 @@ export function rewriteRegionLinks(payload, brokerOrigin) {
   return payload;
 }
 
+/**
+ * The upstream back-pressure headers this broker relays to its client.
+ *
+ * Sentry answers a throttled read with `Retry-After` and a family of
+ * `X-Sentry-Rate-Limit-*` headers, and the MCP server is written to obey them.
+ * Dropping them turns a 429 into a bare status: the client cannot tell how long
+ * to wait, so it retries immediately against a Sentry already refusing it, and
+ * the run burns its budget on requests none of which can succeed.
+ *
+ * A PREFIX allowlist, not a passthrough. The broker exists so that only what it
+ * chose crosses it, and the two things named here carry no credential and no
+ * routing — but a name-by-name list would silently drop whichever member of the
+ * family Sentry adds next, which is the failure this fixes in the first place.
+ */
+const RATE_LIMIT_HEADER_PREFIX = "x-sentry-rate-limit";
+
+export function isBackPressureHeader(name) {
+  const lower = String(name ?? "").toLowerCase();
+  return lower === "retry-after" || lower.startsWith(RATE_LIMIT_HEADER_PREFIX);
+}
+
 function deny(res, status, reason) {
   res.writeHead(status, { "content-type": "application/json" });
   res.end(JSON.stringify({ detail: `sentry-mcp-broker: ${reason}` }));
@@ -376,6 +397,11 @@ export function createHandler(config) {
     // the MCP client reads only the `cursor="…"` value out of it.
     const link = upstreamRes.headers.get("link");
     if (link) headers.link = link;
+    // Back-pressure, relayed for the same reason (see isBackPressureHeader):
+    // without it a 429 arrives stripped of every hint of when to try again.
+    for (const [name, value] of upstreamRes.headers) {
+      if (isBackPressureHeader(name)) headers[name.toLowerCase()] = value;
+    }
     res.writeHead(upstreamRes.status, headers);
     res.end(body);
     log(
@@ -404,8 +430,25 @@ export async function startBroker(config) {
     });
   });
   await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(config.port ?? 0, BIND_HOST, resolve);
+    const onStartupError = (error) => reject(error);
+    server.once("error", onStartupError);
+    server.listen(config.port ?? 0, BIND_HOST, () => {
+      server.removeListener("error", onStartupError);
+      resolve();
+    });
+  });
+  // Past startup that `reject` is a no-op, and it was the server's ONLY `error`
+  // listener — so every later socket error was discarded in silence, which for a
+  // broker whose whole job is to be the one path to Sentry reads as "the run
+  // simply stopped getting answers". Log it instead. Nothing here throws: an
+  // `error` event with no listener is an uncaught exception that would take the
+  // broker down with the run still using it.
+  server.on("error", (error) => {
+    config.log?.(
+      `sentry-mcp-broker: SERVER-ERROR ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   });
   const { port } = server.address();
   // `validateRegionUrl` demands an https URL and accepts the base host; the MCP

--- a/scripts/sentry/broker/sentry-mcp-broker.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.mjs
@@ -418,31 +418,60 @@ export function createHandler(config) {
 }
 
 /**
- * A post-startup `error` on the server is FATAL, and the workflow is why.
+ * Accept-level errors a LISTENER SURVIVES: the runner ran out of a resource for
+ * one connection, not the socket the broker is bound to. Tearing down on these
+ * would turn a momentary fd or memory squeeze into a dead broker, which is the
+ * outcome the handler below exists to avoid, reached faster.
+ */
+const TRANSIENT_ACCEPT_ERRORS = new Set([
+  "EMFILE",
+  "ENFILE",
+  "ENOBUFS",
+  "ENOMEM",
+  "ECONNABORTED",
+  "EAGAIN",
+  "EPROTO",
+]);
+
+/**
+ * What a post-startup `error` on the server does, and the workflow is why it
+ * cannot just be logged.
  *
  * Both broker streams redirect to a log file
  * (.github/workflows/sentry-triage-agent.yml), and that file is printed only
- * when the readiness wait fails. Past readiness, a logged line goes somewhere
- * nobody reads — so logging alone leaves the agent running its whole turn budget
- * against a broker that has stopped accepting connections, which is the silent
+ * when the readiness wait fails. Past readiness a logged line goes somewhere
+ * nobody reads — so logging alone leaves the agent spending its whole turn
+ * budget against a broker that has stopped accepting, which is the silent
  * needs-human verdict issue #1938 was filed for.
  *
- * So say what failed, then STOP. A dead broker is a shape this pipeline already
- * handles loudly: the pre-flight probe refuses to register the toolset and the
- * job fails with `sentry:needs-triage` still on the stub. Being alive and unable
- * to accept is the only state nothing downstream can see.
+ * So a broker that has lost its listener says what failed and STOPS. That shape
+ * this pipeline already handles loudly: the port is released, so the pre-flight
+ * probe cannot register the toolset and the job fails with `sentry:needs-triage`
+ * still on the stub. Alive and unable to accept is the state nothing sees.
  *
- * Fatal is safe because of WHICH errors land here: per-connection failures go to
- * `clientError`, so `error` after `listening` is accept-level and a broker that
- * cannot accept has nothing left to serve. `exit` is injectable so tests can
- * observe the decision rather than take the process down with them.
+ * The DEFAULT is fatal, and the direction is the reason. Staying up when the
+ * listener is gone restores the silence; going down when it was not costs a run
+ * that fails visibly. Only codes known to be per-connection survive, and only
+ * while the listener is demonstrably still up — an unknown code is treated as
+ * the listener being gone, never the other way round.
+ *
+ * Per-connection parse failures never reach here at all; those are `clientError`.
+ * `exit` is injectable so tests observe the decision rather than take the runner
+ * down with them.
  */
-export function handleFatalServerError(error, { server, log, exit }) {
+export function handleServerError(error, { server, log, exit }) {
   log(
     `sentry-mcp-broker: SERVER-ERROR ${
       error instanceof Error ? error.message : String(error)
     }`,
   );
+  const code = error && typeof error === "object" ? error.code : undefined;
+  if (TRANSIENT_ACCEPT_ERRORS.has(code) && server.listening) {
+    log(
+      `sentry-mcp-broker: SERVER-ERROR ${code} is accept-level and the listener is still up; staying up`,
+    );
+    return;
+  }
   try {
     server.close();
   } catch {
@@ -480,7 +509,7 @@ export async function startBroker(config) {
   // Past startup that `reject` is a no-op, and it was the server's ONLY `error`
   // listener, so every later socket error was discarded in silence.
   server.on("error", (error) =>
-    handleFatalServerError(error, {
+    handleServerError(error, {
       server,
       log,
       exit: config.exit ?? ((code) => process.exit(code)),

--- a/scripts/sentry/broker/sentry-mcp-broker.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.mjs
@@ -248,17 +248,19 @@ export function rewriteRegionLinks(payload, brokerOrigin) {
  * The upstream back-pressure headers this broker relays to its client.
  *
  * Sentry answers a throttled read with `Retry-After` and a family of
- * `X-Sentry-Rate-Limit-*` headers, and the MCP server is written to obey them.
- * Dropping them turns a 429 into a bare status: the client cannot tell how long
- * to wait, so it retries immediately against a Sentry already refusing it, and
- * the run burns its budget on requests none of which can succeed.
+ * `X-Sentry-Rate-Limit-*` headers, and the MCP server obeys them. Dropping them
+ * turns a 429 into a bare status: the client cannot tell how long to wait, so it
+ * retries immediately against a Sentry already refusing it.
  *
- * A PREFIX allowlist, not a passthrough. The broker exists so that only what it
- * chose crosses it, and the two things named here carry no credential and no
- * routing — but a name-by-name list would silently drop whichever member of the
- * family Sentry adds next, which is the failure this fixes in the first place.
+ * A PREFIX allowlist, not a passthrough — but the prefix carries its trailing
+ * HYPHEN, so it admits the family and not merely anything starting with those
+ * letters. Without it `x-sentry-rate-limitation` would cross a boundary that
+ * exists to let through only what it chose. Sentry's plural
+ * `X-Sentry-Rate-Limits` is an ingest/envelope response header; every path in
+ * ALLOWED_PATHS is a `/api/0/organizations/` Web API read, so it cannot arrive
+ * here and the hyphen drops nothing.
  */
-const RATE_LIMIT_HEADER_PREFIX = "x-sentry-rate-limit";
+const RATE_LIMIT_HEADER_PREFIX = "x-sentry-rate-limit-";
 
 export function isBackPressureHeader(name) {
   const lower = String(name ?? "").toLowerCase();
@@ -416,15 +418,53 @@ export function createHandler(config) {
 }
 
 /**
+ * A post-startup `error` on the server is FATAL, and the workflow is why.
+ *
+ * Both broker streams redirect to a log file
+ * (.github/workflows/sentry-triage-agent.yml), and that file is printed only
+ * when the readiness wait fails. Past readiness, a logged line goes somewhere
+ * nobody reads — so logging alone leaves the agent running its whole turn budget
+ * against a broker that has stopped accepting connections, which is the silent
+ * needs-human verdict issue #1938 was filed for.
+ *
+ * So say what failed, then STOP. A dead broker is a shape this pipeline already
+ * handles loudly: the pre-flight probe refuses to register the toolset and the
+ * job fails with `sentry:needs-triage` still on the stub. Being alive and unable
+ * to accept is the only state nothing downstream can see.
+ *
+ * Fatal is safe because of WHICH errors land here: per-connection failures go to
+ * `clientError`, so `error` after `listening` is accept-level and a broker that
+ * cannot accept has nothing left to serve. `exit` is injectable so tests can
+ * observe the decision rather than take the process down with them.
+ */
+export function handleFatalServerError(error, { server, log, exit }) {
+  log(
+    `sentry-mcp-broker: SERVER-ERROR ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  try {
+    server.close();
+  } catch {
+    // Already down, which is the outcome this wanted.
+  }
+  exit(1);
+}
+
+/**
  * Starts the broker on `port`. Binds loopback only.
  *
  * @returns {Promise<import("node:http").Server>}
  */
 export async function startBroker(config) {
   const handler = createHandler(config);
+  // One sink for both diagnostics below, with the same console fallback
+  // `createHandler` applies. An optional call would silently discard them
+  // whenever a caller supplies no `log`.
+  const log = config.log ?? ((line) => console.log(line));
   const server = createServer((req, res) => {
     handler(req, res).catch((error) => {
-      config.log?.(`sentry-mcp-broker: HANDLER-ERROR ${error}`);
+      log(`sentry-mcp-broker: HANDLER-ERROR ${error}`);
       if (!res.headersSent) deny(res, 500, "internal error");
       else res.end();
     });
@@ -438,23 +478,14 @@ export async function startBroker(config) {
     });
   });
   // Past startup that `reject` is a no-op, and it was the server's ONLY `error`
-  // listener — so every later socket error was discarded in silence, which for a
-  // broker whose whole job is to be the one path to Sentry reads as "the run
-  // simply stopped getting answers". Log it instead. Nothing here throws: an
-  // `error` event with no listener is an uncaught exception that would take the
-  // broker down with the run still using it.
-  //
-  // Unconditional, with the same console fallback `createHandler` applies: an
-  // optional call would restore the silence this exists to end whenever a caller
-  // supplies no sink.
-  const logServerError = config.log ?? ((line) => console.log(line));
-  server.on("error", (error) => {
-    logServerError(
-      `sentry-mcp-broker: SERVER-ERROR ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  });
+  // listener, so every later socket error was discarded in silence.
+  server.on("error", (error) =>
+    handleFatalServerError(error, {
+      server,
+      log,
+      exit: config.exit ?? ((code) => process.exit(code)),
+    }),
+  );
   const { port } = server.address();
   // `validateRegionUrl` demands an https URL and accepts the base host; the MCP
   // client then keeps the host and re-applies its own (http) protocol, so this

--- a/scripts/sentry/broker/sentry-mcp-broker.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.mjs
@@ -443,8 +443,13 @@ export async function startBroker(config) {
   // simply stopped getting answers". Log it instead. Nothing here throws: an
   // `error` event with no listener is an uncaught exception that would take the
   // broker down with the run still using it.
+  //
+  // Unconditional, with the same console fallback `createHandler` applies: an
+  // optional call would restore the silence this exists to end whenever a caller
+  // supplies no sink.
+  const logServerError = config.log ?? ((line) => console.log(line));
   server.on("error", (error) => {
-    config.log?.(
+    logServerError(
       `sentry-mcp-broker: SERVER-ERROR ${
         error instanceof Error ? error.message : String(error)
       }`,

--- a/scripts/sentry/broker/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.test.mjs
@@ -32,6 +32,7 @@ import {
   assertTokenAbsentFromExecEnv,
   classify,
   handleMatches,
+  handleFatalServerError,
   isAllowedPath,
   isBackPressureHeader,
   isEntryPoint,
@@ -431,51 +432,119 @@ test("rewriteRegionLinks touches only links.regionUrl", () => {
   assert.equal("regionUrl" in payload[2].links, false);
 });
 
-test("a socket error AFTER startup is logged, not swallowed", async () => {
-  // The startup promise's `reject` used to be the server's only `error`
-  // listener, and once that promise settles it is a no-op — so every later
-  // socket error vanished, and a broker that had stopped answering looked
-  // exactly like a Sentry with nothing to say.
-  await withBroker(jsonUpstream([]), async ({ broker, logs }) => {
-    broker.emit("error", new Error("EADDRNOTAVAIL after startup"));
-    assert.ok(
-      logs.some((line) => line.includes("SERVER-ERROR")),
-      `a post-startup server error must reach the log; saw ${JSON.stringify(logs)}`,
-    );
-    assert.ok(
-      logs.some((line) => line.includes("EADDRNOTAVAIL after startup")),
-      "the log line must name what actually failed",
-    );
-  });
+test("a socket error AFTER startup is logged AND fails the broker closed", async () => {
+  // Two halves, and the second is the one that reaches the workflow. The
+  // startup promise's `reject` used to be the server's only `error` listener,
+  // and once that promise settles it is a no-op, so every later socket error
+  // vanished. Logging alone does not fix that: the workflow sends both broker
+  // streams to a file it prints only when readiness fails, so a line written
+  // after readiness is read by nobody and the agent keeps spending its turn
+  // budget against a broker that has stopped accepting.
+  const exits = [];
+  await withBroker(
+    jsonUpstream([]),
+    async ({ broker, logs }) => {
+      broker.emit("error", new Error("EADDRNOTAVAIL after startup"));
+      assert.ok(
+        logs.some((line) => line.includes("SERVER-ERROR")),
+        `a post-startup server error must reach the log; saw ${JSON.stringify(logs)}`,
+      );
+      assert.ok(
+        logs.some((line) => line.includes("EADDRNOTAVAIL after startup")),
+        "the log line must name what actually failed",
+      );
+      assert.deepEqual(exits, [1], "the broker must exit non-zero, not linger");
+      assert.equal(
+        broker.listening,
+        false,
+        "a broker that stopped accepting must not keep the port claimed",
+      );
+    },
+    { exit: (code) => exits.push(code) },
+  );
 });
 
-test("a socket error is reported even when the caller supplies no log sink", async () => {
-  // An optional call on `config.log` would put the silence straight back for
-  // any caller that passes none, which is the whole defect. The console
-  // fallback is the same one `createHandler` already applies.
+test("handleFatalServerError says what failed before it stops, and stops regardless", () => {
+  const lines = [];
+  const exits = [];
+  let closed = 0;
+  handleFatalServerError(new Error("EMFILE"), {
+    server: {
+      close: () => {
+        closed += 1;
+        // The order is load-bearing: a close that throws must not swallow the
+        // exit, or the fatal path leaves the broker alive after all.
+        throw new Error("already down");
+      },
+    },
+    log: (line) => lines.push(line),
+    exit: (code) => exits.push(code),
+  });
+  assert.deepEqual(lines, ["sentry-mcp-broker: SERVER-ERROR EMFILE"]);
+  assert.equal(closed, 1);
+  assert.deepEqual(exits, [1]);
+});
+
+/** Runs `body` with `console.log` captured, restoring it however body ends. */
+async function withCapturedConsole(body) {
+  const lines = [];
+  const realLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await body(lines);
+  } finally {
+    console.log = realLog;
+  }
+  return lines;
+}
+
+test("both broker diagnostics survive a caller that supplies no log sink", async () => {
+  // An optional call on `config.log` puts the silence straight back for any
+  // caller passing none, which is the defect both lines exist to end. The
+  // console fallback is the one `createHandler` already applies.
   const upstream = await startUpstream(jsonUpstream([]));
+  const exits = [];
   const broker = await startBroker({
     token: REAL_TOKEN,
     handle: HANDLE,
     upstream: upstream.origin,
     port: 0,
+    exit: (code) => exits.push(code),
   });
-  const lines = [];
-  const realLog = console.log;
-  console.log = (line) => lines.push(String(line));
-  try {
+  // An unparsable upstream makes the handler throw INSIDE the request path,
+  // which is the only way to reach HANDLER-ERROR.
+  const broken = await startBroker({
+    token: REAL_TOKEN,
+    handle: HANDLE,
+    upstream: "not-a-url",
+    port: 0,
+    exit: (code) => exits.push(code),
+  });
+  let status = null;
+  const lines = await withCapturedConsole(async () => {
+    status = (
+      await call(
+        `http://127.0.0.1:${broken.address().port}`,
+        "/api/0/organizations/",
+      )
+    ).status;
     broker.emit("error", new Error("no sink was supplied"));
-  } finally {
-    console.log = realLog;
-    broker.close();
-    upstream.server.close();
-  }
+  });
+  broker.close();
+  broken.close();
+  upstream.server.close();
+
+  assert.equal(status, 500, "a thrown handler still denies rather than hangs");
+  assert.ok(
+    lines.some((line) => line.includes("HANDLER-ERROR")),
+    `the handler failure must reach the fallback; saw ${JSON.stringify(lines)}`,
+  );
   assert.ok(
     lines.some(
       (line) =>
         line.includes("SERVER-ERROR") && line.includes("no sink was supplied"),
     ),
-    `the fallback must report the error; saw ${JSON.stringify(lines)}`,
+    `the socket failure must reach the fallback; saw ${JSON.stringify(lines)}`,
   );
 });
 
@@ -527,6 +596,13 @@ test("isBackPressureHeader admits the two families and nothing else", () => {
   assert.equal(isBackPressureHeader("set-cookie"), false);
   assert.equal(isBackPressureHeader("x-sentry-token"), false);
   assert.equal(isBackPressureHeader(undefined), false);
+  // The prefix carries its trailing hyphen, so a name that merely STARTS with
+  // those letters is not the family and does not cross.
+  assert.equal(isBackPressureHeader("x-sentry-rate-limitation"), false);
+  assert.equal(isBackPressureHeader("x-sentry-rate-limiter-secret"), false);
+  // Sentry's plural ingest header is not a Web API response header, and the
+  // hyphen excludes it too; every ALLOWED_PATHS entry is a Web API read.
+  assert.equal(isBackPressureHeader("x-sentry-rate-limits"), false);
 });
 
 // ── fail closed: redirects and upstream failures ─────────────────────────────

--- a/scripts/sentry/broker/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.test.mjs
@@ -32,7 +32,7 @@ import {
   assertTokenAbsentFromExecEnv,
   classify,
   handleMatches,
-  handleFatalServerError,
+  handleServerError,
   isAllowedPath,
   isBackPressureHeader,
   isEntryPoint,
@@ -464,12 +464,15 @@ test("a socket error AFTER startup is logged AND fails the broker closed", async
   );
 });
 
-test("handleFatalServerError says what failed before it stops, and stops regardless", () => {
+test("handleServerError says what failed before it stops, and stops regardless", () => {
   const lines = [];
   const exits = [];
   let closed = 0;
-  handleFatalServerError(new Error("EMFILE"), {
+  const error = new Error("listening socket is gone");
+  error.code = "EADDRNOTAVAIL";
+  handleServerError(error, {
     server: {
+      listening: false,
       close: () => {
         closed += 1;
         // The order is load-bearing: a close that throws must not swallow the
@@ -480,9 +483,74 @@ test("handleFatalServerError says what failed before it stops, and stops regardl
     log: (line) => lines.push(line),
     exit: (code) => exits.push(code),
   });
-  assert.deepEqual(lines, ["sentry-mcp-broker: SERVER-ERROR EMFILE"]);
+  assert.deepEqual(lines, [
+    "sentry-mcp-broker: SERVER-ERROR listening socket is gone",
+  ]);
   assert.equal(closed, 1);
   assert.deepEqual(exits, [1]);
+});
+
+test("a transient accept error does NOT take the broker down while it is still listening", () => {
+  // One momentary fd squeeze is not a lost listener. Tearing down on it would
+  // reach the same dead-broker outcome the fatal path exists to prevent, just
+  // sooner — so a code known to be per-connection survives, and says so.
+  for (const code of ["EMFILE", "ENFILE", "ENOBUFS", "ECONNABORTED"]) {
+    const lines = [];
+    const exits = [];
+    let closed = 0;
+    const error = new Error(`accept failed: ${code}`);
+    error.code = code;
+    handleServerError(error, {
+      server: {
+        listening: true,
+        close: () => {
+          closed += 1;
+        },
+      },
+      log: (line) => lines.push(line),
+      exit: (c) => exits.push(c),
+    });
+    assert.equal(closed, 0, `${code} must not close a live listener`);
+    assert.deepEqual(exits, [], `${code} must not exit`);
+    assert.ok(
+      lines.some((line) => line.includes(`accept failed: ${code}`)),
+      `${code} must still be reported`,
+    );
+    assert.ok(
+      lines.some((line) => line.includes("staying up")),
+      `${code} must say it stayed up`,
+    );
+  }
+});
+
+test("the fatal default holds: an unknown code, or a lost listener, stops the broker", () => {
+  // The two directions are not symmetric. Staying up with the listener gone
+  // restores the silence this whole handler exists to end; going down when it
+  // was fine costs a run that fails visibly. So anything not KNOWN to be
+  // per-connection is treated as the listener being gone.
+  const cases = [
+    ["an unknown code", "ESOMETHINGNEW", true],
+    ["no code at all", undefined, true],
+    ["a transient code but a listener that is gone", "EMFILE", false],
+  ];
+  for (const [label, code, listening] of cases) {
+    const exits = [];
+    let closed = 0;
+    const error = new Error(label);
+    if (code) error.code = code;
+    handleServerError(error, {
+      server: {
+        listening,
+        close: () => {
+          closed += 1;
+        },
+      },
+      log: () => {},
+      exit: (c) => exits.push(c),
+    });
+    assert.equal(closed, 1, `${label} must close`);
+    assert.deepEqual(exits, [1], `${label} must exit non-zero`);
+  }
 });
 
 /** Runs `body` with `console.log` captured, restoring it however body ends. */

--- a/scripts/sentry/broker/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.test.mjs
@@ -449,6 +449,36 @@ test("a socket error AFTER startup is logged, not swallowed", async () => {
   });
 });
 
+test("a socket error is reported even when the caller supplies no log sink", async () => {
+  // An optional call on `config.log` would put the silence straight back for
+  // any caller that passes none, which is the whole defect. The console
+  // fallback is the same one `createHandler` already applies.
+  const upstream = await startUpstream(jsonUpstream([]));
+  const broker = await startBroker({
+    token: REAL_TOKEN,
+    handle: HANDLE,
+    upstream: upstream.origin,
+    port: 0,
+  });
+  const lines = [];
+  const realLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    broker.emit("error", new Error("no sink was supplied"));
+  } finally {
+    console.log = realLog;
+    broker.close();
+    upstream.server.close();
+  }
+  assert.ok(
+    lines.some(
+      (line) =>
+        line.includes("SERVER-ERROR") && line.includes("no sink was supplied"),
+    ),
+    `the fallback must report the error; saw ${JSON.stringify(lines)}`,
+  );
+});
+
 // ── back-pressure ────────────────────────────────────────────────────────────
 
 test("a throttled upstream reaches the client WITH its back-off headers", async () => {

--- a/scripts/sentry/broker/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.test.mjs
@@ -33,6 +33,7 @@ import {
   classify,
   handleMatches,
   isAllowedPath,
+  isBackPressureHeader,
   isEntryPoint,
   readTokenFromStdin,
   resolveConfig,
@@ -428,6 +429,74 @@ test("rewriteRegionLinks touches only links.regionUrl", () => {
   assert.equal(payload[0].links.organizationUrl, "https://a");
   assert.equal(payload[1].links, undefined);
   assert.equal("regionUrl" in payload[2].links, false);
+});
+
+test("a socket error AFTER startup is logged, not swallowed", async () => {
+  // The startup promise's `reject` used to be the server's only `error`
+  // listener, and once that promise settles it is a no-op — so every later
+  // socket error vanished, and a broker that had stopped answering looked
+  // exactly like a Sentry with nothing to say.
+  await withBroker(jsonUpstream([]), async ({ broker, logs }) => {
+    broker.emit("error", new Error("EADDRNOTAVAIL after startup"));
+    assert.ok(
+      logs.some((line) => line.includes("SERVER-ERROR")),
+      `a post-startup server error must reach the log; saw ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      logs.some((line) => line.includes("EADDRNOTAVAIL after startup")),
+      "the log line must name what actually failed",
+    );
+  });
+});
+
+// ── back-pressure ────────────────────────────────────────────────────────────
+
+test("a throttled upstream reaches the client WITH its back-off headers", async () => {
+  // The MCP server obeys `Retry-After` and the `X-Sentry-Rate-Limit-*` family.
+  // Relaying only content-type and link turned a 429 into a bare status, so the
+  // client retried at once against a Sentry that was still refusing it.
+  await withBroker(
+    (_req, res) => {
+      res.writeHead(429, {
+        "content-type": "application/json",
+        "retry-after": "42",
+        "x-sentry-rate-limit-limit": "100",
+        "x-sentry-rate-limit-remaining": "0",
+        "x-sentry-rate-limit-reset": "1755600000",
+        "x-sentry-rate-limit-concurrentlimit": "10",
+        // Not back-pressure and not the broker's to relay.
+        "set-cookie": "session=leak-me",
+        "x-served-by": "sentry-edge-7",
+      });
+      res.end(JSON.stringify({ detail: "rate limited" }));
+    },
+    async ({ base }) => {
+      const res = await call(base, "/api/0/organizations/");
+      assert.equal(res.status, 429);
+      assert.equal(res.headers.get("retry-after"), "42");
+      assert.equal(res.headers.get("x-sentry-rate-limit-limit"), "100");
+      assert.equal(res.headers.get("x-sentry-rate-limit-remaining"), "0");
+      assert.equal(res.headers.get("x-sentry-rate-limit-reset"), "1755600000");
+      assert.equal(
+        res.headers.get("x-sentry-rate-limit-concurrentlimit"),
+        "10",
+        "a name-by-name list would have dropped this one",
+      );
+      // Still an allowlist: everything else the upstream sent stays upstream.
+      assert.equal(res.headers.get("set-cookie"), null);
+      assert.equal(res.headers.get("x-served-by"), null);
+    },
+  );
+});
+
+test("isBackPressureHeader admits the two families and nothing else", () => {
+  assert.equal(isBackPressureHeader("Retry-After"), true);
+  assert.equal(isBackPressureHeader("X-Sentry-Rate-Limit-Reset"), true);
+  assert.equal(isBackPressureHeader("x-sentry-rate-limit-anything-new"), true);
+  assert.equal(isBackPressureHeader("authorization"), false);
+  assert.equal(isBackPressureHeader("set-cookie"), false);
+  assert.equal(isBackPressureHeader("x-sentry-token"), false);
+  assert.equal(isBackPressureHeader(undefined), false);
 });
 
 // ── fail closed: redirects and upstream failures ─────────────────────────────

--- a/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs
+++ b/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs
@@ -49,6 +49,14 @@ export const PROBE_TIMEOUT_MS = 30_000;
  * on timeout the whole group is killed by negative pid. Everything the probe
  * started is in that group; nothing else is.
  *
+ * The deadline is SIGKILL, not the default SIGTERM, and that is what makes it a
+ * deadline at all. `spawnSync` sends its `killSignal` and then keeps waiting for
+ * the child to exit; it escalates only when the signal itself ERRORS, which
+ * ignoring SIGTERM does not. A probe shell that traps or ignores it therefore
+ * hangs `spawnSync` forever — and the group kill below can never run, because
+ * the call it follows has not returned. SIGKILL cannot be trapped, so the shell
+ * dies, `spawnSync` returns ETIMEDOUT, and the group cleanup gets its turn.
+ *
  * @param {string} bash
  * @param {string[]} args
  * @param {object} options
@@ -60,6 +68,7 @@ export const runProbeShell = (bash, args, { dirs, ...options }) => {
     cwd: dirs.empty,
     env: probeEnv(dirs),
     detached: true,
+    killSignal: "SIGKILL",
   });
   if (result.error?.code === "ETIMEDOUT" && typeof result.pid === "number") {
     try {

--- a/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.test.mjs
+++ b/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.test.mjs
@@ -238,6 +238,47 @@ test("a probe that outruns its deadline is killed outright, never asked to stop"
   }
 });
 
+test("the deadline holds even when the probe leaves a descendant behind", () => {
+  // The worry this answers: `spawnSync` captures stdout and stderr through
+  // pipes, and a descendant that outlives the shell inherits those write ends —
+  // so if the call waited for EOF rather than for the child, killing the shell
+  // would leave it blocked on a pipe nothing will close, and the negative-pid
+  // group cleanup after it could never run.
+  //
+  // It does not wait. Measured here on both shapes the probe can produce: a
+  // backgrounded descendant, and the `$(…)` command substitution the classifier
+  // actually runs in. Each returns at its deadline, which is also what the group
+  // cleanup below needs in order to happen at all. Absolute paths because the
+  // probe's `$PATH` is an empty directory.
+  const root = mkdtempSync(join(tmpdir(), "gate-probe-descendant-"));
+  try {
+    const dirs = probeDirs(root);
+    for (const [, { candidate, version }] of installedBashes()) {
+      for (const [shape, script] of [
+        ["a backgrounded descendant", "/bin/sleep 30 &\nwhile :; do :; done"],
+        ["a command substitution", 'x="$(/bin/sleep 30; echo late)"'],
+      ]) {
+        const started = Date.now();
+        const result = runProbeShell(candidate, ["-c", script], {
+          dirs,
+          timeout: 500,
+        });
+        assert.equal(
+          result.error?.code,
+          "ETIMEDOUT",
+          `bash ${version} did not report the deadline for ${shape}`,
+        );
+        assert.ok(
+          Date.now() - started < 15_000,
+          `bash ${version} outran its 500ms deadline on ${shape} by holding a captured pipe`,
+        );
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("the extractor refuses a classifier the gate never defines at top level", () => {
   // Column 0 is not top level. A definition nested inside another function is
   // never executed by the gate, so lifting it out reports verdicts for logic

--- a/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.test.mjs
+++ b/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.test.mjs
@@ -22,6 +22,10 @@ import {
   UNTRUSTED_PATH,
 } from "./check-sentry-suites-in-ci-gate-fixtures.mjs";
 import {
+  probeDirs,
+  runProbeShell,
+} from "./check-sentry-suites-in-ci-gate-extract.mjs";
+import {
   GATE,
   gateClassifications,
   GATE_PATH,
@@ -194,6 +198,43 @@ test("the gate probe will not carry a trailer off the closing brace", () => {
     );
   } finally {
     rmSync(join(owned, ".."), { recursive: true, force: true });
+  }
+});
+
+test("a probe that outruns its deadline is killed outright, never asked to stop", () => {
+  // `spawnSync` sends its `killSignal` and then keeps WAITING for the child; it
+  // escalates to SIGKILL only when the signal call itself errors, which a shell
+  // that traps or ignores SIGTERM does not make it do. Under the default signal
+  // such a probe outlives its deadline and this call never returns — so the
+  // group cleanup that follows it never runs either, because the call it follows
+  // has not come back.
+  //
+  // The assertion is on the signal the child died of rather than on a
+  // SIGTERM-ignoring fixture: that fixture is the hang itself, and a suite that
+  // hangs instead of failing tells nobody anything.
+  const root = mkdtempSync(join(tmpdir(), "gate-probe-deadline-"));
+  try {
+    const dirs = probeDirs(root);
+    for (const [, { candidate, version }] of installedBashes()) {
+      // A bash builtin loop: the probe's `$PATH` is an empty directory, so an
+      // external `sleep` would not be found and the shell would exit at once.
+      const result = runProbeShell(candidate, ["-c", "while :; do :; done"], {
+        dirs,
+        timeout: 500,
+      });
+      assert.equal(
+        result.error?.code,
+        "ETIMEDOUT",
+        `bash ${version} did not report the deadline`,
+      );
+      assert.equal(
+        result.signal,
+        "SIGKILL",
+        `bash ${version} was signalled ${result.signal}, which a probe can ignore`,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/scripts/sentry/triage/sentry-triage-archive.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-archive.test.mjs
@@ -1427,6 +1427,20 @@ await test("isSelectableForTriage is exactly Stage B's selector, all three parts
   assertEqual(isSelectableForTriage(), false);
 });
 
+await test("isSelectableForTriage requires a read that says OPEN, not merely one that does not say CLOSED", () => {
+  // Every `readStub` feeding this normalizes a missing or unexpected `state` to
+  // `""`. Under a not-CLOSED test that unreadable state passed, so the
+  // end-state verification could report a re-queue as successful without any
+  // read having confirmed the stub open — the one wrong answer this predicate
+  // must never give.
+  const labels = ["sentry-triage", "sentry:needs-triage"];
+  assertEqual(isSelectableForTriage({ state: "OPEN", labels }), true);
+  assertEqual(isSelectableForTriage({ state: "", labels }), false);
+  assertEqual(isSelectableForTriage({ labels }), false);
+  assertEqual(isSelectableForTriage({ state: null, labels }), false);
+  assertEqual(isSelectableForTriage({ state: "MERGED", labels }), false);
+});
+
 await test("a fence that cannot be posted stops the re-queue instead of exposing the stub", async () => {
   // "Safe first, loud second" assumed making the stub selectable IS the safe
   // act. Once the comment's first line became the regression fence that stopped

--- a/scripts/sentry/triage/sentry-triage-archive.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-archive.test.mjs
@@ -1138,6 +1138,20 @@ await test("runArchive refuses and re-queues a live regression instead of archiv
   );
   // Already open, so there is nothing to reopen.
   assert(!ghCall(ghCalls, "reopen"), "an open stub is left alone");
+  // The end-state check demands `state === "OPEN"`, and this reader normalizes
+  // a missing field to `""`. A `--json` list that forgets `state` therefore does
+  // not degrade — it strands EVERY re-queue on this path while nothing is wrong.
+  // The workflow re-queue's readers carry the same assertion; this is the other
+  // consumer of the predicate.
+  const reads = ghCalls.filter((args) => args[1] === "view");
+  assert(reads.length > 0, "the re-queue must read the stub at all");
+  for (const args of reads) {
+    const fields = args[args.indexOf("--json") + 1] ?? "";
+    assert(
+      fields.split(",").includes("state"),
+      `a stub read asked for "${fields}", which never yields a state the selector can accept`,
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/sentry/triage/sentry-triage-archive.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-archive.test.mjs
@@ -1143,10 +1143,17 @@ await test("runArchive refuses and re-queues a live regression instead of archiv
   // not degrade — it strands EVERY re-queue on this path while nothing is wrong.
   // The workflow re-queue's readers carry the same assertion; this is the other
   // consumer of the predicate.
-  const reads = ghCalls.filter((args) => args[1] === "view");
+  const reads = ghCalls.filter(
+    (args) => args[0] === "issue" && args[1] === "view",
+  );
   assert(reads.length > 0, "the re-queue must read the stub at all");
   for (const args of reads) {
-    const fields = args[args.indexOf("--json") + 1] ?? "";
+    const jsonAt = args.indexOf("--json");
+    assert(
+      jsonAt !== -1,
+      `a stub read passed no --json at all: ${args.join(" ")}`,
+    );
+    const fields = args[jsonAt + 1] ?? "";
     assert(
       fields.split(",").includes("state"),
       `a stub read asked for "${fields}", which never yields a state the selector can accept`,

--- a/scripts/sentry/triage/sentry-triage-digest.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.mjs
@@ -681,10 +681,9 @@ async function main() {
   for (const warning of doubleVerdictWarnings(issues)) {
     process.stderr.write(`::warning::${warning}\n`);
   }
-  const payload = buildDigest(issues, {
-    channel: options.channel,
-    now: new Date(),
-  });
+  // No `now`: the payload carries no clock (see buildDigest), so passing one
+  // only suggests the digest is time-dependent when it is not.
+  const payload = buildDigest(issues, { channel: options.channel });
   // ONLY the payload goes to stdout (the workflow redirects it to a file for
   // the posting step); all diagnostics go to stderr.
   process.stdout.write(`${JSON.stringify(payload)}\n`);

--- a/scripts/sentry/triage/sentry-triage-digest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.test.mjs
@@ -855,6 +855,28 @@ function allText(payload) {
   return payload.blocks.map((block) => block.text.text).join("\n");
 }
 
+await test("the digest carries NO clock, so a `now` cannot change what it renders", () => {
+  // The CLI used to pass `now: new Date()` into a function that never read it.
+  // Removing a dead argument is only safe while it stays dead, and a comment
+  // saying so is not enforcement: pin it, and any future read of `now` fails
+  // here rather than silently changing what the posting step sends to Slack.
+  const issues = [
+    issueFixture({
+      number: 1,
+      shortId: "A-1",
+      labels: ["sentry:verdict-code-fix"],
+      comments: [{ body: verdictComment({ summary: "null deref" }) }],
+    }),
+  ];
+  assertDeepEqual(
+    buildDigest(issues, { channel: "#engineering" }),
+    buildDigest(issues, {
+      channel: "#engineering",
+      now: new Date("2001-02-03T04:05:06Z"),
+    }),
+  );
+});
+
 await test("buildDigest produces a valid chat.postMessage payload shape", () => {
   const payload = buildDigest(
     [

--- a/scripts/sentry/triage/sentry-triage-ingest.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.mjs
@@ -544,14 +544,13 @@ async function fetchSentryIssuesPage(url, token, fetchImpl) {
 
 /**
  * Page through one Sentry issue query. Fails loud past `maxPages` for the same
- * reason `ghPaginate` does: a truncated scan is indistinguishable from a short
- * one at every consumer above this. The queue it feeds is built by DIFFERENCE —
- * a Sentry issue absent from the result set is one no stub gets created for —
- * so silently dropping the tail buries exactly the newest occurrences the run
- * exists to surface, and nothing downstream can tell.
+ * reason `ghPaginate` does: the queue it feeds is built by DIFFERENCE, so an
+ * issue missing from the result set is one no stub gets created for, and a
+ * truncated scan is indistinguishable from a quiet Sentry at every consumer
+ * above this.
  *
- * Exported for the pagination test; the merge entry point below is the caller
- * production uses.
+ * Exported for the pagination test; the merge entry point below is production's
+ * caller.
  */
 export async function fetchAllSentryIssues({
   query,

--- a/scripts/sentry/triage/sentry-triage-ingest.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.mjs
@@ -542,7 +542,18 @@ async function fetchSentryIssuesPage(url, token, fetchImpl) {
   return { issues: Array.isArray(body) ? body : [], next: links.next };
 }
 
-async function fetchAllSentryIssues({
+/**
+ * Page through one Sentry issue query. Fails loud past `maxPages` for the same
+ * reason `ghPaginate` does: a truncated scan is indistinguishable from a short
+ * one at every consumer above this. The queue it feeds is built by DIFFERENCE —
+ * a Sentry issue absent from the result set is one no stub gets created for —
+ * so silently dropping the tail buries exactly the newest occurrences the run
+ * exists to surface, and nothing downstream can tell.
+ *
+ * Exported for the pagination test; the merge entry point below is the caller
+ * production uses.
+ */
+export async function fetchAllSentryIssues({
   query,
   org,
   baseUrl,
@@ -569,6 +580,11 @@ async function fetchAllSentryIssues({
       url = null;
     }
     pages += 1;
+  }
+  if (url) {
+    throw new Error(
+      `Sentry pagination exceeded ${maxPages} pages for query ${JSON.stringify(query)}; refusing to continue silently`,
+    );
   }
   return collected.map(mapSentryIssue);
 }

--- a/scripts/sentry/triage/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.test.mjs
@@ -1213,13 +1213,13 @@ await test("Sentry pagination fails loud past maxPages instead of truncating", a
   );
   assertEqual(served, 3);
 
-  // The bounded case still returns: a scan that ends inside the cap is not an
-  // error, so the guard cannot be a blanket refusal at the last page. Both
-  // terminators, because Sentry uses the SECOND one: it keeps sending a
+  // The bounded case still returns, and the boundary is where it matters:
+  // `maxPages: 2` for a scan that ends ON its last allowed page, so a guard
+  // reading "the cap was reached" rather than "a cursor survived it" is caught.
+  // Both terminators, because Sentry uses the SECOND one: it keeps sending a
   // `rel="next"` link at the end of a result set and signals exhaustion with
-  // `results="false"`. A guard that only recognised a missing Link header would
-  // throw on every real ingest run, which is a far louder break than the silent
-  // truncation above.
+  // `results="false"`. A guard recognising only a missing Link header would
+  // throw on every real ingest run.
   for (const [label, terminator] of [
     ["no Link header at all", null],
     [
@@ -1249,11 +1249,11 @@ await test("Sentry pagination fails loud past maxPages instead of truncating", a
       baseUrl: "https://us.sentry.io",
       token: "t",
       fetchImpl: finite,
-      maxPages: 3,
+      maxPages: 2,
     });
     assert(
       issues.length === 2,
-      `a scan ending with ${label} must return both pages; got ${issues.length}`,
+      `a scan ending exactly at the page budget with ${label} must return both pages; got ${issues.length}`,
     );
   }
 });

--- a/scripts/sentry/triage/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.test.mjs
@@ -1214,32 +1214,48 @@ await test("Sentry pagination fails loud past maxPages instead of truncating", a
   assertEqual(served, 3);
 
   // The bounded case still returns: a scan that ends inside the cap is not an
-  // error, so the guard cannot be a blanket refusal at the last page.
-  let round = 0;
-  const finite = async () => {
-    round += 1;
-    return {
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      json: async () => [{ id: String(round), shortId: `X-${round}` }],
-      headers: {
-        get: () =>
-          round < 2
-            ? '<https://us.sentry.io/api/0/organizations/o/issues/?cursor=next>; rel="next"; results="true"; cursor="next"'
-            : null,
-      },
+  // error, so the guard cannot be a blanket refusal at the last page. Both
+  // terminators, because Sentry uses the SECOND one: it keeps sending a
+  // `rel="next"` link at the end of a result set and signals exhaustion with
+  // `results="false"`. A guard that only recognised a missing Link header would
+  // throw on every real ingest run, which is a far louder break than the silent
+  // truncation above.
+  for (const [label, terminator] of [
+    ["no Link header at all", null],
+    [
+      "Sentry's results=false terminator",
+      '<https://us.sentry.io/api/0/organizations/o/issues/?cursor=end>; rel="next"; results="false"; cursor="end"',
+    ],
+  ]) {
+    let round = 0;
+    const finite = async () => {
+      round += 1;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [{ id: String(round), shortId: `X-${round}` }],
+        headers: {
+          get: () =>
+            round < 2
+              ? '<https://us.sentry.io/api/0/organizations/o/issues/?cursor=next>; rel="next"; results="true"; cursor="next"'
+              : terminator,
+        },
+      };
     };
-  };
-  const issues = await fetchAllSentryIssues({
-    query: "is:unresolved",
-    org: "o",
-    baseUrl: "https://us.sentry.io",
-    token: "t",
-    fetchImpl: finite,
-    maxPages: 3,
-  });
-  assertEqual(issues.length, 2);
+    const issues = await fetchAllSentryIssues({
+      query: "is:unresolved",
+      org: "o",
+      baseUrl: "https://us.sentry.io",
+      token: "t",
+      fetchImpl: finite,
+      maxPages: 3,
+    });
+    assert(
+      issues.length === 2,
+      `a scan ending with ${label} must return both pages; got ${issues.length}`,
+    );
+  }
 });
 
 await test("REST issue normalization flattens pages, drops PRs, uppercases state, carries closed_at + updated_at + labels + body", () => {

--- a/scripts/sentry/triage/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.test.mjs
@@ -26,6 +26,7 @@ import {
   defangBackticks,
   defangMentions,
   extractShortIdFromTitle,
+  fetchAllSentryIssues,
   FIX_SCOPE_ARCHITECTURAL_LABEL,
   ghPaginate,
   indexQueueIssuesByShortId,
@@ -1169,6 +1170,76 @@ await test("ghPaginate fails loud on runaway pagination and non-array responses"
   }
   assert(threw, "expected non-array response to throw");
   assert(/non-array/.test(threw.message), "wrong non-array error");
+});
+
+await test("Sentry pagination fails loud past maxPages instead of truncating", async () => {
+  // The queue is built by DIFFERENCE, so a Sentry issue missing from this
+  // result set is one no stub is created for. A cap that returns partial pages
+  // and reports success is therefore indistinguishable from a quiet Sentry —
+  // the same reason `ghPaginate` throws rather than stopping.
+  let served = 0;
+  const fetchImpl = async () => {
+    served += 1;
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => [{ id: String(served), shortId: `X-${served}` }],
+      // Always another page: this is the runaway the cap exists to bound.
+      headers: {
+        get: () =>
+          '<https://us.sentry.io/api/0/organizations/o/issues/?cursor=next>; rel="next"; results="true"; cursor="next"',
+      },
+    };
+  };
+
+  let threw = null;
+  try {
+    await fetchAllSentryIssues({
+      query: "is:unresolved",
+      org: "o",
+      baseUrl: "https://us.sentry.io",
+      token: "t",
+      fetchImpl,
+      maxPages: 3,
+    });
+  } catch (err) {
+    threw = err;
+  }
+  assert(threw, "expected a truncated Sentry scan to throw");
+  assert(
+    /exceeded 3 pages/.test(threw.message),
+    `wrong Sentry runaway error: ${threw?.message}`,
+  );
+  assertEqual(served, 3);
+
+  // The bounded case still returns: a scan that ends inside the cap is not an
+  // error, so the guard cannot be a blanket refusal at the last page.
+  let round = 0;
+  const finite = async () => {
+    round += 1;
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => [{ id: String(round), shortId: `X-${round}` }],
+      headers: {
+        get: () =>
+          round < 2
+            ? '<https://us.sentry.io/api/0/organizations/o/issues/?cursor=next>; rel="next"; results="true"; cursor="next"'
+            : null,
+      },
+    };
+  };
+  const issues = await fetchAllSentryIssues({
+    query: "is:unresolved",
+    org: "o",
+    baseUrl: "https://us.sentry.io",
+    token: "t",
+    fetchImpl: finite,
+    maxPages: 3,
+  });
+  assertEqual(issues.length, 2);
 });
 
 await test("REST issue normalization flattens pages, drops PRs, uppercases state, carries closed_at + updated_at + labels + body", () => {

--- a/scripts/sentry/triage/sentry-triage-requeue.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.mjs
@@ -237,11 +237,21 @@ export function hasAdmissibleVerdict(comments) {
  * `sentry:needs-triage` — and deliberately does NOT correct this one. Removing
  * `sentry-triage` is how a human retires a stub for good, so putting it back
  * would overrule the withdrawal. Its absence is reported, never repaired.
+ *
+ * The state test demands OPEN rather than not-CLOSED. Every `readStub` feeding
+ * this normalizes a missing or unexpected `state` to `""` — a truncated `gh`
+ * payload, a JSON shape change, a field the reader forgot to request — and `""`
+ * is not `"CLOSED"`, so the loose test called such a stub selectable without any
+ * read ever having confirmed it open. That is the one thing this predicate must
+ * never do: it is the END-STATE test, so a wrong true is a re-queue reporting
+ * success over a stub Stage B cannot see. Stage B's selector says `--state open`;
+ * ask for exactly that and an unreadable state fails closed into the loud
+ * stranded path instead of passing verification by default.
  */
 export function isSelectableForTriage({ state, labels } = {}) {
   const names = Array.isArray(labels) ? labels : [];
   return (
-    String(state ?? "").toUpperCase() !== "CLOSED" &&
+    String(state ?? "").toUpperCase() === "OPEN" &&
     names.includes(QUEUE_LABEL) &&
     names.includes(NEEDS_TRIAGE_LABEL)
   );

--- a/scripts/sentry/triage/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.test.mjs
@@ -960,6 +960,39 @@ await test("runWorkflowRequeue restores needs-triage and sheds the verdict on an
   );
 });
 
+await test("every stub read on the verification path ASKS for state, which the OPEN selector now requires", async () => {
+  // `isSelectableForTriage` demands `state === "OPEN"`, and every reader
+  // normalizes a missing field to `""`. So a `--json` list that forgets `state`
+  // does not degrade — it makes the predicate return false for every stub, and
+  // each re-queue ends in the loud stranded path though nothing is wrong. That
+  // precondition was held by inspection; this holds it by test.
+  const readers = [];
+  const gh = makeClearFailureGh({
+    state: "OPEN",
+    labels: ["sentry-triage", "sentry:verdict-upstream"],
+  });
+  const runGh = async (args) => {
+    if (args[0] === "issue" && args[1] === "view") {
+      const jsonAt = args.indexOf("--json");
+      readers.push(jsonAt === -1 ? "" : args[jsonAt + 1]);
+    }
+    return gh.runGh(args);
+  };
+  await runWorkflowRequeue({
+    runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_BRIEF_CLEAR,
+  });
+  assert(readers.length > 0, "the re-queue must read the stub at all");
+  for (const fields of readers) {
+    assert(
+      fields.split(",").includes("state"),
+      `a stub read asked for "${fields}", which never yields a state the selector can accept`,
+    );
+  }
+});
+
 await test("parseRequeueArgs requires a numeric issue, a repo and a known reason", () => {
   const ok = parseRequeueArgs([
     "--issue",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The Sentry tooling carried eight pre-existing defects found while reviewing the
  D4 directory move (#1929). Six of them fail open: a truncated Sentry scan, an
  unreadable issue state, and a hung probe shell all look like success.
- The MCP broker drops the headers a throttled Sentry sends and discards every
  socket error after startup, so a rate-limited or broken broker reads to the run
  as "Sentry had nothing to say".
- A test helper silently dropped the message its call site passed, and the digest
  CLI passed an option the function never reads.

## The Solution

Fix six of the eight where the fix is small and provable, with a test for each
that fails without it. Report the other two as they actually are: one is an
unclosed race that needs a serialization design, the other is dead code with no
behaviour to test.

## Details

Per finding on #1929, in the issue's order:

1. **Ingest pagination truncated silently — FIXED.** `fetchAllSentryIssues` left
   the loop with a next-page URL still in hand and returned the partial set. The
   triage queue is built by DIFFERENCE, so a dropped tail creates no stubs and
   nothing downstream can tell it from a quiet Sentry. It now throws past
   `maxPages`, the way `ghPaginate` in the same file already did. Exported for
   the test.
2. **`isSelectableForTriage` accepted any non-CLOSED state — FIXED.** Every
   `readStub` feeding it normalizes a missing or unexpected `state` to `""`, and
   `""` is not `"CLOSED"`, so a truncated `gh` payload passed the end-state
   verification without any read confirming the stub open. It now requires
   `OPEN`, which is what Stage B's `--state open` selector asks for. All four
   `readStub` implementations already uppercase, so no caller changes.
3. **Archive-settlement race — NOT FIXED; #1929 stays open for it.** Real and
   unclosed. The archive leg's own post-settlement verification catches only the
   interleavings where the compensation writes land before its verify read; the
   reverse ordering is undetected. Neither candidate closure is a small fix: a
   shared Actions concurrency group would put a per-issue human-gated archive
   dispatch and a repo-wide triage run in one group, where Actions keeps a single
   pending run and cancels the superseded one — a silently dropped approved
   archive is worse than the race. A post-write check cannot see it either,
   because the shed erases both terminal signals in the same operation. Closing
   it is a serialization design with an ADR, not a bug fix.
4. **Probe deadline used SIGTERM — FIXED.** `spawnSync` sends its `killSignal`
   and then keeps waiting; it escalates only when the signal call itself errors,
   which a shell trapping SIGTERM does not make it do. So a trapping probe hung
   `spawnSync` forever, and the process-group cleanup after the call never ran
   because the call never returned. `killSignal: "SIGKILL"`.
5. **Broker dropped back-pressure headers — FIXED.** A 429 reached the MCP client
   without `Retry-After` or the `X-Sentry-Rate-Limit-*` family, so it retried
   blind. Relayed through a PREFIX allowlist rather than a name list: the
   `ConcurrentLimit` member is exactly what a hand-written list would have missed.
   Nothing else crosses — the test pins that `set-cookie` and `x-served-by` stay
   upstream.
6. **Broker post-listen errors were discarded — FIXED, and it now fails closed.**
   The startup promise's `reject` was the server's only `error` listener and is a
   no-op once that promise settles. Logging alone would not have reached anyone:
   the workflow sends both broker streams to a log file it prints only when the
   readiness wait fails, and `broker_pid` is referenced nowhere after that loop,
   so a line written past readiness is read by nobody while the agent keeps
   spending its turn budget. The handler now logs, closes the server and exits
   non-zero — releasing the port, so the pre-flight probe cannot register the
   toolset and the job fails with `sentry:needs-triage` still on the stub. A code
   known to be per-connection (EMFILE, ENOBUFS, ECONNABORTED …) survives, and
   only while `server.listening` still holds; the default is fatal, because
   staying up with the listener gone restores the silence this exists to end.
   Both broker diagnostics share one sink with the console fallback
   `createHandler` already applied, so neither depends on a caller passing one.
7. **Digest `now` argument ignored — REMOVED, no test.** `buildDigest(issues,
   { channel })` never destructured `now`; the CLI passed one anyway. Dead option,
   deleted. There is no behaviour to assert either way, and the 73 existing digest
   tests all call `buildDigest` without it, which already pins the no-clock
   contract.
8. **`assertEqual` dropped its message — FIXED.** The run-record helper took two
   parameters while a call site passed three, so a failure printed a bare value
   mismatch. Third parameter added and prefixed to the thrown text.

Every fix was checked with a negative control: the fix reverted, the new test
observed failing, the fix restored.

## Validation

- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`
  — all mapped commands passed (15 commands, including `pnpm lint:scripts`,
  `tf:test`, the sentry suite gate and every sentry suite).
- `node scripts/sentry/gate/sentry-suite-gate.mjs` — 14 suites asserted from their
  own output, all above their manifest floors. No floor moved; the touched suites
  rose (broker 40→65, ingest 131→133, archive 118→119, run-record 7→14).
- `node scripts/sentry/ci-wiring/check-sentry-suites-in-ci.test.mjs` — 44 pass.
- Negative controls, per fix: pagination guard (test fails: "expected a truncated
  Sentry scan to throw"), selector (fails: "expected false, got true"),
  `killSignal` (fails: "was signalled SIGTERM"), broker headers and broker error
  logging (both fail together), `assertEqual` (fails: "the failure output must
  name what was asserted").
- `pnpm agent:autoreview -- --engine codex` — clean, no actionable findings, on
  the final head.
- `pnpm agent:autoreview -- --engine claude` — five findings across three passes.
  Three produced changes: Sentry's real `results="false"` pagination terminator
  is now pinned alongside the missing-Link case; the broker's server-error report
  is unconditional; both carry a test. Two are answered with evidence rather than
  a change:
  - *"`buildDigest` may still read `now`"* — it does not. Its signature is
    `buildDigest(issues, { channel } = {})`, `now` appears nowhere in
    `sentry-triage-digest.mjs` or `sentry-triage-digest-render.mjs`, and all 73
    digest tests already call it without one.
  - *"nothing proves the production `readStub` returns `state`"* — all four
    implementations (`sentry-triage-workflow-requeue`, `sentry-triage-ingest`,
    `sentry-triage-archive`, `sentry-autofix-hold-revalidate`) request `state` in
    their `--json` field list and normalize it with `.toUpperCase()`. The 40
    re-queue and 119 archive tests drive `ensureSelectableForTriage` end to end
    against stateful fakes and stay green under the stricter predicate, which is
    only possible if those reads return `OPEN`.

## Deferrals

- Archive-settlement race in `sentry-triage-workflow-requeue` stays on https://github.com/mento-protocol/monitoring-monorepo/issues/1929, which is therefore referenced rather than closed.
- Ten more homegrown `assertEqual` helpers with the same message-dropping signature, 65 call sites — https://github.com/mento-protocol/monitoring-monorepo/issues/1945
- A broker that dies *during* the agent step still fails open. Exiting non-zero cannot fail a sibling Actions step from inside a backgrounded process; that window needs a workflow-side watchdog — https://github.com/mento-protocol/monitoring-monorepo/issues/1956

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — the one finding that would make one
      is deferred for exactly that reason.

Refs #1929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect triage queue completeness and re-queue verification predicates plus broker rate-limit behavior—important operational paths, but each fix fails closed and is covered by new tests.
> 
> **Overview**
> Closes several **fail-open** paths in Sentry scripts so truncated scans, bad reads, and broker/probe failures no longer look like success.
> 
> **Triage ingest** now **throws** when `fetchAllSentryIssues` hits `maxPages` with another page still pending (aligned with `ghPaginate`), instead of returning a partial issue set that would silently shrink the stub queue.
> 
> **Re-queue / end-state selection** tightens `isSelectableForTriage` to require **`OPEN`** state (not merely “not `CLOSED`”), so empty or unreadable `gh` payloads cannot pass verification without a confirmed open stub.
> 
> **MCP broker** relays **`Retry-After`** and **`X-Sentry-Rate-Limit-*`** on throttled upstream responses via `isBackPressureHeader`, and **logs post-listen server `error` events** (with console fallback) instead of leaving the process with no listener after startup.
> 
> **CI gate probe shells** use **`killSignal: SIGKILL`** on `spawnSync` timeouts so SIGTERM-ignoring loops cannot hang the extractor forever.
> 
> Minor cleanup: digest CLI stops passing unused `now` to `buildDigest`; test `assertEqual` includes an optional **message** in failure output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ab61b1adb7730fa97132976906d418c0430b21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker handling of rate-limit and retry headers.
  * Improved recovery from temporary server connection errors while shutting down safely on fatal errors.
  * Prevented incomplete issue lists when pagination limits are reached.
  * Restricted triage re-queueing to explicitly open issues with the required labels.
  * Ensured timed-out CI probes terminate reliably, including background processes.

* **Tests**
  * Added regression coverage for broker errors, pagination, triage validation, timeouts, and deterministic digest output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
