### PR TITLE
fix(scripts): bring AGENTS.md back under the context-budget byte cap

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -17,7 +17,7 @@ garden_lane: agent-entry-points
 ## Scope
 
 `scripts/` holds deploy wrappers, agent quality gates, code-health checks, and
-repo maintenance utilities. 38 files sit flat at the top level today.
+repo maintenance utilities.
 
 ## Layout
 
@@ -150,14 +150,11 @@ in the PR that moves a file. Every surface there is mandatory.
   caller plan path, or print, upload, or cache either plan form. The wrapper
   mechanism and its deploy-only bootstrap exception are in
   [ADR 0061](../docs/adr/0061-exact-plan-guard-for-manual-platform-applies.md).
-- `pnpm tf:test` enforces the deployment source-staging contract: the five
-  allowed `gcloud builds submit` / `gcloud app deploy` callsites, the Metrics
-  Bridge build config, its guarded no-refresh bootstrap plans, and the staging
-  bucket IAM. Never add a callsite, an indirect or dynamic deploy form, or a CLI
-  service-account override, and keep inert examples in
-  `scripts/deploy-staging-contract.test.mjs`.
+- `pnpm tf:test` enforces the deployment source-staging contract. Never add a
+  deploy callsite, an indirect or dynamic deploy form, or a CLI service-account
+  override; keep inert examples in `scripts/deploy-staging-contract.test.mjs`.
   [ADR 0053](../docs/adr/0053-explicit-deployment-source-staging.md) owns the
-  contract, its supported static syntax, and its explicit proof limits.
+  contract, the allowed callsites, and its proof limits.
 
 ## Verification
 


### PR DESCRIPTION
## The Problem

Main's required `ci` check is red, and every open PR fails it on its merge ref.
`scripts/AGENTS.md` is 9,270 bytes against the 9,216-byte context-budget route
cap. Two merges landed near-simultaneously — #1964 after the D3 growth from
#1959/#1972 — each green on its own merge ref, jointly over the cap. This is
the drift-through-merge-queue hazard ADR 0064 records, here for byte budgets.

## The Solution

Trim `scripts/AGENTS.md` under the cap without losing normative content:

- Drop the flat-file count from Scope. It read "38 files sit flat" and has been
  wrong since the D2/D4/D3 moves; a literal count silently rots on every move.
- Compress the `pnpm tf:test` bullet to the normative instruction plus the
  ADR 0053 pointer. The removed enumeration (allowed callsites, build config,
  bootstrap plans, staging IAM) is owned verbatim by ADR 0053.

Result: 9,036 bytes, 180 bytes of headroom.

## Validation

- `pnpm agent:context-budget --strict` exits 0.
- `node --test scripts/context/agent-context-budget.test.mjs` — the exact suite
  red on main — passes.
- Quality gate: all mapped commands passed (`trunk check`, context-check,
  ADR reminder, navigation-eval fixtures, `tf:test`).
- Local autoreview: codex clean (0.96), claude clean (its one caveat — whether
  ADR 0053 enumerates the callsites — is true of the ADR; verified outside the
  bundle).

## Deferrals

- None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording trim in agent instructions; no runtime, deploy, or security logic changes.
> 
> **Overview**
> Trims `scripts/AGENTS.md` so it fits the agent context-budget cap again (CI was failing after two merges jointly pushed it over 9,216 bytes).
> 
> Drops the stale “38 files sit flat” count from Scope, and shortens the `pnpm tf:test` operating-rule bullet so the callsite/IAM enumeration lives only in ADR 0053. Normative “don’t add deploy callsites or SA overrides” guidance stays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b31e91adfa14121f5230cd5fe56363e3c75d3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the scope and structure guidance for deployment-related scripts.
  - Strengthened deployment operating rules, including restrictions on new deployment callsites, indirect or dynamic deployment methods, and command-line service-account overrides.
  - Retained references to the relevant architecture decision record and requirements for inert test examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->