### PR TITLE
refactor(scripts): add scripts/pr/ copies of the pr-*-state runtime (D3, 1/3)

### DIFF
--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -179,6 +179,21 @@ scheduled document, for context an agent gets from the directory map in
   a pinned constant, recompute the constant, update every doc that records it,
   and treat operator regeneration as a release step. P6 hit this with
   `scripts/mcp/upstash-mcp-launcher.mjs`.
+- A file read from `origin/main` rather than the working tree cannot move in one
+  PR. `agent-autoreview.sh` materializes the `pr-*-state` helpers from the
+  protected `origin/main` snapshot because the checked-out copies are not
+  trusted, and a missing path there fails closed. The wrapper that runs is
+  whichever one the developer has checked out, so any single PR that both moves
+  the files and repoints the pin leaves one pairing broken: a pre-move wrapper
+  reading a post-move `origin/main`, or a post-move wrapper reading the
+  `origin/main` that still predates its own merge. D3 splits it across three
+  merges — add the copies and teach the wrapper to accept either location; then
+  repoint every consumer; then delete the pre-move copies and the fallback. The
+  middle state keeps both locations live on `origin/main`, which is what lets a
+  wrapper generation from either side of the move keep working. This is stricter
+  than the `pr-description.yml` case above, which degrades to a warning; here
+  there is no fallback to degrade to. Hold the last step until no wrapper old
+  enough to need the pre-move paths is still in use.
 
 ## Sweep checklist for a move
 

--- a/docs/adr/0065-scripts-file-size-watchlist-scope.md
+++ b/docs/adr/0065-scripts-file-size-watchlist-scope.md
@@ -103,9 +103,11 @@ is the largest example and stays in the report: it is the entire subject of
 [issue 1498](https://github.com/mento-protocol/monitoring-monorepo/issues/1498),
 which decomposes it into sourced helper modules, so exempting it would suppress
 exactly the row that already has an owner. `pr-ready-state{,-core}.mjs` sit
-behind one list, `materialize_feedback_runtime`'s `runtime_paths`, which already
-proves itself extensible: `pr-feedback-state-claude.mjs` is an optional sixth
-entry there. One appendable array is not the six-list materializer above it. For
+behind `materialize_feedback_runtime`'s two basename lists, required and
+optional, which already prove themselves extensible: `pr-feedback-state-claude.mjs`
+is the optional entry, and the D3 move (issue 1877) added a location resolver
+under both lists without touching either name. Two appendable arrays are not the
+six-list materializer above it. For
 `deploy-staging-{contract,callsite-discovery}.mjs` only the _test_ is the
 callsite contract's single self-scan exclusion. All four stay measured. A file
 the reorganization already brought under the cap carries no entry.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -64,7 +64,8 @@ that mechanism moves with it, in the same PR.
 
 - **Autoreview runtime materialization.** `agent-autoreview.sh` names its
   runtime files in Perl copy lists and `runtime_paths` arrays, then materializes
-  each from a git blob. A path it omits is absent at runtime.
+  each from an `origin/main` blob. A path it omits is absent at runtime; moving
+  one is staged across PRs (ADR 0064).
 - **Gate source-directory guards.** `agent-quality-gate.sh` gates real-tree
   routing on `$script_source_dir == $repo_root/scripts`, leaving its stub-repo
   unit tests unaffected.

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -4274,42 +4274,94 @@ materialize_filesystem_autoreview_runtime() {
   ' "$source_scripts_dir" "$runtime_dir" "$EUID"
 }
 
+# Resolve one feedback-runtime name against the protected snapshot, preferring
+# the scripts/pr/ location and falling back to the pre-move flat path.
+#
+# The runtime migrates from scripts/ into scripts/pr/ over three merges (issue
+# 1877, track D3), and this wrapper reads every helper blob from origin/main
+# rather than the checked-out tree. A wrapper pinned to one location alone
+# therefore fails closed against the other side of the move: pinned to the flat
+# path it breaks the moment the move lands, pinned to scripts/pr/ it breaks on
+# every origin/main that predates it. Accepting both keeps each wrapper
+# generation working against the origin/main before the move and the one after.
+# Drop the fallback only once no reachable wrapper still needs the flat copies.
+#
+# Prints the resolved repo-relative path, or nothing when the snapshot carries
+# neither location. A git failure is reported and returns nonzero, so absence
+# and inspection failure never collapse into the same answer.
+feedback_runtime_snapshot_path() {
+  local repo="$1"
+  local snapshot_ref="$2"
+  local runtime_name="$3"
+  local candidate
+  local entry
+  for candidate in "scripts/pr/$runtime_name" "scripts/$runtime_name"; do
+    if ! entry="$(
+      git_output "$repo" ls-tree "$snapshot_ref" -- "$candidate"
+    )"; then
+      echo "agent:autoreview: cannot inspect trusted feedback runtime: $candidate" >&2
+      return 1
+    fi
+    if [[ -n "$entry" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 0
+}
+
 materialize_feedback_runtime() {
   local repo="$1"
   local snapshot_ref="$2"
   local runtime_dir="$3"
   local relative_path
-  local optional_entry
-  local optional_runtime_path="scripts/pr-feedback-state-claude.mjs"
+  local runtime_name
+  local resolved_path
+  local index
   local output_path
   local mode
   local size
   local size_value
   local total_size=0
   local max_runtime_bytes=2097152
-  local runtime_paths=(
-    scripts/pr-feedback-state.mjs \
-    scripts/pr-feedback-state-core.mjs \
-    scripts/pr-ready-state.mjs \
-    scripts/pr-ready-state-core.mjs \
-    scripts/pr-ready-state-format.mjs
+  local required_runtime_names=(
+    pr-feedback-state.mjs \
+    pr-feedback-state-core.mjs \
+    pr-ready-state.mjs \
+    pr-ready-state-core.mjs \
+    pr-ready-state-format.mjs
   )
+  local optional_runtime_names=(
+    pr-feedback-state-claude.mjs
+  )
+  local runtime_names=()
+  local runtime_paths=()
 
-  if ! optional_entry="$(
-    git_output "$repo" ls-tree "$snapshot_ref" -- "$optional_runtime_path"
-  )"; then
-    echo "agent:autoreview: cannot inspect optional trusted feedback runtime: $optional_runtime_path" >&2
-    return 1
-  fi
-  if [[ -n "$optional_entry" ]]; then
-    if ! mode="$(
-      git_blob_mode "$repo" "$snapshot_ref" "$optional_runtime_path"
-    )" || [[ "$mode" != "100644" && "$mode" != "100755" ]]; then
-      echo "agent:autoreview: trusted feedback runtime is not a regular Git blob: $optional_runtime_path" >&2
+  for runtime_name in "${required_runtime_names[@]}"; do
+    if ! resolved_path="$(
+      feedback_runtime_snapshot_path "$repo" "$snapshot_ref" "$runtime_name"
+    )"; then
       return 1
     fi
-    runtime_paths+=("$optional_runtime_path")
-  fi
+    if [[ -z "$resolved_path" ]]; then
+      echo "agent:autoreview: trusted feedback runtime is missing $runtime_name at $snapshot_ref: no scripts/pr/ or scripts/ copy" >&2
+      return 1
+    fi
+    runtime_names+=("$runtime_name")
+    runtime_paths+=("$resolved_path")
+  done
+
+  for runtime_name in "${optional_runtime_names[@]}"; do
+    if ! resolved_path="$(
+      feedback_runtime_snapshot_path "$repo" "$snapshot_ref" "$runtime_name"
+    )"; then
+      return 1
+    fi
+    if [[ -n "$resolved_path" ]]; then
+      runtime_names+=("$runtime_name")
+      runtime_paths+=("$resolved_path")
+    fi
+  done
 
   for relative_path in "${runtime_paths[@]}"; do
     if ! mode="$(git_blob_mode "$repo" "$snapshot_ref" "$relative_path")" ||
@@ -4337,8 +4389,13 @@ materialize_feedback_runtime() {
   done
 
   mkdir -p "$runtime_dir/scripts"
-  for relative_path in "${runtime_paths[@]}"; do
-    output_path="$runtime_dir/$relative_path"
+  # The destination stays flat under scripts/ whichever location the snapshot
+  # carried, so the helpers' sibling relative imports and the capture call site
+  # resolve identically on both sides of the move. Each destination basename is
+  # a literal from the lists above, never a path read out of the snapshot.
+  for index in "${!runtime_paths[@]}"; do
+    relative_path="${runtime_paths[$index]}"
+    output_path="$runtime_dir/scripts/${runtime_names[$index]}"
     if ! git_output "$repo" cat-file blob "${snapshot_ref}:${relative_path}" >"$output_path"; then
       echo "agent:autoreview: trusted feedback runtime is missing $relative_path at $snapshot_ref" >&2
       return 1

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6040,6 +6040,140 @@ run_feedback_runtime_aggregate_regression() {
   fi
 }
 
+# The feedback runtime is migrating from flat scripts/ paths into scripts/pr/
+# (issue 1877, track D3) while the wrapper keeps reading every helper blob from
+# the protected origin/main snapshot. Both sides of that move have to work: the
+# pre-move origin/main a wrapper built before the copies landed still reads, and
+# the post-move one where scripts/pr/ is what a later wrapper must prefer.
+run_feedback_runtime_dual_location_regression() {
+  local review_repo="$tmp_dir/feedback-runtime-dual-location"
+  local fallback_bundle="$tmp_dir/feedback-runtime-fallback-bundle"
+  local preferred_bundle="$tmp_dir/feedback-runtime-preferred-bundle"
+  local mixed_bundle="$tmp_dir/feedback-runtime-mixed-bundle"
+  local gh_shim_bin="$tmp_dir/feedback-runtime-dual-location-gh"
+  local runtime_file
+
+  mkdir "$gh_shim_bin"
+  cat >"$gh_shim_bin/gh" <<'GH'
+#!/usr/bin/env bash
+printf 'gh was invoked by the feedback runtime fixture\n' >&2
+exit 90
+GH
+  chmod +x "$gh_shim_bin/gh"
+
+  init_review_repo "$review_repo"
+  git -C "$review_repo" remote add origin \
+    https://github.com/mento-protocol/monitoring-monorepo.git
+  mkdir -p "$review_repo/scripts"
+  printf 'base\n' >"$review_repo/README.md"
+  # Model the pre-move origin/main: only the flat copies exist.
+  cat >"$review_repo/scripts/pr-feedback-state.mjs" <<'FLAT_FEEDBACK_RUNTIME'
+#!/usr/bin/env node
+process.stdout.write('{"findings":[],"testEvidence":{"location":"flat"}}\n');
+FLAT_FEEDBACK_RUNTIME
+  for runtime_file in \
+    pr-feedback-state-core.mjs \
+    pr-ready-state.mjs \
+    pr-ready-state-core.mjs \
+    pr-ready-state-format.mjs; do
+    printf 'export {};\n' >"$review_repo/scripts/$runtime_file"
+  done
+  commit_review_repo "$review_repo" init
+  git -C "$review_repo" switch -c feature >/dev/null 2>&1
+  printf 'feature\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+
+  (
+    cd "$review_repo"
+    run_adapter \
+      "PATH=$gh_shim_bin:$PATH" \
+      --prepare-bundle-dir "$fallback_bundle" \
+      --mode branch \
+      --base main \
+      --feedback-pr 1299
+  )
+  expect_file_contains \
+    "$fallback_bundle/feedback-state.json" \
+    '"location":"flat"'
+  expect_empty_stderr
+
+  # Model the post-move origin/main: both locations exist and scripts/pr/ is the
+  # one the wrapper must run. Distinct bodies make preference observable — a
+  # resolver that silently kept reading the flat copy would still pass a
+  # byte-identical fixture.
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  mkdir -p "$review_repo/scripts/pr"
+  cat >"$review_repo/scripts/pr/pr-feedback-state.mjs" <<'MOVED_FEEDBACK_RUNTIME'
+#!/usr/bin/env node
+process.stdout.write('{"findings":[],"testEvidence":{"location":"scripts-pr"}}\n');
+MOVED_FEEDBACK_RUNTIME
+  for runtime_file in \
+    pr-feedback-state-core.mjs \
+    pr-ready-state.mjs \
+    pr-ready-state-core.mjs \
+    pr-ready-state-format.mjs; do
+    printf 'export {};\n' >"$review_repo/scripts/pr/$runtime_file"
+  done
+  commit_review_repo "$review_repo" "add scripts/pr copies"
+  git -C "$review_repo" update-ref refs/remotes/origin/main HEAD
+  git -C "$review_repo" switch feature >/dev/null 2>&1
+
+  (
+    cd "$review_repo"
+    run_adapter \
+      "PATH=$gh_shim_bin:$PATH" \
+      --prepare-bundle-dir "$preferred_bundle" \
+      --mode branch \
+      --base main \
+      --feedback-pr 1299
+  )
+  expect_file_contains \
+    "$preferred_bundle/feedback-state.json" \
+    '"location":"scripts-pr"'
+  expect_file_not_contains \
+    "$preferred_bundle/feedback-state.json" \
+    '"location":"flat"'
+  expect_empty_stderr
+
+  # Each basename resolves on its own, so a snapshot mid-way through the move
+  # can carry one helper under scripts/pr/ and another only at the flat path.
+  # The flattened destination is what makes that safe: both land as siblings in
+  # the runtime directory, so their relative imports still resolve. Drop one
+  # scripts/pr/ copy and have the preferred entry point import the sibling that
+  # is now reachable only through the fallback.
+  git -C "$review_repo" switch main >/dev/null 2>&1
+  rm "$review_repo/scripts/pr/pr-ready-state-format.mjs"
+  printf 'export const marker = "flat-sibling";\n' \
+    >"$review_repo/scripts/pr-ready-state-format.mjs"
+  cat >"$review_repo/scripts/pr/pr-feedback-state.mjs" <<'MIXED_FEEDBACK_RUNTIME'
+#!/usr/bin/env node
+import { marker } from "./pr-ready-state-format.mjs";
+process.stdout.write(
+  `{"findings":[],"testEvidence":{"location":"scripts-pr","sibling":"${marker}"}}\n`,
+);
+MIXED_FEEDBACK_RUNTIME
+  commit_review_repo "$review_repo" "split the runtime across both locations"
+  git -C "$review_repo" update-ref refs/remotes/origin/main HEAD
+  git -C "$review_repo" switch feature >/dev/null 2>&1
+
+  (
+    cd "$review_repo"
+    run_adapter \
+      "PATH=$gh_shim_bin:$PATH" \
+      --prepare-bundle-dir "$mixed_bundle" \
+      --mode branch \
+      --base main \
+      --feedback-pr 1299
+  )
+  expect_file_contains \
+    "$mixed_bundle/feedback-state.json" \
+    '"location":"scripts-pr"'
+  expect_file_contains \
+    "$mixed_bundle/feedback-state.json" \
+    '"sibling":"flat-sibling"'
+  expect_empty_stderr
+}
+
 run_large_untracked_bound_regression() {
   local review_repo="$tmp_dir/large-untracked-bound"
   local branch_bundle="$tmp_dir/large-untracked-branch-bundle"
@@ -7411,6 +7545,7 @@ run_bundle_integrity_family() {
   run_deploy_directory_checklist_routing_regression
   run_prepared_untracked_symlink_regression
   run_feedback_runtime_aggregate_regression
+  run_feedback_runtime_dual_location_regression
   run_large_untracked_bound_regression
   run_aggregate_untracked_bound_regression
   run_rename_capture_regressions

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4128,10 +4128,14 @@ while IFS= read -r path; do
           # verdict-label maps.
           add_command "pnpm sentry:project:test" "Sentry re-queue chokepoint changed"
           ;;
-        scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs)
+        # Both locations route to the same suite for the length of the D3 move
+        # (issue 1877): scripts/pr/ carries the copies the autoreview wrapper
+        # prefers, scripts/ the pre-move originals it falls back to. Neither arm
+        # is a glob, so each path needs naming outright.
+        scripts/pr-feedback-state.mjs|scripts/pr-feedback-state-core.mjs|scripts/pr-feedback-state-claude.mjs|scripts/pr-feedback-state.test.mjs|scripts/pr/pr-feedback-state.mjs|scripts/pr/pr-feedback-state-core.mjs|scripts/pr/pr-feedback-state-claude.mjs|scripts/pr/pr-feedback-state.test.mjs)
           add_command "pnpm pr:feedback-state:test" "PR feedback-state helper changed"
           ;;
-        scripts/pr-ready-state.mjs|scripts/pr-ready-state-core.mjs|scripts/pr-ready-state-format.mjs|scripts/pr-ready-state.test.mjs)
+        scripts/pr-ready-state.mjs|scripts/pr-ready-state-core.mjs|scripts/pr-ready-state-format.mjs|scripts/pr-ready-state.test.mjs|scripts/pr/pr-ready-state.mjs|scripts/pr/pr-ready-state-core.mjs|scripts/pr/pr-ready-state-format.mjs|scripts/pr/pr-ready-state.test.mjs)
           add_command "pnpm pr:ready-state:test" "PR ready-state helper changed"
           ;;
         scripts/pr/review-process-metrics.mjs|scripts/pr/review-process-metrics.test.mjs)

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4595,6 +4595,31 @@ assert_contains "- node scripts/sentry/ci-wiring/check-sentry-suites-in-ci.test.
 run_gate "scripts/pr-feedback-state-claude.mjs"
 assert_contains "- pnpm pr:feedback-state:test (PR feedback-state helper changed)"
 
+# Paired one-level arms for the D3 move. Neither arm is a glob, so the
+# scripts/pr/ copies route only because they are named outright; a miss here is
+# silent, the suite simply stops running for the copy the wrapper prefers.
+run_gate "scripts/pr/pr-feedback-state.mjs"
+assert_contains "- pnpm pr:feedback-state:test (PR feedback-state helper changed)"
+
+run_gate "scripts/pr/pr-feedback-state-core.mjs"
+assert_contains "- pnpm pr:feedback-state:test (PR feedback-state helper changed)"
+
+run_gate "scripts/pr/pr-feedback-state-claude.mjs"
+assert_contains "- pnpm pr:feedback-state:test (PR feedback-state helper changed)"
+
+run_gate "scripts/pr/pr-ready-state.mjs"
+assert_contains "- pnpm pr:ready-state:test (PR ready-state helper changed)"
+
+run_gate "scripts/pr/pr-ready-state-core.mjs"
+assert_contains "- pnpm pr:ready-state:test (PR ready-state helper changed)"
+
+run_gate "scripts/pr/pr-ready-state-format.mjs"
+assert_contains "- pnpm pr:ready-state:test (PR ready-state helper changed)"
+
+# The pre-move flat paths keep routing while both locations are live.
+run_gate "scripts/pr-ready-state-format.mjs"
+assert_contains "- pnpm pr:ready-state:test (PR ready-state helper changed)"
+
 run_gate "scripts/sanitize-terraform-output.sh"
 assert_contains "- pnpm sanitize:test (Terraform output sanitizer changed)"
 

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   buildFeedbackFindings,
   summarizeFeedbackState,
@@ -2691,6 +2694,28 @@ test("leaves Cursor, Codex, and Claude classification unchanged beside CodeRabbi
   // machinery.
   assertEqual(summary.counts.blockingTopLevelBotComments, 1);
   assertEqual(summary.blockingTopLevelBotComments[0].author, "cursor[bot]");
+});
+
+// D3 middle state (issue 1877). `agent-autoreview.sh` materializes these
+// helpers from the protected origin/main snapshot and prefers the scripts/pr/
+// copy, while every consumer still runs the flat one. Nothing else pins the
+// pair, so a one-sided edit would leave the autoreview trust root executing
+// stale logic with both the CLI and the rest of this suite green. Delete this
+// test together with the flat copies in the move's last step.
+test("the scripts/pr/ feedback-state copies stay byte-identical to the flat originals", () => {
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  for (const name of [
+    "pr-feedback-state.mjs",
+    "pr-feedback-state-core.mjs",
+    "pr-feedback-state-claude.mjs",
+  ]) {
+    const flat = readFileSync(resolve(scriptsDir, name));
+    const moved = readFileSync(resolve(scriptsDir, "pr", name));
+    assert(
+      flat.equals(moved),
+      `scripts/${name} and scripts/pr/${name} have drifted; agent-autoreview runs the scripts/pr/ copy`,
+    );
+  }
 });
 
 if (failed > 0) {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -34,6 +34,9 @@ import {
   watchLoopExitCode,
   workflowPathsFromRules,
 } from "./pr-ready-state.mjs";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 let passed = 0;
 let failed = 0;
@@ -2282,6 +2285,28 @@ test("a passing CodeRabbit check does not clear a real required blocker", () => 
     !summary.required.blockers.some((blocker) => blocker.name === "CodeRabbit"),
     "CodeRabbit must never appear as a required blocker by default",
   );
+});
+
+// D3 middle state (issue 1877). `agent-autoreview.sh` materializes these
+// helpers from the protected origin/main snapshot and prefers the scripts/pr/
+// copy, while every consumer still runs the flat one. Nothing else pins the
+// pair, so a one-sided edit would leave the autoreview trust root executing
+// stale logic with both the CLI and the rest of this suite green. Delete this
+// test together with the flat copies in the move's last step.
+test("the scripts/pr/ ready-state copies stay byte-identical to the flat originals", () => {
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  for (const name of [
+    "pr-ready-state.mjs",
+    "pr-ready-state-core.mjs",
+    "pr-ready-state-format.mjs",
+  ]) {
+    const flat = readFileSync(resolve(scriptsDir, name));
+    const moved = readFileSync(resolve(scriptsDir, "pr", name));
+    assert(
+      flat.equals(moved),
+      `scripts/${name} and scripts/pr/${name} have drifted; agent-autoreview runs the scripts/pr/ copy`,
+    );
+  }
 });
 
 if (failed > 0) {

--- a/scripts/pr/pr-feedback-state-claude.mjs
+++ b/scripts/pr/pr-feedback-state-claude.mjs
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+
+const COMMONMARK_ASCII_PUNCTUATION_ESCAPE =
+  /\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/g;
+const CLAUDE_TASK_COMPLETION_LINE =
+  /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*(?:\s+——\s+\[View\s+job\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+\))?$/i;
+const CLAUDE_VERDICT_NAMESPACE = /^(?:\*\*)?(?:Overall\s+)?Verdict\s*:/i;
+const CLAUDE_CLEAN_VERDICT =
+  /^(?:\*\*)?(?:Overall\s+)?Verdict:\s*LGTM(?:\*\*)?\s*$/i;
+const PROSE_PATTERN_LIBRARY_START = Date.parse("2026-08-13T23:08:10Z");
+const REVIEW_NUMBER_HEADING = /^#{1,6}\s+Code Review\s+—\s+PR\s+#(\d+)$/gm;
+const REVIEW_TITLE_HEADING = /^#{1,6}\s+Review:\s+(.{1,200})$/gim;
+const CLEAN_CONCLUSION_PATTERNS = [
+  /^No\s+P1\/P2\/P3\s+findings(?:\s*[.—-]\s*(?:clean review|nothing rose above the bar for an inline comment))?[.!]?$/i,
+  /^No\s+P1\/P2\s+findings[.!]?$/i,
+  /^No\s+inline\s+(?:comments|findings)(?:\s+(?:filed|posted))?(?:\s*[.—-]\s*nothing rose to a P1\/P2\/P3 flag)?[.!]?$/i,
+  /^No\s+changes\s+requested[.!]?$/i,
+];
+const CLEAN_P3_DISPOSITION_PATTERNS = [
+  /\bno[- ]action(?:\s+requested)?\b/i,
+  /\bnone\s+blocking\b/i,
+  /\bnot\s+(?:a\s+)?blocker\b/i,
+  /\bisn['’]t\s+(?:a\s+)?blocker\b/i,
+  /\bnot\s+worth\s+(?:a\s+)?fix\b/i,
+  /\bnot\s+an?\s+(?:error|issue)\b/i,
+];
+const EXPLICIT_ACTION_LINE =
+  /^(?:\*\*)?(?:Action\s+(?:items?|required)|Changes\s+requested|Needs\s+changes|A\s+fix\s+is\s+required|.{1,160}\s+must\s+be\s+(?:addressed|changed|fixed|implemented|removed|restored|updated|validated)|(?:Please\s+)?(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)|(?:Must|Should|Needs?\s+to)\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate))\b/i;
+const INLINE_DIRECT_ACTION =
+  /\bplease\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)\b/i;
+// `cr-indicator-types` is CodeRabbit's finding marker and the counterpart to
+// Cursor's BUGBOT_BUG_ID: a Claude LGTM verdict that quotes or relays one is
+// not an explicitly clean review.
+const EXPLICIT_SEVERITY =
+  /(?:BUGBOT_BUG_ID|<!--\s*cr-indicator-types\s*:|\b(?:Critical|High|Medium|Low)\s+Severity\b|\bSeverity\s*:\s*(?:Critical|High|Medium|Low)\b)/i;
+const CLEAN_REVIEW_COMPATIBILITY = new Map([
+  [
+    "039923882eee9f880165543ef85e1ca251d84b995a78647b41c2b788d02a4885",
+    {
+      author: "claude[bot]",
+      prNumber: "1544",
+      commentId: "5060594122",
+      headRefOid: "aab83bc74ae0585147a058d92f1f13afac7be109",
+    },
+  ],
+  [
+    "5d4832d96803f81363bc0842a4c1aed89e8fb526cb83834d3373aacd30c5be34",
+    {
+      author: "claude[bot]",
+      prNumber: "1595",
+      commentId: "5069799124",
+      headRefOid: "d4bb77845e635c72b61fa56b375ec3f44b05702e",
+    },
+  ],
+  [
+    "e0394033c85a77330e2ee53cab690a2069263c7e792ab3e443c17949bb728db4",
+    {
+      author: "claude[bot]",
+      prNumber: "1600",
+      commentId: "5073384440",
+      headRefOid: "0ff2700ecbec8d2877caeeaa91bf423cf8fdc2f0",
+    },
+  ],
+  [
+    "17628badc56cb6e53b77c559425020b839847e66357614e65a9707f8bf6d7ee9",
+    {
+      author: "claude[bot]",
+      prNumber: "1825",
+      commentId: "5278516901",
+      headRefOid: "5ce1cad0371551aff0e8b68867a29bb5d2736bf4",
+    },
+  ],
+  [
+    "3816022eb21a2e41e0617c719f6daedc8c1c5c282b4b1b2010e4b739b0c3f1c7",
+    {
+      author: "claude[bot]",
+      prNumber: "1837",
+      commentId: "5281908631",
+      headRefOid: "7d982e05a0256d73d0d7aeafc485dfad338e63ce",
+    },
+  ],
+]);
+
+function normalizedReviewTitle(value) {
+  return String(value ?? "")
+    .replace(COMMONMARK_ASCII_PUNCTUATION_ESCAPE, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function isClaudeAuthor(value) {
+  return /^claude(?:\[bot\])?$/i.test(String(value ?? ""));
+}
+
+function isCleanConclusion(line) {
+  const value = String(line ?? "").trim();
+  return CLEAN_CONCLUSION_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function withoutCleanReviewConclusionLines(value) {
+  return String(value ?? "")
+    .split("\n")
+    .filter((line) => !isCleanConclusion(line))
+    .join("\n");
+}
+
+function reviewLineContent(line) {
+  let value = String(line ?? "").trim();
+  for (let index = 0; index < 3; index += 1) {
+    const stripped = value.replace(
+      /^(?:[-*+]\s+|\d+[.)]\s+|#{1,6}\s+|\[[ xX-]\]\s+)/,
+      "",
+    );
+    if (stripped === value) break;
+    value = stripped;
+  }
+  return value;
+}
+
+function verdictDeclaration(line) {
+  return CLAUDE_VERDICT_NAMESPACE.test(reviewLineContent(line));
+}
+
+function priorityAtLineStart(line) {
+  return reviewLineContent(line).match(
+    /^(?:\*\*)?\[?[Pp]([0-3])\]?(?:\*\*)?(?=[^A-Za-z0-9]|$)/,
+  )?.[1];
+}
+
+function hasCleanP3Disposition(line) {
+  return CLEAN_P3_DISPOSITION_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+function hasExplicitAction(line) {
+  const content = reviewLineContent(line).replace(
+    /^(?:\*\*)?\[?[Pp][0-3]\]?(?:\*\*)?(?:\s*[^A-Za-z0-9\s]\s*|\s+)/,
+    "",
+  );
+  return (
+    EXPLICIT_ACTION_LINE.test(content) || INLINE_DIRECT_ACTION.test(content)
+  );
+}
+
+export function hasControlCharacter(value) {
+  return Array.from(String(value ?? "")).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f);
+  });
+}
+
+export function isOrdinaryReviewTitle(value, expectedTitle) {
+  const title = String(value ?? "").trim();
+  if (
+    !title ||
+    title.length > 200 ||
+    hasControlCharacter(title) ||
+    /<!--|-->/.test(title)
+  )
+    return false;
+  const normalized = normalizedReviewTitle(title);
+  return (
+    normalized.length > 0 && normalized === normalizedReviewTitle(expectedTitle)
+  );
+}
+
+export function hasMarkdownCodeBlockIndentation(lines) {
+  return lines.some((line) => line.trim() && /^(?: {4}| {0,3}\t)/.test(line));
+}
+
+export function isClaudeTaskCompletionLine(value) {
+  return CLAUDE_TASK_COMPLETION_LINE.test(String(value ?? ""));
+}
+
+export function isClaudeLgtmReview(comment) {
+  return (
+    isClaudeAuthor(comment?.author) &&
+    /^\s*(?:#{1,6}\s+)?(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(
+      comment?.body ?? "",
+    )
+  );
+}
+
+export function matchesCleanReviewCompatibilityRegistry(comment, pr, rawBody) {
+  const digest = createHash("sha256").update(rawBody, "utf8").digest("hex");
+  const registered = CLEAN_REVIEW_COMPATIBILITY.get(digest);
+  return (
+    registered !== undefined &&
+    String(comment?.author ?? "").toLowerCase() === registered.author &&
+    String(pr?.number ?? "") === registered.prNumber &&
+    String(comment?.id ?? "") === registered.commentId &&
+    String(pr?.headRefOid ?? "") === registered.headRefOid
+  );
+}
+
+// Returns null for non-Claude or non-verdict comments, false for an explicitly
+// clean review, and true for an actionable or unsupported verdict comment.
+export function classifyClaudeReviewProse(comment, pr) {
+  if (!isClaudeAuthor(comment?.author)) return null;
+  const body = String(comment?.body ?? "");
+  const lines = body.split("\n");
+  const verdictLines = lines.filter(verdictDeclaration);
+  if (verdictLines.length === 0) return null;
+  const createdAt = Date.parse(comment?.createdAt ?? comment?.created_at ?? "");
+  if (!Number.isFinite(createdAt) || createdAt < PROSE_PATTERN_LIBRARY_START)
+    return true;
+
+  if (
+    verdictLines.length !== 1 ||
+    !CLAUDE_CLEAN_VERDICT.test(reviewLineContent(verdictLines[0])) ||
+    body.includes("\r") ||
+    body.includes("\0") ||
+    body.length > 65_536 ||
+    hasMarkdownCodeBlockIndentation(lines) ||
+    /(?:^|\s)(?:```|~~~)|<!--|-->|^\s*(?:>|\|.*\|\s*$)/m.test(body)
+  )
+    return true;
+
+  const reviewNumbers = Array.from(
+    body.matchAll(REVIEW_NUMBER_HEADING),
+    ([, number]) => number,
+  );
+  if (
+    reviewNumbers.length > 1 ||
+    (reviewNumbers.length === 1 &&
+      reviewNumbers[0] !== String(pr?.number ?? ""))
+  )
+    return true;
+
+  const reviewTitles = Array.from(
+    body.matchAll(REVIEW_TITLE_HEADING),
+    ([, title]) => title,
+  );
+  if (
+    reviewTitles.length > 1 ||
+    (reviewTitles.length === 1 &&
+      !isOrdinaryReviewTitle(reviewTitles[0], pr?.title))
+  )
+    return true;
+
+  if (!lines.some(isCleanConclusion)) return true;
+
+  for (const line of lines) {
+    if (isCleanConclusion(line)) continue;
+    const priority = priorityAtLineStart(line);
+    if (
+      priority !== undefined &&
+      (priority !== "3" || !hasCleanP3Disposition(line))
+    )
+      return true;
+    if (hasExplicitAction(line) || EXPLICIT_SEVERITY.test(line)) return true;
+  }
+
+  return false;
+}

--- a/scripts/pr/pr-feedback-state-core.mjs
+++ b/scripts/pr/pr-feedback-state-core.mjs
@@ -1,0 +1,646 @@
+import { createHash } from "node:crypto";
+import * as claudeReview from "./pr-feedback-state-claude.mjs";
+
+const FINDING_EXCERPT_LENGTH = 240;
+const FAILURE_TERM = /\b(?:error|errors|fail|fails|failed|failure|failures)\b/i;
+const NEGATED_FAILURE =
+  /\b(?:no|zero|0)[ \t]+(?:errors?|fails?|failed|failures?)(?:[ \t]+(?:and|or)[ \t]+(?:errors?|fails?|failed|failures?))?(?:[ \t]+(?:are|was|were)[ \t]+(?:found|observed|reported))?(?=[ \t]*(?:[.,;:]|$))/gi;
+const CLEAN_FINDING_MARKER =
+  /^(?:None\s+blocking|No[- ]action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
+const UNSAFE_EVIDENCE_QUALIFIER =
+  /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could|appears?|seems?|probably|likely|possibly|perhaps|unclear|unknown)\b/i;
+const POSITIVE_EVIDENCE =
+  /^(?:clean(?:,\s+well\s+scoped)?(?:\s+fix)?|well\s+scoped(?:\s+fix)?|correct|covered|bounded|mechanical|verified|complete|exact\s+removal\s+condition|(?:no|zero|0)\s+(?:errors?|fails?|failed|failures?)(?:\s+(?:and|or)\s+(?:errors?|fails?|failed|failures?))?(?:\s+(?:are|was|were)\s+(?:found|observed|reported))?|no\s+unrelated\s+version\s+bumps?|no\s+vulnerable\s+sharp@0\.34\.5\s+remains?\s+anywhere\s+in\s+(?:the\s+)?repo(?:'s)?\s+lockfiles|parser\s+should\s+continue\s+rejecting\s+malformed\s+input|fallback\s+should\s+stay|fix\s+is\s+correct|override\s+selector\s+is\s+correctly\s+bounded|lockfile\s+churn\s+beyond\s+sharp\s+itself\s+is\s+confirmed\s+mechanical,\s+not\s+scope\s+creep|(?:the\s+)?bounded\s+selector\s+matches\s+the\s+repo(?:'s)?\s+established\s+override\s+pattern|matches\s+repo\s+convention|(?:the\s+)?inline\s+comment\s+documents\s+the\s+advisory|removal\s+condition\s+comment\s+satisfies\s+the\s+temporary\s+override\s+documentation\s+expectation|tests\s+cover\s+the\s+changed\s+paths)$/i;
+const CLAUDE_REVIEW_TITLE_LINE = /^#{1,6}\s+Review:\s+(.{1,200})$/i;
+const CLAUDE_VERDICT_LINE = /^(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?$/i;
+const CLAUDE_CHECKLIST_HEADING = /^#{1,6}\s+What\s+I\s+checked$/i;
+const CLAUDE_CHECKLIST_ENTRY = /^-\s+\[([^\]])\]\s+(.{1,200})$/;
+const SAFE_CLAUDE_CHECKLIST_TOPICS = new Set([
+  "api contract",
+  "authentication boundary",
+  "checklist routing",
+  "ci status",
+  "configuration scope",
+  "dependency resolution",
+  "documentation examples",
+  "generated artifacts",
+  "operator documentation",
+  "parser behavior",
+  "parser structure",
+  "regression-test coverage",
+  "request-path coverage",
+  "review title",
+  "runtime behavior",
+  "schema compatibility",
+  "session lifecycle",
+  "type safety",
+  "unit tests",
+  "unit-test coverage",
+]);
+const LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT =
+  /^(?:`pnpm-workspace\.yaml`\s+override\s+syntax\/scope|`pnpm-lock\.yaml`\s+regeneration\s+for\s+unrelated\s+drift|Supply-chain\/lockfile-lint\s+compliance\s+and\s+CI\s+status|Other\s+standalone\s+lockfiles\s+for\s+leftover\s+vulnerable\s+`sharp@0\.34\.5`)$/i;
+const LEGACY_SAFE_CLAUDE_FINDING_LINES = new Set([
+  "1. **[P3] None blocking — clean, well-scoped fix.** The bounded selector matches the repo's established override pattern.",
+  "2. **[P3] Good hygiene:** the inline comment documents the advisory and exact removal condition.",
+  "3. **[P3] Lockfile diff is fully mechanical.** No unrelated version bumps.",
+  "4. Confirmed no leftover `sharp@0.34.5` anywhere.",
+  "5. Supply Chain CI already passed on this PR.",
+  "No inline comments filed — nothing rose to an actionable, line-specific issue.",
+]);
+const LEGACY_SAFE_CLAUDE_ROLLUP_LINES = new Set([
+  "2. [P3] No-action: removal-condition comment satisfies the temporary-override documentation expectation.",
+  "4. [P3] No-action: no vulnerable `sharp@0.34.5` remains anywhere in the repo's lockfiles.",
+]);
+const CLEAN_ROLLUP_ENTRY = /^\d+[.)]\s+\[[Pp]3\]\s+(No[- ]action:.*)$/i;
+const CLEAN_REVIEW_SUMMARY =
+  /\b(?:no\s+changes\s+requested|no\s+[Pp][0-2]\s+(?:issues?|findings?)|(?:no|zero|0)\s+(?:Critical|High|Medium|Low)\s+Severity\s+(?:issues?|findings?))\b/gi;
+// CodeRabbit's actionable markers, the counterpart to Cursor's BUGBOT_BUG_ID.
+// `cr-indicator-types` is the HTML marker CodeRabbit stamps on a finding
+// (`potential_issue`, `refactor_suggestion`, ...); the severity badge is the
+// leading `_🎯 Functional Correctness_ | _🟠 Major_ | _🏗️ Heavy lift_` line.
+// Both survive `reviewContradictionBody`, which strips `*_~` but not comments.
+const CODERABBIT_FINDING_MARKER = /<!--\s*cr-indicator-types\s*:/i;
+const CODERABBIT_SEVERITY_BADGE =
+  /_\s*(?:\p{Extended_Pictographic}️?\s*)?(?:Critical|Major|Minor|Trivial)\s*_/u;
+// CodeRabbit's auto-generated NON-finding surfaces. The rate-limit notice, the
+// walkthrough/summary, the `@coderabbitai review` acknowledgement, and the
+// in-thread acks it posts after our "Fixed in <sha>" replies all carry one of
+// these markers and carry no finding. A finding body carries the reply marker
+// too once CodeRabbit edits its "Confirmed as addressed" footer in, so the
+// actionable markers above are always checked FIRST.
+const CODERABBIT_AUTOGENERATED_NON_FINDING = [
+  /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
+  /<!--\s*This is an auto-generated comment:\s*summarize by coderabbit\.ai\s*-->/i,
+  /<!--\s*CodeRabbit review command invocation\s*:/i,
+  /<!--\s*This is an auto-generated reply by CodeRabbit\s*-->/i,
+];
+const CODERABBIT_AUTHORS = new Set(["coderabbitai", "coderabbitai[bot]"]);
+const REVIEW_CONTRADICTION =
+  /(?:BUGBOT_BUG_ID|<!--\s*cr-indicator-types\s*:|\b[Pp][0-2]\b|\b(?:Critical|High|Medium|Low)\s+Severity\b|\bSeverity\s*:\s*(?:Critical|High|Medium|Low)\b|\bAction\s+items?\s*:|\b(?:Action\s+required|changes\s+requested|needs[- ]changes)\b|\b(?:please|must|need(?:s)?\s+to|should)\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)\b|\b(?:but|however|although|yet)\b[^.!?\r\n]*\b(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)\b|(?:^|[\r\n])\s*(?:[-*>]\s*)?(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)\b)/i;
+
+function gateReady(gate) {
+  return gate?.required === false || Boolean(gate?.ready ?? true);
+}
+
+function commentTimestamp(comment) {
+  return Date.parse(comment.updatedAt ?? comment.createdAt ?? "");
+}
+
+function referencedCommitShas(comment) {
+  const body = String(comment.body ?? "");
+  const patterns = [
+    /\bcommit(?:\s+sha|sha|_sha|id|_id)?["':=\s-]+([0-9a-f]{40})\b/gi,
+    /\/(?:blob|commit|commits|tree)\/([0-9a-f]{40})\b/gi,
+  ];
+  return patterns.flatMap((pattern) =>
+    Array.from(body.matchAll(pattern), ([, sha]) => sha.toLowerCase()),
+  );
+}
+
+function isCurrentHeadComment(comment, pr) {
+  const headSha = String(pr?.headRefOid ?? "").toLowerCase();
+  const reviewCommitSha = String(comment.commitOid ?? "").toLowerCase();
+  if (headSha && reviewCommitSha) return reviewCommitSha === headSha;
+
+  const commitShas = referencedCommitShas(comment);
+  if (headSha && commitShas.length > 0) {
+    return commitShas.includes(headSha);
+  }
+
+  const headTimestamp = Date.parse(pr?.headUpdatedAt ?? "");
+  if (!Number.isFinite(headTimestamp)) return false;
+  const timestamp = commentTimestamp(comment);
+  return Number.isFinite(timestamp) && timestamp >= headTimestamp;
+}
+
+function isReviewBotComment(comment) {
+  return [
+    "chatgpt-codex-connector",
+    "chatgpt-codex-connector[bot]",
+    "claude",
+    "claude[bot]",
+    "coderabbitai",
+    "coderabbitai[bot]",
+    "cursor",
+    "cursor[bot]",
+  ].includes(String(comment.author ?? "").toLowerCase());
+}
+
+// Returns true for an actionable CodeRabbit comment, false for one of its
+// auto-generated non-finding surfaces, and null for anything else (including
+// every non-CodeRabbit author), which falls through to the shared prose rules.
+//
+// CodeRabbit's top-level comments are mostly machinery — a walkthrough, a
+// rate-limit notice, a trigger ack, an in-thread ack. Their prose routinely
+// trips the generic contradiction rules (a walkthrough of a change to error
+// handling contains "error"), so they must be classified by marker, not prose.
+// Its real findings arrive as root INLINE comments, which the review-thread and
+// root-review-comment ledgers already own.
+function classifyCodeRabbitComment(comment) {
+  if (!CODERABBIT_AUTHORS.has(String(comment.author ?? "").toLowerCase())) {
+    return null;
+  }
+  const body = String(comment.body ?? "");
+  if (CODERABBIT_FINDING_MARKER.test(body)) return true;
+  if (CODERABBIT_SEVERITY_BADGE.test(body)) return true;
+  if (CODERABBIT_AUTOGENERATED_NON_FINDING.some((rule) => rule.test(body))) {
+    return false;
+  }
+  return null;
+}
+function hasUnnegatedFailure(value) {
+  const scrubbed = String(value ?? "").replace(NEGATED_FAILURE, "");
+  return FAILURE_TERM.test(scrubbed);
+}
+function reviewContradictionBody(value) {
+  return String(value ?? "")
+    .replace(/[*_~]/g, "")
+    .replace(CLEAN_REVIEW_SUMMARY, "");
+}
+function hasReviewActionSignal(value) {
+  return REVIEW_CONTRADICTION.test(reviewContradictionBody(value));
+}
+function hasReviewContradiction(value) {
+  const body = reviewContradictionBody(value);
+  return REVIEW_CONTRADICTION.test(body) || hasUnnegatedFailure(body);
+}
+function isBenignChecklistSubject(value) {
+  const subject = String(value ?? "").trim();
+  if (
+    !subject ||
+    subject.length > 200 ||
+    claudeReview.hasControlCharacter(subject) ||
+    (subject.match(/`/g)?.length ?? 0) % 2 !== 0
+  )
+    return false;
+  if (LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT.test(subject)) return true;
+  const topics = subject.toLowerCase().split(/\s+and\s+/);
+  return (
+    topics.length <= 3 &&
+    topics.every((topic) => SAFE_CLAUDE_CHECKLIST_TOPICS.has(topic))
+  );
+}
+function isSafeClaudePreamble(lines, pr) {
+  const preamble = lines.map((line) => line.trim()).filter(Boolean);
+  let index = 0;
+
+  if (claudeReview.isClaudeTaskCompletionLine(preamble[index])) index += 1;
+  if (preamble[index] === "---") index += 1;
+
+  const reviewTitle = (preamble[index] ?? "").match(CLAUDE_REVIEW_TITLE_LINE);
+  if (reviewTitle) {
+    if (!claudeReview.isOrdinaryReviewTitle(reviewTitle[1], pr?.title))
+      return false;
+    index += 1;
+  }
+
+  if (!CLAUDE_VERDICT_LINE.test(preamble[index] ?? "")) return false;
+  index += 1;
+  if (index === preamble.length) return true;
+  if (!CLAUDE_CHECKLIST_HEADING.test(preamble[index] ?? "")) return false;
+  index += 1;
+
+  let checklistEntries = 0;
+  for (; index < preamble.length; index += 1) {
+    const entry = preamble[index].match(CLAUDE_CHECKLIST_ENTRY);
+    if (
+      !entry ||
+      entry[1].toLowerCase() !== "x" ||
+      !isBenignChecklistSubject(entry[2])
+    )
+      return false;
+    checklistEntries += 1;
+  }
+  return checklistEntries > 0;
+}
+function hasPositiveCleanEvidence(value) {
+  const tail = String(value ?? "")
+    .trim()
+    .match(CLEAN_FINDING_MARKER)?.[1];
+  if (tail === undefined) return false;
+  const evidenceClauses = tail
+    .split(/(?:[!?;]+|\.(?=\s|$)|\b(?:and|but|however|although|yet)\b)/i)
+    .map((clause) => clause.trim())
+    .filter(Boolean);
+  return (
+    evidenceClauses.length > 0 &&
+    evidenceClauses.every((evidence) => {
+      const withoutSafeNegation = evidence.replace(
+        /,\s+not\s+scope\s+creep$/i,
+        "",
+      );
+      return (
+        !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
+        POSITIVE_EVIDENCE.test(evidence)
+      );
+    })
+  );
+}
+function isCleanFindingLine(line) {
+  const raw = String(line ?? "").trim();
+  if (LEGACY_SAFE_CLAUDE_FINDING_LINES.has(raw)) return true;
+  const p3 = raw.match(/^\d+[.)]\s+\[[Pp]3\]\s+(.+)$/);
+  if (p3) return hasPositiveCleanEvidence(p3[1]);
+  return false;
+}
+function isCleanRollupLine(line) {
+  const raw = String(line ?? "").trim();
+  if (LEGACY_SAFE_CLAUDE_ROLLUP_LINES.has(raw)) return true;
+  const entry = raw.match(CLEAN_ROLLUP_ENTRY)?.[1];
+  return entry !== undefined && hasPositiveCleanEvidence(entry);
+}
+function isExplicitlyCleanClaudeReview(comment, pr) {
+  const author = String(comment.author ?? "").toLowerCase();
+  if (author !== "claude" && author !== "claude[bot]") return false;
+  const body = String(comment.body ?? "");
+  const lines = body.split(/\r?\n/);
+  if (claudeReview.hasMarkdownCodeBlockIndentation(lines)) return false;
+  if (!/^\s*(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?\s*$/im.test(body)) return false;
+  const headings = lines.filter((line) =>
+    /^\s*#{1,6}\s+(?:Findings|Roll[- ]up)\s*$/i.test(line),
+  );
+  const headingOrder = headings.map(normalizeText).join(",");
+  if (!/^Findings,Roll up$/i.test(headingOrder)) return false;
+  const findingsIndex = lines.indexOf(headings[0]);
+  const rollupIndex = lines.indexOf(headings[1]);
+  if (!isSafeClaudePreamble(lines.slice(0, findingsIndex), pr)) return false;
+  const nonempty = (line) => line.trim();
+  const findings = lines.slice(findingsIndex + 1, rollupIndex).filter(nonempty);
+  const rollup = lines.slice(rollupIndex + 1).filter(nonempty);
+  if (hasReviewContradiction([...findings, ...rollup].join("\n"))) return false;
+  return (
+    findings.length > 0 &&
+    findings.every(isCleanFindingLine) &&
+    rollup.length > 0 &&
+    rollup.every(isCleanRollupLine)
+  );
+}
+function isActionableReviewBotComment(comment, pr) {
+  if (!isReviewBotComment(comment)) return false;
+  if (
+    claudeReview.matchesCleanReviewCompatibilityRegistry(
+      comment,
+      pr,
+      String(comment.body ?? ""),
+    )
+  )
+    return false;
+  if (
+    claudeReview.isClaudeLgtmReview(comment) &&
+    isExplicitlyCleanClaudeReview(comment, pr)
+  )
+    return false;
+  const claudeProse = claudeReview.classifyClaudeReviewProse(comment, pr);
+  if (claudeProse !== null)
+    return (
+      claudeProse ||
+      hasReviewActionSignal(
+        claudeReview.withoutCleanReviewConclusionLines(comment.body),
+      )
+    );
+  const coderabbit = classifyCodeRabbitComment(comment);
+  if (coderabbit !== null) return coderabbit;
+  if (hasReviewContradiction(comment.body)) return true;
+  const actionableSignal =
+    /(?:\[[Pp]3\]|\*\*[Pp]3\*\*|\b[Pp]3\s*(?::|[-—|]|Badge\b))/.test(
+      comment.body ?? "",
+    );
+  return actionableSignal;
+}
+
+function normalizeText(value) {
+  return String(value ?? "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_~>#|-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function excerpt(value) {
+  const normalized = normalizeText(value);
+  if (normalized.length <= FINDING_EXCERPT_LENGTH) return normalized;
+  return `${normalized.slice(0, FINDING_EXCERPT_LENGTH - 1).trimEnd()}...`;
+}
+
+function titleFromText(value) {
+  const normalized = normalizeText(value);
+  const sentence = normalized.split(/(?<=[.!?])\s+/)[0] ?? normalized;
+  return sentence.length <= 120
+    ? sentence
+    : `${sentence.slice(0, 119).trimEnd()}...`;
+}
+
+function fingerprint(parts) {
+  const input = parts
+    .map((part) =>
+      String(part ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase(),
+    )
+    .join("\0");
+  return `feedback:${createHash("sha256").update(input).digest("hex").slice(0, 16)}`;
+}
+
+function findingSourceId(id, index = null) {
+  if (id === null || id === undefined || id === "") return null;
+  const sourceId = String(id);
+  return index === null ? sourceId : `${sourceId}#${index + 1}`;
+}
+
+function feedbackCommentKey(comment) {
+  return [
+    comment.id ?? "",
+    comment.url ?? "",
+    comment.commitOid ?? "",
+    comment.author ?? "",
+    normalizeText(comment.body ?? ""),
+  ].join("\0");
+}
+
+function buildFinding({
+  source,
+  sourceId = null,
+  author = null,
+  url = null,
+  path = null,
+  line = null,
+  title = "",
+  body = "",
+  state,
+  currentHead = null,
+  outdated = null,
+  replied = null,
+  unresolved = null,
+  blocking = false,
+}) {
+  const findingText = normalizeText(body || title);
+  const titleText = titleFromText(title || body);
+  return {
+    fingerprint: fingerprint([source, author, path, line, findingText]),
+    source,
+    sourceId,
+    author,
+    url,
+    path,
+    line,
+    title: titleText,
+    excerpt: excerpt(body || title),
+    state,
+    currentHead,
+    outdated,
+    replied,
+    unresolved,
+    blocking,
+  };
+}
+
+function reviewThreadFindings(reviewThreads = []) {
+  return reviewThreads.map((thread) => {
+    const unresolved = thread.isResolved === false;
+    const outdated = Boolean(thread.isOutdated);
+    const state = unresolved
+      ? outdated
+        ? "unresolved-outdated"
+        : "unresolved"
+      : outdated
+        ? "resolved-outdated"
+        : "resolved";
+    return buildFinding({
+      source: "review-thread",
+      sourceId: findingSourceId(thread.id),
+      author: thread.author ?? null,
+      url: thread.url ?? null,
+      path: thread.path ?? null,
+      line: thread.line ?? null,
+      title: thread.body ?? "",
+      body: thread.body ?? "",
+      state,
+      currentHead: outdated ? false : true,
+      outdated,
+      replied: null,
+      unresolved,
+      blocking: unresolved,
+    });
+  });
+}
+
+function rootReviewCommentFindings(rootReviewComments = []) {
+  return rootReviewComments.map((comment) => {
+    const replied = Boolean(comment.replied);
+    return buildFinding({
+      source: "review-comment",
+      sourceId: findingSourceId(comment.id),
+      author: comment.author ?? null,
+      url: comment.url ?? null,
+      path: comment.path ?? null,
+      line: comment.line ?? null,
+      title: comment.body ?? "",
+      body: comment.body ?? "",
+      state: replied ? "replied" : "unreplied",
+      currentHead: null,
+      outdated: null,
+      replied,
+      unresolved: !replied,
+      blocking: !replied,
+    });
+  });
+}
+
+function tableCells(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null;
+  const cells = trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => normalizeText(cell));
+  if (cells.length < 2) return null;
+  if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) return null;
+  return cells;
+}
+
+function isPriorityOrSeverity(value) {
+  return /(?:\b[Pp][0-3]\b|\b(?:Critical|High|Medium|Low)\s+Severity\b)/.test(
+    value,
+  );
+}
+
+function tableFindings(body) {
+  const findings = [];
+  for (const line of String(body ?? "").split(/\r?\n/)) {
+    const cells = tableCells(line);
+    if (!cells) continue;
+    const numbered = /^\d+$/.test(cells[0] ?? "");
+    const priorityCell = cells.findIndex(isPriorityOrSeverity);
+    if (!numbered && priorityCell < 0) continue;
+
+    const contentCells = numbered ? cells.slice(1) : cells;
+    const title = contentCells.filter(Boolean).join(" ");
+    if (!title || /^severity\s+issue\b/i.test(title)) continue;
+    findings.push({ title, body: title });
+  }
+  return findings;
+}
+
+function sectionStart(line) {
+  return /^\s*(?:[-*]\s*)?(?:#{1,6}\s*)?(?:\[[Pp][0-3]\]|\b[Pp][0-3]\s+Badge\b|\*\*\s*(?:Critical|High|Medium|Low)\s+Severity\s*\*\*|\b(?:Critical|High|Medium|Low)\s+Severity\b)/.test(
+    line,
+  );
+}
+
+function sectionFindings(body) {
+  const lines = String(body ?? "").split(/\r?\n/);
+  const starts = lines
+    .map((line, index) => (sectionStart(line) ? index : -1))
+    .filter((index) => index >= 0);
+  if (starts.length === 0) return [];
+
+  return starts.map((start, index) => {
+    const end = starts[index + 1] ?? lines.length;
+    const section = lines.slice(start, end).join("\n").trim();
+    return {
+      title: lines[start],
+      body: section,
+    };
+  });
+}
+
+function botCommentSections(comment) {
+  const body = String(comment.body ?? "");
+  const tableSections = tableFindings(body);
+  if (tableSections.length > 0) return tableSections;
+
+  const headingSections = sectionFindings(body);
+  if (headingSections.length > 0) return headingSections;
+
+  return [{ title: body, body }];
+}
+
+function botCommentFindings(comments = [], pr, blockingComments = []) {
+  const blockingKeys = new Set(blockingComments.map(feedbackCommentKey));
+  return comments
+    .filter((comment) => isActionableReviewBotComment(comment, pr))
+    .flatMap((comment) => {
+      const currentHead = isCurrentHeadComment(comment, pr);
+      const blocking = blockingKeys.has(feedbackCommentKey(comment));
+      const source = comment.commitOid
+        ? "top-level-bot-review"
+        : "top-level-bot-comment";
+      return botCommentSections(comment).map((section, index) =>
+        buildFinding({
+          source,
+          sourceId: findingSourceId(comment.id, index),
+          author: comment.author ?? null,
+          url: comment.url ?? null,
+          title: section.title,
+          body: section.body,
+          state: blocking
+            ? "blocking-current-head"
+            : currentHead
+              ? "current-head"
+              : "stale",
+          currentHead,
+          outdated: currentHead ? false : true,
+          replied: null,
+          unresolved: blocking,
+          blocking,
+        }),
+      );
+    });
+}
+
+export function buildFeedbackFindings(readyState, blockingTopLevelBotComments) {
+  const reviewThreads =
+    readyState.reviewThreads ??
+    (readyState.unresolvedReviewThreads ?? []).map((thread) => ({
+      ...thread,
+      isResolved: false,
+    }));
+  const rootReviewComments =
+    readyState.rootReviewComments ??
+    (readyState.unrepliedRootReviewComments ?? []).map((comment) => ({
+      ...comment,
+      replied: false,
+    }));
+
+  return [
+    ...reviewThreadFindings(reviewThreads),
+    ...rootReviewCommentFindings(rootReviewComments),
+    ...botCommentFindings(
+      readyState.topLevelBotComments ?? [],
+      readyState.pr,
+      blockingTopLevelBotComments,
+    ),
+  ];
+}
+
+export function summarizeFeedbackState(readyState) {
+  const gates = readyState.gates ?? {};
+  const requiredBlockers = readyState.required?.blockers ?? [];
+  const feedbackBlockers = requiredBlockers.filter((blocker) => {
+    if (["review-thread", "review-comment"].includes(blocker.kind)) {
+      return true;
+    }
+    if (blocker.kind === "review") {
+      return blocker.state === "CHANGES_REQUESTED";
+    }
+    return (
+      blocker.kind === "gate" &&
+      blocker.name === "Codex PR-description approval"
+    );
+  });
+  const unresolvedReviewThreads = readyState.unresolvedReviewThreads ?? [];
+  const unrepliedRootReviewComments =
+    readyState.unrepliedRootReviewComments ?? [];
+  const topLevelBotComments = readyState.topLevelBotComments ?? [];
+  const blockingTopLevelBotComments = topLevelBotComments.filter(
+    (comment) =>
+      isCurrentHeadComment(comment, readyState.pr) &&
+      isActionableReviewBotComment(comment, readyState.pr),
+  );
+  const findings = buildFeedbackFindings(
+    readyState,
+    blockingTopLevelBotComments,
+  );
+  const feedbackSurfacesReady =
+    unresolvedReviewThreads.length === 0 &&
+    unrepliedRootReviewComments.length === 0 &&
+    blockingTopLevelBotComments.length === 0;
+  const ready =
+    feedbackBlockers.length === 0 &&
+    feedbackSurfacesReady &&
+    gateReady(gates.reviewThreads) &&
+    gateReady(gates.reviewCommentReplies) &&
+    gateReady(gates.codexDescriptionApproval);
+
+  return {
+    ready,
+    pr: readyState.pr,
+    summary: ready
+      ? "Feedback gates are clear."
+      : "Feedback surfaces need attention.",
+    gates: {
+      codexDescriptionApproval: gates.codexDescriptionApproval ?? null,
+      codexReviewSignal: gates.codexReviewSignal ?? null,
+      reviewCommentReplies: gates.reviewCommentReplies ?? null,
+      reviewThreads: gates.reviewThreads ?? null,
+    },
+    requiredFeedbackBlockers: feedbackBlockers,
+    unresolvedReviewThreads,
+    unrepliedRootReviewComments,
+    blockingTopLevelBotComments,
+    topLevelBotComments,
+    findings,
+    counts: {
+      requiredFeedbackBlockers: feedbackBlockers.length,
+      unresolvedReviewThreads: unresolvedReviewThreads.length,
+      unrepliedRootReviewComments: unrepliedRootReviewComments.length,
+      blockingTopLevelBotComments: blockingTopLevelBotComments.length,
+      topLevelBotComments: topLevelBotComments.length,
+      findings: findings.length,
+      blockingFindings: findings.filter((finding) => finding.blocking).length,
+    },
+  };
+}

--- a/scripts/pr/pr-feedback-state.mjs
+++ b/scripts/pr/pr-feedback-state.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+import { fetchReadyState, parseArgs } from "./pr-ready-state.mjs";
+import { summarizeFeedbackState } from "./pr-feedback-state-core.mjs";
+
+function usage() {
+  return `Usage: pnpm --silent pr:feedback-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--watch]
+       pnpm --silent pr:feedback-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--watch]
+       pnpm --silent pr:feedback-state --help
+
+Note: the Node entry point always emits JSON. Use pnpm --silent when invoking
+through pnpm so stdout does not include pnpm's run-script banner. --watch emits
+one compact JSON object per poll.
+`;
+}
+
+function parseFeedbackArgs(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    return { help: true, watch: false, prArg: null, repoArg: null };
+  }
+
+  const unsupported = argv.filter((arg) => ["--compact"].includes(String(arg)));
+  if (unsupported.length > 0) {
+    throw new Error(`${unsupported[0]} is not supported\n${usage()}`);
+  }
+
+  let parsed;
+  try {
+    parsed = parseArgs(argv.includes("--json") ? argv : [...argv, "--json"]);
+  } catch {
+    throw new Error(usage());
+  }
+  return {
+    help: false,
+    watch: parsed.watch,
+    prArg: parsed.prArg,
+    repoArg: parsed.repoArg ?? null,
+  };
+}
+
+function renderFeedbackState(feedbackState, { watch = false } = {}) {
+  return `${JSON.stringify(feedbackState, null, watch ? 0 : 2)}\n`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  try {
+    const { help, watch, prArg, repoArg } = parseFeedbackArgs(
+      process.argv.slice(2),
+    );
+    if (help) {
+      process.stdout.write(usage());
+      return;
+    }
+
+    for (;;) {
+      try {
+        const readyState = await fetchReadyState({
+          prArg,
+          repoArg,
+          includeFeedbackDetails: true,
+        });
+        process.stdout.write(
+          renderFeedbackState(summarizeFeedbackState(readyState), { watch }),
+        );
+      } catch (err) {
+        if (!watch) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[pr-feedback-state] ${message}\n`);
+      }
+      if (!watch) return;
+      await sleep(60_000);
+    }
+  } catch (err) {
+    process.stderr.write(err instanceof Error ? err.message : String(err));
+    if (!String(err).endsWith("\n")) process.stderr.write("\n");
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}
+
+export { parseFeedbackArgs, renderFeedbackState };

--- a/scripts/pr/pr-ready-state-core.mjs
+++ b/scripts/pr/pr-ready-state-core.mjs
@@ -1,0 +1,998 @@
+export const BOT_APPROVER = "chatgpt-codex-connector[bot]";
+const BOT_APPROVER_LOGIN = "chatgpt-codex-connector";
+const OPTIONAL_CHECK_NAMES = new Set([
+  // The "CodeRabbit" check context is advisory in the same way "Cursor Bugbot"
+  // is, and weaker: it PASSES when the review was rate-limited and never ran
+  // (ADR 0066). Report its lag, never await it, and never read a pass on it as
+  // a readiness signal — the ledger reads CodeRabbit's inline findings instead.
+  "CodeRabbit",
+  "Core Web Vitals + accessibility (ui-dashboard)",
+  "Cursor Bugbot",
+  "GraphQL schema diff",
+  "jscpd",
+]);
+
+const PASS_VALUES = new Set(["SUCCESS", "PASSED", "PASS"]);
+const FAIL_VALUES = new Set([
+  "ACTION_REQUIRED",
+  "CANCELLED",
+  "ERROR",
+  "FAIL",
+  "FAILED",
+  "FAILURE",
+  "STALE",
+  "STARTUP_FAILURE",
+  "TIMED_OUT",
+]);
+const PENDING_VALUES = new Set([
+  "EXPECTED",
+  "IN_PROGRESS",
+  "PENDING",
+  "QUEUED",
+  "REQUESTED",
+  "WAITING",
+]);
+const SKIPPED_VALUES = new Set(["NEUTRAL", "SKIPPED"]);
+const HUMAN_OVERRIDE_ASSOCIATIONS = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+const READINESS_OVERRIDE_COMMAND = "/pr-ready-override";
+const CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE = "codex-description-approval";
+
+function normalizeStatusValue(value) {
+  return String(value ?? "")
+    .trim()
+    .toUpperCase();
+}
+
+export function checkDisplayName(check) {
+  return (
+    check.name ??
+    check.context ??
+    check.workflowName ??
+    check.app?.name ??
+    check.__typename ??
+    "unknown check"
+  );
+}
+
+function isOptionalCheckName(name) {
+  return OPTIONAL_CHECK_NAMES.has(name);
+}
+
+export function classifyCheck(check) {
+  const values = [
+    check.conclusion,
+    check.state,
+    check.status,
+    check.rollupStatus,
+  ].map(normalizeStatusValue);
+
+  if (values.some((value) => FAIL_VALUES.has(value))) return "fail";
+  if (values.some((value) => PENDING_VALUES.has(value))) return "pending";
+  if (values.some((value) => SKIPPED_VALUES.has(value))) return "skipped";
+  if (values.some((value) => PASS_VALUES.has(value))) return "pass";
+
+  return "pending";
+}
+
+function checkRunOrderTimestampMs(check) {
+  // Use startedAt so delayed cancellation completion does not make a stale
+  // run appear newer than the passing run that superseded it.
+  const timestamp = check.startedAt ?? check.completedAt ?? null;
+  const parsed = Date.parse(timestamp ?? "");
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function checkIdentity(check) {
+  const appId =
+    check.appId ?? check.app_id ?? check.app?.id ?? check.app?.databaseId ?? "";
+  return [
+    checkDisplayName(check),
+    check.workflowName ?? check.workflow_name ?? "",
+    appId,
+  ].join("\0");
+}
+
+function suppressSupersededCancelledChecks(statusCheckRollup = []) {
+  const latestPassingTimeByIdentity = new Map();
+
+  for (const check of statusCheckRollup) {
+    if (classifyCheck(check) !== "pass") continue;
+    const timestampMs = checkRunOrderTimestampMs(check);
+    if (timestampMs === null) continue;
+    const identity = checkIdentity(check);
+    const previous = latestPassingTimeByIdentity.get(identity) ?? -Infinity;
+    if (timestampMs > previous) {
+      latestPassingTimeByIdentity.set(identity, timestampMs);
+    }
+  }
+
+  return statusCheckRollup.filter((check) => {
+    if (normalizeStatusValue(check.conclusion) !== "CANCELLED") return true;
+    const timestampMs = checkRunOrderTimestampMs(check);
+    if (timestampMs === null) return true;
+    const newerPassingTime = latestPassingTimeByIdentity.get(
+      checkIdentity(check),
+    );
+    return newerPassingTime === undefined || newerPassingTime <= timestampMs;
+  });
+}
+
+export function groupStatusChecks(statusCheckRollup = []) {
+  const grouped = {
+    pass: [],
+    fail: [],
+    pending: [],
+    skipped: [],
+  };
+
+  for (const check of suppressSupersededCancelledChecks(statusCheckRollup)) {
+    const group = classifyCheck(check);
+    grouped[group].push({
+      name: checkDisplayName(check),
+      status: check.status ?? check.state ?? null,
+      conclusion: check.conclusion ?? null,
+      detailsUrl: check.detailsUrl ?? check.targetUrl ?? null,
+    });
+  }
+
+  for (const checks of Object.values(grouped)) {
+    checks.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return grouped;
+}
+
+function requiredContextName(context) {
+  return typeof context === "string" ? context : context.context;
+}
+
+function requiredContextIntegrationId(context) {
+  const value =
+    typeof context === "string"
+      ? null
+      : (context.integrationId ?? context.integration_id ?? null);
+  return value === null || value === undefined ? null : Number(value);
+}
+
+function requiredContextIdentity(context) {
+  return `${requiredContextName(context)}\0${requiredContextIntegrationId(context) ?? ""}`;
+}
+
+function checkAppId(check) {
+  const value =
+    check.appId ??
+    check.app_id ??
+    check.app?.id ??
+    check.app?.databaseId ??
+    null;
+  return value === null || value === undefined ? null : Number(value);
+}
+
+function checkMatchesRequiredContext(check, context) {
+  if (checkDisplayName(check) !== requiredContextName(context)) return false;
+
+  const requiredIntegrationId = requiredContextIntegrationId(context);
+  if (requiredIntegrationId === null) return true;
+
+  const appId = checkAppId(check);
+  return appId !== null && appId === requiredIntegrationId;
+}
+
+function checkToItem(check, { required }) {
+  const state = classifyCheck(check);
+  return {
+    kind: "check",
+    name: checkDisplayName(check),
+    state,
+    required,
+    url: check.detailsUrl ?? check.targetUrl ?? null,
+  };
+}
+
+export function splitRequiredAndOptionalChecks(
+  statusCheckRollup = [],
+  requiredStatusContexts = [],
+  { requiredStatusContextsAvailable = requiredStatusContexts.length > 0 } = {},
+) {
+  const required = [];
+  const optional = [];
+  const seenRequiredContexts = new Set();
+
+  for (const check of suppressSupersededCancelledChecks(statusCheckRollup)) {
+    const name = checkDisplayName(check);
+    const matchedRequiredContext = requiredStatusContexts.find((context) =>
+      checkMatchesRequiredContext(check, context),
+    );
+    const isRequired = requiredStatusContextsAvailable
+      ? matchedRequiredContext !== undefined
+      : !isOptionalCheckName(name);
+    if (isRequired) {
+      seenRequiredContexts.add(
+        matchedRequiredContext === undefined
+          ? name
+          : requiredContextIdentity(matchedRequiredContext),
+      );
+    }
+    const item = checkToItem(check, { required: isRequired });
+    if (isRequired) {
+      required.push(item);
+    } else {
+      optional.push(item);
+    }
+  }
+
+  for (const context of requiredStatusContexts) {
+    const name = requiredContextName(context);
+    if (!seenRequiredContexts.has(requiredContextIdentity(context))) {
+      required.push({
+        kind: "check",
+        name,
+        state: "pending",
+        required: true,
+        url: null,
+      });
+    }
+  }
+
+  const byName = (a, b) => a.name.localeCompare(b.name);
+  required.sort(byName);
+  optional.sort(byName);
+
+  return { required, optional };
+}
+
+export function findUnresolvedReviewThreads(reviewThreads = []) {
+  return summarizeReviewThreads(reviewThreads)
+    .filter((thread) => thread.isResolved === false)
+    .map(({ isResolved: _isResolved, ...thread }) => thread);
+}
+
+export function summarizeReviewThreads(reviewThreads = []) {
+  return reviewThreads.map((thread) => {
+    const firstComment = thread.comments?.nodes?.[0] ?? thread.comments?.[0];
+    return {
+      id: thread.id,
+      path: thread.path ?? null,
+      line: thread.line ?? thread.startLine ?? null,
+      isOutdated: Boolean(thread.isOutdated),
+      isResolved: Boolean(thread.isResolved),
+      author: firstComment?.author?.login ?? firstComment?.user?.login ?? null,
+      url: firstComment?.url ?? null,
+      body: firstComment?.body ?? "",
+    };
+  });
+}
+
+export function findUnrepliedRootReviewComments(
+  reviewComments = [],
+  ignoredAuthors = [],
+  allowedReplyAuthors = null,
+  allowedReplyAuthorAssociations = null,
+) {
+  const repliedRootIds = repliedRootReviewCommentIds(
+    reviewComments,
+    allowedReplyAuthors,
+    allowedReplyAuthorAssociations,
+  );
+  const ignoredAuthorSet = new Set(ignoredAuthors.filter(Boolean));
+
+  return reviewComments
+    .filter((comment) => commentIsRootReviewComment(comment))
+    .filter((comment) => !ignoredAuthorSet.has(comment.user?.login))
+    .filter((comment) => !repliedRootIds.has(comment.id))
+    .map(reviewCommentSummary);
+}
+
+function commentIsRootReviewComment(comment) {
+  return (
+    comment.in_reply_to_id === undefined || comment.in_reply_to_id === null
+  );
+}
+
+function repliedRootReviewCommentIds(
+  reviewComments = [],
+  allowedReplyAuthors = null,
+  allowedReplyAuthorAssociations = null,
+) {
+  const allowedReplyAuthorSet =
+    allowedReplyAuthors === null
+      ? null
+      : new Set(allowedReplyAuthors.filter(Boolean));
+  const allowedReplyAuthorAssociationSet =
+    allowedReplyAuthorAssociations === null
+      ? null
+      : new Set(
+          [...allowedReplyAuthorAssociations]
+            .filter(Boolean)
+            .map((association) => normalizeStatusValue(association)),
+        );
+  const rootAuthorsById = new Map(
+    reviewComments
+      .filter(commentIsRootReviewComment)
+      .map((comment) => [comment.id, comment.user?.login ?? null]),
+  );
+
+  return new Set(
+    reviewComments
+      .filter((comment) => {
+        const rootId = comment.in_reply_to_id;
+        if (rootId === undefined || rootId === null) return false;
+        const replyAuthor = comment.user?.login ?? null;
+        if (
+          replyAuthor !== null &&
+          replyAuthor === rootAuthorsById.get(rootId)
+        ) {
+          return false;
+        }
+
+        if (
+          allowedReplyAuthorSet === null &&
+          allowedReplyAuthorAssociationSet === null
+        ) {
+          return true;
+        }
+
+        return (
+          allowedReplyAuthorSet?.has(replyAuthor) === true ||
+          isTrustedHumanAuthor(comment, allowedReplyAuthorAssociationSet)
+        );
+      })
+      .map((comment) => comment.in_reply_to_id),
+  );
+}
+
+function reviewCommentSummary(comment, { replied = undefined } = {}) {
+  const summary = {
+    id: comment.id,
+    path: comment.path ?? null,
+    line: comment.line ?? comment.original_line ?? null,
+    author: comment.user?.login ?? null,
+    url: comment.html_url ?? comment.url ?? null,
+    body: comment.body ?? "",
+  };
+  if (replied !== undefined) summary.replied = replied;
+  return summary;
+}
+
+function summarizeRootReviewComments(
+  reviewComments = [],
+  ignoredAuthors = [],
+  allowedReplyAuthors = null,
+  allowedReplyAuthorAssociations = null,
+) {
+  const repliedRootIds = repliedRootReviewCommentIds(
+    reviewComments,
+    allowedReplyAuthors,
+    allowedReplyAuthorAssociations,
+  );
+  const ignoredAuthorSet = new Set(ignoredAuthors.filter(Boolean));
+
+  return reviewComments
+    .filter(
+      (comment) =>
+        comment.in_reply_to_id === undefined || comment.in_reply_to_id === null,
+    )
+    .filter((comment) => !ignoredAuthorSet.has(comment.user?.login))
+    .map((comment) =>
+      reviewCommentSummary(comment, {
+        replied: repliedRootIds.has(comment.id),
+      }),
+    );
+}
+
+export function findTopLevelBotComments(issueComments = []) {
+  return issueComments
+    .filter((comment) => {
+      const user = comment.user ?? {};
+      const login = user.login ?? "";
+      return user.type === "Bot" || login.endsWith("[bot]");
+    })
+    .map((comment) => ({
+      id: comment.id,
+      author: comment.user?.login ?? null,
+      url: comment.html_url ?? comment.url ?? null,
+      createdAt: comment.created_at ?? null,
+      updatedAt: comment.updated_at ?? null,
+      body: comment.body ?? "",
+    }));
+}
+
+export function findTopLevelBotReviewComments(reviews = []) {
+  return reviews
+    .filter((review) => {
+      const author = review.author ?? {};
+      const login = author.login ?? "";
+      return (
+        (author.type === "Bot" || login.endsWith("[bot]")) &&
+        String(review.body ?? "").trim() !== ""
+      );
+    })
+    .map((review) => ({
+      id: review.id ?? null,
+      author: review.author?.login ?? null,
+      url: review.url ?? null,
+      createdAt: review.submittedAt ?? null,
+      updatedAt: null,
+      commitOid: review.commit?.oid ?? null,
+      state: review.state ?? null,
+      body: review.body ?? "",
+    }));
+}
+
+export function isCodexReviewRequestBody(body) {
+  return /(^|\s)@codex\s+review\b/i.test(String(body ?? ""));
+}
+
+function isBotApproverLogin(login) {
+  return login === BOT_APPROVER || login === BOT_APPROVER_LOGIN;
+}
+
+function commentReactionContent(reaction) {
+  return String(reaction?.content ?? reaction ?? "").toLowerCase();
+}
+
+function hasCodexEyesReaction(comment, headUpdatedAt, fallbackCurrent = false) {
+  const reactions = comment.reactions;
+  const reactionNodes = Array.isArray(reactions)
+    ? reactions
+    : (reactions?.nodes ?? []);
+
+  return reactionNodes.some((reaction) => {
+    if (
+      commentReactionContent(reaction) !== "eyes" ||
+      !isBotApproverLogin(reaction?.user?.login)
+    ) {
+      return false;
+    }
+
+    if (headUpdatedAt === null) return true;
+
+    const createdAt = parseTimestamp(reaction.created_at ?? reaction.createdAt);
+    if (createdAt === null) return fallbackCurrent;
+    return createdAt >= headUpdatedAt;
+  });
+}
+
+function isAtOrAfter(timestamp, lowerBound) {
+  const parsed = parseTimestamp(timestamp);
+  return parsed !== null && lowerBound !== null && parsed >= lowerBound;
+}
+
+function isCurrentSignal(timestamp, lowerBound) {
+  if (lowerBound === null) return true;
+  return isAtOrAfter(timestamp, lowerBound);
+}
+
+function parseTimestamp(value) {
+  const timestamp = Date.parse(value ?? "");
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function issueCommentAuthorAssociation(comment) {
+  return String(
+    comment.author_association ?? comment.authorAssociation ?? "",
+  ).toUpperCase();
+}
+
+function isHumanOverrideAuthor(comment) {
+  return isTrustedHumanAuthor(comment, HUMAN_OVERRIDE_ASSOCIATIONS);
+}
+
+function isTrustedHumanAuthor(comment, allowedAssociations) {
+  if (allowedAssociations === null) return false;
+  const login = comment.user?.login ?? comment.author?.login ?? "";
+  const type = comment.user?.type ?? comment.author?.type ?? "";
+  return (
+    !String(login).endsWith("[bot]") &&
+    type !== "Bot" &&
+    allowedAssociations.has(issueCommentAuthorAssociation(comment))
+  );
+}
+
+function extractOverrideValue(body, key) {
+  const source = String(body ?? "");
+  const pattern = new RegExp(`(?:^|\\s)${key}=([^\\s]+)`, "i");
+  return source.match(pattern)?.[1] ?? null;
+}
+
+function extractOverrideReason(body) {
+  const match = String(body ?? "").match(/(?:^|\s)reason=(.+)$/im);
+  return match?.[1]?.trim() ?? "";
+}
+
+export function parseReadinessOverrideComment(comment, currentHeadOid = null) {
+  const body = String(comment.body ?? "");
+  if (
+    !body
+      .trimStart()
+      .match(new RegExp(`^${READINESS_OVERRIDE_COMMAND}\\b`, "i"))
+  ) {
+    return null;
+  }
+
+  const gate = extractOverrideValue(body, "gate")?.toLowerCase() ?? null;
+  const head = extractOverrideValue(body, "head");
+  const reason = extractOverrideReason(body);
+  const author = comment.user?.login ?? comment.author?.login ?? null;
+  const createdAt = comment.created_at ?? comment.createdAt ?? null;
+  const base = {
+    gate,
+    head,
+    reason,
+    author,
+    authorAssociation:
+      comment.author_association ?? comment.authorAssociation ?? null,
+    url: comment.html_url ?? comment.url ?? null,
+    createdAt,
+    state: "ignored",
+  };
+
+  if (!isHumanOverrideAuthor(comment)) {
+    return { ...base, reasonIgnored: "author_not_allowed" };
+  }
+  if (gate !== CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE) {
+    return { ...base, reasonIgnored: "unsupported_gate" };
+  }
+  if (!head || !currentHeadOid || head !== currentHeadOid) {
+    return { ...base, reasonIgnored: "head_mismatch" };
+  }
+  if (!reason) {
+    return { ...base, reasonIgnored: "missing_reason" };
+  }
+
+  return {
+    ...base,
+    state: "active",
+  };
+}
+
+function findActiveReadinessOverrides(
+  issueComments = [],
+  currentHeadOid = null,
+) {
+  return issueComments
+    .map((comment) => parseReadinessOverrideComment(comment, currentHeadOid))
+    .filter((override) => override?.state === "active")
+    .sort((a, b) => {
+      const aTime = parseTimestamp(a.createdAt) ?? 0;
+      const bTime = parseTimestamp(b.createdAt) ?? 0;
+      return bTime - aTime;
+    });
+}
+
+function currentHeadUpdatedAt(pr) {
+  return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
+}
+
+function summaryPr(pr, headUpdatedAt = currentHeadUpdatedAt(pr)) {
+  return {
+    number: pr.number,
+    url: pr.url,
+    title: pr.title,
+    state: pr.state ?? null,
+    isDraft: Boolean(pr.isDraft),
+    headRefName: pr.headRefName,
+    headRefOid: pr.headRefOid,
+    baseRefName: pr.baseRefName,
+    mergeable: pr.mergeable ?? null,
+    reviewDecision: pr.reviewDecision ?? null,
+    headUpdatedAt:
+      headUpdatedAt === null ? null : new Date(headUpdatedAt).toISOString(),
+    mergedAt: pr.mergedAt ?? null,
+    closedAt: pr.closedAt ?? null,
+  };
+}
+
+function emptyStatusChecks() {
+  return {
+    pass: [],
+    fail: [],
+    pending: [],
+    skipped: [],
+  };
+}
+
+function terminalGates({ merged }) {
+  return {
+    codexDescriptionApproval: {
+      ready: true,
+      required: merged,
+      state: merged ? "present" : "not_applicable",
+    },
+    codexReviewSignal: {
+      ready: true,
+      required: false,
+      state: merged ? "approved" : "not_applicable",
+      fallbackAction: "wait",
+    },
+    reviewCommentReplies: {
+      ready: true,
+      required: merged,
+      unrepliedCount: 0,
+    },
+    reviewThreads: {
+      ready: true,
+      required: merged,
+      unresolvedCount: 0,
+    },
+  };
+}
+
+function reviewCommitOid(review) {
+  return (
+    review.commit?.oid ??
+    review.commit?.sha ??
+    review.commitId ??
+    review.commit_id ??
+    null
+  );
+}
+
+function isCurrentReviewSignal(review, currentHeadOid, headUpdatedAt) {
+  if (currentHeadOid) return reviewCommitOid(review) === currentHeadOid;
+
+  const submittedAt =
+    review.submittedAt ?? review.submitted_at ?? review.createdAt;
+  return isCurrentSignal(submittedAt, headUpdatedAt);
+}
+
+export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
+  if (headUpdatedAt === null) return false;
+
+  return reactions.some(
+    (reaction) =>
+      reaction.content === "+1" &&
+      isBotApproverLogin(reaction.user?.login) &&
+      parseTimestamp(reaction.created_at ?? reaction.createdAt) >=
+        headUpdatedAt,
+  );
+}
+
+export function hasCodexInFlightReaction(reactions = [], headUpdatedAt = null) {
+  return reactions.some((reaction) => {
+    if (
+      commentReactionContent(reaction) !== "eyes" ||
+      !isBotApproverLogin(reaction.user?.login)
+    ) {
+      return false;
+    }
+    if (headUpdatedAt === null) return true;
+
+    const createdAt = parseTimestamp(reaction.created_at ?? reaction.createdAt);
+    return createdAt !== null && createdAt >= headUpdatedAt;
+  });
+}
+
+export function classifyCodexReviewSignal({
+  issueComments = [],
+  reviews = [],
+  headUpdatedAt = null,
+  currentHeadOid = null,
+  codexApprovalReaction = false,
+  codexInFlightReaction = false,
+} = {}) {
+  if (codexApprovalReaction) return "approved";
+  if (codexInFlightReaction) return "in_flight";
+
+  let hasHistoricalSignal = false;
+  let hasCurrentRequest = false;
+  let hasCurrentInFlightSignal = false;
+
+  for (const comment of issueComments) {
+    const author = comment.user?.login ?? comment.author?.login ?? null;
+    const createdAt = comment.created_at ?? comment.createdAt;
+    const isCurrent = isCurrentSignal(createdAt, headUpdatedAt);
+
+    if (isBotApproverLogin(author) && isCurrent) {
+      hasCurrentInFlightSignal = true;
+    } else if (isBotApproverLogin(author)) {
+      hasHistoricalSignal = true;
+    }
+
+    if (!isCodexReviewRequestBody(comment.body)) continue;
+
+    if (isCurrent) {
+      hasCurrentRequest = true;
+      if (hasCodexEyesReaction(comment, headUpdatedAt, true)) {
+        hasCurrentInFlightSignal = true;
+      }
+    } else {
+      if (hasCodexEyesReaction(comment, headUpdatedAt)) {
+        hasCurrentInFlightSignal = true;
+      }
+      hasHistoricalSignal = true;
+    }
+  }
+
+  for (const review of reviews) {
+    const author = review.author?.login ?? review.user?.login ?? null;
+    if (!isBotApproverLogin(author)) continue;
+
+    if (isCurrentReviewSignal(review, currentHeadOid, headUpdatedAt)) {
+      hasCurrentInFlightSignal = true;
+    } else {
+      hasHistoricalSignal = true;
+    }
+  }
+
+  if (hasCurrentInFlightSignal) return "in_flight";
+  if (hasCurrentRequest) return "requested";
+  if (hasHistoricalSignal) return "stale";
+  return "missing";
+}
+
+export function summarizeTerminalReadyState(pr) {
+  const state = normalizeStatusValue(pr.state);
+  const merged = state === "MERGED";
+  const requiredBlockers = merged
+    ? []
+    : [
+        {
+          kind: "state",
+          name: "Pull request is closed",
+          state: pr.state ?? "CLOSED",
+          required: true,
+          url: pr.url,
+        },
+      ];
+
+  return {
+    ready: merged,
+    required: {
+      ready: merged,
+      blockers: requiredBlockers,
+    },
+    optional: {
+      ready: true,
+      items: [],
+    },
+    gates: terminalGates({ merged }),
+    summary: merged
+      ? "Pull request is already merged."
+      : "Pull request is closed without merging.",
+    pr: summaryPr(pr),
+    statusChecks: emptyStatusChecks(),
+    requiredStatusContexts: [],
+    unresolvedReviewThreads: [],
+    unrepliedRootReviewComments: [],
+    topLevelBotComments: [],
+    codexApprovalReaction: merged,
+    codexReviewSignal: merged ? "approved" : "missing",
+  };
+}
+
+export function summarizeReadyState({
+  pr,
+  issueComments = [],
+  reactions = [],
+  reviewComments = [],
+  reviewThreads = [],
+  requiredStatusContexts = [],
+  requiredStatusContextsError = null,
+  requiredStatusContextsAvailable = requiredStatusContexts.length > 0,
+  includeFeedbackDetails = false,
+}) {
+  const statusChecks = groupStatusChecks(pr.statusCheckRollup ?? []);
+  const splitChecks = splitRequiredAndOptionalChecks(
+    pr.statusCheckRollup ?? [],
+    requiredStatusContexts,
+    { requiredStatusContextsAvailable },
+  );
+  const reviewThreadSummaries = summarizeReviewThreads(reviewThreads);
+  const unresolvedReviewThreads = reviewThreadSummaries
+    .filter((thread) => thread.isResolved === false)
+    .map(({ isResolved: _isResolved, ...thread }) => thread);
+  const rootReviewComments = summarizeRootReviewComments(
+    reviewComments,
+    [pr.author?.login],
+    [pr.author?.login, BOT_APPROVER],
+    HUMAN_OVERRIDE_ASSOCIATIONS,
+  );
+  const unrepliedRootReviewComments = rootReviewComments.filter(
+    (comment) => comment.replied === false,
+  );
+  const topLevelBotComments = [
+    ...findTopLevelBotComments(issueComments),
+    ...findTopLevelBotReviewComments(pr.reviews ?? []),
+  ];
+  const headUpdatedAt = currentHeadUpdatedAt(pr);
+  const codexApprovalReaction = hasCodexApprovalReaction(
+    reactions,
+    headUpdatedAt,
+  );
+  const codexInFlightReaction = hasCodexInFlightReaction(
+    reactions,
+    headUpdatedAt,
+  );
+  const currentHeadOid = pr.headRefOid ?? pr.headOid ?? null;
+  const codexReviewSignal = classifyCodexReviewSignal({
+    issueComments,
+    reviews: pr.reviews ?? [],
+    headUpdatedAt,
+    currentHeadOid,
+    codexApprovalReaction,
+    codexInFlightReaction,
+  });
+  const activeReadinessOverrides = findActiveReadinessOverrides(
+    issueComments,
+    currentHeadOid,
+  );
+  // Keep the gate/head check at the use site so later override types cannot
+  // satisfy this gate merely by appearing in the active override list.
+  const codexDescriptionApprovalOverride = activeReadinessOverrides.find(
+    (override) =>
+      override.gate === CODEX_DESCRIPTION_APPROVAL_OVERRIDE_GATE &&
+      override.head === currentHeadOid,
+  );
+  const codexDescriptionApprovalReady =
+    codexApprovalReaction || Boolean(codexDescriptionApprovalOverride);
+
+  const mergeable = normalizeStatusValue(pr.mergeable) === "MERGEABLE";
+  const reviewDecision = normalizeStatusValue(pr.reviewDecision);
+  const requiredCheckBlockers = splitChecks.required.filter((check) =>
+    ["fail", "pending"].includes(check.state),
+  );
+  const optionalItems = splitChecks.optional.filter((check) =>
+    ["fail", "pending"].includes(check.state),
+  );
+  const requiredBlockers = [];
+
+  if (pr.isDraft) {
+    requiredBlockers.push({
+      kind: "draft",
+      name: "Pull request is draft",
+      state: "draft",
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  if (!mergeable) {
+    requiredBlockers.push({
+      kind: "mergeability",
+      name: "Pull request is not mergeable",
+      state: pr.mergeable ?? "UNKNOWN",
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  if (reviewDecision === "CHANGES_REQUESTED") {
+    requiredBlockers.push({
+      kind: "review",
+      name: "Changes requested",
+      state: pr.reviewDecision,
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  if (reviewDecision === "REVIEW_REQUIRED") {
+    requiredBlockers.push({
+      kind: "review",
+      name: "Review required",
+      state: pr.reviewDecision,
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  if (requiredStatusContextsError !== null) {
+    requiredBlockers.push({
+      kind: "branch-protection",
+      name: "Required status contexts unavailable",
+      state: requiredStatusContextsError,
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  requiredBlockers.push(...requiredCheckBlockers);
+
+  for (const thread of unresolvedReviewThreads) {
+    requiredBlockers.push({
+      kind: "review-thread",
+      name: thread.path ?? thread.id ?? "unresolved review thread",
+      state: thread.isOutdated ? "unresolved-outdated" : "unresolved",
+      required: true,
+      url: thread.url,
+    });
+  }
+
+  for (const comment of unrepliedRootReviewComments) {
+    requiredBlockers.push({
+      kind: "review-comment",
+      name: `unreplied root comment ${comment.id}`,
+      state: "unreplied",
+      required: true,
+      url: comment.url,
+    });
+  }
+
+  const gates = {
+    codexDescriptionApproval: {
+      ready: codexDescriptionApprovalReady,
+      required: true,
+      state: codexApprovalReaction
+        ? "present"
+        : codexDescriptionApprovalOverride
+          ? "overridden"
+          : "missing",
+      ...(codexDescriptionApprovalOverride
+        ? { override: codexDescriptionApprovalOverride }
+        : {}),
+    },
+    codexReviewSignal: {
+      ready: ["approved", "in_flight"].includes(codexReviewSignal),
+      required: false,
+      state: codexReviewSignal,
+      fallbackAction:
+        codexReviewSignal === "missing" || codexReviewSignal === "stale"
+          ? "request_review_once_after_grace"
+          : "wait",
+    },
+    reviewCommentReplies: {
+      ready: unrepliedRootReviewComments.length === 0,
+      required: true,
+      unrepliedCount: unrepliedRootReviewComments.length,
+    },
+    reviewThreads: {
+      ready: unresolvedReviewThreads.length === 0,
+      required: true,
+      unresolvedCount: unresolvedReviewThreads.length,
+    },
+  };
+
+  if (!codexDescriptionApprovalReady) {
+    requiredBlockers.push({
+      kind: "gate",
+      name: "Codex PR-description approval",
+      state: "missing",
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  const required = {
+    ready: requiredBlockers.length === 0,
+    blockers: requiredBlockers,
+  };
+  const optional = {
+    ready: optionalItems.length === 0,
+    items: optionalItems,
+  };
+  const ready = required.ready;
+  const summaryText = ready
+    ? optional.items.length > 0
+      ? `Required gates are clear; ${optional.items.length} optional signal(s) still need attention.`
+      : "Required gates are clear."
+    : `${required.blockers.length} required blocker(s) remain.`;
+
+  const readyStateSummary = {
+    ready,
+    required,
+    optional,
+    gates,
+    summary: summaryText,
+    pr: summaryPr(pr, headUpdatedAt),
+    statusChecks,
+    requiredStatusContexts,
+    unresolvedReviewThreads,
+    unrepliedRootReviewComments,
+    topLevelBotComments,
+    readinessOverrides: activeReadinessOverrides,
+    codexApprovalReaction,
+    codexReviewSignal,
+  };
+
+  if (includeFeedbackDetails) {
+    readyStateSummary.reviewThreads = reviewThreadSummaries;
+    readyStateSummary.rootReviewComments = rootReviewComments;
+  }
+
+  return readyStateSummary;
+}

--- a/scripts/pr/pr-ready-state-format.mjs
+++ b/scripts/pr/pr-ready-state-format.mjs
@@ -1,0 +1,152 @@
+import { BOT_APPROVER } from "./pr-ready-state-core.mjs";
+
+function formatCount(label, items) {
+  return `${label}: ${items.length}`;
+}
+
+function formatShortBody(body) {
+  const oneLine = String(body ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (oneLine.length <= 100) return oneLine;
+  return `${oneLine.slice(0, 97)}...`;
+}
+
+export function formatHuman(summary) {
+  const lines = [];
+  const pr = summary.pr;
+  lines.push(
+    `PR #${pr.number}: ${summary.ready ? "READY" : "NOT READY"} - ${pr.title}`,
+  );
+  lines.push(`URL: ${pr.url}`);
+  if (pr.state) lines.push(`State: ${pr.state}`);
+  lines.push(`Head: ${pr.headRefName} @ ${pr.headRefOid}`);
+  lines.push(`Base: ${pr.baseRefName}`);
+  lines.push(
+    `Mergeability: ${pr.mergeable ?? "UNKNOWN"}; review decision: ${
+      pr.reviewDecision ?? "UNKNOWN"
+    }; draft: ${pr.isDraft ? "yes" : "no"}`,
+  );
+  lines.push(
+    `Readiness: ${summary.required.ready ? "required clear" : "required blocked"}; optional: ${
+      summary.optional.ready
+        ? "clear"
+        : `${summary.optional.items.length} item(s)`
+    }`,
+  );
+  lines.push(
+    `Checks: ${[
+      formatCount("pass", summary.statusChecks.pass),
+      formatCount("fail", summary.statusChecks.fail),
+      formatCount("pending", summary.statusChecks.pending),
+      formatCount("skipped", summary.statusChecks.skipped),
+    ].join(", ")}`,
+  );
+  lines.push(
+    `Review threads unresolved: ${summary.unresolvedReviewThreads.length}`,
+  );
+  lines.push(
+    `Unreplied root review comments: ${summary.unrepliedRootReviewComments.length}`,
+  );
+  lines.push(`Top-level bot comments: ${summary.topLevelBotComments.length}`);
+  lines.push(
+    `${BOT_APPROVER} +1 reaction on PR description: ${
+      summary.codexApprovalReaction ? "yes" : "no"
+    }`,
+  );
+  lines.push(`Codex review signal: ${summary.codexReviewSignal}`);
+  lines.push(
+    `Readiness overrides active: ${summary.readinessOverrides?.length ?? 0}`,
+  );
+
+  const sections = [
+    [
+      "Required blockers",
+      summary.required.blockers,
+      (item) =>
+        `${item.kind}: ${item.name} (${item.state}) ${item.url ?? ""}`.trim(),
+    ],
+    [
+      "Optional lag",
+      summary.optional.items,
+      (item) =>
+        `${item.kind}: ${item.name} (${item.state}) ${item.url ?? ""}`.trim(),
+    ],
+    [
+      "Unresolved review threads",
+      summary.unresolvedReviewThreads,
+      (item) =>
+        `${item.path ?? "unknown path"}:${item.line ?? "?"} ${
+          item.author ? `by ${item.author}` : ""
+        } ${item.url ?? ""}`.trim(),
+    ],
+    [
+      "Unreplied root review comments",
+      summary.unrepliedRootReviewComments,
+      (item) =>
+        `#${item.id} ${item.path ?? "unknown path"}:${item.line ?? "?"} ${
+          item.author ? `by ${item.author}` : ""
+        } ${item.url ?? ""}`.trim(),
+    ],
+    [
+      "Top-level bot comments",
+      summary.topLevelBotComments,
+      (item) =>
+        `${item.author ?? "bot"} ${item.url ?? ""} ${formatShortBody(
+          item.body,
+        )}`.trim(),
+    ],
+    [
+      "Readiness overrides",
+      summary.readinessOverrides ?? [],
+      (item) =>
+        `${item.gate} by ${item.author ?? "unknown"} for ${item.head}: ${
+          item.reason
+        } ${item.url ?? ""}`.trim(),
+    ],
+  ];
+
+  for (const [title, items, render] of sections) {
+    if (items.length === 0) continue;
+    lines.push("");
+    lines.push(`${title}:`);
+    for (const item of items) {
+      lines.push(`- ${render(item)}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function blockerNames(items) {
+  if (items.length === 0) return "none";
+  return items.map((item) => `${item.kind}:${item.name}`).join(", ");
+}
+
+export function formatCompact(summary) {
+  const pendingRequiredChecks = summary.required.blockers.filter(
+    (item) => item.kind === "check" && item.state === "pending",
+  );
+  const failingRequiredChecks = summary.required.blockers.filter(
+    (item) => item.kind === "check" && item.state === "fail",
+  );
+  const nonCheckBlockers = summary.required.blockers.filter(
+    (item) => item.kind !== "check",
+  );
+
+  return [
+    `PR #${summary.pr.number} ${summary.ready ? "READY" : "BLOCKED"}`,
+    `head=${summary.pr.headRefOid}`,
+    `state=${summary.pr.state ?? "UNKNOWN"}`,
+    `mergeable=${summary.pr.mergeable ?? "UNKNOWN"}`,
+    `required_blockers=${summary.required.blockers.length}`,
+    `pending_checks=${blockerNames(pendingRequiredChecks)}`,
+    `failing_checks=${blockerNames(failingRequiredChecks)}`,
+    `other_blockers=${blockerNames(nonCheckBlockers)}`,
+    `threads=${summary.unresolvedReviewThreads.length}`,
+    `unreplied=${summary.unrepliedRootReviewComments.length}`,
+    `codex_approval=${summary.gates.codexDescriptionApproval.state}`,
+    `codex_signal=${summary.codexReviewSignal}`,
+    `overrides=${summary.readinessOverrides?.length ?? 0}`,
+  ].join(" ");
+}

--- a/scripts/pr/pr-ready-state.mjs
+++ b/scripts/pr/pr-ready-state.mjs
@@ -1,0 +1,977 @@
+#!/usr/bin/env node
+/**
+ * Summarize whether a GitHub pull request is ready for review-loop closure.
+ *
+ * Live mode shells out to `gh` only. The parsing helpers are exported so tests
+ * can stay offline and fixture-driven.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkDisplayName,
+  isCodexReviewRequestBody,
+  summarizeReadyState,
+  summarizeTerminalReadyState,
+} from "./pr-ready-state-core.mjs";
+import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
+
+const GH_OUTPUT_MAX_BYTES = 20 * 1024 * 1024;
+
+function runGh(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let failed = false;
+
+    function fail(message) {
+      if (failed) return;
+      failed = true;
+      child.kill();
+      reject(new Error(message));
+    }
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes > GH_OUTPUT_MAX_BYTES) {
+        fail(
+          `gh ${args.join(" ")} stdout exceeded ${GH_OUTPUT_MAX_BYTES} byte limit`,
+        );
+        return;
+      }
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderrBytes += Buffer.byteLength(chunk);
+      if (stderrBytes > GH_OUTPUT_MAX_BYTES) {
+        fail(
+          `gh ${args.join(" ")} stderr exceeded ${GH_OUTPUT_MAX_BYTES} byte limit`,
+        );
+        return;
+      }
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      fail(`gh ${args.join(" ")} failed: ${err.message}`);
+    });
+    child.on("close", (status) => {
+      if (failed) return;
+      if (status !== 0) {
+        reject(
+          new Error(
+            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      resolve(stdout);
+    });
+  });
+}
+
+async function ghJson(args) {
+  const stdout = await runGh(args);
+  return stdout.trim() ? JSON.parse(stdout) : null;
+}
+
+function ghApiArgs(repo, args) {
+  const ghArgs = ["api"];
+  if (repo.host) {
+    ghArgs.push("--hostname", repo.host);
+  }
+  ghArgs.push(...args);
+  return ghArgs;
+}
+
+async function ghApiJsonPages(repo, args) {
+  const parsed = await ghJson([
+    ...ghApiArgs(repo, args),
+    "--paginate",
+    "--slurp",
+  ]);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.flatMap((page) => (Array.isArray(page) ? page : [page]));
+}
+
+async function ghApiJsonResult(repo, args) {
+  try {
+    const stdout = await runGh(ghApiArgs(repo, args));
+    return {
+      ok: true,
+      value: stdout.trim() ? JSON.parse(stdout) : null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function ghApiJsonPagesResult(repo, args) {
+  try {
+    const stdout = await runGh([
+      ...ghApiArgs(repo, args),
+      "--paginate",
+      "--slurp",
+    ]);
+    const parsed = stdout.trim() ? JSON.parse(stdout) : [];
+    return {
+      ok: true,
+      value: Array.isArray(parsed)
+        ? parsed.flatMap((page) => (Array.isArray(page) ? page : [page]))
+        : [],
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function addRequiredContext(byKey, context, integrationId = null) {
+  if (!context) return;
+  const normalizedIntegrationId =
+    integrationId === null || integrationId === undefined
+      ? null
+      : Number(integrationId);
+  const key = `${context}\0${normalizedIntegrationId ?? ""}`;
+  byKey.set(key, {
+    context,
+    integrationId: normalizedIntegrationId,
+  });
+}
+
+function workflowPath(workflow) {
+  return (
+    workflow.path ??
+    workflow.workflow_path ??
+    workflow.workflowPath ??
+    workflow.file_path ??
+    workflow.filePath ??
+    null
+  );
+}
+
+function workflowRepoPath(workflow, rule, fallbackRepoPath = null) {
+  const explicitRepo =
+    workflow.repository_full_name ??
+    workflow.repositoryFullName ??
+    workflow.repository?.full_name ??
+    workflow.repository?.fullName ??
+    workflow.repository_name ??
+    workflow.repositoryName ??
+    null;
+  if (explicitRepo && String(explicitRepo).includes("/")) {
+    return String(explicitRepo);
+  }
+
+  if (
+    rule?.ruleset_source_type === "Repository" &&
+    rule?.ruleset_source &&
+    String(rule.ruleset_source).includes("/")
+  ) {
+    return String(rule.ruleset_source);
+  }
+
+  if (rule?.ruleset_source_type) {
+    return null;
+  }
+
+  return fallbackRepoPath;
+}
+
+function workflowLookupKey(repoPathValue, path) {
+  return repoPathValue && path ? `${repoPathValue}\0${path}` : null;
+}
+
+function flattenRules(rules = [], inherited = {}) {
+  const flattened = [];
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object") continue;
+    const current = {
+      ...inherited,
+      ...rule,
+    };
+    if (rule.type) flattened.push(current);
+    flattened.push(
+      ...flattenRules(rule.rules ?? [], {
+        ruleset_source: current.ruleset_source,
+        ruleset_source_type: current.ruleset_source_type,
+      }),
+    );
+  }
+  return flattened;
+}
+
+export function workflowPathsFromRules(rules = []) {
+  const paths = new Set();
+  for (const rule of flattenRules(rules)) {
+    if (rule.type !== "workflows") continue;
+
+    for (const workflow of rule.parameters?.workflows ?? []) {
+      const path = workflowPath(workflow);
+      if (path) paths.add(path);
+    }
+  }
+
+  return [...paths].sort((a, b) => a.localeCompare(b));
+}
+
+function workflowRepoPathsFromRules(rules = [], fallbackRepoPath = null) {
+  const repoPaths = new Set();
+  for (const rule of flattenRules(rules)) {
+    if (rule.type !== "workflows") continue;
+
+    for (const workflow of rule.parameters?.workflows ?? []) {
+      const path = workflowPath(workflow);
+      const repoPathValue = workflowRepoPath(workflow, rule, fallbackRepoPath);
+      if (path && repoPathValue) repoPaths.add(repoPathValue);
+    }
+  }
+
+  return [...repoPaths].sort((a, b) => a.localeCompare(b));
+}
+
+function unresolvedWorkflowSourcesFromRules(
+  rules = [],
+  fallbackRepoPath = null,
+) {
+  const unresolved = [];
+  for (const rule of flattenRules(rules)) {
+    if (rule.type !== "workflows") continue;
+
+    for (const workflow of rule.parameters?.workflows ?? []) {
+      const path = workflowPath(workflow);
+      if (!path) continue;
+      if (workflowRepoPath(workflow, rule, fallbackRepoPath) === null) {
+        unresolved.push(path);
+      }
+    }
+  }
+
+  return unresolved;
+}
+
+function requiredWorkflowContext(
+  workflow,
+  rule,
+  workflowNameByPath,
+  fallbackRepoPath = null,
+) {
+  const path = workflowPath(workflow);
+  const repoPathValue = workflowRepoPath(workflow, rule, fallbackRepoPath);
+  const keyedName = workflowNameByPath.get(
+    workflowLookupKey(repoPathValue, path),
+  );
+  return (
+    workflow.name ??
+    workflow.workflow_name ??
+    workflow.workflowName ??
+    keyedName ??
+    (path ? workflowNameByPath.get(path) : null) ??
+    null
+  );
+}
+
+function requiredWorkflowJobContexts({
+  workflow,
+  rule,
+  workflowNameByPath,
+  fallbackRepoPath,
+  statusCheckRollup,
+}) {
+  const workflowName = requiredWorkflowContext(
+    workflow,
+    rule,
+    workflowNameByPath,
+    fallbackRepoPath,
+  );
+  if (!workflowName) return [];
+
+  const matchingJobNames = statusCheckRollup
+    .filter((check) => check.workflowName === workflowName)
+    .map(checkDisplayName);
+  return matchingJobNames.length > 0 ? matchingJobNames : [workflowName];
+}
+
+export function requiredStatusContextsFromRules(
+  rules = [],
+  {
+    workflowNameByPath = new Map(),
+    fallbackRepoPath = null,
+    statusCheckRollup = [],
+  } = {},
+) {
+  const byKey = new Map();
+  for (const rule of flattenRules(rules)) {
+    if (rule.type === "required_status_checks") {
+      for (const check of rule.parameters?.required_status_checks ?? []) {
+        addRequiredContext(
+          byKey,
+          check.context,
+          check.integration_id ?? check.integrationId ?? null,
+        );
+      }
+      continue;
+    }
+
+    if (rule.type === "workflows") {
+      for (const workflow of rule.parameters?.workflows ?? []) {
+        for (const context of requiredWorkflowJobContexts({
+          workflow,
+          rule,
+          workflowNameByPath,
+          fallbackRepoPath,
+          statusCheckRollup,
+        })) {
+          addRequiredContext(
+            byKey,
+            context,
+            workflow.integration_id ?? workflow.integrationId ?? null,
+          );
+        }
+      }
+    }
+  }
+
+  return [...byKey.values()].sort((a, b) => a.context.localeCompare(b.context));
+}
+
+export function requiredStatusContextsFromRulesResult(
+  rules = [],
+  {
+    workflowNameByPath = new Map(),
+    workflowNameLookupError = null,
+    fallbackRepoPath = null,
+    statusCheckRollup = [],
+  } = {},
+) {
+  const unresolvedSources =
+    fallbackRepoPath === null
+      ? []
+      : unresolvedWorkflowSourcesFromRules(rules, fallbackRepoPath);
+  if (unresolvedSources.length > 0) {
+    return {
+      contexts: [],
+      error: `Unable to resolve source repository for required workflow(s): ${unresolvedSources.join(", ")}`,
+    };
+  }
+
+  if (workflowPathsFromRules(rules).length > 0 && workflowNameLookupError) {
+    return { contexts: [], error: workflowNameLookupError };
+  }
+
+  return {
+    contexts: requiredStatusContextsFromRules(rules, {
+      workflowNameByPath,
+      fallbackRepoPath,
+      statusCheckRollup,
+    }),
+    error: null,
+  };
+}
+
+export function requiredStatusContextsFromProtection(protection) {
+  if (Array.isArray(protection)) return protection;
+
+  const byKey = new Map();
+  for (const check of protection?.checks ?? []) {
+    addRequiredContext(
+      byKey,
+      check.context,
+      check.app_id ?? check.appId ?? null,
+    );
+  }
+
+  if (byKey.size === 0) {
+    for (const context of protection?.contexts ?? []) {
+      addRequiredContext(byKey, context);
+    }
+  }
+
+  return [...byKey.values()].sort((a, b) => a.context.localeCompare(b.context));
+}
+
+export function splitRepo(repoValue) {
+  const parts = String(repoValue).split("/").filter(Boolean);
+  const name = parts.pop();
+  const owner = parts.pop();
+  if (!owner || !name) {
+    throw new Error(`Unable to parse repository name: ${repoValue}`);
+  }
+  const host = parts.length > 0 ? parts.join("/") : null;
+  return { owner, name, host };
+}
+
+export function repoFromPullRequestUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const [owner, name] = parsed.pathname.split("/").filter(Boolean);
+    if (!owner || !name) return null;
+    return {
+      owner,
+      name,
+      host: parsed.hostname === "github.com" ? null : parsed.hostname,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function repoPath(repo) {
+  return `${repo.owner}/${repo.name}`;
+}
+
+function repoFromPath(path, host = null) {
+  const { owner, name } = splitRepo(path);
+  return { owner, name, host };
+}
+
+function appIdFromAvatarUrl(url) {
+  const match = String(url ?? "").match(/\/in\/(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function latestStatusByContext(statuses = []) {
+  const latest = new Map();
+  for (const status of statuses) {
+    if (!latest.has(status.context)) {
+      latest.set(status.context, status);
+    }
+  }
+  return latest;
+}
+
+function minIsoTimestamp(current, candidate) {
+  if (!candidate) return current;
+  if (!current) return candidate;
+  return Date.parse(candidate) < Date.parse(current) ? candidate : current;
+}
+
+async function fetchStatusSourceMap({ repo, headSha }) {
+  const path = repoPath(repo);
+  const [checkRunsResult, statusesResult] = await Promise.all([
+    ghApiJsonPagesResult(repo, [`repos/${path}/commits/${headSha}/check-runs`]),
+    ghApiJsonPagesResult(repo, [`repos/${path}/commits/${headSha}/statuses`]),
+  ]);
+
+  const sourceMap = new Map();
+  let observedAt = null;
+
+  if (checkRunsResult.ok) {
+    for (const page of checkRunsResult.value ?? []) {
+      for (const checkRun of page.check_runs ?? []) {
+        observedAt = minIsoTimestamp(
+          observedAt,
+          checkRun.created_at ?? checkRun.started_at,
+        );
+        if (
+          checkRun.name &&
+          checkRun.app?.id &&
+          !sourceMap.has(checkRun.name)
+        ) {
+          sourceMap.set(checkRun.name, { appId: Number(checkRun.app.id) });
+        }
+      }
+    }
+  }
+
+  if (statusesResult.ok) {
+    for (const status of latestStatusByContext(statusesResult.value).values()) {
+      observedAt = minIsoTimestamp(observedAt, status.created_at);
+      const appId =
+        appIdFromAvatarUrl(status.avatar_url) ??
+        appIdFromAvatarUrl(status.creator?.avatar_url);
+      if (status.context && appId !== null && !sourceMap.has(status.context)) {
+        sourceMap.set(status.context, { appId });
+      }
+    }
+  }
+
+  return { sourceMap, observedAt };
+}
+
+async function fetchWorkflowNameByPath(repo, pathKey = repoPath(repo)) {
+  const result = await ghApiJsonPagesResult(repo, [
+    `repos/${repoPath(repo)}/actions/workflows?per_page=100`,
+  ]);
+  const byPath = new Map();
+  if (!result.ok) return { byPath, error: result.error };
+
+  for (const page of result.value ?? []) {
+    for (const workflow of page.workflows ?? []) {
+      if (workflow.path && workflow.name) {
+        byPath.set(workflowLookupKey(pathKey, workflow.path), workflow.name);
+        byPath.set(workflow.path, workflow.name);
+      }
+    }
+  }
+
+  return { byPath, error: null };
+}
+
+async function fetchWorkflowNamesForRules(repo, rules) {
+  const fallbackRepoPath = repoPath(repo);
+  const byPath = new Map();
+  const unresolvedSources = unresolvedWorkflowSourcesFromRules(
+    rules,
+    fallbackRepoPath,
+  );
+
+  if (unresolvedSources.length > 0) {
+    return {
+      byPath: new Map(),
+      error: `Unable to resolve source repository for required workflow(s): ${unresolvedSources.join(", ")}`,
+    };
+  }
+
+  const results = await Promise.all(
+    workflowRepoPathsFromRules(rules, fallbackRepoPath).map(
+      async (sourcePath) => {
+        const sourceRepo = repoFromPath(sourcePath, repo.host);
+        return fetchWorkflowNameByPath(sourceRepo, sourcePath);
+      },
+    ),
+  );
+
+  for (const result of results) {
+    if (result.error) return { byPath: new Map(), error: result.error };
+    for (const [key, value] of result.byPath.entries()) {
+      byPath.set(key, value);
+    }
+  }
+
+  return { byPath, error: null };
+}
+
+function rollupAppId(check) {
+  const value =
+    check.appId ??
+    check.app_id ??
+    check.app?.id ??
+    check.app?.databaseId ??
+    null;
+  return value === null || value === undefined ? null : Number(value);
+}
+
+export function annotateStatusCheckSources(statusCheckRollup, sourceMap) {
+  return statusCheckRollup.map((check) => {
+    if (rollupAppId(check) !== null) return check;
+    const source = sourceMap.get(checkDisplayName(check));
+    return source ? { ...check, ...source } : check;
+  });
+}
+
+function validIsoTimestamp(value) {
+  return Number.isFinite(Date.parse(value ?? "")) ? value : null;
+}
+
+function timelineEventTimestamp(item) {
+  return (
+    validIsoTimestamp(item?.created_at) ??
+    validIsoTimestamp(item?.submitted_at) ??
+    validIsoTimestamp(item?.updated_at) ??
+    null
+  );
+}
+
+export function headUpdatedAtFromTimeline(timelineItems = [], headSha) {
+  const normalizedHeadSha = String(headSha ?? "").toLowerCase();
+  if (!normalizedHeadSha) return null;
+
+  let headCommitIndex = -1;
+  let headCommitTimestamp = null;
+  for (const [index, item] of timelineItems.entries()) {
+    if (
+      item?.event === "committed" &&
+      String(item.sha ?? "").toLowerCase() === normalizedHeadSha
+    ) {
+      headCommitIndex = index;
+      headCommitTimestamp = timelineEventTimestamp(item);
+    }
+  }
+  if (headCommitIndex < 0) return null;
+  if (headCommitTimestamp) return headCommitTimestamp;
+
+  for (const item of timelineItems.slice(headCommitIndex + 1)) {
+    const timestamp = timelineEventTimestamp(item);
+    if (timestamp) return timestamp;
+  }
+  return null;
+}
+
+export function fetchHeadUpdatedAt({ headSha, timelineItems, observedAt }) {
+  return minIsoTimestamp(
+    headUpdatedAtFromTimeline(timelineItems, headSha),
+    validIsoTimestamp(observedAt),
+  );
+}
+
+async function fetchReviewThreads({ repo, number }) {
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $cursor) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              isResolved
+              isOutdated
+              path
+              line
+              startLine
+              comments(first: 10) {
+                nodes {
+                  id
+                  url
+                  body
+                  author {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const threads = [];
+  let cursor = null;
+  for (;;) {
+    const args = ghApiArgs(repo, [
+      "graphql",
+      "-f",
+      `owner=${repo.owner}`,
+      "-f",
+      `name=${repo.name}`,
+      "-F",
+      `number=${number}`,
+      "-f",
+      `query=${query}`,
+    ]);
+    if (cursor !== null) {
+      args.push("-f", `cursor=${cursor}`);
+    }
+
+    const data = await ghJson(args);
+
+    const page = data?.data?.repository?.pullRequest?.reviewThreads;
+    if (!page) return threads;
+    threads.push(...(page.nodes ?? []));
+    if (!page.pageInfo?.hasNextPage) return threads;
+    cursor = page.pageInfo.endCursor;
+  }
+}
+
+async function attachCodexRequestReactions({ repo, issueComments }) {
+  return Promise.all(
+    issueComments.map(async (comment) => {
+      if (!isCodexReviewRequestBody(comment.body)) return comment;
+      const result = await ghApiJsonPagesResult(repo, [
+        "-H",
+        "Accept: application/vnd.github+json",
+        `repos/${repoPath(repo)}/issues/comments/${comment.id}/reactions`,
+      ]);
+      if (!result.ok) return comment;
+
+      return {
+        ...comment,
+        reactions: result.value,
+      };
+    }),
+  );
+}
+
+async function fetchRequiredStatusContexts({
+  repo,
+  baseRef,
+  statusCheckRollup = [],
+}) {
+  const encodedBaseRef = encodeURIComponent(baseRef);
+  const result = await ghApiJsonResult(repo, [
+    `repos/${repoPath(repo)}/branches/${encodedBaseRef}/protection/required_status_checks`,
+  ]);
+
+  if (!result.ok) {
+    if (result.error.includes("Branch not protected (HTTP 404)")) {
+      const rulesResult = await ghApiJsonPagesResult(repo, [
+        `repos/${repoPath(repo)}/rules/branches/${encodedBaseRef}`,
+      ]);
+
+      if (!rulesResult.ok) {
+        return {
+          contexts: [],
+          error: rulesResult.error,
+        };
+      }
+
+      const workflowNameByPath = workflowPathsFromRules(rulesResult.value ?? [])
+        .length
+        ? await fetchWorkflowNamesForRules(repo, rulesResult.value ?? [])
+        : { byPath: new Map(), error: null };
+
+      return requiredStatusContextsFromRulesResult(rulesResult.value ?? [], {
+        workflowNameByPath: workflowNameByPath.byPath,
+        workflowNameLookupError: workflowNameByPath.error,
+        fallbackRepoPath: repoPath(repo),
+        statusCheckRollup,
+      });
+    }
+
+    return {
+      contexts: [],
+      error: result.error,
+    };
+  }
+
+  return {
+    contexts: requiredStatusContextsFromProtection(result.value),
+    error: null,
+  };
+}
+
+export async function fetchReadyState({
+  prArg,
+  repoArg,
+  includeFeedbackDetails = false,
+}) {
+  const prViewArgs = [
+    "pr",
+    "view",
+    prArg,
+    "--json",
+    [
+      "author",
+      "baseRefName",
+      "headRefName",
+      "headRefOid",
+      "isDraft",
+      "mergeable",
+      "mergedAt",
+      "number",
+      "reviewDecision",
+      "reviews",
+      "state",
+      "statusCheckRollup",
+      "title",
+      "url",
+      "closedAt",
+    ].join(","),
+  ];
+
+  if (repoArg) {
+    prViewArgs.push("--repo", repoArg);
+  }
+
+  const pr = await ghJson(prViewArgs);
+
+  const number = pr?.number;
+  if (!number) {
+    throw new Error(`Unable to resolve pull request: ${prArg}`);
+  }
+
+  const repo = repoFromPullRequestUrl(pr.url) ?? splitRepo(repoArg);
+  const path = repoPath(repo);
+  if (["MERGED", "CLOSED"].includes(String(pr.state ?? "").toUpperCase())) {
+    return summarizeTerminalReadyState(pr);
+  }
+
+  const statusSourcePromise = fetchStatusSourceMap({
+    repo,
+    headSha: pr.headRefOid,
+  });
+  const issueCommentsPromise = ghApiJsonPages(repo, [
+    `repos/${path}/issues/${number}/comments`,
+  ]);
+  const issueCommentsWithReactionsPromise = issueCommentsPromise.then(
+    (issueComments) => attachCodexRequestReactions({ repo, issueComments }),
+  );
+  const reactionsPromise = ghApiJsonPages(repo, [
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${path}/issues/${number}/reactions`,
+  ]);
+  const reviewCommentsPromise = ghApiJsonPages(repo, [
+    `repos/${path}/pulls/${number}/comments`,
+  ]);
+  const reviewThreadsPromise = fetchReviewThreads({ repo, number });
+  const requiredStatusContextsPromise = fetchRequiredStatusContexts({
+    repo,
+    baseRef: pr.baseRefName,
+    statusCheckRollup: pr.statusCheckRollup ?? [],
+  });
+  const timelinePromise = ghApiJsonPagesResult(repo, [
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${path}/issues/${number}/timeline`,
+  ]);
+
+  const [
+    { sourceMap, observedAt },
+    issueComments,
+    reactions,
+    reviewComments,
+    reviewThreads,
+    requiredStatusContexts,
+    timelineResult,
+  ] = await Promise.all([
+    statusSourcePromise,
+    issueCommentsWithReactionsPromise,
+    reactionsPromise,
+    reviewCommentsPromise,
+    reviewThreadsPromise,
+    requiredStatusContextsPromise,
+    timelinePromise,
+  ]);
+  const headUpdatedAt = fetchHeadUpdatedAt({
+    headSha: pr.headRefOid,
+    timelineItems: timelineResult.ok ? timelineResult.value : [],
+    observedAt,
+  });
+  const annotatedPr = {
+    ...pr,
+    headUpdatedAt,
+    statusCheckRollup: annotateStatusCheckSources(
+      pr.statusCheckRollup ?? [],
+      sourceMap,
+    ),
+  };
+
+  return summarizeReadyState({
+    pr: annotatedPr,
+    issueComments,
+    reactions,
+    reviewComments,
+    reviewThreads,
+    requiredStatusContexts: requiredStatusContexts.contexts,
+    requiredStatusContextsError: requiredStatusContexts.error,
+    requiredStatusContextsAvailable: requiredStatusContexts.error === null,
+    includeFeedbackDetails,
+  });
+}
+
+function usage() {
+  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch] [--until-ready]\n\nNote: --watch --json emits newline-delimited JSON, one summary per poll. --until-ready only affects watch mode.\n`;
+}
+
+function readFlagValue(rest, flag) {
+  const flagIndex = rest.indexOf(flag);
+  if (flagIndex < 0) return undefined;
+
+  const value = rest[flagIndex + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value\n${usage()}`);
+  }
+
+  rest.splice(flagIndex, 2);
+  return value;
+}
+
+export function parseArgs(argv) {
+  const help = argv.includes("--help") || argv.includes("-h");
+  if (help) {
+    return {
+      help: true,
+      json: false,
+      compact: false,
+      watch: false,
+      untilReady: false,
+      prArg: null,
+      repoArg: null,
+    };
+  }
+
+  const json = argv.includes("--json");
+  const compact = argv.includes("--compact");
+  const watch = argv.includes("--watch");
+  const untilReady = argv.includes("--until-ready");
+  const rest = argv.filter(
+    (arg) => !["--json", "--compact", "--watch", "--until-ready"].includes(arg),
+  );
+  const repoArg = readFlagValue(rest, "--repo");
+  let prArg = readFlagValue(rest, "--pr");
+  if (!prArg) {
+    prArg = rest[0];
+    rest.splice(0, 1);
+  }
+  if (!prArg || rest.length > 0) {
+    throw new Error(usage());
+  }
+  if (untilReady && !watch) {
+    throw new Error("--until-ready requires --watch");
+  }
+  return { json, compact, watch, untilReady, prArg, repoArg };
+}
+
+export function renderSummary(summary, { json, compact, watch = false }) {
+  if (json) return `${JSON.stringify(summary, null, watch ? 0 : 2)}\n`;
+  if (compact) return `${formatCompact(summary)}\n`;
+  return formatHuman(summary);
+}
+
+export function watchLoopExitCode(summary, { untilReady = false } = {}) {
+  if (!untilReady) return null;
+
+  const state = String(summary?.pr?.state ?? "").toUpperCase();
+  if (summary?.ready === true || state === "MERGED") return 0;
+  if (state === "CLOSED") return 1;
+  return null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  try {
+    const { help, json, compact, watch, untilReady, prArg, repoArg } =
+      parseArgs(process.argv.slice(2));
+    if (help) {
+      process.stdout.write(usage());
+      return;
+    }
+
+    for (;;) {
+      try {
+        const summary = await fetchReadyState({ prArg, repoArg });
+        process.stdout.write(renderSummary(summary, { json, compact, watch }));
+        const exitCode = watchLoopExitCode(summary, { untilReady });
+        if (watch && exitCode !== null) {
+          process.exitCode = exitCode;
+          return;
+        }
+      } catch (err) {
+        if (!watch) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[pr-ready-state] ${message}\n`);
+      }
+      if (!watch) return;
+      await sleep(60_000);
+    }
+  } catch (err) {
+    process.stderr.write(err instanceof Error ? err.message : String(err));
+    if (!String(err).endsWith("\n")) process.stderr.write("\n");
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}


### PR DESCRIPTION
## The Problem

- The `pr-*-state` helpers belong in `scripts/pr/` (issue 1877, track D3), but
  `agent-autoreview.sh` reads their blobs from the protected `origin/main`
  snapshot rather than the checked-out tree, and a missing path there fails
  closed.
- The wrapper that runs is whichever one the developer has checked out, so a
  single PR that moved the files and repointed the pin together would break one
  pairing: a pre-move wrapper reading a post-move `origin/main`, or a post-move
  wrapper reading the `origin/main` that still predates its own merge.

## The Solution

- Add the six materialized helpers at `scripts/pr/` as byte-identical copies,
  leaving the pre-move flat paths untouched, and teach the wrapper to resolve
  each helper name against `scripts/pr/` first and the flat path second.
- Both locations are now live on `origin/main`, so a wrapper from either side of
  the move works against the `origin/main` before this merge and the one after.
  Consumers repoint in the next PR; the flat copies and the fallback go in the
  one after that.

## Details

- `materialize_feedback_runtime` no longer carries literal repo-relative paths.
  It carries two basename lists — five required, one optional
  (`pr-feedback-state-claude.mjs`) — and resolves each through the new
  `feedback_runtime_snapshot_path`, which `ls-tree`s `scripts/pr/<name>` then
  `scripts/<name>` at the pinned snapshot. A git failure returns nonzero and is
  reported; absence prints nothing. The two never collapse into one answer.
- The materialized destination stays `$runtime_dir/scripts/<basename>` whichever
  location the snapshot carried, so the helpers' sibling relative imports and the
  `capture_feedback_state` call site are unchanged. Each destination basename is
  a literal from the lists, never a path read out of the snapshot.
- The blob-mode check, the 2 MB aggregate cap, and the per-entry size accounting
  are unchanged and now run over the resolved paths. The six helpers total
  ~95 KB, so the cap has ample headroom on either side of the move; the separate
  2 MB Perl copy cap covers only `agent-autoreview.{mjs,core.mjs}` and is not
  touched.
- The copies are byte-identical to the originals (verified by `git hash-object`),
  which the wrapper's per-path blob attestation requires. All sibling imports in
  these files are same-directory, so no import rewriting was needed.
- `agent-quality-gate.sh` gains paired one-level routing arms. Both arms are
  exact-path alternations, not globs, so the `scripts/pr/` copies route only
  because they are named outright.
- Because the wrapper prefers the `scripts/pr/` copies while every consumer
  still runs the flat ones, each suite asserts its own three basenames are
  byte-identical across the two locations. Without it a one-sided edit would
  leave the trust root running stale logic with the CLI and its tests green.
  Both assertions delete with the flat copies in the last step.
- Scope boundary: this PR moves nothing and repoints no consumer. The two test
  files (`pr-feedback-state.test.mjs`, `pr-ready-state.test.mjs`) are not
  materialized from `origin/main` by anything, so they need no copy stage — they
  move as plain renames in the follow-up, which avoids duplicating 163 KB of
  test source and running both copies for the length of the migration.

### Why three merges and not two

Verified against the code, not assumed. The failure mode is hard: a required
path absent at the pinned `origin/main` aborts under `set -e` before the bundle
publishes. Wrapper generation and `origin/main` content vary independently.

A two-PR shape — teach the resolver, then `git mv` everything — leaves the
`(pre-resolver wrapper, post-move main)` pairing broken, because the flat copies
would be gone from `origin/main` while checkouts predating the resolver still
require them. Keeping the flat copies live through a middle merge is exactly what
closes that pairing, so the three-merge shape is the one that holds.

One residual is inherent to removing any pinned path: after the third merge, a
checkout whose wrapper predates this PR fails closed. Hold that merge until no
such checkout is in use. ADR 0064 now records the staged-move requirement and
this residual.

## Validation

- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`
- New `run_feedback_runtime_dual_location_regression` in
  `agent-autoreview.test.sh` covers three snapshots against distinct runtime
  bodies: flat-only `origin/main` runs the flat copy, dual-location runs the
  `scripts/pr/` copy, and a mixed snapshot resolves one helper from each
  location and imports across them.
- Negative controls, all four confirmed to red: inverting the candidate order
  makes the preference assertion report `"location":"flat"`; dropping the flat
  candidate makes the pre-existing flat-fixture aggregate regression fail on the
  missing-runtime message; restoring a per-source destination layout makes the
  mixed leg fail with `MODULE_NOT_FOUND`; appending a byte to one copy makes the
  identity assertion name the drifted pair.
- `node scripts/pr-feedback-state.test.mjs` (47 passed),
  `node scripts/pr-ready-state.test.mjs` (80 passed),
  `node --test scripts/repo-health/file-size-watchlist.test.mjs` (22 passed),
  `node scripts/check-agent-quality-gate-package-scripts.mjs` (clean),
  `pnpm lint:scripts` (clean).
- `git hash-object` on all six pairs: identical blobs.
- Local autoreview, both engines. This PR changes the autoreview runtime itself,
  so the wrapper fails its own self-review closed by design; the bundle was
  prepared and verified from a separate trusted `origin/main` checkout with an
  explicit `AUTOREVIEW_HELPER`, per the runtime-changing procedure in
  `docs/notes/agent-quality-gate-mechanics.md`. The secret scanner accepted the
  bundle.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Recorded as a consequence in
      `docs/adr/0064-scripts-module-directories.md`, which already governs
      `scripts/` moves; this adds the trust-root staged-move rule to it rather
      than opening a competing record.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 969b9ec73f984f0b34ac5c243ecd3686469661e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull-request readiness reporting with human-readable, compact, and JSON output.
  * Added watch and until-ready modes for monitoring checks, reviews, blockers, and approval signals.
  * Added pull-request feedback summaries that identify actionable findings and clean reviews.
  * Readiness evaluation now considers required and optional checks, unresolved review activity, bot feedback, and readiness overrides.
* **Documentation**
  * Added guidance for safely transitioning scripts to new directory locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->