### PR TITLE
fix(babysit): retry pr:ready-state before declaring the repo gate failed

### DIFF
--- a/.claude/babysit-pr.sh
+++ b/.claude/babysit-pr.sh
@@ -67,10 +67,21 @@ babysit_repo_gate() {
   # from corrupting the JSON too. `--repo` is required: a cloud checkout's
   # origin is the credential-proxy URL, which gh cannot map to a repository,
   # so an implicit-repo invocation fails even after the capability gate passes.
+  # Retry once before declaring FAIL. The probe intermittently hits transient
+  # gh auth/network errors that succeed on an immediate retry, and a
+  # single-attempt FAIL turns those into false REPO_GATE_FAIL alarms — six of
+  # them across three PRs on 2026-08-20, every one reproducing clean by hand
+  # seconds later. The sibling hook in the babysit-pr skill's `hooks/` dir
+  # gained this retry on 2026-06-10 for the same symptom, but THIS file is
+  # sourced last and overrides it, so the fix never took effect. Keep both in
+  # step: a change here belongs there too.
   local output
   output=$(cd "$repo_root" && pnpm --silent pr:ready-state --pr "$pr" --repo "${owner}/${repo}" --json 2>/dev/null) || {
-    printf 'FAIL pr:ready-state errored (repro: pnpm pr:ready-state --pr %s --repo %s/%s --json)' "$pr" "$owner" "$repo"
-    return 0
+    sleep 5
+    output=$(cd "$repo_root" && pnpm --silent pr:ready-state --pr "$pr" --repo "${owner}/${repo}" --json 2>/dev/null) || {
+      printf 'FAIL pr:ready-state errored twice (repro: pnpm pr:ready-state --pr %s --repo %s/%s --json)' "$pr" "$owner" "$repo"
+      return 0
+    }
   }
 
   # Explicit boolean test — do NOT use `.ready // …` fallbacks: jq's `//`


### PR DESCRIPTION
## The Problem

- `babysit_repo_gate` ran `pnpm pr:ready-state` once and reported `FAIL` on any error, so a transient gh auth/network blip surfaced as a `REPO_GATE_FAIL` alarm.
- It fired six times across three PRs on 2026-08-20, always on the first poll (`elapsed=0m`), and every one reproduced clean by hand seconds later.

## The Solution

- Retry the probe once, five seconds apart, before declaring the gate failed — the same treatment the sibling hook already applies.

## Details

The retry already existed. `~/.agents/skills/babysit-pr/hooks/mento-protocol__monitoring-monorepo.sh` gained it on 2026-06-10 after this exact symptom produced three false alarms in forty minutes, and its comment says so. It never took effect, because `.claude/babysit-pr.sh` is sourced last and overrides that hook — the fix has been sitting in the copy that loses ever since.

That override is deliberate and stays: this file passes `--repo <owner>/<name>`, which cloud checkouts need because their origin is a credential-proxy URL `gh` cannot map to a repository. So the fix belongs here rather than by deleting the local hook. A comment now marks the two as siblings to keep in step.

**Only the readiness gate changes.** `FEEDBACK_GATE_FAIL` fired alongside it, but that gate lives in the generic `babysit-prs.sh` and already retries once — its message reads "errored twice". Retry count is therefore not what ails it, and adding another here would be copying a fix onto a different problem.

### Confidence

This is a mitigation matched to a consistent signature, not a proven repair. A transient cannot be reproduced on demand, so the change is justified by the failure pattern and by the sibling hook's precedent, not by a red-to-green test. If the alarm survives, the next thing to examine is why **both** gates fail only on the first poll and never later — that shared timing, not the retry count, is the remaining suspect.

## Validation

- `bash -n .claude/babysit-pr.sh` passes.
- No mapped test suite covers this hook; `pnpm agent:quality-gate` maps no commands for the path.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this restores intended behaviour in one hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MP8VmVKmismQuJdsL7hfF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small babysit-hook retry only; no product, auth, or data-path changes. Persistent probe failures still FAIL after two attempts.
> 
> **Overview**
> Stops false `REPO_GATE_FAIL` alarms from a one-shot `pnpm pr:ready-state` probe in `babysit_repo_gate`.
> 
> On probe error, waits 5 seconds and retries once before FAIL. The FAIL message now says the command errored twice. This matches the sibling skill hook that this file overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78827e5b6e42c11f9272fda16bffc1b29b059f65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks by automatically retrying once after a brief delay when the initial check fails.
  * Reports an error only if both attempts are unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->