### PR TITLE
feat(alerts): surface FPMM pools missing value-share coverage

### DIFF
--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -325,6 +325,39 @@ locals {
   pool_depletion_page_active_promql     = local.pool_min_reserve_value_share_promql
   pool_depletion_critical_active_promql = "(${local.pool_min_reserve_value_share_promql}) >= 0.1"
 
+  # ── Value-share coverage gap ─────────────────────────────────────────────
+  # Both bands above read the VALUE-share gauges, which the bridge publishes
+  # only for a pool with a live median AND an on-chain-read `invertRateFeed`
+  # orientation. That gate is fail-closed and correct — a depletion number
+  # derived from a guessed orientation would be worse than none — but it is
+  # silent: a pool that trips it leaves both bands at NoData, and `no_data_state
+  # = "OK"` turns that into no notification at all. This expression is the
+  # visibility companion, the same unless-shape as
+  # `deviation_warning_unavailable_active_promql` above, which covers the
+  # matching data-unavailable gap on the deviation side.
+  #
+  # Left side — pools the bridge sees holding reserves. The count-share gauges
+  # publish whenever normalized reserves sum above zero, so their presence is
+  # exactly "this pool is funded" and needs no separate reserves metric.
+  #
+  # `max`, not `min`: on a fully one-sided pool the thin side reads 0.0, and a
+  # `> 0` threshold would then skip the pool with the WORST depletion exposure.
+  # The fat side is >= 0.5 for any funded pool, so `max` fires for every funded
+  # pool, and the value it fires with reads as the concentration on the heavy
+  # leg. The alert is a presence signal; the number is diagnostic only.
+  #
+  # `without(token_symbol)` folds the two flat per-token series into one series
+  # per pool and drops `__name__`, leaving exactly the pool fingerprint the
+  # alert instances and the `notify_warning_pools_pool` `group_by` are keyed on
+  # — same reason `pool_min_reserve_value_share_promql` aggregates that way.
+  #
+  # Right side — `unless on(chain_id, pool_id, pair)`, not a bare `unless`: the
+  # value gauges carry `token_symbol` and their own `__name__`, so a full
+  # label-set comparison would never match and the rule would fire on every
+  # funded pool. `on()` restricts the join to the pool fingerprint the two
+  # gauge families share.
+  pool_value_share_missing_active_promql = "max without(token_symbol) (mento_pool_reserve_share_token0 or mento_pool_reserve_share_token1) unless on(chain_id, pool_id, pair) (mento_pool_reserve_value_share_token0 or mento_pool_reserve_value_share_token1)"
+
   # Transition markers let resolved notifications say why an alert stopped
   # instead of listing every possible cause. Each base alert rule adds the
   # matching query as annotation-only `Info`; it is not part of the threshold

--- a/alerts/rules/rules-fpmms.tf
+++ b/alerts/rules/rules-fpmms.tf
@@ -705,6 +705,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
 #              the pool still serves both directions.
 #   page     — min value share < 10%. The pool is effectively one-sided;
 #              swappers lose one direction outright once it empties.
+#   warning  — the pool holds reserves but publishes no value share at all, so
+#              neither tier above can see it. Coverage visibility, not a band.
 #
 # Neither tier fires on the 2026-08 CHFm/USDm breach that motivated ADR 0067:
 # that pool bottomed at ~22% min side, above both bands. `Rebalancer Stale`
@@ -925,6 +927,99 @@ resource "grafana_rule_group" "fpmms_depletion" {
       group_wait      = local.notify_page_pool.group_wait
       group_interval  = local.notify_page_pool.group_interval
       repeat_interval = local.notify_page_pool.repeat_interval
+    }
+  }
+
+  # Third rule, and not a depletion band: it reports the state in which the two
+  # bands above go quiet. They read the value-share gauges, the bridge withholds
+  # those when a pool's median is not live or its `invertRateFeed` orientation
+  # has not been read on chain, and `no_data_state = "OK"` makes that silence
+  # indistinguishable from a healthy pool. A funded pool with no value share has
+  # no depletion coverage at all, and nothing says so today.
+  #
+  # It belongs in this group rather than a sibling one for the same reason
+  # `Deviation Breach (anchored)` sits inside `fpmms_deviation`: a rule that
+  # covers the window where another rule's input is unavailable is read with
+  # that rule, and shares its 60s evaluation interval.
+  #
+  # See main.tf for the expression, the `unless on(...)` join, and why the fat
+  # side (`max`) rather than the thin side decides that the pool is funded.
+  rule {
+    name      = "Pool Value Share Missing"
+    condition = "threshold"
+    # 30m, far longer than either band's dwell. The gap is structural — an
+    # unread orientation flag or a feed that has never landed a median stays
+    # that way until someone changes something — so nothing is lost by waiting,
+    # while the dwell absorbs a bridge restart or a run of missed scrapes that
+    # would otherwise read as a minute-long loss of coverage.
+    for            = "30m"
+    exec_err_state = "Error"
+    no_data_state  = "OK"
+
+    # No `keep_firing_for`: no warning rule in this file carries one.
+    #
+    # `description` is deliberately load-bearing only in the Grafana rule-detail
+    # view — the Slack template renders `description` for critical severity
+    # alone, so everything an operator needs in the channel is in `summary`.
+    annotations = {
+      summary          = "Pool holds reserves but publishes no value share, so the depletion rules cannot see it. Check the metrics-bridge logs for an unread `invertRateFeed` or a rate feed with no live median."
+      description      = "`Pool Depletion Risk` and `Pool Nearly One-Sided` both read the `mento_pool_reserve_value_share_token0` / `mento_pool_reserve_value_share_token1` pair. metrics-bridge publishes those only when the pool has a live SortedOracles median and its `invertRateFeed` orientation has been read on chain, and withholds them otherwise rather than publish a share derived from a guessed rate. Both rules treat the resulting silence as OK, so this pool is currently unwatched for depletion. ADR 0067 records the fail-closed decision."
+      resolved_title   = "Pool Value Share Restored"
+      resolved_summary = "The pool publishes value shares again — the depletion rules cover it."
+    }
+
+    labels = {
+      service  = "fpmms"
+      severity = "warning"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "A"
+        expr    = local.pool_value_share_missing_active_promql
+        instant = true
+      })
+    }
+
+    # `gt 0` is a presence test, not a band: the expression only produces a
+    # series for a funded pool that publishes no value share, and that series is
+    # always >= 0.5. Same condition shape as `Deviation Breach (anchored)`.
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "A"
+        conditions = [{
+          evaluator = { params = [0], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["threshold"] }
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+
+    # No annotation-only queries. The value-share annotation queries the two
+    # bands use select exactly the series this rule fires on the ABSENCE of, so
+    # attaching them would hand Grafana a guaranteed-empty query and risk
+    # NoData-ing the whole rule (see alerts/AGENTS.md).
+    notification_settings {
+      contact_point   = local.notify_warning_pools_pool.contact_point
+      group_by        = local.notify_warning_pools_pool.group_by
+      group_wait      = local.notify_warning_pools_pool.group_wait
+      group_interval  = local.notify_warning_pools_pool.group_interval
+      repeat_interval = local.notify_warning_pools_pool.repeat_interval
     }
   }
 }

--- a/docs/adr/0067-pool-criticality-is-depletion-risk.md
+++ b/docs/adr/0067-pool-criticality-is-depletion-risk.md
@@ -173,6 +173,10 @@ inaction**, not when a ratio is large.
   the previous price, so a price-only check would have kept pricing reserves
   off a rate the contract had stopped honouring. This matches
   `hasFreshLiveMedian`, which is how the indexer decides the same question.
+- That silence is no longer dark. `Pool Value Share Missing` (warning,
+  `#alerts-pools`) fires when a pool holds reserves but publishes no value
+  share, so a pool falling out of depletion coverage is reported rather than
+  merely absent. It surfaces the gap; closing one is still a bridge change.
 - `POOL_DEPLETION_CRITICAL_SHARE` and `POOL_DEPLETION_PAGE_SHARE` join the
   Terraform mirror set. `DEVIATION_CRITICAL_RATIO` leaves it; a future editor
   who bumps it will get no drift-check failure, because there is nothing in

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1932,6 +1932,96 @@ test("pool depletion tiers measure value share, not token-count share", () => {
   }
 });
 
+// The depletion bands read gauges the bridge withholds whenever a pool has no
+// live median or an unread `invertRateFeed`, and `no_data_state = "OK"` turns
+// that withholding into no notification at all. A funded pool can therefore
+// lose depletion coverage entirely without anything saying so. These
+// assertions pin the visibility rule that reports the gap.
+test("a funded pool that publishes no value share surfaces as a warning", () => {
+  const stripped = stripComments(
+    readFileSync(path.resolve(repoRoot, "alerts/rules/main.tf"), "utf8"),
+  );
+  const [, expression] = stripped.match(
+    /\bpool_value_share_missing_active_promql\s*=\s*"([^"]+)"/,
+  ) ?? [null, null];
+  assert(
+    expression !== null,
+    "a local should express 'pool has reserves but no value share'",
+  );
+
+  // The gap is the difference between the two gauge families, so the
+  // expression is only meaningful while it reads both.
+  for (const gauge of [
+    "mento_pool_reserve_share_token0",
+    "mento_pool_reserve_share_token1",
+    "mento_pool_reserve_value_share_token0",
+    "mento_pool_reserve_value_share_token1",
+  ]) {
+    assert(
+      expression.includes(gauge),
+      `the coverage-gap expression must read ${gauge}`,
+    );
+  }
+
+  // Both families carry `token_symbol` and their own `__name__`, so a bare
+  // `unless` compares full label sets, never matches, and fires on every
+  // funded pool. The join has to be restricted to the pool fingerprint.
+  assert(
+    expression.includes("unless on(chain_id, pool_id, pair)"),
+    "the coverage-gap join must match on the pool fingerprint only, or it fires on every funded pool",
+  );
+
+  // `max`, not `min`: a fully one-sided pool reads 0.0 on its thin side, and
+  // the rule's `> 0` threshold would then skip exactly the pool with the worst
+  // depletion exposure. The fat side is >= 0.5 for any funded pool.
+  assert(
+    /^max without\(token_symbol\)/.test(expression),
+    "the coverage-gap expression must aggregate the fat side — a min would read 0 on a one-sided pool and never cross the > 0 threshold",
+  );
+
+  const fpmmRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-fpmms.tf"),
+    "utf8",
+  );
+  const rule = ruleBlockNamed(
+    fpmmRules,
+    /\bname\s*=\s*"Pool Value Share Missing"/,
+  );
+  assert(rule, "rules-fpmms.tf should carry the coverage-gap rule");
+  assert(
+    rule.includes("local.pool_value_share_missing_active_promql"),
+    "the coverage-gap rule must evaluate the coverage-gap local",
+  );
+  assert(
+    /\bseverity\s*=\s*"warning"/.test(rule),
+    "a missing-coverage report is a warning, not a page — nothing is on fire yet",
+  );
+  assert(
+    /\blocal\.notify_warning_pools_pool\b/.test(rule),
+    "the coverage-gap rule should route to the pools warning channel like every other pool-mechanics warning",
+  );
+  assert(
+    /\bfor\s*=\s*"30m"/.test(rule),
+    "the coverage gap is structural, so the dwell must be long enough to absorb a bridge restart or a run of missed scrapes",
+  );
+  assert(
+    /\bno_data_state\s*=\s*"OK"/.test(rule),
+    "no series at all means no funded pools reported, which is the fpmms convention for OK",
+  );
+  assert(
+    !/\bkeep_firing_for\s*=/.test(rule),
+    "no warning rule in rules-fpmms.tf holds its incident open",
+  );
+
+  // The V0/V1 queries select exactly the series this rule fires on the ABSENCE
+  // of. Attaching them hands Grafana a guaranteed-empty annotation query, which
+  // can NoData the whole rule (see alerts/AGENTS.md).
+  assert(
+    !rule.includes("local.pool_depletion_value_share_annotation_queries"),
+    "the coverage-gap rule must not attach annotation queries that are empty by construction whenever it fires",
+  );
+});
+
 test("long-lived pool criticals repeat twice daily, short-lived ones hourly", () => {
   const contactPoints = readFileSync(
     path.resolve(repoRoot, "alerts/rules/contact-points.tf"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The pool depletion alerts read the value-share gauges, which metrics-bridge publishes only for a pool with a live oracle median and an on-chain-read `invertRateFeed`. Correct, but silent.
- A pool that trips that gate leaves both depletion rules at NoData, and `no_data_state = "OK"` turns NoData into no notification. The pool has no depletion coverage and nothing says so.
- Today one pool is in that state (Polygon EURm/EUROP). A future pool with an unread `invertRateFeed` would join it invisibly.

## The Solution

- Add `Pool Value Share Missing` — a warning-tier rule that fires when a pool publishes token-count shares but no value shares. The count shares are the bridge's own proof the pool holds reserves, so the difference between the two gauge families is exactly "funded, but outside depletion coverage".
- It reports the gap; it does not fill it. Slack `#alerts-pools`, with a summary that points at the two things that cause it: an unread `invertRateFeed` or a rate feed with no live median.

## Details

**Expression** (`alerts/rules/main.tf`, `pool_value_share_missing_active_promql`):

```promql
max without(token_symbol) (mento_pool_reserve_share_token0 or mento_pool_reserve_share_token1)
  unless on(chain_id, pool_id, pair)
    (mento_pool_reserve_value_share_token0 or mento_pool_reserve_value_share_token1)
```

- Same unless-shape as `deviation_warning_unavailable_active_promql`, which covers the matching data-unavailable gap on the deviation side.
- `unless on(chain_id, pool_id, pair)`, not a bare `unless`: both gauge families carry `token_symbol` and their own `__name__`, so a full label-set comparison would never match and the rule would fire on every funded pool.
- `max`, not the `min` the issue sketched. On a fully one-sided pool the thin side reads `0.0`, and the rule's `> 0` threshold would then skip exactly the pool with the worst depletion exposure. The fat side is `>= 0.5` for any funded pool. No pool sits at a zero count share today, so this is defensive rather than a change to current behaviour — verified live, see Validation.
- `without(token_symbol)` drops `__name__` and `token_symbol`, leaving the pool fingerprint the alert instances, the Slack template, and the `notify_warning_pools_pool` `group_by` are keyed on.

**Rule placement** — third rule inside `grafana_rule_group.fpmms_depletion` rather than a sibling group. `fpmms_deviation` already sets the precedent: `Deviation Breach (anchored)` covers the window where `Deviation Breach`'s input is unavailable and lives in the same group as the rule it backs. A rule that reports another rule's coverage gap is read with that rule, and shares its 60s interval.

**Rule shape** — `severity = "warning"`, `no_data_state = "OK"` per fpmms convention, `exec_err_state = "Error"`, and the instant-query + `__expr__` threshold pair copied from the depletion rules with the `gt 0` condition shape of `Deviation Breach (anchored)`. `notification_settings` copies `local.notify_warning_pools_pool` verbatim.

- `for = "30m"`. The gap is structural — an unread orientation flag or a feed that has never landed a median stays that way until someone changes something — so nothing is lost by waiting, and the dwell absorbs a bridge restart or a run of missed scrapes that would otherwise read as a minute-long loss of coverage.
- No `keep_firing_for`: no warning rule in `rules-fpmms.tf` carries one.
- No annotation-only queries. The `V0`/`V1` queries the depletion bands attach select exactly the series this rule fires on the *absence* of, so attaching them would hand Grafana a guaranteed-empty query and risk NoData-ing the whole rule (`alerts/AGENTS.md`).
- `description` is written for the Grafana rule-detail view only — the Slack template renders `description` for critical severity alone, so everything an operator needs in the channel is in `summary`.

**Merge ordering.** Merge this after the sibling metrics-bridge PR (EURm/EUROP 1:1 fallback, also part of #1955) has **deployed**. Until then this rule fires on Polygon EURm/EUROP, which is a true positive under today's bridge — the pool genuinely has no value share — but it is the gap that PR closes. Landing this first costs one harmless `#alerts-pools` warning that self-resolves on that deploy. No exclusion for EURm/EUROP is encoded here on purpose: once the fallback ships, that pool publishes value shares and drops out of this expression by itself, and a hardcoded exclusion would have to be removed again.

**Not changed:** `check-deviation-threshold-drift.mjs`. This rule mirrors no numeric threshold into `shared-config` — the `> 0` is a presence test, not a tuned band — so there is nothing for the drift checker to compare. Confirmed by running it.

## Validation

Live check against production Mimir (`grafanacloud-prom`), which is the strongest evidence available for a PromQL change:

- `count(max without(token_symbol) (mento_pool_reserve_share_token0 or mento_pool_reserve_share_token1))` → **18** funded pools.
- The full rule expression → **exactly 1 series**: Polygon `EURm/EUROP`, value `0.600`. No false positives across the other 17 pools.
- Returned labels carry the full pool fingerprint (`chain_id`, `chain_name`, `pair`, `pool_id`, `pool_address_short`, `block_explorer_url`), so the Slack title link and the routing `group_by` both resolve.
- `count(min without(token_symbol) (... ) == 0)` → no series, confirming the `max`-over-`min` choice is defensive today rather than a behaviour change.

Local checks:

- `node scripts/alerts/alert-rules-lint.mjs` → `172 PromQL expressions parsed, 55 referenced metric names checked against 70 registered gauges, peg policy validated`. Both gauge families are already registered in metrics-bridge on `main`, so the metric cross-check passes without a bridge change.
- `node --test scripts/alerts/alert-rules-lint.test.mjs` → **50 passed**, including the new pin `a funded pool that publishes no value share surfaces as a warning` (both gauge families in the expression, the `unless on(chain_id, pool_id, pair)` join, the `max` aggregation, and severity / route / dwell / `no_data_state` / no-`keep_firing_for` / no-empty-annotation-query on the rule).
- `node scripts/alerts/check-deviation-threshold-drift.mjs` → `OK: tolerance=1.01, depletion critical=0.2, depletion page=0.1`. Unchanged, as expected.
- `terraform -chdir=alerts/rules init -backend=false && terraform validate` → **Success! The configuration is valid.**
- `terraform fmt -check` → clean. `./tools/trunk check` on the four changed files → no issues.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh` → green.

**No plan diff in this PR.** PR-level Terraform plans are targeted and exclude the fpmms rule groups (they run against dummy secrets), so this change gets `terraform validate` plus the trusted-main plan only. The rule reaches Grafana through the alerts-rules workflow's apply-on-merge behind the production approval gate; there are no manual apply steps.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this implements the visibility gap ADR 0067 already recorded; the ADR gets a short note that the silence is now surfaced.

Part of #1955

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 544806fb0e339c7e2dd91716c7a47066163087e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for funded pools with reserve share data but missing value share metrics.
  * Introduced a warning alert after 30 minutes when value-share coverage is absent.
  * Added operator guidance and resolution details for affected pools.
* **Documentation**
  * Documented the new alert and its routing.
* **Tests**
  * Added regression coverage for detection, severity, timing, and no-data behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->