### PR TITLE
docs: garden package reference packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain [Envio HyperIndex](https://docs.envio.dev/) indexer paired with a Next.js 16 + Plotly.js dashboard.
 
-<!-- agent-context: title="Mento Monitoring Monorepo" status=active owner=eng canonical=true last_verified=2026-07-26 doc_type=reference scope=repo-wide review_interval_days=90 garden_lane=package-readmes-reference -->
+<!-- agent-context: title="Mento Monitoring Monorepo" status=active owner=eng canonical=true last_verified=2026-08-20 doc_type=reference scope=repo-wide review_interval_days=90 garden_lane=package-readmes-reference -->
 
 **Live dashboard:** [monitoring.mento.org](https://monitoring.mento.org)
 
@@ -12,7 +12,7 @@ Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain
 | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [`indexer-envio`](./indexer-envio/)                                     | Envio HyperIndex indexer — Celo, Monad, Polygon, and Ethereum reserve-yield data                            |
 | [`ui-dashboard`](./ui-dashboard/)                                       | Next.js 16 + Plotly.js multi-chain dashboard — all chains shown together, network derived from the pool URL |
-| [`metrics-bridge`](./metrics-bridge/)                                   | Hasura state + isolated CEX/RPC peg observations → Prometheus exporter                                      |
+| [`metrics-bridge`](./metrics-bridge/)                                   | Hasura state + isolated CEX/RPC peg observations → Prometheus metrics and current peg decisions             |
 | [`shared-config`](./shared-config/)                                     | Public `@mento-protocol/config` package for protocol metadata, thresholds, and shared ABIs                  |
 | [`aegis`](./aegis/)                                                     | App Engine v2 alerting service + Aegis Grafana dashboards                                                   |
 | [`integration-probes`](./integration-probes/)                           | Read-only DEX aggregator and cross-chain router probes → Upstash and dashboard                              |
@@ -50,6 +50,10 @@ publishes a bounded consecutive-absence streak; it never discovers or mutates
 source topology. Asset onboarding, policy publication, producer and dashboard
 proof, and protected rule activation are in
 [`docs/notes/peg-monitoring-onboarding.md`](docs/notes/peg-monitoring-onboarding.md).
+The dashboard reads current decisions through its same-origin
+`/api/peg-monitoring` route. Separate server-only routes read peg history and
+alert state from Grafana Cloud. A history failure does not replace or block the
+current decision package.
 
 **Static production endpoint:** `https://indexer.hyperindex.xyz/2f3dd15/v1/graphql`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,7 +3,7 @@ title: Mento Monitoring Technical Specification
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-20
 doc_type: reference
 scope: repo-wide
 review_interval_days: 90
@@ -84,7 +84,10 @@ The system has four principal data paths:
    metric streams to Grafana Cloud for evaluation and routing. The Grafana
    rule source defines warning-only operations consumers for listing and
    indexed-pool reachability; protected activation remains separate, and
-   missing or stale listing evidence cannot fabricate delisting.
+   missing or stale listing evidence cannot fabricate delisting. The dashboard
+   reads current decisions from Metrics Bridge through a same-origin server
+   route. Separate server-only routes read historical series and alert state
+   from Grafana Cloud. History failures do not block the current-state board.
 3. **Event and incident path:** discrete events bypass the metric path.
    QuickNode and governance handlers deliver through their owning Cloud
    Functions. The Sentry-to-Slack bridge is configured directly through the
@@ -103,20 +106,20 @@ The governing decisions are
 
 ## Runtime boundaries
 
-| Surface                    | Responsibility                                          | Runtime or platform          | Owning source                                                                |
-| -------------------------- | ------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------- |
-| Shared config              | Chain, token, deployment, threshold, and ABI metadata   | Published TypeScript package | [`shared-config/AGENTS.md`](./shared-config/AGENTS.md)                       |
-| Indexer and GraphQL        | Event/RPC ingestion, entities, rollups, Hasura API      | Envio hosted                 | [`indexer-envio/AGENTS.md`](./indexer-envio/AGENTS.md)                       |
-| Dashboard                  | Human-facing monitoring and analysis                    | Vercel                       | [`ui-dashboard/AGENTS.md`](./ui-dashboard/AGENTS.md)                         |
-| Metrics bridge             | Indexed Hasura and direct CEX/RPC peg metrics           | Cloud Run                    | [`metrics-bridge/AGENTS.md`](./metrics-bridge/AGENTS.md)                     |
-| Aegis                      | v2 contract view calls to Prometheus metrics            | App Engine                   | [`aegis/AGENTS.md`](./aegis/AGENTS.md)                                       |
-| Collector                  | Aegis and bridge scrape jobs to Grafana Cloud           | Grafana Alloy on App Engine  | `aegis/grafana-agent/`                                                       |
-| Metric rules and routing   | Grafana rules, contact points, templates, mute timings  | Grafana Cloud                | [`alerts/AGENTS.md`](./alerts/AGENTS.md)                                     |
-| Event delivery             | QuickNode handler and on-call rotation announcer        | Cloud Functions              | [`alerts/AGENTS.md`](./alerts/AGENTS.md)                                     |
-| Sentry notification bridge | Direct Sentry-to-Slack alert and channel configuration  | Terraform providers          | [`sentry-bridge/README.md`](./alerts/infra/channels/sentry-bridge/README.md) |
-| Sentry triage and autofix  | Incident ingest, issue projection, and eligible fix PRs | GitHub Actions               | [ADR 0036](./docs/adr/0036-sentry-triage-pipeline.md)                        |
-| Governance watchdog        | Governance event notifications                          | Cloud Function               | [`governance-watchdog/README.md`](./governance-watchdog/README.md)           |
-| Integration probes         | Read-only aggregator and router coverage snapshots      | GitHub Actions and Upstash   | [`integration-probes/AGENTS.md`](./integration-probes/AGENTS.md)             |
+| Surface                    | Responsibility                                                | Runtime or platform          | Owning source                                                                |
+| -------------------------- | ------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| Shared config              | Chain, token, deployment, threshold, and ABI metadata         | Published TypeScript package | [`shared-config/AGENTS.md`](./shared-config/AGENTS.md)                       |
+| Indexer and GraphQL        | Event/RPC ingestion, entities, rollups, Hasura API            | Envio hosted                 | [`indexer-envio/AGENTS.md`](./indexer-envio/AGENTS.md)                       |
+| Dashboard                  | Human-facing monitoring and analysis                          | Vercel                       | [`ui-dashboard/AGENTS.md`](./ui-dashboard/AGENTS.md)                         |
+| Metrics bridge             | Indexed Hasura, direct CEX/RPC metrics, current peg decisions | Cloud Run                    | [`metrics-bridge/AGENTS.md`](./metrics-bridge/AGENTS.md)                     |
+| Aegis                      | v2 contract view calls to Prometheus metrics                  | App Engine                   | [`aegis/AGENTS.md`](./aegis/AGENTS.md)                                       |
+| Collector                  | Aegis and bridge scrape jobs to Grafana Cloud                 | Grafana Alloy on App Engine  | `aegis/grafana-agent/`                                                       |
+| Metric rules and routing   | Grafana rules, contact points, templates, mute timings        | Grafana Cloud                | [`alerts/AGENTS.md`](./alerts/AGENTS.md)                                     |
+| Event delivery             | QuickNode handler and on-call rotation announcer              | Cloud Functions              | [`alerts/AGENTS.md`](./alerts/AGENTS.md)                                     |
+| Sentry notification bridge | Direct Sentry-to-Slack alert and channel configuration        | Terraform providers          | [`sentry-bridge/README.md`](./alerts/infra/channels/sentry-bridge/README.md) |
+| Sentry triage and autofix  | Incident ingest, issue projection, and eligible fix PRs       | GitHub Actions               | [ADR 0036](./docs/adr/0036-sentry-triage-pipeline.md)                        |
+| Governance watchdog        | Governance event notifications                                | Cloud Function               | [`governance-watchdog/README.md`](./governance-watchdog/README.md)           |
+| Integration probes         | Read-only aggregator and router coverage snapshots            | GitHub Actions and Upstash   | [`integration-probes/AGENTS.md`](./integration-probes/AGENTS.md)             |
 
 ## Networks, contracts, and identifiers
 

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -3,7 +3,7 @@ title: Indexer Deployment Reference
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-20
 doc_type: reference
 scope: indexer-envio
 review_interval_days: 90

--- a/integration-probes/README.md
+++ b/integration-probes/README.md
@@ -1,4 +1,4 @@
-<!-- agent-context: title="Integration Probes" status=active owner=eng canonical=true last_verified=2026-07-29 doc_type=reference scope=integration-probes review_interval_days=90 garden_lane=package-readmes-reference -->
+<!-- agent-context: title="Integration Probes" status=active owner=eng canonical=true last_verified=2026-08-20 doc_type=reference scope=integration-probes review_interval_days=90 garden_lane=package-readmes-reference -->
 
 # Integration Probes
 


### PR DESCRIPTION
## The Problem

- The package-reference documentation packet needed a current-source audit before agents could continue to rely on it.
- The repo overview did not describe the current Metrics Bridge decision output or the dashboard split between current decisions and Grafana-backed history and alerts.

## The Solution

- Re-verify all four packet files, keep each as canonical context, and update the two repo-wide references to match the current data flow.

## Details

- `README.md`: keep and update. It now names Metrics Bridge current peg decisions and the dashboard route split.
- `SPEC.md`: keep and update. It now records the same current-state and historical-state boundary.
- `indexer-envio/STATUS.md`: keep. Refresh `last_verified` after checking the current indexer status.
- `integration-probes/README.md`: keep. Refresh `last_verified` after checking the current package contract.
- No packet file was removed, replaced, or moved. The documentation catalog did not change.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including indexer and integration-probe lint, typecheck, coverage, Knip, dependency, Terraform-contract, and documentation checks.
- Frozen packet replay matched `docs-garden:package-readmes-reference:2-of-2` with four files.
- Fresh-context Codex autoreview — clean; the sealed bundle digest matched before and after review.
- `/Users/chapati/.agents/skills/autoreview/scripts/autoreview --engine local --mode local --base origin/main` — clean.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this PR updates verified reference documentation.

Closes #1876

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c09d9e35c68181f42440f7ea6e1930c31ba59b68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verification dates across project documentation and status records.
  * Expanded metrics and dashboard monitoring guidance, including current-state, history, and alert-state routes.
  * Documented authoritative listing checks and bounded absence tracking.
  * Clarified independent handling when historical monitoring data is unavailable.
  * Refined runtime-boundary responsibilities for metrics, dashboards, error reporting, and integration checks.
  * Updated package documentation to reflect current peg-decision behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->