### PR TITLE
docs(agent): capture backlog workflow safeguards

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -119,30 +119,59 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
-  pre-merge head, and merge that remote-tracking ref into the already-published
-  PR branch. Treat the resolved tree as a new substantive head. After resolving
-  it, write the path union to a newline-delimited file:
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`. Before
+  the merge, pin the fetched base and the published PR head to immutable commit
+  IDs:
 
   ```bash
-  (
-    path_tmp="$(mktemp -d)" || exit 1
-    trap 'rm -rf -- "$path_tmp"' EXIT
-    git diff --name-only --no-renames <verified-base-ref> > "$path_tmp/base" || exit 1
-    git diff --name-only --no-renames <pre-merge-head> > "$path_tmp/pre-merge" || exit 1
-    sort -u "$path_tmp/base" "$path_tmp/pre-merge" > "$path_tmp/union" || exit 1
-    mv "$path_tmp/union" <changed-paths-file> || exit 1
-  )
+  base_oid="$(git rev-parse '<verified-base-ref>^{commit}')" || exit 1
+  premerge_oid="$(git rev-parse 'HEAD^{commit}')" || exit 1
   ```
 
-  Stop if this block exits nonzero. Use that union as the review and validation
-  scope. Then run focused validation and the mapped quality gate with
-  `--base <verified-base-ref>` and
-  `--changed-paths-file <changed-paths-file>` so it routes inherited-only paths.
-  Repeat any applicable closeout review if the resolution or inherited base
-  changes a reviewed surface or the change's materiality. Commit and push through
-  `HEAD_REMOTE`. Do not rebase a published PR because the resulting force-push
-  violates this workflow.
+  Merge exact `base_oid`. Resolve the conflicts and run focused validation.
+  Create the merge commit locally, but do not push it yet. Stop concurrent
+  writers. Pin the final local head, require a clean worktree, and require both
+  input commits to be its ancestors:
+
+  ```bash
+  final_head="$(git rev-parse 'HEAD^{commit}')" || exit 1
+  worktree_state="$(git status --porcelain=v1)" || exit 1
+  test -z "$worktree_state" || exit 1
+  git merge-base --is-ancestor "$base_oid" "$final_head" || exit 1
+  git merge-base --is-ancestor "$premerge_oid" "$final_head" || exit 1
+  ```
+
+  Run both mapped gates against the same `final_head`:
+
+  ```bash
+  pnpm agent:quality-gate --base "$base_oid" --head HEAD --run
+  pnpm agent:quality-gate --base "$premerge_oid" --head HEAD --run
+  ```
+
+  Prepare separate verified branch-mode review bundles in different empty
+  directories outside the worktree:
+
+  ```bash
+  pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
+  pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
+  pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
+  pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
+  ```
+
+  The adapter has no `--pr` option. Pass the numeric PR through
+  `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
+  fresh-context review of each bundle. Retain each pre-review manifest and run
+  its generated post-review command with `--expected-bundle-manifest`.
+
+  Bind the two gate results and two post-verified review verdicts to the same
+  `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
+  After every command, resolve `HEAD` with an explicit success check, require it
+  to equal `final_head`, and recheck the clean worktree. Any follow-up fix
+  restarts both gates and both bundle reviews from a new clean final head. Only
+  then push through `HEAD_REMOTE`. Do not rebase a published PR because the
+  resulting force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-20
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -120,9 +120,13 @@ item required.
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
 - Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
-  that remote-tracking ref into the already-published PR branch. Resolve, run
-  focused validation, commit, and push through `HEAD_REMOTE`. Do not rebase a
-  published PR because the resulting force-push violates this workflow.
+  that remote-tracking ref into the already-published PR branch. Treat the
+  resolved tree as a new substantive head. Recompute review scope against the
+  fetched base, then run focused validation and the mapped quality gate. Repeat
+  the applicable closeout review when the resolution or inherited base changes
+  a reviewed surface or materiality. Commit and push through `HEAD_REMOTE`. Do
+  not rebase a published PR because the resulting force-push violates this
+  workflow.
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -119,14 +119,15 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
-  that remote-tracking ref into the already-published PR branch. Treat the
-  resolved tree as a new substantive head. Recompute review scope against the
-  fetched base, then run focused validation and the mapped quality gate. Repeat
-  the applicable closeout review when the resolution or inherited base changes
-  a reviewed surface or materiality. Commit and push through `HEAD_REMOTE`. Do
-  not rebase a published PR because the resulting force-push violates this
-  workflow.
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
+  pre-merge head, and merge that remote-tracking ref into the already-published
+  PR branch. Treat the resolved tree as a new substantive head. Recompute review
+  and validation scope from both the resolved PR diff against the fetched base
+  and the merge delta from the recorded pre-merge head. Then run focused
+  validation and the mapped quality gate. Repeat the applicable closeout review
+  when the resolution or inherited base changes a reviewed surface or
+  materiality. Commit and push through `HEAD_REMOTE`. Do not rebase a published
+  PR because the resulting force-push violates this workflow.
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -121,13 +121,29 @@ item required.
   failures, run focused validation, commit, and push.
 - Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
   pre-merge head, and merge that remote-tracking ref into the already-published
-  PR branch. Treat the resolved tree as a new substantive head. Recompute review
-  and validation scope from both the resolved PR diff against the fetched base
-  and the merge delta from the recorded pre-merge head. Then run focused
-  validation and the mapped quality gate. Repeat the applicable closeout review
-  when the resolution or inherited base changes a reviewed surface or
-  materiality. Commit and push through `HEAD_REMOTE`. Do not rebase a published
-  PR because the resulting force-push violates this workflow.
+  PR branch. Treat the resolved tree as a new substantive head. After resolving
+  it, write the path union to a newline-delimited file:
+
+  ```bash
+  (
+    path_tmp="$(mktemp -d)" || exit 1
+    trap 'rm -rf -- "$path_tmp"' EXIT
+    git diff --name-only --no-renames <verified-base-ref> > "$path_tmp/base" || exit 1
+    git diff --name-only --no-renames <pre-merge-head> > "$path_tmp/pre-merge" || exit 1
+    sort -u "$path_tmp/base" "$path_tmp/pre-merge" > "$path_tmp/union" || exit 1
+    mv "$path_tmp/union" <changed-paths-file> || exit 1
+  )
+  ```
+
+  Stop if this block exits nonzero. Use that union as the review and validation
+  scope. Then run focused validation and the mapped quality gate with
+  `--base <verified-base-ref>` and
+  `--changed-paths-file <changed-paths-file>` so it routes inherited-only paths.
+  Repeat any applicable closeout review if the resolution or inherited base
+  changes a reviewed surface or the change's materiality. Commit and push through
+  `HEAD_REMOTE`. Do not rebase a published PR because the resulting force-push
+  violates this workflow.
+
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -171,6 +171,19 @@ item required.
   test "$base_bundle" != "$premerge_bundle" || exit 1
   test ! -e "$base_bundle" || exit 1
   test ! -e "$premerge_bundle" || exit 1
+  ```
+
+  Before any autoreview entrypoint runs, inspect both exact tree axes:
+  `base_oid..final_head` and `premerge_oid..final_head`. An axis is
+  runtime-sensitive if it changes `scripts/agent-autoreview.sh`,
+  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`, or if
+  the parsed `package.json` `scripts["agent:autoreview"]` value differs. Check
+  the paths and the parsed value on both axes. Fail closed on any Git, blob,
+  JSON, or comparison error.
+
+  When neither axis is runtime-sensitive, use the package adapter:
+
+  ```bash
   pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
     --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
   pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
@@ -178,6 +191,15 @@ item required.
   pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
   pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
   ```
+
+  When either axis is runtime-sensitive, never run the final checkout's
+  `pnpm agent:autoreview` or autoreview wrapper. Follow the trusted pre-change
+  procedure in
+  [`agent-quality-gate-mechanics.md`](../../../docs/notes/agent-quality-gate-mechanics.md).
+  That procedure owns trusted-commit selection, checkout and runtime proof,
+  both axis preparations, pre/post manifest verification, and invalidation.
+  Run `pnpm agent:autoreview:test -- --jobs 1` only as separate behavior proof;
+  it establishes no review provenance.
 
   The adapter has no `--pr` option. Pass the numeric PR through
   `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
@@ -188,8 +210,9 @@ item required.
   `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
   After every command, resolve `HEAD` with an explicit success check, require it
   to equal `final_head`, and recheck the clean worktree. Any follow-up fix
-  restarts both gates and both bundle reviews from a new clean final head. Only
-  then push through `HEAD_REMOTE`. Do not rebase a published PR because the
+  restarts both gates and both bundle reviews from a new clean final head. The
+  trusted-runtime procedure owns its stricter restart conditions. Only then
+  push through `HEAD_REMOTE`. Do not rebase a published PR because the
   resulting force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -38,13 +38,21 @@ gh pr view --json number,url,title,headRefName,headRefOid,baseRefName,headReposi
 
 In a Claude cloud session, resolve the same fields over MCP
 (`list_pull_requests` filtered by head branch, or `pull_request_read` method
-`get`) and bind by content rather than by remote name: the PR must be
-same-repository (`headRepository.nameWithOwner` equals the session-attached
-repo), local `git rev-parse HEAD` must equal the MCP-resolved `headRefOid`
-before editing, and the verified proxy `origin` serves as both `HEAD_REMOTE`
-and `BASE_REMOTE`. Cross-repository (fork) PRs stop on that surface. For the
-post-push guard there, re-resolve with `pull_request_read` method `get` in
-place of `gh pr view` and require the returned `headRefOid` to equal local
+`get`). Bind the result by content rather than by remote name.
+
+Immediately after resolving these fields, stop on every tool surface if
+`isCrossRepository` is `true`. Apply the same stop when another surface proves
+that the head repository differs from the base repository. This repo-local
+adapter cannot yet prove feedback, gate, and review trust roots end to end for
+fork-controlled source. Do not run a repo-local command, mutate a checkout,
+probe feedback, run a gate, or start a review for that target.
+
+For a remaining same-repository Claude cloud target,
+`headRepository.nameWithOwner` must equal the session-attached repo. Local
+`git rev-parse HEAD` must equal the MCP-resolved `headRefOid` before editing,
+and the verified proxy `origin` serves as both `HEAD_REMOTE` and `BASE_REMOTE`.
+For the post-push guard there, re-resolve with `pull_request_read` method `get`
+in place of `gh pr view` and require the returned `headRefOid` to equal local
 `HEAD`.
 
 For an explicit target, accept a bare number or PR URL. Derive and preserve
@@ -56,10 +64,9 @@ repository.
 Before any blocker fix mutates files or Git history, bind the checkout to that
 resolved target:
 
-- Select `HEAD_REMOTE` only after verifying that its repository equals
-  `headRepository.nameWithOwner`. For a cross-repository PR, use a dedicated
-  checkout with the fork as `HEAD_REMOTE`; keep a separately verified
-  `BASE_REMOTE` for `BASE_REPO` and never swap their roles.
+- For the remaining same-repository target, select `HEAD_REMOTE` and
+  `BASE_REMOTE` only after verifying that each remote serves the repository
+  named by both `headRepository.nameWithOwner` and `BASE_REPO`.
 - `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
   the resolved `headRefOid`. If either differs, stop or switch to a clean,
   dedicated checkout at the PR head before editing.
@@ -152,6 +159,18 @@ item required.
   directories outside the worktree:
 
   ```bash
+  worktree_root="$(git rev-parse --show-toplevel)" || exit 1
+  worktree_root="$(cd "$worktree_root" && pwd -P)" || exit 1
+  bundle_parent="$(mktemp -d)" || exit 1
+  bundle_parent="$(cd "$bundle_parent" && pwd -P)" || exit 1
+  case "$bundle_parent/" in
+    "$worktree_root/"*) exit 1 ;;
+  esac
+  base_bundle="$bundle_parent/base"
+  premerge_bundle="$bundle_parent/premerge"
+  test "$base_bundle" != "$premerge_bundle" || exit 1
+  test ! -e "$base_bundle" || exit 1
+  test ! -e "$premerge_bundle" || exit 1
   pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
     --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
   pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -61,12 +61,28 @@ After that initial resolution, pass `--repo <BASE_REPO>` to every `gh pr view`,
 feedback-state, and ready-state call—even when the PR began in the current
 repository.
 
+For every remaining local same-repository target, complete the repository trust
+preflight before any repo-local adapter command. Require `origin` to exist with
+one effective canonical GitHub fetch URL whose normalized slug equals both
+`BASE_REPO` and `headRepository.nameWithOwner`. Fetch `baseRefName` and protected
+`main` through that `origin` into their matching remote-tracking refs. Resolve
+and retain `base_oid` and `protected_main_oid`, then require
+`origin/<baseRefName>` and `origin/main` to keep those exact values. The values
+must match when `baseRefName` is `main`. Fail closed on ambiguity, fetch failure,
+or drift. Never repair the guard by changing a remote URL; use a clean dedicated
+checkout with the correct `origin`.
+
+Immediately before and after every feedback-state, ready-state, gate, or review
+adapter call, recheck the canonical `origin` URL and both retained refs. Any
+drift stops the workflow and invalidates that result. Any refetch restarts this
+preflight and refreshes both pins before another adapter call.
+
 Before any blocker fix mutates files or Git history, bind the checkout to that
 resolved target:
 
-- For the remaining same-repository target, select `HEAD_REMOTE` and
-  `BASE_REMOTE` only after verifying that each remote serves the repository
-  named by both `headRepository.nameWithOwner` and `BASE_REPO`.
+- For the remaining same-repository target, use the verified `origin` as
+  `BASE_REMOTE`. Select `HEAD_REMOTE` only after verifying that it serves the
+  repository named by both `headRepository.nameWithOwner` and `BASE_REPO`.
 - `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
   the resolved `headRefOid`. If either differs, stop or switch to a clean,
   dedicated checkout at the PR head before editing.
@@ -126,9 +142,10 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`. Before
-  the merge, pin the fetched base and the published PR head to immutable commit
-  IDs:
+- Merge conflict: restart the repository trust preflight. Fetch `baseRefName`
+  and protected `main` from the verified `BASE_REMOTE`, then refresh both
+  retained pins before any gate or review adapter. Before the merge, pin the
+  fetched base and the published PR head to immutable commit IDs:
 
   ```bash
   base_oid="$(git rev-parse '<verified-base-ref>^{commit}')" || exit 1
@@ -155,7 +172,7 @@ item required.
   pnpm agent:quality-gate --base "$premerge_oid" --head HEAD --run
   ```
 
-  Prepare separate verified branch-mode review bundles in different empty
+  Prepare separate verified branch-mode review bundles in different absent
   directories outside the worktree:
 
   ```bash
@@ -176,44 +193,88 @@ item required.
   Before any autoreview entrypoint runs, inspect both exact tree axes:
   `base_oid..final_head` and `premerge_oid..final_head`. An axis is
   runtime-sensitive if it changes `scripts/agent-autoreview.sh`,
-  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`, or if
-  the parsed `package.json` `scripts["agent:autoreview"]` value differs. Check
-  the paths and the parsed value on both axes. Fail closed on any Git, blob,
-  JSON, or comparison error.
+  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`. Check
+  all three paths on both axes. Fail closed on any Git, blob, mode, or
+  comparison error.
 
-  When neither axis is runtime-sensitive, use the package adapter:
+  When neither axis is runtime-sensitive, bind the absolute final-checkout
+  wrapper and helper. Never use the package adapter for merge-review
+  provenance:
 
   ```bash
-  pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
-    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
-  pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
-    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
-  pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
-  pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
+  autoreview_wrapper="$worktree_root/scripts/agent-autoreview.sh"
+  autoreview_helper="$worktree_root/scripts/agent-autoreview.mjs"
   ```
 
   When either axis is runtime-sensitive, never run the final checkout's
-  `pnpm agent:autoreview` or autoreview wrapper. Follow the trusted pre-change
-  procedure in
+  autoreview wrapper. Follow the trusted pre-change procedure in
   [`agent-quality-gate-mechanics.md`](../../../docs/notes/agent-quality-gate-mechanics.md).
-  That procedure owns trusted-commit selection, checkout and runtime proof,
-  both axis preparations, pre/post manifest verification, and invalidation.
-  Run `pnpm agent:autoreview:test -- --jobs 1` only as separate behavior proof;
-  it establishes no review provenance.
+  That procedure selects the absolute `autoreview_wrapper` and
+  `autoreview_helper` and owns trusted-commit selection, checkout and runtime
+  proof, both axis preparations, pre/post manifest verification, and
+  invalidation.
+
+  After selecting the two absolute paths, define one direct runner and use it
+  for both axes:
+
+  ```bash
+  run_bound_autoreview() {
+    (
+      cd "$worktree_root" || exit 1
+      AUTOREVIEW_HELPER="$autoreview_helper" \
+        /bin/bash "$autoreview_wrapper" "$@"
+    )
+  }
+  run_bound_autoreview --prepare-bundle-dir "$base_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
+  run_bound_autoreview --prepare-bundle-dir "$premerge_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
+  run_bound_autoreview --verify-bundle-dir "$base_bundle"
+  run_bound_autoreview --verify-bundle-dir "$premerge_bundle"
+  ```
 
   The adapter has no `--pr` option. Pass the numeric PR through
   `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
-  fresh-context review of each bundle. Retain each pre-review manifest and run
-  its generated post-review command with `--expected-bundle-manifest`.
+  fresh-context review of each bundle and retain each pre-review manifest.
+  After both semantic reviews, postverify both bundles through the same bound
+  runner:
+
+  ```bash
+  run_bound_autoreview --verify-bundle-dir "$base_bundle" \
+    --expected-bundle-manifest <retained-base-digest>
+  run_bound_autoreview --verify-bundle-dir "$premerge_bundle" \
+    --expected-bundle-manifest <retained-premerge-digest>
+  ```
+
+  Before and after every preparation or verification call, recheck the
+  normalized `origin` identity, the retained base and protected-main refs,
+  `final_head`, the clean worktree, all three runtime identities, and any
+  trusted-checkout root. Any drift invalidates the call.
+
+  Only after both postverifications pass, run the sequential suite through the
+  direct system shell as separate behavior evidence:
+
+  ```bash
+  (
+    cd "$worktree_root" || exit 1
+    AUTOREVIEW_TEST_FOCUS=suite /bin/bash \
+      "$worktree_root/scripts/agent-autoreview.test.sh" --jobs 1
+  ) || exit 1
+  ```
+
+  Require terminal success. Then run a final origin, retained-ref, head, clean,
+  runtime-identity, and trusted-root recheck. Any suite failure or drift
+  invalidates the sequence and restarts preflight, both gates, both bundles,
+  both reviews, both postverifications, and the direct suite.
 
   Bind the two gate results and two post-verified review verdicts to the same
   `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
   After every command, resolve `HEAD` with an explicit success check, require it
   to equal `final_head`, and recheck the clean worktree. Any follow-up fix
-  restarts both gates and both bundle reviews from a new clean final head. The
+  restarts the full sequence above from a new clean final head. The
   trusted-runtime procedure owns its stricter restart conditions. Only then
-  push through `HEAD_REMOTE`. Do not rebase a published PR because the
-  resulting force-push violates this workflow.
+  push through `HEAD_REMOTE`. Do not rebase a published PR because the resulting
+  force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -119,30 +119,59 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
-  pre-merge head, and merge that remote-tracking ref into the already-published
-  PR branch. Treat the resolved tree as a new substantive head. After resolving
-  it, write the path union to a newline-delimited file:
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`. Before
+  the merge, pin the fetched base and the published PR head to immutable commit
+  IDs:
 
   ```bash
-  (
-    path_tmp="$(mktemp -d)" || exit 1
-    trap 'rm -rf -- "$path_tmp"' EXIT
-    git diff --name-only --no-renames <verified-base-ref> > "$path_tmp/base" || exit 1
-    git diff --name-only --no-renames <pre-merge-head> > "$path_tmp/pre-merge" || exit 1
-    sort -u "$path_tmp/base" "$path_tmp/pre-merge" > "$path_tmp/union" || exit 1
-    mv "$path_tmp/union" <changed-paths-file> || exit 1
-  )
+  base_oid="$(git rev-parse '<verified-base-ref>^{commit}')" || exit 1
+  premerge_oid="$(git rev-parse 'HEAD^{commit}')" || exit 1
   ```
 
-  Stop if this block exits nonzero. Use that union as the review and validation
-  scope. Then run focused validation and the mapped quality gate with
-  `--base <verified-base-ref>` and
-  `--changed-paths-file <changed-paths-file>` so it routes inherited-only paths.
-  Repeat any applicable closeout review if the resolution or inherited base
-  changes a reviewed surface or the change's materiality. Commit and push through
-  `HEAD_REMOTE`. Do not rebase a published PR because the resulting force-push
-  violates this workflow.
+  Merge exact `base_oid`. Resolve the conflicts and run focused validation.
+  Create the merge commit locally, but do not push it yet. Stop concurrent
+  writers. Pin the final local head, require a clean worktree, and require both
+  input commits to be its ancestors:
+
+  ```bash
+  final_head="$(git rev-parse 'HEAD^{commit}')" || exit 1
+  worktree_state="$(git status --porcelain=v1)" || exit 1
+  test -z "$worktree_state" || exit 1
+  git merge-base --is-ancestor "$base_oid" "$final_head" || exit 1
+  git merge-base --is-ancestor "$premerge_oid" "$final_head" || exit 1
+  ```
+
+  Run both mapped gates against the same `final_head`:
+
+  ```bash
+  pnpm agent:quality-gate --base "$base_oid" --head HEAD --run
+  pnpm agent:quality-gate --base "$premerge_oid" --head HEAD --run
+  ```
+
+  Prepare separate verified branch-mode review bundles in different empty
+  directories outside the worktree:
+
+  ```bash
+  pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
+  pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
+  pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
+  pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
+  ```
+
+  The adapter has no `--pr` option. Pass the numeric PR through
+  `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
+  fresh-context review of each bundle. Retain each pre-review manifest and run
+  its generated post-review command with `--expected-bundle-manifest`.
+
+  Bind the two gate results and two post-verified review verdicts to the same
+  `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
+  After every command, resolve `HEAD` with an explicit success check, require it
+  to equal `final_head`, and recheck the clean worktree. Any follow-up fix
+  restarts both gates and both bundle reviews from a new clean final head. Only
+  then push through `HEAD_REMOTE`. Do not rebase a published PR because the
+  resulting force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-20
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -120,9 +120,13 @@ item required.
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
 - Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
-  that remote-tracking ref into the already-published PR branch. Resolve, run
-  focused validation, commit, and push through `HEAD_REMOTE`. Do not rebase a
-  published PR because the resulting force-push violates this workflow.
+  that remote-tracking ref into the already-published PR branch. Treat the
+  resolved tree as a new substantive head. Recompute review scope against the
+  fetched base, then run focused validation and the mapped quality gate. Repeat
+  the applicable closeout review when the resolution or inherited base changes
+  a reviewed surface or materiality. Commit and push through `HEAD_REMOTE`. Do
+  not rebase a published PR because the resulting force-push violates this
+  workflow.
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -119,14 +119,15 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE` and merge
-  that remote-tracking ref into the already-published PR branch. Treat the
-  resolved tree as a new substantive head. Recompute review scope against the
-  fetched base, then run focused validation and the mapped quality gate. Repeat
-  the applicable closeout review when the resolution or inherited base changes
-  a reviewed surface or materiality. Commit and push through `HEAD_REMOTE`. Do
-  not rebase a published PR because the resulting force-push violates this
-  workflow.
+- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
+  pre-merge head, and merge that remote-tracking ref into the already-published
+  PR branch. Treat the resolved tree as a new substantive head. Recompute review
+  and validation scope from both the resolved PR diff against the fetched base
+  and the merge delta from the recorded pre-merge head. Then run focused
+  validation and the mapped quality gate. Repeat the applicable closeout review
+  when the resolution or inherited base changes a reviewed surface or
+  materiality. Commit and push through `HEAD_REMOTE`. Do not rebase a published
+  PR because the resulting force-push violates this workflow.
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -121,13 +121,29 @@ item required.
   failures, run focused validation, commit, and push.
 - Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`, record the
   pre-merge head, and merge that remote-tracking ref into the already-published
-  PR branch. Treat the resolved tree as a new substantive head. Recompute review
-  and validation scope from both the resolved PR diff against the fetched base
-  and the merge delta from the recorded pre-merge head. Then run focused
-  validation and the mapped quality gate. Repeat the applicable closeout review
-  when the resolution or inherited base changes a reviewed surface or
-  materiality. Commit and push through `HEAD_REMOTE`. Do not rebase a published
-  PR because the resulting force-push violates this workflow.
+  PR branch. Treat the resolved tree as a new substantive head. After resolving
+  it, write the path union to a newline-delimited file:
+
+  ```bash
+  (
+    path_tmp="$(mktemp -d)" || exit 1
+    trap 'rm -rf -- "$path_tmp"' EXIT
+    git diff --name-only --no-renames <verified-base-ref> > "$path_tmp/base" || exit 1
+    git diff --name-only --no-renames <pre-merge-head> > "$path_tmp/pre-merge" || exit 1
+    sort -u "$path_tmp/base" "$path_tmp/pre-merge" > "$path_tmp/union" || exit 1
+    mv "$path_tmp/union" <changed-paths-file> || exit 1
+  )
+  ```
+
+  Stop if this block exits nonzero. Use that union as the review and validation
+  scope. Then run focused validation and the mapped quality gate with
+  `--base <verified-base-ref>` and
+  `--changed-paths-file <changed-paths-file>` so it routes inherited-only paths.
+  Repeat any applicable closeout review if the resolution or inherited base
+  changes a reviewed surface or the change's materiality. Commit and push through
+  `HEAD_REMOTE`. Do not rebase a published PR because the resulting force-push
+  violates this workflow.
+
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing
   logs before all-clear. Reply before resolving a thread. The reply forms,

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -171,6 +171,19 @@ item required.
   test "$base_bundle" != "$premerge_bundle" || exit 1
   test ! -e "$base_bundle" || exit 1
   test ! -e "$premerge_bundle" || exit 1
+  ```
+
+  Before any autoreview entrypoint runs, inspect both exact tree axes:
+  `base_oid..final_head` and `premerge_oid..final_head`. An axis is
+  runtime-sensitive if it changes `scripts/agent-autoreview.sh`,
+  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`, or if
+  the parsed `package.json` `scripts["agent:autoreview"]` value differs. Check
+  the paths and the parsed value on both axes. Fail closed on any Git, blob,
+  JSON, or comparison error.
+
+  When neither axis is runtime-sensitive, use the package adapter:
+
+  ```bash
   pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
     --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
   pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
@@ -178,6 +191,15 @@ item required.
   pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
   pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
   ```
+
+  When either axis is runtime-sensitive, never run the final checkout's
+  `pnpm agent:autoreview` or autoreview wrapper. Follow the trusted pre-change
+  procedure in
+  [`agent-quality-gate-mechanics.md`](../../../docs/notes/agent-quality-gate-mechanics.md).
+  That procedure owns trusted-commit selection, checkout and runtime proof,
+  both axis preparations, pre/post manifest verification, and invalidation.
+  Run `pnpm agent:autoreview:test -- --jobs 1` only as separate behavior proof;
+  it establishes no review provenance.
 
   The adapter has no `--pr` option. Pass the numeric PR through
   `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
@@ -188,8 +210,9 @@ item required.
   `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
   After every command, resolve `HEAD` with an explicit success check, require it
   to equal `final_head`, and recheck the clean worktree. Any follow-up fix
-  restarts both gates and both bundle reviews from a new clean final head. Only
-  then push through `HEAD_REMOTE`. Do not rebase a published PR because the
+  restarts both gates and both bundle reviews from a new clean final head. The
+  trusted-runtime procedure owns its stricter restart conditions. Only then
+  push through `HEAD_REMOTE`. Do not rebase a published PR because the
   resulting force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -38,13 +38,21 @@ gh pr view --json number,url,title,headRefName,headRefOid,baseRefName,headReposi
 
 In a Claude cloud session, resolve the same fields over MCP
 (`list_pull_requests` filtered by head branch, or `pull_request_read` method
-`get`) and bind by content rather than by remote name: the PR must be
-same-repository (`headRepository.nameWithOwner` equals the session-attached
-repo), local `git rev-parse HEAD` must equal the MCP-resolved `headRefOid`
-before editing, and the verified proxy `origin` serves as both `HEAD_REMOTE`
-and `BASE_REMOTE`. Cross-repository (fork) PRs stop on that surface. For the
-post-push guard there, re-resolve with `pull_request_read` method `get` in
-place of `gh pr view` and require the returned `headRefOid` to equal local
+`get`). Bind the result by content rather than by remote name.
+
+Immediately after resolving these fields, stop on every tool surface if
+`isCrossRepository` is `true`. Apply the same stop when another surface proves
+that the head repository differs from the base repository. This repo-local
+adapter cannot yet prove feedback, gate, and review trust roots end to end for
+fork-controlled source. Do not run a repo-local command, mutate a checkout,
+probe feedback, run a gate, or start a review for that target.
+
+For a remaining same-repository Claude cloud target,
+`headRepository.nameWithOwner` must equal the session-attached repo. Local
+`git rev-parse HEAD` must equal the MCP-resolved `headRefOid` before editing,
+and the verified proxy `origin` serves as both `HEAD_REMOTE` and `BASE_REMOTE`.
+For the post-push guard there, re-resolve with `pull_request_read` method `get`
+in place of `gh pr view` and require the returned `headRefOid` to equal local
 `HEAD`.
 
 For an explicit target, accept a bare number or PR URL. Derive and preserve
@@ -56,10 +64,9 @@ repository.
 Before any blocker fix mutates files or Git history, bind the checkout to that
 resolved target:
 
-- Select `HEAD_REMOTE` only after verifying that its repository equals
-  `headRepository.nameWithOwner`. For a cross-repository PR, use a dedicated
-  checkout with the fork as `HEAD_REMOTE`; keep a separately verified
-  `BASE_REMOTE` for `BASE_REPO` and never swap their roles.
+- For the remaining same-repository target, select `HEAD_REMOTE` and
+  `BASE_REMOTE` only after verifying that each remote serves the repository
+  named by both `headRepository.nameWithOwner` and `BASE_REPO`.
 - `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
   the resolved `headRefOid`. If either differs, stop or switch to a clean,
   dedicated checkout at the PR head before editing.
@@ -152,6 +159,18 @@ item required.
   directories outside the worktree:
 
   ```bash
+  worktree_root="$(git rev-parse --show-toplevel)" || exit 1
+  worktree_root="$(cd "$worktree_root" && pwd -P)" || exit 1
+  bundle_parent="$(mktemp -d)" || exit 1
+  bundle_parent="$(cd "$bundle_parent" && pwd -P)" || exit 1
+  case "$bundle_parent/" in
+    "$worktree_root/"*) exit 1 ;;
+  esac
+  base_bundle="$bundle_parent/base"
+  premerge_bundle="$bundle_parent/premerge"
+  test "$base_bundle" != "$premerge_bundle" || exit 1
+  test ! -e "$base_bundle" || exit 1
+  test ! -e "$premerge_bundle" || exit 1
   pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
     --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
   pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -61,12 +61,28 @@ After that initial resolution, pass `--repo <BASE_REPO>` to every `gh pr view`,
 feedback-state, and ready-state call—even when the PR began in the current
 repository.
 
+For every remaining local same-repository target, complete the repository trust
+preflight before any repo-local adapter command. Require `origin` to exist with
+one effective canonical GitHub fetch URL whose normalized slug equals both
+`BASE_REPO` and `headRepository.nameWithOwner`. Fetch `baseRefName` and protected
+`main` through that `origin` into their matching remote-tracking refs. Resolve
+and retain `base_oid` and `protected_main_oid`, then require
+`origin/<baseRefName>` and `origin/main` to keep those exact values. The values
+must match when `baseRefName` is `main`. Fail closed on ambiguity, fetch failure,
+or drift. Never repair the guard by changing a remote URL; use a clean dedicated
+checkout with the correct `origin`.
+
+Immediately before and after every feedback-state, ready-state, gate, or review
+adapter call, recheck the canonical `origin` URL and both retained refs. Any
+drift stops the workflow and invalidates that result. Any refetch restarts this
+preflight and refreshes both pins before another adapter call.
+
 Before any blocker fix mutates files or Git history, bind the checkout to that
 resolved target:
 
-- For the remaining same-repository target, select `HEAD_REMOTE` and
-  `BASE_REMOTE` only after verifying that each remote serves the repository
-  named by both `headRepository.nameWithOwner` and `BASE_REPO`.
+- For the remaining same-repository target, use the verified `origin` as
+  `BASE_REMOTE`. Select `HEAD_REMOTE` only after verifying that it serves the
+  repository named by both `headRepository.nameWithOwner` and `BASE_REPO`.
 - `git status --porcelain` must be empty and `git rev-parse HEAD` must equal
   the resolved `headRefOid`. If either differs, stop or switch to a clean,
   dedicated checkout at the PR head before editing.
@@ -126,9 +142,10 @@ item required.
 
 - Failing required check: inspect the failing workflow/log, fix only PR-caused
   failures, run focused validation, commit, and push.
-- Merge conflict: fetch `baseRefName` from the verified `BASE_REMOTE`. Before
-  the merge, pin the fetched base and the published PR head to immutable commit
-  IDs:
+- Merge conflict: restart the repository trust preflight. Fetch `baseRefName`
+  and protected `main` from the verified `BASE_REMOTE`, then refresh both
+  retained pins before any gate or review adapter. Before the merge, pin the
+  fetched base and the published PR head to immutable commit IDs:
 
   ```bash
   base_oid="$(git rev-parse '<verified-base-ref>^{commit}')" || exit 1
@@ -155,7 +172,7 @@ item required.
   pnpm agent:quality-gate --base "$premerge_oid" --head HEAD --run
   ```
 
-  Prepare separate verified branch-mode review bundles in different empty
+  Prepare separate verified branch-mode review bundles in different absent
   directories outside the worktree:
 
   ```bash
@@ -176,44 +193,88 @@ item required.
   Before any autoreview entrypoint runs, inspect both exact tree axes:
   `base_oid..final_head` and `premerge_oid..final_head`. An axis is
   runtime-sensitive if it changes `scripts/agent-autoreview.sh`,
-  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`, or if
-  the parsed `package.json` `scripts["agent:autoreview"]` value differs. Check
-  the paths and the parsed value on both axes. Fail closed on any Git, blob,
-  JSON, or comparison error.
+  `scripts/agent-autoreview.mjs`, or `scripts/agent-autoreview-core.mjs`. Check
+  all three paths on both axes. Fail closed on any Git, blob, mode, or
+  comparison error.
 
-  When neither axis is runtime-sensitive, use the package adapter:
+  When neither axis is runtime-sensitive, bind the absolute final-checkout
+  wrapper and helper. Never use the package adapter for merge-review
+  provenance:
 
   ```bash
-  pnpm agent:autoreview --prepare-bundle-dir "$base_bundle" \
-    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
-  pnpm agent:autoreview --prepare-bundle-dir "$premerge_bundle" \
-    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
-  pnpm agent:autoreview --verify-bundle-dir "$base_bundle"
-  pnpm agent:autoreview --verify-bundle-dir "$premerge_bundle"
+  autoreview_wrapper="$worktree_root/scripts/agent-autoreview.sh"
+  autoreview_helper="$worktree_root/scripts/agent-autoreview.mjs"
   ```
 
   When either axis is runtime-sensitive, never run the final checkout's
-  `pnpm agent:autoreview` or autoreview wrapper. Follow the trusted pre-change
-  procedure in
+  autoreview wrapper. Follow the trusted pre-change procedure in
   [`agent-quality-gate-mechanics.md`](../../../docs/notes/agent-quality-gate-mechanics.md).
-  That procedure owns trusted-commit selection, checkout and runtime proof,
-  both axis preparations, pre/post manifest verification, and invalidation.
-  Run `pnpm agent:autoreview:test -- --jobs 1` only as separate behavior proof;
-  it establishes no review provenance.
+  That procedure selects the absolute `autoreview_wrapper` and
+  `autoreview_helper` and owns trusted-commit selection, checkout and runtime
+  proof, both axis preparations, pre/post manifest verification, and
+  invalidation.
+
+  After selecting the two absolute paths, define one direct runner and use it
+  for both axes:
+
+  ```bash
+  run_bound_autoreview() {
+    (
+      cd "$worktree_root" || exit 1
+      AUTOREVIEW_HELPER="$autoreview_helper" \
+        /bin/bash "$autoreview_wrapper" "$@"
+    )
+  }
+  run_bound_autoreview --prepare-bundle-dir "$base_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$base_oid"
+  run_bound_autoreview --prepare-bundle-dir "$premerge_bundle" \
+    --feedback-pr <pr-number> -- --mode branch --base "$premerge_oid"
+  run_bound_autoreview --verify-bundle-dir "$base_bundle"
+  run_bound_autoreview --verify-bundle-dir "$premerge_bundle"
+  ```
 
   The adapter has no `--pr` option. Pass the numeric PR through
   `--feedback-pr`; `auto` is invalid with an explicit `--base`. Complete a
-  fresh-context review of each bundle. Retain each pre-review manifest and run
-  its generated post-review command with `--expected-bundle-manifest`.
+  fresh-context review of each bundle and retain each pre-review manifest.
+  After both semantic reviews, postverify both bundles through the same bound
+  runner:
+
+  ```bash
+  run_bound_autoreview --verify-bundle-dir "$base_bundle" \
+    --expected-bundle-manifest <retained-base-digest>
+  run_bound_autoreview --verify-bundle-dir "$premerge_bundle" \
+    --expected-bundle-manifest <retained-premerge-digest>
+  ```
+
+  Before and after every preparation or verification call, recheck the
+  normalized `origin` identity, the retained base and protected-main refs,
+  `final_head`, the clean worktree, all three runtime identities, and any
+  trusted-checkout root. Any drift invalidates the call.
+
+  Only after both postverifications pass, run the sequential suite through the
+  direct system shell as separate behavior evidence:
+
+  ```bash
+  (
+    cd "$worktree_root" || exit 1
+    AUTOREVIEW_TEST_FOCUS=suite /bin/bash \
+      "$worktree_root/scripts/agent-autoreview.test.sh" --jobs 1
+  ) || exit 1
+  ```
+
+  Require terminal success. Then run a final origin, retained-ref, head, clean,
+  runtime-identity, and trusted-root recheck. Any suite failure or drift
+  invalidates the sequence and restarts preflight, both gates, both bundles,
+  both reviews, both postverifications, and the direct suite.
 
   Bind the two gate results and two post-verified review verdicts to the same
   `final_head`. Do not edit the worktree or move `HEAD` during this sequence.
   After every command, resolve `HEAD` with an explicit success check, require it
   to equal `final_head`, and recheck the clean worktree. Any follow-up fix
-  restarts both gates and both bundle reviews from a new clean final head. The
+  restarts the full sequence above from a new clean final head. The
   trusted-runtime procedure owns its stricter restart conditions. Only then
-  push through `HEAD_REMOTE`. Do not rebase a published PR because the
-  resulting force-push violates this workflow.
+  push through `HEAD_REMOTE`. Do not rebase a published PR because the resulting
+  force-push violates this workflow.
 
 - Feedback blocker: triage every normalized finding, implement valid fixes, and
   sweep review bodies, top-level comments, threads, annotations, and failing

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -810,29 +810,71 @@ runtime is unchanged; they do not turn an untrusted checkout into trusted
 executable code. Inspect a potentially hostile branch from a separate trusted
 checkout rather than invoking that branch's package scripts.
 
-For a runtime-changing PR, run the clean, detached wrapper and compatible MJS
-helper from the last independently reviewed pre-change commit while the current
-directory remains the reviewed checkout. Protected main is acceptable only when
-its helper still supports the current bundle protocol:
+For each review axis, compare its immutable base tree with the immutable final
+tree before any autoreview entrypoint runs. Treat the axis as runtime-sensitive
+only when `scripts/agent-autoreview.sh`, `scripts/agent-autoreview.mjs`, or
+`scripts/agent-autoreview-core.mjs` differs, or when the parsed
+`package.json` `scripts["agent:autoreview"]` value differs. An unrelated
+`package.json` edit is not sufficient. Fail closed on any Git, blob, JSON, or
+comparison error.
+
+For a runtime-changing PR, pin an immutable `trusted_oid` from the verified base
+repository. It must be the last independently reviewed commit before every
+runtime change found on the review axes. Retain the independent-review evidence.
+Do not infer trust from ancestry alone. Prove that the helper protocol supports
+bundle preparation, numeric feedback capture, explicit branch bases, and bound
+pre/post manifest verification. Protected main is acceptable only with both the
+review and compatibility evidence and only when it predates the runtime change
+under review.
+
+Create a clean detached physical checkout at `trusted_oid` outside the reviewed
+worktree. Require its `HEAD` to equal `trusted_oid` and its worktree to be clean.
+Require the wrapper, helper, and core modes and blob IDs to match `trusted_oid`.
+Stop concurrent writers to both checkouts. From the reviewed checkout directory,
+use the same absolute trusted wrapper and explicit compatible
+`AUTOREVIEW_HELPER` for every required axis preparation. Use that exact trusted
+wrapper for every pre-review manifest check and retained-digest post-review
+check. Before and after every invocation, repeat the trusted `HEAD`, clean-state,
+physical-root, mode, and blob checks, and require the reviewed checkout to remain
+clean at its immutable final head. Never substitute the reviewed checkout's
+package script or wrapper.
+
+The basic one-axis call shape is:
 
 ```bash
 reviewed_checkout=/absolute/path/to/reviewed-checkout
 trusted_checkout=/absolute/path/to/trusted-pre-change-checkout
-bundle_parent=/tmp/autoreview-runtime-review
-mkdir -p "$bundle_parent"
-(
-  cd "$reviewed_checkout"
-  AUTOREVIEW_HELPER="$trusted_checkout/scripts/agent-autoreview.mjs" \
-    "$trusted_checkout/scripts/agent-autoreview.sh" \
-    --prepare-bundle-dir "$bundle_parent/context-bundle" \
-    --mode auto --base origin/main --feedback-pr <number>
-)
-"$trusted_checkout/scripts/agent-autoreview.sh" \
-  --verify-bundle-dir "$bundle_parent/context-bundle"
+review_base_oid="$base_oid" # full immutable OID for this review axis
+bundle_parent="$(mktemp -d)" || exit 1
+bundle="$bundle_parent/context-bundle"
+trusted_wrapper="$trusted_checkout/scripts/agent-autoreview.sh"
+trusted_helper="$trusted_checkout/scripts/agent-autoreview.mjs"
+
+run_trusted_autoreview() {
+  (
+    cd "$reviewed_checkout" || exit 1
+    AUTOREVIEW_HELPER="$trusted_helper" "$trusted_wrapper" "$@"
+  )
+}
+
+run_trusted_autoreview --prepare-bundle-dir "$bundle" \
+  --feedback-pr <number> -- --mode branch --base "$review_base_oid"
+run_trusted_autoreview --verify-bundle-dir "$bundle"
+# Retain the printed manifest digest outside the bundle. After semantic review:
+run_trusted_autoreview --verify-bundle-dir "$bundle" \
+  --expected-bundle-manifest <retained-digest>
 ```
 
-Use that same trusted wrapper for `--expected-bundle-manifest` after the review.
 Never point `trusted_checkout` at the runtime-changing checkout.
+For multiple axes, allocate a distinct absent bundle path for each immutable
+base outside both worktrees, then repeat the preparation and both manifest
+checks with that base. Any fix, `HEAD` movement, dirty worktree, trusted-runtime
+or provenance drift, failed compatibility check, or manifest mismatch
+invalidates every gate and review result. Allocate new bundle paths and restart
+both gates, the sequential autoreview suite, and every bundle review from the
+new clean final head. Run `pnpm agent:autoreview:test -- --jobs 1` on that
+guarded final head only as separate behavior validation; it establishes no
+review provenance. Recheck both worktrees after it.
 
 For a true Codex semantic pass from inside Codex, prepare a repo-context bundle
 and pass that bundle to a fresh-context reviewer:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -807,16 +807,37 @@ and isolation.
 The repo command itself is executable code from the active checkout. The
 committed/pre-change runtime comparisons protect review integrity when the
 runtime is unchanged; they do not turn an untrusted checkout into trusted
-executable code. Inspect a potentially hostile branch from a separate trusted
-checkout rather than invoking that branch's package scripts.
+executable code. Merge-review provenance must not pass through the reviewed
+checkout's package manager, package scripts, or package-manager configuration.
+
+For a same-repository merge review, bind repository identity before any
+repo-local adapter command. Require `origin` to have one effective canonical
+GitHub fetch URL. Normalize that URL and require its slug to equal the resolved
+base repository and head repository. Fetch the resolved base branch and
+protected `main` through that `origin` into their matching remote-tracking refs.
+Pin their immutable values as `base_oid` and `protected_main_oid`. Require
+`origin/<baseRefName>` and `origin/main` to keep those exact values; when the
+base is `main`, require the two pins to match. Fail closed on a missing or
+ambiguous URL, fetch error, malformed object ID, or ref drift. Do not change a
+remote URL to satisfy this guard. Use a clean dedicated checkout with the
+correct `origin`. Other verified remotes may remain, but the wrapper consumes
+only the pinned `origin` identity and refs.
+
+Repeat the canonical origin-URL check and both retained-ref checks immediately
+before and after every feedback-state, ready-state, gate, or review adapter
+call. Any error or drift stops the workflow and invalidates the result. Any
+refetch, including a conflict-triggered base refresh, restarts this preflight and
+refreshes both pins before another adapter call.
 
 For each review axis, compare its immutable base tree with the immutable final
 tree before any autoreview entrypoint runs. Treat the axis as runtime-sensitive
-only when `scripts/agent-autoreview.sh`, `scripts/agent-autoreview.mjs`, or
-`scripts/agent-autoreview-core.mjs` differs, or when the parsed
-`package.json` `scripts["agent:autoreview"]` value differs. An unrelated
-`package.json` edit is not sufficient. Fail closed on any Git, blob, JSON, or
-comparison error.
+only when
+`scripts/agent-autoreview.sh`, `scripts/agent-autoreview.mjs`, or
+`scripts/agent-autoreview-core.mjs` differs. Compare the modes and blob IDs for
+all three paths on both axes. Fail closed on any Git, blob, mode, or comparison
+error. If neither axis is sensitive, use the clean final checkout's absolute
+wrapper and explicit helper. Invoke it through `/bin/bash` from the reviewed
+checkout. Never use `pnpm agent:autoreview` for this merge-review sequence.
 
 For a runtime-changing PR, pin an immutable `trusted_oid` from the verified base
 repository. It must be the last independently reviewed commit before every
@@ -832,12 +853,18 @@ worktree. Require its `HEAD` to equal `trusted_oid` and its worktree to be clean
 Require the wrapper, helper, and core modes and blob IDs to match `trusted_oid`.
 Stop concurrent writers to both checkouts. From the reviewed checkout directory,
 use the same absolute trusted wrapper and explicit compatible
-`AUTOREVIEW_HELPER` for every required axis preparation. Use that exact trusted
-wrapper for every pre-review manifest check and retained-digest post-review
-check. Before and after every invocation, repeat the trusted `HEAD`, clean-state,
-physical-root, mode, and blob checks, and require the reviewed checkout to remain
-clean at its immutable final head. Never substitute the reviewed checkout's
-package script or wrapper.
+`AUTOREVIEW_HELPER` for every required axis preparation. Invoke the wrapper
+through `/bin/bash`. Use that exact trusted wrapper and helper for every
+pre-review manifest check and retained-digest post-review check. Never
+substitute the reviewed checkout's package script or wrapper.
+
+Before and after every preparation or verification invocation, repeat the
+normalized `origin` identity check; require the retained base and protected-main
+refs to keep their pinned OIDs; require the reviewed checkout to remain clean at
+its immutable final head; and repeat the selected wrapper/helper/core
+physical-root, mode, and blob checks. Repeat the detached `trusted_oid` and clean
+checks when the runtime is external. Any check error or drift invalidates the
+invocation.
 
 The basic one-axis call shape is:
 
@@ -847,13 +874,14 @@ trusted_checkout=/absolute/path/to/trusted-pre-change-checkout
 review_base_oid="$base_oid" # full immutable OID for this review axis
 bundle_parent="$(mktemp -d)" || exit 1
 bundle="$bundle_parent/context-bundle"
-trusted_wrapper="$trusted_checkout/scripts/agent-autoreview.sh"
-trusted_helper="$trusted_checkout/scripts/agent-autoreview.mjs"
+autoreview_wrapper="$trusted_checkout/scripts/agent-autoreview.sh"
+autoreview_helper="$trusted_checkout/scripts/agent-autoreview.mjs"
 
 run_trusted_autoreview() {
   (
     cd "$reviewed_checkout" || exit 1
-    AUTOREVIEW_HELPER="$trusted_helper" "$trusted_wrapper" "$@"
+    AUTOREVIEW_HELPER="$autoreview_helper" \
+      /bin/bash "$autoreview_wrapper" "$@"
   )
 }
 
@@ -865,16 +893,34 @@ run_trusted_autoreview --verify-bundle-dir "$bundle" \
   --expected-bundle-manifest <retained-digest>
 ```
 
-Never point `trusted_checkout` at the runtime-changing checkout.
+For a runtime-insensitive review, set `autoreview_wrapper` and
+`autoreview_helper` to the absolute final-checkout paths and use the same direct
+call shape. Never point `trusted_checkout` at the runtime-changing checkout.
 For multiple axes, allocate a distinct absent bundle path for each immutable
 base outside both worktrees, then repeat the preparation and both manifest
-checks with that base. Any fix, `HEAD` movement, dirty worktree, trusted-runtime
-or provenance drift, failed compatibility check, or manifest mismatch
-invalidates every gate and review result. Allocate new bundle paths and restart
-both gates, the sequential autoreview suite, and every bundle review from the
-new clean final head. Run `pnpm agent:autoreview:test -- --jobs 1` on that
-guarded final head only as separate behavior validation; it establishes no
-review provenance. Recheck both worktrees after it.
+checks with that base. Prepare and preverify every bundle, complete every
+semantic review, then postverify every retained digest through the same bound
+runner.
+
+Only after every postverification passes, run the sequential suite without the
+package manager:
+
+```bash
+(
+  cd "$reviewed_checkout" || exit 1
+  AUTOREVIEW_TEST_FOCUS=suite /bin/bash \
+    "$reviewed_checkout/scripts/agent-autoreview.test.sh" --jobs 1
+)
+```
+
+The suite is behavior evidence and establishes no review provenance. Require
+terminal success, then repeat the origin, retained-ref, final-head, clean-state,
+runtime-identity, and trusted-root checks. Any fix, `HEAD` movement, dirty
+worktree, origin identity drift, base or protected-ref drift, trusted-runtime or
+provenance drift, failed compatibility check, sequential-suite failure, or
+manifest mismatch invalidates every result. Restart preflight, both gates, both
+bundle preparations, both semantic reviews and postverifications, and the
+direct sequential suite from the new clean final head.
 
 For a true Codex semantic pass from inside Codex, prepare a repo-context bundle
 and pass that bundle to a fresh-context reviewer:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -43,10 +43,11 @@ sets and 8 minutes for the full workspace (Refs #1415).
 
 If a sandboxed mapped run fails only because a command needs host capabilities,
 rerun the full mapped gate with host access on the same head. The gate reuses
-fresh successes, runs the blocked commands, and records their freshness stamps.
-Running those commands directly proves them but does not warm
-`--skip-if-fresh`; a later push otherwise repeats them and can queue for the
-machine-wide lock.
+stamp-eligible fresh successes and runs the blocked commands. A resumed run does
+not write a whole-run stamp. Trunk and the gate self-test are stamp-exempt and
+always run, including during the later pre-push gate. Other eligible successes
+keep per-command stamps, so the later gate can avoid repeating them. Running a
+command directly proves it but records no per-command stamp.
 
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-18
+last_verified: 2026-08-20
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -40,6 +40,13 @@ freshness stamp, so the next run cannot use `--skip-if-fresh`. Each run appends
 per-command JSON plus one `__run_total__` line to gitignored
 `.tmp/agent-quality-gate/durations.jsonl`. Targets: 3 minutes for common mapped
 sets and 8 minutes for the full workspace (Refs #1415).
+
+If a sandboxed mapped run fails only because a command needs host capabilities,
+rerun the full mapped gate with host access on the same head. The gate reuses
+fresh successes, runs the blocked commands, and records their freshness stamps.
+Running those commands directly proves them but does not warm
+`--skip-if-fresh`; a later push otherwise repeats them and can queue for the
+machine-wide lock.
 
 For a manual full-repository reproduction of the server-side pre-push baseline,
 including when hooks are absent or uncertain, use:

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -100,11 +100,15 @@ even when you never open an authority.
    reviewer must inspect every prepared-bundle pass, with manifest
    verification before and after review. Capture, bundle-integrity,
    sensitive-input, runtime-trust, and explicitly-selected-unavailable-engine
-   failures all fail closed. **If this PR changes `scripts/agent-autoreview*`,
-   the current checkout is not a trust boundary for its own review** — run the
-   wrapper and helper from the last independently reviewed pre-change commit
-   instead, and run `pnpm agent:autoreview:test -- --jobs 1` as the sequential
-   full regression closeout. Authority:
+   failures all fail closed. For merge-review provenance, the `babysit-pr`
+   skill binds `origin`, the immutable base, and protected `main` before any
+   adapter call. It invokes an absolute wrapper and explicit helper through
+   `/bin/bash`, never through the package manager. If either review axis changes
+   `scripts/agent-autoreview.sh`, `scripts/agent-autoreview.mjs`, or
+   `scripts/agent-autoreview-core.mjs`, use the last independently reviewed
+   compatible pre-change runtime. After every semantic review and bound
+   postverification, run the sequential suite through `/bin/bash` as separate
+   behavior evidence. Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 5. **Ship.** Open the PR through the `ship` skill on every surface, including

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -135,7 +135,10 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 - A function invoked directly as an `if`, `while`, or `until` condition, under
   `!`, or as a non-final command in an `&&` or `||` list cannot rely on `set -e`
-  to stop its body.
+  to stop its body. The same rule includes a function in the final operand when
+  an enclosing `if`, `while`, or `until` tests the complete `&&` or `||` list.
+  It excludes a final operand in a top-level bare list, such as `true && f` or
+  `false || f`; those forms retain normal `errexit` behavior.
 - A function used as a pipeline element also cannot rely on `set -e` when an
   enclosing `if`, `while`, or `until` tests the aggregate pipeline status, when
   `!` inverts the pipeline, or when the pipeline is a non-final command in an

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -3,7 +3,7 @@ title: Recurring PR Review Patterns
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-08-20
 doc_type: checklist
 scope: repo-wide
 review_interval_days: 90
@@ -130,6 +130,16 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 - If a setup/cache script uses marker files or input hashes to skip work, the skip condition MUST verify the actual output that downstream commands need, not just the marker. Examples: dependency skips should verify a representative package resolves, Playwright skips should verify the browser executable exists, and codegen skips should verify the generated facade file exists.
 - Write marker files only after every validation step represented by that marker has passed. A failed post-install validation must not leave a fresh marker that makes the next run skip the install or rebuild path.
+
+### Shell failure propagation and fixture environments
+
+- A function invoked as a condition in `if`, `!`, `&&`, or `||` cannot rely on
+  `set -e` to stop its body. Check each load-bearing command explicitly. Add a
+  negative test that proves later commands do not run after the first failure.
+- A fixture that sources or spawns a script must create the feature state it
+  tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
+  load-bearing flag, also run the fixture under the inverse caller state and
+  prove that the target path ran.
 
 ### Supply-chain advisory bumps
 

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -133,12 +133,15 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 ### Shell failure propagation and fixture environments
 
-- A function invoked directly as an `if`, `while`, or `until` condition, under
-  `!`, or as a non-final command in an `&&` or `||` list cannot rely on `set -e`
-  to stop its body. The same rule includes a function in the final operand when
-  an enclosing `if`, `while`, or `until` tests the complete `&&` or `||` list.
-  It excludes a final operand in a top-level bare list, such as `true && f` or
-  `false || f`; those forms retain normal `errexit` behavior.
+- A function cannot rely on `set -e` when it runs directly in an
+  ignored-`errexit` context or anywhere inside a compound command whose
+  aggregate status is tested by `if`, `while`, or `until`, inverted by `!`, or
+  used as a non-final command in an `&&` or `||` list. Compound commands include
+  brace groups, subshells, and `case` commands. This rule includes final
+  operands nested inside a tested compound command. It excludes standalone
+  compound commands and compound commands used as the final operand of a
+  top-level bare `&&` or `||` list; those forms retain normal `errexit`
+  behavior.
 - A function used as a pipeline element also cannot rely on `set -e` when an
   enclosing `if`, `while`, or `until` tests the aggregate pipeline status, when
   `!` inverts the pipeline, or when the pipeline is a non-final command in an

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -136,6 +136,12 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 - A function invoked directly as an `if`, `while`, or `until` condition, under
   `!`, or as a non-final command in an `&&` or `||` list cannot rely on `set -e`
   to stop its body.
+- A function used as a pipeline element also cannot rely on `set -e` when an
+  enclosing `if`, `while`, or `until` tests the aggregate pipeline status, when
+  `!` inverts the pipeline, or when the pipeline is a non-final command in an
+  `&&` or `||` list. This rule excludes a bare pipeline. With `errexit` and
+  `pipefail` enabled, bare `f | cat` stops `f` at its unchecked failure and
+  returns nonzero.
 - Command substitution has two independent suppression mechanisms. With
   `inherit_errexit` disabled, including default non-POSIX Bash, the substitution
   clears `errexit`. Even with `inherit_errexit` enabled, an ignored-errexit

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -133,12 +133,16 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 ### Shell failure propagation and fixture environments
 
-- A function invoked as an `if`, `while`, or `until` condition, under `!`, or as
-  a non-final command in an `&&` or `||` list cannot rely on `set -e` to stop its
-  body. Check each load-bearing command explicitly. For each applicable context,
-  add a negative test that proves remaining commands in the function body do not
-  run after the failure and the caller takes the expected branch, inversion, or
-  list operand.
+- A function invoked as an `if`, `while`, or `until` condition, under `!`, as a
+  non-final command in an `&&` or `||` list or pipeline, or inside a Bash command
+  substitution while `inherit_errexit` is disabled (including default non-POSIX
+  mode) cannot rely on `set -e` to stop its body. Check each load-bearing command
+  explicitly. For each applicable context, add a negative test that proves
+  remaining commands in the function body do not run after the failure and the
+  caller observes the failure. Prove the expected branch, inversion, or list
+  operand for control-flow contexts. Under the repo's `pipefail` contract, prove
+  that the pipeline returns failure. For command substitution, prove that the
+  substitution-owning assignment returns failure.
 - A fixture that sources or spawns a script must create the feature state it
   tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
   load-bearing flag, also run the fixture under the inverse caller state and

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -133,9 +133,10 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 ### Shell failure propagation and fixture environments
 
-- A function invoked as a condition in `if`, `!`, `&&`, or `||` cannot rely on
-  `set -e` to stop its body. Check each load-bearing command explicitly. Add a
-  negative test that proves later commands do not run after the first failure.
+- A function invoked as an `if` condition, under `!`, or as a non-final command
+  in an `&&` or `||` list cannot rely on `set -e` to stop its body. Check each
+  load-bearing command explicitly. Add a negative test that proves later
+  commands do not run after the first failure.
 - A fixture that sources or spawns a script must create the feature state it
   tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
   load-bearing flag, also run the fixture under the inverse caller state and

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -133,15 +133,25 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 ### Shell failure propagation and fixture environments
 
-- A function invoked as an `if`, `while`, or `until` condition, under `!`, as a
-  non-final command in an `&&` or `||` list, or inside a Bash command substitution
-  while `inherit_errexit` is disabled (including default non-POSIX mode) cannot
-  rely on `set -e` to stop its body. Check each load-bearing command explicitly.
-  For each applicable context, add a negative test that proves remaining commands
-  in the function body do not run after the failure and the caller observes the
-  failure. Prove the expected branch, inversion, or list operand for control-flow
-  contexts. For command substitution, prove that the substitution-owning
-  assignment returns failure.
+- A function invoked directly as an `if`, `while`, or `until` condition, under
+  `!`, or as a non-final command in an `&&` or `||` list cannot rely on `set -e`
+  to stop its body.
+- Command substitution has two independent suppression mechanisms. With
+  `inherit_errexit` disabled, including default non-POSIX Bash, the substitution
+  clears `errexit`. Even with `inherit_errexit` enabled, an ignored-errexit
+  context around the standalone assignment-only command, or around an enclosing
+  pipeline whose whole status is tested, suppresses `errexit` in the substituted
+  function body.
+- Check each load-bearing command explicitly. Match every negative test to the
+  exact production call shape. Prove that remaining commands in the function
+  body do not run and that the caller observes failure. For direct contexts,
+  prove the expected branch, inversion, or list operand. For command
+  substitution, use a standalone assignment-only command such as `value=$(f)`
+  and prove that it returns failure. Test both `inherit_errexit` settings and
+  every nested ignored-errexit context that production uses. Do not use `local`,
+  `declare`, `export`, or `readonly`, a command argument, an assignment prefix,
+  or an assignment with a later substitution as status proof; each can mask the
+  substituted function's status.
 - A fixture that sources or spawns a script must create the feature state it
   tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
   load-bearing flag, also run the fixture under the inverse caller state and

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -133,10 +133,12 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 ### Shell failure propagation and fixture environments
 
-- A function invoked as an `if` condition, under `!`, or as a non-final command
-  in an `&&` or `||` list cannot rely on `set -e` to stop its body. Check each
-  load-bearing command explicitly. Add a negative test that proves later
-  commands do not run after the first failure.
+- A function invoked as an `if`, `while`, or `until` condition, under `!`, or as
+  a non-final command in an `&&` or `||` list cannot rely on `set -e` to stop its
+  body. Check each load-bearing command explicitly. For each applicable context,
+  add a negative test that proves remaining commands in the function body do not
+  run after the failure and the caller takes the expected branch, inversion, or
+  list operand.
 - A fixture that sources or spawns a script must create the feature state it
   tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
   load-bearing flag, also run the fixture under the inverse caller state and

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -134,15 +134,14 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 ### Shell failure propagation and fixture environments
 
 - A function invoked as an `if`, `while`, or `until` condition, under `!`, as a
-  non-final command in an `&&` or `||` list or pipeline, or inside a Bash command
-  substitution while `inherit_errexit` is disabled (including default non-POSIX
-  mode) cannot rely on `set -e` to stop its body. Check each load-bearing command
-  explicitly. For each applicable context, add a negative test that proves
-  remaining commands in the function body do not run after the failure and the
-  caller observes the failure. Prove the expected branch, inversion, or list
-  operand for control-flow contexts. Under the repo's `pipefail` contract, prove
-  that the pipeline returns failure. For command substitution, prove that the
-  substitution-owning assignment returns failure.
+  non-final command in an `&&` or `||` list, or inside a Bash command substitution
+  while `inherit_errexit` is disabled (including default non-POSIX mode) cannot
+  rely on `set -e` to stop its body. Check each load-bearing command explicitly.
+  For each applicable context, add a negative test that proves remaining commands
+  in the function body do not run after the failure and the caller observes the
+  failure. Prove the expected branch, inversion, or list operand for control-flow
+  contexts. For command substitution, prove that the substitution-owning
+  assignment returns failure.
 - A fixture that sources or spawns a script must create the feature state it
   tests. Set enable flags and clear ambient opt-outs inside the fixture. For a
   load-bearing flag, also run the fixture under the inverse caller state and


### PR DESCRIPTION
## The Problem

- Shell reviews can miss failure propagation when Bash functions run in conditional contexts.
- Ambient environment flags can make fixtures skip the behavior they claim to test.
- Base-merge repairs and sandbox-only gate retries can leave incomplete current-head validation.

## The Solution

- Add focused review and workflow rules for these recurring failure modes.

## Details

- Require explicit guards for load-bearing commands inside Bash functions used by `if`, `while`, `until`, `!`, non-final `&&` and `||` operands, or final operands when a control-flow construct tests the complete list.
- Apply the same suppression rule when a function runs anywhere inside a brace group, subshell, `case` command, or other compound command whose aggregate status controls `if`, `while`, `until`, `!`, or a non-final `&&` or `||` operand. Preserve the standalone-compound, top-level final-operand, and bare-pipeline exclusions.
- Cover direct pipeline elements when an enclosing control-flow construct tests the aggregate pipeline status, while excluding bare pipelines.
- Cover both command-substitution suppression mechanisms: `inherit_errexit` disabled, and an ignored-errexit context around the assignment or a tested enclosing pipeline even when `inherit_errexit` is enabled.
- Require exact-call-shape tests that prove the function body stops and the caller observes failure through the expected control-flow path or standalone assignment status.
- Require fixtures to set feature flags, clear ambient opt-outs, and prove that the intended path ran.
- Require a full host-access mapped-gate rerun after a sandbox-only failure. Document whole-run, per-command, and stamp-exempt retry behavior.
- Treat conflict resolution as a new substantive PR head. Pin the base and pre-merge commits, create the resolved merge commit locally, and run separate mapped gates and sealed branch reviews against both commits before push.
- Create the two review destinations as distinct absent child paths under a private temporary directory that resolves outside the worktree. Retain both bundles through semantic review and post-verification.
- Inspect both immutable review axes for exact autoreview runtime changes before any autoreview entrypoint runs. Use an independently reviewed compatible pre-change runtime from a detached external checkout when either axis changes that runtime.
- Bind same-repository adapter work to the sole canonical `origin` URL plus pinned base and protected-main refs. Recheck those bindings around every feedback, readiness, gate, and review adapter call.
- Invoke the selected absolute autoreview wrapper through `/bin/bash` with the explicit helper for bundle preparation and verification. Run the direct sequential suite only after all semantic reviews and retained-digest postverifications pass.
- Fail closed on cross-repository PRs immediately after target resolution. This repo-local adapter cannot yet prove feedback, gate, and review trust roots end to end for fork-controlled source.
- Keep the Codex and Claude `babysit-pr` skill mirrors byte-identical.
- This change records review and validation safeguards. It does not make an architecture decision.
- No UI code changed. Browser verification is not applicable.

## Validation

- `pnpm agent:quality-gate --run --base HEAD --keep-going` — all seven mapped commands passed on the frozen five-file local diff. The pre-push hook reran the mapped gate against `origin/main` and passed on exact published head `c7f73af3318224e56c7d20de02dcba5e8d65e138`.
- Executable Bash matrix — all 32 combinations passed across `inherit_errexit` on and off, checked and unchecked load-bearing commands, and the direct, `if`, `while`, `until`, `!`, `&&`, `||`, and tested-pipeline call shapes. The checked cases stopped the body and exposed failure through the expected caller path.
- Final-operand list matrix — all 32 checked and unchecked `&&` and `||` cases passed on Bash 3.2.57 and 5.3.15 across bare lists and complete lists tested by `if`, `while`, or `until`. Bare final operands retained normal `errexit`; tested complete lists reproduced suppression; explicit guards stopped the function tail and exposed failure through the expected caller path.
- Direct-pipeline matrix — all 28 checked and unchecked cases passed on Bash 3.2.57 and 5.3.15 across bare, `if`, `while`, `until`, `!`, `&&`, and `||` pipeline contexts. Bare pipelines stopped at failure; tested aggregate contexts reproduced suppression; explicit guards stopped the function tail and routed the expected caller result.
- Status-masking proof — `local`, `declare`, `export`, `readonly`, a command argument, an assignment prefix, and a later substitution each masked the substituted function's status as documented.
- Two-axis merge fixture — pinned base `f9531f20f1b0d4fe5adcb0d101da13a4538dfb1b` and pre-merge `96e981380db5e38a86c67b8e831d3cc7441867b8` are ancestors of clean final head `aad147506c37776657798f5231a08f666cdc7264`. Separate gate dry runs routed the disjoint dashboard and docs fixture paths. Separate branch bundles bound both review axes to that final head and verified as manifests `ace1dbd7b29028ab43d5f99dcdbb0fd1ad9c36279ce5e95956f620da830352f3` and `8d2863c0e09a46cba695adc4d2a0d28e40541ee49c8e4250b3b6ef0a39d47902`.
- Bundle-directory initialization proof — `mktemp -d` produced a mode-700 parent outside the resolved worktree; the two child paths were distinct and absent. A parent that resolved to the worktree was rejected.
- Runtime-sensitivity detector fixture — unrelated `package.json` and autoreview test changes remained insensitive; an actual `scripts.agent:autoreview` value change and an exact runtime-file change were sensitive; an invalid Git ref failed closed.
- Trusted-runtime call-shape proof — a clean detached checkout at immutable base `1817afb73b61bebdfda379b71299d48897ce9db4` matched the trusted wrapper, helper, and core modes and blob IDs. From the reviewed checkout, the absolute trusted wrapper with explicit `AUTOREVIEW_HELPER` prepared, preverified, and postverified a branch bundle against that base as manifest `b76c5fe69bc16701793b895b349a630db20c33ae6210810372e2fdd7f73b8cdf`.
- Cross-repository boundary audit — both skill mirrors place the universal `isCrossRepository` stop immediately after target metadata resolution and before any repo-local command, checkout mutation, feedback probe, gate, or review. No later fork execution path remains.
- `node scripts/repo-health/check-skills-mirror.test.mjs` — 17 tests passed.
- `node scripts/repo-health/check-skills-mirror.mjs` — the skill mirrors are identical.
- Fresh-context full-branch closeout review — zero findings; patch correct with 0.98 confidence; bundle `6b612a516de51df4e634ef8129cc77f7d200eb4ac3f67d05a3d6ce5326936b24` matched before and after review.
- Compound-enclosure matrix — all 78 cases passed on Bash 3.2.57 and 5.3.15 across brace groups, subshells, `case` commands, tested and inverted compound commands, nested final list operands, and the documented standalone and top-level exclusions.
- Origin/ref guard fixtures — the canonical-origin path passed. Wrong origin, stale `origin/main`, and stale base-ref paths failed closed without changing remote URLs.
- Hostile launch fixture — direct absolute wrapper/helper preparation and verification ignored armed `.npmrc` `script-shell`, workspace `scriptShell`, and package-dispatcher markers.
- Current-head sealed closeout — local bundle manifest `be53ecc18c9c28e85b180d3eaca6e15ba018b572881c44f6655847ad2715ac1c` matched before and after a fresh no-history semantic review. The review reported zero findings, patch correct, with 0.94 confidence. The direct sequential suite ran after postverification and passed all five families in 466 seconds.
- `CI=true pnpm run agent:context-budget --strict` — passed; existing near-cap warnings remain for `scripts/AGENTS.md` and `terraform/AGENTS.md`.
- `git diff --check` — passed.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This change records existing review and validation safeguards.

