### PR TITLE
fix(agent): require positive clean evidence in Claude prose reviews

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -121,17 +121,37 @@ terminal state so late feedback is not missed.
 
 `pr:feedback-state` keeps older exceptions in an exact compatibility registry.
 Each entry binds the raw body digest to its Claude author, PR, comment, and head.
-Reviews from the observed PR #1848 shape onward use a small prose-pattern
-library. The library requires one unhedged `Verdict: LGTM` or `Overall verdict:
-LGTM` line and an explicit no-findings or no-action conclusion. P0-P2 findings,
-P3 lines without a known no-action disposition, direct action requests,
-ambiguous verdicts, and unsupported markup stay blocking. Current-head and
-unresolved-feedback checks remain separate and mandatory.
+Newer reviews go through a small prose-pattern library instead.
+
+The library clears a review only when **every line is positively recognized**.
+A line is recognized when it is blank, the Claude task-completion header, a
+thematic break, a review heading that harvest already validated, the single
+unhedged `Verdict: LGTM` or `Overall verdict: LGTM` line, a bare `Findings` or
+`Roll-up` section label, an explicit no-findings conclusion, or a P3 line whose
+every clause matches the curated `POSITIVE_EVIDENCE` allowlist. Anything else
+blocks, including ordinary narrative prose that carries no finding vocabulary.
+
+Two consequences are deliberate and easy to trip over:
+
+- **A clean review written as free prose blocks.** The observed PR #1848 body
+  is the reference case and is pinned blocking by test. It reads clean to a
+  human, but its narrative paragraphs assert nothing the gate can verify — and
+  one of them in fact asks the reader to confirm CI before merge.
+- **A no-action marker alone is not a disposition.** `No action`, `None
+blocking`, and similar leads must be followed by curated positive evidence.
+  The older behaviour, where such a marker cleared a line on its own, let a
+  defect ride along behind it.
+
+A clean verdict or conclusion may end only in a bare sentence terminator. Any
+trailing sentence blocks, because a tail is unconstrained English and no term
+list separates praise from a defect stated plainly.
 
 The registry and named phrase groups live in
 `scripts/pr-feedback-state-claude.mjs`. Add a phrase only with a real review
 fixture and nearby blocking mutations. The library does not try to prove the
-meaning of arbitrary English prose.
+meaning of arbitrary English prose — it refuses prose it cannot recognize, and
+the compatibility registry is the escape hatch for a specific historical body.
+Current-head and unresolved-feedback checks remain separate and mandatory.
 
 ## Expected CLI contract
 

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -21,10 +21,21 @@ const REVIEW_NUMBER_HEADING_SHAPE = String.raw`^#{1,6}\s+Code Review\s+—\s+PR\
 const REVIEW_TITLE_HEADING_SHAPE = String.raw`^#{1,6}\s+Review:\s+(.{1,200})$`;
 const REVIEW_NUMBER_HEADING = new RegExp(REVIEW_NUMBER_HEADING_SHAPE, "gm");
 const REVIEW_TITLE_HEADING = new RegExp(REVIEW_TITLE_HEADING_SHAPE, "gim");
-const REVIEW_HEADING_LINE = new RegExp(
-  `(?:${REVIEW_NUMBER_HEADING_SHAPE})|(?:${REVIEW_TITLE_HEADING_SHAPE})`,
-  "i",
-);
+// Per-shape single-line forms, each carrying the SAME flags as its harvest
+// counterpart minus `g`/`m`: the number heading stays case-sensitive like its
+// `gm` harvest, the title heading keeps `i` like its `gim` harvest. They are
+// tested against the RAW line, never a trimmed one.
+//
+// Both properties are load-bearing. The line scan treats a review heading as
+// already-validated because harvest checked its PR number and title, so the
+// two must agree on exactly which lines are headings. A single combined
+// case-insensitive pattern applied to a trimmed line disagreed twice: a
+// `   ### Review: <defect>` indented 1-3 spaces is invisible to harvest (whose
+// shape anchors `^#`) yet matched here, and a mis-cased `### code review — PR
+// #9999` is likewise unharvested but matched. Either one skipped the title and
+// PR-number checks entirely and allowlisted a defect on a fail-closed gate.
+const REVIEW_NUMBER_HEADING_LINE = new RegExp(REVIEW_NUMBER_HEADING_SHAPE);
+const REVIEW_TITLE_HEADING_LINE = new RegExp(REVIEW_TITLE_HEADING_SHAPE, "i");
 // `### Review: <PR title>` is the usual heading, but a clean review may instead
 // put the verdict there (`### Review: LGTM ✅`). Only the bare verdict word and
 // an optional approval mark are allowed — never free text, which would let a
@@ -294,11 +305,18 @@ function hasExplicitAction(line) {
 // same reason — the caller proved there is exactly one and that it declares a
 // clean verdict with no tail.
 function isRecognizedCleanReviewLine(line) {
-  const raw = String(line ?? "").trim();
+  const source = String(line ?? "");
+  const raw = source.trim();
   if (!raw) return true;
   if (isClaudeTaskCompletionLine(raw)) return true;
   if (THEMATIC_BREAK.test(raw)) return true;
-  if (REVIEW_HEADING_LINE.test(raw)) return true;
+  // Headings are matched on the UNTRIMMED line so this scan recognizes exactly
+  // the set harvest validated — see the note on REVIEW_NUMBER_HEADING_LINE.
+  if (
+    REVIEW_NUMBER_HEADING_LINE.test(source) ||
+    REVIEW_TITLE_HEADING_LINE.test(source)
+  )
+    return true;
   if (verdictDeclaration(raw)) return true;
   if (CLEAN_SECTION_LABEL.test(reviewLineContent(raw))) return true;
   const priority = priorityAtLineStart(raw);

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -12,8 +12,19 @@ const CLAUDE_VERDICT_NAMESPACE = /^(?:\*\*)?(?:Overall\s+)?Verdict\s*:/i;
 const CLAUDE_CLEAN_VERDICT =
   /^(?:\*\*)?(?:Overall\s+)?Verdict:(?:\*\*)?\s*(?:\*\*)?LGTM(?:\*\*)?\s*(?<tail>[\s\S]*)$/i;
 const PROSE_PATTERN_LIBRARY_START = Date.parse("2026-08-13T23:08:10Z");
-const REVIEW_NUMBER_HEADING = /^#{1,6}\s+Code Review\s+—\s+PR\s+#(\d+)$/gm;
-const REVIEW_TITLE_HEADING = /^#{1,6}\s+Review:\s+(.{1,200})$/gim;
+// One source per heading shape, compiled twice: a global form that harvests
+// every occurrence from the body, and a single-line form the per-line scan
+// uses. Re-spelling either shape would let the harvest and the scan disagree
+// about what a review heading is, which is how a heading would slip past
+// validation and still be treated as recognized.
+const REVIEW_NUMBER_HEADING_SHAPE = String.raw`^#{1,6}\s+Code Review\s+—\s+PR\s+#(\d+)$`;
+const REVIEW_TITLE_HEADING_SHAPE = String.raw`^#{1,6}\s+Review:\s+(.{1,200})$`;
+const REVIEW_NUMBER_HEADING = new RegExp(REVIEW_NUMBER_HEADING_SHAPE, "gm");
+const REVIEW_TITLE_HEADING = new RegExp(REVIEW_TITLE_HEADING_SHAPE, "gim");
+const REVIEW_HEADING_LINE = new RegExp(
+  `(?:${REVIEW_NUMBER_HEADING_SHAPE})|(?:${REVIEW_TITLE_HEADING_SHAPE})`,
+  "i",
+);
 // `### Review: <PR title>` is the usual heading, but a clean review may instead
 // put the verdict there (`### Review: LGTM ✅`). Only the bare verdict word and
 // an optional approval mark are allowed — never free text, which would let a
@@ -54,14 +65,34 @@ const REVIEW_LINE_PREFIX_DEPTH = 3;
 // An empty (`[ ]`) or negated (`[-]`) task box, once the prefixes before it are
 // gone. `[x]`/`[X]` is a completed check and stays eligible.
 const UNCHECKED_TASK_BOX = /^\[[ -]\]\s/;
-const CLEAN_P3_DISPOSITION_PATTERNS = [
-  /\bno[- ]action(?:\s+requested)?\b/i,
-  /\bnone\s+blocking\b/i,
-  /\bnot\s+(?:a\s+)?blocker\b/i,
-  /\bisn['’]t\s+(?:a\s+)?blocker\b/i,
-  /\bnot\s+worth\s+(?:a\s+)?fix\b/i,
-  /\bnot\s+an?\s+(?:error|issue)\b/i,
-];
+// A horizontal rule carries no assertion, so it is recognized clean evidence.
+const THEMATIC_BREAK = /^(?:-{3,}|\*{3,}|_{3,})$/;
+// Section labels a clean review uses to introduce its findings or roll-up.
+// They name a section and assert nothing, so they are recognized clean
+// evidence. Emphasis may wrap the label, and the colon is optional. Anything
+// else after the label makes the line free prose, which is not recognized.
+const CLEAN_SECTION_LABEL =
+  /^(?:\*\*)?(?:Numbered\s+findings?\s+roll[- ]?up|Findings|Roll[- ]?up)\s*:?(?:\*\*)?$/i;
+// The priority marker a finding line opens with, stripped before the rest of
+// the line is judged. Shared by the action scan and the P3 evidence check so
+// the two cannot disagree about where a finding's text begins.
+const PRIORITY_MARKER_PREFIX =
+  /^(?:\*\*)?\[?[Pp][0-3]\]?(?:\*\*)?(?:\s*[^A-Za-z0-9\s]\s*|\s+)/;
+// The clean-evidence grammar, shared with `isExplicitlyCleanClaudeReview` in
+// pr-feedback-state-core.mjs. It lives here because both Claude-review paths
+// read it and a second copy drifted from the first within one PR.
+//
+// A finding line may state the absence of an action, but only when every
+// clause that follows is a curated positive observation. `POSITIVE_EVIDENCE`
+// is an exact-match allowlist: each entry is one reviewed phrase, never an
+// open-ended shape, because anything looser lets a defect ride along behind a
+// no-action marker.
+const CLEAN_FINDING_MARKER =
+  /^(?:None\s+blocking|No[- ]action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
+const UNSAFE_EVIDENCE_QUALIFIER =
+  /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could|appears?|seems?|probably|likely|possibly|perhaps|unclear|unknown)\b/i;
+const POSITIVE_EVIDENCE =
+  /^(?:clean(?:,\s+well\s+scoped)?(?:\s+fix)?|well\s+scoped(?:\s+fix)?|correct|covered|bounded|mechanical|verified|complete|exact\s+removal\s+condition|(?:no|zero|0)\s+(?:errors?|fails?|failed|failures?)(?:\s+(?:and|or)\s+(?:errors?|fails?|failed|failures?))?(?:\s+(?:are|was|were)\s+(?:found|observed|reported))?|no\s+unrelated\s+version\s+bumps?|no\s+vulnerable\s+sharp@0\.34\.5\s+remains?\s+anywhere\s+in\s+(?:the\s+)?repo(?:'s)?\s+lockfiles|parser\s+should\s+continue\s+rejecting\s+malformed\s+input|fallback\s+should\s+stay|fix\s+is\s+correct|override\s+selector\s+is\s+correctly\s+bounded|lockfile\s+churn\s+beyond\s+sharp\s+itself\s+is\s+confirmed\s+mechanical,\s+not\s+scope\s+creep|(?:the\s+)?bounded\s+selector\s+matches\s+the\s+repo(?:'s)?\s+established\s+override\s+pattern|matches\s+repo\s+convention|(?:the\s+)?inline\s+comment\s+documents\s+the\s+advisory|removal\s+condition\s+comment\s+satisfies\s+the\s+temporary\s+override\s+documentation\s+expectation|tests\s+cover\s+the\s+changed\s+paths)$/i;
 const EXPLICIT_ACTION_LINE =
   /^(?:\*\*)?(?:Action\s+(?:items?|required)|Changes\s+requested|Needs\s+changes|A\s+fix\s+is\s+required|.{1,160}\s+must\s+be\s+(?:addressed|changed|fixed|implemented|removed|restored|updated|validated)|(?:Please\s+)?(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate)|(?:Must|Should|Needs?\s+to)\s+(?:add|address|change|ensure|fix|implement|prevent|remove|restore|update|validate))\b/i;
 const INLINE_DIRECT_ACTION =
@@ -205,18 +236,77 @@ function priorityAtLineStart(line) {
   )?.[1];
 }
 
-function hasCleanP3Disposition(line) {
-  return CLEAN_P3_DISPOSITION_PATTERNS.some((pattern) => pattern.test(line));
+// A finding line's text with its list/heading prefixes and priority marker
+// removed, so the evidence check judges the claim rather than the numbering.
+function priorityLineContent(line) {
+  return reviewLineContent(line).replace(PRIORITY_MARKER_PREFIX, "");
+}
+
+// True when a no-action marker is followed only by curated positive
+// observations. Every clause after the marker must clear the hedge filter and
+// match POSITIVE_EVIDENCE exactly, so a defect appended to a no-action lead-in
+// is never read as clean.
+export function hasPositiveCleanEvidence(value) {
+  const tail = String(value ?? "")
+    .trim()
+    .match(CLEAN_FINDING_MARKER)?.[1];
+  if (tail === undefined) return false;
+  const evidenceClauses = tail
+    .split(/(?:[!?;]+|\.(?=\s|$)|\b(?:and|but|however|although|yet)\b)/i)
+    .map((clause) => clause.trim())
+    .filter(Boolean);
+  return (
+    evidenceClauses.length > 0 &&
+    evidenceClauses.every((evidence) => {
+      const withoutSafeNegation = evidence.replace(
+        /,\s+not\s+scope\s+creep$/i,
+        "",
+      );
+      return (
+        !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
+        POSITIVE_EVIDENCE.test(evidence)
+      );
+    })
+  );
 }
 
 function hasExplicitAction(line) {
-  const content = reviewLineContent(line).replace(
-    /^(?:\*\*)?\[?[Pp][0-3]\]?(?:\*\*)?(?:\s*[^A-Za-z0-9\s]\s*|\s+)/,
-    "",
-  );
+  const content = priorityLineContent(line);
   return (
     EXPLICIT_ACTION_LINE.test(content) || INLINE_DIRECT_ACTION.test(content)
   );
+}
+
+// The allowlist half of the prose classifier: a line stays eligible only when
+// it is one of the shapes a clean review is made of. Everything else — any
+// free sentence — makes the review actionable.
+//
+// This inverts the rule the scan used to apply. Rejecting lines that carry
+// finding vocabulary cannot bound natural language: `Anonymous callers can
+// delete every stored record.` names no priority, no severity, and no action
+// verb, so it read as clean on a fail-closed merge gate and the finding was
+// dropped before merge (issue 1966). The same reasoning #1960 applied to
+// verdict and roll-up tails applies to every other line in the body.
+//
+// Headings are recognized because the caller already validated them: the
+// review-number heading must name this PR and the review-title heading must
+// carry this PR's title or a bare LGTM. The verdict line is recognized for the
+// same reason — the caller proved there is exactly one and that it declares a
+// clean verdict with no tail.
+function isRecognizedCleanReviewLine(line) {
+  const raw = String(line ?? "").trim();
+  if (!raw) return true;
+  if (isClaudeTaskCompletionLine(raw)) return true;
+  if (THEMATIC_BREAK.test(raw)) return true;
+  if (REVIEW_HEADING_LINE.test(raw)) return true;
+  if (verdictDeclaration(raw)) return true;
+  if (CLEAN_SECTION_LABEL.test(reviewLineContent(raw))) return true;
+  const priority = priorityAtLineStart(raw);
+  if (priority !== undefined)
+    return (
+      priority === "3" && hasPositiveCleanEvidence(priorityLineContent(raw))
+    );
+  return false;
 }
 
 export function hasControlCharacter(value) {
@@ -324,13 +414,12 @@ export function classifyClaudeReviewProse(comment, pr) {
 
   for (const line of lines) {
     if (isCleanConclusion(line)) continue;
-    const priority = priorityAtLineStart(line);
-    if (
-      priority !== undefined &&
-      (priority !== "3" || !hasCleanP3Disposition(line))
-    )
-      return true;
+    // The explicit-action and severity rules stay in front of the allowlist.
+    // They no longer carry the classification on their own, but they still
+    // guard the recognized shapes themselves — a review-title heading repeats
+    // the PR title, and a title can name a required change.
     if (hasExplicitAction(line) || EXPLICIT_SEVERITY.test(line)) return true;
+    if (!isRecognizedCleanReviewLine(line)) return true;
   }
 
   return false;

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -266,27 +266,42 @@ function priorityLineContent(line) {
 // observations. Every clause after the marker must clear the hedge filter and
 // match POSITIVE_EVIDENCE exactly, so a defect appended to a no-action lead-in
 // is never read as clean.
+// One clause (or a whole tail) counts as clean evidence when it carries no
+// hedge and matches the curated allowlist exactly. Shared by both the
+// full-tail attempt and the per-clause fallback so the two cannot diverge.
+function isCuratedEvidenceClause(evidence) {
+  const withoutSafeNegation = evidence.replace(/,\s+not\s+scope\s+creep$/i, "");
+  return (
+    !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
+    POSITIVE_EVIDENCE.test(evidence)
+  );
+}
+
 export function hasPositiveCleanEvidence(value) {
   const tail = String(value ?? "")
     .trim()
     .match(CLEAN_FINDING_MARKER)?.[1];
   if (tail === undefined) return false;
+  // Try the WHOLE tail against the allowlist before splitting it. Several
+  // curated entries span a conjunction — `no errors and failures were found` is
+  // one exact `POSITIVE_EVIDENCE` phrase — and splitting on `and` first tore it
+  // into `no errors` plus `failures were found`, whose second half is not an
+  // entry, so a curated phrase failed its own allowlist.
+  //
+  // This cannot smuggle anything: `POSITIVE_EVIDENCE` is anchored `^...$`, so a
+  // full-tail match means the entire tail is one reviewed phrase. Splitting
+  // stays as the fallback for genuinely multi-clause evidence.
+  // Strip a trailing sentence terminator first: `POSITIVE_EVIDENCE` is anchored
+  // `^...$` and its entries carry no punctuation, so `...were found.` would
+  // miss. The per-clause path never saw this because its split consumes the
+  // terminator.
+  if (isCuratedEvidenceClause(tail.replace(/[.!?;]+$/, "").trim())) return true;
   const evidenceClauses = tail
     .split(/(?:[!?;]+|\.(?=\s|$)|\b(?:and|but|however|although|yet)\b)/i)
     .map((clause) => clause.trim())
     .filter(Boolean);
   return (
-    evidenceClauses.length > 0 &&
-    evidenceClauses.every((evidence) => {
-      const withoutSafeNegation = evidence.replace(
-        /,\s+not\s+scope\s+creep$/i,
-        "",
-      );
-      return (
-        !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
-        POSITIVE_EVIDENCE.test(evidence)
-      );
-    })
+    evidenceClauses.length > 0 && evidenceClauses.every(isCuratedEvidenceClause)
   );
 }
 

--- a/scripts/pr-feedback-state-claude.mjs
+++ b/scripts/pr-feedback-state-claude.mjs
@@ -98,8 +98,17 @@ const PRIORITY_MARKER_PREFIX =
 // is an exact-match allowlist: each entry is one reviewed phrase, never an
 // open-ended shape, because anything looser lets a defect ride along behind a
 // no-action marker.
+// `No action required` is deliberately NOT here, though it reads like a
+// sibling of `No action`. The body-level fallback scan in
+// `isActionableReviewBotComment` matches `\bAction\s+required\b` through
+// REVIEW_CONTRADICTION, so a line carrying it blocks anyway. Advertising it as
+// accepted here made the two layers disagree: the grammar called the line
+// clean and the gate still blocked it. Narrowing the marker keeps the
+// advertised set honest. The alternative — exempting recognized P3 lines from
+// the fallback scan — would weaken a fail-closed check to fix a false positive,
+// which is the wrong direction on this gate.
 const CLEAN_FINDING_MARKER =
-  /^(?:None\s+blocking|No[- ]action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
+  /^(?:None\s+blocking|No[- ]action|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
 const UNSAFE_EVIDENCE_QUALIFIER =
   /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could|appears?|seems?|probably|likely|possibly|perhaps|unclear|unknown)\b/i;
 const POSITIVE_EVIDENCE =
@@ -308,6 +317,13 @@ function isRecognizedCleanReviewLine(line) {
   const source = String(line ?? "");
   const raw = source.trim();
   if (!raw) return true;
+  // An unticked box means the reviewer never completed the assertion, whatever
+  // the assertion is. This guards EVERY recognized shape rather than repeating
+  // the check per shape: `priorityAtLineStart` and `priorityLineContent` peel
+  // the box exactly as the verdict and conclusion paths do, so without this a
+  // `- [ ] [P3] Good hygiene: tests cover the changed paths.` cleared on
+  // evidence its author had not confirmed.
+  if (hasUncheckedTaskBox(source)) return false;
   if (isClaudeTaskCompletionLine(raw)) return true;
   if (THEMATIC_BREAK.test(raw)) return true;
   // Headings are matched on the UNTRIMMED line so this scan recognizes exactly

--- a/scripts/pr-feedback-state-core.mjs
+++ b/scripts/pr-feedback-state-core.mjs
@@ -5,12 +5,9 @@ const FINDING_EXCERPT_LENGTH = 240;
 const FAILURE_TERM = /\b(?:error|errors|fail|fails|failed|failure|failures)\b/i;
 const NEGATED_FAILURE =
   /\b(?:no|zero|0)[ \t]+(?:errors?|fails?|failed|failures?)(?:[ \t]+(?:and|or)[ \t]+(?:errors?|fails?|failed|failures?))?(?:[ \t]+(?:are|was|were)[ \t]+(?:found|observed|reported))?(?=[ \t]*(?:[.,;:]|$))/gi;
-const CLEAN_FINDING_MARKER =
-  /^(?:None\s+blocking|No[- ]action(?:\s+required)?|Good\s+hygiene|Lockfile\s+diff\s+is\s+fully\s+mechanical)\b[\s:—.,]*(.*)$/i;
-const UNSAFE_EVIDENCE_QUALIFIER =
-  /\b(?:not|never|cannot|can't|doesn't|does\s+not|fails?\s+to|may|might|could|appears?|seems?|probably|likely|possibly|perhaps|unclear|unknown)\b/i;
-const POSITIVE_EVIDENCE =
-  /^(?:clean(?:,\s+well\s+scoped)?(?:\s+fix)?|well\s+scoped(?:\s+fix)?|correct|covered|bounded|mechanical|verified|complete|exact\s+removal\s+condition|(?:no|zero|0)\s+(?:errors?|fails?|failed|failures?)(?:\s+(?:and|or)\s+(?:errors?|fails?|failed|failures?))?(?:\s+(?:are|was|were)\s+(?:found|observed|reported))?|no\s+unrelated\s+version\s+bumps?|no\s+vulnerable\s+sharp@0\.34\.5\s+remains?\s+anywhere\s+in\s+(?:the\s+)?repo(?:'s)?\s+lockfiles|parser\s+should\s+continue\s+rejecting\s+malformed\s+input|fallback\s+should\s+stay|fix\s+is\s+correct|override\s+selector\s+is\s+correctly\s+bounded|lockfile\s+churn\s+beyond\s+sharp\s+itself\s+is\s+confirmed\s+mechanical,\s+not\s+scope\s+creep|(?:the\s+)?bounded\s+selector\s+matches\s+the\s+repo(?:'s)?\s+established\s+override\s+pattern|matches\s+repo\s+convention|(?:the\s+)?inline\s+comment\s+documents\s+the\s+advisory|removal\s+condition\s+comment\s+satisfies\s+the\s+temporary\s+override\s+documentation\s+expectation|tests\s+cover\s+the\s+changed\s+paths)$/i;
+// The clean-evidence grammar (CLEAN_FINDING_MARKER, POSITIVE_EVIDENCE, and the
+// hedge filter) now lives in pr-feedback-state-claude.mjs, which both this path
+// and the prose classifier read. One definition, never two.
 const CLAUDE_REVIEW_TITLE_LINE = /^#{1,6}\s+Review:\s+(.{1,200})$/i;
 const CLAUDE_VERDICT_LINE = /^(?:\*\*)?Verdict:\s*LGTM(?:\*\*)?$/i;
 const CLAUDE_CHECKLIST_HEADING = /^#{1,6}\s+What\s+I\s+checked$/i;
@@ -213,41 +210,18 @@ function isSafeClaudePreamble(lines, pr) {
   }
   return checklistEntries > 0;
 }
-function hasPositiveCleanEvidence(value) {
-  const tail = String(value ?? "")
-    .trim()
-    .match(CLEAN_FINDING_MARKER)?.[1];
-  if (tail === undefined) return false;
-  const evidenceClauses = tail
-    .split(/(?:[!?;]+|\.(?=\s|$)|\b(?:and|but|however|although|yet)\b)/i)
-    .map((clause) => clause.trim())
-    .filter(Boolean);
-  return (
-    evidenceClauses.length > 0 &&
-    evidenceClauses.every((evidence) => {
-      const withoutSafeNegation = evidence.replace(
-        /,\s+not\s+scope\s+creep$/i,
-        "",
-      );
-      return (
-        !UNSAFE_EVIDENCE_QUALIFIER.test(withoutSafeNegation) &&
-        POSITIVE_EVIDENCE.test(evidence)
-      );
-    })
-  );
-}
 function isCleanFindingLine(line) {
   const raw = String(line ?? "").trim();
   if (LEGACY_SAFE_CLAUDE_FINDING_LINES.has(raw)) return true;
   const p3 = raw.match(/^\d+[.)]\s+\[[Pp]3\]\s+(.+)$/);
-  if (p3) return hasPositiveCleanEvidence(p3[1]);
+  if (p3) return claudeReview.hasPositiveCleanEvidence(p3[1]);
   return false;
 }
 function isCleanRollupLine(line) {
   const raw = String(line ?? "").trim();
   if (LEGACY_SAFE_CLAUDE_ROLLUP_LINES.has(raw)) return true;
   const entry = raw.match(CLEAN_ROLLUP_ENTRY)?.[1];
-  return entry !== undefined && hasPositiveCleanEvidence(entry);
+  return entry !== undefined && claudeReview.hasPositiveCleanEvidence(entry);
 }
 function isExplicitlyCleanClaudeReview(comment, pr) {
   const author = String(comment.author ?? "").toLowerCase();

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1452,7 +1452,17 @@ test("accepts only the exact frozen PR #1837 no-action Claude LGTM", () => {
   }
 });
 
-test("accepts the observed PR #1848 Overall-verdict clean review", () => {
+// A human reads the observed PR #1848 review as clean: its verdict is LGTM and
+// its roll-up denies findings. It cleared until issue 1966, but only because
+// none of its five narrative paragraphs happened to use finding vocabulary —
+// nothing established that they were clean. That is the same fail-open #1960
+// closed for verdict and roll-up tails, and a paragraph is the same
+// unconstrained natural language a tail is. On a fail-closed merge gate the
+// classifier now refuses what it cannot recognize, so this body blocks.
+//
+// Treat a future failure here as a warning, not a test to relax: making this
+// body clear again means admitting free prose, which reopens issue 1966.
+test("blocks the observed PR #1848 review because its body is free prose", () => {
   const normalizedReadyState = normalizedReadyStateForClaudeReview(
     PR_1848_CLEAN_CLAUDE_REVIEW,
     {
@@ -1465,10 +1475,9 @@ test("accepts the observed PR #1848 Overall-verdict clean review", () => {
   );
   const feedbackState = summarizeFeedbackState(normalizedReadyState);
 
-  assertEqual(normalizedReadyState.required.ready, true);
-  assertEqual(feedbackState.ready, true);
-  assertEqual(feedbackState.counts.blockingTopLevelBotComments, 0);
-  assertEqual(feedbackState.counts.blockingFindings, 0);
+  assertEqual(feedbackState.ready, false);
+  assertEqual(feedbackState.counts.blockingTopLevelBotComments, 1);
+  assertEqual(feedbackState.counts.blockingFindings > 0, true);
 });
 
 test("classifies the post-#1848 Claude prose pattern library", () => {
@@ -1862,6 +1871,121 @@ test("keeps the observed PR #1954 review actionable because its tails are prose"
   );
   assertEqual(feedbackState.ready, false);
   assertEqual(feedbackState.counts.blockingTopLevelBotComments, 1);
+});
+
+// Issue 1966. #1960 refused prose in a verdict or roll-up TAIL; every other
+// line in the body still passed a blacklist scan, so a defect written as a
+// plain declarative sentence — no priority, no severity, no action verb —
+// cleared the gate. The scan is now an allowlist: a line is ignored only when
+// it is positively recognized as one of the shapes a clean review is made of.
+//
+// Both directions are pinned here. The clean bodies must keep clearing, or the
+// gate is useless; the defect bodies must block, or reviewer findings are
+// dropped before merge.
+test("refuses prose the prose classifier cannot positively recognize", () => {
+  const options = {
+    number: 1848,
+    title: "fix(agent): accept exact no-action Claude review",
+    headRefOid: PR_1848_HEAD,
+    headUpdatedAt: "2026-08-13T22:09:46Z",
+    reactionCreatedAt: "2026-08-20T09:30:00Z",
+  };
+  const expectReady = (label, body, expected) => {
+    const feedbackState = summarizeFeedbackState(
+      normalizedReadyStateForClaudeReview(
+        {
+          ...PR_1848_CLEAN_CLAUDE_REVIEW,
+          id: 5353832860,
+          created_at: "2026-08-20T09:10:48Z",
+          updated_at: "2026-08-20T09:11:54Z",
+          body,
+        },
+        options,
+      ),
+    );
+    assertEqual(
+      feedbackState.ready,
+      expected,
+      `${label}: unexpected feedback-state result`,
+    );
+    assertEqual(
+      feedbackState.counts.blockingTopLevelBotComments,
+      expected ? 0 : 1,
+    );
+  };
+
+  const clean = PR_1954_CLEAN_CLAUDE_BODY;
+  const DEFECT = "Anonymous callers can delete every stored record.";
+
+  // The reproduction from the issue, in the verdict format main itself
+  // accepts: a whole-bold verdict under an exact-title review heading.
+  expectReady(
+    "declarative defect after a clean conclusion",
+    [
+      `### Review: ${options.title}`,
+      "",
+      "**Verdict: LGTM**",
+      "",
+      "No P1/P2 findings.",
+      "",
+      DEFECT,
+    ].join("\n"),
+    false,
+  );
+
+  for (const [label, body] of [
+    ["declarative defect appended to a clean body", `${clean}\n\n${DEFECT}`],
+    ["declarative defect as a bullet", `${clean}\n\n- ${DEFECT}`],
+    ["declarative defect as a numbered item", `${clean}\n\n1. ${DEFECT}`],
+    ["declarative defect as a heading", `${clean}\n\n### ${DEFECT}`],
+    [
+      "declarative defect under a section",
+      `${clean}\n\n### Notes\n\n${DEFECT}`,
+    ],
+    [
+      "declarative defect before the verdict",
+      clean.replace("**Verdict:** LGTM", `${DEFECT}\n\n**Verdict:** LGTM`),
+    ],
+    // The old scan let any P3 line pass on a disposition phrase alone, so a
+    // defect rode along behind "Not a blocker". The line must now carry
+    // curated positive evidence and nothing else.
+    [
+      "P3 disposition carrying a defect",
+      `${clean}\n\n1. [P3] Not a blocker: anonymous callers can delete every stored record.`,
+    ],
+    [
+      "P3 no-action carrying a defect",
+      `${clean}\n\n1. [P3] No action requested. The bot token leaks into the collector step.`,
+    ],
+    // Praise is unconstrained prose too. It is refused for the same reason a
+    // defect is: nothing distinguishes the two by shape.
+    ["summarizing praise", `${clean}\n\nThis is a clean, mechanical PR.`],
+    // A section label is recognized only when it labels and nothing more.
+    [
+      "section label carrying a claim",
+      clean.replace(
+        "**Numbered findings roll-up:**",
+        "**Numbered findings roll-up: the retry loop never terminates**",
+      ),
+    ],
+  ]) {
+    expectReady(label, body, false);
+  }
+
+  for (const [label, body] of [
+    ["bare verdict and roll-up", clean],
+    [
+      "verdict, checklist-free conclusion, and nothing else",
+      `### Review: ${options.title}\n\nVerdict: LGTM\n\nNo P1/P2/P3 findings.`,
+    ],
+    [
+      "P3 observation with curated positive evidence",
+      `${clean}\n\n1. [P3] None blocking: tests cover the changed paths.`,
+    ],
+    ["bare Findings section label", `${clean}\n\n### Findings`],
+  ]) {
+    expectReady(label, body, true);
+  }
 });
 
 test("fails closed on single-field PR #1544 Overall-verdict mutations", () => {

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -2027,6 +2027,21 @@ test("refuses prose the prose classifier cannot positively recognize", () => {
       "P3 'No action required' is not advertised clean",
       `${clean}\n\n1. [P3] No action required: tests cover the changed paths.`,
     ],
+    // Matching a curated phrase as a whole must not let anything ride along
+    // with it. `POSITIVE_EVIDENCE` is anchored, so these fall through to the
+    // per-clause split and fail there.
+    [
+      "curated conjunction phrase with a defect appended",
+      `${clean}\n\n1. [P3] None blocking: no errors and failures were found. Anonymous callers can delete every stored record.`,
+    ],
+    [
+      "curated conjunction phrase joined to a defect",
+      `${clean}\n\n1. [P3] None blocking: no errors and failures were found and anonymous callers can delete every stored record.`,
+    ],
+    [
+      "curated conjunction phrase hedged",
+      `${clean}\n\n1. [P3] None blocking: no errors and failures were probably found.`,
+    ],
   ]) {
     expectReady(label, body, false);
   }
@@ -2046,6 +2061,14 @@ test("refuses prose the prose classifier cannot positively recognize", () => {
     [
       "checked P3 clean-evidence task",
       `${clean}\n\n- [x] [P3] Good hygiene: tests cover the changed paths.`,
+    ],
+    // A curated entry that spans a conjunction must match as a whole. Splitting
+    // on `and` first tore this phrase into `no errors` plus `failures were
+    // found`, and the second half is not an entry, so a curated phrase failed
+    // its own allowlist.
+    [
+      "P3 evidence whose curated phrase spans a conjunction",
+      `${clean}\n\n1. [P3] None blocking: no errors and failures were found.`,
     ],
     ["bare Findings section label", `${clean}\n\n### Findings`],
   ]) {

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -2004,6 +2004,29 @@ test("refuses prose the prose classifier cannot positively recognize", () => {
         "No P1/P2 findings.",
       ].join("\n"),
     ],
+    // An unticked box means the assertion was never completed, whatever the
+    // assertion is. The verdict and conclusion paths already guarded this; the
+    // P3 evidence path peeled the box the same way and did not, so evidence
+    // its author never confirmed cleared the gate.
+    [
+      "unchecked P3 clean-evidence task",
+      `${clean}\n\n- [ ] [P3] Good hygiene: tests cover the changed paths.`,
+    ],
+    [
+      "negated P3 clean-evidence task",
+      `${clean}\n\n- [-] [P3] Good hygiene: tests cover the changed paths.`,
+    ],
+    [
+      "numbered unchecked P3 clean-evidence task",
+      `${clean}\n\n1. [ ] [P3] Good hygiene: tests cover the changed paths.`,
+    ],
+    // `No action required` is not an accepted marker: the body-level fallback
+    // scan matches `Action required` and blocks the comment regardless, so the
+    // grammar must not advertise it as clean. Pins the two layers in agreement.
+    [
+      "P3 'No action required' is not advertised clean",
+      `${clean}\n\n1. [P3] No action required: tests cover the changed paths.`,
+    ],
   ]) {
     expectReady(label, body, false);
   }
@@ -2017,6 +2040,12 @@ test("refuses prose the prose classifier cannot positively recognize", () => {
     [
       "P3 observation with curated positive evidence",
       `${clean}\n\n1. [P3] None blocking: tests cover the changed paths.`,
+    ],
+    // The counterpart to the unchecked-box cases above: a ticked box is a
+    // completed check, so the evidence behind it still clears.
+    [
+      "checked P3 clean-evidence task",
+      `${clean}\n\n- [x] [P3] Good hygiene: tests cover the changed paths.`,
     ],
     ["bare Findings section label", `${clean}\n\n### Findings`],
   ]) {

--- a/scripts/pr-feedback-state.test.mjs
+++ b/scripts/pr-feedback-state.test.mjs
@@ -1968,6 +1968,42 @@ test("refuses prose the prose classifier cannot positively recognize", () => {
         "**Numbered findings roll-up: the retry loop never terminates**",
       ),
     ],
+    // A review heading is recognized only because harvest already validated
+    // its PR number and title. The line scan must therefore recognize exactly
+    // the set harvest sees: matching a TRIMMED line, or matching the number
+    // heading case-insensitively, let an unharvested heading through with its
+    // title and PR-number checks skipped. Markdown still renders a heading
+    // indented up to three spaces, so these are real review bodies.
+    [
+      "indented review heading carrying a defect",
+      [
+        `   ### Review: ${DEFECT}`,
+        "",
+        "**Verdict:** LGTM",
+        "",
+        "No P1/P2 findings.",
+      ].join("\n"),
+    ],
+    [
+      "indented review heading naming another PR",
+      [
+        "   ### Code Review — PR #9999",
+        "",
+        "**Verdict:** LGTM",
+        "",
+        "No P1/P2 findings.",
+      ].join("\n"),
+    ],
+    [
+      "mis-cased review-number heading naming another PR",
+      [
+        "### code review — PR #9999",
+        "",
+        "**Verdict:** LGTM",
+        "",
+        "No P1/P2 findings.",
+      ].join("\n"),
+    ],
   ]) {
     expectReady(label, body, false);
   }


### PR DESCRIPTION
## The Problem

- `pr:feedback-state` cleared a Claude review that names a real defect, as long as the defect was written as a plain declarative sentence. `Anonymous callers can delete every stored record.` carries no priority, no severity, and no action verb, so `classifyClaudeReviewProse`'s blacklist scan let it through.
- It is a fail-closed merge gate, so a false "clean" means reviewer findings are skipped before merge.
- The scan tried to bound natural language with a list of forbidden vocabulary, which cannot be exhaustive.

## The Solution

- Invert the rule. A body line is now ignored only when it is **positively recognized** as clean evidence; anything else — any free sentence — makes the review actionable.
- Reuse the allowlist machinery that already guards the sibling `isExplicitlyCleanClaudeReview` path instead of writing a second grammar.

## Details

Originally stacked on **#1960** (`fix/feedback-state-clean-claude-review`), which rewrote the same function: this work was written on its head `50c3b10b` because branching off `main` would have conflicted. #1960 squash-merged into `main` as `c365e46f` mid-review and its branch was deleted, so the branch is rebased `--onto origin/main` and this PR targets `main` directly. The rebase was a no-op for the three touched files — `50c3b10b` and `c365e46f` have identical contents there — and the suite, probe, and gate were re-run after it.

The hole predates #1960: the same body clears on `main`. #1960 refused prose in a verdict or roll-up **tail**; this extends the same reasoning to every other line in the body.

**Recognized clean shapes** (`isRecognizedCleanReviewLine`), each of which asserts nothing or asserts only cleanliness:

- a blank line, a thematic break, the bounded Claude completion header;
- a review heading — recognized only because the caller already validated it against this PR's number or title;
- the clean verdict line — recognized only because the caller already proved there is exactly one and it has no tail;
- a clean no-findings conclusion (`isCleanConclusion`, unchanged);
- a bare `Findings` / `Roll-up` / `Numbered findings roll-up` section label, with nothing after it;
- a `[P3]` line whose text clears `hasPositiveCleanEvidence`.

**The P3 disposition blacklist is gone.** `CLEAN_P3_DISPOSITION_PATTERNS` cleared a line on a phrase like "Not a blocker" alone, so `1. [P3] Not a blocker: anonymous callers can delete every stored record.` read as clean. A P3 line must now carry curated positive evidence and nothing else.

**One definition of the evidence grammar.** `CLEAN_FINDING_MARKER`, `UNSAFE_EVIDENCE_QUALIFIER`, `POSITIVE_EVIDENCE`, and `hasPositiveCleanEvidence` move from `pr-feedback-state-core.mjs` into `pr-feedback-state-claude.mjs`; core already imports that module and now calls the shared helper. A duplicated grammar caused one of #1960's regressions. `POSITIVE_EVIDENCE` needed **no new entries** — the shapes this path must accept were already covered, and every entry is an allowlist decision, so none were added speculatively.

The two review-heading regexes are compiled from one source string each: a global form harvests every occurrence from the body, a single-line form serves the per-line scan. Re-spelling either would let the harvest and the scan disagree about what a heading is.

`hasExplicitAction` and `EXPLICIT_SEVERITY` stay in front of the allowlist. They no longer carry the classification, but they still guard the recognized shapes themselves — a review-title heading repeats the PR title, and a title can name a required change.

### The one test that moved

`accepts the observed PR #1848 Overall-verdict clean review` → `blocks the observed PR #1848 review because its body is free prose`.

That review reads as clean to a human: LGTM verdict, roll-up denying findings. It cleared only because none of its five narrative paragraphs happened to use finding vocabulary — nothing established that they *were* clean. That is exactly the fail-open #1960 closed for tails, and a paragraph is the same unconstrained natural language a tail is. The classifier now refuses what it cannot recognize, so the body blocks. This matches the existing `keeps the observed PR #1954 review actionable because its tails are prose` precedent, and the test carries the same "treat a failure here as a warning, not a test to relax" note.

No other test moved. The #1544/#1595/#1600/#1825/#1837 compatibility-registry bodies match the digest registry before the prose path and are untouched; every one of their mutation tests already expected a blocked result and still gets one. The post-#1848 prose pattern library passes unchanged in both directions. No test was relaxed, and the allowlist was not widened to rescue any body.

## Validation

**Probe** (`classifyClaudeReviewProse` directly, one line per body; `CLEAN` = classified explicitly clean):

Before:

```
   CLEAN      (want CLEAN     ) clean: PR #1954 bare verdict and roll-up
   CLEAN      (want CLEAN     ) clean: plain LGTM with an explicit no-findings conclusion
   CLEAN      (want CLEAN     ) clean: no-action P3 observation with positive evidence
   CLEAN      (want CLEAN     ) clean: Overall verdict with no findings
   CLEAN      (want CLEAN     ) clean: checked task conclusion
!! CLEAN      (want ACTIONABLE) issue #1966 repro: declarative defect after a clean conclusion
!! CLEAN      (want ACTIONABLE) declarative defect inside the PR #1954 shape
!! CLEAN      (want ACTIONABLE) declarative defect as a bullet
!! CLEAN      (want ACTIONABLE) declarative defect under a heading
!! CLEAN      (want ACTIONABLE) P3 disposition smuggling a defect
!! CLEAN      (want ACTIONABLE) praise tail as a standalone line
   ACTIONABLE (want ACTIONABLE) verdict tail stating a defect (fixed by #1960, pinned here)
!! CLEAN      (want ACTIONABLE) MOVER: narrative-bodied PR #1848 review

7 mismatch(es) vs the post-fix expectation
```

After:

```
   CLEAN      (want CLEAN     ) clean: PR #1954 bare verdict and roll-up
   CLEAN      (want CLEAN     ) clean: plain LGTM with an explicit no-findings conclusion
   CLEAN      (want CLEAN     ) clean: no-action P3 observation with positive evidence
   CLEAN      (want CLEAN     ) clean: Overall verdict with no findings
   CLEAN      (want CLEAN     ) clean: checked task conclusion
   ACTIONABLE (want ACTIONABLE) issue #1966 repro: declarative defect after a clean conclusion
   ACTIONABLE (want ACTIONABLE) declarative defect inside the PR #1954 shape
   ACTIONABLE (want ACTIONABLE) declarative defect as a bullet
   ACTIONABLE (want ACTIONABLE) declarative defect under a heading
   ACTIONABLE (want ACTIONABLE) P3 disposition smuggling a defect
   ACTIONABLE (want ACTIONABLE) praise tail as a standalone line
   ACTIONABLE (want ACTIONABLE) verdict tail stating a defect (fixed by #1960, pinned here)
   ACTIONABLE (want ACTIONABLE) MOVER: narrative-bodied PR #1848 review

0 mismatch(es) vs the post-fix expectation
```

**Negative control.** With the positive-recognition check disabled and the old P3 disposition rule restored — the fix alone, the shared-grammar refactor left in place — the two new tests fail and the probe returns to 7 mismatches:

```
not ok blocks the observed PR #1848 review because its body is free prose
  expected false, got true
not ok refuses prose the prose classifier cannot positively recognize
  expected false, got true
2 pr-feedback-state test(s) failed
```

Re-enabled: `49 pr-feedback-state test(s) passed`, probe back to 0 mismatches.

**Commands**

- `pnpm pr:feedback-state:test` — 49 passed.
- `pnpm lint:scripts` — clean.
- `pnpm agent:quality-gate --run --parallel 4` — all four mapped commands passed (`trunk check`, `lint:scripts`, `pr:feedback-state:test`, `tf:test`), run unpiped.
- `pnpm agent:autoreview --mode branch --base origin/main` with a prompt describing the fail-closed gate and asking it to hunt for remaining false-clean inputs — `autoreview clean: no accepted/actionable findings reported`; `overall: patch is correct (0.91)`. One round, no findings to fix.

## Deferrals

- A standalone `#### What I checked` checklist — one without paired `Findings` / `Roll-up` headings — now blocks a genuinely clean review, because neither the heading nor its `- [x]` entries match a recognized shape. Raised by `claude[bot]` as a P2 and reproduced. Fails safe, so it is a false positive rather than a fail-open. Deferred because the fix must reuse `isBenignChecklistSubject`'s curated topic allowlist, and `pr-feedback-state-core.mjs` imports `pr-feedback-state-claude.mjs` rather than the reverse — so reusing it means a fifth cross-module helper move, which belongs in its own change. Tracked in https://github.com/mento-protocol/monitoring-monorepo/issues/1968.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this tightens an existing classifier rule along the direction #1960 already set; no new constraint on future work.

Closes #1966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gate classification for Claude bot reviews; legitimate narrative LGTM bodies (e.g. PR #1848) will block until covered by the compatibility registry or a recognized shape, which is intentional but affects operator workflow.
> 
> **Overview**
> Closes **#1966** by tightening **`classifyClaudeReviewProse`**: instead of letting most body lines through unless they hit finding vocabulary, each non-conclusion line must match an **allowlist** via **`isRecognizedCleanReviewLine`** (headings, verdict, section labels, thematic breaks, P3 lines with curated positive evidence, etc.). Plain declarative defects and narrative paragraphs no longer slip past as “clean.”
> 
> **P3 disposition phrases alone** (`CLEAN_P3_DISPOSITION_PATTERNS`) are removed; P3 lines must pass shared **`hasPositiveCleanEvidence`**. **`CLEAN_FINDING_MARKER` / `POSITIVE_EVIDENCE`** live only in **`pr-feedback-state-claude.mjs`** so the prose path and **`isExplicitlyCleanClaudeReview`** cannot drift. Review-heading regexes are compiled from one shape string for harvest vs per-line scan.
> 
> The **PR #1848** fixture test now expects **blocked** feedback (free prose in the body). A new test pins both false-clean and still-clean shapes for the allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f042ced54dd684fe50737f49185d636685a50c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-result validation to distinguish recognized clean reviews from unrecognized, contradictory, or malformed prose.
  * Clean reviews now require approved headings, formats, and positive-evidence statements.
  * Findings with qualifiers, unsupported content, unclear evidence, or incorrect formatting are no longer incorrectly treated as clean.
  * Review states remain blocked when narrative text or standalone no-action statements cannot be validated.

* **Documentation**
  * Updated guidance to reflect stricter clean-review requirements and historical compatibility exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
