### PR TITLE
fix(autoreview): let the secret scanner clear known-fake test fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,13 @@ jobs:
               - scripts/agent-autoreview-core.test.mjs
               - scripts/agent-autoreview-target-guard.test.mjs
               - scripts/agent-autoreview.test.sh
+              # agent-autoreview-core.test.mjs scans every Sentry suite and
+              # fails if the secret scanner refuses any of them. Without these
+              # paths a suite that commits a new fake credential merges with the
+              # sentinel green, and diffs whose context reaches it are then
+              # unreviewable (issues 1943, 1970). The assertion only protects
+              # what re-runs when the scanned files change.
+              - scripts/sentry/**/*.test.mjs
               - package.json
               - .node-version
               - .github/workflows/ci.yml

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -301,23 +301,38 @@ they need no scanner change and cannot go stale.
 
 One exception exists, for fixtures that must look like a real provider
 credential because the code under test parses that shape.
-`KNOWN_FAKE_FIXTURE_VALUES` in `scripts/agent-autoreview-core.mjs` holds an
-enumerated list of such values, matched EXACTLY — no trimming, no case folding,
-no prefix matching — so it widens the accepted set by precisely those strings
-and by nothing else. Registering a value is a security change: it is the one
-place a literal that reads as a credential is allowed through, so add an entry
+`KNOWN_FAKE_FIXTURE_LINES` in `scripts/agent-autoreview-core.mjs` holds an
+enumerated list of fixture LINES. Registered lines are dropped from the input
+before any rule runs; every surviving line is judged exactly as it was before
+the registry existed. Registering a line is a security change — it is the one
+place content that reads as a credential is allowed through — so add an entry
 only when composing from parts or using a placeholder genuinely will not work,
 and say in the PR why.
 
-The registry also holds two shapes that are references rather than credentials
-but do not reach the reference grammar: a shell expansion escaped for a JS
-template literal (`\${VAR}`), and one carrying its own shell quoting
-(`'"${VAR}"'`). Both are registered as exact values rather than by teaching the
-grammar to strip escapes or peel quotes. Stripping the escape would clear a
-value the scanner previously refused, because in a real shell file that
-backslash PREVENTS expansion and the application receives the literal `${…}`;
-peeling quotes accepted a quote-wrapped real credential outright. The scanner
-has no file-type context to tell those cases apart, so it does not guess.
+**Membership is the whole line, trimmed, never a value inside it**, and that
+distinction is the entire security argument. An earlier form matched the
+extracted VALUE, and a value is whatever some parser hands over. Four separate
+bypasses followed, each a different parser surrendering a substring while
+adjacent material rode along unexamined: `TOKEN=<fixture>#SUFFIX` read the
+suffix as a comment, `TOKEN="<fixture>"SUFFIX` split on the quote, the
+provider-token loop matched a fixture inside a longer run, and one attempted
+repair left the scanner weaker than before the registry existed. A whole-line
+match has no such surface: appending, prepending, quoting or concatenating
+anything makes it a different line, so it stops matching.
+
+Two consequences follow, both deliberate:
+
+- A fixture value lifted out of its line — used elsewhere, or with a comment
+  appended — is refused. Only the registered line clears.
+- The registry holds two shapes that are references rather than credentials but
+  do not reach the reference grammar: a shell expansion escaped for a JS
+  template literal (`\${VAR}`), and one carrying its own shell quoting
+  (`'"${VAR}"'`). Both are registered as lines rather than by teaching the
+  grammar to strip escapes or peel quotes. Stripping the escape would clear a
+  value the scanner previously refused, because in a real shell file that
+  backslash PREVENTS expansion and the application receives the literal `${…}`;
+  peeling quotes accepted a quote-wrapped real credential outright. The scanner
+  has no file-type context to tell those cases apart, so it does not guess.
 
 A test in `scripts/agent-autoreview-core.test.mjs` runs the scanner over every
 line of every Sentry suite and fails if any line is refused, naming the file,

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -296,7 +296,34 @@ price of a rule that proves inertness from syntax alone.
 A literal in value position stays refused whatever names it: a fixture
 string is a quoted literal, and no syntax separates one from a weak credential,
 so fixtures compose the value from parts or use a documented placeholder marker
-(`fixture-token`, `example-secret`).
+(`fixture-token`, `example-secret`). Prefer one of those two for a new fixture —
+they need no scanner change and cannot go stale.
+
+One exception exists, for fixtures that must look like a real provider
+credential because the code under test parses that shape.
+`KNOWN_FAKE_FIXTURE_VALUES` in `scripts/agent-autoreview-core.mjs` holds an
+enumerated list of such values, matched EXACTLY — no trimming, no case folding,
+no prefix matching — so it widens the accepted set by precisely those strings
+and by nothing else. Registering a value is a security change: it is the one
+place a literal that reads as a credential is allowed through, so add an entry
+only when composing from parts or using a placeholder genuinely will not work,
+and say in the PR why.
+
+The registry also holds two shapes that are references rather than credentials
+but do not reach the reference grammar: a shell expansion escaped for a JS
+template literal (`\${VAR}`), and one carrying its own shell quoting
+(`'"${VAR}"'`). Both are registered as exact values rather than by teaching the
+grammar to strip escapes or peel quotes. Stripping the escape would clear a
+value the scanner previously refused, because in a real shell file that
+backslash PREVENTS expansion and the application receives the literal `${…}`;
+peeling quotes accepted a quote-wrapped real credential outright. The scanner
+has no file-type context to tell those cases apart, so it does not guess.
+
+A test in `scripts/agent-autoreview-core.test.mjs` runs the scanner over every
+line of every Sentry suite and fails if any line is refused, naming the file,
+line, reason, and this registry. That is what catches a new fixture nobody
+registered, so a fixture shape the registry does not yet know surfaces as a
+test failure rather than as an unreviewable file.
 Evidence reads reject symlinks and verify that the opened descriptor still
 identifies the file that was inspected, closing path-swap races.
 

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -804,6 +804,60 @@ const MAX_SHELL_EXPANSION_NESTING = 8;
 // those with it.
 const CREDENTIAL_LITERAL_MIN_LENGTH = 12;
 
+// Fake credentials this repository already commits as test fixtures.
+//
+// The scanner's other rules decide by shape, and a fixture written to look
+// like a real provider token is indistinguishable from one by shape — which is
+// the point of the fixture. Shape rules therefore refused every diff whose
+// hunks reached one, including the `-` and context lines of a diff that only
+// renamed it, so those suites could not be reviewed at all (issue 1943).
+//
+// Membership here is exact-value, never prefix or pattern, and the lookup
+// normalizes nothing. The values the scanner newly accepts are the strings
+// listed below, plus whatever a rule that already trimmed its extracted value
+// hands over as one of them; no value carrying other material can match. An
+// unlisted value, real or invented, goes through the shape rules unchanged.
+// Every entry must be a literal already committed to this tree as a test
+// fixture and must authenticate nothing anywhere.
+//
+// Entries stay listed after their fixture is deleted or renamed. The diff that
+// removes one still carries the old value on its `-` line, and delisting in
+// the same change would make that cleanup unreviewable — the trap this exists
+// to remove.
+//
+// Entries whose fixture carries a provider prefix are written as adjacent
+// fragments, the same convention `agent-autoreview-core.test.mjs` uses for its
+// own adversarial values. Registering a fixture means writing it down, and the
+// pre-change runtime that reviews this file is the one that refuses the whole
+// value on sight; splitting the prefix keeps this file reviewable by it. The
+// fragments are concatenated below, so the registered value is the full token.
+const KNOWN_FAKE_FIXTURE_VALUES = new Set(
+  [
+    // scripts/sentry/broker/sentry-mcp-broker.test.mjs
+    ["sntrys_the_real_read_only_token_value"],
+    // scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
+    ["sntrys_deadbeefdeadbeefdeadbeef"],
+    ["ghs", "_0123456789abcdefghijklmnopqrstuvwxyz"],
+    ["sk", "-ant-oat01-abcdefghijklmnopqrstuvwxyz"],
+    // scripts/sentry/triage/sentry-triage-archive.test.mjs
+    ["sntrys_archive_token"],
+    // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
+    ["ghs", "_AbCdEfGhIjKlMnOpQrStUvWxYz012345"],
+    ["a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"],
+  ].map((fragments) => fragments.join("")),
+);
+
+// Exact-value, on the value as extracted. Nothing is trimmed or case-folded
+// first: trimming would accept ` <fixture> `, which is a value the registry
+// does not hold and the shape rules refused before this existed.
+function knownFakeFixtureValue(value) {
+  return KNOWN_FAKE_FIXTURE_VALUES.has(value);
+}
+
+export function knownFakeFixtureValues() {
+  return [...KNOWN_FAKE_FIXTURE_VALUES];
+}
+
 function shellExpansionWord(word) {
   return (
     word === "" ||
@@ -857,9 +911,16 @@ function shellExpansionReference(expression) {
 // is a reference, not a committed literal. Same `[A-Z0-9_.-]` path + `^…$`
 // anchor, so a trailing inline secret (`local.x ghp_real`, `"local.x"; realKey`)
 // still fails to match and is caught.
+//
+// The `knownFakeFixtureValue()` clause is the one exception to "shape decides":
+// it clears an enumerated list of fake credentials this repository already
+// commits as test fixtures. It widens the accepted set by exactly those
+// strings and by nothing else, so no unlisted credential — real or invented —
+// can reach it. See `KNOWN_FAKE_FIXTURE_VALUES`.
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
+    knownFakeFixtureValue(value) ||
     shellExpansionReference(trimmed) ||
     /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
@@ -1676,18 +1737,23 @@ export function secretLikeReason(text) {
   ) {
     return "Bearer JWT";
   }
+  // Each pattern is anchored on `\b` at both ends, so a match is the whole
+  // token run. Appending real material to a listed fixture lengthens that run
+  // into a value the set does not hold, and the match is still refused.
   const strongPatterns = [
-    /\bgh[pousr]_[A-Za-z0-9]{30,}\b/,
-    /\bgithub_pat_[A-Za-z0-9_]{30,}\b/,
-    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/,
-    /\bAIza[0-9A-Za-z_-]{30,}\b/,
-    /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/,
-    /\bsk-[A-Za-z0-9_-]{24,}\b/,
-    /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/,
-    /\bnpm_[A-Za-z0-9]{30,}\b/,
+    /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g,
+    /\bgithub_pat_[A-Za-z0-9_]{30,}\b/g,
+    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+    /\bAIza[0-9A-Za-z_-]{30,}\b/g,
+    /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/g,
+    /\bsk-[A-Za-z0-9_-]{24,}\b/g,
+    /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/g,
+    /\bnpm_[A-Za-z0-9]{30,}\b/g,
   ];
-  if (strongPatterns.some((pattern) => pattern.test(text))) {
-    return "credential-like token";
+  for (const pattern of strongPatterns) {
+    for (const match of text.matchAll(pattern)) {
+      if (!knownFakeFixtureValue(match[0])) return "credential-like token";
+    }
   }
   const secretUrlPatterns = [
     /https:\/\/hooks\.slack\.com\/services\/[A-Z0-9]{8,}\/[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/i,

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -893,7 +893,12 @@ function shellExpansionWord(word) {
 // satisfy the full reference grammar below. A literal secret cannot acquire
 // that shape by having backslashes removed.
 function unescapeShellExpansions(expression) {
-  return expression.replace(/\\+\$(?=\{)/g, "$");
+  // Exactly ONE backslash, and only when it is not itself escaped. A single
+  // `\$` is the source-level escape a JS template literal needs; `\\$` is a
+  // literal backslash followed by an interpolation, which is a different
+  // string and must not be normalized into a reference. `(?<!\\)` keeps the
+  // second case out.
+  return expression.replace(/(?<!\\)\\\$(?=\{)/g, "$");
 }
 
 function shellExpansionReference(rawExpression) {
@@ -1829,7 +1834,7 @@ export function secretLikeReason(text) {
     }
   }
   const awsCredentialPattern =
-    /^[+ -]?\s*["'`]?aws[_-]?(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|session[_-]?token)["'`]?\s*[:=]\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*["'`]?aws[_-]?(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|session[_-]?token)["'`]?\s*[:=]\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(awsCredentialPattern)) {
     const value = match[1].trim();
     if (
@@ -1840,7 +1845,7 @@ export function secretLikeReason(text) {
     }
   }
   const authorizationPattern =
-    /^[+ -]?\s*["'`]?authorization["'`]?\s*([:=])\s*(["'`]?)([^"'`\r\n]+?)\2[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[\s\S]*?\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*["'`]?authorization["'`]?\s*([:=])\s*(["'`]?)([^"'`\r\n]+?)\2[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[\s\S]*?\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(authorizationPattern)) {
     const value = match[3].trim();
     if (
@@ -1987,7 +1992,7 @@ export function secretLikeReason(text) {
     return "literal wallet recovery phrase";
   }
   const genericTokenAssignmentPattern =
-    /^[+ -]?\s*["'`]?(token|[a-z][a-z0-9]*(?:_[a-z0-9]+)*_token)["'`]?(\s*[:=]\s*)(["'`]?)([^"'`\r\n]+?)\3[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*["'`]?(token|[a-z][a-z0-9]*(?:_[a-z0-9]+)*_token)["'`]?(\s*[:=]\s*)(["'`]?)([^"'`\r\n]+?)\3[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(genericTokenAssignmentPattern)) {
     const key = match[1];
     const operator = match[2];
@@ -2024,7 +2029,7 @@ export function secretLikeReason(text) {
       return "literal credential assignment";
   }
   const wrappedQuotedKeyPattern =
-    /^[+ -]?\s*["'`]?([A-Za-z][A-Za-z0-9_-]*)["'`]?\s*[:=]\s*(.+?)[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[\s\S]*?\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*["'`]?([A-Za-z][A-Za-z0-9_-]*)["'`]?\s*[:=]\s*(.+?)[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[\s\S]*?\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(wrappedQuotedKeyPattern)) {
     const key = match[1];
     const authorizationKey = normalizeCredentialKey(key) === "authorization";
@@ -2071,7 +2076,7 @@ export function secretLikeReason(text) {
     }
   }
   const registryAuthPattern =
-    /^[+ -]?\s*\/\/[^=\r\n]+\/?:_(?:authToken|auth|password)\s*=\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*\/\/[^=\r\n]+\/?:_(?:authToken|auth|password)\s*=\s*["'`]?([^"'`\r\n]+?)["'`]?(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(registryAuthPattern)) {
     const value = match[1].trim();
     if (
@@ -2081,7 +2086,7 @@ export function secretLikeReason(text) {
       return "literal registry credential assignment";
   }
   const unquotedKeyPattern =
-    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)([A-Za-z0-9_$+./=:@%!?~^-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:[#;][^\r\n]*)?)$/gim;
+    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)([A-Za-z0-9_$+./=:@%!?~^-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(unquotedKeyPattern)) {
     const key = match[1];
     const operator = match[2];

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -844,6 +844,22 @@ const KNOWN_FAKE_FIXTURE_VALUES = new Set(
     // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
     ["ghs", "_AbCdEfGhIjKlMnOpQrStUvWxYz012345"],
     ["a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"],
+    // scripts/sentry/triage/sentry-triage-agent-comment.test.mjs — hyphenated
+    // word fixtures. They carry no provider prefix and no high-entropy body,
+    // but `placeholderValue()`'s vocabulary is anchored on a leading
+    // redacted/example/dummy-style word, so `aws-secret-value` misses it. They
+    // are registered here as exact values rather than by widening that
+    // vocabulary to a `<anything>-secret-value` shape, which would accept an
+    // unbounded set.
+    ["aws-secret-value"],
+    ["projection-secret-value"],
+    // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs — a shell
+    // expansion carrying its own shell quoting, so it reaches the scanner as
+    // `'"..."'` rather than a bare reference. Registered as an exact value
+    // instead of teaching the reference grammar to peel quote wrappers: that
+    // peel accepted a quote-wrapped real credential, which is the fail-open
+    // this scanner exists to prevent.
+    ["'\"\\${REPO%%/*}\"'"],
   ].map((fragments) => fragments.join("")),
 );
 
@@ -868,7 +884,20 @@ function shellExpansionWord(word) {
   );
 }
 
-function shellExpansionReference(expression) {
+// A shell snippet embedded in a JS template literal escapes its expansions as
+// `\${VAR}` so JS does not interpolate them. The runtime value is the ordinary
+// `${VAR}` the shell later expands, so it is the same reference the unescaped
+// form already cleared — the backslashes are JS quoting, not part of the value.
+//
+// Only `\$` immediately before `{` is unescaped, and the result must still
+// satisfy the full reference grammar below. A literal secret cannot acquire
+// that shape by having backslashes removed.
+function unescapeShellExpansions(expression) {
+  return expression.replace(/\\+\$(?=\{)/g, "$");
+}
+
+function shellExpansionReference(rawExpression) {
+  const expression = unescapeShellExpansions(rawExpression);
   const head = /^\$\{(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+)(?::?[-=+?])?/.exec(
     expression,
   );

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -804,7 +804,7 @@ const MAX_SHELL_EXPANSION_NESTING = 8;
 // those with it.
 const CREDENTIAL_LITERAL_MIN_LENGTH = 12;
 
-// Fake credentials this repository already commits as test fixtures.
+// Fake-credential fixture LINES this repository already commits.
 //
 // The scanner's other rules decide by shape, and a fixture written to look
 // like a real provider token is indistinguishable from one by shape — which is
@@ -812,74 +812,63 @@ const CREDENTIAL_LITERAL_MIN_LENGTH = 12;
 // hunks reached one, including the `-` and context lines of a diff that only
 // renamed it, so those suites could not be reviewed at all (issue 1943).
 //
-// Membership here is exact-value, never prefix or pattern, and the lookup
-// normalizes nothing. The values the scanner newly accepts are the strings
-// listed below, plus whatever a rule that already trimmed its extracted value
-// hands over as one of them; no value carrying other material can match. An
-// unlisted value, real or invented, goes through the shape rules unchanged.
-// Every entry must be a literal already committed to this tree as a test
-// fixture and must authenticate nothing anywhere.
+// Membership is the WHOLE LINE, trimmed, never a value inside it. That
+// distinction is the entire security argument, and it was learned the hard way:
+// an earlier form of this registry matched the extracted VALUE, and a value is
+// whatever some parser hands over. Four separate bypasses followed, each a
+// different parser handing over a substring while adjacent material rode along
+// unexamined — `TOKEN=<fixture>#SUFFIX` read the suffix as a comment,
+// `TOKEN="<fixture>"SUFFIX` split on the quote, and the provider-token loop
+// matched the fixture inside a longer run. Patching them one at a time kept
+// producing new ones, including one regression that made the scanner weaker
+// than before the registry existed.
 //
-// Entries stay listed after their fixture is deleted or renamed. The diff that
-// removes one still carries the old value on its `-` line, and delisting in
-// the same change would make that cleanup unreviewable — the trap this exists
-// to remove.
+// A whole-line match has no such surface. Appending, prepending, quoting or
+// concatenating anything changes the line, so it stops matching and the shape
+// rules judge it exactly as they did before this registry existed. The accepted
+// set is not merely finite — it is these thirteen strings and nothing else.
 //
-// Entries whose fixture carries a provider prefix are written as adjacent
-// fragments, the same convention `agent-autoreview-core.test.mjs` uses for its
-// own adversarial values. Registering a fixture means writing it down, and the
-// pre-change runtime that reviews this file is the one that refuses the whole
-// value on sight; splitting the prefix keeps this file reviewable by it. The
-// fragments are concatenated below, so the registered value is the full token.
-const KNOWN_FAKE_FIXTURE_VALUES = new Set(
+// Every entry must be a line already committed to this tree as a test fixture
+// and must authenticate nothing anywhere. Entries stay listed after their
+// fixture is deleted or renamed: the diff that removes one still carries the
+// old line on its `-` side, and delisting in the same change would make that
+// cleanup unreviewable — the trap this exists to remove.
+//
+// Provider-prefixed fragments are written adjacently and joined at load, the
+// same convention `agent-autoreview-core.test.mjs` uses for its own adversarial
+// values: registering a fixture means writing it down, and the pre-change
+// runtime that reviews this file is the one that refuses it on sight.
+const KNOWN_FAKE_FIXTURE_LINES = new Set(
   [
-    // scripts/sentry/broker/sentry-mcp-broker.test.mjs
-    ["sntrys_the_real_read_only_token_value"],
-    // scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
-    ["sntrys_deadbeefdeadbeefdeadbeef"],
-    ["ghs", "_0123456789abcdefghijklmnopqrstuvwxyz"],
-    ["sk", "-ant-oat01-abcdefghijklmnopqrstuvwxyz"],
-    // scripts/sentry/triage/sentry-triage-archive.test.mjs
-    ["sntrys_archive_token"],
     // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
-    ["ghs", "_AbCdEfGhIjKlMnOpQrStUvWxYz012345"],
-    ["a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"],
-    // scripts/sentry/triage/sentry-triage-agent-comment.test.mjs — hyphenated
-    // word fixtures. They carry no provider prefix and no high-entropy body,
-    // but `placeholderValue()`'s vocabulary is anchored on a leading
-    // redacted/example/dummy-style word, so `aws-secret-value` misses it. They
-    // are registered here as exact values rather than by widening that
-    // vocabulary to a `<anything>-secret-value` shape, which would accept an
-    // unbounded set.
-    ["aws-secret-value"],
-    ["projection-secret-value"],
-    // scripts/sentry/broker/sentry-mcp-broker.test.mjs — a shell expansion
-    // escaped for a JS template literal. Registered as an exact value rather
-    // than by unescaping `\$` before the reference grammar: in a real shell
-    // file that backslash PREVENTS expansion, so the application receives the
-    // literal `${…}` as its token, and normalizing it away would have cleared
-    // a value the scanner previously refused. The scanner has no file-type
-    // context to tell the two apart, so it must not guess.
-    ["\\${SENTRY_TRIAGE_TOKEN:-}"],
-    // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs — a shell
-    // expansion carrying its own shell quoting, so it reaches the scanner as
-    // `'"..."'` rather than a bare reference. Registered as an exact value
-    // instead of teaching the reference grammar to peel quote wrappers: that
-    // peel accepted a quote-wrapped real credential, which is the fail-open
-    // this scanner exists to prevent.
-    ["'\"\\${REPO%%/*}\"'"],
+    ['"ghs', '_AbCdEfGhIjKlMnOpQrStUvWxYz012345 leak attempt",'],
+    ["'const t = \"ghs", "_AbCdEfGhIjKlMnOpQrStUvWxYz012345\";\\n',"],
+    ["const SHELL_OWNER_TOKEN = `'\"\\${REPO%%/*}\"'`;"],
+    ['const TOKEN = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"; // 36 alnum'],
+    // scripts/sentry/broker/sentry-mcp-broker.test.mjs
+    ['const REAL_TOKEN = "sntrys', '_the_real_read_only_token_value";'],
+    ['token="\\${SENTRY_TRIAGE_TOKEN:-}"'],
+    // scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
+    ['AWS_SECRET_ACCESS_KEY: "aws-secret-value",'],
+    ['SENTRY_PROJECTION_TOKEN: "projection-secret-value",'],
+    ['const GH_TOKEN = "ghs', '_0123456789abcdefghijklmnopqrstuvwxyz";'],
+    ['const OAUTH_TOKEN = "sk', '-ant-oat01-abcdefghijklmnopqrstuvwxyz";'],
+    ['const SENTRY_TOKEN = "sntrys', '_deadbeefdeadbeefdeadbeef";'],
+    // scripts/sentry/triage/sentry-triage-archive.test.mjs
+    ['const TOKEN = "sntrys', '_archive_token";'],
   ].map((fragments) => fragments.join("")),
 );
 
-// Exact-value, on the value as extracted. Nothing is trimmed or case-folded
-// first: trimming would accept ` <fixture> `, which is a value the registry
-// does not hold and the shape rules refused before this existed.
-function knownFakeFixtureValue(value) {
-  return KNOWN_FAKE_FIXTURE_VALUES.has(value);
+// Whole-line membership, on the line as written minus surrounding whitespace
+// and any unified-diff marker. Indentation and diff position are not part of a
+// fixture's identity; everything else is.
+function knownFakeFixtureLine(line) {
+  const withoutDiffMarker = String(line ?? "").replace(/^[+ -]/, "");
+  return KNOWN_FAKE_FIXTURE_LINES.has(withoutDiffMarker.trim());
 }
 
-export function knownFakeFixtureValues() {
-  return [...KNOWN_FAKE_FIXTURE_VALUES];
+export function knownFakeFixtureLines() {
+  return [...KNOWN_FAKE_FIXTURE_LINES];
 }
 
 function shellExpansionWord(word) {
@@ -944,15 +933,13 @@ function shellExpansionReference(expression) {
 // anchor, so a trailing inline secret (`local.x ghp_real`, `"local.x"; realKey`)
 // still fails to match and is caught.
 //
-// The `knownFakeFixtureValue()` clause is the one exception to "shape decides":
-// it clears an enumerated list of fake credentials this repository already
-// commits as test fixtures. It widens the accepted set by exactly those
-// strings and by nothing else, so no unlisted credential — real or invented —
-// can reach it. See `KNOWN_FAKE_FIXTURE_VALUES`.
+// Fixture exemption does NOT live here. It is applied per LINE at the top of
+// `secretLikeReason`, because a value reaching this function is whatever some
+// parser extracted, and exempting a substring lets adjacent material ride along
+// unexamined. See `KNOWN_FAKE_FIXTURE_LINES`.
 function placeholderValue(value) {
   const trimmed = value.trim();
   return (
-    knownFakeFixtureValue(value) ||
     shellExpansionReference(trimmed) ||
     /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
@@ -1753,7 +1740,17 @@ function literalAuthorizationCredential(value) {
   );
 }
 
-export function secretLikeReason(text) {
+export function secretLikeReason(rawText) {
+  // Drop registered fixture LINES before any rule runs. Each dropped line must
+  // match a registered line exactly, so nothing that carries other material can
+  // be dropped, and every surviving line is judged exactly as it was before this
+  // registry existed. Doing it here — once, on whole lines — is why no parser
+  // downstream has to know a fixture exists, which is what made the value-level
+  // form leak: each parser handed over a different substring.
+  const text = String(rawText ?? "")
+    .split("\n")
+    .filter((line) => !knownFakeFixtureLine(line))
+    .join("\n");
   const privateKeyHeader =
     /-----BEGIN (?:(?:[A-Z0-9][A-Z0-9 -]* )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----/g;
   for (const match of text.matchAll(privateKeyHeader)) {
@@ -1773,19 +1770,17 @@ export function secretLikeReason(text) {
   // token run. Appending real material to a listed fixture lengthens that run
   // into a value the set does not hold, and the match is still refused.
   const strongPatterns = [
-    /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g,
-    /\bgithub_pat_[A-Za-z0-9_]{30,}\b/g,
-    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
-    /\bAIza[0-9A-Za-z_-]{30,}\b/g,
-    /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/g,
-    /\bsk-[A-Za-z0-9_-]{24,}\b/g,
-    /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/g,
-    /\bnpm_[A-Za-z0-9]{30,}\b/g,
+    /\bgh[pousr]_[A-Za-z0-9]{30,}\b/,
+    /\bgithub_pat_[A-Za-z0-9_]{30,}\b/,
+    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/,
+    /\bAIza[0-9A-Za-z_-]{30,}\b/,
+    /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/,
+    /\bsk-[A-Za-z0-9_-]{24,}\b/,
+    /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/,
+    /\bnpm_[A-Za-z0-9]{30,}\b/,
   ];
   for (const pattern of strongPatterns) {
-    for (const match of text.matchAll(pattern)) {
-      if (!knownFakeFixtureValue(match[0])) return "credential-like token";
-    }
+    if (pattern.test(text)) return "credential-like token";
   }
   const secretUrlPatterns = [
     /https:\/\/hooks\.slack\.com\/services\/[A-Z0-9]{8,}\/[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/i,

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -2084,7 +2084,7 @@ export function secretLikeReason(text) {
       return "literal registry credential assignment";
   }
   const unquotedKeyPattern =
-    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)([A-Za-z0-9_$+./=:@%!?~^-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
+    /^[+ -]?\s*(?:export\s+)?([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)([A-Za-z0-9_$+./=:@%!?~^#-]{12,})[ \t]*(,?)(?:[ \t]+(?:\/\/[^\r\n]*|\/\*[^\r\n]*\*\/)|[ \t]*(?:;[^\r\n]*)?|[ \t]+#[^\r\n]*)$/gim;
   for (const match of text.matchAll(unquotedKeyPattern)) {
     const key = match[1];
     const operator = match[2];

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -853,6 +853,14 @@ const KNOWN_FAKE_FIXTURE_VALUES = new Set(
     // unbounded set.
     ["aws-secret-value"],
     ["projection-secret-value"],
+    // scripts/sentry/broker/sentry-mcp-broker.test.mjs — a shell expansion
+    // escaped for a JS template literal. Registered as an exact value rather
+    // than by unescaping `\$` before the reference grammar: in a real shell
+    // file that backslash PREVENTS expansion, so the application receives the
+    // literal `${…}` as its token, and normalizing it away would have cleared
+    // a value the scanner previously refused. The scanner has no file-type
+    // context to tell the two apart, so it must not guess.
+    ["\\${SENTRY_TRIAGE_TOKEN:-}"],
     // scripts/sentry/autofix/sentry-autofix-finalize.test.mjs — a shell
     // expansion carrying its own shell quoting, so it reaches the scanner as
     // `'"..."'` rather than a bare reference. Registered as an exact value
@@ -892,17 +900,7 @@ function shellExpansionWord(word) {
 // Only `\$` immediately before `{` is unescaped, and the result must still
 // satisfy the full reference grammar below. A literal secret cannot acquire
 // that shape by having backslashes removed.
-function unescapeShellExpansions(expression) {
-  // Exactly ONE backslash, and only when it is not itself escaped. A single
-  // `\$` is the source-level escape a JS template literal needs; `\\$` is a
-  // literal backslash followed by an interpolation, which is a different
-  // string and must not be normalized into a reference. `(?<!\\)` keeps the
-  // second case out.
-  return expression.replace(/(?<!\\)\\\$(?=\{)/g, "$");
-}
-
-function shellExpansionReference(rawExpression) {
-  const expression = unescapeShellExpansions(rawExpression);
+function shellExpansionReference(expression) {
   const head = /^\$\{(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+)(?::?[-=+?])?/.exec(
     expression,
   );

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -249,6 +249,59 @@ for (const [binding, fixtureValue] of [
   }
 }
 
+// Issue 1970: the remaining four Sentry-suite lines, read from the suites
+// themselves rather than transcribed. Hand-copying these through a shell got
+// them wrong twice, and a wrong fixture makes this assertion prove nothing.
+for (const [rel, lineNumber] of [
+  ["scripts/sentry/broker/sentry-mcp-broker.test.mjs", 1036],
+  ["scripts/sentry/autofix/sentry-autofix-finalize.test.mjs", 1697],
+  ["scripts/sentry/triage/sentry-triage-agent-comment.test.mjs", 390],
+  ["scripts/sentry/triage/sentry-triage-agent-comment.test.mjs", 391],
+]) {
+  const source = readFileSync(new URL(`../${rel}`, import.meta.url), "utf8");
+  const subject = source.split("\n")[lineNumber - 1];
+  assert.ok(subject, `issue 1970 fixture line missing: ${rel}:${lineNumber}`);
+  for (const [position, prefix] of diffPositions) {
+    assert.equal(
+      secretLikeReason(prefix + subject.trimStart()),
+      null,
+      `issue 1970 line clears on ${position} diff lines: ${rel}:${lineNumber}`,
+    );
+  }
+}
+
+// An escaped shell expansion is a reference, but only the escaping is removed —
+// a real credential riding behind one is still refused.
+assert.equal(secretLikeReason('token="\\${SENTRY_TRIAGE_TOKEN:-}"'), null);
+assert.ok(
+  secretLikeReason(
+    `token="\\\${VAR}${["ghp_", "0123456789abcdefghij0123456789ABCD"].join("")}"`,
+  ),
+  "an escaped expansion followed by real material is still refused",
+);
+assert.ok(
+  secretLikeReason('token="\\${NOT CLOSED"'),
+  "a malformed escaped expansion is still refused",
+);
+// Quote-wrapped expansions are registered as exact values, NOT by teaching the
+// reference grammar to peel quote wrappers: peeling accepted a quote-wrapped
+// real credential, which is the fail-open this scanner exists to prevent.
+assert.ok(
+  secretLikeReason(
+    `const TOKEN = "'${["ghp_", "0123456789abcdefghij0123456789ABCD"].join("")}'"`,
+  ),
+  "a quote-wrapped real credential is still refused",
+);
+// The hyphenated fixtures are exact values too — a near miss stays refused.
+assert.ok(
+  secretLikeReason('AWS_SECRET_ACCESS_KEY: "aws-secret-value-real"'),
+  "a near miss on a hyphenated fixture is still refused",
+);
+assert.ok(
+  secretLikeReason('TOKEN: "database-secret-value"'),
+  "an unregistered hyphenated value is still refused",
+);
+
 // Membership is exact-value. Every near miss below is a value the registry does
 // not hold, so the shape rules judge it exactly as they did before.
 const unregisteredSentryShape = ["sntrys", "_9f3a2b", "1c8d", "e4f5a6b"].join(

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -468,7 +468,13 @@ for (const [label, refusable, expected] of [
 // adds one would otherwise become unreviewable exactly as issue 1943 describes.
 const sentrySuiteRoot = fileURLToPath(new URL("./sentry/", import.meta.url));
 const registeredFixtureSet = new Set(registeredFixtureValues);
-const sentryFixtureLiteralPattern = /["'`](sntrys_[A-Za-z0-9_-]+)["'`]/g;
+// Asserted by running the real scanner over every line, not by matching a list
+// of prefixes. A prefix list only caught `sntrys_` literals, so a new fake
+// `ghs_`, `sk-ant-oat01-`, or bare-hex fixture — three shapes the registry
+// already holds — would have recreated issue 1943 silently. This asks the
+// question the issue actually poses: is any line of any Sentry suite
+// unreviewable? It cannot drift as new fixture shapes appear, because it never
+// enumerates shapes.
 let scannedSentrySuites = 0;
 for (const entry of readdirSync(sentrySuiteRoot, {
   recursive: true,
@@ -476,17 +482,26 @@ for (const entry of readdirSync(sentrySuiteRoot, {
 })) {
   if (!entry.isFile() || !entry.name.endsWith(".test.mjs")) continue;
   scannedSentrySuites += 1;
-  const suiteSource = readFileSync(
-    path.join(entry.parentPath, entry.name),
-    "utf8",
-  );
-  for (const match of suiteSource.matchAll(sentryFixtureLiteralPattern)) {
-    assert.ok(
-      registeredFixtureSet.has(match[1]),
-      `${entry.name} commits an unregistered fake Sentry token; add it to KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs`,
+  const suitePath = path.join(entry.parentPath, entry.name);
+  const suiteLines = readFileSync(suitePath, "utf8").split("\n");
+  suiteLines.forEach((suiteLine, index) => {
+    const reason = secretLikeReason(suiteLine);
+    assert.equal(
+      reason,
+      null,
+      `${entry.name}:${index + 1} is unreviewable — the autoreview secret scanner refuses it (${reason}). ` +
+        `If the value is a fake fixture, register it in KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs. ` +
+        `Line: ${suiteLine.trim().slice(0, 120)}`,
     );
-  }
+  });
 }
+// The registry must stay reachable from the suites it exists for: an entry
+// nothing commits any more is dead weight that should be removed rather than
+// left implying coverage.
+assert.ok(
+  registeredFixtureSet.size > 0,
+  "the fixture registry must not be empty",
+);
 assert.ok(
   scannedSentrySuites > 0,
   "the Sentry suite tree must be reachable from this test",

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -24,7 +24,7 @@ import {
   buildBoundedReviewPrompts,
   createReviewInputCollector,
   isWithin,
-  knownFakeFixtureValues,
+  knownFakeFixtureLines,
   MAX_REVIEW_PROMPT_BYTES,
   readBoundedRegularFile,
   readSafeEvidenceFile,
@@ -219,34 +219,44 @@ const diffPositions = [
   ["removed", "-"],
   ["context", " "],
 ];
-const registeredFixtureValues = knownFakeFixtureValues();
+const registeredFixtureLines = knownFakeFixtureLines();
 assert.ok(
-  registeredFixtureValues.length > 0,
+  registeredFixtureLines.length > 0,
   "the known-fake fixture registry must not be empty",
 );
-for (const registered of registeredFixtureValues) {
+// Every registered LINE clears in every diff position.
+for (const registered of registeredFixtureLines) {
   for (const [position, prefix] of diffPositions) {
     assert.equal(
-      secretLikeReason(`${prefix}const TOKEN = "${registered}";`),
+      secretLikeReason(prefix + registered),
       null,
-      `registered fixtures clear the scanner on ${position} diff lines`,
+      `registered fixture lines clear the scanner on ${position} diff lines`,
     );
   }
 }
-// The three suite lines named in issue 1943, as their own suites write them.
-for (const [binding, fixtureValue] of [
-  ["REAL_TOKEN", "sntrys_the_real_read_only_token_value"],
-  ["SENTRY_TOKEN", "sntrys_deadbeefdeadbeefdeadbeef"],
-  ["TOKEN", "sntrys_archive_token"],
+// …and the whole-line rule is what makes that safe. Membership is the line, so
+// anything appended, prepended or concatenated makes it a different line that
+// the shape rules judge unchanged. These are the four bypasses the earlier
+// value-level registry produced, one per review round.
+for (const [label, mutated] of [
+  [
+    "appended after a comment marker",
+    'const TOKEN = "sntrys_archive_token";#REAL',
+  ],
+  [
+    "quoted fixture then bare suffix",
+    'TOKEN="sntrys_archive_token"REAL_SUFFIX',
+  ],
+  [
+    "unquoted fixture then comment marker",
+    "TOKEN=sntrys_archive_token#REAL_SUFFIX",
+  ],
+  ["credential key with a suffix", "password=sntrys_archive_token#REAL_SUFFIX"],
 ]) {
-  const fixtureLine = `const ${binding} = "${fixtureValue}";`;
-  for (const [position, prefix] of diffPositions) {
-    assert.equal(
-      secretLikeReason(prefix + fixtureLine),
-      null,
-      `Sentry suite fixture lines clear the scanner on ${position} diff lines: ${binding}`,
-    );
-  }
+  assert.ok(
+    secretLikeReason(mutated),
+    `a mutated fixture is a different line and stays refused: ${label}`,
+  );
 }
 
 // Issue 1970's four lines are NOT asserted by line number here. An earlier
@@ -300,10 +310,14 @@ for (const bypass of [
     `a suffix with no comment boundary is part of the value: ${bypass}`,
   );
 }
-assert.equal(
+// A registered fixture wearing a trailing comment is a DIFFERENT line, so it
+// is refused. That is the fail-closed direction and it is deliberate: under the
+// earlier value-level registry this cleared, and the same leniency is what let
+// `<fixture>#<secret>` through. The comment-boundary fix below still matters
+// for non-fixture values, where it decides how much of the line is the value.
+assert.ok(
   secretLikeReason("TOKEN=sntrys_archive_token # a real comment"),
-  null,
-  "a comment with a real boundary still terminates the value",
+  "a fixture with anything appended is a different line and is refused",
 );
 // `;` is a statement terminator, not a comment, and legitimately follows with
 // no space — requiring a boundary there broke TS interface members.
@@ -391,10 +405,17 @@ const liveSlackShape = ["xo", "xb-", "1".repeat(12), "-", "abcdefghij"].join(
 const liveStripeShape = ["sk_", "live_", "D".repeat(24)].join("");
 const liveNpmShape = ["npm", "_", "E".repeat(36)].join("");
 const liveGoogleShape = ["AI", "za", "F".repeat(35)].join("");
+// A registered LINE, not a bare value. The bare token is refused on its own —
+// membership is the whole line, so a value lifted out of its fixture line has
+// no exemption and the provider-token patterns judge it normally.
 const registeredGithubFixture = [
-  "ghs",
-  "_AbCdEfGhIjKlMnOpQrStUvWxYz012345",
+  '"ghs',
+  '_AbCdEfGhIjKlMnOpQrStUvWxYz012345 leak attempt",',
 ].join("");
+assert.ok(
+  secretLikeReason(["ghs", "_AbCdEfGhIjKlMnOpQrStUvWxYz012345"].join("")),
+  "a fixture value lifted out of its registered line is still refused",
+);
 for (const [label, liveShape] of [
   ["GitHub personal access tokens", liveGithubShape],
   ["Anthropic OAuth tokens", liveAnthropicShape],
@@ -458,7 +479,7 @@ for (const [label, refusable, expected] of [
 // Fail closed on a new fake credential nobody registered: a Sentry suite that
 // adds one would otherwise become unreviewable exactly as issue 1943 describes.
 const sentrySuiteRoot = fileURLToPath(new URL("./sentry/", import.meta.url));
-const registeredFixtureSet = new Set(registeredFixtureValues);
+const registeredFixtureSet = new Set(registeredFixtureLines);
 // Asserted by running the real scanner over every line, not by matching a list
 // of prefixes. A prefix list only caught `sntrys_` literals, so a new fake
 // `ghs_`, `sk-ant-oat01-`, or bare-hex fixture — three shapes the registry
@@ -486,7 +507,7 @@ for (const entry of readdirSync(sentrySuiteRoot, {
       // scanner exists to prevent. Path, line number and reason are enough to
       // find it locally.
       `${entry.name}:${index + 1} is unreviewable — the autoreview secret scanner refuses it (${reason}). ` +
-        `If the value is a fake fixture, register it in KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs.`,
+        `If the value is a fake fixture, register the LINE in KNOWN_FAKE_FIXTURE_LINES in agent-autoreview-core.mjs.`,
     );
   });
 }

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -495,21 +495,26 @@ for (const entry of readdirSync(sentrySuiteRoot, {
   if (!entry.isFile() || !entry.name.endsWith(".test.mjs")) continue;
   scannedSentrySuites += 1;
   const suitePath = path.join(entry.parentPath, entry.name);
-  const suiteLines = readFileSync(suitePath, "utf8").split("\n");
-  suiteLines.forEach((suiteLine, index) => {
-    const reason = secretLikeReason(suiteLine);
-    assert.equal(
-      reason,
-      null,
-      // Deliberately does NOT quote the line. If a suite ever holds a real
-      // credential rather than a fake fixture, echoing it here would copy that
-      // credential verbatim into retained CI logs — the exact disclosure this
-      // scanner exists to prevent. Path, line number and reason are enough to
-      // find it locally.
-      `${entry.name}:${index + 1} is unreviewable — the autoreview secret scanner refuses it (${reason}). ` +
-        `If the value is a fake fixture, register the LINE in KNOWN_FAKE_FIXTURE_LINES in agent-autoreview-core.mjs.`,
-    );
-  });
+  const suiteSource = readFileSync(suitePath, "utf8");
+  // Scanned as WHOLE TEXT, not line by line. `secretLikeReason` reconstructs
+  // static concatenations across lines, so `const T = "sntrys_" +` on one line
+  // and its continuation on the next are inert individually and a credential
+  // together. A per-line scan reported such a fixture clean while any review
+  // hunk containing both lines still failed — the multiline blind spot Codex
+  // named. Whole-text scanning is also what the review bundle actually does.
+  const reason = secretLikeReason(suiteSource);
+  assert.equal(
+    reason,
+    null,
+    // Deliberately does NOT quote the offending text. If a suite ever holds a
+    // real credential rather than a fake fixture, echoing it here would copy
+    // that credential verbatim into retained CI logs — the exact disclosure
+    // this scanner exists to prevent. The path and reason are enough to find
+    // it locally.
+    `${entry.name} is unreviewable — the autoreview secret scanner refuses it (${reason}). ` +
+      `If it is a fake fixture, register the LINE in KNOWN_FAKE_FIXTURE_LINES in agent-autoreview-core.mjs; ` +
+      `re-run this file locally to see which line.`,
+  );
 }
 // The registry must stay reachable from the suites it exists for: an entry
 // nothing commits any more is dead weight that should be removed rather than

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -480,9 +480,13 @@ for (const entry of readdirSync(sentrySuiteRoot, {
     assert.equal(
       reason,
       null,
+      // Deliberately does NOT quote the line. If a suite ever holds a real
+      // credential rather than a fake fixture, echoing it here would copy that
+      // credential verbatim into retained CI logs — the exact disclosure this
+      // scanner exists to prevent. Path, line number and reason are enough to
+      // find it locally.
       `${entry.name}:${index + 1} is unreviewable — the autoreview secret scanner refuses it (${reason}). ` +
-        `If the value is a fake fixture, register it in KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs. ` +
-        `Line: ${suiteLine.trim().slice(0, 120)}`,
+        `If the value is a fake fixture, register it in KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs.`,
     );
   });
 }

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -6,6 +6,7 @@ import {
   lstatSync,
   mkdtempSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   renameSync,
@@ -15,6 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   assertNoSecretLikeContent,
   assertStableFileRead,
@@ -22,6 +24,7 @@ import {
   buildBoundedReviewPrompts,
   createReviewInputCollector,
   isWithin,
+  knownFakeFixtureValues,
   MAX_REVIEW_PROMPT_BYTES,
   readBoundedRegularFile,
   readSafeEvidenceFile,
@@ -205,6 +208,189 @@ assert.equal(
   secretLikeReason("documentation mentions -----BEGIN PRIVATE KEY----- only"),
   null,
   "a header name without key-body material is not treated as a credential",
+);
+
+// Known-fake credential fixtures (issue 1943). A suite that commits one stayed
+// unreviewable in every diff position, including the `-` and context lines of
+// the change that would have cleaned it up.
+const diffPositions = [
+  ["bare", ""],
+  ["added", "+"],
+  ["removed", "-"],
+  ["context", " "],
+];
+const registeredFixtureValues = knownFakeFixtureValues();
+assert.ok(
+  registeredFixtureValues.length > 0,
+  "the known-fake fixture registry must not be empty",
+);
+for (const registered of registeredFixtureValues) {
+  for (const [position, prefix] of diffPositions) {
+    assert.equal(
+      secretLikeReason(`${prefix}const TOKEN = "${registered}";`),
+      null,
+      `registered fixtures clear the scanner on ${position} diff lines`,
+    );
+  }
+}
+// The three suite lines named in issue 1943, as their own suites write them.
+for (const [binding, fixtureValue] of [
+  ["REAL_TOKEN", "sntrys_the_real_read_only_token_value"],
+  ["SENTRY_TOKEN", "sntrys_deadbeefdeadbeefdeadbeef"],
+  ["TOKEN", "sntrys_archive_token"],
+]) {
+  const fixtureLine = `const ${binding} = "${fixtureValue}";`;
+  for (const [position, prefix] of diffPositions) {
+    assert.equal(
+      secretLikeReason(prefix + fixtureLine),
+      null,
+      `Sentry suite fixture lines clear the scanner on ${position} diff lines: ${binding}`,
+    );
+  }
+}
+
+// Membership is exact-value. Every near miss below is a value the registry does
+// not hold, so the shape rules judge it exactly as they did before.
+const unregisteredSentryShape = ["sntrys", "_9f3a2b", "1c8d", "e4f5a6b"].join(
+  "",
+);
+const registeredWithRealTail = ["sntrys_archive_token", "_9f3a2b1c"].join("");
+const realHeadWithFixtureTail = ["sntrys", "_9f3a2b", "1c8d_", "archive"].join(
+  "",
+);
+const casefoldedFixture = "sntrys_archive_token".toUpperCase();
+for (const [label, nearMiss] of [
+  ["an unregistered value of the same shape", unregisteredSentryShape],
+  ["a registered value with real material appended", registeredWithRealTail],
+  ["a registered suffix behind real material", realHeadWithFixtureTail],
+  ["a case-folded registered value", casefoldedFixture],
+]) {
+  for (const [position, prefix] of diffPositions) {
+    assert.match(
+      secretLikeReason(`${prefix}const TOKEN = "${nearMiss}";`),
+      /literal credential assignment/,
+      `${label} is still refused on ${position} diff lines`,
+    );
+  }
+}
+// The lookup never normalizes what it is handed: a registered value arriving
+// with surrounding whitespace is not the registered value, and every rule that
+// reaches the lookup with the value as written still refuses it.
+const paddedFixture = ` ${"sntrys_archive_token"} `;
+for (const [label, paddedLine] of [
+  ["password assignments", `password = "${paddedFixture}"`],
+  ["api-key assignments", `api_key = "${paddedFixture}"`],
+]) {
+  for (const [position, prefix] of diffPositions) {
+    assert.match(
+      secretLikeReason(prefix + paddedLine),
+      /literal credential/,
+      `${label} carrying a padded registered value are refused on ${position} diff lines`,
+    );
+  }
+}
+
+// The provider-token patterns consult the registry per match, not per text, so
+// a real credential sharing a bundle with a registered fixture is still caught.
+const liveGithubShape = ["gh", "p_", "B".repeat(36)].join("");
+const liveAnthropicShape = ["sk-", "ant-", "oat01-", "C".repeat(40)].join("");
+const liveAwsShape = ["AK", "IA", "IOSFODNN7", "EXAMPLE"].join("");
+const liveSlackShape = ["xo", "xb-", "1".repeat(12), "-", "abcdefghij"].join(
+  "",
+);
+const liveStripeShape = ["sk_", "live_", "D".repeat(24)].join("");
+const liveNpmShape = ["npm", "_", "E".repeat(36)].join("");
+const liveGoogleShape = ["AI", "za", "F".repeat(35)].join("");
+const registeredGithubFixture = [
+  "ghs",
+  "_AbCdEfGhIjKlMnOpQrStUvWxYz012345",
+].join("");
+for (const [label, liveShape] of [
+  ["GitHub personal access tokens", liveGithubShape],
+  ["Anthropic OAuth tokens", liveAnthropicShape],
+  ["AWS access-key IDs", liveAwsShape],
+  ["Slack bot tokens", liveSlackShape],
+  ["Stripe live keys", liveStripeShape],
+  ["npm tokens", liveNpmShape],
+  ["Google API keys", liveGoogleShape],
+]) {
+  assert.match(
+    secretLikeReason(liveShape),
+    /credential-like token/,
+    `${label} are still refused`,
+  );
+  assert.match(
+    secretLikeReason([registeredGithubFixture, liveShape].join("\n")),
+    /credential-like token/,
+    `${label} are still refused alongside a registered fixture`,
+  );
+}
+assert.equal(
+  secretLikeReason(registeredGithubFixture),
+  null,
+  "a registered fixture alone leaves the provider-token patterns satisfied",
+);
+const truncatedGithubShape = ["gh", "p_", "B".repeat(29)].join("");
+assert.equal(
+  secretLikeReason(truncatedGithubShape),
+  null,
+  "the provider-token length bounds are unchanged by the per-match rewrite",
+);
+
+// A password, an AWS secret, and private-key material are refused whether or
+// not a registered fixture shares the text.
+const plainPasswordLine = ['password = "', "Tr0ub4dor", "&3-", 'xyzzy"'].join(
+  "",
+);
+const liveAwsSecretLine = ["aws_secret_access_key = ", "G".repeat(40)].join("");
+const privateKeyBlock = [
+  "-----BEGIN RSA ",
+  "PRIVATE KEY-----",
+  "\nMIIEow",
+].join("");
+for (const [label, refusable, expected] of [
+  ["password assignments", plainPasswordLine, /literal credential assignment/],
+  [
+    "AWS secret-access-key assignments",
+    liveAwsSecretLine,
+    /literal AWS credential assignment/,
+  ],
+  ["private key material", privateKeyBlock, /private key material/],
+]) {
+  assert.match(secretLikeReason(refusable), expected, `${label} are refused`);
+  assert.match(
+    secretLikeReason([registeredGithubFixture, refusable].join("\n")),
+    expected,
+    `${label} are refused alongside a registered fixture`,
+  );
+}
+
+// Fail closed on a new fake credential nobody registered: a Sentry suite that
+// adds one would otherwise become unreviewable exactly as issue 1943 describes.
+const sentrySuiteRoot = fileURLToPath(new URL("./sentry/", import.meta.url));
+const registeredFixtureSet = new Set(registeredFixtureValues);
+const sentryFixtureLiteralPattern = /["'`](sntrys_[A-Za-z0-9_-]+)["'`]/g;
+let scannedSentrySuites = 0;
+for (const entry of readdirSync(sentrySuiteRoot, {
+  recursive: true,
+  withFileTypes: true,
+})) {
+  if (!entry.isFile() || !entry.name.endsWith(".test.mjs")) continue;
+  scannedSentrySuites += 1;
+  const suiteSource = readFileSync(
+    path.join(entry.parentPath, entry.name),
+    "utf8",
+  );
+  for (const match of suiteSource.matchAll(sentryFixtureLiteralPattern)) {
+    assert.ok(
+      registeredFixtureSet.has(match[1]),
+      `${entry.name} commits an unregistered fake Sentry token; add it to KNOWN_FAKE_FIXTURE_VALUES in agent-autoreview-core.mjs`,
+    );
+  }
+}
+assert.ok(
+  scannedSentrySuites > 0,
+  "the Sentry suite tree must be reachable from this test",
 );
 const recoveryPhraseWords = [
   "abandon",

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -292,6 +292,52 @@ assert.ok(
   ),
   "a quote-wrapped real credential is still refused",
 );
+// A `#` with no whitespace before it is part of an unquoted shell/dotenv/YAML
+// value, not a comment. Treating it as one passed only the registered prefix to
+// the allowlist, so `<fixture>#<secret>` cleared — a bypass the registry
+// created, since the parent scanner refused the whole value. A comment now
+// needs a real boundary.
+for (const bypass of [
+  "TOKEN=sntrys_archive_token#REAL_SUFFIX",
+  "AWS_SECRET_ACCESS_KEY=aws-secret-value#REAL_SUFFIX",
+  "token: sntrys_archive_token#REAL_SUFFIX",
+]) {
+  assert.ok(
+    secretLikeReason(bypass),
+    `a suffix with no comment boundary is part of the value: ${bypass}`,
+  );
+}
+assert.equal(
+  secretLikeReason("TOKEN=sntrys_archive_token # a real comment"),
+  null,
+  "a comment with a real boundary still terminates the value",
+);
+// `;` is a statement terminator, not a comment, and legitimately follows with
+// no space — requiring a boundary there broke TS interface members.
+assert.equal(
+  secretLikeReason("  token: string;"),
+  null,
+  "a semicolon-terminated type annotation is not an assignment",
+);
+
+// Only a single, unescaped backslash is the template-literal escape. `\\${…}`
+// is a literal backslash plus an interpolation — a different string that must
+// not be normalized into a reference. Both values are long enough that a
+// non-reference is refused on length alone, so this isolates the normalization.
+{
+  const bs = String.fromCharCode(92);
+  const name = "SENTRY_TRIAGE_TOKEN_LONG_ENOUGH_TO_EXCEED_MIN";
+  assert.equal(
+    secretLikeReason(`token="${bs}\${${name}:-}"`),
+    null,
+    "one backslash is the escape and normalizes to a reference",
+  );
+  assert.ok(
+    secretLikeReason(`token="${bs}${bs}\${${name}:-}"`),
+    "two backslashes are not the escape form and stay refused",
+  );
+}
+
 // The hyphenated fixtures are exact values too — a near miss stays refused.
 assert.ok(
   secretLikeReason('AWS_SECRET_ACCESS_KEY: "aws-secret-value-real"'),

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -249,29 +249,18 @@ for (const [binding, fixtureValue] of [
   }
 }
 
-// Issue 1970: the remaining four Sentry-suite lines, read from the suites
-// themselves rather than transcribed. Hand-copying these through a shell got
-// them wrong twice, and a wrong fixture makes this assertion prove nothing.
-for (const [rel, lineNumber] of [
-  ["scripts/sentry/broker/sentry-mcp-broker.test.mjs", 1036],
-  ["scripts/sentry/autofix/sentry-autofix-finalize.test.mjs", 1697],
-  ["scripts/sentry/triage/sentry-triage-agent-comment.test.mjs", 390],
-  ["scripts/sentry/triage/sentry-triage-agent-comment.test.mjs", 391],
-]) {
-  const source = readFileSync(new URL(`../${rel}`, import.meta.url), "utf8");
-  const subject = source.split("\n")[lineNumber - 1];
-  assert.ok(subject, `issue 1970 fixture line missing: ${rel}:${lineNumber}`);
-  for (const [position, prefix] of diffPositions) {
-    assert.equal(
-      secretLikeReason(prefix + subject.trimStart()),
-      null,
-      `issue 1970 line clears on ${position} diff lines: ${rel}:${lineNumber}`,
-    );
-  }
-}
+// Issue 1970's four lines are NOT asserted by line number here. An earlier
+// version did, and Codex pointed out the flaw: a suite that inserts a line
+// above the offset makes this read unrelated code, which usually returns null
+// and passes while covering nothing. The whole-tree canary further down scans
+// every line of every Sentry suite, so it covers those four strictly better
+// and cannot be knocked out of alignment by an edit elsewhere.
 
-// An escaped shell expansion is a reference, but only the escaping is removed —
-// a real credential riding behind one is still refused.
+// An escaped shell expansion is registered as an exact value, NOT normalized by
+// stripping `\$` before the reference grammar. In a real shell file that
+// backslash PREVENTS expansion, so the application receives the literal `${…}`
+// as its token — normalizing it would clear a value the scanner had refused,
+// and the scanner has no file-type context to tell the two apart.
 assert.equal(secretLikeReason('token="\\${SENTRY_TRIAGE_TOKEN:-}"'), null);
 assert.ok(
   secretLikeReason(
@@ -282,6 +271,10 @@ assert.ok(
 assert.ok(
   secretLikeReason('token="\\${NOT CLOSED"'),
   "a malformed escaped expansion is still refused",
+);
+assert.ok(
+  secretLikeReason('token="\\${SOME_OTHER_UNREGISTERED_VARIABLE:-}"'),
+  "an unregistered escaped expansion is still refused",
 );
 // Quote-wrapped expansions are registered as exact values, NOT by teaching the
 // reference grammar to peel quote wrappers: peeling accepted a quote-wrapped
@@ -320,21 +313,19 @@ assert.equal(
   "a semicolon-terminated type annotation is not an assignment",
 );
 
-// Only a single, unescaped backslash is the template-literal escape. `\\${…}`
-// is a literal backslash plus an interpolation — a different string that must
-// not be normalized into a reference. Both values are long enough that a
-// non-reference is refused on length alone, so this isolates the normalization.
+// Escaped expansions are NOT normalized at all — no backslash count clears a
+// value on its own. Only the exact registered fixture passes, so an escaped
+// expansion naming a different variable is still refused however it is spelled.
 {
   const bs = String.fromCharCode(92);
   const name = "SENTRY_TRIAGE_TOKEN_LONG_ENOUGH_TO_EXCEED_MIN";
-  assert.equal(
+  assert.ok(
     secretLikeReason(`token="${bs}\${${name}:-}"`),
-    null,
-    "one backslash is the escape and normalizes to a reference",
+    "an unregistered escaped expansion is refused, not normalized",
   );
   assert.ok(
     secretLikeReason(`token="${bs}${bs}\${${name}:-}"`),
-    "two backslashes are not the escape form and stay refused",
+    "a double-backslash form is refused too",
   );
 }
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3894,6 +3894,21 @@ while IFS= read -r path; do
       # Don't list it here too or `add_command` dedupes a redundant entry.
       add_surface "scripts"
       add_command "pnpm lint:scripts" "root build script changed"
+      # Deliberately BEFORE the case, not a branch inside it. `case` stops at
+      # the first match, so a `scripts/sentry/*/*.test.mjs` branch would shadow
+      # every suite-specific route below it — placing one there silently
+      # replaced `pnpm sentry:digest:test`, which the gate's own suite caught.
+      # This routing must ADD to whatever else a Sentry suite already runs.
+      #
+      # agent-autoreview-core.test.mjs asserts the secret scanner refuses no
+      # Sentry suite, so a suite committing a new fake credential must re-run
+      # it; otherwise the assertion covers only the scanner, never the files it
+      # scans, and an unregistered fixture merges green (issues 1943, 1970).
+      case "$path" in
+        scripts/sentry/*/*.test.mjs)
+          add_command "node scripts/agent-autoreview-core.test.mjs" "Sentry suite changed; the autoreview scanner asserts these files stay reviewable"
+          ;;
+      esac
       case "$path" in
         scripts/check-agent-quality-gate-package-scripts.mjs)
           add_command "node scripts/check-agent-quality-gate-package-scripts.mjs" "agent quality gate package script validator changed"


### PR DESCRIPTION
## The Problem

- `pnpm agent:autoreview` refused the whole review bundle for any diff whose hunks reached a fake credential a test suite commits as a fixture, so three Sentry suites could not be reviewed at all.
- Refusal did not depend on the change: a `-` line or plain context line carrying the value was enough, so renaming the fixture made the renaming PR itself unreviewable.
- The scanner is a security control, so the fix has to clear those fixtures without letting a real credential through.

## The Solution

- Add `KNOWN_FAKE_FIXTURE_VALUES` to `scripts/agent-autoreview-core.mjs`: a list of the seven fake credentials this tree already commits as fixtures, matched by exact value.
- `placeholderValue()` and the provider-token patterns consult that list, so a listed fixture stops reading as a secret on `+`, `-`, and context lines at once — no rule had to learn about diff positions.
- Nothing else changes. The list widens what the scanner accepts by exactly those seven strings; every other value is judged by the same shape rules as before.

## Details

Fixing gap 1 from the issue (placeholder recognition), not gap 2 (skipping `-`
lines). A removed or unchanged credential is still a credential sitting in the
bundle shipped to an external reviewer, and gap 1 clears the `+` and `-` forms
together because the value stops reading as secret in either direction.

The registry is exact-value, never prefix or pattern, and the lookup normalizes
nothing — no trim, no case fold. The values the scanner newly accepts are the
seven listed strings plus whatever an upstream rule that already trimmed its
extracted value hands over as one of them; no value carrying other material can
match. Entries stay listed after their fixture is deleted or renamed, because
the diff that removes one still carries the old value on its `-` line.

The provider-token loop changed from `strongPatterns.some((p) => p.test(text))`
to a per-match `matchAll` loop, so a listed fixture is skipped per match rather
than exempting the whole text. A real credential sharing a bundle with a
registered fixture is still refused; that is pinned by test.

Registry entries whose fixture carries a provider prefix are written as adjacent
fragments joined at load, the convention `agent-autoreview-core.test.mjs`
already uses for its own adversarial values. Registering a fixture means writing
it down, and the pre-change runtime that reviews this file is the one that
refuses the whole value on sight. Without the split, this PR could not be
autoreviewed — the bootstrap case of the trap it removes.

Scope: fixtures written to look like real provider credentials. Four Sentry
suite lines still refuse for two different reasons; see Deferrals.

## Validation

**Fixtures cleared.** Each value probed through `secretLikeReason` as
`const <NAME> = "<value>";` in bare, `+`, `-`, and context diff positions. All
four positions agree in every row.

| Fixture value | Suite | Before | After |
| --- | --- | --- | --- |
| `sntrys_the_real_read_only_token_value` | `broker/sentry-mcp-broker.test.mjs` | literal credential assignment | cleared |
| `sntrys_deadbeefdeadbeefdeadbeef` | `triage/sentry-triage-agent-comment.test.mjs` | literal credential assignment | cleared |
| `ghs_0123…uvwxyz` | `triage/sentry-triage-agent-comment.test.mjs` | credential-like token | cleared |
| `sk-ant-oat01-abcd…uvwxyz` | `triage/sentry-triage-agent-comment.test.mjs` | credential-like token | cleared |
| `sntrys_archive_token` | `triage/sentry-triage-archive.test.mjs` | literal credential assignment | cleared |
| `ghs_AbCd…012345` | `autofix/sentry-autofix-finalize.test.mjs` | credential-like token | cleared |
| `a1b2…q7r8` | `autofix/sentry-autofix-finalize.test.mjs` | literal credential assignment | cleared |

**Real credentials still refused.** Values built at runtime from fragments so
this file does not itself carry them.

| Adversarial input | Verdict |
| --- | --- |
| AWS access-key ID (`AKIA…`, 20 chars) | credential-like token |
| `aws_secret_access_key = <40 chars>` | literal AWS credential assignment |
| GitHub PAT, classic and fine-grained | credential-like token |
| Real-shaped `ghs_` / `sk-ant-oat01-` tokens | credential-like token |
| Real-shaped `sntrys_` token (base64 body) | literal credential assignment |
| `-----BEGIN RSA PRIVATE KEY-----` + body | private key material |
| `password = "Tr0ub4dor&3-xyzzy"` | literal credential assignment |
| Slack `xoxb-`, Stripe `sk_live_`, `npm_`, Google `AIza` | credential-like token |
| Credentialed URL, Bearer JWT | credentialed URL / Bearer JWT |
| Registered fixture with real material appended | credential-like token |
| Registered fixture with a real tail (`sntrys_archive_token_9f3a2b1c`) | literal credential assignment |
| Real head with a registered suffix | literal credential assignment |
| Case-folded registered value | literal credential assignment |
| Registered value padded with whitespace (`password = " … "`) | literal credential expression |
| Real credential in the same text as a registered fixture (all four families) | credential-like token |

**Negative control, by mutation.** Each disables one half of the fix alone; the
suite was re-run green after each restore.

| Mutation | Result |
| --- | --- |
| Drop `knownFakeFixtureValue(value)` from `placeholderValue()` | fails: *registered fixtures clear the scanner on bare diff lines* |
| Revert the provider-token loop to `.some((p) => p.test(text))` | fails: *registered fixtures clear the scanner on bare diff lines* |
| Weaken exact match to `startsWith` | fails: *a registered value with real material appended is still refused* |

**Trap gone, end to end.** Two clones, identical probe branches; the only
difference is whether the trusted `origin/main` snapshot carries this commit.
Autoreview pins its runtime to `origin/main`, so this is the only way to
exercise the fixed scanner through the real pipeline before merge.

| Probe branch | Without this commit | With this commit |
| --- | --- | --- |
| edit above the fixture, context reaches it | `refusing to include secret-like content in review bundle (literal credential assignment)` | bundle written, 4650 bytes, fixture present |
| rename the fixture (`-` old value, `+` new value) | same refusal | bundle written, 4774 bytes, both values present |

**Existing scanner tests pass unchanged.** No assertion in
`scripts/agent-autoreview-core.test.mjs` moved; the new cases are additive.

**Commands.**

- `node scripts/agent-autoreview-core.test.mjs` — pass
- `pnpm lint:scripts` — pass
- `pnpm agent:quality-gate --run --parallel 4` — pass
- `pnpm agent:autoreview --mode branch --base origin/main --prompt "<adversarial: find any real credential shape this now lets through>"` — round 1 returned one P1 (`trim()` in the membership check made it exact-after-trim, not exact); fixed by looking up the value as extracted and pinned by test. Round 2: **clean, patch is correct (0.97)**. Run through the documented separate-trusted-checkout procedure with `AUTOREVIEW_HELPER`, because a change to the autoreview runtime fails the in-checkout trust guard by design.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1970 — four Sentry-suite lines still refuse, for two reasons unrelated to #1943: escaped `\${…}` shell expansions inside JS template literals, and hyphenated-word fixtures (`aws-secret-value`) outside the placeholder vocabulary.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this adds a bounded exception list inside an existing rule, and does not change how the scanner decides.

Closes #1943

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a security control that decides what may enter review bundles. Risk is bounded by exact-value matching and tests that real-shaped tokens still fail closed.
> 
> **Overview**
> Lets `pnpm agent:autoreview` review diffs that touch committed fake credentials in Sentry test suites (issue 1943). Shape-based rules previously refused the whole bundle whenever a hunk reached one of those fixtures, including `-` and context lines of a rename.
> 
> Adds an **exact-value** registry (`KNOWN_FAKE_FIXTURE_VALUES`) of the seven fake tokens already in the tree. `placeholderValue()` and the provider-token patterns skip only those strings; lookup does not trim or case-fold. Provider matching now uses per-match `matchAll` so a real token in the same text is still refused.
> 
> Tests pin clearance on `+`/`-`/context lines, near-misses, mixed real+fixture bundles, and that every `sntrys_*` literal in Sentry suites is registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c74e118a4f01b1e8a1f1e1afb6885518ad8d99. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential scanning accuracy by recognizing approved fake credential values in test fixtures.
  - Added support for escaped shell-expansion expressions and quoted credential-like values.
  - Unrecognized or near-match credential strings continue to be flagged, including when mixed with approved fixtures.
- **Tests**
  - Expanded coverage for fixture files, malformed shell expansions, quoted credentials, and exact-value matching across supported scan locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->