### PR TITLE
feat(sentry): point the triage digest at #sentry-triage

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -1330,20 +1330,21 @@ jobs:
         run: |
           set -euo pipefail
           # The digest channel is DELIBERATELY hardcoded here (not a secret or
-          # repo variable): #engineering is the standing triage-review channel,
-          # and changing it is a one-line PR. The bot's chat:write.public scope
-          # lets it post to this public channel uninvited (same mechanism as
+          # repo variable): #sentry-triage is the standing triage-review channel,
+          # provisioned by alerts/infra/sentry-triage-channel.tf, and changing it
+          # is a one-line PR. The bot's chat:write.public scope lets it post to
+          # this public channel uninvited (same mechanism as
           # notify-slack-on-main-failure.yml). The script prints ONLY the Slack
           # payload JSON to stdout; diagnostics go to stderr.
           # --repo: same source of truth as the select/triage jobs
           # (GITHUB_REPOSITORY), so the digest reads the run's own repository
           # instead of assuming the script's default (matters on forks/renames).
           node scripts/sentry/triage/sentry-triage-digest.mjs \
-            --channel '#engineering' \
+            --channel '#sentry-triage' \
             --repo "${GITHUB_REPOSITORY}" \
             > "${RUNNER_TEMP}/digest-payload.json"
 
-      - name: Post digest to #engineering
+      - name: Post digest to #sentry-triage
         env:
           # SLACK_BOT_TOKEN reaches ONLY this posting step's env — never the
           # collector step, never echoed, never placed in a URL. Reuses the
@@ -1376,4 +1377,4 @@ jobs:
             echo "Full response: $RESPONSE"
             exit 1
           fi
-          echo "Posted Sentry triage digest to #engineering."
+          echo "Posted Sentry triage digest to #sentry-triage."

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -111,7 +111,7 @@ pnpm sentry:ingest --dry-run                   # Print queue-issue mutations wit
 pnpm sentry:ingest:test                        # Offline tests for the ingest helper (docs/notes/sentry-triage-pipeline.md)
 pnpm sentry:digest:test                        # Offline tests for the per-run Slack verdict-digest collector
 pnpm sentry:broker:test                        # Offline tests for the triage agent's loopback credential broker (ADR 0056)
-SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#engineering'  # Print the Slack digest payload for a batch (needs gh auth; does not post)
+SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#sentry-triage'  # Print the Slack digest payload for a batch (needs gh auth; does not post)
 
 # Public config package
 pnpm --filter @mento-protocol/config build     # Build the public protocol metadata package

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1572,7 +1572,7 @@ error counts. A nonzero recovered count means stubs were found closed while
 still labeled `sentry:needs-triage`; a recurring one points at a producer worth
 investigating, not at the sweep.
 Scheduled workflow failures also route through the repository's main-failure
-notifier. Triage produces a per-run `#engineering` digest. Absence of an
+notifier. Triage produces a per-run `#sentry-triage` digest. Absence of an
 expected record or digest is itself a signal.
 
 ### Provision and change controls
@@ -1852,7 +1852,7 @@ keeps the aliases the local gate trusts safe.
 ```bash
 # Read-only previews that require local credentials:
 pnpm sentry:ingest --dry-run --lookback-days 8
-SENTRY_TRIAGE_ISSUES='[123,456]' pnpm sentry:digest --channel '#engineering'
+SENTRY_TRIAGE_ISSUES='[123,456]' pnpm sentry:digest --channel '#sentry-triage'
 pnpm sentry:autofix:select --cap 2
 pnpm sentry:brief --issue 1731 --dry-run
 ```

--- a/scripts/sentry/triage/sentry-triage-digest.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.mjs
@@ -609,7 +609,7 @@ chat.postMessage payload (JSON) to stdout. The workflow's posting step is the
 only thing that holds the Slack token and POSTs.
 
 Options:
-  --channel <name>     Slack channel to post to (e.g. '#engineering'). Required.
+  --channel <name>     Slack channel to post to (e.g. '#sentry-triage'). Required.
                        Env fallback: SENTRY_TRIAGE_CHANNEL.
   --issues <json>      JSON array of queue-issue numbers (the select job's
                        output). Env fallback: SENTRY_TRIAGE_ISSUES.


### PR DESCRIPTION
## The Problem

- The per-run Sentry triage verdict digest still posts to `#engineering`, even though `#sentry-triage` now exists.
- `#engineering` is not a channel people can mute or leave, so automated triage traffic sits on top of general engineering discussion.

## The Solution

- Point the digest job at `#sentry-triage`, the channel #1951 provisioned.
- Nothing about the digest itself changes: same collector, same payload, same posting step, same bot token.

## Details

- Four references move in `.github/workflows/sentry-triage-agent.yml`: the `--channel` flag, the step name, the closing `echo`, and the comment explaining why the channel is hardcoded rather than a secret or repo variable.
- `sentry-triage-digest.mjs:612` still advertised `#engineering` in its `--help` example, so an operator following the CLI's own output would have built a payload for the retired target. Codex flagged this as P2 on #1951; fixed here, where it belongs with the route change.
- Both `pnpm sentry:digest` examples in `docs/notes/quick-commands.md` and `docs/notes/sentry-triage-pipeline.md` move, along with the "per-run digest" sentence naming the channel.
- The ~24 `#engineering` strings in `sentry-triage-digest.test.mjs` are fixture channel names, not the production target, and stay as they are.
- The bot posts with `chat:write.public`, so it needs no membership in the new channel.

### Ordering precondition — satisfied

#1951 split provisioning from this switch precisely so the consumer could never reach a channel Terraform had not created. Both halves of that precondition are now met:

- `alerts-delivery` apply [run 32351245191](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/32351245191) — `Terraform Apply (alerts/infra): completed/success`.
- `#sentry-triage` verified live in Slack: public, not archived, channel ID `C0BSBEAQBLY`, created by Mento Alerts 2026-08-20 11:04 CEST.

## Validation

- Pre-push quality gate: all mapped commands pass, including `pnpm sentry:digest:test` (73 tests), `pnpm sentry:project:test`, `pnpm tf:test`, `pnpm lint:scripts`, the Sentry CI-coverage check, and `pnpm docs:navigation-eval --check-fixtures`.
- `grep -c engineering .github/workflows/sentry-triage-agent.yml` returns 0 — no stale reference left in the workflow.
- `pnpm agent:autoreview --mode branch --base origin/main` — clean, no accepted or actionable findings (0.98).

Closes #1952.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this is a destination change within the pattern #1951 already established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MP8VmVKmismQuJdsL7hfF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification routing and documentation only; digest behavior and credentials are unchanged, assuming `#sentry-triage` is already provisioned as described in the PR.
> 
> **Overview**
> Moves the per-run Sentry triage Slack digest destination from **`#engineering`** to **`#sentry-triage`**, so automated verdict traffic no longer mixes with general engineering chat.
> 
> The **`digest`** job in `sentry-triage-agent.yml` now passes `--channel '#sentry-triage'` (still hardcoded, not a secret or repo variable), renames the post step and success log line, and updates the inline comment to reference `alerts/infra/sentry-triage-channel.tf`. **`sentry-triage-digest.mjs`** help text uses `#sentry-triage` in the `--channel` example. **`quick-commands.md`** and **`sentry-triage-pipeline.md`** match for local `pnpm sentry:digest` previews and the “per-run digest” sentence.
> 
> No change to collector logic, Slack token handling, or digest tests that use `#engineering` as fixture channel names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624ca79bf6280a82a2fd4ad949f8261226bc7df7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Sentry triage digest notifications now target the `#sentry-triage` Slack channel.
  - Updated command examples, help text, and workflow messages to consistently reference the new channel.
- **Documentation**
  - Refreshed Sentry triage and quick-command documentation with the updated notification destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->