### PR TITLE
fix(agent): accept three clean-Claude-review formats the grammar rejected

### DIFF
--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -5,17 +5,47 @@ const COMMONMARK_ASCII_PUNCTUATION_ESCAPE =
 const CLAUDE_TASK_COMPLETION_LINE =
   /^\*\*Claude\s+finished\s+@[A-Za-z0-9_-]+'s\s+task\s+in\s+\d+m\s+\d+s\*\*(?:\s+——\s+\[View\s+job\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+\))?$/i;
 const CLAUDE_VERDICT_NAMESPACE = /^(?:\*\*)?(?:Overall\s+)?Verdict\s*:/i;
+// Emphasis may wrap the whole declaration (`**Verdict: LGTM**`) or only the
+// label (`**Verdict:** LGTM`) — the same statement either way. `tail` captures
+// anything after the verdict word; `isCleanTail` decides whether it is a plain
+// summarizing sentence or a qualification that keeps the review actionable.
 const CLAUDE_CLEAN_VERDICT =
-  /^(?:\*\*)?(?:Overall\s+)?Verdict:\s*LGTM(?:\*\*)?\s*$/i;
+  /^(?:\*\*)?(?:Overall\s+)?Verdict:(?:\*\*)?\s*(?:\*\*)?LGTM(?:\*\*)?\s*(?<tail>[\s\S]*)$/i;
 const PROSE_PATTERN_LIBRARY_START = Date.parse("2026-08-13T23:08:10Z");
 const REVIEW_NUMBER_HEADING = /^#{1,6}\s+Code Review\s+—\s+PR\s+#(\d+)$/gm;
 const REVIEW_TITLE_HEADING = /^#{1,6}\s+Review:\s+(.{1,200})$/gim;
+// `### Review: <PR title>` is the usual heading, but a clean review may instead
+// put the verdict there (`### Review: LGTM ✅`). Only the bare verdict word and
+// an optional approval mark are allowed — never free text, which would let a
+// heading smuggle a finding past the title check.
+// Alternation, not a character class: `✔️` is U+2714 plus a variation selector,
+// and a combined character inside a class is a lint error and a silent mismatch.
+const CLEAN_REVIEW_TITLE = /^LGTM(?:\s*(?:✅|✔️?|\u{1F44D}️?))*$/iu;
 const CLEAN_CONCLUSION_PATTERNS = [
   /^No\s+P1\/P2\/P3\s+findings(?:\s*[.—-]\s*(?:clean review|nothing rose above the bar for an inline comment))?[.!]?$/i,
   /^No\s+P1\/P2\s+findings[.!]?$/i,
   /^No\s+inline\s+(?:comments|findings)(?:\s+(?:filed|posted))?(?:\s*[.—-]\s*nothing rose to a P1\/P2\/P3 flag)?[.!]?$/i,
   /^No\s+changes\s+requested[.!]?$/i,
 ];
+// A numbered roll-up entry that states the absence of findings, with the
+// severities optionally bracketed and an optional `None — ` lead-in:
+// `1. None — no [P1]/[P2]/[P3] findings.` The trailing `tail` is held to the
+// same clean-summary rule as a verdict tail, so a roll-up that starts by
+// denying findings and then names one stays actionable.
+const CLEAN_CONCLUSION_WITH_TAIL =
+  /^(?:None\s*[—–-]\s*)?No\s+\[?P1\]?\/\[?P2\]?(?:\/\[?P3\]?)?\s+findings(?<tail>[\s\S]*)$/i;
+// A verdict or roll-up may end with a bare sentence terminator, and nothing
+// else. Any remaining prose makes the statement actionable.
+//
+// This is deliberately an allowlist of ONE shape rather than a blacklist of
+// finding vocabulary. A tail is unconstrained natural language, so rejecting
+// selected terms (priorities, contradiction connectives, action verbs) cannot
+// be exhaustive: a defect stated declaratively — `Verdict: LGTM. Anonymous
+// callers can delete every stored record.` — carries none of those markers and
+// would read as clean. On a fail-closed gate that silently drops real reviewer
+// findings before merge, so the only safe rule is that a clean verdict asserts
+// cleanliness and says nothing further.
+const CLEAN_TAIL_SHAPE = /^[.!]?$/;
 const CLEAN_P3_DISPOSITION_PATTERNS = [
   /\bno[- ]action(?:\s+requested)?\b/i,
   /\bnone\s+blocking\b/i,
@@ -93,9 +123,25 @@ function isClaudeAuthor(value) {
   return /^claude(?:\[bot\])?$/i.test(String(value ?? ""));
 }
 
+// Guards whatever trails a clean verdict or roll-up entry: only a bare sentence
+// terminator passes. See CLEAN_TAIL_SHAPE for why this is an allowlist.
+function isCleanTail(tail) {
+  return CLEAN_TAIL_SHAPE.test(String(tail ?? "").trim());
+}
+
+function matchesCleanVerdict(line) {
+  const tail = CLAUDE_CLEAN_VERDICT.exec(line)?.groups?.tail;
+  return tail !== undefined && isCleanTail(tail);
+}
+
 function isCleanConclusion(line) {
-  const value = String(line ?? "").trim();
-  return CLEAN_CONCLUSION_PATTERNS.some((pattern) => pattern.test(value));
+  // Strip list/heading markers first so a numbered roll-up entry is judged on
+  // its text, not its `1. ` prefix.
+  const value = reviewLineContent(line);
+  if (CLEAN_CONCLUSION_PATTERNS.some((pattern) => pattern.test(value)))
+    return true;
+  const tail = CLEAN_CONCLUSION_WITH_TAIL.exec(value)?.groups?.tail;
+  return tail !== undefined && isCleanTail(tail);
 }
 
 export function withoutCleanReviewConclusionLines(value) {
@@ -207,7 +253,7 @@ export function classifyClaudeReviewProse(comment, pr) {
 
   if (
     verdictLines.length !== 1 ||
-    !CLAUDE_CLEAN_VERDICT.test(reviewLineContent(verdictLines[0])) ||
+    !matchesCleanVerdict(reviewLineContent(verdictLines[0])) ||
     body.includes("\r") ||
     body.includes("\0") ||
     body.length > 65_536 ||
@@ -234,7 +280,8 @@ export function classifyClaudeReviewProse(comment, pr) {
   if (
     reviewTitles.length > 1 ||
     (reviewTitles.length === 1 &&
-      !isOrdinaryReviewTitle(reviewTitles[0], pr?.title))
+      !isOrdinaryReviewTitle(reviewTitles[0], pr?.title) &&
+      !CLEAN_REVIEW_TITLE.test(String(reviewTitles[0]).trim()))
   )
     return true;
 

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -46,6 +46,9 @@ const CLEAN_CONCLUSION_WITH_TAIL =
 // findings before merge, so the only safe rule is that a clean verdict asserts
 // cleanliness and says nothing further.
 const CLEAN_TAIL_SHAPE = /^[.!]?$/;
+// A task item whose box is empty (`- [ ]`) or explicitly negated (`- [-]`).
+// `[x]`/`[X]` is a completed check and stays eligible.
+const UNCHECKED_TASK_MARKER = /^\s*(?:[-*+]\s+)?\[[ -]\]\s/;
 const CLEAN_P3_DISPOSITION_PATTERNS = [
   /\bno[- ]action(?:\s+requested)?\b/i,
   /\bnone\s+blocking\b/i,
@@ -135,8 +138,14 @@ function matchesCleanVerdict(line) {
 }
 
 function isCleanConclusion(line) {
-  // Strip list/heading markers first so a numbered roll-up entry is judged on
-  // its text, not its `1. ` prefix.
+  // An UNCHECKED task marker states an intention, not a result: `- [ ] No
+  // P1/P2 findings.` is a box the reviewer never ticked. `reviewLineContent`
+  // strips `[ ]` along with the list bullet, so reject it before stripping —
+  // otherwise the line reads as a completed clean assertion and, worse,
+  // `withoutCleanReviewConclusionLines` deletes it from the actionable scan.
+  if (UNCHECKED_TASK_MARKER.test(String(line ?? ""))) return false;
+  // Strip list/heading markers so a numbered roll-up entry is judged on its
+  // text, not its `1. ` prefix.
   const value = reviewLineContent(line);
   if (CLEAN_CONCLUSION_PATTERNS.some((pattern) => pattern.test(value)))
     return true;

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -284,6 +284,10 @@ export function classifyClaudeReviewProse(comment, pr) {
 
   if (
     verdictLines.length !== 1 ||
+    // Symmetric with isCleanConclusion: an unticked box in front of the
+    // verdict means the reviewer never completed it, and reviewLineContent
+    // peels the box away before the verdict pattern ever sees it.
+    hasUncheckedTaskBox(verdictLines[0]) ||
     !matchesCleanVerdict(reviewLineContent(verdictLines[0])) ||
     body.includes("\r") ||
     body.includes("\0") ||

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -46,9 +46,14 @@ const CLEAN_CONCLUSION_WITH_TAIL =
 // findings before merge, so the only safe rule is that a clean verdict asserts
 // cleanliness and says nothing further.
 const CLEAN_TAIL_SHAPE = /^[.!]?$/;
-// A task item whose box is empty (`- [ ]`) or explicitly negated (`- [-]`).
-// `[x]`/`[X]` is a completed check and stays eligible.
-const UNCHECKED_TASK_MARKER = /^\s*(?:[-*+]\s+)?\[[ -]\]\s/;
+// The prefix grammar `reviewLineContent` peels: bullets, numbering, headings,
+// and task boxes, in any order and up to three deep. `hasUncheckedTaskBox`
+// walks the same pattern and depth — keep them shared, never re-spelled.
+const REVIEW_LINE_PREFIX = /^(?:[-*+]\s+|\d+[.)]\s+|#{1,6}\s+|\[[ xX-]\]\s+)/;
+const REVIEW_LINE_PREFIX_DEPTH = 3;
+// An empty (`[ ]`) or negated (`[-]`) task box, once the prefixes before it are
+// gone. `[x]`/`[X]` is a completed check and stays eligible.
+const UNCHECKED_TASK_BOX = /^\[[ -]\]\s/;
 const CLEAN_P3_DISPOSITION_PATTERNS = [
   /\bno[- ]action(?:\s+requested)?\b/i,
   /\bnone\s+blocking\b/i,
@@ -137,13 +142,33 @@ function matchesCleanVerdict(line) {
   return tail !== undefined && isCleanTail(tail);
 }
 
+// True when an unchecked or negated task box sits anywhere in the line's prefix
+// run. Mirrors `reviewLineContent`'s peel loop step for step — same pattern,
+// same depth — so the two cannot drift into disagreeing about what a prefix is.
+function hasUncheckedTaskBox(line) {
+  let value = String(line ?? "").trim();
+  for (let index = 0; index < REVIEW_LINE_PREFIX_DEPTH; index += 1) {
+    if (UNCHECKED_TASK_BOX.test(value)) return true;
+    const stripped = value.replace(REVIEW_LINE_PREFIX, "");
+    if (stripped === value) break;
+    value = stripped;
+  }
+  return UNCHECKED_TASK_BOX.test(value);
+}
+
 function isCleanConclusion(line) {
-  // An UNCHECKED task marker states an intention, not a result: `- [ ] No
-  // P1/P2 findings.` is a box the reviewer never ticked. `reviewLineContent`
-  // strips `[ ]` along with the list bullet, so reject it before stripping —
-  // otherwise the line reads as a completed clean assertion and, worse,
-  // `withoutCleanReviewConclusionLines` deletes it from the actionable scan.
-  if (UNCHECKED_TASK_MARKER.test(String(line ?? ""))) return false;
+  // An UNCHECKED task box states an intention, not a result: `- [ ] No P1/P2
+  // findings.` is a box the reviewer never ticked. `reviewLineContent` peels
+  // `[ ]` along with bullets, numbering, and headings, so the box must be
+  // caught before it is peeled — otherwise the line reads as a completed clean
+  // assertion and `withoutCleanReviewConclusionLines` also deletes it from the
+  // actionable scan.
+  //
+  // Walk the SAME prefix grammar `reviewLineContent` uses rather than matching
+  // one hand-written shape. A single pattern only covered `- [ ]` and missed
+  // every other order the peeler accepts — `1. [ ]`, `1) [ ]`, `### [ ]`,
+  // `- 1. [ ]` — so the check must follow the peeler step for step.
+  if (hasUncheckedTaskBox(line)) return false;
   // Strip list/heading markers so a numbered roll-up entry is judged on its
   // text, not its `1. ` prefix.
   const value = reviewLineContent(line);
@@ -162,11 +187,8 @@ export function withoutCleanReviewConclusionLines(value) {
 
 function reviewLineContent(line) {
   let value = String(line ?? "").trim();
-  for (let index = 0; index < 3; index += 1) {
-    const stripped = value.replace(
-      /^(?:[-*+]\s+|\d+[.)]\s+|#{1,6}\s+|\[[ xX-]\]\s+)/,
-      "",
-    );
+  for (let index = 0; index < REVIEW_LINE_PREFIX_DEPTH; index += 1) {
+    const stripped = value.replace(REVIEW_LINE_PREFIX, "");
     if (stripped === value) break;
     value = stripped;
   }

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1787,6 +1787,22 @@ test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up"
       "bullet-then-numbered unchecked conclusion",
       clean.replace(ROLLUP, "- 1. [ ] No P1/P2 findings."),
     ],
+    // The verdict line needs the same box check as the conclusion: peeling the
+    // prefix hides an unticked box there too. Closes a hole that predates this
+    // PR — `- [ ] **Verdict: LGTM**` was accepted on main.
+    [
+      "unchecked verdict task",
+      clean.replace(VERDICT, "- [ ] **Verdict:** LGTM"),
+    ],
+    [
+      "numbered unchecked verdict task",
+      clean.replace(VERDICT, "1. [ ] **Verdict:** LGTM"),
+    ],
+    [
+      "unchecked whole-bold verdict task",
+      clean.replace(VERDICT, "- [ ] **Verdict: LGTM**"),
+    ],
+    ["negated verdict task", clean.replace(VERDICT, "- [-] **Verdict:** LGTM")],
   ]) {
     expectReady(label, body, false);
   }
@@ -1800,6 +1816,11 @@ test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up"
   ]) {
     expectReady(label, clean.replace(ROLLUP, conclusion), true);
   }
+  expectReady(
+    "checked verdict task",
+    clean.replace(VERDICT, "- [x] **Verdict:** LGTM"),
+    true,
+  );
 });
 
 // The body actually posted on PR #1954. Its verdict and roll-up each end in a

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1616,6 +1616,183 @@ test("classifies the post-#1848 Claude prose pattern library", () => {
   );
 });
 
+// The PR #1954 layout: the verdict heading carries the verdict rather than the
+// PR title, emphasis wraps only the `Verdict:` label, and the roll-up denies
+// findings with bracketed severities. Each of those shapes made the classifier
+// read a clean LGTM as unaddressed feedback.
+//
+// Deliberately WITHOUT the trailing summary sentences the observed #1954 body
+// carried. A tail is unconstrained prose, so it is always actionable — see the
+// companion test below, which pins that the observed body itself stays blocked.
+const PR_1954_CLEAN_CLAUDE_BODY = [
+  "**Claude finished @chapati23's task in 0m 50s** —— [View job](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/32352528757)",
+  "",
+  "---",
+  "### Review: LGTM ✅",
+  "",
+  "**Verdict:** LGTM",
+  "",
+  "**Numbered findings roll-up:**",
+  "1. None — no [P1]/[P2]/[P3] findings.",
+].join("\n");
+
+test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up", () => {
+  const options = {
+    number: 1848,
+    title: "fix(agent): accept exact no-action Claude review",
+    headRefOid: PR_1848_HEAD,
+    headUpdatedAt: "2026-08-13T22:09:46Z",
+    reactionCreatedAt: "2026-08-20T09:30:00Z",
+  };
+  const comment = (body) => ({
+    ...PR_1848_CLEAN_CLAUDE_REVIEW,
+    id: 5353832859,
+    created_at: "2026-08-20T09:10:48Z",
+    updated_at: "2026-08-20T09:11:54Z",
+    body,
+  });
+  const expectReady = (label, body, expected) => {
+    const feedbackState = summarizeFeedbackState(
+      normalizedReadyStateForClaudeReview(comment(body), options),
+    );
+    assertEqual(
+      feedbackState.ready,
+      expected,
+      `${label}: unexpected feedback-state result`,
+    );
+    assertEqual(
+      feedbackState.counts.blockingTopLevelBotComments,
+      expected ? 0 : 1,
+    );
+  };
+
+  expectReady("bare verdict and roll-up", PR_1954_CLEAN_CLAUDE_BODY, true);
+
+  // The widened grammar must not turn a qualified verdict, a smuggled finding,
+  // or a self-contradicting roll-up into an all-clear. The declarative-defect
+  // cases matter most: they carry no priority, connective, or action verb, so
+  // only refusing tails outright keeps them actionable.
+  const clean = PR_1954_CLEAN_CLAUDE_BODY;
+  const VERDICT = "**Verdict:** LGTM";
+  const ROLLUP = "1. None — no [P1]/[P2]/[P3] findings.";
+  for (const [label, body] of [
+    [
+      "verdict qualified by a required fix",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM. But the abort timeout must be fixed before merge.",
+      ),
+    ],
+    [
+      "verdict tail naming a priority",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM. One [P2] is left for a follow-up.",
+      ),
+    ],
+    [
+      "verdict continuation rather than a new sentence",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM pending rework of the fallback",
+      ),
+    ],
+    [
+      "verdict tail with a direct request",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM. Please restore the validation before merge.",
+      ),
+    ],
+    [
+      "verdict tail stating a defect declaratively",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM. Anonymous callers can delete every stored record.",
+      ),
+    ],
+    [
+      "verdict tail reading as praise",
+      clean.replace(
+        VERDICT,
+        "**Verdict:** LGTM. This is a clean, mechanical channel-rename PR.",
+      ),
+    ],
+    [
+      "roll-up denies findings then names one",
+      clean.replace(
+        ROLLUP,
+        "1. None — no [P1]/[P2] findings. [P1] The bot token leaks into the collector step.",
+      ),
+    ],
+    [
+      "roll-up tail carrying an action",
+      clean.replace(
+        ROLLUP,
+        "1. None — no [P1]/[P2]/[P3] findings. Please fix the fallback before merge.",
+      ),
+    ],
+    [
+      "roll-up tail stating a defect declaratively",
+      clean.replace(
+        ROLLUP,
+        "1. None — no [P1]/[P2]/[P3] findings. Anonymous callers can delete every stored record.",
+      ),
+    ],
+    [
+      "verdict heading smuggling free text",
+      clean.replace("### Review: LGTM ✅", "### Review: LGTM — but see below"),
+    ],
+    [
+      "verdict heading naming another PR",
+      clean.replace("### Review: LGTM ✅", "### Review: some other change"),
+    ],
+  ]) {
+    expectReady(label, body, false);
+  }
+});
+
+// The body actually posted on PR #1954. Its verdict and roll-up each end in a
+// summarizing sentence, and a sentence is unconstrained natural language: no
+// blacklist of priorities, connectives, or action verbs can tell praise from a
+// defect stated plainly. This gate is fail-closed on a merge path, so the tail
+// keeps it actionable even though a human reads the review as clean. Widening
+// the grammar to admit this body would reopen that hole — treat a failure here
+// as a warning, not a test to relax.
+test("keeps the observed PR #1954 review actionable because its tails are prose", () => {
+  const observed = [
+    "**Claude finished @chapati23's task in 0m 50s** —— [View job](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/32352528757)",
+    "",
+    "---",
+    "### Review: LGTM ✅",
+    "",
+    "**Verdict:** LGTM. This is a clean, mechanical channel-rename PR with no gaps.",
+    "",
+    "**Numbered findings roll-up:**",
+    "1. None — no [P1]/[P2]/[P3] findings. All four changed files are internally consistent and match the PR's stated scope.",
+  ].join("\n");
+  const feedbackState = summarizeFeedbackState(
+    normalizedReadyStateForClaudeReview(
+      {
+        ...PR_1848_CLEAN_CLAUDE_REVIEW,
+        id: 5353832859,
+        created_at: "2026-08-20T09:10:48Z",
+        updated_at: "2026-08-20T09:11:54Z",
+        body: observed,
+      },
+      {
+        number: 1848,
+        title: "fix(agent): accept exact no-action Claude review",
+        headRefOid: PR_1848_HEAD,
+        headUpdatedAt: "2026-08-13T22:09:46Z",
+        reactionCreatedAt: "2026-08-20T09:30:00Z",
+      },
+    ),
+  );
+  assertEqual(feedbackState.ready, false);
+  assertEqual(feedbackState.counts.blockingTopLevelBotComments, 1);
+});
+
 test("fails closed on single-field PR #1544 Overall-verdict mutations", () => {
   const clean = PR_1544_CLEAN_CLAUDE_REVIEW.body;
   const reviewHeading = "### Code Review — PR #1544";

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1747,9 +1747,32 @@ test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up"
       "verdict heading naming another PR",
       clean.replace("### Review: LGTM ✅", "### Review: some other change"),
     ],
+    // Stripping the `1. ` roll-up prefix must not also strip an unchecked
+    // task box: `- [ ] No P1/P2 findings.` is an intention, not a result, and
+    // treating it as a clean conclusion would additionally hide the line from
+    // the actionable scan via withoutCleanReviewConclusionLines.
+    [
+      "unchecked task conclusion",
+      clean.replace(ROLLUP, "- [ ] No P1/P2 findings."),
+    ],
+    [
+      "unchecked bracketed roll-up",
+      clean.replace(ROLLUP, "- [ ] None — no [P1]/[P2]/[P3] findings."),
+    ],
+    [
+      "negated task conclusion",
+      clean.replace(ROLLUP, "- [-] No P1/P2 findings."),
+    ],
   ]) {
     expectReady(label, body, false);
   }
+
+  // The counterpart: a ticked box is a completed check and stays eligible.
+  expectReady(
+    "checked task conclusion",
+    clean.replace(ROLLUP, "- [x] No P1/P2 findings."),
+    true,
+  );
 });
 
 // The body actually posted on PR #1954. Its verdict and roll-up each end in a

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1751,6 +1751,10 @@ test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up"
     // task box: `- [ ] No P1/P2 findings.` is an intention, not a result, and
     // treating it as a clean conclusion would additionally hide the line from
     // the actionable scan via withoutCleanReviewConclusionLines.
+    //
+    // Every prefix order reviewLineContent peels is covered. A first fix
+    // matched only the `- [ ]` shape, which left `1. [ ]`, `1) [ ]`, `### [ ]`,
+    // and `- 1. [ ]` all reading as clean.
     [
       "unchecked task conclusion",
       clean.replace(ROLLUP, "- [ ] No P1/P2 findings."),
@@ -1763,16 +1767,39 @@ test("accepts the PR #1954 label-bold verdict and bracketed no-findings roll-up"
       "negated task conclusion",
       clean.replace(ROLLUP, "- [-] No P1/P2 findings."),
     ],
+    [
+      "numbered unchecked conclusion",
+      clean.replace(ROLLUP, "1. [ ] No P1/P2 findings."),
+    ],
+    [
+      "paren-numbered unchecked conclusion",
+      clean.replace(ROLLUP, "1) [ ] No P1/P2 findings."),
+    ],
+    [
+      "numbered negated conclusion",
+      clean.replace(ROLLUP, "2. [-] No P1/P2 findings."),
+    ],
+    [
+      "heading unchecked conclusion",
+      clean.replace(ROLLUP, "### [ ] No P1/P2 findings."),
+    ],
+    [
+      "bullet-then-numbered unchecked conclusion",
+      clean.replace(ROLLUP, "- 1. [ ] No P1/P2 findings."),
+    ],
   ]) {
     expectReady(label, body, false);
   }
 
-  // The counterpart: a ticked box is a completed check and stays eligible.
-  expectReady(
-    "checked task conclusion",
-    clean.replace(ROLLUP, "- [x] No P1/P2 findings."),
-    true,
-  );
+  // The counterpart: a ticked box is a completed check and stays eligible,
+  // under the same prefix orders the rejection covers.
+  for (const [label, conclusion] of [
+    ["checked task conclusion", "- [x] No P1/P2 findings."],
+    ["checked numbered conclusion", "1. [x] No P1/P2 findings."],
+    ["capital-checked conclusion", "- [X] No P1/P2 findings."],
+  ]) {
+    expectReady(label, clean.replace(ROLLUP, conclusion), true);
+  }
 });
 
 // The body actually posted on PR #1954. Its verdict and roll-up each end in a


### PR DESCRIPTION
## The Problem

- A clean `claude[bot]` LGTM on PR #1954 was counted as unaddressed feedback, so `pnpm pr:feedback-state` reported the PR unready while the review's own text said there were no findings.
- Three format variants caused it, each independently sufficient to block.

## The Solution

- Accept those three variants, each narrowly.
- Refuse anything trailing a verdict or roll-up, because a trailing sentence is unconstrained prose that no term list can safely classify.

## Details

The classifier is fail-closed: when it misreads a review, real findings can be skipped before merge. Every widening here is bounded accordingly.

| Guard | Grammar expected | claude[bot] wrote |
| --- | --- | --- |
| Verdict line | `**Verdict: LGTM**` — emphasis wrapping the whole declaration | `**Verdict:** LGTM …` — emphasis on the label only |
| Clean conclusion | `No P1/P2/P3 findings` | `1. None — no [P1]/[P2]/[P3] findings. …` |
| Review heading | `### Review: <PR title>` | `### Review: LGTM ✅` |

The heading allowance admits only the bare verdict word plus an optional approval mark, so a heading cannot carry free text past the title check.

### The first attempt was unsound

The initial `isCleanTail` allowed a short summary sentence if it carried no priority label, contradiction connective, severity marker, or action verb. Local autoreview flagged that as P1, and a probe against the live classifier confirmed it rather than assuming:

```
CLEAN  **Verdict:** LGTM. Anonymous callers can delete every stored record.
CLEAN  1. None — no [P1]/[P2]/[P3] findings. Anonymous callers can delete every stored record.
CLEAN  **Verdict:** LGTM. The bot token reaches the collector step.
```

A defect stated declaratively carries none of the blacklisted markers. A blacklist cannot bound natural language, so the rule is now an allowlist of one shape: a tail may be a bare sentence terminator and nothing else. The same probe after the rework returns `ACTIONABLE` for all three.

### A second fail-open, found in review

Judging a roll-up entry on its text meant calling `reviewLineContent`, which strips `[ ]` along with the list bullet. `- [ ] No P1/P2 findings.` — an unticked box — therefore read as a completed clean assertion, and `withoutCleanReviewConclusionLines` deleted the line from the actionable scan on top of that. Codex caught it; `main` used a bare `trim()`, so the regression arrived with this branch.

`isCleanConclusion` now rejects an unchecked (`[ ]`) or negated (`[-]`) marker before stripping. `[x]`/`[X]` stays eligible as a completed check, pinned by its own positive test so the guard cannot later be widened into rejecting every task item.

The first attempt at that guard matched one hand-written shape, `- [ ]`, while the peeler accepts bullets, numbering, headings, and task boxes in any order up to three deep. Codex caught it again, and a probe found five leaking variants rather than the one reported: `1. [ ]`, `1) [ ]`, `2. [-]`, `### [ ]`, `- 1. [ ]`.

The cause was duplication, so the fix removes it. `REVIEW_LINE_PREFIX` and `REVIEW_LINE_PREFIX_DEPTH` are the single definition; `reviewLineContent` peels with them and `hasUncheckedTaskBox` walks the same pattern to the same depth. A future prefix form is picked up by both or by neither.

The verdict line needed the same box guard as the conclusion — `- [ ] **Verdict:** LGTM` cleared for exactly the same reason, since the peeler removes the box before the verdict pattern sees it. That one is pre-existing rather than introduced here (`- [ ] **Verdict: LGTM**` clears on `main` too), and is fixed because the guard belongs on both lines.

Every fail-open in this PR shares a shape worth noting: each convenience added to accept a benign format also widened what counts as clean, and one arrived purely from re-spelling a grammar instead of sharing it. Any future format variant here deserves the same probe-both-directions treatment, against `main` as well as the branch — a control that only exercises formats `main` rejects proves nothing.

### Known cost

The body actually observed on #1954 still does not auto-clear, because both its verdict and its roll-up end in prose. Admitting it would mean reopening the hole above. `keeps the observed PR #1954 review actionable because its tails are prose` pins this as deliberate, with a comment saying to treat a failure there as a warning rather than a test to relax.

What this does fix is the three shapes themselves, so a clean review written as bare `**Verdict:** LGTM` with a `None — no [P1]/[P2]/[P3] findings.` roll-up under a `### Review: LGTM ✅` heading now clears on its own.

## Validation

- `pnpm pr:feedback-state:test` — 48 pass, up from 46 on `main`. All 46 pre-existing tests unchanged and passing, including the PR #1544/#1595/#1600/#1825/#1837 compatibility-registry cases and the CodeRabbit classification suite.
- New adversarial cases: both declarative-defect bypasses, a praise-shaped tail, a verdict continuation (`LGTM pending rework`), a tail naming `[P2]`, a direct request, a roll-up that denies findings then names a `[P1]`, a roll-up tail carrying an action, both heading-smuggling shapes, and unchecked or negated task conclusions under every prefix order (`- [ ]`, `1. [ ]`, `1) [ ]`, `2. [-]`, `### [ ]`, `- 1. [ ]`) — plus three positive cases keeping `[x]`, `1. [x]`, and `[X]` eligible.
- Negative controls, one per fix: reverting the heading allowance fails the new test, and restoring the old single-shape task-box guard fails it too. Neither is vacuous.
- Every task-box shape probed against `main` as well as the branch, so a pre-existing hole is not mistaken for a regression and vice versa.
- `pnpm agent:autoreview` run three times across the branch's revisions — P1 on the first two, clean at 0.93 on the final tree.
- Pre-push quality gate: all mapped commands pass, including `pnpm lint:scripts`, targeted Trunk, and `pnpm tf:test`.

## Deferrals

- `classifyClaudeReviewProse` clears a review whose finding is written as a plain declarative sentence (`Anonymous callers can delete every stored record.`), because the final scan rejects only priority labels, action verbs, and severity markers. Raised by Codex on this PR; verified pre-existing — the same body clears on `main` — and deferred because the fix inverts the rule for the whole prose path and will stop some currently-clearing reviews from clearing. Tracked in https://github.com/mento-protocol/monitoring-monorepo/issues/1966.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this tightens an existing classifier without changing its contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MP8VmVKmismQuJdsL7hfF
