### PR TITLE
fix(terraform): enforce workflow admission parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,38 +171,18 @@ jobs:
               - .github/actions/pnpm-install/**
               - .github/actions/resolve-eslint-baseline/**
             terraform:
+              # Coarse admission only. `scripts/tf-stacks.mjs` classifies the
+              # exact stacks after this job starts. Keep this list equal to
+              # terraform.stacks.json `workflowAdmissionPatterns`; `pnpm
+              # tf:test` enforces equality and registry-pattern subsumption.
               - terraform/**
-              - alerts/rules/**
-              - alerts/peg-policy-publication/**
-              - alerts/infra/**
-              - aegis/terraform/**
+              - alerts/**
+              - aegis/**
               - governance-watchdog/**
+              - metrics-bridge/**
+              - scripts/**
+              - .github/workflows/**
               - terraform.stacks.json
-              - scripts/terraform/check-metrics-bridge-template-plan.mjs
-              - scripts/terraform/check-metrics-bridge-template-plan.test.mjs
-              - scripts/alerts/check-peg-policy-publication.mjs
-              - scripts/alerts/check-peg-policy-publication.test.mjs
-              - scripts/production-infra-identity-contract/**
-              # Shared parsing cores the contract and the deploy-staging
-              # contract both import (ADR 0064). They sit outside the
-              # production-infra-identity-contract/** prefix above, so they need
-              # their own entries or a parser change stops firing these jobs.
-              - scripts/lib/hcl.mjs
-              - scripts/lib/workflow-yaml.mjs
-              # The peg registry integrity checker and the modules it imports.
-              # The stack registry counts all three as Peg policy publication
-              # inputs, so this filter has to be able to reach that inventory.
-              - scripts/alerts/check-peg-registry-integrity.mjs
-              - scripts/alerts/check-peg-registry-integrity-lineage.mjs
-              - scripts/lib/peg-policy-digest.mjs
-              - scripts/terraform/terraform-fmt-check.mjs
-              - scripts/terraform/tf-platform-plan-guard.mjs
-              - scripts/tf-stacks.mjs
-              - scripts/tf-stacks.test.mjs
-              - .github/workflows/alerts-infra.yml
-              - .github/workflows/infra.yml
-              - .github/workflows/ci.yml
-              - .github/workflows/peg-policy-publication.yml
             alerts:
               - alerts/infra/onchain-event-handler/**
               - alerts/infra/oncall-announcer/**

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -5,79 +5,30 @@ on:
   push:
     branches: [main]
     paths:
+      # Coarse admission only. The discover job classifies exact stacks from
+      # terraform.stacks.json after the workflow starts. Keep this list equal
+      # to `workflowAdmissionPatterns`; `pnpm tf:test` enforces the contract.
       - terraform/**
-      - alerts/rules/**
-      - alerts/peg-policy-publication/**
-      - alerts/infra/**
-      - aegis/terraform/**
-      - governance-watchdog/infra/**
-      - governance-watchdog/src/**
-      - governance-watchdog/package.json
-      - governance-watchdog/pnpm-lock.yaml
-      - governance-watchdog/pnpm-workspace.yaml
-      - governance-watchdog/tsconfig.json
-      - governance-watchdog/tsconfig.build.json
+      - alerts/**
+      - aegis/**
+      - governance-watchdog/**
+      - metrics-bridge/**
+      - scripts/**
+      - .github/workflows/**
       - terraform.stacks.json
-      - scripts/terraform/check-metrics-bridge-template-plan.mjs
-      - scripts/terraform/check-metrics-bridge-template-plan.test.mjs
-      - scripts/alerts/check-peg-policy-publication.mjs
-      - scripts/alerts/check-peg-policy-publication.test.mjs
-      - scripts/production-infra-identity-contract/**
-      # Shared parsing cores (ADR 0064) that sit outside the prefix above.
-      - scripts/lib/hcl.mjs
-      - scripts/lib/workflow-yaml.mjs
-      # The peg registry integrity checker and the modules it imports. The stack
-      # registry counts all three as Peg policy publication inputs, so this
-      # filter has to be able to reach that inventory.
-      - scripts/alerts/check-peg-registry-integrity.mjs
-      - scripts/alerts/check-peg-registry-integrity-lineage.mjs
-      - scripts/lib/peg-policy-digest.mjs
-      - scripts/terraform/terraform-fmt-check.mjs
-      - scripts/terraform/tf-platform-plan-guard.mjs
-      - scripts/tf-stacks.mjs
-      - scripts/tf-stacks.test.mjs
-      - .github/workflows/alerts-infra.yml
-      - .github/workflows/infra.yml
-      - .github/workflows/governance-watchdog.yml
-      - .github/workflows/peg-policy-publication.yml
   pull_request:
     branches: [main]
     paths:
+      # Mirror the push admission boundary above. Registry classification keeps
+      # unrelated changes at the discover-only cost.
       - terraform/**
-      - alerts/rules/**
-      - alerts/peg-policy-publication/**
-      - alerts/infra/**
-      - aegis/terraform/**
-      - governance-watchdog/infra/**
-      - governance-watchdog/src/**
-      - governance-watchdog/package.json
-      - governance-watchdog/pnpm-lock.yaml
-      - governance-watchdog/pnpm-workspace.yaml
-      - governance-watchdog/tsconfig.json
-      - governance-watchdog/tsconfig.build.json
+      - alerts/**
+      - aegis/**
+      - governance-watchdog/**
+      - metrics-bridge/**
+      - scripts/**
+      - .github/workflows/**
       - terraform.stacks.json
-      - scripts/terraform/check-metrics-bridge-template-plan.mjs
-      - scripts/terraform/check-metrics-bridge-template-plan.test.mjs
-      - scripts/alerts/check-peg-policy-publication.mjs
-      - scripts/alerts/check-peg-policy-publication.test.mjs
-      - scripts/production-infra-identity-contract/**
-      # Shared parsing cores (ADR 0064) that sit outside the prefix above.
-      - scripts/lib/hcl.mjs
-      - scripts/lib/workflow-yaml.mjs
-      # The peg registry integrity checker and the modules it imports. The stack
-      # registry counts all three as Peg policy publication inputs, so this
-      # filter has to be able to reach that inventory.
-      - scripts/alerts/check-peg-registry-integrity.mjs
-      - scripts/alerts/check-peg-registry-integrity-lineage.mjs
-      - scripts/lib/peg-policy-digest.mjs
-      - scripts/terraform/terraform-fmt-check.mjs
-      - scripts/terraform/tf-platform-plan-guard.mjs
-      - scripts/tf-stacks.mjs
-      - scripts/tf-stacks.test.mjs
-      - .github/workflows/alerts-infra.yml
-      - .github/workflows/infra.yml
-      - .github/workflows/governance-watchdog.yml
-      - .github/workflows/peg-policy-publication.yml
 
 # See ci.yml for the concurrency rationale: PR runs cancel on new pushes
 # to the same PR ref; push/dispatch events use a SHA-unique group so they

--- a/docs/adr/0028-terraform-stack-registry.md
+++ b/docs/adr/0028-terraform-stack-registry.md
@@ -3,7 +3,7 @@ title: Terraform ownership is a registry with roots split by cadence and blast r
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-24
+last_verified: 2026-08-20
 scope: terraform/infra
 date: 2026-05
 doc_type: adr
@@ -31,7 +31,9 @@ Register every Terraform root in a machine-readable **`terraform.stacks.json`**
 separate GCS state**, split by cadence and blast radius: `platform`, `alerts-rules`
 (daily), `alerts-delivery` (monthly), `aegis`, `governance-watchdog`. CI and scripts
 ask the registry which stacks changed; ownership is never inferred from directory
-names.
+names. The registry also declares one coarse `workflowAdmissionPatterns`
+boundary. Workflows use that boundary to start, then use the stack-specific
+patterns for exact classification.
 
 ## Alternatives considered
 
@@ -45,9 +47,9 @@ names.
 - Cross-stack resource moves are import-then-`state rm` (state can't cross backends),
   as done for the Aegis service-health rule group move into `alerts-rules`.
 - The registry is authoritative for ownership and changed-stack
-  classification. Coarse workflow admission filters and the required CI
-  sentinel still duplicate path coverage until issue #1501 replaces that
-  duplication with enforced parity.
+  classification. The required CI internal Terraform filter and both Infra
+  admission filters copy the registry's broad boundary. `pnpm tf:test` enforces
+  exact equality and proves that the boundary subsumes every stack pattern.
 
 ## Evidence
 

--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -3,7 +3,7 @@ title: scripts/ may use module subdirectories; basenames and pinned paths are th
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-18
+last_verified: 2026-08-20
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -193,9 +193,10 @@ routing, not procedure.
    runs a script from the PR's **base** ref must probe the new path and the
    pre-move path; see the trusted-validator consequence above.
 4. `terraform.stacks.json` — each stack's `changedPathPatterns` enumerates
-   exact `scripts/` paths, which `docs/terraform.md` requires the workflow
-   filters to mirror, and `tf-stacks.test.mjs` asserts three of them per stack.
-   A stale entry stops the stack reacting to its own tooling.
+   exact `scripts/` paths. The registry's broad `workflowAdmissionPatterns`
+   boundary admits `scripts/**`; `tf-stacks.test.mjs` proves it subsumes every
+   stack pattern. A stale stack entry still stops that stack reacting to its
+   own tooling.
 5. `.trunk/trunk.yaml` pre-push hook, and `.gitattributes`.
 6. `.claude/settings.json`, `.codex/hooks.json`,
    `.claude/hooks/session-start.sh`, and the verbatim copies and invocation

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -3,7 +3,7 @@ title: CI Workflow Gates Checklist
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-08-20
 doc_type: checklist
 scope: ci/process
 review_interval_days: 90
@@ -52,6 +52,7 @@ the intended `Code Quality` job, and GitHub grouped the extra failure under the
 advisory schema-diff workflow in the PR UI.
 
 - [ ] **Ruleset-required** workflows MUST NOT use `paths:` / `paths-ignore:` filters — they must run on every PR. If you want path-conditional work, run every PR but skip the expensive job inside via `if:` checks (or `paths-filter`-style gating that reports a green check on no-op).
+- [ ] Registry-backed Terraform routing uses the broad `workflowAdmissionPatterns` list in `terraform.stacks.json`. Keep the required CI workflow unfiltered at workflow level. Its internal `terraform` filter and the Infra push/pull-request filters copy that list. Do not enumerate stack-specific paths in those filters. `pnpm tf:test` enforces exact equality and proves that the boundary subsumes every `changedPathPatterns` entry.
 - [ ] **Advisory** workflows (everything _not_ in the ruleset list above) SHOULD use a workflow-level `paths:` filter so they don't boot a runner on irrelevant PRs. A skipped advisory check is simply absent — it cannot leave a _required_ check pending. This is a deliberate CI-cost control; see `lighthouse.yml`, `size-limit.yml`, and `supply-chain.yml` for the pattern (the workflow-level `paths:` mirrors the in-job `filter` step, which is kept as a fail-closed backstop). **Exception:** a workflow that posts a sticky PR comment AND clears it on revert (e.g. `schema-diff.yml`) must stay unfiltered — a `paths:` skip on a revert PR strands the stale comment because the cleanup step never runs. Keep run/skip in-job there.
 - [ ] **Scheduled advisory** workflows SHOULD state the detection/rebuild SLO they serve and use the slowest cadence that satisfies it. Backstop monitors for multi-hour/day failure modes should prefer daily or similarly low cadence unless there is an explicit operator page-time requirement; do not default to every 15 minutes just because the check is cheap.
 - [ ] If you make an advisory workflow required, add it to the ruleset **and** remove its `paths:` filter in the same change.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@ title: Terraform Stacks
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-20
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -102,12 +102,18 @@ separately reviewed runtime rollover.
 
 ## CI Model
 
-`.github/workflows/infra.yml` uses coarse admission filters. The required
-`.github/workflows/ci.yml` sentinel runs on every PR; its internal filter and
-`scripts/tf-stacks.mjs` use the registry to validate changed stack roots. Until
-[#1501](https://github.com/mento-protocol/monitoring-monorepo/issues/1501)
-enforces parity, add each new `changedPathPatterns` entry to both workflow
-filters too.
+`terraform.stacks.json` owns the coarse `workflowAdmissionPatterns` boundary.
+The required `.github/workflows/ci.yml` workflow runs on every PR and applies
+that boundary only to its internal Terraform job. The advisory
+`.github/workflows/infra.yml` workflow copies the same boundary for push and
+pull-request admission. After either route starts, `scripts/tf-stacks.mjs`
+classifies the exact changed stacks from `changedPathPatterns`. `pnpm tf:test`
+requires all three filters to equal the registry boundary and requires that the
+boundary subsume every stack pattern. Add a new stack input under an existing
+broad boundary. If it needs a new root, extend the registry boundary and all
+three workflow copies in the same change. `.github/workflows/**` is the only
+nested boundary. Using `.github/**` would also admit unrelated repository
+metadata and actions.
 
 `alerts-rules`, `alerts-delivery`, `aegis`, and `governance-watchdog` have CI
 apply behavior on `main`, gated by the `production-infra` GitHub Environment.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,7 +3,7 @@ title: Scripts Instructions
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-18
+last_verified: 2026-08-20
 doc_type: agent-instructions
 scope: scripts
 review_interval_days: 90
@@ -82,16 +82,17 @@ that mechanism moves with it, in the same PR.
   `.github/workflows/` pin a `scripts/` path. `ci.yml` (`autoreviewSuite`,
   `autoreviewRootRuntime`, `versionSkew`; `rootScripts` is the recursive
   `scripts/**`), `infra.yml`, `alerts-rules.yml`, `peg-policy-publication.yml`,
-  and `schema-diff.yml` list individual files. The three terraform filters
-  (`ci.yml` `terraform`; `infra.yml` push and `pull_request`) also name
-  `scripts/lib/hcl.mjs` and `scripts/lib/workflow-yaml.mjs`, outside the
-  recursive `scripts/production-infra-identity-contract/**`; `routing.test.mjs`
-  there asserts all three. A filter also names what its listed files import. A
-  miss is silent — the job stops running while the required `ci` sentinel stays
-  green. ADR 0064 covers when a module glob such as `supply-chain.yml`'s
-  `scripts/supply-chain/**` is the safer pin.
+  and `schema-diff.yml` list individual files. The three Terraform filters are
+  the exception: `ci.yml` `terraform` plus `infra.yml` push and `pull_request`
+  copy the broad `workflowAdmissionPatterns` boundary from
+  `terraform.stacks.json`, including `scripts/**`. `routing.test.mjs` asserts
+  exact equality and proves that boundary subsumes every stack pattern. A miss
+  is silent without that contract — the job stops running while the required
+  `ci` sentinel stays green. ADR 0064 covers when a module glob such as
+  `supply-chain.yml`'s `scripts/supply-chain/**` is the safer pin.
 - **Terraform stack registry.** `terraform.stacks.json` `changedPathPatterns`
-  pins exact `scripts/` paths per stack, mirrored into those filters.
+  pins exact `scripts/` paths per stack. The broad workflow admission boundary
+  covers the directory; `pnpm tf:test` enforces subsumption.
 - **Trusted-validator probes.** `pr-description.yml` runs the validator from the
   PR's base ref via the base branch **name**, so it always resolves to the base
   branch's current tip — never a snapshot from when a PR branched. One probe

--- a/scripts/production-infra-identity-contract/routing.test.mjs
+++ b/scripts/production-infra-identity-contract/routing.test.mjs
@@ -12,9 +12,12 @@ const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const terraformStackPaths = JSON.parse(
+const terraformRegistry = JSON.parse(
   readFileSync(path.join(repositoryRoot, "terraform.stacks.json"), "utf8"),
-).stacks.map((stack) => stack.path);
+);
+const terraformStackPaths = terraformRegistry.stacks.map((stack) => stack.path);
+const terraformWorkflowAdmissionPatterns =
+  terraformRegistry.workflowAdmissionPatterns;
 const gatePath = path.join(repositoryRoot, "scripts/agent-quality-gate.sh");
 const scratchDirectory = mkdtempSync(
   path.join(os.tmpdir(), "production-identity-routing-"),
@@ -28,6 +31,66 @@ const SHARED_PARSING_CORES = [
   "scripts/lib/hcl.mjs",
   "scripts/lib/workflow-yaml.mjs",
 ];
+const NESTED_ADMISSION_EXCEPTIONS = new Set([".github/workflows/**"]);
+
+function parseSimplePathPattern(pattern) {
+  assert.equal(typeof pattern, "string", "path patterns must be strings");
+  assert(pattern.length > 0, "path patterns must not be empty");
+  const recursive = pattern.endsWith("/**");
+  const base = recursive ? pattern.slice(0, -3) : pattern;
+  assert(base.length > 0, `path pattern must name a base path: ${pattern}`);
+  assert(
+    !/[*?{}[\]]/u.test(base),
+    `path pattern uses an unsupported glob shape: ${pattern}`,
+  );
+  return { base, recursive };
+}
+
+function admissionPatternSubsumes(admissionPattern, registryPattern) {
+  const admission = parseSimplePathPattern(admissionPattern);
+  const candidate = parseSimplePathPattern(registryPattern);
+  if (!admission.recursive) {
+    return !candidate.recursive && admission.base === candidate.base;
+  }
+  return (
+    candidate.base === admission.base ||
+    candidate.base.startsWith(`${admission.base}/`)
+  );
+}
+
+function uncoveredRegistryPatterns(stacks, admissionPatterns) {
+  return stacks.flatMap((stack) =>
+    stack.changedPathPatterns
+      .filter(
+        (registryPattern) =>
+          !admissionPatterns.some((admissionPattern) =>
+            admissionPatternSubsumes(admissionPattern, registryPattern),
+          ),
+      )
+      .map((pattern) => ({ pattern, stackId: stack.id })),
+  );
+}
+
+function assertBroadAdmissionPatterns(patterns) {
+  assert(Array.isArray(patterns), "workflowAdmissionPatterns must be an array");
+  assert(patterns.length > 0, "workflowAdmissionPatterns must not be empty");
+  assert.equal(
+    new Set(patterns).size,
+    patterns.length,
+    "workflowAdmissionPatterns must not contain duplicates",
+  );
+  for (const pattern of patterns) {
+    const parsed = parseSimplePathPattern(pattern);
+    const isRootFile = !parsed.recursive && !parsed.base.includes("/");
+    const isTopLevelBoundary = parsed.recursive && !parsed.base.includes("/");
+    assert(
+      isRootFile ||
+        isTopLevelBoundary ||
+        NESTED_ADMISSION_EXCEPTIONS.has(pattern),
+      `workflow admission must use a top-level boundary, documented nested exception, or root file: ${pattern}`,
+    );
+  }
+}
 
 function qualityGatePlan(changedPath) {
   writeFileSync(changedPathsFile, `${changedPath}\n`);
@@ -85,9 +148,91 @@ function assertRoutesAgentGateSelfTest(changedPath) {
 }
 
 try {
+  assertBroadAdmissionPatterns(terraformWorkflowAdmissionPatterns);
+  assert.deepEqual(
+    uncoveredRegistryPatterns(
+      terraformRegistry.stacks,
+      terraformWorkflowAdmissionPatterns,
+    ),
+    [],
+    "every stack changedPathPatterns entry must fit the workflow admission boundary",
+  );
+  assert.equal(
+    admissionPatternSubsumes("scripts/**", "scripts/tf-stacks.mjs"),
+    true,
+    "recursive workflow admission must cover a nested literal",
+  );
+  assert.equal(
+    admissionPatternSubsumes("alerts/**", "alerts/rules/**"),
+    true,
+    "recursive workflow admission must cover a nested recursive pattern",
+  );
+  assert.equal(
+    admissionPatternSubsumes("alerts/rules/**", "alerts/**"),
+    false,
+    "a narrow recursive admission must not cover its parent pattern",
+  );
+  assert.throws(
+    () => assertBroadAdmissionPatterns(["metrics-bridge/peg-registry.json"]),
+    /top-level boundary/u,
+    "workflow admission must reject nested one-file enumeration",
+  );
+  assert.throws(
+    () => assertBroadAdmissionPatterns(["alerts/rules/**"]),
+    /top-level boundary/u,
+    "workflow admission must reject nested stack-specific recursion",
+  );
+  assert.doesNotThrow(
+    () => assertBroadAdmissionPatterns([".github/workflows/**"]),
+    "workflow admission must allow the documented workflow-directory exception",
+  );
+  assert.deepEqual(
+    uncoveredRegistryPatterns(
+      terraformRegistry.stacks,
+      terraformWorkflowAdmissionPatterns.filter(
+        (pattern) => pattern !== "metrics-bridge/**",
+      ),
+    ),
+    [
+      {
+        pattern: "metrics-bridge/peg-registry.json",
+        stackId: "peg-policy-publication",
+      },
+    ],
+    "removing a workflow boundary must expose the registry path it strands",
+  );
+  assert.deepEqual(
+    uncoveredRegistryPatterns(
+      [
+        {
+          id: "future-stack",
+          changedPathPatterns: ["future-root/input.json"],
+        },
+      ],
+      terraformWorkflowAdmissionPatterns,
+    ),
+    [{ pattern: "future-root/input.json", stackId: "future-stack" }],
+    "a future registry root must fail until workflow admission covers it",
+  );
+
   const ciWorkflow = loadYaml(
     readFileSync(path.join(repositoryRoot, ".github/workflows/ci.yml"), "utf8"),
   );
+  const ciTriggers = ciWorkflow.on ?? ciWorkflow[true];
+  for (const eventName of ["pull_request", "push"]) {
+    const trigger = ciTriggers[eventName];
+    assert(trigger, `ci.yml must define the ${eventName} trigger`);
+    assert.equal(
+      trigger.paths,
+      undefined,
+      `required ci.yml ${eventName} trigger must not use paths`,
+    );
+    assert.equal(
+      trigger["paths-ignore"],
+      undefined,
+      `required ci.yml ${eventName} trigger must not use paths-ignore`,
+    );
+  }
   const filterStep = ciWorkflow.jobs.changes.steps.find(
     (step) => step.id === "filter",
   );
@@ -117,10 +262,8 @@ try {
     "ci.yml scripts job must run when rootScripts changes",
   );
 
-  // The three enumerated terraform paths-filters decide whether the terraform
-  // jobs run at all. `scripts/production-infra-identity-contract/**` covers the
-  // contract, but not the shared cores it imports, so each core needs its own
-  // entry in every filter.
+  // These three coarse filters decide whether registry classification runs.
+  // The registry owns the boundary, and every stack-specific path must fit it.
   const infraWorkflow = loadYaml(
     readFileSync(
       path.join(repositoryRoot, ".github/workflows/infra.yml"),
@@ -134,18 +277,84 @@ try {
     ["infra.yml pull_request paths", infraTriggers.pull_request.paths],
   ];
   for (const [label, patterns] of terraformFilters) {
-    assert(Array.isArray(patterns), `${label} must be a path list`);
-    assert(
-      patterns.includes("scripts/production-infra-identity-contract/**"),
-      `${label} must cover the identity contract directory`,
+    assert.deepEqual(
+      patterns,
+      terraformWorkflowAdmissionPatterns,
+      `${label} must equal terraform.stacks.json workflowAdmissionPatterns`,
     );
-    for (const sharedCore of SHARED_PARSING_CORES) {
-      assert(
-        patterns.includes(sharedCore),
-        `${label} must include ${sharedCore}`,
-      );
-    }
+    assert.deepEqual(
+      uncoveredRegistryPatterns(terraformRegistry.stacks, patterns),
+      [],
+      `${label} must admit every stack changedPathPatterns entry`,
+    );
   }
+  assert.equal(
+    ciWorkflow.jobs.changes.outputs.terraform,
+    "${{ steps.filter.outputs.terraform }}",
+    "ci.yml changes job must publish the Terraform admission result",
+  );
+  const terraformJob = ciWorkflow.jobs.terraform;
+  assert(terraformJob, "ci.yml must define the Terraform validation job");
+  assert.equal(
+    terraformJob.needs,
+    "changes",
+    "ci.yml Terraform validation must depend on change detection",
+  );
+  assert.equal(
+    terraformJob.if,
+    "needs.changes.outputs.terraform == 'true'",
+    "ci.yml Terraform validation must use the registry-backed admission result",
+  );
+  const ciValidateChangedStacks = terraformJob.steps.find(
+    (step) => step.name === "Validate changed stacks",
+  );
+  assert(
+    ciValidateChangedStacks,
+    "ci.yml Terraform validation must classify and validate changed stacks",
+  );
+  assert.match(
+    String(ciValidateChangedStacks.run),
+    /scripts\/tf-stacks\.mjs changed/u,
+    "ci.yml Terraform validation must classify stacks through the registry",
+  );
+  assert.match(
+    String(ciValidateChangedStacks.run),
+    /scripts\/tf-stacks\.mjs validate/u,
+    "ci.yml Terraform validation must validate each classified stack",
+  );
+
+  const infraDiscover = infraWorkflow.jobs.discover;
+  assert(infraDiscover, "infra.yml must define the stack discovery job");
+  const infraBuildMatrix = infraDiscover.steps.find(
+    (step) => step.name === "Build changed-stack matrix",
+  );
+  assert(
+    infraBuildMatrix,
+    "infra.yml discovery must build the changed-stack matrix",
+  );
+  assert.match(
+    String(infraBuildMatrix.run),
+    /scripts\/tf-stacks\.mjs changed/u,
+    "infra.yml discovery must classify stacks through the registry",
+  );
+  const infraValidate = infraWorkflow.jobs.validate;
+  assert(infraValidate, "infra.yml must define the stack validation job");
+  assert.equal(
+    infraValidate.needs,
+    "discover",
+    "infra.yml validation must depend on stack discovery",
+  );
+  assert.equal(
+    infraValidate.if,
+    "needs.discover.outputs.has-stacks == 'true'",
+    "infra.yml validation must run for a non-empty registry matrix",
+  );
+  assert(
+    infraValidate.steps.some((step) =>
+      String(step.run).includes("scripts/tf-stacks.mjs validate"),
+    ),
+    "infra.yml validation must validate each classified stack",
+  );
   const productionInfraContract = ciWorkflow.jobs["production-infra-contract"];
   assert(
     productionInfraContract,
@@ -185,6 +394,10 @@ try {
   assert(
     ciWorkflow.jobs.ci.needs.includes("production-infra-contract"),
     "ci sentinel must require production-infra-contract",
+  );
+  assert(
+    ciWorkflow.jobs.ci.needs.includes("terraform"),
+    "ci sentinel must include the Terraform validation job",
   );
   const allGreenStep = ciWorkflow.jobs.ci.steps.find((step) =>
     step.uses?.startsWith("re-actors/alls-green@"),

--- a/scripts/production-infra-identity-contract/routing.test.mjs
+++ b/scripts/production-infra-identity-contract/routing.test.mjs
@@ -80,6 +80,11 @@ function assertBroadAdmissionPatterns(patterns) {
     "workflowAdmissionPatterns must not contain duplicates",
   );
   for (const pattern of patterns) {
+    assert.notEqual(
+      pattern,
+      ".github/**",
+      "workflow admission must not admit all .github metadata",
+    );
     const parsed = parseSimplePathPattern(pattern);
     const isRootFile = !parsed.recursive && !parsed.base.includes("/");
     const isTopLevelBoundary = parsed.recursive && !parsed.base.includes("/");
@@ -181,6 +186,11 @@ try {
     () => assertBroadAdmissionPatterns(["alerts/rules/**"]),
     /top-level boundary/u,
     "workflow admission must reject nested stack-specific recursion",
+  );
+  assert.throws(
+    () => assertBroadAdmissionPatterns([".github/**"]),
+    /must not admit all \.github metadata/u,
+    "workflow admission must reject unrelated GitHub metadata",
   );
   assert.doesNotThrow(
     () => assertBroadAdmissionPatterns([".github/workflows/**"]),

--- a/terraform.stacks.json
+++ b/terraform.stacks.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": 1,
+  "workflowAdmissionPatterns": [
+    "terraform/**",
+    "alerts/**",
+    "aegis/**",
+    "governance-watchdog/**",
+    "metrics-bridge/**",
+    "scripts/**",
+    ".github/workflows/**",
+    "terraform.stacks.json"
+  ],
   "stacks": [
     {
       "id": "platform",


### PR DESCRIPTION
## The Problem

- Terraform stack inputs were copied into three workflow filters by hand.
- A new registry path could miss one filter and silently skip stack discovery while the required CI sentinel stayed green.

## The Solution

- Give the stack registry one coarse workflow-admission boundary and enforce exact parity and coverage for all three workflow copies.

## Details

- Add eight stable `workflowAdmissionPatterns` entries to `terraform.stacks.json`.
- Keep all six stacks and all 62 stack-specific `changedPathPatterns` unchanged.
- Keep the required CI workflow unfiltered at workflow level. Apply the boundary only to its internal Terraform filter.
- Keep exact stack classification in `scripts/tf-stacks.mjs` after CI or Infra starts.
- Reject nested stack-specific admission patterns such as `alerts/rules/**`; allow only the documented `.github/workflows/**` nested boundary.
- Broad roots can start CI or Infra discovery for unrelated files in those roots. Exact classification prevents unrelated stack validation.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed, including six Terraform init/validate pairs, the routing self-test, every affected package quality and coverage gate, workflow trust checks, and documentation checks.
- `CI=true pnpm tf:test` — all Terraform registry and workflow contracts passed.
- Fresh-context Codex autoreview — clean; the sealed bundle digest matched before and after review.
- `/Users/chapati/.agents/skills/autoreview/scripts/autoreview --engine local --mode local --base origin/main` — clean.
- Claude Security scan — unavailable in this Codex environment. Workflow trust checks and the fresh semantic review passed.
- No Terraform plan or apply ran because this PR changes routing contracts, not Terraform resources.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0028 and ADR 0064 now record the enforced boundary.

Closes #1501

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d26db1bf983736518a817aa50ffac7eda3b6e864. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized workflow admission patterns for Terraform and related infrastructure changes.
  * Added validation to ensure workflow filters cover all registered Terraform stacks and remain consistent across CI workflows.

* **Documentation**
  * Updated Terraform architecture, workflow, and checklist documentation to reflect broad path admission and exact stack classification.
  * Refreshed verification dates and implementation guidance across related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->